### PR TITLE
fix(openrouter): include tool_calls in assistant messages

### DIFF
--- a/crates/octos-llm/src/openrouter.rs
+++ b/crates/octos-llm/src/openrouter.rs
@@ -69,16 +69,7 @@ impl LlmProvider for OpenRouterProvider {
     ) -> Result<ChatResponse> {
         let api_messages: Vec<ApiMessage> = messages
             .iter()
-            .map(|m| {
-                let role = m.role.as_str();
-                let content = build_api_content(m);
-                ApiMessage {
-                    role,
-                    content,
-                    tool_call_id: m.tool_call_id.as_deref(),
-                    tool_calls: None,
-                }
-            })
+            .map(|m| build_api_message(m))
             .collect();
 
         let api_tools: Option<Vec<ApiTool>> = if tools.is_empty() {
@@ -184,15 +175,7 @@ impl LlmProvider for OpenRouterProvider {
     ) -> Result<ChatStream> {
         let api_messages: Vec<ApiMessage> = messages
             .iter()
-            .map(|m| {
-                let role = m.role.as_str();
-                ApiMessage {
-                    role,
-                    content: build_api_content(m),
-                    tool_call_id: m.tool_call_id.as_deref(),
-                    tool_calls: None,
-                }
-            })
+            .map(|m| build_api_message(m))
             .collect();
 
         let api_tools: Option<Vec<ApiTool>> = if tools.is_empty() {
@@ -314,6 +297,28 @@ enum ApiContentPart {
 #[derive(Serialize)]
 struct ApiImageUrl {
     url: String,
+}
+
+fn build_api_message(msg: &Message) -> ApiMessage {
+    let role = msg.role.as_str();
+    let content = build_api_content(msg);
+    let tool_calls = msg.tool_calls.as_ref().map(|tcs| {
+        tcs.iter()
+            .map(|tc| ApiToolCall {
+                id: tc.id.clone(),
+                function: FunctionCall {
+                    name: tc.name.clone(),
+                    arguments: tc.arguments.to_string(),
+                },
+            })
+            .collect()
+    });
+    ApiMessage {
+        role,
+        content,
+        tool_call_id: msg.tool_call_id.as_deref(),
+        tool_calls,
+    }
 }
 
 fn build_api_content(msg: &Message) -> Option<ApiContent> {


### PR DESCRIPTION
## Summary
- The OpenRouter provider was hardcoding `tool_calls: None` for all API messages, dropping tool call history from assistant messages in conversation history
- This caused Anthropic (via OpenRouter) to reject multi-turn tool-use conversations with `400 Bad Request: unexpected tool_use_id` errors
- Extracted a shared `build_api_message()` helper that properly serializes tool_calls, matching the OpenAI provider's behavior

## Test plan
- [x] Tested on live OpenRouter → Anthropic multi-turn conversation with tool use via Telegram
- [ ] `cargo test -p octos-llm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)