### PR TITLE
M8.1: Typed ToolContext (runtime-v0.1 gate)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -172,7 +172,9 @@ impl Agent {
                             bg_supervisor.mark_running(&task_id);
                             let bg_started_at = std::time::SystemTime::now();
 
-                            // Helper to create TOOL_CTX for plugin stderr progress streaming
+                            // Helper to create TOOL_CTX for plugin stderr progress streaming.
+                            // Base it on the zero-value context so M8.x placeholder fields
+                            // carry their default-populated values.
                             let make_ctx = || ToolContext {
                                 tool_id: bg_tc_id.clone(),
                                 reporter: bg_reporter.clone(),
@@ -184,6 +186,7 @@ impl Agent {
                                 file_attachment_paths: bg_attachment_ctx
                                     .file_attachment_paths
                                     .clone(),
+                                ..ToolContext::zero()
                             };
 
                             let mut result = TOOL_CTX
@@ -503,9 +506,17 @@ impl Agent {
                         attachment_paths: attachment_ctx.attachment_paths.clone(),
                         audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
                         file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),
+                        ..ToolContext::zero()
                     };
+                    // Thread the typed context into execute_with_context. Legacy tools
+                    // whose trait impl only overrides `execute` still work via the
+                    // default delegation path; migrated tools read the typed fields.
+                    // TOOL_CTX is still scoped for plugin tools that read the task-local.
                     let result = TOOL_CTX
-                        .scope(ctx, tools.execute(&tc_name, &effective_args))
+                        .scope(
+                            ctx.clone(),
+                            tools.execute_with_context(&ctx, &tc_name, &effective_args),
+                        )
                         .await;
 
                     let duration = tool_start.elapsed();

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -1045,6 +1045,7 @@ mod tests {
             ],
             audio_attachment_paths: vec!["/workspace/voice.ogg".to_string()],
             file_attachment_paths: vec!["/workspace/report.pdf".to_string()],
+            ..ToolContext::zero()
         };
 
         let prepared = tool.prepare_effective_args(&json!({}), Some(&ctx));
@@ -1137,6 +1138,7 @@ mod tests {
             attachment_paths: vec![],
             audio_attachment_paths: vec![],
             file_attachment_paths: vec![],
+            ..ToolContext::zero()
         };
 
         let result = crate::tools::TOOL_CTX

--- a/crates/octos-agent/src/tools/delegate.rs
+++ b/crates/octos-agent/src/tools/delegate.rs
@@ -36,7 +36,7 @@ use octos_memory::EpisodeStore;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use super::{Tool, ToolPolicy, ToolRegistry, ToolResult};
+use super::{Tool, ToolContext, ToolPolicy, ToolRegistry, ToolResult};
 use crate::harness_errors::HarnessError;
 use crate::harness_events::HARNESS_EVENT_SCHEMA_V1;
 use crate::task_supervisor::{TaskLifecycleState, TaskSupervisor};
@@ -458,8 +458,27 @@ impl Tool for DelegateTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // M8.1: legacy entry point. Re-enter via execute_with_context with
+        // the zero-value context so out-of-band callers (tests, integrations
+        // that have not been updated) still exercise the same code path.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid delegate_task input")?;
+
+        // M8.1: prefer the sink path threaded through the typed context. Fall
+        // back to the tool's own configured sink for constructors that wired
+        // it directly (and for the legacy zero-context entry path).
+        let effective_sink: Option<&str> = ctx
+            .harness_event_sink
+            .as_deref()
+            .or(self.harness_event_sink.as_deref());
 
         // Step 1: depth guard. A parent whose budget is already exhausted
         // must reject synchronously, without spawning.
@@ -476,7 +495,7 @@ impl Tool for DelegateTool {
                     String::new(),
                     DelegationOutcome::DepthExceeded,
                 );
