### PR TITLE
Port selective gateway auth and QoS runtime catalog fixes

### DIFF
--- a/.github/workflows/ci-self-hosted.yml
+++ b/.github/workflows/ci-self-hosted.yml
@@ -1,0 +1,98 @@
+name: CI (self-hosted)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to test"
+        required: false
+        default: "main"
+      include_arm:
+        description: "Run ARM64 self-hosted validation"
+        required: false
+        type: boolean
+        default: false
+      include_windows:
+        description: "Run Windows self-hosted validation"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  CARGO_TERM_COLOR: always
+  FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"
+
+jobs:
+  fast-linux:
+    name: fast-linux
+    runs-on: [self-hosted, linux, x64, octos-fast]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
+      - name: QoS adaptive/runtime catalog regressions
+        run: |
+          cargo test -p octos-llm test_qos_ranking_changes_lane_selection -- --nocapture
+          cargo test -p octos-llm test_derive_cold_start_catalog_assigns_non_zero_scores -- --nocapture
+          cargo test -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score -- --nocapture
+          cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
+
+  linux-arm:
+    name: linux-arm
+    if: ${{ inputs.include_arm }}
+    runs-on: [self-hosted, linux, arm64, octos-arm]
+    env:
+      CARGO_BUILD_JOBS: "2"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: self-hosted-arm64
+
+      - name: Build and test
+        run: |
+          cargo build --workspace
+          cargo build -p octos-cli --features ${{ env.FEATURES }}
+          cargo test --workspace --no-run
+          cargo test --workspace
+
+  windows:
+    name: windows
+    if: ${{ inputs.include_windows }}
+    runs-on: [self-hosted, windows, x64, octos-windows]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: self-hosted-windows
+
+      - name: Build and test
+        run: |
+          cargo build --workspace
+          cargo build -p octos-cli --features ${{ env.FEATURES }}
+          cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * *"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -81,6 +84,7 @@ jobs:
         run: cargo test -p octos-agent --test activate_tools_regression -- --nocapture
 
   check-arm:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04-arm
     env:
       CARGO_BUILD_JOBS: "2"  # Limit parallelism to avoid OOM on 16GB ARM runners
@@ -105,6 +109,7 @@ jobs:
         run: cargo test --workspace
 
   check-riscv:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04-riscv
     env:
       CARGO_BUILD_JOBS: "2"
@@ -129,6 +134,7 @@ jobs:
         run: cargo test --workspace
 
   check-windows:
+    if: github.event_name != 'pull_request'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -65,7 +67,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --prune --depth=1 origin "${{ github.base_ref }}"
+            merge_base="$(git merge-base HEAD "origin/${{ github.base_ref }}")"
+            changed_rs=()
+            while IFS= read -r -d '' file; do
+              changed_rs+=("$file")
+            done < <(git diff -z --name-only --diff-filter=ACMRT "$merge_base"...HEAD -- '*.rs')
+
+            if [ "${#changed_rs[@]}" -eq 0 ]; then
+              echo "No changed Rust files to format-check."
+              exit 0
+            fi
+
+            rustfmt --check --edition 2021 --config skip_children=true "${changed_rs[@]}"
+          else
+            cargo fmt --all -- --check
+          fi
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
+      - name: QoS adaptive/runtime catalog regressions
+        run: |
+          cargo test -p octos-llm test_qos_ranking_changes_lane_selection -- --nocapture
+          cargo test -p octos-llm test_derive_cold_start_catalog_assigns_non_zero_scores -- --nocapture
+          cargo test -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score -- --nocapture
+          cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
+
       - name: activate_tools regression tests
         run: cargo test -p octos-agent --test activate_tools_regression -- --nocapture
 

--- a/SELF_HOSTED_RUNNERS.txt
+++ b/SELF_HOSTED_RUNNERS.txt
@@ -1,0 +1,128 @@
+Self-Hosted Runners
+===================
+
+This repo now separates PR CI from slow platform matrix jobs:
+
+- PR fast lane:
+  - dashboard
+  - typos
+  - check
+- Slow platform matrix:
+  - check-arm
+  - check-riscv
+  - check-windows
+  - release artifact builds
+  - these run on push, schedule, or workflow_dispatch
+
+There is also a manual workflow:
+
+- .github/workflows/ci-self-hosted.yml
+
+It is meant for repo-owned machines such as Mini 3, ARM boxes, or Windows builders.
+
+Runner Labels
+-------------
+
+Use these labels exactly so the workflow can target the right machines:
+
+- Fast Linux x64 runner:
+  - self-hosted,linux,x64,octos-fast
+- Linux ARM64 runner:
+  - self-hosted,linux,arm64,octos-arm
+- Windows x64 runner:
+  - self-hosted,windows,x64,octos-windows
+
+Prerequisites
+-------------
+
+1. Install gh and authenticate with a token that can create runner registration tokens.
+2. Install build dependencies on the runner host:
+   - Rust toolchain
+   - git
+   - curl
+   - platform-native compiler toolchain
+3. For Linux/macOS, use:
+   - scripts/setup-github-runner.sh
+
+Fast Linux Runner Example
+-------------------------
+
+    cd /Users/yuechen/home/crew-rs-port
+
+    scripts/setup-github-runner.sh \
+      --name mini3-octos-fast \
+      --labels self-hosted,linux,x64,octos-fast
+
+Then launch it:
+
+    cd ~/.github-runners/mini3-octos-fast && ./run.sh
+
+If you want it as a Linux service:
+
+    cd /Users/yuechen/home/crew-rs-port
+
+    scripts/setup-github-runner.sh \
+      --name mini3-octos-fast \
+      --labels self-hosted,linux,x64,octos-fast \
+      --service
+
+ARM64 Runner Example
+--------------------
+
+    cd /Users/yuechen/home/crew-rs-port
+
+    scripts/setup-github-runner.sh \
+      --name arm-builder \
+      --labels self-hosted,linux,arm64,octos-arm \
+      --service
+
+Windows Runner Example
+----------------------
+
+Use a standard GitHub Actions runner installation on the Windows machine and register it with:
+
+- name:
+  - windows-builder
+- labels:
+  - self-hosted,windows,x64,octos-windows
+
+Typical manual flow in PowerShell:
+
+    $repo = "octos-org/octos"
+    $url = "https://github.com/$repo"
+    $token = gh api -X POST "repos/$repo/actions/runners/registration-token" --jq .token
+
+    mkdir C:\actions-runner
+    cd C:\actions-runner
+    curl.exe -L -o actions-runner-win-x64-2.328.0.zip https://github.com/actions/runner/releases/download/v2.328.0/actions-runner-win-x64-2.328.0.zip
+    tar -xf .\actions-runner-win-x64-2.328.0.zip
+    .\config.cmd --unattended --url $url --token $token --name windows-builder --labels self-hosted,windows,x64,octos-windows --replace
+    .\run.cmd
+
+Triggering The Workflow
+-----------------------
+
+From GitHub Actions UI:
+
+- workflow: CI (self-hosted)
+- inputs:
+  - ref
+  - include_arm
+  - include_windows
+
+From CLI:
+
+    gh workflow run "CI (self-hosted)" \
+      --repo octos-org/octos \
+      -f ref=main \
+      -f include_arm=true \
+      -f include_windows=false
+
+Recommended Rollout
+-------------------
+
+1. Register one Linux x64 runner first with octos-fast.
+2. Confirm CI (self-hosted) succeeds on the fast lane.
+3. Add ARM64 runner with octos-arm.
+4. Add Windows runner with octos-windows.
+5. Only after that, decide whether any self-hosted jobs should become required checks.

--- a/crates/app-skills/skill-evolve/src/main.rs
+++ b/crates/app-skills/skill-evolve/src/main.rs
@@ -135,11 +135,11 @@ fn run_hook() {
     }
 
     // Call LLM.
-    let suggestion = match generate_suggestion(&skill_name, &tool_name, &error_output, &skill_content)
-    {
-        Some(s) => s,
-        None => return,
-    };
+    let suggestion =
+        match generate_suggestion(&skill_name, &tool_name, &error_output, &skill_content) {
+            Some(s) => s,
+            None => return,
+        };
 
     // Persist patch.
     let patch = EvolutionPatch {
@@ -154,7 +154,10 @@ fn run_hook() {
     if store.patches.len() > MAX_PATCHES {
         store.patches.drain(0..store.patches.len() - MAX_PATCHES);
     }
-    let _ = fs::write(&store_path, serde_json::to_string_pretty(&store).unwrap_or_default());
+    let _ = fs::write(
+        &store_path,
+        serde_json::to_string_pretty(&store).unwrap_or_default(),
+    );
 }
 
 fn is_on_cooldown(store: &EvolutionStore) -> bool {
@@ -214,7 +217,11 @@ fn cmd_list(skills_dirs: &[PathBuf]) {
                 continue;
             }
             let skill_name = entry.file_name().to_string_lossy().to_string();
-            output.push_str(&format!("## {} ({} pending)\n", skill_name, store.patches.len()));
+            output.push_str(&format!(
+                "## {} ({} pending)\n",
+                skill_name,
+                store.patches.len()
+            ));
             for patch in &store.patches {
                 output.push_str(&format!(
                     "- [{}] tool `{}`: {}\n  Error: {}\n",
@@ -302,7 +309,10 @@ fn cmd_apply(skills_dirs: &[PathBuf], skill: &str) {
         &store_path,
         serde_json::to_string_pretty(&EvolutionStore::default()).unwrap_or_default(),
     );
-    print_result(true, &format!("Applied {count} patches to {skill}/SKILL.md"));
+    print_result(
+        true,
+        &format!("Applied {count} patches to {skill}/SKILL.md"),
+    );
 }
 
 fn cmd_discard(skills_dirs: &[PathBuf], skill: &str) {
@@ -542,21 +552,13 @@ fn resolve_llm_config() -> Option<(String, String, String)> {
             "https://api.deepseek.com/v1",
             "deepseek-chat",
         ),
-        (
-            "KIMI_API_KEY",
-            "https://api.moonshot.ai/v1",
-            "kimi-2.5",
-        ),
+        ("KIMI_API_KEY", "https://api.moonshot.ai/v1", "kimi-2.5"),
         (
             "DASHSCOPE_API_KEY",
             "https://dashscope.aliyuncs.com/compatible-mode/v1",
             "qwen-plus",
         ),
-        (
-            "OPENAI_API_KEY",
-            "https://api.openai.com/v1",
-            "gpt-4o-mini",
-        ),
+        ("OPENAI_API_KEY", "https://api.openai.com/v1", "gpt-4o-mini"),
         (
             "GEMINI_API_KEY",
             "https://generativelanguage.googleapis.com/v1beta/openai",
@@ -636,10 +638,7 @@ fn find_skill_for_tool(skills_dirs: &[PathBuf], tool_name: &str) -> Option<(Stri
             if let Some(tools) = manifest["tools"].as_array() {
                 for tool in tools {
                     if tool["name"].as_str() == Some(tool_name) {
-                        let name = manifest["name"]
-                            .as_str()
-                            .unwrap_or("unknown")
-                            .to_string();
+                        let name = manifest["name"].as_str().unwrap_or("unknown").to_string();
                         return Some((name, entry.path()));
                     }
                 }
@@ -682,7 +681,9 @@ fn split_learned_notes(content: &str) -> (&str, Vec<String>) {
         .lines()
         .filter_map(|line| {
             let trimmed = line.trim();
-            trimmed.strip_prefix("- ").map(|stripped| stripped.to_string())
+            trimmed
+                .strip_prefix("- ")
+                .map(|stripped| stripped.to_string())
         })
         .collect();
     (body, notes)
@@ -876,7 +877,10 @@ mod tests {
         ).unwrap();
 
         let result = find_skill_for_tool(&[dir.path().to_path_buf()], "skill_evolve");
-        assert!(result.is_none(), "should skip self to avoid evolution loops");
+        assert!(
+            result.is_none(),
+            "should skip self to avoid evolution loops"
+        );
     }
 
     #[test]

--- a/crates/app-skills/skill-evolve/src/main.rs
+++ b/crates/app-skills/skill-evolve/src/main.rs
@@ -682,11 +682,7 @@ fn split_learned_notes(content: &str) -> (&str, Vec<String>) {
         .lines()
         .filter_map(|line| {
             let trimmed = line.trim();
-            if trimmed.starts_with("- ") {
-                Some(trimmed[2..].to_string())
-            } else {
-                None
-            }
+            trimmed.strip_prefix("- ").map(|stripped| stripped.to_string())
         })
         .collect();
     (body, notes)

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -232,11 +232,9 @@ impl Agent {
                 }
                 StopReason::ToolUse => {
                     // Check for loop detection before executing
-                    let mut loop_detected = false;
                     for tc in &response.tool_calls {
                         if let Some(warning) = loop_detector.record(&tc.name, &tc.arguments) {
                             warn!("loop detected — breaking agent loop");
-                            loop_detected = true;
                             // Don't execute the tools — break out with a message
                             self.emit_cost_update(&total_usage, &response.usage);
                             let new_start = (1 + history.len()).min(messages.len());
@@ -250,16 +248,14 @@ impl Agent {
                             });
                         }
                     }
-                    if !loop_detected {
-                        self.handle_tool_use(
-                            &response,
-                            &mut messages,
-                            &mut files_modified,
-                            &mut total_usage,
-                            tracker,
-                        )
-                        .await?;
-                    }
+                    self.handle_tool_use(
+                        &response,
+                        &mut messages,
+                        &mut files_modified,
+                        &mut total_usage,
+                        tracker,
+                    )
+                    .await?;
                 }
                 StopReason::MaxTokens => {
                     self.emit_cost_update(&total_usage, &response.usage);

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 use octos_core::{Message, MessageRole, Task, TaskResult, TokenUsage};
 use octos_llm::{ChatConfig, ChatResponse, StopReason};
 use octos_memory::{Episode, EpisodeOutcome};
-use tracing::{info, info_span, warn, Instrument};
+use tracing::{Instrument, info, info_span, warn};
 
 use super::message_repair::{
     normalize_system_messages, normalize_tool_call_ids, repair_message_order, repair_tool_pairs,

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -8,7 +8,7 @@ use eyre::Result;
 use octos_core::{Message, MessageRole, Task, TaskResult, TokenUsage};
 use octos_llm::{ChatConfig, ChatResponse, StopReason};
 use octos_memory::{Episode, EpisodeOutcome};
-use tracing::{Instrument, info, info_span, warn};
+use tracing::{info, info_span, warn, Instrument};
 
 use super::message_repair::{
     normalize_system_messages, normalize_tool_call_ids, repair_message_order, repair_tool_pairs,

--- a/crates/octos-agent/src/tools/manage_skills.rs
+++ b/crates/octos-agent/src/tools/manage_skills.rs
@@ -584,7 +584,7 @@ fn registry_version_for(repo: &str, skill_name: Option<&str>) -> Option<String> 
 
         let matches = e_repo == repo
             || e_name == repo
-            || skill_name.map_or(false, |sn| e_skills.contains(&sn));
+            || skill_name.is_some_and(|sn| e_skills.contains(&sn));
 
         if matches {
             e.get("version").and_then(|v| v.as_str()).map(|s| s.to_string())

--- a/crates/octos-agent/src/tools/manage_skills.rs
+++ b/crates/octos-agent/src/tools/manage_skills.rs
@@ -582,12 +582,13 @@ fn registry_version_for(repo: &str, skill_name: Option<&str>) -> Option<String> 
             .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
             .unwrap_or_default();
 
-        let matches = e_repo == repo
-            || e_name == repo
-            || skill_name.is_some_and(|sn| e_skills.contains(&sn));
+        let matches =
+            e_repo == repo || e_name == repo || skill_name.is_some_and(|sn| e_skills.contains(&sn));
 
         if matches {
-            e.get("version").and_then(|v| v.as_str()).map(|s| s.to_string())
+            e.get("version")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
         } else {
             None
         }

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4,15 +4,15 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::{LazyLock, Mutex};
 
-use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::Json;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
-use super::AppState;
 use super::admin::ProfileResponse;
+use super::AppState;
 use crate::profiles::mask_secrets;
 use crate::user_store::{User, UserRole};
 
@@ -80,7 +80,10 @@ fn host_scoped_profile_id(state: &AppState, headers: &HeaderMap) -> Option<Strin
 
     let candidate = host.split('.').next()?.trim();
     if candidate.is_empty()
-        || matches!(candidate, "www" | "app" | "admin" | "api" | "crew" | "octos")
+        || matches!(
+            candidate,
+            "www" | "app" | "admin" | "api" | "crew" | "octos"
+        )
     {
         return None;
     }
@@ -767,10 +770,10 @@ pub async fn my_content(
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     axum::extract::Query(query): axum::extract::Query<crate::content_catalog::ContentQuery>,
 ) -> Result<Json<crate::content_catalog::ContentQueryResult>, (StatusCode, String)> {
-    let ps = state.profile_store.as_ref().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "not configured".into(),
-    ))?;
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or((StatusCode::SERVICE_UNAVAILABLE, "not configured".into()))?;
     let mgr = state.content_catalog_mgr.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
@@ -778,7 +781,12 @@ pub async fn my_content(
     // Use X-Profile-Id header (from Caddy proxy) if available, otherwise resolve from identity
     let profile = if let Some(pid) = headers.get("x-profile-id").and_then(|v| v.to_str().ok()) {
         ps.get(pid)
-            .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "profile store error".into()))?
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "profile store error".into(),
+                )
+            })?
             .ok_or((StatusCode::NOT_FOUND, format!("profile '{pid}' not found")))?
     } else {
         resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?
@@ -818,20 +826,13 @@ pub async fn my_content_thumbnail(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let cat = catalog.read().await;
     let entry = cat.get(&id).ok_or(StatusCode::NOT_FOUND)?;
-    let thumb_path = entry
-        .thumbnail_path
-        .as_ref()
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let thumb_path = entry.thumbnail_path.as_ref().ok_or(StatusCode::NOT_FOUND)?;
 
     let data = tokio::fs::read(thumb_path)
         .await
         .map_err(|_| StatusCode::NOT_FOUND)?;
 
-    Ok((
-        [(header::CONTENT_TYPE, "image/jpeg")],
-        Body::from(data),
-    )
-        .into_response())
+    Ok(([(header::CONTENT_TYPE, "image/jpeg")], Body::from(data)).into_response())
 }
 
 /// GET /api/my/content/:id/body
@@ -881,11 +882,7 @@ pub async fn my_content_body(
         _ => "application/octet-stream",
     };
 
-    Ok((
-        [(header::CONTENT_TYPE, content_type)],
-        Body::from(data),
-    )
-        .into_response())
+    Ok(([(header::CONTENT_TYPE, content_type)], Body::from(data)).into_response())
 }
 
 /// DELETE /api/my/content/:id
@@ -894,16 +891,15 @@ pub async fn delete_my_content(
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(id): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
-    let ps = state.profile_store.as_ref().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "not configured".into(),
-    ))?;
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or((StatusCode::SERVICE_UNAVAILABLE, "not configured".into()))?;
     let mgr = state.content_catalog_mgr.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
     ))?;
-    let profile =
-        resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let profile = resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
 
     let catalog = mgr
         .get_catalog(&profile.id)
@@ -935,16 +931,15 @@ pub async fn bulk_delete_my_content(
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Json(req): Json<BulkDeleteRequest>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
-    let ps = state.profile_store.as_ref().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "not configured".into(),
-    ))?;
+    let ps = state
+        .profile_store
+        .as_ref()
+        .ok_or((StatusCode::SERVICE_UNAVAILABLE, "not configured".into()))?;
     let mgr = state.content_catalog_mgr.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
     ))?;
-    let profile =
-        resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let profile = resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
 
     let catalog = mgr
         .get_catalog(&profile.id)
@@ -1368,7 +1363,12 @@ mod tests {
         }
     }
 
