### PR TITLE
enhance: OS constraint checks for macOS aliasing

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -471,8 +471,7 @@ impl Agent {
                 tc.id = sanitize_tool_call_id(&tc.id);
 
                 if tc.id.is_empty() || !seen_ids.insert(tc.id.clone()) {
-                    static SEQ: std::sync::atomic::AtomicU64 =
-                        std::sync::atomic::AtomicU64::new(0);
+                    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
                     let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     let new_id = format!("call_{}_{}", i, seq);
                     tracing::warn!(

--- a/crates/octos-agent/src/policy.rs
+++ b/crates/octos-agent/src/policy.rs
@@ -198,14 +198,8 @@ mod tests {
             Decision::Deny
         );
         // And "sudo" standalone should still be caught
-        assert_eq!(
-            policy.check("sudo ls", Path::new("/tmp")),
-            Decision::Ask
-        );
+        assert_eq!(policy.check("sudo ls", Path::new("/tmp")), Decision::Ask);
         // Pattern at end of string
-        assert_eq!(
-            policy.check("run sudo", Path::new("/tmp")),
-            Decision::Ask
-        );
+        assert_eq!(policy.check("run sudo", Path::new("/tmp")), Decision::Ask);
     }
 }

--- a/crates/octos-plugin/src/gating.rs
+++ b/crates/octos-plugin/src/gating.rs
@@ -69,11 +69,11 @@ pub fn check_requirements(reqs: &Requirements, env_vars: &HashMap<String, String
             },
         });
     }
-    
+
     // Check OS constraint. Normalize/accept common macOS alias "darwin".
     if !reqs.os.is_empty() {
         let current_os = std::env::consts::OS;
-        
+
         // Treat "darwin" and "macos" as equivalent to avoid manifest/host mismatch
         // where docs/examples use "darwin" but Rust uses "macos".
         let matched = reqs.os.iter().any(|os| {
@@ -81,12 +81,14 @@ pub fn check_requirements(reqs: &Requirements, env_vars: &HashMap<String, String
                 return true;
             }
             // Accept common aliasing between darwin <-> macos
-            if (os == "darwin" && current_os == "macos") || (os == "macos" && current_os == "darwin") {
+            if (os == "darwin" && current_os == "macos")
+                || (os == "macos" && current_os == "darwin")
+            {
                 return true;
             }
             false
         });
-        
+
         checks.push(GateCheck {
             gate: format!("os:{}", reqs.os.join(",")),
             passed: matched,


### PR DESCRIPTION
Normalize macOS alias 'darwin' to improve OS constraint checks.

Repairing/making the OS string compatible (mapping "darwin" to "macos") is low-risk and avoids common misjudgments.

<img width="1051" height="336" alt="截屏2026-03-17 20 39 05" src="https://github.com/user-attachments/assets/7eb59f80-660d-461f-bb41-940152ba5cd8" />
