### PR TITLE
Stabilize live slides and site acceptance

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:live:smoke": "npx playwright test tests/live-browser.spec.ts",
+    "test:live:background": "npx playwright test tests/background-research-chat.spec.ts",
     "test:live:slides-site": "npx playwright test tests/live-slides-site.spec.ts",
     "test:live:capabilities": "npx playwright test tests/refactor-capabilities.spec.ts",
     "test:live:recovery": "npx playwright test tests/session-recovery.spec.ts",

--- a/e2e/tests/background-research-chat.spec.ts
+++ b/e2e/tests/background-research-chat.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  createNewSession,
+  getAssistantMessageText,
+  login,
+  sendAndWait,
+} from './live-browser-helpers';
+
+const BASE = process.env.OCTOS_TEST_URL || 'https://dspfac.crew.ominix.io';
+const TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
+const PROFILE = process.env.OCTOS_PROFILE || 'dspfac';
+
+test.setTimeout(600_000);
+
+function parseSessionAddress(value: string | null): { sessionId: string; topic?: string } {
+  const raw = value || '';
+  const separator = raw.indexOf('#');
+  if (separator === -1) return { sessionId: raw };
+  const sessionId = raw.slice(0, separator);
+  const topic = raw.slice(separator + 1).trim() || undefined;
+  return { sessionId, topic };
+}
+
+async function currentSession(page: Page) {
+  const stored = await page.evaluate(() => localStorage.getItem('octos_current_session'));
+  return parseSessionAddress(stored);
+}
+
+async function fetchSessionStatus(sessionId: string, topic?: string) {
+  const params = new URLSearchParams();
+  if (topic?.trim()) params.set('topic', topic.trim());
+  const suffix = params.toString() ? `?${params.toString()}` : '';
+  const resp = await fetch(
+    `${BASE}/api/sessions/${encodeURIComponent(sessionId)}/status${suffix}`,
+    {
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'X-Profile-Id': PROFILE,
+      },
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`status fetch failed: ${resp.status}`);
+  }
+  return resp.json() as Promise<{
+    active: boolean;
+    has_deferred_files: boolean;
+    has_bg_tasks: boolean;
+  }>;
+}
+
+async function waitForBackgroundWork(sessionId: string, topic?: string, timeoutMs = 120_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = { active: false, has_deferred_files: false, has_bg_tasks: false };
+  while (Date.now() < deadline) {
+    last = await fetchSessionStatus(sessionId, topic);
+    if (last.has_bg_tasks) return last;
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  }
+  throw new Error(
+    `background work never appeared for ${sessionId}${topic ? `#${topic}` : ''}: ${JSON.stringify(last)}`,
+  );
+}
+
+test.describe('Background research while normal chatting', () => {
+  test('normal chat stays usable while deep research runs in background', async ({ page }) => {
+    await login(page);
+    await createNewSession(page);
+
+    const researchPrompt =
+      "Do a deep research on the latest Rust programming language developments in 2026. Run the pipeline directly, don't ask me to choose.";
+
+    const researchStart = await sendAndWait(page, researchPrompt, {
+      label: 'bg-research-start',
+      maxWait: 120_000,
+      throwOnTimeout: false,
+    });
+
+    expect(researchStart.responseLen).toBeGreaterThan(0);
+
+    const { sessionId, topic } = await currentSession(page);
+    expect(sessionId).toMatch(/^web-/);
+
+    const beforeChatStatus = await waitForBackgroundWork(sessionId, topic, 120_000);
+    expect(beforeChatStatus.has_bg_tasks).toBe(true);
+
+    const marker = `BG_CHAT_OK_${Date.now().toString(36)}`;
+    const normalChat = await sendAndWait(
+      page,
+      `Reply with exactly ${marker}. Do not mention the research task.`,
+      {
+        label: 'bg-normal-chat',
+        maxWait: 90_000,
+      },
+    );
+
+    expect(normalChat.responseText).toContain(marker);
+
+    const assistantText = await getAssistantMessageText(page);
+    expect(assistantText).toContain(marker);
+  });
+});