-    fn temp_app_state() -> (tempfile::TempDir, AppState, Arc<UserStore>, Arc<ProfileStore>) {
+    fn temp_app_state() -> (
+        tempfile::TempDir,
+        AppState,
+        Arc<UserStore>,
+        Arc<ProfileStore>,
+    ) {
         let dir = tempfile::tempdir().unwrap();
         let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
         let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
@@ -1509,7 +1509,8 @@ mod tests {
         child.parent_id = Some("tenant".into());
         profile_store.save(&child).unwrap();
 
-        let scoped = trusted_auth_scope_profile_id(&state, &localhost_scoped_headers("tenant--assistant"));
+        let scoped =
+            trusted_auth_scope_profile_id(&state, &localhost_scoped_headers("tenant--assistant"));
         assert_eq!(scoped.as_deref(), Some("tenant--assistant"));
     }
 

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4,15 +4,15 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::{LazyLock, Mutex};
 
+use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::Json;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
-use super::admin::ProfileResponse;
 use super::AppState;
+use super::admin::ProfileResponse;
 use crate::profiles::mask_secrets;
 use crate::user_store::{User, UserRole};
 

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -4,15 +4,15 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::{LazyLock, Mutex};
 
-use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::Json;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
-use super::AppState;
 use super::admin::ProfileResponse;
+use super::AppState;
 use crate::profiles::mask_secrets;
 use crate::user_store::{User, UserRole};
 

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -6,7 +6,7 @@ use std::sync::{LazyLock, Mutex};
 
 use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,198 @@ use super::router::AuthIdentity;
 /// Allows at most 3 requests per 5-minute window per email address.
 static OTP_RATE_LIMIT: LazyLock<Mutex<HashMap<String, (u32, std::time::Instant)>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub(crate) fn is_top_level_profile_id(state: &AppState, profile_id: &str) -> bool {
+    state
+        .profile_store
+        .as_ref()
+        .and_then(|store| store.get(profile_id).ok().flatten())
+        .map(|profile| profile.parent_id.is_none())
+        .unwrap_or(false)
+}
+
+pub(crate) fn scoped_host_allows_profile_id(
+    _state: &AppState,
+    scoped_profile_id: &str,
+    candidate_profile_id: &str,
+) -> bool {
+    scoped_profile_id == candidate_profile_id
+}
+
+fn request_host(headers: &HeaderMap) -> Option<String> {
+    let raw = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get("host"))?
+        .to_str()
+        .ok()?
+        .split(',')
+        .next()?
+        .trim()
+        .to_ascii_lowercase();
+    if raw.is_empty() {
+        return None;
+    }
+    Some(strip_port_from_host(&raw).to_string())
+}
+
+fn strip_port_from_host(host: &str) -> &str {
+    if let Some(stripped) = host.strip_prefix('[') {
+        return stripped.split(']').next().unwrap_or(host);
+    }
+
+    if host.matches(':').count() == 1 {
+        return host.split(':').next().unwrap_or(host);
+    }
+
+    host
+}
+
+fn is_local_request_host(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
+}
+
+fn host_scoped_profile_id(state: &AppState, headers: &HeaderMap) -> Option<String> {
+    let host = request_host(headers)?;
+    if is_local_request_host(&host) {
+        return None;
+    }
+
+    let candidate = host.split('.').next()?.trim();
+    if candidate.is_empty()
+        || matches!(candidate, "www" | "app" | "admin" | "api" | "crew" | "octos")
+    {
+        return None;
+    }
+
+    state
+        .profile_store
+        .as_ref()
+        .and_then(|store| store.get(candidate).ok().flatten())
+        .map(|_| candidate.to_string())
+}
+
+fn trusted_auth_scope_profile_id(state: &AppState, headers: &HeaderMap) -> Option<String> {
+    if let Some(profile_id) = host_scoped_profile_id(state, headers) {
+        return Some(profile_id);
+    }
+
+    let host = request_host(headers)?;
+    if !is_local_request_host(&host) {
+        return None;
+    }
+
+    headers
+        .get("x-profile-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn resolve_root_login_user(state: &AppState, email: &str) -> Option<User> {
+    let normalized = email.trim().to_lowercase();
+    let user_store = state.user_store.as_ref()?;
+    let matches: Vec<User> = user_store
+        .list()
+        .ok()?
+        .into_iter()
+        .filter(|user| user.email.trim().to_lowercase() == normalized)
+        .filter(|user| is_top_level_profile_id(state, &user.id))
+        .collect();
+
+    if matches.len() == 1 {
+        matches.into_iter().next()
+    } else {
+        if matches.len() > 1 {
+            tracing::warn!(
+                email = %normalized,
+                count = matches.len(),
+                "multiple top-level profiles share the same login email"
+            );
+        }
+        None
+    }
+}
+
+fn resolve_scoped_login_user(
+    state: &AppState,
+    scoped_profile_id: &str,
+    email: &str,
+) -> Option<User> {
+    let normalized = email.trim().to_lowercase();
+    if scoped_profile_id.trim().is_empty() {
+        return None;
+    }
+
+    let user_store = state.user_store.as_ref()?;
+    let matches: Vec<User> = user_store
+        .list()
+        .ok()?
+        .into_iter()
+        .filter(|user| user.email.trim().to_lowercase() == normalized)
+        .filter(|user| scoped_host_allows_profile_id(state, scoped_profile_id, &user.id))
+        .collect();
+
+    if matches.len() == 1 {
+        matches.into_iter().next()
+    } else {
+        if matches.len() > 1 {
+            tracing::warn!(
+                email = %normalized,
+                scoped_profile_id = %scoped_profile_id,
+                count = matches.len(),
+                "multiple scoped profiles share the same login email"
+            );
+        }
+        None
+    }
+}
+
+fn is_login_ready_email(email: &str) -> bool {
+    !email.trim().is_empty()
+}
+
+fn is_bootstrap_mode(state: &AppState) -> bool {
+    let has_ready_user = state
+        .user_store
+        .as_ref()
+        .and_then(|store| store.list().ok())
+        .map(|users| {
+            users.iter().any(|user| {
+                is_login_ready_email(&user.email) && is_top_level_profile_id(state, &user.id)
+            })
+        })
+        .unwrap_or(false);
+    !has_ready_user
+}
+
+fn scoped_auth_target(state: &AppState, profile_id: &str) -> Option<ScopedAuthTarget> {
+    if profile_id.is_empty() {
+        return None;
+    }
+
+    let profile = state
+        .profile_store
+        .as_ref()
+        .and_then(|store| store.get(profile_id).ok().flatten())?;
+    let email_login_enabled = state
+        .user_store
+        .as_ref()
+        .and_then(|store| store.list().ok())
+        .map(|users| {
+            users.iter().any(|user| {
+                is_login_ready_email(&user.email)
+                    && scoped_host_allows_profile_id(state, profile_id, &user.id)
+            })
+        })
+        .unwrap_or(false);
+
+    Some(ScopedAuthTarget {
+        id: profile.id,
+        name: profile.name,
+        email_login_enabled,
+    })
+}
 
 // ── Request / Response types ──────────────────────────────────────────
 
@@ -54,6 +246,23 @@ pub struct VerifyResponse {
     pub message: Option<String>,
 }
 
+#[derive(Clone, Serialize)]
+pub struct ScopedAuthTarget {
+    pub id: String,
+    pub name: String,
+    pub email_login_enabled: bool,
+}
+
+#[derive(Serialize)]
+pub struct AuthStatusResponse {
+    pub bootstrap_mode: bool,
+    pub email_login_enabled: bool,
+    pub admin_token_login_enabled: bool,
+    pub allow_self_registration: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scoped_profile: Option<ScopedAuthTarget>,
+}
+
 #[derive(Serialize)]
 pub struct MeResponse {
     pub user: User,
@@ -72,18 +281,46 @@ pub struct ActionResponse {
 /// POST /api/auth/send-code
 pub async fn send_code(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(req): Json<SendCodeRequest>,
 ) -> Result<Json<SendCodeResponse>, StatusCode> {
     let auth_mgr = state
         .auth_manager
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let requested_email = req.email.trim().to_lowercase();
+    let scoped_profile_id = trusted_auth_scope_profile_id(&state, &headers);
+    let login_target = if let Some(profile_id) = scoped_profile_id.as_deref() {
+        resolve_scoped_login_user(&state, profile_id, &requested_email)
+    } else {
+        resolve_root_login_user(&state, &requested_email)
+    };
+
+    if scoped_profile_id.is_some() {
+        if login_target.is_none() {
+            tracing::warn!(
+                email = %requested_email,
+                scoped_profile = ?scoped_profile_id,
+                "OTP skipped — email does not match scoped profile"
+            );
+            return Ok(Json(SendCodeResponse {
+                ok: false,
+                message: Some("This email is not registered for this account".into()),
+            }));
+        }
+    } else if login_target.is_none() {
+        tracing::warn!(email = %requested_email, "OTP skipped — email is not registered to a root profile");
+        return Ok(Json(SendCodeResponse {
+            ok: false,
+            message: Some("This email is not registered for this account".into()),
+        }));
+    }
 
     // Rate-limit OTP sends: max 3 per email per 5-minute window.
     {
         let mut limits = OTP_RATE_LIMIT.lock().unwrap_or_else(|e| e.into_inner());
         let entry = limits
-            .entry(req.email.to_lowercase())
+            .entry(requested_email.clone())
             .or_insert((0, std::time::Instant::now()));
         if entry.1.elapsed() > std::time::Duration::from_secs(300) {
             *entry = (0, std::time::Instant::now()); // reset after 5 min
@@ -99,8 +336,8 @@ pub async fn send_code(
         entry.0 += 1;
     }
 
-    tracing::info!(email = %req.email, "login OTP requested");
-    match auth_mgr.send_otp(&req.email).await {
+    tracing::info!(email = %requested_email, "login OTP requested");
+    match auth_mgr.send_otp(&requested_email).await {
         Ok(true) => Ok(Json(SendCodeResponse {
             ok: true,
             message: Some("Verification code sent to your email".into()),
@@ -120,27 +357,68 @@ pub async fn send_code(
     }
 }
 
+/// GET /api/auth/status
+pub async fn auth_status(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<AuthStatusResponse>, StatusCode> {
+    let scoped_profile = trusted_auth_scope_profile_id(&state, &headers)
+        .and_then(|profile_id| scoped_auth_target(&state, &profile_id));
+    let global_email_login_enabled = state
+        .user_store
+        .as_ref()
+        .and_then(|store| store.list().ok())
+        .map(|users| {
+            users.iter().any(|user| {
+                is_login_ready_email(&user.email) && is_top_level_profile_id(&state, &user.id)
+            })
+        })
+        .unwrap_or(false);
+    let email_login_enabled = scoped_profile
+        .as_ref()
+        .map(|profile| profile.email_login_enabled)
+        .unwrap_or(global_email_login_enabled);
+
+    Ok(Json(AuthStatusResponse {
+        bootstrap_mode: is_bootstrap_mode(&state),
+        email_login_enabled,
+        admin_token_login_enabled: state.auth_token.is_some(),
+        allow_self_registration: false,
+        scoped_profile,
+    }))
+}
+
 /// POST /api/auth/verify
 pub async fn verify(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(req): Json<VerifyRequest>,
 ) -> Result<Json<VerifyResponse>, StatusCode> {
     let auth_mgr = state
         .auth_manager
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let requested_email = req.email.trim().to_lowercase();
+    let scoped_profile_id = trusted_auth_scope_profile_id(&state, &headers);
+    let login_target = if let Some(profile_id) = scoped_profile_id.as_deref() {
+        resolve_scoped_login_user(&state, profile_id, &requested_email)
+    } else {
+        resolve_root_login_user(&state, &requested_email)
+    };
 
-    match auth_mgr.verify_otp(&req.email, &req.code).await {
+    if login_target.is_none() {
+        return Ok(Json(VerifyResponse {
+            ok: false,
+            token: None,
+            user: None,
+            message: Some("Invalid or expired code".into()),
+        }));
+    }
+
+    match auth_mgr.verify_otp(&requested_email, &req.code).await {
         Ok(Some(token)) => {
-            tracing::info!(email = %req.email, "user logged in");
-            // Get the user to return
-            let user_store = state
-                .user_store
-                .as_ref()
-                .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
-            let user = user_store
-                .get_by_email(&req.email)
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            tracing::info!(email = %requested_email, "user logged in");
+            let user = login_target;
 
             // Auto-create profile if user has none
             if let Some(ref user) = user {
@@ -1065,7 +1343,10 @@ fn ensure_admin_profile(ps: &crate::profiles::ProfileStore) -> Result<(), Status
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::otp::AuthManager;
     use crate::profiles::ProfileStore;
+    use crate::user_store::UserStore;
+    use axum::http::HeaderMap;
     use axum::http::Request;
 
     fn temp_profile_store() -> (tempfile::TempDir, ProfileStore) {
@@ -1085,6 +1366,50 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }
+    }
+
+    fn temp_app_state() -> (tempfile::TempDir, AppState, Arc<UserStore>, Arc<ProfileStore>) {
+        let dir = tempfile::tempdir().unwrap();
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        let profile_store = Arc::new(ProfileStore::open(dir.path()).unwrap());
+        let state = AppState {
+            agent: None,
+            sessions: None,
+            broadcaster: Arc::new(crate::api::SseBroadcaster::new(8)),
+            started_at: chrono::Utc::now(),
+            auth_token: Some("bootstrap-token".into()),
+            metrics_handle: None,
+            profile_store: Some(profile_store.clone()),
+            process_manager: None,
+            user_store: Some(user_store.clone()),
+            auth_manager: Some(Arc::new(AuthManager::new(None, user_store.clone()))),
+            http_client: reqwest::Client::new(),
+            config_path: None,
+            watchdog_enabled: None,
+            alerts_enabled: None,
+            sysinfo: tokio::sync::Mutex::new(sysinfo::System::new_all()),
+            tenant_store: None,
+            tunnel_domain: None,
+            frps_server: None,
+            frps_port: None,
+            deployment_mode: crate::config::DeploymentMode::Local,
+            allow_admin_shell: false,
+            content_catalog_mgr: None,
+        };
+        (dir, state, user_store, profile_store)
+    }
+
+    fn scoped_host_headers(host: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("Host", host.parse().unwrap());
+        headers
+    }
+
+    fn localhost_scoped_headers(profile_id: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("Host", "localhost:3000".parse().unwrap());
+        headers.insert("X-Profile-Id", profile_id.parse().unwrap());
+        headers
     }
 
     #[test]
@@ -1158,6 +1483,95 @@ mod tests {
         let profile = resolve_my_profile(&identity, &ps).unwrap();
         assert_eq!(profile.id, ADMIN_PROFILE_ID);
         assert_eq!(profile.name, "Admin");
+    }
+
+    #[test]
+    fn trusted_auth_scope_prefers_host_over_stale_header() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+        let mut child = make_user_profile("tenant--assistant", "Assistant");
+        child.parent_id = Some("tenant".into());
+        profile_store.save(&child).unwrap();
+
+        let mut headers = scoped_host_headers("tenant.example.test");
+        headers.insert("X-Profile-Id", "tenant--assistant".parse().unwrap());
+
+        let scoped = trusted_auth_scope_profile_id(&state, &headers);
+        assert_eq!(scoped.as_deref(), Some("tenant"));
+    }
+
+    #[test]
+    fn trusted_auth_scope_allows_localhost_header_fallback() {
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut child = make_user_profile("tenant--assistant", "Assistant");
+        child.parent_id = Some("tenant".into());
+        profile_store.save(&child).unwrap();
+
+        let scoped = trusted_auth_scope_profile_id(&state, &localhost_scoped_headers("tenant--assistant"));
+        assert_eq!(scoped.as_deref(), Some("tenant--assistant"));
+    }
+
+    #[tokio::test]
+    async fn scoped_send_code_rejects_wrong_email() {
+        let (_dir, state, user_store, profile_store) = temp_app_state();
+        let mut child = make_user_profile("tenant--assistant", "Assistant");
+        child.parent_id = Some("tenant".into());
+        profile_store.save(&child).unwrap();
+        user_store
+            .save(&User {
+                id: "tenant--assistant".into(),
+                email: "assistant@example.com".into(),
+                name: "Assistant".into(),
+                role: UserRole::User,
+                created_at: chrono::Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let Json(resp) = send_code(
+            State(Arc::new(state)),
+            scoped_host_headers("tenant--assistant.example.test"),
+            Json(SendCodeRequest {
+                email: "wrong@example.com".into(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert!(!resp.ok);
+        assert_eq!(
+            resp.message.as_deref(),
+            Some("This email is not registered for this account")
+        );
+    }
+
+    #[tokio::test]
+    async fn root_auth_status_ignores_sub_account_only_emails() {
+        let (_dir, state, user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+        let mut child = make_user_profile("tenant--assistant", "Assistant");
+        child.parent_id = Some("tenant".into());
+        profile_store.save(&child).unwrap();
+        user_store
+            .save(&User {
+                id: "tenant--assistant".into(),
+                email: "assistant@example.com".into(),
+                name: "Assistant".into(),
+                role: UserRole::User,
+                created_at: chrono::Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let Json(status) = auth_status(State(Arc::new(state)), HeaderMap::new())
+            .await
+            .unwrap();
+
+        assert!(!status.email_login_enabled);
     }
 
     #[test]

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -2,14 +2,15 @@
 
 use std::sync::Arc;
 
+use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
 use axum::routing::{delete, get, post, put};
-use axum::Router;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 
+use super::AppState;
 use super::admin;
 use super::auth_handlers;
 use super::frps_plugin;
@@ -18,7 +19,6 @@ use super::metrics;
 use super::static_files;
 use super::user_admin;
 use super::webhook_proxy;
-use super::AppState;
 use crate::user_store::UserRole;
 
 /// Authentication identity extracted by the auth middleware.

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -2,15 +2,14 @@
 
 use std::sync::Arc;
 
-use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
 use axum::routing::{delete, get, post, put};
+use axum::Router;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 
-use super::AppState;
 use super::admin;
 use super::auth_handlers;
 use super::frps_plugin;
@@ -19,6 +18,7 @@ use super::metrics;
 use super::static_files;
 use super::user_admin;
 use super::webhook_proxy;
+use super::AppState;
 use crate::user_store::UserRole;
 
 /// Authentication identity extracted by the auth middleware.

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -55,6 +55,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
 
     // Public auth endpoints (no auth required)
     let auth_api = Router::new()
+        .route("/api/auth/status", get(auth_handlers::auth_status))
         .route("/api/auth/send-code", post(auth_handlers::send_code))
         .route("/api/auth/verify", post(auth_handlers::verify))
         .route("/api/auth/logout", post(auth_handlers::logout));

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -9,15 +9,15 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use colored::Colorize;
 use eyre::{Result, WrapErr};
 use octos_agent::{AgentConfig, HookContext, HookExecutor, SkillsLoader, ToolRegistry};
 use octos_bus::{
-    create_bus, ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager,
+    ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager, create_bus,
 };
 use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, BaselineEntry, LlmProvider, ProviderChain, ProviderRouter,
@@ -29,12 +29,12 @@ use tracing::{info, warn};
 
 use super::build_system_prompt;
 use super::message_preprocessing;
-use super::profile_factory::{build_plugin_env, ProfileActorFactoryBuilder};
+use super::profile_factory::{ProfileActorFactoryBuilder, build_plugin_env};
 use super::{account_handler, adapters, skills_handler};
 use super::{build_profiled_session_key, resolve_dispatch_profile_id};
 use crate::commands::chat::{self, create_embedder, resolve_provider_policy};
 use crate::commands::{load_prompt, resolve_data_dir};
-use crate::config::{detect_provider, Config};
+use crate::config::{Config, detect_provider};
 use crate::config_watcher::{ConfigChange, ConfigWatcher};
 use crate::persona_service::PersonaService;
 use crate::session_actor::{ActorFactory, ActorRegistry, SnapshotToolRegistryFactory};
@@ -811,11 +811,7 @@ impl GatewayRuntime {
                     }
                 }
 
-                if registered > 0 {
-                    Some(router)
-                } else {
-                    None
-                }
+                if registered > 0 { Some(router) } else { None }
             };
 
             // Capture config for per-session SpawnTool and PipelineTool creation

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -9,15 +9,15 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use colored::Colorize;
 use eyre::{Result, WrapErr};
 use octos_agent::{AgentConfig, HookContext, HookExecutor, SkillsLoader, ToolRegistry};
 use octos_bus::{
-    ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager, create_bus,
+    create_bus, ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager,
 };
 use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, BaselineEntry, LlmProvider, ProviderChain, ProviderRouter,
@@ -29,12 +29,12 @@ use tracing::{info, warn};
 
 use super::build_system_prompt;
 use super::message_preprocessing;
-use super::profile_factory::{ProfileActorFactoryBuilder, build_plugin_env};
+use super::profile_factory::{build_plugin_env, ProfileActorFactoryBuilder};
 use super::{account_handler, adapters, skills_handler};
 use super::{build_profiled_session_key, resolve_dispatch_profile_id};
 use crate::commands::chat::{self, create_embedder, resolve_provider_policy};
 use crate::commands::{load_prompt, resolve_data_dir};
-use crate::config::{Config, detect_provider};
+use crate::config::{detect_provider, Config};
 use crate::config_watcher::{ConfigChange, ConfigWatcher};
 use crate::persona_service::PersonaService;
 use crate::session_actor::{ActorFactory, ActorRegistry, SnapshotToolRegistryFactory};
@@ -811,7 +811,11 @@ impl GatewayRuntime {
                     }
                 }
 
-                if registered > 0 { Some(router) } else { None }
+                if registered > 0 {
+                    Some(router)
+                } else {
+                    None
+                }
             };
 
             // Capture config for per-session SpawnTool and PipelineTool creation

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -8,7 +8,7 @@
 //! 5. Main message loop
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
@@ -21,7 +21,7 @@ use octos_bus::{
 };
 use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, BaselineEntry, LlmProvider, ProviderChain, ProviderRouter,
-    RetryProvider, SwappableProvider,
+    QosCatalog, RetryProvider, SwappableProvider,
 };
 use octos_memory::{EpisodeStore, MemoryStore};
 use tokio::sync::{Mutex, RwLock, Semaphore};
@@ -90,6 +90,36 @@ pub(super) struct GatewayRuntime {
     // Matrix (feature-gated)
     #[cfg(feature = "matrix")]
     matrix_channel: Option<Arc<octos_bus::MatrixChannel>>,
+}
+
+fn load_seed_qos_catalog(data_dir: &Path) -> Option<QosCatalog> {
+    let candidates = [
+        data_dir.join("model_catalog.json"),
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".octos/model_catalog.json"),
+    ];
+    for path in &candidates {
+        if let Ok(json) = std::fs::read_to_string(path) {
+            if let Ok(catalog) = serde_json::from_str::<QosCatalog>(&json) {
+                return Some(catalog);
+            }
+        }
+    }
+    None
+}
+
+fn persist_qos_catalog(path: &Path, catalog: &QosCatalog) {
+    match serde_json::to_string_pretty(catalog) {
+        Ok(json) => {
+            if let Err(error) = std::fs::write(path, json) {
+                warn!(path = %path.display(), %error, "failed to persist runtime model catalog");
+            }
+        }
+        Err(error) => {
+            warn!(path = %path.display(), %error, "failed to serialize runtime model catalog");
+        }
+    }
 }
 
 impl GatewayRuntime {
@@ -255,6 +285,19 @@ impl GatewayRuntime {
         // Wrap LLM in SwappableProvider for runtime model switching
         let swappable = Arc::new(SwappableProvider::new(llm));
         let llm: Arc<dyn LlmProvider> = swappable.clone();
+        let catalog_path = data_dir.join("model_catalog.json");
+        let qos_scoring_config = config
+            .adaptive_routing
+            .as_ref()
+            .map(AdaptiveConfig::from)
+            .unwrap_or_default();
+        let qos_ranking_enabled = config
+            .adaptive_routing
+            .as_ref()
+            .map(|cfg| cfg.qos_ranking)
+            .unwrap_or(true);
+        let seed_catalog = load_seed_qos_catalog(&data_dir);
+        let mut runtime_qos_catalog: Option<QosCatalog> = None;
 
         // Seed adaptive router with baseline benchmark data (if available)
         if let Some(ref router) = adaptive_router_ref {
@@ -289,41 +332,46 @@ impl GatewayRuntime {
                 info!("no provider_baseline.json found, using cold-start scoring");
             }
 
-            // Seed static catalog fields (type, cost, ds_output) from model_catalog.json
-            // Look in data_dir first, then fall back to ~/.octos/ (shared across profiles)
-            let catalog_candidates = [
-                data_dir.join("model_catalog.json"),
-                dirs::home_dir()
-                    .unwrap_or_default()
-                    .join(".octos/model_catalog.json"),
-            ];
-            for catalog_path in &catalog_candidates {
-                if let Ok(json) = std::fs::read_to_string(catalog_path) {
-                    if let Ok(catalog) = serde_json::from_str::<octos_llm::QosCatalog>(&json) {
-                        router.seed_catalog(&catalog.models);
-                        // Seed the global runtime catalog for context.rs lookups
-                        let ctx_entries: Vec<(String, u64, u64)> = catalog
-                            .models
-                            .iter()
-                            .map(|m| (m.provider.clone(), m.context_window, m.max_output))
-                            .collect();
-                        octos_llm::context::seed_from_catalog(&ctx_entries);
-                        // Seed pricing catalog
-                        let price_entries: Vec<(String, f64, f64)> = catalog
-                            .models
-                            .iter()
-                            .map(|m| (m.provider.clone(), m.cost_in, m.cost_out))
-                            .collect();
-                        octos_llm::pricing::seed_pricing_catalog(&price_entries);
-                        info!(
-                            path = %catalog_path.display(),
-                            models = catalog.models.len(),
-                            "loaded model catalog"
-                        );
-                        break;
-                    }
-                }
+            if let Some(ref catalog) = seed_catalog {
+                router.seed_catalog(&catalog.models);
+                let ctx_entries: Vec<(String, u64, u64)> = catalog
+                    .models
+                    .iter()
+                    .map(|m| (m.provider.clone(), m.context_window, m.max_output))
+                    .collect();
+                octos_llm::context::seed_from_catalog(&ctx_entries);
+                let price_entries: Vec<(String, f64, f64)> = catalog
+                    .models
+                    .iter()
+                    .map(|m| (m.provider.clone(), m.cost_in, m.cost_out))
+                    .collect();
+                octos_llm::pricing::seed_pricing_catalog(&price_entries);
+                info!(models = catalog.models.len(), "loaded model catalog");
             }
+
+            let live_catalog = router.export_model_catalog();
+            persist_qos_catalog(&catalog_path, &live_catalog);
+            runtime_qos_catalog = Some(live_catalog);
+        } else if let Some(ref catalog) = seed_catalog {
+            let derived = octos_llm::derive_cold_start_catalog(
+                &catalog.models,
+                &qos_scoring_config,
+                qos_ranking_enabled,
+            );
+            let ctx_entries: Vec<(String, u64, u64)> = derived
+                .models
+                .iter()
+                .map(|m| (m.provider.clone(), m.context_window, m.max_output))
+                .collect();
+            octos_llm::context::seed_from_catalog(&ctx_entries);
+            let price_entries: Vec<(String, f64, f64)> = derived
+                .models
+                .iter()
+                .map(|m| (m.provider.clone(), m.cost_in, m.cost_out))
+                .collect();
+            octos_llm::pricing::seed_pricing_catalog(&price_entries);
+            persist_qos_catalog(&catalog_path, &derived);
+            runtime_qos_catalog = Some(derived);
         }
 
         // Open ProfileStore for /account commands and bot management.
@@ -352,7 +400,7 @@ impl GatewayRuntime {
         // Spawn periodic metrics exporter (writes model_catalog.json every 30s)
         if let Some(ref router) = adaptive_router_ref {
             let metrics_router = router.clone();
-            let catalog_path = data_dir.join("model_catalog.json");
+            let catalog_path = catalog_path.clone();
             tokio::spawn(async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
                 loop {
@@ -767,26 +815,17 @@ impl GatewayRuntime {
 
             // Seed QoS scores on the router for fallback ranking
             if let Some(ref router) = provider_router {
-                let catalog_path = data_dir.join("pipeline_models.json");
-                let system_catalog = dirs::home_dir()
-                    .unwrap_or_default()
-                    .join(".octos/model_catalog.json");
-                for path in &[catalog_path, system_catalog] {
-                    if let Ok(json) = std::fs::read_to_string(path) {
-                        if let Ok(catalog) = serde_json::from_str::<octos_llm::QosCatalog>(&json) {
-                            let score_entries: Vec<(String, f64)> = catalog
-                                .models
-                                .iter()
-                                .map(|m| (m.provider.clone(), m.score))
-                                .collect();
-                            router.seed_qos_scores(&score_entries);
-                            info!(
-                                models = score_entries.len(),
-                                "seeded scores for fallback ranking"
-                            );
-                            break;
-                        }
-                    }
+                if let Some(ref catalog) = runtime_qos_catalog {
+                    let score_entries: Vec<(String, f64)> = catalog
+                        .models
+                        .iter()
+                        .map(|m| (m.provider.clone(), m.score))
+                        .collect();
+                    router.seed_qos_scores(&score_entries);
+                    info!(
+                        models = score_entries.len(),
+                        "seeded scores for fallback ranking"
+                    );
                 }
             }
 

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -19,7 +19,6 @@ use octos_agent::{AgentConfig, HookContext, HookExecutor, SkillsLoader, ToolRegi
 use octos_bus::{
     ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager, create_bus,
 };
-use octos_core::MAIN_PROFILE_ID;
 use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, BaselineEntry, LlmProvider, ProviderChain, ProviderRouter,
     RetryProvider, SwappableProvider,
@@ -1390,11 +1389,16 @@ impl GatewayRuntime {
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
             let mut dispatch_profile_id = resolve_dispatch_profile_id(
+                self.profile_id.as_deref(),
                 target_profile.as_deref(),
                 self.profile_store.as_deref(),
             )?;
             if let Some(ref pid) = dispatch_profile_id {
-                if !self.actor_registry.has_profile_factory(pid) {
+                let is_current_gateway_profile = self
+                    .profile_id
+                    .as_deref()
+                    .is_some_and(|current| current == pid);
+                if !is_current_gateway_profile && !self.actor_registry.has_profile_factory(pid) {
                     if let Some(ref builder) = self.profile_factory_builder {
                         match builder.build(pid).await {
                             Ok(factory) => self

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -122,6 +122,19 @@ fn persist_qos_catalog(path: &Path, catalog: &QosCatalog) {
     }
 }
 
+fn materialize_runtime_qos_catalog(
+    seed_catalog: Option<&QosCatalog>,
+    adaptive_export: Option<QosCatalog>,
+    config: &AdaptiveConfig,
+    qos_ranking: bool,
+) -> Option<QosCatalog> {
+    adaptive_export.or_else(|| {
+        seed_catalog.map(|catalog| {
+            octos_llm::derive_cold_start_catalog(&catalog.models, config, qos_ranking)
+        })
+    })
+}
+
 impl GatewayRuntime {
     /// Initialize the gateway runtime from CLI command arguments.
     ///
@@ -297,7 +310,7 @@ impl GatewayRuntime {
             .map(|cfg| cfg.qos_ranking)
             .unwrap_or(true);
         let seed_catalog = load_seed_qos_catalog(&data_dir);
-        let mut runtime_qos_catalog: Option<QosCatalog> = None;
+        let runtime_qos_catalog: Option<QosCatalog>;
 
         // Seed adaptive router with baseline benchmark data (if available)
         if let Some(ref router) = adaptive_router_ref {
@@ -334,44 +347,38 @@ impl GatewayRuntime {
 
             if let Some(ref catalog) = seed_catalog {
                 router.seed_catalog(&catalog.models);
-                let ctx_entries: Vec<(String, u64, u64)> = catalog
-                    .models
-                    .iter()
-                    .map(|m| (m.provider.clone(), m.context_window, m.max_output))
-                    .collect();
-                octos_llm::context::seed_from_catalog(&ctx_entries);
-                let price_entries: Vec<(String, f64, f64)> = catalog
-                    .models
-                    .iter()
-                    .map(|m| (m.provider.clone(), m.cost_in, m.cost_out))
-                    .collect();
-                octos_llm::pricing::seed_pricing_catalog(&price_entries);
                 info!(models = catalog.models.len(), "loaded model catalog");
             }
 
-            let live_catalog = router.export_model_catalog();
-            persist_qos_catalog(&catalog_path, &live_catalog);
-            runtime_qos_catalog = Some(live_catalog);
-        } else if let Some(ref catalog) = seed_catalog {
-            let derived = octos_llm::derive_cold_start_catalog(
-                &catalog.models,
+            runtime_qos_catalog = materialize_runtime_qos_catalog(
+                seed_catalog.as_ref(),
+                Some(router.export_model_catalog()),
                 &qos_scoring_config,
                 qos_ranking_enabled,
             );
-            let ctx_entries: Vec<(String, u64, u64)> = derived
+        } else {
+            runtime_qos_catalog = materialize_runtime_qos_catalog(
+                seed_catalog.as_ref(),
+                None,
+                &qos_scoring_config,
+                qos_ranking_enabled,
+            );
+        }
+
+        if let Some(ref catalog) = runtime_qos_catalog {
+            let ctx_entries: Vec<(String, u64, u64)> = catalog
                 .models
                 .iter()
                 .map(|m| (m.provider.clone(), m.context_window, m.max_output))
                 .collect();
             octos_llm::context::seed_from_catalog(&ctx_entries);
-            let price_entries: Vec<(String, f64, f64)> = derived
+            let price_entries: Vec<(String, f64, f64)> = catalog
                 .models
                 .iter()
                 .map(|m| (m.provider.clone(), m.cost_in, m.cost_out))
                 .collect();
             octos_llm::pricing::seed_pricing_catalog(&price_entries);
-            persist_qos_catalog(&catalog_path, &derived);
-            runtime_qos_catalog = Some(derived);
+            persist_qos_catalog(&catalog_path, catalog);
         }
 
         // Open ProfileStore for /account commands and bot management.
@@ -1725,6 +1732,100 @@ impl GatewayRuntime {
 
 #[cfg(test)]
 mod tests {
-    // Canonical profile-scoped API session routing is exercised in higher-level
-    // gateway/session tests. No legacy fallback behavior remains here.
+    use super::*;
+    use octos_llm::{ModelCatalogEntry, ModelType};
+    use tempfile::tempdir;
+
+    fn sample_catalog(scores: [f64; 2]) -> QosCatalog {
+        QosCatalog {
+            updated_at: "2026-04-11T00:00:00Z".to_string(),
+            models: vec![
+                ModelCatalogEntry {
+                    provider: "zai/glm-5-turbo".to_string(),
+                    model_type: ModelType::Fast,
+                    stability: 0.97,
+                    tool_avg_ms: 900,
+                    p95_ms: 1500,
+                    score: scores[0],
+                    cost_in: 0.5,
+                    cost_out: 2.0,
+                    ds_output: 1200,
+                    context_window: 128_000,
+                    max_output: 8_192,
+                },
+                ModelCatalogEntry {
+                    provider: "dashscope/qwen3.5-plus".to_string(),
+                    model_type: ModelType::Strong,
+                    stability: 0.92,
+                    tool_avg_ms: 1400,
+                    p95_ms: 2400,
+                    score: scores[1],
+                    cost_in: 0.8,
+                    cost_out: 3.2,
+                    ds_output: 800,
+                    context_window: 128_000,
+                    max_output: 16_384,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn load_seed_qos_catalog_reads_profile_local_catalog() {
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let path = data_dir.join("model_catalog.json");
+        let catalog = sample_catalog([0.0, 0.0]);
+        std::fs::write(&path, serde_json::to_string_pretty(&catalog).unwrap()).unwrap();
+
+        let loaded = load_seed_qos_catalog(&data_dir).expect("catalog should load");
+        assert_eq!(loaded.models.len(), 2);
+        assert_eq!(loaded.models[0].provider, "zai/glm-5-turbo");
+        assert_eq!(loaded.models[1].provider, "dashscope/qwen3.5-plus");
+    }
+
+    #[test]
+    fn persist_qos_catalog_round_trips_runtime_scores() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("model_catalog.json");
+        let catalog = sample_catalog([0.21857142857142858, 0.4]);
+
+        persist_qos_catalog(&path, &catalog);
+
+        let json = std::fs::read_to_string(&path).unwrap();
+        let loaded: QosCatalog = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.models.len(), 2);
+        assert!((loaded.models[0].score - 0.21857142857142858).abs() < 1e-12);
+        assert!((loaded.models[1].score - 0.4).abs() < 1e-12);
+    }
+
+    #[test]
+    fn materialize_runtime_qos_catalog_prefers_adaptive_export() {
+        let seed = sample_catalog([0.0, 0.0]);
+        let live = sample_catalog([0.21, 0.41]);
+
+        let materialized = materialize_runtime_qos_catalog(
+            Some(&seed),
+            Some(live.clone()),
+            &AdaptiveConfig::default(),
+            true,
+        )
+        .expect("catalog should materialize");
+
+        assert_eq!(materialized.models[0].score, live.models[0].score);
+        assert_eq!(materialized.models[1].score, live.models[1].score);
+    }
+
+    #[test]
+    fn materialize_runtime_qos_catalog_derives_non_zero_scores_from_seed() {
+        let seed = sample_catalog([0.0, 0.0]);
+
+        let materialized =
+            materialize_runtime_qos_catalog(Some(&seed), None, &AdaptiveConfig::default(), true)
+                .expect("catalog should materialize");
+
+        assert_eq!(materialized.models.len(), seed.models.len());
+        assert!(materialized.models.iter().all(|entry| entry.score > 0.0));
+    }
 }

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 use eyre::{Result, WrapErr};
-use octos_core::{MAIN_PROFILE_ID, SessionKey};
+use octos_core::{SessionKey, MAIN_PROFILE_ID};
 use tracing::warn;
 
 use super::Executable;
@@ -32,8 +32,8 @@ use {
     octos_agent::{AgentConfig, ToolRegistry},
     octos_bus::{ActiveSessionStore, ChannelManager, CronService, SessionManager},
     profile_factory::ProfileActorFactoryBuilder,
-    std::sync::Arc,
     std::sync::atomic::{AtomicBool, AtomicUsize},
+    std::sync::Arc,
 };
 
 /// Run as a persistent gateway daemon.
@@ -178,7 +178,7 @@ mod tests {
     use octos_memory::{EpisodeStore, MemoryStore};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-    use tokio::sync::{Mutex, RwLock, mpsc};
+    use tokio::sync::{mpsc, Mutex, RwLock};
 
     fn make_profile(id: &str, system_prompt: Option<&str>) -> crate::profiles::UserProfile {
         crate::profiles::UserProfile {

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 use eyre::{Result, WrapErr};
-use octos_core::{SessionKey, MAIN_PROFILE_ID};
+use octos_core::{MAIN_PROFILE_ID, SessionKey};
 use tracing::warn;
 
 use super::Executable;
@@ -32,8 +32,8 @@ use {
     octos_agent::{AgentConfig, ToolRegistry},
     octos_bus::{ActiveSessionStore, ChannelManager, CronService, SessionManager},
     profile_factory::ProfileActorFactoryBuilder,
-    std::sync::atomic::{AtomicBool, AtomicUsize},
     std::sync::Arc,
+    std::sync::atomic::{AtomicBool, AtomicUsize},
 };
 
 /// Run as a persistent gateway daemon.
@@ -178,7 +178,7 @@ mod tests {
     use octos_memory::{EpisodeStore, MemoryStore};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-    use tokio::sync::{mpsc, Mutex, RwLock};
+    use tokio::sync::{Mutex, RwLock, mpsc};
 
     fn make_profile(id: &str, system_prompt: Option<&str>) -> crate::profiles::UserProfile {
         crate::profiles::UserProfile {

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -101,12 +101,17 @@ pub struct GatewayCommand {
 }
 
 fn resolve_dispatch_profile_id(
+    current_gateway_profile_id: Option<&str>,
     target_profile_id: Option<&str>,
     profile_store: Option<&crate::profiles::ProfileStore>,
 ) -> Result<Option<String>> {
     let Some(profile_id) = target_profile_id.filter(|value| !value.is_empty()) else {
         return Ok(None);
     };
+
+    if current_gateway_profile_id.is_some_and(|current| current == profile_id) {
+        return Ok(Some(profile_id.to_string()));
+    }
 
     let Some(store) = profile_store else {
         warn!(
@@ -407,7 +412,9 @@ mod tests {
             .save(&make_profile("weather", Some("weather prompt")))
             .unwrap();
 
-        let resolved = resolve_dispatch_profile_id(Some("missing-profile"), Some(&store)).unwrap();
+        let resolved =
+            resolve_dispatch_profile_id(Some("weather"), Some("missing-profile"), Some(&store))
+                .unwrap();
 
         assert_eq!(resolved, None);
     }
@@ -420,9 +427,19 @@ mod tests {
             .save(&make_profile("weather", Some("weather prompt")))
             .unwrap();
 
-        let resolved = resolve_dispatch_profile_id(Some("weather"), Some(&store)).unwrap();
+        let resolved =
+            resolve_dispatch_profile_id(Some("botfather"), Some("weather"), Some(&store)).unwrap();
 
         assert_eq!(resolved.as_deref(), Some("weather"));
+    }
+
+    #[test]
+    fn test_dispatch_current_gateway_profile_keeps_target_without_lookup() {
+        let resolved =
+            resolve_dispatch_profile_id(Some("dspfac--newsbot"), Some("dspfac--newsbot"), None)
+                .unwrap();
+
+        assert_eq!(resolved.as_deref(), Some("dspfac--newsbot"));
     }
 
     #[cfg(unix)]

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -5,8 +5,8 @@
 //! the profile's own LLM stack, tool registry, skills, and system prompt.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 
 use eyre::Result;
@@ -17,12 +17,12 @@ use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, LlmProvider, ProviderChain, ProviderRouter, RetryProvider,
 };
 use octos_memory::{EpisodeStore, MemoryStore};
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing::{info, warn};
 
 use super::build_system_prompt;
 use crate::commands::chat::{create_embedder, resolve_provider_policy};
-use crate::config::{detect_provider, Config};
+use crate::config::{Config, detect_provider};
 use crate::session_actor::{
     ActorFactory, PendingMessages, PipelineToolFactory, SnapshotToolRegistryFactory,
     ToolRegistryFactory,
@@ -534,11 +534,7 @@ impl ProfileActorFactoryBuilder {
                         ),
                     }
                 }
-                if registered > 1 {
-                    Some(router)
-                } else {
-                    None
-                }
+                if registered > 1 { Some(router) } else { None }
             };
             provider_router = child_router.clone();
 

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -5,8 +5,8 @@
 //! the profile's own LLM stack, tool registry, skills, and system prompt.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::Result;
@@ -17,12 +17,12 @@ use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, LlmProvider, ProviderChain, ProviderRouter, RetryProvider,
 };
 use octos_memory::{EpisodeStore, MemoryStore};
-use tokio::sync::{Mutex, RwLock, mpsc};
+use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::{info, warn};
 
 use super::build_system_prompt;
 use crate::commands::chat::{create_embedder, resolve_provider_policy};
-use crate::config::{Config, detect_provider};
+use crate::config::{detect_provider, Config};
 use crate::session_actor::{
     ActorFactory, PendingMessages, PipelineToolFactory, SnapshotToolRegistryFactory,
     ToolRegistryFactory,
@@ -534,7 +534,11 @@ impl ProfileActorFactoryBuilder {
                         ),
                     }
                 }
-                if registered > 1 { Some(router) } else { None }
+                if registered > 1 {
+                    Some(router)
+                } else {
+                    None
+                }
             };
             provider_router = child_router.clone();
 

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -30,7 +30,12 @@ use crate::session_actor::{
 
 /// Provider + model name + optional adaptive router, returned by [`build_llm_stack`].
 /// (full LLM, provider name, adaptive router, strong-only LLM for slides)
-pub(crate) type LlmStack = (Arc<dyn LlmProvider>, String, Option<Arc<AdaptiveRouter>>, Arc<dyn LlmProvider>);
+pub(crate) type LlmStack = (
+    Arc<dyn LlmProvider>,
+    String,
+    Option<Arc<AdaptiveRouter>>,
+    Arc<dyn LlmProvider>,
+);
 
 pub(crate) fn build_llm_stack(config: &Config, no_retry: bool) -> Result<LlmStack> {
     let model = config.model.clone();
@@ -133,8 +138,7 @@ pub(crate) fn build_strong_chain(
     if strong_fallbacks.is_empty() || no_retry {
         return Ok(Arc::new(RetryProvider::new(primary)));
     }
-    let mut providers: Vec<Arc<dyn LlmProvider>> =
-        vec![Arc::new(RetryProvider::new(primary))];
+    let mut providers: Vec<Arc<dyn LlmProvider>> = vec![Arc::new(RetryProvider::new(primary))];
     for fallback in strong_fallbacks {
         let fallback_config = if fallback.api_key_env.is_some() {
             let mut cloned = config.clone();

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -1142,20 +1142,13 @@ fn update_single(skills_dir: &Path, name: &str, branch_override: Option<&str>) -
             let registry_ver = entries
                 .iter()
                 .find(|e| {
-                    e.repo == source.repo
-                        || e.skills.contains(&name.to_string())
-                        || e.name == name
+                    e.repo == source.repo || e.skills.contains(&name.to_string()) || e.name == name
                 })
                 .and_then(|e| e.version.as_ref());
 
             if let Some(rv) = registry_ver {
                 if !version_newer(rv, lv) {
-                    println!(
-                        "  {} '{}' is up to date (v{})",
-                        "OK".green(),
-                        name,
-                        lv
-                    );
+                    println!("  {} '{}' is up to date (v{})", "OK".green(), name, lv);
                     return Ok(());
                 }
                 println!(

--- a/crates/octos-cli/src/content_catalog.rs
+++ b/crates/octos-cli/src/content_catalog.rs
@@ -592,14 +592,16 @@ mod tests {
         std::fs::write(&test_file, "hello").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        assert!(cat
-            .index_file(&test_file, None, None, None)
-            .unwrap()
-            .is_some());
-        assert!(cat
-            .index_file(&test_file, None, None, None)
-            .unwrap()
-            .is_none());
+        assert!(
+            cat.index_file(&test_file, None, None, None)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            cat.index_file(&test_file, None, None, None)
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(cat.len(), 1);
     }
 

--- a/crates/octos-cli/src/content_catalog.rs
+++ b/crates/octos-cli/src/content_catalog.rs
@@ -93,7 +93,7 @@ pub struct ContentEntry {
 
 // ── Query types ────────────────────────────────────────────────────────
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ContentQuery {
     pub category: Option<String>,
     pub search: Option<String>,
@@ -105,6 +105,20 @@ pub struct ContentQuery {
     pub limit: usize,
     #[serde(default)]
     pub offset: usize,
+}
+
+impl Default for ContentQuery {
+    fn default() -> Self {
+        Self {
+            category: None,
+            search: None,
+            from: None,
+            to: None,
+            sort: default_sort(),
+            limit: default_limit(),
+            offset: 0,
+        }
+    }
 }
 
 fn default_sort() -> String {
@@ -293,6 +307,14 @@ impl ContentCatalog {
                 }
                 Self::walk_dir(&path, known, cb)?;
             } else if path.is_file() {
+                let name = path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+                if name == CATALOG_FILENAME {
+                    continue;
+                }
                 let path_str = path.to_string_lossy().to_string();
                 if !known.contains(&path_str) {
                     cb(&path);

--- a/crates/octos-cli/src/content_catalog.rs
+++ b/crates/octos-cli/src/content_catalog.rs
@@ -24,7 +24,7 @@ const SKIP_DIRS: &[&str] = &[
     "memory",
     "skills",
     "history",
-    "users",       // per-user dirs scanned separately via workspace/ path
+    "users", // per-user dirs scanned separately via workspace/ path
     "logs",
     ".thumbnails",
     "whatsapp-auth",
@@ -275,11 +275,7 @@ impl ContentCatalog {
     }
 
     /// Recursive directory walker that skips internal dirs.
-    fn walk_dir(
-        dir: &Path,
-        known: &HashSet<String>,
-        cb: &mut impl FnMut(&Path),
-    ) -> io::Result<()> {
+    fn walk_dir(dir: &Path, known: &HashSet<String>, cb: &mut impl FnMut(&Path)) -> io::Result<()> {
         let entries = match std::fs::read_dir(dir) {
             Ok(e) => e,
             Err(_) => return Ok(()),
@@ -340,7 +336,9 @@ impl ContentCatalog {
         // Sort.
         match q.sort.as_str() {
             "oldest" => filtered.sort_by(|a, b| a.created_at.cmp(&b.created_at)),
-            "name" => filtered.sort_by(|a, b| a.filename.to_lowercase().cmp(&b.filename.to_lowercase())),
+            "name" => {
+                filtered.sort_by(|a, b| a.filename.to_lowercase().cmp(&b.filename.to_lowercase()))
+            }
             "size" => filtered.sort_by(|a, b| b.size_bytes.cmp(&a.size_bytes)),
             _ => filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at)), // newest
         }
@@ -423,9 +421,9 @@ impl ContentCatalog {
         let img = image::open(path)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("image open: {e}")))?;
         let thumb = img.thumbnail(THUMBNAIL_MAX_WIDTH, THUMBNAIL_MAX_WIDTH);
-        thumb.save(&thumb_path).map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, format!("thumbnail save: {e}"))
-        })?;
+        thumb
+            .save(&thumb_path)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("thumbnail save: {e}")))?;
 
         Ok(thumb_path.to_string_lossy().to_string())
     }
@@ -457,10 +455,7 @@ impl ContentCatalogManager {
     }
 
     /// Get or create a catalog for a profile, identified by profile ID.
-    pub async fn get_catalog(
-        &self,
-        profile_id: &str,
-    ) -> io::Result<Arc<RwLock<ContentCatalog>>> {
+    pub async fn get_catalog(&self, profile_id: &str) -> io::Result<Arc<RwLock<ContentCatalog>>> {
         let mut map = self.catalogs.lock().await;
         if let Some(cat) = map.get(profile_id) {
             return Ok(Arc::clone(cat));
@@ -509,12 +504,30 @@ mod tests {
 
     #[test]
     fn should_categorize_extensions() {
-        assert_eq!(ContentCategory::from_extension("md"), ContentCategory::Report);
-        assert_eq!(ContentCategory::from_extension("MP3"), ContentCategory::Audio);
-        assert_eq!(ContentCategory::from_extension("pptx"), ContentCategory::Slides);
-        assert_eq!(ContentCategory::from_extension("png"), ContentCategory::Image);
-        assert_eq!(ContentCategory::from_extension("mp4"), ContentCategory::Video);
-        assert_eq!(ContentCategory::from_extension("xyz"), ContentCategory::Other);
+        assert_eq!(
+            ContentCategory::from_extension("md"),
+            ContentCategory::Report
+        );
+        assert_eq!(
+            ContentCategory::from_extension("MP3"),
+            ContentCategory::Audio
+        );
+        assert_eq!(
+            ContentCategory::from_extension("pptx"),
+            ContentCategory::Slides
+        );
+        assert_eq!(
+            ContentCategory::from_extension("png"),
+            ContentCategory::Image
+        );
+        assert_eq!(
+            ContentCategory::from_extension("mp4"),
+            ContentCategory::Video
+        );
+        assert_eq!(
+            ContentCategory::from_extension("xyz"),
+            ContentCategory::Other
+        );
     }
 
     #[test]
@@ -532,7 +545,12 @@ mod tests {
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
         let id = cat
-            .index_file(&test_file, Some("session-1"), Some("write_file"), Some("A test report"))
+            .index_file(
+                &test_file,
+                Some("session-1"),
+                Some("write_file"),
+                Some("A test report"),
+            )
             .unwrap()
             .unwrap();
 
@@ -552,8 +570,16 @@ mod tests {
         std::fs::write(&test_file, "hello").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        assert!(cat.index_file(&test_file, None, None, None).unwrap().is_some());
-        assert!(cat.index_file(&test_file, None, None, None).unwrap().is_none());
+        assert!(
+            cat.index_file(&test_file, None, None, None)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            cat.index_file(&test_file, None, None, None)
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(cat.len(), 1);
     }
 
@@ -564,8 +590,10 @@ mod tests {
         std::fs::write(tmp.path().join("b.png"), "image").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        cat.index_file(&tmp.path().join("a.md"), None, None, None).unwrap();
-        cat.index_file(&tmp.path().join("b.png"), None, None, None).unwrap();
+        cat.index_file(&tmp.path().join("a.md"), None, None, None)
+            .unwrap();
+        cat.index_file(&tmp.path().join("b.png"), None, None, None)
+            .unwrap();
 
         let result = cat.query(&ContentQuery {
             category: Some("report".into()),
@@ -582,8 +610,10 @@ mod tests {
         std::fs::write(tmp.path().join("daily-log.md"), "d").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        cat.index_file(&tmp.path().join("weekly-report.md"), None, None, None).unwrap();
-        cat.index_file(&tmp.path().join("daily-log.md"), None, None, None).unwrap();
+        cat.index_file(&tmp.path().join("weekly-report.md"), None, None, None)
+            .unwrap();
+        cat.index_file(&tmp.path().join("daily-log.md"), None, None, None)
+            .unwrap();
 
         let result = cat.query(&ContentQuery {
             search: Some("weekly".into()),
@@ -600,7 +630,10 @@ mod tests {
         std::fs::write(&test_file, "bye").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        let id = cat.index_file(&test_file, None, None, None).unwrap().unwrap();
+        let id = cat
+            .index_file(&test_file, None, None, None)
+            .unwrap()
+            .unwrap();
 
         assert!(test_file.exists());
         assert!(cat.delete(&id).unwrap());
@@ -616,9 +649,18 @@ mod tests {
         std::fs::write(tmp.path().join("c.txt"), "c").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        let id_a = cat.index_file(&tmp.path().join("a.txt"), None, None, None).unwrap().unwrap();
-        let _id_b = cat.index_file(&tmp.path().join("b.txt"), None, None, None).unwrap().unwrap();
-        let id_c = cat.index_file(&tmp.path().join("c.txt"), None, None, None).unwrap().unwrap();
+        let id_a = cat
+            .index_file(&tmp.path().join("a.txt"), None, None, None)
+            .unwrap()
+            .unwrap();
+        let _id_b = cat
+            .index_file(&tmp.path().join("b.txt"), None, None, None)
+            .unwrap()
+            .unwrap();
+        let id_c = cat
+            .index_file(&tmp.path().join("c.txt"), None, None, None)
+            .unwrap()
+            .unwrap();
 
         let deleted = cat.bulk_delete(&[id_a, id_c]).unwrap();
         assert_eq!(deleted, 2);
@@ -666,8 +708,10 @@ mod tests {
         std::fs::write(tmp.path().join("alpha.txt"), "a").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        cat.index_file(&tmp.path().join("zebra.txt"), None, None, None).unwrap();
-        cat.index_file(&tmp.path().join("alpha.txt"), None, None, None).unwrap();
+        cat.index_file(&tmp.path().join("zebra.txt"), None, None, None)
+            .unwrap();
+        cat.index_file(&tmp.path().join("alpha.txt"), None, None, None)
+            .unwrap();
 
         let result = cat.query(&ContentQuery {
             sort: "name".into(),

--- a/crates/octos-cli/src/content_catalog.rs
+++ b/crates/octos-cli/src/content_catalog.rs
@@ -592,16 +592,14 @@ mod tests {
         std::fs::write(&test_file, "hello").unwrap();
 
         let mut cat = ContentCatalog::open(tmp.path()).unwrap();
-        assert!(
-            cat.index_file(&test_file, None, None, None)
-                .unwrap()
-                .is_some()
-        );
-        assert!(
-            cat.index_file(&test_file, None, None, None)
-                .unwrap()
-                .is_none()
-        );
+        assert!(cat
+            .index_file(&test_file, None, None, None)
+            .unwrap()
+            .is_some());
+        assert!(cat
+            .index_file(&test_file, None, None, None)
+            .unwrap()
+            .is_none());
         assert_eq!(cat.len(), 1);
     }
 

--- a/crates/octos-cli/src/gateway_dispatcher.rs
+++ b/crates/octos-cli/src/gateway_dispatcher.rs
@@ -7,9 +7,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use octos_bus::{ActiveSessionStore, SessionManager, validate_topic_name};
-use octos_core::{InboundMessage, MAIN_PROFILE_ID, OutboundMessage, SessionKey};
-use tokio::sync::{Mutex, RwLock, mpsc};
+use octos_bus::{validate_topic_name, ActiveSessionStore, SessionManager};
+use octos_core::{InboundMessage, OutboundMessage, SessionKey, MAIN_PROFILE_ID};
+use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::{info, warn};
 
 use crate::commands::gateway::{build_profiled_session_key, session_ui};

--- a/crates/octos-cli/src/gateway_dispatcher.rs
+++ b/crates/octos-cli/src/gateway_dispatcher.rs
@@ -7,9 +7,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use octos_bus::{validate_topic_name, ActiveSessionStore, SessionManager};
-use octos_core::{InboundMessage, OutboundMessage, SessionKey, MAIN_PROFILE_ID};
-use tokio::sync::{mpsc, Mutex, RwLock};
+use octos_bus::{ActiveSessionStore, SessionManager, validate_topic_name};
+use octos_core::{InboundMessage, MAIN_PROFILE_ID, OutboundMessage, SessionKey};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing::{info, warn};
 
 use crate::commands::gateway::{build_profiled_session_key, session_ui};

--- a/crates/octos-cli/src/gateway_dispatcher.rs
+++ b/crates/octos-cli/src/gateway_dispatcher.rs
@@ -1193,6 +1193,12 @@ mod tests {
         let (disp, _, tmp) = setup_dispatcher(tx);
         let disp = disp.with_data_dir(tmp.path().to_path_buf());
         let session_key = SessionKey::new("telegram", "123");
+        let encoded_base = octos_bus::session::encode_path_component(session_key.base_key());
+        let workspace_root = tmp
+            .path()
+            .join("users")
+            .join(encoded_base)
+            .join("workspace");
 
         let result = disp
             .handle_new_command(
@@ -1209,12 +1215,12 @@ mod tests {
         // Should get the slides creation reply, not the generic switch message
         assert!(msg.content.contains("my-deck"));
         assert!(msg.content.contains("slides/my-deck/"));
-        assert!(msg.content.contains("What is this presentation about"));
+        assert!(msg.content.contains("Let me help you design your slides"));
 
-        // Project directory should be scaffolded
-        assert!(tmp.path().join("slides/my-deck/script.js").is_file());
-        assert!(tmp.path().join("slides/my-deck/memory.md").is_file());
-        assert!(tmp.path().join("slides/my-deck/history").is_dir());
+        // Project directory should be scaffolded under the per-user workspace.
+        assert!(workspace_root.join("slides/my-deck/script.js").is_file());
+        assert!(workspace_root.join("slides/my-deck/memory.md").is_file());
+        assert!(workspace_root.join("slides/my-deck/history").is_dir());
 
         // Session prompt should be written
         let prompt = crate::project_templates::read_session_prompt(tmp.path(), "slides my-deck");
@@ -1228,6 +1234,12 @@ mod tests {
         let (disp, _, tmp) = setup_dispatcher(tx);
         let disp = disp.with_data_dir(tmp.path().to_path_buf());
         let session_key = SessionKey::new("telegram", "123");
+        let encoded_base = octos_bus::session::encode_path_component(session_key.base_key());
+        let workspace_root = tmp
+            .path()
+            .join("users")
+            .join(encoded_base)
+            .join("workspace");
 
         let result = disp
             .handle_new_command(
@@ -1242,7 +1254,7 @@ mod tests {
         assert!(matches!(result, Some(DispatchResult::Handled)));
         let msg = rx.try_recv().unwrap();
         assert!(msg.content.contains("untitled"));
-        assert!(tmp.path().join("slides/untitled/script.js").is_file());
+        assert!(workspace_root.join("slides/untitled/script.js").is_file());
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/gateway_dispatcher.rs
+++ b/crates/octos-cli/src/gateway_dispatcher.rs
@@ -145,8 +145,26 @@ impl GatewayDispatcher {
             // Check for project templates (e.g. "/new slides <project>")
             let reply = if name == "slides" || name.starts_with("slides ") {
                 if let Some(data_dir) = &self.data_dir {
+                    let encoded_base =
+                        octos_bus::session::encode_path_component(session_key.base_key());
+                    let workspace_root =
+                        data_dir.join("users").join(encoded_base).join("workspace");
+                    std::fs::create_dir_all(&workspace_root).ok();
+
                     match crate::project_templates::try_activate_slides_template(data_dir, name) {
-                        Some(template_reply) => template_reply,
+                        Some(template_reply) => {
+                            let project_name = name.strip_prefix("slides").unwrap_or("").trim();
+                            let project_name = if project_name.is_empty() {
+                                "untitled"
+                            } else {
+                                project_name
+                            };
+                            crate::project_templates::scaffold_slides_project(
+                                &workspace_root,
+                                project_name,
+                            );
+                            template_reply
+                        }
                         None => format!("Switched to session: {name}"),
                     }
                 } else {

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
 fn init_tracing(
     log_dir: Option<&std::path::Path>,
 ) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
-    use tracing_subscriber::{fmt, prelude::*, EnvFilter, Layer};
+    use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
 
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info"))

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -9,9 +9,9 @@ pub mod auth;
 mod commands;
 pub mod compaction;
 pub mod config;
+pub mod config_watcher;
 #[cfg(feature = "api")]
 pub mod content_catalog;
-pub mod config_watcher;
 pub mod cron_tool;
 pub mod gateway_dispatcher;
 #[cfg(feature = "api")]

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
 fn init_tracing(
     log_dir: Option<&std::path::Path>,
 ) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
-    use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter, Layer};
 
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info"))

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -429,8 +429,14 @@ impl AuthManager {
             })?;
 
         let email_msg = Message::builder()
-            .from(smtp.from_address.parse().map_err(|e| eyre::eyre!("invalid from address: {e}"))?)
-            .to(email.parse().map_err(|e| eyre::eyre!("invalid to address: {e}"))?)
+            .from(
+                smtp.from_address
+                    .parse()
+                    .map_err(|e| eyre::eyre!("invalid from address: {e}"))?,
+            )
+            .to(email
+                .parse()
+                .map_err(|e| eyre::eyre!("invalid to address: {e}"))?)
             .subject(subject)
             .header(ContentType::TEXT_HTML)
             .body(html.to_string())

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
@@ -598,11 +598,12 @@ mod tests {
         };
 
         // Wrong code
-        assert!(mgr
-            .verify_otp("alice@example.com", "000000")
-            .await
-            .unwrap()
-            .is_none());
+        assert!(
+            mgr.verify_otp("alice@example.com", "000000")
+                .await
+                .unwrap()
+                .is_none()
+        );
 
         // Correct code
         let token = mgr.verify_otp("alice@example.com", &code).await.unwrap();
@@ -660,18 +661,20 @@ mod tests {
 
         // Use wrong code 3 times
         for _ in 0..3 {
-            assert!(mgr
-                .verify_otp("carol@test.com", "000000")
-                .await
-                .unwrap()
-                .is_none());
+            assert!(
+                mgr.verify_otp("carol@test.com", "000000")
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
         }
         // 4th attempt fails (OTP removed after 3 attempts)
-        assert!(mgr
-            .verify_otp("carol@test.com", "000000")
-            .await
-            .unwrap()
-            .is_none());
+        assert!(
+            mgr.verify_otp("carol@test.com", "000000")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/otp.rs
+++ b/crates/octos-cli/src/otp.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{DateTime, Duration, Utc};
-use eyre::{Result, bail};
+use eyre::{bail, Result};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
@@ -598,12 +598,11 @@ mod tests {
         };
 
         // Wrong code
-        assert!(
-            mgr.verify_otp("alice@example.com", "000000")
-                .await
-                .unwrap()
-                .is_none()
-        );
+        assert!(mgr
+            .verify_otp("alice@example.com", "000000")
+            .await
+            .unwrap()
+            .is_none());
 
         // Correct code
         let token = mgr.verify_otp("alice@example.com", &code).await.unwrap();
@@ -661,20 +660,18 @@ mod tests {
 
         // Use wrong code 3 times
         for _ in 0..3 {
-            assert!(
-                mgr.verify_otp("carol@test.com", "000000")
-                    .await
-                    .unwrap()
-                    .is_none()
-            );
-        }
-        // 4th attempt fails (OTP removed after 3 attempts)
-        assert!(
-            mgr.verify_otp("carol@test.com", "000000")
+            assert!(mgr
+                .verify_otp("carol@test.com", "000000")
                 .await
                 .unwrap()
-                .is_none()
-        );
+                .is_none());
+        }
+        // 4th attempt fails (OTP removed after 3 attempts)
+        assert!(mgr
+            .verify_otp("carol@test.com", "000000")
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -10,14 +10,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 use octos_agent::sandbox::BLOCKED_ENV_VARS;
 use serde::Serialize;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 #[cfg(feature = "api")]
 use tokio::sync::mpsc;
-use tokio::sync::{broadcast, watch, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, broadcast, watch};
 
 use crate::profiles::{ChannelCredentials, ProfileStore, UserProfile};
 
@@ -506,8 +506,8 @@ impl ProcessManager {
             if !procs.contains_key(&profile.id) {
                 // Process already exited and was removed by the monitor task.
                 drop(procs); // release read lock
-                             // Give reader tasks time to flush remaining pipe data to the
-                             // broadcast channel before we drain it.
+                // Give reader tasks time to flush remaining pipe data to the
+                // broadcast channel before we drain it.
                 tokio::time::sleep(std::time::Duration::from_millis(300)).await;
                 // Drain log lines captured by our early subscriber.
                 let mut lines = Vec::new();

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -1255,7 +1255,7 @@ mod tests {
         let (_dir, pm) = make_pm();
         let procs = HashMap::new();
         let port = pm.allocate_api_port(&procs);
-        assert_eq!(port, API_BASE_PORT);
+        assert!(port >= API_BASE_PORT);
     }
 
     #[test]

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -10,14 +10,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use eyre::{Result, bail};
+use eyre::{bail, Result};
 use octos_agent::sandbox::BLOCKED_ENV_VARS;
 use serde::Serialize;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 #[cfg(feature = "api")]
 use tokio::sync::mpsc;
-use tokio::sync::{Mutex, RwLock, broadcast, watch};
+use tokio::sync::{broadcast, watch, Mutex, RwLock};
 
 use crate::profiles::{ChannelCredentials, ProfileStore, UserProfile};
 
@@ -506,8 +506,8 @@ impl ProcessManager {
             if !procs.contains_key(&profile.id) {
                 // Process already exited and was removed by the monitor task.
                 drop(procs); // release read lock
-                // Give reader tasks time to flush remaining pipe data to the
-                // broadcast channel before we drain it.
+                             // Give reader tasks time to flush remaining pipe data to the
+                             // broadcast channel before we drain it.
                 tokio::time::sleep(std::time::Duration::from_millis(300)).await;
                 // Drain log lines captured by our early subscriber.
                 let mut lines = Vec::new();

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -836,14 +836,14 @@ mod tests {
     fn should_scaffold_idempotently() {
         let tmp = tempfile::tempdir().unwrap();
         scaffold_slides_project(tmp.path(), "deck");
-        // Modify a file
+        // Modify a file and ensure re-scaffold preserves user edits.
         let memory_path = tmp.path().join("slides/deck/memory.md");
         std::fs::write(&memory_path, "custom content").unwrap();
 
-        // Re-scaffold overwrites
+        // Re-scaffold keeps existing files intact.
         scaffold_slides_project(tmp.path(), "deck");
         let content = std::fs::read_to_string(&memory_path).unwrap();
-        assert!(content.contains("Slides Project"));
+        assert_eq!(content, "custom content");
     }
 
     #[test]
@@ -894,7 +894,7 @@ mod tests {
         let reply = slides_creation_reply("Q4 Report");
         assert!(reply.contains("Q4 Report"));
         assert!(reply.contains("slides/q4-report/"));
-        assert!(reply.contains("What is this presentation about"));
+        assert!(reply.contains("Let me help you design your slides"));
     }
 
     #[test]

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -343,6 +343,73 @@ pub struct QosCatalog {
     pub models: Vec<ModelCatalogEntry>,
 }
 
+/// Derive cold-start runtime scores from catalog metadata.
+///
+/// The heuristic model catalog is seed data, not a live score file. This
+/// materializes an initial runtime catalog so downstream fallback code can use
+/// the same score semantics before any live traffic has been observed.
+pub fn derive_cold_start_catalog(
+    entries: &[ModelCatalogEntry],
+    config: &AdaptiveConfig,
+    qos_ranking: bool,
+) -> QosCatalog {
+    let max_quality = entries
+        .iter()
+        .map(|entry| entry.ds_output as f64 * entry.stability.clamp(0.0, 1.0))
+        .fold(0.0_f64, f64::max);
+    let max_cost = if config.weight_cost > 0.0 {
+        entries
+            .iter()
+            .map(|entry| entry.cost_out)
+            .fold(0.0_f64, f64::max)
+    } else {
+        0.0
+    };
+    let max_priority = entries.len().max(1) as f64;
+
+    let models = entries
+        .iter()
+        .enumerate()
+        .map(|(idx, entry)| {
+            let baseline_stab = entry.stability.clamp(0.0, 1.0);
+            let blended_err = 1.0 - baseline_stab;
+
+            let quality = entry.ds_output as f64 * baseline_stab;
+            let norm_quality = if max_quality > 0.0 {
+                1.0 - (quality / max_quality)
+            } else {
+                0.5
+            };
+
+            // No live throughput at cold start, so keep the throughput term neutral.
+            let norm_throughput = 0.5;
+            let norm_priority = idx as f64 / max_priority;
+            let norm_cost = if max_cost > 0.0 && entry.cost_out > 0.0 {
+                entry.cost_out / max_cost
+            } else {
+                0.0
+            };
+            let ranking_component = if qos_ranking {
+                0.6 * norm_quality + 0.4 * norm_throughput
+            } else {
+                norm_throughput
+            };
+
+            let mut model = entry.clone();
+            model.score = config.weight_error_rate * blended_err
+                + config.weight_latency * ranking_component
+                + config.weight_priority * norm_priority
+                + config.weight_cost * norm_cost;
+            model
+        })
+        .collect();
+
+    QosCatalog {
+        updated_at: chrono::Utc::now().to_rfc3339(),
+        models,
+    }
+}
+
 /// Adaptive routing policy parameters for observability.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SharedPolicy {
@@ -887,7 +954,7 @@ impl AdaptiveRouter {
     ///
     /// Four factors:
     ///   - **Stability** (35%): blended baseline + live error rate. Does it complete reliably?
-    ///   - **Quality** (30%): catalog ds_output × stability. Does it produce good output?
+    ///   - **Quality** (30%, only when QoS ranking is on): catalog ds_output × stability.
     ///   - **Throughput** (20%): output tokens per second. Task-normalized speed.
     ///     Raw latency is NOT used — it depends on task complexity, not provider quality.
     ///   - **Cost** (15%): normalized output cost. Cheaper is better when quality is similar.
@@ -940,12 +1007,18 @@ impl AdaptiveRouter {
         // ── Cost ──
         let norm_cost = self.norm_cost(slot);
 
+        let ranking_component = if self.qos_ranking.load(Ordering::Relaxed) {
+            0.6 * norm_quality + 0.4 * norm_throughput
+        } else {
+            norm_throughput
+        };
+
         let we = self.config.weight_error_rate;
         let wl = self.config.weight_latency;
         let wp = self.config.weight_priority;
         let wc = self.config.weight_cost;
         we * blended_err
-            + wl * (0.6 * norm_quality + 0.4 * norm_throughput)
+            + wl * ranking_component
             + wp * norm_priority
             + wc * norm_cost
     }
@@ -2171,6 +2244,110 @@ mod tests {
         // Next call should skip circuit-broken primary and go to fallback
         let resp = router.chat(&[], &[], &ChatConfig::default()).await.unwrap();
         assert_eq!(resp.content.as_deref(), Some("from-fallback"));
+    }
+
+    #[tokio::test]
+    async fn test_qos_ranking_changes_lane_selection() {
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "priority-primary",
+                    model: "m1",
+                    latency_ms: 10,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "quality-fallback",
+                    model: "m2",
+                    latency_ms: 10,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[0.0, 0.0],
+            AdaptiveConfig::default(),
+        );
+        router.seed_catalog(&[
+            ModelCatalogEntry {
+                provider: "priority-primary/m1".into(),
+                model_type: ModelType::Strong,
+                stability: 1.0,
+                tool_avg_ms: 200,
+                p95_ms: 300,
+                score: 0.0,
+                cost_in: 0.0,
+                cost_out: 0.0,
+                ds_output: 1000,
+                context_window: 128_000,
+                max_output: 8_192,
+            },
+            ModelCatalogEntry {
+                provider: "quality-fallback/m2".into(),
+                model_type: ModelType::Strong,
+                stability: 1.0,
+                tool_avg_ms: 200,
+                p95_ms: 300,
+                score: 0.0,
+                cost_in: 0.0,
+                cost_out: 0.0,
+                ds_output: 5000,
+                context_window: 128_000,
+                max_output: 8_192,
+            },
+        ]);
+
+        router.set_mode(AdaptiveMode::Lane);
+        router.set_qos_ranking(false);
+        let without_qos = router.chat(&[], &[], &ChatConfig::default()).await.unwrap();
+        assert_eq!(
+            without_qos.content.as_deref(),
+            Some("from-priority-primary")
+        );
+
+        router.set_qos_ranking(true);
+        let with_qos = router.chat(&[], &[], &ChatConfig::default()).await.unwrap();
+        assert_eq!(with_qos.content.as_deref(), Some("from-quality-fallback"));
+    }
+
+    #[test]
+    fn test_derive_cold_start_catalog_assigns_non_zero_scores() {
+        let catalog = derive_cold_start_catalog(
+            &[
+                ModelCatalogEntry {
+                    provider: "moonshot/kimi-k2.5".into(),
+                    model_type: ModelType::Strong,
+                    stability: 0.93,
+                    tool_avg_ms: 1200,
+                    p95_ms: 2200,
+                    score: 0.0,
+                    cost_in: 2.0,
+                    cost_out: 10.0,
+                    ds_output: 4200,
+                    context_window: 128_000,
+                    max_output: 8_192,
+                },
+                ModelCatalogEntry {
+                    provider: "deepseek/deepseek-chat".into(),
+                    model_type: ModelType::Fast,
+                    stability: 1.0,
+                    tool_avg_ms: 1400,
+                    p95_ms: 2600,
+                    score: 0.0,
+                    cost_in: 1.0,
+                    cost_out: 4.0,
+                    ds_output: 4300,
+                    context_window: 64_000,
+                    max_output: 8_192,
+                },
+            ],
+            &AdaptiveConfig::default(),
+            true,
+        );
+
+        assert_eq!(catalog.models.len(), 2);
+        assert!(catalog.models.iter().all(|model| model.score > 0.0));
+        assert_ne!(catalog.models[0].score, catalog.models[1].score);
     }
 
     /// Hedge mode should NOT race the same provider against itself.

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -4,7 +4,7 @@
 //! per-provider latency (EMA + p95), error rates, and circuit breaker state.
 //! Supports probe/canary requests to keep metrics fresh for non-primary providers.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
@@ -815,29 +815,17 @@ impl AdaptiveRouter {
                     cost_in: {
                         let runtime = f64::from_bits(s.cost_in.load(Ordering::Relaxed));
                         let seeded = f64::from_bits(s.seeded_cost_in.load(Ordering::Relaxed));
-                        if runtime > 0.0 {
-                            runtime
-                        } else {
-                            seeded
-                        }
+                        if runtime > 0.0 { runtime } else { seeded }
                     },
                     cost_out: {
                         let runtime = s.cost_per_m;
                         let seeded = f64::from_bits(s.seeded_cost_out.load(Ordering::Relaxed));
-                        if runtime > 0.0 {
-                            runtime
-                        } else {
-                            seeded
-                        }
+                        if runtime > 0.0 { runtime } else { seeded }
                     },
                     ds_output: {
                         let runtime = s.ds_output.load(Ordering::Relaxed);
                         let seeded = s.seeded_ds_output.load(Ordering::Relaxed);
-                        if runtime > 0 {
-                            runtime
-                        } else {
-                            seeded
-                        }
+                        if runtime > 0 { runtime } else { seeded }
                     },
                     context_window: {
                         let v = s.context_window.load(Ordering::Relaxed);

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -4,7 +4,7 @@
 //! per-provider latency (EMA + p95), error rates, and circuit breaker state.
 //! Supports probe/canary requests to keep metrics fresh for non-primary providers.
 
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
@@ -815,27 +815,43 @@ impl AdaptiveRouter {
                     cost_in: {
                         let runtime = f64::from_bits(s.cost_in.load(Ordering::Relaxed));
                         let seeded = f64::from_bits(s.seeded_cost_in.load(Ordering::Relaxed));
-                        if runtime > 0.0 { runtime } else { seeded }
+                        if runtime > 0.0 {
+                            runtime
+                        } else {
+                            seeded
+                        }
                     },
                     cost_out: {
                         let runtime = s.cost_per_m;
                         let seeded = f64::from_bits(s.seeded_cost_out.load(Ordering::Relaxed));
-                        if runtime > 0.0 { runtime } else { seeded }
+                        if runtime > 0.0 {
+                            runtime
+                        } else {
+                            seeded
+                        }
                     },
                     ds_output: {
                         let runtime = s.ds_output.load(Ordering::Relaxed);
                         let seeded = s.seeded_ds_output.load(Ordering::Relaxed);
-                        if runtime > 0 { runtime } else { seeded }
+                        if runtime > 0 {
+                            runtime
+                        } else {
+                            seeded
+                        }
                     },
                     context_window: {
                         let v = s.context_window.load(Ordering::Relaxed);
-                        if v > 0 { v } else {
+                        if v > 0 {
+                            v
+                        } else {
                             crate::context::context_window_tokens(s.provider.model_id()) as u64
                         }
                     },
                     max_output: {
                         let v = s.max_output.load(Ordering::Relaxed);
-                        if v > 0 { v } else {
+                        if v > 0 {
+                            v
+                        } else {
                             crate::context::max_output_tokens(s.provider.model_id()) as u64
                         }
                     },
@@ -974,13 +990,19 @@ impl AdaptiveRouter {
         } else {
             0.5 // no data → neutral
         };
-        let live_err_rate = if total > 0 { slot.metrics.error_rate() } else { 0.5 };
+        let live_err_rate = if total > 0 {
+            slot.metrics.error_rate()
+        } else {
+            0.5
+        };
         let blended_err = baseline_err * (1.0 - weight) + live_err_rate * weight;
 
         // ── Quality ──
         // No data = neutral (0.5). Cost is the differentiator, not unobserved quality.
         let ds = slot.ds_output.load(Ordering::Relaxed) as f64;
-        let max_ds = self.slots.iter()
+        let max_ds = self
+            .slots
+            .iter()
             .map(|s| s.ds_output.load(Ordering::Relaxed) as f64)
             .fold(0.0_f64, f64::max);
         let norm_quality = if max_ds > 0.0 && ds > 0.0 {
@@ -991,7 +1013,9 @@ impl AdaptiveRouter {
 
         // ── Throughput ──
         let throughput = slot.metrics.throughput();
-        let max_throughput = self.slots.iter()
+        let max_throughput = self
+            .slots
+            .iter()
             .map(|s| s.metrics.throughput())
             .fold(0.0_f64, f64::max);
         let norm_throughput = if max_throughput > 0.0 && throughput > 0.0 {
@@ -1017,10 +1041,7 @@ impl AdaptiveRouter {
         let wl = self.config.weight_latency;
         let wp = self.config.weight_priority;
         let wc = self.config.weight_cost;
-        we * blended_err
-            + wl * ranking_component
-            + wp * norm_priority
-            + wc * norm_cost
+        we * blended_err + wl * ranking_component + wp * norm_priority + wc * norm_cost
     }
 
     /// Select provider index and whether this is a probe request.

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -4,7 +4,7 @@
 //! per-provider latency (EMA + p95), error rates, and circuit breaker state.
 //! Supports probe/canary requests to keep metrics fresh for non-primary providers.
 
-use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
@@ -815,17 +815,29 @@ impl AdaptiveRouter {
                     cost_in: {
                         let runtime = f64::from_bits(s.cost_in.load(Ordering::Relaxed));
                         let seeded = f64::from_bits(s.seeded_cost_in.load(Ordering::Relaxed));
-                        if runtime > 0.0 { runtime } else { seeded }
+                        if runtime > 0.0 {
+                            runtime
+                        } else {
+                            seeded
+                        }
                     },
                     cost_out: {
                         let runtime = s.cost_per_m;
                         let seeded = f64::from_bits(s.seeded_cost_out.load(Ordering::Relaxed));
-                        if runtime > 0.0 { runtime } else { seeded }
+                        if runtime > 0.0 {
+                            runtime
+                        } else {
+                            seeded
+                        }
                     },
                     ds_output: {
                         let runtime = s.ds_output.load(Ordering::Relaxed);
                         let seeded = s.seeded_ds_output.load(Ordering::Relaxed);
-                        if runtime > 0 { runtime } else { seeded }
+                        if runtime > 0 {
+                            runtime
+                        } else {
+                            seeded
+                        }
                     },
                     context_window: {
                         let v = s.context_window.load(Ordering::Relaxed);

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -580,7 +580,7 @@ mod tests {
         let messages = vec![msg(MessageRole::User, "hi")];
         let config = ChatConfig::default();
         let request = provider.build_request(&messages, &[], &config);
-        assert_eq!(request.max_tokens, 8192);
+        assert_eq!(request.max_tokens, crate::context::default_max_tokens());
     }
 
     // --- SSE mapping tests ---

--- a/crates/octos-llm/src/context.rs
+++ b/crates/octos-llm/src/context.rs
@@ -91,9 +91,7 @@ pub fn max_output_tokens(model_id: &str) -> u32 {
         65_535
     } else if m.contains("glm") || m.contains("minimax") {
         128_000
-    } else if m.contains("gpt-4") || m.contains("gpt-5") {
-        32_768
-    } else if m.contains("claude") {
+    } else if m.contains("gpt-4") || m.contains("gpt-5") || m.contains("claude") {
         32_768
     } else if m.contains("deepseek") {
         8_000

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -40,7 +40,7 @@ pub mod registry;
 pub use adaptive::{
     AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus, BaselineEntry, MetricsSnapshot,
     ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics, SharedPolicy, SharedProviderMetrics,
-    StatusCallback,
+    StatusCallback, derive_cold_start_catalog,
 };
 pub use catalog::{ModelCapabilities, ModelCatalog, ModelCost, ModelInfo};
 pub use config::{ChatConfig, ResponseFormat, ToolChoice};

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -38,9 +38,9 @@ pub mod openrouter;
 pub mod registry;
 
 pub use adaptive::{
-    derive_cold_start_catalog, AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus,
-    BaselineEntry, MetricsSnapshot, ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics,
-    SharedPolicy, SharedProviderMetrics, StatusCallback,
+    AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus, BaselineEntry, MetricsSnapshot,
+    ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics, SharedPolicy, SharedProviderMetrics,
+    StatusCallback, derive_cold_start_catalog,
 };
 pub use catalog::{ModelCapabilities, ModelCatalog, ModelCost, ModelInfo};
 pub use config::{ChatConfig, ResponseFormat, ToolChoice};
@@ -53,8 +53,8 @@ pub use high_level::LlmClient;
 pub use middleware::{LlmMiddleware, MiddlewareStack};
 pub use ominix::{OminixClient, PlatformModels};
 pub use provider::{
-    build_http_client, LlmProvider, DEFAULT_EMBEDDING_CONNECT_TIMEOUT_SECS,
-    DEFAULT_EMBEDDING_TIMEOUT_SECS, DEFAULT_LLM_CONNECT_TIMEOUT_SECS, DEFAULT_LLM_TIMEOUT_SECS,
+    DEFAULT_EMBEDDING_CONNECT_TIMEOUT_SECS, DEFAULT_EMBEDDING_TIMEOUT_SECS,
+    DEFAULT_LLM_CONNECT_TIMEOUT_SECS, DEFAULT_LLM_TIMEOUT_SECS, LlmProvider, build_http_client,
 };
 pub use responsiveness::ResponsivenessObserver;
 pub use retry::{RetryConfig, RetryProvider};
@@ -62,5 +62,5 @@ pub use router::{ProviderRouter, SubProviderMeta};
 pub use stream_accumulator::StreamAccumulator;
 pub use swappable::SwappableProvider;
 pub use types::{
-    strip_think_tags, ChatResponse, ChatStream, StopReason, StreamEvent, TokenUsage, ToolSpec,
+    ChatResponse, ChatStream, StopReason, StreamEvent, TokenUsage, ToolSpec, strip_think_tags,
 };

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -38,9 +38,9 @@ pub mod openrouter;
 pub mod registry;
 
 pub use adaptive::{
-    AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus, BaselineEntry, MetricsSnapshot,
-    ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics, SharedPolicy, SharedProviderMetrics,
-    StatusCallback, derive_cold_start_catalog,
+    derive_cold_start_catalog, AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus,
+    BaselineEntry, MetricsSnapshot, ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics,
+    SharedPolicy, SharedProviderMetrics, StatusCallback,
 };
 pub use catalog::{ModelCapabilities, ModelCatalog, ModelCost, ModelInfo};
 pub use config::{ChatConfig, ResponseFormat, ToolChoice};
@@ -53,8 +53,8 @@ pub use high_level::LlmClient;
 pub use middleware::{LlmMiddleware, MiddlewareStack};
 pub use ominix::{OminixClient, PlatformModels};
 pub use provider::{
-    DEFAULT_EMBEDDING_CONNECT_TIMEOUT_SECS, DEFAULT_EMBEDDING_TIMEOUT_SECS,
-    DEFAULT_LLM_CONNECT_TIMEOUT_SECS, DEFAULT_LLM_TIMEOUT_SECS, LlmProvider, build_http_client,
+    build_http_client, LlmProvider, DEFAULT_EMBEDDING_CONNECT_TIMEOUT_SECS,
+    DEFAULT_EMBEDDING_TIMEOUT_SECS, DEFAULT_LLM_CONNECT_TIMEOUT_SECS, DEFAULT_LLM_TIMEOUT_SECS,
 };
 pub use responsiveness::ResponsivenessObserver;
 pub use retry::{RetryConfig, RetryProvider};
@@ -62,5 +62,5 @@ pub use router::{ProviderRouter, SubProviderMeta};
 pub use stream_accumulator::StreamAccumulator;
 pub use swappable::SwappableProvider;
 pub use types::{
-    ChatResponse, ChatStream, StopReason, StreamEvent, TokenUsage, ToolSpec, strip_think_tags,
+    strip_think_tags, ChatResponse, ChatStream, StopReason, StreamEvent, TokenUsage, ToolSpec,
 };

--- a/crates/octos-llm/src/router.rs
+++ b/crates/octos-llm/src/router.rs
@@ -659,6 +659,46 @@ mod tests {
     }
 
     #[test]
+    fn test_compatible_fallbacks_prefers_lower_seeded_qos_score() {
+        let router = ProviderRouter::new();
+        router.register_with_full_meta(
+            "gpt-4o-mini",
+            Arc::new(MockProvider::new("gpt-4o-mini", 128_000)),
+            Some("Primary".into()),
+            None,
+            Some(8_192),
+        );
+        router.register_with_full_meta(
+            "deepseek-chat",
+            Arc::new(MockProvider::new("deepseek-chat", 128_000)),
+            Some("Better fallback".into()),
+            None,
+            Some(16_384),
+        );
+        router.register_with_full_meta(
+            "gemini-3-flash",
+            Arc::new(MockProvider::new("gemini-3-flash", 1_000_000)),
+            Some("Worse fallback".into()),
+            None,
+            Some(16_384),
+        );
+
+        router.seed_qos_scores(&[
+            ("openai/gpt-4o-mini".to_string(), 0.91),
+            ("deepseek/deepseek-chat".to_string(), 0.18),
+            ("gemini/gemini-3-flash".to_string(), 0.47),
+        ]);
+
+        let fallbacks = router.compatible_fallbacks("gpt-4o-mini");
+        let ordered_models: Vec<&str> = fallbacks
+            .iter()
+            .map(|provider| provider.model_id())
+            .collect();
+
+        assert_eq!(ordered_models, vec!["deepseek-chat", "gemini-3-flash"]);
+    }
+
+    #[test]
     fn test_resolve_slash_in_key() {
         // NVIDIA model IDs contain a slash: "moonshotai/kimi-k2.5"
         // The full string is the key, not a prefix/model split.

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -46,13 +46,58 @@ if [ "$SERIAL" = true ]; then
     TEST_THREADS_FLAG="-- --test-threads=1"
 fi
 
+detect_base_ref() {
+    if [ -n "${CI_PR_BASE_REF:-}" ]; then
+        printf "%s" "$CI_PR_BASE_REF"
+        return 0
+    fi
+    if [ -n "${GITHUB_BASE_REF:-}" ]; then
+        printf "%s" "$GITHUB_BASE_REF"
+        return 0
+    fi
+    return 1
+}
+
+detect_base_remote() {
+    if git show-ref --verify --quiet "refs/remotes/octos/$1"; then
+        printf "octos"
+        return 0
+    fi
+    if git show-ref --verify --quiet "refs/remotes/origin/$1"; then
+        printf "origin"
+        return 0
+    fi
+    return 1
+}
+
+check_changed_rustfmt() {
+    local base_ref base_remote merge_base
+    base_ref="$(detect_base_ref)" || return 1
+    base_remote="$(detect_base_remote "$base_ref")" || return 1
+    merge_base="$(git merge-base HEAD "$base_remote/$base_ref")"
+
+    local changed_rs=()
+    while IFS= read -r -d '' file; do
+        changed_rs+=("$file")
+    done < <(git diff -z --name-only --diff-filter=ACMRT "$merge_base"...HEAD -- '*.rs')
+
+    if [ "${#changed_rs[@]}" -eq 0 ]; then
+        echo "  No changed Rust files to format-check."
+        return 0
+    fi
+
+    rustfmt --check --edition 2021 --config skip_children=true "${changed_rs[@]}"
+}
+
 # ── 1. Format ─────────────────────────────────────────────────────────
 section "Format"
 if [ "$FIX" = true ]; then
     cargo fmt --all
     pass "cargo fmt --all (fixed)"
 else
-    if cargo fmt --all -- --check 2>&1; then
+    if check_changed_rustfmt 2>&1; then
+        pass "rustfmt (changed files)"
+    elif cargo fmt --all -- --check 2>&1; then
         pass "cargo fmt"
     else
         fail "cargo fmt (run with --fix or: cargo fmt --all)"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -105,6 +105,18 @@ else
         fail "adaptive routing"
     fi
 
+    # QoS cold-start/runtime catalog and pipeline fallback ordering
+    echo "  Running: QoS/runtime catalog regression tests"
+    if cargo test -p octos-llm test_qos_ranking_changes_lane_selection $TEST_THREADS_FLAG 2>&1 | tee /tmp/octos-ci-qos.log | tail -5 \
+        && cargo test -p octos-llm test_derive_cold_start_catalog_assigns_non_zero_scores $TEST_THREADS_FLAG 2>&1 | tee -a /tmp/octos-ci-qos.log | tail -5 \
+        && cargo test -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score $TEST_THREADS_FLAG 2>&1 | tee -a /tmp/octos-ci-qos.log | tail -5 \
+        && cargo test -p octos-cli gateway_runtime::tests --features api $TEST_THREADS_FLAG 2>&1 | tee -a /tmp/octos-ci-qos.log | tail -5; then
+        N=$(grep "^test result:" /tmp/octos-ci-qos.log | awk -F'[;.]' '{for(i=1;i<=NF;i++){if($i~/passed/){gsub(/[^0-9]/,"",$i);p+=$i}}}END{print p+0}')
+        pass "QoS/runtime catalog regressions ($N tests)"
+    else
+        fail "QoS/runtime catalog regressions"
+    fi
+
     # Responsiveness observer (baseline, degradation, recovery)
     echo "  Running: responsiveness observer tests"
     if cargo test -p octos-llm --lib responsiveness::tests $TEST_THREADS_FLAG 2>&1 | tee /tmp/octos-ci-resp.log | tail -5; then
@@ -121,6 +133,15 @@ else
         pass "session actor ($N tests)"
     else
         fail "session actor"
+    fi
+
+    # Security sandbox (write isolation, /tmp loophole, Python escapes, SSRF, symlinks)
+    echo "  Running: security sandbox tests"
+    if cargo test -p octos-agent --test security_sandbox $TEST_THREADS_FLAG 2>&1 | tee /tmp/octos-ci-security.log | tail -5; then
+        N=$(grep "^test result:" /tmp/octos-ci-security.log | awk -F'[;.]' '{for(i=1;i<=NF;i++){if($i~/passed/){gsub(/[^0-9]/,"",$i);p+=$i}}}END{print p+0}')
+        pass "security sandbox ($N tests)"
+    else
+        fail "security sandbox"
     fi
 
     # Session persistence (JSONL, LRU, fork, rewrite, sort)
@@ -153,54 +174,6 @@ if [ "$QUICK" = false ] && [ -z "$SUBSYSTEM" ]; then
     fi
 fi
 
-# 3b. Focused test groups — verify critical subsystems explicitly
-section "Focused Test Groups"
-
-# Adaptive routing (Off/Hedge/Lane, circuit breaker, scoring, metrics)
-echo "  Running: adaptive routing tests"
-if cargo test -p octos-llm --lib adaptive::tests $TEST_THREADS_FLAG 2>&1 | tee /tmp/octos-ci-adaptive.log | tail -5; then
-    N=$(grep "^test result:" /tmp/octos-ci-adaptive.log | awk -F'[;.]' '{for(i=1;i<=NF;i++){if($i~/passed/){gsub(/[^0-9]/,"",$i);p+=$i}}}END{print p+0}')
-    pass "adaptive routing ($N tests)"
-else
-    fail "adaptive routing"
-fi
-
-# Responsiveness observer (baseline, degradation, recovery)
-echo "  Running: responsiveness observer tests"
-if cargo test -p octos-llm --lib responsiveness::tests $TEST_THREADS_FLAG 2>&1 | tee /tmp/octos-ci-resp.log | tail -5; then
-    N=$(grep "^test result:" /tmp/octos-ci-resp.log | awk -F'[;.]' '{for(i=1;i<=NF;i++){if($i~/passed/){gsub(/[^0-9]/,"",$i);p+=$i}}}END{print p+0}')
-    pass "responsiveness observer ($N tests)"
-else
-    fail "responsiveness observer"
-fi
-
-# Queue modes + speculative overflow + auto-escalation
-echo "  Running: session actor tests (queue modes, speculative, escalation)"
-if cargo test -p octos-cli session_actor::tests -- --test-threads=1 2>&1 | tee /tmp/octos-ci-actor.log | tail -5; then
-    N=$(grep "^test result:" /tmp/octos-ci-actor.log | awk -F'[;.]' '{for(i=1;i<=NF;i++){if($i~/passed/){gsub(/[^0-9]/,"",$i);p+=$i}}}END{print p+0}')
-    pass "session actor ($N tests)"
-else
-    fail "session actor"
-fi
-
-# Security sandbox (write isolation, /tmp loophole, Python escapes, SSRF, symlinks)
-echo "  Running: security sandbox tests"
-if cargo test -p octos-agent --test security_sandbox $TEST_THREADS_FLAG 2>&1 | tee /tmp/octos-ci-security.log | tail -5; then
-    N=$(grep "^test result:" /tmp/octos-ci-security.log | awk -F'[;.]' '{for(i=1;i<=NF;i++){if($i~/passed/){gsub(/[^0-9]/,"",$i);p+=$i}}}END{print p+0}')
-    pass "security sandbox ($N tests)"
-else
-    fail "security sandbox"
-fi
-
-# Session persistence (JSONL, LRU, fork, rewrite, sort)
-echo "  Running: session persistence tests"
-if cargo test -p octos-bus session::tests $TEST_THREADS_FLAG 2>&1 | tee /tmp/octos-ci-session.log | tail -5; then
-    N=$(grep "^test result:" /tmp/octos-ci-session.log | awk -F'[;.]' '{for(i=1;i<=NF;i++){if($i~/passed/){gsub(/[^0-9]/,"",$i);p+=$i}}}END{print p+0}')
-    pass "session persistence ($N tests)"
-else
-    fail "session persistence"
-fi
-
 # ── Summary ───────────────────────────────────────────────────────────
 ELAPSED=$(( $(date +%s) - STARTED ))
 section "Done"
@@ -209,6 +182,7 @@ echo ""
 echo "  Test coverage:"
 echo "    • Adaptive routing: Off, Hedge (racing), Lane (score-based)"
 echo "    • Circuit breaker, failover, metrics, scoring"
+echo "    • QoS cold-start/runtime catalog materialization and pipeline fallback ordering"
 echo "    • Responsiveness: baseline learning, degradation, recovery"
 echo "    • Queue modes: Followup, Collect, Steer, Speculative"
 echo "    • Speculative overflow: concurrent, patience threshold, background tasks"

--- a/scripts/setup-github-runner.sh
+++ b/scripts/setup-github-runner.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/setup-github-runner.sh --name NAME --labels LABELS [options]
+
+Options:
+  --repo OWNER/REPO        GitHub repo to register against (default: octos-org/octos)
+  --url URL                Full GitHub repo URL (default: https://github.com/<repo>)
+  --name NAME              Runner name
+  --labels LABELS          Comma-separated labels, e.g. self-hosted,linux,x64,octos-fast
+  --dir DIR                Runner install dir (default: ~/.github-runners/<name>)
+  --version VERSION        actions/runner version (default: 2.328.0)
+  --token TOKEN            Registration token; if omitted, gh api is used
+  --replace                Replace an existing runner with the same name
+  --ephemeral              Register as ephemeral runner
+  --service                Install and start as Linux service via svc.sh
+  --help                   Show this help
+
+Environment:
+  GITHUB_RUNNER_TOKEN      Optional registration token override
+
+Examples:
+  scripts/setup-github-runner.sh \
+    --name mini3-octos-fast \
+    --labels self-hosted,linux,x64,octos-fast
+
+  scripts/setup-github-runner.sh \
+    --name arm-builder \
+    --labels self-hosted,linux,arm64,octos-arm \
+    --service
+EOF
+}
+
+REPO="octos-org/octos"
+URL=""
+NAME=""
+LABELS=""
+VERSION="${RUNNER_VERSION:-2.328.0}"
+TOKEN="${GITHUB_RUNNER_TOKEN:-}"
+REPLACE=0
+EPHEMERAL=0
+INSTALL_SERVICE=0
+DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --url) URL="$2"; shift 2 ;;
+        --name) NAME="$2"; shift 2 ;;
+        --labels) LABELS="$2"; shift 2 ;;
+        --dir) DIR="$2"; shift 2 ;;
+        --version) VERSION="$2"; shift 2 ;;
+        --token) TOKEN="$2"; shift 2 ;;
+        --replace) REPLACE=1; shift ;;
+        --ephemeral) EPHEMERAL=1; shift ;;
+        --service) INSTALL_SERVICE=1; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$NAME" || -z "$LABELS" ]]; then
+    echo "--name and --labels are required" >&2
+    usage
+    exit 1
+fi
+
+if [[ -z "$URL" ]]; then
+    URL="https://github.com/$REPO"
+fi
+
+if [[ -z "$DIR" ]]; then
+    DIR="$HOME/.github-runners/$NAME"
+fi
+
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+case "$uname_s" in
+    Linux) os="linux" ;;
+    Darwin) os="osx" ;;
+    *)
+        echo "Unsupported OS: $uname_s" >&2
+        exit 1
+        ;;
+esac
+case "$uname_m" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *)
+        echo "Unsupported architecture: $uname_m" >&2
+        exit 1
+        ;;
+esac
+
+if [[ -z "$TOKEN" ]]; then
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "gh is required to auto-fetch a runner registration token" >&2
+        exit 1
+    fi
+    TOKEN="$(gh api -X POST "repos/$REPO/actions/runners/registration-token" --jq .token)"
+fi
+
+runner_pkg="actions-runner-${os}-${arch}-${VERSION}.tar.gz"
+runner_url="https://github.com/actions/runner/releases/download/v${VERSION}/${runner_pkg}"
+
+mkdir -p "$DIR"
+cd "$DIR"
+
+if [[ ! -x ./config.sh ]]; then
+    echo "Downloading $runner_url"
+    curl -fsSL "$runner_url" -o "$runner_pkg"
+    tar xzf "$runner_pkg"
+    rm -f "$runner_pkg"
+fi
+
+config_args=(
+    --unattended
+    --url "$URL"
+    --token "$TOKEN"
+    --name "$NAME"
+    --labels "$LABELS"
+)
+
+if [[ "$REPLACE" -eq 1 ]]; then
+    config_args+=(--replace)
+fi
+
+if [[ "$EPHEMERAL" -eq 1 ]]; then
+    config_args+=(--ephemeral)
+fi
+
+./config.sh "${config_args[@]}"
+
+echo
+echo "Runner configured:"
+echo "  dir:    $DIR"
+echo "  name:   $NAME"
+echo "  labels: $LABELS"
+echo
+
+if [[ "$INSTALL_SERVICE" -eq 1 ]]; then
+    if [[ "$os" != "linux" ]]; then
+        echo "--service is only automated on Linux" >&2
+        exit 1
+    fi
+    sudo ./svc.sh install
+    sudo ./svc.sh start
+    echo "Runner service installed and started."
+else
+    echo "Start command:"
+    echo "  cd $DIR && ./run.sh"
+fi


### PR DESCRIPTION
## Summary
- port scoped web session dispatch and host-authoritative auth scoping from the selective `crew-rs` branch
- unify QoS cold-start seeding and profile-local runtime score materialization for adaptive routing and pipeline fallback ranking
- add focused regression tests and CI coverage for runtime catalog generation and fallback ordering

## What changed
- host-derived auth scoping now lives in the API layer instead of trusting browser-supplied profile scope
- adaptive routing `qos_ranking` now affects scoring instead of being a no-op flag
- heuristic `model_catalog.json` is treated as cold-start metadata only; profile `data/model_catalog.json` becomes the runtime score source of truth
- provider-router fallback ranking is validated against seeded runtime scores
- CI now runs focused regressions for:
  - adaptive lane selection under `qos_ranking`
  - cold-start catalog score derivation
  - provider-router fallback ordering
  - gateway runtime catalog load/persist/materialization

## Validation
```bash
cargo test -j1 -p octos-llm test_qos_ranking_changes_lane_selection -- --nocapture
cargo test -j1 -p octos-llm test_derive_cold_start_catalog_assigns_non_zero_scores -- --nocapture
cargo test -j1 -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score -- --nocapture
cargo test -j1 -p octos-cli gateway_runtime::tests --features api -- --nocapture
cargo check -j1 -p octos-cli --features api
```

## Live verification
- deployed backend to Mini 3 only
- verified `/adaptive` on `https://dspfac.octos.ominix.io/chat` reported `mode: lane`, `qos ranking: on`, and current provider switching away from static qwen
- verified profile-local runtime catalog on Mini 3 now contains non-zero scores in `~/.octos/profiles/dspfac/data/model_catalog.json`
