### PR TITLE
Harness M4.1A.475: Python and JS progress emitters + examples

### DIFF
--- a/docs/OCTOS_HARNESS_M4_WORKSTREAMS_2026-04-21.md
+++ b/docs/OCTOS_HARNESS_M4_WORKSTREAMS_2026-04-21.md
@@ -175,6 +175,36 @@ Deliverables:
   preserving stderr as human diagnostics
 - browser/API proof that progress survives session switching and reload
 - live mini fleet validation before closing the milestone
+- copyable non-Rust emitter helpers and fixtures:
+  - `examples/harness-event/python/emit_progress.py`
+  - `examples/harness-event/node/emit_progress.mjs`
+  - `examples/harness-event/fixtures/progress-event.jsonl`
+  - `scripts/test-harness-event-emitters.sh`
+
+Exact usage:
+
+```bash
+export OCTOS_EVENT_SINK="file:///tmp/octos-events.jsonl"
+python3 examples/harness-event/python/emit_progress.py \
+  --session-id sess-123 \
+  --task-id task-456 \
+  --workflow deep_research \
+  --phase fetching_sources \
+  --message "Fetching source 3/12" \
+  --progress 0.42
+
+node examples/harness-event/node/emit_progress.mjs \
+  --session-id sess-123 \
+  --task-id task-456 \
+  --workflow deep_research \
+  --phase fetching_sources \
+  --message "Fetching source 3/12" \
+  --progress 0.42
+```
+
+Missing `OCTOS_EVENT_SINK` is a no-op. The emitters only format and deliver the
+record; runtime validation, size checks, and rejection handling stay on the
+consumer side.
 
 Published workstreams:
 

--- a/examples/harness-event/README.md
+++ b/examples/harness-event/README.md
@@ -1,0 +1,46 @@
+# Octos Harness Event Emitters
+
+These copyable helpers emit `octos.harness.event.v1` JSON records for non-Rust
+tools. They write to `OCTOS_EVENT_SINK` when it is set and do nothing when the
+sink is missing.
+
+The contract is:
+
+- `stderr` is for diagnostics only
+- the helper does not validate record size or schema shape
+- the runtime is responsible for consuming and rejecting bad records
+
+## Python
+
+```bash
+export OCTOS_EVENT_SINK="file:///tmp/octos-events.jsonl"
+python3 examples/harness-event/python/emit_progress.py \
+  --session-id sess-123 \
+  --task-id task-456 \
+  --workflow deep_research \
+  --phase fetching_sources \
+  --message "Fetching source 3/12" \
+  --progress 0.42
+```
+
+## JavaScript / Node
+
+```bash
+export OCTOS_EVENT_SINK="file:///tmp/octos-events.jsonl"
+node examples/harness-event/node/emit_progress.mjs \
+  --session-id sess-123 \
+  --task-id task-456 \
+  --workflow deep_research \
+  --phase fetching_sources \
+  --message "Fetching source 3/12" \
+  --progress 0.42
+```
+
+## Validation
+
+Run the fixture test from the repo root:
+
+```bash
+bash scripts/test-harness-event-emitters.sh
+```
+

--- a/examples/harness-event/fixtures/progress-event.jsonl
+++ b/examples/harness-event/fixtures/progress-event.jsonl
@@ -1,0 +1,1 @@
+{"schema":"octos.harness.event.v1","kind":"progress","session_id":"sess-123","task_id":"task-456","workflow":"deep_research","phase":"fetching_sources","message":"Fetching source 3/12","progress":0.42}

