### PR TITLE
Harness M4.3: declarative validator runner

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -33,6 +33,7 @@ mod subprocess_env;
 pub mod task_supervisor;
 pub mod tools;
 pub mod turn;
+pub mod validators;
 pub mod workspace_contract;
 pub mod workspace_git;
 pub mod workspace_policy;
@@ -67,6 +68,10 @@ pub use tools::{
     admin::{AdminApiContext, register_admin_api_tools},
 };
 pub use turn::{Turn, TurnKind, turns_to_messages};
+pub use validators::{
+    VALIDATOR_RESULT_SCHEMA_VERSION, ValidatorInvocation, ValidatorLedger, ValidatorOutcome,
+    ValidatorPhase, ValidatorRunner, ValidatorStatus, run_workspace_validators,
+};
 pub use workspace_git::{
     WorkspaceArtifactStatus, WorkspaceCheckStatus, WorkspaceContractStatus, WorkspaceProjectKind,
     WorkspaceValidationFailure, WorkspaceValidationPhase, commit_all_if_dirty,
@@ -75,11 +80,11 @@ pub use workspace_git::{
     snapshot_workspace_change, snapshot_workspace_turn,
 };
 pub use workspace_policy::{
-    ValidationPolicy, WORKSPACE_POLICY_FILE, WorkspaceArtifactsPolicy, WorkspacePolicy,
-    WorkspacePolicyKind, WorkspaceSnapshotTrigger, WorkspaceSpawnTaskPolicy,
-    WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy, WorkspaceVersionControlProvider,
-    read_workspace_policy, upgrade_workspace_policy_if_legacy, workspace_policy_path,
-    write_workspace_policy,
+    ValidationPolicy, Validator, ValidatorPhaseKind, ValidatorSpec, WORKSPACE_POLICY_FILE,
+    WorkspaceArtifactsPolicy, WorkspacePolicy, WorkspacePolicyKind, WorkspaceSnapshotTrigger,
+    WorkspaceSpawnTaskPolicy, WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy,
+    WorkspaceVersionControlProvider, read_workspace_policy, upgrade_workspace_policy_if_legacy,
+    workspace_policy_path, write_workspace_policy,
 };
 
 #[cfg(test)]

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -239,6 +239,19 @@ impl ToolRegistry {
         self.invalidate_cache();
     }
 
+    /// Return the names of every registered tool.
+    ///
+    /// Used by the validator runner's lightweight dispatcher to capture a
+    /// snapshot of available tools without cloning the full registry.
+    pub fn tool_names(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+
+    /// Return a handle to a tool by name, if it exists.
+    pub fn get_tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        self.tools.get(name).cloned()
+    }
+
     /// Get tool specifications for the LLM, filtered by provider policy if set.
     /// Results are cached and invalidated when the registry is mutated.
     pub fn specs(&self) -> Vec<ToolSpec> {

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -1,0 +1,977 @@
+//! Declarative validator runner (harness M4.3).
+//!
+//! Runs the typed validators declared in `WorkspacePolicy.validation.validators`
+//! and produces durable typed outcomes that block terminal success for the
+//! workspace contract when a required validator fails. Optional failures are
+//! surfaced as warnings without blocking delivery.
+//!
+//! # Safety invariants
+//!
+//! - Command validators go through the shell-safety layer
+//!   ([`crate::policy::SafePolicy`]) and strip [`BLOCKED_ENV_VARS`] before
+//!   invoking a child, reusing the same sanitization as `ShellTool`. No
+//!   `Command::new("sh")` escape hatch.
+//! - Command validator timeouts kill the child process via SIGTERM -> SIGKILL
+//!   on Unix and `taskkill /F /T` on Windows.
+//! - Outcomes carry a stable `schema_version` (starting at 1) so persisted
+//!   records replay across harness upgrades.
+//! - Evidence files live under `<workspace_root>/.octos/validator-evidence/`
+//!   to keep operator-visible logs durable without polluting the workspace.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use eyre::{Result, WrapErr, eyre};
+use metrics::counter;
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+use tracing::{debug, warn};
+
+use crate::policy::{CommandPolicy, Decision, SafePolicy};
+use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
+use crate::tools::{ToolRegistry, ToolResult};
+use crate::workspace_policy::{Validator, ValidatorPhaseKind, ValidatorSpec};
+
+/// Current schema version for [`ValidatorOutcome`] persistence.
+pub const VALIDATOR_RESULT_SCHEMA_VERSION: u32 = 1;
+
+const EVIDENCE_SUBDIR: &str = ".octos/validator-evidence";
+const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 30_000;
+const MAX_EVIDENCE_BYTES: usize = 512 * 1024;
+const KILL_GRACE_PERIOD: Duration = Duration::from_millis(300);
+
+/// Phase in which a validator runs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidatorPhase {
+    TurnEnd,
+    Completion,
+}
+
+impl ValidatorPhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::TurnEnd => "turn_end",
+            Self::Completion => "completion",
+        }
+    }
+}
+
+impl From<ValidatorPhaseKind> for ValidatorPhase {
+    fn from(value: ValidatorPhaseKind) -> Self {
+        match value {
+            ValidatorPhaseKind::TurnEnd => Self::TurnEnd,
+            ValidatorPhaseKind::Completion => Self::Completion,
+        }
+    }
+}
+
+/// Typed terminal status for a validator run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidatorStatus {
+    /// Validator finished successfully.
+    Pass,
+    /// Validator ran to completion but reported a failure.
+    Fail,
+    /// Validator exceeded its timeout budget.
+    Timeout,
+    /// Validator could not run (policy deny, missing tool, etc.).
+    Error,
+}
+
+impl ValidatorStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Fail => "fail",
+            Self::Timeout => "timeout",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// Invocation context shared by a batch of validators for the same workspace.
+#[derive(Clone, Debug)]
+pub struct ValidatorInvocation {
+    pub phase: ValidatorPhase,
+    pub workspace_root: PathBuf,
+    pub repo_label: String,
+}
+
+/// Typed durable outcome of a single validator run.
+///
+/// Carries enough information to replay after reload or restart: the
+/// validator id, typed status, human-readable reason, duration, evidence
+/// path, stderr tail, and schema version.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidatorOutcome {
+    /// Schema version of this record. Starts at 1.
+    pub schema_version: u32,
+    pub validator_id: String,
+    pub phase: ValidatorPhase,
+    pub kind: String,
+    pub repo_label: String,
+    pub required: bool,
+    pub status: ValidatorStatus,
+    pub reason: String,
+    pub duration_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    pub started_at: DateTime<Utc>,
+}
+
+impl ValidatorOutcome {
+    /// Does this outcome satisfy the required-gate contract?
+    ///
+    /// A required failure/timeout/error blocks terminal success. Optional
+    /// validators never block the gate.
+    pub fn required_gate_passed(&self) -> bool {
+        if !self.required {
+            return true;
+        }
+        matches!(self.status, ValidatorStatus::Pass)
+    }
+}
+
+/// Append-only JSONL ledger that persists validator outcomes for replay.
+#[derive(Clone, Debug)]
+pub struct ValidatorLedger {
+    path: Arc<PathBuf>,
+}
+
+impl ValidatorLedger {
+    /// Open (or create) an append-only ledger at `path`. The parent directory
+    /// is created on demand.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("create ledger dir failed: {}", parent.display()))?;
+        }
+        Ok(Self {
+            path: Arc::new(path),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Append a single outcome record to the ledger.
+    pub fn append(&self, outcome: &ValidatorOutcome) -> Result<()> {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.path.as_ref())
+            .wrap_err_with(|| format!("open ledger failed: {}", self.path.display()))?;
+        let json = serde_json::to_string(outcome).wrap_err("serialize validator outcome failed")?;
+        writeln!(file, "{json}")
+            .wrap_err_with(|| format!("write ledger failed: {}", self.path.display()))?;
+        Ok(())
+    }
+
+    /// Read every persisted outcome from the ledger (for replay).
+    pub fn read_all(&self) -> Result<Vec<ValidatorOutcome>> {
+        use std::fs::File;
+        use std::io::{BufRead, BufReader};
+
+        let file = match File::open(self.path.as_ref()) {
+            Ok(file) => file,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => {
+                return Err(eyre!("open ledger failed: {}: {err}", self.path.display()));
+            }
+        };
+        let mut outcomes = Vec::new();
+        for line in BufReader::new(file).lines() {
+            let line = line.wrap_err("read ledger line failed")?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let outcome: ValidatorOutcome = serde_json::from_str(&line)
+                .wrap_err_with(|| format!("parse ledger line failed: {line}"))?;
+            outcomes.push(outcome);
+        }
+        Ok(outcomes)
+    }
+}
+
+/// Dispatches a ToolCall validator. Abstracts over the real `ToolRegistry`
+/// so test harnesses and short-lived call sites can provide a lightweight
+/// implementation without cloning the registry.
+#[async_trait::async_trait]
+pub trait ValidatorToolDispatcher: Send + Sync {
+    async fn dispatch(&self, tool: &str, args: &serde_json::Value) -> Result<ToolResult>;
+}
+
+#[async_trait::async_trait]
+impl ValidatorToolDispatcher for ToolRegistry {
+    async fn dispatch(&self, tool: &str, args: &serde_json::Value) -> Result<ToolResult> {
+        self.execute(tool, args).await
+    }
+}
+
+/// Dispatcher that looks up tools from a pre-captured map of `Arc<dyn Tool>`.
+///
+/// Suitable for short-lived call sites that only hold a `&ToolRegistry`
+/// reference but need a `ValidatorRunner` without cloning the full registry.
+pub struct MapToolDispatcher {
+    tools: std::collections::HashMap<String, std::sync::Arc<dyn crate::tools::Tool>>,
+}
+
+impl MapToolDispatcher {
+    pub fn new() -> Self {
+        Self {
+            tools: std::collections::HashMap::new(),
+        }
+    }
+
+    pub fn insert(
+        &mut self,
+        name: impl Into<String>,
+        tool: std::sync::Arc<dyn crate::tools::Tool>,
+    ) {
+        self.tools.insert(name.into(), tool);
+    }
+
+    pub fn from_registry(registry: &ToolRegistry) -> Self {
+        let mut me = Self::new();
+        for name in registry.tool_names() {
+            if let Some(tool) = registry.get_tool(&name) {
+                me.insert(name, tool);
+            }
+        }
+        me
+    }
+}
+
+impl Default for MapToolDispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatorToolDispatcher for MapToolDispatcher {
+    async fn dispatch(&self, tool: &str, args: &serde_json::Value) -> Result<ToolResult> {
+        let Some(handle) = self.tools.get(tool).cloned() else {
+            return Err(eyre!("tool '{tool}' not registered for validator dispatch"));
+        };
+        handle.execute(args).await
+    }
+}
+
+/// Runner that executes typed validators and produces durable outcomes.
+#[derive(Clone)]
+pub struct ValidatorRunner {
+    dispatcher: Arc<dyn ValidatorToolDispatcher>,
+    evidence_root: PathBuf,
+    policy: Arc<dyn CommandPolicy>,
+    ledger: Option<ValidatorLedger>,
+}
+
+impl std::fmt::Debug for ValidatorRunner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ValidatorRunner")
+            .field("evidence_root", &self.evidence_root)
+            .field("ledger", &self.ledger)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ValidatorRunner {
+    /// Create a runner bound to `tools` with evidence under
+    /// `<workspace_root>/.octos/validator-evidence/`.
+    pub fn new(tools: Arc<ToolRegistry>, workspace_root: impl Into<PathBuf>) -> Self {
+        let dispatcher: Arc<dyn ValidatorToolDispatcher> = tools;
+        Self::with_dispatcher(dispatcher, workspace_root)
+    }
+
+    /// Create a runner that dispatches tool validators through `dispatcher`.
+    pub fn with_dispatcher(
+        dispatcher: Arc<dyn ValidatorToolDispatcher>,
+        workspace_root: impl Into<PathBuf>,
+    ) -> Self {
+        let evidence_root = workspace_root.into().join(EVIDENCE_SUBDIR);
+        Self {
+            dispatcher,
+            evidence_root,
+            policy: Arc::new(SafePolicy::default()),
+            ledger: None,
+        }
+    }
+
+    /// Override the directory where evidence files are written.
+    pub fn with_evidence_root(mut self, path: impl Into<PathBuf>) -> Self {
+        self.evidence_root = path.into();
+        self
+    }
+
+    /// Attach a ledger so outcomes are persisted for replay.
+    pub fn with_ledger(mut self, ledger: ValidatorLedger) -> Self {
+        self.ledger = Some(ledger);
+        self
+    }
+
+    /// Override the command policy (defaults to [`SafePolicy`]).
+    pub fn with_policy(mut self, policy: Arc<dyn CommandPolicy>) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// Run a batch of validators and return typed outcomes in the same order.
+    pub async fn run_all(
+        &self,
+        invocation: &ValidatorInvocation,
+        validators: &[Validator],
+    ) -> Vec<ValidatorOutcome> {
+        self.run_all_with_seeded_env(invocation, validators, &[])
+            .await
+    }
+
+    /// Run validators, pre-seeding the given env vars on each spawned command
+    /// validator child. Intended for tests that prove
+    /// [`BLOCKED_ENV_VARS`] sanitization strips vars even if they were set
+    /// explicitly on the `Command`. Not wired into production code paths.
+    pub async fn run_all_with_seeded_env(
+        &self,
+        invocation: &ValidatorInvocation,
+        validators: &[Validator],
+        seeded_env: &[(&str, &str)],
+    ) -> Vec<ValidatorOutcome> {
+        let _ = std::fs::create_dir_all(&self.evidence_root);
+        let mut outcomes = Vec::with_capacity(validators.len());
+        for validator in validators {
+            let started_at = Utc::now();
+            let started = Instant::now();
+            let kind_label = validator_kind_label(&validator.spec);
+            let outcome = match &validator.spec {
+                ValidatorSpec::Command { cmd, args } => {
+                    self.run_command(
+                        invocation, validator, cmd, args, started_at, started, seeded_env,
+                    )
+                    .await
+                }
+                ValidatorSpec::ToolCall { tool, args } => {
+                    self.run_tool_call(invocation, validator, tool, args, started_at, started)
+                        .await
+                }
+                ValidatorSpec::FileExists { path, min_bytes } => self
+                    .run_file_exists(invocation, validator, path, *min_bytes, started_at, started),
+            };
+
+            record_counter(&outcome, kind_label);
+            if let Some(ref ledger) = self.ledger {
+                if let Err(err) = ledger.append(&outcome) {
+                    warn!(
+                        validator = %outcome.validator_id,
+                        error = %err,
+                        "failed to persist validator outcome"
+                    );
+                }
+            }
+            outcomes.push(outcome);
+        }
+        outcomes
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_command(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        cmd: &str,
+        args: &[String],
+        started_at: DateTime<Utc>,
+        started: Instant,
+        seeded_env: &[(&str, &str)],
+    ) -> ValidatorOutcome {
+        let timeout_ms = validator.timeout_ms.unwrap_or(DEFAULT_COMMAND_TIMEOUT_MS);
+        let timeout_duration = Duration::from_millis(timeout_ms);
+
+        // Shell-safety layer: SafePolicy denies the known-dangerous patterns.
+        let command_string = build_command_string(cmd, args);
+        let decision = self
+            .policy
+            .check(&command_string, &invocation.workspace_root);
+        match decision {
+            Decision::Allow => {}
+            Decision::Deny | Decision::Ask => {
+                return error_outcome(
+                    invocation,
+                    validator,
+                    started_at,
+                    started,
+                    format!("command validator denied by safety policy: {command_string}"),
+                );
+            }
+        }
+
+        let mut command = Command::new(cmd);
+        command
+            .args(args)
+            .current_dir(&invocation.workspace_root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::null());
+        #[cfg(unix)]
+        {
+            // Put the child in its own process group so we can SIGTERM the
+            // whole tree on timeout.
+            command.process_group(0);
+        }
+        // Seeded env first (test hook); sanitization strips blocked ones.
+        for (name, value) in seeded_env {
+            command.env(*name, *value);
+        }
+        sanitize_command_env(&mut command, &EnvAllowlist::empty());
+
+        let child = match command.spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                return error_outcome(
+                    invocation,
+                    validator,
+                    started_at,
+                    started,
+                    format!("failed to spawn command validator: {err}"),
+                );
+            }
+        };
+
+        let child_pid = child.id();
+
+        match timeout(timeout_duration, child.wait_with_output()).await {
+            Ok(Ok(output)) => {
+                let duration_ms = started.elapsed().as_millis() as u64;
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                let exit_code = output.status.code();
+                let evidence_path = self
+                    .write_evidence(&validator.id, invocation, &stdout, &stderr, exit_code)
+                    .await;
+                let status = if output.status.success() {
+                    ValidatorStatus::Pass
+                } else {
+                    ValidatorStatus::Fail
+                };
+                let reason = if output.status.success() {
+                    format!(
+                        "command validator succeeded (exit {})",
+                        exit_code.unwrap_or(0)
+                    )
+                } else {
+                    format!(
+                        "command validator failed (exit {})",
+                        exit_code.unwrap_or(-1)
+                    )
+                };
+                let stderr_tail = stderr_tail(&stderr);
+                ValidatorOutcome {
+                    schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+                    validator_id: validator.id.clone(),
+                    phase: invocation.phase,
+                    kind: validator_kind_label(&validator.spec).to_string(),
+                    repo_label: invocation.repo_label.clone(),
+                    required: validator.required,
+                    status,
+                    reason,
+                    duration_ms,
+                    evidence_path,
+                    stderr: stderr_tail,
+                    started_at,
+                }
+            }
+            Ok(Err(err)) => error_outcome(
+                invocation,
+                validator,
+                started_at,
+                started,
+                format!("command validator wait failed: {err}"),
+            ),
+            Err(_) => {
+                let duration_ms = started.elapsed().as_millis() as u64;
+                if let Some(pid) = child_pid {
+                    kill_child_process(pid).await;
+                }
+                ValidatorOutcome {
+                    schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+                    validator_id: validator.id.clone(),
+                    phase: invocation.phase,
+                    kind: validator_kind_label(&validator.spec).to_string(),
+                    repo_label: invocation.repo_label.clone(),
+                    required: validator.required,
+                    status: ValidatorStatus::Timeout,
+                    reason: format!("command validator timed out after {timeout_ms}ms"),
+                    duration_ms,
+                    evidence_path: None,
+                    stderr: None,
+                    started_at,
+                }
+            }
+        }
+    }
+
+    async fn run_tool_call(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        tool: &str,
+        args: &serde_json::Value,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let timeout_ms = validator.timeout_ms.unwrap_or(DEFAULT_COMMAND_TIMEOUT_MS);
+        let timeout_duration = Duration::from_millis(timeout_ms);
+
+        let dispatcher = self.dispatcher.clone();
+        let tool_name = tool.to_string();
+        let args_value = args.clone();
+        let future = async move { dispatcher.dispatch(&tool_name, &args_value).await };
+
+        match timeout(timeout_duration, future).await {
+            Ok(Ok(result)) => {
+                let duration_ms = started.elapsed().as_millis() as u64;
+                let status = if result.success {
+                    ValidatorStatus::Pass
+                } else {
+                    ValidatorStatus::Fail
+                };
+                let reason = if result.success {
+                    format!("tool validator '{tool}' succeeded")
+                } else {
+                    result.output.clone()
+                };
+                let evidence_path = self
+                    .write_evidence(&validator.id, invocation, &result.output, "", None)
+                    .await;
+                ValidatorOutcome {
+                    schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+                    validator_id: validator.id.clone(),
+                    phase: invocation.phase,
+                    kind: validator_kind_label(&validator.spec).to_string(),
+                    repo_label: invocation.repo_label.clone(),
+                    required: validator.required,
+                    status,
+                    reason,
+                    duration_ms,
+                    evidence_path,
+                    stderr: None,
+                    started_at,
+                }
+            }
+            Ok(Err(err)) => error_outcome(
+                invocation,
+                validator,
+                started_at,
+                started,
+                format!("tool validator '{tool}' failed: {err}"),
+            ),
+            Err(_) => {
+                let duration_ms = started.elapsed().as_millis() as u64;
+                ValidatorOutcome {
+                    schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+                    validator_id: validator.id.clone(),
+                    phase: invocation.phase,
+                    kind: validator_kind_label(&validator.spec).to_string(),
+                    repo_label: invocation.repo_label.clone(),
+                    required: validator.required,
+                    status: ValidatorStatus::Timeout,
+                    reason: format!("tool validator '{tool}' timed out after {timeout_ms}ms"),
+                    duration_ms,
+                    evidence_path: None,
+                    stderr: None,
+                    started_at,
+                }
+            }
+        }
+    }
+
+    fn run_file_exists(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        path: &str,
+        min_bytes: Option<u64>,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let target = if Path::new(path).is_absolute() {
+            PathBuf::from(path)
+        } else {
+            invocation.workspace_root.join(path)
+        };
+        let duration_ms = started.elapsed().as_millis() as u64;
+        let (status, reason) = match std::fs::metadata(&target) {
+            Ok(meta) if meta.is_file() => {
+                if let Some(min) = min_bytes {
+                    if meta.len() < min {
+                        (
+                            ValidatorStatus::Fail,
+                            format!(
+                                "{} is {} bytes, min_bytes is {}",
+                                target.display(),
+                                meta.len(),
+                                min
+                            ),
+                        )
+                    } else {
+                        (
+                            ValidatorStatus::Pass,
+                            format!(
+                                "{} exists ({} bytes, min {})",
+                                target.display(),
+                                meta.len(),
+                                min
+                            ),
+                        )
+                    }
+                } else {
+                    (
+                        ValidatorStatus::Pass,
+                        format!("{} exists ({} bytes)", target.display(), meta.len()),
+                    )
+                }
+            }
+            Ok(_) => (
+                ValidatorStatus::Fail,
+                format!("{} is not a regular file", target.display()),
+            ),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => (
+                ValidatorStatus::Fail,
+                format!("{} does not exist", target.display()),
+            ),
+            Err(err) => (
+                ValidatorStatus::Error,
+                format!("stat {} failed: {err}", target.display()),
+            ),
+        };
+
+        ValidatorOutcome {
+            schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+            validator_id: validator.id.clone(),
+            phase: invocation.phase,
+            kind: validator_kind_label(&validator.spec).to_string(),
+            repo_label: invocation.repo_label.clone(),
+            required: validator.required,
+            status,
+            reason,
+            duration_ms,
+            evidence_path: None,
+            stderr: None,
+            started_at,
+        }
+    }
+
+    async fn write_evidence(
+        &self,
+        validator_id: &str,
+        invocation: &ValidatorInvocation,
+        stdout: &str,
+        stderr: &str,
+        exit_code: Option<i32>,
+    ) -> Option<PathBuf> {
+        if let Err(err) = tokio::fs::create_dir_all(&self.evidence_root).await {
+            warn!(
+                error = %err,
+                dir = %self.evidence_root.display(),
+                "failed to create validator evidence dir"
+            );
+            return None;
+        }
+
+        let stamp = Utc::now().format("%Y%m%dT%H%M%S%3f").to_string();
+        let slug = slug_for_path(&invocation.repo_label);
+        let filename = format!(
+            "{slug}-{phase}-{id}-{stamp}.txt",
+            phase = invocation.phase.as_str(),
+            id = sanitize_filename_component(validator_id),
+        );
+        let path = self.evidence_root.join(filename);
+
+        let mut buffer = String::new();
+        buffer.push_str(&format!("validator_id={}\n", validator_id));
+        buffer.push_str(&format!("phase={}\n", invocation.phase.as_str()));
+        buffer.push_str(&format!("repo_label={}\n", invocation.repo_label));
+        if let Some(code) = exit_code {
+            buffer.push_str(&format!("exit_code={}\n", code));
+        }
+        buffer.push_str("---stdout---\n");
+        buffer.push_str(&truncate_tail(stdout, MAX_EVIDENCE_BYTES / 2));
+        buffer.push_str("\n---stderr---\n");
+        buffer.push_str(&truncate_tail(stderr, MAX_EVIDENCE_BYTES / 2));
+
+        match tokio::fs::File::create(&path).await {
+            Ok(mut file) => {
+                if let Err(err) = file.write_all(buffer.as_bytes()).await {
+                    warn!(
+                        error = %err,
+                        path = %path.display(),
+                        "failed to write validator evidence"
+                    );
+                    return None;
+                }
+                if let Err(err) = file.flush().await {
+                    warn!(
+                        error = %err,
+                        path = %path.display(),
+                        "failed to flush validator evidence"
+                    );
+                }
+                Some(path)
+            }
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    path = %path.display(),
+                    "failed to create validator evidence file"
+                );
+                None
+            }
+        }
+    }
+}
+
+/// Build a representation of the command for the safety-policy check. This is
+/// not forwarded to a shell — we only use it to run the denylist matcher.
+fn build_command_string(cmd: &str, args: &[String]) -> String {
+    let mut s = String::with_capacity(cmd.len() + args.iter().map(|a| a.len() + 1).sum::<usize>());
+    s.push_str(cmd);
+    for arg in args {
+        s.push(' ');
+        s.push_str(arg);
+    }
+    s
+}
+
+fn error_outcome(
+    invocation: &ValidatorInvocation,
+    validator: &Validator,
+    started_at: DateTime<Utc>,
+    started: Instant,
+    reason: String,
+) -> ValidatorOutcome {
+    ValidatorOutcome {
+        schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+        validator_id: validator.id.clone(),
+        phase: invocation.phase,
+        kind: validator_kind_label(&validator.spec).to_string(),
+        repo_label: invocation.repo_label.clone(),
+        required: validator.required,
+        status: ValidatorStatus::Error,
+        reason,
+        duration_ms: started.elapsed().as_millis() as u64,
+        evidence_path: None,
+        stderr: None,
+        started_at,
+    }
+}
+
+fn validator_kind_label(spec: &ValidatorSpec) -> &'static str {
+    match spec {
+        ValidatorSpec::Command { .. } => "command",
+        ValidatorSpec::ToolCall { .. } => "tool_call",
+        ValidatorSpec::FileExists { .. } => "file_exists",
+    }
+}
+
+fn stderr_tail(stderr: &str) -> Option<String> {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(truncate_tail(trimmed, 4096))
+}
+
+fn truncate_tail(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    // Preserve the tail — most useful for diagnosing failures.
+    let start = text.len() - max_bytes;
+    let mut boundary = start;
+    while boundary < text.len() && !text.is_char_boundary(boundary) {
+        boundary += 1;
+    }
+    format!("...[truncated]\n{}", &text[boundary..])
+}
+
+fn slug_for_path(label: &str) -> String {
+    label
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect()
+}
+
+fn sanitize_filename_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn record_counter(outcome: &ValidatorOutcome, kind_label: &'static str) {
+    counter!(
+        "octos_workspace_validator_total",
+        "status" => outcome.status.as_str().to_string(),
+        "phase" => outcome.phase.as_str().to_string(),
+        "kind" => kind_label.to_string(),
+        "required" => outcome.required.to_string(),
+    )
+    .increment(1);
+
+    if outcome.required && outcome.status != ValidatorStatus::Pass {
+        counter!("octos_workspace_validator_required_failed_total").increment(1);
+    } else if !outcome.required && outcome.status != ValidatorStatus::Pass {
+        counter!("octos_workspace_validator_optional_warning_total").increment(1);
+    }
+}
+
+/// Kill a child process (and process group on Unix) cleanly. Used by the
+/// command validator timeout handler.
+async fn kill_child_process(pid: u32) {
+    debug!(pid, "killing validator child on timeout");
+
+    #[cfg(unix)]
+    {
+        use std::process::Command as StdCommand;
+        let _ = StdCommand::new("kill")
+            .args(["-15", &format!("-{pid}")])
+            .status();
+        let _ = StdCommand::new("kill")
+            .args(["-15", &pid.to_string()])
+            .status();
+        tokio::time::sleep(KILL_GRACE_PERIOD).await;
+
+        let still_alive = StdCommand::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .is_ok_and(|status| status.success());
+        if still_alive {
+            let _ = StdCommand::new("kill")
+                .args(["-9", &format!("-{pid}")])
+                .status();
+            let _ = StdCommand::new("kill")
+                .args(["-9", &pid.to_string()])
+                .status();
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .status();
+    }
+}
+
+/// Convenience: run validators for a workspace contract inspection pass.
+///
+/// Consumers that already hold a policy + workspace root use this helper to
+/// walk the typed validator list and collect outcomes.
+pub async fn run_workspace_validators(
+    runner: &ValidatorRunner,
+    invocation: &ValidatorInvocation,
+    validators: &[Validator],
+    phase_filter: Option<ValidatorPhase>,
+) -> Vec<ValidatorOutcome> {
+    let filtered: Vec<Validator> = if let Some(phase) = phase_filter {
+        validators
+            .iter()
+            .filter(|v| ValidatorPhase::from(v.phase) == phase)
+            .cloned()
+            .collect()
+    } else {
+        validators.to_vec()
+    };
+    runner.run_all(invocation, &filtered).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validator_kind_label_matches_spec() {
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::Command {
+                cmd: "x".into(),
+                args: Vec::new()
+            }),
+            "command"
+        );
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::ToolCall {
+                tool: "x".into(),
+                args: serde_json::Value::Null
+            }),
+            "tool_call"
+        );
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::FileExists {
+                path: "x".into(),
+                min_bytes: None
+            }),
+            "file_exists"
+        );
+    }
+
+    #[test]
+    fn truncate_tail_preserves_tail_on_overflow() {
+        let input = "a".repeat(128);
+        let out = truncate_tail(&input, 16);
+        assert!(out.starts_with("...[truncated]\n"));
+        assert!(out.ends_with("aaaaaaaaaaaaaaaa"));
+    }
+
+    #[test]
+    fn schema_version_is_pinned() {
+        assert_eq!(VALIDATOR_RESULT_SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn required_gate_passes_only_on_pass() {
+        let mut outcome = ValidatorOutcome {
+            schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+            validator_id: "x".into(),
+            phase: ValidatorPhase::Completion,
+            kind: "command".into(),
+            repo_label: "slides/x".into(),
+            required: true,
+            status: ValidatorStatus::Pass,
+            reason: String::new(),
+            duration_ms: 0,
+            evidence_path: None,
+            stderr: None,
+            started_at: Utc::now(),
+        };
+        assert!(outcome.required_gate_passed());
+        outcome.status = ValidatorStatus::Fail;
+        assert!(!outcome.required_gate_passed());
+        outcome.status = ValidatorStatus::Timeout;
+        assert!(!outcome.required_gate_passed());
+        outcome.status = ValidatorStatus::Error;
+        assert!(!outcome.required_gate_passed());
+
+        outcome.required = false;
+        outcome.status = ValidatorStatus::Fail;
+        assert!(outcome.required_gate_passed());
+    }
+}

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use glob::glob;
@@ -8,8 +9,13 @@ use crate::behaviour::{
 };
 use crate::task_supervisor::{TaskRuntimeState, TaskSupervisor};
 use crate::tools::ToolRegistry;
+use crate::validators::{
+    ValidatorInvocation, ValidatorOutcome, ValidatorPhase, ValidatorRunner, ValidatorStatus,
+};
+use crate::workspace_git::open_workspace_validator_ledger;
 use crate::workspace_policy::{
-    WorkspacePolicy, WorkspacePolicyKind, WorkspaceSpawnTaskPolicy, read_workspace_policy,
+    Validator, ValidatorPhaseKind, WorkspacePolicy, WorkspacePolicyKind, WorkspaceSpawnTaskPolicy,
+    read_workspace_policy,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,6 +117,32 @@ pub async fn enforce_spawn_task_contract(
             Some(&resolved_artifacts),
         );
         return SpawnTaskContractResult::Failed { error, notify_user };
+    }
+
+    // Run declarative validators (harness M4.3). Required failures block
+    // terminal success via the same gating pathway as a missing-artifact
+    // failure above — we treat a required validator failure as a hard contract
+    // error and return Failed without entering the delivery phase. Optional
+    // failures surface as warning counters through the ledger.
+    match run_declared_validators(
+        tools,
+        workspace_root,
+        &policy.validation.validators,
+        tool_name,
+        ValidatorPhase::Completion,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(error) => {
+            run_failure_actions(
+                workspace_root,
+                supervisor,
+                &task_policy.on_failure,
+                Some(&resolved_artifacts),
+            );
+            return SpawnTaskContractResult::Failed { error, notify_user };
+        }
     }
 
     set_runtime_state(
@@ -412,6 +444,83 @@ fn default_session_policy_requires_contract(tool_name: &str) -> bool {
     WorkspacePolicy::for_session()
         .spawn_tasks
         .contains_key(tool_name)
+}
+
+/// Run declared typed validators for a workspace contract gate.
+///
+/// Persists every outcome to the workspace ledger (for replay). Returns
+/// `Err(reason)` if any required validator fails — the caller treats this as
+/// a contract-gate failure, matching the behaviour of a missing declared
+/// artifact.
+pub async fn run_declared_validators(
+    tools: &ToolRegistry,
+    workspace_root: &Path,
+    validators: &[Validator],
+    repo_label_hint: &str,
+    phase: ValidatorPhase,
+) -> Result<Vec<ValidatorOutcome>, String> {
+    if validators.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let scoped: Vec<Validator> = validators
+        .iter()
+        .filter(|v| match phase {
+            ValidatorPhase::TurnEnd => v.phase == ValidatorPhaseKind::TurnEnd,
+            ValidatorPhase::Completion => v.phase == ValidatorPhaseKind::Completion,
+        })
+        .cloned()
+        .collect();
+    if scoped.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let ledger = match open_workspace_validator_ledger(workspace_root) {
+        Ok(ledger) => Some(ledger),
+        Err(err) => {
+            tracing::warn!(
+                workspace = %workspace_root.display(),
+                error = %err,
+                "failed to open validator ledger; continuing without replay persistence"
+            );
+            None
+        }
+    };
+
+    let runner = build_validator_runner(tools, workspace_root);
+    let runner = match ledger {
+        Some(ledger) => runner.with_ledger(ledger),
+        None => runner,
+    };
+
+    let invocation = ValidatorInvocation {
+        phase,
+        workspace_root: workspace_root.to_path_buf(),
+        repo_label: repo_label_hint.to_string(),
+    };
+
+    let outcomes = runner.run_all(&invocation, &scoped).await;
+    let failures: Vec<&ValidatorOutcome> = outcomes
+        .iter()
+        .filter(|o| o.required && o.status != ValidatorStatus::Pass)
+        .collect();
+    if !failures.is_empty() {
+        let joined = failures
+            .iter()
+            .map(|o| format!("{}: {}", o.validator_id, o.reason))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(format!("required validator failure: {joined}"));
+    }
+    Ok(outcomes)
+}
+
+fn build_validator_runner(tools: &ToolRegistry, workspace_root: &Path) -> ValidatorRunner {
+    // Capture a lightweight snapshot of tool handles for the validator runner.
+    // Avoids cloning the full registry and its LRU bookkeeping.
+    let dispatcher: Arc<dyn crate::validators::ValidatorToolDispatcher> =
+        Arc::new(crate::validators::MapToolDispatcher::from_registry(tools));
+    ValidatorRunner::with_dispatcher(dispatcher, workspace_root)
 }
 
 #[cfg(test)]

--- a/crates/octos-agent/src/workspace_git.rs
+++ b/crates/octos-agent/src/workspace_git.rs
@@ -11,8 +11,9 @@ use serde::Serialize;
 use tracing::warn;
 
 use crate::behaviour::{ActionContext, ActionResult, evaluate_actions_with_context};
+use crate::validators::{ValidatorLedger, ValidatorOutcome, ValidatorStatus};
 use crate::workspace_policy::{
-    WorkspacePolicy, WorkspacePolicyKind, WorkspaceSnapshotTrigger,
+    Validator, WorkspacePolicy, WorkspacePolicyKind, WorkspaceSnapshotTrigger,
     WorkspaceVersionControlProvider, read_workspace_policy,
 };
 
@@ -116,6 +117,18 @@ pub struct WorkspaceContractStatus {
     pub turn_end_checks: Vec<WorkspaceCheckStatus>,
     pub completion_checks: Vec<WorkspaceCheckStatus>,
     pub artifacts: Vec<WorkspaceArtifactStatus>,
+    /// Latest typed validator outcomes (harness M4.3). Read from the persisted
+    /// ledger on each inspect, so replay survives reload/restart.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validator_outcomes: Vec<crate::validators::ValidatorOutcome>,
+    /// Number of optional validator failures recorded in the most recent
+    /// ledger entries. Operator-visible warning counter.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub optional_validator_warnings: usize,
+}
+
+fn is_zero_usize(value: &usize) -> bool {
+    *value == 0
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
@@ -565,6 +578,8 @@ pub fn inspect_workspace_contract(repo: &WorkspaceRepo) -> WorkspaceContractStat
                 turn_end_checks: Vec::new(),
                 completion_checks: Vec::new(),
                 artifacts: Vec::new(),
+                validator_outcomes: Vec::new(),
+                optional_validator_warnings: 0,
             };
         }
         Err(error) => {
@@ -580,6 +595,8 @@ pub fn inspect_workspace_contract(repo: &WorkspaceRepo) -> WorkspaceContractStat
                 turn_end_checks: Vec::new(),
                 completion_checks: Vec::new(),
                 artifacts: Vec::new(),
+                validator_outcomes: Vec::new(),
+                optional_validator_warnings: 0,
             };
         }
     };
