### PR TITLE
Make base domain configurable per mini

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -2306,6 +2306,12 @@ pub struct StatusResponse {
     pub provider: String,
     pub uptime_secs: i64,
     pub agent_configured: bool,
+    /// Public-facing base domain this mini serves profiles under
+    /// (e.g. `"crew.ominix.io"`, `"bot.ominix.io"`). The dashboard and
+    /// octos-web client consume this to render correct preview URLs
+    /// and infer profile IDs from hostnames. Always a concrete string
+    /// — falls back to `DEFAULT_BASE_DOMAIN` when unconfigured.
+    pub base_domain: String,
 }
 
 pub async fn status(State(state): State<Arc<AppState>>) -> Json<StatusResponse> {
@@ -2317,12 +2323,17 @@ pub async fn status(State(state): State<Arc<AppState>>) -> Json<StatusResponse> 
         ),
         None => ("none".to_string(), "none".to_string()),
     };
+    let base_domain = state
+        .base_domain
+        .clone()
+        .unwrap_or_else(|| crate::api::DEFAULT_BASE_DOMAIN.to_string());
     Json(StatusResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
         model,
         provider,
         uptime_secs: uptime.num_seconds(),
         agent_configured: state.agent.is_some(),
+        base_domain,
     })
 }
 
@@ -2788,6 +2799,7 @@ mod tests {
             provider: "openai".into(),
             uptime_secs: 120,
             agent_configured: true,
+            base_domain: "crew.ominix.io".into(),
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["version"], "0.1.0");
@@ -2795,6 +2807,30 @@ mod tests {
         assert_eq!(json["provider"], "openai");
         assert_eq!(json["uptime_secs"], 120);
         assert_eq!(json["agent_configured"], true);
+        assert_eq!(json["base_domain"], "crew.ominix.io");
+    }
+
+    #[tokio::test]
+    async fn status_returns_configured_base_domain() {
+        let state = Arc::new(crate::api::AppState {
+            base_domain: Some("bot.ominix.io".into()),
+            ..crate::api::AppState::empty_for_tests()
+        });
+        let resp = status(State(state)).await;
+        assert_eq!(resp.0.base_domain, "bot.ominix.io");
+    }
+
+    #[tokio::test]
+    async fn status_defaults_base_domain_when_unconfigured() {
+        let state = Arc::new(crate::api::AppState {
+            base_domain: None,
+            ..crate::api::AppState::empty_for_tests()
+        });
+        let resp = status(State(state)).await;
+        // Backward compat: `None` surfaces as the historical `crew.ominix.io`
+        // so existing dashboards / web clients keep rendering the right URL
+        // until operators opt in to a per-mini value.
+        assert_eq!(resp.0.base_domain, "crew.ominix.io");
     }
 
     #[test]

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -18,7 +18,7 @@ pub mod user_admin;
 pub mod webhook_proxy;
 
 pub use metrics::init_metrics;
