### PR TITLE
Harness M4.1A.473: render structured progress in chat UI with replay

### DIFF
--- a/crates/octos-cli/static/app.js
+++ b/crates/octos-cli/static/app.js
@@ -1,13 +1,21 @@
 (function () {
   "use strict";
 
-  var token = sessionStorage.getItem("octos_token") || "";
-  var currentSession = "default";
+  var TOKEN_STORAGE_KEY = "octos_token";
+  var SESSION_STORAGE_KEY = "octos_current_session";
+  var token = sessionStorage.getItem(TOKEN_STORAGE_KEY) || "";
+  var currentSession = localStorage.getItem(SESSION_STORAGE_KEY) || "default";
   var sending = false;
+  var currentAbort = null;
+  var taskRefreshSeq = 0;
+  var taskSnapshots = new Map();
 
   var messagesEl = document.getElementById("messages");
+  var taskStatusEl = document.getElementById("task-status");
   var inputEl = document.getElementById("input");
   var formEl = document.getElementById("chat-form");
+  var sendButton = document.getElementById("send-button");
+  var cancelButton = document.getElementById("cancel-button");
   var sessionListEl = document.getElementById("session-list");
   var statusEl = document.getElementById("status-text");
   var newSessionBtn = document.getElementById("new-session");
@@ -17,20 +25,363 @@
 
   function headers() {
     var h = { "Content-Type": "application/json" };
-    if (token) h["Authorization"] = "Bearer " + token;
+    if (token) h.Authorization = "Bearer " + token;
     return h;
+  }
+
+  function persistCurrentSession(id) {
+    currentSession = id;
+    localStorage.setItem(SESSION_STORAGE_KEY, id);
+  }
+
+  function showAuth() {
+    authModal.classList.remove("hidden");
+  }
+
+  function hideAuth() {
+    authModal.classList.add("hidden");
+  }
+
+  function humanize(value) {
+    var text = String(value || "").replace(/[_-]+/g, " ").trim();
+    if (!text) return "";
+    return text.replace(/\b\w/g, function (ch) {
+      return ch.toUpperCase();
+    });
+  }
+
+  function normalizeProgress(value) {
+    if (typeof value !== "number" || !isFinite(value)) return null;
+    var progress = value <= 1 ? value * 100 : value;
+    return Math.max(0, Math.min(100, progress));
+  }
+
+  function getTaskDetail(task) {
+    var detail =
+      task && task.runtime_detail && typeof task.runtime_detail === "object"
+        ? task.runtime_detail
+        : {};
+    return {
+      workflowKind: task?.workflow_kind || detail.workflow_kind || "",
+      currentPhase: task?.current_phase || detail.current_phase || "",
+      progressMessage: detail.progress_message || task?.progress_message || "",
+      progress: normalizeProgress(detail.progress ?? task?.progress),
+      lifecycleState: task?.lifecycle_state || "",
+      status: task?.status || "",
+      runtimeState: task?.runtime_state || "",
+    };
+  }
+
+  function taskKey(task) {
+    return (
+      task?.id ||
+      task?.child_session_key ||
+      task?.tool_call_id ||
+      task?.session_key ||
+      task?.tool_name ||
+      JSON.stringify({
+        started_at: task?.started_at,
+        updated_at: task?.updated_at,
+        status: task?.status,
+      })
+    );
+  }
+
+  function isActiveTask(task) {
+    var status = String(task?.status || "").toLowerCase();
+    var lifecycle = String(task?.lifecycle_state || "").toLowerCase();
+    return (
+      status === "spawned" ||
+      status === "running" ||
+      lifecycle === "queued" ||
+      lifecycle === "running" ||
+      lifecycle === "verifying"
+    );
+  }
+
+  function clearTaskIndicators() {
+    taskStatusEl.innerHTML = "";
+  }
+
+  function buildTaskIndicator(task) {
+    var detail = getTaskDetail(task);
+    var title = detail.workflowKind || task?.tool_name || "Background task";
+    var phase = detail.currentPhase || detail.lifecycleState || detail.status || "Running";
+    var status = detail.lifecycleState || detail.status || detail.runtimeState || "running";
+    var indicator = document.createElement("div");
+    indicator.className = "session-task-indicator";
+    indicator.setAttribute("data-testid", "session-task-indicator");
+    indicator.dataset.taskKey = taskKey(task);
+    indicator.dataset.sessionId = task?.session_key || currentSession;
+    indicator.dataset.status = String(task?.status || "");
+    indicator.dataset.lifecycleState = String(task?.lifecycle_state || "");
+
+    var spinner = document.createElement("div");
+    spinner.className = "session-task-spinner";
+    spinner.setAttribute("aria-hidden", "true");
+
+    var content = document.createElement("div");
+    content.className = "session-task-content";
+
+    var headline = document.createElement("div");
+    headline.className = "session-task-headline";
+
+    var workflow = document.createElement("span");
+    workflow.className = "session-task-workflow";
+    workflow.setAttribute("data-testid", "task-workflow-kind");
+    workflow.textContent = humanize(title);
+
+    var phaseLabel = document.createElement("span");
+    phaseLabel.className = "session-task-phase";
+    phaseLabel.setAttribute("data-testid", "task-current-phase");
+    phaseLabel.textContent = humanize(phase);
+
+    var statusLabel = document.createElement("span");
+    statusLabel.className = "session-task-status";
+    statusLabel.setAttribute("data-testid", "task-status-label");
+    statusLabel.textContent = humanize(status);
+
+    headline.appendChild(workflow);
+    headline.appendChild(document.createTextNode("·"));
+    headline.appendChild(phaseLabel);
+    headline.appendChild(document.createTextNode("·"));
+    headline.appendChild(statusLabel);
+
+    if (detail.progress !== null) {
+      var progressLabel = document.createElement("span");
+      progressLabel.className = "session-task-status";
+      progressLabel.setAttribute("data-testid", "task-progress-value");
+      progressLabel.textContent = Math.round(detail.progress) + "%";
+      headline.appendChild(document.createTextNode("·"));
+      headline.appendChild(progressLabel);
+    }
+
+    content.appendChild(headline);
+
+    var message = detail.progressMessage || "";
+    if (!message) {
+      message = phase ? humanize(phase) + "..." : statusLabel.textContent || "Working...";
+    }
+
+    var messageEl = document.createElement("div");
+    messageEl.className = "session-task-message";
+    messageEl.setAttribute("data-testid", "task-progress-message");
+    messageEl.textContent = message;
+    content.appendChild(messageEl);
+
+    if (detail.progress !== null) {
+      var progressWrap = document.createElement("div");
+      progressWrap.className = "session-task-progress";
+      progressWrap.setAttribute("data-testid", "task-progress");
+
+      var progressBar = document.createElement("div");
+      progressBar.className = "session-task-progress-bar";
+      progressBar.style.setProperty("--progress", detail.progress + "%");
+      progressBar.setAttribute("aria-hidden", "true");
+
+      progressWrap.appendChild(progressBar);
+      content.appendChild(progressWrap);
+    }
+
+    indicator.appendChild(spinner);
+    indicator.appendChild(content);
+    return indicator;
+  }
+
+  function renderTaskIndicators(sessionId) {
+    if (sessionId !== currentSession) return;
+
+    var activeTasks = [];
+    var seen = new Set();
+    taskSnapshots.forEach(function (entry, key) {
+      if (entry.sessionId !== sessionId) return;
+      if (!isActiveTask(entry.task)) return;
+      if (seen.has(key)) return;
+      seen.add(key);
+      activeTasks.push(entry.task);
+    });
+
+    activeTasks.sort(function (a, b) {
+      var aTime = new Date(a?.updated_at || a?.started_at || 0).getTime();
+      var bTime = new Date(b?.updated_at || b?.started_at || 0).getTime();
+      return aTime - bTime;
+    });
+
+    taskStatusEl.innerHTML = "";
+    if (activeTasks.length === 0) return;
+
+    activeTasks.forEach(function (task) {
+      taskStatusEl.appendChild(buildTaskIndicator(task));
+    });
+  }
+
+  function upsertTaskSnapshot(sessionId, task) {
+    var key = taskKey(task);
+    if (!key) return;
+    taskSnapshots.set(key, { sessionId: sessionId, task: task });
+  }
+
+  function syncTasks(sessionId, tasks) {
+    var seen = new Set();
+    (tasks || []).forEach(function (task) {
+      var key = taskKey(task);
+      if (!key) return;
+      seen.add(key);
+      taskSnapshots.set(key, { sessionId: sessionId, task: task });
+    });
+
+    taskSnapshots.forEach(function (entry, key) {
+      if (entry.sessionId === sessionId && !seen.has(key)) {
+        taskSnapshots.delete(key);
+      }
+    });
+
+    renderTaskIndicators(sessionId);
+  }
+
+  async function fetchJson(url, opts) {
+    var resp = await fetch(url, opts);
+    if (resp.status === 401) {
+      showAuth();
+      throw new Error("unauthorized");
+    }
+    if (!resp.ok) {
+      throw new Error("HTTP " + resp.status);
+    }
+    return resp.json();
+  }
+
+  async function loadSessions() {
+    try {
+      var data = await fetchJson("/api/sessions", { headers: headers() });
+      if (!Array.isArray(data)) {
+        return [];
+      }
+      sessionListEl.innerHTML = "";
+      data.forEach(function (s) {
+        var li = document.createElement("li");
+        li.dataset.id = s.id;
+        li.dataset.sessionId = s.id;
+        li.dataset.active = s.id === currentSession ? "true" : "false";
+        if (s.id === currentSession) li.className = "active";
+
+        var title = document.createElement("button");
+        title.type = "button";
+        title.className = "session-switch-button";
+        title.setAttribute("data-testid", "session-switch-button");
+        title.textContent = s.id + " (" + s.message_count + ")";
+        title.addEventListener("click", function () {
+          selectSession(s.id);
+        });
+
+        var del = document.createElement("button");
+        del.type = "button";
+        del.className = "session-delete";
+        del.setAttribute("data-testid", "session-delete-button");
+        del.title = "Delete session";
+        del.textContent = "x";
+        del.addEventListener("click", function (e) {
+          e.stopPropagation();
+          deleteSession(s.id);
+        });
+
+        li.appendChild(title);
+        li.appendChild(del);
+        sessionListEl.appendChild(li);
+      });
+      return data;
+    } catch (error) {
+      return [];
+    }
+  }
+
+  async function loadHistory(id) {
+    messagesEl.innerHTML = "";
+    try {
+      var msgs = await fetchJson(
+        "/api/sessions/" + encodeURIComponent(id) + "/messages?limit=100",
+        { headers: headers() },
+      );
+      if (!Array.isArray(msgs)) {
+        return;
+      }
+      msgs.forEach(function (m) {
+        if (m.media && m.media.length > 0) {
+          m.media.forEach(function (path) {
+            var name = path.split("/").pop() || "file";
+            appendFileMessage(name, path, "");
+          });
+        } else {
+          appendMessage(m.role.toLowerCase(), m.content);
+        }
+      });
+    } catch (error) {
+      // ignored — auth modal or transient error
+    }
+  }
+
+  async function refreshTaskStatus(sessionId) {
+    var requestSeq = ++taskRefreshSeq;
+    try {
+      var tasks = await fetchJson(
+        "/api/sessions/" + encodeURIComponent(sessionId) + "/tasks",
+        { headers: headers() },
+      );
+      if (requestSeq !== taskRefreshSeq || sessionId !== currentSession) return;
+      if (!Array.isArray(tasks)) {
+        clearTaskIndicators();
+        return;
+      }
+      syncTasks(sessionId, tasks);
+    } catch (error) {
+      if (requestSeq === taskRefreshSeq && sessionId === currentSession) {
+        clearTaskIndicators();
+      }
+    }
+  }
+
+  async function selectSession(id) {
+    persistCurrentSession(id);
+    loadSessions();
+    await loadHistory(id);
+    await refreshTaskStatus(id);
+  }
+
+  function deleteSession(id) {
+    if (!id || !window.confirm('Delete session "' + id + '"?')) return;
+    fetch("/api/sessions/" + encodeURIComponent(id), {
+      method: "DELETE",
+      headers: headers(),
+    })
+      .then(function (r) {
+        if (r.status === 401) {
+          showAuth();
+          return;
+        }
+        if (id === currentSession) {
+          persistCurrentSession("default");
+          messagesEl.innerHTML = "";
+          clearTaskIndicators();
+        }
+        loadSessions();
+      })
+      .catch(function () {});
   }
 
   function appendMessage(role, content) {
     var div = document.createElement("div");
     div.className = "message " + role;
+    div.setAttribute("data-testid", role + "-message");
+
     var roleLabel = document.createElement("div");
     roleLabel.className = "role";
     roleLabel.textContent = role;
     div.appendChild(roleLabel);
+
     var body = document.createElement("div");
     body.textContent = content;
     div.appendChild(body);
+
     messagesEl.appendChild(div);
     messagesEl.scrollTop = messagesEl.scrollHeight;
     return div;
@@ -39,194 +390,152 @@
   function appendFileMessage(filename, path, caption) {
     var div = document.createElement("div");
     div.className = "message assistant";
+    div.setAttribute("data-testid", "assistant-message");
+
     var roleLabel = document.createElement("div");
     roleLabel.className = "role";
     roleLabel.textContent = "assistant";
     div.appendChild(roleLabel);
+
     var body = document.createElement("div");
     var fileUrl = "/api/files?path=" + encodeURIComponent(path);
     var ext = (filename || "").split(".").pop().toLowerCase();
+    var attachment = document.createElement("div");
+    attachment.className = "audio-attachment";
+    attachment.setAttribute("data-testid", "audio-attachment");
+    attachment.dataset.filename = filename || "";
+    attachment.dataset.filePath = path || "";
+
     if (ext === "mp3" || ext === "wav" || ext === "ogg" || ext === "m4a") {
       var audio = document.createElement("audio");
       audio.controls = true;
       audio.src = fileUrl;
-      body.appendChild(audio);
+      attachment.appendChild(audio);
       if (caption) {
         var cap = document.createElement("div");
         cap.textContent = caption;
-        body.appendChild(cap);
+        attachment.appendChild(cap);
       }
     } else {
       var a = document.createElement("a");
       a.href = fileUrl;
       a.download = filename;
       a.textContent = filename || "Download file";
-      body.appendChild(a);
+      attachment.appendChild(a);
     }
+
+    body.appendChild(attachment);
     div.appendChild(body);
     messagesEl.appendChild(div);
     messagesEl.scrollTop = messagesEl.scrollHeight;
   }
 
-  function showAuth() { authModal.classList.remove("hidden"); }
-  function hideAuth() { authModal.classList.add("hidden"); }
-
-  authSubmitBtn.addEventListener("click", function () {
-    token = authTokenEl.value.trim();
-    sessionStorage.setItem("octos_token", token);
-    hideAuth();
-    loadSessions();
-    pollStatus();
-  });
-
-  // Sessions
-  function loadSessions() {
-    fetch("/api/sessions", { headers: headers() })
-      .then(function (r) {
-        if (r.status === 401) { showAuth(); return null; }
-        return r.json();
-      })
-      .then(function (data) {
-        if (!data) return;
-        sessionListEl.innerHTML = "";
-        data.forEach(function (s) {
-          var li = document.createElement("li");
-          li.dataset.id = s.id;
-          li.dataset.sessionId = s.id;
-          li.dataset.active = s.id === currentSession ? "true" : "false";
-          if (s.id === currentSession) li.className = "active";
-          li.addEventListener("click", function () { selectSession(s.id); });
-          var title = document.createElement("span");
-          title.className = "session-title";
-          title.textContent = s.id + " (" + s.message_count + ")";
-          var del = document.createElement("button");
-          del.type = "button";
-          del.className = "session-delete";
-          del.setAttribute("data-testid", "session-delete-button");
-          del.title = "Delete session";
-          del.textContent = "x";
-          del.addEventListener("click", function (e) {
-            e.stopPropagation();
-            deleteSession(s.id);
-          });
-          li.appendChild(title);
-          li.appendChild(del);
-          sessionListEl.appendChild(li);
-        });
-      })
-      .catch(function () {});
-  }
-
-  function selectSession(id) {
-    currentSession = id;
-    loadSessions();
-    loadHistory(id);
-  }
-
-  function deleteSession(id) {
-    if (!id || !window.confirm("Delete session \"" + id + "\"?")) return;
-    fetch("/api/sessions/" + encodeURIComponent(id), {
-      method: "DELETE",
-      headers: headers(),
-    })
-      .then(function (r) {
-        if (r.status === 401) { showAuth(); return; }
-        if (id === currentSession) {
-          currentSession = "default";
-          messagesEl.innerHTML = "";
-        }
-        loadSessions();
-      })
-      .catch(function () {});
-  }
-
-  function loadHistory(id) {
-    messagesEl.innerHTML = "";
-    fetch("/api/sessions/" + encodeURIComponent(id) + "/messages?limit=100", { headers: headers() })
-      .then(function (r) {
-        if (r.status === 401) { showAuth(); return null; }
-        return r.json();
-      })
-      .then(function (msgs) {
-        if (!msgs) return;
-        msgs.forEach(function (m) {
-          if (m.media && m.media.length > 0) {
-            m.media.forEach(function (path) {
-              var name = path.split("/").pop() || "file";
-              appendFileMessage(name, path, "");
-            });
-          } else {
-            appendMessage(m.role.toLowerCase(), m.content);
-          }
-        });
-      })
-      .catch(function () {});
-  }
-
-  newSessionBtn.addEventListener("click", function () {
-    var id = "s_" + Date.now();
-    currentSession = id;
-    messagesEl.innerHTML = "";
-    loadSessions();
-  });
-
-  // Parse SSE lines from a text chunk. Calls handler(jsonData) for each event.
   function parseSseChunk(buffer, text, handler) {
     buffer += text;
     var lines = buffer.split("\n");
-    buffer = lines.pop(); // keep incomplete last line
+    buffer = lines.pop();
     lines.forEach(function (line) {
       if (line.indexOf("data:") !== 0) return;
       var json = line.slice(5).trim();
       if (!json) return;
-      try { handler(JSON.parse(json)); } catch (e) {}
+      try {
+        handler(JSON.parse(json));
+      } catch (error) {}
     });
     return buffer;
   }
 
-  // Chat — POST returns SSE from gateway; read with fetch+ReadableStream
+  function finishStreaming() {
+    sending = false;
+    currentAbort = null;
+    sendButton.disabled = false;
+    cancelButton.classList.add("hidden");
+  }
+
+  cancelButton.addEventListener("click", function () {
+    if (currentAbort) {
+      currentAbort.abort();
+    }
+    finishStreaming();
+  });
+
+  authSubmitBtn.addEventListener("click", function () {
+    token = authTokenEl.value.trim();
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, token);
+    hideAuth();
+    loadSessions();
+    refreshTaskStatus(currentSession);
+  });
+
+  newSessionBtn.addEventListener("click", function () {
+    var id = "s_" + Date.now();
+    persistCurrentSession(id);
+    messagesEl.innerHTML = "";
+    clearTaskIndicators();
+    loadSessions();
+  });
+
   formEl.addEventListener("submit", function (e) {
     e.preventDefault();
     var text = inputEl.value.trim();
     if (!text || sending) return;
+
     sending = true;
-    formEl.querySelector("button").disabled = true;
+    sendButton.disabled = true;
+    cancelButton.classList.remove("hidden");
     inputEl.value = "";
 
     appendMessage("user", text);
 
     var assistantDiv = appendMessage("assistant", "");
     assistantDiv.classList.add("streaming");
+    assistantDiv.dataset.testid = "assistant-message";
     var bodyEl = assistantDiv.querySelector("div:last-child");
     var accumulated = "";
     var sid = currentSession;
     var finished = false;
+    currentAbort = new AbortController();
 
     function finish() {
       if (finished) return;
       finished = true;
       assistantDiv.classList.remove("streaming");
-      sending = false;
-      formEl.querySelector("button").disabled = false;
+      finishStreaming();
     }
 
     fetch("/api/chat", {
       method: "POST",
       headers: headers(),
       body: JSON.stringify({ message: text, session_id: currentSession }),
+      signal: currentAbort.signal,
     })
       .then(function (r) {
-        if (r.status === 401) { showAuth(); finish(); return; }
-        if (!r.body) { finish(); return; }
+        if (r.status === 401) {
+          showAuth();
+          finish();
+          return null;
+        }
+        if (!r.body) {
+          finish();
+          return null;
+        }
         var reader = r.body.getReader();
         var decoder = new TextDecoder();
         var buf = "";
 
         function read() {
           reader.read().then(function (result) {
-            if (result.done) { finish(); return; }
+            if (result.done) {
+              finish();
+              return;
+            }
             buf = parseSseChunk(buf, decoder.decode(result.value, { stream: true }), function (data) {
               if (data.type === "keepalive") return;
+              if (data.type === "task_status" && data.task) {
+                upsertTaskSnapshot(sid, data.task);
+                renderTaskIndicators(sid);
+                return;
+              }
               if ((data.type === "token" || data.type === "delta") && data.text) {
                 accumulated += data.text;
                 bodyEl.textContent = accumulated;
@@ -238,26 +547,36 @@
               } else if (data.type === "done") {
                 if (accumulated) bodyEl.textContent = accumulated;
                 loadSessions();
-                finish();
+                refreshTaskStatus(sid);
                 if (data.has_bg_tasks) {
                   pollForBgFiles(sid);
                 }
+                finish();
               } else if (data.type === "file") {
                 appendFileMessage(data.filename, data.path, data.caption);
               }
             });
             read();
-          }).catch(function () { finish(); });
+          }).catch(function (err) {
+            if (err && err.name === "AbortError") {
+              finish();
+              return;
+            }
+            bodyEl.textContent = "Error: " + err.message;
+            finish();
+          });
         }
+
         read();
+        return null;
       })
       .catch(function (err) {
+        if (err && err.name === "AbortError") return;
         bodyEl.textContent = "Error: " + err.message;
         finish();
       });
   });
 