-                let _ = emit_delegation_event(self.harness_event_sink.as_deref(), &event);
+                let _ = emit_delegation_event(effective_sink, &event);
                 warn!(
                     parent_depth = self.depth_budget.current,
                     max = self.depth_budget.max,
@@ -507,7 +526,7 @@ impl Tool for DelegateTool {
 
         record_delegation(child_budget.current, DelegationOutcome::Accepted);
         let _ = emit_delegation_event(
-            self.harness_event_sink.as_deref(),
+            effective_sink,
             &DelegationEvent::new(
                 child_budget.current,
                 self.parent_task_id.clone().unwrap_or_default(),
@@ -546,7 +565,9 @@ impl Tool for DelegateTool {
             task_supervisor: self.task_supervisor.clone(),
             session_key: self.session_key.clone(),
             parent_task_id: Some(child_task_id.clone()),
-            harness_event_sink: self.harness_event_sink.clone(),
+            // Child inherits the effective sink so the context-threaded path
+            // still reaches grandchildren even if only the ToolContext set it.
+            harness_event_sink: effective_sink.map(|s| s.to_string()),
             worker_config: self.worker_config.clone(),
         };
         tools.register_arc(Arc::new(child_delegate));
@@ -621,7 +642,7 @@ impl Tool for DelegateTool {
         };
         record_delegation(child_budget.current, terminal_outcome);
         let _ = emit_delegation_event(
-            self.harness_event_sink.as_deref(),
+            effective_sink,
             &DelegationEvent::new(
                 child_budget.current,
                 self.parent_task_id.clone().unwrap_or_default(),

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1,4 +1,33 @@
 //! Tool framework for agent tool execution.
+//!
+//! # Typed `ToolContext` migration (M8.1)
+//!
+//! Tools receive execution context through [`ToolContext`]. Historically the
+//! context was delivered indirectly via the [`TOOL_CTX`] task-local, which the
+//! executor populated before calling each tool's [`Tool::execute`]. That works
+//! but makes the carrier invisible at the trait surface, so tools that want a
+//! field must either read the task-local or reach into globals.
+//!
+//! M8.1 introduces [`Tool::execute_with_context`], a typed entry point that
+//! threads `&ToolContext` explicitly. To keep the migration additive:
+//!
+//! - The trait's default implementation of `execute_with_context` falls back
+//!   to the legacy [`Tool::execute`]. Existing tools keep working unchanged.
+//! - Migrated tools override `execute_with_context` and use the typed record.
+//!   Their `execute` impl simply re-enters `execute_with_context` with a
+//!   zero-value context so out-of-band callers (tests, integrations that have
+//!   not been updated) still get predictable behaviour.
+//! - [`ToolContext`] carries the legacy fields *plus* placeholder stubs for
+//!   future milestones: [`AgentDefinitions`], [`ToolPermissions`],
+//!   [`FileStateCache`], [`Notifications`], and [`AppStateHandle`]. Each stub
+//!   is annotated with the future issue that will populate it. They all have
+//!   cheap zero-value constructors so today's executor can build a context
+//!   without wiring.
+//!
+//! The executor still sets [`TOOL_CTX`] for legacy plugin tools that rely on
+//! the task-local read path (see `plugins/tool.rs`). Once every tool is
+//! migrated the task-local becomes redundant and can be retired, but that
+//! clean-up is out of scope for M8.1.
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -10,9 +39,127 @@ use octos_core::TokenUsage;
 
 use crate::progress::ProgressReporter;
 
-/// Execution context available to tools via task-local.
-/// Set by the agent before each tool invocation so plugin tools
-/// can report progress without changing the Tool trait signature.
+/// Registry of [`AgentDefinition`]-style manifests available to tools.
+///
+/// M8.2 will populate this registry from `AgentDefinition` manifests on disk
+/// (see issue #536 → M8.2). Today it is an empty holder so the context can be
+/// constructed without wiring.
+#[derive(Clone, Debug, Default)]
+pub struct AgentDefinitions {
+    // M8.2 will add the concrete definition records here.
+}
+
+impl AgentDefinitions {
+    /// Create an empty agent-definition registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether any agent definitions are registered.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Per-tool permission facts consulted before each execution.
+///
+/// M8.3 will wire real profile-derived permissions into this struct (see
+/// issue #536 → M8.3). Today it unconditionally allows every tool so behaviour
+/// matches the pre-M8.1 status quo.
+#[derive(Clone, Debug)]
+pub struct ToolPermissions {
+    allow_all: bool,
+}
+
+impl Default for ToolPermissions {
+    fn default() -> Self {
+        Self::allow_all()
+    }
+}
+
+impl ToolPermissions {
+    /// Allow-all permissions — the zero-value default carried by the context.
+    pub fn allow_all() -> Self {
+        Self { allow_all: true }
+    }
+
+    /// Check whether the named tool is currently permitted. Always `true`
+    /// while M8.3 is pending.
+    pub fn is_tool_allowed(&self, _tool: &str) -> bool {
+        self.allow_all
+    }
+}
+
+/// File-state cache that mirrors `FileStateCache` from Claude Code.
+///
+/// M8.4 will grow this into the full LRU + mtime/hash invalidation cache
+/// described in the runtime plan (see issue #536 → M8.4). Today it is an
+/// empty stub so the context can hand out a shared handle without allocation.
+#[derive(Debug, Default)]
+pub struct FileStateCache {
+    // M8.4 will add the LRU state, mtime map, hash index, and
+    // `is_partial_view` tracking here.
+}
+
+impl FileStateCache {
+    /// Create an empty file-state cache handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the cache currently has any recorded file entries. Always
+    /// `false` until M8.4 fills in the map.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Inbox of in-flight notifications surfaced to tools and the agent loop.
+///
+/// M8.2/M8.3 will route real notifications (e.g. permission prompts, gate
+/// state) through this handle. Today it is a zero-length inbox.
+#[derive(Clone, Debug, Default)]
+pub struct Notifications {
+    // M8.2/M8.3 will add the notification queue and backpressure state here.
+}
+
+impl Notifications {
+    /// Create an empty notifications inbox.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the inbox is empty (no pending notifications). Always `true`
+    /// until M8.2/M8.3 start enqueueing notifications.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Handle to the ambient app state shared across tools.
+///
+/// M8.3 will use this to expose profile/app state that tools may read (e.g.
+/// the active profile name, locale, workspace contract root). Today it is an
+/// empty handle that tools can carry without wiring.
+#[derive(Clone, Debug, Default)]
+pub struct AppStateHandle {
+    // M8.3 will add the shared state handle (Arc<ProfileState>) here.
+}
+
+impl AppStateHandle {
+    /// Create an empty app-state handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Execution context available to tools.
+///
+/// The legacy fields (`tool_id`, `reporter`, `harness_event_sink`, three
+/// attachment lists) carry today's behaviour. The trailing fields are M8.x
+/// placeholders — see each field's doc comment for the issue that will wire
+/// it up. Building a zero-value context is cheap: all placeholders implement
+/// `Default` and the required handles are backed by `Arc` so cloning is O(1).
 #[derive(Clone)]
 pub struct ToolContext {
     pub tool_id: String,
@@ -22,6 +169,37 @@ pub struct ToolContext {
     pub attachment_paths: Vec<String>,
     pub audio_attachment_paths: Vec<String>,
     pub file_attachment_paths: Vec<String>,
+    /// Agent manifests available to tools. M8.2 will populate this.
+    pub agent_definitions: Arc<AgentDefinitions>,
+    /// Per-tool permission facts. M8.3 will populate this.
+    pub permissions: ToolPermissions,
+    /// File-state cache shared across tools in a turn. M8.4 will populate this.
+    pub file_state_cache: Option<Arc<FileStateCache>>,
+    /// Notification inbox surfaced to tools. M8.2/M8.3 will populate this.
+    pub notifications: Arc<Notifications>,
+    /// Handle to the ambient app state. M8.3 will populate this.
+    pub app_state: AppStateHandle,
+}
+
+impl ToolContext {
+    /// Zero-value context suitable for unit tests and tools that do not need
+    /// live executor wiring. Uses a [`crate::progress::SilentReporter`] and
+    /// leaves every M8.x placeholder at its default.
+    pub fn zero() -> Self {
+        Self {
+            tool_id: String::new(),
+            reporter: Arc::new(crate::progress::SilentReporter),
+            harness_event_sink: None,
+            attachment_paths: Vec::new(),
+            audio_attachment_paths: Vec::new(),
+            file_attachment_paths: Vec::new(),
+            agent_definitions: Arc::new(AgentDefinitions::new()),
+            permissions: ToolPermissions::default(),
+            file_state_cache: None,
+            notifications: Arc::new(Notifications::new()),
+            app_state: AppStateHandle::new(),
+        }
+    }
 }
 
 tokio::task_local! {
@@ -72,6 +250,23 @@ pub struct ToolResult {
 }
 
 /// Trait for implementing tools.
+///
+/// # Context threading
+///
+/// Tools get their execution context through one of two entry points:
+///
+/// - [`Tool::execute`] — the legacy argument-only entry point. Kept as the
+///   primary signature so unmigrated tools, tests, and external callers do
+///   not need to thread a [`ToolContext`]. The default implementation of
+///   `execute_with_context` delegates here, so implementors who override
+///   only `execute` keep working.
+/// - [`Tool::execute_with_context`] — the typed entry point introduced by
+///   M8.1. Migrated tools override this and may read any field on the
+///   [`ToolContext`]. The default body re-enters the legacy [`Tool::execute`]
+///   so unmigrated tools keep working.
+///
+/// A tool should override at most one of the two. Overriding both produces
+/// two independent entry paths that the executor cannot reconcile.
 #[async_trait]
 pub trait Tool: Send + Sync {
     /// Tool name (must be unique).
@@ -90,7 +285,28 @@ pub trait Tool: Send + Sync {
     }
 
     /// Execute the tool with the given arguments.
+    ///
+    /// Kept as the primary entry point so existing tools, tests, and
+    /// integrations do not need to construct a [`ToolContext`]. Migrated
+    /// tools re-enter this via [`Tool::execute_with_context`]; to avoid
+    /// infinite recursion implementors that override `execute_with_context`
+    /// must also override `execute` to call
+    /// `self.execute_with_context(&ToolContext::zero(), args).await`.
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult>;
+
+    /// Execute the tool with typed execution context.
+    ///
+    /// The default implementation delegates to [`Tool::execute`], discarding
+    /// the context. Tools that want to read [`ToolContext`] fields override
+    /// this and ignore `execute`'s default path. See the module-level doc
+    /// comment for the migration pattern.
+    async fn execute_with_context(
+        &self,
+        _ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
+        self.execute(args).await
+    }
 
     /// Downcast support for concrete tool access (e.g. wiring ActivateToolsTool).
     fn as_any(&self) -> &dyn std::any::Any {
@@ -614,5 +830,166 @@ mod path_tests {
         if let Ok(p) = &result {
             assert!(p.starts_with(base));
         }
+    }
+}
+
+#[cfg(test)]
+mod tool_context_tests {
+    //! M8.1 tests — typed `ToolContext` + `execute_with_context` scaffolding.
+
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Tool whose legacy `execute` records how many times it was called.
+    /// Overrides *only* `execute`; the default `execute_with_context` impl
+    /// must delegate here.
+    struct LegacyTool {
+        execute_calls: AtomicUsize,
+    }
+
+    impl LegacyTool {
+        fn new() -> Self {
+            Self {
+                execute_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for LegacyTool {
+        fn name(&self) -> &str {
+            "legacy"
+        }
+        fn description(&self) -> &str {
+            "legacy"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: &Value) -> Result<ToolResult> {
+            self.execute_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: "legacy output".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Tool that consumes the typed `ToolContext` — overrides
+    /// `execute_with_context` and re-enters via zero-value context from
+    /// `execute`.
+    struct ContextAwareTool {
+        with_ctx_calls: AtomicUsize,
+    }
+
+    impl ContextAwareTool {
+        fn new() -> Self {
+            Self {
+                with_ctx_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for ContextAwareTool {
+        fn name(&self) -> &str {
+            "ctx_aware"
+        }
+        fn description(&self) -> &str {
+            "ctx"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, args: &Value) -> Result<ToolResult> {
+            // Re-enter the typed path with the zero context so callers that
+            // still use the legacy entry point see identical behaviour.
+            self.execute_with_context(&ToolContext::zero(), args).await
+        }
+        async fn execute_with_context(
+            &self,
+            ctx: &ToolContext,
+            _args: &Value,
+        ) -> Result<ToolResult> {
+            self.with_ctx_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: format!(
+                    "tool_id={};allow_all={};defs_empty={}",
+                    ctx.tool_id,
+                    ctx.permissions.is_tool_allowed("anything"),
+                    ctx.agent_definitions.is_empty(),
+                ),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[test]
+    fn should_construct_zero_value_tool_context() {
+        let ctx = ToolContext::zero();
+        assert!(ctx.tool_id.is_empty());
+        assert!(ctx.harness_event_sink.is_none());
+        assert!(ctx.attachment_paths.is_empty());
+        assert!(ctx.audio_attachment_paths.is_empty());
+        assert!(ctx.file_attachment_paths.is_empty());
+        // M8.x placeholders — zero-value but constructible without panic.
+        assert!(ctx.agent_definitions.is_empty());
+        assert!(ctx.permissions.is_tool_allowed("any_tool"));
+        assert!(ctx.file_state_cache.is_none());
+        assert!(ctx.notifications.is_empty());
+        // AppStateHandle has no introspection beyond Default; just ensure
+        // it cloned cheaply.
+        let _cloned = ctx.app_state.clone();
+    }
+
+    #[tokio::test]
+    async fn should_delegate_execute_to_execute_with_context() {
+        // Legacy tool: override only `execute`. The default impl of
+        // `execute_with_context` must route to it.
+        let tool = LegacyTool::new();
+        let ctx = ToolContext::zero();
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({}))
+            .await
+            .expect("legacy tool must succeed via default delegation");
+        assert!(result.success);
+        assert_eq!(result.output, "legacy output");
+        assert_eq!(tool.execute_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn should_invoke_execute_with_context_for_migrated_tool() {
+        let tool = ContextAwareTool::new();
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call-42".to_string();
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({}))
+            .await
+            .expect("ctx-aware tool must succeed");
+        assert!(result.success);
+        assert!(result.output.contains("tool_id=call-42"));
+        assert!(result.output.contains("allow_all=true"));
+        assert!(result.output.contains("defs_empty=true"));
+        assert_eq!(tool.with_ctx_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn should_route_migrated_tool_execute_back_through_context_path() {
+        // When a migrated tool is called via the legacy `execute` entry
+        // point, it must still take its ctx-aware branch (invoked with
+        // the zero-value context so out-of-band callers keep working).
+        let tool = ContextAwareTool::new();
+        let result = tool
+            .execute(&serde_json::json!({}))
+            .await
+            .expect("migrated tool's legacy execute must succeed");
+        assert!(result.success);
+        // tool_id is empty because ToolContext::zero() carries no id.
+        assert!(result.output.starts_with("tool_id=;"));
+        assert_eq!(tool.with_ctx_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use serde::Deserialize;
 
-use super::{Tool, ToolResult};
+use super::{Tool, ToolContext, ToolResult};
 
 /// Tool for reading file contents.
 pub struct ReadFileTool {
@@ -68,8 +68,30 @@ impl Tool for ReadFileTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // M8.1: legacy entry point routes through the typed path with a
+        // zero-value context so out-of-band callers still exercise the same
+        // permission and (post-M8.4) file-state-cache logic.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: ReadFileInput =
             serde_json::from_value(args.clone()).wrap_err("invalid read_file tool input")?;
+
+        // M8.1 permission gate (stub): consult the typed permissions record
+        // so the hook is in place before M8.3 wires real allow lists. Today
+        // `ToolPermissions::default()` returns allow-all.
+        if !ctx.permissions.is_tool_allowed(self.name()) {
+            return Ok(ToolResult {
+                output: "read_file is not permitted in this context".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
 
         // Resolve path (with traversal protection)
         let path = match super::resolve_path(&self.base_dir, &input.path) {
@@ -251,5 +273,27 @@ mod tests {
         let tool = ReadFileTool::new("/tmp");
         assert_eq!(tool.name(), "read_file");
         assert!(tool.tags().contains(&"fs"));
+    }
+
+    #[tokio::test]
+    async fn should_read_via_execute_with_context() {
+        // M8.1 migration: `execute_with_context` is the authoritative entry
+        // point. Dispatching through it with a populated `ToolContext` must
+        // produce the same result as the legacy `execute` path.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "alpha\nbeta\n").unwrap();
+
+        let tool = ReadFileTool::new(dir.path());
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "read-via-ctx".to_string();
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "hello.txt"}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("alpha"));
+        assert!(result.output.contains("beta"));
     }
 }

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -571,7 +571,25 @@ impl ToolRegistry {
     /// Respects provider policy: tools hidden from `specs()` are also blocked
     /// from execution. This prevents an LLM from calling tools it shouldn't
     /// have access to.
+    ///
+    /// Delegates to [`ToolRegistry::execute_with_context`] with the zero-value
+    /// [`ToolContext`] so legacy callers continue to work unchanged.
     pub async fn execute(&self, name: &str, args: &serde_json::Value) -> Result<ToolResult> {
+        let ctx = super::ToolContext::zero();
+        self.execute_with_context(&ctx, name, args).await
+    }
+
+    /// Execute a tool by name with a typed [`ToolContext`].
+    ///
+    /// Migrated tools override [`super::Tool::execute_with_context`] and will
+    /// see the caller's context; unmigrated tools fall back to the default
+    /// trait impl which delegates to [`super::Tool::execute`].
+    pub async fn execute_with_context(
+        &self,
+        ctx: &super::ToolContext,
+        name: &str,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         if let Some(ref policy) = self.provider_policy {
             if let policy::PolicyDecision::Deny { reason } = policy.evaluate(name) {
                 eyre::bail!("tool '{}' denied by provider policy ({})", name, reason);
@@ -629,7 +647,7 @@ impl ToolRegistry {
         // Track usage for LRU auto-eviction
         self.record_usage(name);
 
-        tool.execute(args).await
+        tool.execute_with_context(ctx, args).await
     }
 }
 
@@ -1250,5 +1268,102 @@ mod lifecycle_tests {
         let msg = reg.spawn_only_message("mofa_slides");
 
         assert!(msg.contains("Output directory: /tmp/octos-profile/skill-output/"));
+    }
+}
+
+#[cfg(test)]
+mod context_threading_tests {
+    //! M8.1 — tool context threaded through the registry dispatch path.
+
+    use super::super::{Tool, ToolContext, ToolResult};
+    use super::*;
+    use async_trait::async_trait;
+    use eyre::Result;
+    use serde_json::Value;
+    use std::sync::Mutex;
+
+    /// Tool that echoes the `tool_id` it saw on the context, letting tests
+    /// confirm the registry forwarded the caller's `ToolContext` into
+    /// `execute_with_context`.
+    struct CapturingTool {
+        seen: Mutex<Option<String>>,
+    }
+
+    impl CapturingTool {
+        fn new() -> Self {
+            Self {
+                seen: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for CapturingTool {
+        fn name(&self) -> &str {
+            "capturing"
+        }
+        fn description(&self) -> &str {
+            "test-only"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, args: &Value) -> Result<ToolResult> {
+            self.execute_with_context(&ToolContext::zero(), args).await
+        }
+        async fn execute_with_context(
+            &self,
+            ctx: &ToolContext,
+            _args: &Value,
+        ) -> Result<ToolResult> {
+            *self.seen.lock().unwrap() = Some(ctx.tool_id.clone());
+            Ok(ToolResult {
+                output: ctx.tool_id.clone(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn should_pass_context_through_executor() {
+        let mut reg = ToolRegistry::new();
+        let tool = Arc::new(CapturingTool::new());
+        reg.register_arc(tool.clone());
+
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call-m8.1".to_string();
+
+        let result = reg
+            .execute_with_context(&ctx, "capturing", &serde_json::json!({}))
+            .await
+            .expect("capturing tool must succeed");
+        assert!(result.success);
+        assert_eq!(result.output, "call-m8.1");
+
+        let seen = tool.seen.lock().unwrap().clone();
+        assert_eq!(
+            seen.as_deref(),
+            Some("call-m8.1"),
+            "registry must forward the caller's ToolContext into execute_with_context",
+        );
+    }
+
+    #[tokio::test]
+    async fn should_route_legacy_execute_through_zero_value_context() {
+        // The legacy `execute(name, args)` entry must reach the same tool
+        // but with a zero-value context (empty tool_id).
+        let mut reg = ToolRegistry::new();
+        let tool = Arc::new(CapturingTool::new());
+        reg.register_arc(tool.clone());
+
+        let result = reg
+            .execute("capturing", &serde_json::json!({}))
+            .await
+            .expect("capturing tool must succeed via legacy entry");
+        assert!(result.success);
+
+        let seen = tool.seen.lock().unwrap().clone();
+        assert_eq!(seen.as_deref(), Some(""));
     }
 }

--- a/crates/octos-agent/tests/delegate_tool.rs
+++ b/crates/octos-agent/tests/delegate_tool.rs
@@ -272,3 +272,47 @@ fn should_publish_delegated_deny_group_name_on_policy() {
     assert_eq!(policy.deny, vec![DELEGATED_DENY_GROUP.to_string()]);
     assert!(policy.allow.is_empty());
 }
+
+#[tokio::test]
+async fn should_route_delegation_event_through_tool_context_sink() {
+    // M8.1 migration smoke test — DelegateTool is now a context-aware tool.
+    // A tool instance constructed *without* `.with_harness_event_sink(...)`
+    // must still emit its delegation event to the sink path carried by the
+    // `ToolContext` when dispatched through `execute_with_context`. This
+    // proves the tool actually reads from the typed context rather than
+    // relying on its own builder-only wiring.
+    use octos_agent::progress::SilentReporter;
+    use octos_agent::tools::ToolContext;
+    use std::sync::Arc;
+
+    let dir = TempDir::new().unwrap();
+    let memory = memory(&dir).await;
+    let sink_path = dir.path().join("delegation-events.ndjson");
+
+    // DepthBudget already exhausted so execute_with_context emits the
+    // DepthExceeded event and returns. No child is spawned, which keeps the
+    // test hermetic (no real LLM interaction required).
+    let tool = DelegateTool::new(llm("unused"), memory, PathBuf::from(dir.path()))
+        .with_depth_budget(DepthBudget::at_level(MAX_DEPTH));
+
+    let ctx = ToolContext {
+        tool_id: "m8.1-smoke".to_string(),
+        reporter: Arc::new(SilentReporter),
+        harness_event_sink: Some(sink_path.to_string_lossy().to_string()),
+        attachment_paths: Vec::new(),
+        audio_attachment_paths: Vec::new(),
+        file_attachment_paths: Vec::new(),
+        ..ToolContext::zero()
+    };
+
+    let result = tool
+        .execute_with_context(&ctx, &serde_json::json!({"task": "ignored"}))
+        .await;
+    assert!(result.is_err(), "depth-exceeded must fail synchronously");
+
+    let raw = std::fs::read_to_string(&sink_path)
+        .expect("DelegateTool must write the depth-exceeded event to the context sink path");
+    let entry: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+    assert_eq!(entry["kind"], "delegation");
+    assert_eq!(entry["outcome"], "depth_exceeded");
+}


### PR DESCRIPTION
## Summary

Runtime-v0.1 scaffolding: grows `ToolContext` from today's 5-field record into a typed carrier that threads explicitly through every tool call, and introduces `Tool::execute_with_context` as the new entry point. Default trait delegation keeps every existing tool working unchanged; migrated tools opt in.

Closes / refs #536.

### Scaffolding approach

- **Additive trait** — `Tool::execute_with_context(&ctx, args)` defaults to the legacy `execute(args)`. No existing tool is forced to migrate.
- **Dual-path registry** — `ToolRegistry::execute_with_context` threads the caller's context; `ToolRegistry::execute` now delegates to it with `ToolContext::zero()` so every caller that never carried a context keeps working.
- **Placeholder fields in `ToolContext`** — `agent_definitions`, `permissions`, `file_state_cache`, `notifications`, `app_state`. Each is a tiny stub struct (5-10 lines, zero-value constructor, documented with the future-filling M8.x issue). Nothing depends on them today.
- **Executor update** — `agent/execution.rs` builds a single typed context per tool call, clones it into `TOOL_CTX` for legacy plugin tools that still read the task-local, and calls `tools.execute_with_context(&ctx, ...)`.

Scope cap: ~626 insertions / 12 deletions across 7 files — well under the 3.5 kLOC ceiling. ~320 lines are impl, the rest are doc comments, placeholder stubs, and tests.

### Migrated tools

- **`DelegateTool`** — overrides `execute_with_context` and prefers `ctx.harness_event_sink` over its builder-set field, so grand-children inherit the effective sink.
- **`ReadFileTool`** — overrides `execute_with_context` and consults `ctx.permissions.is_tool_allowed("read_file")` before any filesystem access. Today's allow-all default keeps behaviour identical; M8.3 can start denying without touching the tool.

Every other tool continues to go through the legacy `execute` path via the default trait delegation.

### Tests

Unit tests (in `tools/mod.rs`, `tools/registry.rs`, `tools/read_file.rs`):
- `should_construct_zero_value_tool_context`
- `should_delegate_execute_to_execute_with_context`
- `should_invoke_execute_with_context_for_migrated_tool`
- `should_route_migrated_tool_execute_back_through_context_path`
- `should_pass_context_through_executor`
- `should_route_legacy_execute_through_zero_value_context`
- `should_read_via_execute_with_context`

Integration migration smoke test (in `tests/delegate_tool.rs`):
- `should_route_delegation_event_through_tool_context_sink` — constructs a `DelegateTool` with no builder-level sink, carries the sink through `ToolContext`, confirms the depth-exceeded delegation event lands in the context-supplied file.

All existing tests (`cargo test -p octos-agent --lib` = 987 passing; `cargo test --workspace --no-fail-fast` = 2321 passing) keep passing unchanged.

### What M8.2 / M8.3 / M8.4 will bolt on

The placeholder stubs are deliberately minimal so the follow-up issues land cleanly:

| Stub | Future issue | What will happen |
| --- | --- | --- |
| `AgentDefinitions` | M8.2 | parse `AgentDefinition` manifests from disk, register them, expose read APIs |
| `ToolPermissions` | M8.3 | replace `allow_all` with real profile-derived allow/deny decisions |
| `FileStateCache` | M8.4 | LRU + mtime/hash invalidation, `is_partial_view`, fork-safe `clone_file_state_cache` |
| `Notifications` | M8.2/M8.3 | queue + backpressure for tool-surfaced notifications |
| `AppStateHandle` | M8.3 | `Arc<ProfileState>` for active profile, locale, workspace contract root |

None of those will need to touch the `Tool` trait or the executor — every hook is already in place.

## Test plan

- [x] `cargo fmt -p octos-agent -- --check` — clean
- [x] `cargo clippy -p octos-agent --no-deps --all-targets -- -D warnings` — clean
- [x] `cargo test -p octos-agent --lib` — 987 passing
- [x] `cargo test -p octos-agent --test delegate_tool` — 8 passing (including new smoke test)
- [x] `cargo test --workspace --no-fail-fast` — 2321 passing, 0 failed

Notes:
- `cargo fmt --all -- --check` is **not** clean — five pre-existing fmt diffs live on `crates/octos-cli` files untouched by this PR (`api/admin_setup.rs`, `api/auth_handlers.rs`, `commands/admin.rs`, `config.rs`, `setup_state_store.rs`). Verified by running the same command against `origin/main` with none of this PR's changes applied.