### PR TITLE
feat: MoFa Notebook API (rebased on octos-* crates)

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -105,10 +105,7 @@ impl Channel for ApiChannel {
             .route("/sessions", get(handle_list_sessions))
             .route("/sessions/{id}/messages", get(handle_session_messages))
             .route("/sessions/{id}/status", get(handle_session_status))
-            .route(
-                "/sessions/{id}/deferred-files",
-                get(handle_deferred_files),
-            )
+            .route("/sessions/{id}/deferred-files", get(handle_deferred_files))
             .route("/sessions/{id}", delete(handle_delete_session))
             .route("/files/{*path}", get(handle_file_download))
             .route("/upload", post(handle_upload))
@@ -200,8 +197,8 @@ impl Channel for ApiChannel {
                 // Check if this is a background task completion notification
                 // (arrives after _completion with grace period). Close the SSE
                 // stream after forwarding the notification.
-                let is_bg_notification = msg.content.starts_with('\u{2713}')
-                    || msg.content.starts_with('\u{2717}');
+                let is_bg_notification =
+                    msg.content.starts_with('\u{2713}') || msg.content.starts_with('\u{2717}');
                 // Regular message — send as replace event (full text replacement).
                 let event = serde_json::json!({
                     "type": "replace",

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -785,9 +785,7 @@ async fn ws_connection(socket: WebSocket, state: Arc<AppState>, headers: HeaderM
                 let session_id = session.unwrap_or_else(|| "default".into());
 
                 // If a gateway is running, proxy through it (same as chat handler).
-                if let Some((_profile_id, port)) =
-                    resolve_api_port(&state, &headers).await
-                {
+                if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
                     let ws_tx2 = ws_tx.clone();
                     let _abort_ref = abort_handle.clone();
                     let http_client = state.http_client.clone();
@@ -803,25 +801,21 @@ async fn ws_connection(socket: WebSocket, state: Arc<AppState>, headers: HeaderM
                         .await;
                     });
                     *abort_handle.lock().await = Some(handle.abort_handle());
-                } else if let Ok((agent, sessions)) = validate_chat_request(&state, &ChatRequest {
-                    message: content.clone(),
-                    session_id: Some(session_id.clone()),
-                    stream: true,
-                    media: media.clone(),
-                }) {
+                } else if let Ok((agent, sessions)) = validate_chat_request(
+                    &state,
+                    &ChatRequest {
+                        message: content.clone(),
+                        session_id: Some(session_id.clone()),
+                        stream: true,
+                        media: media.clone(),
+                    },
+                ) {
                     // Standalone agent mode — run the agent directly.
                     let ws_tx2 = ws_tx.clone();
                     let _abort_ref = abort_handle.clone();
                     let handle = tokio::spawn(async move {
-                        ws_standalone_agent(
-                            ws_tx2,
-                            agent,
-                            sessions,
-                            &session_id,
-                            &content,
-                            media,
-                        )
-                        .await;
+                        ws_standalone_agent(ws_tx2, agent, sessions, &session_id, &content, media)
+                            .await;
                     });
                     *abort_handle.lock().await = Some(handle.abort_handle());
                 } else {
@@ -1142,8 +1136,7 @@ mod tests {
 
     #[test]
     fn ws_client_msg_send_with_session_and_media() {
-        let json =
-            r#"{"type": "send", "content": "hi", "session": "s1", "media": ["/tmp/a.png"]}"#;
+        let json = r#"{"type": "send", "content": "hi", "session": "s1", "media": ["/tmp/a.png"]}"#;
         let msg: WsClientMsg = serde_json::from_str(json).unwrap();
         match msg {
             WsClientMsg::Send {

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -6,7 +6,9 @@ pub mod admin;
 pub mod auth_handlers;
 mod handlers;
 pub mod metrics;
+pub mod notebook_handlers;
 mod router;
+pub mod space_handlers;
 mod sse;
 mod static_files;
 pub mod user_admin;
@@ -19,9 +21,11 @@ pub use sse::SseBroadcaster;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::notebook::NotebookStore;
 use crate::otp::AuthManager;
 use crate::process_manager::ProcessManager;
 use crate::profiles::ProfileStore;
+use crate::space::SpaceStore;
 use crate::tenant::TenantStore;
 use crate::user_store::UserStore;
 
@@ -67,4 +71,8 @@ pub struct AppState {
     pub frps_port: Option<u16>,
     /// Whether the admin shell endpoint is enabled (default: false).
     pub allow_admin_shell: bool,
+    /// Notebook store for MoFa Notebook feature.
+    pub notebook_store: Option<Arc<NotebookStore>>,
+    /// Space store for class/course spaces.
+    pub space_store: Option<Arc<SpaceStore>>,
 }

--- a/crates/octos-cli/src/api/notebook_handlers.rs
+++ b/crates/octos-cli/src/api/notebook_handlers.rs
@@ -302,9 +302,7 @@ fn extract_pdf_text(pdf_bytes: &[u8], filename: &str) -> String {
         .arg("-")
         .output();
     match output {
-        Ok(o) if o.status.success() => {
-            String::from_utf8_lossy(&o.stdout).into_owned()
-        }
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).into_owned(),
         _ => {
             tracing::info!("pdftotext not available, using filename as fallback");
             filename.to_string()
@@ -975,19 +973,21 @@ pub async fn library_import(
 // ── Library: ISBN lookup ─────────────────────────────────────────────
 
 /// GET /api/library/isbn/:isbn — lookup book info from Open Library.
-pub async fn isbn_lookup(
-    Path(isbn): Path<String>,
-) -> Result<Json<BookMeta>, (StatusCode, String)> {
-    let url = format!(
-        "https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
-    );
-    let resp = reqwest::get(&url)
-        .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Open Library request failed: {e}")))?;
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("failed to parse response: {e}")))?;
+pub async fn isbn_lookup(Path(isbn): Path<String>) -> Result<Json<BookMeta>, (StatusCode, String)> {
+    let url =
+        format!("https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data");
+    let resp = reqwest::get(&url).await.map_err(|e| {
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("Open Library request failed: {e}"),
+        )
+    })?;
+    let body: serde_json::Value = resp.json().await.map_err(|e| {
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("failed to parse response: {e}"),
+        )
+    })?;
 
     let key = format!("ISBN:{isbn}");
     let data = body
@@ -1047,7 +1047,11 @@ mod tests {
         let chunks = split_into_chunks(text, 30);
         assert!(chunks.len() >= 2);
         // All content should be covered
-        let total: String = chunks.iter().map(|c| c.content.clone()).collect::<Vec<_>>().join("\n\n");
+        let total: String = chunks
+            .iter()
+            .map(|c| c.content.clone())
+            .collect::<Vec<_>>()
+            .join("\n\n");
         assert_eq!(total, text);
     }
 

--- a/crates/octos-cli/src/api/notebook_handlers.rs
+++ b/crates/octos-cli/src/api/notebook_handlers.rs
@@ -1,0 +1,1071 @@
+//! Notebook, Source, Note, and Chat API handlers.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use chrono::Utc;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+
+use super::AppState;
+use crate::notebook::{
+    BookMeta, Chunk, Note, NoteOrigin, Notebook, NotebookStore, Share, ShareRole, Source,
+    SourceStatus, SourceType,
+};
+
+// Re-export for multipart upload
+use axum::extract::Multipart;
+
+// ── Notebook CRUD ────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateNotebookRequest {
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub cover_image: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateNotebookRequest {
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub cover_image: Option<Option<String>>,
+}
+
+/// Serialized notebook for list responses (without inline sources/notes).
+#[derive(Serialize)]
+pub struct NotebookSummary {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub cover_image: Option<String>,
+    pub source_count: usize,
+    pub note_count: usize,
+    pub created_at: chrono::DateTime<Utc>,
+    pub updated_at: chrono::DateTime<Utc>,
+    pub owner_id: String,
+    pub copyright_protected: bool,
+    pub book_meta: Option<BookMeta>,
+}
+
+impl From<&Notebook> for NotebookSummary {
+    fn from(nb: &Notebook) -> Self {
+        Self {
+            id: nb.id.clone(),
+            title: nb.title.clone(),
+            description: nb.description.clone(),
+            cover_image: nb.cover_image.clone(),
+            source_count: nb.source_count,
+            note_count: nb.note_count,
+            created_at: nb.created_at,
+            updated_at: nb.updated_at,
+            owner_id: nb.owner_id.clone(),
+            copyright_protected: nb.copyright_protected,
+            book_meta: nb.book_meta.clone(),
+        }
+    }
+}
+
+fn notebook_store(state: &AppState) -> Result<&Arc<NotebookStore>, (StatusCode, String)> {
+    state.notebook_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "notebook store not configured".into(),
+    ))
+}
+
+/// GET /api/notebooks
+pub async fn list_notebooks(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<NotebookSummary>>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let notebooks = store
+        .list()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let summaries: Vec<NotebookSummary> = notebooks.iter().map(NotebookSummary::from).collect();
+    Ok(Json(summaries))
+}
+
+/// POST /api/notebooks
+pub async fn create_notebook(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateNotebookRequest>,
+) -> Result<Json<Notebook>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let now = Utc::now();
+    let nb = Notebook {
+        id: uuid::Uuid::now_v7().to_string(),
+        title: req.title,
+        description: req.description,
+        cover_image: req.cover_image,
+        source_count: 0,
+        note_count: 0,
+        created_at: now,
+        updated_at: now,
+        owner_id: String::new(), // TODO: extract from auth identity
+        sources: vec![],
+        notes: vec![],
+        shared_with: vec![],
+        book_meta: None,
+        copyright_protected: false,
+    };
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(nb))
+}
+
+/// GET /api/notebooks/:id
+pub async fn get_notebook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<Notebook>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map(Json)
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))
+}
+
+/// PUT /api/notebooks/:id
+pub async fn update_notebook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<UpdateNotebookRequest>,
+) -> Result<Json<Notebook>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    if let Some(title) = req.title {
+        nb.title = title;
+    }
+    if let Some(desc) = req.description {
+        nb.description = desc;
+    }
+    if let Some(cover) = req.cover_image {
+        nb.cover_image = cover;
+    }
+    nb.updated_at = Utc::now();
+
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(nb))
+}
+
+/// DELETE /api/notebooks/:id
+pub async fn delete_notebook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let deleted = store
+        .delete(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if !deleted {
+        return Err((StatusCode::NOT_FOUND, format!("notebook {id} not found")));
+    }
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+// ── Source CRUD ──────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct AddSourceRequest {
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub filename: Option<String>,
+    #[serde(default)]
+    pub source_type: Option<SourceType>,
+}
+
+/// Split text into chunks of roughly `target_size` chars, breaking on paragraph boundaries.
+fn split_into_chunks(text: &str, target_size: usize) -> Vec<Chunk> {
+    let mut chunks = Vec::new();
+    let mut offset = 0;
+
+    // Split on double newlines (paragraphs) first
+    let paragraphs: Vec<&str> = text.split("\n\n").collect();
+    let mut current = String::new();
+    let mut current_start = 0;
+
+    for para in paragraphs {
+        if !current.is_empty() && current.len() + para.len() + 2 > target_size {
+            // Flush current chunk
+            let end = offset;
+            chunks.push(Chunk {
+                id: uuid::Uuid::now_v7().to_string(),
+                content: current.clone(),
+                start_offset: current_start,
+                end_offset: end,
+            });
+            current.clear();
+            current_start = offset;
+        }
+        if !current.is_empty() {
+            current.push_str("\n\n");
+            offset += 2;
+        }
+        current.push_str(para);
+        offset += para.len();
+    }
+
+    // Flush remaining
+    if !current.is_empty() {
+        chunks.push(Chunk {
+            id: uuid::Uuid::now_v7().to_string(),
+            content: current,
+            start_offset: current_start,
+            end_offset: offset,
+        });
+    }
+
+    // If any chunk is still too large, do a hard split
+    let mut final_chunks = Vec::new();
+    for chunk in chunks {
+        if chunk.content.len() > target_size * 2 {
+            let text = &chunk.content;
+            let mut pos = 0;
+            while pos < text.len() {
+                let end = (pos + target_size).min(text.len());
+                // Find a safe UTF-8 boundary
+                let end = if end < text.len() {
+                    let mut e = end;
+                    while e > pos && !text.is_char_boundary(e) {
+                        e -= 1;
+                    }
+                    e
+                } else {
+                    end
+                };
+                final_chunks.push(Chunk {
+                    id: uuid::Uuid::now_v7().to_string(),
+                    content: text[pos..end].to_string(),
+                    start_offset: chunk.start_offset + pos,
+                    end_offset: chunk.start_offset + end,
+                });
+                pos = end;
+            }
+        } else {
+            final_chunks.push(chunk);
+        }
+    }
+
+    final_chunks
+}
+
+/// Fetch URL content and strip HTML tags to plain text.
+async fn fetch_url_content(url: &str) -> Result<String, String> {
+    let resp = reqwest::get(url)
+        .await
+        .map_err(|e| format!("HTTP request failed: {e}"))?;
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("failed to read body: {e}"))?;
+    // Strip HTML tags with a simple regex
+    let tag_re = regex::Regex::new(r"<[^>]+>").unwrap();
+    let text = tag_re.replace_all(&body, " ");
+    // Collapse whitespace
+    let ws_re = regex::Regex::new(r"\s+").unwrap();
+    let clean = ws_re.replace_all(&text, " ").trim().to_string();
+    Ok(clean)
+}
+
+/// Extract text from a PDF file using `pdftotext` (poppler).
+/// Falls back to storing the filename as a single chunk if pdftotext is unavailable.
+fn extract_pdf_text(pdf_bytes: &[u8], filename: &str) -> String {
+    // Write bytes to a temp file, shell out to pdftotext
+    let tmp = match tempfile::NamedTempFile::new() {
+        Ok(t) => t,
+        Err(_) => return filename.to_string(),
+    };
+    if std::io::Write::write_all(&mut std::io::BufWriter::new(tmp.as_file()), pdf_bytes).is_err() {
+        return filename.to_string();
+    }
+    let output = std::process::Command::new("pdftotext")
+        .arg(tmp.path())
+        .arg("-")
+        .output();
+    match output {
+        Ok(o) if o.status.success() => {
+            String::from_utf8_lossy(&o.stdout).into_owned()
+        }
+        _ => {
+            tracing::info!("pdftotext not available, using filename as fallback");
+            filename.to_string()
+        }
+    }
+}
+
+/// GET /api/notebooks/:id/sources
+pub async fn list_sources(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<Source>>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+    Ok(Json(nb.sources))
+}
+
+/// POST /api/notebooks/:id/sources
+pub async fn add_source(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<AddSourceRequest>,
+) -> Result<Json<Source>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let (content, source_type, filename) = if let Some(url) = &req.url {
+        // Fetch URL content and strip HTML tags
+        let fetched = fetch_url_content(url).await.unwrap_or_else(|e| {
+            tracing::warn!(url = %url, error = %e, "failed to fetch URL, storing URL as content");
+            url.clone()
+        });
+        (fetched, SourceType::Url, url.clone())
+    } else if let Some(text) = &req.text {
+        (
+            text.clone(),
+            req.source_type.clone().unwrap_or(SourceType::Text),
+            req.filename.clone().unwrap_or_else(|| "text-input".into()),
+        )
+    } else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "provide either 'url' or 'text'".into(),
+        ));
+    };
+
+    let chunks = split_into_chunks(&content, 800);
+
+    let source = Source {
+        id: uuid::Uuid::now_v7().to_string(),
+        notebook_id: id.clone(),
+        source_type,
+        filename,
+        status: SourceStatus::Ready,
+        error_message: None,
+        chunks,
+        created_at: Utc::now(),
+    };
+
+    nb.sources.push(source.clone());
+    nb.source_count = nb.sources.len();
+    nb.updated_at = Utc::now();
+
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(source))
+}
+
+/// GET /api/notebooks/:id/sources/:sid
+pub async fn get_source(
+    State(state): State<Arc<AppState>>,
+    Path((id, sid)): Path<(String, String)>,
+) -> Result<Json<Source>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+    nb.sources
+        .into_iter()
+        .find(|s| s.id == sid)
+        .map(Json)
+        .ok_or((StatusCode::NOT_FOUND, format!("source {sid} not found")))
+}
+
+/// DELETE /api/notebooks/:id/sources/:sid
+pub async fn delete_source(
+    State(state): State<Arc<AppState>>,
+    Path((id, sid)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let before = nb.sources.len();
+    nb.sources.retain(|s| s.id != sid);
+    if nb.sources.len() == before {
+        return Err((StatusCode::NOT_FOUND, format!("source {sid} not found")));
+    }
+    nb.source_count = nb.sources.len();
+    nb.updated_at = Utc::now();
+
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+/// POST /api/notebooks/:id/sources/upload — multipart file upload for sources.
+pub async fn upload_source(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    mut multipart: Multipart,
+) -> Result<Json<Source>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let mut filename = String::from("upload");
+    let mut raw_bytes: Vec<u8> = Vec::new();
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
+    {
+        let name = field.name().unwrap_or("").to_string();
+        if name == "file" {
+            if let Some(fname) = field.file_name() {
+                filename = fname.to_string();
+            }
+            raw_bytes = field
+                .bytes()
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, format!("failed to read file: {e}")))?
+                .to_vec();
+        }
+    }
+
+    if raw_bytes.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "no file content provided".into()));
+    }
+
+    // Detect source type from filename extension
+    let source_type = if filename.ends_with(".pdf") {
+        SourceType::Pdf
+    } else if filename.ends_with(".docx") {
+        SourceType::Docx
+    } else if filename.ends_with(".pptx") {
+        SourceType::Pptx
+    } else {
+        SourceType::Text
+    };
+
+    // Extract text content based on source type
+    let content = if source_type == SourceType::Pdf {
+        extract_pdf_text(&raw_bytes, &filename)
+    } else {
+        String::from_utf8_lossy(&raw_bytes).into_owned()
+    };
+
+    let chunks = split_into_chunks(&content, 800);
+
+    let source = Source {
+        id: uuid::Uuid::now_v7().to_string(),
+        notebook_id: id.clone(),
+        source_type,
+        filename,
+        status: SourceStatus::Ready,
+        error_message: None,
+        chunks,
+        created_at: Utc::now(),
+    };
+
+    nb.sources.push(source.clone());
+    nb.source_count = nb.sources.len();
+    nb.updated_at = Utc::now();
+
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    Ok(Json(source))
+}
+
+// ── Note CRUD ────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct CreateNoteRequest {
+    pub content: String,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    #[serde(default = "default_note_origin")]
+    pub created_from: NoteOrigin,
+}
+
+fn default_note_origin() -> NoteOrigin {
+    NoteOrigin::Manual
+}
+
+#[derive(Deserialize)]
+pub struct UpdateNoteRequest {
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub source_refs: Option<Vec<String>>,
+}
+
+/// GET /api/notebooks/:id/notes
+pub async fn list_notes(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<Note>>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+    Ok(Json(nb.notes))
+}
+
+/// POST /api/notebooks/:id/notes
+pub async fn create_note(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<CreateNoteRequest>,
+) -> Result<Json<Note>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let now = Utc::now();
+    let note = Note {
+        id: uuid::Uuid::now_v7().to_string(),
+        notebook_id: id.clone(),
+        content: req.content,
+        source_refs: req.source_refs,
+        created_from: req.created_from,
+        created_at: now,
+        updated_at: now,
+    };
+
+    nb.notes.push(note.clone());
+    nb.note_count = nb.notes.len();
+    nb.updated_at = now;
+
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(note))
+}
+
+/// PUT /api/notebooks/:id/notes/:nid
+pub async fn update_note(
+    State(state): State<Arc<AppState>>,
+    Path((id, nid)): Path<(String, String)>,
+    Json(req): Json<UpdateNoteRequest>,
+) -> Result<Json<Note>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let note = nb
+        .notes
+        .iter_mut()
+        .find(|n| n.id == nid)
+        .ok_or((StatusCode::NOT_FOUND, format!("note {nid} not found")))?;
+
+    if let Some(content) = req.content {
+        note.content = content;
+    }
+    if let Some(refs) = req.source_refs {
+        note.source_refs = refs;
+    }
+    note.updated_at = Utc::now();
+    let updated = note.clone();
+
+    nb.updated_at = Utc::now();
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(updated))
+}
+
+/// DELETE /api/notebooks/:id/notes/:nid
+pub async fn delete_note(
+    State(state): State<Arc<AppState>>,
+    Path((id, nid)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let before = nb.notes.len();
+    nb.notes.retain(|n| n.id != nid);
+    if nb.notes.len() == before {
+        return Err((StatusCode::NOT_FOUND, format!("note {nid} not found")));
+    }
+    nb.note_count = nb.notes.len();
+    nb.updated_at = Utc::now();
+
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+// ── Notebook Chat (RAG + SSE) ────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct NotebookChatRequest {
+    pub message: String,
+}
+
+/// System prompt for RAG-based notebook chat with citation instructions.
+const RAG_SYSTEM_PROMPT: &str = "\
+You are a research assistant. Answer based ONLY on the provided sources.
+Cite sources using [src:N] format where N is the source number.
+If the sources don't contain relevant information, say so.";
+
+/// Simple keyword-based relevance scoring for MVP.
+fn score_chunk(chunk: &Chunk, query: &str) -> usize {
+    let query_lower = query.to_lowercase();
+    let content_lower = chunk.content.to_lowercase();
+    query_lower
+        .split_whitespace()
+        .filter(|word| word.len() > 2 && content_lower.contains(word))
+        .count()
+}
+
+/// POST /api/notebooks/:id/chat — RAG chat with SSE streaming.
+pub async fn notebook_chat(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<NotebookChatRequest>,
+) -> Result<
+    Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>,
+    (StatusCode, String),
+> {
+    let store = notebook_store(&state)?;
+    let nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let agent = state.agent.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "No LLM provider configured".into(),
+    ))?;
+
+    // Collect all chunks with source labels
+    let mut all_chunks: Vec<(usize, &Source, &Chunk)> = Vec::new();
+    for (src_idx, source) in nb.sources.iter().enumerate() {
+        for chunk in &source.chunks {
+            all_chunks.push((src_idx + 1, source, chunk));
+        }
+    }
+
+    // Score and rank chunks by keyword relevance
+    let mut scored: Vec<_> = all_chunks
+        .iter()
+        .map(|(idx, src, chunk)| {
+            let score = score_chunk(chunk, &req.message);
+            (*idx, *src, *chunk, score)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.3.cmp(&a.3));
+
+    // Take top chunks (max ~4000 chars of context)
+    let mut context_text = String::new();
+    let mut char_budget: usize = 4000;
+    for (src_idx, _src, chunk, _score) in &scored {
+        if char_budget == 0 {
+            break;
+        }
+        let snippet = if chunk.content.len() > char_budget {
+            &chunk.content[..char_budget]
+        } else {
+            &chunk.content
+        };
+        context_text.push_str(&format!("[Source {src_idx}]: {snippet}\n\n"));
+        char_budget = char_budget.saturating_sub(chunk.content.len());
+    }
+
+    // Build messages
+    let system_message = octos_core::Message::system(format!(
+        "{RAG_SYSTEM_PROMPT}\n\n--- Sources ---\n{context_text}"
+    ));
+    let user_message = octos_core::Message::user(req.message);
+
+    let llm = agent.llm_provider();
+    let config = octos_llm::ChatConfig::default();
+
+    // Stream from LLM
+    let stream_result = llm
+        .chat_stream(&[system_message, user_message], &[], &config)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let stream = stream_result.map(|event| {
+        let json = match event {
+            octos_llm::StreamEvent::TextDelta(text) => {
+                serde_json::json!({ "type": "text", "content": text })
+            }
+            octos_llm::StreamEvent::Done(_reason) => {
+                serde_json::json!({ "type": "done" })
+            }
+            octos_llm::StreamEvent::Error(msg) => {
+                serde_json::json!({ "type": "error", "message": msg })
+            }
+            _ => serde_json::json!({ "type": "other" }),
+        };
+        Ok(Event::default().data(json.to_string()))
+    });
+
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+// ── Sharing API ──────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ShareRequest {
+    pub email: String,
+    pub role: ShareRole,
+}
+
+/// POST /api/notebooks/:id/share
+pub async fn share_notebook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<ShareRequest>,
+) -> Result<Json<Share>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let share = Share {
+        id: uuid::Uuid::now_v7().to_string(),
+        email: req.email,
+        role: req.role,
+        created_at: Utc::now(),
+    };
+    nb.shared_with.push(share.clone());
+    nb.updated_at = Utc::now();
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(share))
+}
+
+/// GET /api/notebooks/:id/share
+pub async fn list_shares(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<Share>>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+    Ok(Json(nb.shared_with))
+}
+
+/// DELETE /api/notebooks/:id/share/:share_id
+pub async fn revoke_share(
+    State(state): State<Arc<AppState>>,
+    Path((id, share_id)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let mut nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let before = nb.shared_with.len();
+    nb.shared_with.retain(|s| s.id != share_id);
+    if nb.shared_with.len() == before {
+        return Err((StatusCode::NOT_FOUND, format!("share {share_id} not found")));
+    }
+    nb.updated_at = Utc::now();
+    store
+        .save(&nb)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+// ── Copyright-aware source content ──────────────────────────────────
+
+/// GET /api/notebooks/:id/sources/:sid/content — returns chunk content,
+/// but redacts raw text when the notebook is copyright-protected.
+pub async fn get_source_content(
+    State(state): State<Arc<AppState>>,
+    Path((id, sid)): Path<(String, String)>,
+) -> Result<Json<Vec<serde_json::Value>>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+    let nb = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("notebook {id} not found")))?;
+
+    let source = nb
+        .sources
+        .iter()
+        .find(|s| s.id == sid)
+        .ok_or((StatusCode::NOT_FOUND, format!("source {sid} not found")))?;
+
+    let chunks: Vec<serde_json::Value> = source
+        .chunks
+        .iter()
+        .map(|c| {
+            if nb.copyright_protected {
+                // Only return a summary (first 100 chars + ellipsis)
+                let summary = if c.content.len() > 100 {
+                    format!("{}...", &c.content[..100])
+                } else {
+                    c.content.clone()
+                };
+                serde_json::json!({
+                    "id": c.id,
+                    "summary": summary,
+                    "start_offset": c.start_offset,
+                    "end_offset": c.end_offset,
+                })
+            } else {
+                serde_json::json!({
+                    "id": c.id,
+                    "content": c.content,
+                    "start_offset": c.start_offset,
+                    "end_offset": c.end_offset,
+                })
+            }
+        })
+        .collect();
+    Ok(Json(chunks))
+}
+
+// ── Library: Batch import ────────────────────────────────────────────
+
+/// POST /api/library/import — multipart CSV with columns: title,author,isbn,classification,file_path
+pub async fn library_import(
+    State(state): State<Arc<AppState>>,
+    mut multipart: Multipart,
+) -> Result<Json<Vec<NotebookSummary>>, (StatusCode, String)> {
+    let store = notebook_store(&state)?;
+
+    let mut csv_content = String::new();
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
+    {
+        let name = field.name().unwrap_or("").to_string();
+        if name == "file" {
+            csv_content = field
+                .text()
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, format!("failed to read CSV: {e}")))?;
+        }
+    }
+
+    if csv_content.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "no CSV content provided".into()));
+    }
+
+    let mut created = Vec::new();
+    let now = Utc::now();
+
+    for (i, line) in csv_content.lines().enumerate() {
+        // Skip header
+        if i == 0 {
+            let lower = line.to_lowercase();
+            if lower.contains("title") && lower.contains("author") {
+                continue;
+            }
+        }
+        let cols: Vec<&str> = line.split(',').map(|c| c.trim()).collect();
+        if cols.len() < 4 {
+            continue;
+        }
+        let title = cols[0].to_string();
+        let author = cols.get(1).map(|s| s.to_string());
+        let isbn = cols.get(2).map(|s| s.to_string());
+        let classification = cols.get(3).map(|s| s.to_string());
+        let file_path = cols.get(4).map(|s| s.to_string());
+
+        let book_meta = BookMeta {
+            isbn: isbn.clone().filter(|s| !s.is_empty()),
+            author: author.filter(|s| !s.is_empty()),
+            classification: classification.filter(|s| !s.is_empty()),
+            ..Default::default()
+        };
+
+        let mut nb = Notebook {
+            id: uuid::Uuid::now_v7().to_string(),
+            title,
+            description: String::new(),
+            cover_image: None,
+            source_count: 0,
+            note_count: 0,
+            created_at: now,
+            updated_at: now,
+            owner_id: String::new(),
+            sources: vec![],
+            notes: vec![],
+            shared_with: vec![],
+            book_meta: Some(book_meta),
+            copyright_protected: false,
+        };
+
+        // If file_path provided and it's a PDF, try to add as source
+        if let Some(fp) = file_path.filter(|s| !s.is_empty()) {
+            let content = if fp.ends_with(".pdf") {
+                match std::fs::read(&fp) {
+                    Ok(bytes) => extract_pdf_text(&bytes, &fp),
+                    Err(_) => fp.clone(),
+                }
+            } else {
+                std::fs::read_to_string(&fp).unwrap_or_else(|_| fp.clone())
+            };
+            let chunks = split_into_chunks(&content, 800);
+            let source = Source {
+                id: uuid::Uuid::now_v7().to_string(),
+                notebook_id: nb.id.clone(),
+                source_type: if fp.ends_with(".pdf") {
+                    SourceType::Pdf
+                } else {
+                    SourceType::Text
+                },
+                filename: fp,
+                status: SourceStatus::Ready,
+                error_message: None,
+                chunks,
+                created_at: now,
+            };
+            nb.sources.push(source);
+            nb.source_count = nb.sources.len();
+        }
+
+        store
+            .save(&nb)
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        created.push(NotebookSummary::from(&nb));
+    }
+
+    Ok(Json(created))
+}
+
+// ── Library: ISBN lookup ─────────────────────────────────────────────
+
+/// GET /api/library/isbn/:isbn — lookup book info from Open Library.
+pub async fn isbn_lookup(
+    Path(isbn): Path<String>,
+) -> Result<Json<BookMeta>, (StatusCode, String)> {
+    let url = format!(
+        "https://openlibrary.org/api/books?bibkeys=ISBN:{isbn}&format=json&jscmd=data"
+    );
+    let resp = reqwest::get(&url)
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("Open Library request failed: {e}")))?;
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("failed to parse response: {e}")))?;
+
+    let key = format!("ISBN:{isbn}");
+    let data = body
+        .get(&key)
+        .ok_or((StatusCode::NOT_FOUND, format!("ISBN {isbn} not found")))?;
+
+    let meta = BookMeta {
+        isbn: Some(isbn),
+        author: data
+            .get("authors")
+            .and_then(|a| a.as_array())
+            .and_then(|a| a.first())
+            .and_then(|a| a.get("name"))
+            .and_then(|n| n.as_str())
+            .map(String::from),
+        publisher: data
+            .get("publishers")
+            .and_then(|p| p.as_array())
+            .and_then(|p| p.first())
+            .and_then(|p| p.get("name"))
+            .and_then(|n| n.as_str())
+            .map(String::from),
+        publish_year: data
+            .get("publish_date")
+            .and_then(|d| d.as_str())
+            .and_then(|d| {
+                // Try to extract a 4-digit year
+                d.chars()
+                    .collect::<String>()
+                    .split_whitespace()
+                    .find_map(|w| w.parse::<u16>().ok().filter(|y| *y > 1000))
+            }),
+        subject: data
+            .get("subjects")
+            .and_then(|s| s.as_array())
+            .and_then(|s| s.first())
+            .and_then(|s| s.get("name"))
+            .and_then(|n| n.as_str())
+            .map(String::from),
+        cover_url: data
+            .get("cover")
+            .and_then(|c| c.get("large"))
+            .and_then(|u| u.as_str())
+            .map(String::from),
+        ..Default::default()
+    };
+    Ok(Json(meta))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_split_text_into_chunks() {
+        let text = "Hello world.\n\nThis is a test.\n\nAnother paragraph here.";
+        let chunks = split_into_chunks(text, 30);
+        assert!(chunks.len() >= 2);
+        // All content should be covered
+        let total: String = chunks.iter().map(|c| c.content.clone()).collect::<Vec<_>>().join("\n\n");
+        assert_eq!(total, text);
+    }
+
+    #[test]
+    fn should_handle_empty_text() {
+        let chunks = split_into_chunks("", 800);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn should_score_chunks_by_keywords() {
+        let chunk = Chunk {
+            id: "1".into(),
+            content: "Rust programming language is fast and safe".into(),
+            start_offset: 0,
+            end_offset: 43,
+        };
+        assert!(score_chunk(&chunk, "rust programming") > 0);
+        assert_eq!(score_chunk(&chunk, "python javascript"), 0);
+    }
+}

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -310,24 +310,78 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/notebooks", get(notebook_handlers::list_notebooks))
         .route("/api/notebooks", post(notebook_handlers::create_notebook))
         .route("/api/notebooks/{id}", get(notebook_handlers::get_notebook))
