### PR TITLE
M8.2: AgentDefinition manifest format (runtime-v0.1 gate)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -93,6 +93,7 @@ impl Agent {
                 let tc_args = tool_call.arguments.clone();
                 let attachment_ctx = turn_attachment_ctx.clone();
                 let harness_event_sink = self.harness_event_sink.clone();
+                let agent_definitions = self.agent_definitions.clone();
 
                 tokio::spawn(async move {
                     let tool_start = Instant::now();
@@ -168,6 +169,7 @@ impl Agent {
                         let bg_supervisor = tools.supervisor();
                         let bg_reporter = reporter.clone();
                         let bg_attachment_ctx = attachment_ctx.clone();
+                        let bg_agent_definitions = agent_definitions.clone();
                         tokio::spawn(async move {
                             bg_supervisor.mark_running(&task_id);
                             let bg_started_at = std::time::SystemTime::now();
@@ -186,6 +188,7 @@ impl Agent {
                                 file_attachment_paths: bg_attachment_ctx
                                     .file_attachment_paths
                                     .clone(),
+                                agent_definitions: bg_agent_definitions.clone(),
                                 ..ToolContext::zero()
                             };
 
@@ -506,6 +509,7 @@ impl Agent {
                         attachment_paths: attachment_ctx.attachment_paths.clone(),
                         audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
                         file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),
+                        agent_definitions: agent_definitions.clone(),
                         ..ToolContext::zero()
                     };
                     // Thread the typed context into execute_with_context. Legacy tools

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -172,7 +172,9 @@ impl Agent {
                             bg_supervisor.mark_running(&task_id);
                             let bg_started_at = std::time::SystemTime::now();
 
-                            // Helper to create TOOL_CTX for plugin stderr progress streaming
+                            // Helper to create TOOL_CTX for plugin stderr progress streaming.
+                            // Base it on the zero-value context so M8.x placeholder fields
+                            // carry their default-populated values.
                             let make_ctx = || ToolContext {
                                 tool_id: bg_tc_id.clone(),
                                 reporter: bg_reporter.clone(),
@@ -184,6 +186,7 @@ impl Agent {
                                 file_attachment_paths: bg_attachment_ctx
                                     .file_attachment_paths
                                     .clone(),
+                                ..ToolContext::zero()
                             };
 
                             let mut result = TOOL_CTX
@@ -503,9 +506,17 @@ impl Agent {
                         attachment_paths: attachment_ctx.attachment_paths.clone(),
                         audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
                         file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),
+                        ..ToolContext::zero()
                     };
+                    // Thread the typed context into execute_with_context. Legacy tools
+                    // whose trait impl only overrides `execute` still work via the
+                    // default delegation path; migrated tools read the typed fields.
+                    // TOOL_CTX is still scoped for plugin tools that read the task-local.
                     let result = TOOL_CTX
-                        .scope(ctx, tools.execute(&tc_name, &effective_args))
+                        .scope(
+                            ctx.clone(),
+                            tools.execute_with_context(&ctx, &tc_name, &effective_args),
+                        )
                         .await;
 
                     let duration = tool_start.elapsed();

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -172,6 +172,11 @@ pub struct Agent {
     /// Workspace policy associated with the compaction runner (used by the
     /// post-compaction validator rail to resolve preserved artifacts).
     pub(super) compaction_workspace: Option<crate::workspace_policy::WorkspacePolicy>,
+    /// M8.2 agent manifest registry shared with tools via `ToolContext`.
+    /// Shared behind an `Arc` so every per-tool `ToolContext::agent_definitions`
+    /// clone is O(1). When left at the default (empty registry) the agent
+    /// behaves exactly as pre-M8.2.
+    pub(super) agent_definitions: Arc<crate::agents::AgentDefinitions>,
 }
 
 impl Agent {
@@ -202,6 +207,7 @@ impl Agent {
             realtime: None,
             compaction_runner: None,
             compaction_workspace: None,
+            agent_definitions: Arc::new(crate::agents::AgentDefinitions::new()),
         }
     }
 
@@ -233,7 +239,18 @@ impl Agent {
             realtime: None,
             compaction_runner: None,
             compaction_workspace: None,
+            agent_definitions: Arc::new(crate::agents::AgentDefinitions::new()),
         }
+    }
+
+    /// Attach an [`crate::agents::AgentDefinitions`] registry. Threaded into
+    /// every per-tool [`crate::tools::ToolContext`] so tools that read
+    /// `ctx.agent_definitions` see the live registry instead of the M8.1
+    /// zero-value default. Idempotent — callers may swap the registry at
+    /// any time.
+    pub fn with_agent_definitions(mut self, defs: Arc<crate::agents::AgentDefinitions>) -> Self {
+        self.agent_definitions = defs;
+        self
     }
 
     /// Wire the `activate_tools` tool's back-reference to the shared tool registry.

--- a/crates/octos-agent/src/agents/mod.rs
+++ b/crates/octos-agent/src/agents/mod.rs
@@ -1,0 +1,571 @@
+//! Agent manifest format (M8.2 — runtime-v0.1 gate).
+//!
+//! # What is an `AgentDefinition`?
+//!
+//! An [`AgentDefinition`] is an external, declarative JSON or TOML manifest
+//! that describes a sub-agent's capability envelope: which tools it may use,
+//! which are denied, its model preferences, lifecycle hooks, MCP server
+//! dependencies, and so on. The schema deliberately mirrors Claude Code's
+//! `AgentDefinition` from `loadAgentsDir.ts` so authors moving between the
+//! two runtimes see the same field names and semantics.
+//!
+//! Every field in the manifest is domain-neutral: nothing about the schema
+//! is coding-specific. A "research-worker" manifest carries the same shape
+//! as a "repo-editor" manifest — only the tool allow-list differs. This is
+//! the M8.2 "coding-only" falsification gate for runtime-v0.1.
+//!
+//! # How loading works
+//!
+//! [`AgentDefinitions::load_dir`] scans a directory for `*.json` and `*.toml`
+//! files. Each file's stem is the definition id by default; if the file has
+//! a `name` field it overrides the stem. The loader layers:
+//!
+//! 1. Built-in defaults (shipped under `crates/octos-agent/src/assets/agents/`)
+//!    via [`AgentDefinitions::with_builtins`]. Today these are
+//!    `research-worker` (deep_search / web_fetch / web_search; no
+//!    shell/write/edit) and `repo-editor` (read_file / write_file / edit_file
+//!    / shell / grep / glob; no deep_search).
+//! 2. Local manifests from the caller-supplied directory, which replace
+//!    any built-in with the same id.
+//!
+//! If the directory does not exist the loader returns the built-ins only.
+//!
+//! # How `SpawnTool` resolves a manifest
+//!
+//! `SpawnTool::execute` accepts an optional `agent_definition_id` field. When
+//! set, the tool looks up the id in `ctx.agent_definitions` (the field on
+//! [`crate::tools::ToolContext`] that M8.1 stubbed). The manifest's fields
+//! become defaults for the spawn call; any inline field on the spawn args
+//! overrides the manifest. If both are present, inline wins. This keeps
+//! existing inline spawn callers working byte-for-byte while letting
+//! manifest-driven spawns stay terse at the call site.
+//!
+//! # Forward compatibility
+//!
+//! `version: u32` is required and must be `1` for now. Unknown fields are
+//! rejected (`#[serde(deny_unknown_fields)]`) — v1 only needs back-compat on
+//! read, not forward-compat on write. Future versions that add fields will
+//! bump the version number and relax the deny.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+
+/// Current schema version for [`AgentDefinition`].
+///
+/// Manifests with a different `version` are rejected at load time so callers
+/// cannot accidentally mix incompatible shapes. Future schema revisions bump
+/// this constant.
+pub const AGENT_DEFINITION_SCHEMA_VERSION: u32 = 1;
+
+/// A single agent manifest — the declarative capability envelope for a
+/// spawned sub-agent.
+///
+/// Field order and naming follow Claude Code's `AgentDefinition` from
+/// `loadAgentsDir.ts:76-94`. Every field except `name` and `version` is
+/// optional; default values keep existing inline spawn callers unchanged.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentDefinition {
+    /// Manifest id — also its display name. Required.
+    pub name: String,
+
+    /// Schema version. Must match [`AGENT_DEFINITION_SCHEMA_VERSION`].
+    pub version: u32,
+
+    /// Allow-list of tool ids the sub-agent may use. Empty = inherit the
+    /// parent's default set.
+    #[serde(default)]
+    pub tools: Vec<String>,
+
+    /// Deny-list of tool ids the sub-agent may not use. Deny always wins
+    /// over allow when a tool appears in both.
+    #[serde(default)]
+    pub disallowed_tools: Vec<String>,
+
+    /// Optional model override (e.g. `"anthropic/claude-haiku"`).
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// Optional effort hint (`"low"` / `"medium"` / `"high"`). Free-form for
+    /// now — the runtime may start honouring specific values in a future
+    /// milestone.
+    #[serde(default)]
+    pub effort: Option<String>,
+
+    /// Optional permission mode. Free-form today; M8.3 will map values to
+    /// the typed permission layer.
+    #[serde(default)]
+    pub permission_mode: Option<String>,
+
+    /// MCP server names this sub-agent wants attached. For v1 we only record
+    /// the names — real MCP wiring lands in a later milestone.
+    #[serde(default)]
+    pub mcp_servers: Vec<String>,
+
+    /// Lifecycle hooks this sub-agent inherits. Minimal v1 shape: event +
+    /// command. Future versions may add timeouts, filters, etc.
+    #[serde(default)]
+    pub hooks: Vec<HookRef>,
+
+    /// Optional cap on sub-agent turn count.
+    #[serde(default)]
+    pub max_turns: Option<u32>,
+
+    /// Skill ids the sub-agent wants enabled. For v1 we only record the
+    /// names — real skill loading lands in a later milestone.
+    #[serde(default)]
+    pub skills: Vec<String>,
+
+    /// Optional memory configuration.
+    #[serde(default)]
+    pub memory: Option<MemoryConfig>,
+
+    /// Whether the sub-agent should run as a background worker by default.
+    #[serde(default)]
+    pub background: bool,
+
+    /// Optional isolation mode string. Free-form today; wired to sandbox
+    /// policy in a later milestone.
+    #[serde(default)]
+    pub isolation: Option<String>,
+}
+
+impl AgentDefinition {
+    /// Validate a freshly-loaded manifest. Today we only check the schema
+    /// version — richer validation (e.g. unknown tool ids) lands when the
+    /// permission layer (M8.3) can do cross-referencing.
+    pub fn validate(&self) -> Result<()> {
+        if self.version != AGENT_DEFINITION_SCHEMA_VERSION {
+            eyre::bail!(
+                "agent definition '{}' has unsupported schema version {} (expected {})",
+                self.name,
+                self.version,
+                AGENT_DEFINITION_SCHEMA_VERSION,
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Minimal v1 hook reference — event name + command.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct HookRef {
+    /// Hook event name (e.g. `"before_tool_call"`).
+    pub event: String,
+    /// Shell command the hook should run.
+    pub command: String,
+}
+
+/// Minimal memory configuration carried by a manifest.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryConfig {
+    /// Optional path to the memory store. When `None` the runtime picks a
+    /// default location.
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    /// Whether memory is enabled for this sub-agent. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Built-in manifests shipped inside the crate so downstream users get a
+/// sensible default set without having to author their own.
+///
+/// Pairs are `(id, raw JSON text)`. At load time the raw text is parsed via
+/// [`AgentDefinition::from_json_str`].
+const BUILTIN_AGENTS: &[(&str, &str)] = &[
+    (
+        "research-worker",
+        include_str!("../assets/agents/research-worker.json"),
+    ),
+    (
+        "repo-editor",
+        include_str!("../assets/agents/repo-editor.json"),
+    ),
+];
+
+impl AgentDefinition {
+    /// Parse an [`AgentDefinition`] from JSON text.
+    pub fn from_json_str(text: &str) -> Result<Self> {
+        let def: AgentDefinition =
+            serde_json::from_str(text).wrap_err("failed to parse AgentDefinition as JSON")?;
+        def.validate()?;
+        Ok(def)
+    }
+
+    /// Parse an [`AgentDefinition`] from TOML text.
+    pub fn from_toml_str(text: &str) -> Result<Self> {
+        let def: AgentDefinition =
+            toml::from_str(text).wrap_err("failed to parse AgentDefinition as TOML")?;
+        def.validate()?;
+        Ok(def)
+    }
+}
+
+/// Typed registry of [`AgentDefinition`] records indexed by id.
+///
+/// This is the concrete M8.2 replacement for the M8.1 stub. It lives in
+/// `crate::tools` under the same name so the typed `ToolContext.agent_definitions`
+/// field keeps its signature.
+#[derive(Clone, Debug, Default)]
+pub struct AgentDefinitions {
+    by_id: HashMap<String, AgentDefinition>,
+}
+
+impl AgentDefinitions {
+    /// Create an empty registry. Equivalent to [`Default::default`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the registry has zero manifests.
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Number of registered manifests.
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Look up a manifest by id.
+    pub fn get(&self, id: &str) -> Option<&AgentDefinition> {
+        self.by_id.get(id)
+    }
+
+    /// Insert a manifest, replacing any previous value for the same id.
+    /// Returns the previous value if one existed.
+    pub fn insert(
+        &mut self,
+        id: impl Into<String>,
+        def: AgentDefinition,
+    ) -> Option<AgentDefinition> {
+        self.by_id.insert(id.into(), def)
+    }
+
+    /// Iterate manifest ids.
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.by_id.keys().map(String::as_str)
+    }
+
+    /// Registry containing the crate-shipped built-in manifests only.
+    ///
+    /// Today this is `research-worker` and `repo-editor`. The list is an
+    /// implementation detail and may grow over time.
+    pub fn with_builtins() -> Self {
+        let mut reg = Self::new();
+        for (id, text) in BUILTIN_AGENTS {
+            let def = AgentDefinition::from_json_str(text).unwrap_or_else(|err| {
+                // Built-in manifests are authored by the crate; a parse error
+                // here is a programming bug, not a user-visible condition.
+                panic!("built-in agent definition '{id}' is malformed: {err}");
+            });
+            reg.by_id.insert((*id).to_string(), def);
+        }
+        reg
+    }
+
+    /// Load manifests from a directory, layered on top of the built-ins.
+    ///
+    /// Reads `*.json` and `*.toml` files directly under `dir` (non-recursive).
+    /// Each file's stem is the id unless the file specifies a `name` field
+    /// that overrides it. Local manifests replace built-ins with the same
+    /// id. Missing directories return the built-ins only.
+    pub fn load_dir(dir: &Path) -> Result<Self> {
+        let mut reg = Self::with_builtins();
+        reg.load_dir_into(dir)?;
+        Ok(reg)
+    }
+
+    /// Load manifests from `dir` into an existing registry. Local manifests
+    /// override any previous entry with the same id.
+    pub fn load_dir_into(&mut self, dir: &Path) -> Result<()> {
+        if !dir.exists() {
+            return Ok(());
+        }
+        let iter = std::fs::read_dir(dir)
+            .wrap_err_with(|| format!("failed to read agents dir {}", dir.display()))?;
+        for entry in iter {
+            let entry = entry
+                .wrap_err_with(|| format!("failed to enumerate agents dir {}", dir.display()))?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+                continue;
+            };
+            let text = std::fs::read_to_string(&path)
+                .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+            let def = match ext {
+                "json" => AgentDefinition::from_json_str(&text)
+                    .wrap_err_with(|| format!("failed to parse {}", path.display()))?,
+                "toml" => AgentDefinition::from_toml_str(&text)
+                    .wrap_err_with(|| format!("failed to parse {}", path.display()))?,
+                _ => continue,
+            };
+            // File stem is the default id; the manifest's own `name` field
+            // overrides it when present (it is always present in v1 because
+            // `name` is required, so the stem is effectively a display hint
+            // for humans inspecting the directory).
+            let id = def.name.clone();
+            // Preserve the stem-id convention by rejecting manifests whose
+            // `name` does not match the filename stem. This keeps directory
+            // lookups predictable: `foo.json` registers id `foo`.
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                if stem != id {
+                    tracing::warn!(
+                        file = %path.display(),
+                        stem = %stem,
+                        name = %id,
+                        "agent definition filename stem differs from manifest name; \
+                         using manifest name as id"
+                    );
+                }
+            }
+            self.by_id.insert(id, def);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, text: &str) {
+        std::fs::write(path, text).expect("write manifest");
+    }
+
+    #[test]
+    fn should_parse_minimum_valid_manifest() {
+        // Only `name` and `version` are required. Every other field is
+        // optional and must default cleanly.
+        let json = r#"{"name":"tiny","version":1}"#;
+        let def = AgentDefinition::from_json_str(json).unwrap();
+
+        assert_eq!(def.name, "tiny");
+        assert_eq!(def.version, 1);
+        assert!(def.tools.is_empty());
+        assert!(def.disallowed_tools.is_empty());
+        assert!(def.model.is_none());
+        assert!(def.effort.is_none());
+        assert!(def.permission_mode.is_none());
+        assert!(def.mcp_servers.is_empty());
+        assert!(def.hooks.is_empty());
+        assert!(def.max_turns.is_none());
+        assert!(def.skills.is_empty());
+        assert!(def.memory.is_none());
+        assert!(!def.background);
+        assert!(def.isolation.is_none());
+    }
+
+    #[test]
+    fn should_parse_full_manifest_with_all_12_fields() {
+        // All 12 optional fields plus the two required ones, populated with
+        // realistic values.
+        let json = r#"{
+            "name": "full-agent",
+            "version": 1,
+            "tools": ["read_file", "shell"],
+            "disallowed_tools": ["web_search"],
+            "model": "anthropic/claude-haiku",
+            "effort": "high",
+            "permission_mode": "ask",
+            "mcp_servers": ["jiuwenclaw", "hermes"],
+            "hooks": [
+                {"event": "before_tool_call", "command": "/bin/true"}
+            ],
+            "max_turns": 25,
+            "skills": ["weather", "time"],
+            "memory": {"path": "/tmp/mem", "enabled": true},
+            "background": true,
+            "isolation": "docker"
+        }"#;
+        let def = AgentDefinition::from_json_str(json).unwrap();
+
+        assert_eq!(def.name, "full-agent");
+        assert_eq!(def.version, 1);
+        assert_eq!(
+            def.tools,
+            vec!["read_file".to_string(), "shell".to_string()]
+        );
+        assert_eq!(def.disallowed_tools, vec!["web_search".to_string()]);
+        assert_eq!(def.model.as_deref(), Some("anthropic/claude-haiku"));
+        assert_eq!(def.effort.as_deref(), Some("high"));
+        assert_eq!(def.permission_mode.as_deref(), Some("ask"));
+        assert_eq!(def.mcp_servers.len(), 2);
+        assert_eq!(def.hooks.len(), 1);
+        assert_eq!(def.hooks[0].event, "before_tool_call");
+        assert_eq!(def.hooks[0].command, "/bin/true");
+        assert_eq!(def.max_turns, Some(25));
+        assert_eq!(def.skills, vec!["weather".to_string(), "time".to_string()]);
+        let memory = def.memory.as_ref().expect("memory present");
+        assert_eq!(memory.path.as_deref(), Some(Path::new("/tmp/mem")));
+        assert!(memory.enabled);
+        assert!(def.background);
+        assert_eq!(def.isolation.as_deref(), Some("docker"));
+    }
+
+    #[test]
+    fn should_round_trip_manifest_through_json() {
+        // Serialize -> deserialize should be byte-stable for semantics.
+        let original = AgentDefinition {
+            name: "rt".to_string(),
+            version: 1,
+            tools: vec!["shell".to_string()],
+            disallowed_tools: Vec::new(),
+            model: Some("openai/gpt-4o-mini".to_string()),
+            effort: Some("medium".to_string()),
+            permission_mode: None,
+            mcp_servers: Vec::new(),
+            hooks: vec![HookRef {
+                event: "after_tool_call".to_string(),
+                command: "/usr/bin/env".to_string(),
+            }],
+            max_turns: Some(10),
+            skills: Vec::new(),
+            memory: Some(MemoryConfig {
+                path: None,
+                enabled: false,
+            }),
+            background: false,
+            isolation: None,
+        };
+
+        let json = serde_json::to_string(&original).expect("serialize");
+        let round_tripped = AgentDefinition::from_json_str(&json).expect("deserialize");
+        assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn should_reject_manifest_with_unknown_fields_in_v1() {
+        // `#[serde(deny_unknown_fields)]` must catch forward-incompatible
+        // manifests so v1 consumers cannot silently ignore new fields.
+        let json = r#"{
+            "name": "future",
+            "version": 1,
+            "unknown_future_field": true
+        }"#;
+        let err = AgentDefinition::from_json_str(json).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unknown_future_field") || msg.contains("unknown field"),
+            "expected unknown-field error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn should_merge_builtin_and_local_agents() {
+        // Built-ins provide `research-worker` and `repo-editor`. A local
+        // manifest with the same id must override the built-in.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Override the research-worker built-in with a local variant that
+        // adds `shell` to the tool list.
+        write(
+            &tmp.path().join("research-worker.json"),
+            r#"{"name":"research-worker","version":1,"tools":["deep_search","shell"]}"#,
+        );
+        // Add a brand-new local-only definition.
+        write(
+            &tmp.path().join("local-only.json"),
+            r#"{"name":"local-only","version":1,"tools":["read_file"]}"#,
+        );
+
+        let reg = AgentDefinitions::load_dir(tmp.path()).expect("load_dir");
+
+        // Built-in that was not overridden remains available.
+        let repo_editor = reg.get("repo-editor").expect("repo-editor");
+        assert!(repo_editor.tools.contains(&"read_file".to_string()));
+
+        // Overridden built-in now carries the local fields.
+        let research = reg.get("research-worker").expect("research-worker");
+        assert!(research.tools.contains(&"shell".to_string()));
+
+        // Local-only definition is present.
+        let local = reg.get("local-only").expect("local-only");
+        assert_eq!(local.tools, vec!["read_file".to_string()]);
+    }
+
+    #[test]
+    fn should_load_toml_manifest() {
+        // TOML is supported as a sibling format to JSON.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let toml_text = r#"
+            name = "toml-agent"
+            version = 1
+            tools = ["read_file"]
+            background = true
+        "#;
+        write(&tmp.path().join("toml-agent.toml"), toml_text);
+
+        let reg = AgentDefinitions::load_dir(tmp.path()).expect("load_dir");
+        let def = reg.get("toml-agent").expect("toml-agent");
+        assert_eq!(def.tools, vec!["read_file".to_string()]);
+        assert!(def.background);
+    }
+
+    #[test]
+    fn should_load_empty_registry_when_dir_missing() {
+        let reg = AgentDefinitions::load_dir(Path::new("/tmp/does-not-exist-octos-m82-tests"))
+            .expect("load_dir");
+        // Built-ins are always present even when the caller's dir is missing.
+        assert!(reg.get("research-worker").is_some());
+        assert!(reg.get("repo-editor").is_some());
+    }
+
+    #[test]
+    fn should_reject_manifest_with_mismatched_schema_version() {
+        let json = r#"{"name":"wrong","version":2}"#;
+        let err = AgentDefinition::from_json_str(json).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("version"), "expected version error, got {msg}");
+    }
+
+    #[test]
+    fn should_provide_builtin_research_worker() {
+        let reg = AgentDefinitions::with_builtins();
+        let def = reg
+            .get("research-worker")
+            .expect("research-worker built-in");
+        assert_eq!(def.name, "research-worker");
+        assert!(def.tools.contains(&"deep_search".to_string()));
+        assert!(def.tools.contains(&"web_fetch".to_string()));
+        assert!(def.tools.contains(&"web_search".to_string()));
+        // Research worker explicitly denies shell/write/edit.
+        assert!(def.disallowed_tools.contains(&"shell".to_string()));
+        assert!(def.disallowed_tools.contains(&"write_file".to_string()));
+        assert!(def.disallowed_tools.contains(&"edit_file".to_string()));
+    }
+
+    #[test]
+    fn should_provide_builtin_repo_editor() {
+        let reg = AgentDefinitions::with_builtins();
+        let def = reg.get("repo-editor").expect("repo-editor built-in");
+        assert_eq!(def.name, "repo-editor");
+        for expected in [
+            "read_file",
+            "write_file",
+            "edit_file",
+            "shell",
+            "grep",
+            "glob",
+        ] {
+            assert!(
+                def.tools.contains(&expected.to_string()),
+                "repo-editor missing {expected}"
+            );
+        }
+        // Repo editor denies deep_search.
+        assert!(def.disallowed_tools.contains(&"deep_search".to_string()));
+    }
+}

--- a/crates/octos-agent/src/assets/agents/repo-editor.json
+++ b/crates/octos-agent/src/assets/agents/repo-editor.json
@@ -1,0 +1,9 @@
+{
+  "name": "repo-editor",
+  "version": 1,
+  "tools": ["read_file", "write_file", "edit_file", "shell", "grep", "glob"],
+  "disallowed_tools": ["deep_search"],
+  "effort": "high",
+  "max_turns": 40,
+  "background": false
+}

--- a/crates/octos-agent/src/assets/agents/research-worker.json
+++ b/crates/octos-agent/src/assets/agents/research-worker.json
@@ -1,0 +1,9 @@
+{
+  "name": "research-worker",
+  "version": 1,
+  "tools": ["deep_search", "web_fetch", "web_search"],
+  "disallowed_tools": ["shell", "write_file", "edit_file"],
+  "effort": "medium",
+  "max_turns": 20,
+  "background": false
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod abi_schema;
 mod agent;
+pub mod agents;
 pub mod behaviour;
 pub mod bootstrap;
 pub mod builtin_skills;

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -1045,6 +1045,7 @@ mod tests {
             ],
             audio_attachment_paths: vec!["/workspace/voice.ogg".to_string()],
             file_attachment_paths: vec!["/workspace/report.pdf".to_string()],
+            ..ToolContext::zero()
         };
 
         let prepared = tool.prepare_effective_args(&json!({}), Some(&ctx));
@@ -1137,6 +1138,7 @@ mod tests {
             attachment_paths: vec![],
             audio_attachment_paths: vec![],
             file_attachment_paths: vec![],
+            ..ToolContext::zero()
         };
 
         let result = crate::tools::TOOL_CTX

--- a/crates/octos-agent/src/tools/delegate.rs
+++ b/crates/octos-agent/src/tools/delegate.rs
@@ -36,7 +36,7 @@ use octos_memory::EpisodeStore;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use super::{Tool, ToolPolicy, ToolRegistry, ToolResult};
+use super::{Tool, ToolContext, ToolPolicy, ToolRegistry, ToolResult};
 use crate::harness_errors::HarnessError;
 use crate::harness_events::HARNESS_EVENT_SCHEMA_V1;
 use crate::task_supervisor::{TaskLifecycleState, TaskSupervisor};
@@ -458,8 +458,27 @@ impl Tool for DelegateTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // M8.1: legacy entry point. Re-enter via execute_with_context with
+        // the zero-value context so out-of-band callers (tests, integrations
+        // that have not been updated) still exercise the same code path.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid delegate_task input")?;
+
+        // M8.1: prefer the sink path threaded through the typed context. Fall
+        // back to the tool's own configured sink for constructors that wired
+        // it directly (and for the legacy zero-context entry path).
+        let effective_sink: Option<&str> = ctx
+            .harness_event_sink
+            .as_deref()
+            .or(self.harness_event_sink.as_deref());
 
         // Step 1: depth guard. A parent whose budget is already exhausted
         // must reject synchronously, without spawning.
@@ -476,7 +495,7 @@ impl Tool for DelegateTool {
                     String::new(),
                     DelegationOutcome::DepthExceeded,
                 );
-                let _ = emit_delegation_event(self.harness_event_sink.as_deref(), &event);
+                let _ = emit_delegation_event(effective_sink, &event);
                 warn!(
                     parent_depth = self.depth_budget.current,
                     max = self.depth_budget.max,
@@ -507,7 +526,7 @@ impl Tool for DelegateTool {
 
         record_delegation(child_budget.current, DelegationOutcome::Accepted);
         let _ = emit_delegation_event(
-            self.harness_event_sink.as_deref(),
+            effective_sink,
             &DelegationEvent::new(
                 child_budget.current,
                 self.parent_task_id.clone().unwrap_or_default(),
@@ -546,7 +565,9 @@ impl Tool for DelegateTool {
             task_supervisor: self.task_supervisor.clone(),
             session_key: self.session_key.clone(),
             parent_task_id: Some(child_task_id.clone()),
-            harness_event_sink: self.harness_event_sink.clone(),
+            // Child inherits the effective sink so the context-threaded path
+            // still reaches grandchildren even if only the ToolContext set it.
+            harness_event_sink: effective_sink.map(|s| s.to_string()),
             worker_config: self.worker_config.clone(),
         };
         tools.register_arc(Arc::new(child_delegate));
@@ -621,7 +642,7 @@ impl Tool for DelegateTool {
         };
         record_delegation(child_budget.current, terminal_outcome);
         let _ = emit_delegation_event(
-            self.harness_event_sink.as_deref(),
+            effective_sink,
             &DelegationEvent::new(
                 child_budget.current,
                 self.parent_task_id.clone().unwrap_or_default(),

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1,4 +1,33 @@
 //! Tool framework for agent tool execution.
+//!
+//! # Typed `ToolContext` migration (M8.1)
+//!
+//! Tools receive execution context through [`ToolContext`]. Historically the
+//! context was delivered indirectly via the [`TOOL_CTX`] task-local, which the
+//! executor populated before calling each tool's [`Tool::execute`]. That works
+//! but makes the carrier invisible at the trait surface, so tools that want a
+//! field must either read the task-local or reach into globals.
+//!
+//! M8.1 introduces [`Tool::execute_with_context`], a typed entry point that
+//! threads `&ToolContext` explicitly. To keep the migration additive:
+//!
+//! - The trait's default implementation of `execute_with_context` falls back
+//!   to the legacy [`Tool::execute`]. Existing tools keep working unchanged.
+//! - Migrated tools override `execute_with_context` and use the typed record.
+//!   Their `execute` impl simply re-enters `execute_with_context` with a
+//!   zero-value context so out-of-band callers (tests, integrations that have
+//!   not been updated) still get predictable behaviour.
+//! - [`ToolContext`] carries the legacy fields *plus* placeholder stubs for
+//!   future milestones: [`AgentDefinitions`], [`ToolPermissions`],
+//!   [`FileStateCache`], [`Notifications`], and [`AppStateHandle`]. Each stub
+//!   is annotated with the future issue that will populate it. They all have
+//!   cheap zero-value constructors so today's executor can build a context
+//!   without wiring.
+//!
+//! The executor still sets [`TOOL_CTX`] for legacy plugin tools that rely on
+//! the task-local read path (see `plugins/tool.rs`). Once every tool is
+//! migrated the task-local becomes redundant and can be retired, but that
+//! clean-up is out of scope for M8.1.
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -10,9 +39,127 @@ use octos_core::TokenUsage;
 
 use crate::progress::ProgressReporter;
 
-/// Execution context available to tools via task-local.
-/// Set by the agent before each tool invocation so plugin tools
-/// can report progress without changing the Tool trait signature.
+/// Registry of [`AgentDefinition`]-style manifests available to tools.
+///
+/// M8.2 will populate this registry from `AgentDefinition` manifests on disk
+/// (see issue #536 → M8.2). Today it is an empty holder so the context can be
+/// constructed without wiring.
+#[derive(Clone, Debug, Default)]
+pub struct AgentDefinitions {
+    // M8.2 will add the concrete definition records here.
+}
+
+impl AgentDefinitions {
+    /// Create an empty agent-definition registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether any agent definitions are registered.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Per-tool permission facts consulted before each execution.
+///
+/// M8.3 will wire real profile-derived permissions into this struct (see
+/// issue #536 → M8.3). Today it unconditionally allows every tool so behaviour
+/// matches the pre-M8.1 status quo.
+#[derive(Clone, Debug)]
+pub struct ToolPermissions {
+    allow_all: bool,
+}
+
+impl Default for ToolPermissions {
+    fn default() -> Self {
+        Self::allow_all()
+    }
+}
+
+impl ToolPermissions {
+    /// Allow-all permissions — the zero-value default carried by the context.
+    pub fn allow_all() -> Self {
+        Self { allow_all: true }
+    }
+
+    /// Check whether the named tool is currently permitted. Always `true`
+    /// while M8.3 is pending.
+    pub fn is_tool_allowed(&self, _tool: &str) -> bool {
+        self.allow_all
+    }
+}
+
+/// File-state cache that mirrors `FileStateCache` from Claude Code.
+///
+/// M8.4 will grow this into the full LRU + mtime/hash invalidation cache
+/// described in the runtime plan (see issue #536 → M8.4). Today it is an
+/// empty stub so the context can hand out a shared handle without allocation.
+#[derive(Debug, Default)]
+pub struct FileStateCache {
+    // M8.4 will add the LRU state, mtime map, hash index, and
+    // `is_partial_view` tracking here.
+}
+
+impl FileStateCache {
+    /// Create an empty file-state cache handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the cache currently has any recorded file entries. Always
+    /// `false` until M8.4 fills in the map.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Inbox of in-flight notifications surfaced to tools and the agent loop.
+///
+/// M8.2/M8.3 will route real notifications (e.g. permission prompts, gate
+/// state) through this handle. Today it is a zero-length inbox.
+#[derive(Clone, Debug, Default)]
+pub struct Notifications {
+    // M8.2/M8.3 will add the notification queue and backpressure state here.
+}
+
+impl Notifications {
+    /// Create an empty notifications inbox.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the inbox is empty (no pending notifications). Always `true`
+    /// until M8.2/M8.3 start enqueueing notifications.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Handle to the ambient app state shared across tools.
+///
+/// M8.3 will use this to expose profile/app state that tools may read (e.g.
+/// the active profile name, locale, workspace contract root). Today it is an
+/// empty handle that tools can carry without wiring.
+#[derive(Clone, Debug, Default)]
+pub struct AppStateHandle {
+    // M8.3 will add the shared state handle (Arc<ProfileState>) here.
+}
+
+impl AppStateHandle {
+    /// Create an empty app-state handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Execution context available to tools.
+///
+/// The legacy fields (`tool_id`, `reporter`, `harness_event_sink`, three
+/// attachment lists) carry today's behaviour. The trailing fields are M8.x
+/// placeholders — see each field's doc comment for the issue that will wire
+/// it up. Building a zero-value context is cheap: all placeholders implement
+/// `Default` and the required handles are backed by `Arc` so cloning is O(1).
 #[derive(Clone)]
 pub struct ToolContext {
     pub tool_id: String,
@@ -22,6 +169,37 @@ pub struct ToolContext {
     pub attachment_paths: Vec<String>,
     pub audio_attachment_paths: Vec<String>,
     pub file_attachment_paths: Vec<String>,
+    /// Agent manifests available to tools. M8.2 will populate this.
+    pub agent_definitions: Arc<AgentDefinitions>,
+    /// Per-tool permission facts. M8.3 will populate this.
+    pub permissions: ToolPermissions,
+    /// File-state cache shared across tools in a turn. M8.4 will populate this.
+    pub file_state_cache: Option<Arc<FileStateCache>>,
+    /// Notification inbox surfaced to tools. M8.2/M8.3 will populate this.
+    pub notifications: Arc<Notifications>,
+    /// Handle to the ambient app state. M8.3 will populate this.
+    pub app_state: AppStateHandle,
+}
+
+impl ToolContext {
+    /// Zero-value context suitable for unit tests and tools that do not need
+    /// live executor wiring. Uses a [`crate::progress::SilentReporter`] and
+    /// leaves every M8.x placeholder at its default.
+    pub fn zero() -> Self {
+        Self {
+            tool_id: String::new(),
+            reporter: Arc::new(crate::progress::SilentReporter),
+            harness_event_sink: None,
+            attachment_paths: Vec::new(),
+            audio_attachment_paths: Vec::new(),
+            file_attachment_paths: Vec::new(),
+            agent_definitions: Arc::new(AgentDefinitions::new()),
+            permissions: ToolPermissions::default(),
+            file_state_cache: None,
+            notifications: Arc::new(Notifications::new()),
+            app_state: AppStateHandle::new(),
+        }
+    }
 }
 
 tokio::task_local! {
@@ -72,6 +250,23 @@ pub struct ToolResult {
 }
 
 /// Trait for implementing tools.
+///
+/// # Context threading
+///
+/// Tools get their execution context through one of two entry points:
+///
+/// - [`Tool::execute`] — the legacy argument-only entry point. Kept as the
+///   primary signature so unmigrated tools, tests, and external callers do
+///   not need to thread a [`ToolContext`]. The default implementation of
+///   `execute_with_context` delegates here, so implementors who override
+///   only `execute` keep working.
+/// - [`Tool::execute_with_context`] — the typed entry point introduced by
+///   M8.1. Migrated tools override this and may read any field on the
+///   [`ToolContext`]. The default body re-enters the legacy [`Tool::execute`]
+///   so unmigrated tools keep working.
+///
+/// A tool should override at most one of the two. Overriding both produces
+/// two independent entry paths that the executor cannot reconcile.
 #[async_trait]
 pub trait Tool: Send + Sync {
     /// Tool name (must be unique).
@@ -90,7 +285,28 @@ pub trait Tool: Send + Sync {
     }
 
     /// Execute the tool with the given arguments.
+    ///
+    /// Kept as the primary entry point so existing tools, tests, and
+    /// integrations do not need to construct a [`ToolContext`]. Migrated
+    /// tools re-enter this via [`Tool::execute_with_context`]; to avoid
+    /// infinite recursion implementors that override `execute_with_context`
+    /// must also override `execute` to call
+    /// `self.execute_with_context(&ToolContext::zero(), args).await`.
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult>;
+
+    /// Execute the tool with typed execution context.
+    ///
+    /// The default implementation delegates to [`Tool::execute`], discarding
+    /// the context. Tools that want to read [`ToolContext`] fields override
+    /// this and ignore `execute`'s default path. See the module-level doc
+    /// comment for the migration pattern.
+    async fn execute_with_context(
+        &self,
+        _ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
+        self.execute(args).await
+    }
 
     /// Downcast support for concrete tool access (e.g. wiring ActivateToolsTool).
     fn as_any(&self) -> &dyn std::any::Any {
@@ -614,5 +830,166 @@ mod path_tests {
         if let Ok(p) = &result {
             assert!(p.starts_with(base));
         }
+    }
+}
+
+#[cfg(test)]
+mod tool_context_tests {
+    //! M8.1 tests — typed `ToolContext` + `execute_with_context` scaffolding.
+
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Tool whose legacy `execute` records how many times it was called.
+    /// Overrides *only* `execute`; the default `execute_with_context` impl
+    /// must delegate here.
+    struct LegacyTool {
+        execute_calls: AtomicUsize,
+    }
+
+    impl LegacyTool {
+        fn new() -> Self {
+            Self {
+                execute_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for LegacyTool {
+        fn name(&self) -> &str {
+            "legacy"
+        }
+        fn description(&self) -> &str {
+            "legacy"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: &Value) -> Result<ToolResult> {
+            self.execute_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: "legacy output".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Tool that consumes the typed `ToolContext` — overrides
+    /// `execute_with_context` and re-enters via zero-value context from
+    /// `execute`.
+    struct ContextAwareTool {
+        with_ctx_calls: AtomicUsize,
+    }
+
+    impl ContextAwareTool {
+        fn new() -> Self {
+            Self {
+                with_ctx_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for ContextAwareTool {
+        fn name(&self) -> &str {
+            "ctx_aware"
+        }
+        fn description(&self) -> &str {
+            "ctx"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, args: &Value) -> Result<ToolResult> {
+            // Re-enter the typed path with the zero context so callers that
+            // still use the legacy entry point see identical behaviour.
+            self.execute_with_context(&ToolContext::zero(), args).await
+        }
+        async fn execute_with_context(
+            &self,
+            ctx: &ToolContext,
+            _args: &Value,
+        ) -> Result<ToolResult> {
+            self.with_ctx_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: format!(
+                    "tool_id={};allow_all={};defs_empty={}",
+                    ctx.tool_id,
+                    ctx.permissions.is_tool_allowed("anything"),
+                    ctx.agent_definitions.is_empty(),
+                ),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[test]
+    fn should_construct_zero_value_tool_context() {
+        let ctx = ToolContext::zero();
+        assert!(ctx.tool_id.is_empty());
+        assert!(ctx.harness_event_sink.is_none());
+        assert!(ctx.attachment_paths.is_empty());
+        assert!(ctx.audio_attachment_paths.is_empty());
+        assert!(ctx.file_attachment_paths.is_empty());
+        // M8.x placeholders — zero-value but constructible without panic.
+        assert!(ctx.agent_definitions.is_empty());
+        assert!(ctx.permissions.is_tool_allowed("any_tool"));
+        assert!(ctx.file_state_cache.is_none());
+        assert!(ctx.notifications.is_empty());
+        // AppStateHandle has no introspection beyond Default; just ensure
+        // it cloned cheaply.
+        let _cloned = ctx.app_state.clone();
+    }
+
+    #[tokio::test]
+    async fn should_delegate_execute_to_execute_with_context() {
+        // Legacy tool: override only `execute`. The default impl of
+        // `execute_with_context` must route to it.
+        let tool = LegacyTool::new();
+        let ctx = ToolContext::zero();
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({}))
+            .await
+            .expect("legacy tool must succeed via default delegation");
+        assert!(result.success);
+        assert_eq!(result.output, "legacy output");
+        assert_eq!(tool.execute_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn should_invoke_execute_with_context_for_migrated_tool() {
+        let tool = ContextAwareTool::new();
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call-42".to_string();
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({}))
+            .await
+            .expect("ctx-aware tool must succeed");
+        assert!(result.success);
+        assert!(result.output.contains("tool_id=call-42"));
+        assert!(result.output.contains("allow_all=true"));
+        assert!(result.output.contains("defs_empty=true"));
+        assert_eq!(tool.with_ctx_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn should_route_migrated_tool_execute_back_through_context_path() {
+        // When a migrated tool is called via the legacy `execute` entry
+        // point, it must still take its ctx-aware branch (invoked with
+        // the zero-value context so out-of-band callers keep working).
+        let tool = ContextAwareTool::new();
+        let result = tool
+            .execute(&serde_json::json!({}))
+            .await
+            .expect("migrated tool's legacy execute must succeed");
+        assert!(result.success);
+        // tool_id is empty because ToolContext::zero() carries no id.
+        assert!(result.output.starts_with("tool_id=;"));
+        assert_eq!(tool.with_ctx_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -41,25 +41,12 @@ use crate::progress::ProgressReporter;
 
 /// Registry of [`AgentDefinition`]-style manifests available to tools.
 ///
-/// M8.2 will populate this registry from `AgentDefinition` manifests on disk
-/// (see issue #536 → M8.2). Today it is an empty holder so the context can be
-/// constructed without wiring.
-#[derive(Clone, Debug, Default)]
-pub struct AgentDefinitions {
-    // M8.2 will add the concrete definition records here.
-}
-
-impl AgentDefinitions {
-    /// Create an empty agent-definition registry.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Whether any agent definitions are registered.
-    pub fn is_empty(&self) -> bool {
-        true
-    }
-}
+/// Re-exported from [`crate::agents`] where the schema and loader live. M8.2
+/// filled in the stub shipped by M8.1: the registry now carries real
+/// [`crate::agents::AgentDefinition`] records by id. `ToolContext` keeps its
+/// M8.1 signature (`Arc<AgentDefinitions>`), so consumers of the field do
+/// not need to change.
+pub use crate::agents::AgentDefinitions;
 
 /// Per-tool permission facts consulted before each execution.
 ///

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use serde::Deserialize;
 
-use super::{Tool, ToolResult};
+use super::{Tool, ToolContext, ToolResult};
 
 /// Tool for reading file contents.
 pub struct ReadFileTool {
@@ -68,8 +68,30 @@ impl Tool for ReadFileTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // M8.1: legacy entry point routes through the typed path with a
+        // zero-value context so out-of-band callers still exercise the same
+        // permission and (post-M8.4) file-state-cache logic.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: ReadFileInput =
             serde_json::from_value(args.clone()).wrap_err("invalid read_file tool input")?;
+
+        // M8.1 permission gate (stub): consult the typed permissions record
+        // so the hook is in place before M8.3 wires real allow lists. Today
+        // `ToolPermissions::default()` returns allow-all.
+        if !ctx.permissions.is_tool_allowed(self.name()) {
+            return Ok(ToolResult {
+                output: "read_file is not permitted in this context".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
 
         // Resolve path (with traversal protection)
         let path = match super::resolve_path(&self.base_dir, &input.path) {
@@ -251,5 +273,27 @@ mod tests {
         let tool = ReadFileTool::new("/tmp");
         assert_eq!(tool.name(), "read_file");
         assert!(tool.tags().contains(&"fs"));
+    }
+
+    #[tokio::test]
+    async fn should_read_via_execute_with_context() {
+        // M8.1 migration: `execute_with_context` is the authoritative entry
+        // point. Dispatching through it with a populated `ToolContext` must
+        // produce the same result as the legacy `execute` path.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "alpha\nbeta\n").unwrap();
+
+        let tool = ReadFileTool::new(dir.path());
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "read-via-ctx".to_string();
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "hello.txt"}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("alpha"));
+        assert!(result.output.contains("beta"));
     }
 }

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -571,7 +571,25 @@ impl ToolRegistry {
     /// Respects provider policy: tools hidden from `specs()` are also blocked
     /// from execution. This prevents an LLM from calling tools it shouldn't
     /// have access to.
+    ///
+    /// Delegates to [`ToolRegistry::execute_with_context`] with the zero-value
+    /// [`ToolContext`] so legacy callers continue to work unchanged.
     pub async fn execute(&self, name: &str, args: &serde_json::Value) -> Result<ToolResult> {
+        let ctx = super::ToolContext::zero();
+        self.execute_with_context(&ctx, name, args).await
+    }
+
+    /// Execute a tool by name with a typed [`ToolContext`].
+    ///
+    /// Migrated tools override [`super::Tool::execute_with_context`] and will
+    /// see the caller's context; unmigrated tools fall back to the default
+    /// trait impl which delegates to [`super::Tool::execute`].
+    pub async fn execute_with_context(
+        &self,
+        ctx: &super::ToolContext,
+        name: &str,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         if let Some(ref policy) = self.provider_policy {
             if let policy::PolicyDecision::Deny { reason } = policy.evaluate(name) {
                 eyre::bail!("tool '{}' denied by provider policy ({})", name, reason);
@@ -629,7 +647,7 @@ impl ToolRegistry {
         // Track usage for LRU auto-eviction
         self.record_usage(name);
 
-        tool.execute(args).await
+        tool.execute_with_context(ctx, args).await
     }
 }
 
@@ -1250,5 +1268,102 @@ mod lifecycle_tests {
         let msg = reg.spawn_only_message("mofa_slides");
 
         assert!(msg.contains("Output directory: /tmp/octos-profile/skill-output/"));
+    }
+}
+
+#[cfg(test)]
+mod context_threading_tests {
+    //! M8.1 — tool context threaded through the registry dispatch path.
+
+    use super::super::{Tool, ToolContext, ToolResult};
+    use super::*;
+    use async_trait::async_trait;
+    use eyre::Result;
+    use serde_json::Value;
+    use std::sync::Mutex;
+
+    /// Tool that echoes the `tool_id` it saw on the context, letting tests
+    /// confirm the registry forwarded the caller's `ToolContext` into
+    /// `execute_with_context`.
+    struct CapturingTool {
+        seen: Mutex<Option<String>>,
+    }
+
+    impl CapturingTool {
+        fn new() -> Self {
+            Self {
+                seen: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for CapturingTool {
+        fn name(&self) -> &str {
+            "capturing"
+        }
+        fn description(&self) -> &str {
+            "test-only"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, args: &Value) -> Result<ToolResult> {
+            self.execute_with_context(&ToolContext::zero(), args).await
+        }
+        async fn execute_with_context(
+            &self,
+            ctx: &ToolContext,
+            _args: &Value,
+        ) -> Result<ToolResult> {
+            *self.seen.lock().unwrap() = Some(ctx.tool_id.clone());
+            Ok(ToolResult {
+                output: ctx.tool_id.clone(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn should_pass_context_through_executor() {
+        let mut reg = ToolRegistry::new();
+        let tool = Arc::new(CapturingTool::new());
+        reg.register_arc(tool.clone());
+
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call-m8.1".to_string();
+
+        let result = reg
+            .execute_with_context(&ctx, "capturing", &serde_json::json!({}))
+            .await
+            .expect("capturing tool must succeed");
+        assert!(result.success);
+        assert_eq!(result.output, "call-m8.1");
+
+        let seen = tool.seen.lock().unwrap().clone();
+        assert_eq!(
+            seen.as_deref(),
+            Some("call-m8.1"),
+            "registry must forward the caller's ToolContext into execute_with_context",
+        );
+    }
+
+    #[tokio::test]
+    async fn should_route_legacy_execute_through_zero_value_context() {
+        // The legacy `execute(name, args)` entry must reach the same tool
+        // but with a zero-value context (empty tool_id).
+        let mut reg = ToolRegistry::new();
+        let tool = Arc::new(CapturingTool::new());
+        reg.register_arc(tool.clone());
+
+        let result = reg
+            .execute("capturing", &serde_json::json!({}))
+            .await
+            .expect("capturing tool must succeed via legacy entry");
+        assert!(result.success);
+
+        let seen = tool.seen.lock().unwrap().clone();
+        assert_eq!(seen.as_deref(), Some(""));
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -636,7 +636,7 @@ impl SpawnTool {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct Input {
     task: String,
     #[serde(default)]
@@ -673,6 +673,13 @@ struct Input {
     /// default and finally to [`DEFAULT_MCP_AGENT_TOOL_NAME`].
     #[serde(default)]
     agent_mcp_tool_name: Option<String>,
+    /// Optional id of an [`crate::agents::AgentDefinition`] manifest to
+    /// resolve from [`crate::tools::ToolContext::agent_definitions`]. When
+    /// set, the manifest's fields become defaults for this spawn call;
+    /// fields explicitly provided inline on `Input` override the manifest.
+    /// Inline always wins.
+    #[serde(default)]
+    agent_definition_id: Option<String>,
 }
 
 fn default_backend() -> String {
@@ -681,6 +688,74 @@ fn default_backend() -> String {
 
 fn default_mode() -> String {
     "background".into()
+}
+
+/// Resolve an optional `agent_definition_id` against the context's manifest
+/// registry and layer the manifest's fields onto the inline [`Input`].
+///
+/// Semantics: inline wins. A field already present on `Input` (non-default
+/// for `Option`-typed fields; non-empty for `Vec`-typed fields) is kept as-is.
+/// Missing fields on `Input` are filled from the manifest.
+///
+/// Returns an error when the id is set but does not exist in the registry —
+/// that's almost always a typo, and silently ignoring it would erase the
+/// manifest's safety envelope.
+fn apply_agent_definition(
+    input: &mut Input,
+    registry: &crate::agents::AgentDefinitions,
+) -> Result<()> {
+    let Some(id) = input.agent_definition_id.as_deref() else {
+        return Ok(());
+    };
+    let def = registry.get(id).ok_or_else(|| {
+        eyre::eyre!(
+            "spawn: agent_definition_id '{id}' not found in registry; \
+             available: [{}]",
+            registry.ids().collect::<Vec<_>>().join(", ")
+        )
+    })?;
+
+    // Tool allow-list: manifest provides the default; inline takes
+    // precedence when it is non-empty. Manifest deny-list is merged into
+    // the inline `allowed_tools` as a removal step so a manifest that
+    // marks `shell` as disallowed cannot be re-enabled silently by
+    // inheriting the parent's default allow set.
+    if input.allowed_tools.is_empty() {
+        input.allowed_tools = def.tools.clone();
+    }
+    if !def.disallowed_tools.is_empty() {
+        input
+            .allowed_tools
+            .retain(|name| !def.disallowed_tools.contains(name));
+    }
+
+    // Option-typed fields: manifest only applies when the inline slot is
+    // None.
+    if input.model.is_none() {
+        input.model = def.model.clone();
+    }
+    if input.additional_instructions.is_none() {
+        // `effort` and `permission_mode` flow into later phases; surfacing
+        // them in `additional_instructions` keeps them visible in traces
+        // without baking runtime-specific plumbing into v1. The manifest's
+        // explicit `effort` / `permission_mode` strings are concatenated as
+        // a short prelude.
+        let mut hints = Vec::new();
+        if let Some(effort) = def.effort.as_deref() {
+            hints.push(format!("effort={effort}"));
+        }
+        if let Some(mode) = def.permission_mode.as_deref() {
+            hints.push(format!("permission_mode={mode}"));
+        }
+        if !hints.is_empty() {
+            input.additional_instructions = Some(format!(
+                "(agent_definition={}) {}",
+                def.name,
+                hints.join(", ")
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn should_deliver_output_files(files: &[PathBuf]) -> bool {
@@ -1393,6 +1468,10 @@ impl Tool for SpawnTool {
                 "agent_mcp_tool_name": {
                     "type": "string",
                     "description": "Override the MCP tool name dispatched on the remote agent when backend='agent_mcp'. Defaults to 'run_task'."
+                },
+                "agent_definition_id": {
+                    "type": "string",
+                    "description": "Optional id of an AgentDefinition manifest (see crates/octos-agent/src/agents). The manifest's fields (tools, model, max_turns, etc.) become defaults for this spawn; any inline field on the spawn args overrides the manifest (inline wins)."
                 }
             },
             "required": ["task"]
@@ -1400,8 +1479,28 @@ impl Tool for SpawnTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
-        let input: Input =
+        // Legacy entry point: route through the typed path with a zero-value
+        // context so out-of-band callers behave identically. Manifest-driven
+        // spawns require a populated `ctx.agent_definitions`, so legacy
+        // callers see a "no such manifest" error if they pass
+        // `agent_definition_id` without context — matching the existing
+        // guard behaviour for other ctx-dependent fields.
+        self.execute_with_context(&super::ToolContext::zero(), args)
+            .await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &super::ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
+        let mut input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid spawn tool input")?;
+        // M8.2: if the caller referenced an AgentDefinition manifest by id,
+        // layer the manifest's fields onto the inline Input with "inline
+        // wins" semantics. Unknown ids are a hard error — silently ignoring
+        // them would let a typo erase the manifest's safety envelope.
+        apply_agent_definition(&mut input, ctx.agent_definitions.as_ref())?;
 
         let worker_num = self.worker_count.fetch_add(1, Ordering::SeqCst);
         let worker_id = AgentId::new(format!("subagent-{worker_num}"));
@@ -3542,5 +3641,131 @@ PY
         // Leak the dir so it stays alive for the test
         let dir = Box::leak(Box::new(dir));
         EpisodeStore::open(dir.path()).await.unwrap()
+    }
+
+    /// Build a minimal `Input` from a JSON value with the defaults the
+    /// tests expect. Centralising this keeps the M8.2 manifest tests below
+    /// independent of future serde changes.
+    fn parse_spawn_input(value: serde_json::Value) -> Input {
+        serde_json::from_value(value).expect("input parses")
+    }
+
+    #[test]
+    fn should_resolve_manifest_in_spawn_tool() {
+        // Spawn args reference `research-worker`; the manifest's `tools`
+        // list must flow into the resolved `Input.allowed_tools`. Inline
+        // `allowed_tools` is empty so the manifest fills it in.
+        let registry = crate::agents::AgentDefinitions::with_builtins();
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "research this topic",
+            "agent_definition_id": "research-worker"
+        }));
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        // Research-worker manifest lists deep_search + web_fetch + web_search.
+        for expected in ["deep_search", "web_fetch", "web_search"] {
+            assert!(
+                input.allowed_tools.contains(&expected.to_string()),
+                "manifest tool {expected} did not flow into allowed_tools"
+            );
+        }
+        // Manifest's disallowed_tools (shell/write/edit) must not appear.
+        for forbidden in ["shell", "write_file", "edit_file"] {
+            assert!(
+                !input.allowed_tools.contains(&forbidden.to_string()),
+                "manifest disallowed_tool {forbidden} leaked into allowed_tools"
+            );
+        }
+    }
+
+    #[test]
+    fn should_let_inline_fields_override_manifest() {
+        // Inline `model` must beat the manifest's `model`. The manifest
+        // sets no model on `research-worker`, so we use a local manifest
+        // that has one to make the override visible.
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "with-model",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "with-model",
+                    "version": 1,
+                    "tools": ["read_file"],
+                    "model": "manifest-model"
+                }"#,
+            )
+            .expect("parse"),
+        );
+
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "with-model",
+            "model": "inline-model"
+        }));
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        // Inline wins for model.
+        assert_eq!(input.model.as_deref(), Some("inline-model"));
+    }
+
+    #[test]
+    fn should_let_inline_allowed_tools_override_manifest_allowed_tools() {
+        // When inline `allowed_tools` is non-empty it replaces the manifest
+        // list outright. The manifest's disallowed_tools still prune the
+        // result so a manifest cannot be silently bypassed.
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "example",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "example",
+                    "version": 1,
+                    "tools": ["read_file", "shell"],
+                    "disallowed_tools": ["shell"]
+                }"#,
+            )
+            .expect("parse"),
+        );
+
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "example",
+            "allowed_tools": ["shell", "grep"]
+        }));
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        // Inline list is kept, but manifest's disallow pruned `shell`.
+        assert!(input.allowed_tools.contains(&"grep".to_string()));
+        assert!(!input.allowed_tools.contains(&"shell".to_string()));
+    }
+
+    #[test]
+    fn should_error_when_agent_definition_id_unknown() {
+        // Typos in the id are a hard error so a silent-typo cannot erase
+        // the manifest's safety envelope.
+        let registry = crate::agents::AgentDefinitions::with_builtins();
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "no-such-manifest"
+        }));
+        let err = apply_agent_definition(&mut input, &registry).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no-such-manifest"), "message: {msg}");
+    }
+
+    #[test]
+    fn should_not_mutate_input_when_agent_definition_id_missing() {
+        // No id means no resolution. This preserves the fast path for
+        // callers that never touch manifests.
+        let registry = crate::agents::AgentDefinitions::with_builtins();
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "plain spawn",
+            "allowed_tools": ["shell"]
+        }));
+        let before = input.clone();
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        assert_eq!(input.allowed_tools, before.allowed_tools);
+        assert_eq!(input.model, before.model);
     }
 }

--- a/crates/octos-agent/tests/delegate_tool.rs
+++ b/crates/octos-agent/tests/delegate_tool.rs
@@ -272,3 +272,47 @@ fn should_publish_delegated_deny_group_name_on_policy() {
     assert_eq!(policy.deny, vec![DELEGATED_DENY_GROUP.to_string()]);
     assert!(policy.allow.is_empty());
 }
+
+#[tokio::test]
+async fn should_route_delegation_event_through_tool_context_sink() {
+    // M8.1 migration smoke test — DelegateTool is now a context-aware tool.
+    // A tool instance constructed *without* `.with_harness_event_sink(...)`
+    // must still emit its delegation event to the sink path carried by the
+    // `ToolContext` when dispatched through `execute_with_context`. This
+    // proves the tool actually reads from the typed context rather than
+    // relying on its own builder-only wiring.
+    use octos_agent::progress::SilentReporter;
+    use octos_agent::tools::ToolContext;
+    use std::sync::Arc;
+
+    let dir = TempDir::new().unwrap();
+    let memory = memory(&dir).await;
+    let sink_path = dir.path().join("delegation-events.ndjson");
+
+    // DepthBudget already exhausted so execute_with_context emits the
+    // DepthExceeded event and returns. No child is spawned, which keeps the
+    // test hermetic (no real LLM interaction required).
+    let tool = DelegateTool::new(llm("unused"), memory, PathBuf::from(dir.path()))
+        .with_depth_budget(DepthBudget::at_level(MAX_DEPTH));
+
+    let ctx = ToolContext {
+        tool_id: "m8.1-smoke".to_string(),
+        reporter: Arc::new(SilentReporter),
+        harness_event_sink: Some(sink_path.to_string_lossy().to_string()),
+        attachment_paths: Vec::new(),
+        audio_attachment_paths: Vec::new(),
+        file_attachment_paths: Vec::new(),
+        ..ToolContext::zero()
+    };
+
+    let result = tool
+        .execute_with_context(&ctx, &serde_json::json!({"task": "ignored"}))
+        .await;
+    assert!(result.is_err(), "depth-exceeded must fail synchronously");
+
+    let raw = std::fs::read_to_string(&sink_path)
+        .expect("DelegateTool must write the depth-exceeded event to the context sink path");
+    let entry: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+    assert_eq!(entry["kind"], "delegation");
+    assert_eq!(entry["outcome"], "depth_exceeded");
+}

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -291,10 +291,26 @@ impl ChatCommand {
             chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
             ..Default::default()
         };
+        // M8.2: load sub-agent manifests from `<cwd>/agents/` layered on
+        // top of the crate-shipped built-ins (research-worker, repo-editor).
+        // Missing dirs fall back to built-ins only.
+        let agents_dir = cwd.join("agents");
+        let agent_definitions = match octos_agent::agents::AgentDefinitions::load_dir(&agents_dir) {
+            Ok(defs) => Arc::new(defs),
+            Err(err) => {
+                eprintln!(
+                    "Warning: failed to load agent manifests from {}: {err}",
+                    agents_dir.display()
+                );
+                Arc::new(octos_agent::agents::AgentDefinitions::with_builtins())
+            }
+        };
+
         let mut agent = Agent::new(AgentId::new("chat"), llm, tools, memory)
             .with_config(agent_config)
             .with_reporter(reporter)
-            .with_shutdown(shutdown.clone());
+            .with_shutdown(shutdown.clone())
+            .with_agent_definitions(agent_definitions);
 
         // Load bootstrap files (AGENTS.md, SOUL.md, etc.) from project .octos/ directory
         let project_dir = cwd.join(".octos");


### PR DESCRIPTION
## Summary

Refs #537. Implements the external `AgentDefinition` manifest format — a
declarative JSON/TOML schema that defines a sub-agent's capability
envelope (tools, permissions, hooks, model preferences, MCP servers,
etc.) independent of any inline spawn arguments. Stacked on **PR #546
(M8.1)** — GitHub will show both commit ranges until that lands.

### Schema (12 optional + 2 required fields)

Required: `name: String`, `version: u32 = 1`. Optional, serde-default:

| field | type | notes |
| --- | --- | --- |
| `tools` | `Vec<String>` | allow-list of tool ids |
| `disallowed_tools` | `Vec<String>` | deny-list; deny wins |
| `model` | `Option<String>` | e.g. `anthropic/claude-haiku` |
| `effort` | `Option<String>` | low / medium / high (free-form) |
| `permission_mode` | `Option<String>` | free-form; M8.3 will wire semantics |
| `mcp_servers` | `Vec<String>` | recorded only in v1 |
| `hooks` | `Vec<HookRef>` | `{event, command}` |
| `max_turns` | `Option<u32>` | |
| `skills` | `Vec<String>` | recorded only in v1 |
| `memory` | `Option<MemoryConfig>` | `{path, enabled}` |
| `background` | `bool` | default false |
| `isolation` | `Option<String>` | free-form; sandbox wiring deferred |

Forward-incompatible manifests are rejected via
`#[serde(deny_unknown_fields)]`. The `#[cfg(test)]` module inside
`agents/mod.rs` exercises this path.

### Built-in defaults

Shipped at `crates/octos-agent/src/assets/agents/*.json`:

- `research-worker` — `deep_search`, `web_fetch`, `web_search`; denies
  `shell`, `write_file`, `edit_file`.
- `repo-editor` — `read_file`, `write_file`, `edit_file`, `shell`,
  `grep`, `glob`; denies `deep_search`.

`AgentDefinitions::load_dir(dir)` scans `dir/*.{json,toml}` and layers
local manifests on top of the built-ins. Missing dirs return
built-ins only.

### SpawnTool integration

`SpawnTool::execute_with_context` now reads an optional
`agent_definition_id` from the input. When set, the manifest is
resolved from `ctx.agent_definitions` (the typed field M8.1
introduced). The manifest's fields become defaults; inline fields on
the spawn args override. Unknown ids are a hard error so a typo
cannot silently erase the safety envelope.

Wire site: `chat.rs` loads `<cwd>/agents` into the `Agent` via the new
`Agent::with_agent_definitions`. No other call sites refactored.

### Tests (15 new, all passing)

- `should_parse_minimum_valid_manifest`
- `should_parse_full_manifest_with_all_12_fields`
- `should_round_trip_manifest_through_json`
- `should_reject_manifest_with_unknown_fields_in_v1`
- `should_reject_manifest_with_mismatched_schema_version`
- `should_merge_builtin_and_local_agents`
- `should_load_toml_manifest`
- `should_load_empty_registry_when_dir_missing`
- `should_provide_builtin_research_worker`
- `should_provide_builtin_repo_editor`
- `should_resolve_manifest_in_spawn_tool`
- `should_let_inline_fields_override_manifest`
- `should_let_inline_allowed_tools_override_manifest_allowed_tools`
- `should_error_when_agent_definition_id_unknown`
- `should_not_mutate_input_when_agent_definition_id_missing`

## Out of scope

- Skill loading from manifest `skills` (deferred to a later milestone).
- Real MCP server wiring from `mcp_servers` (names recorded only).
- `ToolContext` definition changes (populated only, per M8.1 contract).

## Gates

- `cargo fmt --all -- --check` — only pre-existing diffs in 5 files
  I did **not** touch: `crates/octos-cli/src/api/admin_setup.rs`,
  `crates/octos-cli/src/api/auth_handlers.rs`,
  `crates/octos-cli/src/commands/admin.rs`,
  `crates/octos-cli/src/config.rs`,
  `crates/octos-cli/src/setup_state_store.rs`. All files I touched
  pass clean.
- `cargo clippy -p octos-agent --no-deps --all-targets -- -D warnings` — green.
- `cargo test -p octos-agent --lib` — 1002 pass, 1 ignored, 0 fail.
- `cargo test --workspace --no-fail-fast` — 2336 pass, 0 fail.

## Test plan

- [ ] Manually spawn a sub-agent with
      `{"task": "...", "agent_definition_id": "research-worker"}`
      and confirm the worker's tool set matches the manifest.
- [ ] Drop a local `agents/research-worker.json` under the chat cwd
      and confirm it overrides the built-in (tool list diff visible
      in worker logs).
- [ ] Pass an unknown `agent_definition_id` and confirm the spawn
      call surfaces the registry's available ids in the error.