--- a/examples/harness-event/node/emit_progress.mjs
+++ b/examples/harness-event/node/emit_progress.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Dependency-light Octos harness event emitter for Node tools.
+ */
+
+import fs from 'node:fs/promises';
+import net from 'node:net';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const SCHEMA = 'octos.harness.event.v1';
+
+export function buildProgressEvent(sessionId, taskId, workflow, phase, message, progress) {
+  const event = {
+    schema: SCHEMA,
+    kind: 'progress',
+    session_id: sessionId,
+    task_id: taskId,
+    workflow,
+    phase,
+    message,
+  };
+  if (progress !== undefined) {
+    event.progress = progress;
+  }
+  return event;
+}
+
+function parseSink(sink) {
+  if (!sink.includes('://')) {
+    return { transport: 'file', path: sink };
+  }
+
+  const url = new URL(sink);
+  if (url.protocol === 'file:') {
+    return { transport: 'file', path: fileURLToPath(url) };
+  }
+  if (url.protocol === 'unix:') {
+    return { transport: 'unix', path: decodeURIComponent(url.pathname || url.host || '') };
+  }
+  return { transport: url.protocol.replace(/:$/, ''), path: sink };
+}
+
+async function appendFile(path, line) {
+  await fs.appendFile(path, line, 'utf8');
+}
+
+async function sendUnixSocket(path, line) {
+  await new Promise((resolve, reject) => {
+    const socket = net.createConnection({ path }, () => {
+      socket.end(line, 'utf8', resolve);
+    });
+    socket.on('error', reject);
+  });
+}
+
+export async function emitEvent(event, sink = process.env.OCTOS_EVENT_SINK || '') {
+  if (!sink) {
+    return false;
+  }
+
+  const line = `${JSON.stringify(event)}\n`;
+  const target = parseSink(sink);
+
+  try {
+    if (target.transport === 'unix') {
+      if (!target.path) {
+        throw new Error('unix sink path is empty');
+      }
+      await sendUnixSocket(target.path, line);
+    } else {
+      await appendFile(target.path, line);
+    }
+    return true;
+  } catch (error) {
+    console.error(`octos event sink write failed: ${error instanceof Error ? error.message : String(error)}`);
+    return false;
+  }
+}
+
+export async function emitProgress(sessionId, taskId, workflow, phase, message, progress, sink) {
+  return emitEvent(
+    buildProgressEvent(sessionId, taskId, workflow, phase, message, progress),
+    sink,
+  );
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const item = argv[i];
+    if (!item.startsWith('--')) {
+      continue;
+    }
+    const key = item.slice(2);
+    const value = argv[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = value;
+    i += 1;
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!args['session-id'] || !args['task-id'] || !args.workflow || !args.phase || !args.message) {
+    console.error('usage: emit_progress.mjs --session-id ... --task-id ... --workflow ... --phase ... --message ... [--progress N] [--sink URI]');
+    return 2;
+  }
+
+  const progress = args.progress === undefined ? undefined : Number(args.progress);
+  const sink = args.sink ?? process.env.OCTOS_EVENT_SINK ?? '';
+  const wrote = await emitProgress(
+    args['session-id'],
+    args['task-id'],
+    args.workflow,
+    args.phase,
+    args.message,
+    Number.isNaN(progress) ? undefined : progress,
+    sink,
+  );
+  return sink ? (wrote ? 0 : 1) : 0;
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const code = await main();
+  process.exitCode = code;
+}