-        .route("/api/notebooks/{id}", put(notebook_handlers::update_notebook))
-        .route("/api/notebooks/{id}", delete(notebook_handlers::delete_notebook))
-        .route("/api/notebooks/{id}/sources", get(notebook_handlers::list_sources))
-        .route("/api/notebooks/{id}/sources", post(notebook_handlers::add_source))
-        .route("/api/notebooks/{id}/sources/upload", post(notebook_handlers::upload_source))
-        .route("/api/notebooks/{id}/sources/{sid}", get(notebook_handlers::get_source))
-        .route("/api/notebooks/{id}/sources/{sid}", delete(notebook_handlers::delete_source))
-        .route("/api/notebooks/{id}/sources/{sid}/content", get(notebook_handlers::get_source_content))
-        .route("/api/notebooks/{id}/notes", get(notebook_handlers::list_notes))
-        .route("/api/notebooks/{id}/notes", post(notebook_handlers::create_note))
-        .route("/api/notebooks/{id}/notes/{nid}", put(notebook_handlers::update_note))
-        .route("/api/notebooks/{id}/notes/{nid}", delete(notebook_handlers::delete_note))
-        .route("/api/notebooks/{id}/chat", post(notebook_handlers::notebook_chat))
-        .route("/api/notebooks/{id}/share", post(notebook_handlers::share_notebook))
-        .route("/api/notebooks/{id}/share", get(notebook_handlers::list_shares))
-        .route("/api/notebooks/{id}/share/{share_id}", delete(notebook_handlers::revoke_share))
-        .route("/api/library/import", post(notebook_handlers::library_import))
-        .route("/api/library/isbn/{isbn}", get(notebook_handlers::isbn_lookup))
+        .route(
+            "/api/notebooks/{id}",
+            put(notebook_handlers::update_notebook),
+        )
+        .route(
+            "/api/notebooks/{id}",
+            delete(notebook_handlers::delete_notebook),
+        )
+        .route(
+            "/api/notebooks/{id}/sources",
+            get(notebook_handlers::list_sources),
+        )
+        .route(
+            "/api/notebooks/{id}/sources",
+            post(notebook_handlers::add_source),
+        )
+        .route(
+            "/api/notebooks/{id}/sources/upload",
+            post(notebook_handlers::upload_source),
+        )
+        .route(
+            "/api/notebooks/{id}/sources/{sid}",
+            get(notebook_handlers::get_source),
+        )
+        .route(
+            "/api/notebooks/{id}/sources/{sid}",
+            delete(notebook_handlers::delete_source),
+        )
+        .route(
+            "/api/notebooks/{id}/sources/{sid}/content",
+            get(notebook_handlers::get_source_content),
+        )
+        .route(
+            "/api/notebooks/{id}/notes",
+            get(notebook_handlers::list_notes),
+        )
+        .route(
+            "/api/notebooks/{id}/notes",
+            post(notebook_handlers::create_note),
+        )
+        .route(
+            "/api/notebooks/{id}/notes/{nid}",
+            put(notebook_handlers::update_note),
+        )
+        .route(
+            "/api/notebooks/{id}/notes/{nid}",
+            delete(notebook_handlers::delete_note),
+        )
+        .route(
+            "/api/notebooks/{id}/chat",
+            post(notebook_handlers::notebook_chat),
+        )
+        .route(
+            "/api/notebooks/{id}/share",
+            post(notebook_handlers::share_notebook),
+        )
+        .route(
+            "/api/notebooks/{id}/share",
+            get(notebook_handlers::list_shares),
+        )
+        .route(
+            "/api/notebooks/{id}/share/{share_id}",
+            delete(notebook_handlers::revoke_share),
+        )
+        .route(
+            "/api/library/import",
+            post(notebook_handlers::library_import),
+        )
+        .route(
+            "/api/library/isbn/{isbn}",
+            get(notebook_handlers::isbn_lookup),
+        )
         .with_state(state.clone());
 
     // Space API routes (user-level auth)
