### PR TITLE
chore: cargo fmt --all

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -173,8 +173,11 @@ impl Channel for ApiChannel {
                         .file_name()
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
-                    let tool_call_id = msg.metadata.get("tool_call_id")
-                        .and_then(|v| v.as_str()).unwrap_or("");
+                    let tool_call_id = msg
+                        .metadata
+                        .get("tool_call_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
                     let event = serde_json::json!({
                         "type": "file",
                         "path": path,
@@ -364,13 +367,21 @@ impl ApiChannel {
                 let path_clone = per_user_path.clone();
                 match tokio::task::spawn_blocking(move || {
                     use std::io::Write;
-                    let mut f = std::fs::OpenOptions::new().append(true).open(&per_user_path)?;
+                    let mut f = std::fs::OpenOptions::new()
+                        .append(true)
+                        .open(&per_user_path)?;
                     writeln!(f, "{}", msg_json)?;
                     Ok::<_, std::io::Error>(())
-                }).await {
+                })
+                .await
+                {
                     Ok(Ok(())) => info!(chat_id = %chat_id, "persisted to per-user session"),
-                    Ok(Err(e)) => tracing::warn!(chat_id = %chat_id, path = %path_clone.display(), error = %e, "per-user session write failed"),
-                    Err(e) => tracing::warn!(chat_id = %chat_id, error = %e, "per-user session spawn_blocking failed"),
+                    Ok(Err(e)) => {
+                        tracing::warn!(chat_id = %chat_id, path = %path_clone.display(), error = %e, "per-user session write failed")
+                    }
+                    Err(e) => {
+                        tracing::warn!(chat_id = %chat_id, error = %e, "per-user session spawn_blocking failed")
+                    }
                 }
             }
         } else {
@@ -611,12 +622,20 @@ async fn handle_session_messages(
             // and aren't already in per-user
             for line in content.lines() {
                 if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
-                    let has_media = v.get("media").and_then(|m| m.as_array()).is_some_and(|a| !a.is_empty());
-                    let is_bg = v.get("content").and_then(|c| c.as_str()).is_some_and(|c| c.starts_with('✓') || c.starts_with('✗'));
+                    let has_media = v
+                        .get("media")
+                        .and_then(|m| m.as_array())
+                        .is_some_and(|a| !a.is_empty());
+                    let is_bg = v
+                        .get("content")
+                        .and_then(|c| c.as_str())
+                        .is_some_and(|c| c.starts_with('✓') || c.starts_with('✗'));
                     if has_media || is_bg {
                         // Check for duplicate by content
                         let content_str = v.get("content").and_then(|c| c.as_str()).unwrap_or("");
-                        if !all_lines.iter().any(|existing| existing.contains(content_str) && !content_str.is_empty()) {
+                        if !all_lines.iter().any(|existing| {
+                            existing.contains(content_str) && !content_str.is_empty()
+                        }) {
                             all_lines.push(line.to_string());
                         }
                     }
@@ -629,8 +648,7 @@ async fn handle_session_messages(
                 let v: serde_json::Value = serde_json::from_str(line).ok()?;
                 let role = v.get("role")?.as_str()?;
                 let content = v.get("content")?.as_str().unwrap_or("");
-                let timestamp =
-                    v.get("timestamp").and_then(|t| t.as_str()).unwrap_or("");
+                let timestamp = v.get("timestamp").and_then(|t| t.as_str()).unwrap_or("");
                 let media: Vec<String> = v
                     .get("media")
                     .and_then(|m| m.as_array())
@@ -684,8 +702,14 @@ async fn handle_session_messages(
             content: m.content.clone(),
             timestamp: m.timestamp.to_rfc3339(),
             media: m.media.clone(),
-            tool_calls: m.tool_calls.as_ref()
-                .map(|tcs| tcs.iter().filter_map(|tc| serde_json::to_value(tc).ok()).collect())
+            tool_calls: m
+                .tool_calls
+                .as_ref()
+                .map(|tcs| {
+                    tcs.iter()
+                        .filter_map(|tc| serde_json::to_value(tc).ok())
+                        .collect()
+                })
                 .unwrap_or_default(),
         })
         .collect();

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -2925,8 +2925,9 @@ pub async fn create_tenant(
     // Validate tenant name (must match TenantStore rules: lowercase alnum + hyphens,
     // no leading/trailing hyphens, max 64 chars)
     use std::sync::LazyLock;
-    static TENANT_NAME_RE: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$|^[a-z0-9]$").unwrap());
+    static TENANT_NAME_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$|^[a-z0-9]$").unwrap()
+    });
     if !TENANT_NAME_RE.is_match(&req.name) {
         return Err((StatusCode::BAD_REQUEST, "Tenant name must be 1-64 lowercase alphanumeric characters or hyphens, cannot start or end with a hyphen".to_string()));
     }
@@ -3103,8 +3104,9 @@ pub async fn register_tenant(
     // Validate tenant name (must match TenantStore rules: lowercase alnum + hyphens,
     // no leading/trailing hyphens, max 64 chars)
     use std::sync::LazyLock;
-    static TENANT_NAME_RE: LazyLock<regex::Regex> =
-        LazyLock::new(|| regex::Regex::new(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$|^[a-z0-9]$").unwrap());
+    static TENANT_NAME_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$|^[a-z0-9]$").unwrap()
+    });
     if !TENANT_NAME_RE.is_match(&req.name) {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -3118,7 +3120,9 @@ pub async fn register_tenant(
     ))?;
 
     // Resolve user's email for legacy tenant matching
-    let user_email = state.user_store.as_ref()
+    let user_email = state
+        .user_store
+        .as_ref()
         .and_then(|us| us.get(&user_id).ok().flatten())
         .map(|u| u.email)
         .unwrap_or_default();
@@ -3188,8 +3192,13 @@ pub async fn register_tenant(
     if !user_email.is_empty() {
         if let Some(auth_manager) = state.auth_manager.as_ref() {
             let (subject, html) = build_register_setup_email(&tenant, domain, server);
-            match auth_manager.send_html_email(&user_email, &subject, &html).await {
-                Ok(true) => { email_sent = true; }
+            match auth_manager
+                .send_html_email(&user_email, &subject, &html)
+                .await
+            {
+                Ok(true) => {
+                    email_sent = true;
+                }
                 Ok(false) => { /* SMTP not configured — skip silently */ }
                 Err(e) => {
                     tracing::warn!(
@@ -3264,7 +3273,9 @@ pub async fn register_setup_script(
     ))?;
 
     // Resolve user's email for legacy tenant matching
-    let user_email = state.user_store.as_ref()
+    let user_email = state
+        .user_store
+        .as_ref()
         .and_then(|us| us.get(&user_id).ok().flatten())
         .map(|u| u.email)
         .unwrap_or_default();
@@ -3369,8 +3380,14 @@ fn build_register_setup_email(
     server: &str,
 ) -> (String, String) {
     let unix_command = html_escape(&build_register_setup_command_unix(tenant, domain, server));
-    let windows_command = html_escape(&build_register_setup_command_windows(tenant, domain, server));
-    let public_url = format!("https://{}.{}", html_escape(&tenant.subdomain), html_escape(domain));
+    let windows_command = html_escape(&build_register_setup_command_windows(
+        tenant, domain, server,
+    ));
+    let public_url = format!(
+        "https://{}.{}",
+        html_escape(&tenant.subdomain),
+        html_escape(domain)
+    );
     let subject = format!("octos setup for {}", tenant.subdomain);
     let html = format!(
         r#"<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 720px; margin: 0 auto; padding: 32px 20px;">
@@ -3451,7 +3468,8 @@ mod register_setup_script_tests {
             updated_at: Utc::now(),
         };
 
-        let (_subject, html) = build_register_setup_email(&tenant, "octos-cloud.org", "163.192.33.32");
+        let (_subject, html) =
+            build_register_setup_email(&tenant, "octos-cloud.org", "163.192.33.32");
 
         assert!(html.contains("install.sh"));
         assert!(html.contains("--tunnel"));
@@ -3465,10 +3483,10 @@ mod register_setup_script_tests {
 #[cfg(test)]
 mod register_tenant_email_tests {
     use super::*;
+    use crate::api::router::AuthIdentity;
     use crate::api::{AppState, SseBroadcaster};
     use crate::config::DeploymentMode;
     use crate::otp::{AuthManager, DashboardAuthConfig, SmtpConfig};
-    use crate::api::router::AuthIdentity;
     use crate::user_store::{User, UserRole, UserStore};
     use std::sync::Arc;
 
@@ -3493,7 +3511,9 @@ mod register_tenant_email_tests {
             watchdog_enabled: None,
             alerts_enabled: None,
             sysinfo: tokio::sync::Mutex::new(sysinfo::System::new()),
-            tenant_store: Some(Arc::new(crate::tenant::TenantStore::open(dir.path()).unwrap())),
+            tenant_store: Some(Arc::new(
+                crate::tenant::TenantStore::open(dir.path()).unwrap(),
+            )),
             tunnel_domain: Some("octos-cloud.org".into()),
             frps_server: Some("163.192.33.32".into()),
             frps_port: Some(7000),

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -489,10 +489,10 @@ pub async fn my_content(
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     axum::extract::Query(query): axum::extract::Query<crate::content_catalog::ContentQuery>,
 ) -> Result<Json<crate::content_catalog::ContentQueryResult>, (StatusCode, String)> {
-    let ps = state.profile_store.as_ref().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "not configured".into(),
-    ))?;
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or((StatusCode::SERVICE_UNAVAILABLE, "not configured".into()))?;
     let mgr = state.content_catalog_mgr.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
@@ -500,7 +500,12 @@ pub async fn my_content(
     // Use X-Profile-Id header (from Caddy proxy) if available, otherwise resolve from identity
     let profile = if let Some(pid) = headers.get("x-profile-id").and_then(|v| v.to_str().ok()) {
         ps.get(pid)
-            .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "profile store error".into()))?
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "profile store error".into(),
+                )
+            })?
             .ok_or((StatusCode::NOT_FOUND, format!("profile '{pid}' not found")))?
     } else {
         resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?
@@ -540,20 +545,13 @@ pub async fn my_content_thumbnail(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let cat = catalog.read().await;
     let entry = cat.get(&id).ok_or(StatusCode::NOT_FOUND)?;
-    let thumb_path = entry
-        .thumbnail_path
-        .as_ref()
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let thumb_path = entry.thumbnail_path.as_ref().ok_or(StatusCode::NOT_FOUND)?;
 
     let data = tokio::fs::read(thumb_path)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
-    Ok((
-        [(header::CONTENT_TYPE, "image/jpeg")],
-        Body::from(data),
-    )
-        .into_response())
+    Ok(([(header::CONTENT_TYPE, "image/jpeg")], Body::from(data)).into_response())
 }
 
 /// GET /api/my/content/:id/body
@@ -603,11 +601,7 @@ pub async fn my_content_body(
         _ => "application/octet-stream",
     };
 
-    Ok((
-        [(header::CONTENT_TYPE, content_type)],
-        Body::from(data),
-    )
-        .into_response())
+    Ok(([(header::CONTENT_TYPE, content_type)], Body::from(data)).into_response())
 }
 
 /// DELETE /api/my/content/:id
@@ -616,16 +610,15 @@ pub async fn delete_my_content(
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(id): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
-    let ps = state.profile_store.as_ref().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "not configured".into(),
-    ))?;
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or((StatusCode::SERVICE_UNAVAILABLE, "not configured".into()))?;
     let mgr = state.content_catalog_mgr.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
     ))?;
-    let profile =
-        resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let profile = resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
 
     let catalog = mgr
         .get_catalog(&profile.id)
@@ -657,16 +650,15 @@ pub async fn bulk_delete_my_content(
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Json(req): Json<BulkDeleteRequest>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
-    let ps = state.profile_store.as_ref().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "not configured".into(),
-    ))?;
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or((StatusCode::SERVICE_UNAVAILABLE, "not configured".into()))?;
     let mgr = state.content_catalog_mgr.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
     ))?;
-    let profile =
-        resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let profile = resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
 
     let catalog = mgr
         .get_catalog(&profile.id)

--- a/crates/octos-cli/src/api/frps_plugin.rs
+++ b/crates/octos-cli/src/api/frps_plugin.rs
@@ -150,14 +150,13 @@ pub async fn frps_auth(
         }
 
         "NewProxy" => {
-            let content: NewProxyContent =
-                serde_json::from_value(req.content).map_err(|e| {
-                    tracing::warn!(error = %e, "frps NewProxy: invalid request content");
-                    (
-                        StatusCode::BAD_REQUEST,
-                        Json(PluginResponse::deny("invalid proxy content")),
-                    )
-                })?;
+            let content: NewProxyContent = serde_json::from_value(req.content).map_err(|e| {
+                tracing::warn!(error = %e, "frps NewProxy: invalid request content");
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(PluginResponse::deny("invalid proxy content")),
+                )
+            })?;
 
             // Look up the tenant by the token used during login
             let tenant = match store.find_by_tunnel_token(&content.privilege_key) {

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -389,30 +389,30 @@ pub async fn session_messages(
 
     // Try standalone store first (skip for source=full — gateway has the merge logic)
     if !use_full {
-    if let Some(sessions) = &state.sessions {
-        let fetch_count = match offset.checked_add(limit) {
-            Some(n) => n,
-            None => return (StatusCode::BAD_REQUEST, "invalid pagination").into_response(),
-        };
-        let key = SessionKey::new("api", &id);
-        let mut sess = sessions.lock().await;
-        let session = sess.get_or_create(&key).await;
-        let messages: Vec<MessageInfo> = session
-            .get_history(fetch_count)
-            .iter()
-            .skip(offset)
-            .take(limit)
-            .map(|m| MessageInfo {
-                role: m.role.to_string(),
-                content: m.content.clone(),
-                timestamp: m.timestamp.to_rfc3339(),
-            })
-            .collect();
-        if !messages.is_empty() {
-            return Json(messages).into_response();
+        if let Some(sessions) = &state.sessions {
+            let fetch_count = match offset.checked_add(limit) {
+                Some(n) => n,
+                None => return (StatusCode::BAD_REQUEST, "invalid pagination").into_response(),
+            };
+            let key = SessionKey::new("api", &id);
+            let mut sess = sessions.lock().await;
+            let session = sess.get_or_create(&key).await;
+            let messages: Vec<MessageInfo> = session
+                .get_history(fetch_count)
+                .iter()
+                .skip(offset)
+                .take(limit)
+                .map(|m| MessageInfo {
+                    role: m.role.to_string(),
+                    content: m.content.clone(),
+                    timestamp: m.timestamp.to_rfc3339(),
+                })
+                .collect();
+            if !messages.is_empty() {
+                return Json(messages).into_response();
+            }
+            // Fall through to gateway for old sessions
         }
-        // Fall through to gateway for old sessions
-    }
     } // !use_full
 
     // Proxy to gateway (old sessions live there)
@@ -693,8 +693,14 @@ pub async fn list_content_files(
         return (StatusCode::SERVICE_UNAVAILABLE, "no gateway").into_response();
     };
 
-    let dirs_param = params.get("dirs").cloned().unwrap_or_else(|| "research,slides,skill-output".to_string());
-    let mut scan_dirs: Vec<String> = dirs_param.split(',').map(|s| s.trim().to_string()).collect();
+    let dirs_param = params
+        .get("dirs")
+        .cloned()
+        .unwrap_or_else(|| "research,slides,skill-output".to_string());
+    let mut scan_dirs: Vec<String> = dirs_param
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect();
 
     // Scan per-user workspace directories that match the requested dirs.
     // Only use original relative dir names — absolute paths from prior
@@ -704,9 +710,13 @@ pub async fn list_content_files(
     if let Ok(entries) = std::fs::read_dir(&users_dir) {
         for entry in entries.flatten() {
             let ws = entry.path().join("workspace");
-            if !ws.exists() { continue; }
+            if !ws.exists() {
+                continue;
+            }
             for dir_name in &requested_dirs {
-                if std::path::Path::new(dir_name.as_str()).is_absolute() { continue; }
+                if std::path::Path::new(dir_name.as_str()).is_absolute() {
+                    continue;
+                }
                 let ws_dir = ws.join(dir_name);
                 if ws_dir.exists() && ws_dir.is_dir() {
                     scan_dirs.push(ws_dir.to_string_lossy().to_string());
@@ -730,24 +740,47 @@ pub async fn list_content_files(
     fn is_output_file(filename: &str) -> bool {
         let lower = filename.to_lowercase();
         // Skip hidden files
-        if lower.starts_with('.') { return false; }
+        if lower.starts_with('.') {
+            return false;
+        }
         // Skip research intermediate files
-        if lower.starts_with('_') { return false; } // _report.md, _search_results.md, _sources.json
+        if lower.starts_with('_') {
+            return false;
+        } // _report.md, _search_results.md, _sources.json
         // Skip intermediates
-        if lower.starts_with("panel-") { return false; }
-        if lower.contains("-ref.") { return false; } // mofa reference images
+        if lower.starts_with("panel-") {
+            return false;
+        }
+        if lower.contains("-ref.") {
+            return false;
+        } // mofa reference images
         // Only keep meaningful output extensions
         matches!(
             lower.rsplit('.').next().unwrap_or(""),
-            "md" | "txt" | "pptx" | "pdf" | "docx" | "xlsx" | "png" | "jpg" | "mp3" | "wav" | "mp4" | "js" | "json"
+            "md" | "txt"
+                | "pptx"
+                | "pdf"
+                | "docx"
+                | "xlsx"
+                | "png"
+                | "jpg"
+                | "mp3"
+                | "wav"
+                | "mp4"
+                | "js"
+                | "json"
         )
     }
 
     fn modified_rfc3339(meta: &std::fs::Metadata) -> String {
-        meta.modified().ok()
+        meta.modified()
+            .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-            .map(|d| chrono::DateTime::from_timestamp(d.as_secs() as i64, 0)
-                .map(|dt| dt.to_rfc3339()).unwrap_or_default())
+            .map(|d| {
+                chrono::DateTime::from_timestamp(d.as_secs() as i64, 0)
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_default()
+            })
             .unwrap_or_default()
     }
 
@@ -758,19 +791,30 @@ pub async fn list_content_files(
         } else {
             data_dir.join(dir_name.as_str())
         };
-        if !dir_path.exists() { continue; }
+        if !dir_path.exists() {
+            continue;
+        }
         if let Ok(entries) = std::fs::read_dir(&dir_path) {
             for entry in entries.flatten() {
                 let path = entry.path();
                 let display_dir = if std::path::Path::new(dir_name.as_str()).is_absolute() {
                     // For workspace paths, show "workspace/research"
                     let p = std::path::Path::new(dir_name.as_str());
-                    let parts: Vec<&str> = p.components().rev().take(2).map(|c| c.as_os_str().to_str().unwrap_or("")).collect();
+                    let parts: Vec<&str> = p
+                        .components()
+                        .rev()
+                        .take(2)
+                        .map(|c| c.as_os_str().to_str().unwrap_or(""))
+                        .collect();
                     parts.into_iter().rev().collect::<Vec<_>>().join("/")
                 } else {
                     dir_name.to_string()
                 };
-                let group_name = format!("{}/{}", display_dir, path.file_name().unwrap_or_default().to_string_lossy());
+                let group_name = format!(
+                    "{}/{}",
+                    display_dir,
+                    path.file_name().unwrap_or_default().to_string_lossy()
+                );
                 if path.is_dir() {
                     // For skill-output and slides: scan subdirs for final outputs
                     // For research: skip subdirs (they contain intermediate search results)
@@ -789,8 +833,14 @@ pub async fn list_content_files(
                                 for sub in sub_entries.flatten() {
                                     let sp = sub.path();
                                     if sp.is_file() {
-                                        let filename = sp.file_name().unwrap_or_default().to_string_lossy().to_string();
-                                        if !is_output_file(&filename) { continue; }
+                                        let filename = sp
+                                            .file_name()
+                                            .unwrap_or_default()
+                                            .to_string_lossy()
+                                            .to_string();
+                                        if !is_output_file(&filename) {
+                                            continue;
+                                        }
                                         if let Ok(meta) = sp.metadata() {
                                             files.push(ContentFile {
                                                 category: categorize(&filename),
@@ -807,8 +857,14 @@ pub async fn list_content_files(
                         }
                     }
                 } else if path.is_file() {
-                    let filename = path.file_name().unwrap_or_default().to_string_lossy().to_string();
-                    if !is_output_file(&filename) { continue; }
+                    let filename = path
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string();
+                    if !is_output_file(&filename) {
+                        continue;
+                    }
                     if let Ok(meta) = path.metadata() {
                         files.push(ContentFile {
                             category: categorize(&filename),
@@ -832,12 +888,23 @@ pub async fn list_content_files(
 
 fn categorize(filename: &str) -> String {
     let lower = filename.to_lowercase();
-    if lower.ends_with(".md") || lower.ends_with(".txt") { "report".into() }
-    else if lower.ends_with(".pptx") || lower.ends_with(".pdf") { "slides".into() }
-    else if lower.ends_with(".png") || lower.ends_with(".jpg") || lower.ends_with(".jpeg") || lower.ends_with(".webp") { "image".into() }
-    else if lower.ends_with(".mp3") || lower.ends_with(".wav") || lower.ends_with(".ogg") { "audio".into() }
-    else if lower.ends_with(".mp4") || lower.ends_with(".webm") { "video".into() }
-    else { "other".into() }
+    if lower.ends_with(".md") || lower.ends_with(".txt") {
+        "report".into()
+    } else if lower.ends_with(".pptx") || lower.ends_with(".pdf") {
+        "slides".into()
+    } else if lower.ends_with(".png")
+        || lower.ends_with(".jpg")
+        || lower.ends_with(".jpeg")
+        || lower.ends_with(".webp")
+    {
+        "image".into()
+    } else if lower.ends_with(".mp3") || lower.ends_with(".wav") || lower.ends_with(".ogg") {
+        "audio".into()
+    } else if lower.ends_with(".mp4") || lower.ends_with(".webm") {
+        "video".into()
+    } else {
+        "other".into()
+    }
 }
 
 /// GET /api/status -- server status.

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -380,8 +380,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/health", get(handlers::health));
 
     // Internal endpoint for frps server plugin (no auth — called by frps on localhost)
-    let internal_routes = Router::new()
-        .route("/api/internal/frps-auth", post(frps_plugin::frps_auth));
+    let internal_routes =
+        Router::new().route("/api/internal/frps-auth", post(frps_plugin::frps_auth));
 
     // Unauthenticated routes (static files + auth endpoints + webhook proxy + internal)
     let public = Router::new()

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1061,8 +1061,14 @@ impl GatewayRuntime {
             plugin_dirs: plugin_dirs_for_spawn.clone(),
             plugin_extra_env: plugin_env.clone(),
             llm_strong: super::profile_factory::build_strong_chain(
-                &config, &config.provider.clone().unwrap_or_else(|| "anthropic".to_string()), false,
-            ).unwrap_or_else(|_| llm_for_compaction.clone()),
+                &config,
+                &config
+                    .provider
+                    .clone()
+                    .unwrap_or_else(|| "anthropic".to_string()),
+                false,
+            )
+            .unwrap_or_else(|_| llm_for_compaction.clone()),
         };
         let profile_factory_builder =
             profile_store
@@ -1483,14 +1489,17 @@ impl GatewayRuntime {
                 // For API channel: send a completion signal so the SSE stream closes
                 // and the web client's assistant message transitions from "streaming" to "complete".
                 if reply_channel == "api" {
-                    let _ = self.agent_handle.send_outbound(octos_core::OutboundMessage {
-                        channel: reply_channel.clone(),
-                        chat_id: reply_chat_id.clone(),
-                        content: String::new(),
-                        reply_to: None,
-                        media: vec![],
-                        metadata: serde_json::json!({"_completion": true}),
-                    }).await;
+                    let _ = self
+                        .agent_handle
+                        .send_outbound(octos_core::OutboundMessage {
+                            channel: reply_channel.clone(),
+                            chat_id: reply_chat_id.clone(),
+                            content: String::new(),
+                            reply_to: None,
+                            media: vec![],
+                            metadata: serde_json::json!({"_completion": true}),
+                        })
+                        .await;
                 }
                 continue;
             }

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -30,7 +30,12 @@ use crate::session_actor::{
 
 /// Provider + model name + optional adaptive router, returned by [`build_llm_stack`].
 /// (full LLM, provider name, adaptive router, strong-only LLM for slides)
-pub(crate) type LlmStack = (Arc<dyn LlmProvider>, String, Option<Arc<AdaptiveRouter>>, Arc<dyn LlmProvider>);
+pub(crate) type LlmStack = (
+    Arc<dyn LlmProvider>,
+    String,
+    Option<Arc<AdaptiveRouter>>,
+    Arc<dyn LlmProvider>,
+);
 
 pub(crate) fn build_llm_stack(config: &Config, no_retry: bool) -> Result<LlmStack> {
     let model = config.model.clone();
@@ -133,8 +138,7 @@ pub(crate) fn build_strong_chain(
     if strong_fallbacks.is_empty() || no_retry {
         return Ok(Arc::new(RetryProvider::new(primary)));
     }
-    let mut providers: Vec<Arc<dyn LlmProvider>> =
-        vec![Arc::new(RetryProvider::new(primary))];
+    let mut providers: Vec<Arc<dyn LlmProvider>> = vec![Arc::new(RetryProvider::new(primary))];
     for fallback in strong_fallbacks {
         let fallback_config = if fallback.api_key_env.is_some() {
             let mut cloned = config.clone();

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -85,8 +85,7 @@ impl ServeCommand {
             // 2. $OCTOS_HOME/config.json or ~/.octos/config.json (data dir)
             // 3. Legacy platform config dir (~/Library/Application Support/octos/ etc.)
             let local_config = cwd.join(".octos").join("config.json");
-            let legacy_config = dirs::config_dir()
-                .map(|d| d.join("octos").join("config.json"));
+            let legacy_config = dirs::config_dir().map(|d| d.join("octos").join("config.json"));
             if local_config.exists() {
                 tracing::info!(path = %local_config.display(), "loading config (project-local)");
                 (Config::from_file(&local_config)?, Some(local_config))
@@ -275,9 +274,13 @@ impl ServeCommand {
             tenant_store: crate::tenant::TenantStore::open(&data_dir)
                 .ok()
                 .map(Arc::new),
-            tunnel_domain: config.tunnel_domain.clone()
+            tunnel_domain: config
+                .tunnel_domain
+                .clone()
                 .or_else(|| std::env::var("TUNNEL_DOMAIN").ok()),
-            frps_server: config.frps_server.clone()
+            frps_server: config
+                .frps_server
+                .clone()
                 .or_else(|| std::env::var("FRPS_SERVER").ok()),
             frps_port: std::env::var("FRPS_PORT").ok().and_then(|p| p.parse().ok()),
             deployment_mode: config.mode.clone(),

--- a/crates/octos-cli/src/content_catalog.rs
+++ b/crates/octos-cli/src/content_catalog.rs
@@ -24,7 +24,7 @@ const SKIP_DIRS: &[&str] = &[
     "memory",
     "skills",
     "history",
-    "users",       // per-user dirs scanned separately via workspace/ path
+    "users", // per-user dirs scanned separately via workspace/ path
     "logs",
     ".thumbnails",
     "whatsapp-auth",
@@ -275,11 +275,7 @@ impl ContentCatalog {
     }
 
     /// Recursive directory walker that skips internal dirs.
-    fn walk_dir(
-        dir: &Path,
-        known: &HashSet<String>,
-        cb: &mut impl FnMut(&Path),
-    ) -> io::Result<()> {
+    fn walk_dir(dir: &Path, known: &HashSet<String>, cb: &mut impl FnMut(&Path)) -> io::Result<()> {
         let entries = match std::fs::read_dir(dir) {
             Ok(e) => e,
             Err(_) => return Ok(()),
@@ -340,7 +336,9 @@ impl ContentCatalog {
         // Sort.
         match q.sort.as_str() {
             "oldest" => filtered.sort_by(|a, b| a.created_at.cmp(&b.created_at)),
-            "name" => filtered.sort_by(|a, b| a.filename.to_lowercase().cmp(&b.filename.to_lowercase())),
+            "name" => {
+                filtered.sort_by(|a, b| a.filename.to_lowercase().cmp(&b.filename.to_lowercase()))
+            }
             "size" => filtered.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes)),
             _ => filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at)), // newest
         }
@@ -423,9 +421,9 @@ impl ContentCatalog {
         let img = image::open(path)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("image open: {e}")))?;
         let thumb = img.thumbnail(THUMBNAIL_MAX_WIDTH, THUMBNAIL_MAX_WIDTH);
-        thumb.save(&thumb_path).map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, format!("thumbnail save: {e}"))
-        })?;
+        thumb
+            .save(&thumb_path)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("thumbnail save: {e}")))?;
 
         Ok(thumb_path.to_string_lossy().to_string())
     }
@@ -457,10 +455,7 @@ impl ContentCatalogManager {
     }
 
     /// Get or create a catalog for a profile, identified by profile ID.
-    pub async fn get_catalog(
-        &self,
-        profile_id: &str,
-    ) -> io::Result<Arc<RwLock<ContentCatalog>>> {
+    pub async fn get_catalog(&self, profile_id: &str) -> io::Result<Arc<RwLock<ContentCatalog>>> {
         let mut map = self.catalogs.lock().await;
         if let Some(cat) = map.get(profile_id) {
             return Ok(Arc::clone(cat));
@@ -509,12 +504,30 @@ mod tests {
 
     #[test]
     fn should_categorize_extensions() {
-        assert_eq!(ContentCategory::from_extension("md"), ContentCategory::Report);
-        assert_eq!(ContentCategory::from_extension("MP3"), ContentCategory::Audio);
-        assert_eq!(ContentCategory::from_extension("pptx"), ContentCategory::Slides);
-        assert_eq!(ContentCategory::from_extension("png"), ContentCategory::Image);
-        assert_eq!(ContentCategory::from_extension("mp4"), ContentCategory::Video);
-        assert_eq!(ContentCategory::from_extension("xyz"), ContentCategory::Other);
+        assert_eq!(
+            ContentCategory::from_extension("md"),
+            ContentCategory::Report
+        );
+        assert_eq!(
+            ContentCategory::from_extension("MP3"),
+            ContentCategory::Audio
+        );
+        assert_eq!(
+            ContentCategory::from_extension("pptx"),
+            ContentCategory::Slides
+        );
+        assert_eq!(
+            ContentCategory::from_extension("png"),
+            ContentCategory::Image
+        );
+        assert_eq!(
+            ContentCategory::from_extension("mp4"),
+            ContentCategory::Video
+        );
+        assert_eq!(
+            ContentCategory::from_extension("xyz"),
+            ContentCategory::Other
+        );
     }
 
     #[test]
@@ -532,7 +545,12 @@ mod tests {
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
         let id = cat
-            .index_file(&test_file, Some("session-1"), Some("write_file"), Some("A test report"))
+            .index_file(
+                &test_file,
+                Some("session-1"),
+                Some("write_file"),
+                Some("A test report"),
+            )
             .unwrap()
             .unwrap();
 
@@ -552,8 +570,16 @@ mod tests {
         std::fs::write(&test_file, "hello").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        assert!(cat.index_file(&test_file, None, None, None).unwrap().is_some());
-        assert!(cat.index_file(&test_file, None, None, None).unwrap().is_none());
+        assert!(
+            cat.index_file(&test_file, None, None, None)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            cat.index_file(&test_file, None, None, None)
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(cat.len(), 1);
     }
 
@@ -564,8 +590,10 @@ mod tests {
         std::fs::write(tmp.path().join("b.png"), "image").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        cat.index_file(&tmp.path().join("a.md"), None, None, None).unwrap();
-        cat.index_file(&tmp.path().join("b.png"), None, None, None).unwrap();
+        cat.index_file(&tmp.path().join("a.md"), None, None, None)
+            .unwrap();
+        cat.index_file(&tmp.path().join("b.png"), None, None, None)
+            .unwrap();
 
         let result = cat.query(&ContentQuery {
             category: Some("report".into()),
@@ -582,8 +610,10 @@ mod tests {
         std::fs::write(tmp.path().join("daily-log.md"), "d").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        cat.index_file(&tmp.path().join("weekly-report.md"), None, None, None).unwrap();
-        cat.index_file(&tmp.path().join("daily-log.md"), None, None, None).unwrap();
+        cat.index_file(&tmp.path().join("weekly-report.md"), None, None, None)
+            .unwrap();
+        cat.index_file(&tmp.path().join("daily-log.md"), None, None, None)
+            .unwrap();
 
         let result = cat.query(&ContentQuery {
             search: Some("weekly".into()),
@@ -600,7 +630,10 @@ mod tests {
         std::fs::write(&test_file, "bye").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        let id = cat.index_file(&test_file, None, None, None).unwrap().unwrap();
+        let id = cat
+            .index_file(&test_file, None, None, None)
+            .unwrap()
+            .unwrap();
 
         assert!(test_file.exists());
         assert!(cat.delete(&id).unwrap());
@@ -616,9 +649,18 @@ mod tests {
         std::fs::write(tmp.path().join("c.txt"), "c").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        let id_a = cat.index_file(&tmp.path().join("a.txt"), None, None, None).unwrap().unwrap();
-        let _id_b = cat.index_file(&tmp.path().join("b.txt"), None, None, None).unwrap().unwrap();
-        let id_c = cat.index_file(&tmp.path().join("c.txt"), None, None, None).unwrap().unwrap();
+        let id_a = cat
+            .index_file(&tmp.path().join("a.txt"), None, None, None)
+            .unwrap()
+            .unwrap();
+        let _id_b = cat
+            .index_file(&tmp.path().join("b.txt"), None, None, None)
+            .unwrap()
+            .unwrap();
+        let id_c = cat
+            .index_file(&tmp.path().join("c.txt"), None, None, None)
+            .unwrap()
+            .unwrap();
 
         let deleted = cat.bulk_delete(&[id_a, id_c]).unwrap();
         assert_eq!(deleted, 2);
@@ -666,8 +708,10 @@ mod tests {
         std::fs::write(tmp.path().join("alpha.txt"), "a").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        cat.index_file(&tmp.path().join("zebra.txt"), None, None, None).unwrap();
-        cat.index_file(&tmp.path().join("alpha.txt"), None, None, None).unwrap();
+        cat.index_file(&tmp.path().join("zebra.txt"), None, None, None)
+            .unwrap();
+        cat.index_file(&tmp.path().join("alpha.txt"), None, None, None)
+            .unwrap();
 
         let result = cat.query(&ContentQuery {
             sort: "name".into(),

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -9,9 +9,9 @@ pub mod auth;
 mod commands;
 pub mod compaction;
 pub mod config;
+pub mod config_watcher;
 #[cfg(feature = "api")]
 pub mod content_catalog;
-pub mod config_watcher;
 pub mod cron_tool;
 pub mod gateway_dispatcher;
 #[cfg(feature = "api")]

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -429,8 +429,14 @@ impl AuthManager {
             })?;
 
         let email_msg = Message::builder()
-            .from(smtp.from_address.parse().map_err(|e| eyre::eyre!("invalid from address: {e}"))?)
-            .to(email.parse().map_err(|e| eyre::eyre!("invalid to address: {e}"))?)
+            .from(
+                smtp.from_address
+                    .parse()
+                    .map_err(|e| eyre::eyre!("invalid from address: {e}"))?,
+            )
+            .to(email
+                .parse()
+                .map_err(|e| eyre::eyre!("invalid to address: {e}"))?)
             .subject(subject)
             .header(ContentType::TEXT_HTML)
             .body(html.to_string())

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -649,7 +649,11 @@ impl ActorFactory {
             // which is unreachable from the sandboxed workspace.
             let topic = session_key.topic().unwrap_or("slides");
             let project_name = topic.strip_prefix("slides").unwrap_or("").trim();
-            let project_name = if project_name.is_empty() { "untitled" } else { project_name };
+            let project_name = if project_name.is_empty() {
+                "untitled"
+            } else {
+                project_name
+            };
             crate::project_templates::scaffold_slides_project(&user_workspace, project_name);
 
             // Copy built-in style templates into workspace/styles/ so the
@@ -1132,8 +1136,9 @@ impl SessionActor {
                      /status — show agent status\n\
                      /adaptive — view adaptive routing\n\
                      /reset — reset session state\n\
-                     /help — show this help"
-                ).await;
+                     /help — show this help",
+                )
+                .await;
                 true
             }
         }

--- a/crates/octos-cli/src/tenant.rs
+++ b/crates/octos-cli/src/tenant.rs
@@ -331,12 +331,7 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
-        let config = render_frpc_config(
-            &tenant,
-            "163.192.33.32",
-            7000,
-            "octos-cloud.org",
-        );
+        let config = render_frpc_config(&tenant, "163.192.33.32", 7000, "octos-cloud.org");
         assert!(config.contains("serverAddr = \"163.192.33.32\""));
         assert!(config.contains("serverPort = 7000"));
         // Uses the per-tenant tunnel_token for auth

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -762,13 +762,17 @@ impl AdaptiveRouter {
                     },
                     context_window: {
                         let v = s.context_window.load(Ordering::Relaxed);
-                        if v > 0 { v } else {
+                        if v > 0 {
+                            v
+                        } else {
                             crate::context::context_window_tokens(s.provider.model_id()) as u64
                         }
                     },
                     max_output: {
                         let v = s.max_output.load(Ordering::Relaxed);
-                        if v > 0 { v } else {
+                        if v > 0 {
+                            v
+                        } else {
                             crate::context::max_output_tokens(s.provider.model_id()) as u64
                         }
                     },
@@ -907,13 +911,19 @@ impl AdaptiveRouter {
         } else {
             0.5 // no data → neutral
         };
-        let live_err_rate = if total > 0 { slot.metrics.error_rate() } else { 0.5 };
+        let live_err_rate = if total > 0 {
+            slot.metrics.error_rate()
+        } else {
+            0.5
+        };
         let blended_err = baseline_err * (1.0 - weight) + live_err_rate * weight;
 
         // ── Quality ──
         // No data = neutral (0.5). Cost is the differentiator, not unobserved quality.
         let ds = slot.ds_output.load(Ordering::Relaxed) as f64;
-        let max_ds = self.slots.iter()
+        let max_ds = self
+            .slots
+            .iter()
             .map(|s| s.ds_output.load(Ordering::Relaxed) as f64)
             .fold(0.0_f64, f64::max);
         let norm_quality = if max_ds > 0.0 && ds > 0.0 {
@@ -924,7 +934,9 @@ impl AdaptiveRouter {
 
         // ── Throughput ──
         let throughput = slot.metrics.throughput();
-        let max_throughput = self.slots.iter()
+        let max_throughput = self
+            .slots
+            .iter()
             .map(|s| s.metrics.throughput())
             .fold(0.0_f64, f64::max);
         let norm_throughput = if max_throughput > 0.0 && throughput > 0.0 {


### PR DESCRIPTION
## Summary

Pure mechanical `cargo fmt --all` fixup. 15 files, 362 insertions / 182 deletions — every change produced by rustfmt, zero manual edits.

## Why

The `check` CI job runs `cargo fmt --all -- --check` against the whole workspace and has been failing on every open PR with 47+ violations. Local verification on `origin/main` with a clean working tree reproduces the same failures, so this is pre-existing debt on the base branch, not something any one PR introduced.

Files touched:

- `crates/octos-bus/src/api_channel.rs`
- `crates/octos-cli/src/api/{admin,auth_handlers,frps_plugin,handlers,router}.rs`
- `crates/octos-cli/src/commands/gateway/{gateway_runtime,profile_factory}.rs`
- `crates/octos-cli/src/commands/serve.rs`
- `crates/octos-cli/src/{content_catalog,main,otp,session_actor,tenant}.rs`
- `crates/octos-llm/src/adaptive.rs`

None of these files overlap with #298 (the openharness PR), so landing this first unblocks that PR's CI without creating a conflict.

## Test plan

- [x] `cargo fmt --all -- --check` exits 0
- [x] `cargo build --workspace` clean
- [ ] CI `check` job turns green (the point of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
