### PR TITLE
Spawn-only task contract enforcement and workspace history tools

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -156,6 +156,41 @@ impl Agent {
                                         success = true,
                                         "spawn_only background tool completed"
                                     );
+
+                                    // Enforce workspace contract BEFORE marking completed.
+                                    // If a contract is defined for this tool and verification
+                                    // fails, mark_failed instead of mark_completed.
+                                    if let Some(workspace_root) = bg_tools.workspace_root() {
+                                        use crate::workspace_contract::{self, ContractVerdict};
+                                        match workspace_contract::enforce(&workspace_root, &bg_name) {
+                                            ContractVerdict::Satisfied { .. } => {
+                                                tracing::info!(
+                                                    tool = %bg_name,
+                                                    "workspace contract satisfied"
+                                                );
+                                            }
+                                            ContractVerdict::Failed { reasons, .. } => {
+                                                let err = format!(
+                                                    "workspace contract failed: {}",
+                                                    reasons.join("; ")
+                                                );
+                                                tracing::warn!(tool = %bg_name, error = %err);
+                                                bg_supervisor.mark_failed(&task_id, err.clone());
+                                                if let Some(ref sender) = bg_sender {
+                                                    let _ = sender(BackgroundResultPayload {
+                                                        task_label: bg_name.clone(),
+                                                        content: format!("✗ {} contract failed: {}", bg_name, err),
+                                                        kind: BackgroundResultKind::Notification,
+                                                    }).await;
+                                                }
+                                                return;
+                                            }
+                                            ContractVerdict::NoContract => {
+                                                // No contract — proceed with existing behaviour
+                                            }
+                                        }
+                                    }
+
                                     let mut sent_files = Vec::new();
                                     // Auto-send files from the background task (with retry)
                                     for file_path in &r.files_to_send {

--- a/crates/octos-agent/src/behaviour.rs
+++ b/crates/octos-agent/src/behaviour.rs
@@ -1,0 +1,353 @@
+//! Deterministic behaviour actions for workspace policy enforcement.
+//!
+//! Actions are simple string specs like `"file_exists:output/*.mp3"` parsed into
+//! an action kind + argument. They run without LLM involvement and are used for
+//! spawn_only task verification, turn-end validation, and cleanup.
+
+use std::path::Path;
+
+use eyre::{Result, eyre};
+use glob::glob;
+use tracing::{info, warn};
+
+/// Result of running a single behaviour action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionResult {
+    Pass,
+    Fail {
+        reason: String,
+    },
+    /// Action succeeded and requests a user notification with the given message.
+    /// Callers should deliver this through the appropriate channel (SSE, Telegram, etc.).
+    Notify {
+        message: String,
+    },
+}
+
+impl ActionResult {
+    pub fn is_pass(&self) -> bool {
+        matches!(self, Self::Pass | Self::Notify { .. })
+    }
+}
+
+/// Extract notification messages from action results.
+pub fn notifications(results: &[(String, ActionResult)]) -> Vec<String> {
+    results
+        .iter()
+        .filter_map(|(_, r)| match r {
+            ActionResult::Notify { message } => Some(message.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Parse and execute a behaviour action spec against a workspace root.
+///
+/// Action specs follow the format `"action_kind:argument"`.
+///
+/// Supported actions:
+/// - `file_exists:<glob>` — at least one file matches the glob pattern
+/// - `file_size_min:<glob>:<bytes>` — matched files are at least N bytes
+/// - `cleanup:<glob>` — remove files matching the glob (always passes)
+/// - `notify_user:<message>` — log a notification (always passes, actual
+///   delivery wired by caller)
+pub fn run_action(workspace_root: &Path, spec: &str) -> Result<ActionResult> {
+    let (kind, arg) = parse_spec(spec)?;
+
+    match kind {
+        "file_exists" => action_file_exists(workspace_root, arg),
+        "file_size_min" => action_file_size_min(workspace_root, arg),
+        "cleanup" => action_cleanup(workspace_root, arg),
+        "notify_user" => action_notify_user(arg),
+        _ => Err(eyre!("unknown behaviour action: {kind}")),
+    }
+}
+
+/// Run a list of action specs. Returns all results. Stops early on error
+/// (action parse/execution failure), but NOT on `ActionResult::Fail`.
+pub fn run_actions(workspace_root: &Path, specs: &[String]) -> Result<Vec<(String, ActionResult)>> {
+    let mut results = Vec::with_capacity(specs.len());
+    for spec in specs {
+        let result = run_action(workspace_root, spec)?;
+        results.push((spec.clone(), result));
+    }
+    Ok(results)
+}
+
+/// Check if all results passed.
+pub fn all_passed(results: &[(String, ActionResult)]) -> bool {
+    results.iter().all(|(_, r)| r.is_pass())
+}
+
+/// Collect failure reasons from results.
+pub fn failure_reasons(results: &[(String, ActionResult)]) -> Vec<String> {
+    results
+        .iter()
+        .filter_map(|(spec, r)| match r {
+            ActionResult::Fail { reason } => Some(format!("{spec}: {reason}")),
+            ActionResult::Pass | ActionResult::Notify { .. } => None,
+        })
+        .collect()
+}
+
+fn parse_spec(spec: &str) -> Result<(&str, &str)> {
+    let (kind, arg) = spec
+        .split_once(':')
+        .ok_or_else(|| eyre!("invalid action spec (expected kind:arg): {spec}"))?;
+    Ok((kind, arg))
+}
+
+fn resolve_glob(workspace_root: &Path, pattern: &str) -> Result<Vec<std::path::PathBuf>> {
+    let full_pattern = workspace_root.join(pattern).to_string_lossy().to_string();
+    let canonical_root = workspace_root
+        .canonicalize()
+        .unwrap_or_else(|_| workspace_root.to_path_buf());
+    let mut matches = Vec::new();
+    for entry in glob(&full_pattern).map_err(|e| eyre!("invalid glob pattern {pattern}: {e}"))? {
+        match entry {
+            Ok(path) => {
+                // Prevent path traversal — only include paths within workspace_root.
+                let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
+                if canonical.starts_with(&canonical_root) {
+                    matches.push(path);
+                } else {
+                    warn!(
+                        path = %path.display(),
+                        workspace = %workspace_root.display(),
+                        "glob match outside workspace root, skipping"
+                    );
+                }
+            }
+            Err(e) => warn!("glob walk error for {pattern}: {e}"),
+        }
+    }
+    Ok(matches)
+}
+
+fn action_file_exists(workspace_root: &Path, pattern: &str) -> Result<ActionResult> {
+    let matches = resolve_glob(workspace_root, pattern)?;
+    if matches.is_empty() {
+        Ok(ActionResult::Fail {
+            reason: format!("no files match pattern: {pattern}"),
+        })
+    } else {
+        info!(pattern, count = matches.len(), "file_exists check passed");
+        Ok(ActionResult::Pass)
+    }
+}
+
+fn action_file_size_min(workspace_root: &Path, arg: &str) -> Result<ActionResult> {
+    // Format: glob_pattern:min_bytes
+    let (pattern, min_str) = arg
+        .rsplit_once(':')
+        .ok_or_else(|| eyre!("file_size_min requires pattern:min_bytes, got: {arg}"))?;
+
+    let min_bytes: u64 = min_str
+        .parse()
+        .map_err(|_| eyre!("file_size_min: invalid byte count: {min_str}"))?;
+
+    let matches = resolve_glob(workspace_root, pattern)?;
+    if matches.is_empty() {
+        return Ok(ActionResult::Fail {
+            reason: format!("no files match pattern: {pattern}"),
+        });
+    }
+
+    for path in &matches {
+        let meta =
+            std::fs::metadata(path).map_err(|e| eyre!("cannot stat {}: {e}", path.display()))?;
+        if meta.len() < min_bytes {
+            return Ok(ActionResult::Fail {
+                reason: format!(
+                    "{} is {} bytes, minimum is {min_bytes}",
+                    path.display(),
+                    meta.len()
+                ),
+            });
+        }
+    }
+
+    Ok(ActionResult::Pass)
+}
+
+fn action_cleanup(workspace_root: &Path, pattern: &str) -> Result<ActionResult> {
+    let matches = resolve_glob(workspace_root, pattern)?;
+    let mut removed = 0;
+    for path in matches {
+        if path.is_file() {
+            if let Err(e) = std::fs::remove_file(&path) {
+                warn!("cleanup: failed to remove {}: {e}", path.display());
+            } else {
+                removed += 1;
+            }
+        } else if path.is_dir() {
+            if let Err(e) = std::fs::remove_dir_all(&path) {
+                warn!("cleanup: failed to remove dir {}: {e}", path.display());
+            } else {
+                removed += 1;
+            }
+        }
+    }
+    info!(pattern, removed, "cleanup action completed");
+    // Cleanup always passes — missing files are fine
+    Ok(ActionResult::Pass)
+}
+
+fn action_notify_user(message: &str) -> Result<ActionResult> {
+    info!(message, "notify_user action");
+    Ok(ActionResult::Notify {
+        message: message.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_pass_when_file_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("output.mp3"), b"audio data").unwrap();
+
+        let result = run_action(temp.path(), "file_exists:output.mp3").unwrap();
+        assert_eq!(result, ActionResult::Pass);
+    }
+
+    #[test]
+    fn should_fail_when_file_missing() {
+        let temp = tempfile::tempdir().unwrap();
+
+        let result = run_action(temp.path(), "file_exists:output.mp3").unwrap();
+        assert!(matches!(result, ActionResult::Fail { .. }));
+    }
+
+    #[test]
+    fn should_match_glob_pattern() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("output")).unwrap();
+        std::fs::write(temp.path().join("output/deck.pptx"), b"slides").unwrap();
+
+        let result = run_action(temp.path(), "file_exists:output/*.pptx").unwrap();
+        assert_eq!(result, ActionResult::Pass);
+    }
+
+    #[test]
+    fn should_check_file_size_minimum() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("audio.mp3"), b"x").unwrap();
+
+        let result = run_action(temp.path(), "file_size_min:audio.mp3:1024").unwrap();
+        assert!(matches!(result, ActionResult::Fail { .. }));
+
+        std::fs::write(temp.path().join("audio.mp3"), vec![0u8; 2048]).unwrap();
+        let result = run_action(temp.path(), "file_size_min:audio.mp3:1024").unwrap();
+        assert_eq!(result, ActionResult::Pass);
+    }
+
+    #[test]
+    fn should_cleanup_matching_files() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("temp")).unwrap();
+        std::fs::write(temp.path().join("temp/tts_1.wav"), b"data").unwrap();
+        std::fs::write(temp.path().join("temp/tts_2.wav"), b"data").unwrap();
+
+        let result = run_action(temp.path(), "cleanup:temp/tts_*").unwrap();
+        assert_eq!(result, ActionResult::Pass);
+        assert!(!temp.path().join("temp/tts_1.wav").exists());
+        assert!(!temp.path().join("temp/tts_2.wav").exists());
+    }
+
+    #[test]
+    fn should_pass_cleanup_when_no_files_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = run_action(temp.path(), "cleanup:nonexistent_*").unwrap();
+        assert_eq!(result, ActionResult::Pass);
+    }
+
+    #[test]
+    fn should_return_notify_with_message() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = run_action(temp.path(), "notify_user:TTS generation failed").unwrap();
+        assert_eq!(
+            result,
+            ActionResult::Notify {
+                message: "TTS generation failed".into()
+            }
+        );
+        assert!(result.is_pass()); // Notify counts as pass
+    }
+
+    #[test]
+    fn should_reject_unknown_action() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = run_action(temp.path(), "unknown_action:arg");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_reject_malformed_spec() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = run_action(temp.path(), "no_colon_here");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_extract_notifications_from_results() {
+        let results = vec![
+            ("file_exists:a.txt".into(), ActionResult::Pass),
+            (
+                "notify_user:done".into(),
+                ActionResult::Notify {
+                    message: "done".into(),
+                },
+            ),
+            (
+                "notify_user:ready".into(),
+                ActionResult::Notify {
+                    message: "ready".into(),
+                },
+            ),
+        ];
+        let notifs = notifications(&results);
+        assert_eq!(notifs, vec!["done", "ready"]);
+    }
+
+    #[test]
+    fn should_reject_path_traversal_in_cleanup() {
+        let temp = tempfile::tempdir().unwrap();
+        // Create a file outside the "workspace" subdirectory
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let outside_file = temp.path().join("secret.txt");
+        std::fs::write(&outside_file, b"sensitive").unwrap();
+
+        // Try to clean up ../secret.txt — should be blocked
+        let result = run_action(&workspace, "cleanup:../secret.txt").unwrap();
+        assert_eq!(result, ActionResult::Pass); // cleanup always passes
+        // But the file outside workspace must NOT be deleted
+        assert!(outside_file.exists(), "path traversal should be blocked");
+    }
+
+    #[test]
+    fn should_run_multiple_actions_and_collect_results() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("output.mp3"), b"audio").unwrap();
+
+        let specs = vec![
+            "file_exists:output.mp3".to_string(),
+            "file_exists:missing.txt".to_string(),
+            "notify_user:done".to_string(),
+        ];
+
+        let results = run_actions(temp.path(), &specs).unwrap();
+        assert_eq!(results.len(), 3);
+        assert!(results[0].1.is_pass());
+        assert!(!results[1].1.is_pass());
+        assert!(results[2].1.is_pass());
+
+        assert!(!all_passed(&results));
+        let failures = failure_reasons(&results);
+        assert_eq!(failures.len(), 1);
+        assert!(failures[0].contains("missing.txt"));
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -8,6 +8,7 @@
 //! - Integration with codex sandboxing (when enabled)
 
 mod agent;
