### PR TITLE
Harness M4.1A.472: deep-search emits structured progress events

### DIFF
--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -6,9 +6,9 @@
 //! Reads JSON from stdin, outputs JSON to stdout, progress to stderr.
 
 use std::collections::{HashMap, HashSet};
-use std::fs;
-use std::io::{self, Read};
-use std::path::PathBuf;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
@@ -261,7 +261,10 @@ async fn run_deep_search(
     // -----------------------------------------------------------------------
     let urls_to_fetch: Vec<String> = all_urls.into_iter().take(max_pages).collect();
     let total_fetch = urls_to_fetch.len();
-    progress_simple(&format!("Fetching {total_fetch} pages in parallel..."));
+    progress_simple(
+        ProgressPhase::Fetch,
+        &format!("Fetching {total_fetch} pages in parallel..."),
+    );
 
     let crawled_pages = fetch_pages_parallel(client, &urls_to_fetch, 20_000).await;
 
@@ -306,10 +309,10 @@ async fn run_deep_search(
             .collect();
 
         if !chase_urls.is_empty() {
-            progress_simple(&format!(
-                "Chasing {} most-referenced sources...",
-                chase_urls.len()
-            ));
+            progress_simple(
+                ProgressPhase::Fetch,
+                &format!("Chasing {} most-referenced sources...", chase_urls.len()),
+            );
             // Mark chased URLs as seen
             for url in &chase_urls {
                 seen_urls.insert(normalize_url(url));
@@ -376,21 +379,27 @@ async fn run_deep_search(
             .take(crawl_domains)
             .flat_map(|(domain, links)| {
                 let take = links.len().min(pages_per_domain);
-                progress_simple(&format!(
-                    "Site crawl: {} ({} internal links, fetching {})",
-                    domain,
-                    links.len(),
-                    take
-                ));
+                progress_simple(
+                    ProgressPhase::Fetch,
+                    &format!(
+                        "Site crawl: {} ({} internal links, fetching {})",
+                        domain,
+                        links.len(),
+                        take
+                    ),
+                );
                 links.into_iter().take(pages_per_domain)
             })
             .collect();
 
         if !to_crawl.is_empty() {
-            progress_simple(&format!(
-                "Site crawl: fetching {} additional pages from top domains...",
-                to_crawl.len()
-            ));
+            progress_simple(
+                ProgressPhase::Fetch,
+                &format!(
+                    "Site crawl: fetching {} additional pages from top domains...",
+                    to_crawl.len()
+                ),
+            );
 
             // Mark as seen
             for url in &to_crawl {
@@ -412,7 +421,8 @@ async fn run_deep_search(
     // -----------------------------------------------------------------------
     // Build structured report
     // -----------------------------------------------------------------------
-    progress_simple("Building report...");
+    progress_simple(ProgressPhase::Synthesize, "Synthesizing report...");
+    progress_simple(ProgressPhase::ReportBuild, "Building report...");
 
     let mut report = String::new();
     report.push_str(&format!("# Deep Research: {query}\n\n"));
@@ -457,6 +467,8 @@ async fn run_deep_search(
 
     // Save report
     let _ = fs::write(dir.join("_report.md"), &report);
+
+    progress_simple_with_fraction(ProgressPhase::Completion, "Deep search complete", Some(1.0));
 
     Output {
         output: report,
@@ -1983,10 +1995,91 @@ fn research_dir(slug: &str) -> PathBuf {
 
 fn progress(step: usize, total: usize, msg: &str) {
     eprintln!("[{step}/{total}] {msg}");
+    let progress_fraction = if total == 0 {
+        None
+    } else {
+        Some(step as f64 / total as f64)
+    };
+    emit_progress_event(ProgressPhase::Search, msg, progress_fraction);
 }
 
-fn progress_simple(msg: &str) {
+fn progress_simple(phase: ProgressPhase, msg: &str) {
+    progress_simple_with_fraction(phase, msg, None);
+}
+
+fn progress_simple_with_fraction(phase: ProgressPhase, msg: &str, progress_fraction: Option<f64>) {
     eprintln!("[*] {msg}");
+    emit_progress_event(phase, msg, progress_fraction);
+}
+
+#[derive(Copy, Clone)]
+enum ProgressPhase {
+    Search,
+    Fetch,
+    Synthesize,
+    ReportBuild,
+    Completion,
+}
+
+impl ProgressPhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            ProgressPhase::Search => "search",
+            ProgressPhase::Fetch => "fetch",
+            ProgressPhase::Synthesize => "synthesize",
+            ProgressPhase::ReportBuild => "report_build",
+            ProgressPhase::Completion => "completion",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct HarnessProgressEvent<'a> {
+    schema: &'static str,
+    kind: &'static str,
+    workflow: &'static str,
+    phase: &'a str,
+    message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    progress_fraction: Option<f64>,
+}
+
+fn emit_progress_event(phase: ProgressPhase, message: &str, progress_fraction: Option<f64>) {
+    let event = HarnessProgressEvent {
+        schema: "octos.harness.event.v1",
+        kind: "progress",
+        workflow: "deep_research",
+        phase: phase.as_str(),
+        message,
+        progress_fraction,
+    };
+
+    let Some(raw_sink) = std::env::var_os("OCTOS_EVENT_SINK") else {
+        return;
+    };
+    if raw_sink.is_empty() {
+        return;
+    }
+
+    let sink_path = PathBuf::from(raw_sink);
+    if let Err(err) = write_progress_event_to_sink(&sink_path, &event) {
+        eprintln!(
+            "[progress] failed to write structured event to {}: {err}",
+            sink_path.display()
+        );
+    }
+}
+
+fn write_progress_event_to_sink(
+    sink: impl AsRef<Path>,
+    event: &HarnessProgressEvent<'_>,
+) -> io::Result<()> {
+    let sink = sink.as_ref();
+    let mut file = OpenOptions::new().create(true).append(true).open(sink)?;
+    let json = serde_json::to_string(event)
+        .map_err(|err| io::Error::other(format!("serialize progress event: {err}")))?;
+    writeln!(file, "{json}")?;
+    file.flush()
 }
 
 // ---------------------------------------------------------------------------
@@ -2127,5 +2220,76 @@ mod tests {
         assert!(is_non_content_url("https://example.com/api/v1/data"));
         assert!(!is_non_content_url("https://example.com/docs/guide"));
         assert!(!is_non_content_url("https://example.com/blog/post-1"));
+    }
+
+    #[test]
+    fn test_structured_progress_events_match_fixture() {
+        let mut sink = std::env::temp_dir();
+        let unique = format!(
+            "deep-search-progress-events-{}-{}.ndjson",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        sink.push(unique);
+        let _ = std::fs::remove_file(&sink);
+
+        let fixture = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/progress_events.ndjson"
+        ));
+
+        let events = [
+            HarnessProgressEvent {
+                schema: "octos.harness.event.v1",
+                kind: "progress",
+                workflow: "deep_research",
+                phase: "search",
+                message: "Searching: \"rust async\"",
+                progress_fraction: Some(0.25),
+            },
+            HarnessProgressEvent {
+                schema: "octos.harness.event.v1",
+                kind: "progress",
+                workflow: "deep_research",
+                phase: "fetch",
+                message: "Fetching 4 pages in parallel...",
+                progress_fraction: None,
+            },
+            HarnessProgressEvent {
+                schema: "octos.harness.event.v1",
+                kind: "progress",
+                workflow: "deep_research",
+                phase: "synthesize",
+                message: "Synthesizing report...",
+                progress_fraction: None,
+            },
+            HarnessProgressEvent {
+                schema: "octos.harness.event.v1",
+                kind: "progress",
+                workflow: "deep_research",
+                phase: "report_build",
+                message: "Building report...",
+                progress_fraction: None,
+            },
+            HarnessProgressEvent {
+                schema: "octos.harness.event.v1",
+                kind: "progress",
+                workflow: "deep_research",
+                phase: "completion",
+                message: "Deep search complete",
+                progress_fraction: Some(1.0),
+            },
+        ];
+
+        for event in &events {
+            write_progress_event_to_sink(&sink, event).unwrap();
+        }
+
+        let actual = std::fs::read_to_string(&sink).unwrap();
+        assert_eq!(actual, fixture);
+        let _ = std::fs::remove_file(&sink);
     }
 }

--- a/crates/app-skills/deep-search/tests/fixtures/progress_events.ndjson
+++ b/crates/app-skills/deep-search/tests/fixtures/progress_events.ndjson
@@ -1,0 +1,5 @@
+{"schema":"octos.harness.event.v1","kind":"progress","workflow":"deep_research","phase":"search","message":"Searching: \"rust async\"","progress_fraction":0.25}
+{"schema":"octos.harness.event.v1","kind":"progress","workflow":"deep_research","phase":"fetch","message":"Fetching 4 pages in parallel..."}
+{"schema":"octos.harness.event.v1","kind":"progress","workflow":"deep_research","phase":"synthesize","message":"Synthesizing report..."}
+{"schema":"octos.harness.event.v1","kind":"progress","workflow":"deep_research","phase":"report_build","message":"Building report..."}
+{"schema":"octos.harness.event.v1","kind":"progress","workflow":"deep_research","phase":"completion","message":"Deep search complete","progress_fraction":1.0}


### PR DESCRIPTION
Closes #472. Part of M4.1A (structured progress contract).

## What landed
- `crates/app-skills/deep-search/src/main.rs` (+189) — emits `octos.harness.event.v1` progress events via `OCTOS_EVENT_SINK` at phase boundaries (fetching_sources, extracting, synthesizing, etc).
- `crates/app-skills/deep-search/tests/fixtures/progress_events.ndjson` (+5) — golden fixture of the expected phase ladder.

## Replaces
The failed 4493753/dc6f7da string-matching approach that tried to parse progress from stderr. stderr is diagnostics only.

## Dependencies
Depends on #470/#471 ABI (PR for `harness-m4/1A-470-471-sink`). Rebase target may change to main once that PR merges.

## Test plan
- [x] Deep-search binary emits the expected phase ladder (fixture assertion)
- [ ] Integration on `harness-m4/integration`
- [ ] Live verification via #474 gate