--- a/examples/harness-event/python/emit_progress.py
+++ b/examples/harness-event/python/emit_progress.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Dependency-light Octos harness event emitter for Python tools."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+SCHEMA = "octos.harness.event.v1"
+
+
+def build_progress_event(
+    session_id: str,
+    task_id: str,
+    workflow: str,
+    phase: str,
+    message: str,
+    progress: float | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "schema": SCHEMA,
+        "kind": "progress",
+        "session_id": session_id,
+        "task_id": task_id,
+        "workflow": workflow,
+        "phase": phase,
+        "message": message,
+    }
+    if progress is not None:
+        event["progress"] = progress
+    return event
+
+
+def _sink_path(sink: str) -> tuple[str, str]:
+    if "://" not in sink:
+        return ("file", sink)
+
+    parsed = urlparse(sink)
+    scheme = parsed.scheme.lower()
+    if scheme == "file":
+        path = unquote(parsed.path)
+        if parsed.netloc and parsed.netloc != "localhost":
+            path = f"/{parsed.netloc}{path}"
+        return ("file", path)
+    if scheme == "unix":
+        path = unquote(parsed.path or parsed.netloc)
+        return ("unix", path)
+    return (scheme, sink)
+
+
+def _append_file(path: str, line: str) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        os.close(fd)
+
+
+def _send_unix_socket(path: str, line: str) -> None:
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.connect(path)
+        sock.sendall(line.encode("utf-8"))
+    finally:
+        sock.close()
+
+
+def emit_event(event: dict[str, Any], sink: str | None = None) -> bool:
+    target = sink if sink is not None else os.environ.get("OCTOS_EVENT_SINK", "")
+    if not target:
+        return False
+
+    line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+    transport, path = _sink_path(target)
+
+    try:
+        if transport == "unix":
+            if not path:
+                raise ValueError("unix sink path is empty")
+            _send_unix_socket(path, line)
+        else:
+            _append_file(path, line)
+        return True
+    except Exception as exc:
+        print(f"octos event sink write failed: {exc}", file=sys.stderr)
+        return False
+
+
+def emit_progress(
+    session_id: str,
+    task_id: str,
+    workflow: str,
+    phase: str,
+    message: str,
+    progress: float | None = None,
+    sink: str | None = None,
+) -> bool:
+    return emit_event(
+        build_progress_event(
+            session_id=session_id,
+            task_id=task_id,
+            workflow=workflow,
+            phase=phase,
+            message=message,
+            progress=progress,
+        ),
+        sink=sink,
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit an Octos harness progress event")
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--workflow", required=True)
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--message", required=True)
+    parser.add_argument("--progress", type=float)
+    parser.add_argument("--sink", default=os.environ.get("OCTOS_EVENT_SINK", ""))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    wrote = emit_progress(
+        session_id=args.session_id,
+        task_id=args.task_id,
+        workflow=args.workflow,
+        phase=args.phase,
+        message=args.message,
+        progress=args.progress,
+        sink=args.sink,
+    )
+    return 0 if not args.sink or wrote else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-harness-event-emitters.sh
+++ b/scripts/test-harness-event-emitters.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PY_HELPER="$ROOT_DIR/examples/harness-event/python/emit_progress.py"
+JS_HELPER="$ROOT_DIR/examples/harness-event/node/emit_progress.mjs"
+FIXTURE="$ROOT_DIR/examples/harness-event/fixtures/progress-event.jsonl"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+assert_file_matches_fixture() {
+    local actual="$1"
+    cmp -s "$actual" "$FIXTURE" || {
+        echo "expected:" >&2
+        cat "$FIXTURE" >&2
+        echo "actual:" >&2
+        cat "$actual" >&2
+        fail "fixture mismatch for $actual"
+    }
+}
+
+main() {
+    require_tool python3
+    require_tool node
+
+    WORK_DIR="$(mktemp -d /tmp/octos-harness-event.XXXXXX)"
+    trap 'rm -rf "$WORK_DIR"' EXIT
+
+    PY_OUT="$WORK_DIR/python.jsonl"
+    JS_OUT="$WORK_DIR/node.jsonl"
+
+    OCTOS_EVENT_SINK="file://$PY_OUT" python3 "$PY_HELPER" \
+        --session-id sess-123 \
+        --task-id task-456 \
+        --workflow deep_research \
+        --phase fetching_sources \
+        --message "Fetching source 3/12" \
+        --progress 0.42 \
+        >"$WORK_DIR/python.stdout" 2>"$WORK_DIR/python.stderr"
+    [ -s "$PY_OUT" ] || fail "python emitter did not write the fixture line"
+    [ ! -s "$WORK_DIR/python.stderr" ] || fail "python emitter should not write diagnostics on success"
+    assert_file_matches_fixture "$PY_OUT"
+
+    OCTOS_EVENT_SINK="file://$JS_OUT" node "$JS_HELPER" \
+        --session-id sess-123 \
+        --task-id task-456 \
+        --workflow deep_research \
+        --phase fetching_sources \
+        --message "Fetching source 3/12" \
+        --progress 0.42 \
+        >"$WORK_DIR/node.stdout" 2>"$WORK_DIR/node.stderr"
+    [ -s "$JS_OUT" ] || fail "node emitter did not write the fixture line"
+    [ ! -s "$WORK_DIR/node.stderr" ] || fail "node emitter should not write diagnostics on success"
+    assert_file_matches_fixture "$JS_OUT"
+
+    OCTOS_EVENT_SINK= python3 "$PY_HELPER" \
+        --session-id sess-123 \
+        --task-id task-456 \
+        --workflow deep_research \
+        --phase fetching_sources \
+        --message "Fetching source 3/12" \
+        --progress 0.42 \
+        >"$WORK_DIR/python-noop.stdout" 2>"$WORK_DIR/python-noop.stderr"
+    [ ! -s "$WORK_DIR/python-noop.stdout" ] || fail "python emitter should stay silent when OCTOS_EVENT_SINK is missing"
+    [ ! -s "$WORK_DIR/python-noop.stderr" ] || fail "python emitter should not emit diagnostics when OCTOS_EVENT_SINK is missing"
+
+    OCTOS_EVENT_SINK= node "$JS_HELPER" \
+        --session-id sess-123 \
+        --task-id task-456 \
+        --workflow deep_research \
+        --phase fetching_sources \
+        --message "Fetching source 3/12" \
+        --progress 0.42 \
+        >"$WORK_DIR/node-noop.stdout" 2>"$WORK_DIR/node-noop.stderr"
+    [ ! -s "$WORK_DIR/node-noop.stdout" ] || fail "node emitter should stay silent when OCTOS_EVENT_SINK is missing"
+    [ ! -s "$WORK_DIR/node-noop.stderr" ] || fail "node emitter should not emit diagnostics when OCTOS_EVENT_SINK is missing"
+
+    echo "harness event emitter tests passed"
+}
+
+main "$@"


### PR DESCRIPTION
Closes #475. Part of M4.1A (structured progress contract).

## What landed
- `examples/harness-event/README.md` (+46) — integration guide.
- `examples/harness-event/python/emit_progress.py` (+143) — reference Python emitter.
- `examples/harness-event/node/emit_progress.mjs` (+131) — reference JS emitter.
- `examples/harness-event/fixtures/progress-event.jsonl` (+1) — golden line for round-trip tests.
- `scripts/test-harness-event-emitters.sh` (+89) — smoke test runner that validates both emitters.
- `docs/OCTOS_HARNESS_M4_WORKSTREAMS_2026-04-21.md` (+30) — emitter integration section added.

## Dependencies
Depends on #470/#471 ABI. Emitters produce events conforming to `octos.harness.event.v1` schema.

## Test plan
- [x] `scripts/test-harness-event-emitters.sh` runs both emitters and validates golden fixture round-trip
- [ ] Integration on `harness-m4/integration`