### PR TITLE
fix(matrix): preserve MSC4357 finish_stream signal in session_actor

### DIFF
--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2946,7 +2946,7 @@ impl SessionActor {
                                 if let Some(ref si) = self.status_indicator {
                                     let _ = si
                                         .channel()
-                                        .edit_message(&self.chat_id, mid, &display_content)
+                                        .finish_stream(&self.chat_id, mid, &display_content)
                                         .await;
                                 }
                                 true
@@ -3618,7 +3618,7 @@ impl SessionActor {
                                 if let Some(ref si) = self.status_indicator {
                                     let _ = si
                                         .channel()
-                                        .edit_message(&self.chat_id, mid, &display_content)
+                                        .finish_stream(&self.chat_id, mid, &display_content)
                                         .await;
                                 }
                                 true


### PR DESCRIPTION
## Summary

`stream_reporter` correctly emits `finish_stream()` on the terminal streaming edit, clearing the MSC4357 `live` marker so the stream terminates cleanly. Immediately after, `session_actor` fires one more edit (to attach token usage metadata like `· 9.9K in · 73 out · 5s`) via `edit_message()`, which re-adds the `live` marker and overwrites the finish signal.

Clients detecting stream end via MSC4357 (e.g. [robrix2](https://github.com/Project-Robius-China/robrix2), any spec-compliant client) therefore never observe `live=false` and fall back to a 5-minute stall-timeout before switching from streaming rendering to rich markdown.

## Evidence

Palpo (Matrix homeserver) event log during a normal bot reply shows the overwrite pattern:

```
stream_order 89  live=true   (body grows from chunks)                  ← stream_reporter
stream_order 90  live=false  (stream_reporter finish_flush_to_channel) ← correct terminal signal
stream_order 92  live=true   (session_actor final edit with footer)    ← overwrites it
```

The final `live=true` at stream_order 92 is the root cause: it undoes what `finish_stream` just correctly signaled.

## Fix

Two identical sites in `session_actor.rs` that fire the "final edit with token metadata" on a successful streaming reply:

```diff
 if let Some(ref si) = self.status_indicator {
     let _ = si
         .channel()
-        .edit_message(&self.chat_id, mid, &display_content)
+        .finish_stream(&self.chat_id, mid, &display_content)
         .await;
 }
```

Both sites are the **final** edit of a streaming reply. `finish_stream()` is the contractually correct call here: on channels without streaming semantics it defers to `edit_message`, but on the Matrix channel it omits the `live` marker (per MSC4357). Using it at both sites makes the session_actor honour the same termination contract that `stream_reporter::finish_flush_to_channel` already does.

## Test plan

- [x] `cargo check --package octos-cli` passes
- [x] Manual: verified on local testenv — after patch, MSC4357-aware clients switch to rich markdown immediately on stream end (previously had to wait the 5-minute stall timeout)

The existing `test_matrix_live_lifecycle` in `matrix_channel.rs` already exercises the `finish_stream()` protocol path; this PR only realigns which caller reaches it, so no new protocol-level tests are needed.

## Scope

This PR is intentionally minimal: only the 4-line correction to the two final-edit sites. No other behavior changes, no new tests, no docs. Orthogonal to #345 (`feat/matrix-media-and-fixes`).