### PR TITLE
Fix topic-scoped site and slides deliverables

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -461,7 +461,7 @@ impl Channel for ApiChannel {
                     reasoning_content: None,
                     timestamp: chrono::Utc::now(),
                 };
-                self.persist_to_session(&msg.chat_id, session_msg).await
+                self.persist_to_session(&msg.chat_id, topic, session_msg).await
             } else {
                 None
             };
@@ -509,30 +509,36 @@ impl Channel for ApiChannel {
             // session_result metadata. This keeps legacy realtime delivery
             // working until every media path is upgraded to the committed
             // session_result contract.
-            let pending = self.pending.lock().await;
-            if let Some(tx) = pending.get(&msg.chat_id) {
+            let mut legacy_events = Vec::new();
+            {
+                let pending = self.pending.lock().await;
+                if pending.get(&msg.chat_id).is_some() {
                 record_result_delivery("legacy_file_event", "fallback", "file");
-                for (original_path, persisted_path) in msg.media.iter().zip(persisted_media.iter())
-                {
-                    let filename = std::path::Path::new(original_path)
-                        .file_name()
-                        .map(|n| n.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    let tool_call_id = msg
-                        .metadata
-                        .get("tool_call_id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    let event = serde_json::json!({
-                        "type": "file",
-                        "path": response_path_for_session_file(&data_dir, Path::new(persisted_path))
-                            .unwrap_or_else(|| persisted_path.clone()),
-                        "filename": filename,
-                        "caption": msg.content,
-                        "tool_call_id": tool_call_id,
-                    });
-                    let _ = tx.send(event.to_string());
+                    for (original_path, persisted_path) in msg.media.iter().zip(persisted_media.iter())
+                    {
+                        let filename = std::path::Path::new(original_path)
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_default();
+                        let tool_call_id = msg
+                            .metadata
+                            .get("tool_call_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        legacy_events.push(serde_json::json!({
+                            "type": "file",
+                            "path": response_path_for_session_file(&data_dir, Path::new(persisted_path))
+                                .unwrap_or_else(|| persisted_path.clone()),
+                            "filename": filename,
+                            "caption": msg.content,
+                            "tool_call_id": tool_call_id,
+                            "topic": topic,
+                        }));
+                    }
                 }
+            }
+            for event in legacy_events {
+                self.broadcast_session_event(&msg.chat_id, topic, event).await;
             }
             return Ok(());
         }
@@ -576,7 +582,7 @@ impl Channel for ApiChannel {
                     reasoning_content: None,
                     timestamp: chrono::Utc::now(),
                 };
-                let _ = self.persist_to_session(&msg.chat_id, session_msg).await;
+                let _ = self.persist_to_session(&msg.chat_id, topic, session_msg).await;
             }
             return Ok(());
         }
