### PR TITLE
Persist session artifacts and expose session files

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -24,7 +25,7 @@ use octos_core::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::channel::Channel;
 use crate::SessionManager;
@@ -98,6 +99,103 @@ impl ApiChannel {
         self.task_query = Some(f);
         self
     }
+
+    fn session_workspace_dir(data_dir: &Path, key: &SessionKey) -> PathBuf {
+        let encoded = crate::session::encode_path_component(key.base_key());
+        data_dir.join("users").join(encoded).join("workspace")
+    }
+
+    fn session_artifact_dir(data_dir: &Path, key: &SessionKey) -> PathBuf {
+        Self::session_workspace_dir(data_dir, key).join(".artifacts")
+    }
+
+    fn sanitize_artifact_name(path: &Path) -> String {
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| "artifact".to_string());
+        name.replace(['/', '\\', '\0'], "_")
+    }
+
+    fn copy_media_into_session_artifacts(artifact_dir: &Path, media: &[String]) -> Vec<String> {
+        if let Err(error) = std::fs::create_dir_all(artifact_dir) {
+            warn!(
+                path = %artifact_dir.display(),
+                %error,
+                "failed to create session artifact directory"
+            );
+            return media.to_vec();
+        }
+
+        let canonical_artifact_dir =
+            std::fs::canonicalize(artifact_dir).unwrap_or_else(|_| artifact_dir.to_path_buf());
+
+        media
+            .iter()
+            .map(|raw| {
+                let source_path = PathBuf::from(raw);
+                if source_path.starts_with(&canonical_artifact_dir) {
+                    return raw.clone();
+                }
+
+                let canonical_source = match std::fs::canonicalize(&source_path) {
+                    Ok(path) => path,
+                    Err(error) => {
+                        warn!(path = %raw, %error, "failed to canonicalize media source");
+                        return raw.clone();
+                    }
+                };
+
+                if canonical_source.starts_with(&canonical_artifact_dir) {
+                    return canonical_source.to_string_lossy().to_string();
+                }
+
+                let safe_name = Self::sanitize_artifact_name(&canonical_source);
+                let dest =
+                    canonical_artifact_dir.join(format!("{}-{safe_name}", uuid::Uuid::now_v7()));
+
+                if canonical_source == dest {
+                    return canonical_source.to_string_lossy().to_string();
+                }
+
+                match std::fs::copy(&canonical_source, &dest) {
+                    Ok(_) => dest.to_string_lossy().to_string(),
+                    Err(error) => {
+                        warn!(
+                            source = %canonical_source.display(),
+                            dest = %dest.display(),
+                            %error,
+                            "failed to materialize media into session artifacts"
+                        );
+                        raw.clone()
+                    }
+                }
+            })
+            .collect()
+    }
+
+    async fn materialize_media_for_session(&self, chat_id: &str, media: &[String]) -> Vec<String> {
+        let key = current_profile_api_session_key(self.profile_id.as_deref(), chat_id);
+        let data_dir = {
+            let sess = self.sessions.lock().await;
+            sess.data_dir()
+        };
+        let artifact_dir = Self::session_artifact_dir(&data_dir, &key);
+        let media = media.to_vec();
+        let media_for_copy = media.clone();
+        match tokio::task::spawn_blocking(move || {
+            Self::copy_media_into_session_artifacts(&artifact_dir, &media_for_copy)
+        })
+        .await
+        {
+            Ok(paths) => paths,
+            Err(error) => {
+                warn!(chat_id = %chat_id, %error, "failed to join media materialization task");
+                media
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -146,19 +244,24 @@ impl Channel for ApiChannel {
 
     async fn send(&self, msg: &OutboundMessage) -> Result<()> {
         if !msg.media.is_empty() {
+            let persisted_media = self
+                .materialize_media_for_session(&msg.chat_id, &msg.media)
+                .await;
+
             // File message — persist to session history AND send SSE event.
             let file_desc = msg
                 .media
                 .iter()
-                .map(|p| {
-                    let name = std::path::Path::new(p)
+                .zip(persisted_media.iter())
+                .map(|(original_path, persisted_path)| {
+                    let name = std::path::Path::new(original_path)
                         .file_name()
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
                     if msg.content.is_empty() {
-                        format!("[file:{p}] {name}")
+                        format!("[file:{persisted_path}] {name}")
                     } else {
-                        format!("[file:{p}] {name} — {}", msg.content)
+                        format!("[file:{persisted_path}] {name} — {}", msg.content)
                     }
                 })
                 .collect::<Vec<_>>()
@@ -166,7 +269,7 @@ impl Channel for ApiChannel {
             let session_msg = Message {
                 role: MessageRole::Assistant,
                 content: file_desc,
-                media: msg.media.clone(),
+                media: persisted_media.clone(),
                 tool_calls: None,
                 tool_call_id: None,
                 reasoning_content: None,
@@ -177,8 +280,9 @@ impl Channel for ApiChannel {
             // Send SSE file event so the web client receives it in real-time
             let pending = self.pending.lock().await;
             if let Some(tx) = pending.get(&msg.chat_id) {
-                for path in &msg.media {
-                    let filename = std::path::Path::new(path)
+                for (original_path, persisted_path) in msg.media.iter().zip(persisted_media.iter())
+                {
+                    let filename = std::path::Path::new(original_path)
                         .file_name()
                         .map(|n| n.to_string_lossy().to_string())
                         .unwrap_or_default();
@@ -189,7 +293,7 @@ impl Channel for ApiChannel {
                         .unwrap_or("");
                     let event = serde_json::json!({
                         "type": "file",
-                        "path": path,
+                        "path": persisted_path,
                         "filename": filename,
                         "caption": msg.content,
                         "tool_call_id": tool_call_id,
@@ -813,12 +917,17 @@ async fn handle_upload(mut multipart: axum::extract::Multipart) -> Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     const TEST_PROFILE_ID: &str = "dspfac";
 
+    fn test_sessions_in(data_dir: &Path) -> Arc<Mutex<SessionManager>> {
+        Arc::new(Mutex::new(SessionManager::open(data_dir).unwrap()))
+    }
+
     fn test_sessions() -> Arc<Mutex<SessionManager>> {
         let dir = tempfile::tempdir().unwrap();
-        Arc::new(Mutex::new(SessionManager::open(dir.path()).unwrap()))
+        test_sessions_in(dir.path())
     }
 
     #[test]
@@ -949,7 +1058,8 @@ mod tests {
 
     #[tokio::test]
     async fn send_completion_with_bg_tasks_closes_and_client_polls() {
-        let sessions = test_sessions();
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
         let ch = ApiChannel::new(
             8091,
             None,
@@ -957,6 +1067,10 @@ mod tests {
             sessions.clone(),
             Some(TEST_PROFILE_ID.to_string()),
         );
+        let source_dir = data_dir.path().join("source");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("test.mp3");
+        std::fs::write(&source, b"bg-audio").unwrap();
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
         {
             let mut pending = ch.pending.lock().await;
@@ -989,7 +1103,7 @@ mod tests {
             chat_id: "test-bg".into(),
             content: String::new(),
             reply_to: None,
-            media: vec!["/tmp/test.mp3".into()],
+            media: vec![source.to_string_lossy().to_string()],
             metadata: serde_json::json!({}),
         };
         ch.send(&file_msg).await.unwrap();
@@ -999,14 +1113,20 @@ mod tests {
         let key = SessionKey::with_profile(TEST_PROFILE_ID, "api", "test-bg");
         let session = sess.get_or_create(&key).await;
         let history = session.get_history(10);
-        assert!(history
+        let stored = history
             .iter()
-            .any(|m| m.media.contains(&"/tmp/test.mp3".to_string())));
+            .flat_map(|m| m.media.iter())
+            .find(|path| path.ends_with("test.mp3"))
+            .cloned()
+            .expect("expected persisted artifact path");
+        assert_ne!(stored, source.to_string_lossy().to_string());
+        assert!(Path::new(&stored).exists());
     }
 
     #[tokio::test]
     async fn send_file_message_persists_to_session() {
-        let sessions = test_sessions();
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
         let ch = ApiChannel::new(
             8091,
             None,
@@ -1014,6 +1134,10 @@ mod tests {
             sessions.clone(),
             Some(TEST_PROFILE_ID.to_string()),
         );
+        let source_dir = data_dir.path().join("source");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("test.mp3");
+        std::fs::write(&source, b"audio").unwrap();
 
         // Send a file message (no active SSE needed — goes straight to session)
         let msg = OutboundMessage {
@@ -1021,7 +1145,7 @@ mod tests {
             chat_id: "test-file".into(),
             content: "Audio file".into(),
             reply_to: None,
-            media: vec!["/tmp/test.mp3".into()],
+            media: vec![source.to_string_lossy().to_string()],
             metadata: serde_json::json!({}),
         };
         ch.send(&msg).await.unwrap();
@@ -1032,9 +1156,59 @@ mod tests {
         let session = sess.get_or_create(&key).await;
         let history = session.get_history(10);
         assert_eq!(history.len(), 1);
-        assert!(history[0].content.contains("/tmp/test.mp3"));
         assert!(history[0].content.contains("Audio file"));
-        assert_eq!(history[0].media, vec!["/tmp/test.mp3".to_string()]);
+        assert_eq!(history[0].media.len(), 1);
+        let persisted = &history[0].media[0];
+        assert_ne!(persisted, &source.to_string_lossy().to_string());
+        assert!(history[0].content.contains(persisted));
+        assert!(Path::new(persisted).exists());
+        assert_eq!(std::fs::read(Path::new(persisted)).unwrap(), b"audio");
+    }
+
+    #[tokio::test]
+    async fn send_file_message_keeps_distinct_artifacts_for_same_basename() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            sessions.clone(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let source_a_dir = data_dir.path().join("source-a");
+        let source_b_dir = data_dir.path().join("source-b");
+        std::fs::create_dir_all(&source_a_dir).unwrap();
+        std::fs::create_dir_all(&source_b_dir).unwrap();
+        let source_a = source_a_dir.join("report.pdf");
+        let source_b = source_b_dir.join("report.pdf");
+        std::fs::write(&source_a, b"alpha").unwrap();
+        std::fs::write(&source_b, b"beta").unwrap();
+
+        for source in [&source_a, &source_b] {
+            let msg = OutboundMessage {
+                channel: "api".into(),
+                chat_id: "collision-chat".into(),
+                content: "report".into(),
+                reply_to: None,
+                media: vec![source.to_string_lossy().to_string()],
+                metadata: serde_json::json!({}),
+            };
+            ch.send(&msg).await.unwrap();
+        }
+
+        let mut sess = sessions.lock().await;
+        let key = SessionKey::with_profile(TEST_PROFILE_ID, "api", "collision-chat");
+        let session = sess.get_or_create(&key).await;
+        let stored: Vec<String> = session
+            .get_history(10)
+            .iter()
+            .flat_map(|m| m.media.iter().cloned())
+            .collect();
+        assert_eq!(stored.len(), 2);
+        assert_ne!(stored[0], stored[1]);
+        assert_eq!(std::fs::read(Path::new(&stored[0])).unwrap().len(), 5);
+        assert_eq!(std::fs::read(Path::new(&stored[1])).unwrap().len(), 4);
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1,6 +1,6 @@
 //! API request handlers.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
@@ -548,6 +548,83 @@ pub async fn session_tasks(
     Json(serde_json::json!([])).into_response()
 }
 
+#[derive(Serialize)]
+pub struct SessionFileInfo {
+    pub filename: String,
+    pub path: String,
+    pub size_bytes: u64,
+    pub modified_at: String,
+}
+
+fn collect_session_files(root: &std::path::Path, out: &mut Vec<SessionFileInfo>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+
+        if metadata.is_dir() {
+            if entry.file_name() == ".git" {
+                continue;
+            }
+            collect_session_files(&path, out);
+            continue;
+        }
+
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let filename = path
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.to_string_lossy().to_string());
+        out.push(SessionFileInfo {
+            filename,
+            path: path.to_string_lossy().to_string(),
+            size_bytes: metadata.len(),
+            modified_at: modified_rfc3339(&metadata),
+        });
+    }
+}
+
+pub async fn session_files(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Response {
+    let data_dir = if let Some(sessions) = &state.sessions {
+        let sess = sessions.lock().await;
+        sess.data_dir()
+    } else {
+        let identity = identity.as_ref().map(|ext| &ext.0);
+        match resolve_profile_data_dir(&state, &headers, identity).await {
+            Ok(data_dir) => data_dir,
+            Err(response) => return response,
+        }
+    };
+
+    let mut files = Vec::new();
+    for workspace in api_session_workspace_dirs(&data_dir, &id) {
+        if workspace.exists() {
+            collect_session_files(&workspace, &mut files);
+        }
+    }
+
+    files.sort_by(|a, b| {
+        b.modified_at
+            .cmp(&a.modified_at)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    files.dedup_by(|left, right| left.path == right.path);
+    Json(files).into_response()
+}
+
 /// DELETE /api/sessions/:id -- delete a session.
 pub async fn delete_session(
     State(state): State<Arc<AppState>>,
@@ -916,9 +993,22 @@ fn api_session_workspace_dirs(
     session_id: &str,
 ) -> Vec<std::path::PathBuf> {
     let profile_id = infer_profile_id_from_data_dir(data_dir);
-    let session_key = SessionKey::with_profile(&profile_id, "api", session_id);
-    let encoded_base = octos_bus::session::encode_path_component(session_key.base_key());
-    vec![data_dir.join("users").join(encoded_base).join("workspace")]
+    let mut dirs = Vec::with_capacity(3);
+    let mut seen = HashSet::new();
+
+    for key in [
+        SessionKey::with_profile(&profile_id, "api", session_id),
+        SessionKey::with_profile(MAIN_PROFILE_ID, "api", session_id),
+        SessionKey::new("api", session_id),
+    ] {
+        let encoded_base = octos_bus::session::encode_path_component(key.base_key());
+        let path = data_dir.join("users").join(encoded_base).join("workspace");
+        if seen.insert(path.clone()) {
+            dirs.push(path);
+        }
+    }
+
+    dirs
 }
 
 #[cfg(test)]
@@ -2366,11 +2456,23 @@ mod tests {
         let base = std::path::Path::new("/tmp/octos-data/profiles/dspfac/data");
         let dirs = api_session_workspace_dirs(base, "slides-123");
 
-        assert_eq!(dirs.len(), 1);
+        assert_eq!(dirs.len(), 3);
         assert_eq!(
             dirs[0],
             base.join("users")
                 .join("dspfac%3Aapi%3Aslides-123")
+                .join("workspace")
+        );
+        assert_eq!(
+            dirs[1],
+            base.join("users")
+                .join("_main%3Aapi%3Aslides-123")
+                .join("workspace")
+        );
+        assert_eq!(
+            dirs[2],
+            base.join("users")
+                .join("api%3Aslides-123")
                 .join("workspace")
         );
     }

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -95,6 +95,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/sessions/{id}/status", get(handlers::session_status))
         .route("/api/sessions/{id}/tasks", get(handlers::session_tasks))
+        .route("/api/sessions/{id}/files", get(handlers::session_files))
         .route("/api/sessions/{id}", delete(handlers::delete_session))
         .route("/api/status", get(handlers::status));
 


### PR DESCRIPTION
## Summary
- persist background/media artifacts into session-owned workspace storage
- expose `/api/sessions/{id}/files` for session workspace hydration
- keep the profiled session key integration from the merged backend base

## Validation
- cargo check -p octos-cli --features api
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- ./scripts/ci.sh