### PR TITLE
Stop auto-delivering slides workspace markdown files

### DIFF
--- a/crates/octos-agent/src/workspace_git.rs
+++ b/crates/octos-agent/src/workspace_git.rs
@@ -1,5 +1,9 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
 
 use eyre::{Result, WrapErr, eyre};
 use tracing::warn;
@@ -96,6 +100,12 @@ pub fn detect_workspace_repo(base_dir: &Path, changed_path: &Path) -> Option<Wor
 }
 
 pub fn init_workspace_repo(project_root: &Path, kind: WorkspaceProjectKind) -> Result<()> {
+    with_repo_git_lock(project_root, || {
+        init_workspace_repo_unlocked(project_root, kind)
+    })
+}
+
+fn init_workspace_repo_unlocked(project_root: &Path, kind: WorkspaceProjectKind) -> Result<()> {
     std::fs::create_dir_all(project_root)
         .wrap_err_with(|| format!("create project dir failed: {}", project_root.display()))?;
 
@@ -127,22 +137,24 @@ pub fn initialize_and_commit(
     kind: WorkspaceProjectKind,
     message: &str,
 ) -> Result<bool> {
-    init_workspace_repo(project_root, kind)?;
-    run_git(project_root, &["add", "-A", "--", "."])?;
+    with_repo_git_lock(project_root, || {
+        init_workspace_repo_unlocked(project_root, kind)?;
+        run_git(project_root, &["add", "-A", "--", "."])?;
 
-    let status = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(["diff", "--cached", "--quiet", "--", "."])
-        .status()
-        .wrap_err("git diff --cached failed")?;
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["diff", "--cached", "--quiet", "--", "."])
+            .status()
+            .wrap_err("git diff --cached failed")?;
 
-    if status.success() {
-        return Ok(false);
-    }
+        if status.success() {
+            return Ok(false);
+        }
 
-    run_git(project_root, &["commit", "-m", message, "--no-verify"])?;
-    Ok(true)
+        run_git(project_root, &["commit", "-m", message, "--no-verify"])?;
+        Ok(true)
+    })
 }
 
 pub fn snapshot_workspace_change(
@@ -154,8 +166,6 @@ pub fn snapshot_workspace_change(
         Some(repo) => repo,
         None => return Ok(None),
     };
-
-    init_workspace_repo(&repo.root, repo.kind)?;
 
     let relative_path = changed_path
         .strip_prefix(&repo.root)
@@ -323,30 +333,32 @@ fn commit_all_if_dirty_with_options(
     message: &str,
     auto_init: bool,
 ) -> Result<bool> {
-    if auto_init {
-        init_workspace_repo(project_root, kind).wrap_err("ensure git repo failed")?;
-    } else if !project_root.join(".git").exists() {
-        return Err(eyre!(
-            "workspace policy requires git repo at {}, but auto_init is disabled",
-            project_root.display()
-        ));
-    }
+    with_repo_git_lock(project_root, || {
+        if auto_init {
+            init_workspace_repo_unlocked(project_root, kind).wrap_err("ensure git repo failed")?;
+        } else if !project_root.join(".git").exists() {
+            return Err(eyre!(
+                "workspace policy requires git repo at {}, but auto_init is disabled",
+                project_root.display()
+            ));
+        }
 
-    run_git(project_root, &["add", "-A", "--", "."])?;
+        run_git(project_root, &["add", "-A", "--", "."])?;
 
-    let status = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(["diff", "--cached", "--quiet", "--", "."])
-        .status()
-        .wrap_err("git diff --cached failed")?;
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["diff", "--cached", "--quiet", "--", "."])
+            .status()
+            .wrap_err("git diff --cached failed")?;
 
-    if status.success() {
-        return Ok(false);
-    }
+        if status.success() {
+            return Ok(false);
+        }
 
-    run_git(project_root, &["commit", "-m", message, "--no-verify"])?;
-    Ok(true)
+        run_git(project_root, &["commit", "-m", message, "--no-verify"])?;
+        Ok(true)
+    })
 }
 
 fn snapshot_plan_for_repo(repo: &WorkspaceRepo) -> Result<WorkspaceTurnSnapshotPlan> {
@@ -436,30 +448,64 @@ fn truncate_utf8_boundary(s: &str, max_len: usize) -> String {
 }
 
 fn run_git(project_root: &Path, args: &[&str]) -> Result<()> {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(project_root)
-        .args(args)
-        .output()
-        .wrap_err_with(|| format!("failed to spawn git {:?}", args))?;
+    let mut attempt = 0_u32;
+    loop {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(args)
+            .output()
+            .wrap_err_with(|| format!("failed to spawn git {:?}", args))?;
 
-    if output.status.success() {
-        return Ok(());
-    }
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    Err(eyre!(
-        "git {:?} failed in {}: {}{}",
-        args,
-        project_root.display(),
-        stderr.trim(),
-        if stdout.trim().is_empty() {
-            String::new()
-        } else {
-            format!(" | stdout: {}", stdout.trim())
+        if output.status.success() {
+            return Ok(());
         }
-    ))
+
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let lock_error = is_git_index_lock_error(&stderr) || is_git_index_lock_error(&stdout);
+        if lock_error && attempt < 5 {
+            attempt += 1;
+            thread::sleep(Duration::from_millis(50 * u64::from(attempt)));
+            continue;
+        }
+
+        return Err(eyre!(
+            "git {:?} failed in {}: {}{}",
+            args,
+            project_root.display(),
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" | stdout: {}", stdout.trim())
+            }
+        ));
+    }
+}
+
+fn with_repo_git_lock<T>(project_root: &Path, op: impl FnOnce() -> Result<T>) -> Result<T> {
+    let lock = repo_git_lock(project_root);
+    let _guard = lock
+        .lock()
+        .map_err(|_| eyre!("workspace git lock poisoned for {}", project_root.display()))?;
+    op()
+}
+
+fn repo_git_lock(project_root: &Path) -> Arc<Mutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
+    let key = std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = locks.lock().expect("workspace git lock map poisoned");
+    guard
+        .entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+fn is_git_index_lock_error(output: &str) -> bool {
+    output.contains(".git/index.lock")
+        || (output.contains("index.lock") && output.contains("Unable to create"))
 }
 
 #[cfg(test)]
