### PR TITLE
Extract gateway QoS catalog helpers

### DIFF
--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -8,7 +8,7 @@
 //! 5. Main message loop
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,6 +37,9 @@ use crate::commands::{load_prompt, resolve_data_dir};
 use crate::config::{detect_provider, Config};
 use crate::config_watcher::{ConfigChange, ConfigWatcher};
 use crate::persona_service::PersonaService;
+use crate::qos_catalog::{
+    load_seed_qos_catalog, materialize_runtime_qos_catalog, persist_qos_catalog,
+};
 use crate::session_actor::{ActorFactory, ActorRegistry, SnapshotToolRegistryFactory};
 use crate::status_layers::StatusComposer;
 
@@ -90,49 +93,6 @@ pub(super) struct GatewayRuntime {
     // Matrix (feature-gated)
     #[cfg(feature = "matrix")]
     matrix_channel: Option<Arc<octos_bus::MatrixChannel>>,
-}
-
-fn load_seed_qos_catalog(data_dir: &Path) -> Option<QosCatalog> {
-    let candidates = [
-        data_dir.join("model_catalog.json"),
-        dirs::home_dir()
-            .unwrap_or_default()
-            .join(".octos/model_catalog.json"),
-    ];
-    for path in &candidates {
-        if let Ok(json) = std::fs::read_to_string(path) {
-            if let Ok(catalog) = serde_json::from_str::<QosCatalog>(&json) {
-                return Some(catalog);
-            }
-        }
-    }
-    None
-}
-
-fn persist_qos_catalog(path: &Path, catalog: &QosCatalog) {
-    match serde_json::to_string_pretty(catalog) {
-        Ok(json) => {
-            if let Err(error) = std::fs::write(path, json) {
-                warn!(path = %path.display(), %error, "failed to persist runtime model catalog");
-            }
-        }
-        Err(error) => {
-            warn!(path = %path.display(), %error, "failed to serialize runtime model catalog");
-        }
-    }
-}
-
-fn materialize_runtime_qos_catalog(
-    seed_catalog: Option<&QosCatalog>,
-    adaptive_export: Option<QosCatalog>,
-    config: &AdaptiveConfig,
-    qos_ranking: bool,
-) -> Option<QosCatalog> {
-    adaptive_export.or_else(|| {
-        seed_catalog.map(|catalog| {
-            octos_llm::derive_cold_start_catalog(&catalog.models, config, qos_ranking)
-        })
-    })
 }
 
 impl GatewayRuntime {
@@ -1665,105 +1625,5 @@ impl GatewayRuntime {
         ch_result?;
         println!("{}", "Gateway stopped.".dimmed());
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use octos_llm::{ModelCatalogEntry, ModelType};
-    use tempfile::tempdir;
-
-    fn sample_catalog(scores: [f64; 2]) -> QosCatalog {
-        QosCatalog {
-            updated_at: "2026-04-11T00:00:00Z".to_string(),
-            models: vec![
-                ModelCatalogEntry {
-                    provider: "zai/glm-5-turbo".to_string(),
-                    model_type: ModelType::Fast,
-                    stability: 0.97,
-                    tool_avg_ms: 900,
-                    p95_ms: 1500,
-                    score: scores[0],
-                    cost_in: 0.5,
-                    cost_out: 2.0,
-                    ds_output: 1200,
-                    context_window: 128_000,
-                    max_output: 8_192,
-                },
-                ModelCatalogEntry {
-                    provider: "dashscope/qwen3.5-plus".to_string(),
-                    model_type: ModelType::Strong,
-                    stability: 0.92,
-                    tool_avg_ms: 1400,
-                    p95_ms: 2400,
-                    score: scores[1],
-                    cost_in: 0.8,
-                    cost_out: 3.2,
-                    ds_output: 800,
-                    context_window: 128_000,
-                    max_output: 16_384,
-                },
-            ],
-        }
-    }
-
-    #[test]
-    fn load_seed_qos_catalog_reads_profile_local_catalog() {
-        let temp = tempdir().unwrap();
-        let data_dir = temp.path().join("profile-data");
-        std::fs::create_dir_all(&data_dir).unwrap();
-        let path = data_dir.join("model_catalog.json");
-        let catalog = sample_catalog([0.0, 0.0]);
-        std::fs::write(&path, serde_json::to_string_pretty(&catalog).unwrap()).unwrap();
-
-        let loaded = load_seed_qos_catalog(&data_dir).expect("catalog should load");
-        assert_eq!(loaded.models.len(), 2);
-        assert_eq!(loaded.models[0].provider, "zai/glm-5-turbo");
-        assert_eq!(loaded.models[1].provider, "dashscope/qwen3.5-plus");
-    }
-
-    #[test]
-    fn persist_qos_catalog_round_trips_runtime_scores() {
-        let temp = tempdir().unwrap();
-        let path = temp.path().join("model_catalog.json");
-        let catalog = sample_catalog([0.21857142857142858, 0.4]);
-
-        persist_qos_catalog(&path, &catalog);
-
-        let json = std::fs::read_to_string(&path).unwrap();
-        let loaded: QosCatalog = serde_json::from_str(&json).unwrap();
-        assert_eq!(loaded.models.len(), 2);
-        assert!((loaded.models[0].score - 0.21857142857142858).abs() < 1e-12);
-        assert!((loaded.models[1].score - 0.4).abs() < 1e-12);
-    }
-
-    #[test]
-    fn materialize_runtime_qos_catalog_prefers_adaptive_export() {
-        let seed = sample_catalog([0.0, 0.0]);
-        let live = sample_catalog([0.21, 0.41]);
-
-        let materialized = materialize_runtime_qos_catalog(
-            Some(&seed),
-            Some(live.clone()),
-            &AdaptiveConfig::default(),
-            true,
-        )
-        .expect("catalog should materialize");
-
-        assert_eq!(materialized.models[0].score, live.models[0].score);
-        assert_eq!(materialized.models[1].score, live.models[1].score);
-    }
-
-    #[test]
-    fn materialize_runtime_qos_catalog_derives_non_zero_scores_from_seed() {
-        let seed = sample_catalog([0.0, 0.0]);
-
-        let materialized =
-            materialize_runtime_qos_catalog(Some(&seed), None, &AdaptiveConfig::default(), true)
-                .expect("catalog should materialize");
-
-        assert_eq!(materialized.models.len(), seed.models.len());
-        assert!(materialized.models.iter().all(|entry| entry.score > 0.0));
     }
 }

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -23,6 +23,7 @@ pub mod persona_service;
 pub mod process_manager;
 pub mod profiles;
 pub mod project_templates;
+mod qos_catalog;
 pub mod session_actor;
 pub mod skills_scope;
 pub mod soul_service;

--- a/crates/octos-cli/src/qos_catalog.rs
+++ b/crates/octos-cli/src/qos_catalog.rs
@@ -1,0 +1,161 @@
+use std::path::Path;
+
+use octos_llm::{AdaptiveConfig, ModelCatalogEntry, QosCatalog};
+
+/// Derive a runtime QoS catalog from static model metadata when no adaptive
+/// router is active.
+pub(crate) fn derive_cold_start_qos_catalog(
+    entries: &[ModelCatalogEntry],
+    config: &AdaptiveConfig,
+    qos_ranking: bool,
+) -> QosCatalog {
+    octos_llm::derive_cold_start_catalog(entries, config, qos_ranking)
+}
+
+pub(crate) fn load_seed_qos_catalog(data_dir: &Path) -> Option<QosCatalog> {
+    let candidates = [
+        data_dir.join("model_catalog.json"),
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".octos/model_catalog.json"),
+    ];
+    for path in &candidates {
+        if let Ok(json) = std::fs::read_to_string(path) {
+            if let Ok(catalog) = serde_json::from_str::<QosCatalog>(&json) {
+                return Some(catalog);
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn persist_qos_catalog(path: &Path, catalog: &QosCatalog) {
+    match serde_json::to_string_pretty(catalog) {
+        Ok(json) => {
+            if let Err(error) = std::fs::write(path, json) {
+                tracing::warn!(
+                    path = %path.display(),
+                    %error,
+                    "failed to persist runtime model catalog"
+                );
+            }
+        }
+        Err(error) => tracing::warn!(
+            path = %path.display(),
+            %error,
+            "failed to serialize runtime model catalog"
+        ),
+    }
+}
+
+pub(crate) fn materialize_runtime_qos_catalog(
+    seed_catalog: Option<&QosCatalog>,
+    adaptive_export: Option<QosCatalog>,
+    config: &AdaptiveConfig,
+    qos_ranking: bool,
+) -> Option<QosCatalog> {
+    adaptive_export.or_else(|| {
+        seed_catalog
+            .map(|catalog| derive_cold_start_qos_catalog(&catalog.models, config, qos_ranking))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_llm::ModelType;
+    use tempfile::tempdir;
+
+    fn sample_catalog(scores: [f64; 2]) -> QosCatalog {
+        QosCatalog {
+            updated_at: "2026-04-11T00:00:00Z".to_string(),
+            models: vec![
+                ModelCatalogEntry {
+                    provider: "zai/glm-5-turbo".to_string(),
+                    model_type: ModelType::Fast,
+                    stability: 0.97,
+                    tool_avg_ms: 900,
+                    p95_ms: 1500,
+                    score: scores[0],
+                    cost_in: 0.5,
+                    cost_out: 2.0,
+                    ds_output: 1200,
+                    context_window: 128_000,
+                    max_output: 8_192,
+                },
+                ModelCatalogEntry {
+                    provider: "dashscope/qwen3.5-plus".to_string(),
+                    model_type: ModelType::Strong,
+                    stability: 0.92,
+                    tool_avg_ms: 1400,
+                    p95_ms: 2400,
+                    score: scores[1],
+                    cost_in: 0.8,
+                    cost_out: 3.2,
+                    ds_output: 800,
+                    context_window: 128_000,
+                    max_output: 16_384,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn load_seed_qos_catalog_reads_profile_local_catalog() {
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let path = data_dir.join("model_catalog.json");
+        let catalog = sample_catalog([0.0, 0.0]);
+        std::fs::write(&path, serde_json::to_string_pretty(&catalog).unwrap()).unwrap();
+
+        let loaded = load_seed_qos_catalog(&data_dir).expect("catalog should load");
+        assert_eq!(loaded.models.len(), 2);
+        assert_eq!(loaded.models[0].provider, "zai/glm-5-turbo");
+        assert_eq!(loaded.models[1].provider, "dashscope/qwen3.5-plus");
+    }
+
+    #[test]
+    fn persist_qos_catalog_round_trips_runtime_scores() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("model_catalog.json");
+        let catalog = sample_catalog([0.21857142857142858, 0.4]);
+
+        persist_qos_catalog(&path, &catalog);
+
+        let json = std::fs::read_to_string(&path).unwrap();
+        let loaded: QosCatalog = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.models.len(), 2);
+        assert!((loaded.models[0].score - 0.21857142857142858).abs() < 1e-12);
+        assert!((loaded.models[1].score - 0.4).abs() < 1e-12);
+    }
+
+    #[test]
+    fn materialize_runtime_qos_catalog_prefers_adaptive_export() {
+        let seed = sample_catalog([0.0, 0.0]);
+        let live = sample_catalog([0.21, 0.41]);
+
+        let materialized = materialize_runtime_qos_catalog(
+            Some(&seed),
+            Some(live.clone()),
+            &AdaptiveConfig::default(),
+            true,
+        )
+        .expect("catalog should materialize");
+
+        assert_eq!(materialized.models[0].score, live.models[0].score);
+        assert_eq!(materialized.models[1].score, live.models[1].score);
+    }
+
+    #[test]
+    fn materialize_runtime_qos_catalog_derives_non_zero_scores_from_seed() {
+        let seed = sample_catalog([0.0, 0.0]);
+
+        let materialized =
+            materialize_runtime_qos_catalog(Some(&seed), None, &AdaptiveConfig::default(), true)
+                .expect("catalog should materialize");
+
+        assert_eq!(materialized.models.len(), seed.models.len());
+        assert!(materialized.models.iter().all(|entry| entry.score > 0.0));
+    }
+}


### PR DESCRIPTION
Selective port of the remaining QoS/runtime slice from the dirty crew-rs tree.

What changed:
- extracted the gateway QoS catalog bootstrap helpers into a dedicated `qos_catalog` module
- wired `gateway_runtime` to use the module for seed loading, runtime materialization, and persistence
- kept the already-merged workspace/session/artifact path untouched

Validation:
- `cargo check -p octos-llm`
- `cargo check -p octos-cli --features api`
- `cargo clippy --workspace -- -D warnings`
- `rustfmt --edition 2024 --check` on touched files

Repo-wide `cargo fmt --all -- --check` and `./scripts/ci.sh` hit pre-existing formatting drift in unrelated files, not this port.