@@ -703,8 +709,14 @@ async fn handle_metrics(State(state): State<ApiState>) -> String {
 impl ApiChannel {
     /// Persist a message to the session JSONL for the given chat_id and
     /// return the authoritative committed message shape when available.
-    async fn persist_to_session(&self, chat_id: &str, message: Message) -> Option<MessageInfo> {
-        let key = current_profile_api_session_key(self.profile_id.as_deref(), chat_id);
+    async fn persist_to_session(
+        &self,
+        chat_id: &str,
+        topic: Option<&str>,
+        message: Message,
+    ) -> Option<MessageInfo> {
+        let key =
+            current_profile_api_session_key_with_topic(self.profile_id.as_deref(), chat_id, topic);
         let mut sess = self.sessions.lock().await;
         let committed = match sess.add_message_with_seq(&key, message.clone()).await {
             Ok(seq) => {
@@ -728,31 +740,33 @@ impl ApiChannel {
         let base_key = key.base_key();
         let encoded = crate::session::encode_path_component(base_key);
         let per_user_dir = data_dir.join("users").join(encoded).join("sessions");
-        let per_user_path = per_user_dir.join("default.jsonl");
-        if per_user_path.exists() {
-            if let Ok(msg_json) = serde_json::to_string(&message) {
-                let path_clone = per_user_path.clone();
-                match tokio::task::spawn_blocking(move || {
-                    use std::io::Write;
-                    let mut f = std::fs::OpenOptions::new()
-                        .append(true)
-                        .open(&per_user_path)?;
-                    writeln!(f, "{}", msg_json)?;
-                    Ok::<_, std::io::Error>(())
-                })
-                .await
-                {
-                    Ok(Ok(())) => info!(chat_id = %chat_id, "persisted to per-user session"),
-                    Ok(Err(e)) => {
-                        tracing::warn!(chat_id = %chat_id, path = %path_clone.display(), error = %e, "per-user session write failed")
-                    }
-                    Err(e) => {
-                        tracing::warn!(chat_id = %chat_id, error = %e, "per-user session spawn_blocking failed")
-                    }
+        let effective_topic = topic.filter(|value| !value.trim().is_empty()).unwrap_or("default");
+        let encoded_topic = crate::session::encode_path_component(effective_topic);
+        let per_user_path = per_user_dir.join(format!("{encoded_topic}.jsonl"));
+        if let Ok(msg_json) = serde_json::to_string(&message) {
+            let path_clone = per_user_path.clone();
+            match tokio::task::spawn_blocking(move || {
+                use std::io::Write;
+                if let Some(parent) = per_user_path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                let mut f = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&per_user_path)?;
+                writeln!(f, "{}", msg_json)?;
+                Ok::<_, std::io::Error>(())
+            })
+            .await
+            {
+                Ok(Ok(())) => info!(chat_id = %chat_id, topic = ?topic, "persisted to per-user session"),
+                Ok(Err(e)) => {
+                    tracing::warn!(chat_id = %chat_id, topic = ?topic, path = %path_clone.display(), error = %e, "per-user session write failed")
+                }
+                Err(e) => {
+                    tracing::warn!(chat_id = %chat_id, topic = ?topic, error = %e, "per-user session spawn_blocking failed")
                 }
             }
-        } else {
-            tracing::debug!(chat_id = %chat_id, path = %per_user_path.display(), "per-user session path not found, skipping");
         }
 
         committed
@@ -2267,6 +2281,56 @@ mod tests {
         assert_eq!(media.len(), 1);
         let persisted = media[0].as_str().expect("persisted path");
         assert!(persisted.starts_with("pf/"));
+    }
+
+    #[tokio::test]
+    async fn send_file_message_with_topic_persists_to_topic_session() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            sessions.clone(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("topic-file".into(), tx);
+        }
+
+        let source_dir = data_dir.path().join("source-topic");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("deck.pptx");
+        std::fs::write(&source, b"deck").unwrap();
+
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "topic-file".into(),
+            content: "Topic deck".into(),
+            reply_to: None,
+            media: vec![source.to_string_lossy().to_string()],
+            metadata: serde_json::json!({ "topic": "slides launch" }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "session_result");
+        assert_eq!(parsed["topic"], "slides launch");
+
+        let mut sess = sessions.lock().await;
+        let topic_key =
+            SessionKey::with_profile_topic(TEST_PROFILE_ID, "api", "topic-file", "slides launch");
+        let base_key = SessionKey::with_profile(TEST_PROFILE_ID, "api", "topic-file");
+        let topic_session = sess.get_or_create(&topic_key).await;
+        let topic_history = topic_session.get_history(10);
+        assert_eq!(topic_history.len(), 1);
+        assert_eq!(topic_history[0].content, "Topic deck");
+        assert_eq!(topic_history[0].media.len(), 1);
+        let base_session = sess.get_or_create(&base_key).await;
+        assert!(base_session.get_history(10).is_empty());
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1593,6 +1593,22 @@ fn run_build_command(command: &mut std::process::Command, label: &str) -> Result
     }
 }
 
+fn configure_site_node_command(
+    command: &mut std::process::Command,
+    project_dir: &std::path::Path,
+) -> Result<(), String> {
+    let cache_dir = project_dir.join(".npm-cache");
+    std::fs::create_dir_all(&cache_dir)
+        .map_err(|e| format!("create site npm cache failed: {e}"))?;
+    command
+        .current_dir(project_dir)
+        .env("npm_config_cache", &cache_dir)
+        .env("NPM_CONFIG_CACHE", &cache_dir)
+        .env("ASTRO_TELEMETRY_DISABLED", "1")
+        .env("NO_UPDATE_NOTIFIER", "1");
+    Ok(())
+}
+
 fn ensure_site_build_output(
     project_dir: &std::path::Path,
     metadata: &SiteProjectMetadata,
@@ -1630,11 +1646,13 @@ fn ensure_site_build_output(
         "astro-site" | "nextjs-app" | "react-vite" => {
             if !project_dir.join("node_modules").exists() {
                 let mut install = std::process::Command::new("npm");
-                install.current_dir(project_dir).arg("install");
+                configure_site_node_command(&mut install, project_dir)?;
+                install.arg("install");
                 run_build_command(&mut install, "npm install")?;
             }
             let mut build = std::process::Command::new("npm");
-            build.current_dir(project_dir).arg("run").arg("build");
+            configure_site_node_command(&mut build, project_dir)?;
+            build.arg("run").arg("build");
             run_build_command(&mut build, "npm run build")?;
         }
         other => return Err(format!("unsupported site template: {other}")),

--- a/crates/octos-cli/src/commands/gateway/adapters/api.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/api.rs
@@ -5,13 +5,14 @@ use octos_bus::{ChannelManager, SessionManager};
 use tokio::sync::Mutex;
 
 use crate::config::ChannelEntry;
+use super::MetricsHandle;
 
 pub fn register(
     channel_mgr: &mut ChannelManager,
     entry: &ChannelEntry,
     shutdown: &Arc<AtomicBool>,
     session_mgr: &Arc<Mutex<SessionManager>>,
-    metrics_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
+    metrics_handle: Option<MetricsHandle>,
     task_query: Option<Arc<dyn Fn(&str) -> serde_json::Value + Send + Sync>>,
     gateway_profile_id: Option<&str>,
     api_port_override: Option<u16>,

--- a/crates/octos-cli/src/commands/gateway/adapters/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/mod.rs
@@ -14,6 +14,11 @@ use tokio::sync::Mutex;
 use crate::config::ChannelEntry;
 
 #[cfg(feature = "api")]
+pub(crate) type MetricsHandle = metrics_exporter_prometheus::PrometheusHandle;
+#[cfg(not(feature = "api"))]
+pub(crate) type MetricsHandle = ();
+
+#[cfg(feature = "api")]
 mod api;
 mod cli;
 #[cfg(feature = "discord")]
@@ -66,7 +71,7 @@ pub struct ChannelRegistrationCtx<'a> {
     pub media_dir: &'a Path,
     pub data_dir: &'a Path,
     pub session_mgr: &'a Arc<Mutex<SessionManager>>,
-    pub metrics_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
+    pub metrics_handle: Option<MetricsHandle>,
     pub task_query: Option<Arc<dyn Fn(&str) -> serde_json::Value + Send + Sync>>,
     pub gateway_profile_id: Option<&'a str>,
     pub api_port_override: Option<u16>,

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -117,7 +117,10 @@ impl GatewayRuntime {
             None => std::env::current_dir().wrap_err("failed to get current directory")?,
         };
         let data_dir = resolve_data_dir(cmd.data_dir.clone())?;
+        #[cfg(feature = "api")]
         let metrics_handle = Some(crate::api::init_metrics());
+        #[cfg(not(feature = "api"))]
+        let metrics_handle = None;
 
         let mut profile_id: Option<String> = None;
         eprintln!(

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -152,6 +152,7 @@ RULES:
 - BEFORE calling mofa_slides: run shell("node --check slides/{slug}/script.js") to validate syntax. Fix any errors before proceeding.
 - ALWAYS use input parameter: mofa_slides(input="slides/{slug}/script.js", out="slides/{slug}/output/deck.pptx", slide_dir="slides/{slug}/output/imgs")
 - NEVER pass slides array inline. ALWAYS use the input file.
+- After mofa_slides succeeds, DO NOT call send_file for the PPTX. The runtime auto-delivers the final deck artifact.
 - On failure: report error, do NOT retry via shell.
 - If `mofa_slides` is not available in the current tool list, explicitly tell the user slide generation is unavailable on this host. Do NOT retry via shell, run_pipeline, or alternative binaries.
 - Read slides/{slug}/memory.md before each response for context.
@@ -224,7 +225,7 @@ When user asks about progress ("做完了吗", "done?", "status"):
   count generated slides from the contract's preview artifact matches
 Report: X previews present, PPTX ready/not ready, generation running/verifying/delivering/completed/failed based on supervisor state, and list any failed contract checks or missing artifacts.
 
-Tools: mofa_slides, read_file, write_file, edit_file, shell, glob, send_file, check_background_tasks, check_workspace_contract
+Tools: mofa_slides, read_file, write_file, edit_file, shell, glob, check_background_tasks, check_workspace_contract
 "#
     )
 }
@@ -536,8 +537,9 @@ BUILD RULES:
 - Workspace policy lives at sites/{site_slug}/.octos-workspace.toml.
 - If template is quarto-lesson, run shell(\"quarto render\") from sites/{site_slug}/ when Quarto is available
 - If template is astro-site, nextjs-app, or react-vite:
+  - project-local npm cache is preconfigured in sites/{site_slug}/.npmrc
   - run shell(\"test -d node_modules || npm install\") from sites/{site_slug}/
-  - then run shell(\"npm run build\") from sites/{site_slug}/
+  - then run shell(\"ASTRO_TELEMETRY_DISABLED=1 npm run build\") from sites/{site_slug}/
 - Never write outside the project dir
 - Treat sites/{site_slug}/{session_file} as the source of truth for template, preview path, and build output
 
@@ -729,6 +731,14 @@ fn write_site_support_files(
 
     std::fs::write(project_dir.join("changelog.md"), "# Changelog\n\n")
         .map_err(|e| format!("write changelog.md failed: {e}"))?;
+
+    std::fs::create_dir_all(project_dir.join(".npm-cache"))
+        .map_err(|e| format!("create .npm-cache dir failed: {e}"))?;
+    std::fs::write(
+        project_dir.join(".npmrc"),
+        "cache=.npm-cache\nfund=false\nupdate-notifier=false\n",
+    )
+    .map_err(|e| format!("write .npmrc failed: {e}"))?;
 
     Ok(())
 }
@@ -960,10 +970,12 @@ mod tests {
         assert!(prompt.contains("workspace state tells you what is true about the deliverable"));
         assert!(prompt.contains("If `mofa_slides` is not available"));
         assert!(prompt.contains("Runtime owns workspace contract enforcement"));
+        assert!(prompt.contains("DO NOT call send_file for the PPTX"));
         assert!(prompt.contains("PROMPT-OWNED GUIDANCE"));
         assert!(!prompt.contains("glob(\"slides/{slug}/output/*.pptx\")"));
         assert!(!prompt.contains("On every meaningful edit: increment NNN"));
         assert!(!prompt.contains("ps aux | grep mofa_slides | grep -v grep"));
+        assert!(!prompt.contains("Tools: mofa_slides, read_file, write_file, edit_file, shell, glob, send_file"));
     }
 
     #[test]
@@ -1016,6 +1028,23 @@ mod tests {
         assert!(prompt.contains("website builder"));
         assert!(prompt.contains("sites/vision-forum/mofa-site-session.json"));
         assert!(prompt.contains("/api/preview/<profile-id>/<session-id>/vision-forum/"));
+        assert!(prompt.contains(".npmrc"));
+        assert!(prompt.contains("ASTRO_TELEMETRY_DISABLED=1 npm run build"));
+    }
+
+    #[test]
+    fn should_write_site_local_npmrc() {
+        let tmp = tempfile::tempdir().unwrap();
+        let metadata = build_site_project_metadata("dspfac", "site-session-123", "site astro", tmp.path())
+            .expect("site metadata");
+        let project_dir = tmp.path().join(&metadata.project_dir);
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        write_site_support_files(&project_dir, &metadata).expect("write site support files");
+
+        let npmrc = std::fs::read_to_string(project_dir.join(".npmrc")).unwrap();
+        assert!(npmrc.contains("cache=.npm-cache"));
+        assert!(project_dir.join(".npm-cache").is_dir());
     }
 
     #[test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -636,6 +636,33 @@ fn system_notice_metadata(sender_user_id: Option<&str>) -> serde_json::Value {
         .unwrap_or_else(|| serde_json::json!({}))
 }
 
+fn stamp_outbound_topic_and_sender(
+    msg: &mut OutboundMessage,
+    topic: Option<&str>,
+    sender_user_id: Option<&str>,
+) {
+    if !msg.metadata.is_object() {
+        msg.metadata = serde_json::json!({});
+    }
+    let metadata = msg
+        .metadata
+        .as_object_mut()
+        .expect("outbound metadata should be normalized to an object");
+
+    if let Some(uid) = sender_user_id {
+        metadata.insert(
+            METADATA_SENDER_USER_ID.to_string(),
+            serde_json::Value::String(uid.to_string()),
+        );
+    }
+
+    if let Some(topic) = topic.filter(|value| !value.is_empty()) {
+        metadata
+            .entry("topic".to_string())
+            .or_insert_with(|| serde_json::Value::String(topic.to_string()));
+    }
+}
+
 async fn dispatch_background_result_to_actor(
     tx: mpsc::Sender<ActorMessage>,
     payload: BackgroundResultPayload,
@@ -846,6 +873,49 @@ async fn snapshot_workspace_turn_for_path(
             ))
         }
     }
+}
+
+fn topic_prefers_structured_deliverables(topic: Option<&str>) -> bool {
+    matches!(
+        topic
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.split_whitespace().next().unwrap_or_default()),
+        Some("slides" | "site")
+    )
+}
+
+fn is_richer_deliverable(path: &std::path::Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase())
+            .as_deref(),
+        Some(
+            "pptx"
+                | "ppt"
+                | "pdf"
+                | "html"
+                | "htm"
+                | "xhtml"
+                | "mp3"
+                | "wav"
+                | "m4a"
+                | "aac"
+                | "flac"
+                | "ogg"
+        )
+    )
+}
+
+fn should_auto_deliver_report_file(topic: Option<&str>, files_modified: &[PathBuf], file: &Path) -> bool {
+    if file.extension().and_then(|e| e.to_str()) != Some("md") {
+        return false;
+    }
+    if topic_prefers_structured_deliverables(topic) {
+        return false;
+    }
+    !files_modified.iter().any(|candidate| is_richer_deliverable(candidate))
 }
 
 async fn emit_workspace_snapshot_notice(
@@ -1748,16 +1818,9 @@ async fn outbound_forwarder(params: ForwarderParams) {
     let key_str = session_key.to_string();
 
     while let Some(mut msg) = proxy_rx.recv().await {
-        // Inject sender_user_id into outbound metadata so the channel
-        // sends as the correct virtual user (appservice identity assertion).
-        if let Some(ref uid) = sender_user_id {
-            if let Some(obj) = msg.metadata.as_object_mut() {
-                obj.insert(
-                    METADATA_SENDER_USER_ID.to_string(),
-                    serde_json::Value::String(uid.clone()),
-                );
-            }
-        }
+        // Preserve sender identity and topic on all actor-originated outbound
+        // messages so topic-scoped file deliveries persist to the right history.
+        stamp_outbound_topic_and_sender(&mut msg, Some(&my_topic), sender_user_id.as_deref());
         let active_topic = active_sessions
             .read()
             .await
@@ -3564,7 +3627,11 @@ impl SessionActor {
                     );
                 }
                 for file in &conv_response.files_modified {
-                    if file.extension().and_then(|e| e.to_str()) == Some("md") {
+                    if should_auto_deliver_report_file(
+                        self.session_key.topic(),
+                        &conv_response.files_modified,
+                        file,
+                    ) {
                         // Resolve relative paths to absolute so the file URL works
                         let abs_file = if file.is_relative() {
                             std::fs::canonicalize(file)
@@ -6351,6 +6418,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_stamp_outbound_topic_and_sender_preserves_topic_scoped_delivery_metadata() {
+        let mut msg = OutboundMessage {
+            channel: "api".to_string(),
+            chat_id: "web-session".to_string(),
+            content: String::new(),
+            reply_to: None,
+            media: vec!["/tmp/deck.pptx".to_string()],
+            metadata: serde_json::json!({
+                "tool_call_id": "call_slides_1"
+            }),
+        };
+
+        stamp_outbound_topic_and_sender(
+            &mut msg,
+            Some("slides browser-deck-abc123"),
+            Some("@octos_weather:localhost"),
+        );
+
+        assert_eq!(
+            msg.metadata.get("topic").and_then(|value| value.as_str()),
+            Some("slides browser-deck-abc123")
+        );
+        assert_eq!(
+            msg.metadata
+                .get(METADATA_SENDER_USER_ID)
+                .and_then(|value| value.as_str()),
+            Some("@octos_weather:localhost")
+        );
+        assert_eq!(
+            msg.metadata
+                .get("tool_call_id")
+                .and_then(|value| value.as_str()),
+            Some("call_slides_1")
+        );
+    }
+
     #[tokio::test]
     async fn test_profile_session_keys_are_persisted_separately() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -6611,5 +6715,41 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn auto_deliver_report_file_allows_markdown_only_sessions() {
+        let files = vec![PathBuf::from("/tmp/report.md")];
+        assert!(should_auto_deliver_report_file(
+            None,
+            &files,
+            Path::new("/tmp/report.md")
+        ));
+    }
+
+    #[test]
+    fn auto_deliver_report_file_skips_slides_topics() {
+        let files = vec![
+            PathBuf::from("/tmp/slides/demo/memory.md"),
+            PathBuf::from("/tmp/slides/demo/output/deck.pptx"),
+        ];
+        assert!(!should_auto_deliver_report_file(
+            Some("slides demo"),
+            &files,
+            Path::new("/tmp/slides/demo/memory.md")
+        ));
+    }
+
+    #[test]
+    fn auto_deliver_report_file_skips_when_richer_deliverable_exists() {
+        let files = vec![
+            PathBuf::from("/tmp/report.md"),
+            PathBuf::from("/tmp/output/index.html"),
+        ];
+        assert!(!should_auto_deliver_report_file(
+            Some("research demo"),
+            &files,
+            Path::new("/tmp/report.md")
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- persist topic-scoped file/session events into the correct per-topic history
- prevent markdown fallback auto-delivery from overriding richer site/slides artifacts
- tighten site/scaffold runtime handling and slides prompt guidance for auto-delivered decks

## Validation
- rebuilt and deployed the patched backend binary to mini1/mini2/mini3
- live slides/site browser suite passed on canary after deploy