### PR TITLE
test(coding-blue): fragile-case e2e matrix (queue modes, races, reloads)

### DIFF
--- a/e2e/tests/CODING_BLUE_MATRIX.md
+++ b/e2e/tests/CODING_BLUE_MATRIX.md
@@ -1,0 +1,157 @@
+# coding-blue fragile-case e2e matrix
+
+One spec file per fragile scenario uncovered across FA-5 through FA-11,
+so coding-blue-r1 (post FA-12 + M7.9) and future releases have strong
+regression coverage.
+
+Run against any mini by setting `OCTOS_TEST_URL`:
+
+```bash
+OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+OCTOS_AUTH_TOKEN=octos-admin-2026 \
+OCTOS_PROFILE=dspfac \
+OCTOS_TEST_EMAIL=dspfac@gmail.com \
+npx playwright test tests/<spec>.spec.ts
+```
+
+If `OCTOS_TEST_URL` is not set, every spec in this matrix is a no-op
+(`test.skip`) so the suite can be wired into CI without pinning a
+target. To list only the matrix specs:
+
+```bash
+npx playwright test tests/queue-mode-*.spec.ts \
+  tests/rapid-consecutive-chats.spec.ts \
+  tests/mixed-long-short-*.spec.ts \
+  tests/out-of-order-response.spec.ts \
+  tests/reload-mid-background.spec.ts \
+  tests/session-switch-race.spec.ts \
+  tests/file-attachment-identity-live.spec.ts \
+  tests/queue-mode-switch-midsession.spec.ts \
+  tests/task-anchor-lifecycle.spec.ts \
+  tests/swarm-review-gate.spec.ts \
+  --list
+```
+
+## Suites
+
+### Suite 1 — Queue mode matrix (5 specs)
+
+| spec | mode | contract |
+| --- | --- | --- |
+| `queue-mode-followup.spec.ts` | followup | strict U1→A1→U2→A2 DOM interleave |
+| `queue-mode-collect.spec.ts` | collect | ONE assistant bubble answers both |
+| `queue-mode-steer.spec.ts` | steer | Q2 overrides Q1 mid-flight; A2 wins |
+| `queue-mode-interrupt.spec.ts` | interrupt | Q2 aborts Q1; A2 lands fresh |
+| `queue-mode-speculative.spec.ts` | speculative | both run concurrent; both bubbles land |
+
+### Suite 2 — Rapid consecutive chats
+
+| spec | notes |
+| --- | --- |
+| `rapid-consecutive-chats.spec.ts` | 5 prompts over ~2.5s; followup; >=3 of 5 reply |
+
+### Suite 3 — Long-running + one-shot mix
+
+| spec | queue mode | notes |
+| --- | --- | --- |
+| `mixed-long-short-followup.spec.ts` | followup | FA-10 rewrite; content-based assertions |
+| `mixed-long-short-speculative.spec.ts` | speculative | concurrent mix; depends on FA-12 |
+
+### Suite 4 — Out-of-order response race (mocked)
+
+| spec | notes |
+| --- | --- |
+| `out-of-order-response.spec.ts` | `page.route` intercept; 3s vs 100ms; FA-8 correlation |
+
+### Suite 5 — Reload mid-background
+
+| spec | notes |
+| --- | --- |
+| `reload-mid-background.spec.ts` | deep research + reload + snapshot + idempotent reload |
+
+### Suite 6 — Session-switch race
+
+| spec | notes |
+| --- | --- |
+| `session-switch-race.spec.ts` | A starts long task; switch to B; return to A; no bleed |
+
+### Suite 7 — File-attachment identity race (live)
+
+| spec | notes |
+| --- | --- |
+| `file-attachment-identity-live.spec.ts` | file attaches to originating turn, not latest |
+
+### Suite 8 — Queue mode switching mid-session
+
+| spec | notes |
+| --- | --- |
+| `queue-mode-switch-midsession.spec.ts` | followup → speculative → followup across Q1/Q2/Q3 |
+
+### Suite 9 — Task-anchor lifecycle trace
+
+| spec | notes |
+| --- | --- |
+| `task-anchor-lifecycle.spec.ts` | spinner on, label transitions, spinner off |
+
+### Suite 10 — Swarm review gate
+
+| spec | notes |
+| --- | --- |
+| `swarm-review-gate.spec.ts` | scaffold only; targets `/swarm/`; fixme'd pending M7.9 |
+
+## Expected status vs releases
+
+| spec | pre-FA-12 (coding-blue) | post FA-12 + M7.9 (coding-blue-r1) |
+| --- | --- | --- |
+| queue-mode-followup | PASS | PASS |
+| queue-mode-collect | PASS | PASS |
+| queue-mode-steer | `test.fixme` pending M7.9 | remove fixme, should PASS |
+| queue-mode-interrupt | PASS (structural) | PASS + tighter labelling |
+| queue-mode-speculative | `test.fixme` (FA-11) | remove fixme, PASS |
+| rapid-consecutive-chats | PASS | PASS |
+| mixed-long-short-followup | PASS | PASS |
+| mixed-long-short-speculative | `test.fixme` (FA-11) | remove fixme, PASS |
+| out-of-order-response | `test.fixme` (FA-8 envelope) | remove fixme, PASS |
+| reload-mid-background | PASS | PASS |
+| session-switch-race | PASS | PASS |
+| file-attachment-identity-live | `test.fixme` (FA-12) | remove fixme, PASS |
+| queue-mode-switch-midsession | `test.fixme` (FA-12/M7.9) | remove fixme, PASS |
+| task-anchor-lifecycle | PASS (basic) | tighten with phase/progress testids |
+| swarm-review-gate | `test.fixme` (M7.9 scaffold) | remove fixme, flesh out |
+
+## Dependencies
+
+- **FA-12 landing**: queue-mode-speculative, mixed-long-short-speculative,
+  file-attachment-identity-live, queue-mode-switch-midsession.
+- **M7.9 landing**: queue-mode-steer (semantics), queue-mode-interrupt
+  (stricter labelling), task-anchor-lifecycle (phase/progress testids),
+  swarm-review-gate.
+- **FA-8 streamId envelope stabilization**: out-of-order-response.
+
+## Guardrails
+
+- Test-only; never modifies production code.
+- Every spec creates its own fresh session via `createNewSession`
+  so specs don't interfere.
+- Failing specs use `test.fixme(true, 'reason — pointer to follow-up')`
+  with an explicit comment, never silent skips.
+- `test.skip(() => !TEST_URL)` at describe-block level so the suite
+  is a no-op without a target.
+
+## Shared helpers
+
+All matrix helpers live in `tests/matrix-helpers.ts`:
+
+- `setQueueMode(page, mode)`
+- `fireRapidPrompts(page, prompts, intervalMs)`
+- `waitForAllAssistantsContent(page, expectedCount, timeoutMs)`
+- `snapshotTaskStore(page)`
+- `waitForTerminalTask(request, baseURL, token, profile, sessionId, timeoutMs)`
+- `getActiveSessionIdOrNull(page)`
+- `countBubbles(page)`
+- `buildEchoShellPrompt(marker)`
+- `resetQueueMode(page)`
+- `expectAssistantsContainAll(page, markers)`
+
+These stack on top of `live-browser-helpers.ts` so DOM selectors stay
+in one place.

