### PR TITLE
fix: GPT-5.x fixed_temperature detection covers all variants

### DIFF
--- a/crates/octos-cli/src/api/metrics.rs
+++ b/crates/octos-cli/src/api/metrics.rs
@@ -27,7 +27,8 @@ pub async fn metrics_handler(State(state): State<Arc<AppState>>) -> String {
 pub fn record_tool_call(name: &str, success: bool, duration_secs: f64) {
     let labels = [("tool", name.to_string()), ("success", success.to_string())];
     counter!("octos_tool_calls_total", &labels).increment(1);
-    histogram!("octos_tool_call_duration_seconds", "tool" => name.to_string()).record(duration_secs);
+    histogram!("octos_tool_call_duration_seconds", "tool" => name.to_string())
+        .record(duration_secs);
 }
 
 /// Record LLM token usage.

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -70,7 +70,7 @@ impl ModelHints {
             is_o_series || m.starts_with("gpt-5") || m.starts_with("gpt-4.1");
 
         let fixed_temperature =
-            is_o_series || m.contains("k2.5") || m == "gpt-5-nano" || m == "gpt-4.1-nano";
+            is_o_series || m.starts_with("gpt-5") || m.contains("k2.5") || m == "gpt-4.1-nano";
 
         let lacks_vision = m.starts_with("deepseek")
             || m.starts_with("minimax")
@@ -748,17 +748,16 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_gpt5() {
-        let h = ModelHints::detect("gpt-5.3-codex");
-        assert!(h.uses_completion_tokens);
-        assert!(!h.fixed_temperature);
-    }
-
-    #[test]
-    fn test_detect_gpt5_nano() {
-        let h = ModelHints::detect("gpt-5-nano");
-        assert!(h.uses_completion_tokens);
-        assert!(h.fixed_temperature);
+    fn test_detect_gpt5_uses_fixed_temperature() {
+        // All gpt-5.* variants use fixed temperature and completion tokens
+        for model in &["gpt-5-nano", "gpt-5.3-codex", "gpt-5.4"] {
+            let h = ModelHints::detect(model);
+            assert!(
+                h.uses_completion_tokens,
+                "{model} should use completion_tokens"
+            );
+            assert!(h.fixed_temperature, "{model} should use fixed_temperature");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Change `fixed_temperature` from exact match (`gpt-5-nano`) to prefix match (`starts_with("gpt-5")`) covering all GPT-5 variants (gpt-5-nano, gpt-5.3-codex, gpt-5.4, etc.)
- Consolidate GPT-5 tests into a single parameterized test with real model names
- Also includes rustfmt fix for `metrics.rs` line length

## Test plan

- [x] `cargo test -p octos-llm detect` — 16 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)