### PR TITLE
Add manifest-id lookup for first-party workflows

### DIFF
--- a/crates/octos-agent/src/first_party_harness.rs
+++ b/crates/octos-agent/src/first_party_harness.rs
@@ -20,7 +20,32 @@ pub struct FirstPartyHarnessManifest {
     pub artifacts: WorkspaceArtifactsPolicy,
     #[serde(default)]
     pub spawn_tasks: BTreeMap<String, WorkspaceSpawnTaskPolicy>,
+    pub workflow: FirstPartyWorkflowDeclaration,
     pub terminal_output: FirstPartyTerminalOutput,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FirstPartyWorkflowDeclaration {
+    pub label: String,
+    pub ack_message: String,
+    pub initial_phase: String,
+    pub allowed_tools: Vec<String>,
+    pub limits: FirstPartyWorkflowLimits,
+    pub additional_instructions: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FirstPartyWorkflowLimits {
+    #[serde(default)]
+    pub max_search_passes: Option<u32>,
+    #[serde(default)]
+    pub max_pipeline_runs: Option<u32>,
+    #[serde(default)]
+    pub max_dialogue_lines: Option<u32>,
+    #[serde(default)]
+    pub target_audio_minutes: Option<u32>,
+    #[serde(default)]
+    pub max_generate_calls: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -68,6 +93,29 @@ impl FirstPartyHarnessManifest {
                 ]),
             },
             spawn_tasks: BTreeMap::new(),
+            workflow: FirstPartyWorkflowDeclaration {
+                label: "Slides deliverable".into(),
+                ack_message: "Slides generation has started in the background. Only the final deck will be delivered once the workspace contract is satisfied.".into(),
+                initial_phase: "design".into(),
+                allowed_tools: vec![
+                    "mofa_slides".into(),
+                    "read_file".into(),
+                    "write_file".into(),
+                    "edit_file".into(),
+                    "shell".into(),
+                    "glob".into(),
+                    "check_background_tasks".into(),
+                    "check_workspace_contract".into(),
+                ],
+                limits: FirstPartyWorkflowLimits {
+                    max_search_passes: None,
+                    max_pipeline_runs: None,
+                    max_dialogue_lines: Some(24),
+                    target_audio_minutes: None,
+                    max_generate_calls: Some(1),
+                },
+                additional_instructions: "You are a background slides producer. Follow the runtime-owned phases in order: design, generate_deck, deliver_result. Write the slide script first, validate it before generation, call mofa_slides once, and deliver only the final deck artifact. Do not send intermediate previews, scratch PNGs, or alternate deck exports.".into(),
+            },
             terminal_output: FirstPartyTerminalOutput {
                 deliver_final_artifact_only: true,
                 deliver_media_only: false,
@@ -101,6 +149,28 @@ impl FirstPartyHarnessManifest {
             validation: ValidationPolicy::default(),
             artifacts: WorkspaceArtifactsPolicy::default(),
             spawn_tasks: BTreeMap::new(),
+            workflow: FirstPartyWorkflowDeclaration {
+                label: "Site deliverable".into(),
+                ack_message: "Site generation has started in the background. Only the final verified site entrypoint will be delivered once the workspace contract is satisfied.".into(),
+                initial_phase: "scaffold".into(),
+                allowed_tools: vec![
+                    "read_file".into(),
+                    "write_file".into(),
+                    "edit_file".into(),
+                    "shell".into(),
+                    "glob".into(),
+                    "check_background_tasks".into(),
+                    "check_workspace_contract".into(),
+                ],
+                limits: FirstPartyWorkflowLimits {
+                    max_search_passes: None,
+                    max_pipeline_runs: None,
+                    max_dialogue_lines: Some(24),
+                    target_audio_minutes: None,
+                    max_generate_calls: Some(1),
+                },
+                additional_instructions: "You are a background site builder. Follow the runtime-owned phases in order: scaffold, build, deliver_result. Read the session metadata to discover the selected template and build output directory, keep edits inside the project root, and deliver only the final built site entrypoint. Do not send intermediate logs, scratch files, or alternate build artifacts.".into(),
+            },
             terminal_output: FirstPartyTerminalOutput {
                 deliver_final_artifact_only: true,
                 deliver_media_only: false,
@@ -166,6 +236,17 @@ mod tests {
             manifest.terminal_output.required_artifact_kind,
             "presentation"
         );
+        assert_eq!(manifest.workflow.label, "Slides deliverable");
+        assert_eq!(manifest.workflow.initial_phase, "design");
+        assert_eq!(manifest.workflow.limits.max_dialogue_lines, Some(24));
+        assert_eq!(manifest.workflow.limits.max_generate_calls, Some(1));
+        assert!(
+            manifest
+                .workflow
+                .allowed_tools
+                .iter()
+                .any(|tool| tool == "mofa_slides")
+        );
         assert!(manifest.terminal_output.deliver_final_artifact_only);
         assert_eq!(
             manifest.artifacts.entries.get("deck").map(String::as_str),
@@ -192,6 +273,9 @@ mod tests {
         assert_eq!(manifest.id, "first_party.sites.out");
         assert_eq!(manifest.workspace.kind, WorkspacePolicyKind::Sites);
         assert_eq!(manifest.terminal_output.required_artifact_kind, "site");
+        assert_eq!(manifest.workflow.label, "Site deliverable");
+        assert_eq!(manifest.workflow.initial_phase, "scaffold");
+        assert_eq!(manifest.workflow.limits.max_dialogue_lines, Some(24));
         assert_eq!(
             manifest.validation.on_completion,
             vec!["file_exists:out/index.html"]

--- a/crates/octos-agent/src/first_party_harness.rs
+++ b/crates/octos-agent/src/first_party_harness.rs
@@ -10,6 +10,52 @@ use crate::workspace_policy::{
 const SLIDES_MANIFEST_TOML: &str = include_str!("first_party_harness/slides.toml");
 const SITES_MANIFEST_TOML: &str = include_str!("first_party_harness/sites.toml");
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FirstPartyHarnessName {
+    Slides,
+    Sites,
+}
+
+impl FirstPartyHarnessName {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Slides => "slides",
+            Self::Sites => "sites",
+        }
+    }
+
+    pub fn manifest(self) -> FirstPartyHarnessManifest {
+        first_party_harness_entry(self).load()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FirstPartyHarnessRegistryEntry {
+    pub name: FirstPartyHarnessName,
+    pub manifest_id: &'static str,
+    pub manifest_asset: &'static str,
+}
+
+impl FirstPartyHarnessRegistryEntry {
+    pub fn load(self) -> FirstPartyHarnessManifest {
+        bundled_manifest(self.manifest_asset, manifest_source(self.name))
+    }
+}
+
+const FIRST_PARTY_HARNESS_REGISTRY: [FirstPartyHarnessRegistryEntry; 2] = [
+    FirstPartyHarnessRegistryEntry {
+        name: FirstPartyHarnessName::Slides,
+        manifest_id: "first_party.slides",
+        manifest_asset: "slides.toml",
+    },
+    FirstPartyHarnessRegistryEntry {
+        name: FirstPartyHarnessName::Sites,
+        manifest_id: "first_party.sites",
+        manifest_asset: "sites.toml",
+    },
+];
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FirstPartyHarnessManifest {
     pub id: String,
@@ -60,11 +106,11 @@ pub struct FirstPartyTerminalOutput {
 
 impl FirstPartyHarnessManifest {
     pub fn slides() -> Self {
-        bundled_manifest("slides.toml", SLIDES_MANIFEST_TOML)
+        FirstPartyHarnessName::Slides.manifest()
     }
 
     pub fn sites() -> Self {
-        bundled_manifest("sites.toml", SITES_MANIFEST_TOML)
+        FirstPartyHarnessName::Sites.manifest()
     }
 
     pub fn site_with_build_output(build_output_dir: &str) -> Self {
@@ -100,6 +146,38 @@ impl FirstPartyHarnessManifest {
     }
 }
 
+pub fn first_party_harness_registry() -> &'static [FirstPartyHarnessRegistryEntry] {
+    &FIRST_PARTY_HARNESS_REGISTRY
+}
+
+pub fn first_party_harness_entry(
+    name: FirstPartyHarnessName,
+) -> &'static FirstPartyHarnessRegistryEntry {
+    first_party_harness_registry()
+        .iter()
+        .find(|entry| entry.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "missing first-party harness registry entry for {}",
+                name.as_str()
+            )
+        })
+}
+
+pub fn resolve_first_party_harness_by_id(id: &str) -> Option<FirstPartyHarnessManifest> {
+    first_party_harness_registry()
+        .iter()
+        .find(|entry| entry.manifest_id == id)
+        .map(|entry| entry.load())
+}
+
+fn manifest_source(name: FirstPartyHarnessName) -> &'static str {
+    match name {
+        FirstPartyHarnessName::Slides => SLIDES_MANIFEST_TOML,
+        FirstPartyHarnessName::Sites => SITES_MANIFEST_TOML,
+    }
+}
+
 fn bundled_manifest(name: &str, source: &str) -> FirstPartyHarnessManifest {
     toml::from_str(source).unwrap_or_else(|error| {
         panic!("bundled first-party harness manifest {name} should parse: {error}")
@@ -112,8 +190,28 @@ mod tests {
     use crate::WorkspacePolicyKind;
 
     #[test]
+    fn registry_lists_bundled_first_party_manifests() {
+        let registry = first_party_harness_registry();
+
+        assert_eq!(registry.len(), 2);
+        assert_eq!(registry[0].name, FirstPartyHarnessName::Slides);
+        assert_eq!(registry[0].manifest_id, "first_party.slides");
+        assert_eq!(registry[1].name, FirstPartyHarnessName::Sites);
+        assert_eq!(registry[1].manifest_id, "first_party.sites");
+    }
+
+    #[test]
+    fn registry_resolves_manifest_by_id() {
+        let manifest = resolve_first_party_harness_by_id("first_party.slides")
+            .expect("slides manifest should resolve");
+
+        assert_eq!(manifest.id, "first_party.slides");
+        assert_eq!(manifest.workflow.label, "Slides deliverable");
+    }
+
+    #[test]
     fn slides_manifest_declares_expected_contract() {
-        let manifest = FirstPartyHarnessManifest::slides();
+        let manifest = FirstPartyHarnessName::Slides.manifest();
 
         assert_eq!(manifest.id, "first_party.slides");
         assert_eq!(manifest.workspace.kind, WorkspacePolicyKind::Slides);
@@ -177,7 +275,7 @@ mod tests {
 
     #[test]
     fn sites_manifest_bundles_only_generic_contract() {
-        let manifest = FirstPartyHarnessManifest::sites();
+        let manifest = FirstPartyHarnessName::Sites.manifest();
 
         assert_eq!(manifest.id, "first_party.sites");
         assert!(manifest.validation.on_turn_end.is_empty());

--- a/crates/octos-agent/src/first_party_harness.rs
+++ b/crates/octos-agent/src/first_party_harness.rs
@@ -3,10 +3,12 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::workspace_policy::{
-    ValidationPolicy, WorkspaceArtifactsPolicy, WorkspacePolicy, WorkspacePolicyKind,
-    WorkspacePolicyWorkspace, WorkspaceSnapshotTrigger, WorkspaceSpawnTaskPolicy,
-    WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy, WorkspaceVersionControlProvider,
+    ValidationPolicy, WorkspaceArtifactsPolicy, WorkspacePolicy, WorkspacePolicyWorkspace,
+    WorkspaceSpawnTaskPolicy, WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy,
 };
+
+const SLIDES_MANIFEST_TOML: &str = include_str!("first_party_harness/slides.toml");
+const SITES_MANIFEST_TOML: &str = include_str!("first_party_harness/sites.toml");
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FirstPartyHarnessManifest {
@@ -58,126 +60,11 @@ pub struct FirstPartyTerminalOutput {
 
 impl FirstPartyHarnessManifest {
     pub fn slides() -> Self {
-        Self {
-            id: "first_party.slides".into(),
-            workspace: WorkspacePolicyWorkspace {
-                kind: WorkspacePolicyKind::Slides,
-            },
-            version_control: git_turn_end_version_control(true),
-            tracking: WorkspaceTrackingPolicy {
-                ignore: vec![
-                    "history/**".into(),
-                    "output/**".into(),
-                    "skill-output/**".into(),
-                    "*.pptx".into(),
-                    "*.tmp".into(),
-                    ".DS_Store".into(),
-                ],
-            },
-            validation: ValidationPolicy {
-                on_turn_end: vec![
-                    "file_exists:script.js".into(),
-                    "file_exists:memory.md".into(),
-                    "file_exists:changelog.md".into(),
-                ],
-                on_source_change: Vec::new(),
-                on_completion: vec![
-                    "file_exists:output/*.pptx".into(),
-                    "file_exists:output/**/slide-*.png".into(),
-                ],
-            },
-            artifacts: WorkspaceArtifactsPolicy {
-                entries: BTreeMap::from([
-                    ("deck".into(), "output/*.pptx".into()),
-                    ("previews".into(), "output/**/slide-*.png".into()),
-                ]),
-            },
-            spawn_tasks: BTreeMap::new(),
-            workflow: FirstPartyWorkflowDeclaration {
-                label: "Slides deliverable".into(),
-                ack_message: "Slides generation has started in the background. Only the final deck will be delivered once the workspace contract is satisfied.".into(),
-                initial_phase: "design".into(),
-                allowed_tools: vec![
-                    "mofa_slides".into(),
-                    "read_file".into(),
-                    "write_file".into(),
-                    "edit_file".into(),
-                    "shell".into(),
-                    "glob".into(),
-                    "check_background_tasks".into(),
-                    "check_workspace_contract".into(),
-                ],
-                limits: FirstPartyWorkflowLimits {
-                    max_search_passes: None,
-                    max_pipeline_runs: None,
-                    max_dialogue_lines: Some(24),
-                    target_audio_minutes: None,
-                    max_generate_calls: Some(1),
-                },
-                additional_instructions: "You are a background slides producer. Follow the runtime-owned phases in order: design, generate_deck, deliver_result. Write the slide script first, validate it before generation, call mofa_slides once, and deliver only the final deck artifact. Do not send intermediate previews, scratch PNGs, or alternate deck exports.".into(),
-            },
-            terminal_output: FirstPartyTerminalOutput {
-                deliver_final_artifact_only: true,
-                deliver_media_only: false,
-                forbid_intermediate_files: true,
-                required_artifact_kind: "presentation".into(),
-            },
-        }
+        bundled_manifest("slides.toml", SLIDES_MANIFEST_TOML)
     }
 
     pub fn sites() -> Self {
-        Self {
-            id: "first_party.sites".into(),
-            workspace: WorkspacePolicyWorkspace {
-                kind: WorkspacePolicyKind::Sites,
-            },
-            version_control: git_turn_end_version_control(true),
-            tracking: WorkspaceTrackingPolicy {
-                ignore: vec![
-                    "node_modules/**".into(),
-                    "dist/**".into(),
-                    "out/**".into(),
-                    "docs/**".into(),
-                    "build/**".into(),
-                    ".astro/**".into(),
-                    ".next/**".into(),
-                    ".quarto/**".into(),
-                    "*.log".into(),
-                    ".DS_Store".into(),
-                ],
-            },
-            validation: ValidationPolicy::default(),
-            artifacts: WorkspaceArtifactsPolicy::default(),
-            spawn_tasks: BTreeMap::new(),
-            workflow: FirstPartyWorkflowDeclaration {
-                label: "Site deliverable".into(),
-                ack_message: "Site generation has started in the background. Only the final verified site entrypoint will be delivered once the workspace contract is satisfied.".into(),
-                initial_phase: "scaffold".into(),
-                allowed_tools: vec![
-                    "read_file".into(),
-                    "write_file".into(),
-                    "edit_file".into(),
-                    "shell".into(),
-                    "glob".into(),
-                    "check_background_tasks".into(),
-                    "check_workspace_contract".into(),
-                ],
-                limits: FirstPartyWorkflowLimits {
-                    max_search_passes: None,
-                    max_pipeline_runs: None,
-                    max_dialogue_lines: Some(24),
-                    target_audio_minutes: None,
-                    max_generate_calls: Some(1),
-                },
-                additional_instructions: "You are a background site builder. Follow the runtime-owned phases in order: scaffold, build, deliver_result. Read the session metadata to discover the selected template and build output directory, keep edits inside the project root, and deliver only the final built site entrypoint. Do not send intermediate logs, scratch files, or alternate build artifacts.".into(),
-            },
-            terminal_output: FirstPartyTerminalOutput {
-                deliver_final_artifact_only: true,
-                deliver_media_only: false,
-                forbid_intermediate_files: true,
-                required_artifact_kind: "site".into(),
-            },
-        }
+        bundled_manifest("sites.toml", SITES_MANIFEST_TOML)
     }
 
     pub fn site_with_build_output(build_output_dir: &str) -> Self {
@@ -213,18 +100,16 @@ impl FirstPartyHarnessManifest {
     }
 }
 
-fn git_turn_end_version_control(fail_on_error: bool) -> WorkspaceVersionControlPolicy {
-    WorkspaceVersionControlPolicy {
-        provider: WorkspaceVersionControlProvider::Git,
-        auto_init: true,
-        trigger: WorkspaceSnapshotTrigger::TurnEnd,
-        fail_on_error,
-    }
+fn bundled_manifest(name: &str, source: &str) -> FirstPartyHarnessManifest {
+    toml::from_str(source).unwrap_or_else(|error| {
+        panic!("bundled first-party harness manifest {name} should parse: {error}")
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::WorkspacePolicyKind;
 
     #[test]
     fn slides_manifest_declares_expected_contract() {
@@ -288,5 +173,15 @@ mod tests {
                 .map(String::as_str),
             Some("out/index.html")
         );
+    }
+
+    #[test]
+    fn sites_manifest_bundles_only_generic_contract() {
+        let manifest = FirstPartyHarnessManifest::sites();
+
+        assert_eq!(manifest.id, "first_party.sites");
+        assert!(manifest.validation.on_turn_end.is_empty());
+        assert!(manifest.validation.on_completion.is_empty());
+        assert!(manifest.artifacts.entries.is_empty());
     }
 }

--- a/crates/octos-agent/src/first_party_harness.rs
+++ b/crates/octos-agent/src/first_party_harness.rs
@@ -1,0 +1,208 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::workspace_policy::{
+    ValidationPolicy, WorkspaceArtifactsPolicy, WorkspacePolicy, WorkspacePolicyKind,
+    WorkspacePolicyWorkspace, WorkspaceSnapshotTrigger, WorkspaceSpawnTaskPolicy,
+    WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy, WorkspaceVersionControlProvider,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FirstPartyHarnessManifest {
+    pub id: String,
+    pub workspace: WorkspacePolicyWorkspace,
+    pub version_control: WorkspaceVersionControlPolicy,
+    pub tracking: WorkspaceTrackingPolicy,
+    #[serde(default)]
+    pub validation: ValidationPolicy,
+    #[serde(default)]
+    pub artifacts: WorkspaceArtifactsPolicy,
+    #[serde(default)]
+    pub spawn_tasks: BTreeMap<String, WorkspaceSpawnTaskPolicy>,
+    pub terminal_output: FirstPartyTerminalOutput,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FirstPartyTerminalOutput {
+    pub deliver_final_artifact_only: bool,
+    pub deliver_media_only: bool,
+    pub forbid_intermediate_files: bool,
+    pub required_artifact_kind: String,
+}
+
+impl FirstPartyHarnessManifest {
+    pub fn slides() -> Self {
+        Self {
+            id: "first_party.slides".into(),
+            workspace: WorkspacePolicyWorkspace {
+                kind: WorkspacePolicyKind::Slides,
+            },
+            version_control: git_turn_end_version_control(true),
+            tracking: WorkspaceTrackingPolicy {
+                ignore: vec![
+                    "history/**".into(),
+                    "output/**".into(),
+                    "skill-output/**".into(),
+                    "*.pptx".into(),
+                    "*.tmp".into(),
+                    ".DS_Store".into(),
+                ],
+            },
+            validation: ValidationPolicy {
+                on_turn_end: vec![
+                    "file_exists:script.js".into(),
+                    "file_exists:memory.md".into(),
+                    "file_exists:changelog.md".into(),
+                ],
+                on_source_change: Vec::new(),
+                on_completion: vec![
+                    "file_exists:output/*.pptx".into(),
+                    "file_exists:output/**/slide-*.png".into(),
+                ],
+            },
+            artifacts: WorkspaceArtifactsPolicy {
+                entries: BTreeMap::from([
+                    ("deck".into(), "output/*.pptx".into()),
+                    ("previews".into(), "output/**/slide-*.png".into()),
+                ]),
+            },
+            spawn_tasks: BTreeMap::new(),
+            terminal_output: FirstPartyTerminalOutput {
+                deliver_final_artifact_only: true,
+                deliver_media_only: false,
+                forbid_intermediate_files: true,
+                required_artifact_kind: "presentation".into(),
+            },
+        }
+    }
+
+    pub fn sites() -> Self {
+        Self {
+            id: "first_party.sites".into(),
+            workspace: WorkspacePolicyWorkspace {
+                kind: WorkspacePolicyKind::Sites,
+            },
+            version_control: git_turn_end_version_control(true),
+            tracking: WorkspaceTrackingPolicy {
+                ignore: vec![
+                    "node_modules/**".into(),
+                    "dist/**".into(),
+                    "out/**".into(),
+                    "docs/**".into(),
+                    "build/**".into(),
+                    ".astro/**".into(),
+                    ".next/**".into(),
+                    ".quarto/**".into(),
+                    "*.log".into(),
+                    ".DS_Store".into(),
+                ],
+            },
+            validation: ValidationPolicy::default(),
+            artifacts: WorkspaceArtifactsPolicy::default(),
+            spawn_tasks: BTreeMap::new(),
+            terminal_output: FirstPartyTerminalOutput {
+                deliver_final_artifact_only: true,
+                deliver_media_only: false,
+                forbid_intermediate_files: true,
+                required_artifact_kind: "site".into(),
+            },
+        }
+    }
+
+    pub fn site_with_build_output(build_output_dir: &str) -> Self {
+        let mut manifest = Self::sites();
+        manifest.id = format!("first_party.sites.{build_output_dir}");
+        manifest.validation = ValidationPolicy {
+            on_turn_end: vec![
+                "file_exists:mofa-site-session.json".into(),
+                "file_exists:site-plan.json".into(),
+                "file_exists:optimized-prompt.md".into(),
+            ],
+            on_source_change: Vec::new(),
+            on_completion: vec![format!("file_exists:{build_output_dir}/index.html")],
+        };
+        manifest.artifacts = WorkspaceArtifactsPolicy {
+            entries: BTreeMap::from([(
+                "entrypoint".into(),
+                format!("{build_output_dir}/index.html"),
+            )]),
+        };
+        manifest
+    }
+
+    pub fn workspace_policy(&self) -> WorkspacePolicy {
+        WorkspacePolicy {
+            workspace: self.workspace.clone(),
+            version_control: self.version_control.clone(),
+            tracking: self.tracking.clone(),
+            validation: self.validation.clone(),
+            artifacts: self.artifacts.clone(),
+            spawn_tasks: self.spawn_tasks.clone(),
+        }
+    }
+}
+
+fn git_turn_end_version_control(fail_on_error: bool) -> WorkspaceVersionControlPolicy {
+    WorkspaceVersionControlPolicy {
+        provider: WorkspaceVersionControlProvider::Git,
+        auto_init: true,
+        trigger: WorkspaceSnapshotTrigger::TurnEnd,
+        fail_on_error,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slides_manifest_declares_expected_contract() {
+        let manifest = FirstPartyHarnessManifest::slides();
+
+        assert_eq!(manifest.id, "first_party.slides");
+        assert_eq!(manifest.workspace.kind, WorkspacePolicyKind::Slides);
+        assert_eq!(
+            manifest.terminal_output.required_artifact_kind,
+            "presentation"
+        );
+        assert!(manifest.terminal_output.deliver_final_artifact_only);
+        assert_eq!(
+            manifest.artifacts.entries.get("deck").map(String::as_str),
+            Some("output/*.pptx")
+        );
+        assert_eq!(
+            manifest
+                .validation
+                .on_completion
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            vec![
+                "file_exists:output/*.pptx",
+                "file_exists:output/**/slide-*.png"
+            ]
+        );
+    }
+
+    #[test]
+    fn site_manifest_externalizes_build_output_specific_contract() {
+        let manifest = FirstPartyHarnessManifest::site_with_build_output("out");
+
+        assert_eq!(manifest.id, "first_party.sites.out");
+        assert_eq!(manifest.workspace.kind, WorkspacePolicyKind::Sites);
+        assert_eq!(manifest.terminal_output.required_artifact_kind, "site");
+        assert_eq!(
+            manifest.validation.on_completion,
+            vec!["file_exists:out/index.html"]
+        );
+        assert_eq!(
+            manifest
+                .artifacts
+                .entries
+                .get("entrypoint")
+                .map(String::as_str),
+            Some("out/index.html")
+        );
+    }
+}

--- a/crates/octos-agent/src/first_party_harness.rs
+++ b/crates/octos-agent/src/first_party_harness.rs
@@ -25,6 +25,12 @@ impl FirstPartyHarnessName {
         }
     }
 
+    pub fn descriptor(
+        self,
+    ) -> &'static crate::first_party_harness_catalog::FirstPartyHarnessDescriptor {
+        crate::first_party_harness_catalog::first_party_harness_descriptor(self)
+    }
+
     pub fn manifest(self) -> FirstPartyHarnessManifest {
         first_party_harness_entry(self).load()
     }
@@ -207,6 +213,14 @@ mod tests {
 
         assert_eq!(manifest.id, "first_party.slides");
         assert_eq!(manifest.workflow.label, "Slides deliverable");
+    }
+
+    #[test]
+    fn harness_name_exposes_descriptor_view() {
+        let descriptor = FirstPartyHarnessName::Slides.descriptor();
+
+        assert_eq!(descriptor.manifest_id, "first_party.slides");
+        assert_eq!(descriptor.output_kind, "presentation");
     }
 
     #[test]

--- a/crates/octos-agent/src/first_party_harness.rs
+++ b/crates/octos-agent/src/first_party_harness.rs
@@ -31,6 +31,10 @@ impl FirstPartyHarnessName {
         crate::first_party_harness_catalog::first_party_harness_descriptor(self)
     }
 
+    pub fn resolved(self) -> crate::first_party_harness_catalog::ResolvedFirstPartyHarness {
+        crate::first_party_harness_catalog::resolve_first_party_harness(self)
+    }
+
     pub fn manifest(self) -> FirstPartyHarnessManifest {
         first_party_harness_entry(self).load()
     }
@@ -221,6 +225,14 @@ mod tests {
 
         assert_eq!(descriptor.manifest_id, "first_party.slides");
         assert_eq!(descriptor.output_kind, "presentation");
+    }
+
+    #[test]
+    fn harness_name_exposes_resolved_view() {
+        let resolved = FirstPartyHarnessName::Slides.resolved();
+
+        assert_eq!(resolved.descriptor.name, FirstPartyHarnessName::Slides);
+        assert_eq!(resolved.manifest.id, "first_party.slides");
     }
 
     #[test]

--- a/crates/octos-agent/src/first_party_harness.rs
+++ b/crates/octos-agent/src/first_party_harness.rs
@@ -10,6 +10,9 @@ use crate::workspace_policy::{
 const SLIDES_MANIFEST_TOML: &str = include_str!("first_party_harness/slides.toml");
 const SITES_MANIFEST_TOML: &str = include_str!("first_party_harness/sites.toml");
 
+pub const FIRST_PARTY_SLIDES_HARNESS_ID: &str = "first_party.slides";
+pub const FIRST_PARTY_SITES_HARNESS_ID: &str = "first_party.sites";
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum FirstPartyHarnessName {
@@ -35,6 +38,10 @@ impl FirstPartyHarnessName {
         crate::first_party_harness_catalog::resolve_first_party_harness(self)
     }
 
+    pub fn manifest_id(self) -> &'static str {
+        first_party_harness_entry(self).manifest_id
+    }
+
     pub fn manifest(self) -> FirstPartyHarnessManifest {
         first_party_harness_entry(self).load()
     }
@@ -56,12 +63,12 @@ impl FirstPartyHarnessRegistryEntry {
 const FIRST_PARTY_HARNESS_REGISTRY: [FirstPartyHarnessRegistryEntry; 2] = [
     FirstPartyHarnessRegistryEntry {
         name: FirstPartyHarnessName::Slides,
-        manifest_id: "first_party.slides",
+        manifest_id: FIRST_PARTY_SLIDES_HARNESS_ID,
         manifest_asset: "slides.toml",
     },
     FirstPartyHarnessRegistryEntry {
         name: FirstPartyHarnessName::Sites,
-        manifest_id: "first_party.sites",
+        manifest_id: FIRST_PARTY_SITES_HARNESS_ID,
         manifest_asset: "sites.toml",
     },
 ];
@@ -205,17 +212,17 @@ mod tests {
 
         assert_eq!(registry.len(), 2);
         assert_eq!(registry[0].name, FirstPartyHarnessName::Slides);
-        assert_eq!(registry[0].manifest_id, "first_party.slides");
+        assert_eq!(registry[0].manifest_id, FIRST_PARTY_SLIDES_HARNESS_ID);
         assert_eq!(registry[1].name, FirstPartyHarnessName::Sites);
-        assert_eq!(registry[1].manifest_id, "first_party.sites");
+        assert_eq!(registry[1].manifest_id, FIRST_PARTY_SITES_HARNESS_ID);
     }
 
     #[test]
     fn registry_resolves_manifest_by_id() {
-        let manifest = resolve_first_party_harness_by_id("first_party.slides")
+        let manifest = resolve_first_party_harness_by_id(FIRST_PARTY_SLIDES_HARNESS_ID)
             .expect("slides manifest should resolve");
 
-        assert_eq!(manifest.id, "first_party.slides");
+        assert_eq!(manifest.id, FIRST_PARTY_SLIDES_HARNESS_ID);
         assert_eq!(manifest.workflow.label, "Slides deliverable");
     }
 
@@ -223,7 +230,7 @@ mod tests {
     fn harness_name_exposes_descriptor_view() {
         let descriptor = FirstPartyHarnessName::Slides.descriptor();
 
-        assert_eq!(descriptor.manifest_id, "first_party.slides");
+        assert_eq!(descriptor.manifest_id, FIRST_PARTY_SLIDES_HARNESS_ID);
         assert_eq!(descriptor.output_kind, "presentation");
     }
 
@@ -232,7 +239,19 @@ mod tests {
         let resolved = FirstPartyHarnessName::Slides.resolved();
 
         assert_eq!(resolved.descriptor.name, FirstPartyHarnessName::Slides);
-        assert_eq!(resolved.manifest.id, "first_party.slides");
+        assert_eq!(resolved.manifest.id, FIRST_PARTY_SLIDES_HARNESS_ID);
+    }
+
+    #[test]
+    fn harness_name_exposes_manifest_id() {
+        assert_eq!(
+            FirstPartyHarnessName::Slides.manifest_id(),
+            FIRST_PARTY_SLIDES_HARNESS_ID
+        );
+        assert_eq!(
+            FirstPartyHarnessName::Sites.manifest_id(),
+            FIRST_PARTY_SITES_HARNESS_ID
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/first_party_harness/sites.toml
+++ b/crates/octos-agent/src/first_party_harness/sites.toml
@@ -1,0 +1,49 @@
+id = "first_party.sites"
+
+[workspace]
+kind = "sites"
+
+[version_control]
+provider = "git"
+auto_init = true
+trigger = "turn_end"
+fail_on_error = true
+
+[tracking]
+ignore = [
+  "node_modules/**",
+  "dist/**",
+  "out/**",
+  "docs/**",
+  "build/**",
+  ".astro/**",
+  ".next/**",
+  ".quarto/**",
+  "*.log",
+  ".DS_Store",
+]
+
+[workflow]
+label = "Site deliverable"
+ack_message = "Site generation has started in the background. Only the final verified site entrypoint will be delivered once the workspace contract is satisfied."
+initial_phase = "scaffold"
+allowed_tools = [
+  "read_file",
+  "write_file",
+  "edit_file",
+  "shell",
+  "glob",
+  "check_background_tasks",
+  "check_workspace_contract",
+]
+additional_instructions = "You are a background site builder. Follow the runtime-owned phases in order: scaffold, build, deliver_result. Read the session metadata to discover the selected template and build output directory, keep edits inside the project root, and deliver only the final built site entrypoint. Do not send intermediate logs, scratch files, or alternate build artifacts."
+
+[workflow.limits]
+max_dialogue_lines = 24
+max_generate_calls = 1
+
+[terminal_output]
+deliver_final_artifact_only = true
+deliver_media_only = false
+forbid_intermediate_files = true
+required_artifact_kind = "site"

--- a/crates/octos-agent/src/first_party_harness/slides.toml
+++ b/crates/octos-agent/src/first_party_harness/slides.toml
@@ -1,0 +1,61 @@
+id = "first_party.slides"
+
+[workspace]
+kind = "slides"
+
+[version_control]
+provider = "git"
+auto_init = true
+trigger = "turn_end"
+fail_on_error = true
+
+[tracking]
+ignore = [
+  "history/**",
+  "output/**",
+  "skill-output/**",
+  "*.pptx",
+  "*.tmp",
+  ".DS_Store",
+]
+
+[validation]
+on_turn_end = [
+  "file_exists:script.js",
+  "file_exists:memory.md",
+  "file_exists:changelog.md",
+]
+on_completion = [
+  "file_exists:output/*.pptx",
+  "file_exists:output/**/slide-*.png",
+]
+
+[artifacts]
+deck = "output/*.pptx"
+previews = "output/**/slide-*.png"
+
+[workflow]
+label = "Slides deliverable"
+ack_message = "Slides generation has started in the background. Only the final deck will be delivered once the workspace contract is satisfied."
+initial_phase = "design"
+allowed_tools = [
+  "mofa_slides",
+  "read_file",
+  "write_file",
+  "edit_file",
+  "shell",
+  "glob",
+  "check_background_tasks",
+  "check_workspace_contract",
+]
+additional_instructions = "You are a background slides producer. Follow the runtime-owned phases in order: design, generate_deck, deliver_result. Write the slide script first, validate it before generation, call mofa_slides once, and deliver only the final deck artifact. Do not send intermediate previews, scratch PNGs, or alternate deck exports."
+
+[workflow.limits]
+max_dialogue_lines = 24
+max_generate_calls = 1
+
+[terminal_output]
+deliver_final_artifact_only = true
+deliver_media_only = false
+forbid_intermediate_files = true
+required_artifact_kind = "presentation"

--- a/crates/octos-agent/src/first_party_harness_catalog.rs
+++ b/crates/octos-agent/src/first_party_harness_catalog.rs
@@ -1,5 +1,6 @@
 use crate::first_party_harness::{
-    FirstPartyHarnessManifest, FirstPartyHarnessName, resolve_first_party_harness_by_id,
+    FIRST_PARTY_SITES_HARNESS_ID, FIRST_PARTY_SLIDES_HARNESS_ID, FirstPartyHarnessManifest,
+    FirstPartyHarnessName, resolve_first_party_harness_by_id,
 };
 use crate::workspace_policy::WorkspacePolicyKind;
 
@@ -23,7 +24,7 @@ pub struct ResolvedFirstPartyHarness {
 const FIRST_PARTY_HARNESS_CATALOG: [FirstPartyHarnessDescriptor; 2] = [
     FirstPartyHarnessDescriptor {
         name: FirstPartyHarnessName::Slides,
-        manifest_id: "first_party.slides",
+        manifest_id: FIRST_PARTY_SLIDES_HARNESS_ID,
         display_name: "Slides",
         summary: "Background slide-deck production with final presentation delivery.",
         workspace_kind: WorkspacePolicyKind::Slides,
@@ -32,7 +33,7 @@ const FIRST_PARTY_HARNESS_CATALOG: [FirstPartyHarnessDescriptor; 2] = [
     },
     FirstPartyHarnessDescriptor {
         name: FirstPartyHarnessName::Sites,
-        manifest_id: "first_party.sites",
+        manifest_id: FIRST_PARTY_SITES_HARNESS_ID,
         display_name: "Sites",
         summary: "Background site builds with final verified entrypoint delivery.",
         workspace_kind: WorkspacePolicyKind::Sites,
@@ -72,6 +73,11 @@ pub fn resolve_first_party_harness(name: FirstPartyHarnessName) -> ResolvedFirst
         descriptor,
         manifest,
     }
+}
+
+pub fn resolve_first_party_harness_by_manifest_id(id: &str) -> Option<ResolvedFirstPartyHarness> {
+    resolve_first_party_harness_descriptor_by_id(id)
+        .map(|descriptor| resolve_first_party_harness(descriptor.name))
 }
 
 pub fn resolve_first_party_harness_descriptor_by_id(
@@ -117,7 +123,7 @@ mod tests {
 
     #[test]
     fn catalog_resolves_descriptor_by_manifest_id() {
-        let descriptor = resolve_first_party_harness_descriptor_by_id("first_party.sites")
+        let descriptor = resolve_first_party_harness_descriptor_by_id(FIRST_PARTY_SITES_HARNESS_ID)
             .expect("sites descriptor should resolve");
 
         assert_eq!(descriptor.name, FirstPartyHarnessName::Sites);
@@ -142,5 +148,14 @@ mod tests {
             resolved.manifest.terminal_output.required_artifact_kind,
             "site"
         );
+    }
+
+    #[test]
+    fn catalog_resolves_by_manifest_id() {
+        let resolved = resolve_first_party_harness_by_manifest_id(FIRST_PARTY_SLIDES_HARNESS_ID)
+            .expect("slides harness should resolve");
+
+        assert_eq!(resolved.descriptor.name, FirstPartyHarnessName::Slides);
+        assert_eq!(resolved.manifest.id, FIRST_PARTY_SLIDES_HARNESS_ID);
     }
 }

--- a/crates/octos-agent/src/first_party_harness_catalog.rs
+++ b/crates/octos-agent/src/first_party_harness_catalog.rs
@@ -1,0 +1,94 @@
+use crate::first_party_harness::FirstPartyHarnessName;
+use crate::workspace_policy::WorkspacePolicyKind;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FirstPartyHarnessDescriptor {
+    pub name: FirstPartyHarnessName,
+    pub manifest_id: &'static str,
+    pub display_name: &'static str,
+    pub summary: &'static str,
+    pub workspace_kind: WorkspacePolicyKind,
+    pub output_kind: &'static str,
+    pub supports_build_output_override: bool,
+}
+
+const FIRST_PARTY_HARNESS_CATALOG: [FirstPartyHarnessDescriptor; 2] = [
+    FirstPartyHarnessDescriptor {
+        name: FirstPartyHarnessName::Slides,
+        manifest_id: "first_party.slides",
+        display_name: "Slides",
+        summary: "Background slide-deck production with final presentation delivery.",
+        workspace_kind: WorkspacePolicyKind::Slides,
+        output_kind: "presentation",
+        supports_build_output_override: false,
+    },
+    FirstPartyHarnessDescriptor {
+        name: FirstPartyHarnessName::Sites,
+        manifest_id: "first_party.sites",
+        display_name: "Sites",
+        summary: "Background site builds with final verified entrypoint delivery.",
+        workspace_kind: WorkspacePolicyKind::Sites,
+        output_kind: "site",
+        supports_build_output_override: true,
+    },
+];
+
+pub fn first_party_harness_catalog() -> &'static [FirstPartyHarnessDescriptor] {
+    &FIRST_PARTY_HARNESS_CATALOG
+}
+
+pub fn first_party_harness_descriptor(
+    name: FirstPartyHarnessName,
+) -> &'static FirstPartyHarnessDescriptor {
+    first_party_harness_catalog()
+        .iter()
+        .find(|descriptor| descriptor.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "missing first-party harness descriptor for {}",
+                name.as_str()
+            )
+        })
+}
+
+pub fn resolve_first_party_harness_descriptor_by_id(
+    id: &str,
+) -> Option<&'static FirstPartyHarnessDescriptor> {
+    first_party_harness_catalog()
+        .iter()
+        .find(|descriptor| descriptor.manifest_id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::first_party_harness::first_party_harness_entry;
+
+    #[test]
+    fn catalog_lists_expected_first_party_descriptors() {
+        let catalog = first_party_harness_catalog();
+
+        assert_eq!(catalog.len(), 2);
+        assert_eq!(catalog[0].name, FirstPartyHarnessName::Slides);
+        assert_eq!(catalog[0].display_name, "Slides");
+        assert_eq!(catalog[1].name, FirstPartyHarnessName::Sites);
+        assert!(catalog[1].supports_build_output_override);
+    }
+
+    #[test]
+    fn catalog_descriptor_matches_registry_entry() {
+        let descriptor = first_party_harness_descriptor(FirstPartyHarnessName::Slides);
+        let registry_entry = first_party_harness_entry(descriptor.name);
+
+        assert_eq!(descriptor.manifest_id, registry_entry.manifest_id);
+    }
+
+    #[test]
+    fn catalog_resolves_descriptor_by_manifest_id() {
+        let descriptor = resolve_first_party_harness_descriptor_by_id("first_party.sites")
+            .expect("sites descriptor should resolve");
+
+        assert_eq!(descriptor.name, FirstPartyHarnessName::Sites);
+        assert_eq!(descriptor.output_kind, "site");
+    }
+}

--- a/crates/octos-agent/src/first_party_harness_catalog.rs
+++ b/crates/octos-agent/src/first_party_harness_catalog.rs
@@ -1,4 +1,6 @@
-use crate::first_party_harness::FirstPartyHarnessName;
+use crate::first_party_harness::{
+    FirstPartyHarnessManifest, FirstPartyHarnessName, resolve_first_party_harness_by_id,
+};
 use crate::workspace_policy::WorkspacePolicyKind;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -10,6 +12,12 @@ pub struct FirstPartyHarnessDescriptor {
     pub workspace_kind: WorkspacePolicyKind,
     pub output_kind: &'static str,
     pub supports_build_output_override: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedFirstPartyHarness {
+    pub descriptor: &'static FirstPartyHarnessDescriptor,
+    pub manifest: FirstPartyHarnessManifest,
 }
 
 const FIRST_PARTY_HARNESS_CATALOG: [FirstPartyHarnessDescriptor; 2] = [
@@ -51,12 +59,36 @@ pub fn first_party_harness_descriptor(
         })
 }
 
+pub fn resolve_first_party_harness(name: FirstPartyHarnessName) -> ResolvedFirstPartyHarness {
+    let descriptor = first_party_harness_descriptor(name);
+    let manifest = resolve_first_party_harness_by_id(descriptor.manifest_id).unwrap_or_else(|| {
+        panic!(
+            "missing first-party harness manifest {}",
+            descriptor.manifest_id
+        )
+    });
+
+    ResolvedFirstPartyHarness {
+        descriptor,
+        manifest,
+    }
+}
+
 pub fn resolve_first_party_harness_descriptor_by_id(
     id: &str,
 ) -> Option<&'static FirstPartyHarnessDescriptor> {
     first_party_harness_catalog()
         .iter()
         .find(|descriptor| descriptor.manifest_id == id)
+}
+
+pub fn resolve_first_party_harness_for_workspace_kind(
+    workspace_kind: WorkspacePolicyKind,
+) -> Option<ResolvedFirstPartyHarness> {
+    first_party_harness_catalog()
+        .iter()
+        .find(|descriptor| descriptor.workspace_kind == workspace_kind)
+        .map(|descriptor| resolve_first_party_harness(descriptor.name))
 }
 
 #[cfg(test)]
@@ -90,5 +122,25 @@ mod tests {
 
         assert_eq!(descriptor.name, FirstPartyHarnessName::Sites);
         assert_eq!(descriptor.output_kind, "site");
+    }
+
+    #[test]
+    fn catalog_resolves_manifest_and_descriptor_together() {
+        let resolved = resolve_first_party_harness(FirstPartyHarnessName::Slides);
+
+        assert_eq!(resolved.descriptor.manifest_id, resolved.manifest.id);
+        assert_eq!(resolved.descriptor.output_kind, "presentation");
+    }
+
+    #[test]
+    fn catalog_resolves_by_workspace_kind() {
+        let resolved = resolve_first_party_harness_for_workspace_kind(WorkspacePolicyKind::Sites)
+            .expect("sites harness should resolve");
+
+        assert_eq!(resolved.descriptor.name, FirstPartyHarnessName::Sites);
+        assert_eq!(
+            resolved.manifest.terminal_output.required_artifact_kind,
+            "site"
+        );
     }
 }

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -51,8 +51,9 @@ pub use first_party_harness::{
     first_party_harness_entry, first_party_harness_registry, resolve_first_party_harness_by_id,
 };
 pub use first_party_harness_catalog::{
-    FirstPartyHarnessDescriptor, first_party_harness_catalog, first_party_harness_descriptor,
-    resolve_first_party_harness_descriptor_by_id,
+    FirstPartyHarnessDescriptor, ResolvedFirstPartyHarness, first_party_harness_catalog,
+    first_party_harness_descriptor, resolve_first_party_harness,
+    resolve_first_party_harness_descriptor_by_id, resolve_first_party_harness_for_workspace_kind,
 };
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor};
 pub use mcp::{McpClient, McpServerConfig};

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -16,6 +16,7 @@ mod compaction;
 pub mod event_bus;
 pub mod exec_env;
 pub mod first_party_harness;
+pub mod first_party_harness_catalog;
 pub mod hooks;
 pub mod loop_detect;
 pub mod mcp;
@@ -48,6 +49,10 @@ pub use first_party_harness::{
     FirstPartyHarnessManifest, FirstPartyHarnessName, FirstPartyHarnessRegistryEntry,
     FirstPartyTerminalOutput, FirstPartyWorkflowDeclaration, FirstPartyWorkflowLimits,
     first_party_harness_entry, first_party_harness_registry, resolve_first_party_harness_by_id,
+};
+pub use first_party_harness_catalog::{
+    FirstPartyHarnessDescriptor, first_party_harness_catalog, first_party_harness_descriptor,
+    resolve_first_party_harness_descriptor_by_id,
 };
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor};
 pub use mcp::{McpClient, McpServerConfig};

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bundled_app_skills;
 mod compaction;
 pub mod event_bus;
 pub mod exec_env;
+pub mod first_party_harness;
 pub mod hooks;
 pub mod loop_detect;
 pub mod mcp;
@@ -43,6 +44,7 @@ pub use agent::{
 };
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
+pub use first_party_harness::{FirstPartyHarnessManifest, FirstPartyTerminalOutput};
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor};
 pub use mcp::{McpClient, McpServerConfig};
 pub use plugins::{PluginLoadResult, PluginLoader};

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -44,7 +44,10 @@ pub use agent::{
 };
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
-pub use first_party_harness::{FirstPartyHarnessManifest, FirstPartyTerminalOutput};
+pub use first_party_harness::{
+    FirstPartyHarnessManifest, FirstPartyTerminalOutput, FirstPartyWorkflowDeclaration,
+    FirstPartyWorkflowLimits,
+};
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor};
 pub use mcp::{McpClient, McpServerConfig};
 pub use plugins::{PluginLoadResult, PluginLoader};

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -46,14 +46,16 @@ pub use agent::{
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
 pub use first_party_harness::{
-    FirstPartyHarnessManifest, FirstPartyHarnessName, FirstPartyHarnessRegistryEntry,
-    FirstPartyTerminalOutput, FirstPartyWorkflowDeclaration, FirstPartyWorkflowLimits,
-    first_party_harness_entry, first_party_harness_registry, resolve_first_party_harness_by_id,
+    FIRST_PARTY_SITES_HARNESS_ID, FIRST_PARTY_SLIDES_HARNESS_ID, FirstPartyHarnessManifest,
+    FirstPartyHarnessName, FirstPartyHarnessRegistryEntry, FirstPartyTerminalOutput,
+    FirstPartyWorkflowDeclaration, FirstPartyWorkflowLimits, first_party_harness_entry,
+    first_party_harness_registry, resolve_first_party_harness_by_id,
 };
 pub use first_party_harness_catalog::{
     FirstPartyHarnessDescriptor, ResolvedFirstPartyHarness, first_party_harness_catalog,
     first_party_harness_descriptor, resolve_first_party_harness,
-    resolve_first_party_harness_descriptor_by_id, resolve_first_party_harness_for_workspace_kind,
+    resolve_first_party_harness_by_manifest_id, resolve_first_party_harness_descriptor_by_id,
+    resolve_first_party_harness_for_workspace_kind,
 };
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor};
 pub use mcp::{McpClient, McpServerConfig};

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -45,8 +45,9 @@ pub use agent::{
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
 pub use first_party_harness::{
-    FirstPartyHarnessManifest, FirstPartyTerminalOutput, FirstPartyWorkflowDeclaration,
-    FirstPartyWorkflowLimits,
+    FirstPartyHarnessManifest, FirstPartyHarnessName, FirstPartyHarnessRegistryEntry,
+    FirstPartyTerminalOutput, FirstPartyWorkflowDeclaration, FirstPartyWorkflowLimits,
+    first_party_harness_entry, first_party_harness_registry, resolve_first_party_harness_by_id,
 };
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor};
 pub use mcp::{McpClient, McpServerConfig};

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
 
+use crate::first_party_harness::FirstPartyHarnessManifest;
 use crate::workspace_git::WorkspaceProjectKind;
 
 pub const WORKSPACE_POLICY_FILE: &str = ".octos-workspace.toml";
@@ -141,74 +142,8 @@ impl WorkspaceSpawnTaskPolicy {
 impl WorkspacePolicy {
     pub fn for_kind(kind: WorkspaceProjectKind) -> Self {
         match kind {
-            WorkspaceProjectKind::Slides => Self {
-                workspace: WorkspacePolicyWorkspace {
-                    kind: WorkspacePolicyKind::Slides,
-                },
-                version_control: WorkspaceVersionControlPolicy {
-                    provider: WorkspaceVersionControlProvider::Git,
-                    auto_init: true,
-                    trigger: WorkspaceSnapshotTrigger::TurnEnd,
-                    fail_on_error: true,
-                },
-                tracking: WorkspaceTrackingPolicy {
-                    ignore: vec![
-                        "history/**".into(),
-                        "output/**".into(),
-                        "skill-output/**".into(),
-                        "*.pptx".into(),
-                        "*.tmp".into(),
-                        ".DS_Store".into(),
-                    ],
-                },
-                validation: ValidationPolicy {
-                    on_turn_end: vec![
-                        "file_exists:script.js".into(),
-                        "file_exists:memory.md".into(),
-                        "file_exists:changelog.md".into(),
-                    ],
-                    on_source_change: Vec::new(),
-                    on_completion: vec![
-                        "file_exists:output/*.pptx".into(),
-                        "file_exists:output/**/slide-*.png".into(),
-                    ],
-                },
-                artifacts: WorkspaceArtifactsPolicy {
-                    entries: BTreeMap::from([
-                        ("deck".into(), "output/*.pptx".into()),
-                        ("previews".into(), "output/**/slide-*.png".into()),
-                    ]),
-                },
-                spawn_tasks: BTreeMap::new(),
-            },
-            WorkspaceProjectKind::Sites => Self {
-                workspace: WorkspacePolicyWorkspace {
-                    kind: WorkspacePolicyKind::Sites,
-                },
-                version_control: WorkspaceVersionControlPolicy {
-                    provider: WorkspaceVersionControlProvider::Git,
-                    auto_init: true,
-                    trigger: WorkspaceSnapshotTrigger::TurnEnd,
-                    fail_on_error: true,
-                },
-                tracking: WorkspaceTrackingPolicy {
-                    ignore: vec![
-                        "node_modules/**".into(),
-                        "dist/**".into(),
-                        "out/**".into(),
-                        "docs/**".into(),
-                        "build/**".into(),
-                        ".astro/**".into(),
-                        ".next/**".into(),
-                        ".quarto/**".into(),
-                        "*.log".into(),
-                        ".DS_Store".into(),
-                    ],
-                },
-                validation: ValidationPolicy::default(),
-                artifacts: WorkspaceArtifactsPolicy::default(),
-                spawn_tasks: BTreeMap::new(),
-            },
+            WorkspaceProjectKind::Slides => FirstPartyHarnessManifest::slides().workspace_policy(),
+            WorkspaceProjectKind::Sites => FirstPartyHarnessManifest::sites().workspace_policy(),
         }
     }
 
@@ -266,23 +201,7 @@ impl WorkspacePolicy {
     }
 
     pub fn for_site_build_output(build_output_dir: &str) -> Self {
-        let mut policy = Self::for_kind(WorkspaceProjectKind::Sites);
-        policy.validation = ValidationPolicy {
-            on_turn_end: vec![
-                "file_exists:mofa-site-session.json".into(),
-                "file_exists:site-plan.json".into(),
-                "file_exists:optimized-prompt.md".into(),
-            ],
-            on_source_change: Vec::new(),
-            on_completion: vec![format!("file_exists:{build_output_dir}/index.html")],
-        };
-        policy.artifacts = WorkspaceArtifactsPolicy {
-            entries: BTreeMap::from([(
-                "entrypoint".into(),
-                format!("{build_output_dir}/index.html"),
-            )]),
-        };
-        policy
+        FirstPartyHarnessManifest::site_with_build_output(build_output_dir).workspace_policy()
     }
 }
 
@@ -410,7 +329,11 @@ mod tests {
             vec!["file_exists:dist/index.html"]
         );
         assert_eq!(
-            policy.artifacts.entries.get("entrypoint").map(String::as_str),
+            policy
+                .artifacts
+                .entries
+                .get("entrypoint")
+                .map(String::as_str),
             Some("dist/index.html")
         );
     }
@@ -512,7 +435,10 @@ mod tests {
             on_failure: Vec::new(),
         };
 
-        assert_eq!(task.delivery_actions(), &["notify_user:deliver".to_string()]);
+        assert_eq!(
+            task.delivery_actions(),
+            &["notify_user:deliver".to_string()]
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
 
-use crate::first_party_harness::FirstPartyHarnessManifest;
+use crate::first_party_harness::{FirstPartyHarnessManifest, FirstPartyHarnessName};
 use crate::workspace_git::WorkspaceProjectKind;
 
 pub const WORKSPACE_POLICY_FILE: &str = ".octos-workspace.toml";
@@ -142,8 +142,12 @@ impl WorkspaceSpawnTaskPolicy {
 impl WorkspacePolicy {
     pub fn for_kind(kind: WorkspaceProjectKind) -> Self {
         match kind {
-            WorkspaceProjectKind::Slides => FirstPartyHarnessManifest::slides().workspace_policy(),
-            WorkspaceProjectKind::Sites => FirstPartyHarnessManifest::sites().workspace_policy(),
+            WorkspaceProjectKind::Slides => {
+                FirstPartyHarnessName::Slides.manifest().workspace_policy()
+            }
+            WorkspaceProjectKind::Sites => {
+                FirstPartyHarnessName::Sites.manifest().workspace_policy()
+            }
         }
     }
 

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
 
-use crate::first_party_harness::{FirstPartyHarnessManifest, FirstPartyHarnessName};
+use crate::first_party_harness::FirstPartyHarnessManifest;
+use crate::first_party_harness_catalog::resolve_first_party_harness_for_workspace_kind;
 use crate::workspace_git::WorkspaceProjectKind;
 
 pub const WORKSPACE_POLICY_FILE: &str = ".octos-workspace.toml";
@@ -141,14 +142,16 @@ impl WorkspaceSpawnTaskPolicy {
 
 impl WorkspacePolicy {
     pub fn for_kind(kind: WorkspaceProjectKind) -> Self {
-        match kind {
-            WorkspaceProjectKind::Slides => {
-                FirstPartyHarnessName::Slides.manifest().workspace_policy()
-            }
-            WorkspaceProjectKind::Sites => {
-                FirstPartyHarnessName::Sites.manifest().workspace_policy()
-            }
-        }
+        let workspace_kind = WorkspacePolicyKind::from(kind);
+        resolve_first_party_harness_for_workspace_kind(workspace_kind)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing first-party harness for workspace kind {}",
+                    workspace_kind.as_str()
+                )
+            })
+            .manifest
+            .workspace_policy()
     }
 
     pub fn for_session() -> Self {

--- a/crates/octos-cli/src/workflows/mod.rs
+++ b/crates/octos-cli/src/workflows/mod.rs
@@ -4,23 +4,46 @@ pub mod site_delivery;
 pub mod slides_delivery;
 
 use octos_agent::{
-    ResolvedFirstPartyHarness, WorkspacePolicy, WorkspacePolicyKind,
-    resolve_first_party_harness_for_workspace_kind,
+    FIRST_PARTY_SITES_HARNESS_ID, FIRST_PARTY_SLIDES_HARNESS_ID, ResolvedFirstPartyHarness,
+    WorkspacePolicy, resolve_first_party_harness_by_manifest_id,
 };
 
 use crate::workflow_runtime::{
     WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
 };
 
-fn resolve_first_party_workflow_harness(kind: WorkflowKind) -> ResolvedFirstPartyHarness {
-    let workspace_kind = match kind {
-        WorkflowKind::Slides => WorkspacePolicyKind::Slides,
-        WorkflowKind::Site => WorkspacePolicyKind::Sites,
-        other => panic!("workflow {other:?} does not have a first-party harness"),
-    };
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FirstPartyWorkflowBinding {
+    kind: WorkflowKind,
+    harness_id: &'static str,
+}
 
-    resolve_first_party_harness_for_workspace_kind(workspace_kind)
-        .unwrap_or_else(|| panic!("missing first-party harness for workflow kind {:?}", kind))
+const FIRST_PARTY_WORKFLOW_BINDINGS: [FirstPartyWorkflowBinding; 2] = [
+    FirstPartyWorkflowBinding {
+        kind: WorkflowKind::Slides,
+        harness_id: FIRST_PARTY_SLIDES_HARNESS_ID,
+    },
+    FirstPartyWorkflowBinding {
+        kind: WorkflowKind::Site,
+        harness_id: FIRST_PARTY_SITES_HARNESS_ID,
+    },
+];
+
+fn first_party_workflow_binding(kind: WorkflowKind) -> &'static FirstPartyWorkflowBinding {
+    FIRST_PARTY_WORKFLOW_BINDINGS
+        .iter()
+        .find(|binding| binding.kind == kind)
+        .unwrap_or_else(|| panic!("workflow {kind:?} does not have a first-party harness"))
+}
+
+fn resolve_first_party_workflow_harness(kind: WorkflowKind) -> ResolvedFirstPartyHarness {
+    let binding = first_party_workflow_binding(kind);
+    resolve_first_party_harness_by_manifest_id(binding.harness_id).unwrap_or_else(|| {
+        panic!(
+            "missing first-party harness manifest {}",
+            binding.harness_id
+        )
+    })
 }
 
 pub(crate) fn build_first_party_workflow(kind: WorkflowKind) -> WorkflowInstance {
@@ -55,4 +78,21 @@ pub(crate) fn workspace_policy_for_first_party_workflow(kind: WorkflowKind) -> W
     resolve_first_party_workflow_harness(kind)
         .manifest
         .workspace_policy()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_binding_resolves_expected_harness_ids() {
+        assert_eq!(
+            first_party_workflow_binding(WorkflowKind::Slides).harness_id,
+            FIRST_PARTY_SLIDES_HARNESS_ID
+        );
+        assert_eq!(
+            first_party_workflow_binding(WorkflowKind::Site).harness_id,
+            FIRST_PARTY_SITES_HARNESS_ID
+        );
+    }
 }

--- a/crates/octos-cli/src/workflows/mod.rs
+++ b/crates/octos-cli/src/workflows/mod.rs
@@ -1,4 +1,40 @@
-pub mod research_report;
 pub mod research_podcast;
+pub mod research_report;
 pub mod site_delivery;
 pub mod slides_delivery;
+
+use octos_agent::FirstPartyHarnessManifest;
+
+use crate::workflow_runtime::{
+    WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
+};
+
+pub(crate) fn build_first_party_workflow(
+    kind: WorkflowKind,
+    harness: FirstPartyHarnessManifest,
+) -> WorkflowInstance {
+    let workflow = harness.workflow;
+    let terminal_output = harness.terminal_output;
+
+    WorkflowInstance {
+        kind,
+        label: workflow.label,
+        ack_message: workflow.ack_message,
+        current_phase: WorkflowPhase::new(workflow.initial_phase),
+        allowed_tools: workflow.allowed_tools,
+        limits: WorkflowLimits {
+            max_search_passes: workflow.limits.max_search_passes,
+            max_pipeline_runs: workflow.limits.max_pipeline_runs,
+            max_dialogue_lines: workflow.limits.max_dialogue_lines,
+            target_audio_minutes: workflow.limits.target_audio_minutes,
+            max_generate_calls: workflow.limits.max_generate_calls,
+        },
+        terminal_output: WorkflowTerminalOutput {
+            deliver_final_artifact_only: terminal_output.deliver_final_artifact_only,
+            deliver_media_only: terminal_output.deliver_media_only,
+            forbid_intermediate_files: terminal_output.forbid_intermediate_files,
+            required_artifact_kind: terminal_output.required_artifact_kind,
+        },
+        additional_instructions: workflow.additional_instructions,
+    }
+}

--- a/crates/octos-cli/src/workflows/mod.rs
+++ b/crates/octos-cli/src/workflows/mod.rs
@@ -3,18 +3,30 @@ pub mod research_report;
 pub mod site_delivery;
 pub mod slides_delivery;
 
-use octos_agent::FirstPartyHarnessManifest;
+use octos_agent::{
+    ResolvedFirstPartyHarness, WorkspacePolicy, WorkspacePolicyKind,
+    resolve_first_party_harness_for_workspace_kind,
+};
 
 use crate::workflow_runtime::{
     WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
 };
 
-pub(crate) fn build_first_party_workflow(
-    kind: WorkflowKind,
-    harness: FirstPartyHarnessManifest,
-) -> WorkflowInstance {
-    let workflow = harness.workflow;
-    let terminal_output = harness.terminal_output;
+fn resolve_first_party_workflow_harness(kind: WorkflowKind) -> ResolvedFirstPartyHarness {
+    let workspace_kind = match kind {
+        WorkflowKind::Slides => WorkspacePolicyKind::Slides,
+        WorkflowKind::Site => WorkspacePolicyKind::Sites,
+        other => panic!("workflow {other:?} does not have a first-party harness"),
+    };
+
+    resolve_first_party_harness_for_workspace_kind(workspace_kind)
+        .unwrap_or_else(|| panic!("missing first-party harness for workflow kind {:?}", kind))
+}
+
+pub(crate) fn build_first_party_workflow(kind: WorkflowKind) -> WorkflowInstance {
+    let harness = resolve_first_party_workflow_harness(kind);
+    let workflow = harness.manifest.workflow;
+    let terminal_output = harness.manifest.terminal_output;
 
     WorkflowInstance {
         kind,
@@ -37,4 +49,10 @@ pub(crate) fn build_first_party_workflow(
         },
         additional_instructions: workflow.additional_instructions,
     }
+}
+
+pub(crate) fn workspace_policy_for_first_party_workflow(kind: WorkflowKind) -> WorkspacePolicy {
+    resolve_first_party_workflow_harness(kind)
+        .manifest
+        .workspace_policy()
 }

--- a/crates/octos-cli/src/workflows/site_delivery.rs
+++ b/crates/octos-cli/src/workflows/site_delivery.rs
@@ -1,6 +1,6 @@
 use crate::workflow_runtime::workflow_families::SiteTemplate;
 use crate::workflow_runtime::{WorkflowInstance, WorkflowKind};
-use octos_agent::{FirstPartyHarnessManifest, FirstPartyHarnessName, WorkspacePolicy};
+use octos_agent::{FirstPartyHarnessManifest, WorkspacePolicy};
 
 pub fn build_output_dir_for_template_kind(template: SiteTemplate) -> &'static str {
     template.output_dir()
@@ -20,12 +20,13 @@ pub fn workspace_policy_for_template(template: &str) -> WorkspacePolicy {
 }
 
 pub fn build() -> WorkflowInstance {
-    super::build_first_party_workflow(WorkflowKind::Site, FirstPartyHarnessName::Sites.manifest())
+    super::build_first_party_workflow(WorkflowKind::Site)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use octos_agent::FirstPartyHarnessName;
 
     #[test]
     fn build_site_workflow_uses_site_output_contract() {

--- a/crates/octos-cli/src/workflows/site_delivery.rs
+++ b/crates/octos-cli/src/workflows/site_delivery.rs
@@ -1,7 +1,5 @@
 use crate::workflow_runtime::workflow_families::SiteTemplate;
-use crate::workflow_runtime::{
-    WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
-};
+use crate::workflow_runtime::{WorkflowInstance, WorkflowKind};
 use octos_agent::{FirstPartyHarnessManifest, WorkspacePolicy};
 
 pub fn build_output_dir_for_template_kind(template: SiteTemplate) -> &'static str {
@@ -22,36 +20,7 @@ pub fn workspace_policy_for_template(template: &str) -> WorkspacePolicy {
 }
 
 pub fn build() -> WorkflowInstance {
-    let harness = FirstPartyHarnessManifest::sites();
-    WorkflowInstance {
-        kind: WorkflowKind::Site,
-        label: "Site deliverable".to_string(),
-        ack_message: "Site generation has started in the background. Only the final verified site entrypoint will be delivered once the workspace contract is satisfied.".to_string(),
-        current_phase: WorkflowPhase::new("scaffold"),
-        allowed_tools: vec![
-            "read_file".into(),
-            "write_file".into(),
-            "edit_file".into(),
-            "shell".into(),
-            "glob".into(),
-            "check_background_tasks".into(),
-            "check_workspace_contract".into(),
-        ],
-        limits: WorkflowLimits {
-            max_search_passes: None,
-            max_pipeline_runs: None,
-            max_dialogue_lines: Some(24),
-            target_audio_minutes: None,
-            max_generate_calls: Some(1),
-        },
-        terminal_output: WorkflowTerminalOutput {
-            deliver_final_artifact_only: harness.terminal_output.deliver_final_artifact_only,
-            deliver_media_only: harness.terminal_output.deliver_media_only,
-            forbid_intermediate_files: harness.terminal_output.forbid_intermediate_files,
-            required_artifact_kind: harness.terminal_output.required_artifact_kind,
-        },
-        additional_instructions: "You are a background site builder. Follow the runtime-owned phases in order: scaffold, build, deliver_result. Read the session metadata to discover the selected template and build output directory, keep edits inside the project root, and deliver only the final built site entrypoint. Do not send intermediate logs, scratch files, or alternate build artifacts.".to_string(),
-    }
+    super::build_first_party_workflow(WorkflowKind::Site, FirstPartyHarnessManifest::sites())
 }
 
 #[cfg(test)]
@@ -128,6 +97,32 @@ mod tests {
         assert_eq!(
             workflow.terminal_output.deliver_final_artifact_only,
             harness.terminal_output.deliver_final_artifact_only
+        );
+    }
+
+    #[test]
+    fn site_workflow_uses_first_party_harness_metadata() {
+        let workflow = build();
+        let harness = FirstPartyHarnessManifest::sites();
+
+        assert_eq!(workflow.label, harness.workflow.label);
+        assert_eq!(workflow.ack_message, harness.workflow.ack_message);
+        assert_eq!(
+            workflow.current_phase.as_str(),
+            harness.workflow.initial_phase
+        );
+        assert_eq!(workflow.allowed_tools, harness.workflow.allowed_tools);
+        assert_eq!(
+            workflow.limits.max_dialogue_lines,
+            harness.workflow.limits.max_dialogue_lines
+        );
+        assert_eq!(
+            workflow.limits.max_generate_calls,
+            harness.workflow.limits.max_generate_calls
+        );
+        assert_eq!(
+            workflow.additional_instructions,
+            harness.workflow.additional_instructions
         );
     }
 }

--- a/crates/octos-cli/src/workflows/site_delivery.rs
+++ b/crates/octos-cli/src/workflows/site_delivery.rs
@@ -1,6 +1,6 @@
 use crate::workflow_runtime::workflow_families::SiteTemplate;
 use crate::workflow_runtime::{WorkflowInstance, WorkflowKind};
-use octos_agent::{FirstPartyHarnessManifest, WorkspacePolicy};
+use octos_agent::{FirstPartyHarnessManifest, FirstPartyHarnessName, WorkspacePolicy};
 
 pub fn build_output_dir_for_template_kind(template: SiteTemplate) -> &'static str {
     template.output_dir()
@@ -20,7 +20,7 @@ pub fn workspace_policy_for_template(template: &str) -> WorkspacePolicy {
 }
 
 pub fn build() -> WorkflowInstance {
-    super::build_first_party_workflow(WorkflowKind::Site, FirstPartyHarnessManifest::sites())
+    super::build_first_party_workflow(WorkflowKind::Site, FirstPartyHarnessName::Sites.manifest())
 }
 
 #[cfg(test)]
@@ -88,7 +88,7 @@ mod tests {
     #[test]
     fn site_workflow_uses_first_party_harness_terminal_output() {
         let workflow = build();
-        let harness = FirstPartyHarnessManifest::sites();
+        let harness = FirstPartyHarnessName::Sites.manifest();
 
         assert_eq!(
             workflow.terminal_output.required_artifact_kind,
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn site_workflow_uses_first_party_harness_metadata() {
         let workflow = build();
-        let harness = FirstPartyHarnessManifest::sites();
+        let harness = FirstPartyHarnessName::Sites.manifest();
 
         assert_eq!(workflow.label, harness.workflow.label);
         assert_eq!(workflow.ack_message, harness.workflow.ack_message);

--- a/crates/octos-cli/src/workflows/site_delivery.rs
+++ b/crates/octos-cli/src/workflows/site_delivery.rs
@@ -2,7 +2,7 @@ use crate::workflow_runtime::workflow_families::SiteTemplate;
 use crate::workflow_runtime::{
     WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
 };
-use octos_agent::WorkspacePolicy;
+use octos_agent::{FirstPartyHarnessManifest, WorkspacePolicy};
 
 pub fn build_output_dir_for_template_kind(template: SiteTemplate) -> &'static str {
     template.output_dir()
@@ -13,7 +13,8 @@ pub fn build_output_dir_for_template(template: &str) -> &'static str {
 }
 
 pub fn workspace_policy_for_template_kind(template: SiteTemplate) -> WorkspacePolicy {
-    WorkspacePolicy::for_site_build_output(build_output_dir_for_template_kind(template))
+    FirstPartyHarnessManifest::site_with_build_output(build_output_dir_for_template_kind(template))
+        .workspace_policy()
 }
 
 pub fn workspace_policy_for_template(template: &str) -> WorkspacePolicy {
@@ -21,6 +22,7 @@ pub fn workspace_policy_for_template(template: &str) -> WorkspacePolicy {
 }
 
 pub fn build() -> WorkflowInstance {
+    let harness = FirstPartyHarnessManifest::sites();
     WorkflowInstance {
         kind: WorkflowKind::Site,
         label: "Site deliverable".to_string(),
@@ -43,10 +45,10 @@ pub fn build() -> WorkflowInstance {
             max_generate_calls: Some(1),
         },
         terminal_output: WorkflowTerminalOutput {
-            deliver_final_artifact_only: true,
-            deliver_media_only: false,
-            forbid_intermediate_files: true,
-            required_artifact_kind: "site".into(),
+            deliver_final_artifact_only: harness.terminal_output.deliver_final_artifact_only,
+            deliver_media_only: harness.terminal_output.deliver_media_only,
+            forbid_intermediate_files: harness.terminal_output.forbid_intermediate_files,
+            required_artifact_kind: harness.terminal_output.required_artifact_kind,
         },
         additional_instructions: "You are a background site builder. Follow the runtime-owned phases in order: scaffold, build, deliver_result. Read the session metadata to discover the selected template and build output directory, keep edits inside the project root, and deliver only the final built site entrypoint. Do not send intermediate logs, scratch files, or alternate build artifacts.".to_string(),
     }
@@ -65,10 +67,12 @@ mod tests {
         assert!(workflow.terminal_output.deliver_final_artifact_only);
         assert!(!workflow.terminal_output.deliver_media_only);
         assert!(workflow.terminal_output.forbid_intermediate_files);
-        assert!(workflow
-            .allowed_tools
-            .iter()
-            .any(|tool| tool == "check_workspace_contract"));
+        assert!(
+            workflow
+                .allowed_tools
+                .iter()
+                .any(|tool| tool == "check_workspace_contract")
+        );
     }
 
     #[test]
@@ -103,8 +107,27 @@ mod tests {
             vec!["file_exists:out/index.html"]
         );
         assert_eq!(
-            policy.artifacts.entries.get("entrypoint").map(String::as_str),
+            policy
+                .artifacts
+                .entries
+                .get("entrypoint")
+                .map(String::as_str),
             Some("out/index.html")
+        );
+    }
+
+    #[test]
+    fn site_workflow_uses_first_party_harness_terminal_output() {
+        let workflow = build();
+        let harness = FirstPartyHarnessManifest::sites();
+
+        assert_eq!(
+            workflow.terminal_output.required_artifact_kind,
+            harness.terminal_output.required_artifact_kind
+        );
+        assert_eq!(
+            workflow.terminal_output.deliver_final_artifact_only,
+            harness.terminal_output.deliver_final_artifact_only
         );
     }
 }

--- a/crates/octos-cli/src/workflows/slides_delivery.rs
+++ b/crates/octos-cli/src/workflows/slides_delivery.rs
@@ -1,12 +1,15 @@
 use crate::workflow_runtime::{WorkflowInstance, WorkflowKind};
-use octos_agent::{FirstPartyHarnessManifest, WorkspacePolicy};
+use octos_agent::{FirstPartyHarnessName, WorkspacePolicy};
 
 pub fn build() -> WorkflowInstance {
-    super::build_first_party_workflow(WorkflowKind::Slides, FirstPartyHarnessManifest::slides())
+    super::build_first_party_workflow(
+        WorkflowKind::Slides,
+        FirstPartyHarnessName::Slides.manifest(),
+    )
 }
 
 pub fn workspace_policy() -> WorkspacePolicy {
-    FirstPartyHarnessManifest::slides().workspace_policy()
+    FirstPartyHarnessName::Slides.manifest().workspace_policy()
 }
 
 #[cfg(test)]
@@ -63,7 +66,7 @@ mod tests {
     #[test]
     fn slides_workflow_uses_first_party_harness_terminal_output() {
         let workflow = build();
-        let harness = FirstPartyHarnessManifest::slides();
+        let harness = FirstPartyHarnessName::Slides.manifest();
 
         assert_eq!(
             workflow.terminal_output.required_artifact_kind,
@@ -78,7 +81,7 @@ mod tests {
     #[test]
     fn slides_workflow_uses_first_party_harness_metadata() {
         let workflow = build();
-        let harness = FirstPartyHarnessManifest::slides();
+        let harness = FirstPartyHarnessName::Slides.manifest();
 
         assert_eq!(workflow.label, harness.workflow.label);
         assert_eq!(workflow.ack_message, harness.workflow.ack_message);

--- a/crates/octos-cli/src/workflows/slides_delivery.rs
+++ b/crates/octos-cli/src/workflows/slides_delivery.rs
@@ -1,9 +1,10 @@
 use crate::workflow_runtime::{
     WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
 };
-use octos_agent::{WorkspacePolicy, WorkspaceProjectKind};
+use octos_agent::{FirstPartyHarnessManifest, WorkspacePolicy};
 
 pub fn build() -> WorkflowInstance {
+    let harness = FirstPartyHarnessManifest::slides();
     WorkflowInstance {
         kind: WorkflowKind::Slides,
         label: "Slides deliverable".to_string(),
@@ -27,17 +28,17 @@ pub fn build() -> WorkflowInstance {
             max_generate_calls: Some(1),
         },
         terminal_output: WorkflowTerminalOutput {
-            deliver_final_artifact_only: true,
-            deliver_media_only: false,
-            forbid_intermediate_files: true,
-            required_artifact_kind: "presentation".into(),
+            deliver_final_artifact_only: harness.terminal_output.deliver_final_artifact_only,
+            deliver_media_only: harness.terminal_output.deliver_media_only,
+            forbid_intermediate_files: harness.terminal_output.forbid_intermediate_files,
+            required_artifact_kind: harness.terminal_output.required_artifact_kind,
         },
         additional_instructions: "You are a background slides producer. Follow the runtime-owned phases in order: design, generate_deck, deliver_result. Write the slide script first, validate it before generation, call mofa_slides once, and deliver only the final deck artifact. Do not send intermediate previews, scratch PNGs, or alternate deck exports.".to_string(),
     }
 }
 
 pub fn workspace_policy() -> WorkspacePolicy {
-    WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides)
+    FirstPartyHarnessManifest::slides().workspace_policy()
 }
 
 #[cfg(test)]
@@ -49,25 +50,60 @@ mod tests {
         let workflow = build();
         assert_eq!(workflow.kind, WorkflowKind::Slides);
         assert_eq!(workflow.current_phase.as_str(), "design");
-        assert_eq!(workflow.terminal_output.required_artifact_kind, "presentation");
+        assert_eq!(
+            workflow.terminal_output.required_artifact_kind,
+            "presentation"
+        );
         assert!(workflow.terminal_output.deliver_final_artifact_only);
         assert!(!workflow.terminal_output.deliver_media_only);
         assert!(workflow.terminal_output.forbid_intermediate_files);
-        assert!(workflow.allowed_tools.iter().any(|tool| tool == "mofa_slides"));
-        assert!(workflow
-            .allowed_tools
-            .iter()
-            .any(|tool| tool == "check_workspace_contract"));
+        assert!(
+            workflow
+                .allowed_tools
+                .iter()
+                .any(|tool| tool == "mofa_slides")
+        );
+        assert!(
+            workflow
+                .allowed_tools
+                .iter()
+                .any(|tool| tool == "check_workspace_contract")
+        );
     }
 
     #[test]
     fn slides_workspace_policy_is_standardized() {
         let policy = workspace_policy();
-        assert_eq!(policy.workspace.kind, octos_agent::WorkspacePolicyKind::Slides);
-        assert!(policy.validation.on_turn_end.contains(&"file_exists:script.js".to_string()));
-        assert!(policy
-            .validation
-            .on_completion
-            .contains(&"file_exists:output/*.pptx".to_string()));
+        assert_eq!(
+            policy.workspace.kind,
+            octos_agent::WorkspacePolicyKind::Slides
+        );
+        assert!(
+            policy
+                .validation
+                .on_turn_end
+                .contains(&"file_exists:script.js".to_string())
+        );
+        assert!(
+            policy
+                .validation
+                .on_completion
+                .contains(&"file_exists:output/*.pptx".to_string())
+        );
+    }
+
+    #[test]
+    fn slides_workflow_uses_first_party_harness_terminal_output() {
+        let workflow = build();
+        let harness = FirstPartyHarnessManifest::slides();
+
+        assert_eq!(
+            workflow.terminal_output.required_artifact_kind,
+            harness.terminal_output.required_artifact_kind
+        );
+        assert_eq!(
+            workflow.terminal_output.deliver_final_artifact_only,
+            harness.terminal_output.deliver_final_artifact_only
+        );
     }
 }

--- a/crates/octos-cli/src/workflows/slides_delivery.rs
+++ b/crates/octos-cli/src/workflows/slides_delivery.rs
@@ -1,40 +1,8 @@
-use crate::workflow_runtime::{
-    WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
-};
+use crate::workflow_runtime::{WorkflowInstance, WorkflowKind};
 use octos_agent::{FirstPartyHarnessManifest, WorkspacePolicy};
 
 pub fn build() -> WorkflowInstance {
-    let harness = FirstPartyHarnessManifest::slides();
-    WorkflowInstance {
-        kind: WorkflowKind::Slides,
-        label: "Slides deliverable".to_string(),
-        ack_message: "Slides generation has started in the background. Only the final deck will be delivered once the workspace contract is satisfied.".to_string(),
-        current_phase: WorkflowPhase::new("design"),
-        allowed_tools: vec![
-            "mofa_slides".into(),
-            "read_file".into(),
-            "write_file".into(),
-            "edit_file".into(),
-            "shell".into(),
-            "glob".into(),
-            "check_background_tasks".into(),
-            "check_workspace_contract".into(),
-        ],
-        limits: WorkflowLimits {
-            max_search_passes: None,
-            max_pipeline_runs: None,
-            max_dialogue_lines: Some(24),
-            target_audio_minutes: None,
-            max_generate_calls: Some(1),
-        },
-        terminal_output: WorkflowTerminalOutput {
-            deliver_final_artifact_only: harness.terminal_output.deliver_final_artifact_only,
-            deliver_media_only: harness.terminal_output.deliver_media_only,
-            forbid_intermediate_files: harness.terminal_output.forbid_intermediate_files,
-            required_artifact_kind: harness.terminal_output.required_artifact_kind,
-        },
-        additional_instructions: "You are a background slides producer. Follow the runtime-owned phases in order: design, generate_deck, deliver_result. Write the slide script first, validate it before generation, call mofa_slides once, and deliver only the final deck artifact. Do not send intermediate previews, scratch PNGs, or alternate deck exports.".to_string(),
-    }
+    super::build_first_party_workflow(WorkflowKind::Slides, FirstPartyHarnessManifest::slides())
 }
 
 pub fn workspace_policy() -> WorkspacePolicy {
@@ -104,6 +72,32 @@ mod tests {
         assert_eq!(
             workflow.terminal_output.deliver_final_artifact_only,
             harness.terminal_output.deliver_final_artifact_only
+        );
+    }
+
+    #[test]
+    fn slides_workflow_uses_first_party_harness_metadata() {
+        let workflow = build();
+        let harness = FirstPartyHarnessManifest::slides();
+
+        assert_eq!(workflow.label, harness.workflow.label);
+        assert_eq!(workflow.ack_message, harness.workflow.ack_message);
+        assert_eq!(
+            workflow.current_phase.as_str(),
+            harness.workflow.initial_phase
+        );
+        assert_eq!(workflow.allowed_tools, harness.workflow.allowed_tools);
+        assert_eq!(
+            workflow.limits.max_dialogue_lines,
+            harness.workflow.limits.max_dialogue_lines
+        );
+        assert_eq!(
+            workflow.limits.max_generate_calls,
+            harness.workflow.limits.max_generate_calls
+        );
+        assert_eq!(
+            workflow.additional_instructions,
+            harness.workflow.additional_instructions
         );
     }
 }

--- a/crates/octos-cli/src/workflows/slides_delivery.rs
+++ b/crates/octos-cli/src/workflows/slides_delivery.rs
@@ -1,20 +1,18 @@
 use crate::workflow_runtime::{WorkflowInstance, WorkflowKind};
-use octos_agent::{FirstPartyHarnessName, WorkspacePolicy};
+use octos_agent::WorkspacePolicy;
 
 pub fn build() -> WorkflowInstance {
-    super::build_first_party_workflow(
-        WorkflowKind::Slides,
-        FirstPartyHarnessName::Slides.manifest(),
-    )
+    super::build_first_party_workflow(WorkflowKind::Slides)
 }
 
 pub fn workspace_policy() -> WorkspacePolicy {
-    FirstPartyHarnessName::Slides.manifest().workspace_policy()
+    super::workspace_policy_for_first_party_workflow(WorkflowKind::Slides)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use octos_agent::FirstPartyHarnessName;
 
     #[test]
     fn build_slides_workflow_uses_presentation_output_contract() {


### PR DESCRIPTION
## Summary
- add stable first-party harness id exports and manifest-id lookup in the catalog
- route workflow binding through a narrow id-based seam instead of ad hoc workflow-kind matching
- keep runtime behavior unchanged while continuing M3.5 / #441

## Validation
- cargo test -p octos-agent first_party_harness::tests::
- cargo test -p octos-agent first_party_harness_catalog::tests::
- cargo test -p octos-cli --features api workflow_uses_first_party_harness_
- cargo test -p octos-cli --features api workflow_binding_resolves_expected_harness_ids
- cargo test -p octos-cli --features api build_slides_workflow_uses_presentation_output_contract
- cargo test -p octos-cli --features api build_site_workflow_uses_site_output_contract