### PR TITLE
M6.1 — structured HarnessError taxonomy with typed events

### DIFF
--- a/crates/octos-agent/src/abi_schema.rs
+++ b/crates/octos-agent/src/abi_schema.rs
@@ -35,6 +35,10 @@ pub const PROGRESS_EVENT_SCHEMA_VERSION: u32 = 1;
 /// Current schema version for `TaskResult`.
 pub const TASK_RESULT_SCHEMA_VERSION: u32 = 1;
 
+/// Current schema version for `HarnessError` events (M6.1, issue #488).
+/// Emitted as part of `octos.harness.event.v1` with `kind: "error"`.
+pub const HARNESS_ERROR_SCHEMA_VERSION: u32 = 1;
+
 /// Typed error returned when a deserialized value advertises a schema version
 /// the running harness does not know how to handle.
 ///

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -8,6 +8,8 @@ use octos_llm::ChatResponse;
 use tracing::{debug, info, warn};
 
 use super::{Agent, MAX_TOOL_TIMEOUT_SECS};
+use crate::harness_errors::HarnessError;
+use crate::harness_events::{lookup_event_sink_context, write_event_to_sink};
 use crate::hooks::{HookEvent, HookPayload, HookResult};
 use crate::progress::ProgressEvent;
 use crate::task_supervisor::TaskRuntimeState;
@@ -595,9 +597,34 @@ impl Agent {
                             )
                         }
                         Err(e) => {
+                            // Classify the tool failure as a typed HarnessError.
+                            // Invariant #1 (#488): every raw tool error escape
+                            // must be routed through classification so the
+                            // metrics counter and the sink event both fire.
+                            let classified =
+                                HarnessError::classify_report(&e, Some(tc_name.as_str()));
+                            classified.record_metric();
+                            if let Some(sink) = harness_event_sink.as_deref() {
+                                if let Some(ctx) = lookup_event_sink_context(sink) {
+                                    let event = classified.to_event(
+                                        ctx.session_id,
+                                        ctx.task_id,
+                                        None,
+                                        None,
+                                    );
+                                    if let Err(error) = write_event_to_sink(sink, &event) {
+                                        tracing::debug!(
+                                            error = %error,
+                                            "failed to write tool-failure harness error event"
+                                        );
+                                    }
+                                }
+                            }
                             warn!(
                                 tool = %tc_name,
                                 error = %e,
+                                variant = classified.variant_name(),
+                                recovery = %classified.recovery_hint(),
                                 duration_ms = duration.as_millis() as u64,
                                 "tool failed"
                             );

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -16,6 +16,8 @@ use super::loop_compaction::{prepare_conversation_messages, prepare_task_message
 use super::message_repair::sanitize_tool_call_id;
 use super::turn_state::{LoopRetryReason, LoopTurnState};
 use super::{Agent, ConversationResponse, TASK_REPORTER, TokenTracker};
+use crate::harness_errors::HarnessError;
+use crate::harness_events::write_event_to_sink;
 use crate::loop_detect::LoopDetector;
 use crate::progress::ProgressEvent;
 use crate::session::SessionLimits;
@@ -47,6 +49,58 @@ struct ShellRetryRecovery {
 }
 
 impl Agent {
+    /// Classify a raw error escaping the agent loop into a `HarnessError`,
+    /// increment the `octos_loop_error_total{variant, recovery}` counter, and
+    /// emit a structured error event via the local harness event sink (if
+    /// one is attached). Returns the classified error so the caller can log
+    /// it or convert it into an `eyre::Report` for the caller's contract.
+    ///
+    /// Invariant (#488): every raw `eyre::Report` that would otherwise bubble
+    /// out of the agent loop must be routed through this classifier.
+    pub(crate) fn classify_loop_error(
+        &self,
+        report: &eyre::Report,
+        tool_name: Option<&str>,
+    ) -> HarnessError {
+        let classified = HarnessError::classify_report(report, tool_name);
+        classified.record_metric();
+
+        if let Some(sink) = self.harness_event_sink.as_deref() {
+            let (session_id, task_id) = self.harness_error_context();
+            let event = classified.to_event(
+                session_id, task_id, /* workflow */ None, /* phase */ None,
+            );
+            if let Err(error) = write_event_to_sink(sink, &event) {
+                tracing::debug!(error = %error, "failed to write harness error event to sink");
+            }
+        }
+
+        tracing::warn!(
+            variant = classified.variant_name(),
+            recovery = %classified.recovery_hint(),
+            error = %report,
+            "harness error classified"
+        );
+        classified
+    }
+
+    fn harness_error_context(&self) -> (String, String) {
+        // The agent loop itself does not own a task_id — those are assigned
+        // per-spawn in `task_supervisor`. Use the registered sink context
+        // (written by `HarnessEventSink::new`) when available; fall back to
+        // stable placeholders so the event still validates.
+        if let Some(sink) = self.harness_event_sink.as_deref() {
+            if let Some(ctx) = crate::harness_events::lookup_event_sink_context(sink) {
+                return (ctx.session_id, ctx.task_id);
+            }
+        }
+        let session_id = self
+            .hook_ctx()
+            .and_then(|ctx| ctx.session_id)
+            .unwrap_or_else(|| "unknown".to_string());
+        (session_id, "agent".to_string())
+    }
+
     fn enforce_session_limits_on_tool_calls(
         &self,
         response: &ChatResponse,
@@ -325,17 +379,28 @@ impl Agent {
                                 message: "Switching provider...".to_string(),
                                 iteration,
                             });
-                            self.call_llm_with_hooks(
-                                &messages,
-                                &tools_spec,
-                                &config,
-                                iteration,
-                                &total_usage,
-                                &mut turn,
-                            )
-                            .await?
+                            match self
+                                .call_llm_with_hooks(
+                                    &messages,
+                                    &tools_spec,
+                                    &config,
+                                    iteration,
+                                    &total_usage,
+                                    &mut turn,
+                                )
+                                .await
+                            {
+                                Ok(r) => r,
+                                Err(e) => {
+                                    let _ = self.classify_loop_error(&e, None);
+                                    return Err(e);
+                                }
+                            }
                         }
-                        Err(e) => return Err(e),
+                        Err(e) => {
+                            let _ = self.classify_loop_error(&e, None);
+                            return Err(e);
+                        }
                     };
                     Self::normalize_inline_invokes(&mut response);
                     self.reporter().report(ProgressEvent::Response {
@@ -433,15 +498,20 @@ impl Agent {
                                     });
                                 }
                             }
