### PR TITLE
fix: move optional deps out of cfg(windows) section

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -28,7 +28,7 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build octos CLI
-        run: cargo build --release -p octos-cli --features "api,telegram,feishu,twilio,wecom"
+        run: cargo build --release -p octos-cli --features "api,telegram,discord,feishu,twilio,wecom,wecom-bot"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -45,12 +45,7 @@ base64 = { workspace = true }
 keyring = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-keyring = { workspace = true, features = ["apple-native"] }
-
-[target.'cfg(windows)'.dependencies]
-keyring = { workspace = true, features = ["windows-native"] }
+# Optional deps gated by feature flags (api, admin-bot)
 axum = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
@@ -61,6 +56,12 @@ lettre = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 teloxide = { workspace = true, optional = true }
 sysinfo = { version = "0.34", optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { workspace = true, features = ["apple-native"] }
+
+[target.'cfg(windows)'.dependencies]
+keyring = { workspace = true, features = ["windows-native"] }
 
 [features]
 default = []

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -405,6 +405,7 @@ impl AuthManager {
 }
 
 /// Generate a 6-digit numeric OTP code.
+#[cfg(feature = "api")]
 fn generate_otp_code() -> String {
     use rand::Rng;
     let mut rng = rand::thread_rng();
@@ -412,13 +413,26 @@ fn generate_otp_code() -> String {
     format!("{code:06}")
 }
 
+#[cfg(not(feature = "api"))]
+fn generate_otp_code() -> String {
+    // Deterministic fallback — OTP is only meaningful with the API server.
+    "000000".to_string()
+}
+
 /// Generate a 32-byte hex session token.
+#[cfg(feature = "api")]
 fn generate_session_token() -> String {
     use rand::Rng;
     let mut rng = rand::thread_rng();
     let mut bytes = [0u8; 32];
     rng.fill(&mut bytes);
     hex_encode(&bytes)
+}
+
+#[cfg(not(feature = "api"))]
+fn generate_session_token() -> String {
+    // Deterministic fallback — sessions are only meaningful with the API server.
+    hex_encode(&[0u8; 32])
 }
 
 fn hex_encode(bytes: &[u8]) -> String {
@@ -447,6 +461,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "api")]
     fn test_generate_otp_code() {
         let code = generate_otp_code();
         assert_eq!(code.len(), 6);
@@ -456,6 +471,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "api")]
     fn test_generate_session_token() {
         let token = generate_session_token();
         assert_eq!(token.len(), 64);


### PR DESCRIPTION
## Summary

- Optional dependencies (`axum`, `rand`, `lettre`, `tower-http`, `futures`, `rust-embed`, `metrics`, `metrics-exporter-prometheus`, `teloxide`, `sysinfo`) were accidentally placed under `[target.'cfg(windows)'.dependencies]` in `crates/octos-cli/Cargo.toml`, making the `api` feature completely broken on Linux/macOS
- Gate `rand`-dependent OTP functions (`generate_otp_code`, `generate_session_token`) behind `#[cfg(feature = "api")]` with deterministic fallbacks, keeping `rand` optional
- Add `discord` and `wecom-bot` to the CI Linux build workflow

This is the root cause of the CI build failures on `main`.

## Test plan
- [x] `cargo check -p octos-cli` (no features) compiles
- [x] `cargo check -p octos-cli --features "api,wecom-bot,discord"` compiles
- [x] `cargo test -p octos-cli --features "api" otp` — 9 tests pass
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)