### PR TITLE
fix: replace CORS wildcard with explicit origin allowlist

### DIFF
--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -31,14 +31,23 @@ pub enum AuthIdentity {
 
 /// Build the axum router with all API routes.
 pub fn build_router(state: Arc<AppState>) -> Router {
-    // Restrict CORS to known origins — localhost dev servers and *.ominix.io.
+    // Restrict CORS to an explicit allowlist of known origins.
+    // Do NOT use suffix matching (e.g. ends_with(".ominix.io")) — a hijacked
+    // subdomain would pass the check and enable cross-origin requests.
+    const ALLOWED_ORIGINS: &[&str] = &[
+        "https://app.ominix.io",
+        "https://admin.ominix.io",
+        "https://api.ominix.io",
+        "https://app.crew.ominix.io",
+        "https://admin.crew.ominix.io",
+        "https://api.crew.ominix.io",
+        "http://localhost:3000",
+        "http://localhost:5173",
+    ];
     let cors = CorsLayer::new()
         .allow_origin(tower_http::cors::AllowOrigin::predicate(|origin, _| {
             let o = origin.to_str().unwrap_or("");
-            o.ends_with(".crew.ominix.io")
-                || o.ends_with(".ominix.io")
-                || o == "http://localhost:3000"
-                || o == "http://localhost:5173"
+            ALLOWED_ORIGINS.contains(&o)
         }))
         .allow_methods(tower_http::cors::Any)
         .allow_headers(tower_http::cors::Any);


### PR DESCRIPTION
## Summary
- Replace `ends_with(".ominix.io")` suffix match with an explicit `ALLOWED_ORIGINS` list of known subdomains
- Prevents hijacked subdomains from passing CORS checks and enabling cross-origin requests
- Keeps localhost dev origins (`localhost:3000`, `localhost:5173`) for development

## Test plan
- [ ] Verify requests from `https://app.ominix.io` are allowed
- [ ] Verify requests from `https://evil.ominix.io` are rejected
- [ ] Verify `http://localhost:3000` still works for dev
- [ ] Run `cargo test -p octos-cli`

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)