### PR TITLE
RP01 — SafetyTier as ToolPolicy group family

### DIFF
--- a/crates/octos-agent/examples/inspection_safety.rs
+++ b/crates/octos-agent/examples/inspection_safety.rs
@@ -1,0 +1,78 @@
+//! # Inspection Safety — Tiered Tool Authorization via `ToolPolicy`
+//!
+//! Demonstrates how a robot integrator expresses supervisory safety tiers
+//! *without* adding a trait method to `Tool`. Each tool is registered with a
+//! `SafetyTier` through the shared `RobotToolRegistry`; the agent enforces
+//! the ceiling by configuring a standard `ToolPolicy` with a single
+//! `group:robot:<tier>` entry.
+//!
+//! Scenario: a gas-pipeline valve inspection. The operator grants the session
+//! `group:robot:safe_motion` — cameras and slow moves only. If the LLM asks
+//! for `fast_arm_move`, `ToolPolicy::evaluate` returns a deny with
+//! `reason = "robot_tier_gate"`, and the existing dispatch site refuses
+//! to execute it.
+//!
+//! ```bash
+//! cargo run --example inspection_safety -p octos-agent
+//! ```
+
+use octos_agent::permissions::SafetyTier;
+use octos_agent::tools::policy::PolicyDecision;
+use octos_agent::tools::robot_groups::{self, RobotToolRegistry};
+use octos_agent::tools::ToolPolicy;
+
+fn main() -> eyre::Result<()> {
+    // Step 1: the robot integrator declares which tools sit at which tier.
+    // This is the config layer — no trait default method, no new Tool API.
+    let mut registry = RobotToolRegistry::new();
+    registry.insert("camera_capture", SafetyTier::Observe);
+    registry.insert("sensor_read", SafetyTier::Observe);
+    registry.insert("valve_slow_turn", SafetyTier::SafeMotion);
+    registry.insert("arm_slow_move", SafetyTier::SafeMotion);
+    registry.insert("fast_arm_move", SafetyTier::FullActuation);
+    registry.insert("joint_full_actuation", SafetyTier::FullActuation);
+    registry.insert("emergency_override", SafetyTier::EmergencyOverride);
+    robot_groups::install_registry(registry);
+
+    // Step 2: the operator chooses a session ceiling. Everything below is
+    // expressed through the ordinary `ToolPolicy` allow list.
+    let policy = ToolPolicy {
+        allow: vec!["group:robot:safe_motion".into()],
+        ..Default::default()
+    };
+
+    println!("Session policy: allow = {:?}", policy.allow);
+    println!("(Operator granted SafeMotion — cameras + slow motion only)\n");
+
+    // Step 3: mock a tiny agent loop. For each tool the LLM wants to run,
+    // consult `ToolPolicy::evaluate`. The dispatch site is the same one the
+    // real `ToolRegistry::execute` uses — no bespoke authorize() call.
+    let tool_plan = [
+        ("camera_capture", "read pressure gauge V-101"),
+        ("valve_slow_turn", "quarter-turn V-101 clockwise"),
+        ("fast_arm_move", "retract at max speed"),
+        ("emergency_override", "disable force limits"),
+    ];
+
+    let mut allowed = 0usize;
+    let mut denied = 0usize;
+    for (tool, rationale) in tool_plan {
+        match policy.evaluate(tool) {
+            PolicyDecision::Allow => {
+                println!("ALLOW  {tool:<24} — {rationale}");
+                allowed += 1;
+            }
+            PolicyDecision::Deny { reason } => {
+                println!("DENY   {tool:<24} — reason: {reason} ({rationale})");
+                denied += 1;
+            }
+        }
+    }
+
+    println!("\nSummary: {allowed} allowed, {denied} denied");
+    assert_eq!(allowed, 2, "camera_capture and valve_slow_turn must pass");
+    assert_eq!(denied, 2, "full_actuation and emergency_override must be gated");
+
+    println!("\nInspection safety demo complete.");
+    Ok(())
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -18,6 +18,7 @@ pub mod exec_env;
 pub mod hooks;
 pub mod loop_detect;
 pub mod mcp;
+pub mod permissions;
 pub mod plugins;
 pub mod policy;
 pub mod progress;
@@ -45,6 +46,7 @@ pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookResult};
 pub use mcp::{McpClient, McpServerConfig};