+pub mod behaviour;
 pub mod bootstrap;
 pub mod builtin_skills;
 pub mod bundled_app_skills;
@@ -31,6 +32,7 @@ pub mod steering;
 pub mod task_supervisor;
 pub mod tools;
 pub mod turn;
+pub mod workspace_contract;
 pub mod workspace_git;
 pub mod workspace_policy;
 
@@ -63,14 +65,15 @@ pub use tools::{
 };
 pub use turn::{Turn, TurnKind, turns_to_messages};
 pub use workspace_git::{
-    WorkspaceProjectKind, commit_all_if_dirty, detect_workspace_repo, init_workspace_repo,
-    initialize_and_commit, list_workspace_repos, snapshot_workspace_change,
+    WorkspaceProjectKind, WorkspaceValidationFailure, commit_all_if_dirty, detect_workspace_repo,
+    init_workspace_repo, initialize_and_commit, list_workspace_repos, snapshot_workspace_change,
     snapshot_workspace_turn,
 };
 pub use workspace_policy::{
-    WORKSPACE_POLICY_FILE, WorkspacePolicy, WorkspacePolicyKind, WorkspaceSnapshotTrigger,
-    WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy, WorkspaceVersionControlProvider,
-    read_workspace_policy, workspace_policy_path, write_workspace_policy,
+    SpawnTaskPolicy, ValidationPolicy, WORKSPACE_POLICY_FILE, WorkspacePolicy, WorkspacePolicyKind,
+    WorkspaceSnapshotTrigger, WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy,
+    WorkspaceVersionControlProvider, read_workspace_policy, workspace_policy_path,
+    write_workspace_policy,
 };
 
 #[cfg(test)]

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1,8 +1,12 @@
 //! Background task lifecycle management for spawn_only tools.
 //!
