### PR TITLE
Introduce declarative workspace policy scaffolds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3560,6 +3560,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "toml",
  "tracing",
  "tree-sitter",
  "tree-sitter-javascript",
@@ -4930,6 +4931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5640,6 +5650,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.12.1",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yml = "0.0.12"
+toml = "0.8"
 base64 = "0.22"
 
 # Crypto

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 chrono = { workspace = true }
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -32,6 +32,7 @@ pub mod task_supervisor;
 pub mod tools;
 pub mod turn;
 pub mod workspace_git;
+pub mod workspace_policy;
 
 pub use agent::{
     Agent, AgentConfig, ConversationResponse, TokenTracker, DEFAULT_SESSION_TIMEOUT_SECS,
@@ -62,6 +63,11 @@ pub use turn::{turns_to_messages, Turn, TurnKind};
 pub use workspace_git::{
     commit_all_if_dirty, detect_workspace_repo, init_workspace_repo, initialize_and_commit,
     list_workspace_repos, snapshot_workspace_change, snapshot_workspace_turn, WorkspaceProjectKind,
+};
+pub use workspace_policy::{
+    read_workspace_policy, workspace_policy_path, write_workspace_policy, WorkspacePolicy,
+    WorkspacePolicyKind, WorkspaceSnapshotTrigger, WorkspaceTrackingPolicy,
+    WorkspaceVersionControlPolicy, WorkspaceVersionControlProvider, WORKSPACE_POLICY_FILE,
 };
 
 #[cfg(test)]

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -1,0 +1,165 @@
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+
+use crate::workspace_git::WorkspaceProjectKind;
+
+pub const WORKSPACE_POLICY_FILE: &str = ".octos-workspace.toml";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspacePolicy {
+    pub workspace: WorkspacePolicyWorkspace,
+    pub version_control: WorkspaceVersionControlPolicy,
+    pub tracking: WorkspaceTrackingPolicy,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspacePolicyWorkspace {
+    pub kind: WorkspacePolicyKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkspacePolicyKind {
+    Slides,
+    Sites,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceVersionControlPolicy {
+    pub provider: WorkspaceVersionControlProvider,
+    pub auto_init: bool,
+    pub trigger: WorkspaceSnapshotTrigger,
+    pub fail_on_error: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkspaceVersionControlProvider {
+    Git,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceSnapshotTrigger {
+    TurnEnd,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceTrackingPolicy {
+    pub ignore: Vec<String>,
+}
+
+impl WorkspacePolicy {
+    pub fn for_kind(kind: WorkspaceProjectKind) -> Self {
+        match kind {
+            WorkspaceProjectKind::Slides => Self {
+                workspace: WorkspacePolicyWorkspace {
+                    kind: WorkspacePolicyKind::Slides,
+                },
+                version_control: WorkspaceVersionControlPolicy {
+                    provider: WorkspaceVersionControlProvider::Git,
+                    auto_init: true,
+                    trigger: WorkspaceSnapshotTrigger::TurnEnd,
+                    fail_on_error: true,
+                },
+                tracking: WorkspaceTrackingPolicy {
+                    ignore: vec![
+                        "history/**".into(),
+                        "output/**".into(),
+                        "skill-output/**".into(),
+                        "*.pptx".into(),
+                        "*.tmp".into(),
+                        ".DS_Store".into(),
+                    ],
+                },
+            },
+            WorkspaceProjectKind::Sites => Self {
+                workspace: WorkspacePolicyWorkspace {
+                    kind: WorkspacePolicyKind::Sites,
+                },
+                version_control: WorkspaceVersionControlPolicy {
+                    provider: WorkspaceVersionControlProvider::Git,
+                    auto_init: true,
+                    trigger: WorkspaceSnapshotTrigger::TurnEnd,
+                    fail_on_error: true,
+                },
+                tracking: WorkspaceTrackingPolicy {
+                    ignore: vec![
+                        "node_modules/**".into(),
+                        "dist/**".into(),
+                        "out/**".into(),
+                        "docs/**".into(),
+                        "build/**".into(),
+                        ".astro/**".into(),
+                        ".next/**".into(),
+                        ".quarto/**".into(),
+                        "*.log".into(),
+                        ".DS_Store".into(),
+                    ],
+                },
+            },
+        }
+    }
+}
+
+pub fn workspace_policy_path(project_root: &Path) -> PathBuf {
+    project_root.join(WORKSPACE_POLICY_FILE)
+}
+
+pub fn read_workspace_policy(project_root: &Path) -> Result<Option<WorkspacePolicy>> {
+    let path = workspace_policy_path(project_root);
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let raw = std::fs::read_to_string(&path)
+        .wrap_err_with(|| format!("read workspace policy failed: {}", path.display()))?;
+    let policy: WorkspacePolicy = toml::from_str(&raw)
+        .wrap_err_with(|| format!("parse workspace policy failed: {}", path.display()))?;
+    Ok(Some(policy))
+}
+
+pub fn write_workspace_policy(project_root: &Path, policy: &WorkspacePolicy) -> Result<()> {
+    std::fs::create_dir_all(project_root)
+        .wrap_err_with(|| format!("create project dir failed: {}", project_root.display()))?;
+    let path = workspace_policy_path(project_root);
+    let rendered = toml::to_string_pretty(policy)
+        .wrap_err_with(|| format!("serialize workspace policy failed: {}", path.display()))?;
+    std::fs::write(&path, rendered)
+        .wrap_err_with(|| format!("write workspace policy failed: {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writes_and_reads_slides_policy() {
+        let temp = tempfile::tempdir().unwrap();
+        let policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let path = workspace_policy_path(temp.path());
+        assert!(path.is_file());
+
+        let rendered = std::fs::read_to_string(&path).unwrap();
+        assert!(rendered.contains("kind = \"slides\""));
+        assert!(rendered.contains("provider = \"git\""));
+        assert!(rendered.contains("trigger = \"turn_end\""));
+        assert!(rendered.contains("\"output/**\""));
+
+        let roundtrip = read_workspace_policy(temp.path()).unwrap().unwrap();
+        assert_eq!(roundtrip, policy);
+    }
+
+    #[test]
+    fn default_site_policy_tracks_build_outputs_as_ignored() {
+        let policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Sites);
+        assert!(policy.tracking.ignore.iter().any(|item| item == "dist/**"));
+        assert!(policy.tracking.ignore.iter().any(|item| item == ".next/**"));
+    }
+}

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -4,7 +4,9 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use octos_agent::{initialize_and_commit, WorkspaceProjectKind};
+use octos_agent::{
+    initialize_and_commit, write_workspace_policy, WorkspacePolicy, WorkspaceProjectKind,
+};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -89,6 +91,12 @@ module.exports = [];
             .map_err(|e| format!("write slides script.js failed: {e}"))?;
     }
 
+    write_workspace_policy(
+        &project_dir,
+        &WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides),
+    )
+    .map_err(|e| format!("write slides workspace policy failed: {e}"))?;
+
     initialize_and_commit(
         &project_dir,
         WorkspaceProjectKind::Slides,
@@ -108,6 +116,7 @@ pub fn slides_creation_reply(project_name: &str) -> String {
          Project directory: slides/{slug}/\n\
          Script: slides/{slug}/script.js\n\
          Memory: slides/{slug}/memory.md\n\n\
+         Workspace policy: slides/{slug}/.octos-workspace.toml\n\
          Local git history is enabled in slides/{slug}/.\n\n\
          Let me help you design your slides. I'll check available style templates first,\n\
          then we'll design the content together."
@@ -137,6 +146,7 @@ RULES:
 - NEVER pass slides array inline. ALWAYS use the input file.
 - On failure: report error, do NOT retry via shell.
 - Read slides/{slug}/memory.md before each response for context.
+- Workspace policy lives at slides/{slug}/.octos-workspace.toml.
 - Maintain a version header at the top of slides/{slug}/script.js:
   // version: v{{NNN}}_{{desc}}
   // updated_at: YYYY-MM-DD
@@ -517,6 +527,7 @@ WORKFLOW:
 BUILD RULES:
 - {template}: build output dir is sites/{site_slug}/{build_output_dir}/
 - Preview route shape: /api/preview/<profile-id>/<session-id>/{site_slug}/
+- Workspace policy lives at sites/{site_slug}/.octos-workspace.toml.
 - If template is quarto-lesson, run shell(\"quarto render\") from sites/{site_slug}/ when Quarto is available
 - If template is astro-site, nextjs-app, or react-vite:
   - run shell(\"test -d node_modules || npm install\") from sites/{site_slug}/
@@ -788,6 +799,11 @@ pub fn scaffold_site_project(
         .ok_or_else(|| "mofa-site skill directory not found".to_string())?;
     run_site_bootstrap(&skill_dir, &project_dir, &metadata)?;
     write_site_support_files(&project_dir, &metadata)?;
+    write_workspace_policy(
+        &project_dir,
+        &WorkspacePolicy::for_kind(WorkspaceProjectKind::Sites),
+    )
+    .map_err(|e| format!("write site workspace policy failed: {e}"))?;
     initialize_and_commit(
         &project_dir,
         WorkspaceProjectKind::Sites,
@@ -813,6 +829,7 @@ pub fn site_creation_reply(metadata: &SiteProjectMetadata) -> String {
          Template: {template}\n\
          Preview route: {preview_url}\n\
          Session metadata: {project_dir}/{session_file}\n\n\
+         Workspace policy: {project_dir}/.octos-workspace.toml\n\
          Local git history is enabled in {project_dir}/.\n\n\
          The scaffold is ready. Edit the source files and refresh the iframe preview to see the built site.",
         site_name = metadata.site_name,
@@ -860,6 +877,7 @@ mod tests {
         assert!(project_dir.join("script.js").is_file());
         assert!(project_dir.join(".git").is_dir());
         assert!(project_dir.join(".gitignore").is_file());
+        assert!(project_dir.join(".octos-workspace.toml").is_file());
 
         let memory = std::fs::read_to_string(project_dir.join("memory.md")).unwrap();
         assert!(memory.contains("test-deck"));
@@ -933,6 +951,7 @@ mod tests {
         assert!(reply.contains("Q4 Report"));
         assert!(reply.contains("slides/q4-report/"));
         assert!(reply.contains("Let me help you design your slides"));
+        assert!(reply.contains(".octos-workspace.toml"));
         assert!(reply.contains("Local git history is enabled"));
     }
 


### PR DESCRIPTION
## Summary
- add a minimal `.octos-workspace.toml` schema and loader in `octos-agent`
- write workspace policy files when scaffolding slides and sites projects
- surface the policy file in creation replies and system prompts

## Validation
- cargo check -p octos-cli --features api
- cargo test -p octos-agent workspace_policy
- cargo test -p octos-cli --bin octos project_templates::tests::should_scaffold_slides_project_directories
- cargo test -p octos-cli --bin octos project_templates::tests::should_generate_correct_reply_text

## Notes
- this is the first policy slice only; runtime enforcement still uses the existing git hook path
- repo-wide `cargo fmt --all -- --check` is currently red on untouched baseline files in `main`, so this PR stays scoped to touched-file behavior

Refs #353
Refs #354