@@ -626,5 +672,13 @@ mod tests {
 
         let report = snapshot_workspace_turn(temp.path(), "apply user request").unwrap();
         assert!(report.validation_failures.is_empty());
+    }
+
+    #[test]
+    fn detects_git_index_lock_errors() {
+        assert!(is_git_index_lock_error(
+            "fatal: Unable to create 'C:/tmp/.git/index.lock': File exists."
+        ));
+        assert!(!is_git_index_lock_error("fatal: not a git repository"));
     }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2777,9 +2777,6 @@ impl SessionActor {
                     }
                 }
 
-                // Auto-deliver report files produced by the agent (e.g. from run_pipeline).
-                // This ensures the file reaches the user's channel (Telegram, web, etc.)
-                // without relying on the LLM to call send_file within its token budget.
                 if conv_response.files_modified.is_empty() {
                     tracing::debug!(session = %self.session_key, "no files_modified in conv_response");
                 } else {
@@ -2788,36 +2785,6 @@ impl SessionActor {
                         files = ?conv_response.files_modified.iter().map(|f| f.display().to_string()).collect::<Vec<_>>(),
                         "conv_response has files_modified"
                     );
-                }
-                for file in &conv_response.files_modified {
-                    if file.extension().and_then(|e| e.to_str()) == Some("md") {
-                        // Resolve relative paths to absolute so the file URL works
-                        let abs_file = if file.is_relative() {
-                            std::fs::canonicalize(file)
-                                .or_else(|_| std::fs::canonicalize(self.data_dir.join(file)))
-                                .unwrap_or_else(|_| file.clone())
-                        } else {
-                            file.clone()
-                        };
-                        info!(
-                            session = %self.session_key,
-                            file = %abs_file.display(),
-                            channel = %self.channel,
-                            chat_id = %self.chat_id,
-                            "auto-delivering report file"
-                        );
-                        let file_msg = OutboundMessage {
-                            channel: self.channel.clone(),
-                            chat_id: self.chat_id.clone(),
-                            content: String::new(),
-                            reply_to: None,
-                            media: vec![abs_file.to_string_lossy().into_owned()],
-                            metadata: serde_json::json!({}),
-                        };
-                        if let Err(e) = self.out_tx.send(file_msg).await {
-                            warn!(session = %self.session_key, error = %e, "failed to auto-deliver report file");
-                        }
-                    }
                 }
 
                 // Send reply

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -284,9 +284,9 @@ impl Tool for RunPipelineTool {
             .join("\n");
 
         // Find the report file from this pipeline run's actual files_modified.
-        // The session actor auto-delivers .md files via file_modified on ToolResult,
-        // so no LLM instruction needed.
-        // Ensure absolute path so session actor can find and deliver the file.
+        // Delivery is driven by files_to_send on ToolResult, so no LLM instruction
+        // or session-level markdown heuristics are needed.
+        // Ensure absolute path so the execution loop can find and deliver the file.
         let report_file = result
             .files_modified
             .iter()


### PR DESCRIPTION
## Summary
- stop treating every markdown file in `conv_response.files_modified` as a user-facing report attachment
- rely on explicit `files_to_send` for automatic delivery instead of session-level `.md` heuristics
- avoid leaking slides workspace metadata files like `memory.md` and `changelog.md` into user chat delivery

## Validation
- `cargo fmt --all --check`
- `cargo check -j1 -p octos-cli --features api`
- `cargo check -j1 -p octos-pipeline`

## Context
- This came out of the Windows slides live runs: deck generation succeeded, but the session actor was also auto-delivering workspace bookkeeping markdown files that should stay internal.