### PR TITLE
fix: post-merge reconcile gap (compaction field + lib.rs fmt)

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -77,11 +77,11 @@ pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironm
 pub use harness_errors::{HarnessError, HarnessErrorEvent, OCTOS_LOOP_ERROR_TOTAL, RecoveryHint};
 pub use harness_events::{
     HARNESS_EVENT_SCHEMA_V1, HarnessArtifactEvent, HarnessCostAttributionEvent,
-    HarnessCredentialRotationEvent, HarnessCredentialRotationSink, HarnessEvent,
-    HarnessEventError, HarnessEventPayload, HarnessEventSink, HarnessFailureEvent,
-    HarnessMcpServerCallEvent, HarnessPhaseEvent, HarnessProgressEvent, HarnessRetryEvent,
-    HarnessSubAgentDispatchEvent, HarnessSwarmDispatchEvent, HarnessValidatorResultEvent,
-    MAX_HARNESS_EVENT_LINE_BYTES, emit_registered_credential_rotation_event,
+    HarnessCredentialRotationEvent, HarnessCredentialRotationSink, HarnessEvent, HarnessEventError,
+    HarnessEventPayload, HarnessEventSink, HarnessFailureEvent, HarnessMcpServerCallEvent,
+    HarnessPhaseEvent, HarnessProgressEvent, HarnessRetryEvent, HarnessSubAgentDispatchEvent,
+    HarnessSwarmDispatchEvent, HarnessValidatorResultEvent, MAX_HARNESS_EVENT_LINE_BYTES,
+    emit_registered_credential_rotation_event,
 };
 pub use hooks::{
     HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,
@@ -102,15 +102,16 @@ pub use task_supervisor::{
 };
 pub use tools::{
     ActivateToolsTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,
-    CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConfigureToolTool, DELEGATED_DENY_GROUP,
-    DELEGATION_METRIC, DEFAULT_DISPATCH_TIMEOUT_SECS, DEFAULT_HTTP_CONNECT_TIMEOUT_SECS,
-    DEFAULT_HTTP_READ_TIMEOUT_SECS, DeepSearchTool, DelegateTool, DelegationEvent,
-    DelegationOutcome, DepthBudget, DiffEditTool, DispatchOutcome, DispatchRequest,
-    DispatchResponse, EditFileTool, GlobTool, GrepTool, HttpMcpAgent, ListDirTool, MAX_DEPTH,
-    ManageSkillsTool, McpAgentBackend, McpAgentBackendConfig, MessageTool, PolicyDecision,
-    ReadFileTool, RecallMemoryTool, RobotToolRegistry, SaveMemoryTool, SendFileTool, SharedBackend,
-    ShellTool, SpawnTool, StdioMcpAgent, SynthesizeResearchTool, Tool, ToolConfigStore, ToolPolicy,
-    ToolRegistry, ToolResult, TurnAttachmentContext, WebFetchTool, WebSearchTool, WriteFileTool,
+    CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConfigureToolTool,
+    DEFAULT_DISPATCH_TIMEOUT_SECS, DEFAULT_HTTP_CONNECT_TIMEOUT_SECS,
+    DEFAULT_HTTP_READ_TIMEOUT_SECS, DELEGATED_DENY_GROUP, DELEGATION_METRIC, DeepSearchTool,
+    DelegateTool, DelegationEvent, DelegationOutcome, DepthBudget, DiffEditTool, DispatchOutcome,
+    DispatchRequest, DispatchResponse, EditFileTool, GlobTool, GrepTool, HttpMcpAgent, ListDirTool,
+    MAX_DEPTH, ManageSkillsTool, McpAgentBackend, McpAgentBackendConfig, MessageTool,
+    PolicyDecision, ReadFileTool, RecallMemoryTool, RobotToolRegistry, SaveMemoryTool,
+    SendFileTool, SharedBackend, ShellTool, SpawnTool, StdioMcpAgent, SynthesizeResearchTool, Tool,
+    ToolConfigStore, ToolPolicy, ToolRegistry, ToolResult, TurnAttachmentContext, WebFetchTool,
+    WebSearchTool, WriteFileTool,
     admin::{AdminApiContext, register_admin_api_tools},
     build_backend_from_config, build_delegated_child_policy, build_dispatch_event_payload,
     dispatch_with_metrics, install_robot_registry, record_dispatch,

--- a/crates/octos-cli/tests/mcp_serve_integration.rs
+++ b/crates/octos-cli/tests/mcp_serve_integration.rs
@@ -468,6 +468,7 @@ async fn should_populate_validator_results_when_workspace_policy_declares_valida
         },
         artifacts: WorkspaceArtifactsPolicy::default(),
         spawn_tasks: std::collections::BTreeMap::new(),
+        compaction: None,
     };
     write_workspace_policy(workspace.path(), &policy).unwrap();
 


### PR DESCRIPTION
Two small post-merge gaps found when verifying integrated main on mini1 (a3c3231):

1. `mcp_serve_integration` test missing `compaction: None` on WorkspacePolicy literal (M7.2a #518 predated M6.3 #499 field addition)
2. `octos-agent/src/lib.rs` re-export lists needed rustfmt fill-reorder

Both caught because the merge-reconciler's gate was `cargo check` (workspace libs), which doesn't build `--tests`. `cargo test --workspace --no-run` fails without these. Local verify green.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo test --workspace --no-run` on mini1
