### PR TITLE
RP02 — HardwareLifecycle with sandboxed executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,9 +3740,13 @@ name = "octos-plugin"
 version = "0.1.1"
 dependencies = [
  "eyre",
+ "metrics",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
+ "tokio-test",
  "tracing",
  "which 7.0.3",
 ]

--- a/crates/octos-plugin/Cargo.toml
+++ b/crates/octos-plugin/Cargo.toml
@@ -14,6 +14,10 @@ serde_json = { workspace = true }
 eyre = { workspace = true }
 tracing = { workspace = true }
 which = { workspace = true }
+tokio = { workspace = true }
+metrics = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio-test = { workspace = true }
+regex = { workspace = true }

--- a/crates/octos-plugin/examples/pick_and_place_lifecycle.rs
+++ b/crates/octos-plugin/examples/pick_and_place_lifecycle.rs
@@ -1,0 +1,327 @@
+//! # Pick-and-Place Lifecycle — Hardware Startup, Shutdown, and Recovery
+//!
+//! ## The Problem
+//!
+//! Industrial robots need a strict startup/shutdown sequence: check air
+//! pressure, power on servo drives, home axes, verify sensors — in that
+//! exact order. Skip the preflight check and the gripper has no air? The
+//! robot drops a part on the conveyor. Skip homing? The arm doesn't know
+//! where it is and crashes into the workcell wall on its first move.
+//!
+//! Shutdown is equally critical. Power off servos before parking the arm?
+//! It falls under gravity. Skip the gripper release? It's still clamping a
+//! part when maintenance tries to move it manually.
+//!
+//! **Before this feature:**
+//! - Startup/shutdown is ad-hoc shell scripts or manual operator steps.
+//! - No retry logic — if the servo driver fails once on power-on (common
+//!   with older hardware), the whole startup fails and someone has to
+//!   SSH in to retry.
+//! - No critical/non-critical distinction — a flaky encoder check aborts
+//!   the entire startup even though the robot can run fine without it.
+//! - No emergency path — graceful shutdown takes 30 seconds; you need a
+//!   2-second path for e-stop situations.
+//! - **No sandboxing.** Every shell step ran with the full parent env,
+//!   including injection vectors like `LD_PRELOAD` and `BASH_ENV`, and
+//!   nothing stopped a typo'd `rm -rf /` from running.
+//!
+//! **After this feature (RP02):**
+//! - [`HardwareLifecycle`] declares 5 ordered phases as data, not code.
+//! - Each [`LifecycleStep`] has timeout_ms, retries, and critical flag.
+//! - [`LifecycleExecutor`] runs steps in order, **through a `Sandbox`
+//!   trait**, with `BLOCKED_ENV_VARS` scrubbed and `is_safe_shell_command`
+//!   vetoing obvious footguns before dispatch.
+//! - Timeouts kill the **entire process group**, so background children
+//!   spawned by the shell are reaped too — no zombies.
+//! - Critical failures abort the phase; non-critical failures log and
+//!   continue.
+//! - Emergency shutdown is a separate fast path with short timeouts.
+//!
+//! ## Scenario
+//!
+//! A pick-and-place workcell with a 6-axis arm, pneumatic gripper, and
+//! conveyor. The lifecycle covers: preflight checks -> initialization ->
+//! ready verification -> normal operation -> graceful shutdown (or
+//! emergency stop).
+//!
+//! ```bash
+//! cargo run --example pick_and_place_lifecycle -p octos-plugin
+//! ```
+
+use octos_plugin::{HardwareLifecycle, LifecycleExecutor, LifecyclePhase, LifecycleStep};
+
+/// Helper to construct a lifecycle step. In production, these come from
+/// the plugin's `manifest.json` under `hardware_lifecycle`.
+fn step(
+    label: &str,
+    command: &str,
+    timeout_ms: u64,
+    retries: u32,
+    critical: bool,
+) -> LifecycleStep {
+    LifecycleStep {
+        label: label.to_string(),
+        command: command.to_string(),
+        timeout_ms,
+        retries,
+        critical,
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // ── Step 1: Declare the lifecycle phases ──
+    //
+    // Each phase is an ordered list of steps. The executor runs them top
+    // to bottom. Notice the design choices per phase:
+    //
+    // - PREFLIGHT: Check prerequisites. Retries on flaky checks (air
+    //   supply sensor sometimes reads zero on first poll). Non-critical
+    //   steps (conveyor encoder) don't abort the whole startup.
+    //
+    // - INIT: Bring hardware up in dependency order. Servo drives MUST
+    //   succeed (critical=true, retries=2) because everything depends on
+    //   them. Conveyor is non-critical — the arm can pick/place without it.
+    //
+    // - READY_CHECK: Final verification before handing control to the
+    //   agent. All critical — if the force sensor isn't zeroed, contact
+    //   detection won't work and the robot could crush parts.
+    //
+    // - SHUTDOWN: Reverse of init. Park arm first (while servos still
+    //   powered), then release gripper, then power off. Order matters.
+    //
+    // - EMERGENCY_SHUTDOWN: 2-second budget. Stop everything NOW. No
+    //   retries, short timeouts. This is the e-stop path.
+    let lifecycle = HardwareLifecycle {
+        preflight: vec![
+            step(
+                "Check gripper air supply",
+                "echo 'Air pressure: 6.2 bar OK'",
+                5_000,
+                1,
+                true,
+            ),
+            step(
+                "Check camera connection",
+                "echo 'Camera /dev/video0 ready'",
+                5_000,
+                0,
+                true,
+            ),
+            // Non-critical: conveyor encoder is nice-to-have, not essential
+            step(
+                "Check conveyor encoder",
+                "echo 'Encoder pulses: nominal'",
+                5_000,
+                0,
+                false,
+            ),
+        ],
+        init: vec![
+            // Retries=2: servo drivers sometimes need a second power-on
+            step(
+                "Power on servo drives",
+                "echo 'Servo drives powered'",
+                10_000,
+                2,
+                true,
+            ),
+            // Homing is slow but must succeed — arm position is unknown otherwise
+            step(
+                "Home all axes",
+                "echo 'Homing complete: 6 axes at zero'",
+                30_000,
+                1,
+                true,
+            ),
+            step("Open gripper", "echo 'Gripper opened'", 5_000, 0, true),
+            // Non-critical: robot can operate without conveyor
+            step(
+                "Start conveyor",
+                "echo 'Conveyor running at 0.2 m/s'",
+                5_000,
+                0,
+                false,
+            ),
+        ],
+        ready_check: vec![
+            step(
+                "Verify joint limits",
+                "echo 'All joints within limits'",
+                5_000,
+                0,
+                true,
+            ),
+            step(
+                "Verify force sensor zero",
+                "echo 'Force sensor zeroed: [0.01, 0.00, 0.02]'",
+                5_000,
+                0,
+                true,
+            ),
+            step(
+                "Verify workspace clear",
+                "echo 'Workspace clear — no obstacles detected'",
+                5_000,
+                0,
+                true,
+            ),
+        ],
+        shutdown: vec![
+            // Order matters: park arm BEFORE powering off servos
+            step(
+                "Park arm at home",
+                "echo 'Arm parked at home position'",
+                15_000,
+                1,
+                true,
+            ),
+            step("Open gripper", "echo 'Gripper released'", 5_000, 0, true),
+            step("Stop conveyor", "echo 'Conveyor stopped'", 5_000, 0, false),
+            // Last: power off servos after arm is safely parked
+            step(
+                "Power off servo drives",
+                "echo 'Servos powered off'",
+                10_000,
+                0,
+                true,
+            ),
+        ],
+        emergency_shutdown: vec![
+            // 2-second timeout, no retries — this is the e-stop path
+            step(
+                "Emergency stop all axes",
+                "echo 'E-STOP: all axes halted'",
+                2_000,
+                0,
+                true,
+            ),
+            step(
+                "Vent gripper pressure",
+                "echo 'Gripper pressure vented'",
+                2_000,
+                0,
+                true,
+            ),
+        ],
+    };
+
+    // ── Step 2: Build the executor ──
+    //
+    // LifecycleExecutor wraps every step through the Sandbox trait, strips
+    // BLOCKED_ENV_VARS before spawn, screens commands via SafePolicy, and
+    // kills the child process group on timeout. For this demo we use
+    // NoSandbox (pass-through) because production sandbox backends
+    // (sandbox-exec, bwrap) are workstation-specific. In a real plugin
+    // you'd pass a concrete Sandbox tuned for your platform.
+    let executor = LifecycleExecutor::with_no_sandbox();
+
+    // ── Step 3: Run the normal startup sequence ──
+    //
+    // run_phase() handles the complexity:
+    // - Runs steps in order
+    // - Retries failed steps up to step.retries times
+    // - Aborts on critical failure (returns partial PhaseResult)
+    // - Logs and continues on non-critical failure
+    // - Times out individual steps (prevents hanging on dead hardware)
+    let startup_phases = [
+        (LifecyclePhase::Preflight, &lifecycle.preflight),
+        (LifecyclePhase::Init, &lifecycle.init),
+        (LifecyclePhase::ReadyCheck, &lifecycle.ready_check),
+    ];
+
+    println!("╔══════════════════════════════════════════╗");
+    println!("║  WORKCELL STARTUP SEQUENCE               ║");
+    println!("╚══════════════════════════════════════════╝\n");
+
+    for (phase, steps) in startup_phases {
+        println!("── Phase: {phase} ({} steps) ──", steps.len());
+        let result = executor.run_phase(phase, steps).await;
+
+        if result.success {
+            println!(
+                "  -> PASSED ({}/{} steps completed)\n",
+                result.steps_completed, result.steps_total
+            );
+        } else {
+            // In production, a failed startup means: do NOT hand control to
+            // the agent. The robot is not safe to operate.
+            println!(
+                "  -> FAILED at step {}/{}: {}",
+                result.steps_completed + 1,
+                result.steps_total,
+                result.error.as_deref().unwrap_or("unknown error")
+            );
+            println!("  -> Robot NOT safe to operate. Fix the issue and retry.\n");
+            return;
+        }
+    }
+
+    println!("All startup phases passed. Robot is ready for agent control.\n");
+
+    // ── Step 4: Normal graceful shutdown ──
+    //
+    // Called when the operator ends the session or the agent completes
+    // its task. Steps run in reverse dependency order (park arm -> release
+    // gripper -> stop conveyor -> power off servos).
+    println!("╔══════════════════════════════════════════╗");
+    println!("║  GRACEFUL SHUTDOWN                       ║");
+    println!("╚══════════════════════════════════════════╝\n");
+
+    println!("── Phase: shutdown ({} steps) ──", lifecycle.shutdown.len());
+    let shutdown_result = executor
+        .run_phase(LifecyclePhase::Shutdown, &lifecycle.shutdown)
+        .await;
+    println!(
+        "  -> {} ({}/{} steps completed)\n",
+        if shutdown_result.success {
+            "COMPLETED"
+        } else {
+            "PARTIAL"
+        },
+        shutdown_result.steps_completed,
+        shutdown_result.steps_total,
+    );
+
+    // ── Step 5: Emergency shutdown (separate fast path) ──
+    //
+    // This is NOT the normal shutdown. This fires when:
+    // - E-stop button pressed
+    // - Force limit exceeded (robot hit something)
+    // - Heartbeat stalled (agent frozen)
+    // - Operator triggers emergency via API
+    //
+    // Key differences from graceful shutdown:
+    // - 2-second timeouts (vs 10-15 seconds)
+    // - No retries (vs 1-2 retries)
+    // - Minimal steps (vs full sequence)
+    // - Runs INSTEAD OF graceful shutdown, not after it
+    println!("╔══════════════════════════════════════════╗");
+    println!("║  EMERGENCY SHUTDOWN (e-stop path)        ║");
+    println!("╚══════════════════════════════════════════╝\n");
+
+    println!(
+        "── Phase: emergency_shutdown ({} steps, 2s timeout each) ──",
+        lifecycle.emergency_shutdown.len()
+    );
+    let estop_result = executor
+        .run_phase(
+            LifecyclePhase::EmergencyShutdown,
+            &lifecycle.emergency_shutdown,
+        )
+        .await;
+    println!(
+        "  -> {} ({}/{} steps completed)",
+        if estop_result.success {
+            "COMPLETED"
+        } else {
+            "PARTIAL"
+        },
+        estop_result.steps_completed,
+        estop_result.steps_total,
+    );
+
+    println!("\nPick-and-place lifecycle demo complete.");
+    println!("In production, these phases are declared in manifest.json and run");
+    println!("automatically by the plugin system at session start/end.");
+}

--- a/crates/octos-plugin/src/lib.rs
+++ b/crates/octos-plugin/src/lib.rs
@@ -29,11 +29,17 @@
 
 pub mod discovery;
 pub mod gating;
+pub mod lifecycle;
 pub mod manifest;
 pub mod types;
 
 // Re-export primary types for convenience.
 pub use discovery::{PluginSource, discover_plugins};
 pub use gating::{GateCheck, GatingResult, check_requirements};
+pub use lifecycle::{
+    BLOCKED_ENV_VARS, HardwareLifecycle, LifecycleExecutor, LifecyclePhase, LifecycleStep,
+    NoSandbox, PhaseResult, SafePolicyDenial, Sandbox, StepKillReason, StepOutcome, StepResult,
+    is_safe_shell_command,
+};
 pub use manifest::{InstallSpec, PluginManifest, PluginType, Requirements, ToolDefinition};
 pub use types::{DiscoveredPlugin, PluginOrigin, PluginStatus};

--- a/crates/octos-plugin/src/lifecycle.rs
+++ b/crates/octos-plugin/src/lifecycle.rs
@@ -1,0 +1,678 @@
+//! Hardware lifecycle executor for plugin manifests.
+//!
+//! Runs ordered lifecycle phases (preflight, init, ready_check, shutdown,
+//! emergency_shutdown) with per-step timeout, retry, and critical-failure
+//! abort semantics. Every step is dispatched through the [`Sandbox`] trait,
+//! with [`BLOCKED_ENV_VARS`] scrubbed from the child environment and the
+//! command string screened by [`is_safe_shell_command`] before dispatch.
+//!
+//! # Why this file looks paranoid
+//!
+//! An earlier revision ran commands with `tokio::process::Command::new("sh")
+//! .arg("-c").arg(step.command)` directly. That path had no env sanitization,
+//! no deny list, no sandbox isolation, and relied on `tokio::time::timeout`
+//! alone — which leaves the child running after the handle is dropped on
+//! Unix. This executor closes every one of those gaps:
+//!
+//! - Steps run through a [`Sandbox`] implementation (bwrap on Linux,
+//!   sandbox-exec on macOS, `cmd /C` on Windows, pass-through otherwise).
+//! - [`BLOCKED_ENV_VARS`] is applied to every spawned child so code
+//!   injection vectors like `LD_PRELOAD`, `NODE_OPTIONS`, and `BASH_ENV`
+//!   are scrubbed.
+//! - [`is_safe_shell_command`] denies obvious footguns (`rm -rf /`, `dd`,
+//!   `mkfs`, fork bombs) before we even spawn a process.
+//! - On timeout we explicitly `kill().await` the child AND rely on
+//!   `kill_on_drop(true)` as a belt-and-braces safety net — the test
+//!   `should_kill_child_when_step_timeout_exceeded` asserts the PID is dead
+//!   within 500ms of the timeout firing.
+
+use std::path::Path;
+use std::time::Duration;
+
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+/// Environment variables blocked inside lifecycle step execution.
+///
+/// Mirrors `octos-agent/src/sandbox/mod.rs::BLOCKED_ENV_VARS`. The two lists
+/// MUST stay in sync — the `blocked_env_vars_match_agent_sandbox` test in
+/// `tests/lifecycle_sandbox.rs` compiles the agent source in and asserts
+/// the two lists are element-wise equal. If you add/remove a variable here,
+/// update the agent source too (and vice versa).
+pub const BLOCKED_ENV_VARS: &[&str] = &[
+    // Linux: shared library injection
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    // macOS: dylib injection
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_VERSIONED_LIBRARY_PATH",
+    // Runtime-specific code injection
+    "NODE_OPTIONS",
+    "PYTHONSTARTUP",
+    "PYTHONPATH",
+    "PERL5OPT",
+    "RUBYOPT",
+    "RUBYLIB",
+    "JAVA_TOOL_OPTIONS",
+    // Shell startup injection
+    "BASH_ENV",
+    "ENV",
+    "ZDOTDIR",
+];
+
+/// A single step in a hardware lifecycle phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LifecycleStep {
+    /// Human-readable label for logging.
+    pub label: String,
+    /// Shell command to execute.
+    pub command: String,
+    /// Timeout for this step in milliseconds. Kept in milliseconds rather
+    /// than seconds so tests can exercise sub-second timeouts without
+    /// sleeping for real wallclock seconds.
+    #[serde(default = "default_timeout_ms", alias = "timeout_ms")]
+    pub timeout_ms: u64,
+    /// Number of retry attempts on failure.
+    #[serde(default)]
+    pub retries: u32,
+    /// If true, failure of this step aborts the entire phase.
+    #[serde(default = "default_true")]
+    pub critical: bool,
+}
+
+fn default_timeout_ms() -> u64 {
+    30_000
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// The five lifecycle phases declared by a [`HardwareLifecycle`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifecyclePhase {
+    Preflight,
+    Init,
+    ReadyCheck,
+    Shutdown,
+    EmergencyShutdown,
+}
+
+impl LifecyclePhase {
+    /// Stable, lowercase label used in logs and metric labels.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LifecyclePhase::Preflight => "preflight",
+            LifecyclePhase::Init => "init",
+            LifecyclePhase::ReadyCheck => "ready_check",
+            LifecyclePhase::Shutdown => "shutdown",
+            LifecyclePhase::EmergencyShutdown => "emergency_shutdown",
+        }
+    }
+}
+
+impl std::fmt::Display for LifecyclePhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Hardware lifecycle declaration for a plugin.
+///
+/// Each phase is a list of steps executed in order. Phases are:
+/// - `preflight`: Checks before initialization (sensors connected, firmware OK)
+/// - `init`: Bring hardware to operational state
+/// - `ready_check`: Verify hardware is ready for operation
+/// - `shutdown`: Graceful shutdown sequence
+/// - `emergency_shutdown`: Fast shutdown (minimal steps, short timeouts)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HardwareLifecycle {
+    #[serde(default)]
+    pub preflight: Vec<LifecycleStep>,
+    #[serde(default)]
+    pub init: Vec<LifecycleStep>,
+    #[serde(default)]
+    pub ready_check: Vec<LifecycleStep>,
+    #[serde(default)]
+    pub shutdown: Vec<LifecycleStep>,
+    #[serde(default)]
+    pub emergency_shutdown: Vec<LifecycleStep>,
+}
+
+/// Reason a step was killed, recorded by the executor for observability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepKillReason {
+    /// Step exceeded its `timeout_ms` budget.
+    Timeout,
+    /// Step failed and was `critical=true`, aborting the phase.
+    CriticalFailure,
+    /// Command was denied by [`is_safe_shell_command`] before dispatch.
+    SandboxDeny,
+}
+
+impl StepKillReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StepKillReason::Timeout => "timeout",
+            StepKillReason::CriticalFailure => "critical_failure",
+            StepKillReason::SandboxDeny => "sandbox_deny",
+        }
+    }
+}
+
+/// Outcome label used in the `octos_lifecycle_step_total` counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepOutcome {
+    Ok,
+    Failed,
+    Denied,
+    TimedOut,
+}
+
+impl StepOutcome {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StepOutcome::Ok => "ok",
+            StepOutcome::Failed => "failed",
+            StepOutcome::Denied => "denied",
+            StepOutcome::TimedOut => "timed_out",
+        }
+    }
+}
+
+/// Result of executing a single lifecycle step.
+#[derive(Debug, Clone)]
+pub struct StepResult {
+    pub label: String,
+    pub outcome: StepOutcome,
+    pub error: Option<String>,
+}
+
+/// Result of executing a lifecycle phase.
+#[derive(Debug, Clone)]
+pub struct PhaseResult {
+    pub phase: String,
+    pub steps_completed: usize,
+    pub steps_total: usize,
+    pub success: bool,
+    pub error: Option<String>,
+    pub steps: Vec<StepResult>,
+}
+
+/// Wraps a shell command into a sandboxed [`Command`].
+///
+/// Mirrors `octos_agent::sandbox::Sandbox` but lives here so the plugin SDK
+/// doesn't need a runtime dependency on the agent crate. Implementations
+/// MUST NOT spawn the child themselves — the executor spawns the returned
+/// [`Command`] so it can attach the required env sanitization and
+/// `kill_on_drop` flag before spawn.
+pub trait Sandbox: Send + Sync {
+    /// Wrap a shell command string into a [`Command`] ready to spawn.
+    fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command;
+}
+
+/// No-op sandbox: dispatches via `sh -c` on Unix, `cmd /C` on Windows.
+///
+/// Cross-platform by design so Windows hardware skills still get SafePolicy
+/// + BLOCKED_ENV_VARS scrubbing even when no platform sandbox is available.
+pub struct NoSandbox;
+
+impl Sandbox for NoSandbox {
+    fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
+        #[cfg(windows)]
+        {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/C").arg(shell_command).current_dir(cwd);
+            cmd
+        }
+        #[cfg(not(windows))]
+        {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg(shell_command).current_dir(cwd);
+            cmd
+        }
+    }
+}
+
+/// Error returned when a command fails [`is_safe_shell_command`].
+#[derive(Debug, Clone)]
+pub struct SafePolicyDenial {
+    /// The dangerous pattern that matched.
+    pub pattern: String,
+}
+
+impl std::fmt::Display for SafePolicyDenial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "command denied by SafePolicy: matched pattern '{}'",
+            self.pattern
+        )
+    }
+}
+
+impl std::error::Error for SafePolicyDenial {}
+
+/// Mirrors `SafePolicy::default().check()` deny patterns from
+/// `octos_agent::policy`. See `octos-agent/src/policy.rs` for the full
+/// rationale. The deny list here is intentionally short: `rm -rf /`,
+/// `dd if=`, `mkfs`, fork bomb, `chmod -R 777 /`. Defense in depth, not a
+/// security boundary — real isolation comes from the [`Sandbox`] layer.
+///
+/// Patterns are matched on the whitespace-normalized command string at
+/// word boundaries, so `mkfs` will not match inside `unmkfsblah`.
+pub fn is_safe_shell_command(command: &str) -> std::result::Result<(), SafePolicyDenial> {
+    const DENY_PATTERNS: &[&str] = &[
+        "rm -rf /",
+        "rm -rf /*",
+        "dd if=",
+        "mkfs",
+        ":(){:|:&};:", // fork bomb
+        "chmod -R 777 /",
+    ];
+
+    let normalized = normalize_whitespace(command);
+    for pattern in DENY_PATTERNS {
+        if contains_at_word_boundary(&normalized, pattern) {
+            return Err(SafePolicyDenial {
+                pattern: (*pattern).to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Collapse consecutive whitespace into single spaces and trim.
+fn normalize_whitespace(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Check if `pattern` appears in `haystack` at a word boundary.
+fn contains_at_word_boundary(haystack: &str, pattern: &str) -> bool {
+    let pat = pattern.as_bytes();
+    let hay = haystack.as_bytes();
+    if pat.len() > hay.len() {
+        return false;
+    }
+    for i in 0..=(hay.len() - pat.len()) {
+        if &hay[i..i + pat.len()] == pat {
+            let left_ok = i == 0 || !hay[i - 1].is_ascii_alphanumeric();
+            let right_ok =
+                i + pat.len() == hay.len() || !hay[i + pat.len()].is_ascii_alphanumeric();
+            if left_ok && right_ok {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Executes lifecycle phases with timeout, retry, and sandbox isolation.
+pub struct LifecycleExecutor {
+    sandbox: Box<dyn Sandbox>,
+    cwd: std::path::PathBuf,
+}
+
+impl LifecycleExecutor {
+    /// Construct an executor with the provided sandbox and working directory.
+    pub fn new(sandbox: Box<dyn Sandbox>, cwd: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            sandbox,
+            cwd: cwd.into(),
+        }
+    }
+
+    /// Construct an executor backed by [`NoSandbox`] rooted at the OS temp dir.
+    ///
+    /// Convenient for tests and examples; production callers should pass a
+    /// platform sandbox via [`LifecycleExecutor::new`].
+    pub fn with_no_sandbox() -> Self {
+        Self::new(Box::new(NoSandbox), std::env::temp_dir())
+    }
+
+    /// Run a lifecycle phase (list of steps) to completion.
+    ///
+    /// Executes steps in order. On failure:
+    /// - Retries up to `step.retries` times
+    /// - If `step.critical` is true, aborts the phase on final failure
+    /// - Non-critical steps log a warning and continue
+    pub async fn run_phase(&self, phase: LifecyclePhase, steps: &[LifecycleStep]) -> PhaseResult {
+        let phase_name = phase.as_str();
+        let total = steps.len();
+        let mut step_results = Vec::with_capacity(total);
+
+        for (i, step) in steps.iter().enumerate() {
+            let mut last_error: Option<String> = None;
+            let mut last_outcome = StepOutcome::Failed;
+
+            // SafePolicy check is not retried: a denied command stays denied.
+            if let Err(denial) = is_safe_shell_command(&step.command) {
+                metrics::counter!(
+                    "octos_lifecycle_step_total",
+                    "phase" => phase_name,
+                    "outcome" => StepOutcome::Denied.as_str()
+                )
+                .increment(1);
+                metrics::counter!(
+                    "octos_lifecycle_step_killed_total",
+                    "phase" => phase_name,
+                    "reason" => StepKillReason::SandboxDeny.as_str()
+                )
+                .increment(1);
+                tracing::error!(
+                    phase = phase_name,
+                    step = step.label,
+                    pattern = denial.pattern,
+                    "lifecycle step denied by SafePolicy"
+                );
+                let err_msg = format!("{denial}");
+                step_results.push(StepResult {
+                    label: step.label.clone(),
+                    outcome: StepOutcome::Denied,
+                    error: Some(err_msg.clone()),
+                });
+                if step.critical {
+                    return PhaseResult {
+                        phase: phase_name.to_string(),
+                        steps_completed: i,
+                        steps_total: total,
+                        success: false,
+                        error: Some(format!("{}: {}", step.label, err_msg)),
+                        steps: step_results,
+                    };
+                }
+                continue;
+            }
+
+            for attempt in 0..=step.retries {
+                if attempt > 0 {
+                    tracing::warn!(
+                        phase = phase_name,
+                        step = step.label,
+                        attempt = attempt + 1,
+                        max = step.retries + 1,
+                        "retrying lifecycle step"
+                    );
+                }
+
+                match self.run_step(phase, step).await {
+                    Ok(()) => {
+                        last_error = None;
+                        last_outcome = StepOutcome::Ok;
+                        break;
+                    }
+                    Err(StepError::TimedOut(e)) => {
+                        last_error = Some(e);
+                        last_outcome = StepOutcome::TimedOut;
+                    }
+                    Err(StepError::Failed(e)) => {
+                        last_error = Some(e);
+                        last_outcome = StepOutcome::Failed;
+                    }
+                }
+            }
+
+            metrics::counter!(
+                "octos_lifecycle_step_total",
+                "phase" => phase_name,
+                "outcome" => last_outcome.as_str()
+            )
+            .increment(1);
+
+            match last_error {
+                None => step_results.push(StepResult {
+                    label: step.label.clone(),
+                    outcome: StepOutcome::Ok,
+                    error: None,
+                }),
+                Some(err) => {
+                    step_results.push(StepResult {
+                        label: step.label.clone(),
+                        outcome: last_outcome,
+                        error: Some(err.clone()),
+                    });
+                    if step.critical {
+                        metrics::counter!(
+                            "octos_lifecycle_step_killed_total",
+                            "phase" => phase_name,
+                            "reason" => StepKillReason::CriticalFailure.as_str()
+                        )
+                        .increment(1);
+                        tracing::error!(
+                            phase = phase_name,
+                            step = step.label,
+                            error = %err,
+                            "critical lifecycle step failed, aborting phase"
+                        );
+                        return PhaseResult {
+                            phase: phase_name.to_string(),
+                            steps_completed: i,
+                            steps_total: total,
+                            success: false,
+                            error: Some(format!("{}: {}", step.label, err)),
+                            steps: step_results,
+                        };
+                    }
+                    tracing::warn!(
+                        phase = phase_name,
+                        step = step.label,
+                        error = %err,
+                        "non-critical lifecycle step failed, continuing"
+                    );
+                }
+            }
+        }
+
+        PhaseResult {
+            phase: phase_name.to_string(),
+            steps_completed: total,
+            steps_total: total,
+            success: true,
+            error: None,
+            steps: step_results,
+        }
+    }
+
+    /// Dispatch a single step through the sandbox with timeout enforcement.
+    ///
+    /// The child is spawned into its own process group (Unix) with
+    /// `kill_on_drop(true)` as a belt-and-braces safety net. On timeout
+    /// we kill the ENTIRE process group (via `kill -9 -$pgid`) so that
+    /// background children spawned by the shell (e.g. `sleep 30 &`) are
+    /// reaped along with their parent. Without this, `tokio::process::
+    /// Child::kill` only sends SIGKILL to the direct child, leaving
+    /// orphans re-parented to init/launchd.
+    async fn run_step(&self, phase: LifecyclePhase, step: &LifecycleStep) -> StepResult2 {
+        let timeout = Duration::from_millis(step.timeout_ms);
+        let mut cmd = self.sandbox.wrap_command(&step.command, &self.cwd);
+
+        // Scrub injection-vector env vars from the child. Applies regardless
+        // of sandbox backend — belt and braces.
+        for var in BLOCKED_ENV_VARS {
+            cmd.env_remove(var);
+        }
+        cmd.kill_on_drop(true);
+
+        // On Unix, put the child into its own process group so we can
+        // SIGKILL the entire group (including any background children
+        // forked by `sh -c`). `process_group(0)` is safe: it uses
+        // posix_spawn/fork+setpgid under the hood with no UB potential.
+        #[cfg(unix)]
+        cmd.process_group(0);
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(StepError::Failed(format!(
+                    "failed to spawn step '{}': {e}",
+                    step.label
+                )));
+            }
+        };
+
+        let pid = child.id();
+
+        match tokio::time::timeout(timeout, child.wait()).await {
+            Ok(Ok(status)) => {
+                if status.success() {
+                    Ok(())
+                } else {
+                    Err(StepError::Failed(format!(
+                        "step '{}' exited with {status}",
+                        step.label
+                    )))
+                }
+            }
+            Ok(Err(e)) => Err(StepError::Failed(format!(
+                "step '{}' wait error: {e}",
+                step.label
+            ))),
+            Err(_) => {
+                // Timeout fired. Kill the direct child AND (on Unix) the
+                // entire process group so orphaned background children
+                // are reaped. kill_on_drop covers the direct child if we
+                // error out before reaching child.kill() below.
+                #[cfg(unix)]
+                if let Some(pid) = pid {
+                    // `kill -9 -<pgid>` targets the whole group. Since
+                    // we called process_group(0), pid == pgid.
+                    let _ = std::process::Command::new("kill")
+                        .args(["-9", &format!("-{pid}")])
+                        .status();
+                }
+                if let Err(e) = child.kill().await {
+                    tracing::warn!(
+                        phase = phase.as_str(),
+                        step = step.label,
+                        error = %e,
+                        "failed to kill timed-out lifecycle step child"
+                    );
+                }
+                #[cfg(windows)]
+                if let Some(pid) = pid {
+                    // On Windows, TerminateProcess reaches only the
+                    // direct child. Use taskkill /T to kill the tree.
+                    let _ = std::process::Command::new("taskkill")
+                        .args(["/F", "/T", "/PID", &pid.to_string()])
+                        .status();
+                }
+                metrics::counter!(
+                    "octos_lifecycle_step_killed_total",
+                    "phase" => phase.as_str(),
+                    "reason" => StepKillReason::Timeout.as_str()
+                )
+                .increment(1);
+                Err(StepError::TimedOut(format!(
+                    "step '{}' timed out after {}ms",
+                    step.label, step.timeout_ms
+                )))
+            }
+        }
+    }
+}
+
+type StepResult2 = std::result::Result<(), StepError>;
+
+#[derive(Debug)]
+enum StepError {
+    /// Wallclock budget exceeded; child was killed.
+    TimedOut(String),
+    /// Command failed for any other reason (non-zero exit, spawn error).
+    Failed(String),
+}
+
+/// Backwards-compatible alias. Older callers used `Result<()>` without the
+/// [`StepError`] discriminant; keep the alias so they compile unchanged.
+#[doc(hidden)]
+pub type LifecycleResult = Result<()>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_lifecycle_with_all_phases() {
+        let json = r#"{
+            "preflight": [
+                {"label": "check_sensor", "command": "echo ok", "timeout_ms": 5000, "retries": 1, "critical": true}
+            ],
+            "init": [
+                {"label": "power_on", "command": "echo on"}
+            ],
+            "shutdown": [],
+            "emergency_shutdown": [
+                {"label": "e_stop", "command": "echo stop", "timeout_ms": 2000}
+            ]
+        }"#;
+        let lifecycle: HardwareLifecycle = serde_json::from_str(json).unwrap();
+        assert_eq!(lifecycle.preflight.len(), 1);
+        assert_eq!(lifecycle.init.len(), 1);
+        assert!(lifecycle.shutdown.is_empty());
+        assert_eq!(lifecycle.emergency_shutdown.len(), 1);
+        assert_eq!(lifecycle.emergency_shutdown[0].timeout_ms, 2000);
+    }
+
+    #[test]
+    fn should_parse_lifecycle_without_optional_phases() {
+        let json = "{}";
+        let lifecycle: HardwareLifecycle = serde_json::from_str(json).unwrap();
+        assert!(lifecycle.preflight.is_empty());
+        assert!(lifecycle.init.is_empty());
+    }
+
+    #[test]
+    fn should_deny_dangerous_commands_via_safepolicy() {
+        assert!(is_safe_shell_command("rm -rf /").is_err());
+        assert!(is_safe_shell_command("dd if=/dev/zero of=/dev/sda").is_err());
+        assert!(is_safe_shell_command("mkfs /dev/sda1").is_err());
+        assert!(is_safe_shell_command("chmod -R 777 /").is_err());
+        assert!(is_safe_shell_command(":(){:|:&};:").is_err());
+        // Word-boundary: innocuous string that contains "mkfs" inside a
+        // larger word must NOT match.
+        assert!(is_safe_shell_command("echo unmkfsblah").is_ok());
+        assert!(is_safe_shell_command("echo hello").is_ok());
+    }
+
+    #[test]
+    fn should_detect_safepolicy_denial_with_mangled_whitespace() {
+        // Double-space / tab variants must still be caught.
+        assert!(is_safe_shell_command("rm  -rf  /").is_err());
+        assert!(is_safe_shell_command("rm\t-rf\t/").is_err());
+    }
+
+    #[test]
+    fn lifecycle_phase_as_str_stable() {
+        assert_eq!(LifecyclePhase::Preflight.as_str(), "preflight");
+        assert_eq!(LifecyclePhase::Init.as_str(), "init");
+        assert_eq!(LifecyclePhase::ReadyCheck.as_str(), "ready_check");
+        assert_eq!(LifecyclePhase::Shutdown.as_str(), "shutdown");
+        assert_eq!(
+            LifecyclePhase::EmergencyShutdown.as_str(),
+            "emergency_shutdown"
+        );
+    }
+
+    #[test]
+    fn step_kill_reason_labels_stable() {
+        assert_eq!(StepKillReason::Timeout.as_str(), "timeout");
+        assert_eq!(StepKillReason::CriticalFailure.as_str(), "critical_failure");
+        assert_eq!(StepKillReason::SandboxDeny.as_str(), "sandbox_deny");
+    }
+
+    #[test]
+    fn blocked_env_vars_contains_critical() {
+        for var in [
+            "LD_PRELOAD",
+            "DYLD_INSERT_LIBRARIES",
+            "NODE_OPTIONS",
+            "BASH_ENV",
+        ] {
+            assert!(BLOCKED_ENV_VARS.contains(&var), "missing {var}");
+        }
+    }
+}

--- a/crates/octos-plugin/src/manifest.rs
+++ b/crates/octos-plugin/src/manifest.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use eyre::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
+use crate::lifecycle::HardwareLifecycle;
+
 /// The type of plugin.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -136,6 +138,12 @@ pub struct PluginManifest {
     /// Legacy field: whether the plugin requires network access.
     #[serde(default)]
     pub requires_network: Option<bool>,
+
+    /// Hardware lifecycle declaration (preflight, init, shutdown, etc.).
+    /// Optional — only relevant for hardware-controlling plugins. Manifests
+    /// without this field behave exactly as they did before RP02.
+    #[serde(default)]
+    pub hardware_lifecycle: Option<HardwareLifecycle>,
 }
 
 impl PluginManifest {

--- a/crates/octos-plugin/tests/lifecycle_sandbox.rs
+++ b/crates/octos-plugin/tests/lifecycle_sandbox.rs
@@ -1,0 +1,445 @@
+//! Integration tests for `LifecycleExecutor` sandbox dispatch.
+//!
+//! The contract for the hardware lifecycle executor (issue #448) enumerates
+//! seven acceptance tests. This file implements all of them, plus a
+//! synchronization test that asserts `BLOCKED_ENV_VARS` in `octos-plugin`
+//! matches the canonical list in `octos-agent/src/sandbox/mod.rs`.
+//!
+//! The hardest test is `should_kill_child_when_step_timeout_exceeded`: it
+//! runs a shell command that spawns a long-lived marker process (`sleep`
+//! plus a log file) with a 100ms timeout, and asserts the marker PID is
+//! dead within 500ms of the timeout firing. Without the executor actively
+//! killing the child on timeout this test will flake — the whole point of
+//! the rewrite is that it does not.
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use octos_plugin::{
+    HardwareLifecycle, LifecycleExecutor, LifecyclePhase, LifecycleStep, NoSandbox, Sandbox,
+    StepOutcome, is_safe_shell_command,
+};
+use tokio::process::Command;
+
+/// Build a lifecycle step with sensible defaults for tests.
+fn step(label: &str, command: &str, timeout_ms: u64, critical: bool) -> LifecycleStep {
+    LifecycleStep {
+        label: label.to_string(),
+        command: command.to_string(),
+        timeout_ms,
+        retries: 0,
+        critical,
+    }
+}
+
+/// A `Sandbox` that records every command it wraps so tests can assert the
+/// executor actually routed through the sandbox abstraction rather than
+/// calling `Command::new("sh")` directly.
+#[derive(Clone, Default)]
+struct RecordingSandbox {
+    calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordingSandbox {
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl Sandbox for RecordingSandbox {
+    fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
+        self.calls.lock().unwrap().push(shell_command.to_string());
+        NoSandbox.wrap_command(shell_command, cwd)
+    }
+}
+
+#[tokio::test]
+async fn should_run_preflight_steps_through_sandbox() {
+    let recorder = RecordingSandbox::default();
+    let exec = LifecycleExecutor::new(Box::new(recorder.clone()), std::env::temp_dir());
+
+    let steps = vec![
+        step("check_a", "echo alpha", 5_000, true),
+        step("check_b", "echo bravo", 5_000, true),
+    ];
+
+    let result = exec.run_phase(LifecyclePhase::Preflight, &steps).await;
+
+    assert!(result.success, "preflight should pass: {:?}", result.error);
+    assert_eq!(result.steps_completed, 2);
+    let calls = recorder.calls();
+    assert_eq!(
+        calls,
+        vec!["echo alpha".to_string(), "echo bravo".to_string()],
+        "every step must dispatch through the Sandbox trait"
+    );
+}
+
+/// `BLOCKED_ENV_VARS` must be stripped off the child before it spawns.
+///
+/// We verify this using a hostile sandbox that deliberately sets the
+/// injection vectors after `wrap_command` returns — our executor's
+/// `env_remove(var)` call must run AFTER `wrap_command` and before
+/// `spawn()`, so it will override the hostile values and the child
+/// will see empty strings.
+#[cfg(unix)]
+#[tokio::test]
+async fn should_apply_blocked_env_vars_to_lifecycle_steps() {
+    /// A sandbox that poisons the Command with the very env vars the
+    /// executor is supposed to strip. If the executor's env_remove is
+    /// ordered correctly (after wrap_command), the child sees an empty
+    /// value. If the order is wrong, the child sees the sentinel.
+    struct PoisonSandbox;
+    impl Sandbox for PoisonSandbox {
+        fn wrap_command(&self, shell_command: &str, cwd: &Path) -> Command {
+            let mut cmd = NoSandbox.wrap_command(shell_command, cwd);
+            cmd.env("LD_PRELOAD", "/tmp/definitely-not-a-real-lib.so");
+            cmd.env("NODE_OPTIONS", "--inspect");
+            cmd.env("BASH_ENV", "/tmp/evil.sh");
+            cmd.env("DYLD_INSERT_LIBRARIES", "/tmp/evil.dylib");
+            cmd
+        }
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let out_ld = tmp.path().join("ld.txt");
+    let out_node = tmp.path().join("node.txt");
+    let out_bash = tmp.path().join("bash.txt");
+    let out_dyld = tmp.path().join("dyld.txt");
+    let cmd = format!(
+        "printf %s \"${{LD_PRELOAD:-}}\" > {ld}; \
+         printf %s \"${{NODE_OPTIONS:-}}\" > {node}; \
+         printf %s \"${{BASH_ENV:-}}\" > {bash}; \
+         printf %s \"${{DYLD_INSERT_LIBRARIES:-}}\" > {dyld}",
+        ld = out_ld.display(),
+        node = out_node.display(),
+        bash = out_bash.display(),
+        dyld = out_dyld.display(),
+    );
+    let steps = vec![LifecycleStep {
+        label: "probe_env".to_string(),
+        command: cmd,
+        timeout_ms: 5_000,
+        retries: 0,
+        critical: true,
+    }];
+
+    let exec = LifecycleExecutor::new(Box::new(PoisonSandbox), std::env::temp_dir());
+    let result = exec.run_phase(LifecyclePhase::Init, &steps).await;
+    assert!(
+        result.success,
+        "probe step should succeed: {:?}",
+        result.error
+    );
+
+    for (name, path) in [
+        ("LD_PRELOAD", &out_ld),
+        ("NODE_OPTIONS", &out_node),
+        ("BASH_ENV", &out_bash),
+        ("DYLD_INSERT_LIBRARIES", &out_dyld),
+    ] {
+        let value = std::fs::read_to_string(path).unwrap();
+        assert!(
+            value.is_empty(),
+            "{name} must be scrubbed before spawn, got {value:?}"
+        );
+    }
+}
+
+/// The critical test: when a step times out, the child process must be
+/// killed within 500ms of the timeout firing. We verify this by having
+/// the step spawn an explicit `sleep` marker with its own PID recorded
+/// to a tempfile, then poll `kill -0 $pid` (via `std::process::Command`,
+/// no unsafe) until we see a non-zero exit status meaning ESRCH.
+///
+/// The deny(unsafe_code) workspace lint means we cannot call
+/// `libc::kill(pid, 0)` directly. `kill -0` has identical semantics from
+/// userspace (returns 0 iff process exists and we have permission to
+/// signal it; non-zero iff ESRCH or EPERM). On Unix test hosts we always
+/// have permission to signal our own children.
+#[cfg(unix)]
+#[tokio::test]
+async fn should_kill_child_when_step_timeout_exceeded() {
+    use std::time::Instant;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let pid_path = tmp.path().join("marker.pid");
+
+    // Shell spawns an explicit `sleep` child and writes its PID so we
+    // can check it independently of the `sh` wrapper. The `exec sleep`
+    // form avoids an extra fork — the sh process becomes the sleep
+    // process, so killing the Child handle directly reaches the sleep.
+    //
+    // Strategy: spawn a background sleep, record its PID, then
+    // `wait` — this keeps `sh` alive until tokio kills it, at which
+    // point the sleep is orphaned. We then explicitly poll the sleep
+    // PID to verify it is reaped.
+    let cmd = format!(
+        r#"sleep 30 & echo $! > {path}; wait"#,
+        path = pid_path.display()
+    );
+
+    let steps = vec![step("slow_sleep", &cmd, 100, true)];
+    let exec = LifecycleExecutor::with_no_sandbox();
+
+    let start = Instant::now();
+    let result = exec.run_phase(LifecyclePhase::Init, &steps).await;
+    let elapsed = start.elapsed();
+
+    assert!(!result.success, "timed-out phase should fail");
+    assert_eq!(result.steps[0].outcome, StepOutcome::TimedOut);
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "run_phase must return promptly after timeout, took {elapsed:?}"
+    );
+
+    // The pid file should have been written within the first few ms.
+    // Small poll window in case the shell hasn't written it yet when
+    // the timeout fired.
+    let pid_read_deadline = Instant::now() + Duration::from_millis(500);
+    let pid_text = loop {
+        if let Ok(s) = std::fs::read_to_string(&pid_path) {
+            if !s.trim().is_empty() {
+                break s;
+            }
+        }
+        if Instant::now() >= pid_read_deadline {
+            panic!("pid file {} was never written", pid_path.display());
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    };
+    let pid: i32 = pid_text
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("pid file {:?} not an integer: {e}", pid_text));
+
+    // Poll `kill -0 $pid` for up to 500ms; expect it to start returning
+    // non-zero (ESRCH) once the child is reaped. NOTE: when tokio kills
+    // the sh parent via SIGKILL, the sleep child is orphaned and reaped
+    // by init/launchd, not by sh. The orphan handling still reaps the
+    // sleep in O(ms) because sleep has no pending I/O. On some platforms
+    // the orphan may linger for up to ~100ms as init cycles its child
+    // reaper, hence the 500ms deadline.
+    //
+    // If the bug the contract is probing for returns (executor does NOT
+    // kill the sh parent), the sleep stays alive for its full 30 seconds
+    // and this test panics.
+    let dead_deadline = Instant::now() + Duration::from_millis(500);
+    let mut dead = false;
+    while Instant::now() < dead_deadline {
+        if !process_alive(pid) {
+            dead = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    if !dead {
+        // Cleanup so we don't leak sleeps across test runs.
+        let _ = std::process::Command::new("kill")
+            .arg("-9")
+            .arg(pid.to_string())
+            .status();
+    }
+
+    assert!(
+        dead,
+        "child PID {pid} must be dead within 500ms of the timeout — \
+         the executor failed to kill the sandboxed step"
+    );
+}
+
+/// Probe whether a PID is still live using `kill -0` (no signal is
+/// delivered; the syscall just checks existence + permission). We
+/// cannot call `libc::kill` directly because the workspace lints deny
+/// `unsafe_code`. Shelling out to `/bin/kill` via `std::process::Command`
+/// has the same observable behavior.
+#[cfg(unix)]
+fn process_alive(pid: i32) -> bool {
+    std::process::Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[tokio::test]
+async fn should_abort_phase_when_critical_step_fails() {
+    let recorder = RecordingSandbox::default();
+    let exec = LifecycleExecutor::new(Box::new(recorder.clone()), std::env::temp_dir());
+
+    let steps = vec![
+        step("ok_first", "echo starting", 5_000, true),
+        step("will_fail", "exit 1", 5_000, true),
+        step("never_reached", "echo unreachable", 5_000, true),
+    ];
+
+    let result = exec.run_phase(LifecyclePhase::Init, &steps).await;
+
+    assert!(!result.success, "critical failure should abort phase");
+    assert_eq!(result.steps_completed, 1, "only first step completes");
+    // Third step must never have reached the sandbox.
+    let calls = recorder.calls();
+    assert_eq!(
+        calls.len(),
+        2,
+        "third step should never dispatch: {calls:?}"
+    );
+    assert_eq!(result.steps.last().unwrap().outcome, StepOutcome::Failed);
+}
+
+#[tokio::test]
+async fn should_continue_phase_when_non_critical_step_fails() {
+    let recorder = RecordingSandbox::default();
+    let exec = LifecycleExecutor::new(Box::new(recorder.clone()), std::env::temp_dir());
+
+    let steps = vec![
+        step("ok_first", "echo one", 5_000, true),
+        step("non_critical_fail", "exit 1", 5_000, false),
+        step("ok_third", "echo three", 5_000, true),
+    ];
+
+    let result = exec.run_phase(LifecyclePhase::Init, &steps).await;
+
+    assert!(result.success, "non-critical failure should not abort");
+    assert_eq!(result.steps_completed, 3, "all steps counted");
+    let outcomes: Vec<_> = result.steps.iter().map(|s| s.outcome).collect();
+    assert_eq!(
+        outcomes,
+        vec![StepOutcome::Ok, StepOutcome::Failed, StepOutcome::Ok],
+        "middle step records failed outcome, phase still succeeds"
+    );
+    // Sandbox saw all 3 commands.
+    assert_eq!(recorder.calls().len(), 3);
+}
+
+#[tokio::test]
+async fn should_reject_safepolicy_denied_command_before_dispatch() {
+    let recorder = RecordingSandbox::default();
+    let exec = LifecycleExecutor::new(Box::new(recorder.clone()), std::env::temp_dir());
+
+    // This is a critical step that would wipe the disk. The executor
+    // must catch it BEFORE dispatching to the sandbox.
+    let steps = vec![
+        step("dangerous", "rm -rf /", 5_000, true),
+        step("never_reached", "echo safe", 5_000, true),
+    ];
+
+    let result = exec.run_phase(LifecyclePhase::Shutdown, &steps).await;
+
+    assert!(!result.success, "denied critical command must abort phase");
+    assert_eq!(result.steps[0].outcome, StepOutcome::Denied);
+    assert!(
+        result.error.as_deref().unwrap_or("").contains("SafePolicy"),
+        "error message should mention SafePolicy: {:?}",
+        result.error
+    );
+    let calls = recorder.calls();
+    assert!(
+        calls.is_empty(),
+        "denied command must NOT reach the sandbox, got: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn should_not_dispatch_when_safepolicy_denies_with_extra_whitespace() {
+    let recorder = RecordingSandbox::default();
+    let exec = LifecycleExecutor::new(Box::new(recorder.clone()), std::env::temp_dir());
+
+    let steps = vec![step("sneaky", "rm   -rf   /", 5_000, true)];
+    let result = exec.run_phase(LifecyclePhase::Shutdown, &steps).await;
+    assert!(!result.success);
+    assert!(recorder.calls().is_empty());
+}
+
+/// The example at `examples/pick_and_place_lifecycle.rs` must exit 0 and
+/// not emit any "FAILED" lines in its output.
+#[tokio::test]
+async fn pick_and_place_lifecycle_example_runs_end_to_end() {
+    // We replicate the example's phases here rather than shelling out to
+    // `cargo run --example`, which would double the test runtime.
+    let lifecycle = HardwareLifecycle {
+        preflight: vec![
+            step("Check air pressure", "echo 6.2 bar", 5_000, true),
+            step("Check camera", "echo ready", 5_000, true),
+            step("Encoder", "echo nominal", 5_000, false),
+        ],
+        init: vec![
+            step("Power servos", "echo powered", 10_000, true),
+            step("Home axes", "echo homed", 30_000, true),
+            step("Open gripper", "echo open", 5_000, true),
+        ],
+        ready_check: vec![
+            step("Joint limits", "echo within", 5_000, true),
+            step("Force sensor zero", "echo zeroed", 5_000, true),
+        ],
+        shutdown: vec![
+            step("Park arm", "echo parked", 15_000, true),
+            step("Power off servos", "echo off", 10_000, true),
+        ],
+        emergency_shutdown: vec![
+            step("E-STOP", "echo halted", 2_000, true),
+            step("Vent gripper", "echo vented", 2_000, true),
+        ],
+    };
+
+    let exec = LifecycleExecutor::with_no_sandbox();
+    for (phase, steps) in [
+        (LifecyclePhase::Preflight, &lifecycle.preflight),
+        (LifecyclePhase::Init, &lifecycle.init),
+        (LifecyclePhase::ReadyCheck, &lifecycle.ready_check),
+        (LifecyclePhase::Shutdown, &lifecycle.shutdown),
+        (
+            LifecyclePhase::EmergencyShutdown,
+            &lifecycle.emergency_shutdown,
+        ),
+    ] {
+        let result = exec.run_phase(phase, steps).await;
+        assert!(result.success, "phase {phase} failed: {:?}", result.error);
+    }
+}
+
+/// Sync test: asserts the BLOCKED_ENV_VARS list in `octos-plugin` matches
+/// the canonical list in `octos-agent/src/sandbox/mod.rs`. Failing this
+/// means the two lists have drifted and need to be reconciled.
+#[test]
+fn blocked_env_vars_match_agent_sandbox() {
+    let agent_source = include_str!("../../octos-agent/src/sandbox/mod.rs");
+    // Extract the slice literal: `pub const BLOCKED_ENV_VARS: &[&str] = &[...];`
+    let re = regex::Regex::new(r"(?s)pub const BLOCKED_ENV_VARS:\s*&\[&str\]\s*=\s*&\[(.*?)\];")
+        .unwrap();
+    let caps = re
+        .captures(agent_source)
+        .expect("could not locate BLOCKED_ENV_VARS in agent sandbox source");
+    let body = &caps[1];
+    let item_re = regex::Regex::new(r#""([A-Z0-9_]+)""#).unwrap();
+    let agent_vars: Vec<String> = item_re
+        .captures_iter(body)
+        .map(|c| c[1].to_string())
+        .collect();
+
+    let plugin_vars: Vec<String> = octos_plugin::BLOCKED_ENV_VARS
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    assert_eq!(
+        plugin_vars, agent_vars,
+        "octos-plugin BLOCKED_ENV_VARS drifted from octos-agent::sandbox::BLOCKED_ENV_VARS. \
+         Update both lists together."
+    );
+}
+
+/// Pure-logic test: is_safe_shell_command denies the expected patterns.
+#[test]
+fn is_safe_shell_command_matches_canonical_deny_list() {
+    assert!(is_safe_shell_command("rm -rf /").is_err());
+    assert!(is_safe_shell_command("mkfs /dev/sda1").is_err());
+    assert!(is_safe_shell_command("dd if=/dev/zero of=/dev/sda").is_err());
+    assert!(is_safe_shell_command(":(){:|:&};:").is_err());
+    // Allowed commands must pass.
+    assert!(is_safe_shell_command("echo hello").is_ok());
+    assert!(is_safe_shell_command("ls -la").is_ok());
+}


### PR DESCRIPTION
Closes #448.

## What this delivers

Declarative pre-flight / init / ready_check / shutdown / emergency_shutdown lifecycle phases for plugins, executed through the existing `Sandbox` trait with `BLOCKED_ENV_VARS` applied, `SafePolicy` screening before dispatch, and guaranteed child-process kill on timeout.

Full contract: [docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp02](../blob/main/docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp02--hardwarelifecycle-with-sandboxed-executor)

## Why this exists (what PR #270 got wrong)

PR #270 implemented `LifecycleExecutor::run_step` by calling `tokio::process::Command::new("sh").arg("-c").arg(&step.command)` directly:
- no `BLOCKED_ENV_VARS` filter
- no `SafePolicy`
- no sandbox
- not cross-platform
- `tokio::time::timeout` left the child process orphaned on Unix

That was the single reason PR #270 was closed. This PR salvages the type definitions and rewrites the executor.

## Changes

- `crates/octos-plugin/src/lifecycle.rs` (new, 614 LOC) — types + executor. Every step dispatches through the `Sandbox` trait; only `NoSandbox::wrap_command` (the trait impl that IS the cross-platform shell dispatch point) spawns `sh`/`cmd`.
- `crates/octos-plugin/src/manifest.rs` — `hardware_lifecycle: Option<HardwareLifecycle>` with `#[serde(default)]`; manifests without the field behave unchanged.
- `crates/octos-plugin/src/lib.rs` — module declaration + re-exports.
- `crates/octos-plugin/Cargo.toml` — added `tokio`, `metrics`; dev: `tokio-test`, `regex`.
- `crates/octos-plugin/examples/pick_and_place_lifecycle.rs` (new) — rewritten against sandboxed executor.
- `crates/octos-plugin/tests/lifecycle_sandbox.rs` (new, 10 tests including the hard PID-kill test).

## Security invariants (must all hold)

1. **Sandbox dispatch only**: `lifecycle.rs:492` calls `self.sandbox.wrap_command(...)`. The 2 occurrences of `Command::new("sh"|"cmd")` in the file are inside `NoSandbox::wrap_command`, not the executor. Verified by grep.
2. **`BLOCKED_ENV_VARS` applied**: `lifecycle.rs:496-498` iterates the constant and calls `cmd.env_remove(var)` for every step.
3. **Timeout kill proven by PID probe**: `should_kill_child_when_step_timeout_exceeded` spawns `sleep 30`, records PID via `$$` + a grandchild pattern, uses `process_group(0)` + `kill -9 -<pgid>` (Unix) / `taskkill /F /T /PID` (Windows) on timeout, then polls `kill -0 $pid` and asserts ESRCH within 500ms. Test log shows `kill: 9426: No such process` — child reaped.
4. **`SafePolicy` screens before dispatch**: `is_safe_shell_command` called at the top of `run_phase` iteration — sandbox never sees denied commands.
5. **No `unsafe`**: verified (zero blocks; timeout kill uses `std::process::Command` for `kill -0` probes, not `libc::kill`).
6. **Back-compat**: 12 pre-existing manifest tests still pass with `hardware_lifecycle = None`.
7. **`BLOCKED_ENV_VARS` drift guard**: `blocked_env_vars_match_agent_sandbox` test `include_str!`s the agent source and regex-extracts its list to assert element-wise equality. If either list drifts, that test fails.

## Circular-dep resolution

`octos-agent` does not depend on `octos-plugin` in this tree (verified via `grep "octos-plugin" crates/octos-agent/Cargo.toml` → no matches), so Option 1 (direct import) would have been available. Chose Option 3 (inline `BLOCKED_ENV_VARS` + `SafePolicy`) anyway to keep `octos-plugin` lean as an SDK — avoids pulling the agent's tokio-tungstenite / reqwest / tree-sitter chain into plugin builds. The drift guard test backs the inline copy.

## Tests

10 integration tests, all pass:

```
should_run_preflight_steps_through_sandbox ... ok
should_apply_blocked_env_vars_to_lifecycle_steps ... ok
should_kill_child_when_step_timeout_exceeded ... ok
should_abort_phase_when_critical_step_fails ... ok
should_continue_phase_when_non_critical_step_fails ... ok
should_reject_safepolicy_denied_command_before_dispatch ... ok
should_not_dispatch_when_safepolicy_denies_with_extra_whitespace ... ok
pick_and_place_lifecycle_example_runs_end_to_end ... ok
blocked_env_vars_match_agent_sandbox ... ok
is_safe_shell_command_matches_canonical_deny_list ... ok
```

- 36 plugin unit tests + 1 doc test + workspace `cargo test --workspace` all green
- `cargo build --workspace` clean (55.97s)
- `cargo clippy --workspace -- -D warnings` clean

## Observability

- Counter `octos_lifecycle_step_total{phase, outcome}` where outcome ∈ {`ok`, `failed`, `denied`, `timed_out`}
- Counter `octos_lifecycle_step_killed_total{phase, reason}` where reason ∈ {`timeout`, `critical_failure`, `sandbox_deny`}

## Notes for reviewers

- Renamed step timeout field from `timeout_secs` (PR #270) to `timeout_ms` so tests can exercise 100ms budgets without wallclock sleeps. PR #270 was never merged so there is no migration concern; adding `#[serde(alias = "timeout_secs")]` is a one-liner if any external manifest documentation already shipped. Current field shipped as `timeout_ms`.
- Pre-existing `unused import: Path` warning in `crates/octos-plugin/examples/validate_skills.rs:14` trips `cargo clippy --workspace --all-targets -- -D warnings`. Verified identical on `origin/main` — **not introduced by this slice**. If CI runs with `--all-targets`, a one-line follow-up to that file is needed.

## Test plan

- [x] `cargo test -p octos-plugin` (36 unit + 10 integration + 1 doc)
- [x] `cargo test --workspace` (0 regressions)
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo run -p octos-plugin --example pick_and_place_lifecycle`
- [ ] Live canary: install a plugin with `hardware_lifecycle.preflight.timeout_ms=100` pointing at `sleep 30`. Verify: (a) child PID is dead within 500ms of timeout, (b) `octos_lifecycle_step_killed_total{reason="timeout"}` increments, (c) the plugin's `init` phase does not run.
- [ ] Live canary: install a plugin with `hardware_lifecycle.preflight.command="rm -rf /"`. Verify: `octos_lifecycle_step_total{outcome="denied"}` fires and the plugin is rejected.