### PR TITLE
fix(coding-blue): FA-11 speculative overflow delivery (server side)

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -246,6 +246,29 @@ impl ApiChannel {
         self
     }
 
+    /// Test helper: subscribe to the watchers fanout for a (chat_id, topic)
+    /// without going through the HTTP `/sessions/:id/events/stream` handler.
+    /// Mirrors the subscribe path that the real SSE handler uses (see
+    /// `handle_session_event_stream`), so integration tests can assert that
+    /// outbound messages carrying `_session_result` metadata are broadcast
+    /// to watchers even when the primary turn's `pending` channel has
+    /// already been removed (FA-11 defect B regression guard).
+    #[doc(hidden)]
+    pub async fn subscribe_watcher_for_tests(
+        &self,
+        chat_id: &str,
+        topic: Option<&str>,
+    ) -> broadcast::Receiver<String> {
+        let mut watchers = self.watchers.lock().await;
+        watchers
+            .entry(watcher_key(chat_id, topic))
+            .or_insert_with(|| {
+                let (tx, _rx) = new_sse_channel();
+                tx
+            })
+            .subscribe()
+    }
+
     fn session_workspace_dir(data_dir: &Path, key: &SessionKey) -> PathBuf {
         let encoded = crate::session::encode_path_component(key.base_key());
         data_dir.join("users").join(encoded).join("workspace")

--- a/crates/octos-cli/src/api/webhook_proxy.rs
+++ b/crates/octos-cli/src/api/webhook_proxy.rs
@@ -244,6 +244,43 @@ pub async fn api_chat_proxy(
     }
 
     if stream {
+        // Inspect upstream content-type BEFORE wrapping as SSE.
+        //
+        // Under `/queue speculative`, the gateway responds to a POST /chat that
+        // arrives while a previous SSE stream is still live with a plain JSON
+        // ack: `{"status":"queued","message":"…"}`. Forcing the outer response
+        // to `text/event-stream` in that case makes the JSON body look like
+        // malformed SSE to the client, which never observes a `done` event and
+        // leaves the corresponding assistant bubble stuck in "streaming"
+        // forever (FA-11 defect A).
+        //
+        // Pass the JSON body through with `content-type: application/json` so
+        // the web client can recognize the ack and subscribe to the
+        // session-event-stream for the overflow reply. Only force SSE
+        // content-type when upstream is actually an SSE stream.
+        let upstream_ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_ascii_lowercase())
+            .unwrap_or_default();
+        if upstream_ct.contains("application/json") {
+            let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::OK);
+            return match resp.bytes().await {
+                Ok(body) => {
+                    let mut response = (status, body.to_vec()).into_response();
+                    response
+                        .headers_mut()
+                        .insert("content-type", "application/json".parse().unwrap());
+                    response
+                }
+                Err(error) => json_error(
+                    StatusCode::BAD_GATEWAY,
+                    &format!("failed to read gateway JSON ack: {error}"),
+                ),
+            };
+        }
+
         let stream = resp.bytes_stream();
         return match Response::builder()
             .status(200)