-//! The `TaskSupervisor` tracks background tasks from spawn to completion,
-//! replacing the bare `AtomicU32` counter with rich task state. This enables
-//! API endpoints to report per-task status, output files, and errors.
+//! The `TaskSupervisor` is a status store that tracks background tasks from
+//! spawn to completion. It does NOT enforce workspace contracts — that
+//! responsibility belongs to `workspace_contract::enforce()`, which runs
+//! inline in `execution.rs` BEFORE the supervisor status is updated.
+//!
+//! The supervisor only sees truth-checked states: `Completed` means the
+//! workspace contract was satisfied, `Failed` means it was not.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -215,7 +219,6 @@ impl TaskSupervisor {
         tasks.values().filter(|t| t.status.is_active()).count()
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -216,6 +216,7 @@ pub mod admin;
 pub mod browser;
 pub mod check_background_tasks;
 pub mod tool_config;
+pub mod workspace_history;
 
 #[cfg(feature = "git")]
 pub mod git;
@@ -247,6 +248,7 @@ pub use activate_tools::ActivateToolsTool;
 pub use browser::BrowserTool;
 pub use check_background_tasks::CheckBackgroundTasksTool;
 pub use tool_config::{ConfigureToolTool, ToolConfigStore};
+pub use workspace_history::{WorkspaceDiffTool, WorkspaceLogTool, WorkspaceShowTool};
 
 #[cfg(feature = "git")]
 pub use git::GitTool;

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -16,7 +16,7 @@ use super::policy::{self, ToolPolicy};
 use super::{
     BrowserTool, ConfigureToolTool, DiffEditTool, EditFileTool, GlobTool, GrepTool, ListDirTool,
     ReadFileTool, ShellTool, Tool, ToolConfigStore, ToolLifecycle, ToolResult, WebFetchTool,
-    WebSearchTool, WriteFileTool,
+    WebSearchTool, WorkspaceDiffTool, WorkspaceLogTool, WorkspaceShowTool, WriteFileTool,
 };
 use crate::sandbox::{NoSandbox, Sandbox};
 
@@ -82,6 +82,8 @@ pub struct ToolRegistry {
     spawn_only_invoked: Arc<std::sync::atomic::AtomicBool>,
     /// Session key for tagging background tasks (set per-session).
     session_key: Option<String>,
+    /// Workspace root for contract enforcement on spawn_only tasks.
+    workspace_root: Option<std::path::PathBuf>,
 }
 
 impl Default for ToolRegistry {
@@ -107,7 +109,18 @@ impl ToolRegistry {
             supervisor: Arc::new(TaskSupervisor::new()),
             spawn_only_invoked: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             session_key: None,
+            workspace_root: None,
         }
+    }
+
+    /// Set the workspace root for contract enforcement.
+    pub fn set_workspace_root(&mut self, root: impl Into<std::path::PathBuf>) {
+        self.workspace_root = Some(root.into());
+    }
+
+    /// Get the workspace root (if set).
+    pub fn workspace_root(&self) -> Option<std::path::PathBuf> {
+        self.workspace_root.clone()
     }
 
     /// Mark a tool name as coming from a plugin binary.
@@ -353,6 +366,7 @@ impl ToolRegistry {
             supervisor: self.supervisor.clone(),
             spawn_only_invoked: self.spawn_only_invoked.clone(),
             session_key: self.session_key.clone(),
+            workspace_root: self.workspace_root.clone(),
         }
     }
 