--- a/e2e/tests/file-attachment-identity-live.spec.ts
+++ b/e2e/tests/file-attachment-identity-live.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Suite 7 — File-attachment identity race (live).
+ *
+ * Adapted from the octos-web mocked spec to run against live octos-web.
+ * We ask the agent to produce a file via the shell tool (so there's a
+ * deterministic artifact), rapid-fire a second quick prompt before the
+ * file bubble finalizes, and verify the file attaches to the bubble whose
+ * tool_call_id matches — not the bubble for the latest prompt.
+ *
+ * Harder without a deterministic file-generating plugin; we use the
+ * built-in shell to `send_file` a small artifact.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/file-attachment-identity-live.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+function buildFileProducePrompt(fileName: string, marker: string): string {
+  return [
+    'Use shell tool only.',
+    'If shell is not already active, call activate_tools with exactly ["shell"] once and only once.',
+    `Run \`mkdir -p ./attach-race && cd ./attach-race && printf '${marker}\\n' > ${fileName} && cat ${fileName}\` to create the file.`,
+    `Then call send_file on ./attach-race/${fileName} so the file is attached to this turn's assistant bubble.`,
+    `Finally return a short message that includes ${marker}.`,
+    'Do not start background work.',
+  ].join(' ');
+}
+
+test.describe('Suite 7 file-attachment-identity (live)', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(360_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('attached file lands on the originating turn, not the latest', async ({
+    page,
+  }) => {
+    // Depends on send_file + tool_call_id routing landing on the current
+    // mini. Gated fixme until FA-12 + M7.9 attach the artifact to the
+    // correct bubble in speculative mode.
+    test.fixme(
+      true,
+      'Live tool_call_id attachment routing pending FA-12 + M7.9 deploy',
+    );
+
+    await login(page);
+    await createNewSession(page);
+    await setQueueMode(page, 'speculative');
+
+    const marker = `ATTACH-${Date.now()}`;
+    const quickMarker = `QUICK-${Date.now() + 1}`;
+
+    const producePrompt = buildFileProducePrompt('identity.txt', marker);
+    const quickPrompt = buildEchoShellPrompt(quickMarker);
+
+    await fireRapidPrompts(page, [producePrompt, quickPrompt], 300);
+
+    await waitForAllAssistantsContent(page, 2, 240_000);
+    await page.waitForTimeout(5_000);
+
+    // Map each assistant bubble to its owned file attachments.
+    const bubbleAttachments = await page.evaluate(() => {
+      const bubbles = document.querySelectorAll("[data-testid='assistant-message']");
+      return Array.from(bubbles).map((bubble) => {
+        const text = (bubble.textContent || '').trim();
+        const files = Array.from(
+          bubble.querySelectorAll(
+            "[data-testid='file-attachment'], [data-testid='audio-attachment']",
+          ),
+        ).map((attachment) => {
+          const el = attachment as HTMLElement;
+          return {
+            filename: el.dataset.filename || '',
+            path: el.dataset.filePath || '',
+            testid: el.getAttribute('data-testid') || '',
+          };
+        });
+        return { text, files };
+      });
+    });
+
+    expect(bubbleAttachments.length).toBeGreaterThanOrEqual(2);
+
+    // The file-producing prompt's bubble must own the identity.txt
+    // attachment; the quick prompt's bubble must NOT.
+    const producerBubble = bubbleAttachments.find((bubble) =>
+      bubble.text.includes(marker),
+    );
+    const quickBubble = bubbleAttachments.find((bubble) =>
+      bubble.text.includes(quickMarker),
+    );
+
+    expect(producerBubble, 'missing producer bubble').toBeTruthy();
+    expect(quickBubble, 'missing quick bubble').toBeTruthy();
+
+    const producerHasFile = (producerBubble?.files || []).some((file) =>
+      (file.filename || file.path).includes('identity.txt'),
+    );
+    const quickHasFile = (quickBubble?.files || []).some((file) =>
+      (file.filename || file.path).includes('identity.txt'),
+    );
+
+    expect(producerHasFile, 'file must attach to the producer bubble').toBe(true);
+    expect(quickHasFile, 'file must NOT attach to the quick bubble').toBe(false);
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/matrix-helpers.ts
+++ b/e2e/tests/matrix-helpers.ts
@@ -1,0 +1,313 @@
+/**
+ * Shared helpers for the coding-blue fragile-case e2e matrix (Suite 1-10).
+ *
+ * Each helper is kept narrow and composable so individual specs in the
+ * matrix stay short and readable. Nothing here mutates production state;
+ * these are read/send helpers that wrap the chat-input DOM interaction.
+ */
+import { expect, type APIRequestContext, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  getInput,
+  getSendButton,
+} from './live-browser-helpers';
+
+export type QueueMode =
+  | 'followup'
+  | 'collect'
+  | 'steer'
+  | 'interrupt'
+  | 'speculative';
+
+export interface QueueModeResult {
+  badgeText: string;
+  feedbackText: string;
+}
+
+/**
+ * Switch the active session's queue mode by sending a `/queue <mode>` slash
+ * command, then wait for the cmd-feedback ack and optionally the
+ * queue-mode-badge to reflect the new mode. Returns both text snapshots.
+ */
+export async function setQueueMode(
+  page: Page,
+  mode: QueueMode,
+  opts: { timeoutMs?: number } = {},
+): Promise<QueueModeResult> {
+  const { timeoutMs = 30_000 } = opts;
+  const input = getInput(page);
+  const sendBtn = getSendButton(page);
+
+  await input.fill(`/queue ${mode}`);
+  await sendBtn.click();
+
+  const feedback = page.locator("[data-testid='cmd-feedback']");
+  await feedback
+    .waitFor({ state: 'visible', timeout: timeoutMs })
+    .catch(() => undefined);
+  const feedbackText = ((await feedback.textContent().catch(() => '')) || '').trim();
+
+  const badge = page.locator("[data-testid='queue-mode-badge']");
+  const badgeText = ((await badge
+    .first()
+    .textContent({ timeout: 5_000 })
+    .catch(() => '')) || '').trim();
+
+  return { badgeText, feedbackText };
+}
+
+/**
+ * Fire N prompts with a fixed interval between each send. Returns the number
+ * of user bubbles observed after the last send — useful for early sanity
+ * checks before waiting for assistants.
+ */
+export async function fireRapidPrompts(
+  page: Page,
+  prompts: readonly string[],
+  intervalMs = 500,
+): Promise<{ sent: number; userBubbles: number }> {
+  const input = getInput(page);
+  const sendBtn = getSendButton(page);
+
+  let sent = 0;
+  for (const prompt of prompts) {
+    await input.fill(prompt);
+    await sendBtn.click();
+    sent += 1;
+    if (sent < prompts.length) {
+      await page.waitForTimeout(intervalMs);
+    }
+  }
+
+  // Give the DOM one tick to reflect the final send.
+  await page.waitForTimeout(250);
+  const userBubbles = await countUserBubbles(page);
+  return { sent, userBubbles };
+}
+
+/**
+ * Poll until N assistant bubbles each hold non-empty text (length > 20) OR
+ * the timeout elapses. Returns the count of "filled" bubbles seen at exit.
+ *
+ * This is intentionally stricter than countAssistantBubbles because some
+ * backend modes spawn placeholder bubbles that stay empty while the real
+ * content is being streamed onto a different bubble.
+ */
+export async function waitForAllAssistantsContent(
+  page: Page,
+  expectedCount: number,
+  timeoutMs = 120_000,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let lastFilled = 0;
+
+  while (Date.now() < deadline) {
+    const filled = await page.evaluate((sel) => {
+      const bubbles = document.querySelectorAll(sel);
+      return Array.from(bubbles).filter((node) => {
+        const text = (node.textContent || '').trim();
+        return text.length > 20;
+      }).length;
+    }, SEL.assistantMessage);
+
+    lastFilled = filled;
+    if (filled >= expectedCount) {
+      // Confirm streaming has stopped so the "filled" count is final.
+      const streaming = await page
+        .locator(SEL.cancelButton)
+        .isVisible({ timeout: 500 })
+        .catch(() => false);
+      if (!streaming) {
+        return filled;
+      }
+    }
+
+    await page.waitForTimeout(1_500);
+  }
+
+  return lastFilled;
+}
+
+/**
+ * Snapshot every localStorage key whose name matches either the brief's
+ * documented `octos_web:task_store:v1:*` prefix OR the currently-shipped
+ * session keys (so the helper is useful even before that prefix lands).
+ */
+export async function snapshotTaskStore(
+  page: Page,
+): Promise<Record<string, string>> {
+  return page.evaluate(() => {
+    const out: Record<string, string> = {};
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (
+        key.startsWith('octos_web:task_store:v1:') ||
+        key.startsWith('octos_session_') ||
+        key.startsWith('octos_current_session') ||
+        key.startsWith('octos_web:') ||
+        key.startsWith('task_store:')
+      ) {
+        out[key] = localStorage.getItem(key) || '';
+      }
+    }
+    return out;
+  });
+}
+
+export interface SessionTaskRow {
+  id?: string | null;
+  status?: string | null;
+  tool_name?: string | null;
+  lifecycle_state?: string | null;
+  child_terminal_state?: string | null;
+  child_join_state?: string | null;
+  completed_at?: string | null;
+  [extra: string]: unknown;
+}
+
+/**
+ * Poll GET /api/sessions/{id}/tasks until at least one row reports a
+ * terminal lifecycle (completed/failed/cancelled) or until the timeout
+ * elapses. Returns the first terminal row, or null on timeout.
+ *
+ * The request context can be the Playwright APIRequestContext or an
+ * object exposing .post/.get — we only need GET.
+ */
+export async function waitForTerminalTask(
+  request: APIRequestContext,
+  baseURL: string,
+  token: string,
+  profile: string,
+  sessionId: string,
+  timeoutMs = 240_000,
+): Promise<SessionTaskRow | null> {
+  const deadline = Date.now() + timeoutMs;
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (profile) headers['X-Profile-Id'] = profile;
+
+  while (Date.now() < deadline) {
+    const resp = await request
+      .get(`${baseURL}/api/sessions/${encodeURIComponent(sessionId)}/tasks`, {
+        headers,
+      })
+      .catch(() => null);
+
+    if (resp && resp.ok()) {
+      const tasks = (await resp.json().catch(() => [])) as SessionTaskRow[];
+      if (Array.isArray(tasks)) {
+        for (const task of tasks) {
+          const terminal =
+            task.status === 'completed' ||
+            task.status === 'failed' ||
+            task.status === 'cancelled' ||
+            task.lifecycle_state === 'ready' ||
+            Boolean(task.completed_at);
+          if (terminal) return task;
+        }
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  }
+
+  return null;
+}
+
+/**
+ * Get the active session id from the sidebar or from the sessions API if the
+ * sidebar isn't rendering a data-active entry yet.
+ */
+export async function getActiveSessionIdOrNull(page: Page): Promise<string | null> {
+  const active = await page
+    .evaluate(() => {
+      const el = document.querySelector<HTMLElement>(
+        "[data-session-id][data-active='true']",
+      );
+      return el?.dataset.sessionId || null;
+    })
+    .catch(() => null);
+  if (active) return active;
+
+  return page
+    .evaluate(async () => {
+      const token =
+        localStorage.getItem('octos_session_token') ||
+        localStorage.getItem('octos_auth_token') ||
+        '';
+      const profile = localStorage.getItem('selected_profile') || '';
+      const headers: Record<string, string> = {};
+      if (token) headers.Authorization = `Bearer ${token}`;
+      if (profile) headers['X-Profile-Id'] = profile;
+      const resp = await fetch('/api/sessions', { headers });
+      if (!resp.ok) return null;
+      const data = await resp.json().catch(() => []);
+      if (!Array.isArray(data) || data.length === 0) return null;
+      return (typeof data[0]?.id === 'string' ? (data[0].id as string) : null);
+    })
+    .catch(() => null);
+}
+
+/**
+ * Count user and assistant bubbles in a single round-trip.
+ */
+export async function countBubbles(page: Page): Promise<{
+  user: number;
+  assistant: number;
+}> {
+  const [user, assistant] = await Promise.all([
+    countUserBubbles(page),
+    countAssistantBubbles(page),
+  ]);
+  return { user, assistant };
+}
+
+/**
+ * Build a quick-echo shell prompt that runs in a couple of seconds via the
+ * shell tool. Useful for most Suite 1 tests where the only thing that
+ * matters is the marker landing in the assistant text.
+ */
+export function buildEchoShellPrompt(marker: string): string {
+  return [
+    'Use shell tool only.',
+    'If shell is not already active, call activate_tools with exactly ["shell"] once and only once.',
+    `Run \`echo ${marker}\` and return only its stdout.`,
+    'Do not explain tool availability.',
+    'Do not start background work.',
+  ].join(' ');
+}
+
+/**
+ * Reset back to followup queue mode. Best-effort — silently succeeds if the
+ * command errors (e.g. offline during teardown).
+ */
+export async function resetQueueMode(page: Page) {
+  try {
+    await setQueueMode(page, 'followup');
+  } catch {
+    // Best effort.
+  }
+}
+
+/**
+ * Assert that at least `expectedCount` bubbles each contain any of the
+ * provided markers. Useful for verifying two independently-routed answers
+ * both landed.
+ */
+export async function expectAssistantsContainAll(
+  page: Page,
+  markers: readonly string[],
+) {
+  const texts = await page
+    .locator(SEL.assistantMessage)
+    .allTextContents()
+    .catch(() => []);
+  const combined = texts.join('\n');
+  for (const marker of markers) {
+    expect(combined).toContain(marker);
+  }
+}

--- a/e2e/tests/mixed-long-short-followup.spec.ts
+++ b/e2e/tests/mixed-long-short-followup.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Suite 3 — Long-running + one-shot mix (followup queue mode).
+ *
+ * Migrated from the coding-blue-mixed-order track (FA-10 rewrite). The
+ * supervisor runs a deep-research-style Q1, then two quick shell echoes
+ * Q2/Q3 behind it. Under followup, they must serialize — all three
+ * user bubbles rendered, assistant answers eventually land for each,
+ * and markers B/C arrive only after A's bubble exists.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/mixed-long-short-followup.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+const LONG_RESEARCH_PROMPT = [
+  'Use shell tool only.',
+  'If shell is not already active, call activate_tools with exactly ["shell"] once.',
+  'Run `echo RESEARCH-START && for i in 1 2 3 4 5; do sleep 2; echo tick-$i; done && echo RESEARCH-DONE`',
+  'then return a short summary mentioning RESEARCH-DONE.',
+  'Do not start background work.',
+].join(' ');
+
+test.describe('Suite 3 mixed-long-short followup', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(540_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('long research + two quick echoes serialize under followup', async ({
+    page,
+  }) => {
+    await login(page);
+    await createNewSession(page);
+    await setQueueMode(page, 'followup');
+
+    const markerB = `MIXFU-B-${Date.now()}`;
+    const markerC = `MIXFU-C-${Date.now() + 1}`;
+    const prompts = [
+      LONG_RESEARCH_PROMPT,
+      buildEchoShellPrompt(markerB),
+      buildEchoShellPrompt(markerC),
+    ];
+
+    await fireRapidPrompts(page, prompts, 500);
+
+    // Up to 8 min for all 3 assistant bubbles to settle under followup.
+    const filled = await waitForAllAssistantsContent(page, 3, 480_000);
+    expect(filled).toBeGreaterThanOrEqual(3);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(3);
+    expect(assistant).toBeGreaterThanOrEqual(3);
+
+    // Content-based assertion: RESEARCH-DONE plus both quick markers must
+    // appear in the assistant thread.
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    const combined = assistantTexts.join('\n');
+    expect(combined).toContain('RESEARCH-DONE');
+    expect(combined).toContain(markerB);
+    expect(combined).toContain(markerC);
+
+    // Ordering: A's research bubble must appear before B/C markers under
+    // followup, since followup waits for the long turn first.
+    const researchIdx = assistantTexts.findIndex((text) =>
+      text.includes('RESEARCH-DONE'),
+    );
+    const markerBIdx = assistantTexts.findIndex((text) => text.includes(markerB));
+    const markerCIdx = assistantTexts.findIndex((text) => text.includes(markerC));
+    expect(researchIdx).toBeGreaterThanOrEqual(0);
+    expect(markerBIdx).toBeGreaterThan(researchIdx);
+    expect(markerCIdx).toBeGreaterThan(researchIdx);
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/mixed-long-short-speculative.spec.ts
+++ b/e2e/tests/mixed-long-short-speculative.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Suite 3 — Long-running + one-shot mix (speculative queue mode).
+ *
+ * Same scenario as mixed-long-short-followup but speculative: the deep
+ * research runs async while Q2/Q3 quick echoes fire concurrently.
+ * Post-FA-12 all 3 must land content.
+ *
+ * Currently expected to fail pre-FA-12 — marked fixme until coding-blue-r1
+ * deploys FA-12 + M7.9 speculative fix to the target mini.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/mixed-long-short-speculative.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+const LONG_RESEARCH_PROMPT = [
+  'Use shell tool only.',
+  'If shell is not already active, call activate_tools with exactly ["shell"] once.',
+  'Run `echo RESEARCH-START && for i in 1 2 3 4 5; do sleep 2; echo tick-$i; done && echo RESEARCH-DONE`',
+  'then return a short summary mentioning RESEARCH-DONE.',
+  'Do not start background work.',
+].join(' ');
+
+test.describe('Suite 3 mixed-long-short speculative', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(540_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('speculative runs long research concurrent with two quick echoes', async ({
+    page,
+  }) => {
+    // Concurrent delivery of A/B/C under speculative is the exact FA-11
+    // shape: three independent streams each need their own final bubble.
+    // Remove fixme when FA-12 + M7.9 land on mini1.
+    test.fixme(
+      true,
+      'Concurrent mixed delivery pending FA-12 + M7.9 landing on target mini',
+    );
+
+    await login(page);
+    await createNewSession(page);
+    await setQueueMode(page, 'speculative');
+
+    const markerB = `MIXSP-B-${Date.now()}`;
+    const markerC = `MIXSP-C-${Date.now() + 1}`;
+    const prompts = [
+      LONG_RESEARCH_PROMPT,
+      buildEchoShellPrompt(markerB),
+      buildEchoShellPrompt(markerC),
+    ];
+
+    await fireRapidPrompts(page, prompts, 300);
+
+    const filled = await waitForAllAssistantsContent(page, 3, 480_000);
+    expect(filled).toBeGreaterThanOrEqual(3);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(3);
+    expect(assistant).toBeGreaterThanOrEqual(3);
+
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+
+    // All three markers must exist in distinct bubbles; speculative is
+    // allowed to deliver them out of order but never merged.
+    const findIdx = (needle: string) =>
+      assistantTexts.findIndex((text) => text.includes(needle));
+
+    const aIdx = findIdx('RESEARCH-DONE');
+    const bIdx = findIdx(markerB);
+    const cIdx = findIdx(markerC);
+
+    expect(aIdx, 'RESEARCH-DONE missing').toBeGreaterThanOrEqual(0);
+    expect(bIdx, `marker ${markerB} missing`).toBeGreaterThanOrEqual(0);
+    expect(cIdx, `marker ${markerC} missing`).toBeGreaterThanOrEqual(0);
+    expect(new Set([aIdx, bIdx, cIdx]).size).toBe(3);
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/out-of-order-response.spec.ts
+++ b/e2e/tests/out-of-order-response.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Suite 4 — Out-of-order response race (mocked adversarial timing).
+ *
+ * Mirrors the pattern from octos-web's concurrent-deep-research-ordering
+ * mocked spec, run against the octos-web deployment at OCTOS_TEST_URL.
+ * The test intercepts /api/chat and injects a 3000ms delay for the first
+ * call and 100ms for the second. FA-8's fix means the streamId correlation
+ * must route each stream's content to its originating user turn, even when
+ * the second stream finalizes first.
+ *
+ * This provides a deterministic equivalent to the live regression in
+ * case live LLM timing doesn't reproduce.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/out-of-order-response.spec.ts
+ */
+import { expect, test, type Route } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+import { countBubbles, waitForAllAssistantsContent } from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+interface SsePayload {
+  delayMs: number;
+  streamId: string;
+  answer: string;
+}
+
+/**
+ * Build a minimal valid SSE body that many octos chat clients accept.
+ * We produce one `text` (or equivalent) delta followed by a `done`
+ * event so the final message lands with the answer text.
+ */
+function buildSseBody(payload: SsePayload): string {
+  const events = [
+    { type: 'stream_started', stream_id: payload.streamId },
+    { type: 'text', stream_id: payload.streamId, text: payload.answer },
+    { type: 'done', stream_id: payload.streamId, reason: 'end_turn' },
+  ];
+  return events.map((evt) => `data: ${JSON.stringify(evt)}\n\n`).join('');
+}
+
+test.describe('Suite 4 out-of-order response race', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(120_000);
+
+  test('streamId correlation keeps answers on their own turns', async ({
+    page,
+  }) => {
+    // The precise SSE envelope expected by the live web client is still
+    // being finalized alongside FA-8 — mocked intercept assertions are
+    // gated fixme until we standardize the envelope.
+    test.fixme(
+      true,
+      'Mocked SSE envelope pending FA-8 streamId schema stabilization',
+    );
+
+    await login(page);
+    await createNewSession(page);
+
+    let chatCalls = 0;
+    await page.route(/\/api\/chat(\?|$)/, async (route: Route) => {
+      chatCalls += 1;
+      const isFirst = chatCalls === 1;
+      const payload: SsePayload = {
+        delayMs: isFirst ? 3_000 : 100,
+        streamId: isFirst ? 'stream-A' : 'stream-B',
+        answer: isFirst
+          ? 'Out-of-order answer A (delayed 3s)'
+          : 'Out-of-order answer B (fast 100ms)',
+      };
+
+      // Honor the delay before returning the SSE body.
+      await new Promise((resolve) => setTimeout(resolve, payload.delayMs));
+
+      await route.fulfill({
+        status: 200,
+        headers: {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+        },
+        body: buildSseBody(payload),
+      });
+    });
+
+    const input = getInput(page);
+    const sendBtn = getSendButton(page);
+
+    await input.fill('FIRST SEND (expects answer A)');
+    await sendBtn.click();
+    await page.waitForTimeout(200);
+    await input.fill('SECOND SEND (expects answer B)');
+    await sendBtn.click();
+
+    await waitForAllAssistantsContent(page, 2, 30_000);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(2);
+    expect(assistant).toBeGreaterThanOrEqual(2);
+
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+
+    // FA-8 contract: the FIRST user's answer bubble carries answer A; the
+    // SECOND user's answer bubble carries answer B. We rely on DOM order
+    // (first user bubble comes before second) to identify which bubble
+    // belongs to which user turn.
+    const roles = await page.evaluate(() => {
+      const nodes = document.querySelectorAll(
+        "[data-testid='user-message'], [data-testid='assistant-message']",
+      );
+      return Array.from(nodes).map((node) => ({
+        role: node.getAttribute('data-testid')?.includes('user') ? 'user' : 'assistant',
+        text: (node.textContent || '').trim(),
+      }));
+    });
+
+    // Find the assistant bubble that immediately follows user #0.
+    let seenUsers = 0;
+    let firstTurnAssistant: string | null = null;
+    let secondTurnAssistant: string | null = null;
+    for (const entry of roles) {
+      if (entry.role === 'user') {
+        seenUsers += 1;
+      } else if (entry.role === 'assistant') {
+        if (seenUsers === 1 && !firstTurnAssistant) firstTurnAssistant = entry.text;
+        if (seenUsers === 2 && !secondTurnAssistant) secondTurnAssistant = entry.text;
+      }
+    }
+
+    expect(firstTurnAssistant, 'missing first-turn assistant bubble').toBeTruthy();
+    expect(secondTurnAssistant, 'missing second-turn assistant bubble').toBeTruthy();
+
+    // Crux of FA-8: A's text must not end up on the second turn's bubble.
+    expect(firstTurnAssistant).toContain('answer A');
+    expect(secondTurnAssistant).toContain('answer B');
+    expect(firstTurnAssistant).not.toContain('answer B');
+    expect(secondTurnAssistant).not.toContain('answer A');
+
+    expect(assistantTexts.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/e2e/tests/queue-mode-collect.spec.ts
+++ b/e2e/tests/queue-mode-collect.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Suite 1 — Queue-mode matrix (2/5): collect.
+ *
+ * Contract: Q2 is batched with Q1 into one turn. One assistant bubble
+ * answers both. The final bubble content must mention both markers.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/queue-mode-collect.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 1 queue-mode-collect', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(360_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('collect batches rapid prompts into one assistant turn', async ({
+    page,
+  }) => {
+    await login(page);
+    await createNewSession(page);
+
+    const { badgeText, feedbackText } = await setQueueMode(page, 'collect');
+    const ack = `${feedbackText}\n${badgeText}`.toLowerCase();
+    expect(ack).toMatch(/collect|queue/);
+
+    const markerA = `COLLECT-Q1-${Date.now()}`;
+    const markerB = `COLLECT-Q2-${Date.now() + 1}`;
+    await fireRapidPrompts(
+      page,
+      [buildEchoShellPrompt(markerA), buildEchoShellPrompt(markerB)],
+      500,
+    );
+
+    // Wait for at least one rich assistant turn — collect may render 1 or 2
+    // bubbles depending on backend fan-out, but the batched response must
+    // name both markers.
+    await waitForAllAssistantsContent(page, 1, 240_000);
+
+    // Allow an extra grace window in case the backend is still finalizing.
+    await page.waitForTimeout(4_000);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(2);
+    expect(assistant).toBeGreaterThanOrEqual(1);
+
+    // Any assistant bubble in the thread must contain both markers so the
+    // batch is provably collected into one answer.
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    const batched = assistantTexts.find(
+      (text) => text.includes(markerA) && text.includes(markerB),
+    );
+    expect(batched, 'collect mode must produce one bubble containing both markers').toBeTruthy();
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/queue-mode-followup.spec.ts
+++ b/e2e/tests/queue-mode-followup.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Suite 1 — Queue-mode matrix (1/5): followup.
+ *
+ * Contract: Q2 waits for Q1 to finish. Strict interleave in the DOM is
+ * user -> assistant -> user -> assistant. Both user prompts land, both
+ * assistant bubbles land, both markers appear in the assistant output.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/queue-mode-followup.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  expectAssistantsContainAll,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 1 queue-mode-followup', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(360_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('followup preserves strict user->assistant->user->assistant interleave', async ({
+    page,
+  }) => {
+    await login(page);
+    await createNewSession(page);
+
+    const { badgeText, feedbackText } = await setQueueMode(page, 'followup');
+    const ack = `${feedbackText}\n${badgeText}`.toLowerCase();
+    expect(ack).toMatch(/followup|queue/);
+
+    const markerA = `FOLLOWUP-Q1-${Date.now()}`;
+    const markerB = `FOLLOWUP-Q2-${Date.now() + 1}`;
+    await fireRapidPrompts(
+      page,
+      [buildEchoShellPrompt(markerA), buildEchoShellPrompt(markerB)],
+      500,
+    );
+
+    const filled = await waitForAllAssistantsContent(page, 2, 240_000);
+    expect(filled).toBeGreaterThanOrEqual(2);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(2);
+    expect(assistant).toBeGreaterThanOrEqual(2);
+
+    // Strict ordering: at the start of the thread, user #0 must come before
+    // user #1 and at least one assistant should sit between them (followup
+    // serializes the turns).
+    const roles = await page.evaluate(() => {
+      const nodes = document.querySelectorAll(
+        "[data-testid='user-message'], [data-testid='assistant-message']",
+      );
+      return Array.from(nodes).map((node) =>
+        node.getAttribute('data-testid')?.includes('user') ? 'user' : 'assistant',
+      );
+    });
+
+    const userIdx = roles
+      .map((role, idx) => (role === 'user' ? idx : -1))
+      .filter((idx) => idx >= 0);
+    expect(userIdx.length).toBe(2);
+    expect(userIdx[1] - userIdx[0]).toBeGreaterThanOrEqual(2);
+
+    // Both markers must appear in assistant output somewhere.
+    await expectAssistantsContainAll(page, [markerA, markerB]);
+
+    // Streaming must be finished by now.
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/queue-mode-interrupt.spec.ts
+++ b/e2e/tests/queue-mode-interrupt.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Suite 1 — Queue-mode matrix (4/5): interrupt.
+ *
+ * Contract: Q2 aborts Q1 immediately. Q1's assistant bubble should carry
+ * an interrupted/cancelled marker (content or status); Q2 proceeds fresh
+ * and its marker lands on the final bubble.
+ *
+ * NOTE: The interrupt marker format is still in flight (FA-11 through
+ * M7.9). We verify the structural contract now — Q2 wins the final
+ * answer — and mark the strict "interrupted label" check fixme.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/queue-mode-interrupt.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 1 queue-mode-interrupt', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(360_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('interrupt aborts Q1 and lands Q2 as the final answer', async ({
+    page,
+  }) => {
+    await login(page);
+    await createNewSession(page);
+
+    const { badgeText, feedbackText } = await setQueueMode(page, 'interrupt');
+    const ack = `${feedbackText}\n${badgeText}`.toLowerCase();
+    expect(ack).toMatch(/interrupt|queue/);
+
+    const markerA = `INTERRUPT-Q1-${Date.now()}`;
+    const markerB = `INTERRUPT-Q2-${Date.now() + 1}`;
+
+    // Q1 is deliberately long so Q2's interrupt actually needs to preempt.
+    const q1 = [
+      `${buildEchoShellPrompt(markerA)}`,
+      'After echoing, run `sleep 30` from the repo root so the turn stays live.',
+    ].join(' ');
+
+    await fireRapidPrompts(page, [q1, buildEchoShellPrompt(markerB)], 1_500);
+
+    await waitForAllAssistantsContent(page, 1, 180_000);
+    await page.waitForTimeout(3_000);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(2);
+    expect(assistant).toBeGreaterThanOrEqual(1);
+
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    const lastText = assistantTexts[assistantTexts.length - 1] || '';
+
+    // The final bubble must contain Q2's marker — that's the hard
+    // contract of interrupt mode.
+    expect(lastText).toContain(markerB);
+
+    // Note: a stricter "earliest assistant bubble is labelled as
+    // cancelled/interrupted" check is intentionally NOT asserted here.
+    // The UI label format is still settling (M7.9 track); once finalized
+    // the next iteration of this spec will add a per-bubble status check
+    // via data-message-status=cancelled or similar.
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/queue-mode-speculative.spec.ts
+++ b/e2e/tests/queue-mode-speculative.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Suite 1 — Queue-mode matrix (5/5): speculative.
+ *
+ * Contract (THIS IS THE FA-11 REGRESSION): both prompts run concurrently;
+ * both assistant bubbles eventually carry their respective content. Both
+ * markers (Q1 and Q2) must land in distinct assistant bubbles, not on
+ * one merged bubble. Post-FA-12 + coding-blue-r1 this spec must pass.
+ *
+ * Currently known to fail against coding-blue pre-FA-12 — marked fixme
+ * with an explicit pointer to the fix it depends on. Remove the fixme
+ * once FA-12 lands on mini1.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/queue-mode-speculative.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 1 queue-mode-speculative (FA-11 regression)', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(360_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('speculative delivers both answers in distinct bubbles', async ({
+    page,
+  }) => {
+    // FA-11 regression — expected to fail until FA-12 + coding-blue-r1
+    // are deployed to the target mini. Remove this fixme once the fix
+    // is live to let the guard catch future regressions.
+    test.fixme(
+      true,
+      'FA-11 concurrent delivery — requires FA-12 landing on target mini',
+    );
+
+    await login(page);
+    await createNewSession(page);
+
+    const { badgeText, feedbackText } = await setQueueMode(page, 'speculative');
+    const ack = `${feedbackText}\n${badgeText}`.toLowerCase();
+    expect(ack).toMatch(/spec|queue/);
+
+    const markerA = `SPEC-Q1-${Date.now()}`;
+    const markerB = `SPEC-Q2-${Date.now() + 1}`;
+
+    // Fire rapidly — speculative must pipeline both concurrently.
+    await fireRapidPrompts(
+      page,
+      [buildEchoShellPrompt(markerA), buildEchoShellPrompt(markerB)],
+      300,
+    );
+
+    const filled = await waitForAllAssistantsContent(page, 2, 240_000);
+    expect(filled).toBeGreaterThanOrEqual(2);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(2);
+    expect(assistant).toBeGreaterThanOrEqual(2);
+
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+
+    // Each marker must live in its own bubble — speculative is allowed to
+    // interleave order but must never merge the two answers.
+    const q1Bubble = assistantTexts.findIndex((text) => text.includes(markerA));
+    const q2Bubble = assistantTexts.findIndex((text) => text.includes(markerB));
+    expect(q1Bubble, `Q1 marker ${markerA} missing from any assistant bubble`).toBeGreaterThanOrEqual(0);
+    expect(q2Bubble, `Q2 marker ${markerB} missing from any assistant bubble`).toBeGreaterThanOrEqual(0);
+    expect(q1Bubble, 'Q1 and Q2 must land in distinct assistant bubbles').not.toBe(q2Bubble);
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/queue-mode-steer.spec.ts
+++ b/e2e/tests/queue-mode-steer.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Suite 1 — Queue-mode matrix (3/5): steer.
+ *
+ * Contract: Q2 overrides Q1 mid-flight. A1 may be truncated or cancelled;
+ * A2 gets Q2's answer. The *final* assistant bubble must contain Q2's
+ * marker; Q1's marker may or may not appear, but Q2 must win.
+ *
+ * NOTE: The current backend support for /queue steer is partially
+ * implemented — the octos-web queue-modes-live.spec.ts explicitly
+ * acknowledges that steer "may process all" prompts. Marked fixme for
+ * backend semantics pending M7.9; assertion is ready when that lands.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/queue-mode-steer.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 1 queue-mode-steer', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(360_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('steer mode surfaces Q2 answer as the final assistant bubble', async ({
+    page,
+  }) => {
+    // Pending clarification on steer-mode backend semantics (M7.9 track).
+    // We leave the spec authored and enforce the structural assertions; the
+    // "Q2 wins" claim is gated behind fixme so CI stays green while the
+    // backend catches up.
+    test.fixme(
+      true,
+      'Steer semantics pending M7.9 backend work — see matrix doc',
+    );
+
+    await login(page);
+    await createNewSession(page);
+
+    const { badgeText, feedbackText } = await setQueueMode(page, 'steer');
+    const ack = `${feedbackText}\n${badgeText}`.toLowerCase();
+    expect(ack).toMatch(/steer|queue/);
+
+    const markerA = `STEER-Q1-${Date.now()}`;
+    const markerB = `STEER-Q2-${Date.now() + 1}`;
+    await fireRapidPrompts(
+      page,
+      [
+        // Q1 is a slow-ish prompt so Q2 can reasonably arrive before it
+        // finishes. The assertions only care that Q2 wins the final bubble.
+        `${buildEchoShellPrompt(markerA)} After echoing, run \`sleep 4\` from the repo root.`,
+        buildEchoShellPrompt(markerB),
+      ],
+      500,
+    );
+
+    await waitForAllAssistantsContent(page, 1, 180_000);
+    await page.waitForTimeout(4_000);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(2);
+    expect(assistant).toBeGreaterThanOrEqual(1);
+
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+
+    const lastText = assistantTexts[assistantTexts.length - 1] || '';
+    // Final turn must win with Q2's marker; Q1 is allowed to be cancelled
+    // or to live as an earlier bubble.
+    expect(lastText).toContain(markerB);
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/queue-mode-switch-midsession.spec.ts
+++ b/e2e/tests/queue-mode-switch-midsession.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Suite 8 — Queue-mode switching mid-session.
+ *
+ * Start in followup, fire Q1. While Q1 is running, send `/queue
+ * speculative`. Fire Q2 — new mode applies. Q1's assistant bubble must
+ * be unchanged; Q2 follows speculative semantics. Send `/queue followup`
+ * again and Q3 is followup.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/queue-mode-switch-midsession.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 8 queue-mode-switch-midsession', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(420_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('mode switches mid-session apply to subsequent turns only', async ({
+    page,
+  }) => {
+    // Mid-session switch behavior around speculative still depends on
+    // FA-12 + M7.9. Gated fixme until those land.
+    test.fixme(
+      true,
+      'Mid-session queue mode switching pending FA-12 + M7.9 landing',
+    );
+
+    await login(page);
+    await createNewSession(page);
+
+    // Q1 under followup.
+    await setQueueMode(page, 'followup');
+    const marker1 = `SW-Q1-${Date.now()}`;
+    await getInput(page).fill(buildEchoShellPrompt(marker1));
+    await getSendButton(page).click();
+
+    // Wait for Q1's assistant bubble to materialize, then snapshot it.
+    await waitForAllAssistantsContent(page, 1, 180_000);
+    const q1Texts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    const q1Snapshot = q1Texts.find((text) => text.includes(marker1)) || '';
+    expect(q1Snapshot).toContain(marker1);
+
+    // Switch to speculative mid-session.
+    const { badgeText: badgeSpec } = await setQueueMode(page, 'speculative');
+    expect(badgeSpec.toLowerCase()).toMatch(/spec|queue/);
+
+    // Q2 under speculative.
+    const marker2 = `SW-Q2-${Date.now() + 1}`;
+    await getInput(page).fill(buildEchoShellPrompt(marker2));
+    await getSendButton(page).click();
+    await waitForAllAssistantsContent(page, 2, 180_000);
+
+    // Q1's text must not have changed when Q2 arrived.
+    const midTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    const q1Still = midTexts.find((text) => text.includes(marker1)) || '';
+    expect(q1Still).toContain(marker1);
+    expect(q1Still).not.toContain(marker2);
+
+    // Switch back to followup for Q3.
+    const { badgeText: badgeFu } = await setQueueMode(page, 'followup');
+    expect(badgeFu.toLowerCase()).toMatch(/followup|queue/);
+
+    const marker3 = `SW-Q3-${Date.now() + 2}`;
+    await getInput(page).fill(buildEchoShellPrompt(marker3));
+    await getSendButton(page).click();
+    await waitForAllAssistantsContent(page, 3, 180_000);
+
+    const user = await countUserBubbles(page);
+    const assistant = await countAssistantBubbles(page);
+    expect(user).toBe(3);
+    expect(assistant).toBeGreaterThanOrEqual(3);
+
+    const finalTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    const combined = finalTexts.join('\n');
+    expect(combined).toContain(marker1);
+    expect(combined).toContain(marker2);
+    expect(combined).toContain(marker3);
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/rapid-consecutive-chats.spec.ts
+++ b/e2e/tests/rapid-consecutive-chats.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Suite 2 — Rapid consecutive chats.
+ *
+ * Fire 5 prompts over 3 seconds (500ms apart) under the default followup
+ * queue mode. Assert all 5 user bubbles render in send order, at least
+ * 3 of 5 get distinct assistant replies within 3 min, and no bubble is
+ * empty after all streams close.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/rapid-consecutive-chats.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  login,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  countBubbles,
+  fireRapidPrompts,
+  resetQueueMode,
+  setQueueMode,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 2 rapid consecutive chats', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(360_000);
+
+  test.afterEach(async ({ page }) => {
+    await resetQueueMode(page);
+  });
+
+  test('5 rapid prompts all land as ordered user bubbles with >=3 answers', async ({
+    page,
+  }) => {
+    await login(page);
+    await createNewSession(page);
+    await setQueueMode(page, 'followup');
+
+    const markers = [0, 1, 2, 3, 4].map((i) => `RAPID-${i}-${Date.now()}`);
+    const prompts = markers.map((marker) => buildEchoShellPrompt(marker));
+
+    await fireRapidPrompts(page, prompts, 500);
+
+    // Wait up to 3 minutes for at least 3 non-empty assistant bubbles.
+    const filled = await waitForAllAssistantsContent(page, 3, 180_000);
+    expect(filled).toBeGreaterThanOrEqual(3);
+
+    const { user, assistant } = await countBubbles(page);
+    expect(user).toBe(5);
+    expect(assistant).toBeGreaterThanOrEqual(3);
+
+    // Send order: the five user bubbles must carry the five markers
+    // in the order they were sent.
+    const userTexts = await page
+      .locator(SEL.userMessage)
+      .allTextContents()
+      .catch(() => []);
+    expect(userTexts).toHaveLength(5);
+    for (let i = 0; i < markers.length; i += 1) {
+      expect(userTexts[i], `user bubble ${i} missing ${markers[i]}`).toContain(markers[i]);
+    }
+
+    // No assistant bubble may be empty after streams close. We permit
+    // "short" placeholders (e.g. whitespace/emoji-only), but zero-length
+    // text is a regression.
+    const assistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    for (const [idx, text] of assistantTexts.entries()) {
+      expect(text.trim().length, `assistant bubble ${idx} is empty`).toBeGreaterThan(0);
+    }
+
+    const streaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(streaming).toBe(false);
+  });
+});

--- a/e2e/tests/reload-mid-background.spec.ts
+++ b/e2e/tests/reload-mid-background.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Suite 5 — Reload during active background task.
+ *
+ * Start a deep-research-style task, wait for the task-anchor bubble to
+ * appear (PR #42 bubble-level spinner), snapshot the task-store
+ * localStorage keys, reload the page, and verify the task-anchor is
+ * still rendered after reload, the localStorage keys are present, the
+ * task eventually reaches a terminal state, and the final content
+ * lands on the correct bubble.
+ *
+ * Then reload AGAIN while terminal and assert the state is idempotent
+ * (no duplicate bubbles).
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/reload-mid-background.spec.ts
+ */
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+import {
+  getActiveSessionIdOrNull,
+  snapshotTaskStore,
+  waitForAllAssistantsContent,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+const LONG_BACKGROUND_PROMPT = [
+  'Do a deep research on the latest Rust programming language developments',
+  'in 2026 via run_pipeline in background mode. Do not ask for confirmation,',
+  'start the pipeline directly and return "Deep research is running in the',
+  'background." as the immediate acknowledgment.',
+].join(' ');
+
+async function waitForTaskAnchor(page: Page, timeoutMs = 60_000) {
+  await page.waitForSelector("[data-testid='task-anchor-message']", {
+    timeout: timeoutMs,
+    state: 'attached',
+  });
+}
+
+test.describe('Suite 5 reload-mid-background', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(720_000);
+
+  test('task-anchor survives reload; terminal state is idempotent', async ({
+    page,
+  }) => {
+    await login(page);
+    await createNewSession(page);
+
+    const sessionIdBefore = await getActiveSessionIdOrNull(page);
+
+    await getInput(page).fill(LONG_BACKGROUND_PROMPT);
+    await getSendButton(page).click();
+
+    // Wait until the bubble-level task anchor appears.
+    await waitForTaskAnchor(page, 120_000);
+
+    // Snapshot the task-store keys so we can assert persistence survives
+    // a reload. If the brief's key prefix isn't yet used, the snapshot
+    // helper falls back to current session keys; we still require that
+    // at least one relevant key is present.
+    const storeBefore = await snapshotTaskStore(page);
+    expect(Object.keys(storeBefore).length).toBeGreaterThan(0);
+
+    // Reload #1 — mid-flight.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector(SEL.chatInput, { timeout: 15_000 });
+    await waitForTaskAnchor(page, 60_000);
+
+    // Task-store keys should still be there after reload.
+    const storeAfter = await snapshotTaskStore(page);
+    expect(Object.keys(storeAfter).length).toBeGreaterThan(0);
+
+    // Wait for the task to reach a non-active (final) state by looking for
+    // non-empty assistant content beyond the "running in the background"
+    // placeholder. Allow a long runway since deep research is slow.
+    await waitForAllAssistantsContent(page, 1, 540_000);
+
+    const userCountAfter = await countUserBubbles(page);
+    const assistantCountAfter = await countAssistantBubbles(page);
+    expect(userCountAfter).toBeGreaterThanOrEqual(1);
+    expect(assistantCountAfter).toBeGreaterThanOrEqual(1);
+
+    // Snapshot bubble counts pre-idempotent-reload.
+    const preReloadUser = userCountAfter;
+    const preReloadAssistant = assistantCountAfter;
+
+    // Reload #2 — terminal state should be idempotent.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector(SEL.chatInput, { timeout: 15_000 });
+    await page.waitForTimeout(5_000);
+
+    const userCountFinal = await countUserBubbles(page);
+    const assistantCountFinal = await countAssistantBubbles(page);
+    expect(userCountFinal).toBe(preReloadUser);
+    // Allow a +1 tolerance because a pending-anchor can briefly collapse
+    // into a terminal bubble on reload, but there must be no duplicate
+    // fan-out.
+    expect(assistantCountFinal).toBeLessThanOrEqual(preReloadAssistant + 1);
+    expect(assistantCountFinal).toBeGreaterThanOrEqual(preReloadAssistant);
+
+    const sessionIdAfter = await getActiveSessionIdOrNull(page);
+    if (sessionIdBefore && sessionIdAfter) {
+      expect(sessionIdAfter).toBe(sessionIdBefore);
+    }
+  });
+});

--- a/e2e/tests/session-switch-race.spec.ts
+++ b/e2e/tests/session-switch-race.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Suite 6 — Session-switch race.
+ *
+ * Create session A, start a long-running task. Before the task completes,
+ * create session B. Fire a quick prompt in B, wait for its answer. Switch
+ * back to session A — the task-anchor should still be present, the
+ * task-store state should belong to A not B. Assert no cross-session
+ * task bleed (Review B B-007 vicinity).
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/session-switch-race.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+  sendAndWait,
+} from './live-browser-helpers';
+import {
+  buildEchoShellPrompt,
+  getActiveSessionIdOrNull,
+} from './matrix-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+const LONG_TASK_PROMPT = [
+  'Do a deep research on Rust async runtime landscape in 2026 via',
+  'run_pipeline in background mode. Do not ask for confirmation,',
+  'start the pipeline directly and return "Deep research is running in',
+  'the background." as the immediate acknowledgment.',
+].join(' ');
+
+test.describe('Suite 6 session-switch-race', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(480_000);
+
+  test('switching to a second session does not bleed task state from the first', async ({
+    page,
+  }) => {
+    await login(page);
+
+    // Session A — start a long background task.
+    await createNewSession(page);
+    const sessionAId = await getActiveSessionIdOrNull(page);
+    expect(sessionAId, 'expected to resolve session A id').toBeTruthy();
+
+    await getInput(page).fill(LONG_TASK_PROMPT);
+    await getSendButton(page).click();
+    await page.waitForSelector("[data-testid='task-anchor-message']", {
+      timeout: 120_000,
+      state: 'attached',
+    });
+
+    const sessionAAnchorCount = await page
+      .locator("[data-testid='task-anchor-message']")
+      .count();
+    expect(sessionAAnchorCount).toBeGreaterThanOrEqual(1);
+
+    // Session B — create and ask a quick question.
+    await createNewSession(page);
+    await page.waitForTimeout(2_000);
+    const sessionBId = await getActiveSessionIdOrNull(page);
+    expect(sessionBId).toBeTruthy();
+    expect(sessionBId).not.toBe(sessionAId);
+
+    // Session B's chat view should start empty — no task anchors from A.
+    const bAnchorCount = await page
+      .locator("[data-testid='task-anchor-message']")
+      .count();
+    expect(bAnchorCount, 'session B must not show session A task anchors').toBe(0);
+
+    const markerB = `SW-B-${Date.now()}`;
+    const bResult = await sendAndWait(page, buildEchoShellPrompt(markerB), {
+      label: 'sw-b',
+      maxWait: 120_000,
+    });
+    expect(bResult.responseText).toContain(markerB);
+
+    // Session B still must not show A's task anchor.
+    const bAnchorCountAfter = await page
+      .locator("[data-testid='task-anchor-message']")
+      .count();
+    expect(bAnchorCountAfter).toBe(0);
+
+    // Switch back to session A via the sidebar.
+    const aSwitchButton = page.locator(
+      `[data-session-id="${sessionAId}"] [data-testid='session-switch-button']`,
+    );
+    await aSwitchButton.waitFor({ state: 'visible', timeout: 15_000 });
+    await aSwitchButton.click();
+    await page.waitForTimeout(3_000);
+
+    // Session A's task anchor must still be rendered.
+    const aAnchorCount = await page
+      .locator("[data-testid='task-anchor-message']")
+      .count();
+    expect(aAnchorCount).toBeGreaterThanOrEqual(1);
+
+    // And the markerB text from session B must not leak into session A.
+    const aAssistantTexts = await page
+      .locator(SEL.assistantMessage)
+      .allTextContents()
+      .catch(() => []);
+    const combined = aAssistantTexts.join('\n');
+    expect(combined).not.toContain(markerB);
+    expect(await countAssistantBubbles(page)).toBeGreaterThanOrEqual(1);
+
+    // Confirm we actually landed back on session A.
+    const activeAfter = await getActiveSessionIdOrNull(page);
+    if (sessionAId && activeAfter) {
+      expect(activeAfter).toBe(sessionAId);
+    }
+  });
+});

--- a/e2e/tests/swarm-review-gate.spec.ts
+++ b/e2e/tests/swarm-review-gate.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Suite 10 — Review-gate PR (scaffold only).
+ *
+ * Targets the swarm-app UI at `/swarm/`. Only functional post-M7.9 —
+ * scaffolded now so the spec is ready to go when the review-submission
+ * UI lands. Verifies the page loads, tabs render, and the dispatch
+ * form is present. Actual review-submission validation is pending the
+ * M7.9 PR + deploy.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/swarm-review-gate.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import { login } from './live-browser-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+test.describe('Suite 10 swarm-review-gate (scaffold)', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(120_000);
+
+  test('swarm app loads and exposes dispatch + review tabs', async ({
+    page,
+  }) => {
+    // M7.9 deliverable — the swarm UI is not yet live on the target
+    // mini. Remove this fixme once the /swarm/ route + dispatch form
+    // ship.
+    test.fixme(
+      true,
+      'Swarm review UI is an M7.9 deliverable — scaffold only',
+    );
+
+    await login(page);
+
+    // Navigate to the swarm app surface. The exact route may shift —
+    // once M7.9 confirms, lock in here.
+    await page.goto('/swarm/', { waitUntil: 'networkidle' });
+
+    // The page must render *something* — a heading or a primary
+    // landmark — not a 404.
+    const bodyText = (await page.locator('body').innerText().catch(() => '')) || '';
+    expect(bodyText.length).toBeGreaterThan(0);
+    expect(bodyText.toLowerCase()).not.toContain('not found');
+
+    // Tabs / dispatch form expectations (placeholders until M7.9):
+    //  - A tab labelled "Dispatch" and one labelled "Review".
+    //  - A form with at least one submit-style button.
+    // These assertions stay in place so the scaffold fails loud the
+    // moment M7.9 lands but the selectors don't match.
+    await expect(page.getByRole('tab', { name: /dispatch/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /review/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /dispatch|submit/i })).toBeVisible();
+  });
+});

--- a/e2e/tests/task-anchor-lifecycle.spec.ts
+++ b/e2e/tests/task-anchor-lifecycle.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Suite 9 — Task-anchor lifecycle trace.
+ *
+ * Long-running task produces `task-anchor-message`, `task-anchor-spinner`,
+ * `task-anchor-label`, `task-anchor-detail` testids. Assert each testid
+ * appears at the expected lifecycle point, the spinner disappears on
+ * completion, and the label transitions from a running state to a
+ * terminal one.
+ *
+ * The brief enumerates additional testids (`task-anchor-phase-*`,
+ * `task-anchor-progress-*`) that arrive with M7.9 PRs — their checks
+ * are gated fixme until those testids ship.
+ *
+ * Run:
+ *   OCTOS_TEST_URL=https://mini1.crew.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/task-anchor-lifecycle.spec.ts
+ */
+import { expect, test } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+
+const TEST_URL = process.env.OCTOS_TEST_URL;
+
+const LONG_PIPELINE_PROMPT = [
+  'Run a deep research pipeline on Rust 2026 via run_pipeline in',
+  'background mode. Do not ask for confirmation — run the pipeline',
+  'directly and return "Deep research is running in the background."',
+  'as the immediate acknowledgment.',
+].join(' ');
+
+test.describe('Suite 9 task-anchor-lifecycle', () => {
+  test.skip(() => !TEST_URL, 'OCTOS_TEST_URL not set — suite is a no-op.');
+  test.setTimeout(720_000);
+
+  test('spinner appears while active, disappears on terminal', async ({
+    page,
+  }) => {
+    await login(page);
+    await createNewSession(page);
+
+    await getInput(page).fill(LONG_PIPELINE_PROMPT);
+    await getSendButton(page).click();
+
+    // Phase 1: the task-anchor-message must render within a bounded
+    // window of the user send.
+    await page.waitForSelector("[data-testid='task-anchor-message']", {
+      timeout: 120_000,
+      state: 'attached',
+    });
+
+    // Phase 2: the spinner must be visible at least once while the task
+    // is active. Poll briefly since streams may produce quick transient
+    // phases before the spinner settles.
+    let sawSpinner = false;
+    const spinnerDeadline = Date.now() + 60_000;
+    while (Date.now() < spinnerDeadline) {
+      const hasSpinner = await page
+        .locator("[data-testid='task-anchor-spinner']")
+        .first()
+        .isVisible({ timeout: 1_000 })
+        .catch(() => false);
+      if (hasSpinner) {
+        sawSpinner = true;
+        break;
+      }
+      await page.waitForTimeout(1_000);
+    }
+    expect(sawSpinner, 'task-anchor-spinner never appeared while task was active').toBe(true);
+
+    // Phase 3: label must be visible and non-empty.
+    const labelText = await page
+      .locator("[data-testid='task-anchor-label']")
+      .first()
+      .textContent({ timeout: 30_000 })
+      .catch(() => '');
+    expect((labelText || '').trim().length).toBeGreaterThan(0);
+
+    // Phase 4: wait for terminal state — spinner must go away and the
+    // label's status text should no longer say "running" or "starting".
+    const terminalDeadline = Date.now() + 540_000;
+    let finalLabel = '';
+    while (Date.now() < terminalDeadline) {
+      const stillStreaming = await page
+        .locator(SEL.cancelButton)
+        .isVisible({ timeout: 1_000 })
+        .catch(() => false);
+      const hasSpinner = await page
+        .locator("[data-testid='task-anchor-spinner']")
+        .first()
+        .isVisible({ timeout: 500 })
+        .catch(() => false);
+      finalLabel =
+        (await page
+          .locator("[data-testid='task-anchor-label']")
+          .first()
+          .textContent({ timeout: 500 })
+          .catch(() => '')) || '';
+      if (!stillStreaming && !hasSpinner && finalLabel.trim().length > 0) {
+        break;
+      }
+      await page.waitForTimeout(5_000);
+    }
+
+    const spinnerAfter = await page
+      .locator("[data-testid='task-anchor-spinner']")
+      .first()
+      .isVisible({ timeout: 1_000 })
+      .catch(() => false);
+    expect(spinnerAfter, 'spinner must disappear on terminal state').toBe(false);
+    expect(finalLabel.trim().length).toBeGreaterThan(0);
+
+    // The label should no longer indicate active running once terminal.
+    const normalized = finalLabel.toLowerCase();
+    expect(normalized).not.toMatch(/\brunning\b|\bstarting\b|\bstreaming\b/);
+
+    // Note: the brief enumerates additional `task-anchor-phase-*` and
+    // `task-anchor-progress-*` testids as M7.9 deliverables. Those
+    // are not yet emitted by the component; once they ship, extend
+    // this spec with phase-transition + monotonic-progress assertions.
+  });
+});


### PR DESCRIPTION
## Summary

Adds a comprehensive e2e test matrix for coding-blue's most fragile cases, codifying every race / edge / mode combination uncovered across FA-5 through FA-11 so coding-blue-r1 (post FA-12 + M7.9) and all future releases have strong regression coverage.

- **15 new specs across 10 suites**, one concept per file, all test-only and gated by `OCTOS_TEST_URL`
- **Shared helpers** in `tests/matrix-helpers.ts`: `setQueueMode`, `fireRapidPrompts`, `waitForAllAssistantsContent`, `snapshotTaskStore`, `waitForTerminalTask`, `getActiveSessionIdOrNull`, `countBubbles`, `buildEchoShellPrompt`, `resetQueueMode`, `expectAssistantsContainAll`
- **Specs currently blocked by follow-ups use `test.fixme(...)`** with a clear comment pointing at the blocking work; no silent skips
- **Matrix README** at `tests/CODING_BLUE_MATRIX.md` documents per-spec contracts, gating on FA-12 / M7.9 / FA-8 envelope work, and how to run against any mini

## Suites

| suite | spec | contract |
| --- | --- | --- |
| 1 | `queue-mode-followup.spec.ts` | strict U1→A1→U2→A2 interleave |
| 1 | `queue-mode-collect.spec.ts` | one bubble answers both |
| 1 | `queue-mode-steer.spec.ts` | Q2 wins (fixme pending M7.9) |
| 1 | `queue-mode-interrupt.spec.ts` | Q2 aborts Q1 |
| 1 | `queue-mode-speculative.spec.ts` | FA-11 regression (fixme pending FA-12) |
| 2 | `rapid-consecutive-chats.spec.ts` | 5 prompts in order, >=3 reply |
| 3 | `mixed-long-short-followup.spec.ts` | long + two quick, serialized |
| 3 | `mixed-long-short-speculative.spec.ts` | long + two quick, concurrent (fixme pending FA-12) |
| 4 | `out-of-order-response.spec.ts` | mocked 3s/100ms; FA-8 correlation |
| 5 | `reload-mid-background.spec.ts` | task-anchor + localStorage + idempotent reload |
| 6 | `session-switch-race.spec.ts` | no cross-session task bleed |
| 7 | `file-attachment-identity-live.spec.ts` | file attaches to originating turn (fixme pending FA-12) |
| 8 | `queue-mode-switch-midsession.spec.ts` | followup→spec→followup (fixme pending FA-12/M7.9) |
| 9 | `task-anchor-lifecycle.spec.ts` | spinner on → label → spinner off |
| 10 | `swarm-review-gate.spec.ts` | scaffold (fixme pending M7.9 /swarm/ UI) |

## Test plan

- [ ] `cd e2e && npx playwright test tests/queue-mode-*.spec.ts tests/rapid-consecutive-chats.spec.ts tests/mixed-long-short-*.spec.ts tests/out-of-order-response.spec.ts tests/reload-mid-background.spec.ts tests/session-switch-race.spec.ts tests/file-attachment-identity-live.spec.ts tests/queue-mode-switch-midsession.spec.ts tests/task-anchor-lifecycle.spec.ts tests/swarm-review-gate.spec.ts --list` shows all 15 tests
- [ ] Without `OCTOS_TEST_URL` set, every matrix spec is reported as skipped (no failure)
- [ ] With `OCTOS_TEST_URL=https://mini1.crew.ominix.io`, non-fixme specs PASS; fixme specs report as expected-fail
- [ ] Existing specs (`coding-hardcases`, `live-slides-site`, `session-recovery`, `live-browser`, `web-client`, `runtime-regression`, `tool-use-regression`, `live-mofa-skills`, `refactor-capabilities`) still list cleanly
- [ ] Post FA-12 deploy: remove fixme from queue-mode-speculative, mixed-long-short-speculative, file-attachment-identity-live, queue-mode-switch-midsession, and re-run
- [ ] Post M7.9 deploy: remove fixme from queue-mode-steer, swarm-review-gate; extend task-anchor-lifecycle with phase/progress assertions