### PR TITLE
fix: SSRF redirect bypass and DNS failure fallthrough in web_fetch

### DIFF
--- a/crates/octos-agent/src/tools/web_fetch.rs
+++ b/crates/octos-agent/src/tools/web_fetch.rs
@@ -197,7 +197,7 @@ impl Tool for WebFetchTool {
 async fn ssrf_safe_fetch(initial_url: &str) -> Result<reqwest::Response, String> {
     let mut current_url = initial_url.to_string();
 
-    for hop in 0..=MAX_REDIRECTS {
+    for _ in 0..MAX_REDIRECTS {
         // Validate the URL and resolve DNS (fail-closed on DNS error).
         let check = super::ssrf::check_ssrf_with_addrs(&current_url).await?;
 
@@ -223,24 +223,20 @@ async fn ssrf_safe_fetch(initial_url: &str) -> Result<reqwest::Response, String>
             .await
             .map_err(|e| format!("Failed to fetch URL: {e}"))?;
 
-        if response.status().is_redirection() {
-            if hop == MAX_REDIRECTS {
-                return Err(format!("Too many redirects (max {MAX_REDIRECTS})"));
-            }
-            let location = response
-                .headers()
-                .get("location")
-                .and_then(|v| v.to_str().ok())
-                .ok_or_else(|| "Redirect with no Location header".to_string())?;
-            // Resolve relative redirects against the current URL.
-            current_url = parsed
-                .join(location)
-                .map_err(|_| format!("Invalid redirect URL: {location}"))?
-                .to_string();
-            continue;
+        if !response.status().is_redirection() {
+            return Ok(response);
         }
 
-        return Ok(response);
+        let location = response
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| "Redirect with no Location header".to_string())?;
+        // Resolve relative redirects against the current URL.
+        current_url = parsed
+            .join(location)
+            .map_err(|_| format!("Invalid redirect URL: {location}"))?
+            .to_string();
     }
 
     Err(format!("Too many redirects (max {MAX_REDIRECTS})"))


### PR DESCRIPTION
## Summary

- Disable reqwest auto-redirects in `web_fetch`. Follow redirects manually (up to 10 hops) with SSRF validation via `check_ssrf_with_addrs()` on each hop
- DNS resolution failures now fail closed (return error) instead of falling through to an unpinned client
- Remove unused shared `client` field from `WebFetchTool` — each request builds a per-hop pinned client

## Security impact

Previously, an attacker-controlled page could:
1. Return a `302` redirect to `http://169.254.169.254/` (cloud metadata) — the initial SSRF check only validated the original hostname
2. Cause DNS resolution to fail, making the code fall through to an unpinned client that bypassed all SSRF protection

Both vectors are now closed.

## Test plan

- [x] `cargo check -p octos-agent` passes
- [x] New test: `test_ssrf_redirect_to_private_ip_blocked`
- [x] New test: `test_ssrf_dns_failure_blocks_request`
- [x] New test: `test_ssrf_metadata_endpoint_blocked`
- [ ] Manual: verify public URL fetch still works (`octos chat` -> ask to fetch a public URL)

Closes #177
Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)