### PR TITLE
docs: strategic landscape analysis — hermes, openJiuwen, MCP/ACP, swarm positioning, agent-chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ scripts/deploy.sh
 !docs/SANDBOX.md
 !docs/SECURITY_ARCHITECTURE.md
 !docs/OCTOS_ROBOTICS_PR270_RP06_NOTE.md
+!docs/OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md
+!docs/OCTOS_PROTOCOL_STRATEGY_2026-04-22.md
+!docs/OCTOS_SWARM_POSITIONING_2026-04-22.md
+!docs/OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md
 
 # mdBook documentation site (EN + ZH)
 !book/book.toml

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ scripts/deploy.sh
 !docs/OCTOS_SWARM_POSITIONING_2026-04-22.md
 !docs/OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md
 !docs/OCTOS_CODING_HARDENING_M6_PLAN_2026-04-22.md
+!docs/OCTOS_SWARM_ORCHESTRATOR_M7_PLAN_2026-04-22.md
 
 # mdBook documentation site (EN + ZH)
 !book/book.toml

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ scripts/deploy.sh
 !docs/OCTOS_PROTOCOL_STRATEGY_2026-04-22.md
 !docs/OCTOS_SWARM_POSITIONING_2026-04-22.md
 !docs/OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md
+!docs/OCTOS_CODING_HARDENING_M6_PLAN_2026-04-22.md
 
 # mdBook documentation site (EN + ZH)
 !book/book.toml

--- a/docs/OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md
+++ b/docs/OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md
@@ -1,0 +1,294 @@
+# Agent-Chat Pattern — Remote Coding Agent Reference Architecture
+
+See also:
+
+- [OCTOS_PROTOCOL_STRATEGY_2026-04-22.md](./OCTOS_PROTOCOL_STRATEGY_2026-04-22.md)
+- [OCTOS_SWARM_POSITIONING_2026-04-22.md](./OCTOS_SWARM_POSITIONING_2026-04-22.md)
+
+## Purpose
+
+Document a real production reference architecture (`~/home/agent-chat/`) that runs Claude and Codex as remote coding agents using **tmux + MCP + Matrix + SSE**. This pattern is a concrete answer to "how do you deploy coding agents remotely today without ACP." Extract lessons and surface implications for octos's protocol and UX strategy.
+
+## Summary
+
+Agent-chat is a multi-agent orchestration platform where Claude and Codex CLIs run inside tmux sessions on multiple servers. Each agent has its own MCP server that talks to a central backend over HTTPS. Humans interact via Matrix (with agent-puppet rooms). A central backend mediates all state (agents, messages, tasks, alerts, supervisor-audit). SSE broadcasts events; per-server push-relays inject notifications directly into tmux panes. No ACP anywhere.
+
+This works because:
+
+1. MCP transports include HTTP, which trivially crosses hosts
+2. tmux is a durable, user-owned, remote-accessible shell context — perfect substrate for an agent to occupy
+3. Matrix is a federated chat protocol with existing human-facing clients
+4. The backend is the source of truth; agents and UI layers are projections
+
+The architecture is ~6.5 MB of Node.js on disk. Several production systemd services run it.
+
+## Topology
+
+```
+                    ┌──────────────────────────────────────────┐
+                    │  Central server                          │
+                    │                                          │
+                    │  backend-v2.js  (:8090)  ← Source of      │
+                    │                            truth         │
+                    │  server.js      (:8084)  ← Dashboard UI   │
+                    │  bridge-matrix.js         ← Matrix bridge│
+                    │  push-relay.js            ← Local tmux   │
+                    │  mcp-server.js (per-agent)               │
+                    └───────────────────┬──────────────────────┘
+                                        │
+                                        │ HTTPS + SSE
+                                        │
+           ┌────────────────────────────┼────────────────────────────┐
+           │                            │                            │
+  ┌────────▼───────┐          ┌─────────▼──────┐          ┌──────────▼────┐
+  │ Remote host 1  │          │ Remote host 2  │          │ Remote host N │
+  │                │          │                │          │               │
+  │ push-relay     │          │ push-relay     │          │ push-relay    │
+  │ mcp-server(s)  │          │ mcp-server(s)  │          │ mcp-server(s) │
+  │                │          │                │          │               │
+  │ tmux sessions: │          │ tmux sessions: │          │ tmux sessions:│
+  │  - Claude A    │          │  - Codex C     │          │  - Claude D   │
+  │  - Codex B     │          │                │          │  - Codex E    │
+  └────────────────┘          └────────────────┘          └───────────────┘
+```
+
+Each Claude/Codex instance runs inside tmux. Each instance has its own MCP server attached; the agent's tool calls land on that MCP server, which forwards to the central backend via HTTPS.
+
+## Message flow
+
+```
+Agent A (Claude/Codex, inside tmux pane on Remote Host 1)
+  │
+  │ tool call: send_message(to=agent-b, body=...)
+  │
+  ▼
+mcp-server.js (local to Agent A)
+  │
+  │ POST /api/messages  (agent-token auth)
+  │
+  ▼
+backend-v2.js (central)
+  │
+  ├──▶ persists message to store
+  │
+  ├──▶ broadcasts SSE event
+  │       │
+  │       ▼
+  │   push-relay.js (Remote Host 2, listening on SSE)
+  │       │
+  │       │ injects notification into Agent B's tmux pane
+  │       │ via `tmux send-keys` or similar
+  │       │
+  │       ▼
+  │   Agent B (Claude/Codex) sees notification in its terminal
+  │   → reads via its own mcp-server's inbox tool
+  │
+  └──▶ bridge-matrix.js receives same SSE event
+         │
+         ▼
+       relays to Matrix room for human visibility
+```
+
+Key properties:
+
+- **Backend is the single source of truth** for agents, groups, messages, cursors, tasks, alerts
+- **MCP is the agent-side protocol** — every agent speaks MCP to its local mcp-server, which speaks HTTPS to backend
+- **SSE is the broadcast substrate** — low-overhead, one-way push
+- **tmux injection is the local push** — agent notifications arrive as literal keystrokes in the agent's terminal
+- **Matrix is the human UI** — agents have puppet users; humans see agents in Matrix rooms
+
+## Backend API surface
+
+The `backend-v2.js` exposes ~60 REST endpoints across 8 domains:
+
+| Domain | Endpoints | Role |
+|---|---|---|
+| Servers | heartbeat, offline, maintenance, list | Multi-server liveness tracking |
+| Agents | register, list, get, patch, delete, undelete, offline, runtime, avatar, groups, tasks | Agent registry + runtime state |
+| Runtime | compact, push-delivered | Compaction events + delivery confirmations |
+| Groups | create, list, get, members, delete, messages | Group messaging |
+| DM | ensure | Direct-message channel setup |
+| Messages | send, get, suppress | Message store |
+| Inbox | get (advances cursor), unread, unread-list | Per-agent inbox cursors |
+| Media | stage, fetch | Base64 media upload |
+| System | info | System event log |
+| Tasks | create, list, get, patch, delete, accept, transition, execution | Task store with FSM |
+| Task graphs | create, list, get, delete, node-patch | DAG orchestration |
+| Alerts | list, stats, get, transition, notes, patch, delete | Alert ticket system |
+| Supervisor | status, agents, control, state, heartbeat | LLM-based focus audit |
+| Subconscious | events, detail, upstream hooks | Claude subconscious/hooks |
+
+This is a **fully-realized orchestration platform**, not a prototype. Features include:
+
+- Agent online/offline with `manualDown` (intentional shutdown vs crash)
+- MCP presence detection (`mcpPresent`)
+- Systemd scope memory monitoring with pressure alerts
+- Swap usage alerting
+- Deletion tombstones with undelete
+- DM + group messages with `request`/`inform`/`reply` types
+- Priority levels (`normal`/`high`/`urgent`)
+- Structured message schemas
+- Task FSM: `created → accepted → in_progress → done`; `in_progress ↔ blocked`
+- Task graph DAGs with node dependencies
+- Alert ticket FSM with deduplication, auto-resolution, reopen windows
+- Authentication: bearer token + agent-token + bridge-secret + subconscious-token
+- Supervisor: LLM-based focus evaluation every 30s with role/boundary/task context
+
+## Key components
+
+### `backend-v2.js` (central, :8090)
+The API server. Source of truth. All data lives here. ~60 REST endpoints, SSE broadcast.
+
+### `server.js` (central, :8084)
+Dashboard UI + message queue + idle detection + reminders + alert UI. The web-facing front door for humans (in addition to Matrix).
+
+### `bridge-matrix.js` (central)
+Matrix bridge. Creates agent puppet users. Maps DMs and groups to Matrix rooms. Relays messages both directions. Configured with `MATRIX_BRIDGE_SECRET`.
+
+### `push-relay.js` (per-server)
+SSE consumer → tmux notification injection. Runs on every host with agents. Subscribes to backend SSE. On each relevant event, injects into the target agent's tmux pane via the tmux CLI. The agent sees the notification as part of its own terminal context, which Claude/Codex will naturally consume on the next iteration.
+
+### `mcp-server.js` (per-agent)
+MCP server exposing agent-chat's messaging/task/alert tools to the agent (Claude or Codex). On the central host, connects directly. On remote hosts, connects via HTTPS. Agent invokes `send_message`, `read_inbox`, `create_task`, etc. through its normal MCP tool-calling mechanism.
+
+### `bin/agentchat`, `bin/agent-up`, `bin/agent-down`, etc.
+CLI lifecycle tools for operators. Create/start/stop/list agents. Register with backend.
+
+## Why this architecture wins for remote coding agents
+
+### MCP-over-HTTPS enables natural multi-host scaling
+
+Every remote agent's MCP server has a central backend URL over HTTPS. No special transport layer; no stdio-binding constraint. This is exactly the advantage MCP has over ACP — remote agents are a first-class deployment pattern.
+
+### tmux as durable shell context
+
+tmux sessions survive SSH disconnects, reboots (with tmux-resurrect or systemd supervision), and supervisor restarts. An agent that occupies a tmux session has a durable workspace without the agent implementation itself needing to handle persistence of the shell state. This is a huge simplification — the agent just runs; tmux handles the "where does it live" question.
+
+### Push-relay pattern for cross-host notifications
+
+Rather than require agents to poll, the central backend broadcasts via SSE and per-server push-relays inject into local tmux sessions. This crosses process/host boundaries via simple push semantics. Latency is low (one SSE hop) and the mechanism is trivial compared to a custom RPC protocol.
+
+### Matrix as the human UI
+
+Humans don't need a bespoke dashboard for individual agent chats — Matrix already solves federated, durable, multi-client, encryption-capable chat. Agent-chat creates puppet users; Matrix does the rest. The human can respond from a phone, desktop, or Element web client. This is the Surface 2 (supervisor UI) problem solved by piggy-backing on existing infrastructure.
+
+### Agent-token auth
+
+Each agent has its own token (`X-Agent-Token` header). Agent-specific routes (runtime updates, task transitions, alert transitions for assigned alerts) enforce agent identity. The token mode supports `hard` (enforce), `audit` (log only), `off` (disabled) — incremental hardening.
+
+### Supervisor with LLM-based focus audit
+
+Every 30s, the supervisor assesses active agents using LLM evaluation against role/boundary/task context. Consecutive negative ratings trigger nudge (to agent) then escalation (to operator). This is an interesting **meta-agent pattern** — an LLM watching other LLMs and nudging them back on track. Analogous to M4.3's validator runner but at a higher level of abstraction (agent behavior, not artifact validity).
+
+## What agent-chat does NOT do
+
+Explicitly absent:
+- **No ACP** — not as client, not as server. Entire system avoids ACP.
+- **No typed workspace contract** — messages are structured (schema.kind, schema.payload) but not contract-gated
+- **No artifact gate** — no analogue of octos's M4.1A workspace contract
+- **No evidence-based completion gate** — no analogue of M4.3 validator runner
+- **No executable skill binaries** — skills live as markdown under `skills/` (advisory, like hermes)
+- **No declarative validation policy** — validation happens in prose or in tests invoked by agents
+
+So agent-chat is **orchestration + communication + monitoring**, not **typed contract delivery**. Those are complementary, not competing, axes.
+
+## Lessons for octos
+
+### Lesson 1 — MCP-over-HTTPS is the remote-agent substrate
+
+Agent-chat validates the MCP protocol strategy (see [OCTOS_PROTOCOL_STRATEGY_2026-04-22.md](./OCTOS_PROTOCOL_STRATEGY_2026-04-22.md)). HTTPS transport + HTTPS auth headers = remote agents Just Work. This is **exactly the pattern octos should adopt** for Priority 1 (octos calls Claude Code / Codex / hermes as MCP sub-agents) and Priority 2 (octos exposes itself via MCP server).
+
+Concretely: when octos's `SpawnTool` gains an `agent_mcp` backend, it should support **URL-based agent addressing**, not just stdio-subprocess. A task can dispatch to a **remote** MCP-agent endpoint as easily as a local subprocess. This makes octos-orchestrated swarms multi-host from day one.
+
+### Lesson 2 — tmux as optional agent substrate
+
+For agents that benefit from a persistent shell context (interactive debugging, long-running compiles, stateful tool sessions), tmux-hosted agents are a proven pattern. Octos's `SpawnTool` currently spawns processes directly. A future extension could support **tmux-hosted spawn**: spawn the agent inside a tmux session, inject progress via tmux send-keys, expose the session for human visibility via SSH.
+
+This is **not** a priority but is a useful pattern to have on the roadmap when developer workflows demand it.
+
+### Lesson 3 — Matrix as supervisor UI transport
+
+Octos already has a Matrix channel (`crates/octos-bus/src/matrix_channel.rs`, 1,600+ LOC per prior review). That channel is currently oriented toward user-facing chat for a single agent. The agent-chat pattern shows a different use: **agents register as Matrix puppets**, and each agent's activity flows into a Matrix room that humans join.
+
+Octos could extend its Matrix support to:
+- Register spawned sub-agents as Matrix puppets
+- Route sub-agent progress events to per-agent Matrix rooms
+- Give the supervisor a federated, encrypted, multi-client UI without building a bespoke dashboard
+
+This is **Surface 2 solved by existing infrastructure**. Bigger win than a custom React swarm view for many enterprise deployments.
+
+### Lesson 4 — Backend-as-source-of-truth with projections
+
+Agent-chat's architecture cleanly separates:
+- **Backend** (state)
+- **SSE** (change notification)
+- **Projections** (Matrix bridge, dashboard UI, push-relay, MCP server per-agent)
+
+Octos's current design mixes these more. `octos serve` is both the REST backend AND the dashboard host. The channel bus is both transport AND persistence.
+
+If octos evolves toward the swarm pattern (many sub-agents, many projections), separating the source-of-truth from the projections would help. Current state of the M4 landing has already moved this direction (e.g., operator dashboard at M4.5 reads existing backend APIs, no UI-side state duplication). Continue in that direction.
+
+### Lesson 5 — Hook into agent subconscious / audit
+
+Agent-chat has a `subconscious` surface for Claude's hook events: `/api/subconscious/upstream/bootstrap`, `session-start`, `user-prompt`, `pretool`, `stop`. This is Anthropic's own hook format; agent-chat receives these as first-class ingestion events.
+
+Octos's `hooks.rs` has a similar pattern at the runtime level. **Supporting the Claude-Code-native hook format** (in addition to octos's own hook events) would let octos-hosted Claude Code instances contribute their introspective data back to octos's supervisor. That's a cheap integration once MCP-agent-tool is in place.
+
+### Lesson 6 — Supervisor-as-LLM-watcher
+
+Agent-chat's supervisor uses an LLM to audit agent focus. Octos doesn't have this pattern. An LLM-based "meta-supervisor" that monitors active sub-agents, nudges them back on task when drift is detected, and escalates to human operator is a natural extension of M4.3 validator runner — not a turn-level validator, but a session-level one. Consider for future roadmap.
+
+## What octos could absorb
+
+Pragmatic integration path:
+
+1. **Immediately usable**: MCP-over-HTTPS remote agent dispatch — absorb into Priority 1 from protocol strategy
+2. **Short-term** (quarters): Matrix-as-supervisor-UI pattern — extend existing Matrix channel with multi-agent projection
+3. **Medium-term** (year): tmux-hosted agent option for `SpawnTool`
+4. **Long-term**: LLM-based focus-audit supervisor — session-level extension of validator runner
+
+These are all **additive to octos's contract-first posture**. They strengthen the swarm-orchestration capability without compromising the workspace-contract / artifact-gate differentiation.
+
+## Relationship to hermes and openJiuwen
+
+Agent-chat is orthogonal to both:
+
+- **Hermes** is a single-agent specialist (`run_agent.py` 10,492 LOC for one deep loop). Agent-chat doesn't replace hermes; it could USE hermes as an agent-inside-tmux, calling hermes via MCP the same way it calls Claude or Codex.
+- **OpenJiuwen** has web Studio for agent creation and TeamAgent for swarm, but lacks agent-chat's specific remote-tmux-hosting and SSE-push-to-tmux-injection. OpenJiuwen and agent-chat are different swarm patterns — openJiuwen's is more "design and deploy" while agent-chat's is more "orchestrate the running ones."
+
+Agent-chat sits between them: lighter than openJiuwen's full Studio, broader than hermes's single agent. **Octos's natural position is to take agent-chat's orchestration pattern and combine it with openJiuwen-like contract-first deployment + hermes-like agent-as-sub-agent invocation.**
+
+## Concrete next-action proposals
+
+### 1. `crates/octos-mcp-remote/` — Remote MCP agent dispatch
+
+Extend `SpawnTool` with a `remote_mcp_agent` backend:
+
+- Task dispatches to `https://agents.example.com/claude-code/mcp` (or similar)
+- Authentication: bearer token per agent endpoint
+- Request-response shaped task (MCP `tools/call`)
+- Result flows back through octos's workspace-contract path
+- Progress observed via M4.1A harness events (or optionally pulled from a companion SSE endpoint)
+
+Scope: ~1 kLOC Rust (building on existing MCP client). Aligns with Priority 1 of the protocol strategy doc; the agent-chat pattern shows the deployment shape this should support.
+
+### 2. Matrix-as-supervisor-UI — Extend existing Matrix channel
+
+Per-agent Matrix room when sub-agent spawns. Agent progress events flow into the room. Human supervisor interacts from any Matrix client. Register sub-agents as Matrix puppets.
+
+Scope: ~500-800 LOC Rust in `octos-bus/src/matrix_channel.rs`. Builds on existing implementation.
+
+### 3. Session supervisor with LLM focus audit (optional, deferred)
+
+An LLM evaluates session focus against contract invariants. Acts as a meta-validator beyond M4.3's per-artifact checks. Nudges or escalates.
+
+Scope: ~1.5 kLOC Rust. Only if demand signal appears.
+
+## Summary
+
+- Agent-chat is a production reference architecture for remote coding agents
+- Key primitives: MCP (protocol), tmux (shell substrate), Matrix (human UI), SSE (change notification), central backend (source of truth)
+- ACP absent; not needed
+- Validates MCP-over-HTTPS as the remote-agent deployment pattern
+- Octos should absorb lessons: MCP-remote dispatch, Matrix-as-supervisor-UI, tmux-hosted agent option, LLM focus audit
+- These additions strengthen octos's swarm-orchestration story without changing its contract-first differentiation

