### PR TITLE
M8.3: Profile system (runtime-v0.1 close-out)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -93,6 +93,7 @@ impl Agent {
                 let tc_args = tool_call.arguments.clone();
                 let attachment_ctx = turn_attachment_ctx.clone();
                 let harness_event_sink = self.harness_event_sink.clone();
+                let agent_definitions = self.agent_definitions.clone();
 
                 tokio::spawn(async move {
                     let tool_start = Instant::now();
@@ -168,6 +169,7 @@ impl Agent {
                         let bg_supervisor = tools.supervisor();
                         let bg_reporter = reporter.clone();
                         let bg_attachment_ctx = attachment_ctx.clone();
+                        let bg_agent_definitions = agent_definitions.clone();
                         tokio::spawn(async move {
                             bg_supervisor.mark_running(&task_id);
                             let bg_started_at = std::time::SystemTime::now();
@@ -186,6 +188,7 @@ impl Agent {
                                 file_attachment_paths: bg_attachment_ctx
                                     .file_attachment_paths
                                     .clone(),
+                                agent_definitions: bg_agent_definitions.clone(),
                                 ..ToolContext::zero()
                             };
 
@@ -506,6 +509,7 @@ impl Agent {
                         attachment_paths: attachment_ctx.attachment_paths.clone(),
                         audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
                         file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),
+                        agent_definitions: agent_definitions.clone(),
                         ..ToolContext::zero()
                     };
                     // Thread the typed context into execute_with_context. Legacy tools

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -172,7 +172,9 @@ impl Agent {
                             bg_supervisor.mark_running(&task_id);
                             let bg_started_at = std::time::SystemTime::now();
 
-                            // Helper to create TOOL_CTX for plugin stderr progress streaming
+                            // Helper to create TOOL_CTX for plugin stderr progress streaming.
+                            // Base it on the zero-value context so M8.x placeholder fields
+                            // carry their default-populated values.
                             let make_ctx = || ToolContext {
                                 tool_id: bg_tc_id.clone(),
                                 reporter: bg_reporter.clone(),
@@ -184,6 +186,7 @@ impl Agent {
                                 file_attachment_paths: bg_attachment_ctx
                                     .file_attachment_paths
                                     .clone(),
+                                ..ToolContext::zero()
                             };
 
                             let mut result = TOOL_CTX
@@ -503,9 +506,17 @@ impl Agent {
                         attachment_paths: attachment_ctx.attachment_paths.clone(),
                         audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
                         file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),
+                        ..ToolContext::zero()
                     };
+                    // Thread the typed context into execute_with_context. Legacy tools
+                    // whose trait impl only overrides `execute` still work via the
+                    // default delegation path; migrated tools read the typed fields.
+                    // TOOL_CTX is still scoped for plugin tools that read the task-local.
                     let result = TOOL_CTX
-                        .scope(ctx, tools.execute(&tc_name, &effective_args))
+                        .scope(
+                            ctx.clone(),
+                            tools.execute_with_context(&ctx, &tc_name, &effective_args),
+                        )
                         .await;
 
                     let duration = tool_start.elapsed();

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -177,6 +177,11 @@ pub struct Agent {
     /// clone is O(1). When left at the default (empty registry) the agent
     /// behaves exactly as pre-M8.2.
     pub(super) agent_definitions: Arc<crate::agents::AgentDefinitions>,
+    /// M8.3 profile envelope applied at bootstrap. Recorded so callers can
+    /// introspect the active profile name, compaction overrides, and model
+    /// preferences. `None` means no profile was explicitly applied — the
+    /// agent runs in legacy pre-M8.3 mode.
+    pub(super) profile: Option<Arc<crate::profile::ProfileDefinition>>,
 }
 
 impl Agent {
@@ -208,6 +213,7 @@ impl Agent {
             compaction_runner: None,
             compaction_workspace: None,
             agent_definitions: Arc::new(crate::agents::AgentDefinitions::new()),
+            profile: None,
         }
     }
 
@@ -240,6 +246,7 @@ impl Agent {
             compaction_runner: None,
             compaction_workspace: None,
             agent_definitions: Arc::new(crate::agents::AgentDefinitions::new()),
+            profile: None,
         }
     }
 
@@ -251,6 +258,32 @@ impl Agent {
     pub fn with_agent_definitions(mut self, defs: Arc<crate::agents::AgentDefinitions>) -> Self {
         self.agent_definitions = defs;
         self
+    }
+
+    /// Record the active [`crate::profile::ProfileDefinition`] envelope.
+    ///
+    /// Call this after the caller has already applied the profile's tool
+    /// filter to the [`crate::tools::ToolRegistry`] (via
+    /// [`crate::tools::ToolRegistry::filter_by_profile`]) and passed the
+    /// filtered registry into [`Agent::new`]. This setter only *records*
+    /// the profile so downstream code can introspect the active name,
+    /// compaction policy overrides, and model preferences.
+    ///
+    /// Fields that today land as *recorded only* (compaction policy, model
+    /// preferences, MCP server ids) keep their semantics — the agent loop
+    /// does not enforce them yet. See the
+    /// [`crate::profile`] module doc for the follow-up milestones that
+    /// wire each field in.
+    pub fn with_profile(mut self, profile: Arc<crate::profile::ProfileDefinition>) -> Self {
+        self.profile = Some(profile);
+        self
+    }
+
+    /// Access the recorded [`crate::profile::ProfileDefinition`], if any.
+    /// Returns `None` when the agent was built without a profile envelope
+    /// (legacy pre-M8.3 mode).
+    pub fn profile(&self) -> Option<Arc<crate::profile::ProfileDefinition>> {
+        self.profile.clone()
     }
 
     /// Wire the `activate_tools` tool's back-reference to the shared tool registry.
@@ -509,5 +542,104 @@ impl Agent {
             .read()
             .unwrap_or_else(|e| e.into_inner())
             .clone()
+    }
+}
+
+#[cfg(test)]
+mod profile_integration_tests {
+    //! M8.3 — bootstrapping an [`Agent`] with the built-in `coding`
+    //! profile must yield the same tool set as today's default path. This
+    //! is the behaviour-parity gate called out in the milestone issue.
+
+    use super::*;
+    use octos_core::AgentId;
+    use octos_llm::{ChatResponse, LlmProvider, ToolSpec};
+    use octos_memory::EpisodeStore;
+
+    struct NoopProvider;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for NoopProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            eyre::bail!("unused in profile integration tests")
+        }
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    async fn agent_default(cwd: &std::path::Path) -> Agent {
+        let memory = Arc::new(
+            EpisodeStore::open(cwd.join("memory-default"))
+                .await
+                .expect("episode store"),
+        );
+        let provider: Arc<dyn LlmProvider> = Arc::new(NoopProvider);
+        let tools = ToolRegistry::with_builtins(cwd);
+        Agent::new(AgentId::new("default"), provider, tools, memory)
+    }
+
+    async fn agent_with_coding_profile(cwd: &std::path::Path) -> Agent {
+        use crate::profile::ProfileDefinition;
+
+        let memory = Arc::new(
+            EpisodeStore::open(cwd.join("memory-profile"))
+                .await
+                .expect("episode store"),
+        );
+        let provider: Arc<dyn LlmProvider> = Arc::new(NoopProvider);
+
+        let coding = ProfileDefinition::builtin("coding").expect("coding builtin");
+        let mut tools = ToolRegistry::with_builtins(cwd);
+        coding.apply_to_registry(&mut tools);
+
+        Agent::new(AgentId::new("coding"), provider, tools, memory).with_profile(Arc::new(coding))
+    }
+
+    fn tool_names(agent: &Agent) -> Vec<String> {
+        let mut names: Vec<String> = agent
+            .tool_registry()
+            .specs()
+            .into_iter()
+            .map(|s| s.name)
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[tokio::test]
+    async fn coding_profile_matches_default_tool_set() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let base = agent_default(tmp.path()).await;
+        let profiled = agent_with_coding_profile(tmp.path()).await;
+
+        assert_eq!(
+            tool_names(&base),
+            tool_names(&profiled),
+            "coding profile must preserve the default tool set byte-for-byte",
+        );
+
+        // The profiled agent also exposes the recorded profile handle.
+        let prof = profiled.profile().expect("profile handle present");
+        assert_eq!(prof.name, "coding");
+        assert_eq!(prof.version, 1);
+    }
+
+    #[tokio::test]
+    async fn agent_without_profile_returns_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = agent_default(tmp.path()).await;
+        assert!(
+            agent.profile().is_none(),
+            "agents built without a profile envelope return None",
+        );
     }
 }

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -172,6 +172,11 @@ pub struct Agent {
     /// Workspace policy associated with the compaction runner (used by the
     /// post-compaction validator rail to resolve preserved artifacts).
     pub(super) compaction_workspace: Option<crate::workspace_policy::WorkspacePolicy>,
+    /// M8.2 agent manifest registry shared with tools via `ToolContext`.
+    /// Shared behind an `Arc` so every per-tool `ToolContext::agent_definitions`
+    /// clone is O(1). When left at the default (empty registry) the agent
+    /// behaves exactly as pre-M8.2.
+    pub(super) agent_definitions: Arc<crate::agents::AgentDefinitions>,
 }
 
 impl Agent {
@@ -202,6 +207,7 @@ impl Agent {
             realtime: None,
             compaction_runner: None,
             compaction_workspace: None,
+            agent_definitions: Arc::new(crate::agents::AgentDefinitions::new()),
         }
     }
 
@@ -233,7 +239,18 @@ impl Agent {
             realtime: None,
             compaction_runner: None,
             compaction_workspace: None,
+            agent_definitions: Arc::new(crate::agents::AgentDefinitions::new()),
         }
+    }
+
+    /// Attach an [`crate::agents::AgentDefinitions`] registry. Threaded into
+    /// every per-tool [`crate::tools::ToolContext`] so tools that read
+    /// `ctx.agent_definitions` see the live registry instead of the M8.1
+    /// zero-value default. Idempotent — callers may swap the registry at
+    /// any time.
+    pub fn with_agent_definitions(mut self, defs: Arc<crate::agents::AgentDefinitions>) -> Self {
+        self.agent_definitions = defs;
+        self
     }
 
     /// Wire the `activate_tools` tool's back-reference to the shared tool registry.

--- a/crates/octos-agent/src/agents/mod.rs
+++ b/crates/octos-agent/src/agents/mod.rs
@@ -1,0 +1,571 @@
+//! Agent manifest format (M8.2 — runtime-v0.1 gate).
+//!
+//! # What is an `AgentDefinition`?
+//!
+//! An [`AgentDefinition`] is an external, declarative JSON or TOML manifest
+//! that describes a sub-agent's capability envelope: which tools it may use,
+//! which are denied, its model preferences, lifecycle hooks, MCP server
+//! dependencies, and so on. The schema deliberately mirrors Claude Code's
+//! `AgentDefinition` from `loadAgentsDir.ts` so authors moving between the
+//! two runtimes see the same field names and semantics.
+//!
+//! Every field in the manifest is domain-neutral: nothing about the schema
+//! is coding-specific. A "research-worker" manifest carries the same shape
+//! as a "repo-editor" manifest — only the tool allow-list differs. This is
+//! the M8.2 "coding-only" falsification gate for runtime-v0.1.
+//!
+//! # How loading works
+//!
+//! [`AgentDefinitions::load_dir`] scans a directory for `*.json` and `*.toml`
+//! files. Each file's stem is the definition id by default; if the file has
+//! a `name` field it overrides the stem. The loader layers:
+//!
+//! 1. Built-in defaults (shipped under `crates/octos-agent/src/assets/agents/`)
+//!    via [`AgentDefinitions::with_builtins`]. Today these are
+//!    `research-worker` (deep_search / web_fetch / web_search; no
+//!    shell/write/edit) and `repo-editor` (read_file / write_file / edit_file
+//!    / shell / grep / glob; no deep_search).
+//! 2. Local manifests from the caller-supplied directory, which replace
+//!    any built-in with the same id.
+//!
+//! If the directory does not exist the loader returns the built-ins only.
+//!
+//! # How `SpawnTool` resolves a manifest
+//!
+//! `SpawnTool::execute` accepts an optional `agent_definition_id` field. When
+//! set, the tool looks up the id in `ctx.agent_definitions` (the field on
+//! [`crate::tools::ToolContext`] that M8.1 stubbed). The manifest's fields
+//! become defaults for the spawn call; any inline field on the spawn args
+//! overrides the manifest. If both are present, inline wins. This keeps
+//! existing inline spawn callers working byte-for-byte while letting
+//! manifest-driven spawns stay terse at the call site.
+//!
+//! # Forward compatibility
+//!
+//! `version: u32` is required and must be `1` for now. Unknown fields are
+//! rejected (`#[serde(deny_unknown_fields)]`) — v1 only needs back-compat on
+//! read, not forward-compat on write. Future versions that add fields will
+//! bump the version number and relax the deny.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+
+/// Current schema version for [`AgentDefinition`].
+///
+/// Manifests with a different `version` are rejected at load time so callers
+/// cannot accidentally mix incompatible shapes. Future schema revisions bump
+/// this constant.
+pub const AGENT_DEFINITION_SCHEMA_VERSION: u32 = 1;
+
+/// A single agent manifest — the declarative capability envelope for a
+/// spawned sub-agent.
+///
+/// Field order and naming follow Claude Code's `AgentDefinition` from
+/// `loadAgentsDir.ts:76-94`. Every field except `name` and `version` is
+/// optional; default values keep existing inline spawn callers unchanged.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AgentDefinition {
+    /// Manifest id — also its display name. Required.
+    pub name: String,
+
+    /// Schema version. Must match [`AGENT_DEFINITION_SCHEMA_VERSION`].
+    pub version: u32,
+
+    /// Allow-list of tool ids the sub-agent may use. Empty = inherit the
+    /// parent's default set.
+    #[serde(default)]
+    pub tools: Vec<String>,
+
+    /// Deny-list of tool ids the sub-agent may not use. Deny always wins
+    /// over allow when a tool appears in both.
+    #[serde(default)]
+    pub disallowed_tools: Vec<String>,
+
+    /// Optional model override (e.g. `"anthropic/claude-haiku"`).
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// Optional effort hint (`"low"` / `"medium"` / `"high"`). Free-form for
+    /// now — the runtime may start honouring specific values in a future
+    /// milestone.
+    #[serde(default)]
+    pub effort: Option<String>,
+
+    /// Optional permission mode. Free-form today; M8.3 will map values to
+    /// the typed permission layer.
+    #[serde(default)]
+    pub permission_mode: Option<String>,
+
+    /// MCP server names this sub-agent wants attached. For v1 we only record
+    /// the names — real MCP wiring lands in a later milestone.
+    #[serde(default)]
+    pub mcp_servers: Vec<String>,
+
+    /// Lifecycle hooks this sub-agent inherits. Minimal v1 shape: event +
+    /// command. Future versions may add timeouts, filters, etc.
+    #[serde(default)]
+    pub hooks: Vec<HookRef>,
+
+    /// Optional cap on sub-agent turn count.
+    #[serde(default)]
+    pub max_turns: Option<u32>,
+
+    /// Skill ids the sub-agent wants enabled. For v1 we only record the
+    /// names — real skill loading lands in a later milestone.
+    #[serde(default)]
+    pub skills: Vec<String>,
+
+    /// Optional memory configuration.
+    #[serde(default)]
+    pub memory: Option<MemoryConfig>,
+
+    /// Whether the sub-agent should run as a background worker by default.
+    #[serde(default)]
+    pub background: bool,
+
+    /// Optional isolation mode string. Free-form today; wired to sandbox
+    /// policy in a later milestone.
+    #[serde(default)]
+    pub isolation: Option<String>,
+}
+
+impl AgentDefinition {
+    /// Validate a freshly-loaded manifest. Today we only check the schema
+    /// version — richer validation (e.g. unknown tool ids) lands when the
+    /// permission layer (M8.3) can do cross-referencing.
+    pub fn validate(&self) -> Result<()> {
+        if self.version != AGENT_DEFINITION_SCHEMA_VERSION {
+            eyre::bail!(
+                "agent definition '{}' has unsupported schema version {} (expected {})",
+                self.name,
+                self.version,
+                AGENT_DEFINITION_SCHEMA_VERSION,
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Minimal v1 hook reference — event name + command.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct HookRef {
+    /// Hook event name (e.g. `"before_tool_call"`).
+    pub event: String,
+    /// Shell command the hook should run.
+    pub command: String,
+}
+
+/// Minimal memory configuration carried by a manifest.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryConfig {
+    /// Optional path to the memory store. When `None` the runtime picks a
+    /// default location.
+    #[serde(default)]
+    pub path: Option<PathBuf>,
+    /// Whether memory is enabled for this sub-agent. Defaults to `true`.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Built-in manifests shipped inside the crate so downstream users get a
+/// sensible default set without having to author their own.
+///
+/// Pairs are `(id, raw JSON text)`. At load time the raw text is parsed via
+/// [`AgentDefinition::from_json_str`].
+const BUILTIN_AGENTS: &[(&str, &str)] = &[
+    (
+        "research-worker",
+        include_str!("../assets/agents/research-worker.json"),
+    ),
+    (
+        "repo-editor",
+        include_str!("../assets/agents/repo-editor.json"),
+    ),
+];
+
+impl AgentDefinition {
+    /// Parse an [`AgentDefinition`] from JSON text.
+    pub fn from_json_str(text: &str) -> Result<Self> {
+        let def: AgentDefinition =
+            serde_json::from_str(text).wrap_err("failed to parse AgentDefinition as JSON")?;
+        def.validate()?;
+        Ok(def)
+    }
+
+    /// Parse an [`AgentDefinition`] from TOML text.
+    pub fn from_toml_str(text: &str) -> Result<Self> {
+        let def: AgentDefinition =
+            toml::from_str(text).wrap_err("failed to parse AgentDefinition as TOML")?;
+        def.validate()?;
+        Ok(def)
+    }
+}
+
+/// Typed registry of [`AgentDefinition`] records indexed by id.
+///
+/// This is the concrete M8.2 replacement for the M8.1 stub. It lives in
+/// `crate::tools` under the same name so the typed `ToolContext.agent_definitions`
+/// field keeps its signature.
+#[derive(Clone, Debug, Default)]
+pub struct AgentDefinitions {
+    by_id: HashMap<String, AgentDefinition>,
+}
+
+impl AgentDefinitions {
+    /// Create an empty registry. Equivalent to [`Default::default`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the registry has zero manifests.
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+
+    /// Number of registered manifests.
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// Look up a manifest by id.
+    pub fn get(&self, id: &str) -> Option<&AgentDefinition> {
+        self.by_id.get(id)
+    }
+
+    /// Insert a manifest, replacing any previous value for the same id.
+    /// Returns the previous value if one existed.
+    pub fn insert(
+        &mut self,
+        id: impl Into<String>,
+        def: AgentDefinition,
+    ) -> Option<AgentDefinition> {
+        self.by_id.insert(id.into(), def)
+    }
+
+    /// Iterate manifest ids.
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.by_id.keys().map(String::as_str)
+    }
+
+    /// Registry containing the crate-shipped built-in manifests only.
+    ///
+    /// Today this is `research-worker` and `repo-editor`. The list is an
+    /// implementation detail and may grow over time.
+    pub fn with_builtins() -> Self {
+        let mut reg = Self::new();
+        for (id, text) in BUILTIN_AGENTS {
+            let def = AgentDefinition::from_json_str(text).unwrap_or_else(|err| {
+                // Built-in manifests are authored by the crate; a parse error
+                // here is a programming bug, not a user-visible condition.
+                panic!("built-in agent definition '{id}' is malformed: {err}");
+            });
+            reg.by_id.insert((*id).to_string(), def);
+        }
+        reg
+    }
+
+    /// Load manifests from a directory, layered on top of the built-ins.
+    ///
+    /// Reads `*.json` and `*.toml` files directly under `dir` (non-recursive).
+    /// Each file's stem is the id unless the file specifies a `name` field
+    /// that overrides it. Local manifests replace built-ins with the same
+    /// id. Missing directories return the built-ins only.
+    pub fn load_dir(dir: &Path) -> Result<Self> {
+        let mut reg = Self::with_builtins();
+        reg.load_dir_into(dir)?;
+        Ok(reg)
+    }
+
+    /// Load manifests from `dir` into an existing registry. Local manifests
+    /// override any previous entry with the same id.
+    pub fn load_dir_into(&mut self, dir: &Path) -> Result<()> {
+        if !dir.exists() {
+            return Ok(());
+        }
+        let iter = std::fs::read_dir(dir)
+            .wrap_err_with(|| format!("failed to read agents dir {}", dir.display()))?;
+        for entry in iter {
+            let entry = entry
+                .wrap_err_with(|| format!("failed to enumerate agents dir {}", dir.display()))?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+                continue;
+            };
+            let text = std::fs::read_to_string(&path)
+                .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+            let def = match ext {
+                "json" => AgentDefinition::from_json_str(&text)
+                    .wrap_err_with(|| format!("failed to parse {}", path.display()))?,
+                "toml" => AgentDefinition::from_toml_str(&text)
+                    .wrap_err_with(|| format!("failed to parse {}", path.display()))?,
+                _ => continue,
+            };
+            // File stem is the default id; the manifest's own `name` field
+            // overrides it when present (it is always present in v1 because
+            // `name` is required, so the stem is effectively a display hint
+            // for humans inspecting the directory).
+            let id = def.name.clone();
+            // Preserve the stem-id convention by rejecting manifests whose
+            // `name` does not match the filename stem. This keeps directory
+            // lookups predictable: `foo.json` registers id `foo`.
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                if stem != id {
+                    tracing::warn!(
+                        file = %path.display(),
+                        stem = %stem,
+                        name = %id,
+                        "agent definition filename stem differs from manifest name; \
+                         using manifest name as id"
+                    );
+                }
+            }
+            self.by_id.insert(id, def);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, text: &str) {
+        std::fs::write(path, text).expect("write manifest");
+    }
+
+    #[test]
+    fn should_parse_minimum_valid_manifest() {
+        // Only `name` and `version` are required. Every other field is
+        // optional and must default cleanly.
+        let json = r#"{"name":"tiny","version":1}"#;
+        let def = AgentDefinition::from_json_str(json).unwrap();
+
+        assert_eq!(def.name, "tiny");
+        assert_eq!(def.version, 1);
+        assert!(def.tools.is_empty());
+        assert!(def.disallowed_tools.is_empty());
+        assert!(def.model.is_none());
+        assert!(def.effort.is_none());
+        assert!(def.permission_mode.is_none());
+        assert!(def.mcp_servers.is_empty());
+        assert!(def.hooks.is_empty());
+        assert!(def.max_turns.is_none());
+        assert!(def.skills.is_empty());
+        assert!(def.memory.is_none());
+        assert!(!def.background);
+        assert!(def.isolation.is_none());
+    }
+
+    #[test]
+    fn should_parse_full_manifest_with_all_12_fields() {
+        // All 12 optional fields plus the two required ones, populated with
+        // realistic values.
+        let json = r#"{
+            "name": "full-agent",
+            "version": 1,
+            "tools": ["read_file", "shell"],
+            "disallowed_tools": ["web_search"],
+            "model": "anthropic/claude-haiku",
+            "effort": "high",
+            "permission_mode": "ask",
+            "mcp_servers": ["jiuwenclaw", "hermes"],
+            "hooks": [
+                {"event": "before_tool_call", "command": "/bin/true"}
+            ],
+            "max_turns": 25,
+            "skills": ["weather", "time"],
+            "memory": {"path": "/tmp/mem", "enabled": true},
+            "background": true,
+            "isolation": "docker"
+        }"#;
+        let def = AgentDefinition::from_json_str(json).unwrap();
+
+        assert_eq!(def.name, "full-agent");
+        assert_eq!(def.version, 1);
+        assert_eq!(
+            def.tools,
+            vec!["read_file".to_string(), "shell".to_string()]
+        );
+        assert_eq!(def.disallowed_tools, vec!["web_search".to_string()]);
+        assert_eq!(def.model.as_deref(), Some("anthropic/claude-haiku"));
+        assert_eq!(def.effort.as_deref(), Some("high"));
+        assert_eq!(def.permission_mode.as_deref(), Some("ask"));
+        assert_eq!(def.mcp_servers.len(), 2);
+        assert_eq!(def.hooks.len(), 1);
+        assert_eq!(def.hooks[0].event, "before_tool_call");
+        assert_eq!(def.hooks[0].command, "/bin/true");
+        assert_eq!(def.max_turns, Some(25));
+        assert_eq!(def.skills, vec!["weather".to_string(), "time".to_string()]);
+        let memory = def.memory.as_ref().expect("memory present");
+        assert_eq!(memory.path.as_deref(), Some(Path::new("/tmp/mem")));
+        assert!(memory.enabled);
+        assert!(def.background);
+        assert_eq!(def.isolation.as_deref(), Some("docker"));
+    }
+
+    #[test]
+    fn should_round_trip_manifest_through_json() {
+        // Serialize -> deserialize should be byte-stable for semantics.
+        let original = AgentDefinition {
+            name: "rt".to_string(),
+            version: 1,
+            tools: vec!["shell".to_string()],
+            disallowed_tools: Vec::new(),
+            model: Some("openai/gpt-4o-mini".to_string()),
+            effort: Some("medium".to_string()),
+            permission_mode: None,
+            mcp_servers: Vec::new(),
+            hooks: vec![HookRef {
+                event: "after_tool_call".to_string(),
+                command: "/usr/bin/env".to_string(),
+            }],
+            max_turns: Some(10),
+            skills: Vec::new(),
+            memory: Some(MemoryConfig {
+                path: None,
+                enabled: false,
+            }),
+            background: false,
+            isolation: None,
+        };
+
+        let json = serde_json::to_string(&original).expect("serialize");
+        let round_tripped = AgentDefinition::from_json_str(&json).expect("deserialize");
+        assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn should_reject_manifest_with_unknown_fields_in_v1() {
+        // `#[serde(deny_unknown_fields)]` must catch forward-incompatible
+        // manifests so v1 consumers cannot silently ignore new fields.
+        let json = r#"{
+            "name": "future",
+            "version": 1,
+            "unknown_future_field": true
+        }"#;
+        let err = AgentDefinition::from_json_str(json).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unknown_future_field") || msg.contains("unknown field"),
+            "expected unknown-field error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn should_merge_builtin_and_local_agents() {
+        // Built-ins provide `research-worker` and `repo-editor`. A local
+        // manifest with the same id must override the built-in.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Override the research-worker built-in with a local variant that
+        // adds `shell` to the tool list.
+        write(
+            &tmp.path().join("research-worker.json"),
+            r#"{"name":"research-worker","version":1,"tools":["deep_search","shell"]}"#,
+        );
+        // Add a brand-new local-only definition.
+        write(
+            &tmp.path().join("local-only.json"),
+            r#"{"name":"local-only","version":1,"tools":["read_file"]}"#,
+        );
+
+        let reg = AgentDefinitions::load_dir(tmp.path()).expect("load_dir");
+
+        // Built-in that was not overridden remains available.
+        let repo_editor = reg.get("repo-editor").expect("repo-editor");
+        assert!(repo_editor.tools.contains(&"read_file".to_string()));
+
+        // Overridden built-in now carries the local fields.
+        let research = reg.get("research-worker").expect("research-worker");
+        assert!(research.tools.contains(&"shell".to_string()));
+
+        // Local-only definition is present.
+        let local = reg.get("local-only").expect("local-only");
+        assert_eq!(local.tools, vec!["read_file".to_string()]);
+    }
+
+    #[test]
+    fn should_load_toml_manifest() {
+        // TOML is supported as a sibling format to JSON.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let toml_text = r#"
+            name = "toml-agent"
+            version = 1
+            tools = ["read_file"]
+            background = true
+        "#;
+        write(&tmp.path().join("toml-agent.toml"), toml_text);
+
+        let reg = AgentDefinitions::load_dir(tmp.path()).expect("load_dir");
+        let def = reg.get("toml-agent").expect("toml-agent");
+        assert_eq!(def.tools, vec!["read_file".to_string()]);
+        assert!(def.background);
+    }
+
+    #[test]
+    fn should_load_empty_registry_when_dir_missing() {
+        let reg = AgentDefinitions::load_dir(Path::new("/tmp/does-not-exist-octos-m82-tests"))
+            .expect("load_dir");
+        // Built-ins are always present even when the caller's dir is missing.
+        assert!(reg.get("research-worker").is_some());
+        assert!(reg.get("repo-editor").is_some());
+    }
+
+    #[test]
+    fn should_reject_manifest_with_mismatched_schema_version() {
+        let json = r#"{"name":"wrong","version":2}"#;
+        let err = AgentDefinition::from_json_str(json).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("version"), "expected version error, got {msg}");
+    }
+
+    #[test]
+    fn should_provide_builtin_research_worker() {
+        let reg = AgentDefinitions::with_builtins();
+        let def = reg
+            .get("research-worker")
+            .expect("research-worker built-in");
+        assert_eq!(def.name, "research-worker");
+        assert!(def.tools.contains(&"deep_search".to_string()));
+        assert!(def.tools.contains(&"web_fetch".to_string()));
+        assert!(def.tools.contains(&"web_search".to_string()));
+        // Research worker explicitly denies shell/write/edit.
+        assert!(def.disallowed_tools.contains(&"shell".to_string()));
+        assert!(def.disallowed_tools.contains(&"write_file".to_string()));
+        assert!(def.disallowed_tools.contains(&"edit_file".to_string()));
+    }
+
+    #[test]
+    fn should_provide_builtin_repo_editor() {
+        let reg = AgentDefinitions::with_builtins();
+        let def = reg.get("repo-editor").expect("repo-editor built-in");
+        assert_eq!(def.name, "repo-editor");
+        for expected in [
+            "read_file",
+            "write_file",
+            "edit_file",
+            "shell",
+            "grep",
+            "glob",
+        ] {
+            assert!(
+                def.tools.contains(&expected.to_string()),
+                "repo-editor missing {expected}"
+            );
+        }
+        // Repo editor denies deep_search.
+        assert!(def.disallowed_tools.contains(&"deep_search".to_string()));
+    }
+}

--- a/crates/octos-agent/src/assets/agents/repo-editor.json
+++ b/crates/octos-agent/src/assets/agents/repo-editor.json
@@ -1,0 +1,9 @@
+{
+  "name": "repo-editor",
+  "version": 1,
+  "tools": ["read_file", "write_file", "edit_file", "shell", "grep", "glob"],
+  "disallowed_tools": ["deep_search"],
+  "effort": "high",
+  "max_turns": 40,
+  "background": false
+}

--- a/crates/octos-agent/src/assets/agents/research-worker.json
+++ b/crates/octos-agent/src/assets/agents/research-worker.json
@@ -1,0 +1,9 @@
+{
+  "name": "research-worker",
+  "version": 1,
+  "tools": ["deep_search", "web_fetch", "web_search"],
+  "disallowed_tools": ["shell", "write_file", "edit_file"],
+  "effort": "medium",
+  "max_turns": 20,
+  "background": false
+}

--- a/crates/octos-agent/src/assets/profiles/coding.json
+++ b/crates/octos-agent/src/assets/profiles/coding.json
@@ -1,0 +1,9 @@
+{
+  "name": "coding",
+  "version": 1,
+  "description": "Default profile — preserves today's no-flag octos chat behaviour byte-for-byte. Tools are not filtered; the M8.2 built-in sub-agents are preloaded.",
+  "tools": {"mode": "default"},
+  "mcp_servers": [],
+  "permissions": "default",
+  "agents": ["research-worker", "repo-editor"]
+}

--- a/crates/octos-agent/src/assets/profiles/swarm.json
+++ b/crates/octos-agent/src/assets/profiles/swarm.json
@@ -1,0 +1,46 @@
+{
+  "name": "swarm",
+  "version": 1,
+  "description": "Swarm coordinator profile. Extends the coding default by opening the swarm-coordination tools (send_to_agent, cancel_task, relaunch_task) and preloads the PM-supervisor agent set.",
+  "tools": {
+    "mode": "allow_list",
+    "tools": [
+      "shell",
+      "read_file",
+      "write_file",
+      "edit_file",
+      "diff_edit",
+      "glob",
+      "grep",
+      "list_dir",
+      "web_search",
+      "web_fetch",
+      "browser",
+      "spawn",
+      "send_to_agent",
+      "cancel_task",
+      "relaunch_task",
+      "check_background_tasks",
+      "check_workspace_contract",
+      "workspace_log",
+      "workspace_show",
+      "workspace_diff",
+      "recall_memory",
+      "save_memory",
+      "deep_search",
+      "synthesize_research",
+      "message",
+      "activate_tools",
+      "configure_tool",
+      "manage_skills"
+    ]
+  },
+  "mcp_servers": [],
+  "permissions": "default",
+  "agents": [
+    "pm-supervisor",
+    "sub-researcher",
+    "sub-coder",
+    "sub-validator"
+  ]
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod abi_schema;
 mod agent;
+pub mod agents;
 pub mod behaviour;
 pub mod bootstrap;
 pub mod builtin_skills;

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -27,6 +27,7 @@ pub mod mcp_server;
 pub mod permissions;
 pub mod plugins;
 pub mod policy;
+pub mod profile;
 pub mod progress;
 pub mod prompt_guard;
 pub mod prompt_layer;

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -1045,6 +1045,7 @@ mod tests {
             ],
             audio_attachment_paths: vec!["/workspace/voice.ogg".to_string()],
             file_attachment_paths: vec!["/workspace/report.pdf".to_string()],
+            ..ToolContext::zero()
         };
 
         let prepared = tool.prepare_effective_args(&json!({}), Some(&ctx));
@@ -1137,6 +1138,7 @@ mod tests {
             attachment_paths: vec![],
             audio_attachment_paths: vec![],
             file_attachment_paths: vec![],
+            ..ToolContext::zero()
         };
 
         let result = crate::tools::TOOL_CTX

--- a/crates/octos-agent/src/profile/mod.rs
+++ b/crates/octos-agent/src/profile/mod.rs
@@ -1,0 +1,679 @@
+//! Profile system (M8.3 — runtime-v0.1 close-out).
+//!
+//! # What is a `ProfileDefinition`?
+//!
+//! A [`ProfileDefinition`] is a single, declarative manifest that describes
+//! how the agent runtime should bootstrap: which tools are available, which
+//! [`crate::agents::AgentDefinition`] sub-agents are preloaded, which MCP
+//! servers are wired, how compaction is tiered, and which models are
+//! preferred. Before M8.3 every one of these settings was wired implicitly
+//! across a dozen startup sites; afterwards, a single profile declaration
+//! consolidates the envelope.
+//!
+//! The built-in `coding` profile captures today's no-flag default verbatim
+//! so `octos chat` keeps producing byte-for-byte the same runtime behaviour
+//! as before. Alternate profiles (e.g. `swarm`) layer on top of `coding`
+//! through explicit allow-list changes and expanded agent sets.
+//!
+//! # Forward compatibility
+//!
+//! Unlike [`crate::agents::AgentDefinition`] (which uses
+//! `#[serde(deny_unknown_fields)]`) this schema is **forward-compatible**:
+//! a v1 client MUST accept a v2 manifest that carries extra fields so the
+//! CLI does not immediately break when a newer config arrives on the host
+//! via config-sync or a mounted volume. The `version` field still acts as
+//! a hard gate — a v2 profile on a v1 client produces a version-mismatch
+//! error *before* the extra fields are considered.
+//!
+//! # Resolution order
+//!
+//! [`ProfileDefinition::load`] accepts either a name or a path:
+//!
+//! 1. If the argument starts with `/`, `./`, or `~/` it is treated as a
+//!    filesystem path. The file is loaded directly.
+//! 2. Otherwise the argument is a profile id. The loader first checks
+//!    `~/.octos/profiles/<id>/profile.{toml,json}`.
+//! 3. Finally the loader falls back to the crate-shipped built-in registry
+//!    (JSON files under `crates/octos-agent/src/assets/profiles/`).
+//!
+//! Today's built-in profiles are `coding` (the default) and `swarm` (an
+//! allow-list extension that enables multi-worker swarm coordination tools).
+//!
+//! # Applied vs recorded settings
+//!
+//! M8.3 deliberately scopes its behaviour to "schema + loader + tool
+//! filter". Some profile fields are populated today but *recorded, not
+//! enforced* until a follow-up milestone wires them in:
+//!
+//! - `compaction_policy` — the tier overrides are parsed and exposed via
+//!   [`ProfileDefinition::compaction_policy`], but the runtime still uses
+//!   the workspace compaction runner from M6.3. M8.5's tiered runner is
+//!   where the profile override becomes active.
+//! - `model_preferences` — parsed and exposed, but the provider chain does
+//!   not yet consult them. A future milestone wires the preferences into
+//!   the adaptive router's lane-scoring input.
+//! - `mcp_servers` — only the ids are captured. Actual server config
+//!   resolution is a follow-up milestone. `coding` and `swarm` ship with
+//!   an empty list so no behaviour change falls out of this.
+//!
+//! The `permissions` stub also lands in a minimal form (default /
+//! restricted) so M8.4 can extend it without schema churn.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+
+use crate::tools::ToolRegistry;
+
+/// Current profile schema version. Manifests whose `version` differs from
+/// this constant are rejected at load time.
+pub const PROFILE_SCHEMA_VERSION: u32 = 1;
+
+/// Crate-shipped profiles available as a built-in fallback after the
+/// user-config search. Ordered (name, raw JSON text).
+const BUILTIN_PROFILES: &[(&str, &str)] = &[
+    ("coding", include_str!("../assets/profiles/coding.json")),
+    ("swarm", include_str!("../assets/profiles/swarm.json")),
+];
+
+/// The source a resolved profile was loaded from. Used by the CLI resolver
+/// to emit an informative `profile resolved: ...` log line.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProfileSource {
+    /// Explicit `--profile <path>` pointing at a file on disk.
+    ExplicitPath,
+    /// Named profile found in `~/.octos/profiles/<name>/profile.{toml,json}`.
+    UserDir,
+    /// Named profile that fell back to the crate-shipped built-in set.
+    Builtin,
+}
+
+/// How the profile narrows the tool registry. Mirrors the three modes
+/// called out in the issue scope:
+///
+/// - `default` — no filter; the registry passes through untouched. This is
+///   what the built-in `coding` profile uses so behaviour parity with the
+///   pre-M8.3 default path is guaranteed.
+/// - `allow_list` — only the named tools survive. Names may reference
+///   [`crate::tools::policy::ToolGroupInfo`] groups via `group:*` strings.
+/// - `deny_list` — every tool survives except the named ones. Useful for
+///   profiles that strip a single capability (e.g. drop `web_fetch` from
+///   an otherwise-default set).
+///
+/// `spawn_only` tools are *never* filtered out regardless of mode — they
+/// carry background-execution wiring that the runtime depends on.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ProfileTools {
+    /// Pass-through filter — registry is not narrowed.
+    #[default]
+    Default,
+    /// Explicit whitelist. Only listed tools (or groups) are kept.
+    AllowList {
+        /// Tool names or `group:<id>` references to keep.
+        #[serde(default)]
+        tools: Vec<String>,
+    },
+    /// Inverse whitelist. Every registered tool except the listed ones is
+    /// kept. Groups are expanded through the same mechanism as allow lists.
+    DenyList {
+        /// Tool names or `group:<id>` references to drop.
+        #[serde(default)]
+        tools: Vec<String>,
+    },
+}
+
+/// Reference to an MCP server that the profile wants attached. For M8.3 we
+/// only capture the `id`; resolution to a concrete config happens in a
+/// follow-up milestone. Extra fields are tolerated (forward-compat).
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct McpServerRef {
+    /// Id of a server config declared elsewhere in the profile dir / config.
+    pub id: String,
+}
+
+/// Coarse permission tier. The `default` variant mirrors today's
+/// allow-everything behaviour — M8.4 will add richer per-tool rules by
+/// extending this enum (adding variants is backward-compatible because we
+/// do not use `deny_unknown_fields` on the containing struct).
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionMode {
+    /// Today's behaviour — every registered tool is executable.
+    #[default]
+    Default,
+    /// Placeholder tier for hardened environments. Carries no runtime
+    /// effect yet; M8.4 will map it to a concrete per-tool rule set.
+    Restricted,
+}
+
+/// Profile-level override for the M8.5 tiered compaction runner.
+///
+/// Today this struct is *recorded only* — the runtime keeps using the
+/// workspace compaction policy from M6.3. Once the M8.5 runner is wired,
+/// the fields become live tier overrides.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ProfileCompactionPolicy {
+    /// Optional target token budget for the final compacted conversation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_budget: Option<u32>,
+    /// Optional trigger threshold (turns or tokens, interpreted by the
+    /// runner). `None` leaves the runner default in place.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preflight_threshold: Option<u32>,
+    /// Optional tiers map (tier-id -> token budget). Free-form today;
+    /// M8.5 will define the tier id vocabulary.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub tiers: HashMap<String, u32>,
+}
+
+/// Model-name hints consulted by the provider chain. Today these are
+/// recorded but not enforced — a follow-up milestone wires them into
+/// adaptive routing.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ModelPreferences {
+    /// Default model id (e.g. `"anthropic/claude-sonnet-4"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    /// Low-latency model id (cheap, fast). May be used for background
+    /// worker dispatch in a follow-up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fast: Option<String>,
+    /// Highest-capability model id. Reserved for orchestrator turns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strong: Option<String>,
+}
+
+/// A single profile manifest.
+///
+/// Field layout and naming mirrors the runtime plan's "profile envelope".
+/// Fields marked *recorded only* land without runtime enforcement in M8.3
+/// and are picked up by a follow-up milestone.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ProfileDefinition {
+    /// Profile id. Also its display name when rendered in logs.
+    pub name: String,
+    /// Schema version. Must equal [`PROFILE_SCHEMA_VERSION`]. Mismatched
+    /// versions produce an error so a forward-compatible client cannot
+    /// accidentally swallow schema churn.
+    pub version: u32,
+    /// Free-text description for humans reading the profile file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Tool filter policy. Defaults to [`ProfileTools::Default`] so the
+    /// registry is left untouched.
+    #[serde(default)]
+    pub tools: ProfileTools,
+    /// MCP servers to attach. Only ids are captured today.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<McpServerRef>,
+    /// Coarse permission tier. Defaults to [`PermissionMode::Default`].
+    #[serde(default)]
+    pub permissions: PermissionMode,
+    /// Optional override for the M8.5 tiered compaction runner. Recorded
+    /// only today.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compaction_policy: Option<ProfileCompactionPolicy>,
+    /// Optional model preferences. Recorded only today.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_preferences: Option<ModelPreferences>,
+    /// Path within the profile dir to a system-prompt template file.
+    /// Resolved against the profile's parent directory at load time; left
+    /// as-is in the struct so tests and callers can inspect the raw hint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_prompt_template: Option<PathBuf>,
+    /// Ids of [`crate::agents::AgentDefinition`] manifests to preload when
+    /// this profile is activated. Consumes the M8.2 registry.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<String>,
+}
+
+impl Default for ProfileDefinition {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            version: PROFILE_SCHEMA_VERSION,
+            description: None,
+            tools: ProfileTools::default(),
+            mcp_servers: Vec::new(),
+            permissions: PermissionMode::default(),
+            compaction_policy: None,
+            model_preferences: None,
+            system_prompt_template: None,
+            agents: Vec::new(),
+        }
+    }
+}
+
+impl ProfileDefinition {
+    /// Validate a freshly-deserialized profile. Today only the schema
+    /// version is enforced — additional cross-field validation lands as
+    /// the permission / compaction wiring comes online.
+    pub fn validate(&self) -> Result<()> {
+        if self.version != PROFILE_SCHEMA_VERSION {
+            eyre::bail!(
+                "profile '{}' has unsupported schema version {} (expected {})",
+                self.name,
+                self.version,
+                PROFILE_SCHEMA_VERSION,
+            );
+        }
+        if self.name.trim().is_empty() {
+            eyre::bail!("profile manifest is missing a non-empty `name` field");
+        }
+        Ok(())
+    }
+
+    /// Parse a profile from JSON text. Validates on success.
+    pub fn from_json_str(text: &str) -> Result<Self> {
+        let def: Self =
+            serde_json::from_str(text).wrap_err("failed to parse ProfileDefinition as JSON")?;
+        def.validate()?;
+        Ok(def)
+    }
+
+    /// Parse a profile from TOML text. Validates on success.
+    pub fn from_toml_str(text: &str) -> Result<Self> {
+        let def: Self =
+            toml::from_str(text).wrap_err("failed to parse ProfileDefinition as TOML")?;
+        def.validate()?;
+        Ok(def)
+    }
+
+    /// Parse from a file on disk, picking the format from the file
+    /// extension (`.toml` -> TOML, everything else -> JSON).
+    pub fn from_file(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .wrap_err_with(|| format!("failed to read profile at {}", path.display()))?;
+        let is_toml = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"));
+        let def = if is_toml {
+            Self::from_toml_str(&text)
+        } else {
+            Self::from_json_str(&text)
+        }
+        .wrap_err_with(|| format!("failed to parse profile at {}", path.display()))?;
+        Ok(def)
+    }
+
+    /// Look up a named built-in profile from the crate-shipped registry.
+    /// Returns `None` when the name is unknown.
+    pub fn builtin(name: &str) -> Option<Self> {
+        BUILTIN_PROFILES.iter().find_map(|(id, text)| {
+            if *id == name {
+                Some(
+                    Self::from_json_str(text).unwrap_or_else(|err| {
+                        panic!("built-in profile '{id}' is malformed: {err}")
+                    }),
+                )
+            } else {
+                None
+            }
+        })
+    }
+
+    /// List built-in profile ids. Useful for CLI help output and tests.
+    pub fn builtin_ids() -> Vec<&'static str> {
+        BUILTIN_PROFILES.iter().map(|(id, _)| *id).collect()
+    }
+
+    /// Resolve a profile from a name or path argument. See the module doc
+    /// for the full resolution order. The returned tuple reports the
+    /// source so the caller can log `profile resolved: ... source=...`.
+    pub fn load(arg: &str) -> Result<(Self, ProfileSource)> {
+        let home = dirs::home_dir();
+        Self::load_with_home(arg, home.as_deref())
+    }
+
+    /// Variant of [`Self::load`] that takes an explicit home directory so
+    /// unit tests can exercise the user-dir lookup without touching the
+    /// real filesystem.
+    pub fn load_with_home(arg: &str, home: Option<&Path>) -> Result<(Self, ProfileSource)> {
+        if looks_like_path(arg) {
+            let resolved = expand_tilde(arg, home);
+            let def = Self::from_file(&resolved)?;
+            return Ok((def, ProfileSource::ExplicitPath));
+        }
+
+        if let Some(home_dir) = home {
+            let profile_dir = home_dir.join(".octos/profiles").join(arg);
+            for candidate in ["profile.toml", "profile.json"] {
+                let path = profile_dir.join(candidate);
+                if path.exists() {
+                    let def = Self::from_file(&path)?;
+                    return Ok((def, ProfileSource::UserDir));
+                }
+            }
+        }
+
+        if let Some(def) = Self::builtin(arg) {
+            return Ok((def, ProfileSource::Builtin));
+        }
+
+        eyre::bail!(
+            "unknown profile '{arg}': not a file, no entry in ~/.octos/profiles/, and \
+             not a built-in ({})",
+            Self::builtin_ids().join(", "),
+        )
+    }
+
+    /// Apply the tool filter declared by this profile to a freshly-built
+    /// [`ToolRegistry`]. See [`ToolRegistry::filter_by_profile`] for the
+    /// spawn-only carve-out.
+    pub fn apply_to_registry(&self, registry: &mut ToolRegistry) {
+        registry.filter_by_profile(&self.tools);
+    }
+}
+
+fn looks_like_path(arg: &str) -> bool {
+    arg.starts_with('/') || arg.starts_with("./") || arg.starts_with("~/") || arg.starts_with("../")
+}
+
+fn expand_tilde(arg: &str, home: Option<&Path>) -> PathBuf {
+    if let Some(rest) = arg.strip_prefix("~/") {
+        if let Some(home_dir) = home {
+            return home_dir.join(rest);
+        }
+    }
+    PathBuf::from(arg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_minimum_valid_profile() {
+        // Only `name` and `version` are required. Every other field must
+        // default cleanly so profile authors can skip sections they are
+        // not customizing.
+        let json = r#"{"name": "tiny", "version": 1}"#;
+        let def = ProfileDefinition::from_json_str(json).expect("parse");
+        assert_eq!(def.name, "tiny");
+        assert_eq!(def.version, 1);
+        assert!(def.description.is_none());
+        assert!(matches!(def.tools, ProfileTools::Default));
+        assert!(def.mcp_servers.is_empty());
+        assert_eq!(def.permissions, PermissionMode::Default);
+        assert!(def.compaction_policy.is_none());
+        assert!(def.model_preferences.is_none());
+        assert!(def.system_prompt_template.is_none());
+        assert!(def.agents.is_empty());
+    }
+
+    #[test]
+    fn should_parse_full_profile_with_all_fields() {
+        // Exercise every optional section in a single manifest so the
+        // round-trip and defaulting paths are both covered.
+        let json = r#"{
+            "name": "full",
+            "version": 1,
+            "description": "kitchen-sink profile",
+            "tools": {"mode": "allow_list", "tools": ["shell", "group:fs"]},
+            "mcp_servers": [{"id": "jiuwenclaw"}],
+            "permissions": "restricted",
+            "compaction_policy": {
+                "token_budget": 8000,
+                "preflight_threshold": 12000,
+                "tiers": {"tier_1": 2000, "tier_2": 4000}
+            },
+            "model_preferences": {
+                "default": "anthropic/claude-sonnet-4",
+                "fast": "anthropic/claude-haiku",
+                "strong": "openai/gpt-5"
+            },
+            "system_prompt_template": "prompts/coder.md",
+            "agents": ["research-worker", "repo-editor"]
+        }"#;
+
+        let def = ProfileDefinition::from_json_str(json).expect("parse");
+        assert_eq!(def.name, "full");
+        assert_eq!(def.description.as_deref(), Some("kitchen-sink profile"));
+        match &def.tools {
+            ProfileTools::AllowList { tools } => {
+                assert_eq!(tools, &vec!["shell".to_string(), "group:fs".to_string()]);
+            }
+            other => panic!("expected AllowList, got {other:?}"),
+        }
+        assert_eq!(def.mcp_servers.len(), 1);
+        assert_eq!(def.mcp_servers[0].id, "jiuwenclaw");
+        assert_eq!(def.permissions, PermissionMode::Restricted);
+        let compaction = def.compaction_policy.as_ref().expect("compaction present");
+        assert_eq!(compaction.token_budget, Some(8000));
+        assert_eq!(compaction.preflight_threshold, Some(12000));
+        assert_eq!(compaction.tiers.get("tier_1"), Some(&2000));
+        let prefs = def
+            .model_preferences
+            .as_ref()
+            .expect("model preferences present");
+        assert_eq!(prefs.default.as_deref(), Some("anthropic/claude-sonnet-4"));
+        assert_eq!(prefs.fast.as_deref(), Some("anthropic/claude-haiku"));
+        assert_eq!(prefs.strong.as_deref(), Some("openai/gpt-5"));
+        assert_eq!(
+            def.system_prompt_template.as_deref(),
+            Some(Path::new("prompts/coder.md"))
+        );
+        assert_eq!(def.agents, vec!["research-worker", "repo-editor"]);
+    }
+
+    #[test]
+    fn should_reject_profile_with_version_mismatch() {
+        let json = r#"{"name": "future", "version": 42}"#;
+        let err = ProfileDefinition::from_json_str(json).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("version") && msg.contains("42"),
+            "expected version error, got {msg}",
+        );
+    }
+
+    #[test]
+    fn should_round_trip_profile_through_json() {
+        let original = ProfileDefinition {
+            name: "rt".to_string(),
+            version: 1,
+            description: Some("round-trip".to_string()),
+            tools: ProfileTools::DenyList {
+                tools: vec!["web_fetch".to_string()],
+            },
+            mcp_servers: vec![McpServerRef {
+                id: "hermes".to_string(),
+            }],
+            permissions: PermissionMode::Default,
+            compaction_policy: Some(ProfileCompactionPolicy {
+                token_budget: Some(2048),
+                preflight_threshold: None,
+                tiers: HashMap::new(),
+            }),
+            model_preferences: None,
+            system_prompt_template: None,
+            agents: vec!["repo-editor".to_string()],
+        };
+
+        let text = serde_json::to_string(&original).expect("serialize");
+        let round = ProfileDefinition::from_json_str(&text).expect("deserialize");
+        assert_eq!(round, original);
+    }
+
+    #[test]
+    fn should_accept_profile_with_unknown_fields_for_forward_compat() {
+        // A v2 producer may introduce new fields. The v1 parser must
+        // ignore them rather than fail, so the CLI keeps working while
+        // the schema evolves.
+        let json = r#"{
+            "name": "future-proof",
+            "version": 1,
+            "tools": {"mode": "default"},
+            "new_v2_field": {"nested": true},
+            "another_extra": 99
+        }"#;
+        let def = ProfileDefinition::from_json_str(json).expect("parse");
+        assert_eq!(def.name, "future-proof");
+        assert!(matches!(def.tools, ProfileTools::Default));
+    }
+
+    #[test]
+    fn should_resolve_profile_name_to_builtin() {
+        let coding = ProfileDefinition::builtin("coding").expect("coding builtin");
+        assert_eq!(coding.name, "coding");
+        assert_eq!(coding.version, 1);
+        // `coding` must declare the default tool filter so behaviour
+        // parity with the pre-M8.3 no-flag path is preserved.
+        assert!(matches!(coding.tools, ProfileTools::Default));
+
+        let swarm = ProfileDefinition::builtin("swarm").expect("swarm builtin");
+        assert_eq!(swarm.name, "swarm");
+        // Unknown names produce `None` so the load() caller can fall
+        // through to a typed error.
+        assert!(ProfileDefinition::builtin("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn should_resolve_profile_path_to_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("custom.json");
+        std::fs::write(
+            &path,
+            r#"{"name": "custom", "version": 1, "description": "from disk"}"#,
+        )
+        .expect("write");
+        let path_str = path.to_string_lossy().to_string();
+
+        let (def, source) =
+            ProfileDefinition::load_with_home(&path_str, None).expect("load from path");
+        assert_eq!(def.name, "custom");
+        assert_eq!(def.description.as_deref(), Some("from disk"));
+        assert_eq!(source, ProfileSource::ExplicitPath);
+    }
+
+    #[test]
+    fn should_resolve_profile_name_via_user_dir() {
+        // Place a profile.json under `<home>/.octos/profiles/<name>/` and
+        // confirm load() picks it up with source=UserDir.
+        let fake_home = tempfile::tempdir().expect("tempdir");
+        let profiles_dir = fake_home.path().join(".octos/profiles/alpha");
+        std::fs::create_dir_all(&profiles_dir).expect("mkdirs");
+        std::fs::write(
+            profiles_dir.join("profile.json"),
+            r#"{"name": "alpha", "version": 1}"#,
+        )
+        .expect("write");
+
+        let (def, source) = ProfileDefinition::load_with_home("alpha", Some(fake_home.path()))
+            .expect("load from user dir");
+        assert_eq!(def.name, "alpha");
+        assert_eq!(source, ProfileSource::UserDir);
+    }
+
+    #[test]
+    fn should_resolve_builtin_when_user_dir_missing() {
+        let fake_home = tempfile::tempdir().expect("tempdir");
+        // No user-dir override; coding must resolve via the built-in
+        // fallback with source=Builtin.
+        let (def, source) = ProfileDefinition::load_with_home("coding", Some(fake_home.path()))
+            .expect("load builtin");
+        assert_eq!(def.name, "coding");
+        assert_eq!(source, ProfileSource::Builtin);
+    }
+
+    #[test]
+    fn should_reject_unknown_profile_name() {
+        let fake_home = tempfile::tempdir().expect("tempdir");
+        let err = ProfileDefinition::load_with_home("no-such-profile", Some(fake_home.path()))
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no-such-profile"));
+    }
+
+    #[test]
+    fn should_load_builtin_coding_profile_without_error() {
+        let coding = ProfileDefinition::builtin("coding").expect("coding");
+        coding.validate().expect("valid");
+        // The default profile must not declare a tool allow/deny list —
+        // otherwise the registry would be filtered and behaviour parity
+        // with the pre-M8.3 no-flag path would regress.
+        assert!(matches!(coding.tools, ProfileTools::Default));
+        // Today's coding default carries no compaction or permission
+        // override — those live at the workspace / app-state level.
+        assert!(coding.compaction_policy.is_none());
+        assert_eq!(coding.permissions, PermissionMode::Default);
+        // Agents preloaded match the M8.2 built-in set so spawn() can
+        // resolve them by id.
+        assert!(coding.agents.contains(&"research-worker".to_string()));
+        assert!(coding.agents.contains(&"repo-editor".to_string()));
+    }
+
+    #[test]
+    fn should_load_builtin_swarm_profile_without_error() {
+        let swarm = ProfileDefinition::builtin("swarm").expect("swarm");
+        swarm.validate().expect("valid");
+        // Swarm must declare an allow list so the registry keeps its
+        // swarm-only tools reachable while normal workers stay denied.
+        match &swarm.tools {
+            ProfileTools::AllowList { tools } => {
+                assert!(tools.contains(&"send_to_agent".to_string()));
+                assert!(tools.contains(&"cancel_task".to_string()));
+                assert!(tools.contains(&"relaunch_task".to_string()));
+            }
+            other => panic!("swarm must declare an allow list, got {other:?}"),
+        }
+        assert!(!swarm.agents.is_empty());
+    }
+
+    #[test]
+    fn looks_like_path_classifies_arguments_correctly() {
+        // Explicit paths start with /, ./, ~/, or ../; everything else is
+        // treated as a profile name for user-dir / builtin lookup.
+        assert!(looks_like_path("/etc/profile.json"));
+        assert!(looks_like_path("./local.toml"));
+        assert!(looks_like_path("~/my-profile.json"));
+        assert!(looks_like_path("../shared.json"));
+        assert!(!looks_like_path("coding"));
+        assert!(!looks_like_path("swarm"));
+    }
+
+    #[test]
+    fn expand_tilde_resolves_against_home() {
+        let home = Path::new("/opt/octos-home");
+        assert_eq!(
+            expand_tilde("~/profiles/foo.json", Some(home)),
+            PathBuf::from("/opt/octos-home/profiles/foo.json"),
+        );
+        // Without a home directory the tilde stays literal.
+        assert_eq!(
+            expand_tilde("~/profiles/foo.json", None),
+            PathBuf::from("~/profiles/foo.json"),
+        );
+    }
+
+    #[test]
+    fn should_reject_profile_with_empty_name() {
+        let json = r#"{"name": "   ", "version": 1}"#;
+        let err = ProfileDefinition::from_json_str(json).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("name"), "expected name error, got {msg}");
+    }
+
+    #[test]
+    fn should_parse_profile_tools_variants() {
+        let default_json = r#"{"mode": "default"}"#;
+        let allow_json = r#"{"mode": "allow_list", "tools": ["shell"]}"#;
+        let deny_json = r#"{"mode": "deny_list", "tools": ["web_fetch"]}"#;
+        let d: ProfileTools = serde_json::from_str(default_json).expect("default");
+        let a: ProfileTools = serde_json::from_str(allow_json).expect("allow");
+        let de: ProfileTools = serde_json::from_str(deny_json).expect("deny");
+        assert!(matches!(d, ProfileTools::Default));
+        match a {
+            ProfileTools::AllowList { tools } => assert_eq!(tools, vec!["shell".to_string()]),
+            _ => panic!("expected allow_list"),
+        }
+        match de {
+            ProfileTools::DenyList { tools } => assert_eq!(tools, vec!["web_fetch".to_string()]),
+            _ => panic!("expected deny_list"),
+        }
+    }
+}