+pub use permissions::{InvalidSafetyTier, SafetyTier};
 pub use plugins::{PluginLoadResult, PluginLoader};
 pub use progress::{ConsoleReporter, ProgressEvent, ProgressReporter, SilentReporter};
 pub use prompt_layer::PromptLayerBuilder;
@@ -60,10 +62,11 @@ pub use tools::{
     ActivateToolsTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,
     CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConfigureToolTool, DeepSearchTool,
     DiffEditTool, EditFileTool, GlobTool, GrepTool, ListDirTool, ManageSkillsTool, MessageTool,
-    ReadFileTool, RecallMemoryTool, SaveMemoryTool, SendFileTool, ShellTool, SpawnTool,
-    SynthesizeResearchTool, TakePhotoTool, Tool, ToolConfigStore, ToolPolicy, ToolRegistry,
-    ToolResult, TurnAttachmentContext, WebFetchTool, WebSearchTool, WriteFileTool,
-    admin::{AdminApiContext, register_admin_api_tools},
+    PolicyDecision, ReadFileTool, RecallMemoryTool, RobotToolRegistry, SaveMemoryTool,
+    SendFileTool, ShellTool, SpawnTool, SynthesizeResearchTool, TakePhotoTool, Tool,
+    ToolConfigStore, ToolPolicy, ToolRegistry, ToolResult, TurnAttachmentContext, WebFetchTool,
+    WebSearchTool, WriteFileTool, admin::{AdminApiContext, register_admin_api_tools},
+    install_robot_registry,
 };
 pub use turn::{Turn, TurnKind, turns_to_messages};
 pub use workspace_git::{

--- a/crates/octos-agent/src/permissions.rs
+++ b/crates/octos-agent/src/permissions.rs
@@ -1,0 +1,156 @@
+//! Supervisory safety tiers for robotic tool authorization.
+//!
+//! The four-tier model expresses how much physical risk a tool can take.
+//! Tiers are enforced through `ToolPolicy` groups (`group:robot:<tier>`),
+//! not through a dedicated trait method — see `tools::robot_groups`.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Safety tiers ordered from least to most dangerous.
+///
+/// `Observe < SafeMotion < FullActuation < EmergencyOverride`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SafetyTier {
+    /// Read-only: cameras, sensors, status queries. No actuation.
+    Observe,
+    /// Low-risk motion: slow moves within verified workspace bounds.
+    SafeMotion,
+    /// Full-speed actuation with force control. Requires operator awareness.
+    FullActuation,
+    /// Bypass all safety limits. Emergency recovery only.
+    EmergencyOverride,
+}
+
+impl SafetyTier {
+    /// Canonical snake_case label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Observe => "observe",
+            Self::SafeMotion => "safe_motion",
+            Self::FullActuation => "full_actuation",
+            Self::EmergencyOverride => "emergency_override",
+        }
+    }
+
+    /// Slice of all tiers ordered least to most dangerous.
+    pub const ALL: &'static [SafetyTier] = &[
+        Self::Observe,
+        Self::SafeMotion,
+        Self::FullActuation,
+        Self::EmergencyOverride,
+    ];
+}
+
+impl fmt::Display for SafetyTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Error returned by `SafetyTier::from_str` for unknown tier names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSafetyTier {
+    pub input: String,
+}
+
+impl fmt::Display for InvalidSafetyTier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid safety tier '{}' (expected one of: observe, safe_motion, full_actuation, emergency_override)",
+            self.input
+        )
+    }
+}
+
+impl std::error::Error for InvalidSafetyTier {}
+
+impl FromStr for SafetyTier {
+    type Err = InvalidSafetyTier;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "observe" => Ok(Self::Observe),
+            "safe_motion" => Ok(Self::SafeMotion),
+            "full_actuation" => Ok(Self::FullActuation),
+            "emergency_override" => Ok(Self::EmergencyOverride),
+            _ => Err(InvalidSafetyTier {
+                input: s.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_order_tiers_from_observe_to_emergency() {
+        assert!(SafetyTier::Observe < SafetyTier::SafeMotion);
+        assert!(SafetyTier::SafeMotion < SafetyTier::FullActuation);
+        assert!(SafetyTier::FullActuation < SafetyTier::EmergencyOverride);
+    }
+
+    #[test]
+    fn should_parse_canonical_names_when_from_str_called() {
+        assert_eq!("observe".parse::<SafetyTier>().unwrap(), SafetyTier::Observe);
+        assert_eq!(
+            "safe_motion".parse::<SafetyTier>().unwrap(),
+            SafetyTier::SafeMotion
+        );
+        assert_eq!(
+            "full_actuation".parse::<SafetyTier>().unwrap(),
+            SafetyTier::FullActuation
+        );
+        assert_eq!(
+            "emergency_override".parse::<SafetyTier>().unwrap(),
+            SafetyTier::EmergencyOverride
+        );
+    }
+
+    #[test]
+    fn should_accept_mixed_case_when_from_str_called() {
+        assert_eq!(
+            "OBSERVE".parse::<SafetyTier>().unwrap(),
+            SafetyTier::Observe
+        );
+        assert_eq!(
+            "Safe_Motion".parse::<SafetyTier>().unwrap(),
+            SafetyTier::SafeMotion
+        );
+        assert_eq!(
+            " emergency_override ".parse::<SafetyTier>().unwrap(),
+            SafetyTier::EmergencyOverride
+        );
+    }
+
+    #[test]
+    fn should_reject_unknown_names_when_from_str_called() {
+        let err = "dangerous".parse::<SafetyTier>().unwrap_err();
+        assert_eq!(err.input, "dangerous");
+        assert!(
+            err.to_string().contains("invalid safety tier"),
+            "error message should name the invalid input: {err}"
+        );
+
+        assert!("".parse::<SafetyTier>().is_err());
+        assert!("safe-motion".parse::<SafetyTier>().is_err());
+    }
+
+    #[test]
+    fn should_serialize_as_snake_case_json() {
+        assert_eq!(
+            serde_json::to_string(&SafetyTier::SafeMotion).unwrap(),
+            "\"safe_motion\""
+        );
+        assert_eq!(
+            serde_json::from_str::<SafetyTier>("\"full_actuation\"").unwrap(),
+            SafetyTier::FullActuation
+        );
+    }
+}

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -182,7 +182,11 @@ pub use registry::ToolRegistry;
 
 // Tool policy
 pub mod policy;
-pub use policy::ToolPolicy;
+pub use policy::{PolicyDecision, ToolPolicy};
+
+// Robot safety-tier groups consulted by ToolPolicy evaluation.
+pub mod robot_groups;
+pub use robot_groups::{RobotToolRegistry, install_registry as install_robot_registry};
 
 // Shared SSRF protection
 pub mod ssrf;

--- a/crates/octos-agent/src/tools/policy.rs
+++ b/crates/octos-agent/src/tools/policy.rs
@@ -1,6 +1,27 @@
 //! Tool policy system with allow/deny lists, groups, and wildcards.
 
+use metrics::counter;
 use serde::{Deserialize, Serialize};
+
+use super::robot_groups;
+
+/// Outcome of `ToolPolicy::evaluate`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyDecision {
+    /// Tool is permitted.
+    Allow,
+    /// Tool is denied. `reason` is the metric label emitted for observability.
+    Deny { reason: &'static str },
+}
+
+/// Metric counter name for policy denials.
+pub const POLICY_DENIAL_COUNTER: &str = "octos_tool_policy_denial_total";
+
+/// Deny reason label used when a robot-tier group gates a tool.
+pub const ROBOT_TIER_GATE_REASON: &str = "robot_tier_gate";
+
+/// Deny reason label used for a non-robot policy deny.
+pub const GENERIC_DENY_REASON: &str = "policy_deny";
 
 /// Tool policy with allow/deny lists and tag-based filtering. Deny always wins over allow.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -20,26 +41,51 @@ pub struct ToolPolicy {
 impl ToolPolicy {
     /// Check if a tool name is permitted by this policy (name-based only).
     pub fn is_allowed(&self, tool_name: &str) -> bool {
-        // Deny checked first (deny-wins semantics)
+        matches!(self.evaluate(tool_name), PolicyDecision::Allow)
+    }
+
+    /// Full evaluation that returns an allow / deny decision plus a metric
+    /// label on deny. Emits `octos_tool_policy_denial_total` with
+    /// `reason="robot_tier_gate"` when the deny was driven by a
+    /// `group:robot:*` entry, otherwise `reason="policy_deny"`.
+    pub fn evaluate(&self, tool_name: &str) -> PolicyDecision {
+        // Deny-wins: explicit deny entries take precedence.
         for entry in &self.deny {
             if entry_matches(entry, tool_name) {
-                return false;
+                let reason = if entry_is_robot_group(entry) {
+                    ROBOT_TIER_GATE_REASON
+                } else {
+                    GENERIC_DENY_REASON
+                };
+                counter!(POLICY_DENIAL_COUNTER, "reason" => reason).increment(1);
+                return PolicyDecision::Deny { reason };
             }
         }
 
-        // Empty allow list = allow everything not denied
+        // Empty allow list = allow everything not denied.
         if self.allow.is_empty() {
-            return true;
+            return PolicyDecision::Allow;
         }
 
-        // Check allow list
         for entry in &self.allow {
             if entry_matches(entry, tool_name) {
-                return true;
+                return PolicyDecision::Allow;
             }
         }
 
-        false
+        // Tool wasn't matched by any allow entry. If the allow list contains
+        // robot-tier groups AND the tool is registered in a robot tier, the
+        // gate is a robot-tier gate — that's the case robotic integrators
+        // care about observing.
+        let reason = if self.allow.iter().any(|entry| entry_is_robot_group(entry))
+            && robot_groups::tool_has_tier(tool_name)
+        {
+            ROBOT_TIER_GATE_REASON
+        } else {
+            GENERIC_DENY_REASON
+        };
+        counter!(POLICY_DENIAL_COUNTER, "reason" => reason).increment(1);
+        PolicyDecision::Deny { reason }
     }
 
     /// Check if a tool is permitted by both name policy and tag requirements.
@@ -74,7 +120,12 @@ impl ToolPolicy {
 
 /// Check if a policy entry (group, wildcard, or exact name) matches a tool name.
 fn entry_matches(entry: &str, tool_name: &str) -> bool {
-    // Group expansion
+    // Robot-tier groups resolve through the dynamic registry so integrators
+    // register tool-to-tier mappings at runtime.
+    if entry_is_robot_group(entry) {
+        return robot_groups::group_covers_tool(entry, tool_name);
+    }
+    // Static named groups (group:fs, group:runtime, ...)
     if let Some(tools) = expand_group(entry) {
         return tools.contains(&tool_name);
     }
@@ -84,6 +135,10 @@ fn entry_matches(entry: &str, tool_name: &str) -> bool {
     }
     // Exact match
     entry == tool_name
+}
+
+fn entry_is_robot_group(entry: &str) -> bool {
+    robot_groups::parse_group_name(entry).is_some()
 }
 
 /// Metadata about a tool group, used by the `activate_tools` tool to present

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -558,8 +558,8 @@ impl ToolRegistry {
     /// have access to.
     pub async fn execute(&self, name: &str, args: &serde_json::Value) -> Result<ToolResult> {
         if let Some(ref policy) = self.provider_policy {
-            if !policy.is_allowed(name) {
-                eyre::bail!("tool '{}' denied by provider policy", name);
+            if let policy::PolicyDecision::Deny { reason } = policy.evaluate(name) {
+                eyre::bail!("tool '{}' denied by provider policy ({})", name, reason);
             }
         }
 

--- a/crates/octos-agent/src/tools/robot_groups.rs
+++ b/crates/octos-agent/src/tools/robot_groups.rs
@@ -1,0 +1,231 @@
+//! Registry mapping robot tools to supervisory safety tiers.
+//!
+//! The four groups `group:robot:observe`, `group:robot:safe_motion`,
+//! `group:robot:full_actuation`, and `group:robot:emergency_override` are
+//! resolved through this registry. Integrators register each robot tool with
+//! the minimum tier it requires; `ToolPolicy::evaluate` then expands group
+//! names against the current registry, so tools move through the standard
+//! allow / deny pipeline without any Tool-trait changes.
+//!
+//! Subset semantics (strictly nested):
+//!   observe ⊂ safe_motion ⊂ full_actuation ⊂ emergency_override
+//!
+//! A policy granting `group:robot:safe_motion` implicitly allows every
+//! `observe` tool. Granting `group:robot:emergency_override` allows all four
+//! tiers.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{OnceLock, RwLock};
+
+use crate::permissions::SafetyTier;
+
+/// Group name prefix — every robot-tier group is `group:robot:<tier>`.
+pub const ROBOT_GROUP_PREFIX: &str = "group:robot:";
+
+/// Build the canonical group name for a tier.
+pub fn group_name(tier: SafetyTier) -> String {
+    format!("{ROBOT_GROUP_PREFIX}{}", tier.label())
+}
+
+/// Parse a group name and return the embedded tier, if any.
+pub fn parse_group_name(group: &str) -> Option<SafetyTier> {
+    let tier = group.strip_prefix(ROBOT_GROUP_PREFIX)?;
+    tier.parse::<SafetyTier>().ok()
+}
+
+/// Registry of robot tools keyed by the minimum tier each one requires.
+#[derive(Debug, Default, Clone)]
+pub struct RobotToolRegistry {
+    /// One entry per tier holding the explicit tools at that tier
+    /// (not the expanded subset — subset expansion is done on read).
+    by_tier: BTreeMap<SafetyTier, BTreeSet<String>>,
+}
+
+impl RobotToolRegistry {
+    /// Create an empty registry. The robot integrator populates it.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a tool at the given tier. Returns `true` if newly inserted.
+    pub fn insert(&mut self, tool_name: impl Into<String>, tier: SafetyTier) -> bool {
+        let name = tool_name.into();
+        // Keep a tool in at most one tier — prefer the most-recently-set.
+        for set in self.by_tier.values_mut() {
+            set.remove(&name);
+        }
+        self.by_tier.entry(tier).or_default().insert(name)
+    }
+
+    /// Remove a tool from every tier. Returns `true` if anything was removed.
+    pub fn remove(&mut self, tool_name: &str) -> bool {
+        let mut removed = false;
+        for set in self.by_tier.values_mut() {
+            removed |= set.remove(tool_name);
+        }
+        removed
+    }
+
+    /// Tier a tool is registered at, if any.
+    pub fn tier_of(&self, tool_name: &str) -> Option<SafetyTier> {
+        for (tier, set) in &self.by_tier {
+            if set.contains(tool_name) {
+                return Some(*tier);
+            }
+        }
+        None
+    }
+
+    /// True if any robot tool is registered.
+    pub fn is_empty(&self) -> bool {
+        self.by_tier.values().all(|set| set.is_empty())
+    }
+
+    /// All tools permitted at `tier` (includes all lower tiers — subset semantics).
+    pub fn tools_for_tier(&self, tier: SafetyTier) -> Vec<String> {
+        let mut out: BTreeSet<String> = BTreeSet::new();
+        for (t, set) in &self.by_tier {
+            if *t <= tier {
+                out.extend(set.iter().cloned());
+            }
+        }
+        out.into_iter().collect()
+    }
+
+    /// True if `tool_name` is at `tier` or lower (i.e. permitted at `tier`).
+    pub fn matches_group(&self, group: &str, tool_name: &str) -> bool {
+        match parse_group_name(group) {
+            Some(tier) => self
+                .tier_of(tool_name)
+                .is_some_and(|actual| actual <= tier),
+            None => false,
+        }
+    }
+}
+
+/// Global registry instance. Tests and integrators mutate it through
+/// `install_registry` or `with_registry_mut`.
+static GLOBAL: OnceLock<RwLock<RobotToolRegistry>> = OnceLock::new();
+
+fn cell() -> &'static RwLock<RobotToolRegistry> {
+    GLOBAL.get_or_init(|| RwLock::new(RobotToolRegistry::new()))
+}
+
+/// Replace the global registry with `next`. Useful for integrators and tests.
+pub fn install_registry(next: RobotToolRegistry) {
+    let lock = cell();
+    *lock.write().unwrap_or_else(|e| e.into_inner()) = next;
+}
+
+/// Read-only snapshot of the global registry.
+pub fn snapshot() -> RobotToolRegistry {
+    cell().read().unwrap_or_else(|e| e.into_inner()).clone()
+}
+
+/// Mutate the global registry in place.
+pub fn with_registry_mut<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut RobotToolRegistry) -> R,
+{
+    let mut guard = cell().write().unwrap_or_else(|e| e.into_inner());
+    f(&mut guard)
+}
+
+/// Fast path used by `ToolPolicy::evaluate` — true if `tool_name` falls under
+/// robot group `group` per the global registry.
+pub fn group_covers_tool(group: &str, tool_name: &str) -> bool {
+    if !group.starts_with(ROBOT_GROUP_PREFIX) {
+        return false;
+    }
+    cell()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .matches_group(group, tool_name)
+}
+
+/// True if any robot group references `tool_name` (i.e. the tool has a tier).
+pub fn tool_has_tier(tool_name: &str) -> bool {
+    cell()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .tier_of(tool_name)
+        .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_produce_canonical_group_names() {
+        assert_eq!(group_name(SafetyTier::Observe), "group:robot:observe");
+        assert_eq!(
+            group_name(SafetyTier::SafeMotion),
+            "group:robot:safe_motion"
+        );
+        assert_eq!(
+            group_name(SafetyTier::FullActuation),
+            "group:robot:full_actuation"
+        );
+        assert_eq!(
+            group_name(SafetyTier::EmergencyOverride),
+            "group:robot:emergency_override"
+        );
+    }
+
+    #[test]
+    fn should_round_trip_group_names() {
+        for tier in SafetyTier::ALL {
+            assert_eq!(parse_group_name(&group_name(*tier)), Some(*tier));
+        }
+        assert!(parse_group_name("group:robot:banana").is_none());
+        assert!(parse_group_name("group:fs").is_none());
+    }
+
+    #[test]
+    fn should_expand_tier_to_include_lower_tiers() {
+        let mut reg = RobotToolRegistry::new();
+        reg.insert("camera_read", SafetyTier::Observe);
+        reg.insert("slow_move", SafetyTier::SafeMotion);
+        reg.insert("fast_move", SafetyTier::FullActuation);
+        reg.insert("e_stop", SafetyTier::EmergencyOverride);
+
+        let observe = reg.tools_for_tier(SafetyTier::Observe);
+        assert_eq!(observe, vec!["camera_read".to_string()]);
+
+        let safe = reg.tools_for_tier(SafetyTier::SafeMotion);
+        assert_eq!(safe, vec!["camera_read".to_string(), "slow_move".to_string()]);
+
+        let full = reg.tools_for_tier(SafetyTier::FullActuation);
+        assert_eq!(full.len(), 3);
+        assert!(full.contains(&"fast_move".to_string()));
+
+        let emergency = reg.tools_for_tier(SafetyTier::EmergencyOverride);
+        assert_eq!(emergency.len(), 4);
+    }
+
+    #[test]
+    fn should_match_group_when_tool_tier_at_or_below_grant() {
+        let mut reg = RobotToolRegistry::new();
+        reg.insert("camera_read", SafetyTier::Observe);
+        reg.insert("fast_move", SafetyTier::FullActuation);
+
+        assert!(reg.matches_group("group:robot:safe_motion", "camera_read"));
+        assert!(!reg.matches_group("group:robot:safe_motion", "fast_move"));
+        assert!(reg.matches_group("group:robot:full_actuation", "fast_move"));
+        assert!(reg.matches_group("group:robot:emergency_override", "fast_move"));
+        assert!(!reg.matches_group("group:robot:observe", "fast_move"));
+        // Non-robot group never matches here.
+        assert!(!reg.matches_group("group:fs", "camera_read"));
+    }
+
+    #[test]
+    fn should_move_tool_to_new_tier_on_reinsert() {
+        let mut reg = RobotToolRegistry::new();
+        reg.insert("arm", SafetyTier::Observe);
+        assert_eq!(reg.tier_of("arm"), Some(SafetyTier::Observe));
+        reg.insert("arm", SafetyTier::FullActuation);
+        assert_eq!(reg.tier_of("arm"), Some(SafetyTier::FullActuation));
+        assert_eq!(reg.tools_for_tier(SafetyTier::Observe), Vec::<String>::new());
+    }
+}

--- a/crates/octos-agent/tests/robot_tool_policy.rs
+++ b/crates/octos-agent/tests/robot_tool_policy.rs
@@ -1,0 +1,121 @@
+//! Acceptance tests for RP01: SafetyTier as ToolPolicy group family.
+//!
+//! These tests lock in the behaviour a robot integrator depends on —
+//! tiered tools must be gated by `ToolPolicy::evaluate` through the
+//! existing allow/deny pipeline, with no new trait method on `Tool`.
+
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+use octos_agent::permissions::SafetyTier;
+use octos_agent::tools::policy::PolicyDecision;
+use octos_agent::tools::robot_groups::{self, RobotToolRegistry};
+use octos_agent::tools::ToolPolicy;
+
+/// The robot-group registry is process-wide state. Serialize tests that
+/// mutate it so they don't race against each other.
+fn registry_guard() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+fn install_demo_registry() {
+    let mut reg = RobotToolRegistry::new();
+    reg.insert("camera_read", SafetyTier::Observe);
+    reg.insert("sensor_probe", SafetyTier::Observe);
+    reg.insert("slow_move", SafetyTier::SafeMotion);
+    reg.insert("valve_turn", SafetyTier::SafeMotion);
+    reg.insert("fast_move", SafetyTier::FullActuation);
+    reg.insert("e_stop_bypass", SafetyTier::EmergencyOverride);
+    robot_groups::install_registry(reg);
+}
+
+#[test]
+fn should_deny_safe_motion_tool_when_policy_allows_only_observe() {
+    let _g = registry_guard();
+    install_demo_registry();
+
+    let policy = ToolPolicy {
+        allow: vec!["group:robot:observe".into()],
+        ..Default::default()
+    };
+
+    match policy.evaluate("slow_move") {
+        PolicyDecision::Deny { reason } => assert_eq!(reason, "robot_tier_gate"),
+        PolicyDecision::Allow => panic!("slow_move (safe_motion) must be denied under observe-only policy"),
+    }
+    assert!(policy.evaluate("camera_read") == PolicyDecision::Allow);
+}
+
+#[test]
+fn should_allow_observe_tool_when_policy_is_empty() {
+    let _g = registry_guard();
+    install_demo_registry();
+
+    let policy = ToolPolicy::default();
+    assert_eq!(policy.evaluate("camera_read"), PolicyDecision::Allow);
+    assert_eq!(policy.evaluate("sensor_probe"), PolicyDecision::Allow);
+    // Empty policy must also allow non-robot tools.
+    assert_eq!(policy.evaluate("read_file"), PolicyDecision::Allow);
+}
+
+#[test]
+fn should_allow_full_actuation_tool_when_policy_grants_full_actuation_group() {
+    let _g = registry_guard();
+    install_demo_registry();
+
+    let policy = ToolPolicy {
+        allow: vec!["group:robot:full_actuation".into()],
+        ..Default::default()
+    };
+
+    assert_eq!(policy.evaluate("fast_move"), PolicyDecision::Allow);
+    // Subset semantics: lower-tier tools also pass.
+    assert_eq!(policy.evaluate("slow_move"), PolicyDecision::Allow);
+    assert_eq!(policy.evaluate("camera_read"), PolicyDecision::Allow);
+    // Higher-tier tool must remain blocked.
+    match policy.evaluate("e_stop_bypass") {
+        PolicyDecision::Deny { reason } => assert_eq!(reason, "robot_tier_gate"),
+        PolicyDecision::Allow => panic!("emergency_override tool must stay gated"),
+    }
+}
+
+#[test]
+fn should_reject_invalid_tier_string_in_from_str() {
+    // from_str is case-insensitive but strict about the set of accepted names.
+    let err = "dangerous".parse::<SafetyTier>().unwrap_err();
+    assert_eq!(err.input, "dangerous");
+    assert!(
+        err.to_string().contains("invalid safety tier"),
+        "error must identify itself: {err}"
+    );
+    assert!("".parse::<SafetyTier>().is_err());
+    assert!("safe-motion".parse::<SafetyTier>().is_err());
+    // Canonical names still parse.
+    assert_eq!(
+        "Observe".parse::<SafetyTier>().unwrap(),
+        SafetyTier::Observe
+    );
+}
+
+#[test]
+#[ignore = "runs the example binary — enable with `cargo test -p octos-agent -- --ignored`"]
+fn inspection_safety_example_runs_end_to_end_against_policy() {
+    let status = Command::new(env!("CARGO"))
+        .args([
+            "run",
+            "--quiet",
+            "--example",
+            "inspection_safety",
+            "-p",
+            "octos-agent",
+        ])
+        .status()
+        .expect("spawn cargo run --example inspection_safety");
+    assert!(
+        status.success(),
+        "inspection_safety example should exit cleanly"
+    );
+}


### PR DESCRIPTION
Closes #447.

## What this delivers

Express robot safety tiers as named groups on the existing `ToolPolicy` (deny-wins, wildcards, groups). Robot integrators configure `allow_groups = ["group:robot:safe_motion"]` in their profile; `ToolPolicy::evaluate` enforces at the existing dispatch site. No new trait method on `Tool`. No separate authorize() layer.

Full contract: [docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp01](../blob/main/docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp01--safetytier-as-toolpolicy-group-family)

## Changes

- `crates/octos-agent/src/permissions.rs` (new, 156 LOC) — `SafetyTier` enum + case-insensitive `FromStr` + typed `InvalidSafetyTier` error.
- `crates/octos-agent/src/tools/robot_groups.rs` (new, 231 LOC) — `RobotToolRegistry` with tier-subset expansion. Global `OnceLock<RwLock<_>>` for integrators.
- `crates/octos-agent/src/tools/policy.rs` (+71/-7) — added `PolicyDecision::evaluate`, metric counter `octos_tool_policy_denial_total` with `reason` label. `entry_matches` routes `group:robot:*` through the dynamic registry before static groups.
- `crates/octos-agent/src/tools/registry.rs` (+2/-2) — dispatch site uses `evaluate`; error includes deny reason.
- `crates/octos-agent/examples/inspection_safety.rs` (new, 78 LOC) — integrator registers tools by tier; operator policy gates `group:robot:safe_motion`; mock loop calls `policy.evaluate(tool)`.
- `crates/octos-agent/tests/robot_tool_policy.rs` (new, 121 LOC) — 5 acceptance tests.

## Invariants

1. `ToolPolicy::evaluate` consults robot groups via the same pathway as static named groups.
2. `SafetyTier::from_str` accepts the 4 canonical names case-insensitively; rejects all others with a typed error.
3. `Tool` trait is untouched — no new default method.
4. Deleted PR #270 types (`RobotPermissionPolicy`, `WorkspaceBounds`, `PermissionDenied`) are not re-exported.
5. Example uses only `ToolPolicy` config — no bespoke `authorize()` call.

## Tests

```
test should_deny_safe_motion_tool_when_policy_allows_only_observe ... ok
test should_allow_observe_tool_when_policy_is_empty ... ok
test should_allow_full_actuation_tool_when_policy_grants_full_actuation_group ... ok
test should_reject_invalid_tier_string_in_from_str ... ok
test inspection_safety_example_runs_end_to_end_against_policy ... ok (--ignored)
```

## Test plan

- [x] `cargo build -p octos-agent`
- [x] `cargo test -p octos-agent --test robot_tool_policy`
- [x] `cargo test -p octos-agent -- --ignored inspection_safety_example_runs_end_to_end_against_policy`
- [ ] Live canary: operator configures robot group on dspfac.crew.ominix.io; dispatch of unregistered tier tool fails with 403 + `reason=robot_tier_gate` in metrics.