### PR TITLE
RP06 — remove octos-dora-mcp stub crate (Option B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ scripts/deploy.sh
 !docs/OCTOS_HARNESS_DEVELOPER_INTERFACE.md
 !docs/SANDBOX.md
 !docs/SECURITY_ARCHITECTURE.md
+!docs/OCTOS_ROBOTICS_PR270_RP06_NOTE.md
 
 # mdBook documentation site (EN + ZH)
 !book/book.toml

--- a/docs/OCTOS_ROBOTICS_PR270_RP06_NOTE.md
+++ b/docs/OCTOS_ROBOTICS_PR270_RP06_NOTE.md
@@ -1,0 +1,53 @@
+# RP06 — octos-dora-mcp Disposition Note
+
+**Issue:** #452 (RP06 — octos-dora-mcp: real forwarding OR removal)
+**Decision:** Option B (removal)
+**Status:** No-op on main.
+
+## Summary
+
+The `octos-dora-mcp` crate proposed in PR #270 was **never merged to `main`**.
+Pre-merge inspection of `origin/main` (and of this stacked branch
+`robotics-rp/06-dora-mcp`, which is `origin/main` + RP01) shows:
+
+- No `crates/octos-dora-mcp/` directory.
+- No `examples/dora-bridge-config/` directory.
+- No `octos_dora_mcp` imports or `octos-dora-mcp` Cargo entries anywhere.
+
+Therefore the RP06 "deletion" contract is vacuously satisfied: there is
+nothing to delete on this branch. This note records the decision and the
+rationale so future contributors understand why the crate is absent.
+
+## Why removal over real forwarding (Option A)
+
+The PR #270 `DoraToolBridge::execute` implementation is a placeholder that
+returns a formatted string instead of forwarding a tool invocation into a
+dora-rs dataflow. Shipping that stub in `main` would mislead LLM tool
+registration: the tool spec advertises real forwarding while `execute`
+fabricates a response.
+
+Delivering real forwarding requires, at minimum:
+
+- External deps: `dora-arrow`, `zenoh` (or an equivalent transport).
+- A real dora-rs daemon fixture for integration testing.
+- A trust/safety story for letting a dataflow node reply to an LLM-invoked
+  tool call (timeouts, resource caps, signed node manifests, etc.).
+
+None of that is in place in the current robotics release preparation
+window, and demand from robotics integrators has not surfaced a concrete
+driver for the surface area. Clean removal now keeps `main` honest; the
+deferred work is tracked in a successor issue opened at the same time as
+this note.
+
+## Follow-up
+
+The successor issue linked from #452 captures:
+
+- The desired Option A surface (trait-backed `DoraToolBridge` with real
+  dataflow forwarding).
+- External dependencies (`dora-arrow`, `zenoh`) and the integration test
+  harness they imply.
+- The "unblocked by" condition: demand signal from at least one robotics
+  integrator with a concrete dataflow we can forward to.
+
+Until then, `main` intentionally does not carry an `octos-dora-mcp` crate.


### PR DESCRIPTION
Closes #452. Successor tracked in #455.

## Decision

Supervisor selected **Option B (removal)** for this slice. Real dora-rs forwarding requires external deps (`dora-arrow`, `zenoh`) and a real integration harness we don't have demand-validated; the PR #270 stub shipped a placeholder string in `DoraToolBridge::execute` which would mislead LLM tool registration.

## Finding

**The crate was never merged to `main`.** Verification:
- `ls crates/octos-dora-mcp` → `No such file or directory`
- `ls examples/dora-bridge-config` → `No such file or directory`
- `grep -r "octos_dora_mcp\|octos-dora-mcp" . --exclude-dir={target,.git}` → zero matches (no Cargo.toml references, no source imports)

So the deletion is vacuous. This PR records the disposition.

## Changes

- `docs/OCTOS_ROBOTICS_PR270_RP06_NOTE.md` (new, 53 LOC) — disposition note: no-op rationale + link to successor #455
- `.gitignore` — allowlist entry for the new doc (follows the repo pattern for every tracked `docs/*.md`)

## Successor issue

[#455 — Real dora-rs forwarding for octos-dora-mcp (deferred from RP06)](https://github.com/octos-org/octos/issues/455). Labeled `enhancement + robotics`. Lists external deps needed (dora-arrow, zenoh) and the unblock condition ("demand signal from at least one robotics integrator").

## Invariants

1. `cargo build --workspace` — success
2. No `octos_dora_mcp` / `octos-dora-mcp` references anywhere
3. Successor issue opened
4. Full test suite green (0 regressions)

## Stacking

Based on `robotics-rp/01-tool-policy-tiers` (RP01 canonical SafetyTier). The stacking is cosmetic for RP06 since no code needed `SafetyTier` — but it mirrors the family's dispatch topology. Target will retarget to `main` after RP01 lands.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [ ] No live verification needed — this PR is documentary.