### PR TITLE
fix: validate username in hook tilde expansion to prevent path traversal

### DIFF
--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -496,6 +496,8 @@ fn expand_tilde(path: &str) -> String {
         };
         // Reject usernames with path traversal or unsafe characters.
         // Only allow alphanumeric, hyphen, underscore, and dot (no leading dot).
+        // This allowlist implicitly blocks path separators (/ \), null bytes,
+        // and other injection characters on all platforms.
         let is_safe_username = !username.is_empty()
             && !username.starts_with('.')
             && username
@@ -741,12 +743,12 @@ mod tests {
     }
 
     #[test]
-    fn test_expand_tilde_rejects_empty_username() {
-        // ~/ is handled by the first branch; bare ~ with suffix but no username
-        // after stripping ~ would be empty, should not expand
-        // Note: "~/" is handled by the first branch (home dir), this tests "~"
-        // which is also first branch. The empty-username path is covered by
-        // is_safe_username check.
+    fn test_expand_tilde_rejects_unsafe_chars() {
+        // Null bytes and backslashes in username are blocked by the allowlist
+        assert_eq!(expand_tilde("~user\0evil"), "~user\0evil");
+        assert_eq!(expand_tilde("~user\\evil"), "~user\\evil");
+        assert_eq!(expand_tilde("~user:evil"), "~user:evil");
+        assert_eq!(expand_tilde("~ spaces"), "~ spaces");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Validate the username component in `expand_tilde()` against `[a-zA-Z0-9_-.]` (no leading dot)
- `~../../bin/evil` now returns unexpanded instead of producing `/Users/../../bin/evil`
- Invalid usernames logged via `tracing::warn` for visibility

## Security impact

`expand_tilde("~../../bin/evil")` previously produced `/Users/../../bin/evil` which resolves to `/bin/evil`. A crafted hook config or tilde-expanded argument could point to an arbitrary path on the filesystem.

## Test plan

- [x] `cargo check -p octos-agent` passes
- [x] New test: `test_expand_tilde_rejects_traversal` — `../`, `...`, leading dot
- [x] New test: `test_expand_tilde_allows_valid_usernames` — hyphens, underscores, dots
- [x] Existing `test_expand_tilde` still passes (valid usernames unaffected)

Closes #181

Generated with [Claude Code](https://claude.com/claude-code)