-  // Enter to send, Shift+Enter for newline
   inputEl.addEventListener("keydown", function (e) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -265,24 +584,31 @@
     }
   });
 
-  // Status polling
   function pollStatus() {
     fetch("/api/status", { headers: headers() })
       .then(function (r) {
-        if (r.status === 401) { showAuth(); return null; }
+        if (r.status === 401) {
+          showAuth();
+          return null;
+        }
         return r.json();
       })
       .then(function (data) {
         if (!data) return;
         var uptime = Math.floor(data.uptime_secs / 60);
-        statusEl.textContent = data.model + " | " + data.provider + " | up " + uptime + "m | v" + data.version;
+        statusEl.textContent =
+          data.model + " | " + data.provider + " | up " + uptime + "m | v" + data.version;
       })
       .catch(function () {
         statusEl.textContent = "Disconnected";
       });
   }
 
-  // Poll session history for background task files (TTS, slides, etc.)
+  function pollTaskStatus() {
+    if (!currentSession) return;
+    refreshTaskStatus(currentSession);
+  }
+
   function pollForBgFiles(sessionId) {
     var startTime = new Date().toISOString();
     var attempts = 0;
@@ -291,10 +617,17 @@
 
     function poll() {
       if (attempts++ >= maxAttempts) return;
-      fetch("/api/sessions/" + encodeURIComponent(sessionId) + "/messages?limit=100", { headers: headers() })
-        .then(function (r) { return r.ok ? r.json() : null; })
+      fetch("/api/sessions/" + encodeURIComponent(sessionId) + "/messages?limit=100", {
+        headers: headers(),
+      })
+        .then(function (r) {
+          return r.ok ? r.json() : null;
+        })
         .then(function (msgs) {
-          if (!msgs) { setTimeout(poll, 2000); return; }
+          if (!msgs) {
+            setTimeout(poll, 2000);
+            return;
+          }
           var done = false;
           msgs.forEach(function (m) {
             if (m.timestamp > startTime && m.media && m.media.length > 0) {
@@ -306,20 +639,33 @@
                 }
               });
             }
-            if (m.timestamp > startTime && (m.content.charAt(0) === "\u2713" || m.content.charAt(0) === "\u2717")) {
+            if (
+              m.timestamp > startTime &&
+              m.content &&
+              (m.content.charAt(0) === "\u2713" || m.content.charAt(0) === "\u2717")
+            ) {
               done = true;
             }
           });
           if (!done) setTimeout(poll, 2000);
         })
