### PR TITLE
fix: add matrix channel support to octos channels status

### DIFF
--- a/crates/octos-cli/src/commands/channels.rs
+++ b/crates/octos-cli/src/commands/channels.rs
@@ -124,6 +124,8 @@ fn is_channel_compiled(channel_type: &str) -> bool {
         "wecom-bot" => true,
         #[cfg(feature = "qq-bot")]
         "qq-bot" => true,
+        #[cfg(feature = "matrix")]
+        "matrix" => true,
         _ => false,
     }
 }

--- a/scripts/local-deploy.sh
+++ b/scripts/local-deploy.sh
@@ -166,7 +166,7 @@ case "$MODE" in
         echo "    Mode: minimal (CLI + chat only)"
         ;;
     full)
-        CLI_FEATURES="api,telegram,discord,slack,whatsapp,feishu,email,twilio,wecom"
+        CLI_FEATURES="api,telegram,discord,slack,whatsapp,feishu,email,twilio,wecom,matrix"
         echo "    Mode: full (all channels + dashboard + skills)"
         ;;
 esac


### PR DESCRIPTION
- Add #[cfg(feature = "matrix")] case to is_channel_compiled()
- Add matrix to CLI_FEATURES in --full mode of local-deploy.sh
- Fixes 'matrix no' status even when compiled with --features matrix