### PR TITLE
fix: restrict X-Profile-Id auth to loopback origin

### DIFF
--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -438,7 +438,15 @@ async fn user_auth_middleware(
     // 2. Accept X-Profile-Id header for chat API routes (proxy auth).
     // The reverse proxy (Caddy) sets this header to identify the profile,
     // so requests through the proxy are implicitly authenticated.
-    if !profile_id.is_empty() {
+    // SECURITY: Only accept this header from loopback addresses to prevent
+    // profile impersonation via misconfigured reverse proxy or SSRF.
+    let is_loopback = req
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip().is_loopback())
+        .unwrap_or(false);
+
+    if !profile_id.is_empty() && is_loopback {
         // Validate that the profile actually exists to prevent spoofing.
         if let Some(ref store) = state.profile_store {
             if store.get(&profile_id).ok().flatten().is_none() {
@@ -461,6 +469,13 @@ async fn user_auth_middleware(
             });
             return Ok(next.run(req).await);
         }
+    }
+
+    if !profile_id.is_empty() && !is_loopback {
+        tracing::warn!(
+            profile_id = %profile_id,
+            "X-Profile-Id header rejected: request not from loopback address"
+        );
     }
 
     tracing::warn!(

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -506,7 +506,10 @@ impl ServeCommand {
         println!();
 
         let listener = tokio::net::TcpListener::bind(&addr).await?;
-        axum::serve(listener, app)
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
             .with_graceful_shutdown(async {
                 let _ = tokio::signal::ctrl_c().await;
                 println!();


### PR DESCRIPTION
## Summary
- Only accept X-Profile-Id header when peer address is loopback (127.0.0.1 or ::1)
- Adds `ConnectInfo<SocketAddr>` via `into_make_service_with_connect_info` in serve.rs
- Logs warning when X-Profile-Id is rejected due to non-loopback origin
- Prevents profile impersonation via misconfigured reverse proxy or SSRF

Closes #186

## Test plan
- [ ] Verify `cargo check -p octos-cli` passes
- [ ] Test that X-Profile-Id auth works from localhost (127.0.0.1)
- [ ] Test that X-Profile-Id auth is rejected from non-loopback addresses
- [ ] Test that token-based auth still works regardless of origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)