-                            self.handle_tool_use(
-                                &response,
-                                &mut messages,
-                                &mut files_modified,
-                                Some(&mut files_to_send),
-                                &mut turn,
-                                tracker,
-                            )
-                            .await?;
+                            if let Err(e) = self
+                                .handle_tool_use(
+                                    &response,
+                                    &mut messages,
+                                    &mut files_modified,
+                                    Some(&mut files_to_send),
+                                    &mut turn,
+                                    tracker,
+                                )
+                                .await
+                            {
+                                let _ = self.classify_loop_error(&e, None);
+                                return Err(e);
+                            }
 
                             if let Some(recovery) = recover_shell_retry(
                                 &messages,
@@ -615,7 +685,7 @@ impl Agent {
                 prepare_task_messages(self, &mut messages, &mut turn);
                 let total_usage = turn.total_usage().clone();
 
-                let (mut response, _streamed) = self
+                let (mut response, _streamed) = match self
                     .call_llm_with_hooks(
                         &messages,
                         &tools_spec,
@@ -624,7 +694,14 @@ impl Agent {
                         &total_usage,
                         &mut turn,
                     )
-                    .await?;
+                    .await
+                {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        let _ = self.classify_loop_error(&e, None);
+                        return Err(e);
+                    }
+                };
                 Self::normalize_inline_invokes(&mut response);
                 turn.record_usage(response.usage.input_tokens, response.usage.output_tokens, None);
 
@@ -718,15 +795,20 @@ impl Agent {
                         ));
                     }
                     StopReason::ToolUse => {
-                        self.handle_tool_use(
-                            &response,
-                            &mut messages,
-                            &mut files_modified,
-                            Some(&mut files_to_send),
-                            &mut turn,
-                            None,
-                        )
-                        .await?;
+                        if let Err(e) = self
+                            .handle_tool_use(
+                                &response,
+                                &mut messages,
+                                &mut files_modified,
+                                Some(&mut files_to_send),
+                                &mut turn,
+                                None,
+                            )
+                            .await
+                        {
+                            let _ = self.classify_loop_error(&e, None);
+                            return Err(e);
+                        }
                     }
                     StopReason::MaxTokens => {
                         self.emit_cost_update(turn.total_usage(), &response.usage);

--- a/crates/octos-agent/src/harness_errors.rs
+++ b/crates/octos-agent/src/harness_errors.rs
@@ -1,0 +1,589 @@
+//! Structured harness error taxonomy (M6.1, issue #488).
+//!
+//! Classifies every failure that escapes the agent loop into a finite set of
+//! variants, each with exactly one primary `RecoveryHint`. Unlike hermes's
+//! 809-LOC Python regex classifier, this is a deterministic enum-driven
+//! dispatcher that composes with the existing `harness_events` + `abi_schema`
+//! + metrics infrastructure.
+//!
+//! Invariants (per issue #488):
+//!   1. No raw `eyre::Report` escapes the agent loop without classification.
+//!      Callers convert reports via [`HarnessError::classify_report`].
+//!   2. Classification is deterministic — identical input maps to the same
+//!      variant and `RecoveryHint` across every invocation.
+//!   3. Each variant has exactly one primary `RecoveryHint`.
+//!   4. Events emitted via [`HarnessError::to_event`] conform to
+//!      `octos.harness.event.v1` and round-trip through
+//!      `HarnessEvent::from_json_line`.
+//!   5. The schema version is registered as
+//!      [`abi_schema::HARNESS_ERROR_SCHEMA_VERSION`].
+//!
+//! M6.7 note: [`HarnessError::DelegateDepthExceeded`] is reserved for the
+//! delegation-depth enforcement task so that variant naming stays consistent
+//! across the M6 series.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use metrics::counter;
+use octos_core::truncated_utf8;
+use octos_llm::{LlmError, LlmErrorKind};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::abi_schema::HARNESS_ERROR_SCHEMA_VERSION;
+use crate::harness_events::{HARNESS_EVENT_SCHEMA_V1, HarnessEvent, HarnessEventPayload};
+
+const MAX_HARNESS_ERROR_MESSAGE_BYTES: usize = 1024;
+/// Prometheus counter name for loop-level harness errors. Labels:
+/// `{variant, recovery}` — both are stable snake_case identifiers.
+pub const OCTOS_LOOP_ERROR_TOTAL: &str = "octos_loop_error_total";
+
+/// Recommended recovery action for a `HarnessError`. Each variant maps to
+/// exactly one hint — we surface it to the dashboard and the retry layer can
+/// use it as a deterministic dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryHint {
+    /// Transient failure — retry with exponential backoff (rate limit, network,
+    /// timeout).
+    BackoffRetry,
+    /// Provider-side failure — the retry layer should switch lanes (fallback
+    /// provider, alternate model).
+    SwitchProvider,
+    /// Prompt or conversation history too large — compact context before the
+    /// next call.
+    CompactContext,
+    /// Non-retryable — surface to operator. Includes auth errors, invalid
+    /// requests, content filtered responses, and structural budget violations
+    /// like delegation depth exceeded.
+    FailFast,
+    /// Internal invariant violation — log and bail out; operators must
+    /// investigate. Not retryable.
+    Bug,
+}
+
+impl RecoveryHint {
+    /// Stable snake_case identifier used in Prometheus labels and JSON
+    /// payloads. Never returns operator-supplied text.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RecoveryHint::BackoffRetry => "backoff_retry",
+            RecoveryHint::SwitchProvider => "switch_provider",
+            RecoveryHint::CompactContext => "compact_context",
+            RecoveryHint::FailFast => "fail_fast",
+            RecoveryHint::Bug => "bug",
+        }
+    }
+}
+
+impl fmt::Display for RecoveryHint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Typed classification of runtime failures the agent loop can hit.
+///
+/// Every variant carries a short diagnostic `message`; variants that own
+/// additional structured context (HTTP status, retry_after hint, limits,
+/// tool_name) expose them as named fields. Variant naming is frozen — other
+/// milestones reference these names through `variant_name()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HarnessError {
+    /// Rate limited by an LLM provider (HTTP 429). Retry after the optional
+    /// `retry_after_secs` hint.
+    RateLimited {
+        retry_after_secs: Option<u64>,
+        message: String,
+    },
+    /// Request exceeded the provider's context window. Callers must compact
+    /// history and retry; a raw retry will keep failing.
+    ContextOverflow {
+        limit: Option<u32>,
+        used: Option<u32>,
+        message: String,
+    },
+    /// Authentication failed (HTTP 401/403). Never retry — surface to operator.
+    Authentication { message: String },
+    /// The request itself was malformed (HTTP 400, non-context) — bad
+    /// parameters, invalid schema, etc.
+    InvalidRequest { detail: String, message: String },
+    /// Response was blocked by the provider's safety filter.
+    ContentFiltered { message: String },
+    /// Provider returned 5xx / the stream broke / the model is unavailable —
+    /// the retry layer should switch providers.
+    ProviderUnavailable {
+        status: Option<u16>,
+        message: String,
+    },
+    /// Network-level failure (DNS, TCP reset, TLS error).
+    Network { message: String },
+    /// Request timed out (client-side or provider-side).
+    Timeout { message: String },
+    /// A tool's `execute` returned `Err(...)` or panicked. Distinct from
+    /// plugin spawn failures so the dashboard can separate fault domains.
+    ToolExecution { tool_name: String, message: String },
+    /// A plugin executable could not be spawned (missing binary, exec denied).
+    PluginSpawn {
+        plugin_name: String,
+        message: String,
+    },
+    /// A plugin process exceeded its execution timeout.
+    PluginTimeout {
+        plugin_name: String,
+        timeout_secs: u64,
+        message: String,
+    },
+    /// A plugin returned malformed stdout / violated the binary protocol.
+    PluginProtocol {
+        plugin_name: String,
+        message: String,
+    },
+    /// Reserved for M6.7 — the spawn/delegate chain exceeded its configured
+    /// depth limit. Included here so variant naming stays stable across M6.x
+    /// milestones.
+    DelegateDepthExceeded {
+        depth: u32,
+        limit: u32,
+        message: String,
+    },
+    /// Catch-all for agent-internal bugs (poisoned locks, unexpected state,
+    /// etc.). Treat as `RecoveryHint::Bug`.
+    Internal { message: String },
+}
+
+/// Structured payload body for `HarnessEventPayload::Error`. Serialized as
+/// part of `octos.harness.event.v1`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HarnessErrorEvent {
+    /// Schema version of this payload — registered in
+    /// [`abi_schema::HARNESS_ERROR_SCHEMA_VERSION`].
+    #[serde(default = "default_harness_error_schema_version")]
+    pub schema_version: u32,
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
+    /// Snake_case variant identifier — matches
+    /// [`HarnessError::variant_name`] and is used as the `variant` label on
+    /// `octos_loop_error_total`.
+    pub variant: String,
+    /// Snake_case recovery hint — matches [`RecoveryHint::as_str`].
+    pub recovery: String,
+    /// Human-readable diagnostic (truncated to 1 KiB).
+    pub message: String,
+    /// Extra structured context (retry_after, limits, tool_name, etc.).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub details: HashMap<String, Value>,
+}
+
+fn default_harness_error_schema_version() -> u32 {
+    HARNESS_ERROR_SCHEMA_VERSION
+}
+
+impl HarnessError {
+    /// Stable snake_case identifier for this variant. Used in Prometheus
+    /// labels and the `variant` field of
+    /// [`HarnessEventPayload::Error`].
+    pub fn variant_name(&self) -> &'static str {
+        match self {
+            HarnessError::RateLimited { .. } => "rate_limited",
+            HarnessError::ContextOverflow { .. } => "context_overflow",
+            HarnessError::Authentication { .. } => "authentication",
+            HarnessError::InvalidRequest { .. } => "invalid_request",
+            HarnessError::ContentFiltered { .. } => "content_filtered",
+            HarnessError::ProviderUnavailable { .. } => "provider_unavailable",
+            HarnessError::Network { .. } => "network",
+            HarnessError::Timeout { .. } => "timeout",
+            HarnessError::ToolExecution { .. } => "tool_execution",
+            HarnessError::PluginSpawn { .. } => "plugin_spawn",
+            HarnessError::PluginTimeout { .. } => "plugin_timeout",
+            HarnessError::PluginProtocol { .. } => "plugin_protocol",
+            HarnessError::DelegateDepthExceeded { .. } => "delegate_depth_exceeded",
+            HarnessError::Internal { .. } => "internal",
+        }
+    }
+
+    /// Primary recovery hint for this variant. Each variant maps to exactly
+    /// one hint — this is an invariant, not a heuristic.
+    pub fn recovery_hint(&self) -> RecoveryHint {
+        match self {
+            // Transient — exponential backoff retries.
+            HarnessError::RateLimited { .. }
+            | HarnessError::Network { .. }
+            | HarnessError::Timeout { .. }
+            | HarnessError::PluginTimeout { .. } => RecoveryHint::BackoffRetry,
+
+            // Provider-side — the retry layer should try a fallback provider.
+            HarnessError::ProviderUnavailable { .. } => RecoveryHint::SwitchProvider,
+
+            // Conversation too large — compaction, not retries, unblocks it.
+            HarnessError::ContextOverflow { .. } => RecoveryHint::CompactContext,
+
+            // Non-retryable — surface to operator.
+            HarnessError::Authentication { .. }
+            | HarnessError::InvalidRequest { .. }
+            | HarnessError::ContentFiltered { .. }
+            | HarnessError::DelegateDepthExceeded { .. }
+            | HarnessError::ToolExecution { .. }
+            | HarnessError::PluginSpawn { .. }
+            | HarnessError::PluginProtocol { .. } => RecoveryHint::FailFast,
+
+            // Internal invariant broken — bug, not recoverable.
+            HarnessError::Internal { .. } => RecoveryHint::Bug,
+        }
+    }
+
+    /// Human-readable diagnostic message (truncated to 1 KiB for storage in
+    /// sink events).
+    pub fn message(&self) -> &str {
+        match self {
+            HarnessError::RateLimited { message, .. }
+            | HarnessError::ContextOverflow { message, .. }
+            | HarnessError::Authentication { message }
+            | HarnessError::InvalidRequest { message, .. }
+            | HarnessError::ContentFiltered { message }
+            | HarnessError::ProviderUnavailable { message, .. }
+            | HarnessError::Network { message }
+            | HarnessError::Timeout { message }
+            | HarnessError::ToolExecution { message, .. }
+            | HarnessError::PluginSpawn { message, .. }
+            | HarnessError::PluginTimeout { message, .. }
+            | HarnessError::PluginProtocol { message, .. }
+            | HarnessError::DelegateDepthExceeded { message, .. }
+            | HarnessError::Internal { message } => message,
+        }
+    }
+
+    /// Prometheus label tuple `(variant, recovery)` for
+    /// `octos_loop_error_total`.
+    pub fn metric_labels(&self) -> (&'static str, &'static str) {
+        (self.variant_name(), self.recovery_hint().as_str())
+    }
+
+    /// Increment the `octos_loop_error_total{variant, recovery}` counter for
+    /// this error. Callers should invoke this once per classification at the
+    /// loop boundary — emitting the event (via [`Self::to_event`]) is a
+    /// separate step because sinks are per-task, whereas metrics are global.
+    pub fn record_metric(&self) {
+        let (variant, recovery) = self.metric_labels();
+        counter!(
+            OCTOS_LOOP_ERROR_TOTAL,
+            "variant" => variant,
+            "recovery" => recovery,
+        )
+        .increment(1);
+    }
+
+    /// Classify a raw `eyre::Report` at an agent-loop boundary. Downcasts to
+    /// `LlmError` first; falls back to `ToolExecution` with the provided
+    /// `tool_name`, or `Internal` when no tool context is available.
+    ///
+    /// This is the canonical entry point that enforces invariant #1 ("no raw
+    /// `eyre::Report` escapes the agent loop without classification"): every
+    /// `Err(report)` at an error boundary must be passed through here.
+    pub fn classify_report(report: &eyre::Report, tool_name: Option<&str>) -> Self {
+        if let Some(llm) = report.downcast_ref::<LlmError>() {
+            return Self::from_llm_error(llm);
+        }
+        let message = truncate(&report.to_string(), MAX_HARNESS_ERROR_MESSAGE_BYTES);
+        match tool_name {
+            Some(name) => HarnessError::ToolExecution {
+                tool_name: name.to_string(),
+                message,
+            },
+            None => HarnessError::Internal { message },
+        }
+    }
+
+    /// Classify an owned `LlmError` borrow without consuming it. Public so
+    /// callers can opportunistically classify in diagnostic paths.
+    pub fn from_llm_error(err: &LlmError) -> Self {
+        let message = truncate(&err.message, MAX_HARNESS_ERROR_MESSAGE_BYTES);
+        match &err.kind {
+            LlmErrorKind::Authentication => HarnessError::Authentication { message },
+            LlmErrorKind::RateLimited { retry_after_secs } => HarnessError::RateLimited {
+                retry_after_secs: *retry_after_secs,
+                message,
+            },
+            LlmErrorKind::ContextOverflow { limit, used } => HarnessError::ContextOverflow {
+                limit: *limit,
+                used: *used,
+                message,
+            },
+            LlmErrorKind::ModelNotFound { model } => HarnessError::ProviderUnavailable {
+                status: Some(404),
+                message: format!("model not found: {model}"),
+            },
+            LlmErrorKind::ServerError { status } => HarnessError::ProviderUnavailable {
+                status: Some(*status),
+                message,
+            },
+            LlmErrorKind::Network => HarnessError::Network { message },
+            LlmErrorKind::Timeout => HarnessError::Timeout { message },
+            LlmErrorKind::InvalidRequest { detail } => HarnessError::InvalidRequest {
+                detail: truncate(detail, MAX_HARNESS_ERROR_MESSAGE_BYTES),
+                message,
+            },
+            LlmErrorKind::ContentFiltered => HarnessError::ContentFiltered { message },
+            LlmErrorKind::StreamError => HarnessError::ProviderUnavailable {
+                status: None,
+                message,
+            },
+            LlmErrorKind::Provider { .. } => HarnessError::ProviderUnavailable {
+                status: None,
+                message,
+            },
+        }
+    }
+
+    /// Build a `HarnessEvent` carrying this error. The emitted payload is a
+    /// valid `octos.harness.event.v1` record and round-trips through
+    /// `HarnessEvent::from_json_line`.
+    pub fn to_event(
+        &self,
+        session_id: impl Into<String>,
+        task_id: impl Into<String>,
+        workflow: Option<&str>,
+        phase: Option<&str>,
+    ) -> HarnessEvent {
+        HarnessEvent {
+            schema: HARNESS_EVENT_SCHEMA_V1.to_string(),
+            payload: HarnessEventPayload::Error {
+                data: self.to_event_body(session_id, task_id, workflow, phase),
+            },
+        }
+    }
+
+    /// Build just the payload body — used by the `From<HarnessError>` impl
+    /// for [`HarnessEventPayload`] and internally by [`Self::to_event`].
+    pub fn to_event_body(
+        &self,
+        session_id: impl Into<String>,
+        task_id: impl Into<String>,
+        workflow: Option<&str>,
+        phase: Option<&str>,
+    ) -> HarnessErrorEvent {
+        HarnessErrorEvent {
+            schema_version: HARNESS_ERROR_SCHEMA_VERSION,
+            session_id: session_id.into(),
+            task_id: task_id.into(),
+            workflow: workflow.map(ToOwned::to_owned),
+            phase: phase.map(ToOwned::to_owned),
+            variant: self.variant_name().to_string(),
+            recovery: self.recovery_hint().as_str().to_string(),
+            message: truncate(self.message(), MAX_HARNESS_ERROR_MESSAGE_BYTES),
+            details: self.details(),
+        }
+    }
+
+    fn details(&self) -> HashMap<String, Value> {
+        let mut out = HashMap::new();
+        match self {
+            HarnessError::RateLimited {
+                retry_after_secs, ..
+            } => {
+                if let Some(secs) = retry_after_secs {
+                    out.insert("retry_after_secs".into(), Value::from(*secs));
+                }
+            }
+            HarnessError::ContextOverflow { limit, used, .. } => {
+                if let Some(limit) = limit {
+                    out.insert("limit".into(), Value::from(*limit));
+                }
+                if let Some(used) = used {
+                    out.insert("used".into(), Value::from(*used));
+                }
+            }
+            HarnessError::ProviderUnavailable { status, .. } => {
+                if let Some(status) = status {
+                    out.insert("status".into(), Value::from(*status));
+                }
+            }
+            HarnessError::InvalidRequest { detail, .. } => {
+                out.insert("detail".into(), Value::from(detail.clone()));
+            }
+            HarnessError::ToolExecution { tool_name, .. } => {
+                out.insert("tool_name".into(), Value::from(tool_name.clone()));
+            }
+            HarnessError::PluginSpawn { plugin_name, .. }
+            | HarnessError::PluginProtocol { plugin_name, .. } => {
+                out.insert("plugin_name".into(), Value::from(plugin_name.clone()));
+            }
+            HarnessError::PluginTimeout {
+                plugin_name,
+                timeout_secs,
+                ..
+            } => {
+                out.insert("plugin_name".into(), Value::from(plugin_name.clone()));
+                out.insert("timeout_secs".into(), Value::from(*timeout_secs));
+            }
+            HarnessError::DelegateDepthExceeded { depth, limit, .. } => {
+                out.insert("depth".into(), Value::from(*depth));
+                out.insert("limit".into(), Value::from(*limit));
+            }
+            HarnessError::Authentication { .. }
+            | HarnessError::ContentFiltered { .. }
+            | HarnessError::Network { .. }
+            | HarnessError::Timeout { .. }
+            | HarnessError::Internal { .. } => {}
+        }
+        out
+    }
+}
+
+impl fmt::Display for HarnessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} ({}): {}",
+            self.variant_name(),
+            self.recovery_hint().as_str(),
+            self.message()
+        )
+    }
+}
+
+impl std::error::Error for HarnessError {}
+
+impl From<LlmError> for HarnessError {
+    fn from(err: LlmError) -> Self {
+        HarnessError::from_llm_error(&err)
+    }
+}
+
+impl From<HarnessError> for HarnessEventPayload {
+    fn from(err: HarnessError) -> Self {
+        // Without a concrete session/task, we default to "unknown" IDs — the
+        // loop-boundary helper always provides real IDs, but this impl exists
+        // so the enum composes with the `HarnessEventPayload` public API.
+        HarnessEventPayload::Error {
+            data: err.to_event_body("unknown", "unknown", None, None),
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    truncated_utf8(s, max, "…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn variant_name_covers_every_variant() {
+        // If you add a variant, add it here. This test keeps variant_name()
+        // and recovery_hint() in lockstep with the enum.
+        let samples = [
+            HarnessError::RateLimited {
+                retry_after_secs: None,
+                message: "x".into(),
+            },
+            HarnessError::ContextOverflow {
+                limit: None,
+                used: None,
+                message: "x".into(),
+            },
+            HarnessError::Authentication {
+                message: "x".into(),
+            },
+            HarnessError::InvalidRequest {
+                detail: "x".into(),
+                message: "x".into(),
+            },
+            HarnessError::ContentFiltered {
+                message: "x".into(),
+            },
+            HarnessError::ProviderUnavailable {
+                status: None,
+                message: "x".into(),
+            },
+            HarnessError::Network {
+                message: "x".into(),
+            },
+            HarnessError::Timeout {
+                message: "x".into(),
+            },
+            HarnessError::ToolExecution {
+                tool_name: "shell".into(),
+                message: "x".into(),
+            },
+            HarnessError::PluginSpawn {
+                plugin_name: "demo".into(),
+                message: "x".into(),
+            },
+            HarnessError::PluginTimeout {
+                plugin_name: "demo".into(),
+                timeout_secs: 30,
+                message: "x".into(),
+            },
+            HarnessError::PluginProtocol {
+                plugin_name: "demo".into(),
+                message: "x".into(),
+            },
+            HarnessError::DelegateDepthExceeded {
+                depth: 3,
+                limit: 2,
+                message: "x".into(),
+            },
+            HarnessError::Internal {
+                message: "x".into(),
+            },
+        ];
+        for err in samples {
+            assert!(!err.variant_name().is_empty());
+            assert!(!err.recovery_hint().as_str().is_empty());
+            let ev = err.to_event("s", "t", None, None);
+            ev.validate().expect("event validates");
+        }
+    }
+
+    #[test]
+    fn classify_report_with_tool_context_uses_tool_execution() {
+        let report = eyre::eyre!("shell exited with status 1");
+        let err = HarnessError::classify_report(&report, Some("shell"));
+        assert!(matches!(err, HarnessError::ToolExecution { .. }));
+        assert_eq!(err.variant_name(), "tool_execution");
+    }
+
+    #[test]
+    fn classify_report_without_tool_context_is_internal() {
+        let report = eyre::eyre!("unexpected state");
+        let err = HarnessError::classify_report(&report, None);
+        assert!(matches!(err, HarnessError::Internal { .. }));
+        assert_eq!(err.recovery_hint(), RecoveryHint::Bug);
+    }
+
+    #[test]
+    fn classify_report_downcasts_llm_error() {
+        let llm = LlmError::from_status(429, "Too Many Requests");
+        let report: eyre::Report = llm.into();
+        let err = HarnessError::classify_report(&report, Some("shell"));
+        assert_eq!(err.variant_name(), "rate_limited");
+    }
+
+    #[test]
+    fn from_payload_conversion_emits_error_kind() {
+        let err = HarnessError::Authentication {
+            message: "bad key".into(),
+        };
+        let payload: HarnessEventPayload = err.into();
+        let HarnessEventPayload::Error { data } = payload else {
+            panic!("expected Error payload");
+        };
+        assert_eq!(data.variant, "authentication");
+        assert_eq!(data.recovery, "fail_fast");
+    }
+
+    #[test]
+    fn message_truncation_bounded_at_1_kib() {
+        let huge = "x".repeat(MAX_HARNESS_ERROR_MESSAGE_BYTES + 200);
+        let err = HarnessError::Internal { message: huge };
+        let body = err.to_event_body("s", "t", None, None);
+        assert!(body.message.len() <= MAX_HARNESS_ERROR_MESSAGE_BYTES + "…".len());
+    }
+}

--- a/crates/octos-agent/src/harness_events.rs
+++ b/crates/octos-agent/src/harness_events.rs
@@ -17,6 +17,8 @@ use tokio::io::AsyncReadExt;
 use tokio::task::JoinHandle;
 use tracing::warn;
 
+use crate::abi_schema::HARNESS_ERROR_SCHEMA_VERSION;
+use crate::harness_errors::HarnessErrorEvent;
 use crate::task_supervisor::TaskSupervisor;
 use crate::validators::VALIDATOR_RESULT_SCHEMA_VERSION;
 
@@ -166,6 +168,10 @@ pub enum HarnessEventPayload {
     Failure {
         #[serde(flatten)]
         data: HarnessFailureEvent,
+    },
+    Error {
+        #[serde(flatten)]
+        data: HarnessErrorEvent,
     },
 }
 
@@ -385,6 +391,20 @@ impl HarnessEvent {
                 validate_optional_name("phase", data.phase.as_deref(), MAX_PHASE_BYTES)?;
                 validate_bounded("failure message", &data.message, MAX_MESSAGE_BYTES)?;
             }
+            HarnessEventPayload::Error { data } => {
+                if data.schema_version > HARNESS_ERROR_SCHEMA_VERSION {
+                    return Err(HarnessEventError(format!(
+                        "unsupported harness error schema_version {} (max supported: {})",
+                        data.schema_version, HARNESS_ERROR_SCHEMA_VERSION
+                    )));
+                }
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                validate_optional_name("phase", data.phase.as_deref(), MAX_PHASE_BYTES)?;
+                validate_bounded("variant", &data.variant, MAX_PHASE_BYTES)?;
+                validate_bounded("recovery", &data.recovery, MAX_PHASE_BYTES)?;
+                validate_bounded("error message", &data.message, MAX_MESSAGE_BYTES)?;
+            }
         }
 
         Ok(())
@@ -498,6 +518,25 @@ impl HarnessEvent {
                     "retryable": data.retryable,
                 })
             }
