### PR TITLE
M8.5: 3-tier compaction (runtime-v0.2 workstream)

### DIFF
--- a/crates/octos-agent/src/agent/compaction.rs
+++ b/crates/octos-agent/src/agent/compaction.rs
@@ -5,6 +5,7 @@ use tracing::{info, warn};
 
 use super::Agent;
 use crate::compaction::CompactionPhase;
+use crate::compaction_tiered::Tier1Report;
 
 impl Agent {
     pub(super) fn trim_to_context_window(&self, messages: &mut Vec<Message>) -> bool {
@@ -101,6 +102,51 @@ impl Agent {
             "harness M6.3 compaction preflight fired"
         );
         self.enforce_preservation(messages, CompactionPhase::Preflight);
+    }
+
+    /// M8.5 tier 1: cheap per-turn micro-compaction.  Runs the
+    /// [`crate::compaction_tiered::MicroCompactionPolicy`] in-place across the
+    /// current message list so the next LLM request inherits placeholder-
+    /// shaped tool results instead of the original payloads. Runs only when a
+    /// [`crate::compaction_tiered::TieredCompactionRunner`] is wired.
+    ///
+    /// Callers must pass `protected_tool_call_ids` — any tool_call_id listed
+    /// there is left untouched, preserving the M6 contract-gated artifact
+    /// guarantees for pending retry buckets.
+    pub(super) fn run_tier1_compaction(
+        &self,
+        messages: &mut [Message],
+        protected_tool_call_ids: &[String],
+    ) -> Tier1Report {
+        let Some(runner) = self.tiered_compaction.as_ref() else {
+            return Tier1Report::default();
+        };
+        let report = runner.run_tier1(messages, protected_tool_call_ids);
+        if report.performed() {
+            info!(
+                results_pruned = report.results_pruned,
+                bytes_reclaimed = report.bytes_reclaimed,
+                protected = protected_tool_call_ids.len(),
+                "harness M8.5 tier-1 micro-compaction fired"
+            );
+            metrics::counter!(
+                "octos_tier1_compaction_pruned_total",
+                "scope" => "tool_results".to_string(),
+            )
+            .increment(report.results_pruned as u64);
+        }
+        report
+    }
+
+    /// M8.5 tier 2: build the opaque `context_management` payload when the
+    /// attached [`crate::compaction_tiered::TieredCompactionRunner`] has the
+    /// feature enabled and the active provider speaks the Anthropic wire
+    /// format.  Call-sites merge the returned JSON into
+    /// `ChatConfig.context_management`; returning `None` means the request
+    /// should be sent untouched.
+    pub(super) fn build_tier2_context_management(&self) -> Option<serde_json::Value> {
+        let runner = self.tiered_compaction.as_ref()?;
+        runner.build_tier2_payload_for(self.llm.provider_name())
     }
 
     /// Run declarative compaction per-iteration (after M0 message prep). Only

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -36,6 +36,53 @@ fn split_tool_calls(
     tool_calls.chunks(batch_size).collect()
 }
 
+/// M8.5 tier 1 safety helper: collect the set of `tool_call_id`s that are
+/// currently in an unresolved state (i.e. an assistant tool call whose
+/// matching [`MessageRole::Tool`] reply has not landed yet). Those IDs are
+/// passed to the tier-1 prune pass as "protected" so we never drop a tool
+/// result that a pending retry/contract-gate handler still needs.
+///
+/// Works purely off the message list so it also covers contract-gated
+/// artifacts that are referenced by message indices — content-clearing
+/// preserves indices, but full pruning would not, so the prune pass
+/// explicitly skips these.
+fn collect_protected_tool_call_ids(messages: &[Message]) -> Vec<String> {
+    let mut requested: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut answered: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for msg in messages {
+        match msg.role {
+            MessageRole::Assistant => {
+                if let Some(ref calls) = msg.tool_calls {
+                    for call in calls {
+                        requested.insert(call.id.clone());
+                    }
+                }
+            }
+            MessageRole::Tool => {
+                if let Some(ref id) = msg.tool_call_id {
+                    answered.insert(id.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+    requested.difference(&answered).cloned().collect()
+}
+
+/// M8.5 tier 2 helper: returns a `ChatConfig` with the agent's tier-2
+/// `context_management` payload attached when the active provider is
+/// Anthropic-flavoured.  Returns a clone with the field left as-is in every
+/// other case so non-Anthropic providers never see the Anthropic-only
+/// header.
+fn with_tier2_context_management(config: &ChatConfig, agent: &Agent) -> ChatConfig {
+    let Some(payload) = agent.build_tier2_context_management() else {
+        return config.clone();
+    };
+    let mut out = config.clone();
+    out.context_management = Some(payload);
+    out
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ShellRetryRecoveryKind {
     DiffLikeSuccess,
@@ -485,6 +532,12 @@ impl Agent {
                     if iteration == 1 {
                         self.maybe_run_preflight_compaction(&mut messages);
                     }
+                    // Harness M8.5 tier 1: cheap in-place stale/oversized
+                    // tool-result pruning. Runs every iteration (including
+                    // the first so large bootstrap payloads shrink before
+                    // tier 3 considers whether to summarise).
+                    let protected_ids = collect_protected_tool_call_ids(&messages);
+                    self.run_tier1_compaction(&mut messages, &protected_ids);
                     prepare_conversation_messages(self, &mut messages, &mut turn);
                     // Harness M6.3: post-prep compaction pass so the declarative
                     // runner sees the final shape of the conversation (after
@@ -507,11 +560,17 @@ impl Agent {
                         message_bytes = messages.iter().map(|m| m.content.len()).sum::<usize>(),
                         "calling LLM"
                     );
+                    // M8.5 tier 2: optionally decorate the outgoing ChatConfig
+                    // with the Anthropic `context_management` payload so the
+                    // server can clear old tool uses on its side. Non-Anthropic
+                    // providers ignore `context_management` via
+                    // `skip_serializing_if`.
+                    let call_config = with_tier2_context_management(&config, self);
                     let (mut response, streamed) = match self
                         .call_llm_with_hooks(
                             &messages,
                             &tools_spec,
-                            &config,
+                            &call_config,
                             iteration,
                             &total_usage,
                             &mut turn,
@@ -534,7 +593,7 @@ impl Agent {
                                 .call_llm_with_hooks(
                                     &messages,
                                     &tools_spec,
-                                    &config,
+                                    &call_config,
                                     iteration,
                                     &total_usage,
                                     &mut turn,
@@ -849,14 +908,20 @@ impl Agent {
                 }
 
                 let tools_spec = self.tools.specs();
+                // M8.5 tier 1: also runs in task mode so background workers
+                // benefit from the same cheap shrinkage before their LLM call.
+                let protected_ids = collect_protected_tool_call_ids(&messages);
+                self.run_tier1_compaction(&mut messages, &protected_ids);
                 prepare_task_messages(self, &mut messages, &mut turn);
                 let total_usage = turn.total_usage().clone();
 
+                // M8.5 tier 2: decorate the config with the Anthropic header.
+                let call_config = with_tier2_context_management(&config, self);
                 let (mut response, _streamed) = match self
                     .call_llm_with_hooks(
                         &messages,
                         &tools_spec,
-                        &config,
+                        &call_config,
                         iteration,
                         &total_usage,
                         &mut turn,

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -172,6 +172,13 @@ pub struct Agent {
     /// Workspace policy associated with the compaction runner (used by the
     /// post-compaction validator rail to resolve preserved artifacts).
     pub(super) compaction_workspace: Option<crate::workspace_policy::WorkspacePolicy>,
+    /// Three-tier compaction runner (harness M8.5). Optional — when wired,
+    /// the loop runs tier 1 (micro-compaction) at the top of each iteration
+    /// and decorates Anthropic requests with the tier-2
+    /// `context_management` payload. Tier 3 delegates to the existing
+    /// [`crate::compaction::CompactionRunner`] wrapped as a
+    /// [`crate::compaction_tiered::FullCompactor`].
+    pub(super) tiered_compaction: Option<Arc<crate::compaction_tiered::TieredCompactionRunner>>,
 }
 
 impl Agent {
@@ -202,6 +209,7 @@ impl Agent {
             realtime: None,
             compaction_runner: None,
             compaction_workspace: None,
+            tiered_compaction: None,
         }
     }
 
@@ -233,6 +241,7 @@ impl Agent {
             realtime: None,
             compaction_runner: None,
             compaction_workspace: None,
+            tiered_compaction: None,
         }
     }
 
@@ -368,6 +377,25 @@ impl Agent {
     /// Access the attached workspace policy used for compaction gating.
     pub fn compaction_workspace(&self) -> Option<&crate::workspace_policy::WorkspacePolicy> {
         self.compaction_workspace.as_ref()
+    }
+
+    /// Wire the M8.5 three-tier compaction runner. Tier 1 runs at the top
+    /// of every loop iteration; tier 2 decorates outgoing Anthropic
+    /// requests; tier 3 is the existing declarative runner wrapped behind a
+    /// [`crate::compaction_tiered::FullCompactor`].
+    pub fn with_tiered_compaction(
+        mut self,
+        runner: Arc<crate::compaction_tiered::TieredCompactionRunner>,
+    ) -> Self {
+        self.tiered_compaction = Some(runner);
+        self
+    }
+
+    /// Access the attached three-tier compaction runner, if any.
+    pub fn tiered_compaction(
+        &self,
+    ) -> Option<Arc<crate::compaction_tiered::TieredCompactionRunner>> {
+        self.tiered_compaction.clone()
     }
 
     /// Beat the heartbeat once (if a realtime controller is attached) and

--- a/crates/octos-agent/src/compaction_tiered.rs
+++ b/crates/octos-agent/src/compaction_tiered.rs
@@ -1,0 +1,745 @@
+//! Three-tier compaction surface (M8.5, issue #540).
+//!
+//! Today octos ships a single tier of compaction: the declarative
+//! [`crate::compaction::CompactionRunner`] with contract-gated artifacts,
+//! placeholder replacement, and token budgets.  Claude Code, by contrast,
+//! runs three tiers and the cheap tier-1 pass alone keeps 20-40% of turns
+//! from ever hitting the expensive summarizer.
+//!
+//! This module adds the first two tiers as independent policies and wraps
+//! the existing runner behind a [`FullCompactor`] trait so the caller can
+//! see a single [`TieredCompactionRunner`] surface:
+//!
+//! 1. [`MicroCompactionPolicy`] — per-iteration stale tool-result pruning.
+//!    Cheap, synchronous, in-place.  Replaces oversized or stale tool
+//!    results with a typed [`ToolResultPlaceholder`] so the `tool_call_id`
+//!    (and therefore the assistant/tool pairing) stays intact.
+//! 2. [`ApiMicroCompactionConfig`] — a *builder*, not a runtime loop.
+//!    Emits the opaque `context_management` JSON payload that Anthropic's
+//!    server-side `clear_tool_uses_20250919` mechanism expects.  The
+//!    agent loop plumbs this into `ChatConfig.context_management` before
+//!    every Anthropic request; other providers ignore it silently.
+//! 3. [`FullCompactor`] — the existing heavy summary+contract-artifacts
+//!    pass.  Unchanged; merely wrapped so the tiered runner can ask
+//!    "should I run tier 3?" in one place.
+//!
+//! The runner is intentionally synchronous — callers that need async
+//! summarisers can drive them from their own [`FullCompactor`] impl.
+
+use octos_core::{Message, MessageRole};
+use serde::{Deserialize, Serialize};
+
+use crate::compaction::{
+    CompactionOutcome, CompactionPhase, CompactionRunner as FullCompactionRunner,
+    TOOL_RESULT_PLACEHOLDER_SCHEMA_VERSION, ToolResultPlaceholder,
+};
+
+// ─── Tier 1: MicroCompactionPolicy ───────────────────────────────────────────
+
+/// Default age (in user turns) at which a tool result becomes pruneable.
+pub const DEFAULT_TIER1_MAX_AGE_TURNS: u32 = 5;
+
+/// Default byte threshold for immediate content-clearing (regardless of age).
+pub const DEFAULT_TIER1_MAX_SIZE_BYTES_PER_RESULT: u32 = 8 * 1024;
+
+/// Per-iteration stale tool-result pruning policy (tier 1).
+///
+/// Runs in-place over the conversation and replaces a tool result's content
+/// with a typed [`ToolResultPlaceholder`] when either:
+///
+/// * the tool result is older than `max_age_turns` user-message boundaries, or
+/// * the tool result's content is larger than `max_size_bytes_per_result`.
+///
+/// The `tool_call_id` is always preserved so the assistant/tool pairing the
+/// provider enforces stays intact.  Tool results whose `tool_call_id` is
+/// listed in `protected_tool_call_ids` are never touched, which lets the
+/// caller hand off a set of IDs referenced by unresolved retry buckets or
+/// workspace-contract artifacts.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MicroCompactionPolicy {
+    /// Drop tool results older than this many user-turn boundaries.
+    pub max_age_turns: u32,
+    /// Tool results larger than this (in bytes) get content-cleared on sight.
+    pub max_size_bytes_per_result: u32,
+}
+
+impl Default for MicroCompactionPolicy {
+    fn default() -> Self {
+        Self {
+            max_age_turns: DEFAULT_TIER1_MAX_AGE_TURNS,
+            max_size_bytes_per_result: DEFAULT_TIER1_MAX_SIZE_BYTES_PER_RESULT,
+        }
+    }
+}
+
+impl MicroCompactionPolicy {
+    /// Convenience builder matching the parent module's fluent style.
+    pub fn with_max_age_turns(mut self, max_age_turns: u32) -> Self {
+        self.max_age_turns = max_age_turns;
+        self
+    }
+
+    /// Convenience builder for the size threshold.
+    pub fn with_max_size_bytes_per_result(mut self, max_size_bytes_per_result: u32) -> Self {
+        self.max_size_bytes_per_result = max_size_bytes_per_result;
+        self
+    }
+
+    /// Prune stale/oversized tool results in-place.
+    ///
+    /// `protected_tool_call_ids` receives tool_call IDs that must survive the
+    /// pass untouched (e.g. those referenced by an unresolved retry bucket or
+    /// by a contract-gated artifact awaiting delivery).
+    pub fn prune(
+        &self,
+        messages: &mut [Message],
+        protected_tool_call_ids: &[String],
+    ) -> Tier1Report {
+        if self.max_age_turns == 0 && self.max_size_bytes_per_result == u32::MAX {
+            return Tier1Report::default();
+        }
+
+        // ID -> tool_name, turn_id so we can build a typed placeholder even
+        // after the assistant message is far behind us.
+        let mut id_to_meta: std::collections::HashMap<String, (String, u32)> =
+            std::collections::HashMap::new();
+        let mut turn_counter: u32 = 0;
+        for msg in messages.iter() {
+            if msg.role == MessageRole::User {
+                turn_counter += 1;
+            }
+            if msg.role == MessageRole::Assistant {
+                if let Some(ref calls) = msg.tool_calls {
+                    for call in calls {
+                        id_to_meta
+                            .entry(call.id.clone())
+                            .or_insert_with(|| (call.name.clone(), turn_counter));
+                    }
+                }
+            }
+        }
+
+        // Current turn = the highest user-turn index we counted.
+        let current_turn = turn_counter;
+        let age_threshold = self.max_age_turns;
+        let size_threshold = self.max_size_bytes_per_result as usize;
+
+        let mut results_pruned = 0usize;
+        let mut bytes_reclaimed: u64 = 0;
+
+        for msg in messages.iter_mut() {
+            if msg.role != MessageRole::Tool {
+                continue;
+            }
+            let Some(ref id) = msg.tool_call_id else {
+                continue;
+            };
+            if protected_tool_call_ids.iter().any(|p| p == id) {
+                continue;
+            }
+            if ToolResultPlaceholder::from_placeholder_content(&msg.content).is_ok() {
+                // Already a placeholder from an earlier pass; nothing to do.
+                continue;
+            }
+
+            let (tool_name, turn_id) = id_to_meta
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| ("unknown_tool".to_string(), 0));
+
+            let age = current_turn.saturating_sub(turn_id);
+            let content_len = msg.content.len();
+            let oversized = size_threshold != usize::MAX && content_len > size_threshold;
+            let stale = age_threshold > 0 && age > age_threshold;
+
+            let reason: Option<&'static str> = match (stale, oversized) {
+                (true, _) => Some("tier1_stale"),
+                (false, true) => Some("tier1_oversized"),
+                _ => None,
+            };
+            let Some(reason) = reason else { continue };
+
+            let placeholder = ToolResultPlaceholder {
+                schema_version: TOOL_RESULT_PLACEHOLDER_SCHEMA_VERSION,
+                tool_name,
+                tool_call_id: id.clone(),
+                turn_id: Some(turn_id),
+                original_byte_len: Some(content_len as u64),
+                reason: reason.to_string(),
+            };
+            let replacement = placeholder.to_placeholder_content();
+            bytes_reclaimed += content_len.saturating_sub(replacement.len()) as u64;
+            msg.content = replacement;
+            results_pruned += 1;
+        }
+
+        Tier1Report {
+            results_pruned,
+            bytes_reclaimed,
+        }
+    }
+}
+
+/// Outcome of a single tier-1 pass.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Tier1Report {
+    /// Number of tool results whose content was content-cleared.
+    pub results_pruned: usize,
+    /// Bytes saved by swapping out original content for a placeholder.
+    pub bytes_reclaimed: u64,
+}
+
+impl Tier1Report {
+    /// Whether the pass actually performed any work.
+    pub fn performed(&self) -> bool {
+        self.results_pruned > 0
+    }
+}
+
+// ─── Tier 2: ApiMicroCompactionConfig ────────────────────────────────────────
+
+/// Default turns to keep when the tier-2 header is enabled.
+pub const DEFAULT_TIER2_KEEP_LAST_N_TURNS: u32 = 10;
+
+/// Anthropic server-side tool-use clearing request BUILDER (tier 2).
+///
+/// This is deliberately **not** a runtime loop.  The Claude Code inspiration
+/// that motivates this tier — `apiMicrocompact` / `clear_tool_uses_20250919`
+/// — is a request-time decoration: the client opts in by attaching a
+/// `context_management` JSON payload to its API request and lets the server
+/// prune stale tool uses on its side.  We emit exactly that payload; we do
+/// not try to replicate Anthropic's server-side clearing logic ourselves.
+///
+/// When [`Self::enabled`] is `false` (the default), [`Self::into_context_management_json`]
+/// returns `None` and the agent loop sends no additional payload.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiMicroCompactionConfig {
+    /// Opt-in flag.  Defaults to `false` so environments where the Anthropic
+    /// server does not yet accept the header keep the old behaviour.
+    pub enabled: bool,
+    /// Translated to `keep.value` inside the payload. `keep.type` is fixed
+    /// to `"tool_uses"` because that is the unit Anthropic's server-side
+    /// header operates on.
+    pub keep_last_n_turns: u32,
+    /// If `false`, the caller opts out of the Anthropic header even when
+    /// `enabled` is `true`.  Useful for A/B gating without flipping the
+    /// canonical config flag.
+    pub emit_clear_tool_uses_header: bool,
+}
+
+impl Default for ApiMicroCompactionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            keep_last_n_turns: DEFAULT_TIER2_KEEP_LAST_N_TURNS,
+            emit_clear_tool_uses_header: true,
+        }
+    }
+}
+
+impl ApiMicroCompactionConfig {
+    /// Enable the builder and leave the rest at the defaults.
+    pub fn enabled() -> Self {
+        Self {
+            enabled: true,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_keep_last_n_turns(mut self, keep: u32) -> Self {
+        self.keep_last_n_turns = keep;
+        self
+    }
+
+    pub fn with_emit_clear_tool_uses_header(mut self, emit: bool) -> Self {
+        self.emit_clear_tool_uses_header = emit;
+        self
+    }
+
+    /// Build the opaque `context_management` payload.  Returns `None` when
+    /// tier 2 is disabled (or the header has been explicitly suppressed) so
+    /// the caller can safely merge it into `ChatConfig.context_management`
+    /// without introducing noise.
+    pub fn into_context_management_json(&self) -> Option<serde_json::Value> {
+        if !self.enabled || !self.emit_clear_tool_uses_header {
+            return None;
+        }
+        Some(serde_json::json!({
+            "edits": [
+                {
+                    "type": "clear_tool_uses_20250919",
+                    "keep": {
+                        "type": "tool_uses",
+                        "value": self.keep_last_n_turns,
+                    }
+                }
+            ]
+        }))
+    }
+
+    /// Build a `(provider_name, payload)` pair that a call-site can feed into
+    /// `build_tier2_payload_for`.  Separate helper so tests can assert the
+    /// provider gating without instantiating a full agent.
+    pub fn payload_for_provider(&self, provider_name: &str) -> Option<serde_json::Value> {
+        if !is_anthropic_provider(provider_name) {
+            return None;
+        }
+        self.into_context_management_json()
+    }
+}
+
+/// Classifier used by [`ApiMicroCompactionConfig::payload_for_provider`] and
+/// [`TieredCompactionRunner::build_tier2_payload_for`].  Exposed so tests can
+/// exercise it directly.
+pub fn is_anthropic_provider(provider_name: &str) -> bool {
+    // Registry labels sometimes include upstream aliases (`zai`, `r9s`,
+    // `glm`, `any`, `bedrock-anthropic`, etc.) that still speak the
+    // Anthropic wire format.  Rather than hard-coding every alias we treat
+    // any label that *contains* `anthropic` or equals `claude` as
+    // Anthropic-compatible.  Unknown vendors default to OFF so tier 2 is
+    // never accidentally emitted to OpenAI/Gemini.
+    let lowered = provider_name.to_ascii_lowercase();
+    lowered == "anthropic" || lowered.contains("anthropic") || lowered == "claude"
+}
+
+// ─── Tier 3: FullCompactor trait ─────────────────────────────────────────────
+
+/// Wrapper trait around the existing [`FullCompactionRunner`].  Tier 3 is
+/// already implemented in `crate::compaction`; this trait only exists so the
+/// [`TieredCompactionRunner`] has a single pluggable surface that tests can
+/// substitute without booting the full policy stack.
+pub trait FullCompactor: Send + Sync {
+    /// Return `Some(tokens)` when the conversation exceeds the threshold at
+    /// which tier 3 should fire, and `None` otherwise.  Wraps the existing
+    /// `CompactionRunner::needs_preflight`.
+    fn needs_compaction(&self, messages: &[Message]) -> Option<u32>;
+
+    /// Perform tier 3.  Delegates to the existing runner and returns the raw
+    /// outcome so callers can surface metrics.
+    fn compact(&self, messages: &mut Vec<Message>, phase: CompactionPhase) -> CompactionOutcome;
+}
+
+impl FullCompactor for FullCompactionRunner {
+    fn needs_compaction(&self, messages: &[Message]) -> Option<u32> {
+        self.needs_preflight(messages)
+    }
+
+    fn compact(&self, messages: &mut Vec<Message>, phase: CompactionPhase) -> CompactionOutcome {
+        self.run(messages, phase)
+    }
+}
+
+/// Outcome of a tier-3 pass, exposed so callers can record metrics without
+/// reaching into the inner [`CompactionOutcome`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Tier3Report {
+    pub performed: bool,
+    pub messages_dropped: usize,
+    pub tool_results_replaced: usize,
+    pub tokens_before: u32,
+    pub tokens_after: u32,
+    pub summarizer_kind: &'static str,
+}
+
+impl From<CompactionOutcome> for Tier3Report {
+    fn from(o: CompactionOutcome) -> Self {
+        Self {
+            performed: o.performed,
+            messages_dropped: o.messages_dropped,
+            tool_results_replaced: o.tool_results_replaced,
+            tokens_before: o.tokens_before,
+            tokens_after: o.tokens_after,
+            summarizer_kind: o.summarizer_kind,
+        }
+    }
+}
+
+// ─── Three-tier runner ───────────────────────────────────────────────────────
+
+/// Unified three-tier compaction runner.
+///
+/// The runner only owns configuration/behaviour; it never mutates an agent.
+/// Call sites wire the tiers independently:
+///
+/// * tier 1: `runner.run_tier1(&mut messages, &protected_ids)` at the top of
+///   every loop iteration after the previous response lands.
+/// * tier 2: `runner.build_tier2_payload_for(provider_name)` at request-
+///   build time. Merge the returned JSON into
+///   `ChatConfig.context_management` for Anthropic; drop on the floor for
+///   other providers.
+/// * tier 3: `runner.maybe_run_tier3(&mut messages, phase)` at the budget
+///   threshold (today's trigger path — nothing there changes).
+pub struct TieredCompactionRunner {
+    tier1: MicroCompactionPolicy,
+    tier2: ApiMicroCompactionConfig,
+    tier3: Box<dyn FullCompactor>,
+}
+
+impl std::fmt::Debug for TieredCompactionRunner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TieredCompactionRunner")
+            .field("tier1", &self.tier1)
+            .field("tier2", &self.tier2)
+            .field("tier3", &"<dyn FullCompactor>")
+            .finish()
+    }
+}
+
+impl TieredCompactionRunner {
+    /// Build a runner from explicit tier configuration.
+    pub fn new(
+        tier1: MicroCompactionPolicy,
+        tier2: ApiMicroCompactionConfig,
+        tier3: Box<dyn FullCompactor>,
+    ) -> Self {
+        Self {
+            tier1,
+            tier2,
+            tier3,
+        }
+    }
+
+    /// Access the tier 1 policy.
+    pub fn tier1(&self) -> &MicroCompactionPolicy {
+        &self.tier1
+    }
+
+    /// Access the tier 2 config.
+    pub fn tier2(&self) -> &ApiMicroCompactionConfig {
+        &self.tier2
+    }
+
+    /// Run tier 1 in-place over `messages`, skipping any tool results whose
+    /// `tool_call_id` appears in `protected_tool_call_ids`.
+    pub fn run_tier1(
+        &self,
+        messages: &mut [Message],
+        protected_tool_call_ids: &[String],
+    ) -> Tier1Report {
+        self.tier1.prune(messages, protected_tool_call_ids)
+    }
+
+    /// Build the opaque tier 2 payload without considering provider gating.
+    /// Call-sites that know the provider is Anthropic can use this; every
+    /// other caller should prefer [`Self::build_tier2_payload_for`].
+    pub fn build_tier2_payload(&self) -> Option<serde_json::Value> {
+        self.tier2.into_context_management_json()
+    }
+
+    /// Build the tier 2 payload only if `provider_name` is Anthropic-flavoured.
+    pub fn build_tier2_payload_for(&self, provider_name: &str) -> Option<serde_json::Value> {
+        self.tier2.payload_for_provider(provider_name)
+    }
+
+    /// Run tier 3 when the underlying [`FullCompactor`] reports the
+    /// conversation exceeds its threshold. Returns `None` when tier 3 does
+    /// not fire so the caller can emit a `no-op` metric.
+    pub fn maybe_run_tier3(
+        &self,
+        messages: &mut Vec<Message>,
+        phase: CompactionPhase,
+    ) -> Option<Tier3Report> {
+        self.tier3.needs_compaction(messages)?;
+        let outcome = self.tier3.compact(messages, phase);
+        Some(outcome.into())
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compaction::{CompactionPolicy, CompactionRunner as FullCompactionRunner};
+    use octos_core::ToolCall;
+
+    fn user_msg(content: &str) -> Message {
+        Message {
+            role: MessageRole::User,
+            content: content.to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn assistant_tool_call(tool_name: &str, tool_id: &str) -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: Some(vec![ToolCall {
+                id: tool_id.to_string(),
+                name: tool_name.to_string(),
+                arguments: serde_json::json!({}),
+                metadata: None,
+            }]),
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn tool_result(tool_id: &str, content: &str) -> Message {
+        Message {
+            role: MessageRole::Tool,
+            content: content.to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tool_id.to_string()),
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        }
+    }
+
+    fn tiered_runner(
+        tier1: MicroCompactionPolicy,
+        tier2: ApiMicroCompactionConfig,
+    ) -> TieredCompactionRunner {
+        // Tier 3 is only used by maybe_run_tier3 and the integration test; a
+        // stock runner with a tiny budget is enough to exercise its surface
+        // without pulling in policy wiring.
+        let policy = CompactionPolicy::default();
+        let tier3: Box<dyn FullCompactor> = Box::new(FullCompactionRunner::new(policy));
+        TieredCompactionRunner::new(tier1, tier2, tier3)
+    }
+
+    #[test]
+    fn should_prune_tool_results_older_than_max_age() {
+        // 6 user turns; keep_age=2 so turns 1..=4 are stale.
+        let mut messages = vec![user_msg("turn-1")];
+        for i in 2..=6 {
+            messages.push(assistant_tool_call("read_file", &format!("call_{i}")));
+            messages.push(tool_result(&format!("call_{i}"), &format!("content-{i}")));
+            messages.push(user_msg(&format!("turn-{i}")));
+        }
+
+        let policy = MicroCompactionPolicy::default()
+            .with_max_age_turns(2)
+            .with_max_size_bytes_per_result(u32::MAX);
+        let report = policy.prune(&mut messages, &[]);
+
+        assert!(report.performed(), "some results should have been pruned");
+        // Stale tool results (call_2..call_4) should now hold the placeholder.
+        for i in 2..=4 {
+            let id = format!("call_{i}");
+            let tool = messages
+                .iter()
+                .find(|m| m.tool_call_id.as_deref() == Some(&id))
+                .expect("tool result present");
+            assert!(
+                ToolResultPlaceholder::from_placeholder_content(&tool.content).is_ok(),
+                "call_{i} content was not content-cleared: {:?}",
+                tool.content
+            );
+        }
+        // Recent tool results (call_5, call_6) stay intact.
+        for i in 5..=6 {
+            let id = format!("call_{i}");
+            let tool = messages
+                .iter()
+                .find(|m| m.tool_call_id.as_deref() == Some(&id))
+                .expect("tool result present");
+            assert_eq!(tool.content, format!("content-{i}"));
+        }
+    }
+
+    #[test]
+    fn should_clear_oversized_tool_results_to_placeholder() {
+        let mut messages = vec![
+            user_msg("q"),
+            assistant_tool_call("shell", "call_big"),
+            tool_result("call_big", &"x".repeat(50_000)),
+        ];
+        // Disable the age-based pruning so only the size path fires.
+        let policy = MicroCompactionPolicy::default()
+            .with_max_age_turns(u32::MAX)
+            .with_max_size_bytes_per_result(1024);
+        let report = policy.prune(&mut messages, &[]);
+        assert_eq!(report.results_pruned, 1);
+        assert!(report.bytes_reclaimed > 45_000);
+        let tool = &messages[2];
+        let parsed = ToolResultPlaceholder::from_placeholder_content(&tool.content)
+            .expect("placeholder round-trips");
+        assert_eq!(parsed.tool_call_id, "call_big");
+        assert_eq!(parsed.original_byte_len, Some(50_000));
+        assert_eq!(parsed.reason, "tier1_oversized");
+    }
+
+    #[test]
+    fn should_preserve_tool_call_id_on_pruned_results() {
+        let mut messages = vec![
+            user_msg("q"),
+            assistant_tool_call("shell", "call_alpha"),
+            tool_result("call_alpha", &"y".repeat(50_000)),
+            user_msg("q2"),
+        ];
+        let policy = MicroCompactionPolicy::default()
+            .with_max_age_turns(u32::MAX)
+            .with_max_size_bytes_per_result(1024);
+        policy.prune(&mut messages, &[]);
+        let tool = &messages[2];
+        assert_eq!(
+            tool.tool_call_id.as_deref(),
+            Some("call_alpha"),
+            "tool_call_id must survive the prune"
+        );
+    }
+
+    #[test]
+    fn should_skip_tool_results_referenced_by_retry_bucket() {
+        // The caller hands a protected set of IDs (e.g. from a pending
+        // retry bucket or contract-gated artifact).  Tier 1 must leave
+        // those tool results fully intact.
+        let mut messages = vec![user_msg("turn-1")];
+        for i in 2..=6 {
+            messages.push(assistant_tool_call("shell", &format!("call_{i}")));
+            messages.push(tool_result(&format!("call_{i}"), &format!("content-{i}")));
+            messages.push(user_msg(&format!("turn-{i}")));
+        }
+
+        let protected = vec!["call_2".to_string(), "call_4".to_string()];
+        let policy = MicroCompactionPolicy::default()
+            .with_max_age_turns(1)
+            .with_max_size_bytes_per_result(u32::MAX);
+        policy.prune(&mut messages, &protected);
+
+        for id in &protected {
+            let tool = messages
+                .iter()
+                .find(|m| m.tool_call_id.as_deref() == Some(id))
+                .expect("protected tool result still present");
+            assert!(
+                !tool
+                    .content
+                    .starts_with(crate::compaction::TOOL_RESULT_PLACEHOLDER_PREFIX),
+                "protected {id} was incorrectly pruned: {:?}",
+                tool.content
+            );
+        }
+    }
+
+    #[test]
+    fn should_report_bytes_reclaimed_and_count_pruned() {
+        let mut messages = vec![
+            user_msg("q"),
+            assistant_tool_call("tool_a", "call_a"),
+            tool_result("call_a", &"a".repeat(20_000)),
+            assistant_tool_call("tool_b", "call_b"),
+            tool_result("call_b", &"b".repeat(20_000)),
+            user_msg("q2"),
+        ];
+        let policy = MicroCompactionPolicy::default()
+            .with_max_age_turns(u32::MAX)
+            .with_max_size_bytes_per_result(1024);
+        let report = policy.prune(&mut messages, &[]);
+        assert_eq!(report.results_pruned, 2);
+        // bytes_reclaimed is at least 2*(content-placeholder) bytes, well
+        // over 30KB total.
+        assert!(report.bytes_reclaimed > 30_000);
+    }
+
+    #[test]
+    fn should_build_tier2_payload_only_when_enabled() {
+        let disabled = ApiMicroCompactionConfig::default();
+        assert!(disabled.into_context_management_json().is_none());
+
+        let enabled = ApiMicroCompactionConfig::enabled().with_keep_last_n_turns(7);
+        let payload = enabled
+            .into_context_management_json()
+            .expect("payload emitted when enabled");
+        assert_eq!(payload["edits"][0]["type"], "clear_tool_uses_20250919");
+        assert_eq!(payload["edits"][0]["keep"]["value"], 7);
+        assert_eq!(payload["edits"][0]["keep"]["type"], "tool_uses");
+
+        let suppressed =
+            ApiMicroCompactionConfig::enabled().with_emit_clear_tool_uses_header(false);
+        assert!(
+            suppressed.into_context_management_json().is_none(),
+            "header suppression must override the enabled flag"
+        );
+    }
+
+    #[test]
+    fn should_skip_tier2_payload_for_non_anthropic_providers() {
+        let config = ApiMicroCompactionConfig::enabled();
+        assert!(
+            config.payload_for_provider("openai").is_none(),
+            "OpenAI must not receive the Anthropic header"
+        );
+        assert!(
+            config.payload_for_provider("gemini").is_none(),
+            "Gemini must not receive the Anthropic header"
+        );
+        assert!(
+            config.payload_for_provider("openrouter").is_none(),
+            "openrouter proxies many vendors; safest default is OFF"
+        );
+        assert!(config.payload_for_provider("anthropic").is_some());
+        assert!(
+            config.payload_for_provider("bedrock-anthropic").is_some(),
+            "AWS Bedrock Claude speaks the Anthropic wire format"
+        );
+    }
+
+    #[test]
+    fn should_treat_tier1_as_no_op_when_both_thresholds_inactive() {
+        let mut messages = vec![
+            user_msg("q"),
+            assistant_tool_call("tool", "call_1"),
+            tool_result("call_1", &"x".repeat(16_000)),
+        ];
+        let policy = MicroCompactionPolicy {
+            max_age_turns: 0,
+            max_size_bytes_per_result: u32::MAX,
+        };
+        let report = policy.prune(&mut messages, &[]);
+        assert_eq!(report, Tier1Report::default());
+        assert_eq!(messages[2].content.len(), 16_000);
+    }
+
+    #[test]
+    fn should_expose_tiered_runner_api() {
+        let runner = tiered_runner(
+            MicroCompactionPolicy::default(),
+            ApiMicroCompactionConfig::enabled(),
+        );
+        assert_eq!(runner.tier1().max_age_turns, DEFAULT_TIER1_MAX_AGE_TURNS);
+        assert!(runner.tier2().enabled);
+        assert!(runner.build_tier2_payload_for("anthropic").is_some());
+        assert!(runner.build_tier2_payload_for("openai").is_none());
+    }
+
+    #[test]
+    fn should_skip_tier3_when_below_threshold() {
+        // Small conversation -> CompactionRunner.needs_preflight == None so
+        // maybe_run_tier3 returns None cleanly.
+        let runner = tiered_runner(
+            MicroCompactionPolicy::default(),
+            ApiMicroCompactionConfig::default(),
+        );
+        let mut messages = vec![user_msg("hi")];
+        let out = runner.maybe_run_tier3(&mut messages, CompactionPhase::OnDemand);
+        assert!(out.is_none(), "tier 3 should not fire for tiny convos");
+    }
+
+    #[test]
+    fn should_preserve_placeholder_idempotency() {
+        // Running tier 1 twice on the same messages must be a no-op on the
+        // second pass (the placeholder marker prefix is recognised).
+        let mut messages = vec![
+            user_msg("q"),
+            assistant_tool_call("tool", "call_1"),
+            tool_result("call_1", &"z".repeat(50_000)),
+        ];
+        let policy = MicroCompactionPolicy::default()
+            .with_max_age_turns(u32::MAX)
+            .with_max_size_bytes_per_result(1024);
+        let first = policy.prune(&mut messages, &[]);
+        assert_eq!(first.results_pruned, 1);
+        let second = policy.prune(&mut messages, &[]);
+        assert_eq!(second.results_pruned, 0);
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -14,6 +14,7 @@ pub mod bootstrap;
 pub mod builtin_skills;
 pub mod bundled_app_skills;
 pub mod compaction;
+pub mod compaction_tiered;
 pub mod cost_ledger;
 pub mod event_bus;
 pub mod exec_env;
@@ -66,6 +67,11 @@ pub use agent::{
         AgentError, Heartbeat, HeartbeatState, RealtimeConfig, RealtimeHookEnricher,
         SensorContextInjector, SensorSnapshot, SensorSource,
     },
+};
+pub use compaction_tiered::{
+    ApiMicroCompactionConfig, DEFAULT_TIER1_MAX_AGE_TURNS, DEFAULT_TIER1_MAX_SIZE_BYTES_PER_RESULT,
+    DEFAULT_TIER2_KEEP_LAST_N_TURNS, FullCompactor, MicroCompactionPolicy, Tier1Report,
+    Tier3Report, TieredCompactionRunner, is_anthropic_provider,
 };
 pub use cost_ledger::{
     BudgetProjection, BudgetRejectionReason, COST_ATTRIBUTION_COUNTER, COST_LEDGER_FILE,

--- a/crates/octos-agent/src/summarizer.rs
+++ b/crates/octos-agent/src/summarizer.rs
@@ -298,6 +298,7 @@ rather than appending duplicates.\n\n",
                 schema,
                 strict: true,
             }),
+            context_management: None,
         };
         let messages = vec![Message::user(prompt)];
         // Bridge the async LLM call to the synchronous Summarizer contract.

--- a/crates/octos-agent/tests/tiered_compaction_loop.rs
+++ b/crates/octos-agent/tests/tiered_compaction_loop.rs
@@ -1,0 +1,298 @@
+//! M8.5 acceptance test: the three-tier compaction runner is wired into the
+//! agent loop and actually shrinks an oversized tool result between
+//! iterations.
+//!
+//! This test runs against a mock `LlmProvider` so there is no network
+//! traffic.  It only checks behaviour the call-site owns (tier 1 applied
+//! in-place, tier 2 payload lifted into `ChatConfig.context_management`).
+//! Contract/M6 semantics are covered by `compaction_policy.rs`.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_agent::compaction::{CompactionPolicy, CompactionRunner as FullCompactionRunner};
+use octos_agent::compaction_tiered::FullCompactor;
+use octos_agent::{
+    Agent, ApiMicroCompactionConfig, MicroCompactionPolicy, TieredCompactionRunner, ToolRegistry,
+};
+use octos_core::{AgentId, Message, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, ToolSpec};
+use octos_memory::EpisodeStore;
+
+/// Provider that:
+///   1. First call: returns a tool use of `dump_big` so the agent executes
+///      it and produces a huge tool result.
+///   2. Second call: captures the messages array (so the test can assert
+///      tier 1 pruned the big output) and ends the turn.
+///   3. Records every `ChatConfig.context_management` the loop plumbed in,
+///      so the tier 2 assertion has something to look at.
+struct RecordingProvider {
+    calls: AtomicUsize,
+    captured_messages: Mutex<Vec<Message>>,
+    captured_context_management: Mutex<Vec<Option<serde_json::Value>>>,
+    provider_name: &'static str,
+}
+
+#[async_trait]
+impl LlmProvider for RecordingProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        _tools: &[ToolSpec],
+        config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        let idx = self.calls.fetch_add(1, Ordering::SeqCst);
+        self.captured_context_management
+            .lock()
+            .unwrap()
+            .push(config.context_management.clone());
+        if idx == 0 {
+            Ok(ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![ToolCall {
+                    id: "call_dump".to_string(),
+                    name: "dump_big".to_string(),
+                    arguments: serde_json::json!({}),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: Default::default(),
+                provider_index: None,
+            })
+        } else {
+            *self.captured_messages.lock().unwrap() = messages.to_vec();
+            Ok(ChatResponse {
+                content: Some("done".to_string()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: Default::default(),
+                provider_index: None,
+            })
+        }
+    }
+
+    fn model_id(&self) -> &str {
+        "mock-model"
+    }
+
+    fn provider_name(&self) -> &str {
+        self.provider_name
+    }
+}
+
+struct DumpBigTool;
+
+#[async_trait]
+impl octos_agent::Tool for DumpBigTool {
+    fn name(&self) -> &str {
+        "dump_big"
+    }
+
+    fn description(&self) -> &str {
+        "Emit a ~50KB payload so tier 1 has something to shrink"
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object", "properties": {}})
+    }
+
+    async fn execute(&self, _args: &serde_json::Value) -> Result<octos_agent::ToolResult> {
+        Ok(octos_agent::ToolResult {
+            output: "Z".repeat(50_000),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+fn build_tiered_runner(
+    tier1: MicroCompactionPolicy,
+    tier2: ApiMicroCompactionConfig,
+) -> Arc<TieredCompactionRunner> {
+    let policy = CompactionPolicy::default();
+    let tier3: Box<dyn FullCompactor> = Box::new(FullCompactionRunner::new(policy));
+    Arc::new(TieredCompactionRunner::new(tier1, tier2, tier3))
+}
+
+#[tokio::test]
+async fn tier1_shrinks_50kb_tool_result_to_placeholder_on_next_iteration() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = Arc::new(RecordingProvider {
+        calls: AtomicUsize::new(0),
+        captured_messages: Mutex::new(Vec::new()),
+        captured_context_management: Mutex::new(Vec::new()),
+        provider_name: "anthropic",
+    });
+    let provider_for_agent: Arc<dyn LlmProvider> = provider.clone();
+
+    let mut tools = ToolRegistry::with_builtins(dir.path());
+    tools.register(DumpBigTool);
+
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let runner = build_tiered_runner(
+        MicroCompactionPolicy::default()
+            .with_max_age_turns(u32::MAX) // disable stale path, keep size path
+            .with_max_size_bytes_per_result(1024),
+        ApiMicroCompactionConfig::enabled().with_keep_last_n_turns(4),
+    );
+    let agent = Agent::new(AgentId::new("m85-test"), provider_for_agent, tools, memory)
+        .with_tiered_compaction(runner);
+
+    let result = agent
+        .process_message("please dump and return", &[], vec![])
+        .await
+        .expect("loop should finish");
+
+    // Two LLM calls: the initial tool-use and the follow-up endturn.
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+
+    // On iteration 2 the provider sees a messages array where the tool
+    // result for `call_dump` is a placeholder, not 50KB of "Z".
+    let captured = provider.captured_messages.lock().unwrap().clone();
+    let tool_msg = captured
+        .iter()
+        .find(|m| m.tool_call_id.as_deref() == Some("call_dump"))
+        .expect("tool result present in iteration 2");
+    assert!(
+        tool_msg
+            .content
+            .starts_with(octos_agent::compaction::TOOL_RESULT_PLACEHOLDER_PREFIX),
+        "tier 1 did not shrink the 50KB tool result: {:?}",
+        &tool_msg.content.chars().take(80).collect::<String>()
+    );
+    assert!(
+        tool_msg.content.len() < 1_000,
+        "placeholder is still too large: {} bytes",
+        tool_msg.content.len()
+    );
+
+    // Tier 2 payload made it into both outgoing requests.
+    let captured_ctx = provider.captured_context_management.lock().unwrap().clone();
+    assert_eq!(captured_ctx.len(), 2);
+    for (i, ctx) in captured_ctx.iter().enumerate() {
+        let payload = ctx
+            .as_ref()
+            .unwrap_or_else(|| panic!("iteration {i} missing context_management payload"));
+        assert_eq!(payload["edits"][0]["type"], "clear_tool_uses_20250919");
+        assert_eq!(payload["edits"][0]["keep"]["value"], 4);
+    }
+
+    // The conversation still ends cleanly.
+    assert_eq!(result.content, "done");
+}
+
+#[tokio::test]
+async fn tier2_payload_is_omitted_for_non_anthropic_provider() {
+    let dir = tempfile::tempdir().unwrap();
+    let provider = Arc::new(RecordingProvider {
+        calls: AtomicUsize::new(0),
+        captured_messages: Mutex::new(Vec::new()),
+        captured_context_management: Mutex::new(Vec::new()),
+        provider_name: "openai",
+    });
+    let provider_for_agent: Arc<dyn LlmProvider> = provider.clone();
+
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let runner = build_tiered_runner(
+        MicroCompactionPolicy::default(),
+        ApiMicroCompactionConfig::enabled(),
+    );
+    let agent = Agent::new(
+        AgentId::new("m85-openai"),
+        provider_for_agent,
+        tools,
+        memory,
+    )
+    .with_tiered_compaction(runner);
+
+    // One-shot: provider returns EndTurn immediately so the loop makes a
+    // single LLM call; the captured config_management must be None.
+    // (We reuse RecordingProvider but skip the tool path by filtering on
+    // call index; easier: use a custom minimal provider.)
+    // The RecordingProvider above returns tool use on first call, so here we
+    // deliberately use a different scenario: just observe the first call.
+    // Registering no extra tool means `dump_big` is absent and execution
+    // would fail, so we override the behaviour inline by using a minimal
+    // provider built right here.
+    // Simplification: let the loop run one LLM call and verify
+    // captured_context_management[0] is None.
+
+    struct EndTurnImmediately(AtomicUsize, Mutex<Vec<Option<serde_json::Value>>>);
+
+    #[async_trait]
+    impl LlmProvider for EndTurnImmediately {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            config: &ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            self.1
+                .lock()
+                .unwrap()
+                .push(config.context_management.clone());
+            Ok(ChatResponse {
+                content: Some("done".into()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: Default::default(),
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "mock-openai"
+        }
+        fn provider_name(&self) -> &str {
+            "openai"
+        }
+    }
+
+    let _ = agent; // discard the RecordingProvider path above; this test
+    // builds its own agent so the provider_name inside the agent matches
+    // the provider's own `provider_name()`.
+    let openai_provider = Arc::new(EndTurnImmediately(
+        AtomicUsize::new(0),
+        Mutex::new(Vec::new()),
+    ));
+    let openai_provider_dyn: Arc<dyn LlmProvider> = openai_provider.clone();
+
+    let dir2 = tempfile::tempdir().unwrap();
+    let tools2 = ToolRegistry::with_builtins(dir2.path());
+    let memory2 = Arc::new(
+        EpisodeStore::open(dir2.path().join("memory"))
+            .await
+            .unwrap(),
+    );
+    let runner2 = build_tiered_runner(
+        MicroCompactionPolicy::default(),
+        ApiMicroCompactionConfig::enabled(),
+    );
+    let agent_openai = Agent::new(
+        AgentId::new("m85-openai2"),
+        openai_provider_dyn,
+        tools2,
+        memory2,
+    )
+    .with_tiered_compaction(runner2);
+
+    let _ = agent_openai
+        .process_message("hi", &[], vec![])
+        .await
+        .expect("loop ends cleanly");
+
+    let captured = openai_provider.1.lock().unwrap().clone();
+    assert_eq!(captured.len(), 1);
+    assert!(
+        captured[0].is_none(),
+        "non-Anthropic provider must not receive the tier-2 header: {:?}",
+        captured[0]
+    );
+}

--- a/crates/octos-cli/src/persona_service.rs
+++ b/crates/octos-cli/src/persona_service.rs
@@ -219,6 +219,7 @@ impl PersonaService {
             stop_sequences: vec![],
             reasoning_effort: None,
             response_format: None,
+            context_management: None,
         };
 
         match self.llm.chat(&messages, &[], &config).await {
@@ -376,6 +377,7 @@ impl PersonaService {
             stop_sequences: vec![],
             reasoning_effort: None,
             response_format: None,
+            context_management: None,
         };
 
         match self.llm.chat(&messages, &[], &config).await {

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -75,7 +75,7 @@ impl AnthropicProvider {
         &'a self,
         messages: &'a [Message],
         tools: &'a [ToolSpec],
-        config: &ChatConfig,
+        config: &'a ChatConfig,
     ) -> AnthropicRequest<'a> {
         AnthropicRequest {
             model: &self.model,
@@ -109,6 +109,7 @@ impl AnthropicProvider {
                 }
             },
             tools: if tools.is_empty() { None } else { Some(tools) },
+            context_management: config.context_management.as_ref(),
         }
     }
 }
@@ -265,6 +266,13 @@ struct AnthropicRequest<'a> {
     system: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<&'a [ToolSpec]>,
+    /// M8.5 tier 2: forwarded from `ChatConfig.context_management`. Opaque
+    /// payload (typically `{ "edits": [ { "type":
+    /// "clear_tool_uses_20250919", ... } ] }`) that tells Anthropic's server
+    /// to clear old tool uses on its side. Only emitted when the field is
+    /// non-null and the caller opted in via the builder.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context_management: Option<&'a serde_json::Value>,
 }
 
 #[derive(Serialize)]
@@ -592,6 +600,40 @@ mod tests {
         let config = ChatConfig::default();
         let request = provider.build_request(&messages, &[], &config);
         assert_eq!(request.max_tokens, crate::context::default_max_tokens());
+    }
+
+    #[test]
+    fn should_forward_context_management_payload_when_set() {
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let messages = vec![msg(MessageRole::User, "hi")];
+        let payload = serde_json::json!({
+            "edits": [
+                {
+                    "type": "clear_tool_uses_20250919",
+                    "keep": { "type": "input_tokens", "value": 10 }
+                }
+            ]
+        });
+        let config = ChatConfig {
+            context_management: Some(payload.clone()),
+            ..Default::default()
+        };
+        let request = provider.build_request(&messages, &[], &config);
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(body["context_management"], payload);
+    }
+
+    #[test]
+    fn should_omit_context_management_when_not_set() {
+        let provider = AnthropicProvider::new("test-key", "claude-test");
+        let messages = vec![msg(MessageRole::User, "hi")];
+        let config = ChatConfig::default();
+        let request = provider.build_request(&messages, &[], &config);
+        let body = serde_json::to_value(&request).unwrap();
+        assert!(
+            body.get("context_management").is_none(),
+            "field must be omitted when not configured: {body}"
+        );
     }
 
     // --- SSE mapping tests ---

--- a/crates/octos-llm/src/config.rs
+++ b/crates/octos-llm/src/config.rs
@@ -26,6 +26,13 @@ pub struct ChatConfig {
     /// conforming to the given schema (JSON mode or JSON Schema).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
+    /// Anthropic-only: opaque `context_management` payload (e.g. the
+    /// `clear_tool_uses_20250919` config) that decorates the request so the
+    /// server performs tier-2 tool-use clearing on its side. M8.5 wires this
+    /// from the `ApiMicroCompactionConfig` builder. Providers other than
+    /// Anthropic ignore this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_management: Option<serde_json::Value>,
 }
 
 /// Structured output format for chat responses.
@@ -70,6 +77,7 @@ impl Default for ChatConfig {
             stop_sequences: Vec::new(),
             reasoning_effort: None,
             response_format: None,
+            context_management: None,
         }
     }
 }
@@ -120,6 +128,7 @@ mod tests {
             stop_sequences: vec!["STOP".to_string()],
             reasoning_effort: None,
             response_format: None,
+            context_management: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         let deserialized: ChatConfig = serde_json::from_str(&json).unwrap();
@@ -138,11 +147,29 @@ mod tests {
             stop_sequences: vec![],
             reasoning_effort: None,
             response_format: None,
+            context_management: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert!(json.get("max_tokens").is_none());
         assert!(json.get("temperature").is_none());
         assert!(json.get("stop_sequences").is_none());
+        assert!(json.get("context_management").is_none());
+    }
+
+    #[test]
+    fn should_serialize_context_management_when_present() {
+        let config = ChatConfig {
+            context_management: Some(serde_json::json!({
+                "edits": [
+                    { "type": "clear_tool_uses_20250919", "keep": { "type": "input_tokens", "value": 10 } }
+                ]
+            })),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        let cm = json.get("context_management").expect("field present");
+        assert!(cm.is_object());
+        assert!(cm.get("edits").is_some());
     }
 
     #[test]


### PR DESCRIPTION
Refs #540.

## Why three tiers

Today octos runs a single compaction pass: full summarisation + contract-
gated artifact preservation + `ToolResultPlaceholder` swap, all gated
behind a token-budget threshold. Claude Code verification showed its
three-tier stack saves 20-40% of turns from ever hitting the expensive
tier-3 summariser by running two cheaper passes first.

This PR adds the first two tiers as independent policies and wraps the
existing `compaction::CompactionRunner` behind a `FullCompactor` trait so
the caller sees one `TieredCompactionRunner` surface.

## Tier split

**Tier 1 — `MicroCompactionPolicy`** (new)
- Per-iteration in-place prune of stale/oversized tool results.
- Thresholds: `max_age_turns` (default 5), `max_size_bytes_per_result`
  (default 8 KiB).
- Content replaced with the existing `ToolResultPlaceholder`, so the
  `tool_call_id` stays intact and provider pairing invariants hold.
- Accepts a `protected_tool_call_ids` list so unresolved retry-bucket
  entries / contract-gated artifacts are skipped.

**Tier 2 — `ApiMicroCompactionConfig`** (new)
- Request-time builder, **not** a runtime loop.
- Emits Anthropic's `{ edits: [{ type: "clear_tool_uses_20250919", keep:
  { type: "tool_uses", value: N } }] }` payload.
- Off by default. When enabled, plumbed through a new optional
  `ChatConfig.context_management` field (serde-skipped when `None`) that
  the Anthropic provider forwards verbatim in `AnthropicRequest`.
- Non-Anthropic providers (OpenAI, Gemini, OpenRouter, etc.) ignore
  silently via `#[serde(skip_serializing_if = "Option::is_none")]`; the
  runner also short-circuits provider-name-gated in `payload_for_provider`.

**Tier 3 — `FullCompactor` trait**
- Wraps the existing `compaction::CompactionRunner`. Tier 3 behaviour,
  the summariser trait, the preservation ledger, and phase events are
  all unchanged. The trait exists so the tiered runner has one
  `needs_compaction` + `compact` surface.

## Wiring sites

- `agent/loop_runner.rs::process_message_inner` — tier 1 runs at the top
  of every iteration (before `prepare_conversation_messages`); tier 2
  decorates `ChatConfig` via `with_tier2_context_management` immediately
  before `call_llm_with_hooks`.
- `agent/loop_runner.rs::run_task` — same pair of hooks for background
  workers.
- Tier 3 trigger path untouched — today's preflight + turn-end passes
  still fire through the existing `CompactionRunner`.

## Retry-bucket safety check

Tier 1 only ever swaps a `Message.content` field — it never drops a
`Message` or changes an index, so `LoopRetryState` (which tracks errors
by variant/counter, not by message index) stays consistent. On top of
that, `collect_protected_tool_call_ids` builds the set of
currently-outstanding tool_call IDs (assistant calls without a matching
tool reply) and hands it to `prune` so any `tool_call_id` in flight is
left untouched even if the size/age threshold would otherwise prune it.

## Tests

Required (all in `crates/octos-agent/src/compaction_tiered.rs`):
- `should_prune_tool_results_older_than_max_age`
- `should_clear_oversized_tool_results_to_placeholder`
- `should_preserve_tool_call_id_on_pruned_results`
- `should_skip_tool_results_referenced_by_retry_bucket`
- `should_report_bytes_reclaimed_and_count_pruned`
- `should_build_tier2_payload_only_when_enabled`
- `should_skip_tier2_payload_for_non_anthropic_providers`

Plus four bonus unit tests (no-op threshold, runner API, tier 3 skip,
idempotency) and two integration tests in
`crates/octos-agent/tests/tiered_compaction_loop.rs` that drive a real
`Agent::process_message` loop through a mock provider and verify:
1. A 50 KB tool result is shrunk to the placeholder before the next
   iteration's LLM call (tier 1 end-to-end).
2. The tier-2 payload is omitted for an OpenAI provider.

A new Anthropic unit test
(`should_forward_context_management_payload_when_set`) proves the
`context_management` JSON round-trips through `AnthropicRequest`
serialisation, and a paired test proves the field is omitted by default.

## Gates

- `cargo fmt -p octos-agent -p octos-llm -- --check` — clean (pre-existing
  formatting drift in `octos-cli/src/api/admin_setup.rs` and
  `auth_handlers.rs` is not introduced by this PR).
- `cargo clippy -p octos-agent --no-deps --all-targets -- -D warnings` — clean.
- `cargo clippy -p octos-llm --no-deps --all-targets -- -D warnings` — clean.
- `cargo test -p octos-agent --lib` — 991 pass / 0 fail (11 new).
- `cargo test -p octos-llm --lib` — 267 pass / 0 fail (3 new).
- `cargo test --workspace --no-fail-fast` — all green.

## Test plan

- [ ] Canary runner with `octos chat` + `ApiMicroCompactionConfig::enabled()`
      once Anthropic accepts the header in prod; confirm 400s don't appear.
- [ ] Watch `octos_tier1_compaction_pruned_total{scope="tool_results"}`
      to confirm tier 1 is firing on long-turn workflows.
- [ ] Confirm retry buckets for unresolved tool calls still retry cleanly
      after the next deploy.