### PR TITLE
RP03 — Domain-hook pattern via BeforeSpawnVerify payload extension

### DIFF
--- a/crates/octos-agent/examples/robot_domain_hook.rs
+++ b/crates/octos-agent/examples/robot_domain_hook.rs
@@ -1,0 +1,189 @@
+//! Robot-integrator demo of the RP03 domain-hook pattern.
+//!
+//! This example shows how to veto a dispatched sub-task based on live robot
+//! telemetry **without** adding any robot-specific `HookEvent` variants to the
+//! core agent. The pattern is:
+//!
+//! 1. Implement `HookPayloadEnricher` in integrator code. The trait has one
+//!    synchronous method that reads the latest sensor snapshot from an
+//!    `Arc`-shared state and attaches it to `HookPayload.domain_data`.
+//! 2. Register the enricher on the shared `HookExecutor` via
+//!    `HookExecutor::with_enricher(Arc::new(my_enricher))`.
+//! 3. Write a before-hook shell script that reads the payload from stdin,
+//!    parses `domain_data`, and exits 1 to deny.
+//!
+//! Run with: `cargo run -p octos-agent --example robot_domain_hook`
+//!
+//! Expected output (last line):
+//!
+//! ```text
+//! hook decision: Deny("force 55.2 N exceeds 40 N limit")
+//! ```
+
+use std::io::Write as _;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use octos_agent::{
+    HookConfig, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,
+};
+
+/// A snapshot of the robot's physical state, refreshed by an external polling
+/// task in a real integration. Here we just hold fixed values for the demo.
+#[derive(Debug, Clone, Copy)]
+struct RobotSnapshot {
+    /// End-effector force magnitude in Newtons.
+    force_n: f64,
+    /// Emergency-stop engaged.
+    estop: bool,
+    /// Latest pose within the configured safe workspace.
+    workspace_in_bounds: bool,
+}
+
+/// Real integrators would back this with `Arc<RwLock<_>>` updated by a sensor
+/// polling task. For the demo we use a `Mutex` and a fixed value.
+struct RobotSensorBus {
+    latest: Mutex<RobotSnapshot>,
+}
+
+impl RobotSensorBus {
+    fn current(&self) -> RobotSnapshot {
+        *self.latest.lock().unwrap()
+    }
+}
+
+/// Enricher that reads the latest robot snapshot and attaches it to every hook
+/// payload as `domain_data`. The hook script filters on these fields.
+struct RobotSensorEnricher {
+    bus: Arc<RobotSensorBus>,
+}
+
+impl HookPayloadEnricher for RobotSensorEnricher {
+    fn enrich(&self, _event: &HookEvent, payload: &mut HookPayload) {
+        let snap = self.bus.current();
+        payload.domain_data = Some(serde_json::json!({
+            "force_n": snap.force_n,
+            "estop": snap.estop,
+            "workspace_in_bounds": snap.workspace_in_bounds,
+        }));
+    }
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    // 1. Set up the shared sensor bus. In a real robot integration this would
+    //    be populated by a tokio task polling the robot controller.
+    let bus = Arc::new(RobotSensorBus {
+        latest: Mutex::new(RobotSnapshot {
+            force_n: 55.2,
+            estop: false,
+            workspace_in_bounds: true,
+        }),
+    });
+
+    // 2. Drop the before-hook script to a temp path. Integrators usually ship
+    //    this under `~/.octos/hooks/` and point to it via config.json.
+    let dir = tempfile::tempdir()?;
+    let script_path = dir.path().join("robot_guard.sh");
+    let script = r#"#!/bin/sh
+# Before-hook for BeforeSpawnVerify. Reads stdin JSON and denies motion if:
+#   - e-stop is engaged, OR
+#   - force_n exceeds 40 N, OR
+#   - workspace_in_bounds is false.
+payload="$(cat)"
+
+estop=$(printf '%s' "$payload" \
+    | sed -n 's/.*"estop":[[:space:]]*\(true\|false\).*/\1/p' \
+    | head -n1)
+force=$(printf '%s' "$payload" \
+    | sed -n 's/.*"force_n":[[:space:]]*\([0-9][0-9]*\(\.[0-9]*\)*\).*/\1/p' \
+    | head -n1)
+bounds=$(printf '%s' "$payload" \
+    | sed -n 's/.*"workspace_in_bounds":[[:space:]]*\(true\|false\).*/\1/p' \
+    | head -n1)
+
+if [ "$estop" = "true" ]; then
+    printf "e-stop engaged"
+    exit 1
+fi
+if [ "$bounds" = "false" ]; then
+    printf "end-effector outside safe workspace"
+    exit 1
+fi
+if [ -n "$force" ]; then
+    violates=$(awk -v f="$force" 'BEGIN { print (f > 40) ? 1 : 0 }')
+    if [ "$violates" = "1" ]; then
+        printf "force %s N exceeds 40 N limit" "$force"
+        exit 1
+    fi
+fi
+exit 0
+"#;
+    write_exec(&script_path, script)?;
+
+    // 3. Build a HookExecutor that fires the guard on BeforeSpawnVerify and
+    //    registers the robot sensor enricher. This is the pattern integrators
+    //    wire into `ChatSession::with_hooks` / gateway construction.
+    let executor = HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeSpawnVerify,
+        command: vec![script_path.to_string_lossy().to_string()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+    }])
+    .with_enricher(Arc::new(RobotSensorEnricher { bus: bus.clone() }));
+
+    // 4. Simulate the agent reaching its pre-motion verify checkpoint: the
+    //    spawn tool would build a BeforeSpawnVerify payload and call run().
+    let payload = HookPayload::before_spawn_verify(
+        "task-move-arm",
+        "Pick object at (0.42, 0.11, 0.08)",
+        "parent-session",
+        "child-session",
+        Some("robot"),
+        Some("pre_motion"),
+        Some("motion candidate ready"),
+        vec![],
+        None,
+    );
+    let result = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+
+    println!("hook decision: {result:?}");
+
+    // Demonstrate the allow path by lowering the force reading.
+    {
+        let mut snap = bus.latest.lock().unwrap();
+        snap.force_n = 12.0;
+    }
+    let payload = HookPayload::before_spawn_verify(
+        "task-move-arm-2",
+        "Place object",
+        "parent-session",
+        "child-session",
+        Some("robot"),
+        Some("pre_motion"),
+        Some("safer motion candidate"),
+        vec![],
+        None,
+    );
+    let result2 = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+    println!("hook decision (after relaxing force): {result2:?}");
+
+    // Exit nonzero if the deny path did not fire as expected so CI catches
+    // regressions of the pattern.
+    match result {
+        HookResult::Deny(_) => Ok(()),
+        other => Err(eyre::eyre!(
+            "expected Deny for 55.2 N over-limit, got {other:?}"
+        )),
+    }
+}
+
+fn write_exec(path: &std::path::Path, contents: &str) -> eyre::Result<()> {
+    let mut file = std::fs::File::create(path)?;
+    file.write_all(contents.as_bytes())?;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms)?;
+    Ok(())
+}

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -4,9 +4,11 @@
 //! Before-hooks can deny operations (exit code 1). Circuit breaker auto-disables
 //! hooks after consecutive failures.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
