### PR TITLE
refactor: consolidate duplicated dedup_check across 5 channels

### DIFF
--- a/crates/octos-bus/src/discord_channel.rs
+++ b/crates/octos-bus/src/discord_channel.rs
@@ -19,10 +19,8 @@ use serenity::builder::{CreateAttachment, CreateEmbed, CreateMessage};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
-/// Maximum message IDs to track for dedup.
-const MAX_SEEN_IDS: usize = 1000;
-
 use crate::channel::Channel;
+use crate::dedup::MessageDedup;
 use crate::media::download_media;
 
 pub struct DiscordChannel {
@@ -31,7 +29,7 @@ pub struct DiscordChannel {
     allowed_senders: HashSet<String>,
     shutdown: Arc<AtomicBool>,
     media_dir: PathBuf,
-    seen_ids: Arc<std::sync::Mutex<HashSet<String>>>,
+    dedup: Arc<MessageDedup>,
 }
 
 impl DiscordChannel {
@@ -48,22 +46,8 @@ impl DiscordChannel {
             allowed_senders: allowed_senders.into_iter().collect(),
             shutdown,
             media_dir,
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: Arc::new(MessageDedup::new()),
         }
-    }
-
-    /// Check if a message ID has been seen; add if not.
-    #[cfg(test)]
-    fn dedup_check(&self, msg_id: &str) -> bool {
-        let mut seen = self.seen_ids.lock().unwrap_or_else(|e| e.into_inner());
-        if seen.contains(msg_id) {
-            return true;
-        }
-        if seen.len() >= MAX_SEEN_IDS {
-            seen.clear();
-        }
-        seen.insert(msg_id.to_string());
-        false
     }
 
     /// Parse an emoji string into a serenity ReactionType.
@@ -94,7 +78,7 @@ struct Handler {
     allowed_senders: HashSet<String>,
     media_dir: PathBuf,
     download_http: HttpClient,
-    seen_ids: Arc<std::sync::Mutex<HashSet<String>>>,
+    dedup: Arc<MessageDedup>,
 }
 
 #[async_trait]
@@ -105,17 +89,10 @@ impl EventHandler for Handler {
         }
 
         // Dedup: skip messages already seen (e.g. on reconnect)
-        {
-            let msg_id_str = msg.id.to_string();
-            let mut seen = self.seen_ids.lock().unwrap_or_else(|e| e.into_inner());
-            if seen.contains(&msg_id_str) {
-                debug!(msg_id = %msg_id_str, "Discord: dedup filtered message");
-                return;
-            }
-            if seen.len() >= MAX_SEEN_IDS {
-                seen.clear();
-            }
-            seen.insert(msg_id_str);
+        let msg_id_str = msg.id.to_string();
+        if self.dedup.is_duplicate(&msg_id_str) {
+            debug!(msg_id = %msg_id_str, "Discord: dedup filtered message");
+            return;
         }
 
         let sender_id = msg.author.id.to_string();
@@ -197,7 +174,7 @@ impl Channel for DiscordChannel {
             allowed_senders: self.allowed_senders.clone(),
             media_dir: self.media_dir.clone(),
             download_http: HttpClient::new(),
-            seen_ids: Arc::clone(&self.seen_ids),
+            dedup: Arc::clone(&self.dedup),
         };
 
         let mut client = Client::builder(&self.token, intents)
@@ -379,7 +356,7 @@ mod tests {
             allowed_senders: allowed.into_iter().map(String::from).collect(),
             shutdown: Arc::new(AtomicBool::new(false)),
             media_dir: PathBuf::from("/tmp/test-media"),
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: Arc::new(MessageDedup::new()),
         }
     }
 
@@ -417,19 +394,9 @@ mod tests {
     #[test]
     fn test_dedup() {
         let ch = make_channel(vec![]);
-        assert!(!ch.dedup_check("msg1"));
-        assert!(ch.dedup_check("msg1")); // duplicate
-        assert!(!ch.dedup_check("msg2"));
-    }
-
-    #[test]
-    fn test_dedup_overflow_clears() {
-        let ch = make_channel(vec![]);
-        for i in 0..MAX_SEEN_IDS {
-            ch.dedup_check(&format!("msg_{i}"));
-        }
-        assert!(!ch.dedup_check("new_msg"));
-        assert!(!ch.dedup_check("msg_0"));
+        assert!(!ch.dedup.is_duplicate("msg1"));
+        assert!(ch.dedup.is_duplicate("msg1")); // duplicate
+        assert!(!ch.dedup.is_duplicate("msg2"));
     }
 
     #[test]

--- a/crates/octos-bus/src/feishu_channel.rs
+++ b/crates/octos-bus/src/feishu_channel.rs
@@ -22,12 +22,11 @@ use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tracing::{debug, error, info, warn};
 
 use crate::channel::Channel;
+use crate::dedup::MessageDedup;
 use crate::media::{download_media, is_image};
 
 /// Token refresh interval (slightly under 2 hours).
 const TOKEN_TTL_SECS: u64 = 7000;
-/// Maximum message IDs to track for dedup.
-const MAX_SEEN_IDS: usize = 1000;
 
 fn base_url_for_region(region: &str) -> String {
     match region {
@@ -150,7 +149,7 @@ pub struct FeishuChannel {
     http: Client,
     media_dir: PathBuf,
     token_cache: Arc<tokio::sync::Mutex<Option<(String, Instant)>>>,
-    seen_ids: Arc<std::sync::Mutex<HashSet<String>>>,
+    dedup: MessageDedup,
     /// "ws" for WebSocket long connection, "webhook" for HTTP webhook mode.
     mode: String,
     /// Port for webhook HTTP server (only used in webhook mode).
@@ -179,7 +178,7 @@ impl FeishuChannel {
             http: Client::new(),
             media_dir,
             token_cache: Arc::new(tokio::sync::Mutex::new(None)),
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             mode: "ws".to_string(),
             webhook_port: 9321,
             encrypt_key: None,
@@ -450,19 +449,6 @@ impl FeishuChannel {
         Ok(message_id)
     }
 
-    /// Check if a message ID has been seen; add if not. Trims when over capacity.
-    fn dedup_check(&self, msg_id: &str) -> bool {
-        let mut seen = self.seen_ids.lock().unwrap_or_else(|e| e.into_inner());
-        if seen.contains(msg_id) {
-            return true;
-        }
-        if seen.len() >= MAX_SEEN_IDS {
-            seen.clear();
-        }
-        seen.insert(msg_id.to_string());
-        false
-    }
-
     /// Determine receive_id_type from chat_id prefix.
     fn receive_id_type(chat_id: &str) -> &'static str {
         if chat_id.starts_with("oc_") {
@@ -493,7 +479,7 @@ impl FeishuChannel {
             .get("message_id")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        if message_id.is_empty() || self.dedup_check(message_id) {
+        if message_id.is_empty() || self.dedup.is_duplicate(message_id) {
             debug!(message_id, "Feishu: dedup filtered message");
             return None;
         }
@@ -1104,7 +1090,7 @@ mod tests {
             http: Client::new(),
             media_dir: PathBuf::from("/tmp/test-feishu-media"),
             token_cache: Arc::new(tokio::sync::Mutex::new(None)),
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             mode: "ws".into(),
             webhook_port: 9321,
             encrypt_key: None,
@@ -1159,19 +1145,9 @@ mod tests {
     #[test]
     fn test_dedup() {
         let ch = make_channel(vec![]);
-        assert!(!ch.dedup_check("msg1"));
-        assert!(ch.dedup_check("msg1")); // duplicate
-        assert!(!ch.dedup_check("msg2"));
-    }
-
-    #[test]
-    fn test_dedup_overflow_clears() {
-        let ch = make_channel(vec![]);
-        for i in 0..MAX_SEEN_IDS {
-            ch.dedup_check(&format!("msg_{i}"));
-        }
-        assert!(!ch.dedup_check("new_msg"));
-        assert!(!ch.dedup_check("msg_0"));
+        assert!(!ch.dedup.is_duplicate("msg1"));
+        assert!(ch.dedup.is_duplicate("msg1")); // duplicate
+        assert!(!ch.dedup.is_duplicate("msg2"));
     }
 
     #[test]

--- a/crates/octos-bus/src/qq_bot_channel.rs
+++ b/crates/octos-bus/src/qq_bot_channel.rs
@@ -27,6 +27,7 @@ extern crate rustls;
 extern crate rustls_native_certs;
 
 use crate::channel::Channel;
+use crate::dedup::MessageDedup;
 
 /// QQ Bot token endpoint.
 const TOKEN_URL: &str = "https://bots.qq.com/app/getAppAccessToken";
@@ -38,8 +39,6 @@ const MAX_RECONNECT_ATTEMPTS: u32 = 100;
 const RECONNECT_BASE_DELAY_MS: u64 = 5000;
 /// Max reconnect delay in milliseconds.
 const RECONNECT_MAX_DELAY_MS: u64 = 60000;
-/// Maximum message IDs to track for dedup.
-const MAX_SEEN_IDS: usize = 1000;
 /// Max message length for QQ Bot text messages.
 const MAX_MSG_LENGTH: usize = 4000;
 /// Safety margin before token expiry (seconds).
@@ -77,7 +76,7 @@ pub struct QQBotChannel {
     client_secret: String,
     allowed_senders: HashSet<String>,
     shutdown: Arc<AtomicBool>,
-    seen_ids: Arc<std::sync::Mutex<HashSet<String>>>,
+    dedup: MessageDedup,
     http_client: Client,
     access_token: Arc<Mutex<Option<TokenState>>>,
     session_state: Arc<Mutex<Option<SessionState>>>,
@@ -99,7 +98,7 @@ impl QQBotChannel {
             client_secret: client_secret.to_string(),
             allowed_senders: allowed_senders.into_iter().collect(),
             shutdown,
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             c2c_chats: Arc::new(std::sync::Mutex::new(HashSet::new())),
             http_client: Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
@@ -113,19 +112,6 @@ impl QQBotChannel {
 
     fn check_allowed(&self, sender_id: &str) -> bool {
         self.allowed_senders.is_empty() || self.allowed_senders.contains(sender_id)
-    }
-
-    /// Check if a message ID has been seen; add if not.
-    fn dedup_check(&self, msg_id: &str) -> bool {
-        let mut seen = self.seen_ids.lock().unwrap_or_else(|e| e.into_inner());
-        if seen.contains(msg_id) {
-            return true;
-        }
-        if seen.len() >= MAX_SEEN_IDS {
-            seen.clear();
-        }
-        seen.insert(msg_id.to_string());
-        false
     }
 
     /// Fetch or refresh the access token.
@@ -321,7 +307,7 @@ impl QQBotChannel {
             return None;
         }
 
-        if !msg_id.is_empty() && self.dedup_check(msg_id) {
+        if !msg_id.is_empty() && self.dedup.is_duplicate(msg_id) {
             debug!(msg_id, "QQBot: dedup filtered message");
             return None;
         }
@@ -369,7 +355,7 @@ impl QQBotChannel {
             return None;
         }
 
-        if !msg_id.is_empty() && self.dedup_check(msg_id) {
+        if !msg_id.is_empty() && self.dedup.is_duplicate(msg_id) {
             debug!(msg_id, "QQBot: dedup filtered C2C message");
             return None;
         }
@@ -773,7 +759,7 @@ mod tests {
             client_secret: "test_secret".into(),
             allowed_senders: allowed.into_iter().map(String::from).collect(),
             shutdown: Arc::new(AtomicBool::new(false)),
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             c2c_chats: Arc::new(std::sync::Mutex::new(HashSet::new())),
             http_client: Client::new(),
             access_token: Arc::new(Mutex::new(None)),
@@ -810,19 +796,9 @@ mod tests {
     #[test]
     fn should_detect_duplicate_messages() {
         let bot = make_bot(vec![]);
-        assert!(!bot.dedup_check("msg1"));
-        assert!(bot.dedup_check("msg1"));
-        assert!(!bot.dedup_check("msg2"));
-    }
-
-    #[test]
-    fn should_clear_dedup_on_overflow() {
-        let bot = make_bot(vec![]);
-        for i in 0..MAX_SEEN_IDS {
-            bot.dedup_check(&format!("msg_{i}"));
-        }
-        assert!(!bot.dedup_check("new_msg"));
-        assert!(!bot.dedup_check("msg_0"));
+        assert!(!bot.dedup.is_duplicate("msg1"));
+        assert!(bot.dedup.is_duplicate("msg1"));
+        assert!(!bot.dedup.is_duplicate("msg2"));
     }
 
     #[test]

--- a/crates/octos-bus/src/wecom_bot_channel.rs
+++ b/crates/octos-bus/src/wecom_bot_channel.rs
@@ -26,6 +26,7 @@ extern crate rustls;
 extern crate rustls_native_certs;
 
 use crate::channel::Channel;
+use crate::dedup::MessageDedup;
 
 /// Default WeCom WebSocket endpoint.
 const WS_URL: &str = "wss://openws.work.weixin.qq.com";
@@ -39,8 +40,6 @@ const MAX_RECONNECT_ATTEMPTS: u32 = 100;
 const RECONNECT_BASE_DELAY_MS: u64 = 5000;
 /// Max reconnect delay in milliseconds.
 const RECONNECT_MAX_DELAY_MS: u64 = 60000;
-/// Maximum message IDs to track for dedup.
-const MAX_SEEN_IDS: usize = 1000;
 /// Max message length for WeCom markdown.
 const MAX_MSG_LENGTH: usize = 4096;
 /// Maximum req_id entries to track for stream replies.
@@ -63,7 +62,7 @@ pub struct WeComBotChannel {
     secret: String,
     allowed_senders: HashSet<String>,
     shutdown: Arc<AtomicBool>,
-    seen_ids: Arc<std::sync::Mutex<HashSet<String>>>,
+    dedup: MessageDedup,
     /// Shared write-half of the WebSocket, set once connected.
     ws_sink: Arc<Mutex<Option<WsSink>>>,
     /// Maps `chat_id` → `req_id` from the most recent inbound message.
@@ -83,7 +82,7 @@ impl WeComBotChannel {
             secret: secret.to_string(),
             allowed_senders: allowed_senders.into_iter().collect(),
             shutdown,
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             ws_sink: Arc::new(Mutex::new(None)),
             req_id_map: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
@@ -91,19 +90,6 @@ impl WeComBotChannel {
 
     fn check_allowed(&self, sender_id: &str) -> bool {
         self.allowed_senders.is_empty() || self.allowed_senders.contains(sender_id)
-    }
-
-    /// Check if a message ID has been seen; add if not.
-    fn dedup_check(&self, msg_id: &str) -> bool {
-        let mut seen = self.seen_ids.lock().unwrap_or_else(|e| e.into_inner());
-        if seen.contains(msg_id) {
-            return true;
-        }
-        if seen.len() >= MAX_SEEN_IDS {
-            seen.clear();
-        }
-        seen.insert(msg_id.to_string());
-        false
     }
 
     /// Store a `req_id` for a chat so streaming replies can reference it.
@@ -142,7 +128,7 @@ impl WeComBotChannel {
             self.store_req_id(chat_id, req_id);
         }
 
-        if !msg_id.is_empty() && self.dedup_check(msg_id) {
+        if !msg_id.is_empty() && self.dedup.is_duplicate(msg_id) {
             debug!(msg_id, "WeComBot: dedup filtered message");
             return None;
         }
@@ -711,7 +697,7 @@ mod tests {
             secret: "test_secret".into(),
             allowed_senders: allowed.into_iter().map(String::from).collect(),
             shutdown: Arc::new(AtomicBool::new(false)),
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             ws_sink: Arc::new(Mutex::new(None)),
             req_id_map: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
@@ -745,19 +731,9 @@ mod tests {
     #[test]
     fn should_detect_duplicate_messages() {
         let bot = make_bot(vec![]);
-        assert!(!bot.dedup_check("msg1"));
-        assert!(bot.dedup_check("msg1"));
-        assert!(!bot.dedup_check("msg2"));
-    }
-
-    #[test]
-    fn should_clear_dedup_on_overflow() {
-        let bot = make_bot(vec![]);
-        for i in 0..MAX_SEEN_IDS {
-            bot.dedup_check(&format!("msg_{i}"));
-        }
-        assert!(!bot.dedup_check("new_msg"));
-        assert!(!bot.dedup_check("msg_0"));
+        assert!(!bot.dedup.is_duplicate("msg1"));
+        assert!(bot.dedup.is_duplicate("msg1"));
+        assert!(!bot.dedup.is_duplicate("msg2"));
     }
 
     #[test]

--- a/crates/octos-bus/src/wecom_channel.rs
+++ b/crates/octos-bus/src/wecom_channel.rs
@@ -18,6 +18,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use crate::channel::Channel;
+use crate::dedup::MessageDedup;
 use crate::media::{download_media, is_image};
 use crate::wecom_crypto::{
     decode_aes_key, decrypt_wecom_message, verify_wecom_signature, xml_extract,
@@ -25,8 +26,6 @@ use crate::wecom_crypto::{
 
 /// Token refresh interval (slightly under 2 hours).
 const TOKEN_TTL_SECS: u64 = 7000;
-/// Maximum message IDs to track for dedup.
-const MAX_SEEN_IDS: usize = 1000;
 /// WeCom API base URL.
 const WECOM_API: &str = "https://qyapi.weixin.qq.com/cgi-bin";
 
@@ -45,7 +44,7 @@ pub struct WeComChannel {
     http: Client,
     media_dir: PathBuf,
     token_cache: Arc<tokio::sync::Mutex<Option<(String, Instant)>>>,
-    seen_ids: Arc<std::sync::Mutex<HashSet<String>>>,
+    dedup: MessageDedup,
     webhook_port: u16,
 }
 
@@ -75,7 +74,7 @@ impl WeComChannel {
             http: Client::new(),
             media_dir,
             token_cache: Arc::new(tokio::sync::Mutex::new(None)),
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             webhook_port: 9322,
         }
     }
@@ -212,26 +211,13 @@ impl WeComChannel {
         Ok(())
     }
 
-    /// Check if a message ID has been seen; add if not.
-    fn dedup_check(&self, msg_id: &str) -> bool {
-        let mut seen = self.seen_ids.lock().unwrap_or_else(|e| e.into_inner());
-        if seen.contains(msg_id) {
-            return true;
-        }
-        if seen.len() >= MAX_SEEN_IDS {
-            seen.clear();
-        }
-        seen.insert(msg_id.to_string());
-        false
-    }
-
     /// Parse a decrypted WeCom XML message into an InboundMessage.
     async fn parse_message(&self, xml: &str) -> Option<InboundMessage> {
         let msg_type = xml_extract(xml, "MsgType")?;
         let from_user = xml_extract(xml, "FromUserName")?;
         let msg_id = xml_extract(xml, "MsgId").unwrap_or_default();
 
-        if !msg_id.is_empty() && self.dedup_check(&msg_id) {
+        if !msg_id.is_empty() && self.dedup.is_duplicate(&msg_id) {
             debug!(msg_id, "WeCom: dedup filtered message");
             return None;
         }
@@ -584,7 +570,7 @@ mod tests {
             http: Client::new(),
             media_dir: PathBuf::from("/tmp/test-wecom-media"),
             token_cache: Arc::new(tokio::sync::Mutex::new(None)),
-            seen_ids: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            dedup: MessageDedup::new(),
             webhook_port: 9322,
         }
     }
@@ -592,19 +578,9 @@ mod tests {
     #[test]
     fn test_dedup() {
         let ch = make_channel(vec![]);
-        assert!(!ch.dedup_check("msg1"));
-        assert!(ch.dedup_check("msg1")); // duplicate
-        assert!(!ch.dedup_check("msg2"));
-    }
-
-    #[test]
-    fn test_dedup_overflow_clears() {
-        let ch = make_channel(vec![]);
-        for i in 0..MAX_SEEN_IDS {
-            ch.dedup_check(&format!("msg_{i}"));
-        }
-        assert!(!ch.dedup_check("new_msg"));
-        assert!(!ch.dedup_check("msg_0"));
+        assert!(!ch.dedup.is_duplicate("msg1"));
+        assert!(ch.dedup.is_duplicate("msg1")); // duplicate
+        assert!(!ch.dedup.is_duplicate("msg2"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace copy-pasted `seen_ids: Arc<Mutex<HashSet<String>>>` + `dedup_check()` in discord, wecom, wecom_bot, feishu, and qq_bot channels with the existing `MessageDedup` from `dedup.rs`
- Remove duplicated `MAX_SEEN_IDS` constants and inline dedup logic from each channel
- Update all tests to use `dedup.is_duplicate()` directly; remove overflow tests (LRU eviction is tested in `dedup.rs`)

## Test plan
- [x] `cargo check -p octos-bus` passes
- [ ] `cargo test -p octos-bus` passes
- [ ] Verify dedup behavior unchanged (MessageDedup uses LRU+TTL which is strictly better than the old HashSet+clear approach)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)