--- a/docs/OCTOS_CODING_HARDENING_M6_PLAN_2026-04-22.md
+++ b/docs/OCTOS_CODING_HARDENING_M6_PLAN_2026-04-22.md
@@ -1,0 +1,283 @@
+# Octos Coding Hardening — M6 Plan (Track 1)
+
+See also:
+
+- [OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md](./OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md)
+- [OCTOS_PROTOCOL_STRATEGY_2026-04-22.md](./OCTOS_PROTOCOL_STRATEGY_2026-04-22.md)
+- [OCTOS_SWARM_POSITIONING_2026-04-22.md](./OCTOS_SWARM_POSITIONING_2026-04-22.md)
+
+## Purpose
+
+Close the free-form coding capability gap with hermes, so octos stands as a strong standalone coding agent. Do this by **re-expressing every hermes innovation through octos's native harness primitives** — not by porting hermes's code.
+
+This is **Track 1**. Track 2 (PM + agent swarm orchestrator — MCP sub-agent dispatch, Matrix-as-supervisor-UI, remote-agent dispatch) is deliberately out of scope here and will open as a separate family after M6 lands.
+
+## Why "not copy hermes"
+
+Hermes earned its capability through ~19 kLOC of Python accumulated in a coding-specialist context. The innovations are real — 15-reason error taxonomy, iterative LLM compression, persistent credential pool, 7 retry counter classes, smart content routing — but the implementation is structured for a Python REPL-first single-agent CLI. Direct port to Rust would give octos hermes's capability, but miss **the leverage of octos's harness foundation**.
+
+Octos already has:
+
+- M4.1A **structured progress events** (`octos.harness.event.v1`) over `OCTOS_EVENT_SINK` → every harness-level signal is observable and replayable
+- M4.3 **declarative validator runner** → completion is evidence-based, not prose-based
+- M4.6 **schema-versioned ABI** → `WorkspacePolicy` / `HookPayload` / `TaskResult` / `ProgressEventEnvelope` all carry `schema_version`; external developers can depend on stable shapes
+- M4.5 **operator dashboard** → runtime truth is visible without log archaeology
+- M5 **coding runner contract** (phase classifier + evidence-based completion gate)
+- `RetryProvider` / `ProviderChain` / `AdaptiveRouter` — existing 3-layer LLM failover
+- Rust type-safety + `deny(unsafe_code)` — compile-time guarantees hermes cannot offer
+- Hybrid BM25+HNSW memory
+- 3-backend sandbox with shared `BLOCKED_ENV_VARS`, symlink-safe `O_NOFOLLOW`, shared SSRF protection
+- Executable skill binaries (not prose markdown)
+
+**The re-expression principle**: each hermes innovation becomes typed, schema-versioned, event-observable, validator-gateable, and session-durable on octos. The feature composes with the rest of the harness rather than sitting alongside it as an isolated coding-loop hack.
+
+## How re-expression wins per feature
+
+| Hermes feature | Hermes shape | Octos M6 shape (built on harness) |
+|---|---|---|
+| 15-reason error classifier | 809 LOC Python with hardcoded regex patterns, 4 recovery-hint flags | **Typed `HarnessError` enum**, schema-versioned, emitted as `harness.event.v1 error` records via `OCTOS_EVENT_SINK`. Dashboard shows per-variant rates. Validator can gate on "no unrecovered rate-limit in last N turns." Event replay reconstructs loop health post-hoc. |
+| Persistent credential pool | 1,319 LOC Python with file-based JSON, 4 strategies, OAuth refresh | **`CredentialPool` trait + redb-backed state**, typed cooldown expiry, schema-versioned config, rotation events emitted to sink. Integrates with existing `AdaptiveRouter`. Config lives in profile-level typed section (M4.6 schema-stable). |
+| Iterative context compression with Goal/Progress/Decisions template | 777 LOC Python with prompt engineering | **Typed `SessionSummary { goal, constraints, progress_done, progress_in_progress, decisions, files, next_steps }`** with serde round-trip. Compaction emits progress events per phase (analyzing → summarizing → refining → done). Next-summary-updates-prior-summary pattern in durable state. Validator gates: "summary must preserve declared artifacts." |
+| 7 per-iteration retry counters | `self._invalid_tool_retries`, `self._invalid_json_retries`, etc. sprinkled through 10,492-LOC `run_agent.py` | **`LoopRetryState` struct** with typed variants, bounded per-variant limits, state survives compaction, each bucket emits typed retry events. Operator dashboard shows retry-rate per kind. Budget controller (M6.2) can decide "escalate this session — 3/3 invalid-tool retries exhausted." |
+| Budget-grace-call (one free iteration past hard cap) | Ad-hoc flag in loop body | **Typed `BudgetState::GracePending`** event. Validator can gate "grace call must include summarization." Observable on dashboard. |
+| Content-classified smart model routing | 195 LOC Python keyword heuristic | Extend existing `AdaptiveRouter` with **schema-versioned content classifier config**. Classifier is pure (no LLM call), decision emitted as event. Operator can A/B-test routing policies via schema-stable profile config. |
+| Delegate-task subagent with MAX_DEPTH=2 | 1,088 LOC Python ThreadPoolExecutor, blocked-tools list | **`DelegateTool`** synchronous sibling of `SpawnTool` with typed `DepthBudget`, MAX_DEPTH via config, child task emits contract-gated artifacts. Reuses M4.1A event sink, M4.3 validator runner, M4.6 ABI. Restricted toolset declared as policy groups (RP01 style). |
+| Preflight compression | Conditional block before first API call | **Compaction policy** (M6.3) declares preflight budget; harness event emitted when triggered. Validator gates: "preflight must not drop declared artifacts." |
+| Tool output pruning | Cheap pre-pass replacing old tool results | Expressed as **pre-compaction validator rule**: "tool results older than N turns → replaced with placeholder preserving {tool_name, turn_id}." Schema-versioned placeholder format so downstream consumers don't break. |
+| Fenced `<memory-context>` tags | String-level XML wrapper | Typed wrapping in `SessionSummary` serde; memory context becomes a first-class field with schema version. Rendering is one option, not the truth. |
+
+Every row shows the same pattern: **hermes has the implementation; octos-M6 has the implementation AND the platform primitive**.
+
+## M6 sub-milestone structure
+
+Six contract-bound issues following the RP / M4 family style.
+
+### M6.1 — Structured harness error taxonomy
+
+**Problem**: octos's errors are `eyre::Result<T>` with no runtime structure. Failure modes can't be observed, counted, or gated.
+
+**Deliverables**:
+- New `crates/octos-agent/src/harness_errors.rs` with typed `HarnessError` enum (variants: `ProviderRateLimit`, `ProviderAuth`, `ProviderOverloaded`, `ProviderServerError`, `ProviderTimeout`, `ProviderPayloadTooLarge`, `ProviderModelNotFound`, `ProviderFormatError`, `ThinkingSignatureError`, `ContextOverflow`, `ToolCallMalformed`, `ToolResultInvalid`, `EmptyContent`, `Incomplete`, `UnknownTransient`, `UnknownTerminal`)
+- Each variant carries `RecoveryHint::{Retry, RotateCredential, Compact, Fallback, FailFast, Grace}`
+- `HarnessError` implements `From<octos_llm::LlmError>` with pattern-based classification
+- Emits `harness.event.v1 { kind: "error", variant, recovery_hint }` to `OCTOS_EVENT_SINK`
+- Prometheus: `octos_loop_error_total{variant, recovery}` counter
+- M4.5 dashboard card: per-variant error rate per session
+- Schema-versioned per M4.6 (`HARNESS_ERROR_SCHEMA_VERSION = 1`)
+
+**Size**: ~800 LOC Rust incl. tests.
+
+**Dependencies**: M4.1A, M4.6.
+
+### M6.2 — Loop retry-bucket state machine
+
+**Problem**: Single counter in `loop_runner.rs` can't distinguish "provider rate-limited 3 times" from "model returned malformed JSON 3 times" — different recoveries needed.
+
+**Deliverables**:
+- New `crates/octos-agent/src/agent/loop_state.rs` with typed `LoopRetryState`
+- Per-variant bounded counters matching M6.1's `HarnessError` variants
+- `LoopRetryState::observe(HarnessError) -> LoopDecision` returns `{Continue, Escalate, Exhausted, RotateAndRetry, CompactAndRetry}`
+- State serde-stable (survives compaction + session reload per existing session persistence)
+- Integrates with existing `recover_shell_retry_output` (which becomes a `LoopRetryState::ShellSpiral` variant)
+- **Budget-grace-call**: `LoopRetryState` understands "one free iteration past budget if at least one productive tool call happened"
+- Events emitted per retry observation
+
+**Size**: ~500 LOC Rust.
+
+**Dependencies**: M6.1.
+
+### M6.3 — Contract-gated compaction policy
+
+**Problem**: Octos compaction (`crates/octos-agent/src/compaction.rs`, extractive only) doesn't preserve declared invariants. On long coding sessions, architectural decisions at turn 15 vanish by turn 45.
+
+**Deliverables**:
+- `WorkspacePolicy.compaction` — declarative compaction policy (M4.3 validator-style)
+- Fields: `token_budget`, `preserved_artifacts` (glob list), `preserved_invariants` (goal, decisions, file_list), `summarizer` (extractive | llm-iterative), `preflight_threshold`, `prune_tool_results_after_turns`
+- New `Summarizer` trait in `crates/octos-agent/src/summarizer.rs` with impls
+- Compaction itself emits progress events (`compaction.phase = "analyzing" | "summarizing" | "refining" | "done"`)
+- Validator rail: "post-compaction, declared artifacts must still be referenced in context"
+- Preflight compaction: before first LLM call, check token budget vs declared threshold
+- Tool output pruning: typed `ToolResultPlaceholder { tool_name, turn_id, schema_version }` replaces old results
+
+**Size**: ~1,200 LOC Rust (policy parsing + trait + extractive impl + preflight + pruning).
+
+**Dependencies**: M4.3 validator runner.
+
+### M6.4 — LLM-iterative summarizer
+
+**Problem**: Extractive compaction preserves recency but loses semantic coherence. For coding sessions where turn-15 decisions drive turn-45 edits, an LLM must do the work.
+
+**Deliverables**:
+- `LlmIterativeSummarizer` impl of `Summarizer` trait
+- Typed `SessionSummary` struct — serde-stable, schema-versioned
+  ```rust
+  struct SessionSummary {
+      schema_version: u32,  // = 1
+      goal: String,
+      constraints: Vec<String>,
+      progress_done: Vec<String>,
+      progress_in_progress: Vec<String>,
+      decisions: Vec<DecisionRecord>,
+      files: Vec<FileRecord>,
+      next_steps: Vec<String>,
+  }
+  ```
+- Structured prompt template (not free prose — returns JSON matching `SessionSummary`)
+- Iterative refinement: next summary takes prior summary + new turns → outputs updated summary (not from-scratch)
+- Fallback to extractive if LLM call fails 3x
+- Schema-versioned per M4.6; compat test with legacy session state
+
+**Size**: ~900 LOC Rust.
+
+**Dependencies**: M6.3, M4.6.
+
+### M6.5 — Credential pool + failover
+
+**Problem**: A single 429 from Claude API at turn 47 kills a 60-turn coding session. `AdaptiveRouter` does hedge racing across providers but doesn't persist per-credential state or rotate within a provider.
+
+**Deliverables**:
+- New `crates/octos-llm/src/credential_pool.rs`
+- `CredentialPool` trait with 4 strategies: `FillFirst`, `RoundRobin`, `Random`, `LeastUsed`
+- Redb-backed persistent state: per-credential cooldown expiry, 429 count, `reset_at` from response headers, last-used timestamp
+- OAuth refresh hook for credentials that support it
+- Integrates with existing `AdaptiveRouter` → rotation events emitted via `OCTOS_EVENT_SINK`
+- Typed `CredentialPoolConfig` in profile config (M4.6 schema-versioned)
+- Strategy selection is config-driven, not hardcoded
+- Counter `octos_llm_credential_rotation_total{reason, strategy}`
+
+**Size**: ~1,400 LOC Rust.
+
+**Dependencies**: M4.6. Can start in parallel with M6.1/M6.2.
+
+### M6.6 — Content-classified smart routing
+
+**Problem**: Today octos's `AdaptiveRouter` routes by provider health, not by content complexity. Simple turns (e.g., "yes, continue") consume expensive model budget.
+
+**Deliverables**:
+- Extends `AdaptiveRouter` with `ContentClassifier`
+- Pure heuristic classifier: message length, code-fence presence, URL presence, keyword matching (`debug`, `refactor`, `fix`, `test`, `trace`, `error`, `implement` → strong model; otherwise → cheap model)
+- Typed `RoutingConfig` in profile config with overridable keyword list
+- Routing decision emitted as event
+- A/B toggle: route all / route none / route by classifier (operator can disable for sensitive deployments)
+
+**Size**: ~400 LOC Rust.
+
+**Dependencies**: M6.5.
+
+### M6.7 — Synchronous delegate tool
+
+**Problem**: Octos has async `SpawnTool` (fire-and-forget, deliver-later). No synchronous "parent blocks until child done" pattern. Forces unnatural workflow decomposition.
+
+**Deliverables**:
+- New `crates/octos-agent/src/tools/delegate.rs`
+- `DelegateTool` is synchronous sibling of `SpawnTool`
+- Typed `DepthBudget` with configurable `MAX_DEPTH = 2` (grandchild rejected by default)
+- Child task inherits parent's workspace contract but runs with restricted tool policy (declared via RP01-style groups: `group:delegated` excludes `delegate_task`, `clarify`, `memory`, `send_message`, `execute_code`)
+- Result flows back through contract-gated delivery (M4.1A-compatible)
+- Parent waits on child via existing `TaskSupervisor` lifecycle; integrates with `TaskLifecycleState`
+
+**Size**: ~700 LOC Rust.
+
+**Dependencies**: M4.1A, RP01 (ToolPolicy groups).
+
+### M6.8 — Operator dashboard integration
+
+**Problem**: M6.1-M6.7 add many new events, counters, and state — M4.5 dashboard doesn't show them by default.
+
+**Deliverables**:
+- Extend `HarnessPage.tsx` with coding-loop health cards:
+  - Error taxonomy breakdown (per session and aggregate)
+  - Retry bucket state (which sessions spiraling)
+  - Compaction event log with semantic context
+  - Credential pool status (cooldowns, rotations)
+  - Routing decisions breakdown (cheap vs strong)
+  - Delegate tree visualization (per session)
+- Backend surfaces via existing admin API; no new API shape
+
+**Size**: ~1,500 LOC TypeScript + ~300 LOC Rust.
+
+**Dependencies**: M6.1 through M6.7.
+
+## Phasing and parallel dispatch
+
+```
+Phase M6A (foundations, parallel)
+┌──────────────────────────────────┐
+│ M6.1 Structured error taxonomy   │  ← 2 weeks, independent
+│ M6.5 Credential pool + failover  │  ← 2-3 weeks, independent (depends on M4.6 only)
+└──────────────────────────────────┘
+              │
+              ▼
+Phase M6B (loop hardening, parallel)
+┌──────────────────────────────────┐
+│ M6.2 Loop retry-bucket state     │  ← 2 weeks, depends on M6.1
+│ M6.6 Smart routing               │  ← 1 week, depends on M6.5
+│ M6.7 Delegate tool               │  ← 2 weeks, depends on RP01 (done) + M4.1A
+└──────────────────────────────────┘
+              │
+              ▼
+Phase M6C (context management, sequential)
+┌──────────────────────────────────┐
+│ M6.3 Compaction policy           │  ← 2-3 weeks, depends on M4.3
+│ M6.4 LLM-iterative summarizer    │  ← 3 weeks, depends on M6.3
+└──────────────────────────────────┘
+              │
+              ▼
+Phase M6D (surfaces)
+┌──────────────────────────────────┐
+│ M6.8 Dashboard integration       │  ← 2 weeks, depends on M6.1-M6.7
+└──────────────────────────────────┘
+```
+
+Total: **~7,700 LOC Rust + 1,500 LOC TypeScript**, **3-4 engineer-months** with parallel dispatch of M6A (2 engineers), M6B (2-3 engineers, 1 per workstream), M6C (1 engineer, sequential), M6D (1 engineer + frontend support).
+
+## Success criteria
+
+M6 is complete when all of the following hold:
+
+1. **60-turn coding session** on a flaky LLM provider completes successfully. Criterion: zero session losses across 10 runs with simulated 429 storms.
+2. **Context coherence at turn 45** — a decision made at turn 15 is referenced in a turn-45 edit via the typed `SessionSummary.decisions` field. Measurable via replay.
+3. **Structured error rate** — `octos_loop_error_total` distinguishes at least 10 of the 15 `HarnessError` variants in a real session, with correct `recovery_hint` routing.
+4. **Credential rotation** under simulated outage — 3 credentials configured, primary exhausts 429s, rotation triggers within 1 RTT, session continues.
+5. **Smart routing cost win** — A/B run shows ≥30% token-cost reduction on a mixed coding workload (debugging + writing + questions).
+6. **Delegate tool safety** — MAX_DEPTH=2 enforced; grandchild rejected with typed error; parent gets meaningful result via contract-gated delivery.
+7. **Compaction semantic preservation** — post-compaction validator confirms declared artifacts still referenced in 100% of runs; LLM-iterative summarizer preserves decisions across 3 consecutive compactions.
+8. **Dashboard coverage** — operator diagnoses a stalled session from M6.8 dashboard alone, without reading logs. Test: inject one failure per M6.1-M6.7 surface, verify dashboard shows it.
+
+## Out of scope — explicitly deferred to Track 2 (swarm orchestration)
+
+The following are **not** M6 work. They are the PM+swarm track and will open as a separate family after M6 ships.
+
+- `crates/octos-agent/src/tools/mcp_agent.rs` — calling remote MCP-exposed agents as sub-agents
+- `crates/octos-agent/src/mcp_server.rs` — exposing octos sessions as MCP tools for outer orchestrators
+- Matrix-as-supervisor-UI (sub-agent Matrix puppets, per-agent rooms)
+- Contract authoring + swarm dispatch dashboard (React)
+- Cost / provenance ledger
+- Agent-chat-style remote-agent-in-tmux pattern
+- ACP server / client
+
+M6 is **octos-as-strong-coding-agent**, not octos-as-orchestrator-of-coding-agents. Those are different products; confusing them led to earlier dithering.
+
+## Relationship to M5
+
+M5 (`OCTOS_HARNESS_M5_CODING_RUNNER_CONTRACT.md` on origin/main) introduces `TaskKind` + `CodingHarnessPolicy` + phase classifier + evidence-based completion gate. That is **product correctness** — "the agent can't ghost-succeed." M6 is **loop resilience** — "the agent can complete a 60-turn session without falling over." Complementary.
+
+M5 should land first (per current plan); M6 opens as soon as M5.1/M5.2 give octos a typed coding-session shape to attach M6's improvements to. If M5 is still in progress, the foundations phase M6A can run in parallel without stepping on M5's territory (M6.1 error taxonomy and M6.5 credential pool touch different files than M5's phase classifier).
+
+## What to do now
+
+1. Open 8 contract-bound issues on `octos-org/octos` following the RP / M4 family pattern:
+   - `#M6.1` through `#M6.8` — titles from the sub-milestone structure above
+2. Create `robotics` / `harness` label siblings: `coding-loop`
+3. Author release-slice contract doc `OCTOS_CODING_HARDENING_M6_KICKOFF_2026-04-22.md` (this doc becomes the family plan; kickoff doc is narrower)
+4. Dispatch Phase M6A (M6.1 + M6.5) as the first parallel slice
+5. Hold Track 2 (swarm orchestrator) until M6 completes
+
+## Summary
+
+- Track 1 = M6 coding loop hardening = **octos as strong standalone coding agent**, via re-expression of hermes innovations through octos's harness primitives
+- 8 sub-milestones, ~7.7 kLOC Rust + 1.5 kLOC TypeScript
+- 3-4 engineer-months with parallel dispatch
+- **Not a port of hermes** — each feature composes with M4.1A events + M4.3 validators + M4.6 ABI + M4.5 dashboard
+- Track 2 (PM+swarm orchestrator) deferred until M6 lands
+- Success: 60-turn coding session under simulated provider flakiness completes with no human intervention, context coherence preserved, all surfaces observable on dashboard

--- a/docs/OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md
+++ b/docs/OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md
@@ -1,0 +1,214 @@
+# Octos Competitive Landscape — 2026-04-22
+
+See also:
+
+- [OCTOS_PROTOCOL_STRATEGY_2026-04-22.md](./OCTOS_PROTOCOL_STRATEGY_2026-04-22.md)
+- [OCTOS_SWARM_POSITIONING_2026-04-22.md](./OCTOS_SWARM_POSITIONING_2026-04-22.md)
+
+## Purpose
+
+Capture a structured comparison of octos against the two codebases the team has asked about as competitive references:
+
+- `hermes-agent` — Python agent framework, coding-loop specialist
+- `openJiuwen-ai` — multi-project Chinese agent platform with web Studio + A2A C++ SDK + RL training
+
+The comparison is deliberately coding-harness-centric. Other axes (multi-channel, platform surface, enterprise features) are noted where they differ materially but are not the primary lens.
+
+## Verdict
+
+The three systems occupy distinct vertices, not a shared axis:
+
+- **hermes** — coding-loop depth specialist; Claude-Code-class CLI; ACP bidirectional; ~19 kLOC coding-specialized Python
+- **octos** — contract-first API platform; typed workspace policy; executable skill binaries; 14-channel bus; Rust type-safety; weak CLI UI; no ACP
+- **openJiuwen** — web-Studio-first platform; Chinese enterprise IM heavy; agent teams / swarm primitives; actual RL training; A2A C++ SDK; MCP-only protocol stack (ACP stub); deep 3-tier LLM compression
+
+For free-form 60-turn coding sessions with API instability, **hermes leads**. For contract-first background-task delivery with multi-tenant safety, **octos leads**. For enterprise agent deployment with dashboard + Chinese IM + team orchestration, **openJiuwen leads**. None of the three dominates.
+
+## Hermes capability profile
+
+### Footprint
+~19 kLOC of coding-specialized Python:
+
+- `run_agent.py` — 10,492 LOC. 7 distinct retry-counter classes (`_invalid_tool_retries`, `_invalid_json_retries`, `_empty_content_retries`, `_incomplete_scratchpad_retries`, `_codex_incomplete_retries`, `_thinking_prefill_retries`, `_unicode_sanitization_passes`). Budget-grace-call gives one free iteration past the hard budget cap.
+- `agent/context_compressor.py` — 777 LOC. LLM-based iterative summarization with a structured Goal / Constraints / Progress / Decisions / Files / Next Steps template. On subsequent compactions, *updates* the previous summary rather than summarizes from scratch.
+- `agent/error_classifier.py` — 809 LOC. 15-reason enum (`auth`, `auth_permanent`, `billing`, `rate_limit`, `overloaded`, `server_error`, `timeout`, `context_overflow`, `payload_too_large`, `model_not_found`, `format_error`, `thinking_signature`, `long_context_tier`, `format_error`, `unknown`) with 4 recovery-hint flags (`retryable`, `should_compress`, `should_rotate_credential`, `should_fallback`).
+- `agent/credential_pool.py` — 1,319 LOC. Persistent per-credential cooldowns, OAuth refresh, 4 rotation strategies (`fill_first`, `round_robin`, `random`, `least_used`), provider-supplied `reset_at` timestamps, JWT claims decoding, disk-persisted.
+- `agent/smart_model_routing.py` — 195 LOC. Content-classified cheap-vs-strong routing.
+- `tools/delegate_tool.py` — 1,088 LOC. Synchronous subagent with MAX_DEPTH=2 safety cap.
+- `hermes_state.py` — 1,238 LOC. SQLite+FTS5, schema v6, WAL, parent_session chains.
+- `mini_swe_runner.py` — 709 LOC. SWE-bench-oriented separate runner.
+- `acp_adapter/` — 1,784 LOC bidirectional ACP server.
+- `agent/copilot_acp_client.py` — 570 LOC ACP client wrapping Copilot.
+- `agent/retry_utils.py` — jittered exponential backoff with monotonic counter seed for decorrelation.
+
+### CLI
+Explicitly modeled on Claude Code. `pyproject.toml` pins `prompt_toolkit>=3.0.52` + `rich>=14.3.3`. Uses curses for interactive checklists. Custom `KawaiiSpinner`, diff renderer, fenced `<memory-context>` markers to prevent memory/discourse confusion.
+
+### Protocol
+ACP bidirectional. Registered as ACP agent. Can serve editors (Zed, etc.) and can consume Copilot's ACP server as a chat backend.
+
+### Weaknesses
+Not an API platform. Skills are prose markdown (advisory, not executable). Thin channel gateway. Single provider-per-request. No workspace-contract or validator runner.
+
+## Octos capability profile
+
+### Footprint (post-M4 merges, current main)
+- `octos-agent` — agent loop, tool system, sandbox, MCP, compaction, plugins
+- `octos-bus` — 14-channel message bus (Telegram/Discord/Slack/WhatsApp/Email/WeChat/Matrix/etc.), sessions, coalescing, cron, heartbeat
+- `octos-pipeline` — DOT-graph pipeline engine with per-node model selection, parallel fan-out, deadlines, checkpoints, human gates
+- `octos-plugin` — plugin SDK with manifest discovery, gating, `hardware_lifecycle` (RP02)
+- `octos-llm` — 4 native providers + 8 OpenAI-compatible; 3-layer failover (`RetryProvider` → `ProviderChain` → `AdaptiveRouter` with hedge racing + circuit breakers)
+- `octos-memory` — redb EpisodeStore + MEMORY.md + HybridSearch (BM25 + HNSW vector)
+- `octos-core` — Task, Message, Error types
+- `octos-cli` — CLI + 91 REST endpoints via `octos serve`
+
+### Landed M4 surface
+- `harness_events.rs` — `octos.harness.event.v1` schema + `OCTOS_EVENT_SINK` env protocol (M4.1A.470+471)
+- `validators.rs` — declarative validator runner (command / tool / file-exists) with evidence ledger (M4.3)
+- `abi_schema.rs` — `schema_version` on WorkspacePolicy, HookPayload, TaskResult, ProgressEventEnvelope (M4.6)
+- `hooks.rs` — 10 lifecycle events with HookPayloadEnricher + domain_data (M4.1A + RP03)
+- `TaskLifecycleState` — stable public states (`Queued`/`Running`/`Verifying`/`Ready`/`Failed`) (M4.1A)
+- Operator dashboard React pages (M4.5)
+- 4 starter skills (report, audio, coding, generic) (M4.2)
+- RP family: SafetyTier as ToolPolicy groups, sandboxed HardwareLifecycle, domain-hook pattern, pipeline deadline/checkpoint, realtime heartbeat + sensor injection, dora-mcp removed
+
+### CLI
+`colored = "2"` + `clap` only. No `ratatui`/`crossterm`/`indicatif`/`dialoguer`. Functional not polished. The presentation investment went into the admin dashboard.
+
+### Protocol
+MCP client only. No ACP (neither client nor server). No A2A.
+
+### Unique strengths
+- Rust type-safety + `deny(unsafe_code)` workspace-wide
+- Typed durable workspace contracts
+- Hybrid BM25+HNSW memory search
+- 3-backend local sandbox (Bwrap / macOS sandbox-exec / Docker) with shared `BLOCKED_ENV_VARS`
+- Symlink-safe `O_NOFOLLOW` file I/O
+- Shared SSRF protection (`tools/ssrf.rs`)
+- Cross-platform (Windows `cmd /C`, Unix `sh -c`)
+- Rustls TLS (no OpenSSL)
+- Plugin system with executable skill binaries
+
+### Weaknesses
+Coding-loop resilience thin. No credential pool, no persistent per-key cooldowns, no structured error taxonomy, no LLM-based iterative compression. CLI presentation minimal. No ACP. No multi-agent swarm primitive.
+
+## OpenJiuwen capability profile
+
+### Footprint
+538 MB across 6 subprojects; ~470 kLOC Python + TypeScript + C++:
+
+- `agent-core/` (~189 kLOC Python) — SDK + `harness/` DeepAgent coding framework (`deep_agent.py` 1,533 LOC, `factory.py` 314 LOC, `task_loop/` 3,546 LOC, `rails/` 3,588 LOC, `tools/` 4,560 LOC, `subagents/` browser + code + research)
+- `agent-studio/` (~172 kLOC: 54 kLOC FastAPI backend + 116 kLOC React/TS frontend + `plugin_server/` + `sandbox_server/`) — full agent-creation IDE, 22 routers, helm charts
+- `agent-protocol/` (~30 kLOC C++) — full A2A C++ SDK + MCP C++ SDK
+- `agent-tools/` — vLLM affinity + AIC reference agents
+- `deepsearch/` (48 kLOC Python) — separate deep-research service
+- `jiuwenclaw/` (82 kLOC Python + 20 kLOC TS) — the end-user coding/chat app; 14-channel bus with Chinese enterprise IM depth (Feishu 1,827 LOC, DingDing 1,122, WeCom 914, WeChat 1,032, Xiaoyi 1,458); `agentserver/` (7,943 LOC); `deep_agent/permissions/` (1,098 LOC) with LLM-assessed command risk; `skilldev/` 10-stage pipeline (3,526 LOC)
+
+### Coding-loop depth
+`react_agent.py` invoke loop. Single `for iteration in range(max_iterations)` (15 default, `sys.maxsize` when `enable_task_loop=True`). One-shot context-fix retry. **No retry-counter classes. No credential pool. No semantic error classifier. No MAX_DEPTH on subagent.**
+
+### Context management
+3-tier LLM-based compressor:
+- `DialogueCompressor` (551 LOC) — ReAct-block JSON compression with priority ordering and bilingual preservation
+- `RoundLevelCompressor` (1,150 LOC) — aggressive fallback
+- `CurrentRoundCompressor` (1,006 LOC) — in-flight round compression
+
+Strong design; **comparable to hermes's iterative template** though simpler in that it's single-pass rather than iterative-refinement-of-prior-summary.
+
+### Protocol
+Full C++ SDKs for **A2A** (Google's Agent-to-Agent) and **MCP**. A2A is a unique capability neither hermes nor octos has. ACP exists only as a 79-LOC stub channel in `jiuwenclaw/channel/acp_channel.py`.
+
+### RL training
+`dev_tools/agentrl/` (5,563 LOC) with PPO trainer, rollout store, `verl_executor.py` for VeRL framework integration, reward registry. `jiuwenclaw/evolution/` (1,909 LOC) with signal_detector, evolver, online experience generation. **Genuine RL infrastructure** — hermes and octos have none.
+
+### Web Studio
+~170 kLOC full-stack React + FastAPI agent-creation IDE. Pages for Agents, Workflows, Models, Prompts, KnowledgeBase, MemoryBase, Plugins, Dashboard. Plus `plugin_server/` and `sandbox_server/` (FastAPI gateway + Python kernel multi-process isolation + JS kernel + Dockerfiles). This is the **supervisor UI** octos lacks.
+
+### Weaknesses
+Not safe under API instability (no credential pool, no structured error recovery). Thin CLI. No ACP. No SWE-bench runner. Permissions system uses LLM-assessed risk (`assess_command_risk_with_llm`) which adds latency and has non-determinism concerns.
+
+## Capability matrix
+
+| Axis | hermes | octos | openJiuwen |
+|------|--------|-------|------------|
+| Coding-loop retry counters | 7 classes | None structured | None |
+| LLM failover / credential pool | Persistent per-credential cooldowns, 4 strategies, OAuth refresh | 3-layer (Retry → Chain → Adaptive) | None |
+| Structured error taxonomy | 15-reason enum + 4 recovery flags | None | None |
+| LLM-based context compaction | Iterative, structured Goal/Progress template | Extractive only | 3-tier single-pass |
+| Sandbox | Local subprocess only | 3-backend local (bwrap / macOS / Docker) | Remote containerized gateway |
+| Workspace contract | None | Typed + durable | None |
+| Validator runner | None | Declarative (M4.3) | Generic ReAct rail completion |
+| Executable skill binaries | Prose markdown only | Yes, manifest + JSON protocol | Skill marketplace + 10-stage skilldev pipeline |
+| Subagent / delegation | Synchronous, MAX_DEPTH=2 | `spawn_only` background | Synchronous TaskTool, **no depth limit** |
+| Agent teams / swarm | None | None | TeamAgent system (8,882 LOC) |
+| RL training | None | None | agentrl (5,563 LOC) + online evolver |
+| SWE-bench runner | `mini_swe_runner.py` 709 LOC | None | None |
+| CLI UI framework | prompt_toolkit + rich + curses | `colored` + `clap` only | Stub (54 LOC `app_cli.py`) |
+| Web Studio / supervisor UI | Minimal | Admin dashboard (M4.5) | Full-stack Studio (~170 kLOC) |
+| Multi-channel bus | 1 channel | 14 channels | 14 channels (Chinese IM heavy) |
+| ACP server | ✓ (1,784 LOC) | ✗ | Stub (79 LOC) |
+| ACP client | ✓ (Copilot shim 570 LOC) | ✗ | ✗ |
+| MCP client | ✓ | ✓ | ✓ (Python) + C++ SDK |
+| MCP server (agent-as-tool) | ✗ | ✗ | ✗ |
+| A2A (Google agent-to-agent) | ✗ | ✗ | ✓ (C++ SDK) |
+| Hybrid BM25 + HNSW memory | ✗ | ✓ | Graph + lite + long-term split |
+| Durable task lifecycle states | Session-level | `TaskLifecycleState` enum | Generic session persistence |
+| Schema-versioned ABI | ✗ | ✓ (M4.6) | ✗ |
+| Deny(unsafe_code) type safety | Python | Rust | Python |
+
+## Coding-loop failure mode analysis
+
+For a 60-turn coding session on flaky LLM infrastructure:
+
+- **hermes**: survives. Error classifier routes 429 → credential rotation or wait. Retry counters catch and recover malformed tool calls. Iterative compressor keeps architectural decisions from turn 15 available at turn 45. Budget-grace-call lets the model summarize at end.
+- **octos**: survives provider-level outages (3-layer failover) but loses session coherence on long runs — extractive compaction doesn't preserve architectural decisions; no retry-counter taxonomy for tool-call malformation.
+- **openJiuwen**: drops at turn 30-45 if the provider hiccups. No credential pool. One-shot retry only. The 3-tier LLM compressor keeps it going on coherence, but compression itself consumes tokens without adaptive routing to cheap models for the compression call.
+
+## Delta estimates
+
+### To reach hermes parity on free-form coding
+
+| Target | From octos | From openJiuwen |
+|---|---|---|
+| Credential pool | ~1,300 LOC Rust | ~1,300 LOC Python |
+| Structured error classifier | ~800 LOC | ~800 LOC |
+| Smart content-classified routing | ~200 LOC | ~200 LOC (already has AdaptiveRouter pattern implicit) |
+| ACP bidirectional | ~3,500 LOC | ~2,000 LOC (stub to replace) |
+| SWE-bench runner | ~1,000 LOC | ~1,000 LOC |
+| MAX_DEPTH on subagent | ~100 LOC | ~100 LOC |
+| Iterative context-refinement-of-prior-summary | ~500 LOC | ~300 LOC (already has 3-tier base) |
+| CLI TUI (ratatui / prompt_toolkit equivalent) | ~2,000 LOC | ~2,000 LOC |
+| **Total** | **~9,400 LOC Rust** | **~7,700 LOC Python** |
+| **Time** | 3-4 engineer-months | 2-3 engineer-months |
+
+### To reach openJiuwen parity on platform surface (octos)
+
+Much larger gap than the hermes gap:
+- Web Studio agent-creation IDE: ~100-120 kLOC React + 40-50 kLOC Rust backend; **6-12 months, 3 engineers**
+- Agent teams / swarm: ~9 kLOC Rust; 2-3 months
+- RL training: ~5 kLOC (leveraging existing RL framework); 3-6 months
+- Skill marketplace + 10-stage skilldev pipeline: ~4 kLOC; 2 months
+- A2A protocol: ~3-5 kLOC Rust port; 1-2 months
+- Chinese enterprise IM channels (Feishu/DingDing/WeCom/WeChat/Xiaoyi): ~6 kLOC Rust; 3-4 months
+- **Total: 120-170 kLOC over 12-18 months, 4-5 engineer team**
+
+The openJiuwen gap is an order of magnitude wider than the hermes gap. Closing it would be a different company, not a different milestone.
+
+## Strategic implication
+
+Octos's current roadmap (M4 productization → M5 coding runner contract) pursues **contract-first platform quality** — the same axis where octos already differentiates. This is defensible and focused.
+
+Pursuing hermes parity would require adding the 9.4 kLOC of coding-loop-resilience work, most of which sits outside the current M4/M5 contract vocabulary (error taxonomy, credential pool, iterative compression are loop concerns, not contract concerns). That work should either go into a dedicated **M6 coding loop hardening** milestone or be explicitly deferred.
+
+Pursuing openJiuwen parity would require a pivot — web Studio + agent teams + RL training represent a different product bet. Not recommended unless the company decides to compete with openJiuwen on Chinese enterprise agent deployment, which is a sales-first question not a roadmap-first question.
+
+## Recommended posture
+
+- **Keep octos's axis**: contract-first API platform. M5 coding runner contract is consistent.
+- **Close the two highest-leverage protocol gaps** (see `OCTOS_PROTOCOL_STRATEGY_2026-04-22.md`): MCP-server-of-octos so orchestrators can call octos as a sub-agent; MCP-client-to-other-agents (Claude Code, Codex) so octos can orchestrate them.
+- **Defer hermes-style coding-loop depth** unless user signal demands it. The contract-first completion gate (M5) is a different approach to solving "how do we trust a coding agent": hermes answers via loop resilience, octos answers via contract-gated delivery. Both are valid; they're different products.
+- **Do not pursue openJiuwen-class Web Studio** unless the enterprise-agent-deployment market becomes the primary product. Current roadmap implies it is not.
+
+## Next review
+
+Revisit this analysis after M5 completion. If an M6 coding-loop milestone is opened, this doc should be the gap spec for it.

--- a/docs/OCTOS_PROTOCOL_STRATEGY_2026-04-22.md
+++ b/docs/OCTOS_PROTOCOL_STRATEGY_2026-04-22.md
@@ -1,0 +1,239 @@
+# Octos Protocol Strategy — 2026-04-22
+
+See also:
+
+- [OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md](./OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md)
+- [OCTOS_SWARM_POSITIONING_2026-04-22.md](./OCTOS_SWARM_POSITIONING_2026-04-22.md)
+
+## Purpose
+
+Record octos's strategic posture on agent-interchange protocols: **MCP**, **ACP**, and **A2A**. Document the competitive dynamics between Anthropic, Zed, Google, and third-party orchestrators. Define the recommended octos protocol roadmap.
+
+## Protocols in play
+
+### MCP — Model Context Protocol
+
+- Published by **Anthropic** (November 2024)
+- Anthropic-controlled spec
+- Architecture: LLM host ↔ tool/data **server**
+- Exposes: `tools` (callable functions), `resources` (readable data), `prompts` (reusable prompts)
+- Transport: stdio, SSE, HTTP
+- Orchestration ownership: **host** decides when/how to call each tool
+
+### ACP — Agent Client Protocol
+
+- Originated with **Zed** editor for AI coding-agent integration
+- Anthropic supports it for Claude Code editor integration (but deliberately not as the primary sub-agent exposure mechanism)
+- Architecture: editor/outer-client ↔ full **agent**
+- Flows: initialize, prompt, streaming thinking + tool calls + results + replies, session fork/load, authentication, MCP-server-forwarding
+- Transport: JSON-RPC; in practice always stdio (client spawns agent as subprocess)
+- Orchestration ownership: **agent** owns the full loop internally; client just sends user turns and reads streams
+
+### A2A — Agent-to-Agent Protocol
+
+- Published by **Google**
+- Architecture: agent ↔ agent, peer-to-peer
+- Positioned as an open standard for multi-agent orchestration
+- OpenJiuwen has a complete C++ SDK; Anthropic and OpenAI have not adopted publicly
+
+## Does ACP require the sub-agent to run on the same computer?
+
+**In practice today: yes. By spec: no.**
+
+ACP is JSON-RPC over a transport. The transport is not fixed by the spec — it could be stdio, TCP, WebSocket, or HTTP. But every production implementation uses stdio: the client spawns the agent as a child process and communicates over stdin/stdout.
+
+Examples:
+- Zed calling Claude Code: Zed spawns `claude --acp` as a subprocess
+- hermes's `copilot_acp_client.py`: `subprocess.Popen(["copilot", "--acp"], ...)` with pipes
+- hermes's own ACP server (`acp_adapter/server.py`): runs under `hermes acp` as an stdio JSON-RPC server
+
+Consequences of stdio-default:
+- Same machine, same user, shared filesystem
+- Simple authentication (parent process spawned you, so trusted)
+- Cannot scale across hosts
+- No network auth layer needed
+- Agent has access to editor's working directory
+
+For **remote** ACP you would need either a TCP/WebSocket transport shim (nothing in the spec forbids it) or a relay pattern. No standard implementation provides this today.
+
+**Practical implication**: ACP is a desktop/developer-workstation protocol. Multi-tenant server deployments need a non-ACP orchestration path (REST, gRPC, or a networked-transport extension of ACP).
+
+## MCP vs ACP — the substance
+
+### Technical comparison
+
+| Dimension | MCP | ACP |
+|---|---|---|
+| What is standardized | LLM ↔ tool/data server | Editor/client ↔ agent |
+| Who is the server | Tool/resource provider (DB, filesystem, API) | The agent itself |
+| Who is the client | LLM host (Claude Desktop, Claude Code, Codex, …) | Editor or outer orchestrator |
+| What flows | `tools`, `resources`, `prompts`; host chooses when to call | Full agent session: prompt, reply, tool-call streaming, session fork |
+| Orchestration | **Host** owns the loop | **Agent** owns the loop |
+| Context footprint in caller | Small (just tool I/O) | Large (full streamed session) |
+| Canonical use | Extending an agent with tools | Swapping in a full agent |
+
+### Why each protocol won the use case it did
+
+MCP won tool-extension because:
+- Tool calls are bounded: one request, one response
+- Agents need many tools; standardizing the tool interface is high-leverage
+- Anthropic controlled the spec and shipped Claude with MCP client from day one
+
+ACP won editor-integration because:
+- Editors need streaming UX (live thinking, live tool calls, syntax highlighting of agent output)
+- Editors need session lifecycle (fork, list, load, authenticate)
+- Zed introduced it and the open-source editor ecosystem adopted it
+
+## Why Codex uses MCP to launch sub-agents (including Claude Code)
+
+OpenAI's Codex CLI can consume MCP servers as tools. Anthropic shipped `claude mcp serve` — a mode that exposes Claude Code itself as an MCP server. This makes **Claude Code callable as a tool by Codex**.
+
+### Seven technical reasons MCP beats ACP for sub-agent composition
+
+1. **Agent-as-tool is the cleanest composition primitive.** MCP treats the sub-agent as a callable function. Parent's loop doesn't change — just another tool. ACP would require integrating streaming session lifecycle into the parent's loop.
+
+2. **Context isolation.** If Codex spawns Claude Code to fix a bug, Claude Code internally runs 50 tool calls. With MCP, all that stays inside Claude Code's context — only the final result lands in Codex's context. With ACP, every internal tool call would stream back. For a 20-turn Codex session × 3 sub-agent spawns, MCP gives ~5 kB of sub-agent telemetry; ACP gives ~50 kB. **~10× context saving.**
+
+3. **Request-response matches spawn semantics.** `tools/call` in MCP is request-response — maps cleanly to `future.await`. ACP's streaming session is awkward to treat as a future.
+
+4. **Hierarchical composition.** MCP-inside-MCP is natural: sub-agents can themselves have sub-agents arbitrarily deep via the same protocol. ACP doesn't recurse cleanly.
+
+5. **Simpler authorization.** MCP call = "can this tool be called?" (one allow/deny). ACP = "can this agent initialize a session? capabilities granted? session fork allowed?" (more surface).
+
+6. **No interactive-UX baggage.** MCP doesn't carry "streaming thinking" or "tool call live preview" — because sub-agent-orchestration doesn't need those. ACP carries editor-UX concerns that are irrelevant agent-to-agent.
+
+7. **Remote sub-agents work natively.** MCP has HTTP and SSE transports as first-class, alongside stdio. A sub-agent can run on a different host, inside a container, in a different datacenter — invoked via `https://agents.example.com/claude-code/mcp`. ACP is stdio-only in every production implementation; multi-host ACP requires a non-standard transport shim. This is the **decisive architectural gap for multi-tenant and cloud-deployed orchestration**: MCP naturally supports sub-agent pools on remote hosts (centralized Claude-Code-as-a-service, per-tenant Codex instances, GPU-bound agents on dedicated nodes); ACP does not. The earlier "same-computer" constraint on ACP is an MCP advantage, not just a ACP footnote.
+
+### The political reason — Anthropic's deliberate MCP-first positioning
+
+MCP and ACP have asymmetric political positioning for Anthropic:
+
+**MCP**:
+- Anthropic's own protocol; Anthropic controls the spec
+- Every MCP-using agent is in Anthropic's ecosystem
+- Anthropic benefits from more MCP adoption
+
+**ACP**:
+- Zed's protocol
+- Treats agents as interchangeable (Claude Code, Copilot, OpenClaw, jiuwenclaw, hermes, Cursor agent — all peer)
+- An editor can swap Claude Code for a competitor with minimal work — commoditizes the agent layer
+
+An outside reading: Anthropic would prefer orchestrators consume Claude Code via MCP rather than ACP. MCP:
+- Keeps Anthropic's protocol dominant in the composition story
+- Lets Claude Code stay differentiated as "the best tool" among peer tools rather than "one agent among peer agents"
+- Avoids the ACP commoditization dynamic where the orchestrator layer captures the value
+
+Evidence this is real:
+- Anthropic shipped `claude mcp serve` — making Claude Code an MCP tool — as the **first-class** sub-agent-exposure mechanism
+- Anthropic supports ACP for editor integration but did not push it as the agent-to-agent composition path
+- Codex, hermes, and future orchestrators are converging on MCP-for-sub-agents because it's the best technical fit AND the path of least resistance inside Anthropic's protocol ecosystem
+
+### Validation: hermes's ACP-as-chat-backend is awkward
+
+Hermes's `copilot_acp_client.py` (570 LOC) wraps Copilot's ACP server as a chat backend. The docstring: *"Each request starts a short-lived ACP session, sends the formatted conversation as a single prompt, collects text chunks, and converts the result back into the minimal shape Hermes expects from an OpenAI client."*
+
+Hermes is fighting the protocol — forcing ACP's streaming session shape into a request-response mold because request-response is what sub-agent composition actually needs. A more natural design would be: expose Copilot as an MCP tool. One call, one result.
+
+The existence of 570 LOC to make ACP look like MCP is itself evidence that MCP is the right shape for sub-agent composition.
+
+## Octos's protocol gap — current state
+
+| Protocol | Octos | Recommendation |
+|---|---|---|
+| MCP client | ✓ present (consumes MCP tool servers) | Keep; extend for sub-agent use case |
+| MCP server (octos-as-tool) | ✗ absent | **Add** |
+| ACP client | ✗ absent | Add later (editor integration) |
+| ACP server (octos-as-agent) | ✗ absent | Add later (editor integration) |
+| A2A client / server | ✗ absent | Deferred unless enterprise demand |
+
+## Recommended octos protocol roadmap
+
+### Priority 1 — MCP sub-agent adapter (consume agents as tools)
+
+**Rationale**: octos as orchestrator. Claude Code, Codex, hermes, jiuwenclaw all expose (or will expose) themselves as MCP servers. Octos should be able to dispatch a contract to `claude_code_tool(task="...")` and receive a result. Fits the swarm-future thesis from `OCTOS_SWARM_POSITIONING_2026-04-22.md`.
+
+**Scope**:
+- New Rust module `crates/octos-agent/src/tools/mcp_agent.rs`
+- `SpawnTool` gains an `agent_mcp` backend: spawn configured MCP agent binary (e.g., `claude mcp serve`, `codex mcp serve`), speak MCP to it, treat it as a callable
+- Route task I/O through octos's workspace contract → `MessageTool` semantics
+- Sub-agent's internal state stays isolated; only declared artifacts surface
+- Reuse M4.1A harness events (`octos.harness.event.v1`) for progress observability
+- Reuse M4.3 validator runner for output gating
+- Supports hierarchical composition (sub-agent spawns its own sub-agents)
+
+**Estimate**: ~1 kLOC Rust. ~1 engineer-month including tests.
+
+**Deliverable**: one RP-family-style contract-bound issue. Working name: **`#OCTOS_MCP_AGENT` — Call MCP-exposed agents (Claude Code / Codex / etc.) as contract-bound sub-agents**.
+
+### Priority 2 — MCP server mode (expose octos as tool)
+
+**Rationale**: symmetric to priority 1. Once octos can orchestrate, it should also be orchestrable. Lets outer orchestrators (another octos instance, Codex, Claude Code, jiuwenclaw) use octos as a sub-agent. Fits swarm-of-swarms topology.
+
+**Scope**:
+- New Rust module `crates/octos-agent/src/mcp_server.rs` (naming TBD)
+- Expose octos's existing tool registry as MCP tools, subject to `ToolPolicy` allow lists
+- Or expose entire octos sessions as MCP "task" tools: outer MCP client invokes `octos_task(contract=...)` → octos runs the session → returns workspace-contract-gated result
+- Preferred: **session-level MCP tool**, not tool-by-tool MCP (keeps isolation semantics of MCP-for-sub-agents)
+- Authentication: MCP transport options (stdio parent-trust, HTTP with bearer token)
+
+**Estimate**: ~1.5 kLOC Rust. 1-1.5 engineer-months.
+
+**Deliverable**: contract-bound issue. Working name: **`#OCTOS_MCP_SERVER` — Expose octos sessions via MCP**.
+
+### Priority 3 — ACP client (editor and desktop integration)
+
+**Rationale**: octos-as-desktop-agent for developers using ACP-native editors (Zed, etc.). Less leverage than MCP paths but needed for the developer-workstation use case.
+
+**Scope**:
+- New Rust module `crates/octos-agent/src/acp_client.rs`
+- Speak ACP over stdio; connect to editor or outer-ACP client
+- Map ACP session lifecycle to octos Session
+- Stream M4.1A harness events as ACP progress frames
+
+**Estimate**: ~2 kLOC Rust. 1.5-2 engineer-months. (ACP's streaming semantics are richer than MCP's request-response.)
+
+**Deliverable**: optional, after Priority 1 and 2 ship.
+
+### Priority 4 — ACP server (octos-as-agent-to-editor)
+
+**Rationale**: only if octos pursues a Claude-Code-style developer-workstation product. Editor connects to octos via ACP, octos serves coding-agent capability. Predicated on a CLI TUI product posture which is currently **not** octos's direction.
+
+**Estimate**: ~3 kLOC Rust, ~2 engineer-months. Only ship if the product bet is coding-first.
+
+### Priority 5 — A2A
+
+**Deferred**. No current demand signal. OpenJiuwen is the only platform with a real A2A implementation. Revisit if Chinese enterprise agent market becomes a target.
+
+## Why this sequencing beats ACP-first
+
+The earlier internal analysis suggested ACP-client first. **Revised posture**: MCP-agent-tool first.
+
+| Criterion | MCP-agent-tool (P1) | ACP-client (P3) |
+|---|---|---|
+| Complexity | Simple — agent is one tool | Streaming session lifecycle |
+| Context overhead in parent | Small | Large |
+| Fits octos's existing infra | Directly — already has MCP client + ToolRegistry | Needs new session-mapping layer |
+| Fits swarm topology | Yes — agents-as-tools composes hierarchically | Awkward — ACP-inside-ACP doesn't recurse |
+| Effort | ~1 kLOC | ~2 kLOC |
+| Consistency with industry direction | Codex / Claude Code both ship MCP sub-agent support | Editor-side only |
+| Anthropic relationship | Aligned — uses Anthropic's protocol | Forces ACP commoditization on Anthropic |
+| Competitive positioning | Octos orchestrates Claude Code / Codex as sub-agents | Octos peers with Claude Code in Zed's editor |
+
+MCP-agent-tool is strictly more leveraged. Octos becomes a **super-orchestrator** that uses best-in-class coding agents (Claude Code, Codex, hermes) as workers for tasks where their coding-loop depth matters, while octos contributes contract-first task decomposition, workspace validation, multi-channel dispatch, and durable task supervision.
+
+## Competitive positioning after P1+P2 land
+
+**Octos becomes**: the contract-first orchestration platform that can call any MCP-exposed agent as a sub-agent and be called by any MCP host as a sub-agent. Lives above the agent-layer commodity, differentiated by contracts + validators + multi-channel + platform substrate.
+
+**Octos does not become**: a hermes-class coding-loop specialist. That's fine; octos orchestrates hermes-class agents when coding depth matters. Division of labor: octos decomposes and validates; Claude Code / hermes / Codex does the coding.
+
+## Open questions for the team
+
+1. Does the team want **session-level** MCP tool exposure (one MCP tool = one full octos session) or **tool-level** MCP exposure (each of octos's ~20 tools becomes an MCP tool)? Session-level is the swarm-friendly choice; tool-level is legacy agent-as-toolkit.
+2. For `OCTOS_MCP_AGENT`, should octos bundle known-good MCP agent configs (Claude Code, Codex) as starter templates, or require operators to configure them?
+3. Is HTTP MCP transport needed, or is stdio-only sufficient for the first pass?
+4. Should the ACP client path ever be prioritized, or is it perpetually P3? (Ties to the CLI-TUI question in `OCTOS_SWARM_POSITIONING_2026-04-22.md`.)
+
+## Next review
+
+Revisit after Priority 1 ships. The strategic claim — "MCP-for-sub-agents is the path forward" — should be validated by real orchestration against Claude Code and/or Codex with observable token savings and swarm-topology success.

--- a/docs/OCTOS_SWARM_ORCHESTRATOR_M7_PLAN_2026-04-22.md
+++ b/docs/OCTOS_SWARM_ORCHESTRATOR_M7_PLAN_2026-04-22.md
@@ -1,0 +1,228 @@
+# Octos Swarm Orchestrator — M7 Plan (Track 2)
+
+See also:
+
+- [OCTOS_SWARM_POSITIONING_2026-04-22.md](./OCTOS_SWARM_POSITIONING_2026-04-22.md)
+- [OCTOS_PROTOCOL_STRATEGY_2026-04-22.md](./OCTOS_PROTOCOL_STRATEGY_2026-04-22.md)
+- [OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md](./OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md)
+- [OCTOS_CODING_HARDENING_M6_PLAN_2026-04-22.md](./OCTOS_CODING_HARDENING_M6_PLAN_2026-04-22.md) — Track 1
+
+## Purpose
+
+Turn octos from a strong standalone coding agent (Track 1 / M6) into a **PM + swarm orchestrator**. Under the swarm-future thesis (humans author contracts, agents call agents), octos's architectural bet is already contract-first, API-first, schema-versioned — M7 adds the connective tissue that makes octos call best-in-class coding agents (Claude Code, Codex, hermes) as sub-agents, exposes octos sessions to outer orchestrators as callable tools, and surfaces swarm state to supervisors.
+
+## Why M7 can ship in parallel with M6 merge gate
+
+M6 work (8 PRs pending merge) touches core agent-loop files: `loop_runner.rs`, `execution.rs`, `plugins/tool.rs`, plus additive extensions to `harness_events.rs`, `task_supervisor.rs`, `metrics.rs`.
+
+M7 work is almost entirely **new files** in different modules:
+- `crates/octos-agent/src/tools/mcp_agent.rs` (new)
+- `crates/octos-agent/src/mcp_server.rs` (new)
+- `crates/octos-cli/src/swarm/` (new module)
+- `crates/octos-bus/src/matrix_channel.rs` (extend — M6 doesn't touch)
+
+Shared files (`harness_events.rs`, `metrics.rs`, `task_supervisor.rs`, `abi_schema.rs`, `lib.rs`) remain additive-only — M7 adds new variants + counters + re-exports, the same pattern the integration-reconciler already resolved cleanly for M6.
+
+**M7 Wave 1 dispatches immediately**. Subsequent waves follow M6's merge cadence.
+
+## Architectural thesis
+
+Octos at end of M7:
+
+- **As orchestrator**: `SpawnTool` gains an MCP-agent backend. Configured agent binaries (`claude mcp serve`, `codex mcp serve`) or remote MCP endpoints (`https://agents.example.com/claude-code/mcp`) become contract-bound sub-agents. Task dispatched → MCP `tools/call` → sub-agent runs its own loop → result flows back through workspace contract → parent never sees sub-agent internal state (context isolation win).
+- **As callable worker**: octos exposes running sessions as MCP tools. Outer orchestrators (another octos instance, Codex, Claude Code, hermes, jiuwenclaw) can invoke octos via the same `tools/call` API.
+- **As swarm supervisor**: First-class `Swarm::dispatch(contracts, topology, budget) -> SwarmResult` primitive replaces the manual orchestration pattern supervisors run today. Hybrid: humans authoring contracts, swarm primitive fanning out.
+- **As visible to humans**: Matrix-as-supervisor-UI (extending existing channel) registers sub-agents as puppets, routes progress events to per-agent rooms. The human supervises via Element (desktop / mobile / web) — zero net-new UI code. Plus contract-authoring dispatch form in the existing React dashboard.
+
+Each piece is typed, schema-versioned, validator-gateable. Consistent with octos's existing harness posture.
+
+## Sub-milestones
+
+Eight contract-bound issues, same RP / M4 / M6 family style.
+
+### M7.1 — MCP agent-tool backend for SpawnTool
+
+**Problem**: No way to call external MCP-exposed agents (Claude Code, Codex, hermes) as sub-agents. Today `SpawnTool` only spawns configured `app-skill` binaries.
+
+**Deliverable**: `crates/octos-agent/src/tools/mcp_agent.rs` (new). Extends `SpawnTool` config with `agent_mcp` backend variant. Supports both local (stdio subprocess, e.g., `claude mcp serve`) and remote (HTTPS, e.g., `https://agents.example.com/claude-code/mcp`) MCP endpoints. Request-response via `tools/call`. Result routed through workspace contract → M4.1A artifact delivery. Context isolation: sub-agent's internal state stays inside the MCP call; only final result lands in parent context.
+
+**Size**: ~1,200 LOC Rust.
+
+**Dependencies**: Existing MCP client in `octos-agent`; M4.1A contract-gated delivery (landed).
+
+### M7.2 — MCP server mode (octos as callable tool)
+
+**Problem**: No way for outer orchestrators (another octos, Codex, Claude Code) to call octos as a sub-agent. Octos's REST API exists but isn't MCP-shaped.
+
+**Deliverable**: `crates/octos-agent/src/mcp_server.rs` (new). Exposes octos sessions as MCP tools. Session-level exposure (one MCP tool = one full octos session that runs to completion and returns the workspace-contract artifact). Supports stdio transport (default), HTTP (for remote). Authentication: stdio parent-trust, HTTP bearer token.
+
+**Size**: ~1,500 LOC Rust.
+
+**Dependencies**: Existing MCP protocol types in `octos-agent`; existing session machinery.
+
+### M7.3 — Matrix-as-supervisor-UI
+
+**Problem**: Supervisor has no live view of multiple concurrent sub-agents without a bespoke dashboard. Agent-chat pattern (`~/home/agent-chat/`) validates using Matrix for this.
+
+**Deliverable**: Extend `crates/octos-bus/src/matrix_channel.rs`. On sub-agent spawn, register Matrix puppet user (`@<agent-label>-<session>:homeserver`) and per-swarm room. Route M4.1A harness events to the room as messages from the corresponding puppet. Human replies in the room route back to the sub-agent as steering input. Supervisor uses Element / Fluffy / any Matrix client — zero net-new UI code.
+
+**Size**: ~800 LOC Rust (extends existing 1,600+ LOC matrix channel).
+
+**Dependencies**: None. Can dispatch in Wave 1 in parallel with M7.1 / M7.2.
+
+### M7.4 — Cost / provenance ledger
+
+**Problem**: No attribution for swarm dispatches. Once supervisor spawns N sub-agents for a contract, budget accountability disappears.
+
+**Deliverable**: New ledger per dispatch: `supervisor_session_id + contract_id + task_id + model + tokens_in/out + cost + timestamp`. Redb-backed persistent store (same pattern as M6.5 credential pool). Emitted as `octos.harness.event.v1 { kind: "cost_attribution" }`. Operator summary extension with per-contract cost breakdown. Optional budget enforcement (fail dispatch if projected cost exceeds budget).
+
+**Size**: ~1,000 LOC Rust.
+
+**Dependencies**: M7.1 + M7.2 (to have dispatches to attribute).
+
+### M7.5 — Swarm orchestration primitive
+
+**Problem**: Supervisor orchestration pattern (author contract → fan out N agents → aggregate → report) is manual today. PM wrote it by hand during RP and M6. Should be a first-class API.
+
+**Deliverable**: New `crates/octos-swarm/` crate with `Swarm::dispatch(contracts, topology, budget) -> SwarmResult`. Topology types: `Parallel(n)`, `Sequential`, `Pipeline`, `Fanout(Pattern)`. Records dispatch provenance, aggregates artifacts, runs M4.3 validator on aggregate output, rolls up cost via M7.4 ledger. Re-entry on partial failure (redispatch failed sub-contracts). Session-durable (supervisor can reload state after crash).
+
+**Size**: ~2,500 LOC Rust (new crate).
+
+**Dependencies**: M7.1, M7.4.
+
+### M7.6 — Contract authoring + swarm dispatch dashboard
+
+**Problem**: Dashboard is diagnostic (M4.5 / M6.8). Supervisor needs to author contracts + dispatch + monitor + decide-at-gates.
+
+**Deliverable**: `dashboard/src/pages/SwarmPage.tsx` + supporting components:
+- Contract editor (syntax-highlighted JSON/TOML)
+- Dispatch form (select contract, pool, topology, budget)
+- Live swarm view (per-agent progress, cost, lifecycle state)
+- PR review surface (contract invariant checks + M4.3 validator evidence + cost attribution)
+- Integration with M7.5 Swarm primitive
+
+**Size**: ~6,000 LOC React + ~1,500 LOC Rust backend (additive to admin API).
+
+**Dependencies**: M7.1, M7.4, M7.5.
+
+### M7.7 — ACP client adapter (deferred niche)
+
+**Problem**: Editor integration (Zed, Claude Code editor mode) uses ACP. Octos-as-ACP-agent lets editors invoke octos as the coding agent.
+
+**Deliverable**: `crates/octos-agent/src/acp_client.rs` + `acp_server.rs`. ACP JSON-RPC over stdio. Maps ACP session lifecycle to octos session. Streams M4.1A harness events as ACP progress frames.
+
+**Size**: ~3,000 LOC Rust.
+
+**Dependencies**: None, but LOW priority per protocol-strategy doc. Deferred unless editor-integration demand signals.
+
+### M7.8 — Live fleet gate + release validation
+
+**Problem**: Need a repo-side gate that validates swarm dispatch end-to-end on real canary (analogous to M4.1A.474 live gate).
+
+**Deliverable**: `scripts/validate-m7-swarm-live.sh` + `e2e/tests/swarm-dispatch-gate.spec.ts`. Authors fixture contract, dispatches via M7.5 Swarm primitive, verifies: sub-agents spawned, progress events flowed, artifacts delivered, cost ledger attributed, Matrix rooms created, validator ran, reload preserves state. Exit codes with structured diagnostic JSON.
+
+**Size**: ~800 LOC bash + TypeScript.
+
+**Dependencies**: M7.1-M7.6 all merged.
+
+## Phasing + parallel dispatch
+
+```
+Phase M7A (parallel, Wave 1)       ← dispatches NOW
+┌──────────────────────────────────────┐
+│ M7.1 MCP agent-tool backend          │  ← 3-4 weeks, new file
+│ M7.2 MCP server mode                 │  ← 3-4 weeks, new file
+│ M7.3 Matrix-as-supervisor-UI         │  ← 2 weeks, extends existing matrix channel
+└──────────────────────────────────────┘
+                │
+                ▼
+Phase M7B (parallel, Wave 2)       ← after M7A merges
+┌──────────────────────────────────────┐
+│ M7.4 Cost / provenance ledger        │  ← depends on M7.1+M7.2
+│ M7.5 Swarm orchestration primitive   │  ← depends on M7.1+M7.4
+└──────────────────────────────────────┘
+                │
+                ▼
+Phase M7C (Wave 3)
+┌──────────────────────────────────────┐
+│ M7.6 Contract authoring + dashboard  │  ← depends on M7.4+M7.5
+└──────────────────────────────────────┘
+                │
+                ▼
+Phase M7D (optional / deferred)
+┌──────────────────────────────────────┐
+│ M7.7 ACP client (editor niche)       │  ← deferred unless demand
+└──────────────────────────────────────┘
+                │
+                ▼
+Phase M7E (final gate)
+┌──────────────────────────────────────┐
+│ M7.8 Live fleet gate                 │  ← after M7.1-M7.6
+└──────────────────────────────────────┘
+```
+
+**Total**: ~14 kLOC Rust + ~6 kLOC TS, 4-6 engineer-months with parallel dispatch.
+
+## Success criteria
+
+M7 is complete when all of the following hold:
+
+1. **Octos dispatches Claude Code as sub-agent**: configured `claude mcp serve` endpoint, octos calls `tools/call` with a typed contract, Claude Code executes its internal loop, result returns through workspace contract, parent context remains small (under 5 kB of sub-agent telemetry).
+2. **Octos exposes itself as MCP tool**: `octos serve --mcp` mode accepts `tools/call` from outer orchestrator, runs session, returns contract-gated artifact.
+3. **Remote agent dispatch works**: URL-based MCP endpoint (HTTPS) dispatches identically to local stdio.
+4. **Matrix supervisor UI live**: supervisor joins per-swarm Matrix room on Element mobile, sees 3 sub-agents progress, replies to steer one, reply routes to correct sub-agent.
+5. **Swarm primitive**: `Swarm::dispatch` call fans out N contracts, aggregates, rolls up cost via ledger, runs validator on aggregate.
+6. **Dashboard contract-authoring**: supervisor writes contract in `SwarmPage`, dispatches with one click, sees live progress + cost + validator evidence.
+7. **Live fleet gate**: `scripts/validate-m7-swarm-live.sh --base-url https://dspfac.crew.ominix.io` runs end-to-end + exits 0.
+8. **No M6 regressions**: all M6 tests remain green; shared files (`harness_events.rs`, `metrics.rs`, `task_supervisor.rs`) only grow.
+
+## Out of scope — explicitly deferred
+
+- ACP server (octos-as-ACP-agent) — unless coding-first product pivot
+- A2A protocol — only if enterprise agent-to-agent demand materializes
+- Multi-tenant cost policy enforcement beyond per-contract ceiling
+- `slam-nav-sim` or robotics-specific swarm templates (RP family separately)
+- SWE-bench orchestration (hermes has this; if octos needs it, separate milestone)
+
+## Hermes comparison (re-expression principle preserved)
+
+| Hermes coding capability | M7 re-expression |
+|---|---|
+| ACP server + Copilot ACP client | MCP-first: M7.1 + M7.2 with optional ACP deferred to M7.7 |
+| Sync `delegate_task` with MAX_DEPTH=2 | Already in M6.7; M7.1 extends to external agents via MCP |
+| Full Python `run_agent.py` monolith | Typed `SpawnTool.agent_mcp` + `Swarm::dispatch` — composable primitives |
+| No central budget / cost attribution | M7.4 cost ledger with per-contract + schema-versioned |
+| No supervisor UI (hermes is CLI-first) | M7.3 Matrix puppet pattern + M7.6 React dispatch dashboard |
+
+Every M7 feature composes with M4.1A events, M4.3 validators, M4.5 dashboard, M6 coding-loop hardening. No parallel implementations.
+
+## Conflict surface analysis vs in-flight M6 work
+
+| File | M6 touches | M7 touches | Conflict risk |
+|---|---|---|---|
+| `crates/octos-agent/src/tools/mcp_agent.rs` | — | M7.1 (new) | None |
+| `crates/octos-agent/src/mcp_server.rs` | — | M7.2 (new) | None |
+| `crates/octos-swarm/` | — | M7.5 (new crate) | None |
+| `crates/octos-bus/src/matrix_channel.rs` | — | M7.3 (extends) | None |
+| `crates/octos-agent/src/harness_events.rs` | M6.1/2/3/5/6 add variants | M7.1/7.4/7.5 add variants | Additive — integration-reconciler pattern |
+| `crates/octos-cli/src/api/metrics.rs` | M6 adds counters | M7 adds counters | Additive |
+| `crates/octos-agent/src/task_supervisor.rs` | M6 adds match arms | M7.5 adds variants to match | Additive |
+| `dashboard/src/pages/HarnessPage.tsx` | M6.8 extends | M7.6 adds new page | None |
+
+**M7A dispatches immediately.** M7B+ waves fire after M7A merges on the same additive-conflict resolution pattern the integration-reconciler proved for M6.
+
+## Governance
+
+Same as M6 family: contract-bound issues with allowed-files lists, required invariants, named acceptance tests. PM gate-QA on agent return. Integration-branch composition verifies Wave-1 + Wave-2 before human merge gate.
+
+## Next actions
+
+1. Open 8 contract-bound issues (M7.1 through M7.8)
+2. Create 3 worktrees from origin/main for Wave 1 (M7.1, M7.2, M7.3 — all disjoint)
+3. Dispatch 3 parallel background implementers
+4. Gate QA + open PRs as agents return
+5. After Wave 1 merges, dispatch Wave 2 (M7.4, M7.5)
+6. After Wave 2 merges, dispatch M7.6
+7. After M7.6 merges, optionally dispatch M7.7 (editor niche) + M7.8 (live gate)
+
+Total dispatch-to-completion estimate with swarm-scale orchestration: 1-2 PM sessions. With sequential engineering: 4-6 months.

--- a/docs/OCTOS_SWARM_POSITIONING_2026-04-22.md
+++ b/docs/OCTOS_SWARM_POSITIONING_2026-04-22.md
@@ -1,0 +1,183 @@
+# Octos Swarm Positioning — 2026-04-22
+
+See also:
+
+- [OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md](./OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md)
+- [OCTOS_PROTOCOL_STRATEGY_2026-04-22.md](./OCTOS_PROTOCOL_STRATEGY_2026-04-22.md)
+- [OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md](./OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md)
+
+## Purpose
+
+Resolve the strategic question "should octos invest in a Claude-Code-class CLI TUI?" and articulate what UI surfaces octos actually needs given the direction AI coding is moving.
+
+## Thesis
+
+The future of AI coding is **program-manager + agent-swarm**, not **human + imperative CLI**. Interaction between humans and agents becomes dispatch-shaped (author a contract, monitor aggregate progress, decide at gates) rather than REPL-shaped. Interaction between agents becomes protocol-mediated (MCP, ACP, A2A) rather than CLI-mediated.
+
+Consequences:
+
+1. **Claude-Code-class CLI TUI is investment in a pattern that's losing share** to dispatch-oriented workflows. Not worthless, but not load-bearing.
+2. **Supervisor/PM UI is the growing surface** — and it's dashboard-shaped (web), not TUI-shaped (terminal).
+3. **Minimal scripting CLI is still needed** — but `octos admin operator-summary --json` is the right aesthetic, not `ratatui`-animated input areas.
+
+## Evidence
+
+Lived session experience: this document's author has been PM/supervisor for a 17-PR delivery. Across that delivery:
+
+- 10+ parallel implementer agents dispatched, none invoked imperatively at a CLI
+- Human input consisted of high-level directives ("prefer C", "review PR 270", "create the issues", "close the merge")
+- Translation from directive to swarm dispatch happened in the supervisor layer
+- Imperative agent CLI interaction: **zero occurrences**
+- Dispatch artifacts used: GitHub issues, contract docs, PR bodies, task-tracker state — all dashboard-shaped, not terminal-shaped
+
+Industry direction:
+
+- Anthropic **Managed Agents** platform — API-first agent orchestration
+- Anthropic **Skills** — contract-bound tool extensions
+- GitHub **Copilot Workspace** — contract-first task decomposition UI
+- **Devin, Cursor agent mode, Amazon Q Developer** — task-shaped interaction
+- **agent-chat** (see separate doc) — production system running Claude/Codex in tmux on remote hosts, messaging via MCP + Matrix
+- Emerging protocols (MCP, ACP, A2A) — all exist to let agents call agents
+
+Where imperative CLI still dominates:
+- Single-developer exploration, debugging, learning
+- Local test iteration
+- Ad-hoc shell productivity
+
+Real but shrinking share of total AI-coding time.
+
+## Three interface surfaces
+
+When agents call agents, the UI surface splits into three distinct shapes:
+
+### Surface 1 — Agent-to-agent wire protocol
+
+**What**: the format agents use to call other agents.
+
+**Octos today**: MCP client only. Can consume MCP tool servers. Cannot be consumed as an agent; cannot call other agents as agents.
+
+**Octos needed**: MCP-server mode (expose octos sessions as MCP tools for outer orchestrators); MCP-agent-tool backend for `SpawnTool` (call Claude Code / Codex / hermes as sub-agents via MCP). Specifics in [OCTOS_PROTOCOL_STRATEGY_2026-04-22.md](./OCTOS_PROTOCOL_STRATEGY_2026-04-22.md).
+
+**Size**: ~2.5 kLOC Rust, 2-3 engineer-months total for P1 + P2.
+
+### Surface 2 — Program-manager / dispatch UI
+
+**What**: the human-facing UI for authoring contracts, dispatching to swarms, monitoring aggregate, and deciding at gates.
+
+**Shape**: web/desktop dashboard, not terminal TUI. Real-time state via SSE. Contract editor. Swarm dispatch form. Live agent view. PR review surface that understands contract invariants. Cost / provenance ledger.
+
+**Similar products**: Linear for issue tracking, GitHub Projects for orchestration, Devin for agent monitoring. Octos's M4.5 operator dashboard is the start.
+
+**Octos today**: M4.5 landed — reactive/diagnostic dashboard. Shows task lifecycle state, missing-artifact conditions, validator failures. Does NOT yet support: contract authoring, dispatch-to-swarm form, live multi-agent view, review surface.
+
+**Octos needed** (priority-ordered):
+
+1. **Swarm-aware dashboard view** — aggregate multiple concurrent tasks under a dispatched contract, show per-agent progress, surface at-a-glance "which are stuck / succeeded / spending budget."
+2. **Contract editor** — syntax-aware editing of workspace policy + RP/M4-family contracts, with validation against the schema version.
+3. **Dispatch form** — select contract, select agent pool (local MCP agents, remote MCP servers, sub-octos instances), set budget, fire. Becomes the "New Swarm Run" action.
+4. **Cost / provenance ledger** — every agent call attributed to supervisor + contract + task + model + tokens + cost. Essential once swarm size goes from 10 (manual) to 1000 (automated).
+5. **PR review hooks** — surface contract invariants, validator evidence (from M4.3), pre-existing latent-issue awareness when reviewing.
+
+**Size**: ~15-25 kLOC React + ~5-8 kLOC Rust backend. 4-6 engineer-months.
+
+### Surface 3 — Minimal scripting CLI
+
+**What**: scriptable CLI for CI, cron, shell pipelines, SSH operator sessions. JSON output. No animation.
+
+**Octos today**: `clap` + `colored = "2"`. Sufficient for the scripting use case. `octos admin operator-summary --json` is the right aesthetic.
+
+**Octos needed**: none incremental. This surface is fine as-is.
+
+**What is *not* needed**: `ratatui`-based animated input areas, prompt_toolkit-equivalent fixed bottom input with streaming-above layout, curses-based interactive multi-select. **That presentation investment goes into Surface 2**, not Surface 3.
+
+## Revised roadmap implication
+
+### Before this strategic frame
+
+Earlier analysis (see [OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md](./OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md)) identified a ~9.4 kLOC gap between octos and hermes on coding-loop resilience, plus ~2 kLOC on CLI TUI polish.
+
+The instinct: "close both gaps to reach hermes parity."
+
+### After this strategic frame
+
+The CLI TUI gap should **not** be closed. It's investment in a pattern (human-commanding-agent-via-REPL) that the swarm-future compresses.
+
+Revised priorities:
+
+| Original suggestion | Revised priority |
+|---|---|
+| M5 coding runner contract | Keep — phase classifier + evidence gate are swarm-friendly (supervisor can trust `lifecycle_state == ready && validators pass`) |
+| Close hermes CLI TUI gap (~2 kLOC ratatui) | **Skip** — wrong surface |
+| Close hermes coding-loop-resilience gap (~9.4 kLOC) | **Defer** — contract-gated delivery is octos's answer to the same problem; redispatch-on-failure is the swarm answer to flaky loops |
+| MCP sub-agent tool (octos calls other MCP agents) | **Priority 1** — strongly aligned with swarm future |
+| MCP server (octos callable as MCP tool) | **Priority 2** — symmetric value |
+| ACP client (octos consumes ACP agents) | Priority 3 — editor-integration niche only |
+| ACP server (octos exposes via ACP) | Priority 4 — only if coding-first product pivot |
+| Supervisor / PM dashboard (Surface 2 items above) | **Priority 1 track alongside MCP** — unlocks the PM-shaped interaction pattern |
+| Cost / provenance ledger | **Priority 2** — needed once swarm size scales |
+| Agent-chat-style remote-agent-in-tmux pattern | **Priority 2 alternative track** — see [OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md](./OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md) |
+
+### Two tracks, one direction
+
+The MCP protocol track (agent-to-agent wire) and the supervisor dashboard track (PM-to-swarm UX) are complementary. Both point at the same product bet:
+
+**Octos becomes the orchestration platform that invokes best-in-class agents (Claude Code, Codex, hermes, domain-specific) as sub-agents via MCP, under typed workspace contracts, visible through a supervisor dashboard, with durable artifact delivery and evidence-based completion gating.**
+
+This is a strictly more leveraged position than trying to out-Claude-Code Claude Code on the CLI aesthetic. The CLI aesthetic is where coding was two years ago; the orchestration platform is where coding is going.
+
+## CLI posture decision
+
+**Decision**: do not invest in ratatui/TUI CLI. Keep the scripting CLI minimal. Make the supervisor dashboard the presentation-layer investment.
+
+**Rationale**:
+1. The swarm-future pattern reduces human-imperative-CLI usage toward zero
+2. Supervisor dashboard captures the interaction that grows (contract authoring + dispatch + review + decide-at-gates)
+3. Octos's architectural bet (contract-first, API-first, multi-channel) is natively dashboard-shaped; the CLI was never the product surface
+4. The 2 kLOC of ratatui work is non-trivial and ongoing; amortizing that investment against a declining usage pattern is a bad trade
+5. Claude Code's own CLI polish is the result of Anthropic treating Claude Code as their own distribution surface — octos does not have that product positioning
+
+**If this decision turns out wrong**, the signal will be: heavy developer demand for an octos CLI with rich live interaction, combined with insufficient coverage of the same workflows in the dashboard. Monitor; don't pre-commit.
+
+## Who is the "human" in a swarm future
+
+In the swarm pattern, the human's job becomes:
+
+1. **Author contracts** — describe what the agent/swarm should deliver, in typed schema
+2. **Dispatch to swarms** — set topology, pool, budget, deadline
+3. **Monitor aggregate** — which agents green, which stuck, what's burning budget, what's the drift from contract
+4. **Decide at gates** — merge this? rescope that failure? redispatch repair? escalate?
+5. **Review outputs** — PR diffs, test results, validator evidence, cost attribution
+6. **Triage failures** — drill into an agent's actual work when the aggregate report shows an anomaly
+
+Zero of these six fits a terminal REPL. All six fit a dashboard.
+
+The surviving CLI use case is:
+
+7. **Scripting / CI / cron** — run supervisor-authored workflows on a schedule, with JSON output that feeds other tooling
+
+This is Surface 3, which octos already handles adequately.
+
+## Non-trivial prediction
+
+**2 years out** (mid-2028): the human's role compresses further, from swarm supervisor to program portfolio manager. The PM-of-agents becomes itself machine-executable — the human then approves programs, approves budgets, approves merges. The interaction becomes even more dashboard-shaped.
+
+If this prediction holds, the order-of-investment for octos is:
+1. Today: contract authoring + swarm dispatch dashboard
+2. +1 year: programs-of-contracts (many related contracts dispatched as a unit)
+3. +2 years: portfolio view of multiple concurrent programs across teams
+
+Each layer is more dashboard-shaped than the last. Each is further from the CLI TUI pattern.
+
+## Caveat
+
+The swarm pattern today requires **very capable individual agents**. Claude Opus 4.7 is at the frontier of what can act as both supervisor AND worker. A year ago this wouldn't have worked. If model progress slows, some workloads fall back to human-in-the-loop with stronger CLI UX expectations. Watch model capability — if plateau, reopen the CLI question.
+
+## Summary
+
+- Swarm pattern is the forward direction
+- Three UI surfaces diverge: wire protocol, supervisor dashboard, scripting CLI
+- Claude-Code-class TUI is the dying pattern; skip that investment
+- Supervisor dashboard is the growing pattern; invest there
+- Scripting CLI is sufficient; leave it
+- MCP (not ACP) is the protocol for agent-to-agent composition in the swarm future
+- Octos's architectural bet is already aligned; doubling down on that direction is the winning move


### PR DESCRIPTION
Companion strategic-intelligence docs from the 2026-04-22 analysis session. Docs-only; no code changes.

## Four docs, cross-linked

### `docs/OCTOS_COMPETITIVE_LANDSCAPE_2026-04-22.md`
Three-way capability comparison: hermes (coding-loop specialist, ~19 kLOC), openJiuwen (web-Studio-first multi-project platform, ~470 kLOC), octos (contract-first API platform). Capability matrix across 20+ axes. Delta estimates: octos → hermes parity = ~9.4 kLOC, 3-4 engineer-months; octos → openJiuwen parity = 120-170 kLOC, 12-18 months. Recommended posture: keep octos's contract-first axis; defer hermes-style coding-loop depth; do not pursue openJiuwen-class Studio.

### `docs/OCTOS_PROTOCOL_STRATEGY_2026-04-22.md`
MCP vs ACP vs A2A. Seven technical reasons MCP beats ACP for sub-agent composition (including context isolation, request-response fit, hierarchical composition, and **remote transport** — MCP's HTTP/SSE support is a decisive architectural advantage for multi-tenant / cloud deployments; ACP is stdio-only in every production implementation). Political read: Anthropic's `claude mcp serve` is deliberate MCP-first positioning for sub-agent composition. Why Codex uses MCP (not ACP) for sub-agent spawning. Recommended protocol roadmap:

- **Priority 1**: MCP sub-agent adapter (octos calls Claude Code / Codex / hermes as sub-agents via MCP) — ~1 kLOC Rust
- **Priority 2**: MCP server mode (octos callable as MCP tool by outer orchestrators) — ~1.5 kLOC
- **Priority 3**: ACP client (editor integration niche) — deferred
- **Priority 4**: ACP server — only if coding-first product pivot
- **Priority 5**: A2A — deferred

### `docs/OCTOS_SWARM_POSITIONING_2026-04-22.md`
Program-manager + swarm thesis. Under the agent-calls-agent pattern, the human role compresses toward dispatch/review/decide; imperative CLI usage declines. UI surface splits into three: (1) wire protocol, (2) supervisor dashboard, (3) minimal scripting CLI. **Decision: do not invest in Claude-Code-class CLI TUI** (wrong surface, declining pattern). Invest in supervisor dashboard instead (contract authoring + dispatch + review + cost/provenance ledger). Revised roadmap priorities.

### `docs/OCTOS_AGENT_CHAT_PATTERN_2026-04-22.md`
Reference architecture from `~/home/agent-chat/` — a real production system running Claude and Codex in tmux sessions on remote hosts, using **MCP + Matrix + SSE + tmux injection**. No ACP anywhere. Central backend (`backend-v2.js`) is source of truth with ~60 REST endpoints; per-server push-relay injects notifications into tmux panes. Matrix provides the human UI with agent puppets. Validates MCP-over-HTTPS as the remote coding-agent substrate. Six lessons for octos including Matrix-as-supervisor-UI (cheap win on existing Matrix channel infra).

## Summary recommendation

Octos's contract-first architectural bet is aligned with the swarm-future direction. Concrete next issues to open:

1. **`crates/octos-agent/src/tools/mcp_agent.rs`** — SpawnTool backend that calls configured MCP agent servers (local stdio OR remote HTTPS) as contract-bound sub-agents. Reuses M4.1A harness events for observability, M4.3 validators for output gating. ~1 kLOC.
2. **`crates/octos-agent/src/mcp_server.rs`** — expose octos sessions as MCP tools (session-level, not tool-by-tool). ~1.5 kLOC.
3. **Matrix-as-supervisor-UI extension** — extend existing `crates/octos-bus/src/matrix_channel.rs` to register sub-agents as Matrix puppets. ~500-800 LOC.
4. **Supervisor dashboard contract-authoring view** (M4.5 extension) — swarm dispatch form + live multi-agent state + cost ledger. ~15-25 kLOC React + 5-8 kLOC Rust backend.

## Test plan

- [x] Four docs committed with gitignore allowlist entries
- [ ] Review by architect for strategic alignment
- [ ] Translate accepted recommendations into contract-bound issues in next milestone

Docs-only; no code changes; no CI impact beyond doc render.