-        .catch(function () { setTimeout(poll, 2000); });
+        .catch(function () {
+          setTimeout(poll, 2000);
+        });
     }
 
     setTimeout(poll, 2000);
   }
 
-  // Init
-  loadSessions();
+  async function bootstrap() {
+    await loadSessions();
+    await loadHistory(currentSession);
+    await refreshTaskStatus(currentSession);
+  }
+
+  bootstrap();
   pollStatus();
+  pollTaskStatus();
   setInterval(pollStatus, 30000);
+  setInterval(pollTaskStatus, 2500);
 })();

--- a/crates/octos-cli/static/index.html
+++ b/crates/octos-cli/static/index.html
@@ -16,10 +16,12 @@
       <ul id="session-list"></ul>
     </aside>
     <main id="chat">
+      <div id="task-status" aria-live="polite"></div>
       <div id="messages"></div>
       <form id="chat-form">
-        <textarea id="input" placeholder="Type a message..." rows="2"></textarea>
-        <button type="submit">Send</button>
+        <textarea id="input" data-testid="chat-input" placeholder="Type a message..." rows="2"></textarea>
+        <button id="send-button" type="submit" data-testid="send-button">Send</button>
+        <button id="cancel-button" type="button" data-testid="cancel-button" class="hidden">Cancel</button>
       </form>
     </main>
     <footer id="status-bar">

