### PR TITLE
Harness M4.1A: structured progress ABI + runtime sink (closes #470, #471)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -70,6 +70,7 @@ impl Agent {
                 let tc_id = tool_call.id.clone();
                 let tc_args = tool_call.arguments.clone();
                 let attachment_ctx = turn_attachment_ctx.clone();
+                let harness_event_sink = self.harness_event_sink.clone();
 
                 tokio::spawn(async move {
                     let tool_start = Instant::now();
@@ -153,6 +154,7 @@ impl Agent {
                             let make_ctx = || ToolContext {
                                 tool_id: bg_tc_id.clone(),
                                 reporter: bg_reporter.clone(),
+                                harness_event_sink: harness_event_sink.clone(),
                                 attachment_paths: bg_attachment_ctx.attachment_paths.clone(),
                                 audio_attachment_paths: bg_attachment_ctx
                                     .audio_attachment_paths
@@ -475,6 +477,7 @@ impl Agent {
                     let ctx = ToolContext {
                         tool_id: tc_id.clone(),
                         reporter: reporter.clone(),
+                        harness_event_sink: harness_event_sink.clone(),
                         attachment_paths: attachment_ctx.attachment_paths.clone(),
                         audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
                         file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -147,6 +147,8 @@ pub struct Agent {
     pub(super) hooks: Option<Arc<HookExecutor>>,
     /// Session-level context for hook payloads.
     pub(super) hook_context: std::sync::Mutex<Option<HookContext>>,
+    /// Local harness event sink path shared with child tools in this agent.
+    pub(super) harness_event_sink: Option<String>,
     /// Shutdown signal.
     pub(super) shutdown: Arc<AtomicBool>,
     /// Optional per-session runtime limits for tool rounds and per-tool calls.
@@ -176,6 +178,7 @@ impl Agent {
             reporter: RwLock::new(Arc::new(SilentReporter)),
             hooks: None,
             hook_context: std::sync::Mutex::new(None),
+            harness_event_sink: None,
             shutdown: Arc::new(AtomicBool::new(false)),
             session_limits: None,
             session_usage: std::sync::Mutex::new(SessionUsage::default()),
@@ -203,6 +206,7 @@ impl Agent {
             reporter: RwLock::new(Arc::new(SilentReporter)),
             hooks: None,
             hook_context: std::sync::Mutex::new(None),
+            harness_event_sink: None,
             shutdown: Arc::new(AtomicBool::new(false)),
             session_limits: None,
             session_usage: std::sync::Mutex::new(SessionUsage::default()),
@@ -283,6 +287,12 @@ impl Agent {
     /// Set session-level context for hook payloads.
     pub fn with_hook_context(self, ctx: HookContext) -> Self {
         *self.hook_context.lock().unwrap_or_else(|e| e.into_inner()) = Some(ctx);
+        self
+    }
+
+    /// Set the local harness event sink path for child tools.
+    pub fn with_harness_event_sink(mut self, sink_path: impl Into<String>) -> Self {
+        self.harness_event_sink = Some(sink_path.into());
         self
     }
 

--- a/crates/octos-agent/src/harness_events.rs
+++ b/crates/octos-agent/src/harness_events.rs
@@ -1,0 +1,737 @@
+//! Structured harness event ABI and local sink transport.
+//!
+//! Child tools/workflows write newline-delimited JSON events to a local path
+//! exposed through `OCTOS_EVENT_SINK`. The runtime consumes those events and
+//! folds them into durable task snapshots.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::io::AsyncReadExt;
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+use crate::task_supervisor::TaskSupervisor;
+
+pub const HARNESS_EVENT_SCHEMA_V1: &str = "octos.harness.event.v1";
+pub const MAX_HARNESS_EVENT_LINE_BYTES: usize = 16 * 1024;
+const MAX_SESSION_ID_BYTES: usize = 256;
+const MAX_TASK_ID_BYTES: usize = 128;
+const MAX_WORKFLOW_BYTES: usize = 128;
+const MAX_PHASE_BYTES: usize = 64;
+const MAX_MESSAGE_BYTES: usize = 2 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessEventError(String);
+
+impl std::fmt::Display for HarnessEventError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for HarnessEventError {}
+
+type HarnessResult<T> = std::result::Result<T, HarnessEventError>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessEvent {
+    pub schema: String,
+    #[serde(flatten)]
+    pub payload: HarnessEventPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HarnessEventPayload {
+    Progress {
+        #[serde(flatten)]
+        data: HarnessProgressEvent,
+    },
+    Phase {
+        #[serde(flatten)]
+        data: HarnessPhaseEvent,
+    },
+    Artifact {
+        #[serde(flatten)]
+        data: HarnessArtifactEvent,
+    },
+    ValidatorResult {
+        #[serde(flatten)]
+        data: HarnessValidatorResultEvent,
+    },
+    Retry {
+        #[serde(flatten)]
+        data: HarnessRetryEvent,
+    },
+    Failure {
+        #[serde(flatten)]
+        data: HarnessFailureEvent,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessProgressEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    pub phase: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress: Option<f32>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessPhaseEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    pub phase: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessArtifactEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessValidatorResultEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    pub validator: String,
+    pub passed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessRetryEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessFailureEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retryable: Option<bool>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+impl HarnessEvent {
+    pub fn progress(
+        session_id: impl Into<String>,
+        task_id: impl Into<String>,
+        workflow: Option<impl Into<String>>,
+        phase: impl Into<String>,
+        message: Option<impl Into<String>>,
+        progress: Option<f32>,
+    ) -> Self {
+        Self {
+            schema: HARNESS_EVENT_SCHEMA_V1.to_string(),
+            payload: HarnessEventPayload::Progress {
+                data: HarnessProgressEvent {
+                    session_id: session_id.into(),
+                    task_id: task_id.into(),
+                    workflow: workflow.map(Into::into),
+                    phase: phase.into(),
+                    message: message.map(Into::into),
+                    progress,
+                    extra: HashMap::new(),
+                },
+            },
+        }
+    }
+
+    pub fn phase_event(
+        session_id: impl Into<String>,
+        task_id: impl Into<String>,
+        workflow: Option<impl Into<String>>,
+        phase: impl Into<String>,
+        message: Option<impl Into<String>>,
+    ) -> Self {
+        Self {
+            schema: HARNESS_EVENT_SCHEMA_V1.to_string(),
+            payload: HarnessEventPayload::Phase {
+                data: HarnessPhaseEvent {
+                    session_id: session_id.into(),
+                    task_id: task_id.into(),
+                    workflow: workflow.map(Into::into),
+                    phase: phase.into(),
+                    message: message.map(Into::into),
+                    extra: HashMap::new(),
+                },
+            },
+        }
+    }
+
+    pub fn from_json_line(line: &str) -> HarnessResult<Self> {
+        if line.len() > MAX_HARNESS_EVENT_LINE_BYTES {
+            return Err(HarnessEventError(format!(
+                "harness event line exceeded {} bytes",
+                MAX_HARNESS_EVENT_LINE_BYTES
+            )));
+        }
+
+        let event: Self = serde_json::from_str(line)
+            .map_err(|error| HarnessEventError(format!("invalid harness event JSON: {error}")))?;
+        event.validate()?;
+        Ok(event)
+    }
+
+    pub fn validate(&self) -> HarnessResult<()> {
+        if self.schema != HARNESS_EVENT_SCHEMA_V1 {
+            return Err(HarnessEventError(format!(
+                "unsupported harness event schema: {}",
+                self.schema
+            )));
+        }
+
+        match &self.payload {
+            HarnessEventPayload::Progress { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                validate_phase(&data.phase)?;
+                validate_optional_message(data.message.as_deref())?;
+                validate_progress(data.progress)?;
+            }
+            HarnessEventPayload::Phase { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                validate_phase(&data.phase)?;
+                validate_optional_message(data.message.as_deref())?;
+            }
+            HarnessEventPayload::Artifact { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                validate_optional_name("phase", data.phase.as_deref(), MAX_PHASE_BYTES)?;
+                validate_bounded("artifact name", &data.name, MAX_MESSAGE_BYTES)?;
+                validate_optional_message(data.message.as_deref())?;
+                if let Some(path) = data.path.as_deref() {
+                    validate_bounded("artifact path", path, MAX_MESSAGE_BYTES)?;
+                }
+            }
+            HarnessEventPayload::ValidatorResult { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                validate_optional_name("phase", data.phase.as_deref(), MAX_PHASE_BYTES)?;
+                validate_bounded("validator", &data.validator, MAX_MESSAGE_BYTES)?;
+                validate_optional_message(data.message.as_deref())?;
+            }
+            HarnessEventPayload::Retry { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                validate_optional_name("phase", data.phase.as_deref(), MAX_PHASE_BYTES)?;
+                validate_optional_message(data.message.as_deref())?;
+            }
+            HarnessEventPayload::Failure { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                validate_optional_name("phase", data.phase.as_deref(), MAX_PHASE_BYTES)?;
+                validate_bounded("failure message", &data.message, MAX_MESSAGE_BYTES)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn runtime_detail_value(
+        &self,
+        fallback_workflow_kind: Option<&str>,
+        fallback_current_phase: Option<&str>,
+    ) -> Value {
+        match &self.payload {
+            HarnessEventPayload::Progress { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                let current_phase = Some(data.phase.as_str()).or(fallback_current_phase);
+                let message = data.message.as_deref();
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "progress",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "phase": data.phase,
+                    "current_phase": current_phase,
+                    "message": message,
+                    "progress_message": message,
+                    "progress": data.progress,
+                })
+            }
+            HarnessEventPayload::Phase { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                let current_phase = Some(data.phase.as_str()).or(fallback_current_phase);
+                let message = data.message.as_deref();
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "phase",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "phase": data.phase,
+                    "current_phase": current_phase,
+                    "message": message,
+                    "progress_message": message,
+                })
+            }
+            HarnessEventPayload::Artifact { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                let current_phase = data.phase.as_deref().or(fallback_current_phase);
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "artifact",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "phase": data.phase,
+                    "current_phase": current_phase,
+                    "artifact_name": data.name,
+                    "artifact_path": data.path,
+                    "message": data.message,
+                })
+            }
+            HarnessEventPayload::ValidatorResult { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                let current_phase = data.phase.as_deref().or(fallback_current_phase);
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "validator_result",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "phase": data.phase,
+                    "current_phase": current_phase,
+                    "validator": data.validator,
+                    "passed": data.passed,
+                    "message": data.message,
+                })
+            }
+            HarnessEventPayload::Retry { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                let current_phase = data.phase.as_deref().or(fallback_current_phase);
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "retry",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "phase": data.phase,
+                    "current_phase": current_phase,
+                    "attempt": data.attempt,
+                    "message": data.message,
+                })
+            }
+            HarnessEventPayload::Failure { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                let current_phase = data.phase.as_deref().or(fallback_current_phase);
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "failure",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "phase": data.phase,
+                    "current_phase": current_phase,
+                    "message": data.message,
+                    "retryable": data.retryable,
+                })
+            }
+        }
+    }
+
+    pub fn session_id(&self) -> &str {
+        match &self.payload {
+            HarnessEventPayload::Progress { data } => &data.session_id,
+            HarnessEventPayload::Phase { data } => &data.session_id,
+            HarnessEventPayload::Artifact { data } => &data.session_id,
+            HarnessEventPayload::ValidatorResult { data } => &data.session_id,
+            HarnessEventPayload::Retry { data } => &data.session_id,
+            HarnessEventPayload::Failure { data } => &data.session_id,
+        }
+    }
+
+    pub fn task_id(&self) -> &str {
+        match &self.payload {
+            HarnessEventPayload::Progress { data } => &data.task_id,
+            HarnessEventPayload::Phase { data } => &data.task_id,
+            HarnessEventPayload::Artifact { data } => &data.task_id,
+            HarnessEventPayload::ValidatorResult { data } => &data.task_id,
+            HarnessEventPayload::Retry { data } => &data.task_id,
+            HarnessEventPayload::Failure { data } => &data.task_id,
+        }
+    }
+
+    pub fn workflow(&self) -> Option<&str> {
+        match &self.payload {
+            HarnessEventPayload::Progress { data } => data.workflow.as_deref(),
+            HarnessEventPayload::Phase { data } => data.workflow.as_deref(),
+            HarnessEventPayload::Artifact { data } => data.workflow.as_deref(),
+            HarnessEventPayload::ValidatorResult { data } => data.workflow.as_deref(),
+            HarnessEventPayload::Retry { data } => data.workflow.as_deref(),
+            HarnessEventPayload::Failure { data } => data.workflow.as_deref(),
+        }
+    }
+
+    pub fn phase(&self) -> Option<&str> {
+        match &self.payload {
+            HarnessEventPayload::Progress { data } => Some(data.phase.as_str()),
+            HarnessEventPayload::Phase { data } => Some(data.phase.as_str()),
+            HarnessEventPayload::Artifact { data } => data.phase.as_deref(),
+            HarnessEventPayload::ValidatorResult { data } => data.phase.as_deref(),
+            HarnessEventPayload::Retry { data } => data.phase.as_deref(),
+            HarnessEventPayload::Failure { data } => data.phase.as_deref(),
+        }
+    }
+}
+
+fn validate_common_ids(session_id: &str, task_id: &str) -> HarnessResult<()> {
+    validate_bounded("session_id", session_id, MAX_SESSION_ID_BYTES)?;
+    validate_bounded("task_id", task_id, MAX_TASK_ID_BYTES)?;
+    Ok(())
+}
+
+fn validate_optional_name(
+    field: &'static str,
+    value: Option<&str>,
+    max: usize,
+) -> HarnessResult<()> {
+    if let Some(value) = value {
+        validate_bounded(field, value, max)?;
+    }
+    Ok(())
+}
+
+fn validate_phase(phase: &str) -> HarnessResult<()> {
+    validate_bounded("phase", phase, MAX_PHASE_BYTES)?;
+    if !is_valid_phase_name(phase) {
+        return Err(HarnessEventError(format!(
+            "invalid phase name '{phase}': expected snake_case"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_optional_message(message: Option<&str>) -> HarnessResult<()> {
+    if let Some(message) = message {
+        validate_bounded("message", message, MAX_MESSAGE_BYTES)?;
+    }
+    Ok(())
+}
+
+fn validate_progress(progress: Option<f32>) -> HarnessResult<()> {
+    if let Some(progress) = progress
+        && !(0.0..=1.0).contains(&progress)
+    {
+        return Err(HarnessEventError(format!(
+            "progress must be between 0.0 and 1.0, got {progress}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_bounded(field: &'static str, value: &str, max: usize) -> HarnessResult<()> {
+    if value.is_empty() {
+        return Err(HarnessEventError(format!("{field} cannot be empty")));
+    }
+    if value.len() > max {
+        return Err(HarnessEventError(format!("{field} exceeded {max} bytes")));
+    }
+    Ok(())
+}
+
+fn is_valid_phase_name(phase: &str) -> bool {
+    let mut chars = phase.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+}
+
+/// Local sink that feeds structured child events into a task supervisor.
+pub struct HarnessEventSink {
+    sink_file: tempfile::NamedTempFile,
+    stop: Arc<AtomicBool>,
+    reader: JoinHandle<()>,
+}
+
+impl HarnessEventSink {
+    pub fn new(
+        task_supervisor: Arc<TaskSupervisor>,
+        task_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> std::io::Result<Self> {
+        let sink_file = tempfile::NamedTempFile::new()?;
+        let path = sink_file.path().to_path_buf();
+        let task_id = task_id.into();
+        let session_id = session_id.into();
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader_stop = stop.clone();
+
+        let reader = tokio::spawn(run_reader(
+            path,
+            task_supervisor,
+            task_id,
+            session_id,
+            reader_stop,
+        ));
+
+        Ok(Self {
+            sink_file,
+            stop,
+            reader,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.sink_file.path()
+    }
+}
+
+impl Drop for HarnessEventSink {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.reader.abort();
+    }
+}
+
+async fn run_reader(
+    path: PathBuf,
+    task_supervisor: Arc<TaskSupervisor>,
+    task_id: String,
+    session_id: String,
+    stop: Arc<AtomicBool>,
+) {
+    let mut file = loop {
+        match tokio::fs::OpenOptions::new().read(true).open(&path).await {
+            Ok(file) => break file,
+            Err(error) => {
+                if stop.load(Ordering::Acquire) {
+                    return;
+                }
+                warn!(path = %path.display(), error = %error, "failed to open harness event sink");
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        }
+    };
+
+    let mut carry = Vec::new();
+    let mut chunk = vec![0_u8; 4096];
+
+    loop {
+        if stop.load(Ordering::Acquire) {
+            break;
+        }
+
+        let read = match file.read(&mut chunk).await {
+            Ok(read) => read,
+            Err(error) => {
+                warn!(path = %path.display(), error = %error, "failed to read harness event sink");
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                continue;
+            }
+        };
+
+        if read == 0 {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            continue;
+        }
+
+        carry.extend_from_slice(&chunk[..read]);
+        while let Some(pos) = carry.iter().position(|byte| *byte == b'\n') {
+            let mut line = carry.drain(..=pos).collect::<Vec<u8>>();
+            if line.last() == Some(&b'\n') {
+                line.pop();
+            }
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            if line.len() > MAX_HARNESS_EVENT_LINE_BYTES {
+                warn!(
+                    path = %path.display(),
+                    task_id = %task_id,
+                    "dropping oversized harness event line"
+                );
+                continue;
+            }
+
+            let Ok(line) = String::from_utf8(line) else {
+                warn!(
+                    path = %path.display(),
+                    task_id = %task_id,
+                    "dropping non-utf8 harness event line"
+                );
+                continue;
+            };
+
+            let Ok(event) = HarnessEvent::from_json_line(&line) else {
+                warn!(
+                    path = %path.display(),
+                    task_id = %task_id,
+                    "dropping invalid harness event line"
+                );
+                continue;
+            };
+
+            if event.session_id() != session_id || event.task_id() != task_id {
+                warn!(
+                    path = %path.display(),
+                    task_id = %task_id,
+                    session_id = %session_id,
+                    "ignoring harness event for unexpected task/session"
+                );
+                continue;
+            }
+
+            if let Err(error) = task_supervisor.apply_harness_event(&task_id, &event) {
+                warn!(
+                    path = %path.display(),
+                    task_id = %task_id,
+                    error = %error,
+                    "failed to apply harness event"
+                );
+            }
+        }
+
+        if carry.len() > MAX_HARNESS_EVENT_LINE_BYTES {
+            warn!(
+                path = %path.display(),
+                task_id = %task_id,
+                "discarding partial oversized harness event"
+            );
+            carry.clear();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_event_round_trips_and_keeps_schema() {
+        let event = HarnessEvent::progress(
+            "session-1",
+            "task-1",
+            Some("deep_research"),
+            "fetching_sources",
+            Some("Fetching source 3/12"),
+            Some(0.42),
+        );
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""schema":"octos.harness.event.v1""#));
+        assert!(json.contains(r#""kind":"progress""#));
+
+        let parsed = HarnessEvent::from_json_line(&json).unwrap();
+        assert_eq!(parsed.schema, HARNESS_EVENT_SCHEMA_V1);
+        assert_eq!(parsed.session_id(), "session-1");
+        assert_eq!(parsed.task_id(), "task-1");
+        assert_eq!(parsed.workflow(), Some("deep_research"));
+        assert_eq!(parsed.phase(), Some("fetching_sources"));
+
+        let detail = parsed.runtime_detail_value(None, None);
+        assert_eq!(detail["workflow_kind"], "deep_research");
+        assert_eq!(detail["current_phase"], "fetching_sources");
+        assert_eq!(detail["progress_message"], "Fetching source 3/12");
+    }
+
+    #[test]
+    fn ignores_unknown_future_fields() {
+        let mut json = serde_json::to_value(HarnessEvent::phase_event(
+            "s",
+            "t",
+            Some("demo"),
+            "running",
+            Some("phase changed"),
+        ))
+        .unwrap();
+        json.as_object_mut()
+            .unwrap()
+            .insert("future_field".into(), Value::String("ok".into()));
+        let parsed = HarnessEvent::from_json_line(&json.to_string()).unwrap();
+
+        assert_eq!(parsed.workflow(), Some("demo"));
+        assert_eq!(parsed.phase(), Some("running"));
+    }
+
+    #[test]
+    fn rejects_oversized_fields_and_invalid_phases() {
+        let oversized = HarnessEvent::progress(
+            "session-1",
+            "task-1",
+            Some("deep_research"),
+            "fetching_sources",
+            Some("x".repeat(MAX_MESSAGE_BYTES + 1)),
+            Some(0.42),
+        );
+        assert!(oversized.validate().is_err());
+
+        let invalid_phase = HarnessEvent::progress(
+            "session-1",
+            "task-1",
+            Some("deep_research"),
+            "FetchSources",
+            Some("ok"),
+            Some(0.42),
+        );
+        assert!(invalid_phase.validate().is_err());
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -15,6 +15,7 @@ pub mod bundled_app_skills;
 mod compaction;
 pub mod event_bus;
 pub mod exec_env;
+pub mod harness_events;
 pub mod hooks;
 pub mod loop_detect;
 pub mod mcp;
@@ -44,6 +45,12 @@ pub use agent::{
 };
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
+pub use harness_events::{
+    HARNESS_EVENT_SCHEMA_V1, HarnessArtifactEvent, HarnessEvent, HarnessEventError,
+    HarnessEventPayload, HarnessEventSink, HarnessFailureEvent, HarnessPhaseEvent,
+    HarnessProgressEvent, HarnessRetryEvent, HarnessValidatorResultEvent,
+    MAX_HARNESS_EVENT_LINE_BYTES,
+};
 pub use hooks::{HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookResult};
 pub use mcp::{McpClient, McpServerConfig};
 pub use plugins::{PluginLoadResult, PluginLoader};

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -466,6 +466,8 @@ impl Tool for PluginTool {
             cmd.env_remove(var);
         }
 
+        let ctx: Option<ToolContext> = TOOL_CTX.try_with(|c| c.clone()).ok();
+
         // Inject extra environment variables (e.g. provider base URLs, API keys)
         for (key, val) in &self.extra_env {
             if should_forward_env_name(key, &env_allowlist) {
@@ -475,9 +477,16 @@ impl Tool for PluginTool {
                     plugin = %self.plugin_name,
                     tool = %self.tool_def.name,
                     env = %key,
-                    "skipping non-allowlisted secret environment variable for plugin tool"
+                "skipping non-allowlisted secret environment variable for plugin tool"
                 );
             }
+        }
+
+        if let Some(sink) = ctx
+            .as_ref()
+            .and_then(|ctx| ctx.harness_event_sink.as_deref())
+        {
+            cmd.env("OCTOS_EVENT_SINK", sink);
         }
 
         // Set working directory so relative paths in tool args (e.g.
@@ -496,7 +505,6 @@ impl Tool for PluginTool {
             cmd.env("OCTOS_WORK_DIR", dir);
         }
 
-        let ctx: Option<ToolContext> = TOOL_CTX.try_with(|c| c.clone()).ok();
         let effective_args = self.prepare_effective_args(args, ctx.as_ref());
 
         let mut child = cmd.spawn().wrap_err_with(|| {
@@ -968,6 +976,7 @@ mod tests {
         let ctx = ToolContext {
             tool_id: "tool-1".to_string(),
             reporter: Arc::new(SilentReporter),
+            harness_event_sink: None,
             attachment_paths: vec![
                 "/workspace/voice.ogg".to_string(),
                 "/workspace/report.pdf".to_string(),
@@ -1024,6 +1033,91 @@ mod tests {
             "output should contain echoed input, got: {}",
             result.output
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn execute_structured_progress_event_updates_task_supervisor() {
+        use crate::task_supervisor::TaskSupervisor;
+        use serde_json::json;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let task_id = supervisor.register("structured_tool", "call-1", Some("api:session"));
+        supervisor.mark_running(&task_id);
+
+        let script_path = dir.path().join("script.sh");
+        let event_json = json!({
+            "schema": "octos.harness.event.v1",
+            "kind": "progress",
+            "session_id": "api:session",
+            "task_id": task_id.clone(),
+            "workflow": "deep_research",
+            "phase": "fetching_sources",
+            "message": "Fetching source 3/12",
+            "progress": 0.42
+        })
+        .to_string();
+        write_test_script(
+            &script_path,
+            &format!(
+                "#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '{}' >> \"$OCTOS_EVENT_SINK\"\nprintf '{{\"output\":\"ok\",\"success\":true}}'\n",
+                event_json
+            ),
+        );
+
+        let def = make_tool_def("structured_tool", "writes harness events");
+        let tool = PluginTool::new("test-plugin".into(), def, script_path)
+            .with_timeout(Duration::from_secs(5));
+
+        let sink = crate::harness_events::HarnessEventSink::new(
+            supervisor.clone(),
+            task_id.clone(),
+            "api:session",
+        )
+        .expect("create sink");
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        supervisor.set_on_change(move |task| {
+            let _ = tx.send(task.clone());
+        });
+
+        let ctx = ToolContext {
+            tool_id: "tool-1".to_string(),
+            reporter: Arc::new(SilentReporter),
+            harness_event_sink: Some(sink.path().display().to_string()),
+            attachment_paths: vec![],
+            audio_attachment_paths: vec![],
+            file_attachment_paths: vec![],
+        };
+
+        let result = crate::tools::TOOL_CTX
+            .scope(ctx, tool.execute(&json!({})))
+            .await
+            .expect("tool execution should succeed");
+        assert!(result.success);
+
+        let updated = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("callback should fire")
+            .expect("task snapshot should be sent");
+
+        let detail: serde_json::Value =
+            serde_json::from_str(updated.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(detail["workflow_kind"], "deep_research");
+        assert_eq!(detail["current_phase"], "fetching_sources");
+        assert_eq!(detail["progress_message"], "Fetching source 3/12");
+        assert_eq!(updated.status, crate::task_supervisor::TaskStatus::Running);
+        assert_eq!(
+            updated.lifecycle_state(),
+            crate::task_supervisor::TaskLifecycleState::Running
+        );
+
+        let task = supervisor.get_task(&task_id).expect("task missing");
+        let task_detail: serde_json::Value =
+            serde_json::from_str(task.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(task_detail["current_phase"], "fetching_sources");
+        assert_eq!(task_detail["progress_message"], "Fetching source 3/12");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -20,6 +20,8 @@ use octos_core::TaskId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::harness_events::{HarnessEvent, HarnessEventPayload};
+
 const CURRENT_TASK_LEDGER_SCHEMA: u32 = 1;
 
 /// Lifecycle status of a background task.
@@ -537,6 +539,60 @@ impl TaskSupervisor {
         }
     }
 
+    /// Apply a structured harness event to a tracked task.
+    pub fn apply_harness_event(
+        &self,
+        task_id: &str,
+        event: &HarnessEvent,
+    ) -> Result<(), &'static str> {
+        let snapshot = self.get_task(task_id).ok_or("unknown task")?;
+        let (workflow_kind, current_phase) = workflow_labels(snapshot.runtime_detail.as_deref());
+        let runtime_detail =
+            event.runtime_detail_value(workflow_kind.as_deref(), current_phase.as_deref());
+
+        match &event.payload {
+            HarnessEventPayload::Progress { .. }
+            | HarnessEventPayload::Phase { .. }
+            | HarnessEventPayload::Retry { .. } => {
+                self.mark_runtime_state(
+                    task_id,
+                    TaskRuntimeState::ExecutingTool,
+                    Some(runtime_detail.to_string()),
+                );
+            }
+            HarnessEventPayload::Artifact { .. } => {
+                self.mark_runtime_state(
+                    task_id,
+                    TaskRuntimeState::DeliveringOutputs,
+                    Some(runtime_detail.to_string()),
+                );
+            }
+            HarnessEventPayload::ValidatorResult { data } => {
+                self.mark_runtime_state(
+                    task_id,
+                    TaskRuntimeState::VerifyingOutputs,
+                    Some(runtime_detail.to_string()),
+                );
+                if !data.passed {
+                    let message = data.message.clone().unwrap_or_else(|| {
+                        "validator rejected structured harness event".to_string()
+                    });
+                    self.mark_failed(task_id, message);
+                }
+            }
+            HarnessEventPayload::Failure { data } => {
+                self.mark_runtime_state(
+                    task_id,
+                    TaskRuntimeState::Failed,
+                    Some(runtime_detail.to_string()),
+                );
+                self.mark_failed(task_id, data.message.clone());
+            }
+        }
+
+        Ok(())
+    }
+
     fn persist_snapshot_by_id(&self, task_id: &str) {
         let snapshot = {
             let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
@@ -745,6 +801,44 @@ mod tests {
         assert_eq!(task.lifecycle_state(), TaskLifecycleState::Ready);
         assert!(task.completed_at.is_some());
         assert_eq!(task.output_files, vec!["output.mp3"]);
+    }
+
+    #[test]
+    fn should_apply_harness_progress_event_and_notify() {
+        let supervisor = TaskSupervisor::new();
+        let id = supervisor.register("deep_search", "call-9", Some("api:session"));
+        supervisor.mark_running(&id);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        supervisor.set_on_change(move |task| {
+            let _ = tx.send(task.clone());
+        });
+
+        let event = crate::harness_events::HarnessEvent::progress(
+            "api:session",
+            id.clone(),
+            Some("deep_research"),
+            "fetching_sources",
+            Some("Fetching source 3/12"),
+            Some(0.42),
+        );
+
+        supervisor.apply_harness_event(&id, &event).unwrap();
+
+        let task = supervisor.get_task(&id).expect("task missing");
+        let detail: serde_json::Value =
+            serde_json::from_str(task.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(detail["workflow_kind"], "deep_research");
+        assert_eq!(detail["current_phase"], "fetching_sources");
+        assert_eq!(detail["progress_message"], "Fetching source 3/12");
+        let progress = detail["progress"].as_f64().unwrap();
+        assert!((progress - 0.42).abs() < 0.0001);
+
+        let notified = rx.try_recv().expect("callback should fire");
+        let notified_detail: serde_json::Value =
+            serde_json::from_str(notified.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(notified_detail["current_phase"], "fetching_sources");
+        assert_eq!(notified.lifecycle_state(), TaskLifecycleState::Running);
     }
 
     #[test]

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -17,6 +17,8 @@ use crate::progress::ProgressReporter;
 pub struct ToolContext {
     pub tool_id: String,
     pub reporter: Arc<dyn ProgressReporter>,
+    /// Local newline-delimited JSON sink for structured harness progress.
+    pub harness_event_sink: Option<String>,
     pub attachment_paths: Vec<String>,
     pub audio_attachment_paths: Vec<String>,
     pub file_attachment_paths: Vec<String>,

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -14,6 +14,7 @@ use super::{Tool, ToolResult};
 use crate::policy::{CommandPolicy, Decision, SafePolicy};
 use crate::sandbox::{NoSandbox, Sandbox};
 use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
+use crate::tools::TOOL_CTX;
 
 /// Tool for executing shell commands.
 pub struct ShellTool {
@@ -129,6 +130,14 @@ fn apply_git_tool_env(cmd: &mut tokio::process::Command, command: &str) {
     }
 }
 
+fn apply_harness_event_sink_env(cmd: &mut tokio::process::Command) {
+    if let Ok(ctx) = TOOL_CTX.try_with(|ctx| ctx.clone())
+        && let Some(sink) = ctx.harness_event_sink
+    {
+        cmd.env("OCTOS_EVENT_SINK", sink);
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct ShellInput {
     command: String,
@@ -216,6 +225,7 @@ impl Tool for ShellTool {
         apply_frontend_tool_env(&mut cmd, &self.cwd);
         apply_git_tool_env(&mut cmd, &input.command);
         sanitize_command_env(&mut cmd, &EnvAllowlist::empty());
+        apply_harness_event_sink_env(&mut cmd);
 
         let child = match cmd.spawn() {
             Ok(c) => c,

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use super::{Tool, ToolPolicy, ToolRegistry, ToolResult};
+use crate::harness_events::HarnessEventSink;
 use crate::task_supervisor::TaskSupervisor;
 use crate::workspace_git::{
     WorkspaceContractStatus, WorkspaceProjectKind,
@@ -1438,6 +1439,35 @@ impl Tool for SpawnTool {
                     );
                 }
 
+                let harness_event_sink = match (
+                    task_supervisor.as_ref(),
+                    tracked_task_id.as_ref(),
+                    parent_session_key.as_ref(),
+                ) {
+                    (Some(supervisor), Some(task_id), Some(session_key)) => {
+                        match HarnessEventSink::new(
+                            supervisor.clone(),
+                            task_id.clone(),
+                            session_key.clone(),
+                        ) {
+                            Ok(sink) => Some(sink),
+                            Err(error) => {
+                                warn!(
+                                    task_id = %task_id,
+                                    session_key = %session_key,
+                                    error = %error,
+                                    "failed to create harness event sink; continuing without structured child progress"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    _ => None,
+                };
+                let harness_event_sink_path = harness_event_sink
+                    .as_ref()
+                    .map(|sink| sink.path().display().to_string());
+
                 let mut tools = ToolRegistry::with_builtins(&working_dir);
                 // Load plugin tools so subagents can use fm_tts, etc.
                 if !plugin_dirs.is_empty() {
@@ -1465,6 +1495,9 @@ impl Tool for SpawnTool {
                 let mut effective_config = worker_config.clone().unwrap_or_default();
                 effective_config.suppress_auto_send_files = true;
                 worker = worker.with_config(effective_config);
+                if let Some(ref sink_path) = harness_event_sink_path {
+                    worker = worker.with_harness_event_sink(sink_path.clone());
+                }
                 if let Some(ref hooks) = worker_hooks {
                     worker = worker.with_hooks(hooks.clone());
                 }


### PR DESCRIPTION
Part of M4.1A (structured progress contract). Replaces stderr-as-truth with durable `octos.harness.event.v1` events.

Closes #470 and #471 — contracts adjacent; delivered as a single commit from Euler's parallel lane.

## What landed
- `crates/octos-agent/src/harness_events.rs` (new, 737 LOC) — typed event structures for progress, phase change, artifact, validator_result, retry, failure. `schema_version` stamped.
- `crates/octos-agent/src/task_supervisor.rs` (+94) — task-status bridge.
- `crates/octos-agent/src/plugins/tool.rs` (+98), `tools/shell.rs` (+10), `tools/spawn.rs` (+33) — sink integration at workflow/plugin sites.
- `crates/octos-agent/src/{agent/execution.rs, agent/mod.rs, lib.rs, tools/mod.rs}` — wiring + re-exports.

## Why two issues on one PR
#470 (ABI) and #471 (runtime sink) are load-bearing for each other — the sink cannot land without the types and the types have no consumer without the sink. Single commit delivers both. Splitting would force a merge-dependency without reviewer value.

## Test plan
- [x] `cargo build -p octos-agent` green (in originating worktree)
- [ ] `cargo test --workspace` green on integration branch `harness-m4/integration`
- [ ] Live canary: part of M4.1A.474 gate (#474)

Stacked PRs #472, #473, #475 build on this ABI.