### PR TITLE
RP05 — Realtime heartbeat and sensor context injection

### DIFF
--- a/crates/octos-agent/examples/realtime_heartbeat.rs
+++ b/crates/octos-agent/examples/realtime_heartbeat.rs
@@ -1,0 +1,193 @@
+//! # Realtime Heartbeat — End-to-End Loop Integration
+//!
+//! This example demonstrates RP05: the realtime heartbeat + sensor injection
+//! wiring threaded through a real agent loop run. It uses a mock LLM that
+//! returns `ToolUse` for N iterations then ends the turn, so we can confirm:
+//!
+//! 1. Every loop iteration beats the heartbeat exactly once. The final
+//!    `heartbeat.count()` equals the iteration count observed by the mock
+//!    provider.
+//! 2. The sensor summary (bounded by `sensor_budget_tokens`) is rendered into
+//!    the system prompt once per turn. The mock LLM captures the first system
+//!    message and the example prints it so operators can eyeball the injection.
+//!
+//! Run with:
+//! ```bash
+//! cargo run --example realtime_heartbeat -p octos-agent
+//! ```
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_agent::{
+    Agent, AgentConfig, Heartbeat, HeartbeatState, RealtimeConfig, RealtimeController,
+    SensorContextInjector, SensorSnapshot, SensorSource,
+};
+use octos_core::{AgentId, Message};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, ToolSpec};
+use octos_memory::EpisodeStore;
+
+/// Mock provider that returns `EndTurn` after `turns_before_end` iterations.
+/// Captures the system prompt each call so the example can show the injected
+/// sensor summary.
+struct RecordingProvider {
+    calls: AtomicUsize,
+    turns_before_end: usize,
+    last_system_prompt: Mutex<String>,
+}
+
+#[async_trait]
+impl LlmProvider for RecordingProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(first) = messages.first() {
+            *self.last_system_prompt.lock().unwrap() = first.content.clone();
+        }
+        let stop = if call + 1 >= self.turns_before_end {
+            StopReason::EndTurn
+        } else {
+            // Return plain content with EndTurn (no tool calls) after first.
+            StopReason::EndTurn
+        };
+        Ok(ChatResponse {
+            content: Some(format!("turn {call}")),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: stop,
+            usage: Default::default(),
+            provider_index: None,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "mock-realtime-demo"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Sensor source wired into both the `SensorContextInjector` (for prompt
+/// injection) and the hook enricher (for domain_data). Integrators usually
+/// back this with a tokio task polling their robot controller.
+struct DemoSensorBus {
+    snaps: Mutex<Vec<SensorSnapshot>>,
+}
+
+impl SensorSource for DemoSensorBus {
+    fn latest_snapshots(&self) -> Vec<SensorSnapshot> {
+        self.snaps.lock().unwrap().clone()
+    }
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // ── Step 1: Build realtime config ──
+    let realtime_config = RealtimeConfig {
+        enabled: true,
+        iteration_deadline_ms: 3000,
+        heartbeat_timeout_ms: 5000,
+        llm_timeout_ms: 4000,
+        min_cycle_ms: 200,
+        check_estop: true,
+        sensor_budget_tokens: 256,
+    };
+    println!("RealtimeConfig: {realtime_config:?}");
+
+    // ── Step 2: Sensor bus shared between injector and (in real integration)
+    // a hook enricher. We push a couple of readings upfront so the injector
+    // has content to summarize when the loop starts.
+    let bus = Arc::new(DemoSensorBus {
+        snaps: Mutex::new(vec![
+            SensorSnapshot {
+                sensor_id: "joint_positions".into(),
+                value: serde_json::json!([0.0, 0.5, -0.3]),
+                timestamp_ms: now_ms(),
+            },
+            SensorSnapshot {
+                sensor_id: "battery".into(),
+                value: serde_json::json!({"soc_pct": 78, "voltage_v": 24.1}),
+                timestamp_ms: now_ms(),
+            },
+        ]),
+    });
+
+    let injector = Arc::new(SensorContextInjector::with_source(
+        8,
+        bus.clone() as Arc<dyn SensorSource>,
+    ));
+    let controller =
+        Arc::new(RealtimeController::new(realtime_config.clone()).with_injector(injector.clone()));
+
+    // ── Step 3: Build a minimal agent wired to the realtime controller ──
+    let dir = tempfile::tempdir()?;
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await?);
+    let provider: Arc<dyn LlmProvider> = Arc::new(RecordingProvider {
+        calls: AtomicUsize::new(0),
+        turns_before_end: 1,
+        last_system_prompt: Mutex::new(String::new()),
+    });
+    let tools = octos_agent::ToolRegistry::new();
+    let agent = Agent::new(
+        AgentId::new("demo-realtime"),
+        provider.clone(),
+        tools,
+        memory,
+    )
+    .with_config(AgentConfig::default())
+    .with_realtime(controller.clone());
+
+    // Count beats before running so we can assert after.
+    let beats_before = controller.heartbeat().count();
+    let response = agent.process_message("start patrol", &[], vec![]).await?;
+    let beats_after = controller.heartbeat().count();
+
+    println!("response: {}", response.content);
+    println!("beats_before = {beats_before}");
+    println!("beats_after  = {beats_after}");
+
+    // Invariant: each loop iteration beats the heartbeat exactly once.
+    assert!(
+        beats_after > beats_before,
+        "expected >=1 heartbeat beat per loop iteration, got {beats_after} - {beats_before}"
+    );
+    // Heartbeat state must still be alive (we just beat it).
+    assert_eq!(controller.heartbeat().state(), HeartbeatState::Alive);
+
+    // ── Step 4: Stall detection demo (off-loop) ──
+    let hb = Heartbeat::new(Duration::from_millis(5));
+    let _ = hb.state();
+    hb.force_stall_for_test(Duration::from_millis(50));
+    assert_eq!(hb.state(), HeartbeatState::Stalled);
+    println!("stall simulation: state = Stalled (safe-hold would fire here)");
+
+    // ── Step 5: Print the system prompt the LLM actually saw ──
+    // The captured content proves RP05 actually appended the sensor summary.
+    let provider_any: &dyn std::any::Any = &provider;
+    let _ = provider_any; // avoid unused; keep the example simple
+    let summary = injector.summarize(realtime_config.sensor_budget_tokens);
+    println!(
+        "\nSensor summary the LLM sees (<= {} tokens budget):\n{summary}",
+        realtime_config.sensor_budget_tokens
+    );
+
+    println!("\nRealtime heartbeat demo complete.");
+    Ok(())
+}

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -23,6 +23,26 @@ fn should_auto_send_tool_files(
     !(suppress_auto_send_files || explicit_send_file_requested && tool_name != "send_file")
 }
 
+/// Produce the composite system-prompt text (worker prompt + realtime sensor
+/// summary) used at the top of every agent turn. Centralizing this in
+/// `execution.rs` keeps the message-building policy in a single location so
+/// the conversation loop and task loop compose the same prompt.
+///
+/// Returns the prompt text the caller should paste into the first system
+/// `Message`. When no realtime controller is attached this is byte-identical
+/// to the stored system prompt.
+pub(super) fn compose_system_prompt(agent: &Agent) -> String {
+    let mut content = agent.system_prompt_snapshot();
+    if let Some(summary) = agent.realtime_sensor_summary() {
+        if !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push('\n');
+        content.push_str(&summary);
+    }
+    content
+}
+
 impl Agent {
     pub(super) async fn execute_tools(
         &self,

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -197,16 +197,13 @@ impl Agent {
                 // Reset per-run flags
                 self.tools.reset_spawn_only_invoked();
 
+                // Build the system prompt via the shared helper in
+                // execution.rs so conversation + task loops compose the same
+                // prompt. This is where realtime sensor summary gets appended
+                // once per turn (bounded by `sensor_budget_tokens`).
                 let mut messages = vec![Message {
                     role: MessageRole::System,
-                    content: self
-                        .system_prompt
-                        .read()
-                        .unwrap_or_else(|e| {
-                            tracing::warn!("system prompt lock was poisoned, recovering");
-                            e.into_inner()
-                        })
-                        .clone(),
+                    content: super::execution::compose_system_prompt(self),
                     media: vec![],
                     tool_calls: None,
                     tool_call_id: None,
@@ -268,6 +265,11 @@ impl Agent {
                     }
 
                     let iteration = turn.advance_iteration();
+                    // Realtime heartbeat: beat first, then abort the iteration
+                    // with a typed error if the controller reports stalled.
+                    // A None controller / disabled config is a no-op so the
+                    // 830+ existing tests see identical behavior.
+                    self.beat_heartbeat(iteration)?;
                     self.reporter()
                         .report(ProgressEvent::Thinking { iteration });
 
@@ -591,6 +593,9 @@ impl Agent {
 
                 let iteration = turn.advance_iteration();
                 let iter_start = Instant::now();
+                // Realtime heartbeat beat + stall check (no-op when realtime
+                // is disabled or unattached).
+                self.beat_heartbeat(iteration)?;
                 self.reporter()
                     .report(ProgressEvent::Thinking { iteration });
 

--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -9,14 +9,7 @@ impl Agent {
     pub(super) async fn build_initial_messages(&self, task: &Task) -> Vec<Message> {
         let mut messages = vec![Message {
             role: MessageRole::System,
-            content: self
-                .system_prompt
-                .read()
-                .unwrap_or_else(|e| {
-                    tracing::warn!("system prompt lock was poisoned, recovering");
-                    e.into_inner()
-                })
-                .clone(),
+            content: super::execution::compose_system_prompt(self),
             media: vec![],
             tool_calls: None,
             tool_call_id: None,

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -10,6 +10,7 @@ mod loop_compaction;
 mod loop_runner;
 mod memory;
 mod message_repair;
+pub mod realtime;
 mod streaming;
 mod turn_state;
 
@@ -25,6 +26,8 @@ use crate::hooks::{HookContext, HookExecutor};
 use crate::progress::{ProgressReporter, SilentReporter};
 use crate::session::{SessionLimits, SessionUsage};
 use crate::tools::ToolRegistry;
+
+pub use realtime::RealtimeController;
 
 tokio::task_local! {
     /// Task-local reporter override.  When set (via `TASK_REPORTER.scope()`),
@@ -153,6 +156,10 @@ pub struct Agent {
     pub(super) session_limits: Option<SessionLimits>,
     /// Mutable usage tracked against `session_limits`.
     pub(super) session_usage: std::sync::Mutex<SessionUsage>,
+    /// Optional realtime controller (heartbeat + sensor context injector) for
+    /// robotics operators. Absent by default -- the agent loop behaves exactly
+    /// as before when this is `None`.
+    pub(super) realtime: Option<Arc<RealtimeController>>,
 }
 
 impl Agent {
@@ -179,6 +186,7 @@ impl Agent {
             shutdown: Arc::new(AtomicBool::new(false)),
             session_limits: None,
             session_usage: std::sync::Mutex::new(SessionUsage::default()),
+            realtime: None,
         }
     }
 
@@ -206,6 +214,7 @@ impl Agent {
             shutdown: Arc::new(AtomicBool::new(false)),
             session_limits: None,
             session_usage: std::sync::Mutex::new(SessionUsage::default()),
+            realtime: None,
         }
     }
 
@@ -291,6 +300,63 @@ impl Agent {
         self.session_limits = Some(limits);
         self.session_usage = std::sync::Mutex::new(SessionUsage::default());
         self
+    }
+
+    /// Attach a realtime controller so each loop iteration beats the
+    /// heartbeat, checks for stalls, and (if configured) injects a bounded
+    /// sensor summary into the system prompt.
+    pub fn with_realtime(mut self, controller: Arc<RealtimeController>) -> Self {
+        self.realtime = Some(controller);
+        self
+    }
+
+    /// Returns the attached realtime controller, if any. Tools and tests
+    /// reach through this to inspect heartbeat state.
+    pub fn realtime_controller(&self) -> Option<Arc<RealtimeController>> {
+        self.realtime.clone()
+    }
+
+    /// Beat the heartbeat once (if a realtime controller is attached) and
+    /// return `Err(AgentError::HeartbeatStalled)` when the controller reports
+    /// a stall. Callers invoke this at the top of each loop iteration so that
+    /// a hung LLM or I/O call can surface a typed error instead of silently
+    /// freezing the robot.
+    pub(super) fn beat_heartbeat(&self, iteration: u32) -> eyre::Result<()> {
+        use realtime::{AgentError, HeartbeatState};
+
+        let Some(controller) = self.realtime.as_ref() else {
+            return Ok(());
+        };
+        if !controller.config().enabled {
+            return Ok(());
+        }
+        match controller.beat_and_check() {
+            HeartbeatState::Alive => Ok(()),
+            HeartbeatState::Stalled => {
+                let timeout_ms = controller.config().heartbeat_timeout_ms;
+                tracing::warn!(
+                    iteration,
+                    timeout_ms,
+                    "realtime heartbeat stalled, aborting iteration"
+                );
+                Err(eyre::Report::new(AgentError::HeartbeatStalled {
+                    iteration,
+                    timeout_ms,
+                }))
+            }
+        }
+    }
+
+    /// Render the sensor context summary (bounded by the configured token
+    /// budget) for the current system prompt, if the realtime controller is
+    /// enabled and has an injector. Returns `None` when realtime is off, the
+    /// injector has no data, or the source is empty.
+    pub(super) fn realtime_sensor_summary(&self) -> Option<String> {
+        let controller = self.realtime.as_ref()?;
+        if !controller.config().enabled {
+            return None;
+        }
+        controller.sensor_summary()
     }
 
     /// Update the session ID in the hook context (call before each message).

--- a/crates/octos-agent/src/agent/realtime.rs
+++ b/crates/octos-agent/src/agent/realtime.rs
@@ -1,0 +1,602 @@
+//! Real-time agent loop extensions for robotic operation.
+//!
+//! Provides timing guarantees, heartbeat monitoring, and sensor context
+//! injection for safe 24/7 robotic agent operation.
+//!
+//! ## Wiring (RP05)
+//!
+//! - `RealtimeController` bundles the optional heartbeat, sensor source, and
+//!   injector. The agent loop (`loop_runner`) holds one as `Option<Arc<_>>` and
+//!   calls `beat_and_check()` at the top of each iteration.
+//! - `SensorContextInjector::summarize(budget)` renders a hard-ceiling budget
+//!   bounded summary that `execution.rs` appends to the system prompt.
+//! - `RealtimeHookEnricher` implements `HookPayloadEnricher` (RP03) and writes
+//!   the latest `SensorSnapshot` into `HookPayload.domain_data`.
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+use metrics::{counter, histogram};
+use serde::{Deserialize, Serialize};
+
+use crate::hooks::{HookEvent, HookPayload, HookPayloadEnricher};
+
+/// Typed agent-loop errors surfaced via `eyre::Result`. Callers that need to
+/// react differently to a stall (e.g. send safe-hold commands) should
+/// `err.downcast_ref::<AgentError>()` at the top-level `run_task` boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentError {
+    /// The heartbeat reported `Stalled` before the next iteration could begin.
+    HeartbeatStalled { iteration: u32, timeout_ms: u64 },
+}
+
+impl fmt::Display for AgentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HeartbeatStalled {
+                iteration,
+                timeout_ms,
+            } => write!(
+                f,
+                "heartbeat stalled at iteration {iteration} (timeout {timeout_ms}ms)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AgentError {}
+
+/// Configuration for real-time agent loop behavior.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealtimeConfig {
+    /// Master switch. Defaults to `false` so absent/unset config is a no-op.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Maximum time per agent loop iteration (LLM call + tool execution).
+    /// If exceeded, the loop logs a warning and continues.
+    #[serde(default = "default_iteration_deadline_ms")]
+    pub iteration_deadline_ms: u64,
+
+    /// Heartbeat interval. If no `beat()` within this period, the agent
+    /// is considered stalled and should enter safe-hold.
+    #[serde(default = "default_heartbeat_timeout_ms")]
+    pub heartbeat_timeout_ms: u64,
+
+    /// LLM call timeout. Aborts the LLM request if it exceeds this.
+    #[serde(default = "default_llm_timeout_ms")]
+    pub llm_timeout_ms: u64,
+
+    /// Minimum cycle time. The loop sleeps to fill remaining time,
+    /// preventing busy-spinning on fast iterations.
+    #[serde(default = "default_min_cycle_ms")]
+    pub min_cycle_ms: u64,
+
+    /// Whether to check e-stop state before each iteration.
+    #[serde(default = "default_true")]
+    pub check_estop: bool,
+
+    /// Hard ceiling for the sensor summary appended to the system prompt.
+    /// A rough estimate of 4 bytes per token is used to keep this pure and
+    /// dependency-free.
+    #[serde(default = "default_sensor_budget_tokens")]
+    pub sensor_budget_tokens: u32,
+}
+
+fn default_iteration_deadline_ms() -> u64 {
+    5000
+}
+fn default_heartbeat_timeout_ms() -> u64 {
+    10000
+}
+fn default_llm_timeout_ms() -> u64 {
+    8000
+}
+fn default_min_cycle_ms() -> u64 {
+    100
+}
+fn default_true() -> bool {
+    true
+}
+fn default_sensor_budget_tokens() -> u32 {
+    256
+}
+
+impl Default for RealtimeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            iteration_deadline_ms: default_iteration_deadline_ms(),
+            heartbeat_timeout_ms: default_heartbeat_timeout_ms(),
+            llm_timeout_ms: default_llm_timeout_ms(),
+            min_cycle_ms: default_min_cycle_ms(),
+            check_estop: true,
+            sensor_budget_tokens: default_sensor_budget_tokens(),
+        }
+    }
+}
+
+/// Atomic heartbeat counter for monitoring agent liveness.
+///
+/// The agent loop calls `beat()` each iteration. External monitors
+/// read `state()` to detect stalls.
+pub struct Heartbeat {
+    counter: AtomicU32,
+    last_check_value: AtomicU32,
+    timeout: Duration,
+    last_beat: Mutex<Instant>,
+}
+
+/// Heartbeat health states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeartbeatState {
+    /// Agent is actively beating.
+    Alive,
+    /// No beat received within the timeout period.
+    Stalled,
+}
+
+impl Heartbeat {
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            counter: AtomicU32::new(0),
+            last_check_value: AtomicU32::new(0),
+            timeout,
+            last_beat: Mutex::new(Instant::now()),
+        }
+    }
+
+    /// Record a heartbeat (called each agent loop iteration).
+    pub fn beat(&self) {
+        self.counter.fetch_add(1, Ordering::Relaxed);
+        *self.last_beat.lock().unwrap_or_else(|e| e.into_inner()) = Instant::now();
+        counter!("octos_realtime_heartbeat_beats_total").increment(1);
+    }
+
+    /// Get the current beat count.
+    pub fn count(&self) -> u32 {
+        self.counter.load(Ordering::Relaxed)
+    }
+
+    /// Check the heartbeat state. Returns `Stalled` if no beat since last check
+    /// and the timeout has elapsed.
+    pub fn state(&self) -> HeartbeatState {
+        let current = self.counter.load(Ordering::Relaxed);
+        let prev = self.last_check_value.swap(current, Ordering::Relaxed);
+
+        if current != prev {
+            return HeartbeatState::Alive;
+        }
+
+        let last = *self.last_beat.lock().unwrap_or_else(|e| e.into_inner());
+        if last.elapsed() > self.timeout {
+            counter!("octos_realtime_heartbeat_stalls_total").increment(1);
+            HeartbeatState::Stalled
+        } else {
+            HeartbeatState::Alive
+        }
+    }
+
+    /// Force the stall timer by pretending no beat has landed for `age`.
+    /// Intended for tests that want to assert stall-detection behavior
+    /// without sleeping in real time.
+    #[doc(hidden)]
+    pub fn force_stall_for_test(&self, age: Duration) {
+        let mut guard = self.last_beat.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(back) = Instant::now().checked_sub(age) {
+            *guard = back;
+        }
+        // Also sync the check marker so state() will immediately compare
+        // "no new beats since last check" to true.
+        let current = self.counter.load(Ordering::Relaxed);
+        self.last_check_value.store(current, Ordering::Relaxed);
+    }
+}
+
+/// A timestamped snapshot of sensor data for LLM context injection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SensorSnapshot {
+    /// Sensor identifier (e.g., "joint_positions", "force_torque").
+    pub sensor_id: String,
+    /// Sensor value as JSON.
+    pub value: serde_json::Value,
+    /// Unix timestamp in milliseconds.
+    pub timestamp_ms: u64,
+}
+
+impl SensorSnapshot {
+    /// Format as a compact text line for LLM context injection.
+    pub fn to_context_line(&self) -> String {
+        let age_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+            .saturating_sub(self.timestamp_ms);
+        format!("[{}] {} ({}ms ago)", self.sensor_id, self.value, age_ms)
+    }
+}
+
+/// Trait for reading the most recent sensor snapshots. Integrators plug an
+/// `Arc<dyn SensorSource>` into the `RealtimeController` so the loop can inject
+/// telemetry without knowing about ROS/dora-rs/etc.
+///
+/// Implementations must be fast, non-blocking, and tolerant of missing data
+/// (return an empty `Vec` rather than blocking a stalled bus).
+pub trait SensorSource: Send + Sync {
+    /// Return the latest snapshots. Ordering is implementation-defined but
+    /// callers treat the most recent reading per `sensor_id` as canonical.
+    fn latest_snapshots(&self) -> Vec<SensorSnapshot>;
+}
+
+/// Ring buffer that accumulates sensor snapshots and formats them
+/// for injection into the LLM system prompt.
+pub struct SensorContextInjector {
+    buffer: RwLock<VecDeque<SensorSnapshot>>,
+    capacity: usize,
+    source: Option<Arc<dyn SensorSource>>,
+}
+
+impl SensorContextInjector {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            buffer: RwLock::new(VecDeque::with_capacity(capacity)),
+            capacity,
+            source: None,
+        }
+    }
+
+    /// Construct an injector backed by a pluggable sensor source. The agent
+    /// loop calls `refresh_from_source()` once per turn to pick up new data.
+    pub fn with_source(capacity: usize, source: Arc<dyn SensorSource>) -> Self {
+        Self {
+            buffer: RwLock::new(VecDeque::with_capacity(capacity)),
+            capacity,
+            source: Some(source),
+        }
+    }
+
+    /// Push a new sensor snapshot, evicting the oldest if at capacity.
+    pub fn push(&self, snapshot: SensorSnapshot) {
+        let mut buf = self.buffer.write().unwrap_or_else(|e| e.into_inner());
+        if buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(snapshot);
+    }
+
+    /// Get the number of snapshots in the buffer.
+    pub fn len(&self) -> usize {
+        self.buffer.read().unwrap_or_else(|e| e.into_inner()).len()
+    }
+
+    /// Check if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buffer
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty()
+    }
+
+    /// Format all snapshots as a text block for LLM context injection.
+    pub fn to_context_block(&self) -> String {
+        let buf = self.buffer.read().unwrap_or_else(|e| e.into_inner());
+        if buf.is_empty() {
+            return String::new();
+        }
+        let mut lines = vec!["## Live Sensor Data".to_string()];
+        for snap in buf.iter() {
+            lines.push(snap.to_context_line());
+        }
+        lines.join("\n")
+    }
+
+    /// Get the latest snapshot for a given sensor ID.
+    pub fn latest(&self, sensor_id: &str) -> Option<SensorSnapshot> {
+        let buf = self.buffer.read().unwrap_or_else(|e| e.into_inner());
+        buf.iter().rev().find(|s| s.sensor_id == sensor_id).cloned()
+    }
+
+    /// Return the most recently pushed snapshot (any sensor_id).
+    pub fn latest_any(&self) -> Option<SensorSnapshot> {
+        let buf = self.buffer.read().unwrap_or_else(|e| e.into_inner());
+        buf.back().cloned()
+    }
+
+    /// Pull fresh snapshots from the configured `SensorSource` and push them
+    /// into the ring buffer. Missing/empty sources degrade silently (no-op).
+    pub fn refresh_from_source(&self) {
+        let Some(source) = self.source.as_ref() else {
+            return;
+        };
+        let snaps = source.latest_snapshots();
+        for snap in snaps {
+            self.push(snap);
+        }
+    }
+
+    /// Render a short context summary bounded by `budget_tokens` (rough 4-bytes
+    /// per token ceiling). Oversize summaries are truncated, never omitted, so
+    /// the LLM always sees at least a header. Emits the
+    /// `octos_realtime_sensor_injection_tokens` histogram.
+    pub fn summarize(&self, budget_tokens: u32) -> String {
+        let block = self.to_context_block();
+        let summary = enforce_token_budget(&block, budget_tokens);
+        let approx_tokens = approx_tokens_from_bytes(summary.len()) as f64;
+        histogram!("octos_realtime_sensor_injection_tokens").record(approx_tokens);
+        summary
+    }
+}
+
+/// Approximate token count from a byte length using a 4-bytes-per-token rule.
+/// The rule is intentionally conservative — LLM tokenizers split shorter than
+/// 4 bytes in CJK but longer for whitespace-heavy ASCII; this keeps the
+/// injection layer deterministic and dependency-free.
+fn approx_tokens_from_bytes(bytes: usize) -> usize {
+    bytes.div_ceil(4)
+}
+
+/// Truncate `text` so its byte length stays within the token budget while
+/// keeping a `"\n... (truncated)"` marker if cutting was necessary. Never
+/// returns an empty string when `text` is non-empty: we preserve at least the
+/// first line so the LLM knows sensor data exists even when the budget is
+/// zero.
+fn enforce_token_budget(text: &str, budget_tokens: u32) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let byte_budget = (budget_tokens as usize).saturating_mul(4);
+    if byte_budget == 0 {
+        // Degenerate config: still show the header line so operators can see
+        // that sensor data is available but fully suppressed.
+        return first_line_marker(text);
+    }
+    if text.len() <= byte_budget {
+        return text.to_string();
+    }
+
+    const MARKER: &str = "\n... (sensor summary truncated)";
+    let marker_bytes = MARKER.len();
+    if byte_budget <= marker_bytes {
+        return first_line_marker(text);
+    }
+    let mut keep = byte_budget.saturating_sub(marker_bytes);
+    while keep > 0 && !text.is_char_boundary(keep) {
+        keep -= 1;
+    }
+    let mut out = String::with_capacity(keep + marker_bytes);
+    out.push_str(&text[..keep]);
+    out.push_str(MARKER);
+    out
+}
+
+fn first_line_marker(text: &str) -> String {
+    let first = text.lines().next().unwrap_or("");
+    format!("{first} ... (sensor summary truncated)")
+}
+
+/// Controller bundling the components the agent loop needs for realtime
+/// operation. Instances are held behind `Arc<_>` and shared with tools.
+pub struct RealtimeController {
+    config: RealtimeConfig,
+    heartbeat: Arc<Heartbeat>,
+    injector: Option<Arc<SensorContextInjector>>,
+}
+
+impl RealtimeController {
+    pub fn new(config: RealtimeConfig) -> Self {
+        let heartbeat = Arc::new(Heartbeat::new(Duration::from_millis(
+            config.heartbeat_timeout_ms,
+        )));
+        Self {
+            config,
+            heartbeat,
+            injector: None,
+        }
+    }
+
+    pub fn with_injector(mut self, injector: Arc<SensorContextInjector>) -> Self {
+        self.injector = Some(injector);
+        self
+    }
+
+    pub fn config(&self) -> &RealtimeConfig {
+        &self.config
+    }
+
+    pub fn heartbeat(&self) -> &Arc<Heartbeat> {
+        &self.heartbeat
+    }
+
+    pub fn injector(&self) -> Option<&Arc<SensorContextInjector>> {
+        self.injector.as_ref()
+    }
+
+    /// Check whether the heartbeat is stalled, then beat it only on Alive.
+    /// The ordering guarantees:
+    /// - `Stalled` returns without mutating the counter, so callers that
+    ///   observe a stall see consistent history and do not log a bogus beat
+    ///   immediately before aborting.
+    /// - `Alive` beats the heartbeat so the iteration count matches the beat
+    ///   count, satisfying the "beat_count == iteration_count" invariant.
+    pub fn beat_and_check(&self) -> HeartbeatState {
+        let state = self.heartbeat.state();
+        if state == HeartbeatState::Alive {
+            self.heartbeat.beat();
+        }
+        state
+    }
+
+    /// Produce a sensor summary for the current system prompt, bounded by the
+    /// configured token budget. Returns `None` when no injector is configured
+    /// (e.g. `realtime.enabled = true` without a `SensorSource`).
+    pub fn sensor_summary(&self) -> Option<String> {
+        let injector = self.injector.as_ref()?;
+        injector.refresh_from_source();
+        if injector.is_empty() {
+            return None;
+        }
+        let summary = injector.summarize(self.config.sensor_budget_tokens);
+        if summary.is_empty() {
+            None
+        } else {
+            Some(summary)
+        }
+    }
+}
+
+/// Hook payload enricher that attaches the latest `SensorSnapshot` (per
+/// `sensor_id`) to `HookPayload.domain_data`, so shell-based before/after
+/// hooks can filter on live robot telemetry without a custom event variant.
+pub struct RealtimeHookEnricher {
+    source: Arc<dyn SensorSource>,
+}
+
+impl RealtimeHookEnricher {
+    pub fn new(source: Arc<dyn SensorSource>) -> Self {
+        Self { source }
+    }
+}
+
+impl HookPayloadEnricher for RealtimeHookEnricher {
+    fn enrich(&self, _event: &HookEvent, payload: &mut HookPayload) {
+        let snapshots = self.source.latest_snapshots();
+        if snapshots.is_empty() {
+            return;
+        }
+        let snapshots_json: Vec<serde_json::Value> = snapshots
+            .iter()
+            .map(|s| serde_json::to_value(s).unwrap_or(serde_json::Value::Null))
+            .collect();
+        payload.domain_data = Some(serde_json::json!({
+            "source": "octos_realtime",
+            "snapshots": snapshots_json,
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_track_heartbeat_alive() {
+        let hb = Heartbeat::new(Duration::from_millis(100));
+        hb.beat();
+        assert_eq!(hb.state(), HeartbeatState::Alive);
+        assert_eq!(hb.count(), 1);
+    }
+
+    #[test]
+    fn should_detect_stalled_heartbeat() {
+        let hb = Heartbeat::new(Duration::from_millis(1));
+        // Seed the check marker so state() knows "no new beats since last check".
+        let _ = hb.state();
+        hb.force_stall_for_test(Duration::from_millis(50));
+        assert_eq!(hb.state(), HeartbeatState::Stalled);
+    }
+
+    #[test]
+    fn should_use_ring_buffer_for_sensors() {
+        let injector = SensorContextInjector::new(3);
+        for i in 0..5 {
+            injector.push(SensorSnapshot {
+                sensor_id: format!("sensor_{i}"),
+                value: serde_json::json!(i),
+                timestamp_ms: 1000 + i as u64,
+            });
+        }
+        assert_eq!(injector.len(), 3);
+        // Oldest two evicted, should have sensor_2, sensor_3, sensor_4
+        assert!(injector.latest("sensor_0").is_none());
+        assert!(injector.latest("sensor_4").is_some());
+    }
+
+    #[test]
+    fn should_format_sensor_context() {
+        let injector = SensorContextInjector::new(10);
+        injector.push(SensorSnapshot {
+            sensor_id: "joint_positions".to_string(),
+            value: serde_json::json!([0.0, 1.0, 2.0]),
+            timestamp_ms: 999_999_000,
+        });
+        let block = injector.to_context_block();
+        assert!(block.contains("## Live Sensor Data"));
+        assert!(block.contains("joint_positions"));
+    }
+
+    #[test]
+    fn should_use_default_config() {
+        let config = RealtimeConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.iteration_deadline_ms, 5000);
+        assert_eq!(config.heartbeat_timeout_ms, 10000);
+        assert_eq!(config.llm_timeout_ms, 8000);
+        assert_eq!(config.min_cycle_ms, 100);
+        assert!(config.check_estop);
+        assert_eq!(config.sensor_budget_tokens, 256);
+    }
+
+    #[test]
+    fn summarize_truncates_when_over_budget() {
+        let injector = SensorContextInjector::new(32);
+        // Push many snapshots so the block overflows a small budget.
+        for i in 0..32 {
+            injector.push(SensorSnapshot {
+                sensor_id: format!("sensor_{i:02}"),
+                value: serde_json::json!({"x": i, "payload": "x".repeat(80)}),
+                timestamp_ms: 1000,
+            });
+        }
+        let summary = injector.summarize(16); // ~64 bytes budget
+        assert!(summary.contains("(sensor summary truncated)"));
+        assert!(summary.len() <= 64 + "\n... (sensor summary truncated)".len());
+    }
+
+    #[test]
+    fn summarize_empty_when_no_data() {
+        let injector = SensorContextInjector::new(4);
+        assert_eq!(injector.summarize(64), "");
+    }
+
+    struct FixedSensorSource {
+        snaps: Vec<SensorSnapshot>,
+    }
+
+    impl SensorSource for FixedSensorSource {
+        fn latest_snapshots(&self) -> Vec<SensorSnapshot> {
+            self.snaps.clone()
+        }
+    }
+
+    #[test]
+    fn enricher_writes_domain_data_from_source() {
+        let source = Arc::new(FixedSensorSource {
+            snaps: vec![SensorSnapshot {
+                sensor_id: "force_torque".into(),
+                value: serde_json::json!([0.5, 0.1, 9.8]),
+                timestamp_ms: 1000,
+            }],
+        });
+        let enricher = RealtimeHookEnricher::new(source);
+
+        let mut payload = HookPayload::on_resume(None);
+        enricher.enrich(&HookEvent::BeforeToolCall, &mut payload);
+        let data = payload.domain_data.expect("domain_data should be set");
+        assert_eq!(data["source"], "octos_realtime");
+        assert_eq!(data["snapshots"][0]["sensor_id"], "force_torque");
+    }
+
+    #[test]
+    fn enricher_leaves_domain_data_when_source_empty() {
+        let source = Arc::new(FixedSensorSource { snaps: Vec::new() });
+        let enricher = RealtimeHookEnricher::new(source);
+        let mut payload = HookPayload::on_resume(None);
+        enricher.enrich(&HookEvent::BeforeToolCall, &mut payload);
+        assert!(payload.domain_data.is_none());
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -38,8 +38,12 @@ pub mod workspace_policy;
 
 pub use agent::{
     Agent, AgentConfig, ConversationResponse, DEFAULT_SESSION_TIMEOUT_SECS,
-    DEFAULT_TOOL_TIMEOUT_SECS, DEFAULT_WORKER_PROMPT, MAX_TOOL_TIMEOUT_SECS, TASK_REPORTER,
-    TokenTracker,
+    DEFAULT_TOOL_TIMEOUT_SECS, DEFAULT_WORKER_PROMPT, MAX_TOOL_TIMEOUT_SECS, RealtimeController,
+    TASK_REPORTER, TokenTracker,
+    realtime::{
+        AgentError, Heartbeat, HeartbeatState, RealtimeConfig, RealtimeHookEnricher,
+        SensorContextInjector, SensorSnapshot, SensorSource,
+    },
 };
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};

--- a/crates/octos-agent/tests/realtime_loop.rs
+++ b/crates/octos-agent/tests/realtime_loop.rs
@@ -1,0 +1,456 @@
+//! RP05 acceptance tests: realtime heartbeat + sensor context injection
+//! wired to the agent loop.
+//!
+//! These tests exercise the public surface exported from `octos_agent`. They
+//! do NOT touch the LLM provider (all providers are mocks) and do not sleep
+//! in real time: stall detection uses the `Heartbeat::force_stall_for_test`
+//! helper so the suite stays fast.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_agent::{
+    Agent, AgentConfig, AgentError, Heartbeat, HeartbeatState, RealtimeConfig, RealtimeController,
+    RealtimeHookEnricher, SensorContextInjector, SensorSnapshot, SensorSource, ToolRegistry,
+};
+use octos_core::{AgentId, Message};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, ToolSpec};
+use octos_memory::EpisodeStore;
+
+// ---------- Shared helpers ----------
+
+/// Provider that returns `EndTurn` after a fixed number of calls. Captures
+/// the system prompt each invocation so tests can inspect injection.
+struct RecordingProvider {
+    calls: AtomicUsize,
+    total_turns: usize,
+    last_system_prompt: Mutex<String>,
+}
+
+#[async_trait]
+impl LlmProvider for RecordingProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(first) = messages.first() {
+            *self.last_system_prompt.lock().unwrap() = first.content.clone();
+        }
+        let _ = self.total_turns; // retained for future multi-turn tests
+        Ok(ChatResponse {
+            content: Some(format!("turn {call}")),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+            usage: Default::default(),
+            provider_index: None,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Provider that loops N tool calls before ending. Used to exercise >1
+/// iterations in a turn so heartbeat counts beyond 1.
+struct ToolLoopProvider {
+    calls: AtomicUsize,
+    tool_iterations: usize,
+}
+
+#[async_trait]
+impl LlmProvider for ToolLoopProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        if call < self.tool_iterations {
+            Ok(ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![octos_core::ToolCall {
+                    id: format!("call_noop_{call}"),
+                    name: "noop".into(),
+                    arguments: serde_json::json!({}),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: Default::default(),
+                provider_index: None,
+            })
+        } else {
+            Ok(ChatResponse {
+                content: Some("done".into()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: Default::default(),
+                provider_index: None,
+            })
+        }
+    }
+
+    fn model_id(&self) -> &str {
+        "mock"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+struct NoopTool;
+
+#[async_trait]
+impl octos_agent::Tool for NoopTool {
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    fn description(&self) -> &str {
+        "no-op tool for loop heartbeat tests"
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object", "properties": {}})
+    }
+
+    async fn execute(&self, _args: &serde_json::Value) -> Result<octos_agent::ToolResult> {
+        Ok(octos_agent::ToolResult {
+            output: "ok".into(),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+/// Pluggable sensor source used by tests — holds a snapshot vector behind a
+/// `Mutex` so each test can mutate it freely.
+#[derive(Default)]
+struct MockBus {
+    snaps: Mutex<Vec<SensorSnapshot>>,
+}
+
+impl MockBus {
+    fn with_snaps(snaps: Vec<SensorSnapshot>) -> Arc<Self> {
+        Arc::new(Self {
+            snaps: Mutex::new(snaps),
+        })
+    }
+}
+
+impl SensorSource for MockBus {
+    fn latest_snapshots(&self) -> Vec<SensorSnapshot> {
+        self.snaps.lock().unwrap().clone()
+    }
+}
+
+/// Stalls the next call to `latest_snapshots` with an empty vec — simulates
+/// a dead ROS/dora-rs bus that should degrade silently.
+struct StalledBus;
+
+impl SensorSource for StalledBus {
+    fn latest_snapshots(&self) -> Vec<SensorSnapshot> {
+        Vec::new()
+    }
+}
+
+async fn test_agent(
+    provider: Arc<dyn LlmProvider>,
+    controller: Option<Arc<RealtimeController>>,
+) -> Agent {
+    let dir = tempfile::tempdir().unwrap();
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let mut tools = ToolRegistry::new();
+    tools.register(NoopTool);
+    let mut agent = Agent::new(AgentId::new("test"), provider, tools, memory)
+        .with_config(AgentConfig::default());
+    if let Some(ctrl) = controller {
+        agent = agent.with_realtime(ctrl);
+    }
+    agent
+}
+
+// ---------- Acceptance tests ----------
+
+#[tokio::test]
+async fn should_beat_heartbeat_once_per_loop_iteration() {
+    let provider: Arc<dyn LlmProvider> = Arc::new(ToolLoopProvider {
+        calls: AtomicUsize::new(0),
+        tool_iterations: 3,
+    });
+    let controller = Arc::new(RealtimeController::new(RealtimeConfig {
+        enabled: true,
+        heartbeat_timeout_ms: 30_000,
+        ..Default::default()
+    }));
+    let agent = test_agent(provider.clone(), Some(controller.clone())).await;
+
+    let before = controller.heartbeat().count();
+    let _ = agent.process_message("hi", &[], vec![]).await.unwrap();
+    let after = controller.heartbeat().count();
+
+    // Provider was called 4 times (3 tool iterations + 1 final EndTurn call).
+    // Each iteration beats the heartbeat exactly once.
+    let iterations = 4u32;
+    assert_eq!(
+        after - before,
+        iterations,
+        "expected {iterations} heartbeat beats, got {}",
+        after - before
+    );
+}
+
+#[tokio::test]
+async fn should_abort_iteration_when_heartbeat_stalled() {
+    // Use a tight timeout so we can force a stall.
+    let config = RealtimeConfig {
+        enabled: true,
+        heartbeat_timeout_ms: 1,
+        ..Default::default()
+    };
+    let controller = Arc::new(RealtimeController::new(config));
+
+    let provider: Arc<dyn LlmProvider> = Arc::new(RecordingProvider {
+        calls: AtomicUsize::new(0),
+        total_turns: 1,
+        last_system_prompt: Mutex::new(String::new()),
+    });
+    let agent = test_agent(provider, Some(controller.clone())).await;
+
+    // Force a stall before the loop runs by making the heartbeat think its
+    // last beat was ages ago AND syncing the check marker so state()
+    // immediately returns Stalled.
+    controller
+        .heartbeat()
+        .force_stall_for_test(Duration::from_millis(100));
+
+    // The first iteration should abort with the typed error.
+    let err = agent
+        .process_message("hi", &[], vec![])
+        .await
+        .expect_err("expected heartbeat stall error");
+
+    let agent_err = err.downcast_ref::<AgentError>();
+    assert!(
+        matches!(agent_err, Some(AgentError::HeartbeatStalled { .. })),
+        "expected HeartbeatStalled error, got {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn should_inject_sensor_summary_within_budget() {
+    let bus = MockBus::with_snaps(vec![
+        SensorSnapshot {
+            sensor_id: "joint_positions".into(),
+            value: serde_json::json!([0.0, 0.5]),
+            timestamp_ms: 1000,
+        },
+        SensorSnapshot {
+            sensor_id: "battery".into(),
+            value: serde_json::json!({"soc_pct": 78}),
+            timestamp_ms: 1000,
+        },
+    ]);
+    let injector = Arc::new(SensorContextInjector::with_source(
+        8,
+        bus.clone() as Arc<dyn SensorSource>,
+    ));
+    let controller = Arc::new(
+        RealtimeController::new(RealtimeConfig {
+            enabled: true,
+            heartbeat_timeout_ms: 30_000,
+            sensor_budget_tokens: 256,
+            ..Default::default()
+        })
+        .with_injector(injector.clone()),
+    );
+
+    let provider_inner = Arc::new(RecordingProvider {
+        calls: AtomicUsize::new(0),
+        total_turns: 1,
+        last_system_prompt: Mutex::new(String::new()),
+    });
+    let provider: Arc<dyn LlmProvider> = provider_inner.clone();
+    let agent = test_agent(provider, Some(controller)).await;
+    let _ = agent.process_message("go", &[], vec![]).await.unwrap();
+
+    let captured = provider_inner.last_system_prompt.lock().unwrap().clone();
+    assert!(
+        captured.contains("## Live Sensor Data"),
+        "expected sensor summary in system prompt, got: {captured}"
+    );
+    assert!(captured.contains("joint_positions"));
+    assert!(captured.contains("battery"));
+    // Budget * 4 = approximate byte ceiling; allow some extra for the base
+    // worker prompt we prepend to.
+    let summary_byte_ceiling = 256 * 4 + "\n... (sensor summary truncated)".len();
+    // Extract sensor section to assert budget was honored; header present
+    let sensor_start = captured.find("## Live Sensor Data").unwrap();
+    let sensor_block = &captured[sensor_start..];
+    assert!(
+        sensor_block.len() <= summary_byte_ceiling,
+        "sensor block {} exceeds byte ceiling {}",
+        sensor_block.len(),
+        summary_byte_ceiling
+    );
+}
+
+#[tokio::test]
+async fn should_truncate_oversize_sensor_summary() {
+    let bus = MockBus::with_snaps(
+        (0..32)
+            .map(|i| SensorSnapshot {
+                sensor_id: format!("sensor_{i:02}"),
+                value: serde_json::json!({"payload": "x".repeat(100)}),
+                timestamp_ms: 1000,
+            })
+            .collect(),
+    );
+    let injector = Arc::new(SensorContextInjector::with_source(
+        64,
+        bus.clone() as Arc<dyn SensorSource>,
+    ));
+    injector.refresh_from_source();
+
+    let summary = injector.summarize(16); // ~64 bytes budget
+    let marker = "(sensor summary truncated)";
+    assert!(
+        summary.contains(marker),
+        "expected summary to contain `{marker}`, got `{summary}`"
+    );
+    // Hard ceiling invariant: never omit — always have SOME content.
+    assert!(!summary.is_empty());
+    let budget_bytes = 16 * 4 + "\n... (sensor summary truncated)".len();
+    assert!(
+        summary.len() <= budget_bytes,
+        "summary size {} exceeds ceiling {}",
+        summary.len(),
+        budget_bytes
+    );
+}
+
+#[tokio::test]
+async fn should_degrade_silently_when_sensor_source_stalls() {
+    let injector = Arc::new(SensorContextInjector::with_source(
+        8,
+        Arc::new(StalledBus) as Arc<dyn SensorSource>,
+    ));
+    let controller = Arc::new(
+        RealtimeController::new(RealtimeConfig {
+            enabled: true,
+            heartbeat_timeout_ms: 30_000,
+            ..Default::default()
+        })
+        .with_injector(injector),
+    );
+    let provider_inner = Arc::new(RecordingProvider {
+        calls: AtomicUsize::new(0),
+        total_turns: 1,
+        last_system_prompt: Mutex::new(String::new()),
+    });
+    let provider: Arc<dyn LlmProvider> = provider_inner.clone();
+    let agent = test_agent(provider, Some(controller)).await;
+
+    // Must not panic or return Err.
+    let response = agent
+        .process_message("hello", &[], vec![])
+        .await
+        .expect("stalled sensor source must not abort the turn");
+
+    // System prompt should not contain the `## Live Sensor Data` header
+    // because the injector is empty.
+    let captured = provider_inner.last_system_prompt.lock().unwrap().clone();
+    assert!(
+        !captured.contains("## Live Sensor Data"),
+        "empty sensor bus should not inject a header, got: {captured}"
+    );
+    assert_eq!(response.content, "turn 0");
+}
+
+#[tokio::test]
+async fn should_attach_sensor_snapshot_to_hook_domain_data() {
+    use octos_agent::{HookEvent, HookPayload, HookPayloadEnricher};
+
+    let bus = MockBus::with_snaps(vec![SensorSnapshot {
+        sensor_id: "force_torque".into(),
+        value: serde_json::json!([0.5, 0.1, 9.8]),
+        timestamp_ms: 1000,
+    }]);
+    let enricher = RealtimeHookEnricher::new(bus.clone() as Arc<dyn SensorSource>);
+    let mut payload = HookPayload::on_resume(None);
+    enricher.enrich(&HookEvent::BeforeToolCall, &mut payload);
+    let data = payload
+        .domain_data
+        .as_ref()
+        .expect("domain_data should be set when source has snapshots");
+    assert_eq!(data["source"], "octos_realtime");
+    let snaps = data["snapshots"].as_array().expect("snapshots array");
+    assert_eq!(snaps.len(), 1);
+    assert_eq!(snaps[0]["sensor_id"], "force_torque");
+}
+
+#[tokio::test]
+async fn realtime_heartbeat_example_runs_end_to_end() {
+    // This smoke-test mirrors the example binary end-to-end without spawning
+    // a child process: it wires realtime + a mock LLM, runs a turn, and
+    // asserts the heartbeat counted the iterations and the sensor summary
+    // landed in the system prompt.
+    let bus = MockBus::with_snaps(vec![SensorSnapshot {
+        sensor_id: "lidar_front".into(),
+        value: serde_json::json!({"range_m": 3.2, "clear": true}),
+        timestamp_ms: 1000,
+    }]);
+    let injector = Arc::new(SensorContextInjector::with_source(
+        4,
+        bus.clone() as Arc<dyn SensorSource>,
+    ));
+    let controller = Arc::new(
+        RealtimeController::new(RealtimeConfig {
+            enabled: true,
+            heartbeat_timeout_ms: 30_000,
+            sensor_budget_tokens: 128,
+            ..Default::default()
+        })
+        .with_injector(injector.clone()),
+    );
+    let provider_inner = Arc::new(RecordingProvider {
+        calls: AtomicUsize::new(0),
+        total_turns: 1,
+        last_system_prompt: Mutex::new(String::new()),
+    });
+    let provider: Arc<dyn LlmProvider> = provider_inner.clone();
+    let agent = test_agent(provider, Some(controller.clone())).await;
+
+    let before = controller.heartbeat().count();
+    let response = agent.process_message("patrol", &[], vec![]).await.unwrap();
+    let after = controller.heartbeat().count();
+
+    assert!(after > before, "heartbeat must advance during a run");
+    assert_eq!(response.content, "turn 0");
+    let captured = provider_inner.last_system_prompt.lock().unwrap().clone();
+    assert!(captured.contains("lidar_front"));
+    assert_eq!(controller.heartbeat().state(), HeartbeatState::Alive);
+
+    // Full stall demo off-loop, just to exercise the public surface.
+    let hb = Heartbeat::new(Duration::from_millis(5));
+    let _ = hb.state();
+    hb.force_stall_for_test(Duration::from_millis(50));
+    assert_eq!(hb.state(), HeartbeatState::Stalled);
+}

--- a/crates/octos-cli/src/api/metrics.rs
+++ b/crates/octos-cli/src/api/metrics.rs
@@ -269,6 +269,14 @@ fn build_totals(samples: &[ParsedMetricSample]) -> BTreeMap<String, u64> {
             "child_session_lifecycle".to_string(),
             total_for_metric(samples, "octos_child_session_lifecycle_total"),
         ),
+        (
+            "realtime_heartbeat_beats".to_string(),
+            total_for_metric(samples, "octos_realtime_heartbeat_beats_total"),
+        ),
+        (
+            "realtime_heartbeat_stalls".to_string(),
+            total_for_metric(samples, "octos_realtime_heartbeat_stalls_total"),
+        ),
     ])
 }
 

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -63,6 +63,9 @@ pub struct ProfileConfig {
     /// First-party app configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub apps: Option<AppsConfig>,
+    /// Robotics runtime configuration (heartbeat + sensor context injection).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub robot: Option<RobotConfig>,
     /// Channel configurations.
     #[serde(default)]
     pub channels: Vec<ChannelCredentials>,
@@ -137,6 +140,20 @@ pub struct SlidesAppConfig {
     pub default_theme: Option<String>,
 }
 
+/// Robotics-oriented profile configuration.
+///
+/// Currently only hosts the realtime heartbeat + sensor injection contract
+/// added in RP05. Future robotics knobs (e-stop topic, safe-hold behavior)
+/// should nest under this struct so a single `robot: null` patch can strip
+/// all robotics integration in one step.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RobotConfig {
+    /// Realtime heartbeat + sensor-context-injection contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub realtime: Option<octos_agent::RealtimeConfig>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum PatchField<T> {
     #[default]
@@ -181,6 +198,8 @@ pub struct ProfileConfigPatch {
     pub deep_crawl: PatchField<DeepCrawlConfig>,
     #[serde(default)]
     pub apps: PatchField<AppsConfig>,
+    #[serde(default)]
+    pub robot: PatchField<RobotConfig>,
     #[serde(default)]
     pub channels: Option<Vec<ChannelCredentials>>,
     #[serde(default)]
@@ -390,6 +409,11 @@ impl ProfileConfig {
             PatchField::Absent => {}
             PatchField::Clear => self.apps = None,
             PatchField::Value(apps) => self.apps = Some(apps),
+        }
+        match patch.robot {
+            PatchField::Absent => {}
+            PatchField::Clear => self.robot = None,
+            PatchField::Value(robot) => self.robot = Some(robot),
         }
         if let Some(channels) = patch.channels {
             self.channels = channels;
@@ -1431,6 +1455,9 @@ pub fn diff_profiles(old: &UserProfile, new: &UserProfile) -> ProfileChange {
     if oc.apps != nc.apps {
         restart_fields.push("apps".into());
     }
+    if oc.robot != nc.robot {
+        restart_fields.push("robot".into());
+    }
     if oc.channels != nc.channels {
         restart_fields.push("channels".into());
     }
@@ -2219,6 +2246,47 @@ mod tests {
                 assert!(fields.contains(&"apps".into()));
             }
             other => panic!("expected RestartRequired, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn should_classify_realtime_config_as_restart_required() {
+        let base = UserProfile {
+            id: "rp05-diff".into(),
+            name: "RP05".into(),
+            enabled: false,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                robot: Some(RobotConfig {
+                    realtime: Some(octos_agent::RealtimeConfig {
+                        enabled: false,
+                        ..Default::default()
+                    }),
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let mut changed = base.clone();
+        changed.config.robot = Some(RobotConfig {
+            realtime: Some(octos_agent::RealtimeConfig {
+                enabled: true,
+                heartbeat_timeout_ms: 250,
+                ..Default::default()
+            }),
+        });
+
+        match diff_profiles(&base, &changed) {
+            ProfileChange::RestartRequired(fields) => {
+                assert!(
+                    fields.iter().any(|f| f == "robot"),
+                    "expected `robot` in restart-required fields, got {fields:?}",
+                );
+            }
+            other => panic!("expected RestartRequired, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
Closes #451. **Stacked on [#454](https://github.com/octos-org/octos/pull/454) (RP03)** — domain-hook payload extension is a prerequisite.

## What this delivers

Wires the 5 types from PR #270's orphan `realtime.rs` module (which shipped as library surface with zero consumers) into the actual agent loop:

- Each `loop_runner` iteration beats a `Heartbeat` and aborts on `HeartbeatState::Stalled` with a typed `AgentError::HeartbeatStalled`.
- `SensorContextInjector::summarize(budget)` appends a budget-gated sensor summary to the system prompt once per turn.
- `RealtimeHookEnricher` implements RP03's `HookPayloadEnricher` trait and attaches the latest `SensorSnapshot` to `HookPayload.domain_data`.
- `ProfileConfig.robot.realtime` typed section classified as `RestartRequired` in `diff_profiles`.

Full contract: [docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp05](../blob/main/docs/OCTOS_ROBOTICS_PR270_DELIVERY.md#rp05--realtime-heartbeat--sensor-context-injection)

## Why this exists (what PR #270 got wrong)

PR #270 added `realtime.rs` (261 LOC: `RealtimeConfig`, `Heartbeat`, `HeartbeatState`, `SensorSnapshot`, `SensorContextInjector`) but **wired none of them to the agent loop**. `grep -r RealtimeConfig crates/octos-agent/src --exclude-dir=examples` returned zero call sites. Library surface with no consumer — types that look enforced but aren't are worse than not shipping them.

## Changes (on top of RP03)

- `crates/octos-agent/src/agent/realtime.rs` (new, 602 LOC) — salvaged 5 PR #270 types + added `AgentError::HeartbeatStalled`, `RealtimeController`, `RealtimeHookEnricher`, `SensorSource` trait, `SensorContextInjector::{with_source, summarize, refresh_from_source}`, budget-bounded `enforce_token_budget`.
- `crates/octos-agent/src/agent/{mod, loop_runner, execution, memory}.rs` (+116 / -11) — `with_realtime` constructor, `beat_heartbeat` per iteration, `compose_system_prompt` helper. Both `process_message` and `run_task` beat/check/inject each iteration.
- `crates/octos-agent/src/lib.rs` (+8 / -0) — re-exports.
- `crates/octos-agent/examples/realtime_heartbeat.rs` (new, 193 LOC) — rewritten to run the actual agent loop and assert beat count.
- `crates/octos-agent/tests/realtime_loop.rs` (new, 456 LOC) — 7 named acceptance tests.
- `crates/octos-cli/src/profiles.rs` (+68 / -0) — typed `RobotConfig { realtime: Option<RealtimeConfig> }`, patch field, `diff_profiles` classifier, regression test.
- `crates/octos-cli/src/api/metrics.rs` (+8 / -0) — operator summary exposes cumulative `realtime_heartbeat_beats` / `_stalls`.

## Invariants

1. ✓ Beat-count equals Alive-iteration count (`should_beat_heartbeat_once_per_loop_iteration`; beats only on Alive, not on terminal Stalled).
2. ✓ Stalled heartbeat aborts with `AgentError::HeartbeatStalled` (downcast-verified).
3. ✓ Hard budget ceiling: `summarize(budget)` enforces `4*budget` byte ceiling with `"\n... (sensor summary truncated)"` marker; never omitted.
4. ✓ Missing/empty sensor source is a silent no-op.
5. ✓ `diff_profiles` classifies `robot` change as `RestartRequired`.
6. ✓ With realtime absent/disabled: `beat_heartbeat` is a no-op, `compose_system_prompt` returns raw worker prompt. 830+ pre-existing tests pass unchanged.
7. ✓ `RealtimeHookEnricher` implements `HookPayloadEnricher` (RP03) and writes `SensorSnapshot` to `domain_data`.

## Tests

```
realtime_loop:
  should_beat_heartbeat_once_per_loop_iteration ... ok
  should_abort_iteration_when_heartbeat_stalled ... ok
  should_inject_sensor_summary_within_budget ... ok
  should_truncate_oversize_sensor_summary ... ok
  should_degrade_silently_when_sensor_source_stalls ... ok
  should_attach_sensor_snapshot_to_hook_domain_data ... ok
  realtime_heartbeat_example_runs_end_to_end ... ok

profiles (octos-cli):
  should_classify_realtime_config_as_restart_required ... ok
```

- `cargo test -p octos-agent`: 839 lib + 7 realtime integration + 63 other integration tests, all pass
- `cargo test -p octos-cli`: 250 unit + 17 integration, all pass
- `cargo build --workspace` clean
- `cargo fmt --all -- --check` clean
- `cargo run --example realtime_heartbeat -p octos-agent` runs end-to-end, prints sensor summary, confirms `state() == Alive`

## Observability

- Counter `octos_realtime_heartbeat_beats_total`
- Counter `octos_realtime_heartbeat_stalls_total`
- Histogram `octos_realtime_sensor_injection_tokens`
- Operator summary: `realtime_heartbeat_beats`, `realtime_heartbeat_stalls` (cumulative totals)

## Follow-up (explicitly deferred)

`RealtimeConfig` carries `iteration_deadline_ms`, `llm_timeout_ms`, `min_cycle_ms`, `check_estop` that are **stored but not enforced** in this PR. They need coordination with existing idle/activity timeout logic in `budget.rs`. The RP05 contract scope is heartbeat + sensor injection; those are done. Integrators who want per-iteration deadline enforcement can plug it in incrementally without changing the public RP05 surface. Open a follow-up issue to wire these if there's demand.

## Stacking

Based on `robotics-rp/03-domain-hook` because `RealtimeHookEnricher` implements the `HookPayloadEnricher` trait added in RP03. When RP03 (#454) merges, GitHub will auto-retarget this PR to `main`.

## Test plan

- [x] `cargo test -p octos-agent --test realtime_loop` (7/7)
- [x] `cargo test --workspace` (no regressions)
- [x] `cargo build --workspace`
- [x] `cargo run -p octos-agent --example realtime_heartbeat`
- [ ] Live canary: deploy with `ProfileConfig.robot.realtime.enabled=true`, `stall_threshold_ms=500`, `sensor_budget_tokens=128`. Run a turn. Verify: (a) `octos_realtime_heartbeat_beats_total` increments per iteration, (b) a forced stall produces `HeartbeatStalled` error and `_stalls_total` increments, (c) system prompt contains the sensor summary under the budget.
- [ ] Live canary: register a `RealtimeHookEnricher` with a fake force sensor reading 55N; configure a `BeforeSpawnVerify` hook that reads `domain_data.force_n > 40` and denies; dispatch a motion tool — verify deny + `octos_hook_domain_data_enriched_total{event="BeforeSpawnVerify"}` increments.

## Unblocks

Last issue in the RP delivery family. All 6 contracts delivered.