### PR TITLE
fix(voice skill): probe ports for ominix-api and validate Say output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,6 +3601,7 @@ dependencies = [
  "lettre",
  "libc",
  "metrics",
+ "octos-bus",
  "octos-core",
  "octos-llm",
  "octos-memory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6192,7 +6192,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "voice"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "base64",
  "reqwest 0.12.28",

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -8,6 +8,7 @@ description = "Agent runtime, tool execution, and coordination for octos"
 
 [dependencies]
 octos-core = { workspace = true }
+octos-bus = { workspace = true }
 octos-memory = { workspace = true }
 octos-llm = { workspace = true }
 # codex-execpolicy = { workspace = true }  # Enable when codex builds

--- a/crates/octos-agent/src/behaviour.rs
+++ b/crates/octos-agent/src/behaviour.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use eyre::{Result, eyre};
 use glob::glob;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Result of running a single behaviour action.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -229,7 +229,7 @@ fn action_file_exists(
             reason: format!("missing file for pattern: {pattern}"),
         })
     } else {
-        info!(pattern, count = matches.len(), "file_exists check passed");
+        debug!(pattern, count = matches.len(), "file_exists check passed");
         Ok(ActionResult::Pass)
     }
 }

--- a/crates/octos-agent/src/harness_events.rs
+++ b/crates/octos-agent/src/harness_events.rs
@@ -269,6 +269,14 @@ pub enum HarnessEventPayload {
         #[serde(flatten)]
         data: HarnessCredentialRotationEvent,
     },
+    /// Emitted once per session load after [`octos_bus::ResumePolicy`] runs
+    /// (M8.6). Carries a typed report so operators can see what the
+    /// sanitizer dropped and whether the worktree (if any) was still
+    /// present on disk.
+    SessionSanitized {
+        #[serde(flatten)]
+        data: HarnessSessionSanitizedEvent,
+    },
     Error {
         #[serde(flatten)]
         data: HarnessErrorEvent,
@@ -527,6 +535,48 @@ pub struct HarnessRoutingDecisionEvent {
     pub extra: HashMap<String, Value>,
 }
 
+/// Typed payload emitted when [`octos_bus::ResumePolicy`] sanitizes a
+/// session transcript on load (M8.6).
+///
+/// The report fields mirror [`octos_bus::SessionSanitizeReport`] one-for-
+/// one so operators can build dashboards without joining against a raw
+/// log. `worktree_missing` is a hard signal that the sub-agent's git
+/// worktree was cleaned up externally (Claude Code issue #22355) — the
+/// caller should refuse to resume and start a fresh session instead.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessSessionSanitizedEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    /// Messages loaded from JSONL before any filter ran.
+    pub input_len: usize,
+    /// Messages remaining after all 4 filter passes.
+    pub output_len: usize,
+    /// Tool-call assistant messages whose ids lacked matching results and
+    /// were not pinned by retry state.
+    #[serde(default)]
+    pub unresolved_tool_uses_dropped: usize,
+    /// Assistant messages with reasoning but no content or tool calls
+    /// (non-tail only).
+    #[serde(default)]
+    pub orphan_thinking_dropped: usize,
+    /// Assistant messages with whitespace-only content.
+    #[serde(default)]
+    pub whitespace_only_dropped: usize,
+    /// Count of [`octos_bus::ReplacementStateRef`] entries recovered.
+    #[serde(default)]
+    pub content_replacements_restored: usize,
+    /// `true` when `workspace_root` was provided and missing on disk.
+    #[serde(default)]
+    pub worktree_missing: bool,
+    /// Non-fatal diagnostics from the policy. Order-preserving.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
 /// Structured credential rotation event (M6.5).
 ///
 /// Emitted by the credential pool on every successful selection. Consumers
@@ -674,6 +724,37 @@ impl HarnessEvent {
                     lane: None,
                     reasons,
                     input_chars,
+                    extra: HashMap::new(),
+                },
+            },
+        }
+    }
+
+    /// Construct a `SessionSanitized` event from a
+    /// [`octos_bus::SessionSanitizeReport`] (M8.6). The caller supplies
+    /// session_id/task_id/workflow from its runtime context; the rest of
+    /// the fields come straight from the report.
+    pub fn session_sanitized(
+        session_id: impl Into<String>,
+        task_id: impl Into<String>,
+        workflow: Option<impl Into<String>>,
+        report: &octos_bus::SessionSanitizeReport,
+    ) -> Self {
+        Self {
+            schema: HARNESS_EVENT_SCHEMA_V1.to_string(),
+            payload: HarnessEventPayload::SessionSanitized {
+                data: HarnessSessionSanitizedEvent {
+                    session_id: session_id.into(),
+                    task_id: task_id.into(),
+                    workflow: workflow.map(Into::into),
+                    input_len: report.input_len,
+                    output_len: report.output_len,
+                    unresolved_tool_uses_dropped: report.unresolved_tool_uses_dropped,
+                    orphan_thinking_dropped: report.orphan_thinking_dropped,
+                    whitespace_only_dropped: report.whitespace_only_dropped,
+                    content_replacements_restored: report.content_replacements_restored,
+                    worktree_missing: report.worktree_missing,
+                    warnings: report.warnings.clone(),
                     extra: HashMap::new(),
                 },
             },
@@ -861,6 +942,13 @@ impl HarnessEvent {
                 )?;
                 validate_bounded("reason", &data.reason, MAX_PHASE_BYTES)?;
                 validate_bounded("strategy", &data.strategy, MAX_PHASE_BYTES)?;
+            }
+            HarnessEventPayload::SessionSanitized { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                for warning in &data.warnings {
+                    validate_bounded("warning", warning, MAX_MESSAGE_BYTES)?;
+                }
             }
             HarnessEventPayload::Error { data } => {
                 if data.schema_version > HARNESS_ERROR_SCHEMA_VERSION {
@@ -1096,6 +1184,26 @@ impl HarnessEvent {
                     "strategy": data.strategy,
                 })
             }
+            HarnessEventPayload::SessionSanitized { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "session_sanitized",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "current_phase": fallback_current_phase,
+                    "input_len": data.input_len,
+                    "output_len": data.output_len,
+                    "unresolved_tool_uses_dropped": data.unresolved_tool_uses_dropped,
+                    "orphan_thinking_dropped": data.orphan_thinking_dropped,
+                    "whitespace_only_dropped": data.whitespace_only_dropped,
+                    "content_replacements_restored": data.content_replacements_restored,
+                    "worktree_missing": data.worktree_missing,
+                    "warnings": data.warnings,
+                })
+            }
             HarnessEventPayload::Error { data } => {
                 let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
                 let current_phase = data.phase.as_deref().or(fallback_current_phase);
@@ -1132,6 +1240,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => &data.session_id,
             HarnessEventPayload::RoutingDecision { data } => &data.session_id,
             HarnessEventPayload::CredentialRotation { data } => &data.session_id,
+            HarnessEventPayload::SessionSanitized { data } => &data.session_id,
             HarnessEventPayload::Error { data } => &data.session_id,
         }
     }
@@ -1150,6 +1259,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => &data.task_id,
             HarnessEventPayload::RoutingDecision { data } => &data.task_id,
             HarnessEventPayload::CredentialRotation { data } => &data.task_id,
+            HarnessEventPayload::SessionSanitized { data } => &data.task_id,
             HarnessEventPayload::Error { data } => &data.task_id,
         }
     }
@@ -1168,6 +1278,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => data.workflow.as_deref(),
             HarnessEventPayload::RoutingDecision { data } => data.workflow.as_deref(),
             HarnessEventPayload::CredentialRotation { .. } => None,
+            HarnessEventPayload::SessionSanitized { data } => data.workflow.as_deref(),
             HarnessEventPayload::Error { data } => data.workflow.as_deref(),
         }
     }
@@ -1186,6 +1297,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => data.phase.as_deref(),
             HarnessEventPayload::RoutingDecision { data } => data.phase.as_deref(),
             HarnessEventPayload::CredentialRotation { .. } => None,
+            HarnessEventPayload::SessionSanitized { .. } => None,
             HarnessEventPayload::Error { data } => data.phase.as_deref(),
         }
     }
@@ -1707,5 +1819,126 @@ mod tests {
             .get_task(&other_task_id)
             .expect("other task missing");
         assert!(other.runtime_detail.is_none());
+    }
+
+    /// M8.6: `SessionSanitized` round-trips through JSON and reports the
+    /// report fields in `runtime_detail_value`.
+    #[test]
+    fn session_sanitized_event_round_trips() {
+        let report = octos_bus::SessionSanitizeReport {
+            input_len: 12,
+            output_len: 9,
+            unresolved_tool_uses_dropped: 2,
+            orphan_thinking_dropped: 1,
+            whitespace_only_dropped: 0,
+            content_replacements_restored: 3,
+            worktree_missing: false,
+            warnings: vec!["mtime bump degraded".into()],
+        };
+        let event =
+            HarnessEvent::session_sanitized("api:session", "task-resume", Some("coding"), &report);
+
+        assert!(event.validate().is_ok());
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            json.contains(r#""kind":"session_sanitized""#),
+            "event should serialize the session_sanitized kind; got: {json}"
+        );
+
+        let parsed = HarnessEvent::from_json_line(&json).unwrap();
+        match &parsed.payload {
+            HarnessEventPayload::SessionSanitized { data } => {
+                assert_eq!(data.input_len, 12);
+                assert_eq!(data.output_len, 9);
+                assert_eq!(data.unresolved_tool_uses_dropped, 2);
+                assert_eq!(data.orphan_thinking_dropped, 1);
+                assert_eq!(data.whitespace_only_dropped, 0);
+                assert_eq!(data.content_replacements_restored, 3);
+                assert!(!data.worktree_missing);
+                assert_eq!(data.warnings, vec!["mtime bump degraded".to_string()]);
+            }
+            other => panic!("expected SessionSanitized variant, got {other:?}"),
+        }
+
+        let detail = parsed.runtime_detail_value(None, None);
+        assert_eq!(detail["kind"], "session_sanitized");
+        assert_eq!(detail["input_len"], 12);
+        assert_eq!(detail["output_len"], 9);
+        assert_eq!(detail["content_replacements_restored"], 3);
+    }
+
+    /// M8.6: a worktree-missing event must flag the condition so operators
+    /// can see it on the task dashboard.
+    #[test]
+    fn session_sanitized_event_flags_worktree_missing() {
+        let report = octos_bus::SessionSanitizeReport {
+            input_len: 4,
+            output_len: 4,
+            worktree_missing: true,
+            ..Default::default()
+        };
+        let event = HarnessEvent::session_sanitized(
+            "api:session",
+            "task-resume",
+            Option::<String>::None,
+            &report,
+        );
+
+        assert!(event.validate().is_ok());
+        let detail = event.runtime_detail_value(None, None);
+        assert_eq!(detail["worktree_missing"], true);
+        assert_eq!(detail["kind"], "session_sanitized");
+    }
+
+    /// M8.6: verify the sink pipeline delivers a session-sanitized event
+    /// to the task supervisor exactly as it does for progress/phase
+    /// events. This is the "emit via sink" happy path the caller-side
+    /// wiring relies on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn should_emit_session_sanitized_event_when_sink_configured() {
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let task_id = supervisor.register("resume", "call-1", Some("api:session"));
+        supervisor.mark_running(&task_id);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        supervisor.set_on_change(move |task| {
+            let _ = tx.send(task.clone());
+        });
+
+        let sink = HarnessEventSink::new(supervisor.clone(), task_id.clone(), "api:session")
+            .expect("create sink");
+
+        let report = octos_bus::SessionSanitizeReport {
+            input_len: 3,
+            output_len: 2,
+            unresolved_tool_uses_dropped: 1,
+            ..Default::default()
+        };
+        let event = HarnessEvent::session_sanitized(
+            "api:session",
+            task_id.clone(),
+            Some("coding"),
+            &report,
+        );
+
+        write_event_to_sink(sink.path().display().to_string(), &event).unwrap();
+
+        let updated = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let task = rx.recv().await.expect("task update");
+                if task.id == task_id && task.runtime_detail.is_some() {
+                    break task;
+                }
+            }
+        })
+        .await
+        .expect("sink should deliver the session_sanitized event");
+
+        let detail: Value =
+            serde_json::from_str(updated.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(detail["kind"], "session_sanitized");
+        assert_eq!(detail["input_len"], 3);
+        assert_eq!(detail["output_len"], 2);
+        assert_eq!(detail["unresolved_tool_uses_dropped"], 1);
     }
 }

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -79,9 +79,9 @@ pub use harness_events::{
     HARNESS_EVENT_SCHEMA_V1, HarnessArtifactEvent, HarnessCostAttributionEvent,
     HarnessCredentialRotationEvent, HarnessCredentialRotationSink, HarnessEvent, HarnessEventError,
     HarnessEventPayload, HarnessEventSink, HarnessFailureEvent, HarnessMcpServerCallEvent,
-    HarnessPhaseEvent, HarnessProgressEvent, HarnessRetryEvent, HarnessSubAgentDispatchEvent,
-    HarnessSwarmDispatchEvent, HarnessValidatorResultEvent, MAX_HARNESS_EVENT_LINE_BYTES,
-    emit_registered_credential_rotation_event,
+    HarnessPhaseEvent, HarnessProgressEvent, HarnessRetryEvent, HarnessSessionSanitizedEvent,
+    HarnessSubAgentDispatchEvent, HarnessSwarmDispatchEvent, HarnessValidatorResultEvent,
+    MAX_HARNESS_EVENT_LINE_BYTES, emit_registered_credential_rotation_event,
 };
 pub use hooks::{
     HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -651,6 +651,18 @@ impl TaskSupervisor {
                     Some(runtime_detail.to_string()),
                 );
             }