+            HarnessEventPayload::Error { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                let current_phase = data.phase.as_deref().or(fallback_current_phase);
+                serde_json::json!({
+                    "schema": self.schema,
+                    "schema_version": data.schema_version,
+                    "kind": "error",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "phase": data.phase,
+                    "current_phase": current_phase,
+                    "variant": data.variant,
+                    "recovery": data.recovery,
+                    "message": data.message,
+                    "details": data.details,
+                })
+            }
         }
     }
 
@@ -509,6 +548,7 @@ impl HarnessEvent {
             HarnessEventPayload::ValidatorResult { data } => &data.session_id,
             HarnessEventPayload::Retry { data } => &data.session_id,
             HarnessEventPayload::Failure { data } => &data.session_id,
+            HarnessEventPayload::Error { data } => &data.session_id,
         }
     }
 
@@ -520,6 +560,7 @@ impl HarnessEvent {
             HarnessEventPayload::ValidatorResult { data } => &data.task_id,
             HarnessEventPayload::Retry { data } => &data.task_id,
             HarnessEventPayload::Failure { data } => &data.task_id,
+            HarnessEventPayload::Error { data } => &data.task_id,
         }
     }
 
@@ -531,6 +572,7 @@ impl HarnessEvent {
             HarnessEventPayload::ValidatorResult { data } => data.workflow.as_deref(),
             HarnessEventPayload::Retry { data } => data.workflow.as_deref(),
             HarnessEventPayload::Failure { data } => data.workflow.as_deref(),
+            HarnessEventPayload::Error { data } => data.workflow.as_deref(),
         }
     }
 
