### PR TITLE
fix: eliminate production unwrap/expect calls

### DIFF
--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -12,7 +12,7 @@ use crate::mcp::McpServerConfig;
 use crate::sandbox::BLOCKED_ENV_VARS;
 use crate::tools::{Tool, ToolRegistry};
 
-use super::extras::{SkillExtras, resolve_extras};
+use super::extras::{resolve_extras, SkillExtras};
 use super::manifest::PluginManifest;
 use super::tool::PluginTool;
 
@@ -289,7 +289,12 @@ impl PluginLoader {
             .tools
             .iter()
             .filter(|t| t.spawn_only && t.spawn_only_message.is_some())
-            .map(|t| (t.name.clone(), t.spawn_only_message.clone().unwrap()))
+            .map(|t| {
+                (
+                    t.name.clone(),
+                    t.spawn_only_message.clone().unwrap_or_default(),
+                )
+            })
             .collect();
 
         let tools: Vec<PluginTool> = manifest

--- a/crates/octos-bus/src/feishu_channel.rs
+++ b/crates/octos-bus/src/feishu_channel.rs
@@ -757,11 +757,11 @@ impl FeishuChannel {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Feishu webhook: invalid JSON body: {e}");
-                    return axum::http::Response::builder()
-                        .status(400)
-                        .header("Content-Type", "application/json")
-                        .body(serde_json::json!({"error": "invalid json"}).to_string())
-                        .unwrap();
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        axum::Json(serde_json::json!({"error": "invalid json"})),
+                    )
+                        .into_response();
                 }
             };
 
@@ -784,11 +784,11 @@ impl FeishuChannel {
                     let computed = verify_signature(timestamp, nonce, ek, &body);
                     if computed != expected_sig {
                         warn!("Feishu webhook: signature mismatch");
-                        return axum::http::Response::builder()
-                            .status(403)
-                            .header("Content-Type", "application/json")
-                            .body(serde_json::json!({"error": "signature mismatch"}).to_string())
-                            .unwrap();
+                        return (
+                            axum::http::StatusCode::FORBIDDEN,
+                            axum::Json(serde_json::json!({"error": "signature mismatch"})),
+                        )
+                            .into_response();
                     }
                 }
             }
@@ -803,32 +803,31 @@ impl FeishuChannel {
                             Ok(v) => v,
                             Err(e) => {
                                 warn!("Feishu webhook: failed to parse decrypted event: {e}");
-                                return axum::http::Response::builder()
-                                    .status(400)
-                                    .header("Content-Type", "application/json")
-                                    .body(
-                                        serde_json::json!({"error": "decrypt parse error"})
-                                            .to_string(),
-                                    )
-                                    .unwrap();
+                                return (
+                                    axum::http::StatusCode::BAD_REQUEST,
+                                    axum::Json(
+                                        serde_json::json!({"error": "decrypt parse error"}),
+                                    ),
+                                )
+                                    .into_response();
                             }
                         },
                         Err(e) => {
                             warn!("Feishu webhook: decryption failed: {e}");
-                            return axum::http::Response::builder()
-                                .status(400)
-                                .header("Content-Type", "application/json")
-                                .body(serde_json::json!({"error": "decryption failed"}).to_string())
-                                .unwrap();
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::Json(serde_json::json!({"error": "decryption failed"})),
+                            )
+                                .into_response();
                         }
                     }
                 } else {
                     warn!("Feishu webhook: received encrypted event but no encrypt_key configured");
-                    return axum::http::Response::builder()
-                        .status(400)
-                        .header("Content-Type", "application/json")
-                        .body(serde_json::json!({"error": "no encrypt key configured"}).to_string())
-                        .unwrap();
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        axum::Json(serde_json::json!({"error": "no encrypt key configured"})),
+                    )
+                        .into_response();
                 }
             } else {
                 body_json
@@ -841,11 +840,7 @@ impl FeishuChannel {
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
                 info!("Feishu webhook: url_verification challenge received");
-                return axum::http::Response::builder()
-                    .status(200)
-                    .header("Content-Type", "application/json")
-                    .body(serde_json::json!({"challenge": challenge}).to_string())
-                    .unwrap();
+                return axum::Json(serde_json::json!({"challenge": challenge})).into_response();
             }
 
             // Verification token check (for non-encrypted plaintext events)
@@ -856,21 +851,18 @@ impl FeishuChannel {
                     .unwrap_or("");
                 if !event_token.is_empty() && event_token != vt {
                     warn!("Feishu webhook: verification token mismatch");
-                    return axum::http::Response::builder()
-                        .status(403)
-                        .header("Content-Type", "application/json")
-                        .body(serde_json::json!({"error": "token mismatch"}).to_string())
-                        .unwrap();
+                    return (
+                        axum::http::StatusCode::FORBIDDEN,
+                        axum::Json(serde_json::json!({"error": "token mismatch"})),
+                    )
+                        .into_response();
                 }
             }
 
             // Forward event to the channel for processing
             let _ = state.inbound_tx.send(event_json).await;
 
-            axum::http::Response::builder()
-                .status(200)
-                .body("ok".to_string())
-                .unwrap()
+            "ok".into_response()
         }
 
         // Internal channel for passing parsed events

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -243,15 +243,17 @@ impl SessionManager {
     /// Get or create a session. Loads from disk on first access.
     pub fn get_or_create(&mut self, key: &SessionKey) -> &mut Session {
         let key_str = key.0.clone();
-        if !self.cache.contains(&key_str) {
-            let session = self
-                .load_from_disk(key)
-                .unwrap_or_else(|| Session::new(key.clone()));
-            self.cache.put(key_str.clone(), session);
-        }
-        self.cache
-            .get_mut(&key_str)
-            .expect("session must exist: inserted above")
+        let disk_session = if self.cache.contains(&key_str) {
+            None
+        } else {
+            Some(
+                self.load_from_disk(key)
+                    .unwrap_or_else(|| Session::new(key.clone())),
+            )
+        };
+        self.cache.get_or_insert_mut(key_str, || {
+            disk_session.unwrap_or_else(|| Session::new(key.clone()))
+        })
     }
 
     /// Add a message to a session and persist it.

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -741,8 +741,7 @@ impl ProcessManager {
     /// Internal: start a bridge process. Returns the WS port.
     async fn start_bridge_inner(&self, profile: &UserProfile) -> Result<u16> {
         let mut bridges = self.bridges.write().await;
-        if bridges.contains_key(&profile.id) {
-            let existing = bridges.get(&profile.id).unwrap();
+        if let Some(existing) = bridges.get(&profile.id) {
             return Ok(existing.ws_port);
         }
 


### PR DESCRIPTION
## Summary

- **feishu_channel.rs**: Replace 8 `Response::builder().body().unwrap()` calls with `(StatusCode, Json).into_response()` -- idiomatic axum, no panics
- **plugins/loader.rs**: Replace `spawn_only_message.clone().unwrap()` with `.unwrap_or_default()` (filter already ensures `is_some()` but the unwrap was unnecessary)
- **process_manager.rs**: Replace `bridges.get(&profile.id).unwrap()` with `if let Some(existing)` pattern
- **session.rs**: Replace `expect("session must exist")` after LRU cache insert with `get_or_insert_mut()` which atomically inserts-and-returns a mutable reference

Note: `run_dir.rs` line 156 unwraps are inside `#[cfg(test)]` -- not production code, skipped.

## Test plan

- [x] `cargo check --workspace` passes
- [ ] `cargo test --workspace` passes (CI)
- [ ] Verify feishu webhook error responses still return correct status codes and JSON bodies

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)