@@ -507,6 +544,119 @@ data: {"type":"done","content":"","tokens_in":1,"tokens_out":2}
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["error"], "upstream request timed out after 50ms");
+
+        server.abort();
+    }
+
+    /// FA-11 defect A: A JSON queued-ack reply from the gateway must NOT be
+    /// wrapped as SSE. Under `/queue speculative`, the gateway returns
+    /// `application/json {status:"queued",...}` when a second prompt arrives
+    /// while an earlier SSE stream is still live. Forcing SSE content-type
+    /// made the JSON body look like malformed SSE to the client, which never
+    /// observed a `done` event and left the assistant bubble stuck streaming
+    /// forever.
+    #[tokio::test]
+    async fn should_passthrough_json_queued_ack() {
+        use axum::Router;
+        use axum::routing::post;
+
+        // Upstream stub returning JSON ack on /chat.
+        let app = Router::new().route(
+            "/chat",
+            post(|| async {
+                (
+                    [("content-type", "application/json")],
+                    r#"{"status":"queued","message":"Message queued — response will arrive on the existing stream"}"#,
+                )
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let state = crate::api::AppState::empty_for_tests();
+        let response = super::api_chat_proxy(
+            &state,
+            port,
+            None,
+            "hi",
+            Some("test-session"),
+            None,
+            &[],
+            false,
+            true, // stream = true, the path where the bug happens
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            content_type.contains("application/json"),
+            "expected content-type application/json, got {content_type}"
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "queued");
+
+        server.abort();
+    }
+
+    /// Under the normal SSE path (upstream returns `text/event-stream`), the
+    /// proxy must keep forwarding SSE with `content-type: text/event-stream`.
+    /// This guards the FA-11 fix from regressing the happy path.
+    #[tokio::test]
+    async fn should_keep_sse_when_upstream_is_sse() {
+        use axum::Router;
+        use axum::routing::post;
+
+        let app = Router::new().route(
+            "/chat",
+            post(|| async {
+                (
+                    [("content-type", "text/event-stream")],
+                    "data: {\"type\":\"done\",\"content\":\"hi\",\"tokens_in\":1,\"tokens_out\":1}\n\n",
+                )
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let state = crate::api::AppState::empty_for_tests();
+        let response = super::api_chat_proxy(
+            &state,
+            port,
+            None,
+            "hi",
+            Some("test-session"),
+            None,
+            &[],
+            false,
+            true,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            content_type.contains("text/event-stream"),
+            "expected content-type text/event-stream, got {content_type}"
+        );
 
         server.abort();
     }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4232,19 +4232,41 @@ impl SessionActor {
                     // Intermediate tool_call/tool_result messages are NOT saved
                     // to avoid tool_call ID collisions when multiple overflow
                     // tasks run concurrently (e.g. two deep_search_0 IDs).
-                    {
+                    //
+                    // Capture the committed seq + timestamp so the outbound
+                    // fanout below can carry `_session_result` metadata. The
+                    // ApiChannel routes that metadata through
+                    // `broadcast_session_event` → watchers, which survives
+                    // the primary turn's SSE stream completion. Without this,
+                    // the overflow reply would only route through
+                    // `pending[session_id]` — already removed when the
+                    // primary turn completed — and would be silently dropped
+                    // (FA-11 defect B).
+                    let final_reply_timestamp = chrono::Utc::now();
+                    let final_reply = Message {
+                        role: MessageRole::Assistant,
+                        content: final_content.clone(),
+                        media: vec![],
+                        tool_calls: None,
+                        tool_call_id: None,
+                        reasoning_content: conv_response.reasoning_content.clone(),
+                        timestamp: final_reply_timestamp,
+                    };
+                    let committed_seq = {
                         let mut handle = session_handle.lock().await;
-                        let final_reply = Message {
-                            role: MessageRole::Assistant,
-                            content: final_content.clone(),
-                            media: vec![],
-                            tool_calls: None,
-                            tool_call_id: None,
-                            reasoning_content: conv_response.reasoning_content.clone(),
-                            timestamp: chrono::Utc::now(),
-                        };
-                        let _ = handle.add_message(final_reply).await;
-                    }
+                        handle
+                            .add_message_with_seq(final_reply)
+                            .await
+                            .map_err(|error| {
+                                warn!(
+                                    session = %session_key,
+                                    error = %error,
+                                    "failed to persist overflow assistant message"
+                                );
+                                error
+                            })
+                            .ok()
+                    };
 
                     let reply = strip_think_tags(&final_content);
                     // Prepend thinking content when show_thinking is enabled
@@ -4273,6 +4295,28 @@ impl SessionActor {
                             .is_some_and(|sr| sr.message_id.is_some());
 
                     if !reply.trim().is_empty() && !already_streamed {
+                        let mut metadata = serde_json::Map::new();
+                        metadata.insert(
+                            "_history_persisted".to_string(),
+                            serde_json::Value::Bool(committed_seq.is_some()),
+                        );
+                        if let Some(topic) = session_key.topic() {
+                            metadata
+                                .insert("topic".to_string(), serde_json::Value::from(topic));
+                        }
+                        if let Some(seq) = committed_seq {
+                            metadata.insert(
+                                "_session_result".to_string(),
+                                serde_json::json!({
+                                    "seq": seq,
+                                    "role": "assistant",
+                                    "content": reply.clone(),
+                                    "timestamp": final_reply_timestamp.to_rfc3339(),
+                                    "media": Vec::<String>::new(),
+                                    "response_to_client_message_id": overflow_reply_to.clone(),
+                                }),
+                            );
+                        }
                         let _ = out_tx
                             .send(OutboundMessage {
                                 channel: channel.clone(),
@@ -4280,7 +4324,7 @@ impl SessionActor {
                                 content: reply,
                                 reply_to: overflow_reply_to.clone(),
                                 media: vec![],
-                                metadata: serde_json::json!({}),
+                                metadata: serde_json::Value::Object(metadata),
                             })
                             .await;
                     }
@@ -6187,6 +6231,137 @@ mod tests {
         }
 
         // Clean shutdown
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// FA-11 defect B regression: the overflow assistant reply MUST carry
+    /// `_session_result` metadata so `ApiChannel::send` can route it via
+    /// `broadcast_session_event → watchers`. Without this metadata the reply
+    /// routes only through `pending[session_id]`, which was removed when
+    /// the primary turn emitted its `_completion` marker — so the overflow
+    /// reply was silently dropped.
+    #[tokio::test]
+    async fn should_emit_session_result_metadata_for_overflow_reply() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Agent: 5 fast warmups + slow (12s) primary + fast overflow response.
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![
+                (Duration::from_millis(200), make_response("warmup1")),
+                (Duration::from_millis(200), make_response("warmup2")),
+                (Duration::from_millis(200), make_response("warmup3")),
+                (Duration::from_millis(200), make_response("warmup4")),
+                (Duration::from_millis(200), make_response("warmup5")),
+                (Duration::from_secs(12), make_response("slow primary answer")),
+                (
+                    Duration::from_millis(400),
+                    make_response("overflow FA12 result payload"),
+                ),
+                (Duration::from_millis(200), make_response("post-overflow")),
+            ],
+        ));
+        let router_a: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "router-a",
+            vec![(Duration::from_millis(500), make_response("unused"))],
+        ));
+        let router_b: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "router-b",
+            vec![(Duration::from_millis(500), make_response("unused"))],
+        ));
+
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_speculative_actor(agent_llm, vec![router_a, router_b], &dir).await;
+
+        // Warmup to establish responsiveness baseline.
+        for i in 0..5 {
+            tx.send(make_inbound(&format!("warmup {i}"))).await.unwrap();
+            let _ = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+        }
+
+        // Slow primary prompt.
+        tx.send(make_inbound("please run a big analysis"))
+            .await
+            .unwrap();
+
+        // Wait past patience (10s) so the second prompt is served as overflow.
+        tokio::time::sleep(Duration::from_secs(11)).await;
+        tx.send(make_inbound("please answer FA-12 probe"))
+            .await
+            .unwrap();
+
+        // Collect OutboundMessage records until we've seen both non-empty
+        // replies (overflow + slow primary).
+        let mut outbound_replies: Vec<OutboundMessage> = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        while outbound_replies.len() < 2 {
+            match tokio::time::timeout_at(deadline, rx.recv()).await {
+                Ok(Some(msg)) => {
+                    if !msg.content.trim().is_empty() {
+                        outbound_replies.push(msg);
+                    }
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        assert!(
+            outbound_replies.len() >= 2,
+            "expected at least 2 replies (overflow + primary), got {}: {:?}",
+            outbound_replies.len(),
+            outbound_replies
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>()
+        );
+
+        let overflow = outbound_replies
+            .iter()
+            .find(|msg| msg.content.contains("FA12") || msg.content.contains("overflow"))
+            .expect("overflow reply not found");
+        let session_result = overflow.metadata.get("_session_result").unwrap_or_else(|| {
+            panic!(
+                "overflow outbound must carry `_session_result` metadata — \
+                 got metadata = {}",
+                overflow.metadata
+            )
+        });
+        assert_eq!(
+            session_result.get("role").and_then(|v| v.as_str()),
+            Some("assistant"),
+            "session_result role must be 'assistant'"
+        );
+        assert!(
+            session_result
+                .get("seq")
+                .and_then(|v| v.as_u64())
+                .is_some(),
+            "session_result must include committed seq, got {}",
+            session_result
+        );
+        assert!(
+            session_result
+                .get("content")
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| s.contains("FA12") || s.contains("overflow")),
+            "session_result.content must match reply content, got {}",
+            session_result
+        );
+        assert!(
+            session_result.get("timestamp").is_some(),
+            "session_result must include rfc3339 timestamp, got {}",
+            session_result
+        );
+        assert!(
+            overflow
+                .metadata
+                .get("_history_persisted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            "overflow outbound must flag history as persisted"
+        );
+
         drop(tx);
         let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
     }

--- a/crates/octos-cli/tests/speculative_overflow_delivery.rs
+++ b/crates/octos-cli/tests/speculative_overflow_delivery.rs
@@ -1,0 +1,131 @@
+//! FA-12 integration test — guards the speculative queue overflow reply
+//! wiring end-to-end.
+//!
+//! FA-11 root-caused two coupled defects. Defect B lives in
+//! [`octos_cli::session_actor`]: the speculative overflow task emitted its
+//! reply with empty metadata, so [`octos_bus::ApiChannel::send`] routed it
+//! only via the `pending[session_id]` channel — which was removed the
+//! moment the primary turn emitted its `_completion` marker. The reply was
+//! silently dropped and the client's bubble stayed stuck "streaming"
+//! forever.
+//!
+//! The fix threads `_session_result` metadata through the outbound path so
+//! [`ApiChannel::send`] can broadcast the committed message onto the
+//! watchers fanout (which survives primary-turn completion).
+//!
+//! The authoritative end-to-end assertion lives as a unit test inside
+//! `session_actor.rs` (see
+//! `should_emit_session_result_metadata_for_overflow_reply`) because it
+//! needs access to the crate-private test fixture helpers
+//! (`setup_speculative_actor`, `DelayedMockProvider`, `make_inbound`). This
+//! integration test guards the complementary contract on the consumer side:
+//! given the exact metadata shape that the overflow path now emits, the
+//! `ApiChannel::send` routing contract recognises it as a committed session
+//! result and surfaces it on the watchers fanout rather than silently
+//! dropping it when `pending` is empty.
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use octos_bus::api_channel::ApiChannel;
+use octos_bus::session::SessionManager;
+use octos_bus::Channel;
+use octos_core::OutboundMessage;
+use tokio::sync::Mutex;
+
+fn test_sessions(dir: &std::path::Path) -> Arc<Mutex<SessionManager>> {
+    Arc::new(Mutex::new(
+        SessionManager::open(&dir.join("sessions")).unwrap(),
+    ))
+}
+
+/// Simulates the FA-11 race: primary turn's SSE channel has already been
+/// removed from `pending` (after the primary's `_completion` marker), and
+/// THEN the overflow reply arrives carrying `_session_result` metadata.
+///
+/// Before the fix: the overflow's outbound message had empty metadata. It
+/// went through the generic `send()` path, found no `pending[chat_id]`, and
+/// was silently dropped.
+///
+/// After the fix: the `_session_result` metadata triggers a committed
+/// fanout to the watchers channel — surviving the primary's completion —
+/// and the waiting session-event-stream subscriber observes the reply.
+#[tokio::test]
+async fn should_emit_session_result_metadata_for_overflow_reply() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let sessions = test_sessions(data_dir.path());
+    let channel = ApiChannel::new(
+        8191,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        sessions,
+        None,
+    );
+
+    // Subscribe a watcher BEFORE the overflow reply arrives — mimics the
+    // web client's `GET /api/sessions/:id/events/stream` subscription that
+    // is established when the JSON queued-ack comes back from POST /chat.
+    let mut watcher_rx = channel
+        .subscribe_watcher_for_tests("test-chat", None)
+        .await;
+
+    // The overflow reply carries the exact metadata shape that
+    // `session_actor::serve_overflow` now emits.
+    let overflow_reply = OutboundMessage {
+        channel: "api".into(),
+        chat_id: "test-chat".into(),
+        content: "FA-12 overflow answer payload".into(),
+        reply_to: Some("client-msg-bravo".into()),
+        media: vec![],
+        metadata: serde_json::json!({
+            "_history_persisted": true,
+            "_session_result": {
+                "seq": 42,
+                "role": "assistant",
+                "content": "FA-12 overflow answer payload",
+                "timestamp": "2026-04-23T17:30:00Z",
+                "media": [],
+                "response_to_client_message_id": "client-msg-bravo",
+            }
+        }),
+    };
+
+    // Act: send the overflow reply. NOTE: we deliberately do NOT populate
+    // `pending[test-chat]` — the primary turn's SSE stream has already
+    // closed, which is the exact FA-11 race condition.
+    channel.send(&overflow_reply).await.unwrap();
+
+    // Assert: the watchers channel sees a `session_result` event carrying
+    // the overflow reply. This proves `_session_result` metadata causes
+    // `ApiChannel::send` to route through `broadcast_session_event` even
+    // when `pending` is empty.
+    let event_payload = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        watcher_rx.recv(),
+    )
+    .await
+    .expect("timed out waiting for session_result event on watcher")
+    .expect("watcher closed without event");
+
+    let event: serde_json::Value = serde_json::from_str(&event_payload).unwrap();
+    assert_eq!(
+        event["type"], "session_result",
+        "expected session_result event, got: {event}"
+    );
+    assert_eq!(
+        event["message"]["seq"], 42,
+        "expected seq=42, got: {}",
+        event["message"]
+    );
+    assert_eq!(
+        event["message"]["content"], "FA-12 overflow answer payload",
+        "expected overflow content in message, got: {}",
+        event["message"]
+    );
+    assert_eq!(
+        event["message"]["response_to_client_message_id"], "client-msg-bravo",
+        "correlation id must survive for reducer-layer bubble routing"
+    );
+}


### PR DESCRIPTION
## Summary

Server-side half of the FA-12 coding-blue release blocker. Fixes the FA-11 race where the speculative queue overflow reply was silently dropped.

- **Defect A** (`crates/octos-cli/src/api/webhook_proxy.rs`): when upstream returns `application/json` (the `{status:"queued"}` ack), the proxy no longer force-wraps it as SSE. Inspect content-type first; pass JSON through as JSON, keep SSE as SSE.
- **Defect B** (`crates/octos-cli/src/session_actor.rs`): `serve_overflow` now captures the committed message seq via `add_message_with_seq` and attaches `_session_result` metadata (seq, role, content, rfc3339 timestamp, media, `response_to_client_message_id`) to the outbound reply. `ApiChannel::send` broadcasts through `broadcast_session_event → watchers`, which survives the primary turn's `pending` removal.
- Companion `ApiChannel::subscribe_watcher_for_tests` helper (doc-hidden, `#[cfg(feature = "api")]`) so integration tests can assert the watchers fanout directly.

This PR MUST land with the octos-web sibling PR (Defect C). Alone, Defect A+B without C still leaves the web client showing a stuck bubble because the JSON ack side-channel isn't wired up.

## Commits

- `b1b5fc85` fix(coding-blue): webhook_proxy passthroughs JSON queued acks (FA-11 defect A)
- `dda02fe9` fix(coding-blue): serve_overflow emits _session_result for reliable delivery (FA-11 defect B)

## Test plan

- [x] `cargo check --workspace --features api` — clean
- [x] `cargo test -p octos-cli --features api webhook_proxy` — 6 passed (2 new)
- [x] `cargo test -p octos-cli --features api speculative_overflow` — integration test passes
- [x] `cargo test -p octos-cli --features api should_emit_session_result` — unit test passes
- [x] `cargo test --workspace --features api` — 2717 passed, 0 failed (above 2358 baseline)
- [ ] Post-deploy: rerun coding-blue-long-running queue-speculative subtest against mini1 (requires landing C too).

## Sibling

- octos-web PR: `fix/coding-blue-speculative-delivery` against `release/coding-blue`