-pub use router::build_router;
+pub use router::{DEFAULT_BASE_DOMAIN, build_router, cors_allowlist_for_base_domain};
 pub use sse::SseBroadcaster;
 pub use swarm::{
     BroadcasterSwarmEventSink, CostAttributionView, CostAttributionsResponse, DispatchIndexRow,
@@ -137,6 +137,12 @@ pub struct AppState {
     pub run_id_cache: Arc<RunIdCache>,
     /// Tunnel domain (e.g. "octos-cloud.org").
     pub tunnel_domain: Option<String>,
+    /// Public-facing base domain each mini serves profiles under
+    /// (e.g. `"crew.ominix.io"`, `"bot.ominix.io"`, `"ocean.ominix.io"`).
+    /// `None` is treated as `"crew.ominix.io"` by callers for backward
+    /// compatibility. See `crate::config::Config::base_domain` for the
+    /// config / env-var wiring.
+    pub base_domain: Option<String>,
     /// frps server address for tunnel config generation.
     pub frps_server: Option<String>,
     /// frps control port.
@@ -208,6 +214,7 @@ impl AppState {
             tenant_store: None,
             run_id_cache: Arc::new(RunIdCache::new()),
             tunnel_domain: None,
+            base_domain: None,
             frps_server: None,
             frps_port: None,
             deployment_mode: crate::config::DeploymentMode::Local,

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -34,28 +34,55 @@ pub enum AuthIdentity {
     User { id: String, role: UserRole },
 }
 
+/// Backward-compatible default when the operator has not configured a
+/// base domain via `config.base_domain` or `OCTOS_BASE_DOMAIN`.
+pub const DEFAULT_BASE_DOMAIN: &str = "crew.ominix.io";
+
+/// Compose the CORS allowlist for a given base domain.
+///
+/// The returned list always contains the bare-`ominix.io` entries and
+/// the loopback dev origins, plus the three `app./admin./api.` entries
+/// for the configured base domain. `None` falls back to the legacy
+/// `crew.ominix.io` triple so existing minis keep working without config
+/// changes.
+pub fn cors_allowlist_for_base_domain(base: Option<&str>) -> Vec<String> {
+    let base = base.unwrap_or(DEFAULT_BASE_DOMAIN);
+    vec![
+        "https://app.ominix.io".to_string(),
+        "https://admin.ominix.io".to_string(),
+        "https://api.ominix.io".to_string(),
+        format!("https://app.{base}"),
+        format!("https://admin.{base}"),
+        format!("https://api.{base}"),
+        "http://localhost:3000".to_string(),
+        "http://localhost:5173".to_string(),
+    ]
+}
+
 /// Build the axum router with all API routes.
 pub fn build_router(state: Arc<AppState>) -> Router {
     // Restrict CORS to an explicit allowlist of known origins.
     // Do NOT use suffix matching (e.g. ends_with(".ominix.io")) — a hijacked
     // subdomain would pass the check and enable cross-origin requests.
-    const ALLOWED_ORIGINS: &[&str] = &[
-        "https://app.ominix.io",
-        "https://admin.ominix.io",
-        "https://api.ominix.io",
-        "https://app.crew.ominix.io",
-        "https://admin.crew.ominix.io",
-        "https://api.crew.ominix.io",
-        "http://localhost:3000",
-        "http://localhost:5173",
-    ];
-    let cors = CorsLayer::new()
-        .allow_origin(tower_http::cors::AllowOrigin::predicate(|origin, _| {
-            let o = origin.to_str().unwrap_or("");
-            ALLOWED_ORIGINS.contains(&o)
-        }))
-        .allow_methods(tower_http::cors::Any)
-        .allow_headers(tower_http::cors::Any);
+    //
+    // The allowlist is composed from `state.base_domain` at startup so each
+    // mini accepts its own public subdomain variants (`crew.`, `bot.`,
+    // `octos.`, `ocean.`) without redeploys. `None` preserves the legacy
+    // `crew.ominix.io` triple.
+    let allowed_origins: Arc<Vec<String>> =
+        Arc::new(cors_allowlist_for_base_domain(state.base_domain.as_deref()));
+    let cors = {
+        let allowed = allowed_origins.clone();
+        CorsLayer::new()
+            .allow_origin(tower_http::cors::AllowOrigin::predicate(
+                move |origin, _| {
+                    let o = origin.to_str().unwrap_or("");
+                    allowed.iter().any(|s| s == o)
+                },
+            ))
+            .allow_methods(tower_http::cors::Any)
+            .allow_headers(tower_http::cors::Any)
+    };
 
     // Public auth endpoints (no auth required)
     let auth_api = Router::new()
@@ -1057,5 +1084,44 @@ mod tests {
         assert_eq!(body["error"], "not_found");
 
         server.abort();
+    }
+
+    #[test]
+    fn should_compose_cors_allowlist_from_base_domain() {
+        let list = cors_allowlist_for_base_domain(Some("bot.ominix.io"));
+        assert!(
+            list.contains(&"https://app.bot.ominix.io".to_string()),
+            "missing app.bot.ominix.io in {list:?}"
+        );
+        assert!(
+            list.contains(&"https://admin.bot.ominix.io".to_string()),
+            "missing admin.bot.ominix.io in {list:?}"
+        );
+        assert!(
+            list.contains(&"https://api.bot.ominix.io".to_string()),
+            "missing api.bot.ominix.io in {list:?}"
+        );
+        // The bare ominix.io entries remain for shared landing pages.
+        assert!(list.contains(&"https://app.ominix.io".to_string()));
+    }
+
+    #[test]
+    fn should_default_cors_to_crew_ominix_io_when_unset() {
+        // Backward-compat: when no base_domain is configured the server
+        // must still accept the historical `*.crew.ominix.io` origins so
+        // existing minis keep working without a config change.
+        let list = cors_allowlist_for_base_domain(None);
+        assert!(list.contains(&"https://app.crew.ominix.io".to_string()));
+        assert!(list.contains(&"https://admin.crew.ominix.io".to_string()));
+        assert!(list.contains(&"https://api.crew.ominix.io".to_string()));
+    }
+
+    #[test]
+    fn should_not_accept_unrelated_origin_in_base_domain_allowlist() {
+        // Defence-in-depth: a subdomain of a different tenant must never
+        // appear in the composed list even when a base_domain is set.
+        let list = cors_allowlist_for_base_domain(Some("bot.ominix.io"));
+        assert!(!list.iter().any(|s| s.contains("evil.example.com")));
+        assert!(!list.iter().any(|s| s.contains("ocean.ominix.io")));
     }
 }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -501,6 +501,13 @@ impl ServeCommand {
                 .tunnel_domain
                 .clone()
                 .or_else(|| std::env::var("TUNNEL_DOMAIN").ok()),
+            // `OCTOS_BASE_DOMAIN` (env) takes precedence over config.json so
+            // operators can override without touching the file. `None` falls
+            // back to `crate::api::DEFAULT_BASE_DOMAIN` at read sites.
+            base_domain: std::env::var("OCTOS_BASE_DOMAIN")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .or_else(|| config.base_domain.clone().filter(|s| !s.trim().is_empty())),
             frps_server: config
                 .frps_server
                 .clone()

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -135,6 +135,17 @@ pub struct Config {
     #[serde(default)]
     pub tunnel_domain: Option<String>,
 
+    /// Public-facing base domain each mini serves profiles under
+    /// (e.g. `"crew.ominix.io"`, `"bot.ominix.io"`, `"ocean.ominix.io"`).
+    ///
+    /// Used to compose CORS allowlist entries and surface preview URLs
+    /// in the admin dashboard. When `None` the server defaults to
+    /// `"crew.ominix.io"` for backward compatibility. Also read from
+    /// `OCTOS_BASE_DOMAIN` env var, which takes precedence over the
+    /// value in `config.json` when both are set.
+    #[serde(default)]
+    pub base_domain: Option<String>,
+
     /// frps server address for cloud/tenant mode (e.g. "163.192.33.32").
     /// Also read from FRPS_SERVER env var.
     #[serde(default)]
@@ -1349,6 +1360,23 @@ mod tests {
         let json = r#"{"provider": "anthropic"}"#;
         let config: Config = serde_json::from_str(json).unwrap();
         assert!(config.tool_policy_by_provider.is_empty());
+    }
+
+    #[test]
+    fn should_deserialize_base_domain_from_config_json() {
+        let json = r#"{"base_domain": "ocean.ominix.io"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.base_domain.as_deref(), Some("ocean.ominix.io"));
+    }
+
+    #[test]
+    fn should_default_base_domain_to_none_when_absent() {
+        // Backward compat: existing configs without `base_domain` must
+        // deserialize to `None` so read sites fall back to the legacy
+        // `crew.ominix.io` default.
+        let json = r#"{"provider": "anthropic"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(config.base_domain.is_none());
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1460,6 +1460,7 @@ pub(crate) fn config_from_profile(
         voice: None,
         mode: Default::default(),
         tunnel_domain: None,
+        base_domain: None,
         frps_server: None,
         allow_admin_shell: false,
         #[cfg(feature = "api")]

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -317,6 +317,25 @@ export type DeploymentModeBody = { mode: DeploymentMode }
 
 export type DeploymentModeDetection = { detected: DeploymentMode }
 
+// ── Server info (public) ─────────────────────────────────────────────
+
+export interface ServerStatus {
+  version: string
+  model: string
+  provider: string
+  uptime_secs: number
+  agent_configured: boolean
+  /** Public-facing base domain this mini serves profiles under
+   *  (e.g. `"crew.ominix.io"`, `"bot.ominix.io"`). Always a concrete
+   *  string — the server substitutes `"crew.ominix.io"` when
+   *  unconfigured. */
+  base_domain: string
+}
+
+export const systemApi = {
+  status: () => authedRequest<ServerStatus>('/status'),
+}
+
 // ── Auth API (public) ───────────────────────────────────────────────
 
 export const authApi = {

--- a/dashboard/src/pages/profile/HomePage.tsx
+++ b/dashboard/src/pages/profile/HomePage.tsx
@@ -7,8 +7,14 @@ import ConfirmDialog from '../../components/ConfirmDialog'
 import StatusBadge from '../../components/StatusBadge'
 import { CHANNEL_COLORS, CHANNEL_LABELS } from '../../types'
 import type { ProfileResponse } from '../../types'
-import { api, myApi } from '../../api'
+import { api, myApi, systemApi } from '../../api'
 import { useToast } from '../../components/Toast'
+
+/// Backward-compatible default when the server hasn't sent back a
+/// `base_domain` field yet (older release, network glitch, etc.). Must
+/// match `DEFAULT_BASE_DOMAIN` on the server so preview URLs are stable
+/// on mini1 without config changes.
+const DEFAULT_BASE_DOMAIN = 'crew.ominix.io'
 
 export default function HomePage() {
   const { isAdmin } = useAuth()
@@ -34,6 +40,11 @@ export default function HomePage() {
   const [newSubdomain, setNewSubdomain] = useState('')
   const [newSubEmail, setNewSubEmail] = useState('')
   const [createSubLoading, setCreateSubLoading] = useState(false)
+  // Public base domain advertised by the server — drives the preview
+  // URL so mini2/3/5 render `*.bot./*.octos./*.ocean.ominix.io` instead
+  // of mini1's `*.crew.ominix.io`. Falls back to `DEFAULT_BASE_DOMAIN`
+  // while the status request is in flight or if it fails.
+  const [baseDomain, setBaseDomain] = useState<string>(DEFAULT_BASE_DOMAIN)
 
   const loadSubAccounts = useCallback(async () => {
     if (parentId || !profileId) return
@@ -53,6 +64,25 @@ export default function HomePage() {
   useEffect(() => {
     loadSubAccounts()
   }, [loadSubAccounts])
+
+  useEffect(() => {
+    let cancelled = false
+    systemApi
+      .status()
+      .then((s) => {
+        if (cancelled) return
+        if (s.base_domain && typeof s.base_domain === 'string') {
+          setBaseDomain(s.base_domain)
+        }
+      })
+      .catch(() => {
+        // Leave the fallback in place — the preview URL is cosmetic and
+        // the legacy `crew.ominix.io` default keeps mini1 working.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const handleCreateSubAccount = async () => {
     if (!profileId || !newSubName.trim()) return
@@ -250,7 +280,7 @@ export default function HomePage() {
               disabled={!!parentId && isOwn}
             />
             <p className="text-xs text-gray-500 mt-1">
-              Public URL preview: <span className="font-mono text-gray-400">https://{(publicSubdomain || profileId) || 'your-subdomain'}.crew.ominix.io</span>
+              Public URL preview: <span className="font-mono text-gray-400">https://{(publicSubdomain || profileId) || 'your-subdomain'}.{baseDomain}</span>
             </p>
             {!!parentId && isOwn && (
               <p className="text-xs text-gray-500 mt-1">Sub-account users cannot change their own public subdomain. The parent account controls it.</p>
@@ -369,7 +399,7 @@ export default function HomePage() {
                   placeholder="newsbot"
                   className="w-full bg-white/5 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-accent"
                 />
-                <p className="text-[11px] text-gray-500 mt-1">Public URL: <span className="font-mono">https://{newSubdomain || 'newsbot'}.crew.ominix.io</span></p>
+                <p className="text-[11px] text-gray-500 mt-1">Public URL: <span className="font-mono">https://{newSubdomain || 'newsbot'}.{baseDomain}</span></p>
               </div>
               <div>
                 <label className="block text-xs text-gray-400 mb-1">Email (for web client login)</label>


### PR DESCRIPTION
## Summary
- Each mini serves profiles under a different base domain (mini1=`crew.ominix.io`, mini2=`bot.`, mini3=`octos.`, mini5=`ocean.`), but the CORS allowlist and the dashboard preview URLs hardcoded `crew.ominix.io` — so CORS rejected legitimate origins on mini2/3/5 and the admin sub-account form showed the wrong URL.
- Add `base_domain: Option<String>` to `Config` (also `OCTOS_BASE_DOMAIN` env var), propagate through `AppState`, and compose the CORS allowlist at router-build time via `cors_allowlist_for_base_domain`.
- Surface the value on `/api/status` so the dashboard (and the octos-web client in the sibling PR) can render the correct host. `None` falls back to `crew.ominix.io` so mini1 keeps working with no config change.

## Changes
- `crates/octos-cli/src/config.rs`: new `base_domain: Option<String>` field.
- `crates/octos-cli/src/api/router.rs`: `DEFAULT_BASE_DOMAIN`, `cors_allowlist_for_base_domain`, build the CORS predicate from `state.base_domain`.
- `crates/octos-cli/src/api/handlers.rs`: `StatusResponse` gains `base_domain: String`.
- `crates/octos-cli/src/api/mod.rs`, `crates/octos-cli/src/commands/serve.rs`: wire field into `AppState` with env-var > config precedence.
- `dashboard/src/pages/profile/HomePage.tsx` + `dashboard/src/api.ts`: the two `crew.ominix.io` preview URLs now read from `systemApi.status()`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check -p octos-cli --features api`
- [x] `cargo test -p octos-cli --features api --lib` (616 tests pass)
- [x] New unit tests: CORS allowlist composition for `bot.ominix.io`, backward-compat default to `crew.ominix.io`, status-endpoint `base_domain` field, config.json round-trip.
- [x] `cd dashboard && npm run typecheck && npm run build`
- [ ] Operator per-mini follow-up: set `"base_domain": "<mini-domain>"` in `~/.octos/config.json` and `launchctl kickstart -k system/io.octos.serve`.

## Backward compatibility
- `base_domain` unset → server returns `"crew.ominix.io"` on `/api/status` and the CORS list is exactly the pre-PR one. No existing mini needs a config change to keep working.

## Out of scope
- No server-side redirect/enforcement of the base domain — this is a display + CORS concern only.
- No deploy — PR-only; supervisor decides.