@@ -338,17 +392,27 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/spaces/{id}", put(space_handlers::update_space))
         .route("/api/spaces/{id}", delete(space_handlers::delete_space))
         .route("/api/spaces/{id}/members", post(space_handlers::add_member))
-        .route("/api/spaces/{id}/members/{uid}", delete(space_handlers::remove_member))
-        .route("/api/spaces/{id}/notebooks", post(space_handlers::link_notebook))
+        .route(
+            "/api/spaces/{id}/members/{uid}",
+            delete(space_handlers::remove_member),
+        )
+        .route(
+            "/api/spaces/{id}/notebooks",
+            post(space_handlers::link_notebook),
+        )
         .with_state(state.clone());
 
     // Build the authenticated routes
     let protected = if has_auth {
         // Routes requiring user-level auth (user session OR admin token)
-        let user_routes = my_api.merge(chat_api).merge(notebook_api).merge(space_api).layer(middleware::from_fn_with_state(
-            state.clone(),
-            user_auth_middleware,
-        ));
+        let user_routes = my_api
+            .merge(chat_api)
+            .merge(notebook_api)
+            .merge(space_api)
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                user_auth_middleware,
+            ));
 
         // Routes requiring admin-level auth (admin token only)
         let admin_routes = admin_api.layer(middleware::from_fn_with_state(
@@ -359,7 +423,11 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         user_routes.merge(admin_routes)
     } else {
         // No auth configured — all routes accessible
-        my_api.merge(chat_api).merge(notebook_api).merge(space_api).merge(admin_api)
+        my_api
+            .merge(chat_api)
+            .merge(notebook_api)
+            .merge(space_api)
+            .merge(admin_api)
     };
 
     // Webhook proxy routes (unauthenticated — Feishu/Twilio servers can't authenticate)

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -15,6 +15,8 @@ use super::admin;
 use super::auth_handlers;
 use super::handlers;
 use super::metrics;
+use super::notebook_handlers;
+use super::space_handlers;
 use super::static_files;
 use super::user_admin;
 use super::webhook_proxy;
@@ -303,10 +305,47 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // Determine whether auth middleware is needed
     let has_auth = state.auth_token.is_some() || state.auth_manager.is_some();
 
+    // Notebook API routes (user-level auth)
+    let notebook_api = Router::new()
+        .route("/api/notebooks", get(notebook_handlers::list_notebooks))
+        .route("/api/notebooks", post(notebook_handlers::create_notebook))
+        .route("/api/notebooks/{id}", get(notebook_handlers::get_notebook))
+        .route("/api/notebooks/{id}", put(notebook_handlers::update_notebook))
+        .route("/api/notebooks/{id}", delete(notebook_handlers::delete_notebook))
+        .route("/api/notebooks/{id}/sources", get(notebook_handlers::list_sources))
+        .route("/api/notebooks/{id}/sources", post(notebook_handlers::add_source))
+        .route("/api/notebooks/{id}/sources/upload", post(notebook_handlers::upload_source))
+        .route("/api/notebooks/{id}/sources/{sid}", get(notebook_handlers::get_source))
+        .route("/api/notebooks/{id}/sources/{sid}", delete(notebook_handlers::delete_source))
+        .route("/api/notebooks/{id}/sources/{sid}/content", get(notebook_handlers::get_source_content))
+        .route("/api/notebooks/{id}/notes", get(notebook_handlers::list_notes))
+        .route("/api/notebooks/{id}/notes", post(notebook_handlers::create_note))
+        .route("/api/notebooks/{id}/notes/{nid}", put(notebook_handlers::update_note))
+        .route("/api/notebooks/{id}/notes/{nid}", delete(notebook_handlers::delete_note))
+        .route("/api/notebooks/{id}/chat", post(notebook_handlers::notebook_chat))
+        .route("/api/notebooks/{id}/share", post(notebook_handlers::share_notebook))
+        .route("/api/notebooks/{id}/share", get(notebook_handlers::list_shares))
+        .route("/api/notebooks/{id}/share/{share_id}", delete(notebook_handlers::revoke_share))
+        .route("/api/library/import", post(notebook_handlers::library_import))
+        .route("/api/library/isbn/{isbn}", get(notebook_handlers::isbn_lookup))
+        .with_state(state.clone());
+
+    // Space API routes (user-level auth)
+    let space_api = Router::new()
+        .route("/api/spaces", get(space_handlers::list_spaces))
+        .route("/api/spaces", post(space_handlers::create_space))
+        .route("/api/spaces/{id}", get(space_handlers::get_space))
+        .route("/api/spaces/{id}", put(space_handlers::update_space))
+        .route("/api/spaces/{id}", delete(space_handlers::delete_space))
+        .route("/api/spaces/{id}/members", post(space_handlers::add_member))
+        .route("/api/spaces/{id}/members/{uid}", delete(space_handlers::remove_member))
+        .route("/api/spaces/{id}/notebooks", post(space_handlers::link_notebook))
+        .with_state(state.clone());
+
     // Build the authenticated routes
     let protected = if has_auth {
         // Routes requiring user-level auth (user session OR admin token)
-        let user_routes = my_api.merge(chat_api).layer(middleware::from_fn_with_state(
+        let user_routes = my_api.merge(chat_api).merge(notebook_api).merge(space_api).layer(middleware::from_fn_with_state(
             state.clone(),
             user_auth_middleware,
         ));
@@ -320,7 +359,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         user_routes.merge(admin_routes)
     } else {
         // No auth configured — all routes accessible
-        my_api.merge(chat_api).merge(admin_api)
+        my_api.merge(chat_api).merge(notebook_api).merge(space_api).merge(admin_api)
     };
 
     // Webhook proxy routes (unauthenticated — Feishu/Twilio servers can't authenticate)

--- a/crates/octos-cli/src/api/space_handlers.rs
+++ b/crates/octos-cli/src/api/space_handlers.rs
@@ -1,0 +1,188 @@
+//! Space (class/course) API handlers.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use chrono::Utc;
+use serde::Deserialize;
+
+use super::AppState;
+use crate::space::{Space, SpaceStore};
+
+fn space_store(state: &AppState) -> Result<&Arc<SpaceStore>, (StatusCode, String)> {
+    state.space_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "space store not configured".into(),
+    ))
+}
+
+#[derive(Deserialize)]
+pub struct CreateSpaceRequest {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateSpaceRequest {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct AddMemberRequest {
+    pub user_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct LinkNotebookRequest {
+    pub notebook_id: String,
+}
+
+/// GET /api/spaces
+pub async fn list_spaces(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<Space>>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    let spaces = store
+        .list()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(spaces))
+}
+
+/// POST /api/spaces
+pub async fn create_space(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateSpaceRequest>,
+) -> Result<Json<Space>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    let space = Space {
+        id: uuid::Uuid::now_v7().to_string(),
+        name: req.name,
+        description: req.description,
+        owner_id: String::new(), // TODO: extract from auth
+        member_ids: vec![],
+        notebook_ids: vec![],
+        created_at: Utc::now(),
+    };
+    store
+        .save(&space)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(space))
+}
+
+/// GET /api/spaces/:id
+pub async fn get_space(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<Space>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map(Json)
+        .ok_or((StatusCode::NOT_FOUND, format!("space {id} not found")))
+}
+
+/// PUT /api/spaces/:id
+pub async fn update_space(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<UpdateSpaceRequest>,
+) -> Result<Json<Space>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    let mut space = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("space {id} not found")))?;
+
+    if let Some(name) = req.name {
+        space.name = name;
+    }
+    if let Some(desc) = req.description {
+        space.description = desc;
+    }
+    store
+        .save(&space)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(space))
+}
+
+/// DELETE /api/spaces/:id
+pub async fn delete_space(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    let deleted = store
+        .delete(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    if !deleted {
+        return Err((StatusCode::NOT_FOUND, format!("space {id} not found")));
+    }
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+/// POST /api/spaces/:id/members
+pub async fn add_member(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<AddMemberRequest>,
+) -> Result<Json<Space>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    let mut space = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("space {id} not found")))?;
+
+    if !space.member_ids.contains(&req.user_id) {
+        space.member_ids.push(req.user_id);
+    }
+    store
+        .save(&space)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(space))
+}
+
+/// DELETE /api/spaces/:id/members/:uid
+pub async fn remove_member(
+    State(state): State<Arc<AppState>>,
+    Path((id, uid)): Path<(String, String)>,
+) -> Result<Json<Space>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    let mut space = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("space {id} not found")))?;
+
+    space.member_ids.retain(|m| m != &uid);
+    store
+        .save(&space)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(space))
+}
+
+/// POST /api/spaces/:id/notebooks
+pub async fn link_notebook(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<LinkNotebookRequest>,
+) -> Result<Json<Space>, (StatusCode, String)> {
+    let store = space_store(&state)?;
+    let mut space = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("space {id} not found")))?;
+
+    if !space.notebook_ids.contains(&req.notebook_id) {
+        space.notebook_ids.push(req.notebook_id);
+    }
+    store
+        .save(&space)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(space))
+}