--- a/crates/octos-agent/src/tools/delegate.rs
+++ b/crates/octos-agent/src/tools/delegate.rs
@@ -36,7 +36,7 @@ use octos_memory::EpisodeStore;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use super::{Tool, ToolPolicy, ToolRegistry, ToolResult};
+use super::{Tool, ToolContext, ToolPolicy, ToolRegistry, ToolResult};
 use crate::harness_errors::HarnessError;
 use crate::harness_events::HARNESS_EVENT_SCHEMA_V1;
 use crate::task_supervisor::{TaskLifecycleState, TaskSupervisor};
@@ -458,8 +458,27 @@ impl Tool for DelegateTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // M8.1: legacy entry point. Re-enter via execute_with_context with
+        // the zero-value context so out-of-band callers (tests, integrations
+        // that have not been updated) still exercise the same code path.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid delegate_task input")?;
+
+        // M8.1: prefer the sink path threaded through the typed context. Fall
+        // back to the tool's own configured sink for constructors that wired
+        // it directly (and for the legacy zero-context entry path).
+        let effective_sink: Option<&str> = ctx
+            .harness_event_sink
+            .as_deref()
+            .or(self.harness_event_sink.as_deref());
 
         // Step 1: depth guard. A parent whose budget is already exhausted
         // must reject synchronously, without spawning.