--- a/e2e/tests/live-slides-site.spec.ts
+++ b/e2e/tests/live-slides-site.spec.ts
@@ -26,8 +26,22 @@ test.setTimeout(600_000);
 async function collectPreviewUrls(page: Page): Promise<string[]> {
   const text = await getAssistantMessageText(page);
   const matches =
-    text.match(/\/api\/preview\/[^\s"'<>]+\/signal-atlas\/index\.html/gi) || [];
-  return Array.from(new Set(matches.filter((value) => value.trim().length > 0)));
+    text.match(/\/api\/preview\/[^\s"'<>]+\/signal-atlas(?:\/index\.html|\/)?/gi) || [];
+  return Array.from(
+    new Set(
+      matches
+        .map((value) => normalizePreviewUrl(value))
+        .filter((value) => value.trim().length > 0),
+    ),
+  );
+}
+
+function normalizePreviewUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+  if (trimmed.endsWith('/index.html')) return trimmed;
+  if (trimmed.endsWith('/')) return `${trimmed}index.html`;
+  return trimmed;
 }
 
 async function waitForPreviewBody(
@@ -111,21 +125,29 @@ test.describe('Live deliverable flows', () => {
   test('site flow renders a built preview page and survives reload', async ({
     page,
   }) => {
+    const siteMarker = `browser-site-${Date.now().toString(36)}`;
+
     await sendAndWait(page, '/new site astro', {
       label: 'site-init',
       maxWait: 90_000,
     });
 
     const creationText = await getAssistantMessageText(page);
-    const previewUrls =
-      creationText.match(/\/api\/preview\/[^\s"'<>]+\/signal-atlas\/index\.html/gi) || [];
+    const previewUrls = Array.from(
+      new Set(
+        (
+          creationText.match(/\/api\/preview\/[^\s"'<>]+\/signal-atlas(?:\/index\.html|\/)?/gi) ||
+          []
+        ).map((value) => normalizePreviewUrl(value)),
+      ),
+    );
     expect(previewUrls).toHaveLength(1);
 
     const previewUrl = previewUrls[0];
 
     await sendAndWait(
       page,
-      'Update the homepage so the visible title says "Browser Site Acceptance" and the page clearly includes a "Live preview" section. Rebuild the site so the preview reflects it.',
+      `Update the homepage so the visible title says "Browser Site Acceptance ${siteMarker}" and the page clearly includes a "Live preview ${siteMarker}" section. Rebuild the site so the preview reflects it.`,
       {
         label: 'site-build',
         maxWait: 240_000,
@@ -137,18 +159,18 @@ test.describe('Live deliverable flows', () => {
       const body = await waitForPreviewBody(
         previewPage,
         previewUrl,
-        'Browser Site Acceptance',
+        `Browser Site Acceptance ${siteMarker}`,
         240_000,
       );
 
-      expect(body).toContain('Browser Site Acceptance');
-      expect(body).toContain('Live preview');
+      expect(body).toContain(`Browser Site Acceptance ${siteMarker}`);
+      expect(body).toContain(`Live preview ${siteMarker}`);
 
       await previewPage.reload({ waitUntil: 'networkidle' });
       const reloadedBody =
         (await previewPage.locator('body').innerText().catch(() => '')) || '';
-      expect(reloadedBody).toContain('Browser Site Acceptance');
-      expect(reloadedBody).toContain('Live preview');
+      expect(reloadedBody).toContain(`Browser Site Acceptance ${siteMarker}`);
+      expect(reloadedBody).toContain(`Live preview ${siteMarker}`);
     } finally {
       await previewPage.close();
     }


### PR DESCRIPTION
## Summary
- tighten live slides/site browser acceptance assertions
- normalize equivalent preview URL shapes for site reload validation

## Validation
- `npx playwright test tests/live-slides-site.spec.ts`
- passed live on canary