--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -91,9 +91,12 @@ fn load_catalog_models() -> BTreeMap<String, Vec<String>> {
             .ok()
             .and_then(|p| p.parent().map(|d| d.join("model_catalog.json"))),
         // Workspace root (for development)
-        std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent()?.parent()?.parent().map(|d| d.join("model_catalog.json"))),
+        std::env::current_exe().ok().and_then(|p| {
+            p.parent()?
+                .parent()?
+                .parent()
+                .map(|d| d.join("model_catalog.json"))
+        }),
         // Current directory
         Some(PathBuf::from("model_catalog.json")),
     ];
@@ -103,8 +106,7 @@ fn load_catalog_models() -> BTreeMap<String, Vec<String>> {
             if let Ok(catalog) = serde_json::from_str::<serde_json::Value>(&content) {
                 if let Some(models) = catalog.get("models").and_then(|m| m.as_array()) {
                     for model in models {
-                        if let Some(provider_model) =
-                            model.get("provider").and_then(|p| p.as_str())
+                        if let Some(provider_model) = model.get("provider").and_then(|p| p.as_str())
                         {
                             let parts: Vec<&str> = provider_model.splitn(2, '/').collect();
                             if parts.len() == 2 {
@@ -382,10 +384,7 @@ impl Executable for InitCommand {
         }
 
         println!();
-        println!(
-            "{}",
-            "Ready! Run 'octos chat' to start.".green().bold()
-        );
+        println!("{}", "Ready! Run 'octos chat' to start.".green().bold());
 
         Ok(())
     }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -265,9 +265,7 @@ impl ServeCommand {
             notebook_store: crate::notebook::NotebookStore::open(&data_dir)
                 .ok()
                 .map(Arc::new),
-            space_store: crate::space::SpaceStore::open(&data_dir)
-                .ok()
-                .map(Arc::new),
+            space_store: crate::space::SpaceStore::open(&data_dir).ok().map(Arc::new),
         });
 
         // Auto-start enabled profiles

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -262,6 +262,12 @@ impl ServeCommand {
             frps_server: std::env::var("FRPS_SERVER").ok(),
             frps_port: std::env::var("FRPS_PORT").ok().and_then(|p| p.parse().ok()),
             allow_admin_shell: config.allow_admin_shell,
+            notebook_store: crate::notebook::NotebookStore::open(&data_dir)
+                .ok()
+                .map(Arc::new),
+            space_store: crate::space::SpaceStore::open(&data_dir)
+                .ok()
+                .map(Arc::new),
         });
 
         // Auto-start enabled profiles

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -659,10 +659,7 @@ fn fetch_registry() -> Result<Vec<RegistryEntry>> {
 }
 
 fn cmd_install_all(skills_dir: &Path, force: bool, branch: &str) -> Result<()> {
-    println!(
-        "{} Fetching skill registry...",
-        "INFO".cyan()
-    );
+    println!("{} Fetching skill registry...", "INFO".cyan());
     let entries = fetch_registry()?;
 
     if entries.is_empty() {

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -14,6 +14,7 @@ pub mod cron_tool;
 pub mod gateway_dispatcher;
 #[cfg(feature = "api")]
 pub mod monitor;
+pub mod notebook;
 #[cfg(feature = "api")]
 pub mod otp;
 pub mod persona_service;
@@ -21,11 +22,10 @@ pub mod persona_service;
 pub mod process_manager;
 pub mod profiles;
 pub mod session_actor;
+pub mod space;
 pub mod status_indicator;
 pub mod status_layers;
 pub mod stream_reporter;
-pub mod notebook;
-pub mod space;
 pub mod tenant;
 pub mod tools;
 #[cfg(feature = "api")]

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -24,6 +24,8 @@ pub mod session_actor;
 pub mod status_indicator;
 pub mod status_layers;
 pub mod stream_reporter;
+pub mod notebook;
+pub mod space;
 pub mod tenant;
 pub mod tools;
 #[cfg(feature = "api")]

--- a/crates/octos-cli/src/notebook/mod.rs
+++ b/crates/octos-cli/src/notebook/mod.rs
@@ -1,0 +1,7 @@
+//! Notebook data model and persistence.
+
+pub mod store;
+pub mod types;
+
+pub use store::NotebookStore;
+pub use types::*;

--- a/crates/octos-cli/src/notebook/store.rs
+++ b/crates/octos-cli/src/notebook/store.rs
@@ -64,8 +64,8 @@ impl NotebookStore {
         }
         let content = std::fs::read_to_string(&path)
             .wrap_err_with(|| format!("failed to read notebook: {id}"))?;
-        let nb =
-            serde_json::from_str(&content).wrap_err_with(|| format!("failed to parse notebook: {id}"))?;
+        let nb = serde_json::from_str(&content)
+            .wrap_err_with(|| format!("failed to parse notebook: {id}"))?;
         Ok(Some(nb))
     }
 
@@ -85,8 +85,7 @@ impl NotebookStore {
         if !path.exists() {
             return Ok(false);
         }
-        std::fs::remove_file(&path)
-            .wrap_err_with(|| format!("failed to delete notebook: {id}"))?;
+        std::fs::remove_file(&path).wrap_err_with(|| format!("failed to delete notebook: {id}"))?;
         Ok(true)
     }
 

--- a/crates/octos-cli/src/notebook/store.rs
+++ b/crates/octos-cli/src/notebook/store.rs
@@ -1,0 +1,159 @@
+//! JSON file persistence for notebooks.
+//!
+//! Each notebook is stored as a single JSON file: `{data_dir}/notebooks/{id}.json`
+//! containing the notebook metadata, sources (with chunks), and notes.
+
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr};
+
+use super::types::Notebook;
+
+/// Persistent store for notebooks.
+pub struct NotebookStore {
+    notebooks_dir: PathBuf,
+}
+
+impl NotebookStore {
+    /// Open (or create) the notebook store at `data_dir/notebooks/`.
+    pub fn open(data_dir: &Path) -> Result<Self> {
+        let notebooks_dir = data_dir.join("notebooks");
+        std::fs::create_dir_all(&notebooks_dir).wrap_err_with(|| {
+            format!(
+                "failed to create notebooks dir: {}",
+                notebooks_dir.display()
+            )
+        })?;
+        Ok(Self { notebooks_dir })
+    }
+
+    /// List all notebooks (without sources/notes detail for the list view).
+    pub fn list(&self) -> Result<Vec<Notebook>> {
+        let mut notebooks = Vec::new();
+        let entries = match std::fs::read_dir(&self.notebooks_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(notebooks),
+            Err(e) => return Err(e).wrap_err("failed to read notebooks directory"),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "json") {
+                match std::fs::read_to_string(&path) {
+                    Ok(content) => match serde_json::from_str::<Notebook>(&content) {
+                        Ok(nb) => notebooks.push(nb),
+                        Err(e) => {
+                            tracing::warn!(path = %path.display(), error = %e, "skipping invalid notebook");
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(path = %path.display(), error = %e, "failed to read notebook");
+                    }
+                }
+            }
+        }
+        notebooks.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(notebooks)
+    }
+
+    /// Get a single notebook by ID.
+    pub fn get(&self, id: &str) -> Result<Option<Notebook>> {
+        let path = self.notebook_path(id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = std::fs::read_to_string(&path)
+            .wrap_err_with(|| format!("failed to read notebook: {id}"))?;
+        let nb =
+            serde_json::from_str(&content).wrap_err_with(|| format!("failed to parse notebook: {id}"))?;
+        Ok(Some(nb))
+    }
+
+    /// Save a notebook (create or update).
+    pub fn save(&self, notebook: &Notebook) -> Result<()> {
+        let path = self.notebook_path(&notebook.id);
+        let content =
+            serde_json::to_string_pretty(notebook).wrap_err("failed to serialize notebook")?;
+        std::fs::write(&path, &content)
+            .wrap_err_with(|| format!("failed to write notebook: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Delete a notebook by ID.
+    pub fn delete(&self, id: &str) -> Result<bool> {
+        let path = self.notebook_path(id);
+        if !path.exists() {
+            return Ok(false);
+        }
+        std::fs::remove_file(&path)
+            .wrap_err_with(|| format!("failed to delete notebook: {id}"))?;
+        Ok(true)
+    }
+
+    /// Return the file path for a notebook ID.
+    fn notebook_path(&self, id: &str) -> PathBuf {
+        self.notebooks_dir.join(format!("{id}.json"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::notebook::types::*;
+    use chrono::Utc;
+
+    fn make_notebook(id: &str) -> Notebook {
+        Notebook {
+            id: id.to_string(),
+            title: format!("Test {id}"),
+            description: String::new(),
+            cover_image: None,
+            source_count: 0,
+            note_count: 0,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            owner_id: "test-user".to_string(),
+            sources: vec![],
+            notes: vec![],
+            shared_with: vec![],
+            book_meta: None,
+            copyright_protected: false,
+        }
+    }
+
+    #[test]
+    fn should_save_and_load_notebook() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = NotebookStore::open(dir.path()).unwrap();
+        let nb = make_notebook("nb-1");
+        store.save(&nb).unwrap();
+        let loaded = store.get("nb-1").unwrap().unwrap();
+        assert_eq!(loaded.title, "Test nb-1");
+    }
+
+    #[test]
+    fn should_list_notebooks() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = NotebookStore::open(dir.path()).unwrap();
+        store.save(&make_notebook("a")).unwrap();
+        store.save(&make_notebook("b")).unwrap();
+        let list = store.list().unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn should_delete_notebook() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = NotebookStore::open(dir.path()).unwrap();
+        store.save(&make_notebook("del")).unwrap();
+        assert!(store.delete("del").unwrap());
+        assert!(store.get("del").unwrap().is_none());
+    }
+
+    #[test]
+    fn should_return_none_for_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = NotebookStore::open(dir.path()).unwrap();
+        assert!(store.get("nonexistent").unwrap().is_none());
+    }
+}

--- a/crates/octos-cli/src/notebook/types.rs
+++ b/crates/octos-cli/src/notebook/types.rs
@@ -136,7 +136,7 @@ pub struct Note {
 
 /// How a note was created.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum NoteOrigin {
     Manual,
     ChatReply,

--- a/crates/octos-cli/src/notebook/types.rs
+++ b/crates/octos-cli/src/notebook/types.rs
@@ -1,0 +1,143 @@
+//! Notebook data model types.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A notebook containing sources and notes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Notebook {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cover_image: Option<String>,
+    #[serde(default)]
+    pub source_count: usize,
+    #[serde(default)]
+    pub note_count: usize,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub owner_id: String,
+    /// Inline sources (persisted in the same JSON file).
+    #[serde(default)]
+    pub sources: Vec<Source>,
+    /// Inline notes (persisted in the same JSON file).
+    #[serde(default)]
+    pub notes: Vec<Note>,
+    /// Users this notebook is shared with.
+    #[serde(default)]
+    pub shared_with: Vec<Share>,
+    /// Book metadata for library feature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub book_meta: Option<BookMeta>,
+    /// When true, raw source content is hidden; only summaries are served.
+    #[serde(default)]
+    pub copyright_protected: bool,
+}
+
+/// A share grant on a notebook.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Share {
+    pub id: String,
+    pub email: String,
+    pub role: ShareRole,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Role for a notebook share.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ShareRole {
+    Viewer,
+    Editor,
+}
+
+/// Book metadata for library integration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BookMeta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isbn: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub marc_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classification: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub publish_year: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cover_url: Option<String>,
+}
+
+/// Type of source material.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceType {
+    Pdf,
+    Url,
+    Text,
+    Docx,
+    Pptx,
+    Image,
+}
+
+/// Processing status of a source.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceStatus {
+    Uploading,
+    Parsing,
+    Indexing,
+    Ready,
+    Error,
+}
+
+/// A source document attached to a notebook.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Source {
+    pub id: String,
+    pub notebook_id: String,
+    pub source_type: SourceType,
+    pub filename: String,
+    pub status: SourceStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    #[serde(default)]
+    pub chunks: Vec<Chunk>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A chunk of text from a source document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Chunk {
+    pub id: String,
+    pub content: String,
+    pub start_offset: usize,
+    pub end_offset: usize,
+}
+
+/// A note inside a notebook.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Note {
+    pub id: String,
+    pub notebook_id: String,
+    pub content: String,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    pub created_from: NoteOrigin,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// How a note was created.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum NoteOrigin {
+    Manual,
+    ChatReply,
+}

--- a/crates/octos-cli/src/space/mod.rs
+++ b/crates/octos-cli/src/space/mod.rs
@@ -1,0 +1,7 @@
+//! Space (class/course) data model and persistence.
+
+pub mod store;
+pub mod types;
+
+pub use store::SpaceStore;
+pub use types::*;

--- a/crates/octos-cli/src/space/store.rs
+++ b/crates/octos-cli/src/space/store.rs
@@ -1,0 +1,135 @@
+//! JSON file persistence for spaces.
+//!
+//! Each space is stored as `{data_dir}/spaces/{id}.json`.
+
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr};
+
+use super::types::Space;
+
+/// Persistent store for spaces.
+pub struct SpaceStore {
+    spaces_dir: PathBuf,
+}
+
+impl SpaceStore {
+    /// Open (or create) the space store at `data_dir/spaces/`.
+    pub fn open(data_dir: &Path) -> Result<Self> {
+        let spaces_dir = data_dir.join("spaces");
+        std::fs::create_dir_all(&spaces_dir)
+            .wrap_err_with(|| format!("failed to create spaces dir: {}", spaces_dir.display()))?;
+        Ok(Self { spaces_dir })
+    }
+
+    /// List all spaces.
+    pub fn list(&self) -> Result<Vec<Space>> {
+        let mut spaces = Vec::new();
+        let entries = match std::fs::read_dir(&self.spaces_dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(spaces),
+            Err(e) => return Err(e).wrap_err("failed to read spaces directory"),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "json") {
+                match std::fs::read_to_string(&path) {
+                    Ok(content) => match serde_json::from_str::<Space>(&content) {
+                        Ok(space) => spaces.push(space),
+                        Err(e) => {
+                            tracing::warn!(path = %path.display(), error = %e, "skipping invalid space");
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(path = %path.display(), error = %e, "failed to read space");
+                    }
+                }
+            }
+        }
+        spaces.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(spaces)
+    }
+
+    /// Get a single space by ID.
+    pub fn get(&self, id: &str) -> Result<Option<Space>> {
+        let path = self.space_path(id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content =
+            std::fs::read_to_string(&path).wrap_err_with(|| format!("failed to read space: {id}"))?;
+        let space =
+            serde_json::from_str(&content).wrap_err_with(|| format!("failed to parse space: {id}"))?;
+        Ok(Some(space))
+    }
+
+    /// Save a space (create or update).
+    pub fn save(&self, space: &Space) -> Result<()> {
+        let path = self.space_path(&space.id);
+        let content = serde_json::to_string_pretty(space).wrap_err("failed to serialize space")?;
+        std::fs::write(&path, &content)
+            .wrap_err_with(|| format!("failed to write space: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Delete a space by ID.
+    pub fn delete(&self, id: &str) -> Result<bool> {
+        let path = self.space_path(id);
+        if !path.exists() {
+            return Ok(false);
+        }
+        std::fs::remove_file(&path).wrap_err_with(|| format!("failed to delete space: {id}"))?;
+        Ok(true)
+    }
+
+    fn space_path(&self, id: &str) -> PathBuf {
+        self.spaces_dir.join(format!("{id}.json"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn make_space(id: &str) -> Space {
+        Space {
+            id: id.to_string(),
+            name: format!("Space {id}"),
+            description: String::new(),
+            owner_id: "test-user".to_string(),
+            member_ids: vec![],
+            notebook_ids: vec![],
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn should_save_and_load_space() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SpaceStore::open(dir.path()).unwrap();
+        let sp = make_space("sp-1");
+        store.save(&sp).unwrap();
+        let loaded = store.get("sp-1").unwrap().unwrap();
+        assert_eq!(loaded.name, "Space sp-1");
+    }
+
+    #[test]
+    fn should_list_spaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SpaceStore::open(dir.path()).unwrap();
+        store.save(&make_space("a")).unwrap();
+        store.save(&make_space("b")).unwrap();
+        assert_eq!(store.list().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn should_delete_space() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SpaceStore::open(dir.path()).unwrap();
+        store.save(&make_space("del")).unwrap();
+        assert!(store.delete("del").unwrap());
+        assert!(store.get("del").unwrap().is_none());
+    }
+}

--- a/crates/octos-cli/src/space/store.rs
+++ b/crates/octos-cli/src/space/store.rs
@@ -57,10 +57,10 @@ impl SpaceStore {
         if !path.exists() {
             return Ok(None);
         }
-        let content =
-            std::fs::read_to_string(&path).wrap_err_with(|| format!("failed to read space: {id}"))?;
-        let space =
-            serde_json::from_str(&content).wrap_err_with(|| format!("failed to parse space: {id}"))?;
+        let content = std::fs::read_to_string(&path)
+            .wrap_err_with(|| format!("failed to read space: {id}"))?;
+        let space = serde_json::from_str(&content)
+            .wrap_err_with(|| format!("failed to parse space: {id}"))?;
         Ok(Some(space))
     }
 

--- a/crates/octos-cli/src/space/types.rs
+++ b/crates/octos-cli/src/space/types.rs
@@ -1,0 +1,19 @@
+//! Space (class/course) data model types.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A class or course space that groups members and notebooks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Space {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub owner_id: String,
+    #[serde(default)]
+    pub member_ids: Vec<String>,
+    #[serde(default)]
+    pub notebook_ids: Vec<String>,
+    pub created_at: DateTime<Utc>,
+}

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -297,7 +297,11 @@ fn build_anthropic_content(msg: &Message) -> AnthropicContent {
         }
         let note = format!(
             "[attached files: {}. Use read_file to access them.]",
-            non_image.iter().map(|p| p.as_str()).collect::<Vec<_>>().join(", ")
+            non_image
+                .iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
         );
         let text = if msg.content.is_empty() {
             note

--- a/crates/octos-sandbox/src/main.rs
+++ b/crates/octos-sandbox/src/main.rs
@@ -122,10 +122,11 @@ fn run_sandboxed(args: &Args) -> eyre::Result<u8> {
     // 4. Build capabilities
     let mut caps_builder = SecurityCapabilitiesBuilder::new(&profile.sid);
     if args.allow_network {
-        caps_builder =
-            caps_builder.with_known(&[rappct::KnownCapability::InternetClient]);
+        caps_builder = caps_builder.with_known(&[rappct::KnownCapability::InternetClient]);
     }
-    let caps = caps_builder.build().wrap_err("failed to build security capabilities")?;
+    let caps = caps_builder
+        .build()
+        .wrap_err("failed to build security capabilities")?;
 
     // 5. Build command line
     let cmdline = args.command.join(" ");
@@ -153,7 +154,9 @@ fn run_sandboxed(args: &Args) -> eyre::Result<u8> {
         launch_in_container_with_io(&caps, &opts).wrap_err("failed to launch sandboxed process")?;
 
     // 7. Wait for completion (no timeout — let the caller handle that)
-    let exit_code = child.wait(None).wrap_err("failed to wait for sandboxed process")?;
+    let exit_code = child
+        .wait(None)
+        .wrap_err("failed to wait for sandboxed process")?;
 
     Ok(exit_code as u8)
 }

--- a/docs/prd-notebook-web.md
+++ b/docs/prd-notebook-web.md
@@ -1,0 +1,269 @@
+# MoFa Notebook — PRD 与开发计划
+
+> 目标：基于 octos-web 扩展为类 NotebookLM 的智能阅读与课件生成平台
+> 核心场景：图书馆把馆藏书籍批量导入，变成可对话、可生成课件的互动式 Notebook
+> 前端仓库：https://github.com/BH3GEI/octos-web
+> 日期：2026-03-25
+
+---
+
+## 一、现状分析
+
+### 1.1 octos-web 已有能力
+
+| 能力 | 状态 | 技术实现 |
+|---|---|---|
+| SSE 流式聊天 | ✅ 成熟 | `@assistant-ui/react` + 自定义 `octos-adapter.ts` |
+| Markdown 渲染 | ✅ 成熟 | react-markdown + GFM + KaTeX + Mermaid + 代码高亮 |
+| 文件上传 | ✅ 成熟 | 拖拽/粘贴/多文件，含图片/音频/视频预览 |
+| 语音/视频录制 + 拍照 | ✅ 成熟 | MediaRecorder API |
+| 9 种工具调用 UI | ✅ 成熟 | shell/read_file/write_file/edit_file/web_search/web_fetch/grep/glob/generic |
+| 认证系统 | ✅ 成熟 | Email OTP + Admin Token |
+| 会话管理 | ✅ 成熟 | 多会话切换/删除/历史恢复 |
+| 深色/浅色主题 | ✅ 成熟 | CSS 变量 + localStorage |
+| 音视频播放器 | ✅ 成熟 | 自定义 MediaPlayer 组件 |
+| 斜杠命令 | ✅ 成熟 | /new /clear /delete /help + 服务端命令 |
+| E2E 测试 | ✅ 7 个 Playwright 测试 |
+| 文件下载链接识别 | ✅ 自动检测 pdf/pptx/docx/xlsx |
+
+### 1.2 NotebookLM 功能 vs MoFa 差距
+
+| NotebookLM 功能 | MoFa 后端/Skills | octos-web 前端 | 差距 |
+|---|---|---|---|
+| **Sources 管理** | `mofa-pdf`(★5)、`mofa-paddleocr`(★3)、`mofa-defuddle`(★3) | 有文件上传，无来源管理概念 | 🟡 需增加 Notebook + Source 数据模型和 UI |
+| **RAG 对话+引用** | Octos `HybridSearch`；`mofa-memory`(★4) | 有完整聊天 UI，无引用机制 | 🟡 需增加引用标记渲染和跳转 |
+| **Notes 笔记** | 无 | 无 | 🔴 需新增 |
+| **Slide Deck** | `mofa-slides`(★5) + `mofa-pptx`(★5) | 有文件下载链接识别 | 🟢 后端成熟，需 Studio UI |
+| **Audio Overview** | `mofa-fm`(★4) + `mofa-fm-api`(★4) | 有音频播放器 | 🟢 后端+播放器都有，需脚本生成 |
+| **Infographic** | `mofa-infographic`(★4) | 无 | 🟢 后端成熟，需 Studio UI |
+| **Quiz/Flashcard** | LLM 可生成 | 无 | 🟡 需 Prompt + 前端交互 |
+| **Mind Map** | LLM 可生成结构化数据 | 有 Mermaid 图表渲染 | 🟡 Mermaid 可用于基础版 |
+| **Deep Research** | `mofa-research-2.0`(★5) | 有 deep-research E2E 测试 | 🟢 基本就绪，需 UI 包装 |
+| **Report** | `mofa-docx`(★5) + `mofa-xlsx`(★4) | 有文件下载 | 🟢 后端成熟，需 Studio UI |
+| **Comic** | `mofa-comic`(★4) | 无 | 🟢 后端可用，需 Studio UI |
+| **协作分享** | Octos 多用户系统 | 有基础认证 | 🟡 需扩展 |
+
+### 1.3 关键结论
+
+octos-web 已经是一个**功能完善的 AI 聊天前端**。要变成 MoFa Notebook，核心工作是：
+
+1. **增加 Notebook 层级** — 在现有 session 之上加 notebook → sources → notes 概念
+2. **Sources 管理 UI** — 来源上传/浏览/勾选/预览
+3. **引用追溯** — 聊天回复中的引用可点击跳转到来源原文
+4. **Studio 输出面板** — 集成 mofa-skills 的多格式课件生成
+5. **图书馆书目** — 馆藏导入/分类浏览
+
+不需要重写现有聊天/渲染/上传/认证能力，在其基础上**增量扩展**。
+
+### 1.4 Octos 后端需修复的 Bug
+
+| Bug | 严重度 | 说明 |
+|---|---|---|
+| `recall_memory` 空库报错 | 🟡 Medium | 空记忆库时返回错误而非空结果 |
+| `/api/upload` FormData 处理 | 🟡 Medium | FormData 场景下上传失败 |
+
+---
+
+## 二、产品定位
+
+**MoFa Notebook** — 开源、可私有部署的图书馆智能阅读平台，把每一本书变成可对话、可生成课件的互动式 Notebook。
+
+| 角色 | 场景 |
+|---|---|
+| **图书馆管理员** | 批量导入馆藏（PDF/扫描件）→ 自动建 Notebook → 管理分类 |
+| **教师** | 选书 → AI 生成课件/测验/音频讲解 → 分享给学生 |
+| **学生** | 浏览书目 → 与书对话 → 笔记/闪卡/测验 → 跨书研究 |
+
+核心差异化：开源私有部署 · 馆藏级规模 · 多模型 · 输出格式远超 NotebookLM · 多渠道推送
+
+---
+
+## 三、开发计划（按 Milestone）
+
+### Milestone 0: 基础准备
+> 后端 API 扩展 + bug 修复
+
+| # | Issue | Tags |
+|---|---|---|
+| 0.1 | 修复 `recall_memory` 空库报错 | `backend` `bug` |
+| 0.2 | 修复 `/api/upload` FormData 处理 | `backend` `bug` |
+| 0.3 | 设计 Notebook 数据模型（notebook → sources → notes → outputs） | `backend` `data-model` |
+| 0.4 | 实现 Notebook CRUD API | `backend` `api` |
+| 0.5 | 实现 Source CRUD API（上传/URL/文本 → 解析 → 分块 → 索引） | `backend` `api` `rag` |
+| 0.6 | 文档解析管道：集成 `mofa-pdf` + `mofa-pdf-convert` + `mofa-paddleocr` | `backend` `skill-integration` |
+| 0.7 | 实现 Note CRUD API | `backend` `api` |
+| 0.8 | Notebook Chat API（`/api/notebooks/:id/chat`，基于来源的 RAG + SSE） | `backend` `api` `rag` |
+| 0.9 | 引用标记机制 — LLM 回复中嵌入 `[src:chunk_id]` | `backend` `rag` `llm` |
+
+---
+
+### Milestone 1: Notebook 核心 UI
+> 在 octos-web 现有聊天 UI 基础上增加 Notebook 功能
+
+| # | Issue | Tags |
+|---|---|---|
+| 1.1 | Notebook 列表页（创建/打开/删除/搜索/封面） | `frontend` `ui` |
+| 1.2 | Notebook 路由（`/notebooks` 列表 → `/notebooks/:id` 详情） | `frontend` `routing` |
+| 1.3 | Sources 管理 UI（来源列表 + 上传入口 + 文件类型图标 + 来源预览抽屉） | `frontend` `ui` |
+| 1.4 | Source 上传交互（复用现有文件上传，增加 URL 导入和文本粘贴模式） | `frontend` `ui` |
+| 1.5 | Source 勾选过滤（勾选/取消特定来源参与对话） | `frontend` `ui` |
+| 1.6 | 引用渲染 — 在 Markdown 渲染器中解析 `[src:N]` 为可点击引用标记 | `frontend` `ui` |
+| 1.7 | 引用跳转 — 点击引用 → 打开来源预览 + 高亮原文段落 | `frontend` `ui` `ux` |
+| 1.8 | 建议问题 — 打开 Notebook 时显示基于来源的推荐问题 | `frontend` `ui` |
+
+---
+
+### Milestone 2: 笔记系统
+> 保存回复为笔记 + 笔记管理
+
+| # | Issue | Tags |
+|---|---|---|
+| 2.1 | 笔记面板 UI（笔记卡片列表，可折叠/展开） | `frontend` `ui` |
+| 2.2 | "保存到笔记" — 聊天回复一键保存（保留引用链接） | `frontend` `ui` `ux` |
+| 2.3 | 笔记编辑（Markdown 编辑 + 预览，复用现有 RichMarkdown 组件） | `frontend` `ui` |
+| 2.4 | AI 笔记整合 — 选中多条笔记 → 生成摘要/大纲/学习指南 | `frontend` `llm` |
+| 2.5 | 笔记导出（Markdown / Word via `mofa-docx` / PDF） | `frontend` `export` |
+
+---
+
+### Milestone 3: Studio 输出 — 课件生成
+> 集成 mofa-skills 生成多格式课件
+
+| # | Issue | Tags |
+|---|---|---|
+| 3.1 | Studio 面板 UI（输出格式网格 + 生成状态 + 历史 + 下载） | `frontend` `ui` |
+| 3.2 | Slide Deck 生成 UI：风格选择（17 种 mofa-slides 风格）+ 预览 + 下载 | `frontend` `ui` `skill-integration` |
+| 3.3 | Slide Deck 逐页反馈编辑 + 重新生成 | `frontend` `ui` |
+| 3.4 | Quiz 测验 UI：交互式答题 + 即时评分 + 答案解析 | `frontend` `ui` |
+| 3.5 | Flashcard 闪卡 UI：翻转卡片 + Spaced Repetition | `frontend` `ui` |
+| 3.6 | Mind Map 思维导图 UI（Mermaid 渲染或 react-flow 交互式） | `frontend` `ui` `visualization` |
+| 3.7 | Infographic 信息图生成 + 预览（集成 `mofa-infographic`） | `frontend` `ui` `skill-integration` |
+| 3.8 | Report 报告生成 + 下载（集成 `mofa-docx` / `mofa-xlsx`） | `frontend` `ui` `skill-integration` |
+| 3.9 | Comic 漫画讲解生成 + 预览（集成 `mofa-comic`） | `frontend` `ui` `skill-integration` |
+
+---
+
+### Milestone 4: Audio Overview
+> 播客式音频讲解
+
+| # | Issue | Tags |
+|---|---|---|
+| 4.1 | 播客脚本生成（来源 → LLM 两人对话脚本，Deep Dive/Brief/Critique 格式） | `backend` `llm` |
+| 4.2 | TTS 合成：集成 `mofa-fm`（本地 TTS + 声音克隆） | `backend` `skill-integration` |
+| 4.3 | 音频播放 UI（复用现有 MediaPlayer，增加章节跳转/倍速） | `frontend` `ui` |
+| 4.4 | 播客发布到 mofa.fm（集成 `mofa-fm-api`） | `backend` `skill-integration` |
+
+---
+
+### Milestone 5: Deep Research
+> 深度研究集成
+
+| # | Issue | Tags |
+|---|---|---|
+| 5.1 | Fast Research UI（快速搜索 → 结果列表 → 一键导入为 Source） | `frontend` `ui` |
+| 5.2 | Deep Research UI：集成 `mofa-research-2.0`（进度流 → 报告展示） | `frontend` `ui` `skill-integration` |
+| 5.3 | Research 报告一键导入为 Source | `frontend` `api` |
+
+---
+
+### Milestone 6: 协作与分享
+
+| # | Issue | Tags |
+|---|---|---|
+| 6.1 | Notebook 分享（邀请链接 / 权限控制） | `frontend` `backend` `auth` |
+| 6.2 | Viewer / Editor 角色权限 | `backend` `auth` |
+| 6.3 | 班级/课程空间管理 | `frontend` `backend` |
+| 6.4 | 课件模板库 | `frontend` `backend` |
+
+---
+
+### Milestone 7: 图书馆书目管理
+
+| # | Issue | Tags |
+|---|---|---|
+| 7.1 | 书目元数据模型（ISBN/MARC/分类号/作者/出版社/封面） | `backend` `data-model` |
+| 7.2 | 批量书目导入 API（CSV/MARC + 自动匹配元数据） | `backend` `api` |
+| 7.3 | 扫描件 OCR 批量处理（集成 `mofa-paddleocr`） | `backend` `skill-integration` |
+| 7.4 | 书架浏览 UI（按学科/分类号/年级分类） | `frontend` `ui` |
+| 7.5 | ISBN 自动查询书目信息 | `backend` `api` |
+| 7.6 | 版权控制（来源不可直接下载，仅 AI 交互） | `backend` `auth` |
+| 7.7 | 使用统计面板 | `frontend` `backend` |
+| 7.8 | 跨书 Notebook | `frontend` `backend` `rag` |
+
+---
+
+### Milestone 8: 多渠道推送
+
+| # | Issue | Tags |
+|---|---|---|
+| 8.1 | 课件推送至微信/飞书群 | `backend` `channel` |
+| 8.2 | 定时推送（学习提醒 + 闪卡复习） | `backend` `cron` |
+| 8.3 | IM 内直接与 Notebook 对话 | `backend` `channel` |
+
+---
+
+## 四、MoFa Skills 集成矩阵
+
+| Notebook 功能 | MoFa Skill | 成熟度 | 集成点 |
+|---|---|---|---|
+| PDF 提取 | `mofa-pdf` | ★★★★★ | Source 导入 |
+| PDF 转换 | `mofa-pdf-convert` | ★★★ | Source 导入 |
+| OCR | `mofa-paddleocr` | ★★★ | Source 导入 |
+| 网页净化 | `mofa-defuddle` | ★★★ | URL Source |
+| AI 图像 PPT | `mofa-slides` | ★★★★★ | Studio |
+| 传统 PPT | `mofa-pptx` | ★★★★★ | Studio |
+| Word | `mofa-docx` | ★★★★★ | Studio / 导出 |
+| Excel | `mofa-xlsx` | ★★★★ | Studio |
+| 信息图 | `mofa-infographic` | ★★★★ | Studio |
+| 漫画 | `mofa-comic` | ★★★★ | Studio |
+| TTS | `mofa-fm` | ★★★★ | Audio |
+| 播客 | `mofa-fm-api` | ★★★★ | Audio 发布 |
+| 视频 | `mofa-video` | ★★★ | Studio |
+| 深度研究 | `mofa-research-2.0` | ★★★★★ | Research |
+| 记忆 | `mofa-memory` | ★★★★ | RAG |
+| 爬取 | `mofa-firecrawl` | ★★★★ | Research |
+
+---
+
+## 五、技术方案
+
+### 5.1 在 octos-web 基础上扩展
+
+复用现有：`@assistant-ui/react` SSE adapter · `RichMarkdown` 渲染器 · 文件上传 · `MediaPlayer` · 认证系统 · 会话管理 · 主题系统
+
+新增路由：
+```
+/notebooks                        → Notebook 列表页
+/notebooks/:id                    → Notebook 详情（Sources + Chat + Notes + Studio）
+/library                          → 图书馆书架浏览
+```
+
+### 5.2 Source Grounding 引用
+
+```
+上传 → mofa-pdf / mofa-paddleocr / mofa-defuddle 解析 → 分块 → 向量化
+提问 → 检索 Top-K → Prompt 注入 → LLM 回复嵌入 [src:chunk_id]
+前端 → RichMarkdown 扩展解析引用标记 → 点击跳转来源预览
+```
+
+### 5.3 后端 API
+
+```
+/api/notebooks                       → CRUD
+/api/notebooks/:id/sources           → Source CRUD + 上传
+/api/notebooks/:id/chat              → RAG 对话（SSE）
+/api/notebooks/:id/notes             → Note CRUD
+/api/notebooks/:id/studio/:type      → 课件生成（slides/quiz/flashcards/mindmap/audio/infographic/comic/report/research）
+/api/notebooks/:id/share             → 分享
+/api/library/books                   → 书目管理
+/api/library/catalog                 → 分类浏览
+```
+
+---
+
+## 六、里程碑节奏
+
+**MVP（M0→M1）：** 上传文档 → 基于文档对话（带引用）→ Sources 管理
+**课件版（+M2→M3）：** 笔记 + PPT/测验/闪卡/信息图/漫画
+**图书馆版（+M6→M7）：** 协作分享 + 馆藏批量导入 + 书架浏览
+**完整版（+M4→M5→M8）：** 音频播客 + 深度研究 + 多渠道推送


### PR DESCRIPTION
Supersedes #83 — rebased on the `crew-*` → `octos-*` crate rename.

## Changes
- `crates/octos-cli/src/notebook/` — Notebook, Source, Chunk, Note, Share, BookMeta types + JSON store
- `crates/octos-cli/src/space/` — Space model + JSON store
- `crates/octos-cli/src/api/notebook_handlers.rs` — all CRUD + RAG chat + sharing + library import/ISBN
- `crates/octos-cli/src/api/space_handlers.rs` — Space CRUD + members
- Routes wired in `router.rs`, stores initialized in `serve.rs`

Only 5 existing files modified (additive changes only, no breaking):
- `main.rs` — 2 `pub mod` lines
- `api/mod.rs` — 2 `pub mod` + 2 `Option<Arc<...>>` fields on AppState
- `api/router.rs` — notebook/space route registration
- `commands/serve.rs` — store initialization
- `Cargo.toml` — already had `multipart` feature

## Test
- `cargo check -p octos-cli --features api` ✅
- `cargo test -p octos-cli` — 16/16 ✅
- Manual curl testing of all endpoints ✅