### PR TITLE
Stabilize workspace versioning and account-scoped API sessions

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -31,6 +31,7 @@ pub mod steering;
 pub mod task_supervisor;
 pub mod tools;
 pub mod turn;
+pub mod workspace_git;
 
 pub use agent::{
     Agent, AgentConfig, ConversationResponse, DEFAULT_SESSION_TIMEOUT_SECS,
@@ -59,6 +60,11 @@ pub use tools::{
     admin::{AdminApiContext, register_admin_api_tools},
 };
 pub use turn::{Turn, TurnKind, turns_to_messages};
+pub use workspace_git::{
+    WorkspaceProjectKind, commit_all_if_dirty, detect_workspace_repo, init_workspace_repo,
+    initialize_and_commit, list_workspace_repos, snapshot_workspace_change,
+    snapshot_workspace_turn,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -34,9 +34,8 @@ pub mod turn;
 pub mod workspace_git;
 
 pub use agent::{
-    Agent, AgentConfig, ConversationResponse, DEFAULT_SESSION_TIMEOUT_SECS,
+    Agent, AgentConfig, ConversationResponse, TokenTracker, DEFAULT_SESSION_TIMEOUT_SECS,
     DEFAULT_TOOL_TIMEOUT_SECS, DEFAULT_WORKER_PROMPT, MAX_TOOL_TIMEOUT_SECS, TASK_REPORTER,
-    TokenTracker,
 };
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
@@ -46,24 +45,23 @@ pub use plugins::{PluginLoadResult, PluginLoader};
 pub use progress::{ConsoleReporter, ProgressEvent, ProgressReporter, SilentReporter};
 pub use prompt_layer::PromptLayerBuilder;
 pub use provider_tools::{ProviderToolsets, ToolAdjustment};
-pub use sandbox::{Sandbox, SandboxConfig, SandboxMode, create_sandbox};
+pub use sandbox::{create_sandbox, Sandbox, SandboxConfig, SandboxMode};
 pub use session::{SessionLimits, SessionState, SessionStateHandle, SessionUsage};
 pub use skills::{SkillInfo, SkillsLoader};
 pub use steering::{SteeringMessage, SteeringReceiver, SteeringSender};
 pub use task_supervisor::{BackgroundTask, TaskStatus, TaskSupervisor};
 pub use tools::{
+    admin::{register_admin_api_tools, AdminApiContext},
     ActivateToolsTool, BrowserTool, ConfigureToolTool, DeepSearchTool, DiffEditTool, EditFileTool,
     GlobTool, GrepTool, ListDirTool, ManageSkillsTool, MessageTool, ReadFileTool, RecallMemoryTool,
     SaveMemoryTool, SendFileTool, ShellTool, SpawnTool, SynthesizeResearchTool, TakePhotoTool,
     Tool, ToolConfigStore, ToolPolicy, ToolRegistry, ToolResult, WebFetchTool, WebSearchTool,
     WriteFileTool,
-    admin::{AdminApiContext, register_admin_api_tools},
 };
-pub use turn::{Turn, TurnKind, turns_to_messages};
+pub use turn::{turns_to_messages, Turn, TurnKind};
 pub use workspace_git::{
-    WorkspaceProjectKind, commit_all_if_dirty, detect_workspace_repo, init_workspace_repo,
-    initialize_and_commit, list_workspace_repos, snapshot_workspace_change,
-    snapshot_workspace_turn,
+    commit_all_if_dirty, detect_workspace_repo, init_workspace_repo, initialize_and_commit,
+    list_workspace_repos, snapshot_workspace_change, snapshot_workspace_turn, WorkspaceProjectKind,
 };
 
 #[cfg(test)]

--- a/crates/octos-agent/src/tools/admin/skills.rs
+++ b/crates/octos-agent/src/tools/admin/skills.rs
@@ -38,7 +38,7 @@ impl Tool for ManageSkillsTool {
         "admin_manage_skills"
     }
     fn description(&self) -> &str {
-        "Manage skills for a profile: list installed skills, install from GitHub (user/repo), or remove by name. Sub-accounts share their parent profile's skills."
+        "Manage customer-installed skills for exactly one profile or sub-account: list installed skills, install from GitHub (user/repo), or remove by name."
     }
     fn input_schema(&self) -> serde_json::Value {
         serde_json::json!({

--- a/crates/octos-agent/src/tools/diff_edit.rs
+++ b/crates/octos-agent/src/tools/diff_edit.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use serde::Deserialize;
+use tracing::warn;
 
 use super::{Tool, ToolResult};
 
@@ -113,6 +114,16 @@ impl Tool for DiffEditTool {
 
         if let Err(e) = super::write_no_follow(&path, new_content.as_bytes()).await {
             return Ok(super::file_io_error(e, &input.path));
+        }
+
+        if let Err(error) =
+            crate::workspace_git::snapshot_workspace_change(&self.base_dir, &path, "diff_edit")
+        {
+            warn!(
+                path = %input.path,
+                error = %error,
+                "workspace git snapshot failed after diff_edit"
+            );
         }
 
         Ok(ToolResult {

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use serde::Deserialize;
+use tracing::warn;
 
 use super::{Tool, ToolResult};
 
@@ -118,6 +119,16 @@ impl Tool for EditFileTool {
         // Write back (O_NOFOLLOW)
         if let Err(e) = super::write_no_follow(&path, new_content.as_bytes()).await {
             return Ok(super::file_io_error(e, &input.path));
+        }
+
+        if let Err(error) =
+            crate::workspace_git::snapshot_workspace_change(&self.base_dir, &path, "edit_file")
+        {
+            warn!(
+                path = %input.path,
+                error = %error,
+                "workspace git snapshot failed after edit_file"
+            );
         }
 
         Ok(ToolResult {

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use serde::Deserialize;
+use tracing::warn;
 
 use super::{Tool, ToolResult};
 
@@ -86,6 +87,16 @@ impl Tool for WriteFileTool {
         // Write file (O_NOFOLLOW atomically rejects symlinks, no TOCTOU race)
         if let Err(e) = super::write_no_follow(&path, input.content.as_bytes()).await {
             return Ok(super::file_io_error(e, &input.path));
+        }
+
+        if let Err(error) =
+            crate::workspace_git::snapshot_workspace_change(&self.base_dir, &path, "write_file")
+        {
+            warn!(
+                path = %input.path,
+                error = %error,
+                "workspace git snapshot failed after write_file"
+            );
         }
 
         let line_count = input.content.lines().count();

--- a/crates/octos-agent/src/workspace_git.rs
+++ b/crates/octos-agent/src/workspace_git.rs
@@ -1,0 +1,369 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use eyre::{Result, WrapErr, eyre};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorkspaceProjectKind {
+    Slides,
+    Sites,
+}
+
+impl WorkspaceProjectKind {
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::Slides => "slides",
+            Self::Sites => "site",
+        }
+    }
+
+    fn directory_name(self) -> &'static str {
+        match self {
+            Self::Slides => "slides",
+            Self::Sites => "sites",
+        }
+    }
+
+    fn gitignore_template(self) -> &'static str {
+        match self {
+            Self::Slides => "/history/\n/output/\n/skill-output/\n*.pptx\n*.tmp\n.DS_Store\n",
+            Self::Sites => {
+                "/node_modules/\n/dist/\n/out/\n/docs/\n/build/\n/.astro/\n/.next/\n/.quarto/\n*.log\n.DS_Store\n"
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceRepo {
+    pub kind: WorkspaceProjectKind,
+    pub root: PathBuf,
+    pub slug: String,
+}
+
+pub fn detect_workspace_repo(base_dir: &Path, changed_path: &Path) -> Option<WorkspaceRepo> {
+    let relative = changed_path.strip_prefix(base_dir).ok()?;
+    let mut components = relative.components();
+    let category = components.next()?.as_os_str().to_str()?;
+    let slug = components.next()?.as_os_str().to_str()?.to_string();
+    let kind = match category {
+        "slides" => WorkspaceProjectKind::Slides,
+        "sites" => WorkspaceProjectKind::Sites,
+        _ => return None,
+    };
+
+    Some(WorkspaceRepo {
+        kind,
+        root: base_dir.join(category).join(&slug),
+        slug,
+    })
+}
+
+pub fn init_workspace_repo(project_root: &Path, kind: WorkspaceProjectKind) -> Result<()> {
+    std::fs::create_dir_all(project_root)
+        .wrap_err_with(|| format!("create project dir failed: {}", project_root.display()))?;
+
+    let gitignore_path = project_root.join(".gitignore");
+    if !gitignore_path.exists() {
+        std::fs::write(&gitignore_path, kind.gitignore_template())
+            .wrap_err_with(|| format!("write .gitignore failed: {}", gitignore_path.display()))?;
+    }
+
+    if !project_root.join(".git").exists() {
+        run_git(project_root, &["init"])?;
+    }
+
+    ensure_local_identity(project_root)?;
+    Ok(())
+}
+
+pub fn commit_all_if_dirty(project_root: &Path, message: &str) -> Result<bool> {
+    init_workspace_repo(project_root, infer_kind_from_root(project_root)?)
+        .wrap_err("ensure git repo failed")?;
+    run_git(project_root, &["add", "-A", "--", "."])?;
+
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["diff", "--cached", "--quiet", "--", "."])
+        .status()
+        .wrap_err("git diff --cached failed")?;
+
+    if status.success() {
+        return Ok(false);
+    }
+
+    run_git(project_root, &["commit", "-m", message, "--no-verify"])?;
+    Ok(true)
+}
+
+pub fn initialize_and_commit(
+    project_root: &Path,
+    kind: WorkspaceProjectKind,
+    message: &str,
+) -> Result<bool> {
+    init_workspace_repo(project_root, kind)?;
+    run_git(project_root, &["add", "-A", "--", "."])?;
+
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["diff", "--cached", "--quiet", "--", "."])
+        .status()
+        .wrap_err("git diff --cached failed")?;
+
+    if status.success() {
+        return Ok(false);
+    }
+
+    run_git(project_root, &["commit", "-m", message, "--no-verify"])?;
+    Ok(true)
+}
+
+pub fn snapshot_workspace_change(
+    base_dir: &Path,
+    changed_path: &Path,
+    operation: &str,
+) -> Result<Option<String>> {
+    let repo = match detect_workspace_repo(base_dir, changed_path) {
+        Some(repo) => repo,
+        None => return Ok(None),
+    };
+
+    init_workspace_repo(&repo.root, repo.kind)?;
+
+    let relative_path = changed_path
+        .strip_prefix(&repo.root)
+        .unwrap_or(changed_path)
+        .display()
+        .to_string();
+    let message = format!(
+        "Update {} via {}: {}",
+        repo.kind.display_name(),
+        operation,
+        relative_path
+    );
+
+    if commit_all_if_dirty(&repo.root, &message)? {
+        Ok(Some(message))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn list_workspace_repos(base_dir: &Path) -> Result<Vec<WorkspaceRepo>> {
+    let mut repos = Vec::new();
+
+    for (category, kind) in [
+        ("slides", WorkspaceProjectKind::Slides),
+        ("sites", WorkspaceProjectKind::Sites),
+    ] {
+        let category_dir = base_dir.join(category);
+        if !category_dir.exists() {
+            continue;
+        }
+
+        for entry in std::fs::read_dir(&category_dir).wrap_err_with(|| {
+            format!("read workspace category failed: {}", category_dir.display())
+        })? {
+            let entry = entry.wrap_err_with(|| {
+                format!(
+                    "read workspace repo entry failed: {}",
+                    category_dir.display()
+                )
+            })?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let slug = entry.file_name().to_string_lossy().to_string();
+            repos.push(WorkspaceRepo {
+                kind,
+                root: path,
+                slug,
+            });
+        }
+    }
+
+    repos.sort_by(|a, b| {
+        a.kind
+            .display_name()
+            .cmp(b.kind.display_name())
+            .then_with(|| a.slug.cmp(&b.slug))
+    });
+    Ok(repos)
+}
+
+pub fn snapshot_workspace_turn(base_dir: &Path, summary: &str) -> Result<Vec<String>> {
+    let repos = list_workspace_repos(base_dir)?;
+    let mut committed = Vec::new();
+    let summary = normalize_turn_summary(summary);
+
+    for repo in repos {
+        let repo_label = format!("{}/{}", repo.kind.directory_name(), repo.slug);
+        let message = format!("Turn snapshot for {repo_label}: {summary}");
+        if commit_all_if_dirty(&repo.root, &message)? {
+            committed.push(repo_label);
+        }
+    }
+
+    Ok(committed)
+}
+
+fn infer_kind_from_root(project_root: &Path) -> Result<WorkspaceProjectKind> {
+    let parent = project_root
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            eyre!(
+                "cannot infer workspace project kind from {}",
+                project_root.display()
+            )
+        })?;
+
+    match parent {
+        "slides" => Ok(WorkspaceProjectKind::Slides),
+        "sites" => Ok(WorkspaceProjectKind::Sites),
+        _ => Err(eyre!(
+            "unsupported workspace project root for git snapshot: {}",
+            project_root.display()
+        )),
+    }
+}
+
+fn ensure_local_identity(project_root: &Path) -> Result<()> {
+    run_git(
+        project_root,
+        &["config", "--local", "user.name", "Octos Workspace"],
+    )?;
+    run_git(
+        project_root,
+        &["config", "--local", "user.email", "octos@local"],
+    )?;
+    Ok(())
+}
+
+fn normalize_turn_summary(summary: &str) -> String {
+    let compact = summary.split_whitespace().collect::<Vec<_>>().join(" ");
+    let fallback = if compact.is_empty() {
+        "update workspace".to_string()
+    } else {
+        compact
+    };
+
+    truncate_utf8_boundary(&fallback, 72)
+}
+
+fn truncate_utf8_boundary(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        return s.to_string();
+    }
+
+    let mut end = max_len;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
+}
+
+fn run_git(project_root: &Path, args: &[&str]) -> Result<()> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(args)
+        .output()
+        .wrap_err_with(|| format!("failed to spawn git {:?}", args))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Err(eyre!(
+        "git {:?} failed in {}: {}{}",
+        args,
+        project_root.display(),
+        stderr.trim(),
+        if stdout.trim().is_empty() {
+            String::new()
+        } else {
+            format!(" | stdout: {}", stdout.trim())
+        }
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_slides_repo_from_changed_path() {
+        let base = Path::new("/tmp/workspace");
+        let changed = base.join("slides/demo/script.js");
+        let repo = detect_workspace_repo(base, &changed).expect("repo");
+        assert_eq!(repo.kind, WorkspaceProjectKind::Slides);
+        assert_eq!(repo.root, base.join("slides/demo"));
+        assert_eq!(repo.slug, "demo");
+    }
+
+    #[test]
+    fn ignores_non_project_paths() {
+        let base = Path::new("/tmp/workspace");
+        let changed = base.join("skill-output/demo/file.txt");
+        assert!(detect_workspace_repo(base, &changed).is_none());
+    }
+
+    #[test]
+    fn initializes_and_commits_repo() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_root = temp.path().join("slides").join("deck");
+        std::fs::create_dir_all(&project_root).unwrap();
+        std::fs::write(project_root.join("script.js"), "module.exports = [];\n").unwrap();
+
+        let committed = initialize_and_commit(
+            &project_root,
+            WorkspaceProjectKind::Slides,
+            "Initialize slides workspace",
+        )
+        .unwrap();
+
+        assert!(committed);
+        assert!(project_root.join(".git").exists());
+        assert!(project_root.join(".gitignore").exists());
+    }
+
+    #[test]
+    fn lists_workspace_repos_by_category() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("slides").join("deck-a")).unwrap();
+        std::fs::create_dir_all(temp.path().join("sites").join("newsbot")).unwrap();
+
+        let repos = list_workspace_repos(temp.path()).unwrap();
+        let labels: Vec<String> = repos
+            .iter()
+            .map(|repo| format!("{}/{}", repo.kind.directory_name(), repo.slug))
+            .collect();
+
+        assert_eq!(labels, vec!["sites/newsbot", "slides/deck-a"]);
+    }
+
+    #[test]
+    fn snapshots_all_dirty_workspace_repos() {
+        let temp = tempfile::tempdir().unwrap();
+        let slides_root = temp.path().join("slides").join("deck-a");
+        let sites_root = temp.path().join("sites").join("newsbot");
+        std::fs::create_dir_all(&slides_root).unwrap();
+        std::fs::create_dir_all(&sites_root).unwrap();
+        std::fs::write(slides_root.join("script.js"), "module.exports = [];\n").unwrap();
+        std::fs::write(sites_root.join("index.html"), "<h1>hello</h1>\n").unwrap();
+
+        let committed = snapshot_workspace_turn(temp.path(), "apply user request").unwrap();
+
+        assert_eq!(committed, vec!["sites/newsbot", "slides/deck-a"]);
+        assert!(slides_root.join(".git").exists());
+        assert!(sites_root.join(".git").exists());
+    }
+}

--- a/crates/octos-agent/src/workspace_git.rs
+++ b/crates/octos-agent/src/workspace_git.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use eyre::{Result, WrapErr, eyre};
+use eyre::{eyre, Result, WrapErr};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WorkspaceProjectKind {

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -6,28 +6,28 @@
 
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use async_trait::async_trait;
-use axum::Json;
-use axum::Router;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
+use axum::Json;
+use axum::Router;
 use chrono::Utc;
 use eyre::Result;
 use octos_core::{
-    InboundMessage, MAIN_PROFILE_ID, Message, MessageRole, OutboundMessage, SessionKey,
+    InboundMessage, Message, MessageRole, OutboundMessage, SessionKey, MAIN_PROFILE_ID,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{mpsc, Mutex};
 use tracing::info;
 
-use crate::SessionManager;
 use crate::channel::Channel;
+use crate::SessionManager;
 
 /// Callback that returns serialized task list for a session key.
 pub type TaskQueryFn = dyn Fn(&str) -> serde_json::Value + Send + Sync;
@@ -999,11 +999,9 @@ mod tests {
         let key = SessionKey::with_profile(TEST_PROFILE_ID, "api", "test-bg");
         let session = sess.get_or_create(&key).await;
         let history = session.get_history(10);
-        assert!(
-            history
-                .iter()
-                .any(|m| m.media.contains(&"/tmp/test.mp3".to_string()))
-        );
+        assert!(history
+            .iter()
+            .any(|m| m.media.contains(&"/tmp/test.mp3".to_string())));
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -19,7 +19,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use chrono::Utc;
 use eyre::Result;
-use octos_core::{InboundMessage, Message, MessageRole, OutboundMessage, SessionKey};
+use octos_core::{
+    InboundMessage, MAIN_PROFILE_ID, Message, MessageRole, OutboundMessage, SessionKey,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc};
 use tracing::info;
@@ -36,7 +38,7 @@ struct ApiState {
     inbound_tx: mpsc::Sender<InboundMessage>,
     pending: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<String>>>>,
     auth_token: Option<String>,
-    profile_id: String,
+    profile_id: Option<String>,
     sessions: Arc<Mutex<SessionManager>>,
     task_query: Option<Arc<TaskQueryFn>>,
 }
@@ -61,7 +63,7 @@ struct ChatRequest {
 pub struct ApiChannel {
     port: u16,
     auth_token: Option<String>,
-    profile_id: String,
+    profile_id: Option<String>,
     shutdown: Arc<AtomicBool>,
     pending: Arc<Mutex<HashMap<String, mpsc::UnboundedSender<String>>>>,
     /// Track last sent content per chat_id for delta computation.
@@ -77,7 +79,7 @@ impl ApiChannel {
         auth_token: Option<String>,
         shutdown: Arc<AtomicBool>,
         sessions: Arc<Mutex<SessionManager>>,
-        profile_id: String,
+        profile_id: Option<String>,
     ) -> Self {
         Self {
             port,
@@ -340,7 +342,7 @@ impl Channel for ApiChannel {
 impl ApiChannel {
     /// Persist a message to the session JSONL for the given chat_id.
     async fn persist_to_session(&self, chat_id: &str, message: Message) {
-        let key = SessionKey::with_profile(&self.profile_id, "api", chat_id);
+        let key = current_profile_api_session_key(self.profile_id.as_deref(), chat_id);
         let mut sess = self.sessions.lock().await;
         if let Err(e) = sess.add_message(&key, message.clone()).await {
             tracing::warn!(chat_id = %chat_id, error = %e, "failed to persist message to session");
@@ -509,10 +511,80 @@ struct PaginationParams {
     /// "full" to read from disk (complete history), default reads from memory (compacted for LLM).
     #[serde(default)]
     source: Option<String>,
+    /// Return only messages strictly newer than this sequence number.
+    #[serde(default)]
+    since_seq: Option<usize>,
+    /// Explicit topic override for multi-topic sessions.
+    #[serde(default)]
+    topic: Option<String>,
 }
 
 fn default_limit() -> usize {
     100
+}
+
+fn current_profile_api_session_key(profile_id: Option<&str>, chat_id: &str) -> SessionKey {
+    SessionKey::with_profile(
+        profile_id
+            .filter(|value| !value.is_empty())
+            .unwrap_or(MAIN_PROFILE_ID),
+        "api",
+        chat_id,
+    )
+}
+
+fn api_session_key_candidates(
+    profile_id: Option<&str>,
+    id: &str,
+    topic: Option<&str>,
+) -> Vec<SessionKey> {
+    let mut keys = Vec::with_capacity(3);
+
+    if let Some(topic) = topic.filter(|value| !value.is_empty()) {
+        if let Some(profile_id) = profile_id.filter(|value| !value.is_empty()) {
+            keys.push(SessionKey::with_profile_topic(profile_id, "api", id, topic));
+        }
+        keys.push(SessionKey::with_profile_topic(
+            MAIN_PROFILE_ID,
+            "api",
+            id,
+            topic,
+        ));
+        keys.push(SessionKey::with_topic("api", id, topic));
+    } else {
+        if let Some(profile_id) = profile_id.filter(|value| !value.is_empty()) {
+            keys.push(SessionKey::with_profile(profile_id, "api", id));
+        }
+        keys.push(SessionKey::with_profile(MAIN_PROFILE_ID, "api", id));
+        keys.push(SessionKey::new("api", id));
+    }
+
+    keys.dedup_by(|left, right| left.0 == right.0);
+    keys
+}
+
+fn api_chat_id_from_session_key(id: &str) -> Option<&str> {
+    id.strip_prefix("api:")
+        .or_else(|| id.split_once(":api:").map(|(_, chat_id)| chat_id))
+}
+
+fn message_info_from_history_message(message: &Message) -> MessageInfo {
+    MessageInfo {
+        role: message.role.to_string(),
+        content: message.content.clone(),
+        timestamp: message.timestamp.to_rfc3339(),
+        media: message.media.clone(),
+        tool_calls: message
+            .tool_calls
+            .as_ref()
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|call| serde_json::to_value(call).ok())
+                    .collect()
+            })
+            .unwrap_or_default(),
+    }
 }
 
 /// GET /sessions/:id/status — check if a session has an active task.
@@ -536,7 +608,7 @@ async fn handle_session_tasks(
     let Some(ref query_fn) = state.task_query else {
         return Json(serde_json::json!([])).into_response();
     };
-    let session_key = SessionKey::with_profile(&state.profile_id, "api", &id);
+    let session_key = current_profile_api_session_key(state.profile_id.as_deref(), &id);
     let tasks = query_fn(&session_key.0);
     Json(tasks).into_response()
 }
@@ -544,12 +616,11 @@ async fn handle_session_tasks(
 /// GET /sessions — list all API sessions.
 async fn handle_list_sessions(State(state): State<ApiState>) -> Response {
     let sess = state.sessions.lock().await;
-    let prefix = format!("{}:api:", state.profile_id);
     let list: Vec<SessionInfo> = sess
         .list_sessions()
         .into_iter()
         .filter_map(|(id, count)| {
-            let chat_id = id.strip_prefix(&prefix)?;
+            let chat_id = api_chat_id_from_session_key(&id)?;
             Some(SessionInfo {
                 id: chat_id.to_string(),
                 message_count: count,
@@ -571,126 +642,48 @@ async fn handle_session_messages(
         Some(n) => n,
         None => return (StatusCode::BAD_REQUEST, "invalid pagination").into_response(),
     };
-    let key = SessionKey::with_profile(&state.profile_id, "api", &id);
+    let candidates =
+        api_session_key_candidates(state.profile_id.as_deref(), &id, params.topic.as_deref());
 
     // source=full reads the append-only JSONL file (complete history).
     // Default reads from in-memory (may be compacted for LLM context).
     if params.source.as_deref() == Some("full") {
         let sess = state.sessions.lock().await;
-        let flat_path = sess.session_path(&key);
-        let data_dir = sess.data_dir();
-        drop(sess);
-
-        // Per-user session dir: data/users/{base_key}/sessions/
-        // Contains default.jsonl + topic files like 123.jsonl
-        // Read ALL jsonl files to merge messages across topics.
-        let per_user_dir = {
-            let base_key = key.base_key();
-            let encoded = crate::session::encode_path_component(base_key);
-            data_dir.join("users").join(encoded).join("sessions")
-        };
-
-        // Read from ALL per-user JSONL files + flat path and merge.
-        let mut all_lines = Vec::new();
-
-        // Primary: all per-user JSONL files (user messages + assistant responses)
-        if let Ok(entries) = std::fs::read_dir(&per_user_dir) {
-            for entry in entries.flatten() {
-                if entry.path().extension().is_some_and(|x| x == "jsonl") {
-                    if let Ok(content) = tokio::fs::read_to_string(entry.path()).await {
-                        all_lines.extend(content.lines().map(|l| l.to_string()));
-                    }
-                }
+        for candidate in &candidates {
+            if let Some(session) = sess.load(candidate).await {
+                let messages: Vec<MessageInfo> = session
+                    .messages
+                    .iter()
+                    .enumerate()
+                    .filter(|(seq, _)| params.since_seq.is_none_or(|since| *seq > since))
+                    .skip(offset)
+                    .take(limit)
+                    .map(|(_, message)| message_info_from_history_message(message))
+                    .collect();
+                return Json(messages).into_response();
             }
-        }
-        // Secondary: flat path (has file deliveries that may not be in per-user)
-        if let Ok(content) = tokio::fs::read_to_string(&flat_path).await {
-            // Only add lines from flat that have media (file deliveries) or bg notifications
-            // and aren't already in per-user
-            for line in content.lines() {
-                if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
-                    let has_media = v
-                        .get("media")
-                        .and_then(|m| m.as_array())
-                        .is_some_and(|a| !a.is_empty());
-                    let is_bg = v
-                        .get("content")
-                        .and_then(|c| c.as_str())
-                        .is_some_and(|c| c.starts_with('✓') || c.starts_with('✗'));
-                    if has_media || is_bg {
-                        // Check for duplicate by content
-                        let content_str = v.get("content").and_then(|c| c.as_str()).unwrap_or("");
-                        if !all_lines.iter().any(|existing| {
-                            existing.contains(content_str) && !content_str.is_empty()
-                        }) {
-                            all_lines.push(line.to_string());
-                        }
-                    }
-                }
-            }
-        }
-        let messages: Vec<MessageInfo> = all_lines
-            .iter()
-            .filter_map(|line| {
-                let v: serde_json::Value = serde_json::from_str(line).ok()?;
-                let role = v.get("role")?.as_str()?;
-                let content = v.get("content")?.as_str().unwrap_or("");
-                let timestamp = v.get("timestamp").and_then(|t| t.as_str()).unwrap_or("");
-                let media: Vec<String> = v
-                    .get("media")
-                    .and_then(|m| m.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let tool_calls: Vec<serde_json::Value> = v
-                    .get("tool_calls")
-                    .and_then(|tc| tc.as_array())
-                    .map(|arr| arr.to_vec())
-                    .unwrap_or_default();
-                Some(MessageInfo {
-                    role: role.to_string(),
-                    content: content.to_string(),
-                    timestamp: timestamp.to_string(),
-                    media,
-                    tool_calls,
-                })
-            })
-            .skip(offset)
-            .take(limit)
-            .collect();
-        if !messages.is_empty() {
-            return Json(messages).into_response();
         }
         return (StatusCode::NOT_FOUND, "session not found").into_response();
     }
 
-    let mut sess = state.sessions.lock().await;
-    let session = sess.get_or_create(&key).await;
-    let history = session.get_history(fetch_count).to_vec();
-    let messages: Vec<MessageInfo> = history
-        .iter()
-        .skip(offset)
-        .take(limit)
-        .map(|m| MessageInfo {
-            role: m.role.to_string(),
-            content: m.content.clone(),
-            timestamp: m.timestamp.to_rfc3339(),
-            media: m.media.clone(),
-            tool_calls: m
-                .tool_calls
-                .as_ref()
-                .map(|tcs| {
-                    tcs.iter()
-                        .filter_map(|tc| serde_json::to_value(tc).ok())
-                        .collect()
-                })
-                .unwrap_or_default(),
-        })
-        .collect();
-    Json(messages).into_response()
+    let sess = state.sessions.lock().await;
+    for candidate in &candidates {
+        if let Some(session) = sess.load(candidate).await {
+            let history = session.get_history(fetch_count).to_vec();
+            let messages: Vec<MessageInfo> = history
+                .iter()
+                .enumerate()
+                .filter(|(seq, _)| params.since_seq.is_none_or(|since| *seq > since))
+                .skip(offset)
+                .take(limit)
+                .map(|(_, message)| message_info_from_history_message(message))
+                .collect();
+            if !messages.is_empty() {
+                return Json(messages).into_response();
+            }
+        }
+    }
+    Json(Vec::<MessageInfo>::new()).into_response()
 }
 
 /// DELETE /sessions/:id — delete a session.
@@ -698,11 +691,17 @@ async fn handle_delete_session(
     State(state): State<ApiState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Response {
-    let key = SessionKey::with_profile(&state.profile_id, "api", &id);
     let mut sess = state.sessions.lock().await;
-    match sess.clear(&key).await {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
-        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    let mut last_error: Option<String> = None;
+    for candidate in api_session_key_candidates(state.profile_id.as_deref(), &id, None) {
+        match sess.clear(&candidate).await {
+            Ok(()) => return StatusCode::NO_CONTENT.into_response(),
+            Err(error) => last_error = Some(error.to_string()),
+        }
+    }
+    match last_error {
+        Some(error) => (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+        None => StatusCode::NO_CONTENT.into_response(),
     }
 }
 
@@ -838,13 +837,35 @@ mod tests {
     }
 
     #[test]
+    fn api_session_key_candidates_prefer_current_profile() {
+        let keys = api_session_key_candidates(Some("dspfac--newsbot"), "web-123", None);
+
+        assert_eq!(keys[0].0, "dspfac--newsbot:api:web-123");
+        assert_eq!(keys[1].0, "_main:api:web-123");
+        assert_eq!(keys[2].0, "api:web-123");
+    }
+
+    #[test]
+    fn api_chat_id_from_profiled_session_key_strips_prefix() {
+        assert_eq!(
+            api_chat_id_from_session_key("dspfac--newsbot:api:web-123"),
+            Some("web-123")
+        );
+        assert_eq!(
+            api_chat_id_from_session_key("_main:api:web-123"),
+            Some("web-123")
+        );
+        assert_eq!(api_chat_id_from_session_key("api:web-123"), Some("web-123"));
+    }
+
+    #[test]
     fn api_channel_name() {
         let ch = ApiChannel::new(
             8091,
             None,
             Arc::new(AtomicBool::new(false)),
             test_sessions(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
         assert_eq!(ch.name(), "api");
     }
@@ -856,7 +877,7 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             test_sessions(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
         assert_eq!(ch.max_message_length(), 1_000_000);
     }
@@ -868,7 +889,7 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             test_sessions(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
         {
@@ -899,7 +920,7 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             test_sessions(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
         {
@@ -934,7 +955,7 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             sessions.clone(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
         {
@@ -993,7 +1014,7 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             sessions.clone(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
 
         // Send a file message (no active SSE needed — goes straight to session)
@@ -1026,7 +1047,7 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             sessions.clone(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
 
         // Send background task notification (checkmark)
@@ -1056,7 +1077,7 @@ mod tests {
             None,
             Arc::new(AtomicBool::new(false)),
             test_sessions(),
-            TEST_PROFILE_ID.to_string(),
+            Some(TEST_PROFILE_ID.to_string()),
         );
         let msg = OutboundMessage {
             channel: "api".into(),

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use axum::extract::State;
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
+use axum::extract::State;
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -400,10 +400,51 @@ pub struct PaginationParams {
     pub offset: usize,
     #[serde(default)]
     pub source: Option<String>,
+    #[serde(default)]
+    pub since_seq: Option<usize>,
+    #[serde(default)]
+    pub topic: Option<String>,
 }
 
 fn default_page_limit() -> usize {
     100
+}
+
+fn standalone_api_session_key_with_topic(
+    headers: &HeaderMap,
+    session_id: &str,
+    topic: Option<&str>,
+) -> SessionKey {
+    SessionKey::with_profile_topic(
+        api_profile_id_from_headers(headers),
+        "api",
+        session_id,
+        topic.unwrap_or_default(),
+    )
+}
+
+fn session_messages_proxy_path(
+    id: &str,
+    limit: usize,
+    offset: usize,
+    source: Option<&str>,
+    since_seq: Option<usize>,
+    topic: Option<&str>,
+) -> String {
+    let mut path = format!("/sessions/{id}/messages?limit={limit}&offset={offset}");
+    if let Some(source) = source {
+        path.push_str("&source=");
+        path.push_str(source);
+    }
+    if let Some(since_seq) = since_seq {
+        path.push_str("&since_seq=");
+        path.push_str(&since_seq.to_string());
+    }
+    if let Some(topic) = topic.filter(|value| !value.is_empty()) {
+        path.push_str("&topic=");
+        path.push_str(&octos_bus::session::encode_path_component(topic));
+    }
+    path
 }
 
 pub async fn session_messages(
@@ -425,7 +466,7 @@ pub async fn session_messages(
                 Some(n) => n,
                 None => return (StatusCode::BAD_REQUEST, "invalid pagination").into_response(),
             };
-            let key = standalone_api_session_key(&headers, &id);
+            let key = standalone_api_session_key_with_topic(&headers, &id, params.topic.as_deref());
             let mut sess = sessions.lock().await;
             let session = sess.get_or_create(&key).await;
             let messages: Vec<MessageInfo> = session
@@ -448,9 +489,17 @@ pub async fn session_messages(
 
     // Proxy to gateway.
     if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
-        let path = format!(
-            "/sessions/{id}/messages?limit={}&offset={}&source=full",
-            limit, offset
+        let path = session_messages_proxy_path(
+            &id,
+            limit,
+            offset,
+            if use_full {
+                Some("full")
+            } else {
+                params.source.as_deref()
+            },
+            params.since_seq,
+            params.topic.as_deref(),
         );
         return super::webhook_proxy::api_get_proxy(&state, port, &path).await;
     }
@@ -2388,14 +2437,35 @@ mod tests {
         let params: PaginationParams = serde_json::from_str(json).unwrap();
         assert_eq!(params.limit, 100);
         assert_eq!(params.offset, 0);
+        assert_eq!(params.since_seq, None);
+        assert_eq!(params.topic, None);
     }
 
     #[test]
     fn pagination_custom_values() {
-        let json = r#"{"limit": 50, "offset": 10}"#;
+        let json = r#"{"limit": 50, "offset": 10, "since_seq": 3, "topic": "slides demo"}"#;
         let params: PaginationParams = serde_json::from_str(json).unwrap();
         assert_eq!(params.limit, 50);
         assert_eq!(params.offset, 10);
+        assert_eq!(params.since_seq, Some(3));
+        assert_eq!(params.topic.as_deref(), Some("slides demo"));
+    }
+
+    #[test]
+    fn session_messages_proxy_path_includes_topic_and_since_seq() {
+        let path = session_messages_proxy_path(
+            "slides-123",
+            100,
+            5,
+            Some("full"),
+            Some(8),
+            Some("slides untitled-deck"),
+        );
+
+        assert_eq!(
+            path,
+            "/sessions/slides-123/messages?limit=100&offset=5&source=full&since_seq=8&topic=slides%20untitled-deck"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -3,26 +3,25 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use axum::Extension;
-use axum::Json;
 use axum::extract::State;
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
+use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
+use axum::Extension;
+use axum::Json;
 use futures::stream::StreamExt;
 use octos_agent::Agent;
-use octos_core::{AgentId, MAIN_PROFILE_ID, Message, SessionKey};
+use octos_core::{AgentId, Message, SessionKey, MAIN_PROFILE_ID};
 use serde::{Deserialize, Serialize};
 
-use axum::http::HeaderMap;
-
-use super::AppState;
 use super::auth_handlers::ADMIN_PROFILE_ID;
 use super::metrics::MetricsReporter;
 use super::router::AuthIdentity;
 use super::sse::ChannelReporter;
-use crate::project_templates::{SiteProjectMetadata, read_site_project_metadata};
+use super::AppState;
+use crate::project_templates::{read_site_project_metadata, SiteProjectMetadata};
 
 /// POST /api/chat -- send a message, get a response.
 /// When `stream: true`, returns SSE events. Otherwise returns JSON.
@@ -1364,7 +1363,11 @@ fn resolve_preview_asset_path(
                 Some(nested_index)
             } else if !request_path.contains('.') {
                 let html = candidate.with_extension("html");
-                if html.exists() { Some(html) } else { None }
+                if html.exists() {
+                    Some(html)
+                } else {
+                    None
+                }
             } else {
                 None
             }
@@ -1706,14 +1709,14 @@ pub async fn list_content_files(
         if lower.starts_with('_') {
             return false;
         } // _report.md, _search_results.md, _sources.json
-        // Skip intermediates
+          // Skip intermediates
         if lower.starts_with("panel-") {
             return false;
         }
         if lower.contains("-ref.") {
             return false;
         } // mofa reference images
-        // Only keep meaningful output extensions
+          // Only keep meaningful output extensions
         matches!(
             lower.rsplit('.').next().unwrap_or(""),
             "md" | "markdown"

--- a/crates/octos-cli/src/commands/gateway/adapters/api.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/api.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use octos_bus::{ChannelManager, SessionManager};
 use tokio::sync::Mutex;

--- a/crates/octos-cli/src/commands/gateway/adapters/api.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/api.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use octos_bus::{ChannelManager, SessionManager};
-use octos_core::MAIN_PROFILE_ID;
 use tokio::sync::Mutex;
 
 use crate::config::ChannelEntry;
@@ -32,7 +31,7 @@ pub fn register(
         auth_token,
         shutdown.clone(),
         session_mgr.clone(),
-        gateway_profile_id.unwrap_or(MAIN_PROFILE_ID).to_string(),
+        gateway_profile_id.map(str::to_string),
     );
     channel_mgr.register(Arc::new(channel));
     Ok(())

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -9,15 +9,15 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use colored::Colorize;
 use eyre::{Result, WrapErr};
 use octos_agent::{AgentConfig, HookContext, HookExecutor, ToolRegistry};
 use octos_bus::{
-    ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager, create_bus,
+    create_bus, ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager,
 };
 use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, BaselineEntry, LlmProvider, ProviderChain, ProviderRouter,
@@ -29,12 +29,12 @@ use tracing::{info, warn};
 
 use super::build_system_prompt;
 use super::message_preprocessing;
-use super::profile_factory::{ProfileActorFactoryBuilder, build_plugin_env};
+use super::profile_factory::{build_plugin_env, ProfileActorFactoryBuilder};
 use super::{account_handler, adapters, skills_handler};
 use super::{build_profiled_session_key, resolve_dispatch_profile_id};
 use crate::commands::chat::{self, create_embedder, resolve_provider_policy};
 use crate::commands::{load_prompt, resolve_data_dir};
-use crate::config::{Config, detect_provider};
+use crate::config::{detect_provider, Config};
 use crate::config_watcher::{ConfigChange, ConfigWatcher};
 use crate::persona_service::PersonaService;
 use crate::session_actor::{ActorFactory, ActorRegistry, SnapshotToolRegistryFactory};
@@ -755,7 +755,11 @@ impl GatewayRuntime {
                     }
                 }
 
-                if registered > 0 { Some(router) } else { None }
+                if registered > 0 {
+                    Some(router)
+                } else {
+                    None
+                }
             };
 
             // Capture config for per-session SpawnTool and PipelineTool creation

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use colored::Colorize;
 use eyre::{Result, WrapErr};
-use octos_agent::{AgentConfig, HookContext, HookExecutor, SkillsLoader, ToolRegistry};
+use octos_agent::{AgentConfig, HookContext, HookExecutor, ToolRegistry};
 use octos_bus::{
     ActiveSessionStore, ChannelManager, CronService, HeartbeatService, SessionManager, create_bus,
 };
@@ -491,52 +491,8 @@ impl GatewayRuntime {
         };
         let asr_language = voice_config.as_ref().and_then(|vc| vc.asr_language.clone());
 
-        // Collect extra skills dirs: parent profile (for sub-accounts) + global
-        let mut extra_skills_dirs: Vec<PathBuf> = Vec::new();
-        if data_dir != project_dir {
-            // Sub-account: also add parent profile's skills dir
-            if let Some(ref parent_path) = cmd.parent_profile {
-                if let Ok(parent_content) = std::fs::read_to_string(parent_path) {
-                    if let Ok(parent) =
-                        serde_json::from_str::<crate::profiles::UserProfile>(&parent_content)
-                    {
-                        if let Some(ref store) = profile_store {
-                            extra_skills_dirs.push(store.resolve_data_dir(&parent));
-                        }
-                    }
-                }
-            }
-            extra_skills_dirs.push(project_dir.clone());
-        }
-
-        // Skills priority (highest first):
-        //   1. Profile skills (data_dir/skills or sub-account/skills)
-        //   2. Parent profile skills (if sub-account)
-        //   3. Global profile skills (project_dir/skills)
-        //   4. Bundled app-skills (project_dir/bundled-app-skills)
-        // Note: platform skills (voice, etc.) are admin-only — loaded in serve.rs
-        let skills_loader = if data_dir != project_dir {
-            let mut loader = SkillsLoader::new(&data_dir);
-            for dir in &extra_skills_dirs {
-                loader.add_skills_dir(dir);
-            }
-            loader
-        } else {
-            SkillsLoader::new(&project_dir)
-        };
-        // Add shared layered dirs (lower priority than profile skills)
-        let mut skills_loader = skills_loader;
-        skills_loader
-            .add_skills_path(project_dir.join(octos_agent::bootstrap::BUNDLED_APP_SKILLS_DIR));
-        // Extra skills dirs from OCTOS_SKILLS_PATH env var
-        if let Ok(extra) = std::env::var("OCTOS_SKILLS_PATH") {
-            for p in extra.split(':') {
-                let p = p.trim();
-                if !p.is_empty() {
-                    skills_loader.add_skills_path(p);
-                }
-            }
-        }
+        // Customer-installed skills are strictly account-scoped.
+        let skills_loader = crate::skills_scope::build_account_skills_loader(&data_dir);
 
         // Create message bus (before publisher is consumed by channel manager)
         let (agent_handle, publisher) = create_bus();
@@ -639,19 +595,7 @@ impl GatewayRuntime {
 
             // Load plugins with a dedicated work directory for output files
             let plugin_work_dir = data_dir.join("skill-output");
-            let mut plugin_dirs = crate::config::Config::plugin_dirs_from_project(&project_dir);
-            // Prepend per-profile skills dir (highest priority)
-            let profile_skills = data_dir.join("skills");
-            if profile_skills.exists() && !plugin_dirs.contains(&profile_skills) {
-                plugin_dirs.insert(0, profile_skills);
-            }
-            // Sub-account: also add parent profile's skills dir
-            for dir in &extra_skills_dirs {
-                let parent_skills = dir.join("skills");
-                if parent_skills.exists() && !plugin_dirs.contains(&parent_skills) {
-                    plugin_dirs.push(parent_skills);
-                }
-            }
+            let plugin_dirs = crate::skills_scope::build_account_plugin_dirs(&data_dir);
             plugin_result = octos_agent::PluginLoadResult::default();
             if !plugin_dirs.is_empty() {
                 match octos_agent::PluginLoader::load_into_with_work_dir(
@@ -1043,11 +987,6 @@ impl GatewayRuntime {
             tools.register(octos_agent::ActivateToolsTool::new());
         }
 
-        // Extract supervisor before consuming tools into the factory snapshot.
-        // Used by the API channel's task query callback (gated behind api feature).
-        #[cfg(feature = "api")]
-        let supervisor = tools.supervisor();
-
         // Create the base tool registry snapshot (excludes session-specific tools)
         let tool_registry_factory = Arc::new(SnapshotToolRegistryFactory::new(tools));
 
@@ -1285,7 +1224,6 @@ impl GatewayRuntime {
             let base_prompt = gw_config.system_prompt.clone();
             let data_dir_p = data_dir.clone();
             let project_dir_p = project_dir.clone();
-            let extra_dirs_p = extra_skills_dirs.clone();
             let memory_store_p = memory_store.clone();
             let tool_config_p = tool_config.clone();
             let indicators = status_indicators.clone();
@@ -1295,15 +1233,11 @@ impl GatewayRuntime {
                     let base = base_prompt.clone();
                     let dd = data_dir_p.clone();
                     let pd = project_dir_p.clone();
-                    let eds = extra_dirs_p.clone();
                     let ms = memory_store_p.clone();
                     let tc = tool_config_p.clone();
                     let prompt_lock = system_prompt_for_persona.clone();
                     tokio::spawn(async move {
-                        let mut sl = SkillsLoader::new(&dd);
-                        for dir in &eds {
-                            sl.add_skills_dir(dir);
-                        }
+                        let sl = crate::skills_scope::build_account_skills_loader(&dd);
                         let new_prompt =
                             build_system_prompt(base.as_deref(), &dd, &pd, &ms, &sl, &tc).await;
                         *prompt_lock.write().unwrap_or_else(|e| e.into_inner()) = new_prompt;

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -106,7 +106,7 @@ fn resolve_dispatch_profile_id(
     profile_store: Option<&crate::profiles::ProfileStore>,
 ) -> Result<Option<String>> {
     let Some(profile_id) = target_profile_id.filter(|value| !value.is_empty()) else {
-        return Ok(None);
+        return Ok(current_gateway_profile_id.map(str::to_string));
     };
 
     if current_gateway_profile_id.is_some_and(|current| current == profile_id) {
@@ -440,6 +440,20 @@ mod tests {
                 .unwrap();
 
         assert_eq!(resolved.as_deref(), Some("dspfac--newsbot"));
+    }
+
+    #[test]
+    fn test_dispatch_without_target_uses_current_gateway_profile() {
+        let resolved = resolve_dispatch_profile_id(Some("dspfac--newsbot"), None, None).unwrap();
+
+        assert_eq!(resolved.as_deref(), Some("dspfac--newsbot"));
+    }
+
+    #[test]
+    fn test_dispatch_without_target_keeps_main_when_gateway_unscoped() {
+        let resolved = resolve_dispatch_profile_id(None, None, None).unwrap();
+
+        assert_eq!(resolved, None);
     }
 
     #[cfg(unix)]

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -32,8 +32,8 @@ use {
     octos_agent::{AgentConfig, ToolRegistry},
     octos_bus::{ActiveSessionStore, ChannelManager, CronService, SessionManager},
     profile_factory::ProfileActorFactoryBuilder,
-    std::sync::Arc,
     std::sync::atomic::{AtomicBool, AtomicUsize},
+    std::sync::Arc,
 };
 
 /// Run as a persistent gateway daemon.

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use clap::Args;
 use eyre::{Result, WrapErr};
-use octos_core::{MAIN_PROFILE_ID, SessionKey};
+use octos_core::{SessionKey, MAIN_PROFILE_ID};
 use tracing::warn;
 
 use super::Executable;
@@ -178,7 +178,7 @@ mod tests {
     use octos_memory::{EpisodeStore, MemoryStore};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
-    use tokio::sync::{Mutex, RwLock, mpsc};
+    use tokio::sync::{mpsc, Mutex, RwLock};
 
     fn make_profile(id: &str, system_prompt: Option<&str>) -> crate::profiles::UserProfile {
         crate::profiles::UserProfile {

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -5,8 +5,8 @@
 //! the profile's own LLM stack, tool registry, skills, and system prompt.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::Result;
@@ -17,12 +17,12 @@ use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, LlmProvider, ProviderChain, ProviderRouter, RetryProvider,
 };
 use octos_memory::{EpisodeStore, MemoryStore};
-use tokio::sync::{Mutex, RwLock, mpsc};
+use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::{info, warn};
 
 use super::build_system_prompt;
 use crate::commands::chat::{create_embedder, resolve_provider_policy};
-use crate::config::{Config, detect_provider};
+use crate::config::{detect_provider, Config};
 use crate::session_actor::{
     ActorFactory, PendingMessages, PipelineToolFactory, SnapshotToolRegistryFactory,
     ToolRegistryFactory,
@@ -500,7 +500,11 @@ impl ProfileActorFactoryBuilder {
                         ),
                     }
                 }
-                if registered > 1 { Some(router) } else { None }
+                if registered > 1 {
+                    Some(router)
+                } else {
+                    None
+                }
             };
             provider_router = child_router.clone();
 

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 
 use eyre::Result;
-use octos_agent::{AgentConfig, HookContext, HookExecutor, SkillsLoader, ToolRegistry};
+use octos_agent::{AgentConfig, HookContext, HookExecutor, ToolRegistry};
 use octos_bus::{ActiveSessionStore, CronService, SessionManager};
 use octos_core::OutboundMessage;
 use octos_llm::{
@@ -311,29 +311,7 @@ impl ProfileActorFactoryBuilder {
         let model_id = llm.model_id().to_string();
 
         let profile_data_dir = self.profile_store.resolve_data_dir(&effective_profile);
-        let mut extra_skills_dirs: Vec<PathBuf> = Vec::new();
-        if profile_data_dir != self.project_dir {
-            if let Some(parent_id) = effective_profile.parent_id.as_deref() {
-                if let Some(parent) = self.profile_store.get(parent_id)? {
-                    extra_skills_dirs.push(self.profile_store.resolve_data_dir(&parent));
-                }
-            }
-            extra_skills_dirs.push(self.project_dir.clone());
-        }
-
-        let mut skills_loader = if profile_data_dir != self.project_dir {
-            let mut loader = SkillsLoader::new(&profile_data_dir);
-            for dir in &extra_skills_dirs {
-                loader.add_skills_dir(dir);
-            }
-            loader
-        } else {
-            SkillsLoader::new(&self.project_dir)
-        };
-        skills_loader.add_skills_path(
-            self.project_dir
-                .join(octos_agent::bootstrap::BUNDLED_APP_SKILLS_DIR),
-        );
+        let skills_loader = crate::skills_scope::build_account_skills_loader(&profile_data_dir);
 
         let mut child_plugin_prompt_fragments = Vec::new();
         let mut child_plugin_hooks: Vec<octos_agent::HookConfig> = Vec::new();
@@ -405,19 +383,7 @@ impl ProfileActorFactoryBuilder {
                     .to_string_lossy()
                     .to_string(),
             ));
-            let mut plugin_dirs =
-                crate::config::Config::plugin_dirs_from_project(&self.project_dir);
-            let profile_skills = profile_data_dir.join("skills");
-            if profile_skills.exists() && !plugin_dirs.contains(&profile_skills) {
-                plugin_dirs.insert(0, profile_skills);
-            }
-            // Include parent profile skills dir so child bots can use parent's skills
-            for dir in &extra_skills_dirs {
-                let skills = dir.join("skills");
-                if skills.exists() && !plugin_dirs.contains(&skills) {
-                    plugin_dirs.push(skills);
-                }
-            }
+            let plugin_dirs = crate::skills_scope::build_account_plugin_dirs(&profile_data_dir);
             if !plugin_dirs.is_empty() {
                 match octos_agent::PluginLoader::load_into_with_work_dir(
                     &mut tools,

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -198,25 +198,12 @@ impl Executable for SkillsCommand {
 
 // ── Public API for programmatic access ───────────────────────────────
 
-/// Resolve the skills directory for a profile.
-/// Sub-accounts resolve to their parent profile's skills dir.
+/// Resolve the installed customer skills directory for exactly the requested account.
 pub fn resolve_profile_skills_dir(
     store: &crate::profiles::ProfileStore,
     profile_id: &str,
 ) -> Result<PathBuf> {
-    let profile = store
-        .get(profile_id)?
-        .ok_or_else(|| eyre::eyre!("profile '{profile_id}' not found"))?;
-    let target = if let Some(ref parent_id) = profile.parent_id {
-        store
-            .get(parent_id)?
-            .ok_or_else(|| eyre::eyre!("parent profile '{parent_id}' not found"))?
-    } else {
-        profile
-    };
-    let data_dir = store.resolve_data_dir(&target);
-    std::fs::create_dir_all(data_dir.join("skills")).ok();
-    Ok(data_dir.join("skills"))
+    crate::skills_scope::resolve_account_skills_dir(store, profile_id)
 }
 
 /// List installed skills in a directory (returns structured data).

--- a/crates/octos-cli/src/gateway_dispatcher.rs
+++ b/crates/octos-cli/src/gateway_dispatcher.rs
@@ -7,9 +7,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use octos_bus::{ActiveSessionStore, SessionManager, validate_topic_name};
-use octos_core::{InboundMessage, MAIN_PROFILE_ID, OutboundMessage, SessionKey};
-use tokio::sync::{Mutex, RwLock, mpsc};
+use octos_bus::{validate_topic_name, ActiveSessionStore, SessionManager};
+use octos_core::{InboundMessage, OutboundMessage, SessionKey, MAIN_PROFILE_ID};
+use tokio::sync::{mpsc, Mutex, RwLock};
 use tracing::{info, warn};
 
 use crate::commands::gateway::{build_profiled_session_key, session_ui};

--- a/crates/octos-cli/src/gateway_dispatcher.rs
+++ b/crates/octos-cli/src/gateway_dispatcher.rs
@@ -159,11 +159,18 @@ impl GatewayDispatcher {
                             } else {
                                 project_name
                             };
-                            crate::project_templates::scaffold_slides_project(
+                            match crate::project_templates::scaffold_slides_project(
                                 &workspace_root,
                                 project_name,
-                            );
-                            template_reply
+                            ) {
+                                Ok(_) => template_reply,
+                                Err(error) => {
+                                    warn!(topic = name, "slides scaffold failed: {error}");
+                                    format!(
+                                        "{template_reply}\n\nSlides git/bootstrap failed: {error}"
+                                    )
+                                }
+                            }
                         }
                         None => format!("Switched to session: {name}"),
                     }

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
 fn init_tracing(
     log_dir: Option<&std::path::Path>,
 ) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
-    use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter, Layer};
 
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info"))

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -24,6 +24,7 @@ pub mod process_manager;
 pub mod profiles;
 pub mod project_templates;
 pub mod session_actor;
+pub mod skills_scope;
 pub mod soul_service;
 pub mod status_indicator;
 pub mod status_layers;

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -4,6 +4,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use octos_agent::{WorkspaceProjectKind, initialize_and_commit};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -27,19 +28,22 @@ const SESSION_PROMPTS_DIR: &str = "session_prompts";
 /// Creates the following structure:
 /// ```text
 /// slides/<slug>/
-///   history/       — versioned script snapshots
+///   history/       — optional manual exports (git is the primary history)
 ///   output/        — generated PPTX files
 ///   assets/        — images, logos, branding
 ///   memory.md      — project-level memory
 ///   changelog.md   — edit history
 ///   script.js      — slide generation script template
 /// ```
-pub fn scaffold_slides_project(data_dir: &Path, project_name: &str) -> PathBuf {
+pub fn scaffold_slides_project(data_dir: &Path, project_name: &str) -> Result<PathBuf, String> {
     let slug = slugify(project_name);
     let project_dir = data_dir.join("slides").join(&slug);
-    std::fs::create_dir_all(project_dir.join("history")).ok();
-    std::fs::create_dir_all(project_dir.join("output")).ok();
-    std::fs::create_dir_all(project_dir.join("assets")).ok();
+    std::fs::create_dir_all(project_dir.join("history"))
+        .map_err(|e| format!("create slides history dir failed: {e}"))?;
+    std::fs::create_dir_all(project_dir.join("output"))
+        .map_err(|e| format!("create slides output dir failed: {e}"))?;
+    std::fs::create_dir_all(project_dir.join("assets"))
+        .map_err(|e| format!("create slides assets dir failed: {e}"))?;
 
     // Only write template files if they don't exist yet — avoid
     // overwriting LLM-written content on session actor restart.
@@ -50,11 +54,13 @@ pub fn scaffold_slides_project(data_dir: &Path, project_name: &str) -> PathBuf {
             "# {} -- Slides Project\n\n## Style decisions\n\n## User preferences\n\n## Current state\n- Created: {}\n- Slides: 0\n",
             project_name, today
         );
-        std::fs::write(&memory_path, &memory).ok();
+        std::fs::write(&memory_path, &memory)
+            .map_err(|e| format!("write slides memory.md failed: {e}"))?;
     }
 
     if !project_dir.join("changelog.md").exists() {
-        std::fs::write(project_dir.join("changelog.md"), "# Changelog\n\n").ok();
+        std::fs::write(project_dir.join("changelog.md"), "# Changelog\n\n")
+            .map_err(|e| format!("write slides changelog.md failed: {e}"))?;
     }
 
     // Empty script.js — LLM MUST write real content before mofa_slides can run.
@@ -62,6 +68,9 @@ pub fn scaffold_slides_project(data_dir: &Path, project_name: &str) -> PathBuf {
     if !script_path.exists() {
         let template = format!(
             r#"// {} -- Slides Generation Script
+// version: v001_initial
+// updated_at: {}
+// change_summary: Initial scaffold created by /new slides
 // EMPTY: The agent must write slide content here before generating.
 // Use mofa_slides with input pointing to this file after writing content.
 //
@@ -73,13 +82,22 @@ pub fn scaffold_slides_project(data_dir: &Path, project_name: &str) -> PathBuf {
 
 module.exports = [];
 "#,
-            project_name
+            project_name,
+            chrono::Utc::now().format("%Y-%m-%d")
         );
-        std::fs::write(&script_path, &template).ok();
+        std::fs::write(&script_path, &template)
+            .map_err(|e| format!("write slides script.js failed: {e}"))?;
     }
 
+    initialize_and_commit(
+        &project_dir,
+        WorkspaceProjectKind::Slides,
+        "Initialize slides workspace",
+    )
+    .map_err(|e| format!("initialize slides git repo failed: {e}"))?;
+
     info!(project = %project_name, slug = %slug, "scaffolded slides project");
-    project_dir
+    Ok(project_dir)
 }
 
 /// Build the user-facing reply after scaffolding a slides project.
@@ -90,6 +108,7 @@ pub fn slides_creation_reply(project_name: &str) -> String {
          Project directory: slides/{slug}/\n\
          Script: slides/{slug}/script.js\n\
          Memory: slides/{slug}/memory.md\n\n\
+         Local git history is enabled in slides/{slug}/.\n\n\
          Let me help you design your slides. I'll check available style templates first,\n\
          then we'll design the content together."
     )
@@ -118,7 +137,15 @@ RULES:
 - NEVER pass slides array inline. ALWAYS use the input file.
 - On failure: report error, do NOT retry via shell.
 - Read slides/{slug}/memory.md before each response for context.
-- After edits: update memory.md. Before edits: copy script.js to history/v{{NNN}}_{{desc}}.js.
+- Maintain a version header at the top of slides/{slug}/script.js:
+  // version: v{{NNN}}_{{desc}}
+  // updated_at: YYYY-MM-DD
+  // change_summary: <one line>
+- Local git is already initialized in slides/{slug}/ and is the primary revision history.
+- Do NOT create ad hoc versioned JS filenames as the main history mechanism.
+- On every meaningful edit: increment NNN, update the script.js version header, append the same version tag to changelog.md, and rely on git auto-commits for revision history.
+- After edits: update memory.md.
+- If the user asks for change history, inspect it with shell("git -C slides/{slug} log --oneline -- script.js changelog.md memory.md").
 
 STYLE TOML — create at styles/{{name}}.toml when user wants a custom style:
 ```toml
@@ -485,6 +512,7 @@ WORKFLOW:
 2. Preserve the selected framework: {template}
 3. Maintain the extracted structure while removing private/source-specific branding
 4. After source edits, rebuild the site so the iframe preview stays current
+5. Local git is already initialized in sites/{site_slug}/; rely on git auto-commits for revision history instead of ad hoc backup files
 
 BUILD RULES:
 - {template}: build output dir is sites/{site_slug}/{build_output_dir}/
@@ -500,6 +528,7 @@ EXPECTATIONS:
 - Keep the preview working under a session-scoped subpath
 - Prefer editing existing scaffold files over recreating the project
 - When adding pages, keep navigation and internal links aligned with the build path
+- If the user asks for change history, inspect it with shell("git -C sites/{site_slug} log --oneline -- .")
 
 Tools: read_file, write_file, edit_file, shell, glob
 "#,
@@ -759,6 +788,12 @@ pub fn scaffold_site_project(
         .ok_or_else(|| "mofa-site skill directory not found".to_string())?;
     run_site_bootstrap(&skill_dir, &project_dir, &metadata)?;
     write_site_support_files(&project_dir, &metadata)?;
+    initialize_and_commit(
+        &project_dir,
+        WorkspaceProjectKind::Sites,
+        "Initialize site workspace",
+    )
+    .map_err(|e| format!("initialize site git repo failed: {e}"))?;
 
     info!(
         session_id = %session_id,
@@ -778,6 +813,7 @@ pub fn site_creation_reply(metadata: &SiteProjectMetadata) -> String {
          Template: {template}\n\
          Preview route: {preview_url}\n\
          Session metadata: {project_dir}/{session_file}\n\n\
+         Local git history is enabled in {project_dir}/.\n\n\
          The scaffold is ready. Edit the source files and refresh the iframe preview to see the built site.",
         site_name = metadata.site_name,
         project_dir = metadata.project_dir,
@@ -814,7 +850,7 @@ mod tests {
     #[test]
     fn should_scaffold_slides_project_directories() {
         let tmp = tempfile::tempdir().unwrap();
-        let project_dir = scaffold_slides_project(tmp.path(), "test-deck");
+        let project_dir = scaffold_slides_project(tmp.path(), "test-deck").unwrap();
 
         assert!(project_dir.join("history").is_dir());
         assert!(project_dir.join("output").is_dir());
@@ -822,6 +858,8 @@ mod tests {
         assert!(project_dir.join("memory.md").is_file());
         assert!(project_dir.join("changelog.md").is_file());
         assert!(project_dir.join("script.js").is_file());
+        assert!(project_dir.join(".git").is_dir());
+        assert!(project_dir.join(".gitignore").is_file());
 
         let memory = std::fs::read_to_string(project_dir.join("memory.md")).unwrap();
         assert!(memory.contains("test-deck"));
@@ -835,13 +873,13 @@ mod tests {
     #[test]
     fn should_scaffold_idempotently() {
         let tmp = tempfile::tempdir().unwrap();
-        scaffold_slides_project(tmp.path(), "deck");
+        scaffold_slides_project(tmp.path(), "deck").unwrap();
         // Modify a file and ensure re-scaffold preserves user edits.
         let memory_path = tmp.path().join("slides/deck/memory.md");
         std::fs::write(&memory_path, "custom content").unwrap();
 
         // Re-scaffold keeps existing files intact.
-        scaffold_slides_project(tmp.path(), "deck");
+        scaffold_slides_project(tmp.path(), "deck").unwrap();
         let content = std::fs::read_to_string(&memory_path).unwrap();
         assert_eq!(content, "custom content");
     }
@@ -895,6 +933,7 @@ mod tests {
         assert!(reply.contains("Q4 Report"));
         assert!(reply.contains("slides/q4-report/"));
         assert!(reply.contains("Let me help you design your slides"));
+        assert!(reply.contains("Local git history is enabled"));
     }
 
     #[test]

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -4,7 +4,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use octos_agent::{WorkspaceProjectKind, initialize_and_commit};
+use octos_agent::{initialize_and_commit, WorkspaceProjectKind};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -128,6 +128,53 @@ fn system_notice_metadata(sender_user_id: Option<&str>) -> serde_json::Value {
         .unwrap_or_else(|| serde_json::json!({}))
 }
 
+fn git_turn_summary(content: &str) -> String {
+    let compact = content.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.is_empty() {
+        "agent turn update".to_string()
+    } else {
+        compact
+    }
+}
+
+async fn snapshot_workspace_turn_for_path(
+    session_key: &SessionKey,
+    workspace_root: std::path::PathBuf,
+    turn_summary: &str,
+) {
+    let turn_summary = git_turn_summary(turn_summary);
+
+    match tokio::task::spawn_blocking(move || {
+        octos_agent::snapshot_workspace_turn(&workspace_root, &turn_summary)
+    })
+    .await
+    {
+        Ok(Ok(committed)) => {
+            if !committed.is_empty() {
+                info!(
+                    session = %session_key,
+                    repos = ?committed,
+                    "workspace git turn snapshot committed"
+                );
+            }
+        }
+        Ok(Err(error)) => {
+            warn!(
+                session = %session_key,
+                error = %error,
+                "workspace git turn snapshot failed"
+            );
+        }
+        Err(error) => {
+            warn!(
+                session = %session_key,
+                error = %error,
+                "workspace git turn snapshot task failed"
+            );
+        }
+    }
+}
+
 // ── Messages ────────────────────────────────────────────────────────────────
 
 /// Messages dispatched to a session actor.
@@ -697,7 +744,11 @@ impl ActorFactory {
             } else {
                 project_name
             };
-            crate::project_templates::scaffold_slides_project(&user_workspace, project_name);
+            if let Err(error) =
+                crate::project_templates::scaffold_slides_project(&user_workspace, project_name)
+            {
+                warn!(session = %session_key, "slides scaffold failed in workspace: {error}");
+            }
 
             // Copy built-in style templates into workspace/styles/ so the
             // agent's glob("styles/*.toml") can discover them.
@@ -999,6 +1050,15 @@ struct SessionActor {
 }
 
 impl SessionActor {
+    async fn snapshot_workspace_turn_if_needed(&self, turn_summary: &str) {
+        snapshot_workspace_turn_for_path(
+            &self.session_key,
+            self.user_workspace.clone(),
+            turn_summary,
+        )
+        .await;
+    }
+
     /// Check if this session is currently the active session for its chat.
     /// When inactive, streaming edits bypass the pending buffer, so we must
     /// skip streaming and let the reply go through the proxy path.
@@ -2512,6 +2572,9 @@ impl SessionActor {
             }
         }
 
+        self.snapshot_workspace_turn_if_needed(&inbound.content)
+            .await;
+
         // Reset per-session cancellation flag so the next message starts fresh.
         // This must happen AFTER the agent finishes, so it has had a chance to
         // observe the shutdown signal during its iteration loop.
@@ -2592,6 +2655,7 @@ impl SessionActor {
         let history = pre_primary_history.to_vec();
         let active_sessions = self.active_sessions.clone();
         let overflow_cancelled = Arc::clone(&self.overflow_cancelled);
+        let user_workspace = self.user_workspace.clone();
 
         tokio::spawn(async move {
             // Save user message to history first
@@ -2687,6 +2751,8 @@ impl SessionActor {
                     session = %session_key,
                     "overflow task cancelled by command, suppressing response"
                 );
+                snapshot_workspace_turn_for_path(&session_key, user_workspace.clone(), &content)
+                    .await;
                 // Still decrement and return — skip sending any reply.
                 overflow_counter.fetch_sub(1, Ordering::Release);
                 return;
@@ -2777,6 +2843,8 @@ impl SessionActor {
                         .await;
                 }
             }
+
+            snapshot_workspace_turn_for_path(&session_key, user_workspace, &content).await;
             // Decrement active overflow counter
             overflow_counter.fetch_sub(1, Ordering::Release);
         });
@@ -3126,6 +3194,9 @@ impl SessionActor {
                     .await;
             }
         }
+
+        self.snapshot_workspace_turn_if_needed(&inbound.content)
+            .await;
 
         // Reset per-session cancellation flag so the next message starts fresh.
         self.cancelled.store(false, Ordering::Release);

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -5,8 +5,8 @@
 //! to the wrong chat.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use octos_agent::tools::{MessageTool, SendFileTool, SpawnTool, ToolPolicy, ToolRegistry};
@@ -14,15 +14,15 @@ use octos_agent::{Agent, AgentConfig, HookContext, HookExecutor, TokenTracker};
 use octos_bus::{ActiveSessionStore, SessionHandle, SessionManager};
 use octos_core::AgentId;
 use octos_core::{
-    InboundMessage, MAIN_PROFILE_ID, METADATA_SENDER_USER_ID, Message, MessageRole,
-    OutboundMessage, SessionKey,
+    InboundMessage, Message, MessageRole, OutboundMessage, SessionKey, MAIN_PROFILE_ID,
+    METADATA_SENDER_USER_ID,
 };
 use octos_llm::{
     AdaptiveMode, AdaptiveRouter, EmbeddingProvider, LlmProvider, ProviderRouter,
     ResponsivenessObserver,
 };
 use octos_memory::{EpisodeStore, MemoryStore};
-use tokio::sync::{Mutex, RwLock, Semaphore, mpsc};
+use tokio::sync::{mpsc, Mutex, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 

--- a/crates/octos-cli/src/skills_scope.rs
+++ b/crates/octos-cli/src/skills_scope.rs
@@ -1,0 +1,98 @@
+use std::path::{Path, PathBuf};
+
+use eyre::Result;
+use octos_agent::SkillsLoader;
+
+use crate::profiles::ProfileStore;
+
+/// Resolve the installed skills directory for exactly the requested account.
+///
+/// This is intentionally strict: sub-accounts do not inherit their parent
+/// profile's installed customer skills.
+pub fn resolve_account_skills_dir(store: &ProfileStore, profile_id: &str) -> Result<PathBuf> {
+    let profile = store
+        .get(profile_id)?
+        .ok_or_else(|| eyre::eyre!("profile '{profile_id}' not found"))?;
+    let data_dir = store.resolve_data_dir(&profile);
+    Ok(data_dir.join("skills"))
+}
+
+/// Build a skills loader scoped to the current account only.
+pub fn build_account_skills_loader(data_dir: &Path) -> SkillsLoader {
+    SkillsLoader::new(data_dir)
+}
+
+/// Return plugin/skill package directories for the current account only.
+pub fn build_account_plugin_dirs(data_dir: &Path) -> Vec<PathBuf> {
+    let skills_dir = data_dir.join("skills");
+    if skills_dir.exists() {
+        vec![skills_dir]
+    } else {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+    use crate::profiles::{GatewaySettings, ProfileConfig, UserProfile};
+
+    #[test]
+    fn resolve_account_skills_dir_keeps_sub_account_isolated() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+
+        let parent = UserProfile {
+            id: "dspfac".into(),
+            name: "DSPFAC".into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            config: ProfileConfig {
+                gateway: GatewaySettings::default(),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let child = UserProfile {
+            id: "dspfac--newsbot".into(),
+            name: "Newsbot".into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: Some("dspfac".into()),
+            config: ProfileConfig {
+                gateway: GatewaySettings::default(),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        store.save(&parent).unwrap();
+        store.save(&child).unwrap();
+
+        let parent_dir = resolve_account_skills_dir(&store, "dspfac").unwrap();
+        let child_dir = resolve_account_skills_dir(&store, "dspfac--newsbot").unwrap();
+
+        assert_ne!(parent_dir, child_dir);
+        assert!(child_dir.to_string_lossy().contains("dspfac--newsbot"));
+    }
+
+    #[test]
+    fn account_plugin_dirs_only_include_current_account_skills() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir
+            .path()
+            .join("profiles")
+            .join("dspfac--newsbot")
+            .join("data");
+        let skills_dir = data_dir.join("skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+
+        let dirs = build_account_plugin_dirs(&data_dir);
+        assert_eq!(dirs, vec![skills_dir]);
+    }
+}


### PR DESCRIPTION
## Summary
- add local workspace git snapshots for slides and sites, including turn-end snapshots that catch shell and generator side effects
- scope customer skills to the active account instead of inheriting from parent/shared installs
- fix profiled API session lookup and topic-aware history so profiled slides/site sessions resolve the right history and session key

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo check -p octos-cli --features api
- ./scripts/ci.sh