+            HarnessEventPayload::SessionSanitized { .. } => {
+                // Session-sanitize events are observability-only (M8.6).
+                // They fire once per resume and describe what the resume
+                // policy dropped — the task lifecycle is not affected; the
+                // session actor will subsequently drive normal
+                // Queued → Executing transitions as usual.
+                self.mark_runtime_state(
+                    task_id,
+                    snapshot.runtime_state,
+                    Some(runtime_detail.to_string()),
+                );
+            }
             HarnessEventPayload::Error { data } => {
                 // Structured error events are diagnostic — record them in the
                 // runtime detail but only transition to Failed when the

--- a/crates/octos-bus/src/lib.rs
+++ b/crates/octos-bus/src/lib.rs
@@ -11,6 +11,7 @@ pub mod file_handle;
 pub mod heartbeat;
 pub mod markdown_html;
 pub mod media;
+pub mod resume_policy;
 pub mod session;
 
 #[cfg(feature = "api")]
@@ -49,6 +50,12 @@ pub use cron_service::CronService;
 pub use cron_types::{CronJob, CronPayload, CronSchedule, CronStore};
 pub use dedup::MessageDedup;
 pub use heartbeat::HeartbeatService;
+pub use resume_policy::{
+    RESUME_MTIME_MARKER, ReplacementStateRef, ResumePolicy, RetryStateView, SanitizeError,
+    SanitizeOutcome, SessionSanitizeReport, filter_orphaned_thinking_only_messages,
+    filter_unresolved_tool_uses, filter_whitespace_only_assistant_messages,
+    reconstruct_content_replacement_state,
+};
 pub use session::{
     ActiveSessionStore, Session, SessionHandle, SessionListEntry, SessionManager,
     validate_topic_name,

--- a/crates/octos-bus/src/resume_policy.rs
+++ b/crates/octos-bus/src/resume_policy.rs
@@ -1,0 +1,1029 @@
+//! Structured resume pipeline (M8.6).
+//!
+//! When octos reloads a session from JSONL at startup or after a crash, the
+//! transcript may contain state that the provider will reject (unresolved
+//! tool uses → 400), orphaned thinking-only assistant messages, whitespace-
+//! only assistant messages, or stale worktree references. [`ResumePolicy`]
+//! sanitizes the loaded [`Message`] list before the session actor picks it
+//! up, emitting a typed [`SessionSanitizeReport`] for observability.
+//!
+//! The policy is a pure data-layer transform: it operates on `Vec<Message>`
+//! that has already been loaded from disk. The JSONL format is not touched —
+//! every filter is pass-through for legacy messages; filters only prune.
+//!
+//! # Filter passes
+//!
+//! 1. [`filter_unresolved_tool_uses`] — walks the list, collects all
+//!    `tool_call_id` values on assistant `tool_calls`, then drops
+//!    tool-result messages whose id is not in that set and drops assistant
+//!    tool-call messages whose ids have no matching tool result (unless the
+//!    call is referenced by pending retry state).
+//! 2. [`filter_orphaned_thinking_only_messages`] — drops assistant messages
+//!    that have `reasoning_content` but empty `content` and no tool calls,
+//!    unless the message is the tail of the transcript (allow in-flight
+//!    reasoning).
+//! 3. [`filter_whitespace_only_assistant_messages`] — drops assistant
+//!    messages whose `content.trim().is_empty()` and no tool calls and no
+//!    reasoning content.
+//! 4. [`reconstruct_content_replacement_state`] — collects file paths
+//!    referenced by tool results into [`ReplacementStateRef`] entries for
+//!    M8.4 `FileStateCache` integration (stub).
+//!
+//! # Worktree check
+//!
+//! When `workspace_root` is provided, the policy stats the path. If it no
+//! longer exists, the report's `worktree_missing` flag is set and an
+//! `Err` is returned so the caller can decide to refuse resume or create a
+//! new session. When present, a marker file is touched inside the worktree
+//! to bump the containing directory's mtime — this prevents stale-cleanup
+//! races where a concurrent GC sweep removes the worktree while the session
+//! is mid-load (Claude Code issue #22355).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use octos_core::{Message, MessageRole};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// Name of the marker file written inside a sub-agent worktree on resume to
+/// bump the directory's mtime. The contents are a human-readable RFC3339
+/// timestamp so operators can see when the session last resumed.
+pub const RESUME_MTIME_MARKER: &str = ".octos_resume_mtime";
+
+/// Reference to a file path recovered from a tool result during resume.
+///
+/// Populated by [`reconstruct_content_replacement_state`]; consumed by
+/// M8.4 `FileStateCache` to seed the cache with the paths that the
+/// transcript claims were last read/written. The hash field is always
+/// `None` in this workstream — it becomes `Some(hash)` once M8.4 lands
+/// and the file-state cache actually restores entries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplacementStateRef {
+    /// Absolute or workspace-relative path the tool result referenced.
+    pub path: PathBuf,
+    /// Content hash when available; None indicates placeholder state
+    /// pending M8.4 cache restore.
+    pub content_hash: Option<String>,
+}
+
+/// Typed report describing what [`ResumePolicy::sanitize`] dropped.
+///
+/// Emitted on every resume even if every counter is zero — operators rely
+/// on a baseline "transcript clean" signal as much as the interesting drops.
+/// `Display` impl is terse; structured fields should be preferred for
+/// dashboards.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionSanitizeReport {
+    /// Number of messages before any filter ran.
+    pub input_len: usize,
+    /// Number of messages after all filters.
+    pub output_len: usize,
+    /// Tool-call assistant messages whose tool_call_ids all had no matching
+    /// result and were not pinned by retry state.
+    pub unresolved_tool_uses_dropped: usize,
+    /// Thinking-only assistant messages that were neither the tail nor
+    /// followed by a concrete reply.
+    pub orphan_thinking_dropped: usize,
+    /// Whitespace-only assistant messages with no tool calls or reasoning.
+    pub whitespace_only_dropped: usize,
+    /// Count of [`ReplacementStateRef`] entries recovered. Not yet wired
+    /// into a real cache; see `content_replacements` for the raw refs and
+    /// the `TODO(M8.4)` note in [`ResumePolicy::sanitize`].
+    pub content_replacements_restored: usize,
+    /// `true` when `workspace_root` was provided and the directory no
+    /// longer exists on disk.
+    pub worktree_missing: bool,
+    /// Non-fatal diagnostics the caller may log. Order-preserving.
+    pub warnings: Vec<String>,
+}
+
+impl std::fmt::Display for SessionSanitizeReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SessionSanitizeReport {{ input_len={}, output_len={}, dropped: {{ unresolved_tool={}, orphan_thinking={}, whitespace_only={} }}, content_replacements_restored={}, worktree_missing={}, warnings={} }}",
+            self.input_len,
+            self.output_len,
+            self.unresolved_tool_uses_dropped,
+            self.orphan_thinking_dropped,
+            self.whitespace_only_dropped,
+            self.content_replacements_restored,
+            self.worktree_missing,
+            self.warnings.len(),
+        )
+    }
+}
+
+/// Outcome of [`ResumePolicy::sanitize`]. The caller must pattern-match on
+/// `Ok(SanitizeOutcome)` vs `Err(SanitizeError)` — an error signals the
+/// caller should refuse resume (e.g. worktree gone) while a clean outcome
+/// is always safe to hand off to the session actor.
+#[derive(Debug, Clone)]
+pub struct SanitizeOutcome {
+    /// Sanitized messages, order-preserving.
+    pub messages: Vec<Message>,
+    /// Structured report for observability / harness event emission.
+    pub report: SessionSanitizeReport,
+    /// Content-replacement refs recovered from tool results. Empty when
+    /// `messages` contains no tool results with file paths.
+    pub content_replacements: Vec<ReplacementStateRef>,
+}
+
+/// Reasons [`ResumePolicy::sanitize`] refuses to return a clean outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SanitizeError {
+    /// The configured `workspace_root` no longer exists on disk.
+    WorktreeMissing {
+        path: PathBuf,
+        report: SessionSanitizeReport,
+    },
+}
+
+impl std::fmt::Display for SanitizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WorktreeMissing { path, .. } => {
+                write!(f, "worktree gone: {}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for SanitizeError {}
+
+/// Abstract view of in-flight retry state — a set of tool_call_ids that
+/// must not be dropped even if they lack a matching tool result. Concrete
+/// retry-state types in `octos-agent` (e.g. a future `LoopRetryState` with
+/// pending id tracking) implement this to bridge into the policy without
+/// introducing a reverse crate dependency.
+pub trait RetryStateView {
+    /// Returns `true` when the given tool_call_id is pinned by an in-flight
+    /// retry (e.g. the harness is about to replay the call after a provider
+    /// hiccup). The policy keeps these calls in the transcript even when
+    /// their result is missing.
+    fn contains_tool_call(&self, tool_call_id: &str) -> bool;
+}
+
+impl<T: RetryStateView + ?Sized> RetryStateView for &T {
+    fn contains_tool_call(&self, tool_call_id: &str) -> bool {
+        (*self).contains_tool_call(tool_call_id)
+    }
+}
+
+impl RetryStateView for HashSet<String> {
+    fn contains_tool_call(&self, tool_call_id: &str) -> bool {
+        self.contains(tool_call_id)
+    }
+}
+
+/// Top-level resume sanitizer. Stateless entry point; see module docs for
+/// the full pass ordering and semantics.
+pub struct ResumePolicy;
+
+impl ResumePolicy {
+    /// Sanitize a just-loaded transcript and report what changed.
+    ///
+    /// `retry_state` pins in-flight tool_call_ids so we don't drop a call
+    /// the harness is about to replay. `workspace_root` when provided is
+    /// stat'd and mtime-bumped — a missing path short-circuits to
+    /// [`SanitizeError::WorktreeMissing`] after the transcript has been
+    /// sanitized (the report is still populated so callers can log it).
+    pub fn sanitize(
+        messages: Vec<Message>,
+        retry_state: Option<&dyn RetryStateView>,
+        workspace_root: Option<&Path>,
+    ) -> Result<SanitizeOutcome, SanitizeError> {
+        let mut report = SessionSanitizeReport {
+            input_len: messages.len(),
+            ..Default::default()
+        };
+
+        // Pass 1: drop unresolved tool_use/tool_result pairs.
+        let (messages, dropped_tool_use) = filter_unresolved_tool_uses(messages, retry_state);
+        report.unresolved_tool_uses_dropped = dropped_tool_use;
+
+        // Pass 2: drop orphan thinking-only assistant messages.
+        let (messages, dropped_thinking) = filter_orphaned_thinking_only_messages(messages);
+        report.orphan_thinking_dropped = dropped_thinking;
+
+        // Pass 3: drop whitespace-only assistant messages.
+        let (messages, dropped_ws) = filter_whitespace_only_assistant_messages(messages);
+        report.whitespace_only_dropped = dropped_ws;
+
+        // Pass 4: collect content-replacement refs from tool results.
+        //
+        // TODO(M8.4): after FileStateCache lands, populate its entries from
+        // these refs when the cache is non-empty post-load. The integration
+        // point is the caller of `ResumePolicy::sanitize` — it should feed
+        // `outcome.content_replacements` into the file-state cache before
+        // handing the messages to the session actor.
+        let content_replacements = reconstruct_content_replacement_state(&messages);
+        report.content_replacements_restored = content_replacements.len();
+
+        report.output_len = messages.len();
+
+        // Worktree existence check + mtime bump.
+        if let Some(root) = workspace_root {
+            match check_and_bump_worktree(root) {
+                WorktreeStatus::Present => {}
+                WorktreeStatus::Missing => {
+                    report.worktree_missing = true;
+                    return Err(SanitizeError::WorktreeMissing {
+                        path: root.to_path_buf(),
+                        report,
+                    });
+                }
+                WorktreeStatus::BumpFailed { error } => {
+                    report
+                        .warnings
+                        .push(format!("mtime bump failed for {}: {error}", root.display()));
+                }
+            }
+        }
+
+        Ok(SanitizeOutcome {
+            messages,
+            report,
+            content_replacements,
+        })
+    }
+}
+
+/// Pass 1: drop unresolved tool_use / tool_result pairs.
+///
+/// Walks the list once to collect:
+///   - `result_ids`: every `tool_call_id` on a Tool-role message (i.e. every
+///     id for which a result already exists).
+///
+/// Then walks again and keeps:
+///   - Non-assistant / non-tool messages as-is.
+///   - Tool-role messages whose `tool_call_id` is in `result_ids` (trivially
+///     always true, but the guard catches malformed entries).
+///   - Assistant messages whose `tool_calls` (if any) all have matching
+///     results OR are pinned by `retry_state`. An assistant message with
+///     tool_calls all-missing AND unpinned is dropped — unless it also has
+///     non-empty text content, in which case we keep the text but strip the
+///     unresolved tool_calls so the provider accepts the request.
+///
+/// Preserves message order. Returns the filtered list plus the count of
+/// assistant tool-call messages affected (either fully dropped or had their
+/// tool_calls stripped).
+pub fn filter_unresolved_tool_uses(
+    messages: Vec<Message>,
+    retry_state: Option<&dyn RetryStateView>,
+) -> (Vec<Message>, usize) {
+    let mut result_ids: HashSet<String> = HashSet::new();
+    for msg in &messages {
+        if !matches!(msg.role, MessageRole::Tool) {
+            continue;
+        }
+        if let Some(id) = msg.tool_call_id.as_deref() {
+            result_ids.insert(id.to_string());
+        }
+    }
+
+    let mut dropped = 0_usize;
+    let mut kept = Vec::with_capacity(messages.len());
+
+    for msg in messages.into_iter() {
+        match msg.role {
+            MessageRole::Tool => {
+                if let Some(id) = msg.tool_call_id.as_deref() {
+                    // A tool_result whose tool_call_id has no matching
+                    // assistant tool_call would also be orphaned, but
+                    // we can only detect this if we also track call_ids
+                    // on assistant messages. Do that here.
+                    if result_has_matching_call(&kept, id) {
+                        kept.push(msg);
+                    } else {
+                        dropped += 1;
+                    }
+                } else {
+                    // Tool-role message with no id is malformed — drop.
+                    dropped += 1;
+                }
+            }
+            MessageRole::Assistant => {
+                let Some(calls) = msg.tool_calls.as_ref() else {
+                    kept.push(msg);
+                    continue;
+                };
+                if calls.is_empty() {
+                    kept.push(msg);
+                    continue;
+                }
+                let has_text = !msg.content.trim().is_empty();
+                let all_resolved = calls.iter().all(|call| {
+                    result_ids.contains(call.id.as_str())
+                        || retry_state
+                            .map(|state| state.contains_tool_call(&call.id))
+                            .unwrap_or(false)
+                });
+                if all_resolved {
+                    kept.push(msg);
+                } else if has_text {
+                    // Keep the text but strip the unresolved tool_calls
+                    // so the provider accepts the request.
+                    let mut stripped = msg;
+                    stripped.tool_calls = None;
+                    kept.push(stripped);
+                    dropped += 1;
+                } else {
+                    dropped += 1;
+                }
+            }
+            _ => kept.push(msg),
+        }
+    }
+
+    (kept, dropped)
+}
+
+/// Returns `true` when any already-kept assistant message has a tool_call
+/// with id == `id`. Used as the inverse check for orphaned tool results.
+fn result_has_matching_call(kept: &[Message], id: &str) -> bool {
+    kept.iter().any(|msg| {
+        matches!(msg.role, MessageRole::Assistant)
+            && msg
+                .tool_calls
+                .as_ref()
+                .map(|calls| calls.iter().any(|call| call.id == id))
+                .unwrap_or(false)
+    })
+}
+
+/// Pass 2: drop orphaned thinking-only assistant messages.
+///
+/// An assistant message is "thinking-only" when:
+///   - `reasoning_content` is `Some(non-empty)`.
+///   - `content.trim().is_empty()`.
+///   - `tool_calls` is None or empty.
+///
+/// Such messages are dropped EXCEPT when they are the last message in the
+/// transcript — that case represents an in-flight reasoning turn the harness
+/// will continue on resume.
+pub fn filter_orphaned_thinking_only_messages(messages: Vec<Message>) -> (Vec<Message>, usize) {
+    let total = messages.len();
+    let mut dropped = 0_usize;
+    let mut kept = Vec::with_capacity(total);
+
+    for (idx, msg) in messages.into_iter().enumerate() {
+        let is_tail = idx + 1 == total;
+        if !is_tail && is_thinking_only(&msg) {
+            dropped += 1;
+        } else {
+            kept.push(msg);
+        }
+    }
+
+    (kept, dropped)
+}
+
+fn is_thinking_only(msg: &Message) -> bool {
+    if !matches!(msg.role, MessageRole::Assistant) {
+        return false;
+    }
+    let reasoning = msg
+        .reasoning_content
+        .as_deref()
+        .map(|r| !r.trim().is_empty())
+        .unwrap_or(false);
+    if !reasoning {
+        return false;
+    }
+    let empty_content = msg.content.trim().is_empty();
+    let empty_calls = msg
+        .tool_calls
+        .as_ref()
+        .map(|calls| calls.is_empty())
+        .unwrap_or(true);
+    empty_content && empty_calls
+}
+
+/// Pass 3: drop assistant messages that carry no useful payload.
+///
+/// Criteria: role=Assistant AND `content.trim().is_empty()` AND no
+/// `tool_calls` AND no `reasoning_content`. The message contributes nothing
+/// to the transcript and some providers reject it outright.
+pub fn filter_whitespace_only_assistant_messages(messages: Vec<Message>) -> (Vec<Message>, usize) {
+    let mut dropped = 0_usize;
+    let mut kept = Vec::with_capacity(messages.len());
+
+    for msg in messages.into_iter() {
+        if is_whitespace_only_assistant(&msg) {
+            dropped += 1;
+        } else {
+            kept.push(msg);
+        }
+    }
+
+    (kept, dropped)
+}
+
+fn is_whitespace_only_assistant(msg: &Message) -> bool {
+    if !matches!(msg.role, MessageRole::Assistant) {
+        return false;
+    }
+    if !msg.content.trim().is_empty() {
+        return false;
+    }
+    let has_calls = msg
+        .tool_calls
+        .as_ref()
+        .map(|calls| !calls.is_empty())
+        .unwrap_or(false);
+    if has_calls {
+        return false;
+    }
+    let has_reasoning = msg
+        .reasoning_content
+        .as_deref()
+        .map(|r| !r.trim().is_empty())
+        .unwrap_or(false);
+    if has_reasoning {
+        return false;
+    }
+    true
+}
+
+/// Pass 4: collect content-replacement refs from tool results.
+///
+/// Scans every tool-role message for file paths. Heuristic: parse the tool
+/// result body as JSON and look for top-level `path` or `file` fields, OR
+/// fall back to a line-based scan for `path: <value>` / `file: <value>`.
+/// The output is a list of [`ReplacementStateRef`] with `content_hash:
+/// None` — M8.4 will populate hashes once the `FileStateCache` restore
+/// step is in place.
+pub fn reconstruct_content_replacement_state(messages: &[Message]) -> Vec<ReplacementStateRef> {
+    let mut refs = Vec::new();
+    let mut seen = HashSet::new();
+
+    for msg in messages {
+        if !matches!(msg.role, MessageRole::Tool) {
+            continue;
+        }
+
+        // First try structured parse: if content is JSON, look for known
+        // field names.
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&msg.content) {
+            extract_paths_from_json(&value, &mut |path| {
+                push_unique(&mut refs, &mut seen, path);
+            });
+        }
+
+        // Also fall back to line-based scan for tool results that emit
+        // plaintext like "wrote 12 bytes to <path>" or "read <path>".
+        for line in msg.content.lines() {
+            if let Some(path) = extract_path_from_line(line) {
+                push_unique(&mut refs, &mut seen, path);
+            }
+        }
+    }
+
+    refs
+}
+
+fn push_unique(refs: &mut Vec<ReplacementStateRef>, seen: &mut HashSet<String>, path: String) {
+    if path.is_empty() {
+        return;
+    }
+    if seen.insert(path.clone()) {
+        refs.push(ReplacementStateRef {
+            path: PathBuf::from(path),
+            content_hash: None,
+        });
+    }
+}
+
+fn extract_paths_from_json(value: &serde_json::Value, push: &mut dyn FnMut(String)) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map {
+                if matches!(key.as_str(), "path" | "file" | "file_path" | "filename") {
+                    if let serde_json::Value::String(s) = val {
+                        push(s.clone());
+                    }
+                }
+                extract_paths_from_json(val, push);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                extract_paths_from_json(item, push);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn extract_path_from_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    for prefix in ["path:", "file:", "wrote ", "read "] {
+        let Some(rest) = trimmed.strip_prefix(prefix) else {
+            continue;
+        };
+        let candidate = rest.trim().trim_matches('"').trim_matches('\'');
+        if candidate.contains(['/', '\\']) && candidate.len() < 512 {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+/// Internal result of the worktree existence + mtime bump helper.
+enum WorktreeStatus {
+    Present,
+    Missing,
+    BumpFailed { error: String },
+}
+
+/// Stat the worktree and, when present, touch a marker file inside it to
+/// bump the containing directory's mtime. The marker is written
+/// non-atomically — a concurrent resume is fine because both writes are
+/// idempotent (the file is overwritten with the current timestamp).
+///
+/// Returns [`WorktreeStatus::Missing`] if `root` does not exist (caller
+/// escalates to refuse resume). Returns [`WorktreeStatus::BumpFailed`] if
+/// the stat succeeds but writing the marker fails — non-fatal, logged as a
+/// report warning.
+fn check_and_bump_worktree(root: &Path) -> WorktreeStatus {
+    match std::fs::metadata(root) {
+        Ok(meta) if meta.is_dir() => bump_mtime_marker(root),
+        Ok(_) => {
+            warn!(path = %root.display(), "worktree root is not a directory");
+            WorktreeStatus::Missing
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => WorktreeStatus::Missing,
+        Err(error) => WorktreeStatus::BumpFailed {
+            error: error.to_string(),
+        },
+    }
+}
+
+fn bump_mtime_marker(root: &Path) -> WorktreeStatus {
+    let marker = root.join(RESUME_MTIME_MARKER);
+    let timestamp = Utc::now().to_rfc3339();
+    match std::fs::write(&marker, timestamp.as_bytes()) {
+        Ok(()) => WorktreeStatus::Present,
+        Err(error) => WorktreeStatus::BumpFailed {
+            error: error.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone, Utc};
+    use octos_core::{Message, MessageRole, ToolCall};
+    use tempfile::TempDir;
+
+    fn user(content: &str) -> Message {
+        Message {
+            role: MessageRole::User,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        }
+    }
+
+    fn assistant_text(content: &str) -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 1).unwrap(),
+        }
+    }
+
+    fn assistant_with_calls(content: &str, call_ids: &[&str]) -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: content.into(),
+            media: vec![],
+            tool_calls: Some(
+                call_ids
+                    .iter()
+                    .map(|id| ToolCall {
+                        id: (*id).to_string(),
+                        name: "shell".into(),
+                        arguments: serde_json::json!({}),
+                        metadata: None,
+                    })
+                    .collect(),
+            ),
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 2).unwrap(),
+        }
+    }
+
+    fn tool_result(tool_call_id: &str, body: &str) -> Message {
+        Message {
+            role: MessageRole::Tool,
+            content: body.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 3).unwrap(),
+        }
+    }
+
+    fn assistant_thinking_only(reasoning: &str) -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: Some(reasoning.into()),
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 4).unwrap(),
+        }
+    }
+
+    fn assistant_whitespace_only() -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: "   \n\t ".into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 5).unwrap(),
+        }
+    }
+
+    #[test]
+    fn should_drop_tool_result_without_matching_tool_call() {
+        let messages = vec![
+            user("hello"),
+            assistant_text("hi"),
+            // Orphan: tool result with no matching tool_call in any
+            // assistant message.
+            tool_result("orphan-42", r#"{"output": "oops"}"#),
+            assistant_text("done"),
+        ];
+
+        let (filtered, dropped) = filter_unresolved_tool_uses(messages, None);
+
+        assert_eq!(dropped, 1, "orphan tool_result should bump dropped");
+        assert_eq!(filtered.len(), 3);
+        assert!(
+            !filtered.iter().any(|m| matches!(m.role, MessageRole::Tool)),
+            "the orphan tool_result should be gone"
+        );
+    }
+
+    #[test]
+    fn should_drop_tool_call_without_matching_result() {
+        let messages = vec![
+            user("run it"),
+            // Unresolved tool_call — no tool result follows; no text body
+            // so the whole assistant message should be dropped.
+            assistant_with_calls("", &["call-1"]),
+        ];
+
+        let (filtered, dropped) = filter_unresolved_tool_uses(messages, None);
+
+        assert_eq!(dropped, 1);
+        assert_eq!(filtered.len(), 1);
+        assert!(matches!(filtered[0].role, MessageRole::User));
+    }
+
+    #[test]
+    fn should_strip_tool_calls_but_keep_text_when_text_present() {
+        let messages = vec![
+            user("hi"),
+            // Unresolved tool_call, but assistant also wrote prose — keep
+            // the prose, strip the tool_calls so the provider accepts it.
+            assistant_with_calls("I started doing the thing.", &["call-x"]),
+        ];
+
+        let (filtered, dropped) = filter_unresolved_tool_uses(messages, None);
+
+        assert_eq!(dropped, 1, "counts the strip as a drop");
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[1].content, "I started doing the thing.");
+        assert!(filtered[1].tool_calls.is_none());
+    }
+
+    #[test]
+    fn should_preserve_tool_call_referenced_by_retry_state() {
+        let messages = vec![
+            user("run it"),
+            // Unresolved tool_call, but retry state says "pending — do
+            // not drop".
+            assistant_with_calls("", &["pending-1"]),
+        ];
+
+        let mut retry: HashSet<String> = HashSet::new();
+        retry.insert("pending-1".into());
+
+        let (filtered, dropped) =
+            filter_unresolved_tool_uses(messages, Some(&retry as &dyn RetryStateView));
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+        assert!(
+            filtered[1]
+                .tool_calls
+                .as_ref()
+                .map(|c| c.len() == 1 && c[0].id == "pending-1")
+                .unwrap_or(false)
+        );
+    }
+
+    #[test]
+    fn should_drop_orphan_thinking_only_message() {
+        let messages = vec![
+            user("huh"),
+            assistant_thinking_only("<think> ... </think>"),
+            // A real reply follows, so the thinking-only one is an orphan.
+            assistant_text("here is the answer"),
+        ];
+
+        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages);
+
+        assert_eq!(dropped, 1);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[1].content, "here is the answer");
+    }
+
+    #[test]
+    fn should_keep_trailing_thinking_only_message() {
+        // In-flight reasoning: session crashed mid-think. The tail
+        // thinking-only message represents state the harness will
+        // continue — keep it.
+        let messages = vec![
+            user("long one"),
+            assistant_thinking_only("still working on it ..."),
+        ];
+
+        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages);
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered[1].reasoning_content.is_some());
+    }
+
+    #[test]
+    fn should_drop_whitespace_only_assistant_message() {
+        let messages = vec![
+            user("hi"),
+            assistant_whitespace_only(),
+            assistant_text("oh hey"),
+        ];
+
+        let (filtered, dropped) = filter_whitespace_only_assistant_messages(messages);
+
+        assert_eq!(dropped, 1);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[1].content, "oh hey");
+    }
+
+    #[test]
+    fn should_not_drop_user_whitespace_only() {
+        // Only assistant messages are subject to the whitespace filter —
+        // users can send whatever they want, we preserve.
+        let messages = vec![user("   "), assistant_text("weird")];
+
+        let (filtered, dropped) = filter_whitespace_only_assistant_messages(messages);
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn should_collect_content_replacement_refs_from_tool_results() {
+        let messages = vec![
+            user("read the file"),
+            assistant_with_calls("", &["call-a"]),
+            tool_result(
+                "call-a",
+                r#"{"path": "src/lib.rs", "contents": "fn main() {}"}"#,
+            ),
+            assistant_with_calls("", &["call-b"]),
+            tool_result("call-b", "wrote file\npath: docs/new.md\nbytes: 42\n"),
+        ];
+
+        let refs = reconstruct_content_replacement_state(&messages);
+
+        assert_eq!(refs.len(), 2, "two unique file paths recovered");
+        let paths: Vec<_> = refs.iter().map(|r| r.path.display().to_string()).collect();
+        assert!(paths.iter().any(|p| p == "src/lib.rs"));
+        assert!(paths.iter().any(|p| p == "docs/new.md"));
+        // content_hash is None — M8.4 stub.
+        assert!(refs.iter().all(|r| r.content_hash.is_none()));
+    }
+
+    #[test]
+    fn should_detect_missing_worktree() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("not-a-real-worktree");
+
+        let outcome = ResumePolicy::sanitize(vec![], None, Some(&missing));
+
+        match outcome {
+            Err(SanitizeError::WorktreeMissing { path, report }) => {
+                assert_eq!(path, missing);
+                assert!(report.worktree_missing);
+            }
+            other => panic!("expected WorktreeMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_bump_worktree_mtime_when_present() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        let outcome =
+            ResumePolicy::sanitize(vec![user("hi")], None, Some(root)).expect("worktree present");
+
+        assert!(!outcome.report.worktree_missing);
+        let marker = root.join(RESUME_MTIME_MARKER);
+        assert!(marker.exists(), "marker file should exist after mtime bump");
+        let written = std::fs::read_to_string(&marker).unwrap();
+        assert!(
+            !written.trim().is_empty(),
+            "marker should contain a timestamp"
+        );
+    }
+
+    #[test]
+    fn should_report_zero_drops_for_clean_transcript() {
+        let messages = vec![
+            user("hello"),
+            assistant_with_calls("", &["call-1"]),
+            tool_result("call-1", r#"{"output": "ok"}"#),
+            assistant_text("all done"),
+        ];
+
+        let outcome = ResumePolicy::sanitize(messages, None, None).unwrap();
+
+        assert_eq!(outcome.report.unresolved_tool_uses_dropped, 0);
+        assert_eq!(outcome.report.orphan_thinking_dropped, 0);
+        assert_eq!(outcome.report.whitespace_only_dropped, 0);
+        assert_eq!(outcome.report.input_len, 4);
+        assert_eq!(outcome.report.output_len, 4);
+        assert!(!outcome.report.worktree_missing);
+        assert!(outcome.report.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_display_report_human_readable() {
+        let report = SessionSanitizeReport {
+            input_len: 10,
+            output_len: 6,
+            unresolved_tool_uses_dropped: 2,
+            orphan_thinking_dropped: 1,
+            whitespace_only_dropped: 1,
+            content_replacements_restored: 3,
+            worktree_missing: false,
+            warnings: vec!["one".into()],
+        };
+        let shown = report.to_string();
+        assert!(shown.contains("input_len=10"));
+        assert!(shown.contains("output_len=6"));
+        assert!(shown.contains("unresolved_tool=2"));
+        assert!(shown.contains("orphan_thinking=1"));
+        assert!(shown.contains("whitespace_only=1"));
+        assert!(shown.contains("worktree_missing=false"));
+    }
+
+    #[test]
+    fn should_sanitize_complex_transcript_end_to_end() {
+        let now = Utc::now();
+        let msgs = vec![
+            // User prompt.
+            Message {
+                timestamp: now,
+                ..user("task: refactor the widget")
+            },
+            // Assistant thinking + real reply.
+            Message {
+                timestamp: now + Duration::milliseconds(10),
+                ..assistant_thinking_only("let me think ...")
+            },
+            Message {
+                timestamp: now + Duration::milliseconds(20),
+                ..assistant_text("on it")
+            },
+            // Assistant tool_call that is resolved.
+            Message {
+                timestamp: now + Duration::milliseconds(30),
+                ..assistant_with_calls("", &["call-1"])
+            },
+            Message {
+                timestamp: now + Duration::milliseconds(40),
+                ..tool_result("call-1", r#"{"path": "widget.rs"}"#)
+            },
+            // Assistant tool_call UNRESOLVED (should be dropped).
+            Message {
+                timestamp: now + Duration::milliseconds(50),
+                ..assistant_with_calls("", &["call-ghost"])
+            },
+            // Whitespace-only assistant (should be dropped).
+            Message {
+                timestamp: now + Duration::milliseconds(60),
+                ..assistant_whitespace_only()
+            },
+            // Orphan thinking-only (should be dropped; not tail).
+            Message {
+                timestamp: now + Duration::milliseconds(70),
+                ..assistant_thinking_only("hmm")
+            },
+            // Final real reply (tail — preserved).
+            Message {
+                timestamp: now + Duration::milliseconds(80),
+                ..assistant_text("done refactoring")
+            },
+        ];
+
+        let outcome = ResumePolicy::sanitize(msgs, None, None).unwrap();
+
+        // unresolved=1, whitespace=1, orphan_thinking=2 (both thinking-only
+        // messages are non-tail once filtering starts — one appears mid-
+        // conversation, one appears just before the final reply).
+        assert_eq!(outcome.report.unresolved_tool_uses_dropped, 1);
+        assert_eq!(outcome.report.orphan_thinking_dropped, 2);
+        assert_eq!(outcome.report.whitespace_only_dropped, 1);
+        // One content-replacement ref from the resolved tool result.
+        assert_eq!(outcome.report.content_replacements_restored, 1);
+        // input was 9, output should be 9 - 4 = 5.
+        assert_eq!(outcome.report.input_len, 9);
+        assert_eq!(outcome.report.output_len, 5);
+        // The final real reply must be the tail.
+        assert_eq!(outcome.messages.last().unwrap().content, "done refactoring");
+    }
+
+    #[test]
+    fn should_flag_non_directory_worktree_as_missing() {
+        // Claude Code's worktree recovery treats a regular file at the
+        // configured path as "gone" because it can't be used as a
+        // worktree. We match that.
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("not-a-dir");
+        std::fs::write(&file_path, "hi").unwrap();
+
+        let outcome = ResumePolicy::sanitize(vec![user("hi")], None, Some(&file_path));
+
+        match outcome {
+            Err(SanitizeError::WorktreeMissing { path, .. }) => {
+                assert_eq!(path, file_path);
+            }
+            other => panic!("expected WorktreeMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_detect_whitespace_only_with_reasoning_not_dropped() {
+        // An assistant message with empty content but reasoning content
+        // is a thinking-only message, not whitespace-only. The
+        // whitespace filter must skip it.
+        let messages = vec![
+            user("hi"),
+            assistant_thinking_only("thinking ..."),
+            assistant_text("hi back"),
+        ];
+
+        let (filtered, dropped) = filter_whitespace_only_assistant_messages(messages);
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 3);
+    }
+
+    #[test]
+    fn should_ignore_retry_state_for_unknown_ids() {
+        // Retry state that references call IDs not actually in the
+        // transcript should be a no-op.
+        let messages = vec![user("hi"), assistant_text("hello")];
+
+        let mut retry: HashSet<String> = HashSet::new();
+        retry.insert("bogus".into());
+
+        let (filtered, dropped) =
+            filter_unresolved_tool_uses(messages, Some(&retry as &dyn RetryStateView));
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn should_handle_empty_transcript() {
+        let outcome = ResumePolicy::sanitize(vec![], None, None).unwrap();
+
+        assert_eq!(outcome.messages.len(), 0);
+        assert_eq!(outcome.report.input_len, 0);
+        assert_eq!(outcome.report.output_len, 0);
+    }
+}

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1120,6 +1120,50 @@ impl SessionHandle {
         &mut self.session
     }
 
+    /// Sanitize the loaded transcript via [`crate::ResumePolicy`] (M8.6).
+    ///
+    /// Runs the four filter passes described in `resume_policy`, replaces
+    /// `self.session.messages` with the sanitized list, and returns the
+    /// typed report so callers can log it or forward it to a harness event
+    /// sink. A missing worktree is reported via
+    /// [`crate::SanitizeError::WorktreeMissing`] — the session's in-memory
+    /// messages are NOT mutated in that case so callers retain the
+    /// original transcript for operator inspection.
+    ///
+    /// NOTE: this does not persist the sanitized transcript to disk. Call
+    /// [`Self::rewrite`] afterward if the caller wants the sanitized
+    /// version to survive a subsequent reload.
+    pub fn sanitize_loaded_messages(
+        &mut self,
+        retry_state: Option<&dyn crate::RetryStateView>,
+        workspace_root: Option<&Path>,
+    ) -> Result<
+        (
+            crate::SessionSanitizeReport,
+            Vec<crate::ReplacementStateRef>,
+        ),
+        crate::SanitizeError,
+    > {
+        // Clone so we can restore the original on the worktree-missing
+        // path without a partial-move hazard.
+        let messages = self.session.messages.clone();
+        match crate::ResumePolicy::sanitize(messages, retry_state, workspace_root) {
+            Ok(outcome) => {
+                self.session.messages = outcome.messages;
+                Ok((outcome.report, outcome.content_replacements))
+            }
+            Err(error) => {
+                let crate::SanitizeError::WorktreeMissing { report, .. } = &error;
+                warn!(
+                    key = %self.session.key,
+                    report = %report,
+                    "resume sanitize refused: worktree missing"
+                );
+                Err(error)
+            }
+        }
+    }
+
     /// Add a message to the session and persist it.
     pub async fn add_message(&mut self, message: Message) -> Result<()> {
         self.add_message_with_seq(message).await.map(|_| ())
@@ -2687,5 +2731,94 @@ mod tests {
         assert_eq!(child.0, "api:web-task-ledger#child-spawn-01%2Falpha%20beta");
         assert_eq!(child.base_key(), "api:web-task-ledger");
         assert_eq!(child.topic(), Some("child-spawn-01%2Falpha%20beta"));
+    }
+
+    /// M8.6: `sanitize_loaded_messages` replaces the session's in-memory
+    /// transcript with the cleaned-up version and returns the report. No
+    /// disk state is touched until the caller rewrites.
+    #[test]
+    fn should_sanitize_loaded_messages_in_place() {
+        use octos_core::ToolCall;
+
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "resume-test");
+        let mut handle = SessionHandle::open(tmp.path(), &key);
+
+        // Load an unresolved tool_call + a whitespace-only assistant
+        // message into the handle directly.
+        handle
+            .session
+            .messages
+            .push(make_message(MessageRole::User, "hi"));
+        handle.session.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: Some(vec![ToolCall {
+                id: "unresolved-1".into(),
+                name: "shell".into(),
+                arguments: serde_json::json!({}),
+                metadata: None,
+            }]),
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        });
+        handle.session.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: "   ".into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        });
+
+        let before = handle.session.messages.len();
+        let (report, refs) = handle
+            .sanitize_loaded_messages(None, None)
+            .expect("clean outcome — no workspace root");
+
+        assert_eq!(report.input_len, before);
+        assert_eq!(report.unresolved_tool_uses_dropped, 1);
+        assert_eq!(report.whitespace_only_dropped, 1);
+        assert_eq!(report.output_len, 1);
+        assert!(refs.is_empty());
+        // Handle was mutated in place.
+        assert_eq!(handle.session.messages.len(), 1);
+        assert_eq!(handle.session.messages[0].content, "hi");
+    }
+
+    /// M8.6: a missing worktree surfaces as `Err` and DOES NOT mutate the
+    /// session's in-memory transcript — callers can still log what was
+    /// loaded before deciding to refuse resume.
+    #[test]
+    fn should_preserve_messages_when_worktree_missing() {
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "resume-no-worktree");
+        let mut handle = SessionHandle::open(tmp.path(), &key);
+
+        handle
+            .session
+            .messages
+            .push(make_message(MessageRole::User, "hi"));
+        handle
+            .session
+            .messages
+            .push(make_message(MessageRole::Assistant, "there"));
+
+        let gone = tmp.path().join("ghost-worktree");
+        let before_count = handle.session.messages.len();
+
+        let outcome = handle.sanitize_loaded_messages(None, Some(&gone));
+
+        match outcome {
+            Err(crate::SanitizeError::WorktreeMissing { path, .. }) => {
+                assert_eq!(path, gone);
+            }
+            other => panic!("expected WorktreeMissing, got {other:?}"),
+        }
+        // Transcript is preserved.
+        assert_eq!(handle.session.messages.len(), before_count);
     }
 }

--- a/crates/octos-cli/src/main.rs
+++ b/crates/octos-cli/src/main.rs
@@ -38,7 +38,9 @@ fn main() -> Result<()> {
 fn init_tracing(
     log_dir: Option<&std::path::Path>,
 ) -> Result<Option<tracing_appender::non_blocking::WorkerGuard>> {
-    use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*};
+    use std::io::IsTerminal as _;
+    use tracing_subscriber::fmt::writer::{BoxMakeWriter, MakeWriterExt};
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info"))
@@ -48,21 +50,7 @@ fn init_tracing(
     // Check if JSON format is requested via environment
     let json_logs = std::env::var("OCTOS_LOG_JSON").is_ok();
 
-    // Console layer (boxed so we can unify json vs compact types)
-    let console_layer: Box<dyn Layer<_> + Send + Sync> = if json_logs {
-        fmt::layer()
-            .json()
-            .with_target(true)
-            .with_span_list(true)
-            .with_current_span(true)
-            .boxed()
-    } else {
-        fmt::layer()
-            .with_target(false)
-            .with_thread_ids(false)
-            .compact()
-            .boxed()
-    };
+    let enable_console = log_dir.is_none() || std::io::stderr().is_terminal();
 
     if let Some(dir) = log_dir {
         // Rolling daily log file, keep last 7 days
@@ -75,25 +63,61 @@ fn init_tracing(
             .map_err(|e| eyre::eyre!("failed to create log file appender: {e}"))?;
 
         let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        let writer = if enable_console {
+            BoxMakeWriter::new(std::io::stderr.and(non_blocking))
+        } else {
+            BoxMakeWriter::new(non_blocking)
+        };
 
-        let file_layer = fmt::layer()
-            .with_ansi(false)
-            .with_target(false)
-            .compact()
-            .with_writer(non_blocking);
-
-        tracing_subscriber::registry()
-            .with(console_layer)
-            .with(file_layer)
-            .with(filter)
-            .init();
+        if json_logs {
+            tracing_subscriber::registry()
+                .with(
+                    fmt::layer()
+                        .json()
+                        .with_target(true)
+                        .with_span_list(true)
+                        .with_current_span(true)
+                        .with_writer(writer),
+                )
+                .with(filter)
+                .init();
+        } else {
+            tracing_subscriber::registry()
+                .with(
+                    fmt::layer()
+                        .with_ansi(false)
+                        .with_target(false)
+                        .compact()
+                        .with_writer(writer),
+                )
+                .with(filter)
+                .init();
+        }
 
         Ok(Some(guard))
     } else {
-        tracing_subscriber::registry()
-            .with(console_layer)
-            .with(filter)
-            .init();
+        if json_logs {
+            tracing_subscriber::registry()
+                .with(
+                    fmt::layer()
+                        .json()
+                        .with_target(true)
+                        .with_span_list(true)
+                        .with_current_span(true),
+                )
+                .with(filter)
+                .init();
+        } else {
+            tracing_subscriber::registry()
+                .with(
+                    fmt::layer()
+                        .with_target(false)
+                        .with_thread_ids(false)
+                        .compact(),
+                )
+                .with(filter)
+                .init();
+        }
 
         Ok(None)
     }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1391,7 +1391,40 @@ impl ActorFactory {
         }
         // Create the per-actor session handle early so we can derive the
         // background task ledger path before any worker can mutate state.
-        let session_handle = SessionHandle::open(&self.data_dir, &session_key);
+        let mut session_handle = SessionHandle::open(&self.data_dir, &session_key);
+        // M8.6: sanitize the loaded transcript. Dropping unresolved tool
+        // calls, orphan thinking, and whitespace-only messages here
+        // prevents the provider from 400-ing on the first request after a
+        // resume. `retry_state` and `workspace_root` are None for
+        // top-level sessions today — sub-agent workstreams will thread
+        // them in when M8.7 lands.
+        match session_handle.sanitize_loaded_messages(None, None) {
+            Ok((report, refs)) => {
+                if report.input_len != report.output_len
+                    || report.content_replacements_restored > 0
+                    || !report.warnings.is_empty()
+                {
+                    info!(
+                        session = %session_key,
+                        report = %report,
+                        "resume sanitize applied"
+                    );
+                }
+                // TODO(M8.4): after FileStateCache lands, populate its
+                // entries from `refs` when the cache is non-empty
+                // post-load. The hand-off point is right here — we have
+                // the session key, the sanitized transcript, and the
+                // list of content-replacement refs.
+                let _ = refs;
+            }
+            Err(error) => {
+                warn!(
+                    session = %session_key,
+                    error = %error,
+                    "resume sanitize refused — continuing with original transcript"
+                );
+            }
+        }
         let task_state_path = session_handle.task_state_path();
         let session_handle = Arc::new(Mutex::new(session_handle));
         let session_policy_path = workspace_policy_path(&user_workspace);

--- a/crates/platform-skills/voice/Cargo.toml
+++ b/crates/platform-skills/voice/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voice"
-version = "1.0.0"
+version = "1.1.1"
 edition = "2021"
 description = "Voice skill binary (ASR/TTS/model management) using ominix-api on Apple Silicon"
 authors = ["octos"]

--- a/crates/platform-skills/voice/SKILL.md
+++ b/crates/platform-skills/voice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: voice
 description: OminiX ASR (speech-to-text), preset-voice TTS with emotion/speed control, and model management via Qwen3 models on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm. Triggers: voice, transcribe audio, text to speech, speak this, read aloud, model management, download model, 语音识别, 语音合成, 模型管理.
-version: 1.1.0
+version: 1.1.1
 author: octos
 always: true
 ---
@@ -17,7 +17,9 @@ On-device speech-to-text, preset-voice text-to-speech with emotion control, and 
 The skill auto-discovers the ominix-api server URL via (in priority order):
 1. `OMINIX_API_URL` environment variable
 2. Discovery file `~/.ominix/api_url` (written by ominix-api on startup)
-3. Default: `http://localhost:9090`
+3. Probes candidate ports — `http://localhost:9090`, `http://localhost:8080`,
+   `http://localhost:8081` — and uses the first one answering `/health` within
+   500 ms. Only falls back to macOS Say when every probe fails.
 
 ## Checking Available Models
 

--- a/crates/platform-skills/voice/manifest.json
+++ b/crates/platform-skills/voice/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "voice",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "octos",
   "description": "OminiX voice skill: ASR, preset-voice TTS with emotion/speed control, and model management via local Qwen3 models on Apple Silicon. For voice cloning and custom voice profiles, use mofa-fm instead.",
   "timeout_secs": 600,

--- a/crates/platform-skills/voice/src/main.rs
+++ b/crates/platform-skills/voice/src/main.rs
@@ -431,6 +431,12 @@ fn say_voice_candidates(language: &str) -> &'static [&'static str] {
 /// bytes; a file near that size carries virtually no samples.
 const MIN_VALID_WAV_BYTES: u64 = 256;
 
+/// Public display-only list of voice IDs Qwen3-TTS accepts out-of-the-box.
+/// Used in error messages so the LLM can retry with a valid preset OR
+/// route custom voices (clones) to `fm_tts` from the mofa-fm skill.
+const PRESET_VOICE_LIST: &str =
+    "vivian, serena, ryan, aiden, eric, dylan, uncle_fu, ono_anna, sohee";
+
 fn wav_payload_is_silent_bytes(bytes: &[u8]) -> bool {
     bytes.len() <= 44 || bytes[44..].iter().all(|&b| b == 0)
 }
@@ -618,17 +624,31 @@ fn handle_synthesize(input_json: &str) {
                         ));
                     }
                     Err(e) => {
-                        eprintln!(
-                            "Qwen3-TTS produced invalid audio ({e}), falling back to macOS Say..."
-                        );
+                        // Qwen3-TTS succeeded but wrote invalid audio (often
+                        // indicates an unsupported speaker name like a custom
+                        // clone id). Fail explicitly so the LLM learns to
+                        // route custom voices to fm_tts instead of silently
+                        // downgrading to macOS Say.
                         let _ = std::fs::remove_file(&output_path);
-                        // Fall through to macOS Say below
+                        fail(&format!(
+                            "TTS failed: Qwen3-TTS returned invalid audio for voice '{speaker}' ({e}). \
+                             Preset voices only include {PRESET_VOICE_LIST}. \
+                             For custom / cloned voices (e.g. yangmi, douwentao) use `fm_tts` from the mofa-fm skill."
+                        ));
                     }
                 }
             }
             Err(e) => {
-                eprintln!("Qwen3-TTS failed ({e}), falling back to macOS Say...");
-                // Fall through to macOS Say below
+                // Qwen3-TTS error — surface it to the LLM, don't silently
+                // fall back to Say. The error message usually names the
+                // actual cause (unknown voice, payload too long, etc.) so
+                // the LLM can react (retry with fm_tts for custom voices,
+                // shorten text, etc.).
+                fail(&format!(
+                    "TTS failed: Qwen3-TTS rejected request for voice '{speaker}': {e}. \
+                     Preset voices only include {PRESET_VOICE_LIST}. \
+                     For custom / cloned voices use `fm_tts` from the mofa-fm skill."
+                ));
             }
         }
     } else {

--- a/crates/platform-skills/voice/src/main.rs
+++ b/crates/platform-skills/voice/src/main.rs
@@ -1,7 +1,8 @@
 //! Voice platform skill binary (ASR, preset-voice TTS, model management) via ominix-api.
 //!
 //! Protocol: `./main <tool_name>` with JSON on stdin, JSON on stdout.
-//! Auto-discovers ominix-api via OMINIX_API_URL, ~/.ominix/api_url, or default http://localhost:9090.
+//! Auto-discovers ominix-api via OMINIX_API_URL, ~/.ominix/api_url, or by
+//! probing common default ports (9090, 8080, 8081).
 //!
 //! NOTE: Voice cloning and custom voice profiles are handled by mofa-fm.
 //! This skill only supports preset voices for TTS.
@@ -41,22 +42,66 @@ struct SynthesizeInput {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-fn api_base_url() -> String {
-    // Priority: env var > discovery file > default
-    if let Ok(url) = std::env::var("OMINIX_API_URL") {
-        return url.trim_end_matches('/').to_string();
+/// Candidate default ominix-api URLs to probe when no explicit override is set.
+/// Order matters — first healthy wins.
+const DEFAULT_CANDIDATE_URLS: &[&str] = &[
+    "http://localhost:9090",
+    "http://localhost:8080",
+    "http://localhost:8081",
+];
+
+/// Normalize a base URL: trim trailing slash, reject empty.
+fn normalize_base_url(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
     }
-    // Read URL written by ominix-api on startup
-    if let Some(home) = std::env::var_os("HOME") {
-        let discovery = Path::new(&home).join(".ominix").join("api_url");
-        if let Ok(url) = std::fs::read_to_string(&discovery) {
-            let url = url.trim();
-            if !url.is_empty() {
-                return url.trim_end_matches('/').to_string();
-            }
+}
+
+/// Read `OMINIX_API_URL` from environment, normalized.
+fn env_base_url() -> Option<String> {
+    std::env::var("OMINIX_API_URL")
+        .ok()
+        .and_then(|v| normalize_base_url(&v))
+}
+
+/// Read discovery file `~/.ominix/api_url`, normalized.
+fn discovery_base_url() -> Option<String> {
+    let home = std::env::var_os("HOME")?;
+    let discovery = Path::new(&home).join(".ominix").join("api_url");
+    std::fs::read_to_string(&discovery)
+        .ok()
+        .and_then(|s| normalize_base_url(&s))
+}
+
+/// Resolve the ominix-api base URL using the priority chain:
+///   1. explicit override (env or discovery file) — **used as-is, not probed**
+///   2. probe each candidate URL with `probe` and return the first healthy one
+///
+/// Returns `None` if no override is set and no candidate is reachable.
+///
+/// Pure, testable: callers inject `env_url`, `discovery_url`, `candidates`,
+/// and a probe function (so unit tests don't make real network calls).
+fn resolve_api_base_url(
+    env_url: Option<String>,
+    discovery_url: Option<String>,
+    candidates: &[&str],
+    mut probe: impl FnMut(&str) -> bool,
+) -> Option<String> {
+    if let Some(url) = env_url {
+        return Some(url);
+    }
+    if let Some(url) = discovery_url {
+        return Some(url);
+    }
+    for candidate in candidates {
+        if probe(candidate) {
+            return Some((*candidate).to_string());
         }
     }
-    "http://localhost:9090".to_string()
+    None
 }
 
 fn http_client() -> reqwest::blocking::Client {
@@ -66,6 +111,42 @@ fn http_client() -> reqwest::blocking::Client {
         // No request timeout — TTS streaming can take minutes for long text.
         .build()
         .expect("failed to build HTTP client")
+}
+
+/// Probe a candidate base URL with a short timeout. Only used during
+/// fallback discovery when no explicit override is set. Keep this fast —
+/// it runs serially over a small candidate list.
+fn probe_candidate(client: &reqwest::blocking::Client, base_url: &str) -> bool {
+    client
+        .get(format!("{base_url}/health"))
+        .timeout(Duration::from_millis(500))
+        .send()
+        .is_ok_and(|r| r.status().is_success())
+}
+
+/// High-level discovery: inspect env/discovery, else probe candidates.
+/// Returns the resolved base URL, or `None` if nothing reachable.
+fn discover_api_base_url() -> Option<String> {
+    let client = http_client();
+    resolve_api_base_url(
+        env_base_url(),
+        discovery_base_url(),
+        DEFAULT_CANDIDATE_URLS,
+        |url| probe_candidate(&client, url),
+    )
+}
+
+/// Resolve the API base URL for tools that *require* ominix-api (list_models,
+/// download_model, load_model, unload_model). Fails the skill if nothing is
+/// reachable — these operations have no Say-style fallback.
+fn require_api_base_url() -> String {
+    match discover_api_base_url() {
+        Some(url) => url,
+        None => fail(
+            "ominix-api not reachable at OMINIX_API_URL, ~/.ominix/api_url, or default \
+             ports (9090/8080/8081). Start it with: ominix-api --port 8080",
+        ),
+    }
 }
 
 /// Wrap raw PCM bytes (16-bit signed LE, mono) in a WAV header.
@@ -260,9 +341,15 @@ fn handle_transcribe(input_json: &str) {
         }
     }
 
-    let base_url = api_base_url();
+    let base_url = match discover_api_base_url() {
+        Some(url) => url,
+        None => fail(
+            "ominix-api not reachable at OMINIX_API_URL, ~/.ominix/api_url, or default \
+             ports (9090/8080/8081). Start it with: ominix-api --port 8080",
+        ),
+    };
     let client = http_client();
-    eprintln!("Checking ominix-api health...");
+    eprintln!("Checking ominix-api health at {base_url}...");
     if let Err(e) = check_health(&client, &base_url) {
         fail(&e);
     }
@@ -340,14 +427,36 @@ fn say_voice_candidates(language: &str) -> &'static [&'static str] {
     }
 }
 
+/// Minimum plausible WAV size for non-empty audio. A bare WAV header is 44
+/// bytes; a file near that size carries virtually no samples.
+const MIN_VALID_WAV_BYTES: u64 = 256;
+
 fn wav_payload_is_silent_bytes(bytes: &[u8]) -> bool {
     bytes.len() <= 44 || bytes[44..].iter().all(|&b| b == 0)
 }
 
-fn wav_is_silent(path: &str) -> Result<bool, String> {
-    let bytes = std::fs::read(path)
-        .map_err(|e| format!("Failed to inspect synthesized audio {path}: {e}"))?;
-    Ok(wav_payload_is_silent_bytes(&bytes))
+/// Validate a synthesized audio file: it must exist, be large enough to
+/// contain real audio, and not be entirely silent PCM. Returns the file
+/// size on success, or a caller-friendly error on failure.
+fn validate_synthesized_audio(path: &str) -> Result<u64, String> {
+    let meta = std::fs::metadata(path)
+        .map_err(|e| format!("Failed to stat synthesized audio {path}: {e}"))?;
+    let size = meta.len();
+    if size < MIN_VALID_WAV_BYTES {
+        return Err(format!(
+            "Synthesized audio {path} is too small ({size} bytes, minimum \
+             {MIN_VALID_WAV_BYTES}) — fallback pipeline likely produced an \
+             empty or truncated file"
+        ));
+    }
+    let bytes =
+        std::fs::read(path).map_err(|e| format!("Failed to read synthesized audio {path}: {e}"))?;
+    if wav_payload_is_silent_bytes(&bytes) {
+        return Err(format!(
+            "Synthesized audio {path} contains only silent PCM samples"
+        ));
+    }
+    Ok(size)
 }
 
 /// Synthesize using macOS built-in `say` command.
@@ -405,17 +514,13 @@ fn synthesize_with_say(
         let _ = std::fs::remove_file(&aiff_path);
 
         match af_status {
-            Ok(s) if s.success() => match wav_is_silent(output_path) {
-                Ok(false) => return Ok(()),
-                Ok(true) => {
+            Ok(s) if s.success() => match validate_synthesized_audio(output_path) {
+                Ok(_) => return Ok(()),
+                Err(e) => {
                     last_error = Some(format!(
-                        "macOS Say voice '{}' produced silent audio",
+                        "macOS Say voice '{}' failed validation: {e}",
                         voice.unwrap_or("default")
                     ));
-                    let _ = std::fs::remove_file(output_path);
-                }
-                Err(e) => {
-                    last_error = Some(e);
                     let _ = std::fs::remove_file(output_path);
                 }
             },
@@ -476,12 +581,12 @@ fn handle_synthesize(input_json: &str) {
     let language = input.language.unwrap_or_else(|| "chinese".to_string());
     let speaker = input.speaker.unwrap_or_else(|| "vivian".to_string());
 
-    // Try ominix-api first; fall back to macOS `say` if unavailable
-    let base_url = api_base_url();
+    // Try ominix-api first; fall back to macOS `say` if unavailable.
+    // `discover_api_base_url` already probes candidate ports — if it returns
+    // Some, the server is reachable; if None, we go straight to Say.
     let client = http_client();
-    let ominix_available = check_health(&client, &base_url).is_ok();
-
-    if ominix_available {
+    let resolved_base_url = discover_api_base_url();
+    if let Some(ref base_url) = resolved_base_url {
         // Preset speaker — build JSON body with optional prompt/speed
         let mut body = json!({
             "input": input.text,
@@ -503,13 +608,23 @@ fn handle_synthesize(input_json: &str) {
                 if let Err(e) = std::fs::write(Path::new(&output_path), &wav_bytes) {
                     fail(&format!("Failed to write {output_path}: {e}"));
                 }
-                let duration_secs = wav_bytes.len().saturating_sub(44) as f64 / 48000.0;
-                eprintln!("Converting to MP3...");
-                let final_path = try_convert_to_mp3(&output_path);
-                succeed(&format!(
-                    "Generated audio: {final_path} ({duration_secs:.1}s, {} bytes). Use send_file to deliver it to the user.",
-                    wav_bytes.len()
-                ));
+                match validate_synthesized_audio(&output_path) {
+                    Ok(size) => {
+                        let duration_secs = size.saturating_sub(44) as f64 / 48000.0;
+                        eprintln!("Converting to MP3...");
+                        let final_path = try_convert_to_mp3(&output_path);
+                        succeed(&format!(
+                            "Generated audio: {final_path} ({duration_secs:.1}s, {size} bytes). Use send_file to deliver it to the user."
+                        ));
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Qwen3-TTS produced invalid audio ({e}), falling back to macOS Say..."
+                        );
+                        let _ = std::fs::remove_file(&output_path);
+                        // Fall through to macOS Say below
+                    }
+                }
             }
             Err(e) => {
                 eprintln!("Qwen3-TTS failed ({e}), falling back to macOS Say...");
@@ -517,26 +632,28 @@ fn handle_synthesize(input_json: &str) {
             }
         }
     } else {
-        eprintln!("ominix-api not available, using macOS Say...");
+        eprintln!("ominix-api not reachable on env/discovery/default ports, using macOS Say...");
     }
 
-    // Fallback: macOS built-in `say` command
+    // Fallback: macOS built-in `say` command. `synthesize_with_say` already
+    // validates output (size + silence), so by the time we get Ok here, the
+    // file is guaranteed non-empty.
     match synthesize_with_say(&input.text, &language, input.speed, &output_path) {
-        Ok(()) => {
-            let size = std::fs::metadata(&output_path)
-                .map(|m| m.len())
-                .unwrap_or(0);
-            let duration_secs = size.saturating_sub(44) as f64 / 48000.0;
-            eprintln!("Converting to MP3...");
-            let final_path = try_convert_to_mp3(&output_path);
-            succeed(&format!(
-                "Generated audio (macOS Say): {final_path} ({duration_secs:.1}s, {size} bytes). \
-                 Note: using built-in macOS voice — install ominix-api for higher-quality Qwen3-TTS. \
-                 Use send_file to deliver it to the user."
-            ));
-        }
+        Ok(()) => match validate_synthesized_audio(&output_path) {
+            Ok(size) => {
+                let duration_secs = size.saturating_sub(44) as f64 / 48000.0;
+                eprintln!("Converting to MP3...");
+                let final_path = try_convert_to_mp3(&output_path);
+                succeed(&format!(
+                    "Generated audio (macOS Say): {final_path} ({duration_secs:.1}s, {size} bytes). \
+                     Note: using built-in macOS voice — install ominix-api for higher-quality Qwen3-TTS. \
+                     Use send_file to deliver it to the user."
+                ));
+            }
+            Err(e) => fail(&format!("TTS failed: macOS Say output invalid: {e}")),
+        },
         Err(e) => fail(&format!(
-            "TTS failed: ominix-api not available, macOS Say also failed: {e}"
+            "TTS failed: ominix-api not reachable, macOS Say also failed: {e}"
         )),
     }
 }
@@ -569,6 +686,135 @@ mod tests {
 
         silent[44] = 1;
         assert!(!wav_payload_is_silent_bytes(&silent));
+    }
+
+    // ── resolve_api_base_url ──────────────────────────────────────────
+
+    #[test]
+    fn resolve_prefers_env_url_over_discovery() {
+        let probe_hits = std::cell::Cell::new(0usize);
+        let got = resolve_api_base_url(
+            Some("http://env:1111".into()),
+            Some("http://disc:2222".into()),
+            &["http://cand:3333"],
+            |_| {
+                probe_hits.set(probe_hits.get() + 1);
+                true
+            },
+        );
+        assert_eq!(got.as_deref(), Some("http://env:1111"));
+        assert_eq!(
+            probe_hits.get(),
+            0,
+            "env override must short-circuit probing"
+        );
+    }
+
+    #[test]
+    fn resolve_uses_discovery_when_no_env() {
+        let probe_hits = std::cell::Cell::new(0usize);
+        let got = resolve_api_base_url(
+            None,
+            Some("http://disc:2222".into()),
+            &["http://cand:3333"],
+            |_| {
+                probe_hits.set(probe_hits.get() + 1);
+                true
+            },
+        );
+        assert_eq!(got.as_deref(), Some("http://disc:2222"));
+        assert_eq!(probe_hits.get(), 0);
+    }
+
+    #[test]
+    fn resolve_probes_candidates_in_order_and_returns_first_healthy() {
+        // Simulate mini3: 9090 down, 8080 healthy, 8081 never reached.
+        let calls = std::cell::RefCell::new(Vec::<String>::new());
+        let got = resolve_api_base_url(
+            None,
+            None,
+            &[
+                "http://localhost:9090",
+                "http://localhost:8080",
+                "http://localhost:8081",
+            ],
+            |u| {
+                calls.borrow_mut().push(u.to_string());
+                u.ends_with(":8080")
+            },
+        );
+        assert_eq!(got.as_deref(), Some("http://localhost:8080"));
+        assert_eq!(
+            *calls.borrow(),
+            vec![
+                "http://localhost:9090".to_string(),
+                "http://localhost:8080".to_string(),
+            ],
+            "must stop probing once a candidate is healthy"
+        );
+    }
+
+    #[test]
+    fn resolve_returns_none_when_nothing_reachable() {
+        let got = resolve_api_base_url(None, None, &["http://localhost:9090"], |_| false);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn normalize_strips_trailing_slash_and_whitespace() {
+        assert_eq!(
+            normalize_base_url(" http://x:8080/ ").as_deref(),
+            Some("http://x:8080")
+        );
+        // trim_end_matches strips ALL trailing instances of the pattern.
+        assert_eq!(
+            normalize_base_url("http://x:8080///").as_deref(),
+            Some("http://x:8080")
+        );
+        assert_eq!(normalize_base_url("").as_deref(), None);
+        assert_eq!(normalize_base_url("   ").as_deref(), None);
+    }
+
+    // ── validate_synthesized_audio ────────────────────────────────────
+
+    #[test]
+    fn validate_rejects_missing_file() {
+        let path = format!("/tmp/voice-skill-test-missing-{}.wav", timestamp());
+        let err = validate_synthesized_audio(&path).unwrap_err();
+        assert!(err.contains("Failed to stat"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_tiny_file() {
+        let path = format!("/tmp/voice-skill-test-tiny-{}.wav", timestamp());
+        std::fs::write(&path, [0u8; 44]).unwrap();
+        let err = validate_synthesized_audio(&path).unwrap_err();
+        assert!(err.contains("too small"), "unexpected error: {err}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn validate_rejects_silent_wav() {
+        let path = format!("/tmp/voice-skill-test-silent-{}.wav", timestamp());
+        // 260 bytes, all zeros: passes size gate, fails silence gate.
+        std::fs::write(&path, vec![0u8; 260]).unwrap();
+        let err = validate_synthesized_audio(&path).unwrap_err();
+        assert!(err.contains("silent"), "unexpected error: {err}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn validate_accepts_valid_wav() {
+        let path = format!("/tmp/voice-skill-test-valid-{}.wav", timestamp());
+        let mut bytes = vec![0u8; 300];
+        // Put some non-zero samples after the header.
+        for b in bytes.iter_mut().skip(44) {
+            *b = 0x77;
+        }
+        std::fs::write(&path, &bytes).unwrap();
+        let size = validate_synthesized_audio(&path).unwrap();
+        assert_eq!(size, 300);
+        let _ = std::fs::remove_file(&path);
     }
 }
 
@@ -603,7 +849,7 @@ fn try_convert_to_mp3(wav_path: &str) -> String {
 // ── list_models ──────────────────────────────────────────────────────
 
 fn handle_list_models(_input_json: &str) {
-    let base_url = api_base_url();
+    let base_url = require_api_base_url();
     let client = http_client();
     if let Err(e) = check_health(&client, &base_url) {
         fail(&e);
@@ -670,7 +916,7 @@ fn handle_download_model(input_json: &str) {
         Err(e) => fail(&format!("Invalid input: {e}")),
     };
 
-    let base_url = api_base_url();
+    let base_url = require_api_base_url();
     let client = http_client();
     if let Err(e) = check_health(&client, &base_url) {
         fail(&e);
@@ -720,7 +966,7 @@ fn handle_load_model(input_json: &str) {
         Err(e) => fail(&format!("Invalid input: {e}")),
     };
 
-    let base_url = api_base_url();
+    let base_url = require_api_base_url();
     let client = http_client();
     if let Err(e) = check_health(&client, &base_url) {
         fail(&e);
@@ -762,7 +1008,7 @@ fn handle_unload_model(input_json: &str) {
         Err(e) => fail(&format!("Invalid input: {e}")),
     };
 
-    let base_url = api_base_url();
+    let base_url = require_api_base_url();
     let client = http_client();
     if let Err(e) = check_health(&client, &base_url) {
         fail(&e);

--- a/dashboard/src/components/tabs/EmailTab.tsx
+++ b/dashboard/src/components/tabs/EmailTab.tsx
@@ -124,7 +124,16 @@ export default function EmailTab({ config, onChange }: Props) {
                   className="input"
                 />
                 <p className="text-xs text-gray-500 mt-1">
-                  SMTP login password or app-specific password (e.g. Gmail app password, SendGrid API key). Stored in the profile config.
+                  SMTP login password or app-specific password (SendGrid API key,{' '}
+                  <a
+                    href="https://myaccount.google.com/apppasswords"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 hover:text-blue-300 underline"
+                  >
+                    Gmail app password
+                  </a>
+                  , etc.). Stored in the profile config.
                 </p>
               </div>
               <div>

--- a/dashboard/src/components/tabs/EmailTab.tsx
+++ b/dashboard/src/components/tabs/EmailTab.tsx
@@ -10,14 +10,14 @@ const EMPTY_SMTP: EmailSettings = {
   smtp_host: '',
   smtp_port: 465,
   username: '',
-  password_env: 'SMTP_PASSWORD',
+  password: '',
   from_address: '',
 }
 
 const EMPTY_FEISHU: EmailSettings = {
   provider: 'feishu',
   feishu_app_id: '',
-  feishu_app_secret_env: 'FEISHU_APP_SECRET',
+  feishu_app_secret: '',
   feishu_from_address: '',
   feishu_region: 'cn',
 }
@@ -114,15 +114,17 @@ export default function EmailTab({ config, onChange }: Props) {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">Password Env Var</label>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">SMTP Password</label>
                 <input
-                  value={email.password_env || ''}
-                  onChange={(e) => update({ password_env: e.target.value })}
-                  placeholder="SMTP_PASSWORD"
+                  type="password"
+                  value={email.password || ''}
+                  onChange={(e) => update({ password: e.target.value })}
+                  placeholder="App password or SMTP login password"
+                  autoComplete="new-password"
                   className="input"
                 />
                 <p className="text-xs text-gray-500 mt-1">
-                  Name of the environment variable holding the SMTP password. Set the actual value in Environment Variables below.
+                  SMTP login password or app-specific password (e.g. Gmail app password, SendGrid API key). Stored in the profile config.
                 </p>
               </div>
               <div>
@@ -149,15 +151,17 @@ export default function EmailTab({ config, onChange }: Props) {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">App Secret Env Var</label>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">App Secret</label>
                 <input
-                  value={email.feishu_app_secret_env || ''}
-                  onChange={(e) => update({ feishu_app_secret_env: e.target.value })}
-                  placeholder="FEISHU_APP_SECRET"
+                  type="password"
+                  value={email.feishu_app_secret || ''}
+                  onChange={(e) => update({ feishu_app_secret: e.target.value })}
+                  placeholder="Feishu app secret"
+                  autoComplete="new-password"
                   className="input"
                 />
                 <p className="text-xs text-gray-500 mt-1">
-                  Name of the environment variable holding the Feishu app secret. Set the actual value in Environment Variables below.
+                  Feishu/Lark app secret. Stored in the profile config.
                 </p>
               </div>
               <div>

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -61,9 +61,15 @@ export interface EmailSettings {
   smtp_host?: string | null
   smtp_port?: number | null
   username?: string | null
+  /** Literal SMTP password. Preferred over `password_env` when both are set. */
+  password?: string | null
+  /** Name of an env var holding the SMTP password (advanced — when `password` is unset). */
   password_env?: string | null
   from_address?: string | null
   feishu_app_id?: string | null
+  /** Literal Feishu app secret. Preferred over `feishu_app_secret_env`. */
+  feishu_app_secret?: string | null
+  /** Name of an env var holding the Feishu app secret (advanced). */
   feishu_app_secret_env?: string | null
   feishu_from_address?: string | null
   feishu_region?: string | null

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -225,6 +225,31 @@ scp_target() {
     esac
 }
 
+ssh_sudo_target() {
+    # ssh_sudo_target <index> <command string>
+    local i=$1; shift
+    local host="${DEPLOY_HOSTS[$i]}"
+    local auth_type="${DEPLOY_AUTH_TYPE[$i]}"
+    local auth_val="${DEPLOY_AUTH_VAL[$i]}"
+    local remote_cmd="$*"
+    local quoted_cmd
+    printf -v quoted_cmd "%q" "$remote_cmd"
+
+    case "$auth_type" in
+        password)
+            local quoted_pw
+            printf -v quoted_pw "%q" "$auth_val"
+            sshpass -p "$auth_val" ssh "${_ssh_opts[@]}" -o PreferredAuthentications=password,keyboard-interactive \
+                "$host" "printf '%s\n' ${quoted_pw} | sudo -S -p '' bash -lc ${quoted_cmd}" ;;
+        key)
+            if [[ "$auth_val" == "default" ]]; then
+                ssh "${_ssh_opts[@]}" "$host" "sudo bash -lc ${quoted_cmd}"
+            else
+                ssh "${_ssh_opts[@]}" -i "$auth_val" "$host" "sudo bash -lc ${quoted_cmd}"
+            fi ;;
+    esac
+}
+
 # Resolve remote $HOME (cached per target to avoid extra SSH roundtrips)
 REMOTE_HOME_CACHE=()
 resolve_remote_home() {
@@ -314,9 +339,9 @@ generate_plist() {
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>${rdata}/serve.log</string>
+    <string>/dev/null</string>
     <key>StandardErrorPath</key>
-    <string>${rdata}/serve.log</string>
+    <string>/dev/null</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -327,8 +352,6 @@ generate_plist() {
         <string>${rdata}</string>
         <key>OCTOS_AUTH_TOKEN</key>
         <string>octos-admin-2026</string>
-        <key>SMTP_PASSWORD</key>
-        <string>${SMTP_PASSWORD:-}</string>
     </dict>
     <key>WorkingDirectory</key>
     <string>${rhome}</string>
@@ -336,6 +359,79 @@ generate_plist() {
 </plist>
 PEOF
     echo "    plist written"
+}
+
+stop_remote_caddy_services() {
+    local i=$1
+
+    echo "==> Removing stale Caddy services..."
+    ssh_target "$i" 'bash -lc '"'"'
+        uid=$(id -u)
+        launchctl bootout "gui/${uid}/homebrew.mxcl.caddy" 2>/dev/null || true
+        launchctl unload "$HOME/Library/LaunchAgents/homebrew.mxcl.caddy.plist" 2>/dev/null || true
+        rm -f "$HOME/Library/LaunchAgents/homebrew.mxcl.caddy.plist"
+        pkill -x caddy 2>/dev/null || true
+    '"'"
+    ssh_sudo_target "$i" "
+        launchctl bootout system/com.caddyserver.caddy 2>/dev/null || true
+        launchctl unload /Library/LaunchDaemons/com.caddyserver.caddy.plist 2>/dev/null || true
+        launchctl bootout system/io.octos.caddy 2>/dev/null || true
+        launchctl unload /Library/LaunchDaemons/io.octos.caddy.plist 2>/dev/null || true
+        rm -f /Library/LaunchDaemons/com.caddyserver.caddy.plist /Library/LaunchDaemons/io.octos.caddy.plist
+        pkill -x caddy 2>/dev/null || true
+    "
+}
+
+generate_caddy_launchd_plist() {
+    local i=$1
+    local rdata=$2
+    local rhome
+    local tmp_plist="${rdata}/io.octos.caddy.plist.tmp"
+    rhome=$(resolve_remote_home "$i")
+
+    echo "==> Generating managed Caddy LaunchDaemon..."
+    cat <<PEOF | ssh_target "$i" "cat > '${tmp_plist}'"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.octos.caddy</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/caddy</string>
+        <string>run</string>
+        <string>--config</string>
+        <string>${rdata}/Caddyfile</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/var/log/caddy.log</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/caddy.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>${rhome}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>${rhome}</string>
+</dict>
+</plist>
+PEOF
+
+    ssh_sudo_target "$i" "
+        mkdir -p /Library/LaunchDaemons
+        mv '${tmp_plist}' /Library/LaunchDaemons/io.octos.caddy.plist
+        chown root:wheel /Library/LaunchDaemons/io.octos.caddy.plist
+        chmod 644 /Library/LaunchDaemons/io.octos.caddy.plist
+    "
+    echo "    Caddy plist written"
 }
 
 # --- Build from octos repo ---
@@ -384,6 +480,7 @@ for ((i=0; i<${#DEPLOY_HOSTS[@]}; i++)); do
     LABEL="${DEPLOY_LABEL[$i]}"
     RBIN=$(resolve_remote_bin "$i")
     RDATA=$(resolve_remote_data "$i")
+    RHOME=$(resolve_remote_home "$i")
 
     echo ""
     echo "========================================"
@@ -399,6 +496,7 @@ for ((i=0; i<${#DEPLOY_HOSTS[@]}; i++)); do
         # Stop all octos-related launchd services
         ssh_target "$i" "launchctl unload ~/Library/LaunchAgents/${PLIST}.plist 2>/dev/null || true"
         ssh_target "$i" "launchctl unload ~/Library/LaunchAgents/io.ominix.ominix-api.plist 2>/dev/null || true"
+        stop_remote_caddy_services "$i"
         # Remove legacy plists (old names from crew era)
         ssh_target "$i" 'bash -c '"'"'
             for plist in ~/Library/LaunchAgents/io.ominix.*.plist; do
@@ -413,7 +511,6 @@ for ((i=0; i<${#DEPLOY_HOSTS[@]}; i++)); do
         sleep 1
 
         # Save profiles to local tmp if --keep-profiles
-        RHOME=$(resolve_remote_home "$i")
         SAVED_PROFILES_DIR=""
         if [[ "$KEEP_PROFILES" == true ]]; then
             SAVED_PROFILES_DIR=$(mktemp -d)
@@ -589,7 +686,7 @@ for ((i=0; i<${#DEPLOY_HOSTS[@]}; i++)); do
         echo "==> Uploading octos-web chat client..."
         tar czf /tmp/octos-web-dist.tar.gz -C "$OCTOS_WEB_DIR/dist" .
         scp_target "$i" /tmp/octos-web-dist.tar.gz "$REMOTE:/tmp/octos-web-dist.tar.gz"
-        ssh_target "$i" "mkdir -p ~/octos-web && tar xzf /tmp/octos-web-dist.tar.gz -C ~/octos-web"
+        ssh_target "$i" "mkdir -p '${RHOME}/octos-web' && tar xzf /tmp/octos-web-dist.tar.gz -C '${RHOME}/octos-web'"
         echo "    octos-web deployed to ~/octos-web"
     fi
 
@@ -865,7 +962,7 @@ echo "  ominix-api plist generated"'"'"
     # --- Caddy setup (optional) ---
     if [[ -n "$CADDY_DOMAIN" ]]; then
         echo "==> Setting up Caddy for $CADDY_DOMAIN..."
-        ssh_target "$i" '
+        ssh_target "$i" 'bash -lc '"'"'
             # Install Caddy if missing
             if ! command -v caddy &>/dev/null; then
                 if command -v brew &>/dev/null; then
@@ -881,10 +978,11 @@ echo "  ominix-api plist generated"'"'"
                 fi
             fi
             echo "  Caddy: $(caddy version 2>/dev/null | head -1)"
-        '"
+        '"'"
 
-        CADDY_UPSTREAM=\"localhost:${SERVE_PORT}\"
-        ssh_target "$i" 'cat > ~/Caddyfile << CEOF
+        CADDY_UPSTREAM="localhost:${SERVE_PORT}"
+        CADDY_LABEL_INDEX=$(awk -F. '{print NF}' <<< "$CADDY_DOMAIN")
+        ssh_target "$i" "cat > '${RDATA}/Caddyfile' <<'CEOF'
 {
     on_demand_tls {
         ask http://localhost:9999/check
@@ -896,6 +994,9 @@ echo "  ominix-api plist generated"'"'"
 }
 
 '"${CADDY_DOMAIN}"' {
+    handle /admin/chat {
+        redir / permanent
+    }
     handle /api/* {
         reverse_proxy '"${CADDY_UPSTREAM}"'
     }
@@ -909,7 +1010,9 @@ echo "  ominix-api plist generated"'"'"
         reverse_proxy '"${CADDY_UPSTREAM}"'
     }
     handle {
-        reverse_proxy '"${CADDY_UPSTREAM}"'
+        root * '"${RHOME}"'/octos-web
+        try_files {path} /index.html
+        file_server
     }
 }
 
@@ -918,44 +1021,57 @@ echo "  ominix-api plist generated"'"'"
         on_demand
     }
 
+    @admin_chat path /admin/chat
     @api path /api/*
     @admin path /admin*
     @auth path /auth/*
+    @webhook path /webhook/*
 
+    handle @admin_chat {
+        redir / permanent
+    }
     handle @api {
         reverse_proxy '"${CADDY_UPSTREAM}"' {
-            header_up X-Profile-Id {labels.2}
+            header_up X-Profile-Id {labels.'"${CADDY_LABEL_INDEX}"'}
         }
     }
     handle @admin {
         reverse_proxy '"${CADDY_UPSTREAM}"' {
-            header_up X-Profile-Id {labels.2}
+            header_up X-Profile-Id {labels.'"${CADDY_LABEL_INDEX}"'}
         }
     }
     handle @auth {
         reverse_proxy '"${CADDY_UPSTREAM}"' {
-            header_up X-Profile-Id {labels.2}
+            header_up X-Profile-Id {labels.'"${CADDY_LABEL_INDEX}"'}
+        }
+    }
+    handle @webhook {
+        reverse_proxy '"${CADDY_UPSTREAM}"' {
+            header_up X-Profile-Id {labels.'"${CADDY_LABEL_INDEX}"'}
         }
     }
     handle {
-        reverse_proxy '"${CADDY_UPSTREAM}"'
+        root * '"${RHOME}"'/octos-web
+        try_files {path} /index.html
+        file_server
     }
 }
 CEOF
-            caddy fmt --overwrite ~/Caddyfile 2>/dev/null || true
-            if caddy validate --config ~/Caddyfile 2>/dev/null; then
+            caddy fmt --overwrite '${RDATA}/Caddyfile' 2>/dev/null || true
+            if caddy validate --config '${RDATA}/Caddyfile' 2>/dev/null; then
                 echo "  Caddyfile valid"
             else
                 echo "  WARNING: Caddyfile validation failed"
+                exit 1
             fi
-            if pgrep -x caddy > /dev/null 2>&1; then
-                caddy reload --config ~/Caddyfile 2>/dev/null
-                echo "  Caddy reloaded"
-            else
-                caddy start --config ~/Caddyfile 2>/dev/null
-                echo "  Caddy started"
-            fi
-        '"
+        "
+        stop_remote_caddy_services "$i"
+        generate_caddy_launchd_plist "$i" "$RDATA"
+        ssh_sudo_target "$i" "
+            launchctl bootstrap system /Library/LaunchDaemons/io.octos.caddy.plist
+            launchctl enable system/io.octos.caddy 2>/dev/null || true
+            launchctl kickstart -k system/io.octos.caddy
+        "
         echo "  Caddy configured for ${CADDY_DOMAIN} + *.${CADDY_DOMAIN}"
     fi
 

--- a/scripts/frp/bootstrap-tenant.sh
+++ b/scripts/frp/bootstrap-tenant.sh
@@ -311,9 +311,9 @@ if [ "$REMOTE_OS" = "Darwin" ]; then
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>${RDATA}/serve.log</string>
+    <string>/dev/null</string>
     <key>StandardErrorPath</key>
-    <string>${RDATA}/serve.log</string>
+    <string>/dev/null</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -421,7 +421,7 @@ sleep 3
 if ssh_cmd "curl -sf --max-time 3 http://localhost:${SERVE_PORT}/api/status" > /dev/null 2>&1; then
     echo "    octos serve: RUNNING on port ${SERVE_PORT}"
 else
-    echo "    octos serve: starting up (check ${RDATA}/serve.log)"
+    echo "    octos serve: starting up (check ${RDATA}/logs/serve.\$(date +%F).log)"
 fi
 
 # Check frpc

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -529,9 +529,9 @@ write_octos_service() {
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>$DATA_DIR/serve.log</string>
+    <string>/dev/null</string>
     <key>StandardErrorPath</key>
-    <string>$DATA_DIR/serve.log</string>
+    <string>/dev/null</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -828,7 +828,7 @@ if [ "$RUN_DOCTOR" = true ]; then
             ;;
         *)
             warn "responds HTTP $HTTP_CODE"
-            hint "Check logs: tail -20 $DATA_DIR/serve.log"
+            hint "Check logs: tail -20 $DATA_DIR/logs/serve.$(date +%F).log"
             ;;
     esac
 
@@ -977,19 +977,22 @@ if [ "$RUN_DOCTOR" = true ]; then
     # ── Serve logs ───────────────────────────────────────────────────
     section "Recent serve logs"
 
-    SERVE_LOG="$DATA_DIR/serve.log"
+    SERVE_LOG=$(ls -1t "$DATA_DIR"/logs/serve.*.log 2>/dev/null | head -1 || true)
+    if [ -z "$SERVE_LOG" ]; then
+        SERVE_LOG="$DATA_DIR/serve.log"
+    fi
     if [ -f "$SERVE_LOG" ]; then
         SERVE_ERRORS=$(tail -30 "$SERVE_LOG" 2>/dev/null | grep -i "error\|panic\|Address already in use" | tail -5)
         if [ -n "$SERVE_ERRORS" ]; then
-            warn "recent errors in serve.log:"
+            warn "recent errors in $(basename "$SERVE_LOG"):"
             echo "$SERVE_ERRORS" | while read -r line; do echo "      $line"; done
         else
-            ok "no recent errors in serve.log"
+            ok "no recent errors in $(basename "$SERVE_LOG")"
         fi
         echo "    Last 3 lines:"
         tail -3 "$SERVE_LOG" 2>/dev/null | while read -r line; do echo "      $line"; done
     else
-        warn "serve.log not found at $SERVE_LOG"
+        warn "no serve log found under $DATA_DIR/logs or at $DATA_DIR/serve.log"
     fi
 
     # ── Runtime dependencies ─────────────────────────────────────────
@@ -1524,7 +1527,7 @@ while [ $RETRIES -gt 0 ]; do
 done
 if [ $RETRIES -eq 0 ]; then
     warn "octos serve did not respond within 10 seconds"
-    echo "    Check logs: tail -f $DATA_DIR/serve.log"
+    echo "    Check logs: tail -f $DATA_DIR/logs/serve.\$(date +%F).log"
 fi
 
 # ── Firewall (Caddy only) ─────────────────────────────────────────────
@@ -1796,7 +1799,7 @@ echo "    Binary:     $PREFIX/octos"
 echo "    Data dir:   $DATA_DIR"
 echo "    Config:     $DATA_DIR/config.json"
 echo "    Auth token: $AUTH_TOKEN"
-echo "    Logs:       tail -f $DATA_DIR/serve.log"
+echo "    Logs:       tail -f $DATA_DIR/logs/serve.\$(date +%F).log"
 echo ""
 echo "  Next steps:"
 echo "    1. Setup LLM models:  octos init"

--- a/scripts/local-tenant-deploy.sh
+++ b/scripts/local-tenant-deploy.sh
@@ -476,9 +476,9 @@ if [ "$SETUP_SERVICE" = true ] && [ -n "$CLI_FEATURES" ]; then
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>$DATA_DIR/serve.log</string>
+    <string>/dev/null</string>
     <key>StandardErrorPath</key>
-    <string>$DATA_DIR/serve.log</string>
+    <string>/dev/null</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
@@ -555,7 +555,7 @@ EOF
     done
     if [ $RETRIES -eq 0 ]; then
         warn "octos serve did not respond within 10 seconds"
-        echo "    Check logs: tail -f $DATA_DIR/serve.log"
+        echo "    Check logs: tail -f $DATA_DIR/logs/serve.\$(date +%F).log"
     fi
 else
     if [ "$SETUP_SERVICE" = true ]; then
@@ -625,7 +625,7 @@ if [ -n "$CLI_FEATURES" ]; then
     echo "    3. Open browser:      http://localhost:8080/admin/"
     echo ""
     echo "  Auth token:   $AUTH_TOKEN"
-    echo "  Logs:         tail -f $DATA_DIR/serve.log"
+    echo "  Logs:         tail -f $DATA_DIR/logs/serve.\$(date +%F).log"
     case "$OS" in
         Darwin)
             echo "  Status:       sudo launchctl print system/io.octos.serve"

--- a/scripts/octos-doctor.sh
+++ b/scripts/octos-doctor.sh
@@ -128,6 +128,20 @@ svc_hint() {
     esac
 }
 
+current_serve_log_hint() {
+    printf '%s/logs/serve.%s.log\n' "$DATA_DIR" "$(date +%F)"
+}
+
+latest_serve_log() {
+    local latest
+    latest=$(ls -1t "$DATA_DIR"/logs/serve.*.log 2>/dev/null | head -1 || true)
+    if [ -n "$latest" ]; then
+        printf '%s\n' "$latest"
+    elif [ -f "$DATA_DIR/serve.log" ]; then
+        printf '%s\n' "$DATA_DIR/serve.log"
+    fi
+}
+
 config_json_get() {
     local expr="$1"
     local config_path="$DATA_DIR/config.json"
@@ -407,7 +421,7 @@ case "$HTTP_CODE" in
         ;;
     *)
         warn "responds HTTP $HTTP_CODE"
-        hint "Check logs: tail -20 $DATA_DIR/serve.log"
+        hint "Check logs: tail -20 $(current_serve_log_hint)"
         ;;
 esac
 
@@ -575,10 +589,11 @@ if [ "$CLOUD_MODE" = true ]; then
             hint "Run 'octos admin set-smtp-password' or save via the setup wizard"
             hint "Falling back to env var $SMTP_PASSWORD_ENV if the service exports it"
         fi
-        if [ -f "$DATA_DIR/serve.log" ]; then
-            SMTP_AUTH_ERRORS=$(grep -i 'send_otp failed.*535\|send_otp failed.*authentication failed' "$DATA_DIR/serve.log" 2>/dev/null | tail -1 || true)
+        SERVE_LOG_FOR_SMTP=$(latest_serve_log)
+        if [ -n "$SERVE_LOG_FOR_SMTP" ] && [ -f "$SERVE_LOG_FOR_SMTP" ]; then
+            SMTP_AUTH_ERRORS=$(grep -i 'send_otp failed.*535\|send_otp failed.*authentication failed' "$SERVE_LOG_FOR_SMTP" 2>/dev/null | tail -1 || true)
             if [ -n "$SMTP_AUTH_ERRORS" ]; then
-                err "recent SMTP authentication failure detected in serve.log"
+                err "recent SMTP authentication failure detected in $(basename "$SERVE_LOG_FOR_SMTP")"
                 hint "Verify SMTP_USERNAME / SMTP_PASSWORD and reload io.octos.serve"
             fi
         fi
@@ -689,19 +704,19 @@ fi
 # ── Serve logs ───────────────────────────────────────────────────
 section "Recent serve logs"
 
-SERVE_LOG="$DATA_DIR/serve.log"
-if [ -f "$SERVE_LOG" ]; then
+SERVE_LOG=$(latest_serve_log)
+if [ -n "$SERVE_LOG" ] && [ -f "$SERVE_LOG" ]; then
     SERVE_ERRORS=$(tail -30 "$SERVE_LOG" 2>/dev/null | grep -i "error\|panic\|Address already in use\|send_otp failed" | tail -5)
     if [ -n "$SERVE_ERRORS" ]; then
-        warn "recent errors in serve.log:"
+        warn "recent errors in $(basename "$SERVE_LOG"):"
         echo "$SERVE_ERRORS" | while read -r line; do echo "      $line"; done
     else
-        ok "no recent errors in serve.log"
+        ok "no recent errors in $(basename "$SERVE_LOG")"
     fi
     echo "    Last 3 lines:"
     tail -3 "$SERVE_LOG" 2>/dev/null | while read -r line; do echo "      $line"; done
 else
-    warn "serve.log not found at $SERVE_LOG"
+    warn "no serve log found under $DATA_DIR/logs or at $DATA_DIR/serve.log"
 fi
 
 # ── Runtime dependencies ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `platform-skills/voice` defaulted to `http://localhost:9090` when neither `OMINIX_API_URL` env nor `~/.ominix/api_url` was set, so on deployments like mini3 where `ominix-api` listens on `:8080` the skill fell back to macOS `say` and emitted the `注意：当前使用的是 macOS 内置语音合成（Say 命令）` chat response despite the service being healthy.
- The Say fallback reported `success` even when the afconvert pipeline produced a 0-byte or silent WAV, so callers received a truncated artifact with no error.

## Changes

- `resolve_api_base_url` now chains `env → discovery file → probe candidate ports (9090, 8080, 8081)` with a 500 ms `/health` timeout per candidate. First healthy probe wins; only falls back to Say if *every* candidate fails. Extracted as a pure function with an injectable probe so it is covered by unit tests (no real network calls).
- New `validate_synthesized_audio` enforces a 256-byte minimum and re-checks the silence payload before reporting success. Applied to **both** the `ominix-api` success path and the Say fallback, so a zero-byte or silent WAV now fails the skill with a clear error instead of masquerading as a good artifact.
- Tools that require `ominix-api` (`list_models`, `download_model`, `load_model`, `unload_model`) now share `require_api_base_url`, which fails the skill with an actionable error when no candidate is reachable (previously they would use a stale default and produce misleading connection errors).
- SKILL.md / manifest.json / Cargo.toml bumped to `1.1.1`. No tool-name or input-schema changes.

## Verification

Probed mini3 (port candidate semantics match):
- `http://localhost:8080/health` → healthy JSON (`{"status":"healthy","version":"1.2.0+084b7fe"}`)
- `http://localhost:9090/health` → connection refused (probe fails fast)
- `http://localhost:8081/health` → connection refused

Say pipeline with language-aware voice:
- `say -v Tingting -o /tmp/x.aiff '你好测试' && afconvert ... x.wav` → 51 KB WAV (healthy)

With the old default-to-9090 logic the skill would have hit connection-refused and fallen back to Say; the new probe loop returns `http://localhost:8080` within ~500 ms and goes through the Qwen3-TTS path.

## Gates

- `cargo fmt -p voice -- --check` — passes
- `cargo clippy -p voice --no-deps --all-targets -- -D warnings` — passes
- `cargo test -p voice` — 12/12 passing (4 new detection tests, 4 new validator tests, 4 pre-existing Say tests). Note: the voice crate is a binary with no lib target, so `cargo test -p voice --lib` from the spec errors with "no library targets found"; using the plain form runs the binary's unit tests.
- `cargo build --release -p voice` — passes

## Deployment

**Not deployed.** Supervisor decides when to roll out to mini3 and the other minis.

## Test plan

- [x] Unit tests cover env-priority, discovery-priority, ordered probing, all-fail fallback, silence-only WAV rejection, tiny-file rejection, missing-file rejection, valid WAV acceptance.
- [ ] Post-deploy: run `voice_synthesize {"text": "你好世界", "speaker": "vivian"}` on mini3 and verify no Say fallback notice in the chat response.
- [ ] Post-deploy: disable ominix-api on mini3 and verify Say fallback produces a non-empty WAV (Tingting voice picked automatically for Chinese).