@@ -601,6 +618,8 @@ pub fn inspect_workspace_contract(repo: &WorkspaceRepo) -> WorkspaceContractStat
             turn_end_checks: Vec::new(),
             completion_checks: Vec::new(),
             artifacts: Vec::new(),
+            validator_outcomes: Vec::new(),
+            optional_validator_warnings: 0,
         };
     }
 
@@ -639,9 +658,16 @@ fn inspect_managed_workspace_contract(
         &artifact_context,
         &policy.validation.on_completion,
     );
+
+    let validator_outcomes = latest_validator_outcomes(&repo.root, &policy.validation.validators);
+    let validator_gate_passed =
+        required_validators_satisfied(&policy.validation.validators, &validator_outcomes);
+    let optional_validator_warnings = count_optional_validator_warnings(&validator_outcomes);
+
     let ready = check_list_passed(&turn_end_checks)
         && check_list_passed(&completion_checks)
-        && artifacts.iter().all(|artifact| artifact.present);
+        && artifacts.iter().all(|artifact| artifact.present)
+        && validator_gate_passed;
 
     WorkspaceContractStatus {
         repo_label,
@@ -655,7 +681,77 @@ fn inspect_managed_workspace_contract(
         turn_end_checks,
         completion_checks,
         artifacts,
+        validator_outcomes,
+        optional_validator_warnings,
     }
+}
+
+/// Path of the validator ledger scoped to a workspace repo.
+pub fn workspace_validator_ledger_path(project_root: &Path) -> PathBuf {
+    project_root.join(".octos").join("validator_outcomes.jsonl")
+}
+
+/// Open (or create) the validator ledger for `project_root`.
+pub fn open_workspace_validator_ledger(project_root: &Path) -> Result<ValidatorLedger> {
+    ValidatorLedger::open(workspace_validator_ledger_path(project_root))
+}
+
+fn latest_validator_outcomes(project_root: &Path, declared: &[Validator]) -> Vec<ValidatorOutcome> {
+    if declared.is_empty() {
+        return Vec::new();
+    }
+    let ledger_path = workspace_validator_ledger_path(project_root);
+    let ledger = match ValidatorLedger::open(&ledger_path) {
+        Ok(ledger) => ledger,
+        Err(_) => return Vec::new(),
+    };
+    let all = ledger.read_all().unwrap_or_default();
+    let declared_ids: std::collections::HashSet<&str> = declared
+        .iter()
+        .map(|validator| validator.id.as_str())
+        .collect();
+
+    // Reduce to latest outcome per declared validator id.
+    let mut latest: HashMap<String, ValidatorOutcome> = HashMap::new();
+    for outcome in all {
+        if !declared_ids.contains(outcome.validator_id.as_str()) {
+            continue;
+        }
+        let slot = latest
+            .entry(outcome.validator_id.clone())
+            .or_insert_with(|| outcome.clone());
+        if outcome.started_at > slot.started_at {
+            *slot = outcome;
+        }
+    }
+    // Preserve declared order for stable UI output.
+    declared
+        .iter()
+        .filter_map(|validator| latest.remove(validator.id.as_str()))
+        .collect()
+}
+
+fn required_validators_satisfied(declared: &[Validator], outcomes: &[ValidatorOutcome]) -> bool {
+    for validator in declared {
+        if !validator.required {
+            continue;
+        }
+        let outcome = outcomes
+            .iter()
+            .find(|outcome| outcome.validator_id == validator.id);
+        match outcome {
+            Some(outcome) if outcome.status == ValidatorStatus::Pass => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+fn count_optional_validator_warnings(outcomes: &[ValidatorOutcome]) -> usize {
+    outcomes
+        .iter()
+        .filter(|outcome| !outcome.required && outcome.status != ValidatorStatus::Pass)
+        .count()
 }
 
 fn evaluate_check_specs(

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -33,6 +33,78 @@ pub struct ValidationPolicy {
     /// Tier 3: expensive checks run on completion/publish only (10-30s). e.g. Playwright.
     #[serde(default)]
     pub on_completion: Vec<String>,
+    /// Typed declarative validators (M4.3). Runs via `ValidatorRunner`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validators: Vec<Validator>,
+}
+
+/// Typed declarative validator spec.
+///
+/// Each validator is identified by a stable `id`, produces a typed
+/// [`crate::validators::ValidatorOutcome`], and may be `required` (a failure
+/// blocks terminal success) or optional (a failure produces a warning only).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Validator {
+    /// Stable identifier, unique within the validator list.
+    pub id: String,
+    /// Required validators block terminal success when they fail.
+    #[serde(default = "default_required")]
+    pub required: bool,
+    /// Optional per-validator timeout in milliseconds. Applies to command and
+    /// tool validators. File-existence validators ignore the timeout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    /// Which lifecycle phase this validator runs in. Defaults to completion.
+    #[serde(default, skip_serializing_if = "is_default_phase")]
+    pub phase: ValidatorPhaseKind,
+    #[serde(flatten)]
+    pub spec: ValidatorSpec,
+}
+
+fn default_required() -> bool {
+    true
+}
+
+fn is_default_phase(phase: &ValidatorPhaseKind) -> bool {
+    *phase == ValidatorPhaseKind::default()
+}
+
+/// Lifecycle phase a validator runs in.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidatorPhaseKind {
+    /// Runs on every turn end (cheap checks).
+    TurnEnd,
+    /// Runs on completion / publish (expensive checks).
+    #[default]
+    Completion,
+}
+
+/// The typed body of a [`Validator`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ValidatorSpec {
+    /// Run a subprocess command. Dispatched via the shell-safety layer and
+    /// existing `BLOCKED_ENV_VARS` sanitization. No direct `Command::new("sh")`
+    /// bypass.
+    Command {
+        cmd: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+    },
+    /// Invoke a registered agent tool. Outcome status follows the tool's
+    /// `ToolResult.success`.
+    ToolCall {
+        tool: String,
+        #[serde(default)]
+        args: serde_json::Value,
+    },
+    /// Assert that a file exists (and optionally meets a minimum byte count).
+    FileExists {
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min_bytes: Option<u64>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -172,6 +244,7 @@ impl WorkspacePolicy {
                         "file_exists:output/deck.pptx".into(),
                         "file_exists:output/**/slide-*.png".into(),
                     ],
+                    validators: Vec::new(),
                 },
                 artifacts: WorkspaceArtifactsPolicy {
                     entries: BTreeMap::from([
@@ -276,6 +349,7 @@ impl WorkspacePolicy {
             ],
             on_source_change: Vec::new(),
             on_completion: vec![format!("file_exists:{build_output_dir}/index.html")],
+            validators: Vec::new(),
         };
         policy.artifacts = WorkspaceArtifactsPolicy {
             entries: BTreeMap::from([
@@ -566,5 +640,63 @@ mod tests {
         assert!(
             upgrade_workspace_policy_if_legacy(&current, WorkspaceProjectKind::Slides).is_none()
         );
+    }
+
+    #[test]
+    fn should_roundtrip_typed_validators_through_toml() {
+        let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+        policy.validation.validators = vec![
+            Validator {
+                id: "cmd".into(),
+                required: true,
+                timeout_ms: Some(3000),
+                phase: ValidatorPhaseKind::Completion,
+                spec: ValidatorSpec::Command {
+                    cmd: "echo".into(),
+                    args: vec!["hello".into()],
+                },
+            },
+            Validator {
+                id: "file".into(),
+                required: false,
+                timeout_ms: None,
+                phase: ValidatorPhaseKind::TurnEnd,
+                spec: ValidatorSpec::FileExists {
+                    path: "out.txt".into(),
+                    min_bytes: Some(128),
+                },
+            },
+            Validator {
+                id: "tool".into(),
+                required: true,
+                timeout_ms: Some(5000),
+                phase: ValidatorPhaseKind::Completion,
+                spec: ValidatorSpec::ToolCall {
+                    tool: "custom_tool".into(),
+                    args: serde_json::json!({"mode": "strict"}),
+                },
+            },
+        ];
+        let rendered = toml::to_string_pretty(&policy).unwrap();
+        assert!(rendered.contains("[[validation.validators]]"));
+        assert!(rendered.contains("kind = \"command\""));
+        assert!(rendered.contains("kind = \"file_exists\""));
+        assert!(rendered.contains("kind = \"tool_call\""));
+        let parsed: WorkspacePolicy = toml::from_str(&rendered).unwrap();
+        assert_eq!(parsed, policy);
+    }
+
+    #[test]
+    fn validator_defaults_to_required_and_completion_phase() {
+        let toml = r#"
+            id = "x"
+            kind = "file_exists"
+            path = "output.txt"
+        "#;
+        let parsed: Validator = toml::from_str(toml).unwrap();
+        assert_eq!(parsed.id, "x");
+        assert!(parsed.required, "required defaults to true");
+        assert_eq!(parsed.phase, ValidatorPhaseKind::Completion);
+        assert!(parsed.timeout_ms.is_none());
     }
 }

--- a/crates/octos-agent/tests/validator_runner.rs
+++ b/crates/octos-agent/tests/validator_runner.rs
@@ -1,0 +1,730 @@
+//! Integration tests for the declarative validator runner (harness M4.3).
+//!
+//! These tests exercise typed validator specs, evidence capture, timeout
+//! behaviour, replay through the persisted ledger, and operator counters.
+//!
+//! Run with `cargo test -p octos-agent --test validator_runner`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_agent::validators::{
+    VALIDATOR_RESULT_SCHEMA_VERSION, ValidatorInvocation, ValidatorLedger, ValidatorPhase,
+    ValidatorRunner, ValidatorStatus,
+};
+use octos_agent::workspace_policy::{Validator, ValidatorPhaseKind, ValidatorSpec};
+use octos_agent::{Tool, ToolRegistry, ToolResult};
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+fn command_validator(id: &str, cmd: &str, args: &[&str]) -> Validator {
+    Validator {
+        id: id.to_string(),
+        required: true,
+        timeout_ms: Some(5000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::Command {
+            cmd: cmd.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+        },
+    }
+}
+
+fn file_exists_validator(id: &str, path: &str, min_bytes: Option<u64>) -> Validator {
+    Validator {
+        id: id.to_string(),
+        required: true,
+        timeout_ms: None,
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::FileExists {
+            path: path.to_string(),
+            min_bytes,
+        },
+    }
+}
+
+fn tool_call_validator(id: &str, tool: &str, args: Value) -> Validator {
+    Validator {
+        id: id.to_string(),
+        required: true,
+        timeout_ms: Some(5000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::ToolCall {
+            tool: tool.to_string(),
+            args,
+        },
+    }
+}
+
+/// A minimal tool that always succeeds (for ToolCall validator tests).
+struct OkTool;
+
+#[async_trait]
+impl Tool for OkTool {
+    fn name(&self) -> &str {
+        "ok"
+    }
+
+    fn description(&self) -> &str {
+        "test tool"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+
+    async fn execute(&self, _args: &Value) -> eyre::Result<ToolResult> {
+        Ok(ToolResult {
+            success: true,
+            output: "ok".into(),
+            ..Default::default()
+        })
+    }
+}
+
+/// A minimal tool that always fails.
+struct FailTool;
+
+#[async_trait]
+impl Tool for FailTool {
+    fn name(&self) -> &str {
+        "fail"
+    }
+
+    fn description(&self) -> &str {
+        "test tool"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({"type": "object"})
+    }
+
+    async fn execute(&self, _args: &Value) -> eyre::Result<ToolResult> {
+        Ok(ToolResult {
+            success: false,
+            output: "tool reports failure".into(),
+            ..Default::default()
+        })
+    }
+}
+
+fn registry_with_tools() -> Arc<ToolRegistry> {
+    let mut registry = ToolRegistry::new();
+    registry.register(OkTool);
+    registry.register(FailTool);
+    Arc::new(registry)
+}
+
+#[tokio::test]
+async fn should_block_ready_when_required_command_validator_fails() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    // Fails intentionally: exit 1
+    let validators = vec![Validator {
+        id: "cmd_fail".into(),
+        required: true,
+        timeout_ms: Some(3000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::Command {
+            cmd: "sh".into(),
+            args: vec!["-c".into(), "exit 1".into()],
+        },
+    }];
+
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    assert_eq!(outcomes.len(), 1);
+    let outcome = &outcomes[0];
+    assert_eq!(outcome.validator_id, "cmd_fail");
+    assert_eq!(outcome.status, ValidatorStatus::Fail);
+    assert_eq!(outcome.schema_version, VALIDATOR_RESULT_SCHEMA_VERSION);
+    assert_eq!(outcome.schema_version, 1);
+    assert!(outcome.required);
+    assert!(!outcomes.iter().all(|o| o.required_gate_passed()));
+}
+
+#[tokio::test]
+async fn should_warn_but_not_block_when_optional_validator_fails() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    let validators = vec![Validator {
+        id: "optional_fail".into(),
+        required: false,
+        timeout_ms: Some(3000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::FileExists {
+            path: "does-not-exist.txt".into(),
+            min_bytes: None,
+        },
+    }];
+
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+    assert!(!outcomes[0].required);
+    // Required gate passes because the only failure is optional.
+    assert!(outcomes.iter().all(|o| o.required_gate_passed()));
+}
+
+#[tokio::test]
+async fn should_record_duration_and_evidence_path_for_command_validator() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    let validators = vec![Validator {
+        id: "echo_cmd".into(),
+        required: true,
+        timeout_ms: Some(3000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::Command {
+            cmd: "sh".into(),
+            args: vec!["-c".into(), "echo hello".into()],
+        },
+    }];
+
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::TurnEnd,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    let outcome = &outcomes[0];
+    assert_eq!(outcome.status, ValidatorStatus::Pass);
+    // duration_ms is recorded (non-zero for a real subprocess invocation is typical,
+    // but we only assert it's set — 0ms is still a valid recorded value).
+    assert!(outcome.duration_ms < 10_000);
+    let evidence_path = outcome
+        .evidence_path
+        .as_ref()
+        .expect("command validator must record evidence path");
+    assert!(evidence_path.exists(), "evidence file must be written");
+    let evidence = std::fs::read_to_string(evidence_path).unwrap();
+    assert!(evidence.contains("hello"), "evidence captures stdout");
+}
+
+#[tokio::test]
+async fn should_expose_stderr_in_outcome_for_operator_visibility() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    let validators = vec![Validator {
+        id: "stderr_cmd".into(),
+        required: true,
+        timeout_ms: Some(3000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::Command {
+            cmd: "sh".into(),
+            args: vec!["-c".into(), "echo hello >&2; exit 1".into()],
+        },
+    }];
+
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    let outcome = &outcomes[0];
+    assert_eq!(outcome.status, ValidatorStatus::Fail);
+    let stderr = outcome
+        .stderr
+        .as_ref()
+        .expect("stderr should be captured when command fails with stderr output");
+    assert!(stderr.contains("hello"));
+}
+
+#[tokio::test]
+async fn should_kill_child_process_on_validator_timeout() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    // Use a sentinel file the child touches — once removed by the kill handler,
+    // we know the child was actually reaped. The child sleeps far longer than the
+    // validator timeout so it must be killed, not naturally exit.
+    let sentinel = dir.path().join("sentinel");
+    let sentinel_path = sentinel.display().to_string();
+    let pid_file = dir.path().join("child.pid");
+    let pid_path = pid_file.display().to_string();
+
+    let validators = vec![Validator {
+        id: "timeout_cmd".into(),
+        required: true,
+        timeout_ms: Some(300),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::Command {
+            cmd: "sh".into(),
+            args: vec![
+                "-c".into(),
+                format!(
+                    "echo $$ > {pid_path}; touch {sentinel_path}; sleep 30",
+                    pid_path = pid_path,
+                    sentinel_path = sentinel_path,
+                ),
+            ],
+        },
+    }];
+
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+
+    let before = std::time::Instant::now();
+    let outcomes = runner.run_all(&invocation, &validators).await;
+    let elapsed = before.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "runner must kill child and return before sleep finishes; elapsed = {:?}",
+        elapsed
+    );
+
+    let outcome = &outcomes[0];
+    assert_eq!(outcome.status, ValidatorStatus::Timeout);
+    assert!(
+        outcome.reason.to_lowercase().contains("timeout") || outcome.reason.contains("timed out")
+    );
+
+    // PID probe: give the OS a moment, then verify the child is truly gone.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let pid_raw = std::fs::read_to_string(&pid_file).unwrap_or_default();
+    let pid: i32 = pid_raw.trim().parse().unwrap_or(0);
+    if pid > 0 {
+        // `kill -0 <pid>` succeeds if and only if the PID is alive.
+        let status = std::process::Command::new("kill")
+            .arg("-0")
+            .arg(pid.to_string())
+            .status();
+        if let Ok(status) = status {
+            assert!(
+                !status.success(),
+                "child PID {pid} must be dead after validator timeout (sandbox-exec or sh wrapper)"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn should_pass_file_exists_validator_when_file_meets_size_floor() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    std::fs::write(dir.path().join("artifact.bin"), vec![0u8; 2048]).unwrap();
+
+    let validators = vec![file_exists_validator("file_ok", "artifact.bin", Some(1024))];
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    assert_eq!(outcomes[0].status, ValidatorStatus::Pass);
+}
+
+#[tokio::test]
+async fn should_fail_file_exists_validator_when_size_under_floor() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    std::fs::write(dir.path().join("artifact.bin"), b"x").unwrap();
+
+    let validators = vec![file_exists_validator(
+        "file_small",
+        "artifact.bin",
+        Some(1024),
+    )];
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+    assert!(outcomes[0].reason.contains("min_bytes") || outcomes[0].reason.contains("bytes"));
+}
+
+#[tokio::test]
+async fn should_pass_tool_call_validator_when_tool_succeeds() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    let validators = vec![tool_call_validator("tool_ok", "ok", json!({}))];
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    assert_eq!(outcomes[0].status, ValidatorStatus::Pass);
+}
+
+#[tokio::test]
+async fn should_fail_tool_call_validator_when_tool_reports_unsuccessful() {
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    let validators = vec![tool_call_validator("tool_fail", "fail", json!({}))];
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+    assert!(outcomes[0].reason.contains("tool reports failure"));
+}
+
+#[tokio::test]
+async fn should_persist_outcomes_and_replay_them_byte_for_byte() {
+    let dir = tempdir().unwrap();
+    let ledger_path = dir.path().join("validator_ledger.jsonl");
+    let ledger = ValidatorLedger::open(ledger_path.clone()).unwrap();
+
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf())
+        .with_ledger(ledger.clone());
+
+    std::fs::write(dir.path().join("artifact.bin"), vec![0u8; 4096]).unwrap();
+
+    let validators = vec![
+        file_exists_validator("file_ok", "artifact.bin", Some(1024)),
+        command_validator("cmd_ok", "sh", &["-c", "echo hi"]),
+    ];
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let original = runner.run_all(&invocation, &validators).await;
+    assert_eq!(original.len(), 2);
+
+    // Replay: re-open the ledger and read the persisted outcomes from disk.
+    let reopened = ValidatorLedger::open(ledger_path).unwrap();
+    let replayed = reopened.read_all().unwrap();
+
+    assert_eq!(replayed.len(), original.len());
+    for (live, restored) in original.iter().zip(replayed.iter()) {
+        assert_eq!(
+            serde_json::to_value(live).unwrap(),
+            serde_json::to_value(restored).unwrap(),
+            "replayed outcome must match byte-for-byte"
+        );
+        assert_eq!(restored.schema_version, 1);
+    }
+}
+
+#[tokio::test]
+async fn should_strip_blocked_env_vars_from_command_validator_child() {
+    // Spawn a re-entrant child that pre-seeds LD_PRELOAD in its own env, then
+    // asks the runner to spawn a command validator. The runner must strip
+    // BLOCKED_ENV_VARS before invoking sh.
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    // Probe the blocked-env sanitization path directly. The runner pre-clears
+    // every BLOCKED_ENV_VAR on the child Command, even if set earlier on the
+    // Command builder, so the child process sees an empty variable.
+    let probe_path = dir.path().join("probe.txt");
+    let validators = vec![Validator {
+        id: "env_probe".into(),
+        required: true,
+        timeout_ms: Some(5000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::Command {
+            cmd: "sh".into(),
+            args: vec![
+                "-c".into(),
+                format!(
+                    "printf '%s' \"${{LD_PRELOAD:-__unset__}}\" > {}",
+                    probe_path.display()
+                ),
+            ],
+        },
+    }];
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    // Invoke via a helper that pre-seeds LD_PRELOAD on the spawned command.
+    runner
+        .run_all_with_seeded_env(&invocation, &validators, &[("LD_PRELOAD", "/tmp/leak.so")])
+        .await;
+
+    let probe = std::fs::read_to_string(&probe_path).unwrap_or_default();
+    assert_eq!(
+        probe.trim(),
+        "__unset__",
+        "LD_PRELOAD must be stripped from command validator child, got {probe:?}"
+    );
+}
+
+#[tokio::test]
+async fn should_block_spawn_task_contract_when_required_validator_fails() {
+    use octos_agent::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract};
+    use octos_agent::workspace_policy::{
+        Validator, ValidatorPhaseKind, ValidatorSpec, WorkspacePolicy, WorkspaceSpawnTaskPolicy,
+        write_workspace_policy,
+    };
+    use std::time::UNIX_EPOCH;
+
+    let dir = tempdir().unwrap();
+    let mut policy = WorkspacePolicy::for_session();
+    // Add a required validator that cannot pass: the artifact is a single byte
+    // but the validator requires at least 1KiB.
+    policy.artifacts.entries.clear();
+    policy
+        .artifacts
+        .entries
+        .insert("primary_audio".into(), "*.mp3".into());
+    policy.validation.validators = vec![Validator {
+        id: "min_bytes_gate".into(),
+        required: true,
+        timeout_ms: None,
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::FileExists {
+            path: "tts_result.mp3".into(),
+            min_bytes: Some(1024),
+        },
+    }];
+    policy.spawn_tasks.insert(
+        "fm_tts".into(),
+        WorkspaceSpawnTaskPolicy {
+            artifact: Some("primary_audio".into()),
+            artifacts: Vec::new(),
+            on_verify: vec!["file_exists:$artifact".into()],
+            on_complete: Vec::new(),
+            on_deliver: Vec::new(),
+            on_failure: vec!["notify_user:validator gate failed".into()],
+        },
+    );
+    write_workspace_policy(dir.path(), &policy).unwrap();
+
+    // Tiny artifact that passes file_exists but fails min_bytes.
+    std::fs::write(dir.path().join("tts_result.mp3"), vec![0u8; 16]).unwrap();
+
+    let registry = ToolRegistry::with_builtins(dir.path());
+    let result = enforce_spawn_task_contract(
+        &registry,
+        "fm_tts",
+        "tool-call-validator-1",
+        &[],
+        UNIX_EPOCH,
+        None,
+    )
+    .await;
+
+    match result {
+        SpawnTaskContractResult::Failed { error, .. } => {
+            assert!(
+                error.contains("min_bytes_gate")
+                    || error.contains("min_bytes")
+                    || error.contains("validator"),
+                "expected validator-gate failure, got {error}"
+            );
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+
+    // And the ledger must have a persisted outcome for replay.
+    let ledger_path = dir.path().join(".octos").join("validator_outcomes.jsonl");
+    assert!(ledger_path.exists(), "ledger must be created");
+    let ledger = ValidatorLedger::open(ledger_path).unwrap();
+    let outcomes = ledger.read_all().unwrap();
+    assert!(
+        outcomes
+            .iter()
+            .any(|o| o.validator_id == "min_bytes_gate" && o.status == ValidatorStatus::Fail)
+    );
+}
+
+#[tokio::test]
+async fn should_not_block_spawn_task_contract_when_optional_validator_fails() {
+    use octos_agent::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract};
+    use octos_agent::workspace_policy::{
+        Validator, ValidatorPhaseKind, ValidatorSpec, WorkspacePolicy, WorkspaceSpawnTaskPolicy,
+        write_workspace_policy,
+    };
+    use std::time::UNIX_EPOCH;
+
+    let dir = tempdir().unwrap();
+    let mut policy = WorkspacePolicy::for_session();
+    policy.artifacts.entries.clear();
+    policy
+        .artifacts
+        .entries
+        .insert("primary_audio".into(), "*.mp3".into());
+    policy.validation.validators = vec![Validator {
+        id: "optional_warn".into(),
+        required: false,
+        timeout_ms: None,
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::FileExists {
+            path: "never-here.txt".into(),
+            min_bytes: None,
+        },
+    }];
+    policy.spawn_tasks.insert(
+        "fm_tts".into(),
+        WorkspaceSpawnTaskPolicy {
+            artifact: Some("primary_audio".into()),
+            artifacts: Vec::new(),
+            on_verify: vec!["file_exists:$artifact".into()],
+            on_complete: Vec::new(),
+            on_deliver: Vec::new(),
+            on_failure: Vec::new(),
+        },
+    );
+    write_workspace_policy(dir.path(), &policy).unwrap();
+
+    std::fs::write(dir.path().join("tts_result.mp3"), vec![0u8; 2048]).unwrap();
+
+    let registry = ToolRegistry::with_builtins(dir.path());
+    let result = enforce_spawn_task_contract(
+        &registry,
+        "fm_tts",
+        "tool-call-validator-2",
+        &[],
+        UNIX_EPOCH,
+        None,
+    )
+    .await;
+
+    assert!(
+        matches!(result, SpawnTaskContractResult::Satisfied { .. }),
+        "optional validator must not block, got {result:?}"
+    );
+
+    let ledger_path = dir.path().join(".octos").join("validator_outcomes.jsonl");
+    let ledger = ValidatorLedger::open(ledger_path).unwrap();
+    let outcomes = ledger.read_all().unwrap();
+    let warn = outcomes
+        .iter()
+        .find(|o| o.validator_id == "optional_warn")
+        .expect("optional warning must be persisted");
+    assert!(!warn.required);
+    assert_eq!(warn.status, ValidatorStatus::Fail);
+}
+
+#[tokio::test]
+async fn should_reflect_required_validator_fail_in_inspect_ready_flag() {
+    use octos_agent::workspace_git::WorkspaceProjectKind;
+    use octos_agent::workspace_git::inspect_workspace_contract_at_root;
+    use octos_agent::workspace_policy::{
+        Validator, ValidatorPhaseKind, ValidatorSpec, WorkspacePolicy, write_workspace_policy,
+    };
+
+    let tmp = tempdir().unwrap();
+    let repo = tmp.path().join("slides").join("demo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let mut policy = WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides);
+    policy.validation.validators = vec![Validator {
+        id: "gate".into(),
+        required: true,
+        timeout_ms: None,
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::FileExists {
+            path: "output/deck.pptx".into(),
+            min_bytes: None,
+        },
+    }];
+    write_workspace_policy(&repo, &policy).unwrap();
+
+    // Make all existing artifacts and turn-end checks pass.
+    std::fs::write(repo.join("script.js"), "// slides").unwrap();
+    std::fs::write(repo.join("memory.md"), "# memory").unwrap();
+    std::fs::write(repo.join("changelog.md"), "# changelog").unwrap();
+    std::fs::create_dir_all(repo.join("output")).unwrap();
+    std::fs::write(repo.join("output/deck.pptx"), b"deck").unwrap();
+    std::fs::write(repo.join("output/imgs/slide-01.png"), b"png").ok();
+    std::fs::create_dir_all(repo.join("output/imgs")).unwrap();
+    std::fs::write(repo.join("output/imgs/slide-01.png"), b"png").unwrap();
+
+    // Before any validator runs, inspect must flag ready=false because the
+    // declared required validator has no Pass outcome yet.
+    let status = inspect_workspace_contract_at_root(&repo).unwrap();
+    assert!(
+        !status.ready,
+        "ready must be false until the required validator has a persisted Pass outcome"
+    );
+
+    // Persist a Pass outcome for the gate and re-inspect.
+    let ledger_path = repo.join(".octos").join("validator_outcomes.jsonl");
+    let ledger = ValidatorLedger::open(&ledger_path).unwrap();
+    let outcome = octos_agent::validators::ValidatorOutcome {
+        schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+        validator_id: "gate".into(),
+        phase: ValidatorPhase::Completion,
+        kind: "file_exists".into(),
+        repo_label: "slides/demo".into(),
+        required: true,
+        status: ValidatorStatus::Pass,
+        reason: "manual seed".into(),
+        duration_ms: 0,
+        evidence_path: None,
+        stderr: None,
+        started_at: chrono::Utc::now(),
+    };
+    ledger.append(&outcome).unwrap();
+
+    let status = inspect_workspace_contract_at_root(&repo).unwrap();
+    assert!(
+        status.ready,
+        "ready must be true after required validator passes"
+    );
+    assert_eq!(status.validator_outcomes.len(), 1);
+    assert_eq!(status.validator_outcomes[0].validator_id, "gate");
+    assert_eq!(status.optional_validator_warnings, 0);
+}
+
+#[tokio::test]
+async fn should_block_command_validator_with_dangerous_pattern() {
+    // `rm -rf /` is denied by SafePolicy. The runner must refuse to spawn it
+    // and surface a typed Fail result instead.
+    let dir = tempdir().unwrap();
+    let runner = ValidatorRunner::new(registry_with_tools(), dir.path().to_path_buf());
+
+    let validators = vec![Validator {
+        id: "dangerous".into(),
+        required: true,
+        timeout_ms: Some(3000),
+        phase: ValidatorPhaseKind::Completion,
+        spec: ValidatorSpec::Command {
+            cmd: "sh".into(),
+            args: vec!["-c".into(), "rm -rf /".into()],
+        },
+    }];
+    let invocation = ValidatorInvocation {
+        phase: ValidatorPhase::Completion,
+        workspace_root: dir.path().to_path_buf(),
+        repo_label: "slides/demo".into(),
+    };
+    let outcomes = runner.run_all(&invocation, &validators).await;
+
+    let outcome = &outcomes[0];
+    assert_eq!(outcome.status, ValidatorStatus::Error);
+    assert!(
+        outcome.reason.to_lowercase().contains("denied")
+            || outcome.reason.to_lowercase().contains("policy")
+    );
+}

--- a/crates/octos-cli/src/api/metrics.rs
+++ b/crates/octos-cli/src/api/metrics.rs
@@ -269,6 +269,18 @@ fn build_totals(samples: &[ParsedMetricSample]) -> BTreeMap<String, u64> {
             "child_session_lifecycle".to_string(),
             total_for_metric(samples, "octos_child_session_lifecycle_total"),
         ),
+        (
+            "workspace_validator_runs".to_string(),
+            total_for_metric(samples, "octos_workspace_validator_total"),
+        ),
+        (
+            "workspace_validator_required_failures".to_string(),
+            total_for_metric(samples, "octos_workspace_validator_required_failed_total"),
+        ),
+        (
+            "workspace_validator_optional_warnings".to_string(),
+            total_for_metric(samples, "octos_workspace_validator_optional_warning_total"),
+        ),
     ])
 }
 
@@ -328,6 +340,14 @@ fn build_breakdowns(samples: &[ParsedMetricSample]) -> BTreeMap<String, Vec<Valu
                 samples,
                 "octos_child_session_lifecycle_total",
                 &["kind", "outcome"],
+            ),
+        ),
+        (
+            "workspace_validator_runs".to_string(),
+            breakdown(
+                samples,
+                "octos_workspace_validator_total",
+                &["status", "phase", "kind", "required"],
             ),
         ),
     ])

--- a/crates/octos-cli/src/workflows/site_delivery.rs
+++ b/crates/octos-cli/src/workflows/site_delivery.rs
@@ -52,6 +52,7 @@ pub fn workspace_policy_for_template_kind(template: SiteTemplate) -> WorkspacePo
             ],
             on_source_change: Vec::new(),
             on_completion: vec![format!("file_exists:{build_output_dir}/index.html")],