@@ -476,7 +495,7 @@ impl Tool for DelegateTool {
                     String::new(),
                     DelegationOutcome::DepthExceeded,
                 );
-                let _ = emit_delegation_event(self.harness_event_sink.as_deref(), &event);
+                let _ = emit_delegation_event(effective_sink, &event);
                 warn!(
                     parent_depth = self.depth_budget.current,
                     max = self.depth_budget.max,
@@ -507,7 +526,7 @@ impl Tool for DelegateTool {
 
         record_delegation(child_budget.current, DelegationOutcome::Accepted);
         let _ = emit_delegation_event(
-            self.harness_event_sink.as_deref(),
+            effective_sink,
             &DelegationEvent::new(
                 child_budget.current,
                 self.parent_task_id.clone().unwrap_or_default(),
@@ -546,7 +565,9 @@ impl Tool for DelegateTool {
             task_supervisor: self.task_supervisor.clone(),
             session_key: self.session_key.clone(),
             parent_task_id: Some(child_task_id.clone()),
-            harness_event_sink: self.harness_event_sink.clone(),
+            // Child inherits the effective sink so the context-threaded path
+            // still reaches grandchildren even if only the ToolContext set it.
+            harness_event_sink: effective_sink.map(|s| s.to_string()),
             worker_config: self.worker_config.clone(),
         };
         tools.register_arc(Arc::new(child_delegate));
@@ -621,7 +642,7 @@ impl Tool for DelegateTool {
         };
         record_delegation(child_budget.current, terminal_outcome);
         let _ = emit_delegation_event(
-            self.harness_event_sink.as_deref(),
+            effective_sink,
             &DelegationEvent::new(
                 child_budget.current,
                 self.parent_task_id.clone().unwrap_or_default(),

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1,4 +1,33 @@
 //! Tool framework for agent tool execution.
+//!
+//! # Typed `ToolContext` migration (M8.1)
+//!
+//! Tools receive execution context through [`ToolContext`]. Historically the
+//! context was delivered indirectly via the [`TOOL_CTX`] task-local, which the
+//! executor populated before calling each tool's [`Tool::execute`]. That works
+//! but makes the carrier invisible at the trait surface, so tools that want a
+//! field must either read the task-local or reach into globals.
+//!
+//! M8.1 introduces [`Tool::execute_with_context`], a typed entry point that
+//! threads `&ToolContext` explicitly. To keep the migration additive:
+//!
+//! - The trait's default implementation of `execute_with_context` falls back
+//!   to the legacy [`Tool::execute`]. Existing tools keep working unchanged.
+//! - Migrated tools override `execute_with_context` and use the typed record.
+//!   Their `execute` impl simply re-enters `execute_with_context` with a
+//!   zero-value context so out-of-band callers (tests, integrations that have
+//!   not been updated) still get predictable behaviour.
+//! - [`ToolContext`] carries the legacy fields *plus* placeholder stubs for
+//!   future milestones: [`AgentDefinitions`], [`ToolPermissions`],
+//!   [`FileStateCache`], [`Notifications`], and [`AppStateHandle`]. Each stub
+//!   is annotated with the future issue that will populate it. They all have
+//!   cheap zero-value constructors so today's executor can build a context
+//!   without wiring.
+//!
+//! The executor still sets [`TOOL_CTX`] for legacy plugin tools that rely on
+//! the task-local read path (see `plugins/tool.rs`). Once every tool is
+//! migrated the task-local becomes redundant and can be retired, but that
+//! clean-up is out of scope for M8.1.
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -10,9 +39,127 @@ use octos_core::TokenUsage;
 
 use crate::progress::ProgressReporter;
 
-/// Execution context available to tools via task-local.
-/// Set by the agent before each tool invocation so plugin tools
-/// can report progress without changing the Tool trait signature.
+/// Registry of [`AgentDefinition`]-style manifests available to tools.
+///
+/// M8.2 will populate this registry from `AgentDefinition` manifests on disk
+/// (see issue #536 → M8.2). Today it is an empty holder so the context can be
+/// constructed without wiring.
+#[derive(Clone, Debug, Default)]
+pub struct AgentDefinitions {
+    // M8.2 will add the concrete definition records here.
+}
+
+impl AgentDefinitions {
+    /// Create an empty agent-definition registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether any agent definitions are registered.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Per-tool permission facts consulted before each execution.
+///
+/// M8.3 will wire real profile-derived permissions into this struct (see
+/// issue #536 → M8.3). Today it unconditionally allows every tool so behaviour
+/// matches the pre-M8.1 status quo.
+#[derive(Clone, Debug)]
+pub struct ToolPermissions {
+    allow_all: bool,
+}
+
+impl Default for ToolPermissions {
+    fn default() -> Self {
+        Self::allow_all()
+    }
+}
+
+impl ToolPermissions {
+    /// Allow-all permissions — the zero-value default carried by the context.
+    pub fn allow_all() -> Self {
+        Self { allow_all: true }
+    }
+
+    /// Check whether the named tool is currently permitted. Always `true`
+    /// while M8.3 is pending.
+    pub fn is_tool_allowed(&self, _tool: &str) -> bool {
+        self.allow_all
+    }
+}
+
+/// File-state cache that mirrors `FileStateCache` from Claude Code.
+///
+/// M8.4 will grow this into the full LRU + mtime/hash invalidation cache
+/// described in the runtime plan (see issue #536 → M8.4). Today it is an
+/// empty stub so the context can hand out a shared handle without allocation.
+#[derive(Debug, Default)]
+pub struct FileStateCache {
+    // M8.4 will add the LRU state, mtime map, hash index, and
+    // `is_partial_view` tracking here.
+}
+
+impl FileStateCache {
+    /// Create an empty file-state cache handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the cache currently has any recorded file entries. Always
+    /// `false` until M8.4 fills in the map.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Inbox of in-flight notifications surfaced to tools and the agent loop.
+///
+/// M8.2/M8.3 will route real notifications (e.g. permission prompts, gate
+/// state) through this handle. Today it is a zero-length inbox.
+#[derive(Clone, Debug, Default)]
+pub struct Notifications {
+    // M8.2/M8.3 will add the notification queue and backpressure state here.
+}
+
+impl Notifications {
+    /// Create an empty notifications inbox.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the inbox is empty (no pending notifications). Always `true`
+    /// until M8.2/M8.3 start enqueueing notifications.
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+/// Handle to the ambient app state shared across tools.
+///
+/// M8.3 will use this to expose profile/app state that tools may read (e.g.
+/// the active profile name, locale, workspace contract root). Today it is an
+/// empty handle that tools can carry without wiring.
+#[derive(Clone, Debug, Default)]
+pub struct AppStateHandle {
+    // M8.3 will add the shared state handle (Arc<ProfileState>) here.
+}
+
+impl AppStateHandle {
+    /// Create an empty app-state handle.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Execution context available to tools.
+///
+/// The legacy fields (`tool_id`, `reporter`, `harness_event_sink`, three
+/// attachment lists) carry today's behaviour. The trailing fields are M8.x
+/// placeholders — see each field's doc comment for the issue that will wire
+/// it up. Building a zero-value context is cheap: all placeholders implement
+/// `Default` and the required handles are backed by `Arc` so cloning is O(1).
 #[derive(Clone)]
 pub struct ToolContext {
     pub tool_id: String,
@@ -22,6 +169,37 @@ pub struct ToolContext {
     pub attachment_paths: Vec<String>,
     pub audio_attachment_paths: Vec<String>,
     pub file_attachment_paths: Vec<String>,
+    /// Agent manifests available to tools. M8.2 will populate this.
+    pub agent_definitions: Arc<AgentDefinitions>,
+    /// Per-tool permission facts. M8.3 will populate this.
+    pub permissions: ToolPermissions,
+    /// File-state cache shared across tools in a turn. M8.4 will populate this.
+    pub file_state_cache: Option<Arc<FileStateCache>>,
+    /// Notification inbox surfaced to tools. M8.2/M8.3 will populate this.
+    pub notifications: Arc<Notifications>,
+    /// Handle to the ambient app state. M8.3 will populate this.
+    pub app_state: AppStateHandle,
+}
+
+impl ToolContext {
+    /// Zero-value context suitable for unit tests and tools that do not need
+    /// live executor wiring. Uses a [`crate::progress::SilentReporter`] and
+    /// leaves every M8.x placeholder at its default.
+    pub fn zero() -> Self {
+        Self {
+            tool_id: String::new(),
+            reporter: Arc::new(crate::progress::SilentReporter),
+            harness_event_sink: None,
+            attachment_paths: Vec::new(),
+            audio_attachment_paths: Vec::new(),
+            file_attachment_paths: Vec::new(),
+            agent_definitions: Arc::new(AgentDefinitions::new()),
+            permissions: ToolPermissions::default(),
+            file_state_cache: None,
+            notifications: Arc::new(Notifications::new()),
+            app_state: AppStateHandle::new(),
+        }
+    }
 }
 
 tokio::task_local! {
@@ -72,6 +250,23 @@ pub struct ToolResult {
 }
 
 /// Trait for implementing tools.
+///
+/// # Context threading
+///
+/// Tools get their execution context through one of two entry points:
+///
+/// - [`Tool::execute`] — the legacy argument-only entry point. Kept as the
+///   primary signature so unmigrated tools, tests, and external callers do
+///   not need to thread a [`ToolContext`]. The default implementation of
+///   `execute_with_context` delegates here, so implementors who override
+///   only `execute` keep working.
+/// - [`Tool::execute_with_context`] — the typed entry point introduced by
+///   M8.1. Migrated tools override this and may read any field on the
+///   [`ToolContext`]. The default body re-enters the legacy [`Tool::execute`]
+///   so unmigrated tools keep working.
+///
+/// A tool should override at most one of the two. Overriding both produces
+/// two independent entry paths that the executor cannot reconcile.
 #[async_trait]
 pub trait Tool: Send + Sync {
     /// Tool name (must be unique).
@@ -90,7 +285,28 @@ pub trait Tool: Send + Sync {
     }
 
     /// Execute the tool with the given arguments.
+    ///
+    /// Kept as the primary entry point so existing tools, tests, and
+    /// integrations do not need to construct a [`ToolContext`]. Migrated
+    /// tools re-enter this via [`Tool::execute_with_context`]; to avoid
+    /// infinite recursion implementors that override `execute_with_context`
+    /// must also override `execute` to call
+    /// `self.execute_with_context(&ToolContext::zero(), args).await`.
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult>;
+
+    /// Execute the tool with typed execution context.
+    ///
+    /// The default implementation delegates to [`Tool::execute`], discarding
+    /// the context. Tools that want to read [`ToolContext`] fields override
+    /// this and ignore `execute`'s default path. See the module-level doc
+    /// comment for the migration pattern.
+    async fn execute_with_context(
+        &self,
+        _ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
+        self.execute(args).await
+    }
 
     /// Downcast support for concrete tool access (e.g. wiring ActivateToolsTool).
     fn as_any(&self) -> &dyn std::any::Any {
@@ -614,5 +830,166 @@ mod path_tests {
         if let Ok(p) = &result {
             assert!(p.starts_with(base));
         }
+    }
+}
+
+#[cfg(test)]
+mod tool_context_tests {
+    //! M8.1 tests — typed `ToolContext` + `execute_with_context` scaffolding.
+
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Tool whose legacy `execute` records how many times it was called.
+    /// Overrides *only* `execute`; the default `execute_with_context` impl
+    /// must delegate here.
+    struct LegacyTool {
+        execute_calls: AtomicUsize,
+    }
+
+    impl LegacyTool {
+        fn new() -> Self {
+            Self {
+                execute_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for LegacyTool {
+        fn name(&self) -> &str {
+            "legacy"
+        }
+        fn description(&self) -> &str {
+            "legacy"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: &Value) -> Result<ToolResult> {
+            self.execute_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: "legacy output".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Tool that consumes the typed `ToolContext` — overrides
+    /// `execute_with_context` and re-enters via zero-value context from
+    /// `execute`.
+    struct ContextAwareTool {
+        with_ctx_calls: AtomicUsize,
+    }
+
+    impl ContextAwareTool {
+        fn new() -> Self {
+            Self {
+                with_ctx_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for ContextAwareTool {
+        fn name(&self) -> &str {
+            "ctx_aware"
+        }
+        fn description(&self) -> &str {
+            "ctx"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, args: &Value) -> Result<ToolResult> {
+            // Re-enter the typed path with the zero context so callers that
+            // still use the legacy entry point see identical behaviour.
+            self.execute_with_context(&ToolContext::zero(), args).await
+        }
+        async fn execute_with_context(
+            &self,
+            ctx: &ToolContext,
+            _args: &Value,
+        ) -> Result<ToolResult> {
+            self.with_ctx_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolResult {
+                output: format!(
+                    "tool_id={};allow_all={};defs_empty={}",
+                    ctx.tool_id,
+                    ctx.permissions.is_tool_allowed("anything"),
+                    ctx.agent_definitions.is_empty(),
+                ),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[test]
+    fn should_construct_zero_value_tool_context() {
+        let ctx = ToolContext::zero();
+        assert!(ctx.tool_id.is_empty());
+        assert!(ctx.harness_event_sink.is_none());
+        assert!(ctx.attachment_paths.is_empty());
+        assert!(ctx.audio_attachment_paths.is_empty());
+        assert!(ctx.file_attachment_paths.is_empty());
+        // M8.x placeholders — zero-value but constructible without panic.
+        assert!(ctx.agent_definitions.is_empty());
+        assert!(ctx.permissions.is_tool_allowed("any_tool"));
+        assert!(ctx.file_state_cache.is_none());
+        assert!(ctx.notifications.is_empty());
+        // AppStateHandle has no introspection beyond Default; just ensure
+        // it cloned cheaply.
+        let _cloned = ctx.app_state.clone();
+    }
+
+    #[tokio::test]
+    async fn should_delegate_execute_to_execute_with_context() {
+        // Legacy tool: override only `execute`. The default impl of
+        // `execute_with_context` must route to it.
+        let tool = LegacyTool::new();
+        let ctx = ToolContext::zero();
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({}))
+            .await
+            .expect("legacy tool must succeed via default delegation");
+        assert!(result.success);
+        assert_eq!(result.output, "legacy output");
+        assert_eq!(tool.execute_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn should_invoke_execute_with_context_for_migrated_tool() {
+        let tool = ContextAwareTool::new();
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call-42".to_string();
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({}))
+            .await
+            .expect("ctx-aware tool must succeed");
+        assert!(result.success);
+        assert!(result.output.contains("tool_id=call-42"));
+        assert!(result.output.contains("allow_all=true"));
+        assert!(result.output.contains("defs_empty=true"));
+        assert_eq!(tool.with_ctx_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn should_route_migrated_tool_execute_back_through_context_path() {
+        // When a migrated tool is called via the legacy `execute` entry
+        // point, it must still take its ctx-aware branch (invoked with
+        // the zero-value context so out-of-band callers keep working).
+        let tool = ContextAwareTool::new();
+        let result = tool
+            .execute(&serde_json::json!({}))
+            .await
+            .expect("migrated tool's legacy execute must succeed");
+        assert!(result.success);
+        // tool_id is empty because ToolContext::zero() carries no id.
+        assert!(result.output.starts_with("tool_id=;"));
+        assert_eq!(tool.with_ctx_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -41,25 +41,12 @@ use crate::progress::ProgressReporter;
 
 /// Registry of [`AgentDefinition`]-style manifests available to tools.
 ///
-/// M8.2 will populate this registry from `AgentDefinition` manifests on disk
-/// (see issue #536 → M8.2). Today it is an empty holder so the context can be
-/// constructed without wiring.
-#[derive(Clone, Debug, Default)]
-pub struct AgentDefinitions {
-    // M8.2 will add the concrete definition records here.
-}
-
-impl AgentDefinitions {
-    /// Create an empty agent-definition registry.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Whether any agent definitions are registered.
-    pub fn is_empty(&self) -> bool {
-        true
-    }
-}
+/// Re-exported from [`crate::agents`] where the schema and loader live. M8.2
+/// filled in the stub shipped by M8.1: the registry now carries real
+/// [`crate::agents::AgentDefinition`] records by id. `ToolContext` keeps its
+/// M8.1 signature (`Arc<AgentDefinitions>`), so consumers of the field do
+/// not need to change.
+pub use crate::agents::AgentDefinitions;
 
 /// Per-tool permission facts consulted before each execution.
 ///

--- a/crates/octos-agent/src/tools/policy.rs
+++ b/crates/octos-agent/src/tools/policy.rs
@@ -119,7 +119,7 @@ impl ToolPolicy {
 }
 
 /// Check if a policy entry (group, wildcard, or exact name) matches a tool name.
-fn entry_matches(entry: &str, tool_name: &str) -> bool {
+pub(crate) fn entry_matches(entry: &str, tool_name: &str) -> bool {
     // Robot-tier groups resolve through the dynamic registry so integrators
     // register tool-to-tier mappings at runtime.
     if entry_is_robot_group(entry) {

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use serde::Deserialize;
 
-use super::{Tool, ToolResult};
+use super::{Tool, ToolContext, ToolResult};
 
 /// Tool for reading file contents.
 pub struct ReadFileTool {
@@ -68,8 +68,30 @@ impl Tool for ReadFileTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // M8.1: legacy entry point routes through the typed path with a
+        // zero-value context so out-of-band callers still exercise the same
+        // permission and (post-M8.4) file-state-cache logic.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: ReadFileInput =
             serde_json::from_value(args.clone()).wrap_err("invalid read_file tool input")?;
+
+        // M8.1 permission gate (stub): consult the typed permissions record
+        // so the hook is in place before M8.3 wires real allow lists. Today
+        // `ToolPermissions::default()` returns allow-all.
+        if !ctx.permissions.is_tool_allowed(self.name()) {
+            return Ok(ToolResult {
+                output: "read_file is not permitted in this context".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
 
         // Resolve path (with traversal protection)
         let path = match super::resolve_path(&self.base_dir, &input.path) {
@@ -251,5 +273,27 @@ mod tests {
         let tool = ReadFileTool::new("/tmp");
         assert_eq!(tool.name(), "read_file");
         assert!(tool.tags().contains(&"fs"));
+    }
+
+    #[tokio::test]
+    async fn should_read_via_execute_with_context() {
+        // M8.1 migration: `execute_with_context` is the authoritative entry
+        // point. Dispatching through it with a populated `ToolContext` must
+        // produce the same result as the legacy `execute` path.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "alpha\nbeta\n").unwrap();
+
+        let tool = ReadFileTool::new(dir.path());
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "read-via-ctx".to_string();
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "hello.txt"}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("alpha"));
+        assert!(result.output.contains("beta"));
     }
 }

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -318,6 +318,73 @@ impl ToolRegistry {
         self.retain(|name| policy.is_allowed(name));
     }
 
+    /// Narrow the registry to the tools permitted by a profile's tool
+    /// declaration ([`crate::profile::ProfileTools`]).
+    ///
+    /// Unlike [`ToolRegistry::apply_policy`] this method consumes the
+    /// profile-shaped enum directly so the CLI does not need to translate
+    /// profile modes into a [`ToolPolicy`] round-trip. Behaviour by mode:
+    ///
+    /// - [`crate::profile::ProfileTools::Default`] — no-op. The registry
+    ///   passes through untouched so the built-in `coding` profile
+    ///   preserves today's behaviour byte-for-byte.
+    /// - [`crate::profile::ProfileTools::AllowList`] — keeps tools whose
+    ///   names match the allow list (plain name, `group:<id>`, or
+    ///   `<prefix>*` wildcard). Any tool marked `spawn_only` is retained
+    ///   regardless — they carry background-execution wiring the runtime
+    ///   depends on.
+    /// - [`crate::profile::ProfileTools::DenyList`] — drops tools matching
+    ///   any deny list entry (same matching rules). Spawn-only tools are
+    ///   likewise preserved.
+    ///
+    /// The filter runs in-place. Cache invalidation is handled by
+    /// [`ToolRegistry::retain`]. Intended to be called as a post-build
+    /// step during startup; never from inside the agent loop.
+    pub fn filter_by_profile(&mut self, tools: &crate::profile::ProfileTools) {
+        use crate::profile::ProfileTools;
+
+        match tools {
+            ProfileTools::Default => {
+                // No-op — the default mode is the behaviour-parity path.
+            }
+            ProfileTools::AllowList { tools: allow } => {
+                if allow.is_empty() {
+                    // Empty allow list would evict the entire registry
+                    // minus spawn_only tools; that is a surprising outcome
+                    // for profile authors, so treat it as a pass-through
+                    // with a warning. Authors who really want to kill
+                    // every tool should use an explicit `deny_list`.
+                    tracing::warn!(
+                        "profile declares empty allow_list — skipping filter; use deny_list to \
+                         blacklist tools"
+                    );
+                    return;
+                }
+                let spawn_only = self.spawn_only.clone();
+                let allow_entries: Vec<String> = allow.clone();
+                self.retain(|name| {
+                    spawn_only.contains(name)
+                        || allow_entries
+                            .iter()
+                            .any(|entry| policy::entry_matches(entry, name))
+                });
+            }
+            ProfileTools::DenyList { tools: deny } => {
+                if deny.is_empty() {
+                    return;
+                }
+                let spawn_only = self.spawn_only.clone();
+                let deny_entries: Vec<String> = deny.clone();
+                self.retain(|name| {
+                    spawn_only.contains(name)
+                        || !deny_entries
+                            .iter()
+                            .any(|entry| policy::entry_matches(entry, name))
+                });
+            }
+        }
+    }
+
     /// Set a provider-specific policy that filters `specs()` and `execute()`.
     ///
     /// Unlike `apply_policy` which permanently removes tools from the registry,
@@ -1365,5 +1432,235 @@ mod context_threading_tests {
 
         let seen = tool.seen.lock().unwrap().clone();
         assert_eq!(seen.as_deref(), Some(""));
+    }
+}
+
+#[cfg(test)]
+mod profile_filter_tests {
+    //! M8.3 — `filter_by_profile` narrows the registry through a
+    //! [`crate::profile::ProfileTools`] declaration. Behaviour parity
+    //! with today's default path is covered by the
+    //! `default_mode_is_pass_through` test.
+
+    use super::*;
+    use crate::profile::ProfileTools;
+
+    fn builtin_names(reg: &ToolRegistry) -> Vec<String> {
+        let mut names: Vec<String> = reg.tools.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn should_not_filter_when_profile_mode_is_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+        let before = builtin_names(&reg);
+
+        reg.filter_by_profile(&ProfileTools::Default);
+
+        let after = builtin_names(&reg);
+        assert_eq!(before, after, "default mode must not narrow the registry");
+    }
+
+    #[test]
+    fn should_filter_tool_registry_by_allow_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+
+        reg.filter_by_profile(&ProfileTools::AllowList {
+            tools: vec!["read_file".into(), "group:search".into()],
+        });
+
+        let names: Vec<String> = reg.tools.keys().cloned().collect();
+        assert!(names.contains(&"read_file".to_string()));
+        // group:search expands to glob/grep/list_dir.
+        assert!(names.contains(&"glob".to_string()));
+        assert!(names.contains(&"grep".to_string()));
+        assert!(names.contains(&"list_dir".to_string()));
+        // Not on the allow list, not spawn_only -> evicted.
+        assert!(!names.contains(&"shell".to_string()));
+        assert!(!names.contains(&"web_fetch".to_string()));
+    }
+
+    #[test]
+    fn should_filter_tool_registry_by_deny_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+        let before = builtin_names(&reg);
+
+        reg.filter_by_profile(&ProfileTools::DenyList {
+            tools: vec!["web_fetch".into(), "browser".into()],
+        });
+
+        let after = builtin_names(&reg);
+        assert!(!after.contains(&"web_fetch".to_string()));
+        assert!(!after.contains(&"browser".to_string()));
+        // Everything else must survive.
+        let expected_survivors: Vec<String> = before
+            .iter()
+            .filter(|n| n.as_str() != "web_fetch" && n.as_str() != "browser")
+            .cloned()
+            .collect();
+        for n in expected_survivors {
+            assert!(
+                after.contains(&n),
+                "{n} should survive the deny-list filter",
+            );
+        }
+    }
+
+    #[test]
+    fn should_not_filter_spawn_only_tools_from_allow_list() {
+        // A spawn_only tool that does not appear in the allow list must
+        // still be retained — it carries background execution wiring the
+        // runtime depends on.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+        reg.mark_spawn_only("mofa_slides", None);
+        // Fake-register the tool so the filter has something to keep.
+        // We reuse an existing builtin name for the test; mark_spawn_only
+        // is just an annotation, it doesn't need the name to exist in
+        // `self.tools` — for the retention check we need a real entry,
+        // so register a no-op tool under that name.
+        use async_trait::async_trait;
+        use eyre::Result;
+        use serde_json::Value;
+        struct Noop;
+        #[async_trait]
+        impl Tool for Noop {
+            fn name(&self) -> &str {
+                "mofa_slides"
+            }
+            fn description(&self) -> &str {
+                "noop"
+            }
+            fn input_schema(&self) -> Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(&self, _: &Value) -> Result<ToolResult> {
+                Ok(ToolResult::default())
+            }
+        }
+        reg.register(Noop);
+
+        reg.filter_by_profile(&ProfileTools::AllowList {
+            tools: vec!["read_file".into()],
+        });
+
+        let names: Vec<String> = reg.tools.keys().cloned().collect();
+        assert!(
+            names.contains(&"mofa_slides".to_string()),
+            "spawn_only tools must survive an allow-list filter",
+        );
+        assert!(names.contains(&"read_file".to_string()));
+        assert!(!names.contains(&"shell".to_string()));
+    }
+
+    #[test]
+    fn should_not_filter_spawn_only_tools_from_deny_list() {
+        // Same invariant, but the user declared a deny list that *names*
+        // the spawn-only tool. The registry must still retain it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+        reg.mark_spawn_only("mofa_slides", None);
+
+        use async_trait::async_trait;
+        use eyre::Result;
+        use serde_json::Value;
+        struct Noop;
+        #[async_trait]
+        impl Tool for Noop {
+            fn name(&self) -> &str {
+                "mofa_slides"
+            }
+            fn description(&self) -> &str {
+                "noop"
+            }
+            fn input_schema(&self) -> Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(&self, _: &Value) -> Result<ToolResult> {
+                Ok(ToolResult::default())
+            }
+        }
+        reg.register(Noop);
+
+        reg.filter_by_profile(&ProfileTools::DenyList {
+            tools: vec!["mofa_slides".into()],
+        });
+
+        let names: Vec<String> = reg.tools.keys().cloned().collect();
+        assert!(
+            names.contains(&"mofa_slides".to_string()),
+            "spawn_only tools cannot be evicted by a profile deny list",
+        );
+    }
+
+    #[test]
+    fn empty_allow_list_is_a_pass_through_with_warning() {
+        // Defensive: an empty allow list would wipe the registry (minus
+        // spawn_only). That is almost always an author mistake, so the
+        // filter treats it as a pass-through. Authors who really want an
+        // empty registry should use `deny_list` explicitly.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+        let before = builtin_names(&reg);
+
+        reg.filter_by_profile(&ProfileTools::AllowList { tools: Vec::new() });
+
+        let after = builtin_names(&reg);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn empty_deny_list_is_a_pass_through() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+        let before = builtin_names(&reg);
+
+        reg.filter_by_profile(&ProfileTools::DenyList { tools: Vec::new() });
+
+        let after = builtin_names(&reg);
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn allow_list_wildcard_matches_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+
+        reg.filter_by_profile(&ProfileTools::AllowList {
+            tools: vec!["workspace_*".into()],
+        });
+
+        let names: Vec<String> = reg.tools.keys().cloned().collect();
+        assert!(names.contains(&"workspace_log".to_string()));
+        assert!(names.contains(&"workspace_show".to_string()));
+        assert!(names.contains(&"workspace_diff".to_string()));
+        assert!(!names.contains(&"shell".to_string()));
+    }
+
+    #[test]
+    fn coding_profile_produces_same_registry_as_default_builtins() {
+        // Behaviour parity gate: applying the built-in `coding` profile
+        // to a builtin registry must leave the registry IDENTICAL to
+        // what today's no-flag default path produces. This is the
+        // critical regression guard called out in the M8.3 issue.
+        use crate::profile::ProfileDefinition;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let reference = ToolRegistry::with_builtins(dir.path());
+        let reference_names = builtin_names(&reference);
+
+        let coding = ProfileDefinition::builtin("coding").expect("coding builtin");
+        let mut profiled = ToolRegistry::with_builtins(dir.path());
+        coding.apply_to_registry(&mut profiled);
+
+        let profiled_names = builtin_names(&profiled);
+        assert_eq!(
+            reference_names, profiled_names,
+            "coding profile must preserve behaviour parity with the default path",
+        );
     }
 }

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -571,7 +571,25 @@ impl ToolRegistry {
     /// Respects provider policy: tools hidden from `specs()` are also blocked
     /// from execution. This prevents an LLM from calling tools it shouldn't
     /// have access to.
+    ///
+    /// Delegates to [`ToolRegistry::execute_with_context`] with the zero-value
+    /// [`ToolContext`] so legacy callers continue to work unchanged.
     pub async fn execute(&self, name: &str, args: &serde_json::Value) -> Result<ToolResult> {
+        let ctx = super::ToolContext::zero();
+        self.execute_with_context(&ctx, name, args).await
+    }
+
+    /// Execute a tool by name with a typed [`ToolContext`].
+    ///
+    /// Migrated tools override [`super::Tool::execute_with_context`] and will
+    /// see the caller's context; unmigrated tools fall back to the default
+    /// trait impl which delegates to [`super::Tool::execute`].
+    pub async fn execute_with_context(
+        &self,
+        ctx: &super::ToolContext,
+        name: &str,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         if let Some(ref policy) = self.provider_policy {
             if let policy::PolicyDecision::Deny { reason } = policy.evaluate(name) {
                 eyre::bail!("tool '{}' denied by provider policy ({})", name, reason);
@@ -629,7 +647,7 @@ impl ToolRegistry {
         // Track usage for LRU auto-eviction
         self.record_usage(name);
 
-        tool.execute(args).await
+        tool.execute_with_context(ctx, args).await
     }
 }
 
@@ -1250,5 +1268,102 @@ mod lifecycle_tests {
         let msg = reg.spawn_only_message("mofa_slides");
 
         assert!(msg.contains("Output directory: /tmp/octos-profile/skill-output/"));
+    }
+}
+
+#[cfg(test)]
+mod context_threading_tests {
+    //! M8.1 — tool context threaded through the registry dispatch path.
+
+    use super::super::{Tool, ToolContext, ToolResult};
+    use super::*;
+    use async_trait::async_trait;
+    use eyre::Result;
+    use serde_json::Value;
+    use std::sync::Mutex;
+
+    /// Tool that echoes the `tool_id` it saw on the context, letting tests
+    /// confirm the registry forwarded the caller's `ToolContext` into
+    /// `execute_with_context`.
+    struct CapturingTool {
+        seen: Mutex<Option<String>>,
+    }
+
+    impl CapturingTool {
+        fn new() -> Self {
+            Self {
+                seen: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for CapturingTool {
+        fn name(&self) -> &str {
+            "capturing"
+        }
+        fn description(&self) -> &str {
+            "test-only"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, args: &Value) -> Result<ToolResult> {
+            self.execute_with_context(&ToolContext::zero(), args).await
+        }
+        async fn execute_with_context(
+            &self,
+            ctx: &ToolContext,
+            _args: &Value,
+        ) -> Result<ToolResult> {
+            *self.seen.lock().unwrap() = Some(ctx.tool_id.clone());
+            Ok(ToolResult {
+                output: ctx.tool_id.clone(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn should_pass_context_through_executor() {
+        let mut reg = ToolRegistry::new();
+        let tool = Arc::new(CapturingTool::new());
+        reg.register_arc(tool.clone());
+
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call-m8.1".to_string();
+
+        let result = reg
+            .execute_with_context(&ctx, "capturing", &serde_json::json!({}))
+            .await
+            .expect("capturing tool must succeed");
+        assert!(result.success);
+        assert_eq!(result.output, "call-m8.1");
+
+        let seen = tool.seen.lock().unwrap().clone();
+        assert_eq!(
+            seen.as_deref(),
+            Some("call-m8.1"),
+            "registry must forward the caller's ToolContext into execute_with_context",
+        );
+    }
+
+    #[tokio::test]
+    async fn should_route_legacy_execute_through_zero_value_context() {
+        // The legacy `execute(name, args)` entry must reach the same tool
+        // but with a zero-value context (empty tool_id).
+        let mut reg = ToolRegistry::new();
+        let tool = Arc::new(CapturingTool::new());
+        reg.register_arc(tool.clone());
+
+        let result = reg
+            .execute("capturing", &serde_json::json!({}))
+            .await
+            .expect("capturing tool must succeed via legacy entry");
+        assert!(result.success);
+
+        let seen = tool.seen.lock().unwrap().clone();
+        assert_eq!(seen.as_deref(), Some(""));
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -636,7 +636,7 @@ impl SpawnTool {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct Input {
     task: String,
     #[serde(default)]
@@ -673,6 +673,13 @@ struct Input {
     /// default and finally to [`DEFAULT_MCP_AGENT_TOOL_NAME`].
     #[serde(default)]
     agent_mcp_tool_name: Option<String>,
+    /// Optional id of an [`crate::agents::AgentDefinition`] manifest to
+    /// resolve from [`crate::tools::ToolContext::agent_definitions`]. When
+    /// set, the manifest's fields become defaults for this spawn call;
+    /// fields explicitly provided inline on `Input` override the manifest.
+    /// Inline always wins.
+    #[serde(default)]
+    agent_definition_id: Option<String>,
 }
 
 fn default_backend() -> String {
@@ -681,6 +688,74 @@ fn default_backend() -> String {
 
 fn default_mode() -> String {
     "background".into()
+}
+
+/// Resolve an optional `agent_definition_id` against the context's manifest
+/// registry and layer the manifest's fields onto the inline [`Input`].
+///
+/// Semantics: inline wins. A field already present on `Input` (non-default
+/// for `Option`-typed fields; non-empty for `Vec`-typed fields) is kept as-is.
+/// Missing fields on `Input` are filled from the manifest.
+///
+/// Returns an error when the id is set but does not exist in the registry —
+/// that's almost always a typo, and silently ignoring it would erase the
+/// manifest's safety envelope.
+fn apply_agent_definition(
+    input: &mut Input,
+    registry: &crate::agents::AgentDefinitions,
+) -> Result<()> {
+    let Some(id) = input.agent_definition_id.as_deref() else {
+        return Ok(());
+    };
+    let def = registry.get(id).ok_or_else(|| {
+        eyre::eyre!(
+            "spawn: agent_definition_id '{id}' not found in registry; \
+             available: [{}]",
+            registry.ids().collect::<Vec<_>>().join(", ")
+        )
+    })?;
+
+    // Tool allow-list: manifest provides the default; inline takes
+    // precedence when it is non-empty. Manifest deny-list is merged into
+    // the inline `allowed_tools` as a removal step so a manifest that
+    // marks `shell` as disallowed cannot be re-enabled silently by
+    // inheriting the parent's default allow set.
+    if input.allowed_tools.is_empty() {
+        input.allowed_tools = def.tools.clone();
+    }
+    if !def.disallowed_tools.is_empty() {
+        input
+            .allowed_tools
+            .retain(|name| !def.disallowed_tools.contains(name));
+    }
+
+    // Option-typed fields: manifest only applies when the inline slot is
+    // None.
+    if input.model.is_none() {
+        input.model = def.model.clone();
+    }
+    if input.additional_instructions.is_none() {
+        // `effort` and `permission_mode` flow into later phases; surfacing
+        // them in `additional_instructions` keeps them visible in traces
+        // without baking runtime-specific plumbing into v1. The manifest's
+        // explicit `effort` / `permission_mode` strings are concatenated as
+        // a short prelude.
+        let mut hints = Vec::new();
+        if let Some(effort) = def.effort.as_deref() {
+            hints.push(format!("effort={effort}"));
+        }
+        if let Some(mode) = def.permission_mode.as_deref() {
+            hints.push(format!("permission_mode={mode}"));
+        }
+        if !hints.is_empty() {
+            input.additional_instructions = Some(format!(
+                "(agent_definition={}) {}",
+                def.name,
+                hints.join(", ")
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn should_deliver_output_files(files: &[PathBuf]) -> bool {
@@ -1393,6 +1468,10 @@ impl Tool for SpawnTool {
                 "agent_mcp_tool_name": {
                     "type": "string",
                     "description": "Override the MCP tool name dispatched on the remote agent when backend='agent_mcp'. Defaults to 'run_task'."
+                },
+                "agent_definition_id": {
+                    "type": "string",
+                    "description": "Optional id of an AgentDefinition manifest (see crates/octos-agent/src/agents). The manifest's fields (tools, model, max_turns, etc.) become defaults for this spawn; any inline field on the spawn args overrides the manifest (inline wins)."
                 }
             },
             "required": ["task"]
@@ -1400,8 +1479,28 @@ impl Tool for SpawnTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
-        let input: Input =
+        // Legacy entry point: route through the typed path with a zero-value
+        // context so out-of-band callers behave identically. Manifest-driven
+        // spawns require a populated `ctx.agent_definitions`, so legacy
+        // callers see a "no such manifest" error if they pass
+        // `agent_definition_id` without context — matching the existing
+        // guard behaviour for other ctx-dependent fields.
+        self.execute_with_context(&super::ToolContext::zero(), args)
+            .await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &super::ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
+        let mut input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid spawn tool input")?;
+        // M8.2: if the caller referenced an AgentDefinition manifest by id,
+        // layer the manifest's fields onto the inline Input with "inline
+        // wins" semantics. Unknown ids are a hard error — silently ignoring
+        // them would let a typo erase the manifest's safety envelope.
+        apply_agent_definition(&mut input, ctx.agent_definitions.as_ref())?;
 
         let worker_num = self.worker_count.fetch_add(1, Ordering::SeqCst);
         let worker_id = AgentId::new(format!("subagent-{worker_num}"));
@@ -3542,5 +3641,131 @@ PY
         // Leak the dir so it stays alive for the test
         let dir = Box::leak(Box::new(dir));
         EpisodeStore::open(dir.path()).await.unwrap()
+    }
+
+    /// Build a minimal `Input` from a JSON value with the defaults the
+    /// tests expect. Centralising this keeps the M8.2 manifest tests below
+    /// independent of future serde changes.
+    fn parse_spawn_input(value: serde_json::Value) -> Input {
+        serde_json::from_value(value).expect("input parses")
+    }
+
+    #[test]
+    fn should_resolve_manifest_in_spawn_tool() {
+        // Spawn args reference `research-worker`; the manifest's `tools`
+        // list must flow into the resolved `Input.allowed_tools`. Inline
+        // `allowed_tools` is empty so the manifest fills it in.
+        let registry = crate::agents::AgentDefinitions::with_builtins();
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "research this topic",
+            "agent_definition_id": "research-worker"
+        }));
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        // Research-worker manifest lists deep_search + web_fetch + web_search.
+        for expected in ["deep_search", "web_fetch", "web_search"] {
+            assert!(
+                input.allowed_tools.contains(&expected.to_string()),
+                "manifest tool {expected} did not flow into allowed_tools"
+            );
+        }
+        // Manifest's disallowed_tools (shell/write/edit) must not appear.
+        for forbidden in ["shell", "write_file", "edit_file"] {
+            assert!(
+                !input.allowed_tools.contains(&forbidden.to_string()),
+                "manifest disallowed_tool {forbidden} leaked into allowed_tools"
+            );
+        }
+    }
+
+    #[test]
+    fn should_let_inline_fields_override_manifest() {
+        // Inline `model` must beat the manifest's `model`. The manifest
+        // sets no model on `research-worker`, so we use a local manifest
+        // that has one to make the override visible.
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "with-model",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "with-model",
+                    "version": 1,
+                    "tools": ["read_file"],
+                    "model": "manifest-model"
+                }"#,
+            )
+            .expect("parse"),
+        );
+
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "with-model",
+            "model": "inline-model"
+        }));
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        // Inline wins for model.
+        assert_eq!(input.model.as_deref(), Some("inline-model"));
+    }
+
+    #[test]
+    fn should_let_inline_allowed_tools_override_manifest_allowed_tools() {
+        // When inline `allowed_tools` is non-empty it replaces the manifest
+        // list outright. The manifest's disallowed_tools still prune the
+        // result so a manifest cannot be silently bypassed.
+        let mut registry = crate::agents::AgentDefinitions::new();
+        registry.insert(
+            "example",
+            crate::agents::AgentDefinition::from_json_str(
+                r#"{
+                    "name": "example",
+                    "version": 1,
+                    "tools": ["read_file", "shell"],
+                    "disallowed_tools": ["shell"]
+                }"#,
+            )
+            .expect("parse"),
+        );
+
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "example",
+            "allowed_tools": ["shell", "grep"]
+        }));
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        // Inline list is kept, but manifest's disallow pruned `shell`.
+        assert!(input.allowed_tools.contains(&"grep".to_string()));
+        assert!(!input.allowed_tools.contains(&"shell".to_string()));
+    }
+
+    #[test]
+    fn should_error_when_agent_definition_id_unknown() {
+        // Typos in the id are a hard error so a silent-typo cannot erase
+        // the manifest's safety envelope.
+        let registry = crate::agents::AgentDefinitions::with_builtins();
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "do it",
+            "agent_definition_id": "no-such-manifest"
+        }));
+        let err = apply_agent_definition(&mut input, &registry).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no-such-manifest"), "message: {msg}");
+    }
+
+    #[test]
+    fn should_not_mutate_input_when_agent_definition_id_missing() {
+        // No id means no resolution. This preserves the fast path for
+        // callers that never touch manifests.
+        let registry = crate::agents::AgentDefinitions::with_builtins();
+        let mut input = parse_spawn_input(serde_json::json!({
+            "task": "plain spawn",
+            "allowed_tools": ["shell"]
+        }));
+        let before = input.clone();
+        apply_agent_definition(&mut input, &registry).expect("apply");
+
+        assert_eq!(input.allowed_tools, before.allowed_tools);
+        assert_eq!(input.model, before.model);
     }
 }

--- a/crates/octos-agent/tests/delegate_tool.rs
+++ b/crates/octos-agent/tests/delegate_tool.rs
@@ -272,3 +272,47 @@ fn should_publish_delegated_deny_group_name_on_policy() {
     assert_eq!(policy.deny, vec![DELEGATED_DENY_GROUP.to_string()]);
     assert!(policy.allow.is_empty());
 }
+
+#[tokio::test]
+async fn should_route_delegation_event_through_tool_context_sink() {
+    // M8.1 migration smoke test — DelegateTool is now a context-aware tool.
+    // A tool instance constructed *without* `.with_harness_event_sink(...)`
+    // must still emit its delegation event to the sink path carried by the
+    // `ToolContext` when dispatched through `execute_with_context`. This
+    // proves the tool actually reads from the typed context rather than
+    // relying on its own builder-only wiring.
+    use octos_agent::progress::SilentReporter;
+    use octos_agent::tools::ToolContext;
+    use std::sync::Arc;
+
+    let dir = TempDir::new().unwrap();
+    let memory = memory(&dir).await;
+    let sink_path = dir.path().join("delegation-events.ndjson");
+
+    // DepthBudget already exhausted so execute_with_context emits the
+    // DepthExceeded event and returns. No child is spawned, which keeps the
+    // test hermetic (no real LLM interaction required).
+    let tool = DelegateTool::new(llm("unused"), memory, PathBuf::from(dir.path()))
+        .with_depth_budget(DepthBudget::at_level(MAX_DEPTH));
+
+    let ctx = ToolContext {
+        tool_id: "m8.1-smoke".to_string(),
+        reporter: Arc::new(SilentReporter),
+        harness_event_sink: Some(sink_path.to_string_lossy().to_string()),
+        attachment_paths: Vec::new(),
+        audio_attachment_paths: Vec::new(),
+        file_attachment_paths: Vec::new(),
+        ..ToolContext::zero()
+    };
+
+    let result = tool
+        .execute_with_context(&ctx, &serde_json::json!({"task": "ignored"}))
+        .await;
+    assert!(result.is_err(), "depth-exceeded must fail synchronously");
+
+    let raw = std::fs::read_to_string(&sink_path)
+        .expect("DelegateTool must write the depth-exceeded event to the context sink path");
+    let entry: serde_json::Value = serde_json::from_str(raw.trim()).unwrap();
+    assert_eq!(entry["kind"], "delegation");
+    assert_eq!(entry["outcome"], "depth_exceeded");
+}

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -291,10 +291,26 @@ impl ChatCommand {
             chat_max_tokens: config.gateway.as_ref().and_then(|g| g.max_output_tokens),
             ..Default::default()
         };
+        // M8.2: load sub-agent manifests from `<cwd>/agents/` layered on
+        // top of the crate-shipped built-ins (research-worker, repo-editor).
+        // Missing dirs fall back to built-ins only.
+        let agents_dir = cwd.join("agents");
+        let agent_definitions = match octos_agent::agents::AgentDefinitions::load_dir(&agents_dir) {
+            Ok(defs) => Arc::new(defs),
+            Err(err) => {
+                eprintln!(
+                    "Warning: failed to load agent manifests from {}: {err}",
+                    agents_dir.display()
+                );
+                Arc::new(octos_agent::agents::AgentDefinitions::with_builtins())
+            }
+        };
+
         let mut agent = Agent::new(AgentId::new("chat"), llm, tools, memory)
             .with_config(agent_config)
             .with_reporter(reporter)
-            .with_shutdown(shutdown.clone());
+            .with_shutdown(shutdown.clone())
+            .with_agent_definitions(agent_definitions);
 
         // Load bootstrap files (AGENTS.md, SOUL.md, etc.) from project .octos/ directory
         let project_dir = cwd.join(".octos");

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -61,6 +61,15 @@ pub struct ChatCommand {
     /// Send a single message and exit (non-interactive mode).
     #[arg(short, long)]
     pub message: Option<String>,
+
+    /// Runtime profile to apply at startup (M8.3). Accepts a built-in name
+    /// (`coding`, `swarm`), a user-dir id under `~/.octos/profiles/<id>/`,
+    /// or an explicit path to a profile JSON/TOML file.
+    ///
+    /// Defaults to `coding` which preserves today's no-flag behaviour
+    /// byte-for-byte.
+    #[arg(long)]
+    pub profile: Option<String>,
 }
 
 /// Exit commands.
@@ -162,6 +171,21 @@ impl ChatCommand {
             EpisodeStore::open(&data_dir)
                 .await
                 .wrap_err("failed to open episode store")?,
+        );
+
+        // Resolve the runtime profile (M8.3). Order:
+        //   1. --profile CLI arg, if present;
+        //   2. `~/.octos/profile` symlink, if it exists (points at a
+        //      profile name or dir);
+        //   3. fallback to the built-in `coding` profile.
+        // The resolved profile's tool filter is applied after the full
+        // registry has been assembled, preserving the existing bootstrap
+        // path (plugins, MCP, pipelines etc. all register first).
+        let (profile, profile_source_label) = resolve_profile(&self.profile)?;
+        tracing::info!(
+            "profile resolved: name={} source={}",
+            profile.name,
+            profile_source_label
         );
 
         // Create tool registry (with sandbox if configured)
@@ -274,6 +298,11 @@ impl ChatCommand {
             tools.set_provider_policy(policy);
         }
 
+        // M8.3: narrow the tool registry through the resolved profile.
+        // Runs AFTER every other filter so profile narrowing is the final
+        // envelope and `spawn_only` tools are still preserved.
+        profile.apply_to_registry(&mut tools);
+
         // Set up Ctrl+C handler
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
@@ -306,11 +335,28 @@ impl ChatCommand {
             }
         };
 
+        // M8.3: share the resolved profile with the Agent so downstream
+        // code can introspect the envelope. The tool filter has already
+        // been applied above.
+        let profile_arc = Arc::new(profile);
         let mut agent = Agent::new(AgentId::new("chat"), llm, tools, memory)
             .with_config(agent_config)
             .with_reporter(reporter)
             .with_shutdown(shutdown.clone())
-            .with_agent_definitions(agent_definitions);
+            .with_agent_definitions(agent_definitions)
+            .with_profile(profile_arc.clone());
+
+        // M8.3: if the profile declares a system_prompt_template, try to
+        // read it relative to `~/.octos/profiles/<name>/`. The path is a
+        // hint — missing files are a warning, not an error, so profiles
+        // referring to templates that ship separately keep working.
+        if let Some(template_rel) = profile_arc.system_prompt_template.as_ref() {
+            if let Some(prompt_text) =
+                super::load_profile_prompt_template(&profile_arc.name, template_rel)
+            {
+                agent.set_system_prompt(prompt_text);
+            }
+        }
 
         // Load bootstrap files (AGENTS.md, SOUL.md, etc.) from project .octos/ directory
         let project_dir = cwd.join(".octos");
@@ -467,6 +513,68 @@ impl ChatCommand {
 
         Ok(())
     }
+}
+
+/// M8.3 — resolve the runtime profile for an `octos chat` invocation.
+///
+/// Resolution order:
+///
+/// 1. `--profile <name_or_path>` CLI arg, if present.
+/// 2. `~/.octos/profile` symlink, if it exists (its target is treated as a
+///    profile name or path using the same rules as the CLI arg).
+/// 3. Built-in `coding` profile — the behaviour-parity fallback.
+///
+/// Returns the resolved [`octos_agent::profile::ProfileDefinition`] plus a
+/// human-readable source label (`cli`, `symlink`, or `default`) suitable for
+/// inclusion in the `profile resolved: ...` log line.
+pub(crate) fn resolve_profile(
+    cli_arg: &Option<String>,
+) -> Result<(octos_agent::profile::ProfileDefinition, &'static str)> {
+    use octos_agent::profile::ProfileDefinition;
+
+    if let Some(arg) = cli_arg.as_deref() {
+        let (def, _) = ProfileDefinition::load(arg)
+            .wrap_err_with(|| format!("failed to load profile '{arg}'"))?;
+        return Ok((def, "cli"));
+    }
+
+    // `~/.octos/profile` symlink (or plain file containing a profile name).
+    // A symlink target can be either a path (dereferences normally through
+    // filesystem APIs, which `load` will then detect as a path arg) or a
+    // simple profile name if the link points at a directory under
+    // `~/.octos/profiles/`.
+    if let Some(home) = dirs::home_dir() {
+        let pointer = home.join(".octos/profile");
+        if pointer.symlink_metadata().is_ok() {
+            // Plain symlink: dereference and feed the target into `load`.
+            if let Ok(target) = std::fs::read_link(&pointer) {
+                let target_str = target.to_string_lossy().to_string();
+                if let Ok((def, _)) = ProfileDefinition::load(&target_str) {
+                    return Ok((def, "symlink"));
+                }
+                tracing::warn!(
+                    target = %target.display(),
+                    "~/.octos/profile symlink target could not be resolved; falling back to default"
+                );
+            } else if let Ok(text) = std::fs::read_to_string(&pointer) {
+                // Regular file: treat its first non-empty line as a profile name.
+                let name = text
+                    .lines()
+                    .map(str::trim)
+                    .find(|l| !l.is_empty())
+                    .unwrap_or("");
+                if !name.is_empty() {
+                    if let Ok((def, _)) = ProfileDefinition::load(name) {
+                        return Ok((def, "symlink"));
+                    }
+                }
+            }
+        }
+    }
+
+    let (def, _) = octos_agent::profile::ProfileDefinition::load("coding")
+        .wrap_err("failed to load built-in coding profile")?;
+    Ok((def, "default"))
 }
 
 /// Find the matching provider-specific tool policy for the active model.

--- a/crates/octos-cli/src/commands/mod.rs
+++ b/crates/octos-cli/src/commands/mod.rs
@@ -164,6 +164,42 @@ pub(crate) fn load_bootstrap_files(data_dir: &std::path::Path) -> String {
     parts.join("\n\n")
 }
 
+/// M8.3: load a profile's `system_prompt_template` hint.
+///
+/// The path is treated as relative to `~/.octos/profiles/<profile_name>/`.
+/// Missing files are not an error — we log and return `None` so the agent
+/// keeps its default prompt. Empty files are also treated as missing.
+pub(crate) fn load_profile_prompt_template(
+    profile_name: &str,
+    template_rel: &std::path::Path,
+) -> Option<String> {
+    let home = dirs::home_dir()?;
+    let base = home.join(".octos/profiles").join(profile_name);
+    let path = base.join(template_rel);
+    match std::fs::read_to_string(&path) {
+        Ok(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "profile system_prompt_template exists but is empty; using default prompt"
+                );
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %err,
+                "profile system_prompt_template not found; using default prompt"
+            );
+            None
+        }
+    }
+}
+
 impl Executable for Command {
     fn execute(self) -> Result<()> {
         match self {


### PR DESCRIPTION
Closes #538. Stacked on top of #546 (M8.1) and #547 (M8.2).

## Summary

A new `ProfileDefinition` manifest consolidates the agent runtime
envelope (tools, agents, MCP, compaction, permissions, model
preferences, system prompt template) into a single declarative schema.
The CLI gains `--profile <name_or_path>` on `octos chat` so a user can
swap the entire envelope with one flag. The built-in `coding` profile
preserves today's no-flag behaviour byte-for-byte.

Together with M8.1 + M8.2 this completes **runtime-v0.1** — tools see a
typed context, sub-agent manifests are first-class, and the startup
surface is profile-driven.

## Schema (v1)

`ProfileDefinition` fields:

- `name: String`, `version: u32` (= 1) — required
- `description: Option<String>`
- `tools: ProfileTools` — `{mode: default}` | `{mode: allow_list, tools: [...]}` | `{mode: deny_list, tools: [...]}`
- `mcp_servers: Vec<McpServerRef>` — ids only (wiring is follow-up)
- `permissions: PermissionMode` — `default` | `restricted` (M8.4 extends this)
- `compaction_policy: Option<ProfileCompactionPolicy>` — recorded; M8.5 will enforce
- `model_preferences: Option<ModelPreferences>` — `{default, fast, strong}`, recorded
- `system_prompt_template: Option<PathBuf>` — relative to `~/.octos/profiles/<name>/`
- `agents: Vec<String>` — ids consumed from M8.2's registry

**Forward-compatible**: unknown fields are tolerated (no `deny_unknown_fields`) so v1 clients keep parsing v2 manifests. The `version` field remains a hard gate.

## Resolution order

`ProfileDefinition::load("<name_or_path>")`:

1. Arg starting with `/`, `./`, `~/`, or `../` → load as a file path.
2. Else look under `~/.octos/profiles/<name>/profile.{toml,json}`.
3. Else fall back to the crate-shipped built-ins.

CLI default (no `--profile` flag):
1. `~/.octos/profile` symlink / file (first non-empty line is the profile name)
2. fallback to `coding`

Log line: `profile resolved: name=<n> source=<cli|symlink|default>`

## Built-in profiles

- **`coding`** — default, `tools.mode = default`, built-in `research-worker` + `repo-editor` agents preloaded. Preserves today's no-flag behaviour.
- **`swarm`** — allow-list adding swarm-coordination tools (`send_to_agent`, `cancel_task`, `relaunch_task`, `spawn`, `check_background_tasks`) and PM-supervisor agent set. Target is the swarm workflow (agents listed are placeholder ids for now).

## Behaviour parity

The critical regression guard is `coding_profile_produces_same_registry_as_default_builtins` (in `tools::registry::profile_filter_tests`) plus `coding_profile_matches_default_tool_set` (in `agent::profile_integration_tests`). Both assert that applying the built-in `coding` profile to a default `ToolRegistry` yields the same tool set as `ToolRegistry::with_builtins`. Full workspace tests pass.

## Filter behaviour

`ToolRegistry::filter_by_profile(&ProfileTools)` runs as a post-build step — the existing registration path (plugins, MCP, pipeline tool) is untouched. `spawn_only` tools are **never** filtered out regardless of mode; they carry background-execution wiring the runtime depends on. Empty allow lists are a pass-through with a warning (so author mistakes don't silently wipe the registry).

## Recorded, not enforced

The milestone deliberately ships these as recorded only:

- `compaction_policy` — parsed and exposed; M8.5 tiered runner consumes it.
- `model_preferences` — parsed and exposed; adaptive router integration is follow-up.
- `mcp_servers` — only ids are captured; actual server config resolution is follow-up.

This is documented in the profile module doc and the `with_profile` setter's doc comment.

## Stacking

Stacks on `feature/m8.2-agent-definition-manifest` (#547), which stacks on `feature/m8.1-typed-tool-context` (#546). M8.1 + M8.2 commits are in the PR diff because they are not yet merged into main.

## Test delta

+27 new tests (16 profile schema/loader, 9 registry filter, 2 agent integration). M8.2 baseline: 1002 lib tests. After: 1029 lib tests.

## Notes

Pre-existing fmt and clippy drift in `crates/octos-cli/src/api/admin*.rs`, `crates/octos-cli/src/api/auth_handlers.rs`, `crates/octos-cli/src/commands/admin.rs`, `crates/octos-cli/src/config.rs`, `crates/octos-cli/src/setup_state_store.rs`, `crates/octos-cli/src/api/webhook_proxy.rs`, `crates/octos-cli/src/process_manager.rs`, `crates/octos-cli/src/otp.rs`, `crates/octos-cli/src/content_catalog.rs`, `crates/octos-cli/src/api/handlers.rs`, and `crates/octos-agent/src/agent/budget.rs` — not touched in this PR.

## Test plan

- [x] `cargo fmt --all -- --check` on files I touched
- [x] `cargo clippy -p octos-agent --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy -p octos-cli --no-deps --features api --all-targets -- -D warnings` — no new issues in files I touched (pre-existing count = 36 before and after)
- [x] `cargo test -p octos-agent --lib` — 1029 pass, 1 ignored
- [x] `cargo test --workspace --no-fail-fast` — all pass
- [ ] Manual: `octos chat --profile coding` in a test workspace shows `profile resolved: name=coding source=cli` and behaves identically to no-flag default
- [ ] Manual: `octos chat --profile swarm` applies the swarm allow list