--- a/crates/octos-cli/static/style.css
+++ b/crates/octos-cli/static/style.css
@@ -68,6 +68,23 @@ html, body { height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Sego
 }
 #session-list li:hover { background: var(--surface2); color: var(--text); }
 #session-list li.active { background: var(--surface2); color: var(--accent); font-weight: 600; }
+.session-switch-button {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.session-switch-button:hover {
+  color: inherit;
+}
 .session-title {
   flex: 1;
   min-width: 0;
@@ -98,10 +115,79 @@ html, body { height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Sego
   flex-direction: column;
   min-width: 0;
 }
+#task-status {
+  padding: 16px 24px 0;
+}
+#task-status:empty {
+  display: none;
+}
+.session-task-indicator {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  max-width: 720px;
+  margin: 0 auto 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(14, 165, 233, 0.25);
+  border-radius: var(--radius);
+  background: rgba(14, 165, 233, 0.08);
+}
+.session-task-spinner {
+  width: 16px;
+  height: 16px;
+  margin-top: 3px;
+  border-radius: 999px;
+  border: 2px solid rgba(56, 189, 248, 0.25);
+  border-top-color: var(--accent);
+  animation: spin 0.9s linear infinite;
+  flex: 0 0 auto;
+}
+.session-task-content {
+  flex: 1;
+  min-width: 0;
+}
+.session-task-headline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+}
+.session-task-workflow {
+  color: var(--accent-hover);
+}
+.session-task-phase {
+  color: #cbd5e1;
+}
+.session-task-status {
+  color: var(--text-dim);
+  font-weight: 600;
+}
+.session-task-message {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+.session-task-progress {
+  margin-top: 8px;
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(15, 52, 96, 0.6);
+}
+.session-task-progress-bar {
+  height: 100%;
+  width: var(--progress, 0%);
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+}
 #messages {
   flex: 1;
   overflow-y: auto;
-  padding: 24px;
+  padding: 0 24px 24px;
 }
 .message {
   max-width: 720px;
@@ -117,6 +203,12 @@ html, body { height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Sego
 .message.assistant { background: var(--assistant-bg); margin-right: 80px; }
 .message .role { font-size: 11px; font-weight: 700; text-transform: uppercase; color: var(--text-dim); margin-bottom: 4px; }
 .message.user .role { color: var(--accent); }
+.audio-attachment {
+  margin-top: 8px;
+}
+.audio-attachment audio {
+  width: 100%;
+}
 
 /* Chat form */
 #chat-form {
@@ -150,6 +242,7 @@ html, body { height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Sego
 }
 #chat-form button:hover { background: var(--accent-hover); }
 #chat-form button:disabled { opacity: 0.5; cursor: not-allowed; }
+.hidden { display: none !important; }
 
 /* Status bar */
 #status-bar {
@@ -213,6 +306,7 @@ html, body { height: 100%; font-family: -apple-system, BlinkMacSystemFont, "Sego
   vertical-align: text-bottom;
 }
 @keyframes blink { 50% { opacity: 0; } }
+@keyframes spin { to { transform: rotate(360deg); } }
 
 /* Responsive */
 @media (max-width: 640px) {

--- a/e2e/tests/background-task-header-switching.spec.ts
+++ b/e2e/tests/background-task-header-switching.spec.ts
@@ -14,10 +14,73 @@ import {
   login,
   sendAndWait,
 } from './live-browser-helpers';
-import { getActiveSessionId } from './coding-hardcases-helpers';
+import { getActiveSessionId, getSessionTasks } from './coding-hardcases-helpers';
 
 const TASK_INDICATOR = 'main .session-task-indicator';
+const TASK_WORKFLOW = "[data-testid='task-workflow-kind']";
+const TASK_PHASE = "[data-testid='task-current-phase']";
+const TASK_MESSAGE = "[data-testid='task-progress-message']";
+const TASK_PROGRESS_VALUE = "[data-testid='task-progress-value']";
 const AUDIO_ATTACHMENT = "[data-testid='audio-attachment']";
+
+function humanize(value: string) {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function taskKey(task: any): string {
+  return (
+    task?.id ||
+    task?.child_session_key ||
+    task?.tool_call_id ||
+    task?.session_key ||
+    task?.tool_name ||
+    `${task?.started_at || ''}:${task?.updated_at || ''}:${task?.status || ''}`
+  );
+}
+
+function isActiveTask(task: any): boolean {
+  const status = String(task?.status || '').toLowerCase();
+  const lifecycle = String(task?.lifecycle_state || '').toLowerCase();
+  return (
+    status === 'spawned' ||
+    status === 'running' ||
+    lifecycle === 'queued' ||
+    lifecycle === 'running' ||
+    lifecycle === 'verifying'
+  );
+}
+
+function uniqueActiveTasks(tasks: any[]) {
+  const seen = new Set<string>();
+  return tasks.filter((task) => {
+    if (!isActiveTask(task)) return false;
+    const key = taskKey(task);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+async function waitForActiveTask(page: Page, sessionId: string) {
+  const deadline = Date.now() + 60_000;
+  let lastTasks: any[] = [];
+
+  while (Date.now() < deadline) {
+    lastTasks = await getSessionTasks(page, sessionId);
+    const activeTasks = uniqueActiveTasks(lastTasks);
+    if (activeTasks.length > 0) {
+      return activeTasks[0];
+    }
+    await page.waitForTimeout(2_000);
+  }
+
+  throw new Error(
+    `Timed out waiting for an active task in ${sessionId}. Last tasks: ${JSON.stringify(lastTasks)}`,
+  );
+}
 
 async function startPodcast(page: Page, marker: string) {
   const prompt =
@@ -30,12 +93,9 @@ async function startPodcast(page: Page, marker: string) {
   await getInput(page).fill(prompt);
   await getSendButton(page).click();
 
-  await expect(page.locator(TASK_INDICATOR)).toContainText(/running/i, {
+  await expect(page.locator(TASK_INDICATOR)).toHaveCount(1, {
     timeout: 60_000,
   });
-  await expect(page.locator(TASK_INDICATOR)).toContainText(
-    /Background work continues independently/i,
-  );
 
   return prompt;
 }
@@ -114,6 +174,28 @@ test.describe('background task header session switching', () => {
     const marker = `BG-PODCAST-${Date.now()}`;
     const prompt = await startPodcast(page, marker);
     const originSessionId = await getActiveSessionId(page);
+    const activeTask = await waitForActiveTask(page, originSessionId);
+    const runtimeDetail = activeTask.runtime_detail || {};
+
+    await expect(page.locator(TASK_INDICATOR)).toHaveCount(1);
+    if (runtimeDetail.workflow_kind) {
+      await expect(page.locator(TASK_WORKFLOW)).toContainText(
+        humanize(String(runtimeDetail.workflow_kind)),
+      );
+    }
+    if (runtimeDetail.current_phase) {
+      await expect(page.locator(TASK_PHASE)).toContainText(
+        humanize(String(runtimeDetail.current_phase)),
+      );
+    }
+    if (runtimeDetail.progress_message) {
+      await expect(page.locator(TASK_MESSAGE)).toContainText(
+        String(runtimeDetail.progress_message),
+      );
+    }
+    if (typeof runtimeDetail.progress === 'number') {
+      await expect(page.locator(TASK_PROGRESS_VALUE)).toContainText(/%$/);
+    }
 
     await expect(page.locator(TASK_INDICATOR)).toBeVisible();
     await expect(page.locator(SEL.userMessage).last()).toContainText(prompt.slice(0, 80));
@@ -136,8 +218,32 @@ test.describe('background task header session switching', () => {
 
     await switchToSession(page, originSessionId);
     await expect(page.locator(TASK_INDICATOR)).toBeVisible({ timeout: 15_000 });
-    await expect(page.locator(TASK_INDICATOR)).toContainText(/running/i);
+    await expect(page.locator(TASK_INDICATOR)).toHaveCount(1);
     await expect(await getChatThreadText(page)).toContain(marker);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector(SEL.chatInput, { timeout: 15_000 });
+    await expect.poll(async () => getChatThreadText(page), {
+      timeout: 15_000,
+    }).toContain(marker);
+    const reloadedTask = await waitForActiveTask(page, originSessionId);
+    const reloadedDetail = reloadedTask.runtime_detail || {};
+    await expect(page.locator(TASK_INDICATOR)).toHaveCount(1, { timeout: 15_000 });
+    if (reloadedDetail.workflow_kind) {
+      await expect(page.locator(TASK_WORKFLOW)).toContainText(
+        humanize(String(reloadedDetail.workflow_kind)),
+      );
+    }
+    if (reloadedDetail.current_phase) {
+      await expect(page.locator(TASK_PHASE)).toContainText(
+        humanize(String(reloadedDetail.current_phase)),
+      );
+    }
+    if (reloadedDetail.progress_message) {
+      await expect(page.locator(TASK_MESSAGE)).toContainText(
+        String(reloadedDetail.progress_message),
+      );
+    }
 
     const originMedia = await waitForSessionMedia(page, originSessionId, 240_000);
     await switchToSession(page, originSessionId);

--- a/e2e/tests/coding-hardcases-helpers.ts
+++ b/e2e/tests/coding-hardcases-helpers.ts
@@ -9,9 +9,26 @@ import {
 } from './live-browser-helpers';
 
 export interface SessionTask {
+  id?: string | null;
   label?: string | null;
   status?: string | null;
   tool_name?: string | null;
+  tool_call_id?: string | null;
+  session_key?: string | null;
+  started_at?: string | null;
+  updated_at?: string | null;
+  lifecycle_state?: string | null;
+  workflow_kind?: string | null;
+  current_phase?: string | null;
+  progress_message?: string | null;
+  progress?: number | null;
+  runtime_detail?: {
+    workflow_kind?: string | null;
+    current_phase?: string | null;
+    progress_message?: string | null;
+    progress?: number | null;
+    [key: string]: unknown;
+  } | null;
   child_join_state?: string | null;
   child_session_key?: string | null;
   child_terminal_state?: string | null;


### PR DESCRIPTION
Closes #473. Part of M4.1A (structured progress contract).

## What landed
- `crates/octos-cli/static/app.js` (+606/-139) — chat UI subscribes to structured progress events via SSE; renders phase/status in chat header; replays on session switch / browser reload.
- `crates/octos-cli/static/index.html` (+6) — header slot for progress.
- `crates/octos-cli/static/style.css` (+96) — styles.
- `e2e/tests/background-task-header-switching.spec.ts` (+118) — asserts progress survives session switching + reload.
- `e2e/tests/coding-hardcases-helpers.ts` (+17) — shared helpers.

## Dependencies
Depends on #470/#471 ABI + #472 emitter. Assertions in the e2e spec match fields defined by #470.

## Test plan
- [x] e2e spec authored
- [ ] Playwright run on `harness-m4/integration`
- [ ] Live canary via #474

## Surface note
This modifies the raw `static/app.js` path, not `dashboard/src/`. M4.5 (#468 operator dashboard) touches `dashboard/src/`. Different surfaces; no conflict expected.