+            validators: Vec::new(),
         },
         artifacts: WorkspaceArtifactsPolicy {
             entries: BTreeMap::from([

--- a/crates/octos-cli/src/workflows/slides_delivery.rs
+++ b/crates/octos-cli/src/workflows/slides_delivery.rs
@@ -73,6 +73,7 @@ pub fn workspace_policy() -> WorkspacePolicy {
                 "file_exists:output/deck.pptx".into(),
                 "file_exists:output/**/slide-*.png".into(),
             ],
+            validators: Vec::new(),
         },
         artifacts: WorkspaceArtifactsPolicy {
             entries: BTreeMap::from([


### PR DESCRIPTION
Closes #466.

## What this delivers
Workspace policy can now declare typed validators that produce durable, replayable outcomes. Required failures block `ready`/delivery through the same mechanism as missing artifacts. Optional failures warn. Every run writes an evidence trail.

## Changes (commit 6f4abc0, 10 files, +2092/-8)

### New modules
- `crates/octos-agent/src/validators.rs` (977 LOC) — typed `Validator { id, required, timeout_ms, phase, spec }` with `ValidatorSpec::{Command, ToolCall, FileExists}`. `ValidatorRunner` (cloneable) + pluggable `ValidatorToolDispatcher` trait. `ValidatorOutcome { schema_version: u32, validator_id, phase, kind, repo_label, required, status, reason, duration_ms, evidence_path, stderr, started_at }`. `ValidatorLedger`: append-only JSONL at `<workspace>/.octos/validator_outcomes.jsonl`. Evidence files under `<workspace>/.octos/validator-evidence/`.
- `crates/octos-agent/tests/validator_runner.rs` (730 LOC) — 15 integration tests.

### Modified
- `workspace_policy.rs` (+132) — extends `ValidationPolicy` with `validators: Vec<Validator>`. TOML round-trip preserved; empty list skip-serialized; existing string validators still work.
- `workspace_git.rs` (+100), `workspace_contract.rs` (+111) — merges ledger outcomes into `WorkspaceContractStatus.validator_outcomes` on inspect; required non-pass flips `ready=false` the same way missing artifacts do.
- `lib.rs`, `tools/registry.rs`, `api/metrics.rs`, two workflow files — wiring + counters.

## Invariants
1. ✓ Same `ready` gate mechanism as missing-artifact; spawn contract returns `Failed` without entering delivery
2. ✓ Every command validator passes through `SafePolicy.check()`; dangerous patterns → `ValidatorStatus::Error` without spawning. No hardcoded `Command::new("sh")` in the runner.
3. ✓ `BLOCKED_ENV_VARS` stripped even when callers explicitly set them — proven by seeding `LD_PRELOAD` on the `Command` and verifying the child sees `__unset__`
4. ✓ Timeout kills child + PID probe — SIGTERM → 300ms grace → SIGKILL (Unix, with `process_group(0)` so the whole tree dies); test captures `$$`, asserts elapsed < 10s, then `kill -0 <pid>` confirms reaped
5. ✓ `VALIDATOR_RESULT_SCHEMA_VERSION = 1` stamped on every outcome
6. ✓ Byte-for-byte replay — `ValidatorLedger::read_all` after reopen matches live outcomes via `serde_json::to_value` equality
7. ✓ No new `unsafe`

## Tests (15, all green)

Required blocks terminal success:
- `should_block_ready_when_required_command_validator_fails`
- `should_block_spawn_task_contract_when_required_validator_fails`
- `should_reflect_required_validator_fail_in_inspect_ready_flag`

Optional warns but doesn't block:
- `should_warn_but_not_block_when_optional_validator_fails`
- `should_not_block_spawn_task_contract_when_optional_validator_fails`

Outcome fields:
- `should_record_duration_and_evidence_path_for_command_validator`

Operator visibility:
- `should_expose_stderr_in_outcome_for_operator_visibility`
- `should_kill_child_process_on_validator_timeout`

Replay:
- `should_persist_outcomes_and_replay_them_byte_for_byte`

Safety:
- `should_block_command_validator_with_dangerous_pattern`
- `should_strip_blocked_env_vars_from_command_validator_child`

Plus 4 more for coverage.

## Operator surface
`WorkspaceContractStatus` returned by `check_workspace_contract` + inspect now carries `validator_outcomes` and `optional_validator_warnings` fields.

New Prometheus counters (wired into operator summary):
- `octos_workspace_validator_total{status,phase,kind,required}`
- `octos_workspace_validator_required_failed_total`
- `octos_workspace_validator_optional_warning_total`

Surfaced as `workspace_validator_runs`, `workspace_validator_required_failures`, `workspace_validator_optional_warnings` on the operator summary JSON.

## Coordination with siblings
- **M4.5 (#485)** — dashboard auto-picks up the new counters via its per-gateway summary pull; no dashboard change needed.
- **M4.6 (#482)** — `VALIDATOR_RESULT_SCHEMA_VERSION = 1` stamped on outcomes; ABI versioning doc should cite validator results as a v1-stable type. Follow-up commit on M4.6 branch can add `VALIDATOR_OUTCOME_SCHEMA_VERSION` to the central module if desired.
- **M4.1A** — no direct overlap.

## Verification
- `cargo build --workspace`: clean
- `cargo test --workspace --lib --tests`: 15 new + 1700+ pre-existing, all green
- `cargo clippy --workspace --lib --tests`: no new warnings
- `cargo fmt --all -- --check`: clean

## Test plan
- [x] 15 integration tests
- [x] Workspace tests green
- [ ] Integration on `harness-m4/integration`
- [ ] Live canary: operator dashboard (M4.5) should show validator outcomes for a real run