### PR TITLE
Fix Windows subdomain TLS routing in installers

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1356,6 +1356,11 @@ if ($Domain -and (Test-Command "caddy")) {
     respond /check 200
 }
 
+http:// {
+    @octos host $Domain *.$Domain
+    redir @octos https://{host}{uri} 308
+}
+
 $Domain {
     handle /api/* {
         reverse_proxy $caddyUpstream
@@ -1374,32 +1379,30 @@ $Domain {
     }
 }
 
-*.$Domain {
+https:// {
     tls {
         on_demand
     }
 
-    @api path /api/*
-    @admin path /admin*
-    @auth path /auth/*
+    @sub host *.$Domain
 
-    handle @api {
-        reverse_proxy $caddyUpstream {
-            header_up X-Profile-Id {labels.2}
+    handle @sub {
+        @api path /api/*
+        @admin path /admin*
+        @auth path /auth/*
+
+        handle @api {
+            reverse_proxy $caddyUpstream
         }
-    }
-    handle @admin {
-        reverse_proxy $caddyUpstream {
-            header_up X-Profile-Id {labels.2}
+        handle @admin {
+            reverse_proxy $caddyUpstream
         }
-    }
-    handle @auth {
-        reverse_proxy $caddyUpstream {
-            header_up X-Profile-Id {labels.2}
+        handle @auth {
+            reverse_proxy $caddyUpstream
         }
-    }
-    handle {
-        reverse_proxy $caddyUpstream
+        handle {
+            reverse_proxy $caddyUpstream
+        }
     }
 }
 "@ | Set-Content -Path $caddyfile -Encoding UTF8

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1683,6 +1683,11 @@ if [ -n "$CADDY_DOMAIN" ]; then
     respond /check 200
 }
 
+http:// {
+    @octos host ${CADDY_DOMAIN} *.${CADDY_DOMAIN}
+    redir @octos https://{host}{uri} 308
+}
+
 ${CADDY_DOMAIN} {
     handle /api/* {
         reverse_proxy ${CADDY_UPSTREAM}
@@ -1701,32 +1706,30 @@ ${CADDY_DOMAIN} {
     }
 }
 
-*.${CADDY_DOMAIN} {
+https:// {
     tls {
         on_demand
     }
 
-    @api path /api/*
-    @admin path /admin*
-    @auth path /auth/*
+    @sub host *.${CADDY_DOMAIN}
 
-    handle @api {
-        reverse_proxy ${CADDY_UPSTREAM} {
-            header_up X-Profile-Id {labels.2}
+    handle @sub {
+        @api path /api/*
+        @admin path /admin*
+        @auth path /auth/*
+
+        handle @api {
+            reverse_proxy ${CADDY_UPSTREAM}
         }
-    }
-    handle @admin {
-        reverse_proxy ${CADDY_UPSTREAM} {
-            header_up X-Profile-Id {labels.2}
+        handle @admin {
+            reverse_proxy ${CADDY_UPSTREAM}
         }
-    }
-    handle @auth {
-        reverse_proxy ${CADDY_UPSTREAM} {
-            header_up X-Profile-Id {labels.2}
+        handle @auth {
+            reverse_proxy ${CADDY_UPSTREAM}
         }
-    }
-    handle {
-        reverse_proxy ${CADDY_UPSTREAM}
+        handle {
+            reverse_proxy ${CADDY_UPSTREAM}
+        }
     }
 }
 CADDYEOF


### PR DESCRIPTION
## Summary
- stop generating wildcard site-address Caddy configs for profile subdomains
- switch installers to root-domain site + generic https host matcher with on-demand TLS
- remove legacy subdomain  injection from generated Caddy configs

## Why
Windows live had broken  subdomains at the TLS layer. Caddy was attempting wildcard certificate issuance semantics for the wildcard site address, which failed without DNS challenge and surfaced as  during handshake.

## Validation
- applied the equivalent Caddy change live on 
- verified  returns 
- verified child public-subdomain routing works after rename
- verified old slug and internal child-id host no longer scope to the child