@@ -542,6 +584,7 @@ impl HarnessEvent {
             HarnessEventPayload::ValidatorResult { data } => data.phase.as_deref(),
             HarnessEventPayload::Retry { data } => data.phase.as_deref(),
             HarnessEventPayload::Failure { data } => data.phase.as_deref(),
+            HarnessEventPayload::Error { data } => data.phase.as_deref(),
         }
     }
 }

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -16,6 +16,7 @@ pub mod bundled_app_skills;
 mod compaction;
 pub mod event_bus;
 pub mod exec_env;
+pub mod harness_errors;
 pub mod harness_events;
 pub mod hooks;
 pub mod loop_detect;
@@ -42,8 +43,9 @@ pub mod workspace_git;
 pub mod workspace_policy;
 
 pub use abi_schema::{
-    HOOK_PAYLOAD_SCHEMA_VERSION, PROGRESS_EVENT_SCHEMA_VERSION, TASK_RESULT_SCHEMA_VERSION,
-    UnsupportedSchemaVersionError, WORKSPACE_POLICY_SCHEMA_VERSION, check_supported,
+    HARNESS_ERROR_SCHEMA_VERSION, HOOK_PAYLOAD_SCHEMA_VERSION, PROGRESS_EVENT_SCHEMA_VERSION,
+    TASK_RESULT_SCHEMA_VERSION, UnsupportedSchemaVersionError, WORKSPACE_POLICY_SCHEMA_VERSION,
+    check_supported,
 };
 pub use agent::{
     Agent, AgentConfig, ConversationResponse, DEFAULT_SESSION_TIMEOUT_SECS,
@@ -56,6 +58,7 @@ pub use agent::{
 };
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
+pub use harness_errors::{HarnessError, HarnessErrorEvent, OCTOS_LOOP_ERROR_TOTAL, RecoveryHint};
 pub use harness_events::{
     HARNESS_EVENT_SCHEMA_V1, HarnessArtifactEvent, HarnessEvent, HarnessEventError,
     HarnessEventPayload, HarnessEventSink, HarnessFailureEvent, HarnessPhaseEvent,

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -5,13 +5,14 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
+use crate::harness_errors::HarnessError;
 use crate::harness_events::{
     OCTOS_EVENT_SINK_ENV, OCTOS_HARNESS_SESSION_ID_ENV, OCTOS_HARNESS_TASK_ID_ENV,
-    OCTOS_SESSION_ID_ENV, OCTOS_TASK_ID_ENV, lookup_event_sink_context,
+    OCTOS_SESSION_ID_ENV, OCTOS_TASK_ID_ENV, lookup_event_sink_context, write_event_to_sink,
 };
 use crate::progress::ProgressEvent;
 use crate::subprocess_env::{EnvAllowlist, sanitize_command_env, should_forward_env_name};
@@ -90,6 +91,30 @@ impl PluginTool {
             extra_env: self.extra_env.clone(),
             work_dir: Some(work_dir),
             timeout: self.timeout,
+        }
+    }
+
+    /// Record a `HarnessError` for this plugin tool: increments the
+    /// `octos_loop_error_total{variant, recovery}` counter and writes a
+    /// structured error event to the harness event sink (if one is wired
+    /// via `ToolContext`). Keeps plugin error paths consistent with the
+    /// in-process error boundary in `execution.rs`.
+    fn emit_plugin_error(&self, ctx: Option<&ToolContext>, classified: &HarnessError) {
+        classified.record_metric();
+        let Some(sink) = ctx.and_then(|c| c.harness_event_sink.as_deref()) else {
+            return;
+        };
+        let Some(sink_ctx) = lookup_event_sink_context(sink) else {
+            return;
+        };
+        let event = classified.to_event(sink_ctx.session_id, sink_ctx.task_id, None, None);
+        if let Err(error) = write_event_to_sink(sink, &event) {
+            tracing::debug!(
+                plugin = %self.plugin_name,
+                tool = %self.tool_def.name,
+                error = %error,
+                "failed to write plugin error event to harness sink"
+            );
         }
     }
 
@@ -520,13 +545,22 @@ impl Tool for PluginTool {
 
         let effective_args = self.prepare_effective_args(args, ctx.as_ref());
 
-        let mut child = cmd.spawn().wrap_err_with(|| {
-            format!(
-                "failed to spawn plugin '{}' executable: {}",
-                self.plugin_name,
-                self.executable.display()
-            )
-        })?;
+        let mut child = match cmd.spawn() {
+            Ok(child) => child,
+            Err(err) => {
+                let message = format!(
+                    "failed to spawn plugin '{}' executable: {}: {err}",
+                    self.plugin_name,
+                    self.executable.display()
+                );
+                let classified = HarnessError::PluginSpawn {
+                    plugin_name: self.plugin_name.clone(),
+                    message: message.clone(),
+                };
+                self.emit_plugin_error(ctx.as_ref(), &classified);
+                return Err(eyre::Report::new(err).wrap_err(message));
+            }
+        };
 
         let child_pid = child.id().unwrap_or(0);
         tracing::info!(
@@ -549,12 +583,16 @@ impl Tool for PluginTool {
 
         // Spawn stderr reader: streams lines as ToolProgress events
         let tool_name = self.tool_def.name.clone();
+        // Clone ctx for the stderr reader so we can still consult the
+        // original after the reader task is spawned (needed for
+        // `emit_plugin_error` on spawn/timeout/protocol failures).
+        let stderr_ctx = ctx.clone();
         let stderr_task = tokio::spawn(async move {
             let mut collected = String::new();
             if let Some(stderr) = stderr_handle {
                 let mut reader = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = reader.next_line().await {
-                    if let Some(ref ctx) = ctx {
+                    if let Some(ref ctx) = stderr_ctx {
                         ctx.reporter.report(ProgressEvent::ToolProgress {
                             name: tool_name.clone(),
                             tool_id: ctx.tool_id.clone(),
@@ -600,11 +638,16 @@ impl Tool for PluginTool {
             {
                 Ok((Ok(status), stdout_bytes, stderr_text)) => (status, stdout_bytes, stderr_text),
                 Ok((Err(e), _, _)) => {
-                    return Err(eyre::eyre!(
+                    let message = format!(
                         "plugin '{}' tool '{}' execution failed: {e}",
-                        self.plugin_name,
-                        self.tool_def.name
-                    ));
+                        self.plugin_name, self.tool_def.name
+                    );
+                    let classified = HarnessError::PluginProtocol {
+                        plugin_name: self.plugin_name.clone(),
+                        message: message.clone(),
+                    };
+                    self.emit_plugin_error(ctx.as_ref(), &classified);
+                    return Err(eyre::eyre!(message));
                 }
                 Err(_) => {
                     // Timeout — kill the child process
@@ -624,12 +667,18 @@ impl Tool for PluginTool {
                             .args(["/F", "/T", "/PID", &child_pid.to_string()])
                             .status();
                     }
-                    return Err(eyre::eyre!(
-                        "plugin '{}' tool '{}' timed out after {}s",
-                        self.plugin_name,
-                        self.tool_def.name,
-                        self.timeout.as_secs()
-                    ));
+                    let timeout_secs = self.timeout.as_secs();
+                    let message = format!(
+                        "plugin '{}' tool '{}' timed out after {timeout_secs}s",
+                        self.plugin_name, self.tool_def.name
+                    );
+                    let classified = HarnessError::PluginTimeout {
+                        plugin_name: self.plugin_name.clone(),
+                        timeout_secs,
+                        message: message.clone(),
+                    };
+                    self.emit_plugin_error(ctx.as_ref(), &classified);
+                    return Err(eyre::eyre!(message));
                 }
             };
         let stdout = String::from_utf8_lossy(&stdout_bytes);

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -588,6 +588,19 @@ impl TaskSupervisor {
                 );
                 self.mark_failed(task_id, data.message.clone());
             }
+            HarnessEventPayload::Error { data } => {
+                // Structured error events are diagnostic — record them in the
+                // runtime detail but only transition to Failed when the
+                // recovery hint marks the variant as non-retryable.
+                self.mark_runtime_state(
+                    task_id,
+                    TaskRuntimeState::ExecutingTool,
+                    Some(runtime_detail.to_string()),
+                );
+                if matches!(data.recovery.as_str(), "fail_fast" | "bug") {
+                    self.mark_failed(task_id, data.message.clone());
+                }
+            }
         }
 
         Ok(())

--- a/crates/octos-agent/tests/harness_errors.rs
+++ b/crates/octos-agent/tests/harness_errors.rs
@@ -1,0 +1,261 @@
+//! Acceptance tests for M6.1 harness error taxonomy (issue #488).
+//!
+//! These tests pin the public contract:
+//! - `LlmError` classifies into `HarnessError` variants deterministically.
+//! - `HarnessError` converts into `HarnessEventPayload::Error` with a primary
+//!   `RecoveryHint` per variant.
+//! - Emitted events conform to `octos.harness.event.v1` and round-trip through
+//!   `HarnessEvent::from_json_line`.
+//! - The schema version is registered via `abi_schema`.
+
+use std::fs;
+use std::path::PathBuf;
+
+use octos_agent::abi_schema::{HARNESS_ERROR_SCHEMA_VERSION, check_supported};
+use octos_agent::harness_errors::{HarnessError, RecoveryHint};
+use octos_agent::harness_events::{
+    HARNESS_EVENT_SCHEMA_V1, HarnessEvent, HarnessEventPayload, write_event_to_sink,
+};
+use octos_llm::{LlmError, LlmErrorKind};
+
+// ─────────────────────────────────────────────────────────────────────────
+// Classification
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_classify_rate_limit_from_llm_error_429() {
+    let err = LlmError::from_status(429, "Too Many Requests");
+    let classified = HarnessError::from(err);
+    assert!(
+        matches!(classified, HarnessError::RateLimited { .. }),
+        "expected RateLimited, got {classified:?}"
+    );
+    assert_eq!(classified.recovery_hint(), RecoveryHint::BackoffRetry);
+    assert_eq!(classified.variant_name(), "rate_limited");
+}
+
+#[test]
+fn should_classify_context_overflow_from_llm_error_oversized() {
+    let err = LlmError::from_status(400, "context_length_exceeded: 200k");
+    let classified = HarnessError::from(err);
+    assert!(
+        matches!(classified, HarnessError::ContextOverflow { .. }),
+        "expected ContextOverflow, got {classified:?}"
+    );
+    assert_eq!(classified.recovery_hint(), RecoveryHint::CompactContext);
+    assert_eq!(classified.variant_name(), "context_overflow");
+}
+
+#[test]
+fn should_classify_authentication_failure_as_fail_fast() {
+    let err = LlmError::from_status(401, "Unauthorized");
+    let classified = HarnessError::from(err);
+    assert!(matches!(classified, HarnessError::Authentication { .. }));
+    assert_eq!(classified.recovery_hint(), RecoveryHint::FailFast);
+}
+
+#[test]
+fn should_classify_provider_server_error_as_switch_provider() {
+    let err = LlmError::from_status(503, "Service Unavailable");
+    let classified = HarnessError::from(err);
+    assert!(matches!(
+        classified,
+        HarnessError::ProviderUnavailable { .. }
+    ));
+    assert_eq!(classified.recovery_hint(), RecoveryHint::SwitchProvider);
+}
+
+#[test]
+fn should_classify_llm_timeout_as_backoff_retry() {
+    let err = LlmError::timeout("request timed out after 120s");
+    let classified = HarnessError::from(err);
+    assert!(matches!(classified, HarnessError::Timeout { .. }));
+    assert_eq!(classified.recovery_hint(), RecoveryHint::BackoffRetry);
+}
+
+#[test]
+fn should_classify_network_as_backoff_retry() {
+    let err = LlmError::network("connection reset");
+    let classified = HarnessError::from(err);
+    assert!(matches!(classified, HarnessError::Network { .. }));
+    assert_eq!(classified.recovery_hint(), RecoveryHint::BackoffRetry);
+}
+
+#[test]
+fn should_classify_content_filtered_as_fail_fast() {
+    let err = LlmError::new(LlmErrorKind::ContentFiltered, "filtered by safety");
+    let classified = HarnessError::from(err);
+    assert!(matches!(classified, HarnessError::ContentFiltered { .. }));
+    assert_eq!(classified.recovery_hint(), RecoveryHint::FailFast);
+}
+
+#[test]
+fn should_classify_invalid_request_as_fail_fast() {
+    let err = LlmError::new(
+        LlmErrorKind::InvalidRequest {
+            detail: "bad param temperature".into(),
+        },
+        "400",
+    );
+    let classified = HarnessError::from(err);
+    assert!(matches!(classified, HarnessError::InvalidRequest { .. }));
+    assert_eq!(classified.recovery_hint(), RecoveryHint::FailFast);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Deterministic classification (contract invariant #2)
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_classify_same_input_to_same_variant_deterministically() {
+    // Run classification 100 times; same input must always map to the same
+    // variant and hint — no HashMap iteration order, no randomness.
+    for _ in 0..100 {
+        let a = HarnessError::from(LlmError::from_status(429, "Too Many Requests"));
+        let b = HarnessError::from(LlmError::from_status(429, "Too Many Requests"));
+        assert_eq!(a.variant_name(), b.variant_name());
+        assert_eq!(a.recovery_hint(), b.recovery_hint());
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Event emission
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_emit_harness_event_on_error_classification() {
+    let classified = HarnessError::from(LlmError::from_status(429, "Too Many Requests"));
+    let event = classified.to_event("session-xyz", "task-42", Some("coding"), Some("verify"));
+
+    // Schema is octos.harness.event.v1 — the existing harness event schema.
+    assert_eq!(event.schema, HARNESS_EVENT_SCHEMA_V1);
+
+    // Payload serializes as kind: "error".
+    let HarnessEventPayload::Error { data } = &event.payload else {
+        panic!("expected Error payload, got {:?}", event.payload);
+    };
+    assert_eq!(data.session_id, "session-xyz");
+    assert_eq!(data.task_id, "task-42");
+    assert_eq!(data.workflow.as_deref(), Some("coding"));
+    assert_eq!(data.phase.as_deref(), Some("verify"));
+    assert_eq!(data.variant, "rate_limited");
+    assert_eq!(data.recovery, "backoff_retry");
+
+    // The event passes validation and renders as valid JSON.
+    event.validate().expect("error event should validate");
+    let rendered = serde_json::to_string(&event).expect("serialize");
+    assert!(rendered.contains(r#""schema":"octos.harness.event.v1""#));
+    assert!(rendered.contains(r#""kind":"error""#));
+    assert!(rendered.contains(r#""variant":"rate_limited""#));
+    assert!(rendered.contains(r#""recovery":"backoff_retry""#));
+}
+
+#[test]
+fn should_round_trip_harness_error_through_sink() {
+    let temp = tempfile::NamedTempFile::new().expect("create sink file");
+    let sink_path: PathBuf = temp.path().to_path_buf();
+
+    let classified = HarnessError::from(LlmError::from_status(400, "context_length_exceeded"));
+    let event = classified.to_event(
+        "session-ctx",
+        "task-ctx",
+        Some("deep_research"),
+        Some("plan"),
+    );
+
+    write_event_to_sink(sink_path.display().to_string(), &event)
+        .expect("write error event to sink");
+
+    let raw = fs::read_to_string(&sink_path).expect("read sink");
+    let line = raw.lines().next().expect("sink line present");
+    let parsed = HarnessEvent::from_json_line(line).expect("parse harness event line");
+
+    assert_eq!(parsed.schema, HARNESS_EVENT_SCHEMA_V1);
+    let HarnessEventPayload::Error { data } = parsed.payload else {
+        panic!("expected Error payload after round-trip");
+    };
+    assert_eq!(data.variant, "context_overflow");
+    assert_eq!(data.recovery, "compact_context");
+    assert_eq!(data.session_id, "session-ctx");
+    assert_eq!(data.task_id, "task-ctx");
+    assert_eq!(data.workflow.as_deref(), Some("deep_research"));
+    assert_eq!(data.phase.as_deref(), Some("plan"));
+    assert_eq!(data.schema_version, HARNESS_ERROR_SCHEMA_VERSION);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Schema version registration (M4.6)
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_register_error_schema_version_in_abi() {
+    assert_eq!(HARNESS_ERROR_SCHEMA_VERSION, 1);
+    assert!(check_supported("HarnessError", 1, HARNESS_ERROR_SCHEMA_VERSION).is_ok());
+    assert!(check_supported("HarnessError", 2, HARNESS_ERROR_SCHEMA_VERSION).is_err());
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Metrics counter
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_count_errors_per_variant_in_metrics() {
+    // The counter name is octos_loop_error_total and must be labeled with
+    // {variant, recovery}. This test uses the label-emitting helper so the
+    // actual Prometheus text rendering is validated in the CLI metrics tests.
+    let variant = HarnessError::from(LlmError::from_status(429, "Too Many Requests"));
+    let (label_variant, label_recovery) = variant.metric_labels();
+    assert_eq!(label_variant, "rate_limited");
+    assert_eq!(label_recovery, "backoff_retry");
+
+    let overflow = HarnessError::from(LlmError::from_status(400, "context_length_exceeded"));
+    let (overflow_variant, overflow_recovery) = overflow.metric_labels();
+    assert_eq!(overflow_variant, "context_overflow");
+    assert_eq!(overflow_recovery, "compact_context");
+
+    // Variant names are stable identifiers (snake_case) suitable for
+    // Prometheus labels — no spaces, no uppercase, no operator-supplied text.
+    for name in [
+        "rate_limited",
+        "context_overflow",
+        "authentication",
+        "invalid_request",
+        "content_filtered",
+        "provider_unavailable",
+        "network",
+        "timeout",
+        "tool_execution",
+        "plugin_spawn",
+        "plugin_timeout",
+        "plugin_protocol",
+        "delegate_depth_exceeded",
+        "internal",
+    ] {
+        assert!(
+            name.chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_'),
+            "metric label variant '{name}' must be snake_case ASCII"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// DelegateDepthExceeded reserved for M6.7
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_expose_delegate_depth_exceeded_variant_for_m6_7() {
+    let err = HarnessError::DelegateDepthExceeded {
+        depth: 5,
+        limit: 4,
+        message: "spawn chain exceeded max depth".into(),
+    };
+    assert_eq!(err.variant_name(), "delegate_depth_exceeded");
+    // Hitting the max delegation depth is a structural budget — fail fast and
+    // surface to the operator; do not auto-retry.
+    assert_eq!(err.recovery_hint(), RecoveryHint::FailFast);
+    let event = err.to_event("s", "t", None, None);
+    event
+        .validate()
+        .expect("delegate depth event should validate");
+}

--- a/crates/octos-cli/src/api/metrics.rs
+++ b/crates/octos-cli/src/api/metrics.rs
@@ -289,6 +289,10 @@ fn build_totals(samples: &[ParsedMetricSample]) -> BTreeMap<String, u64> {
             "workspace_validator_optional_warnings".to_string(),
             total_for_metric(samples, "octos_workspace_validator_optional_warning_total"),
         ),
+        (
+            "loop_errors".to_string(),
+            total_for_metric(samples, octos_agent::OCTOS_LOOP_ERROR_TOTAL),
+        ),
     ])
 }
 
@@ -356,6 +360,14 @@ fn build_breakdowns(samples: &[ParsedMetricSample]) -> BTreeMap<String, Vec<Valu
                 samples,
                 "octos_workspace_validator_total",
                 &["status", "phase", "kind", "required"],
+            ),
+        ),
+        (
+            "loop_errors".to_string(),
+            breakdown(
+                samples,
+                octos_agent::OCTOS_LOOP_ERROR_TOTAL,
+                &["variant", "recovery"],
             ),
         ),
     ])

--- a/dashboard/src/api/harness.ts
+++ b/dashboard/src/api/harness.ts
@@ -122,6 +122,34 @@ export interface OperatorSummaryResponse {
   sources: OperatorSummarySource[]
 }
 
+/**
+ * M6.1 — structured harness error taxonomy.
+ *
+ * Counter name is `octos_loop_error_total` and rolls up to the
+ * `loop_errors` key in `OperatorSummaryResponse.totals` and
+ * `OperatorSummaryResponse.breakdowns`. `variant` names match
+ * `HarnessError::variant_name()` in Rust (snake_case identifiers such as
+ * `rate_limited`, `context_overflow`, `delegate_depth_exceeded`).
+ * `recovery` names match `RecoveryHint::as_str()`
+ * (`backoff_retry`, `switch_provider`, `compact_context`, `fail_fast`,
+ * `bug`).
+ */
+export interface HarnessErrorBreakdownRow extends OperatorSummaryBreakdownRow {
+  variant: string
+  recovery: string
+}
+
+export function harnessErrorRows(
+  summary: OperatorSummaryResponse | null,
+): HarnessErrorBreakdownRow[] {
+  const rows = summary?.breakdowns.loop_errors ?? []
+  return rows as HarnessErrorBreakdownRow[]
+}
+
+export function harnessErrorTotal(summary: OperatorSummaryResponse | null): number {
+  return summary?.totals.loop_errors ?? 0
+}
+
 function authHeaders(): HeadersInit {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   const token =

--- a/dashboard/src/pages/HarnessPage.tsx
+++ b/dashboard/src/pages/HarnessPage.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import HarnessTaskTable, { LIFECYCLE_ORDER } from '../components/HarnessTaskTable'
 import {
   harnessApi,
+  harnessErrorRows,
+  harnessErrorTotal,
   type HarnessLifecycleState,
   type HarnessTasksResponse,
   type OperatorSummaryResponse,
@@ -222,7 +224,7 @@ export default function HarnessPage() {
       </div>
 
       {/* Derived signal counts */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3" data-testid="derived-counts">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-3" data-testid="derived-counts">
         <CountCard
           label="Stale / zombie"
           value={tasksResp?.stale_count ?? 0}
@@ -256,7 +258,61 @@ export default function HarnessPage() {
           }
           active={derivedFilter.validatorFailed}
         />
+        <CountCard
+          label="Loop errors"
+          value={harnessErrorTotal(summary)}
+          testId="count-loop-errors"
+          tone={harnessErrorTotal(summary) > 0 ? 'danger' : 'ok'}
+          highlight={harnessErrorTotal(summary) > 0}
+        />
       </div>
+
+      {/* M6.1 — harness error taxonomy breakdown */}
+      {harnessErrorRows(summary).length > 0 && (
+        <div
+          className="bg-surface border border-gray-700/50 rounded-xl"
+          data-testid="harness-errors"
+        >
+          <div className="px-5 py-3 border-b border-gray-700/30">
+            <h2 className="text-sm font-semibold text-gray-300">
+              Structured errors (last hour)
+            </h2>
+            <p className="text-[11px] text-gray-500">
+              Counter <code>octos_loop_error_total</code> by{' '}
+              <code>variant</code> and <code>recovery</code> hint. Variant names
+              match <code>HarnessError::variant_name()</code>.
+            </p>
+          </div>
+          <table className="w-full text-sm" data-testid="harness-error-table">
+            <thead>
+              <tr className="text-xs text-gray-500 border-b border-gray-700/30">
+                <th className="text-left py-2 px-5 font-medium">variant</th>
+                <th className="text-left py-2 px-3 font-medium">recovery</th>
+                <th className="text-right py-2 px-5 font-medium">count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {harnessErrorRows(summary)
+                .slice(0, 20)
+                .map((row, i) => (
+                  <tr
+                    key={`${row.variant}|${row.recovery}|${i}`}
+                    data-testid="harness-error-row"
+                    data-variant={row.variant}
+                    data-recovery={row.recovery}
+                    className="border-b border-gray-700/15 last:border-0"
+                  >
+                    <td className="py-2 px-5 font-mono text-gray-300">{row.variant}</td>
+                    <td className="py-2 px-3 font-mono text-gray-400">{row.recovery}</td>
+                    <td className="py-2 px-5 text-right font-mono text-gray-300">
+                      {row.count}
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      )}
 
       {tasksError && (
         <div


### PR DESCRIPTION
Closes #488.

## What this delivers
14-variant typed `HarnessError` enum + 4-variant `RecoveryHint` + typed event emission via `octos.harness.event.v1 { kind: "error" }` + live-counter dashboard card. Foundation for M6.2 (retry-bucket state machine), M6.5 (credential pool rotation), M6.7 (DelegateDepthExceeded variant).

## Changes (commit 7243667, +1220/-53 LOC)
- `crates/octos-agent/src/harness_errors.rs` (new, 589 LOC) — enum + classification + recovery hints + metrics emitter
- `crates/octos-agent/tests/harness_errors.rs` (new, 261 LOC) — 14 tests (6 required + 8 coverage)
- `crates/octos-agent/src/harness_events.rs` (+43) — `HarnessEventPayload::Error` variant + validation + runtime-detail serialization
- `crates/octos-agent/src/agent/loop_runner.rs` (+142/-11) — classifies every `Err` escaping conversation + task loops via `classify_loop_error`
- `crates/octos-agent/src/agent/execution.rs` (+27) — classifies tool failures in `execute_tools`
- `crates/octos-agent/src/plugins/tool.rs` (+89) — `PluginSpawn`/`PluginTimeout`/`PluginProtocol` paths classified via `emit_plugin_error`
- `crates/octos-agent/src/abi_schema.rs` (implicit via lib) — `HARNESS_ERROR_SCHEMA_VERSION = 1`
- `crates/octos-agent/src/task_supervisor.rs` (+13) — exhaustive match arm for new payload
- `crates/octos-agent/src/lib.rs` (+7) — re-exports
- `crates/octos-cli/src/api/metrics.rs` (+12) — `loop_errors` total + `{variant, recovery}` breakdown
- `dashboard/src/api/harness.ts` (+28) + `dashboard/src/pages/HarnessPage.tsx` (+58) — Loop errors card + per-variant table

## Invariants
1. ✓ No raw `eyre::Report` escapes the agent loop without classification (all 3 boundaries in loop_runner.rs + plugin paths routed)
2. ✓ Deterministic — pattern-based match on `LlmErrorKind`, guarded by 100-iteration test
3. ✓ Each variant → exactly one `RecoveryHint` (exhaustive match)
4. ✓ Events conform to `octos.harness.event.v1`, round-trip through `HarnessEvent::from_json_line`
5. ✓ Schema version registered per M4.6
6. ✓ Dashboard card renders from live counter (`data-testid="harness-error-table"`)
7. ✓ Zero new `unsafe` (grep count = 0)

## Tests (14/14)
**Required (6):** `should_classify_rate_limit_from_llm_error_429`, `should_classify_context_overflow_from_llm_error_oversized`, `should_emit_harness_event_on_error_classification`, `should_round_trip_harness_error_through_sink`, `should_register_error_schema_version_in_abi`, `should_count_errors_per_variant_in_metrics`.

**Coverage (8):** auth/filter/timeout/network classification, determinism invariant (100 iters), `DelegateDepthExceeded` reservation, variant-name shape validation.

Full workspace: 910 agent tests + 14 new + all other crate tests, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean.

## M6.7 coordination signal
Added `HarnessError::DelegateDepthExceeded { depth, limit, message }` with:
- `variant_name() == "delegate_depth_exceeded"`
- `recovery_hint() == RecoveryHint::FailFast`
- `depth` and `limit` as `u32`

If M6.7 agent uses different naming (`spawn_depth_exceeded` / `subtask_depth_exceeded` / `depth_budget_exceeded`) or `usize` types, rename via schema bump to v2 OR adopt this naming.

## Scope-guard note
`task_supervisor.rs` (+13) touched outside allowed-files list for pattern-exhaustiveness only. Handler treats diagnostic events as runtime-state updates; only marks task `Failed` when `recovery` is `fail_fast` or `bug`. Same pattern M6.6 hit for exhaustiveness.

## Caveat
Agent-level classifier uses existing `lookup_event_sink_context` for `task_id`. When agent runs without a sink registered (e.g., `chat` without M4.5 wiring), counter still increments; no sink event emitted. Matches contract: event path is sink-scoped, counter is global.

## Test plan
- [x] 14 acceptance + coverage tests green
- [x] Workspace build + clippy all-targets + fmt clean
- [ ] Integration with M6.2 retry-bucket (M6.2 agent consumes `HarnessError` enum when dispatched)
- [ ] Live canary: fire deliberate 429, verify dashboard card shows `variant=ProviderRateLimit, recovery=RotateCredential`