### PR TITLE
Add CI check for typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
             exit 1
           fi
 
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.33.1
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,36 @@
+[default]
+extend-ignore-identifiers-re = [
+    # *sigh* this just isn't worth the cost of fixing
+    "AttributeID.*Supress.*",
+]
+
+[default.extend-identifiers]
+# *sigh* this just isn't worth the cost of fixing
+AttributeIDSupressMenu = "AttributeIDSupressMenu"
+
+[default.extend-words]
+# Don't correct the surname "Teh"
+teh = "teh"
+Hashi = "Hashi"
+consts = "consts"
+# Voice preset name (ono_anna)
+ono = "ono"
+# WeChat API event name
+scaned = "scaned"
+# Timezone abbreviation (IST)
+ist = "ist"
+# Test data fragment in SSE test
+hel = "hel"
+# Homoglyph security test string
+nore = "nore"
+# WhatsApp API field name
+pn = "pn"
+# Both spellings are acceptable
+unparseable = "unparseable"
+# Base64 placeholder token
+iz = "iz"
+# One-Time Passwords (OTPs)
+ot = "ot"
+
+[files]
+extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
This pull request adds automated typo checking to the CI workflow and configures custom spelling exceptions to avoid false positives.

**Typo Checker Configuration:**

* Introduced a `typos.toml` configuration file that:
  * Ignores specific identifiers and words that are intentional or not worth correcting (e.g., names, API fields, test data).
  * Extends the list of words and identifiers that should not be flagged as typos, such as "teh", "Hashi", "ono", and others.
  * Excludes certain file types and directories (like `.js`, `.css`, `.html`, and static example files) from typo checking.