+use metrics::counter;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::warn;
@@ -128,6 +130,14 @@ pub struct HookPayload {
     pub output_files: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_action: Option<String>,
+
+    /// Opaque integrator-supplied context (robotics, domain-specific sensors, etc).
+    /// Populated by a `HookPayloadEnricher` registered on `HookExecutor`.
+    /// Serialized form is truncated to `MAX_PAYLOAD_FIELD_BYTES`; if the rendered
+    /// JSON exceeds that limit the field is replaced with a `{"truncated": true}`
+    /// marker object so hook scripts always see valid JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain_data: Option<serde_json::Value>,
 }
 
 /// Maximum byte length for arguments/result fields in hook payloads.
@@ -507,8 +517,32 @@ impl HookPayload {
             current_phase: None,
             output_files: Vec::new(),
             failure_action: None,
+            domain_data: None,
         }
     }
+}
+
+/// Synchronous extension point for integrators to attach opaque, domain-specific
+/// context to hook payloads before they are serialized to the hook process stdin.
+///
+/// Robotics integrators use this to attach live sensor telemetry (force/torque,
+/// workspace bounds, e-stop state) that their shell-based before-hooks then
+/// filter on. The core agent stays domain-agnostic: it does not introduce
+/// robot-specific `HookEvent` variants.
+///
+/// Invariants:
+/// - `enrich` runs on the Tokio runtime before payload serialization; keep it
+///   cheap and non-blocking. Expensive I/O must be done off-thread ahead of time
+///   and surfaced through an `Arc`-shared snapshot.
+/// - The populated `HookPayload.domain_data` is subject to truncation: anything
+///   whose rendered JSON exceeds `MAX_PAYLOAD_FIELD_BYTES` is replaced with
+///   a `{"truncated": true}` marker object.
+/// - Implementors MUST be `Send + Sync` so the executor can share them through
+///   `Arc`.
+pub trait HookPayloadEnricher: Send + Sync {
+    /// Mutate the payload in place. Typically sets `payload.domain_data` to a
+    /// JSON object describing the integrator's domain state for `event`.
+    fn enrich(&self, event: &HookEvent, payload: &mut HookPayload);
 }
 
 /// Result of running hooks for an event.
