### PR TITLE
fix: add config flag to disable admin_shell endpoint (default: off)

### DIFF
--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -65,4 +65,6 @@ pub struct AppState {
     pub frps_server: Option<String>,
     /// frps control port.
     pub frps_port: Option<u16>,
+    /// Whether the admin shell endpoint is enabled (default: false).
+    pub allow_admin_shell: bool,
 }

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -264,8 +264,6 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/admin/system/update", post(admin::system_update))
         // Model limits (from model_limits.json)
         .route("/api/admin/model-limits", get(admin::model_limits))
-        // Remote shell (for debugging/development via coding agents)
-        .route("/api/admin/shell", post(admin::admin_shell))
         // Tunnel tenant management
         .route("/api/admin/tenants", get(admin::list_tenants))
         .route("/api/admin/tenants", post(admin::create_tenant))
@@ -275,6 +273,17 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/api/admin/tenants/{id}/setup-script",
             get(admin::tenant_setup_script),
         );
+
+    // Conditionally enable admin shell endpoint (disabled by default).
+    let admin_api = if state.allow_admin_shell {
+        tracing::warn!(
+            "admin shell endpoint enabled (POST /api/admin/shell). \
+             Disable with allow_admin_shell = false in config for production."
+        );
+        admin_api.route("/api/admin/shell", post(admin::admin_shell))
+    } else {
+        admin_api
+    };
 
     // Determine whether auth middleware is needed
     let has_auth = state.auth_token.is_some() || state.auth_manager.is_some();

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -261,6 +261,7 @@ impl ServeCommand {
             tunnel_domain: std::env::var("TUNNEL_DOMAIN").ok(),
             frps_server: std::env::var("FRPS_SERVER").ok(),
             frps_port: std::env::var("FRPS_PORT").ok().and_then(|p| p.parse().ok()),
+            allow_admin_shell: config.allow_admin_shell,
         });
 
         // Auto-start enabled profiles

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -109,6 +109,12 @@ pub struct Config {
     #[serde(default)]
     pub voice: Option<VoiceConfig>,
 
+    /// Enable the admin shell endpoint (POST /api/admin/shell).
+    /// Default: false. Only enable for development/debugging.
+    /// A leaked admin token with this enabled grants full server access.
+    #[serde(default)]
+    pub allow_admin_shell: bool,
+
     /// Dashboard user authentication configuration (email OTP).
     /// When set, enables multi-user login via email verification codes.
     #[cfg(feature = "api")]
@@ -1064,11 +1070,9 @@ mod tests {
         let config: Config = serde_json::from_str(json).unwrap();
         assert_eq!(config.tool_policy_by_provider.len(), 2);
         assert!(config.tool_policy_by_provider.contains_key("gemini"));
-        assert!(
-            config
-                .tool_policy_by_provider
-                .contains_key("claude-sonnet-4-20250514")
-        );
+        assert!(config
+            .tool_policy_by_provider
+            .contains_key("claude-sonnet-4-20250514"));
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
-use eyre::{Result, WrapErr, bail};
+use eyre::{bail, Result, WrapErr};
 use serde::{Deserialize, Serialize};
 
 use crate::config::{ChannelEntry, Config, FallbackModel, GatewayConfig};
@@ -793,6 +793,7 @@ pub(crate) fn config_from_profile(
         auth_token: None,
         adaptive_routing: None,
         voice: None,
+        allow_admin_shell: false,
         #[cfg(feature = "api")]
         dashboard_auth: None,
         #[cfg(feature = "api")]
@@ -1482,11 +1483,9 @@ mod tests {
         assert!(empty.is_empty());
 
         // Duplicate should fail
-        assert!(
-            store
-                .create_sub_account("parent", "work bot", vec![], GatewaySettings::default())
-                .is_err()
-        );
+        assert!(store
+            .create_sub_account("parent", "work bot", vec![], GatewaySettings::default())
+            .is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `allow_admin_shell: bool` to `Config` (default `false`, serde default `false`)
- Add `allow_admin_shell: bool` to `AppState`, wired from config in `serve.rs`
- The `/api/admin/shell` route is only registered when the flag is `true`
- When enabled, `tracing::warn` logs at startup for visibility
- Profile-derived configs always set `allow_admin_shell: false`

## Security impact

Previously, `admin_shell` was always registered. A leaked admin token granted full `sh -c` execution on the server. Now the endpoint doesn't exist unless explicitly opted in via config.

To enable for development:
```json
{
  "allow_admin_shell": true
}
```

## Test plan

- [x] `cargo check -p octos-cli` passes
- [ ] Verify `POST /api/admin/shell` returns 404 with default config
- [ ] Verify endpoint works when `allow_admin_shell: true`
- [ ] Verify warning log appears at startup when enabled

Closes #182

Generated with [Claude Code](https://claude.com/claude-code)