### PR TITLE
fix: add concurrency cap to pipeline parallel fan-out

### DIFF
--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -95,6 +95,9 @@ pub struct ExecutorConfig {
     /// Shared shutdown signal — set to true to cancel all pipeline workers.
     /// Propagated to each worker agent's shutdown flag.
     pub shutdown: Arc<std::sync::atomic::AtomicBool>,
+    /// Maximum number of parallel workers for fan-out stages (default 8).
+    /// Prevents unbounded resource consumption under high parallelism.
+    pub max_parallel_workers: usize,
 }
 
 /// A single planned sub-task from the LLM planner.
@@ -755,9 +758,12 @@ impl PipelineExecutor {
 
                 let fan_start = Instant::now();
 
-                // Prepare and execute all targets concurrently
+                // Prepare and execute all targets concurrently, capped by semaphore
                 let total_targets = targets.len();
                 let par_completed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                let semaphore = Arc::new(tokio::sync::Semaphore::new(
+                    self.config.max_parallel_workers,
+                ));
                 let mut futures = Vec::new();
                 for target_id in &targets {
                     let target_node = graph
@@ -800,7 +806,9 @@ impl PipelineExecutor {
                     let par_done = par_completed.clone();
                     let par_node_label = node.label.as_deref().unwrap_or(&node.id).to_string();
 
+                    let sem = semaphore.clone();
                     futures.push(async move {
+                        let _permit = sem.acquire().await.expect("semaphore closed");
                         let start = Instant::now();
                         let result = execute_with_retries_static(
                             &handler,
@@ -1577,6 +1585,7 @@ mod tests {
             plugin_dirs: vec![],
             status_bridge: None,
             shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_parallel_workers: 8,
         }
     }
 

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -243,6 +243,7 @@ impl Tool for RunPipelineTool {
             plugin_dirs: self.plugin_dirs.clone(),
             status_bridge,
             shutdown: shutdown.clone(),
+            max_parallel_workers: 8,
         };
 
         // Pipeline-level timeout: default 1800s (30 min), clamped to [60, 1800].

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -59,6 +59,7 @@ async fn make_config(provider: Arc<dyn LlmProvider>, dir: &TempDir) -> ExecutorC
         plugin_dirs: vec![],
         status_bridge: None,
         shutdown: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        max_parallel_workers: 8,
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `max_parallel_workers: usize` to `ExecutorConfig` (default 8)
- Gate DynamicParallel fan-out spawns behind `tokio::sync::Semaphore`
- Prevents unbounded worker concurrency that saturates LLM rate limits, contends on HNSW locks, and exhausts the tokio thread pool

Closes #183

## Test plan
- [ ] `cargo check -p octos-pipeline` passes (verified)
- [ ] `cargo test -p octos-pipeline` passes
- [ ] Manual test with 20+ parallel targets confirms at most 8 run concurrently