### PR TITLE
fix: merge divergent EpisodeStore search APIs

### DIFF
--- a/crates/octos-memory/src/hybrid_search.rs
+++ b/crates/octos-memory/src/hybrid_search.rs
@@ -63,6 +63,11 @@ impl HybridIndex {
         }
     }
 
+    /// Returns true if no documents have been indexed.
+    pub fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
     /// Set custom hybrid scoring weights. Weights should sum to 1.0.
     pub fn with_weights(mut self, vector_weight: f32, bm25_weight: f32) -> Self {
         self.vector_weight = vector_weight;

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -151,7 +151,44 @@ impl EpisodeStore {
     }
 
     /// Find episodes relevant to a query in the given directory.
+    ///
+    /// Delegates to `find_relevant_hybrid` (BM25-only, no embedding) and
+    /// post-filters by CWD. Falls back to a direct DB scan if the hybrid
+    /// index is empty.
     pub async fn find_relevant(
+        &self,
+        cwd: &Path,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<Episode>> {
+        // Check if hybrid index has documents
+        let index_populated = self
+            .index
+            .read()
+            .map(|idx| !idx.is_empty())
+            .unwrap_or(false);
+
+        if index_populated {
+            // Over-fetch to account for CWD filtering, then filter
+            let candidates = self.find_relevant_hybrid(query, None, limit * 4).await?;
+            let filtered: Vec<Episode> = candidates
+                .into_iter()
+                .filter(|ep| ep.working_dir == cwd)
+                .take(limit)
+                .collect();
+
+            if !filtered.is_empty() {
+                return Ok(filtered);
+            }
+            // Fall through to DB scan if hybrid returned no CWD matches
+        }
+
+        // Fallback: direct DB scan (for empty index or no CWD matches)
+        self.find_relevant_db_scan(cwd, query, limit).await
+    }
+
+    /// Direct DB scan fallback for CWD-scoped relevance search.
+    async fn find_relevant_db_scan(
         &self,
         cwd: &Path,
         query: &str,


### PR DESCRIPTION
## Summary
- `find_relevant` now delegates to `find_relevant_hybrid` (BM25-only, no embedding) with a CWD post-filter
- Falls back to direct DB scan if the hybrid index is empty or returns no CWD matches
- Adds `HybridIndex::is_empty()` helper method
- Unifies the two search paths so `find_relevant` benefits from proper BM25 scoring (IDF, term frequency normalization)

Closes #191

## Test plan
- [ ] Existing `test_find_relevant` and `test_find_relevant_no_matches` tests still pass
- [ ] Verify CWD filtering works correctly (episodes from other dirs excluded)
- [ ] Verify fallback to DB scan when hybrid index is empty
- [ ] Run `cargo test -p octos-memory` and `cargo check --workspace`