@@ -531,6 +565,8 @@ pub struct HookExecutor {
     /// Per-hook consecutive failure count.
     failures: Vec<AtomicU32>,
     failure_threshold: u32,
+    /// Optional domain-data enricher applied to payloads before serialization.
+    enricher: Option<Arc<dyn HookPayloadEnricher>>,
 }
 
 impl HookExecutor {
@@ -544,13 +580,46 @@ impl HookExecutor {
             hooks,
             failures,
             failure_threshold,
+            enricher: None,
         }
+    }
+
+    /// Attach a synchronous domain-data enricher. Additive: callers that do
+    /// not register an enricher see no payload change.
+    pub fn with_enricher(mut self, enricher: Arc<dyn HookPayloadEnricher>) -> Self {
+        self.enricher = Some(enricher);
+        self
     }
 
     /// Run all matching hooks for the given event sequentially.
     /// Returns `Deny` on the first before-hook that exits with 1.
     pub async fn run(&self, event: HookEvent, payload: &HookPayload) -> HookResult {
-        let payload_json = match serde_json::to_string(payload) {
+        // Apply the optional enricher before serialization so integrators can
+        // attach domain-specific telemetry (force/torque, workspace bounds,
+        // e-stop) that the hook script filters on.
+        let payload_owned;
+        let payload_ref: &HookPayload = if let Some(ref enricher) = self.enricher {
+            let mut enriched = payload.clone();
+            enricher.enrich(&event, &mut enriched);
+            if let Some(ref data) = enriched.domain_data {
+                // Truncate to MAX_PAYLOAD_FIELD_BYTES. Replace with a
+                // marker object so hook scripts always receive valid JSON.
+                let serialized = serde_json::to_string(data).unwrap_or_default();
+                if serialized.len() > MAX_PAYLOAD_FIELD_BYTES {
+                    enriched.domain_data = Some(serde_json::json!({"truncated": true}));
+                }
+                counter!(
+                    "octos_hook_domain_data_enriched_total",
+                    "event" => format!("{:?}", event)
+                )
+                .increment(1);
+            }
+            payload_owned = enriched;
+            &payload_owned
+        } else {
+            payload
+        };
+        let payload_json = match serde_json::to_string(payload_ref) {
             Ok(j) => j,
             Err(e) => return HookResult::Error(format!("failed to serialize payload: {e}")),
         };
@@ -566,7 +635,7 @@ impl HookExecutor {
             if matches!(event, HookEvent::BeforeToolCall | HookEvent::AfterToolCall)
                 && !hook.tool_filter.is_empty()
             {
-                let tool_name = payload.tool_name.as_deref().unwrap_or("");
+                let tool_name = payload_ref.tool_name.as_deref().unwrap_or("");
                 if !hook.tool_filter.iter().any(|f| f == tool_name) {
                     continue;
                 }
@@ -1090,6 +1159,7 @@ mod tests {
             current_phase: None,
             output_files: Vec::new(),
             failure_action: None,
+            domain_data: None,
         };
         let result = executor.run(HookEvent::AfterToolCall, &payload).await;
         // Hook should be skipped (circuit broken), not denied

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -43,7 +43,9 @@ pub use agent::{
 };
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
-pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookResult};
+pub use hooks::{
+    HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,
+};
 pub use mcp::{McpClient, McpServerConfig};
 pub use plugins::{PluginLoadResult, PluginLoader};
 pub use progress::{ConsoleReporter, ProgressEvent, ProgressReporter, SilentReporter};

--- a/crates/octos-agent/tests/domain_hook.rs
+++ b/crates/octos-agent/tests/domain_hook.rs
@@ -1,0 +1,413 @@
+//! Integration tests for the domain-hook pattern (RP03).
+//!
+//! These tests exercise the public `HookPayloadEnricher` extension point and
+//! prove the end-to-end integration with a real shell-script hook. They are
+//! deliberately test-heavy because the value of RP03 is the shell pattern:
+//! integrators attach robot sensor data in Rust, then filter in POSIX shell.
+//!
+//! Invariants covered:
+//! - `HookPayload.domain_data` serializes only when `Some`.
+//! - Enriched domain_data whose JSON exceeds `MAX_PAYLOAD_FIELD_BYTES` (1024)
+//!   becomes a `{"truncated": true}` marker object.
+//! - A before-hook can read `domain_data.force_n` from stdin JSON and exit 1
+//!   to deny a `BeforeSpawnVerify` event.
+
+use std::io::Write as _;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+
+use octos_agent::{
+    HookConfig, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,
+};
+
+/// Test enricher that attaches a fixed `force_n` reading.
+struct StaticForceEnricher {
+    force_n: f64,
+}
+
+impl HookPayloadEnricher for StaticForceEnricher {
+    fn enrich(&self, _event: &HookEvent, payload: &mut HookPayload) {
+        payload.domain_data = Some(serde_json::json!({
+            "force_n": self.force_n,
+            "source": "static-test-enricher",
+        }));
+    }
+}
+
+#[tokio::test]
+async fn should_include_domain_data_when_enricher_registered() {
+    // A deny-hook that writes the stdin JSON to a side channel file and
+    // exits 0 so we can assert that domain_data was serialized in the payload.
+    let dir = tempfile::tempdir().unwrap();
+    let captured = dir.path().join("captured.json");
+    let script_path = dir.path().join("capture.sh");
+    let script = format!(
+        "#!/bin/sh\ncat > {captured_quoted}\nexit 0\n",
+        captured_quoted = shell_quote(captured.to_str().unwrap())
+    );
+    write_exec(&script_path, &script);
+
+    let executor = HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeSpawnVerify,
+        command: vec![script_path.to_string_lossy().to_string()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+    }])
+    .with_enricher(Arc::new(StaticForceEnricher { force_n: 12.5 }));
+
+    let payload = HookPayload::before_spawn_verify(
+        "task-1",
+        "move-arm",
+        "parent",
+        "child",
+        Some("robot"),
+        Some("verify"),
+        Some("candidate"),
+        vec![],
+        None,
+    );
+    let result = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+    assert!(matches!(result, HookResult::Allow));
+
+    let captured_json = std::fs::read_to_string(&captured).unwrap();
+    let captured: serde_json::Value = serde_json::from_str(&captured_json).unwrap();
+    let domain_data = captured
+        .get("domain_data")
+        .expect("domain_data field present");
+    assert_eq!(
+        domain_data.get("force_n").and_then(|v| v.as_f64()),
+        Some(12.5)
+    );
+    assert_eq!(
+        domain_data.get("source").and_then(|v| v.as_str()),
+        Some("static-test-enricher")
+    );
+}
+
+#[tokio::test]
+async fn should_omit_domain_data_when_no_enricher() {
+    // Without any enricher registered, the payload field must be absent
+    // (serde skip_serializing_if = Option::is_none). Prior hook tests must
+    // still pass and must not observe new payload shape.
+    let dir = tempfile::tempdir().unwrap();
+    let captured = dir.path().join("captured.json");
+    let script_path = dir.path().join("capture.sh");
+    let script = format!(
+        "#!/bin/sh\ncat > {captured_quoted}\nexit 0\n",
+        captured_quoted = shell_quote(captured.to_str().unwrap())
+    );
+    write_exec(&script_path, &script);
+
+    let executor = HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeSpawnVerify,
+        command: vec![script_path.to_string_lossy().to_string()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+    }]);
+
+    let payload = HookPayload::before_spawn_verify(
+        "task-1",
+        "move-arm",
+        "parent",
+        "child",
+        Some("robot"),
+        Some("verify"),
+        Some("candidate"),
+        vec![],
+        None,
+    );
+    let result = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+    assert!(matches!(result, HookResult::Allow));
+
+    let captured_json = std::fs::read_to_string(&captured).unwrap();
+    // No enricher -> no domain_data key at all
+    assert!(
+        !captured_json.contains("\"domain_data\""),
+        "payload should not contain domain_data without enricher: {captured_json}"
+    );
+}
+
+/// Enricher that attaches a giant blob larger than MAX_PAYLOAD_FIELD_BYTES.
+struct OversizeEnricher;
+
+impl HookPayloadEnricher for OversizeEnricher {
+    fn enrich(&self, _event: &HookEvent, payload: &mut HookPayload) {
+        // 4 KiB of ASCII exceeds the 1024 byte field cap.
+        let blob: String = "A".repeat(4096);
+        payload.domain_data = Some(serde_json::json!({
+            "blob": blob,
+        }));
+    }
+}
+
+#[tokio::test]
+async fn should_truncate_domain_data_at_max_payload_field_bytes() {
+    let dir = tempfile::tempdir().unwrap();
+    let captured = dir.path().join("captured.json");
+    let script_path = dir.path().join("capture.sh");
+    let script = format!(
+        "#!/bin/sh\ncat > {captured_quoted}\nexit 0\n",
+        captured_quoted = shell_quote(captured.to_str().unwrap())
+    );
+    write_exec(&script_path, &script);
+
+    let executor = HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeSpawnVerify,
+        command: vec![script_path.to_string_lossy().to_string()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+    }])
+    .with_enricher(Arc::new(OversizeEnricher));
+
+    let payload = HookPayload::before_spawn_verify(
+        "task-1",
+        "move-arm",
+        "parent",
+        "child",
+        Some("robot"),
+        Some("verify"),
+        Some("candidate"),
+        vec![],
+        None,
+    );
+    let _ = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+
+    let captured_json = std::fs::read_to_string(&captured).unwrap();
+    let captured: serde_json::Value = serde_json::from_str(&captured_json).unwrap();
+    let domain_data = captured
+        .get("domain_data")
+        .expect("domain_data still present after truncation");
+    assert_eq!(
+        domain_data.get("truncated").and_then(|v| v.as_bool()),
+        Some(true),
+        "oversize domain_data must be replaced with a {{\"truncated\": true}} marker, got: {domain_data}"
+    );
+    // Ensure the original giant blob is gone.
+    assert!(
+        !captured_json.contains("AAAAAAAAAAAA"),
+        "truncated payload must not leak the oversize blob"
+    );
+    // Whole serialized payload stays small.
+    assert!(
+        captured_json.len() < 2048,
+        "truncated payload length must be bounded, got {}",
+        captured_json.len()
+    );
+}
+
+/// Enricher that attaches a dynamically computed force reading.
+struct DynamicForceEnricher {
+    reading: std::sync::Mutex<f64>,
+}
+
+impl HookPayloadEnricher for DynamicForceEnricher {
+    fn enrich(&self, _event: &HookEvent, payload: &mut HookPayload) {
+        let n = *self.reading.lock().unwrap();
+        payload.domain_data = Some(serde_json::json!({
+            "force_n": n,
+            "limit_n": 40.0,
+        }));
+    }
+}
+
+#[tokio::test]
+async fn should_deny_before_spawn_verify_when_domain_data_violates() {
+    // Real shell before-hook that parses domain_data.force_n and exits 1 when
+    // it exceeds 40 N. No jq dependency - use sed-based field extraction.
+    let dir = tempfile::tempdir().unwrap();
+    let script_path = dir.path().join("force_guard.sh");
+    let script = r#"#!/bin/sh
+# Read entire stdin and extract domain_data.force_n by pattern matching.
+payload="$(cat)"
+# Extract the numeric value after `"force_n":` using sed.
+force=$(printf '%s' "$payload" \
+    | sed -n 's/.*"force_n":[[:space:]]*\([0-9][0-9]*\(\.[0-9]*\)*\).*/\1/p' \
+    | head -n1)
+if [ -z "$force" ]; then
+    echo "missing force_n" >&2
+    exit 0
+fi
+# POSIX shell has no float arithmetic; use awk to compare.
+violates=$(awk -v f="$force" 'BEGIN { print (f > 40) ? 1 : 0 }')
+if [ "$violates" = "1" ]; then
+    printf "force %s N exceeds 40 N limit" "$force"
+    exit 1
+fi
+exit 0
+"#;
+    write_exec(&script_path, script);
+
+    let executor = HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeSpawnVerify,
+        command: vec![script_path.to_string_lossy().to_string()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+    }])
+    .with_enricher(Arc::new(DynamicForceEnricher {
+        reading: std::sync::Mutex::new(55.2),
+    }));
+
+    let payload = HookPayload::before_spawn_verify(
+        "task-1",
+        "move-arm",
+        "parent",
+        "child",
+        Some("robot"),
+        Some("verify"),
+        Some("candidate"),
+        vec![],
+        None,
+    );
+    let result = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+    match result {
+        HookResult::Deny(reason) => {
+            assert!(
+                reason.contains("exceeds 40 N"),
+                "expected deny reason to mention force limit, got: {reason}"
+            );
+        }
+        other => panic!("expected HookResult::Deny, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn should_allow_before_spawn_verify_when_domain_data_within_limits() {
+    // Same script, but force value is safe -> hook exits 0 -> Allow.
+    let dir = tempfile::tempdir().unwrap();
+    let script_path = dir.path().join("force_guard.sh");
+    let script = r#"#!/bin/sh
+payload="$(cat)"
+force=$(printf '%s' "$payload" \
+    | sed -n 's/.*"force_n":[[:space:]]*\([0-9][0-9]*\(\.[0-9]*\)*\).*/\1/p' \
+    | head -n1)
+if [ -z "$force" ]; then
+    exit 0
+fi
+violates=$(awk -v f="$force" 'BEGIN { print (f > 40) ? 1 : 0 }')
+if [ "$violates" = "1" ]; then
+    printf "force %s N exceeds 40 N limit" "$force"
+    exit 1
+fi
+exit 0
+"#;
+    write_exec(&script_path, script);
+
+    let executor = HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeSpawnVerify,
+        command: vec![script_path.to_string_lossy().to_string()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+    }])
+    .with_enricher(Arc::new(DynamicForceEnricher {
+        reading: std::sync::Mutex::new(12.0),
+    }));
+
+    let payload = HookPayload::before_spawn_verify(
+        "task-1",
+        "move-arm",
+        "parent",
+        "child",
+        Some("robot"),
+        Some("verify"),
+        Some("candidate"),
+        vec![],
+        None,
+    );
+    let result = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+    assert!(
+        matches!(result, HookResult::Allow),
+        "safe force reading must be allowed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn robot_domain_hook_example_runs_end_to_end() {
+    // Acceptance test for the `robot_domain_hook` example. We don't execute
+    // the example binary (that would require `cargo run --example`); instead,
+    // we replicate its end-to-end shape in-process:
+    //   enricher attaches force reading -> before-hook denies motion.
+    let dir = tempfile::tempdir().unwrap();
+    let script_path = dir.path().join("robot_guard.sh");
+    let script = r#"#!/bin/sh
+payload="$(cat)"
+force=$(printf '%s' "$payload" \
+    | sed -n 's/.*"force_n":[[:space:]]*\([0-9][0-9]*\(\.[0-9]*\)*\).*/\1/p' \
+    | head -n1)
+estop=$(printf '%s' "$payload" \
+    | sed -n 's/.*"estop":[[:space:]]*\(true\|false\).*/\1/p' \
+    | head -n1)
+if [ "$estop" = "true" ]; then
+    printf "e-stop engaged"
+    exit 1
+fi
+if [ -n "$force" ]; then
+    violates=$(awk -v f="$force" 'BEGIN { print (f > 40) ? 1 : 0 }')
+    if [ "$violates" = "1" ]; then
+        printf "force %s N exceeds 40 N limit" "$force"
+        exit 1
+    fi
+fi
+exit 0
+"#;
+    write_exec(&script_path, script);
+
+    struct RobotEnricher;
+    impl HookPayloadEnricher for RobotEnricher {
+        fn enrich(&self, _event: &HookEvent, payload: &mut HookPayload) {
+            payload.domain_data = Some(serde_json::json!({
+                "force_n": 62.3,
+                "estop": false,
+                "workspace_in_bounds": true,
+            }));
+        }
+    }
+
+    let executor = HookExecutor::new(vec![HookConfig {
+        event: HookEvent::BeforeSpawnVerify,
+        command: vec![script_path.to_string_lossy().to_string()],
+        timeout_ms: 5000,
+        tool_filter: vec![],
+    }])
+    .with_enricher(Arc::new(RobotEnricher));
+
+    let payload = HookPayload::before_spawn_verify(
+        "task-demo",
+        "move-end-effector",
+        "parent-sess",
+        "child-sess",
+        Some("robot"),
+        Some("pre_motion"),
+        Some("motion candidate ready"),
+        vec![],
+        None,
+    );
+    let result = executor.run(HookEvent::BeforeSpawnVerify, &payload).await;
+    match result {
+        HookResult::Deny(reason) => {
+            assert!(
+                reason.contains("exceeds 40 N"),
+                "expected deny due to force, got: {reason}"
+            );
+        }
+        other => panic!("robot_domain_hook_example_runs_end_to_end must deny, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn write_exec(path: &std::path::Path, contents: &str) {
+    let mut file = std::fs::File::create(path).unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
+    let mut perms = std::fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).unwrap();
+}
+
+/// Minimal single-quote escaping for a shell path. Paths under `tempfile::tempdir`
+/// never contain single quotes on supported platforms, but we stay defensive.
+fn shell_quote(s: &str) -> String {
+    let escaped = s.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}


### PR DESCRIPTION
Closes #449.

## What this delivers

Extends `HookPayload` with an opaque `domain_data: Option<serde_json::Value>` field. Robot integrators register a `HookPayloadEnricher` that populates domain context (force/torque, workspace bounds, e-stop state); their before-hook script filters on that data and denies via exit 1 or modifies via exit 2. Uses main's existing `BeforeSpawnVerify` primitive — no new `HookEvent` variants.

Full contract: [docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp03](../blob/main/docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp03--domain-hook-pattern-via-beforespawnverify--payload-extension)

## Changes

- `crates/octos-agent/src/hooks.rs` (+74/-0) — `domain_data` field, `HookPayloadEnricher` trait, `HookExecutor::with_enricher`, enrichment + truncation + counter in `run()`.
- `crates/octos-agent/src/lib.rs` (+4/-0) — re-export `HookPayloadEnricher`.
- `crates/octos-agent/tests/domain_hook.rs` (new, 413 LOC) — 6 shell-script-backed tests.
- `crates/octos-agent/examples/robot_domain_hook.rs` (new, 189 LOC).

`agent/execution.rs` and `agent/loop_runner.rs` are untouched — enrichment lives on `HookExecutor` which those sites already consume via `self.hooks.clone()`.

## Invariants

1. `HookPayload.domain_data: Option<Value>`, serialize-skipped when `None`.
2. `HookPayloadEnricher` trait: exactly one synchronous method.
3. Truncation at `MAX_PAYLOAD_FIELD_BYTES=1024` via a `{"truncated": true}` marker object (preserves valid JSON for hook scripts).
4. No-enricher path unchanged — 830 existing lib tests pass.
5. **No new `HookEvent` variants** — rejects PR #270's `BeforeMotion`/`AfterMotion`/`ForceLimit`/`WorkspaceBoundary`/`EmergencyStop` and `RobotPayload` (grep confirms absence).
6. Example denies via `BeforeSpawnVerify` + `domain_data`.

## Tests

```
test should_include_domain_data_when_enricher_registered ... ok
test should_deny_before_spawn_verify_when_domain_data_violates ... ok
test robot_domain_hook_example_runs_end_to_end ... ok
test should_allow_before_spawn_verify_when_domain_data_within_limits ... ok
test should_omit_domain_data_when_no_enricher ... ok
test should_truncate_domain_data_at_max_payload_field_bytes ... ok
```

## Observability

`octos_hook_domain_data_enriched_total{event}` — fires on each successful enrichment, labeled by event for dashboard splits.

## Test plan

- [x] `cargo test -p octos-agent --test domain_hook` (6/6)
- [x] `cargo test -p octos-agent --lib` (830/830; no regressions)
- [x] `cargo build --workspace`
- [x] `cargo run -p octos-agent --example robot_domain_hook`
- [ ] Live canary: register a robot enricher, configure a BeforeSpawnVerify shell hook that reads `domain_data.force_n > 40` and denies; dispatch motion tool with fake high-force reading → verify 403 + counter increment.

## Unblocks

RP05 (#451) uses `HookPayloadEnricher` for the `RealtimeHookEnricher`.