@@ -617,6 +631,9 @@ impl ToolRegistry {
         registry.register(WebSearchTool::new());
         registry.register(WebFetchTool::new());
         registry.register(BrowserTool::new());
+        registry.register(WorkspaceLogTool::new(cwd));
+        registry.register(WorkspaceShowTool::new(cwd));
+        registry.register(WorkspaceDiffTool::new(cwd));
         #[cfg(feature = "git")]
         registry.register(super::GitTool::new(cwd));
         #[cfg(feature = "ast")]
@@ -635,6 +652,9 @@ impl ToolRegistry {
         "glob",
         "grep",
         "list_dir",
+        "workspace_log",
+        "workspace_show",
+        "workspace_diff",
         #[cfg(feature = "git")]
         "git",
         #[cfg(feature = "ast")]
@@ -657,6 +677,9 @@ impl ToolRegistry {
         registry.register(GlobTool::new(cwd));
         registry.register(GrepTool::new(cwd));
         registry.register(ListDirTool::new(cwd));
+        registry.register(WorkspaceLogTool::new(cwd));
+        registry.register(WorkspaceShowTool::new(cwd));
+        registry.register(WorkspaceDiffTool::new(cwd));
         #[cfg(feature = "git")]
         registry.register(super::GitTool::new(cwd));
         #[cfg(feature = "ast")]

--- a/crates/octos-agent/src/tools/workspace_history.rs
+++ b/crates/octos-agent/src/tools/workspace_history.rs
@@ -1,0 +1,768 @@
+//! Read-only workspace git history tools.
+//!
+//! Three tools that give the agent visibility into workspace git history
+//! without modifying it. All run server-side outside the sandbox.
+//!
+//! - `workspace_log`: git log for a workspace project
+//! - `workspace_show`: read a file at a specific commit
+//! - `workspace_diff`: diff between two commits for a file
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use async_trait::async_trait;
+use eyre::{Result, WrapErr};
+use serde::Deserialize;
+
+use super::{Tool, ToolResult};
+use crate::workspace_git::detect_workspace_repo;
+
+/// Max output length for git commands (50KB).
+const MAX_OUTPUT: usize = 50_000;
+
+/// Run a git command in a directory and return stdout as a string.
+fn run_git(dir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .wrap_err_with(|| format!("failed to run git {:?}", args))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(eyre::eyre!("git {:?} failed: {}", args, stderr.trim()));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Resolve a workspace project path from a relative slides/sites path.
+/// Returns the project root if it has a .git directory.
+fn resolve_workspace_git_root(base_dir: &Path, project_path: &str) -> Result<PathBuf> {
+    let full = base_dir.join(project_path);
+
+    // Must be under base_dir
+    let canonical_base = base_dir
+        .canonicalize()
+        .unwrap_or_else(|_| base_dir.to_path_buf());
+    let canonical_full = full.canonicalize().unwrap_or_else(|_| full.clone());
+    if !canonical_full.starts_with(&canonical_base) {
+        return Err(eyre::eyre!("path outside workspace: {project_path}"));
+    }
+
+    // Detect workspace repo from the path
+    if let Some(repo) = detect_workspace_repo(base_dir, &full) {
+        if repo.root.join(".git").exists() {
+            return Ok(repo.root);
+        }
+    }
+
+    // Fallback: check if the path itself is a git repo
+    if full.join(".git").exists() {
+        return Ok(full);
+    }
+
+    Err(eyre::eyre!(
+        "no git repository found at {project_path}. Use a path like slides/<name> or sites/<name>."
+    ))
+}
+
+// ── workspace_log ──────────────────────────────────────────────────
+
+/// Tool: view git commit history for a workspace project.
+pub struct WorkspaceLogTool {
+    base_dir: PathBuf,
+}
+
+impl WorkspaceLogTool {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceLogInput {
+    /// Workspace project path, e.g. "slides/my-deck" or "sites/blog".
+    project: String,
+    /// Max number of commits to show (default 20).
+    #[serde(default = "default_limit")]
+    limit: usize,
+}
+
+fn default_limit() -> usize {
+    20
+}
+
+#[async_trait]
+impl Tool for WorkspaceLogTool {
+    fn name(&self) -> &str {
+        "workspace_log"
+    }
+
+    fn description(&self) -> &str {
+        "View git commit history for a workspace project (slides or sites). Shows recent commits with hashes you can use with workspace_show and workspace_diff."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["fs", "workspace"]
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "description": "Workspace project path, e.g. 'slides/my-deck' or 'sites/blog'"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max commits to show (default 20)"
+                }
+            },
+            "required": ["project"]
+        })
+    }
+
+    async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        let input: WorkspaceLogInput =
+            serde_json::from_value(args.clone()).wrap_err("invalid workspace_log input")?;
+
+        let repo_root = match resolve_workspace_git_root(&self.base_dir, &input.project) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult {
+                    output: e.to_string(),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        };
+
+        let limit_str = input.limit.min(100).to_string();
+        let mut output = match run_git(&repo_root, &["log", "--oneline", "--all", "-n", &limit_str])
+        {
+            Ok(o) => o,
+            Err(e) => {
+                return Ok(ToolResult {
+                    output: format!("git log failed: {e}"),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        };
+
+        if output.is_empty() {
+            output = "(no commits yet)".to_string();
+        }
+
+        octos_core::truncate_utf8(&mut output, MAX_OUTPUT, "\n... (truncated)");
+
+        Ok(ToolResult {
+            output,
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+// ── workspace_show ─────────────────────────────────────────────────
+
+/// Tool: read a file at a specific commit in workspace git history.
+pub struct WorkspaceShowTool {
+    base_dir: PathBuf,
+}
+
+impl WorkspaceShowTool {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceShowInput {
+    /// Workspace project path, e.g. "slides/my-deck".
+    project: String,
+    /// Git commit hash (short or full).
+    commit: String,
+    /// File path relative to project root, e.g. "script.js".
+    file: String,
+}
+
+#[async_trait]
+impl Tool for WorkspaceShowTool {
+    fn name(&self) -> &str {
+        "workspace_show"
+    }
+
+    fn description(&self) -> &str {
+        "Read the contents of a file at a specific git commit in a workspace project. Use workspace_log first to find commit hashes."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["fs", "workspace"]
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "description": "Workspace project path, e.g. 'slides/my-deck'"
+                },
+                "commit": {
+                    "type": "string",
+                    "description": "Git commit hash (from workspace_log)"
+                },
+                "file": {
+                    "type": "string",
+                    "description": "File path relative to project root, e.g. 'script.js'"
+                }
+            },
+            "required": ["project", "commit", "file"]
+        })
+    }
+
+    async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        let input: WorkspaceShowInput =
+            serde_json::from_value(args.clone()).wrap_err("invalid workspace_show input")?;
+
+        // Reject commit hashes with path traversal
+        if input.commit.contains("..") || input.commit.contains('/') {
+            return Ok(ToolResult {
+                output: "invalid commit hash".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
+
+        // Reject file paths with traversal
+        if input.file.contains("..") {
+            return Ok(ToolResult {
+                output: "path traversal not allowed".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
+
+        let repo_root = match resolve_workspace_git_root(&self.base_dir, &input.project) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult {
+                    output: e.to_string(),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        };
+
+        let ref_spec = format!("{}:{}", input.commit, input.file);
+        let mut output = match run_git(&repo_root, &["show", &ref_spec]) {
+            Ok(o) => o,
+            Err(e) => {
+                return Ok(ToolResult {
+                    output: format!("git show failed: {e}"),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        };
+
+        octos_core::truncate_utf8(&mut output, MAX_OUTPUT, "\n... (truncated)");
+
+        Ok(ToolResult {
+            output,
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+// ── workspace_diff ─────────────────────────────────────────────────
+
+/// Tool: show what changed between two commits for a file.
+pub struct WorkspaceDiffTool {
+    base_dir: PathBuf,
+}
+
+impl WorkspaceDiffTool {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceDiffInput {
+    /// Workspace project path, e.g. "slides/my-deck".
+    project: String,
+    /// Older commit hash.
+    from_commit: String,
+    /// Newer commit hash (or "HEAD" for current).
+    #[serde(default = "default_head")]
+    to_commit: String,
+    /// Optional file path to scope the diff.
+    #[serde(default)]
+    file: Option<String>,
+}
+
+fn default_head() -> String {
+    "HEAD".to_string()
+}
+
+#[async_trait]
+impl Tool for WorkspaceDiffTool {
+    fn name(&self) -> &str {
+        "workspace_diff"
+    }
+
+    fn description(&self) -> &str {
+        "Show what changed between two commits in a workspace project. Optionally scope to a specific file."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["fs", "workspace"]
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "project": {
+                    "type": "string",
+                    "description": "Workspace project path, e.g. 'slides/my-deck'"
+                },
+                "from_commit": {
+                    "type": "string",
+                    "description": "Older commit hash (from workspace_log)"
+                },
+                "to_commit": {
+                    "type": "string",
+                    "description": "Newer commit hash, or 'HEAD' for current (default: HEAD)"
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Optional file path to scope the diff"
+                }
+            },
+            "required": ["project", "from_commit"]
+        })
+    }
+
+    async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        let input: WorkspaceDiffInput =
+            serde_json::from_value(args.clone()).wrap_err("invalid workspace_diff input")?;
+
+        // Reject traversal in commit refs
+        for ref_str in [&input.from_commit, &input.to_commit] {
+            if ref_str.contains('/') && !ref_str.starts_with("HEAD") {
+                return Ok(ToolResult {
+                    output: "invalid commit ref".to_string(),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        }
+
+        if let Some(ref f) = input.file {
+            if f.contains("..") {
+                return Ok(ToolResult {
+                    output: "path traversal not allowed".to_string(),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        }
+
+        let repo_root = match resolve_workspace_git_root(&self.base_dir, &input.project) {
+            Ok(r) => r,
+            Err(e) => {
+                return Ok(ToolResult {
+                    output: e.to_string(),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        };
+
+        let range = format!("{}..{}", input.from_commit, input.to_commit);
+        let mut git_args = vec!["diff", &range, "--"];
+        if let Some(ref f) = input.file {
+            git_args.push(f);
+        }
+
+        let mut output = match run_git(&repo_root, &git_args) {
+            Ok(o) => o,
+            Err(e) => {
+                return Ok(ToolResult {
+                    output: format!("git diff failed: {e}"),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        };
+
+        if output.is_empty() {
+            output = "(no changes between these commits)".to_string();
+        }
+
+        octos_core::truncate_utf8(&mut output, MAX_OUTPUT, "\n... (truncated)");
+
+        Ok(ToolResult {
+            output,
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Set up a git repo with 3 commits for testing.
+    fn setup_test_repo() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().unwrap();
+        let slides = temp.path().join("slides").join("test-deck");
+        std::fs::create_dir_all(&slides).unwrap();
+
+        // git init
+        Command::new("git")
+            .args(["init"])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@test"])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+
+        // Commit 1: initial script.js
+        std::fs::write(
+            slides.join("script.js"),
+            "// v1\nslide 1\nslide 2\nslide 3\n",
+        )
+        .unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "Initial script", "--no-verify"])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+
+        // Commit 2: edit slide 2
+        std::fs::write(
+            slides.join("script.js"),
+            "// v2\nslide 1\nslide 2 EDITED\nslide 3\n",
+        )
+        .unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "Edit slide 2", "--no-verify"])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+
+        // Commit 3: delete slide 3
+        std::fs::write(slides.join("script.js"), "// v3\nslide 1\nslide 2 EDITED\n").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "Delete slide 3", "--no-verify"])
+            .current_dir(&slides)
+            .output()
+            .unwrap();
+
+        temp
+    }
+
+    // ── workspace_log tests ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn should_show_commit_history() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceLogTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({"project": "slides/test-deck"}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("Delete slide 3"));
+        assert!(result.output.contains("Edit slide 2"));
+        assert!(result.output.contains("Initial script"));
+    }
+
+    #[tokio::test]
+    async fn should_limit_commit_count() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceLogTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({"project": "slides/test-deck", "limit": 1}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        let lines: Vec<&str> = result.output.trim().lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert!(result.output.contains("Delete slide 3"));
+    }
+
+    #[tokio::test]
+    async fn should_fail_for_missing_project() {
+        let temp = tempfile::tempdir().unwrap();
+        let tool = WorkspaceLogTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({"project": "slides/nonexistent"}))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        // Error may be "no git repository" or "path outside workspace" depending
+        // on whether the path exists on disk for canonicalization.
+        assert!(
+            result.output.contains("no git repository")
+                || result.output.contains("path outside workspace"),
+            "unexpected error: {}",
+            result.output
+        );
+    }
+
+    // ── workspace_show tests ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn should_show_file_at_old_commit() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceShowTool::new(temp.path());
+
+        // Get first commit hash
+        let log_output = run_git(
+            &temp.path().join("slides/test-deck"),
+            &["log", "--oneline", "--reverse"],
+        )
+        .unwrap();
+        let first_hash = log_output
+            .lines()
+            .next()
+            .unwrap()
+            .split(' ')
+            .next()
+            .unwrap();
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "commit": first_hash,
+                "file": "script.js"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("// v1"));
+        assert!(result.output.contains("slide 3")); // v1 still had slide 3
+        assert!(!result.output.contains("EDITED")); // v1 didn't have the edit
+    }
+
+    #[tokio::test]
+    async fn should_show_current_version_at_head() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceShowTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "commit": "HEAD",
+                "file": "script.js"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("// v3"));
+        assert!(!result.output.contains("slide 3")); // v3 deleted slide 3
+    }
+
+    #[tokio::test]
+    async fn should_reject_path_traversal_in_commit() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceShowTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "commit": "../../etc/passwd",
+                "file": "script.js"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.output.contains("invalid commit hash"));
+    }
+
+    #[tokio::test]
+    async fn should_reject_path_traversal_in_file() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceShowTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "commit": "HEAD",
+                "file": "../../etc/passwd"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.output.contains("path traversal not allowed"));
+    }
+
+    #[tokio::test]
+    async fn should_fail_for_nonexistent_file_at_commit() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceShowTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "commit": "HEAD",
+                "file": "nonexistent.js"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+    }
+
+    // ── workspace_diff tests ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn should_diff_between_two_commits() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceDiffTool::new(temp.path());
+
+        // Get first and last commit hashes
+        let log_output = run_git(
+            &temp.path().join("slides/test-deck"),
+            &["log", "--oneline", "--reverse"],
+        )
+        .unwrap();
+        let hashes: Vec<&str> = log_output
+            .lines()
+            .map(|l| l.split(' ').next().unwrap())
+            .collect();
+        let first = hashes[0];
+        let last = hashes[2];
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "from_commit": first,
+                "to_commit": last,
+                "file": "script.js"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        // Diff should show changes from v1 to v3
+        assert!(result.output.contains("-// v1"));
+        assert!(result.output.contains("+// v3"));
+        assert!(result.output.contains("-slide 3")); // slide 3 was removed
+    }
+
+    #[tokio::test]
+    async fn should_diff_to_head_by_default() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceDiffTool::new(temp.path());
+
+        let log_output = run_git(
+            &temp.path().join("slides/test-deck"),
+            &["log", "--oneline", "--reverse"],
+        )
+        .unwrap();
+        let first = log_output
+            .lines()
+            .next()
+            .unwrap()
+            .split(' ')
+            .next()
+            .unwrap();
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "from_commit": first
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("-// v1"));
+        assert!(result.output.contains("+// v3"));
+    }
+
+    #[tokio::test]
+    async fn should_show_no_changes_for_same_commit() {
+        let temp = setup_test_repo();
+        let tool = WorkspaceDiffTool::new(temp.path());
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "project": "slides/test-deck",
+                "from_commit": "HEAD",
+                "to_commit": "HEAD"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("no changes"));
+    }
+
+    // ── tool metadata ──────────────────────────────────────────────
+
+    #[test]
+    fn should_have_correct_tool_names() {
+        let log = WorkspaceLogTool::new("/tmp");
+        let show = WorkspaceShowTool::new("/tmp");
+        let diff = WorkspaceDiffTool::new("/tmp");
+
+        assert_eq!(log.name(), "workspace_log");
+        assert_eq!(show.name(), "workspace_show");
+        assert_eq!(diff.name(), "workspace_diff");
+
+        assert!(log.tags().contains(&"workspace"));
+        assert!(show.tags().contains(&"workspace"));
+        assert!(diff.tags().contains(&"workspace"));
+    }
+}

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1,0 +1,273 @@
+//! Workspace contract enforcement for spawn_only background tasks.
+//!
+//! A contract defines what must be true before a background task is considered
+//! "completed": output files exist, pass size checks, and get delivered.
+//! The contract runs inline between tool execution and supervisor status update,
+//! so `mark_completed` only fires after verification passes.
+//!
+//! This is NOT a post-processing step — it gates the status transition itself.
+
+use std::path::Path;
+
+use tracing::{info, warn};
+
+use crate::behaviour;
+use crate::workspace_policy::{SpawnTaskPolicy, read_workspace_policy};
+
+/// Result of enforcing a spawn task contract.
+#[derive(Debug)]
+pub enum ContractVerdict {
+    /// All verify actions passed. `on_complete` actions have been run.
+    /// Contains notification messages from any `notify_user` actions.
+    Satisfied { notifications: Vec<String> },
+    /// Verify failed or on_failure actions were run.
+    /// Contains the failure reasons and any notification messages.
+    Failed {
+        reasons: Vec<String>,
+        notifications: Vec<String>,
+    },
+    /// No contract defined for this tool — pass through to existing behaviour.
+    NoContract,
+}
+
+/// Look up and enforce the workspace contract for a spawn_only tool.
+///
+/// Call this AFTER the tool executes successfully but BEFORE `mark_completed`.
+/// If this returns `Failed`, call `mark_failed` instead.
+pub fn enforce(workspace_root: &Path, tool_name: &str) -> ContractVerdict {
+    let policy = match read_workspace_policy(workspace_root) {
+        Ok(Some(p)) => p,
+        Ok(None) => return ContractVerdict::NoContract,
+        Err(e) => {
+            warn!(tool = %tool_name, error = %e, "failed to read workspace policy for contract");
+            return ContractVerdict::NoContract;
+        }
+    };
+
+    let Some(task_policy) = policy.spawn_tasks.get(tool_name) else {
+        return ContractVerdict::NoContract;
+    };
+
+    if task_policy.on_verify.is_empty() && task_policy.on_complete.is_empty() {
+        return ContractVerdict::NoContract;
+    };
+
+    enforce_policy(workspace_root, tool_name, task_policy)
+}
+
+/// Enforce a specific spawn task policy. Separated for testability.
+pub fn enforce_policy(
+    workspace_root: &Path,
+    tool_name: &str,
+    policy: &SpawnTaskPolicy,
+) -> ContractVerdict {
+    // Step 1: Run verify actions
+    if !policy.on_verify.is_empty() {
+        match behaviour::run_actions(workspace_root, &policy.on_verify) {
+            Ok(results) => {
+                if !behaviour::all_passed(&results) {
+                    let reasons = behaviour::failure_reasons(&results);
+                    warn!(
+                        tool = %tool_name,
+                        failures = ?reasons,
+                        "spawn task contract verify failed"
+                    );
+                    // Run on_failure actions
+                    let notifications = run_failure_actions(workspace_root, tool_name, policy);
+                    return ContractVerdict::Failed {
+                        reasons,
+                        notifications,
+                    };
+                }
+            }
+            Err(e) => {
+                warn!(tool = %tool_name, error = %e, "contract verify actions errored");
+                let notifications = run_failure_actions(workspace_root, tool_name, policy);
+                return ContractVerdict::Failed {
+                    reasons: vec![format!("verify error: {e}")],
+                    notifications,
+                };
+            }
+        }
+    }
+
+    // Step 2: Run on_complete actions
+    let mut notifications = Vec::new();
+    if !policy.on_complete.is_empty() {
+        match behaviour::run_actions(workspace_root, &policy.on_complete) {
+            Ok(results) => {
+                notifications = behaviour::notifications(&results);
+                if !behaviour::all_passed(&results) {
+                    let reasons = behaviour::failure_reasons(&results);
+                    warn!(
+                        tool = %tool_name,
+                        failures = ?reasons,
+                        "spawn task contract on_complete actions failed"
+                    );
+                    return ContractVerdict::Failed {
+                        reasons,
+                        notifications,
+                    };
+                }
+            }
+            Err(e) => {
+                warn!(tool = %tool_name, error = %e, "on_complete actions errored");
+                return ContractVerdict::Failed {
+                    reasons: vec![format!("on_complete error: {e}")],
+                    notifications,
+                };
+            }
+        }
+    }
+
+    info!(
+        tool = %tool_name,
+        notifications = notifications.len(),
+        "spawn task contract satisfied"
+    );
+    ContractVerdict::Satisfied { notifications }
+}
+
+/// Run on_failure actions and collect notifications.
+fn run_failure_actions(
+    workspace_root: &Path,
+    tool_name: &str,
+    policy: &SpawnTaskPolicy,
+) -> Vec<String> {
+    if policy.on_failure.is_empty() {
+        return Vec::new();
+    }
+    match behaviour::run_actions(workspace_root, &policy.on_failure) {
+        Ok(results) => behaviour::notifications(&results),
+        Err(e) => {
+            warn!(tool = %tool_name, error = %e, "on_failure actions errored");
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace_git::WorkspaceProjectKind;
+    use crate::workspace_policy::{WorkspacePolicy, write_workspace_policy};
+
+    #[test]
+    fn should_return_no_contract_when_no_policy() {
+        let temp = tempfile::tempdir().unwrap();
+        let verdict = enforce(temp.path(), "tts");
+        assert!(matches!(verdict, ContractVerdict::NoContract));
+    }
+
+    #[test]
+    fn should_return_no_contract_when_tool_not_in_policy() {
+        let temp = tempfile::tempdir().unwrap();
+        let policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let verdict = enforce(temp.path(), "unknown_tool");
+        assert!(matches!(verdict, ContractVerdict::NoContract));
+    }
+
+    #[test]
+    fn should_satisfy_when_verify_passes() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("output.mp3"), b"audio data here").unwrap();
+
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.spawn_tasks.insert(
+            "tts".into(),
+            SpawnTaskPolicy {
+                on_verify: vec!["file_exists:output.mp3".into()],
+                on_complete: vec!["notify_user:Audio ready".into()],
+                on_failure: vec![],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let verdict = enforce(temp.path(), "tts");
+        match verdict {
+            ContractVerdict::Satisfied { notifications } => {
+                assert_eq!(notifications, vec!["Audio ready"]);
+            }
+            other => panic!("expected Satisfied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_fail_when_verify_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        // Do NOT create output.mp3
+
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.spawn_tasks.insert(
+            "tts".into(),
+            SpawnTaskPolicy {
+                on_verify: vec!["file_exists:output.mp3".into()],
+                on_complete: vec!["notify_user:Audio ready".into()],
+                on_failure: vec!["notify_user:TTS failed".into()],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let verdict = enforce(temp.path(), "tts");
+        match verdict {
+            ContractVerdict::Failed {
+                reasons,
+                notifications,
+            } => {
+                assert!(!reasons.is_empty());
+                assert!(reasons[0].contains("no files match"));
+                assert_eq!(notifications, vec!["TTS failed"]);
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_run_cleanup_on_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("temp")).unwrap();
+        std::fs::write(temp.path().join("temp/tts_work.wav"), b"temp data").unwrap();
+
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.spawn_tasks.insert(
+            "tts".into(),
+            SpawnTaskPolicy {
+                on_verify: vec!["file_exists:output.mp3".into()],
+                on_complete: vec![],
+                on_failure: vec!["cleanup:temp/tts_*".into()],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let verdict = enforce(temp.path(), "tts");
+        assert!(matches!(verdict, ContractVerdict::Failed { .. }));
+        assert!(!temp.path().join("temp/tts_work.wav").exists());
+    }
+
+    #[test]
+    fn should_fail_when_file_too_small() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("output.mp3"), b"x").unwrap(); // 1 byte
+
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.spawn_tasks.insert(
+            "tts".into(),
+            SpawnTaskPolicy {
+                on_verify: vec!["file_size_min:output.mp3:1024".into()],
+                on_complete: vec![],
+                on_failure: vec![],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let verdict = enforce(temp.path(), "tts");
+        match verdict {
+            ContractVerdict::Failed { reasons, .. } => {
+                assert!(reasons[0].contains("bytes"));
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+}

--- a/crates/octos-agent/src/workspace_git.rs
+++ b/crates/octos-agent/src/workspace_git.rs
@@ -1,11 +1,13 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use eyre::{eyre, Result, WrapErr};
+use eyre::{Result, WrapErr, eyre};
+
+use tracing::warn;
 
 use crate::workspace_policy::{
-    read_workspace_policy, WorkspacePolicyKind, WorkspaceSnapshotTrigger,
-    WorkspaceVersionControlProvider,
+    WorkspacePolicyKind, WorkspaceSnapshotTrigger, WorkspaceVersionControlProvider,
+    read_workspace_policy,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -50,6 +52,14 @@ pub struct WorkspaceRepo {
 pub struct WorkspaceTurnSnapshotReport {
     pub committed: Vec<String>,
     pub enforced_failures: Vec<WorkspaceTurnSnapshotFailure>,
+    pub validation_failures: Vec<WorkspaceValidationFailure>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceValidationFailure {
+    pub repo_label: String,
+    pub check: String,
+    pub reason: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -63,6 +73,7 @@ enum WorkspaceTurnSnapshotPlan {
     PolicyGit {
         auto_init: bool,
         fail_on_error: bool,
+        turn_end_validators: Vec<String>,
     },
     Skip,
 }
@@ -218,10 +229,14 @@ pub fn snapshot_workspace_turn(
     let mut report = WorkspaceTurnSnapshotReport::default();
     let summary = normalize_turn_summary(summary);
 
-    for repo in repos {
+    // Collect (repo_root, validators) from the plan phase so we don't re-read
+    // the workspace policy during validation.
+    let mut pending_validations: Vec<(PathBuf, String, Vec<String>)> = Vec::new();
+
+    for repo in &repos {
         let repo_label = format!("{}/{}", repo.kind.directory_name(), repo.slug);
         let message = format!("Turn snapshot for {repo_label}: {summary}");
-        match snapshot_plan_for_repo(&repo) {
+        match snapshot_plan_for_repo(repo) {
             Ok(WorkspaceTurnSnapshotPlan::Skip) => {}
             Ok(WorkspaceTurnSnapshotPlan::LegacyGit) => {
                 if commit_all_if_dirty(&repo.root, &message)? {
@@ -231,18 +246,22 @@ pub fn snapshot_workspace_turn(
             Ok(WorkspaceTurnSnapshotPlan::PolicyGit {
                 auto_init,
                 fail_on_error,
+                turn_end_validators,
             }) => {
                 match commit_all_if_dirty_with_options(&repo.root, repo.kind, &message, auto_init) {
-                    Ok(true) => report.committed.push(repo_label),
+                    Ok(true) => report.committed.push(repo_label.clone()),
                     Ok(false) => {}
                     Err(error) => {
                         if fail_on_error {
                             report.enforced_failures.push(WorkspaceTurnSnapshotFailure {
-                                repo_label,
+                                repo_label: repo_label.clone(),
                                 error: error.to_string(),
                             });
                         }
                     }
+                }
+                if !turn_end_validators.is_empty() {
+                    pending_validations.push((repo.root.clone(), repo_label, turn_end_validators));
                 }
             }
             Err(error) => {
@@ -254,7 +273,49 @@ pub fn snapshot_workspace_turn(
         }
     }
 
+    // Run turn-end validators using the already-parsed policy data.
+    run_turn_end_validators(&pending_validations, &mut report);
+
     Ok(report)
+}
+
+/// Run tier 1 turn-end validators using pre-parsed policy data.
+///
+/// Each entry is `(repo_root, repo_label, validator_specs)` collected during
+/// the snapshot plan phase, avoiding a second policy read from disk.
+fn run_turn_end_validators(
+    validations: &[(PathBuf, String, Vec<String>)],
+    report: &mut WorkspaceTurnSnapshotReport,
+) {
+    use crate::behaviour::{ActionResult, run_action};
+
+    for (repo_root, repo_label, specs) in validations {
+        for spec in specs {
+            match run_action(repo_root, spec) {
+                Ok(ActionResult::Pass | ActionResult::Notify { .. }) => {}
+                Ok(ActionResult::Fail { reason }) => {
+                    report.validation_failures.push(WorkspaceValidationFailure {
+                        repo_label: repo_label.clone(),
+                        check: spec.clone(),
+                        reason,
+                    });
+                }
+                Err(e) => {
+                    warn!(
+                        repo = %repo_label,
+                        check = %spec,
+                        error = %e,
+                        "turn-end validator failed to execute"
+                    );
+                    report.validation_failures.push(WorkspaceValidationFailure {
+                        repo_label: repo_label.clone(),
+                        check: spec.clone(),
+                        reason: format!("validator error: {e}"),
+                    });
+                }
+            }
+        }
+    }
 }
 
 fn commit_all_if_dirty_with_options(
@@ -314,6 +375,7 @@ fn snapshot_plan_for_repo(repo: &WorkspaceRepo) -> Result<WorkspaceTurnSnapshotP
     Ok(WorkspaceTurnSnapshotPlan::PolicyGit {
         auto_init: policy.version_control.auto_init,
         fail_on_error: policy.version_control.fail_on_error,
+        turn_end_validators: policy.validation.on_turn_end,
     })
 }
 
@@ -404,7 +466,7 @@ fn run_git(project_root: &Path, args: &[&str]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workspace_policy::{write_workspace_policy, WorkspacePolicy};
+    use crate::workspace_policy::{WorkspacePolicy, write_workspace_policy};
 
     #[test]
     fn detects_slides_repo_from_changed_path() {
@@ -502,8 +564,73 @@ mod tests {
         assert!(report.committed.is_empty());
         assert_eq!(report.enforced_failures.len(), 1);
         assert_eq!(report.enforced_failures[0].repo_label, "slides/deck-a");
-        assert!(report.enforced_failures[0]
-            .error
-            .contains("parse workspace policy failed"));
+        assert!(
+            report.enforced_failures[0]
+                .error
+                .contains("parse workspace policy failed")
+        );
+    }
+
+    #[test]
+    fn should_report_validation_failures_at_turn_end() {
+        let temp = tempfile::tempdir().unwrap();
+        let slides_root = temp.path().join("slides").join("deck-a");
+        std::fs::create_dir_all(&slides_root).unwrap();
+        std::fs::write(slides_root.join("script.js"), "module.exports = [];\n").unwrap();
+
+        // Write policy with a turn-end validator that will fail
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.validation.on_turn_end = vec!["file_exists:output/*.pptx".into()];
+        write_workspace_policy(&slides_root, &policy).unwrap();
+
+        let report = snapshot_workspace_turn(temp.path(), "apply user request").unwrap();
+
+        // Git snapshot should succeed
+        assert_eq!(report.committed, vec!["slides/deck-a"]);
+        // But validation should fail (no .pptx file)
+        assert_eq!(report.validation_failures.len(), 1);
+        assert_eq!(report.validation_failures[0].repo_label, "slides/deck-a");
+        assert_eq!(
+            report.validation_failures[0].check,
+            "file_exists:output/*.pptx"
+        );
+        assert!(
+            report.validation_failures[0]
+                .reason
+                .contains("no files match")
+        );
+    }
+
+    #[test]
+    fn should_pass_validation_when_artifact_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let slides_root = temp.path().join("slides").join("deck-b");
+        std::fs::create_dir_all(&slides_root).unwrap();
+        std::fs::write(slides_root.join("script.js"), "module.exports = [];\n").unwrap();
+
+        // Create the expected output
+        std::fs::create_dir_all(slides_root.join("output")).unwrap();
+        std::fs::write(slides_root.join("output/deck.pptx"), b"PK").unwrap();
+
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.validation.on_turn_end = vec!["file_exists:output/*.pptx".into()];
+        write_workspace_policy(&slides_root, &policy).unwrap();
+
+        let report = snapshot_workspace_turn(temp.path(), "apply user request").unwrap();
+
+        assert_eq!(report.committed, vec!["slides/deck-b"]);
+        assert!(report.validation_failures.is_empty());
+    }
+
+    #[test]
+    fn should_skip_validation_when_no_policy() {
+        let temp = tempfile::tempdir().unwrap();
+        let slides_root = temp.path().join("slides").join("deck-c");
+        std::fs::create_dir_all(&slides_root).unwrap();
+        std::fs::write(slides_root.join("script.js"), "module.exports = [];\n").unwrap();
+
+        // No policy file — no validation
+        let report = snapshot_workspace_turn(temp.path(), "apply user request").unwrap();
+        assert!(report.validation_failures.is_empty());
     }
 }

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use eyre::{Result, WrapErr};
@@ -12,6 +13,38 @@ pub struct WorkspacePolicy {
     pub workspace: WorkspacePolicyWorkspace,
     pub version_control: WorkspaceVersionControlPolicy,
     pub tracking: WorkspaceTrackingPolicy,
+    #[serde(default)]
+    pub validation: ValidationPolicy,
+    #[serde(default)]
+    pub spawn_tasks: HashMap<String, SpawnTaskPolicy>,
+}
+
+/// Tiered validation checks run at different points in the turn lifecycle.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationPolicy {
+    /// Tier 1: cheap checks run every turn (< 100ms). e.g. file_exists, build exit code.
+    #[serde(default)]
+    pub on_turn_end: Vec<String>,
+    /// Tier 2: medium checks run when source files change (1-5s). e.g. preview render.
+    #[serde(default)]
+    pub on_source_change: Vec<String>,
+    /// Tier 3: expensive checks run on completion/publish only (10-30s). e.g. Playwright.
+    #[serde(default)]
+    pub on_completion: Vec<String>,
+}
+
+/// Behaviour policy for a spawn_only background task.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpawnTaskPolicy {
+    /// Checks to verify the task did what was requested (scope, output validity).
+    #[serde(default)]
+    pub on_verify: Vec<String>,
+    /// Actions to run on successful completion + verify pass (send file, cleanup).
+    #[serde(default)]
+    pub on_complete: Vec<String>,
+    /// Actions to run on failure or verify failure (cleanup, notify).
+    #[serde(default)]
+    pub on_failure: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,6 +129,8 @@ impl WorkspacePolicy {
                         ".DS_Store".into(),
                     ],
                 },
+                validation: ValidationPolicy::default(),
+                spawn_tasks: HashMap::new(),
             },
             WorkspaceProjectKind::Sites => Self {
                 workspace: WorkspacePolicyWorkspace {
@@ -121,6 +156,8 @@ impl WorkspacePolicy {
                         ".DS_Store".into(),
                     ],
                 },
+                validation: ValidationPolicy::default(),
+                spawn_tasks: HashMap::new(),
             },
         }
     }
@@ -183,5 +220,119 @@ mod tests {
         let policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Sites);
         assert!(policy.tracking.ignore.iter().any(|item| item == "dist/**"));
         assert!(policy.tracking.ignore.iter().any(|item| item == ".next/**"));
+    }
+
+    #[test]
+    fn should_parse_policy_with_spawn_tasks() {
+        let toml_str = r#"
+[workspace]
+kind = "slides"
+
+[version_control]
+provider = "git"
+auto_init = true
+trigger = "turn_end"
+fail_on_error = true
+
+[tracking]
+ignore = ["output/**"]
+
+[spawn_tasks.tts]
+on_verify = ["file_exists:output/*.mp3"]
+on_complete = ["send_file:output/*.mp3", "cleanup:temp/tts_*"]
+on_failure = ["cleanup:temp/tts_*", "notify_user:TTS generation failed"]
+
+[spawn_tasks.slides]
+on_verify = ["scope_check:modified_slides"]
+on_complete = ["send_file:output/*.pptx"]
+on_failure = ["cleanup:temp/slides_*"]
+"#;
+
+        let policy: WorkspacePolicy = toml::from_str(toml_str).unwrap();
+        assert_eq!(policy.spawn_tasks.len(), 2);
+
+        let tts = &policy.spawn_tasks["tts"];
+        assert_eq!(tts.on_verify, vec!["file_exists:output/*.mp3"]);
+        assert_eq!(tts.on_complete.len(), 2);
+        assert_eq!(tts.on_failure.len(), 2);
+
+        let slides = &policy.spawn_tasks["slides"];
+        assert_eq!(slides.on_verify, vec!["scope_check:modified_slides"]);
+    }
+
+    #[test]
+    fn should_parse_policy_with_validation() {
+        let toml_str = r#"
+[workspace]
+kind = "sites"
+
+[version_control]
+provider = "git"
+auto_init = true
+trigger = "turn_end"
+fail_on_error = true
+
+[tracking]
+ignore = []
+
+[validation]
+on_turn_end = ["file_exists:index.html", "build_check"]
+on_source_change = ["preview_render"]
+on_completion = ["playwright:homepage_loads"]
+"#;
+
+        let policy: WorkspacePolicy = toml::from_str(toml_str).unwrap();
+        assert_eq!(policy.validation.on_turn_end.len(), 2);
+        assert_eq!(policy.validation.on_source_change, vec!["preview_render"]);
+        assert_eq!(
+            policy.validation.on_completion,
+            vec!["playwright:homepage_loads"]
+        );
+    }
+
+    #[test]
+    fn should_default_new_sections_when_absent() {
+        let toml_str = r#"
+[workspace]
+kind = "slides"
+
+[version_control]
+provider = "git"
+auto_init = true
+trigger = "turn_end"
+fail_on_error = true
+
+[tracking]
+ignore = []
+"#;
+
+        let policy: WorkspacePolicy = toml::from_str(toml_str).unwrap();
+        assert!(policy.validation.on_turn_end.is_empty());
+        assert!(policy.validation.on_source_change.is_empty());
+        assert!(policy.validation.on_completion.is_empty());
+        assert!(policy.spawn_tasks.is_empty());
+    }
+
+    #[test]
+    fn should_roundtrip_policy_with_spawn_tasks() {
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.spawn_tasks.insert(
+            "tts".into(),
+            SpawnTaskPolicy {
+                on_verify: vec!["file_exists:output/*.mp3".into()],
+                on_complete: vec!["send_file:output/*.mp3".into()],
+                on_failure: vec!["cleanup:temp/tts_*".into()],
+            },
+        );
+        policy.validation = ValidationPolicy {
+            on_turn_end: vec!["file_exists:output/*.pptx".into()],
+            on_source_change: vec![],
+            on_completion: vec![],
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &policy).unwrap();
+        let roundtrip = read_workspace_policy(temp.path()).unwrap().unwrap();
+        assert_eq!(roundtrip, policy);
     }
 }


### PR DESCRIPTION
## Summary

- Workspace contract layer (`workspace_contract.rs`) — enforces `[spawn_tasks]` policy inline in `execution.rs` BEFORE `mark_completed`, so TaskSupervisor only sees truth-checked states
- Behaviour action engine (`behaviour.rs`) — deterministic actions: `file_exists`, `file_size_min`, `cleanup`, `notify_user` with path traversal protection
- Workspace policy extensions — `[validation]` (tiered) and `[spawn_tasks.<tool>]` (on_verify/on_complete/on_failure), backward compatible via `#[serde(default)]`
- Turn-end validators in `workspace_git.rs` — tier 1 checks after git snapshots, no double policy read
- Workspace history tools — `workspace_log`, `workspace_show`, `workspace_diff` (read-only, server-side, outside sandbox)

## Test plan

- [x] 743 unit tests pass (`cargo test -p octos-agent --lib`)
- [x] Zero clippy warnings
- [x] Full workspace builds clean
- [x] Live slides API tests pass on Mini 1 (6/6)
- [x] Live TTS file delivery tests pass on Mini 1 (3/3)
- [x] Git workspace policy verified via SSH on Mini 1 (8 commits across 6 rounds)
- [ ] Wire `set_workspace_root()` in session_actor for contract enforcement on real sessions
- [ ] Add `[spawn_tasks.fm_tts]` and `[spawn_tasks.voice_synthesize]` to default session policy

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)