### PR TITLE
M8.6: Structured resume pipeline (runtime-v0.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3601,6 +3601,7 @@ dependencies = [
  "lettre",
  "libc",
  "metrics",
+ "octos-bus",
  "octos-core",
  "octos-llm",
  "octos-memory",

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -8,6 +8,7 @@ description = "Agent runtime, tool execution, and coordination for octos"
 
 [dependencies]
 octos-core = { workspace = true }
+octos-bus = { workspace = true }
 octos-memory = { workspace = true }
 octos-llm = { workspace = true }
 # codex-execpolicy = { workspace = true }  # Enable when codex builds

--- a/crates/octos-agent/src/harness_events.rs
+++ b/crates/octos-agent/src/harness_events.rs
@@ -269,6 +269,14 @@ pub enum HarnessEventPayload {
         #[serde(flatten)]
         data: HarnessCredentialRotationEvent,
     },
+    /// Emitted once per session load after [`octos_bus::ResumePolicy`] runs
+    /// (M8.6). Carries a typed report so operators can see what the
+    /// sanitizer dropped and whether the worktree (if any) was still
+    /// present on disk.
+    SessionSanitized {
+        #[serde(flatten)]
+        data: HarnessSessionSanitizedEvent,
+    },
     Error {
         #[serde(flatten)]
         data: HarnessErrorEvent,
@@ -527,6 +535,48 @@ pub struct HarnessRoutingDecisionEvent {
     pub extra: HashMap<String, Value>,
 }
 
+/// Typed payload emitted when [`octos_bus::ResumePolicy`] sanitizes a
+/// session transcript on load (M8.6).
+///
+/// The report fields mirror [`octos_bus::SessionSanitizeReport`] one-for-
+/// one so operators can build dashboards without joining against a raw
+/// log. `worktree_missing` is a hard signal that the sub-agent's git
+/// worktree was cleaned up externally (Claude Code issue #22355) — the
+/// caller should refuse to resume and start a fresh session instead.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HarnessSessionSanitizedEvent {
+    pub session_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow: Option<String>,
+    /// Messages loaded from JSONL before any filter ran.
+    pub input_len: usize,
+    /// Messages remaining after all 4 filter passes.
+    pub output_len: usize,
+    /// Tool-call assistant messages whose ids lacked matching results and
+    /// were not pinned by retry state.
+    #[serde(default)]
+    pub unresolved_tool_uses_dropped: usize,
+    /// Assistant messages with reasoning but no content or tool calls
+    /// (non-tail only).
+    #[serde(default)]
+    pub orphan_thinking_dropped: usize,
+    /// Assistant messages with whitespace-only content.
+    #[serde(default)]
+    pub whitespace_only_dropped: usize,
+    /// Count of [`octos_bus::ReplacementStateRef`] entries recovered.
+    #[serde(default)]
+    pub content_replacements_restored: usize,
+    /// `true` when `workspace_root` was provided and missing on disk.
+    #[serde(default)]
+    pub worktree_missing: bool,
+    /// Non-fatal diagnostics from the policy. Order-preserving.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
 /// Structured credential rotation event (M6.5).
 ///
 /// Emitted by the credential pool on every successful selection. Consumers
@@ -674,6 +724,37 @@ impl HarnessEvent {
                     lane: None,
                     reasons,
                     input_chars,
+                    extra: HashMap::new(),
+                },
+            },
+        }
+    }
+
+    /// Construct a `SessionSanitized` event from a
+    /// [`octos_bus::SessionSanitizeReport`] (M8.6). The caller supplies
+    /// session_id/task_id/workflow from its runtime context; the rest of
+    /// the fields come straight from the report.
+    pub fn session_sanitized(
+        session_id: impl Into<String>,
+        task_id: impl Into<String>,
+        workflow: Option<impl Into<String>>,
+        report: &octos_bus::SessionSanitizeReport,
+    ) -> Self {
+        Self {
+            schema: HARNESS_EVENT_SCHEMA_V1.to_string(),
+            payload: HarnessEventPayload::SessionSanitized {
+                data: HarnessSessionSanitizedEvent {
+                    session_id: session_id.into(),
+                    task_id: task_id.into(),
+                    workflow: workflow.map(Into::into),
+                    input_len: report.input_len,
+                    output_len: report.output_len,
+                    unresolved_tool_uses_dropped: report.unresolved_tool_uses_dropped,
+                    orphan_thinking_dropped: report.orphan_thinking_dropped,
+                    whitespace_only_dropped: report.whitespace_only_dropped,
+                    content_replacements_restored: report.content_replacements_restored,
+                    worktree_missing: report.worktree_missing,
+                    warnings: report.warnings.clone(),
                     extra: HashMap::new(),
                 },
             },
@@ -861,6 +942,13 @@ impl HarnessEvent {
                 )?;
                 validate_bounded("reason", &data.reason, MAX_PHASE_BYTES)?;
                 validate_bounded("strategy", &data.strategy, MAX_PHASE_BYTES)?;
+            }
+            HarnessEventPayload::SessionSanitized { data } => {
+                validate_common_ids(&data.session_id, &data.task_id)?;
+                validate_optional_name("workflow", data.workflow.as_deref(), MAX_WORKFLOW_BYTES)?;
+                for warning in &data.warnings {
+                    validate_bounded("warning", warning, MAX_MESSAGE_BYTES)?;
+                }
             }
             HarnessEventPayload::Error { data } => {
                 if data.schema_version > HARNESS_ERROR_SCHEMA_VERSION {
@@ -1096,6 +1184,26 @@ impl HarnessEvent {
                     "strategy": data.strategy,
                 })
             }
+            HarnessEventPayload::SessionSanitized { data } => {
+                let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
+                serde_json::json!({
+                    "schema": self.schema,
+                    "kind": "session_sanitized",
+                    "session_id": data.session_id,
+                    "task_id": data.task_id,
+                    "workflow": workflow,
+                    "workflow_kind": workflow,
+                    "current_phase": fallback_current_phase,
+                    "input_len": data.input_len,
+                    "output_len": data.output_len,
+                    "unresolved_tool_uses_dropped": data.unresolved_tool_uses_dropped,
+                    "orphan_thinking_dropped": data.orphan_thinking_dropped,
+                    "whitespace_only_dropped": data.whitespace_only_dropped,
+                    "content_replacements_restored": data.content_replacements_restored,
+                    "worktree_missing": data.worktree_missing,
+                    "warnings": data.warnings,
+                })
+            }
             HarnessEventPayload::Error { data } => {
                 let workflow = data.workflow.as_deref().or(fallback_workflow_kind);
                 let current_phase = data.phase.as_deref().or(fallback_current_phase);
@@ -1132,6 +1240,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => &data.session_id,
             HarnessEventPayload::RoutingDecision { data } => &data.session_id,
             HarnessEventPayload::CredentialRotation { data } => &data.session_id,
+            HarnessEventPayload::SessionSanitized { data } => &data.session_id,
             HarnessEventPayload::Error { data } => &data.session_id,
         }
     }
@@ -1150,6 +1259,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => &data.task_id,
             HarnessEventPayload::RoutingDecision { data } => &data.task_id,
             HarnessEventPayload::CredentialRotation { data } => &data.task_id,
+            HarnessEventPayload::SessionSanitized { data } => &data.task_id,
             HarnessEventPayload::Error { data } => &data.task_id,
         }
     }
@@ -1168,6 +1278,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => data.workflow.as_deref(),
             HarnessEventPayload::RoutingDecision { data } => data.workflow.as_deref(),
             HarnessEventPayload::CredentialRotation { .. } => None,
+            HarnessEventPayload::SessionSanitized { data } => data.workflow.as_deref(),
             HarnessEventPayload::Error { data } => data.workflow.as_deref(),
         }
     }
@@ -1186,6 +1297,7 @@ impl HarnessEvent {
             HarnessEventPayload::CostAttribution { data } => data.phase.as_deref(),
             HarnessEventPayload::RoutingDecision { data } => data.phase.as_deref(),
             HarnessEventPayload::CredentialRotation { .. } => None,
+            HarnessEventPayload::SessionSanitized { .. } => None,
             HarnessEventPayload::Error { data } => data.phase.as_deref(),
         }
     }
@@ -1707,5 +1819,126 @@ mod tests {
             .get_task(&other_task_id)
             .expect("other task missing");
         assert!(other.runtime_detail.is_none());
+    }
+
+    /// M8.6: `SessionSanitized` round-trips through JSON and reports the
+    /// report fields in `runtime_detail_value`.
+    #[test]
+    fn session_sanitized_event_round_trips() {
+        let report = octos_bus::SessionSanitizeReport {
+            input_len: 12,
+            output_len: 9,
+            unresolved_tool_uses_dropped: 2,
+            orphan_thinking_dropped: 1,
+            whitespace_only_dropped: 0,
+            content_replacements_restored: 3,
+            worktree_missing: false,
+            warnings: vec!["mtime bump degraded".into()],
+        };
+        let event =
+            HarnessEvent::session_sanitized("api:session", "task-resume", Some("coding"), &report);
+
+        assert!(event.validate().is_ok());
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            json.contains(r#""kind":"session_sanitized""#),
+            "event should serialize the session_sanitized kind; got: {json}"
+        );
+
+        let parsed = HarnessEvent::from_json_line(&json).unwrap();
+        match &parsed.payload {
+            HarnessEventPayload::SessionSanitized { data } => {
+                assert_eq!(data.input_len, 12);
+                assert_eq!(data.output_len, 9);
+                assert_eq!(data.unresolved_tool_uses_dropped, 2);
+                assert_eq!(data.orphan_thinking_dropped, 1);
+                assert_eq!(data.whitespace_only_dropped, 0);
+                assert_eq!(data.content_replacements_restored, 3);
+                assert!(!data.worktree_missing);
+                assert_eq!(data.warnings, vec!["mtime bump degraded".to_string()]);
+            }
+            other => panic!("expected SessionSanitized variant, got {other:?}"),
+        }
+
+        let detail = parsed.runtime_detail_value(None, None);
+        assert_eq!(detail["kind"], "session_sanitized");
+        assert_eq!(detail["input_len"], 12);
+        assert_eq!(detail["output_len"], 9);
+        assert_eq!(detail["content_replacements_restored"], 3);
+    }
+
+    /// M8.6: a worktree-missing event must flag the condition so operators
+    /// can see it on the task dashboard.
+    #[test]
+    fn session_sanitized_event_flags_worktree_missing() {
+        let report = octos_bus::SessionSanitizeReport {
+            input_len: 4,
+            output_len: 4,
+            worktree_missing: true,
+            ..Default::default()
+        };
+        let event = HarnessEvent::session_sanitized(
+            "api:session",
+            "task-resume",
+            Option::<String>::None,
+            &report,
+        );
+
+        assert!(event.validate().is_ok());
+        let detail = event.runtime_detail_value(None, None);
+        assert_eq!(detail["worktree_missing"], true);
+        assert_eq!(detail["kind"], "session_sanitized");
+    }
+
+    /// M8.6: verify the sink pipeline delivers a session-sanitized event
+    /// to the task supervisor exactly as it does for progress/phase
+    /// events. This is the "emit via sink" happy path the caller-side
+    /// wiring relies on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn should_emit_session_sanitized_event_when_sink_configured() {
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let task_id = supervisor.register("resume", "call-1", Some("api:session"));
+        supervisor.mark_running(&task_id);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        supervisor.set_on_change(move |task| {
+            let _ = tx.send(task.clone());
+        });
+
+        let sink = HarnessEventSink::new(supervisor.clone(), task_id.clone(), "api:session")
+            .expect("create sink");
+
+        let report = octos_bus::SessionSanitizeReport {
+            input_len: 3,
+            output_len: 2,
+            unresolved_tool_uses_dropped: 1,
+            ..Default::default()
+        };
+        let event = HarnessEvent::session_sanitized(
+            "api:session",
+            task_id.clone(),
+            Some("coding"),
+            &report,
+        );
+
+        write_event_to_sink(sink.path().display().to_string(), &event).unwrap();
+
+        let updated = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let task = rx.recv().await.expect("task update");
+                if task.id == task_id && task.runtime_detail.is_some() {
+                    break task;
+                }
+            }
+        })
+        .await
+        .expect("sink should deliver the session_sanitized event");
+
+        let detail: Value =
+            serde_json::from_str(updated.runtime_detail.as_deref().unwrap()).unwrap();
+        assert_eq!(detail["kind"], "session_sanitized");
+        assert_eq!(detail["input_len"], 3);
+        assert_eq!(detail["output_len"], 2);
+        assert_eq!(detail["unresolved_tool_uses_dropped"], 1);
     }
 }

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -79,9 +79,9 @@ pub use harness_events::{
     HARNESS_EVENT_SCHEMA_V1, HarnessArtifactEvent, HarnessCostAttributionEvent,
     HarnessCredentialRotationEvent, HarnessCredentialRotationSink, HarnessEvent, HarnessEventError,
     HarnessEventPayload, HarnessEventSink, HarnessFailureEvent, HarnessMcpServerCallEvent,
-    HarnessPhaseEvent, HarnessProgressEvent, HarnessRetryEvent, HarnessSubAgentDispatchEvent,
-    HarnessSwarmDispatchEvent, HarnessValidatorResultEvent, MAX_HARNESS_EVENT_LINE_BYTES,
-    emit_registered_credential_rotation_event,
+    HarnessPhaseEvent, HarnessProgressEvent, HarnessRetryEvent, HarnessSessionSanitizedEvent,
+    HarnessSubAgentDispatchEvent, HarnessSwarmDispatchEvent, HarnessValidatorResultEvent,
+    MAX_HARNESS_EVENT_LINE_BYTES, emit_registered_credential_rotation_event,
 };
 pub use hooks::{
     HookConfig, HookContext, HookEvent, HookExecutor, HookPayload, HookPayloadEnricher, HookResult,

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -651,6 +651,18 @@ impl TaskSupervisor {
                     Some(runtime_detail.to_string()),
                 );
             }
+            HarnessEventPayload::SessionSanitized { .. } => {
+                // Session-sanitize events are observability-only (M8.6).
+                // They fire once per resume and describe what the resume
+                // policy dropped — the task lifecycle is not affected; the
+                // session actor will subsequently drive normal
+                // Queued → Executing transitions as usual.
+                self.mark_runtime_state(
+                    task_id,
+                    snapshot.runtime_state,
+                    Some(runtime_detail.to_string()),
+                );
+            }
             HarnessEventPayload::Error { data } => {
                 // Structured error events are diagnostic — record them in the
                 // runtime detail but only transition to Failed when the

--- a/crates/octos-bus/src/lib.rs
+++ b/crates/octos-bus/src/lib.rs
@@ -11,6 +11,7 @@ pub mod file_handle;
 pub mod heartbeat;
 pub mod markdown_html;
 pub mod media;
+pub mod resume_policy;
 pub mod session;
 
 #[cfg(feature = "api")]
@@ -49,6 +50,12 @@ pub use cron_service::CronService;
 pub use cron_types::{CronJob, CronPayload, CronSchedule, CronStore};
 pub use dedup::MessageDedup;
 pub use heartbeat::HeartbeatService;
+pub use resume_policy::{
+    RESUME_MTIME_MARKER, ReplacementStateRef, ResumePolicy, RetryStateView, SanitizeError,
+    SanitizeOutcome, SessionSanitizeReport, filter_orphaned_thinking_only_messages,
+    filter_unresolved_tool_uses, filter_whitespace_only_assistant_messages,
+    reconstruct_content_replacement_state,
+};
 pub use session::{
     ActiveSessionStore, Session, SessionHandle, SessionListEntry, SessionManager,
     validate_topic_name,

--- a/crates/octos-bus/src/resume_policy.rs
+++ b/crates/octos-bus/src/resume_policy.rs
@@ -1,0 +1,1029 @@
+//! Structured resume pipeline (M8.6).
+//!
+//! When octos reloads a session from JSONL at startup or after a crash, the
+//! transcript may contain state that the provider will reject (unresolved
+//! tool uses → 400), orphaned thinking-only assistant messages, whitespace-
+//! only assistant messages, or stale worktree references. [`ResumePolicy`]
+//! sanitizes the loaded [`Message`] list before the session actor picks it
+//! up, emitting a typed [`SessionSanitizeReport`] for observability.
+//!
+//! The policy is a pure data-layer transform: it operates on `Vec<Message>`
+//! that has already been loaded from disk. The JSONL format is not touched —
+//! every filter is pass-through for legacy messages; filters only prune.
+//!
+//! # Filter passes
+//!
+//! 1. [`filter_unresolved_tool_uses`] — walks the list, collects all
+//!    `tool_call_id` values on assistant `tool_calls`, then drops
+//!    tool-result messages whose id is not in that set and drops assistant
+//!    tool-call messages whose ids have no matching tool result (unless the
+//!    call is referenced by pending retry state).
+//! 2. [`filter_orphaned_thinking_only_messages`] — drops assistant messages
+//!    that have `reasoning_content` but empty `content` and no tool calls,
+//!    unless the message is the tail of the transcript (allow in-flight
+//!    reasoning).
+//! 3. [`filter_whitespace_only_assistant_messages`] — drops assistant
+//!    messages whose `content.trim().is_empty()` and no tool calls and no
+//!    reasoning content.
+//! 4. [`reconstruct_content_replacement_state`] — collects file paths
+//!    referenced by tool results into [`ReplacementStateRef`] entries for
+//!    M8.4 `FileStateCache` integration (stub).
+//!
+//! # Worktree check
+//!
+//! When `workspace_root` is provided, the policy stats the path. If it no
+//! longer exists, the report's `worktree_missing` flag is set and an
+//! `Err` is returned so the caller can decide to refuse resume or create a
+//! new session. When present, a marker file is touched inside the worktree
+//! to bump the containing directory's mtime — this prevents stale-cleanup
+//! races where a concurrent GC sweep removes the worktree while the session
+//! is mid-load (Claude Code issue #22355).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use octos_core::{Message, MessageRole};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// Name of the marker file written inside a sub-agent worktree on resume to
+/// bump the directory's mtime. The contents are a human-readable RFC3339
+/// timestamp so operators can see when the session last resumed.
+pub const RESUME_MTIME_MARKER: &str = ".octos_resume_mtime";
+
+/// Reference to a file path recovered from a tool result during resume.
+///
+/// Populated by [`reconstruct_content_replacement_state`]; consumed by
+/// M8.4 `FileStateCache` to seed the cache with the paths that the
+/// transcript claims were last read/written. The hash field is always
+/// `None` in this workstream — it becomes `Some(hash)` once M8.4 lands
+/// and the file-state cache actually restores entries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplacementStateRef {
+    /// Absolute or workspace-relative path the tool result referenced.
+    pub path: PathBuf,
+    /// Content hash when available; None indicates placeholder state
+    /// pending M8.4 cache restore.
+    pub content_hash: Option<String>,
+}
+
+/// Typed report describing what [`ResumePolicy::sanitize`] dropped.
+///
+/// Emitted on every resume even if every counter is zero — operators rely
+/// on a baseline "transcript clean" signal as much as the interesting drops.
+/// `Display` impl is terse; structured fields should be preferred for
+/// dashboards.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionSanitizeReport {
+    /// Number of messages before any filter ran.
+    pub input_len: usize,
+    /// Number of messages after all filters.
+    pub output_len: usize,
+    /// Tool-call assistant messages whose tool_call_ids all had no matching
+    /// result and were not pinned by retry state.
+    pub unresolved_tool_uses_dropped: usize,
+    /// Thinking-only assistant messages that were neither the tail nor
+    /// followed by a concrete reply.
+    pub orphan_thinking_dropped: usize,
+    /// Whitespace-only assistant messages with no tool calls or reasoning.
+    pub whitespace_only_dropped: usize,
+    /// Count of [`ReplacementStateRef`] entries recovered. Not yet wired
+    /// into a real cache; see `content_replacements` for the raw refs and
+    /// the `TODO(M8.4)` note in [`ResumePolicy::sanitize`].
+    pub content_replacements_restored: usize,
+    /// `true` when `workspace_root` was provided and the directory no
+    /// longer exists on disk.
+    pub worktree_missing: bool,
+    /// Non-fatal diagnostics the caller may log. Order-preserving.
+    pub warnings: Vec<String>,
+}
+
+impl std::fmt::Display for SessionSanitizeReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SessionSanitizeReport {{ input_len={}, output_len={}, dropped: {{ unresolved_tool={}, orphan_thinking={}, whitespace_only={} }}, content_replacements_restored={}, worktree_missing={}, warnings={} }}",
+            self.input_len,
+            self.output_len,
+            self.unresolved_tool_uses_dropped,
+            self.orphan_thinking_dropped,
+            self.whitespace_only_dropped,
+            self.content_replacements_restored,
+            self.worktree_missing,
+            self.warnings.len(),
+        )
+    }
+}
+
+/// Outcome of [`ResumePolicy::sanitize`]. The caller must pattern-match on
+/// `Ok(SanitizeOutcome)` vs `Err(SanitizeError)` — an error signals the
+/// caller should refuse resume (e.g. worktree gone) while a clean outcome
+/// is always safe to hand off to the session actor.
+#[derive(Debug, Clone)]
+pub struct SanitizeOutcome {
+    /// Sanitized messages, order-preserving.
+    pub messages: Vec<Message>,
+    /// Structured report for observability / harness event emission.
+    pub report: SessionSanitizeReport,
+    /// Content-replacement refs recovered from tool results. Empty when
+    /// `messages` contains no tool results with file paths.
+    pub content_replacements: Vec<ReplacementStateRef>,
+}
+
+/// Reasons [`ResumePolicy::sanitize`] refuses to return a clean outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SanitizeError {
+    /// The configured `workspace_root` no longer exists on disk.
+    WorktreeMissing {
+        path: PathBuf,
+        report: SessionSanitizeReport,
+    },
+}
+
+impl std::fmt::Display for SanitizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WorktreeMissing { path, .. } => {
+                write!(f, "worktree gone: {}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for SanitizeError {}
+
+/// Abstract view of in-flight retry state — a set of tool_call_ids that
+/// must not be dropped even if they lack a matching tool result. Concrete
+/// retry-state types in `octos-agent` (e.g. a future `LoopRetryState` with
+/// pending id tracking) implement this to bridge into the policy without
+/// introducing a reverse crate dependency.
+pub trait RetryStateView {
+    /// Returns `true` when the given tool_call_id is pinned by an in-flight
+    /// retry (e.g. the harness is about to replay the call after a provider
+    /// hiccup). The policy keeps these calls in the transcript even when
+    /// their result is missing.
+    fn contains_tool_call(&self, tool_call_id: &str) -> bool;
+}
+
+impl<T: RetryStateView + ?Sized> RetryStateView for &T {
+    fn contains_tool_call(&self, tool_call_id: &str) -> bool {
+        (*self).contains_tool_call(tool_call_id)
+    }
+}
+
+impl RetryStateView for HashSet<String> {
+    fn contains_tool_call(&self, tool_call_id: &str) -> bool {
+        self.contains(tool_call_id)
+    }
+}
+
+/// Top-level resume sanitizer. Stateless entry point; see module docs for
+/// the full pass ordering and semantics.
+pub struct ResumePolicy;
+
+impl ResumePolicy {
+    /// Sanitize a just-loaded transcript and report what changed.
+    ///
+    /// `retry_state` pins in-flight tool_call_ids so we don't drop a call
+    /// the harness is about to replay. `workspace_root` when provided is
+    /// stat'd and mtime-bumped — a missing path short-circuits to
+    /// [`SanitizeError::WorktreeMissing`] after the transcript has been
+    /// sanitized (the report is still populated so callers can log it).
+    pub fn sanitize(
+        messages: Vec<Message>,
+        retry_state: Option<&dyn RetryStateView>,
+        workspace_root: Option<&Path>,
+    ) -> Result<SanitizeOutcome, SanitizeError> {
+        let mut report = SessionSanitizeReport {
+            input_len: messages.len(),
+            ..Default::default()
+        };
+
+        // Pass 1: drop unresolved tool_use/tool_result pairs.
+        let (messages, dropped_tool_use) = filter_unresolved_tool_uses(messages, retry_state);
+        report.unresolved_tool_uses_dropped = dropped_tool_use;
+
+        // Pass 2: drop orphan thinking-only assistant messages.
+        let (messages, dropped_thinking) = filter_orphaned_thinking_only_messages(messages);
+        report.orphan_thinking_dropped = dropped_thinking;
+
+        // Pass 3: drop whitespace-only assistant messages.
+        let (messages, dropped_ws) = filter_whitespace_only_assistant_messages(messages);
+        report.whitespace_only_dropped = dropped_ws;
+
+        // Pass 4: collect content-replacement refs from tool results.
+        //
+        // TODO(M8.4): after FileStateCache lands, populate its entries from
+        // these refs when the cache is non-empty post-load. The integration
+        // point is the caller of `ResumePolicy::sanitize` — it should feed
+        // `outcome.content_replacements` into the file-state cache before
+        // handing the messages to the session actor.
+        let content_replacements = reconstruct_content_replacement_state(&messages);
+        report.content_replacements_restored = content_replacements.len();
+
+        report.output_len = messages.len();
+
+        // Worktree existence check + mtime bump.
+        if let Some(root) = workspace_root {
+            match check_and_bump_worktree(root) {
+                WorktreeStatus::Present => {}
+                WorktreeStatus::Missing => {
+                    report.worktree_missing = true;
+                    return Err(SanitizeError::WorktreeMissing {
+                        path: root.to_path_buf(),
+                        report,
+                    });
+                }
+                WorktreeStatus::BumpFailed { error } => {
+                    report
+                        .warnings
+                        .push(format!("mtime bump failed for {}: {error}", root.display()));
+                }
+            }
+        }
+
+        Ok(SanitizeOutcome {
+            messages,
+            report,
+            content_replacements,
+        })
+    }
+}
+
+/// Pass 1: drop unresolved tool_use / tool_result pairs.
+///
+/// Walks the list once to collect:
+///   - `result_ids`: every `tool_call_id` on a Tool-role message (i.e. every
+///     id for which a result already exists).
+///
+/// Then walks again and keeps:
+///   - Non-assistant / non-tool messages as-is.
+///   - Tool-role messages whose `tool_call_id` is in `result_ids` (trivially
+///     always true, but the guard catches malformed entries).
+///   - Assistant messages whose `tool_calls` (if any) all have matching
+///     results OR are pinned by `retry_state`. An assistant message with
+///     tool_calls all-missing AND unpinned is dropped — unless it also has
+///     non-empty text content, in which case we keep the text but strip the
+///     unresolved tool_calls so the provider accepts the request.
+///
+/// Preserves message order. Returns the filtered list plus the count of
+/// assistant tool-call messages affected (either fully dropped or had their
+/// tool_calls stripped).
+pub fn filter_unresolved_tool_uses(
+    messages: Vec<Message>,
+    retry_state: Option<&dyn RetryStateView>,
+) -> (Vec<Message>, usize) {
+    let mut result_ids: HashSet<String> = HashSet::new();
+    for msg in &messages {
+        if !matches!(msg.role, MessageRole::Tool) {
+            continue;
+        }
+        if let Some(id) = msg.tool_call_id.as_deref() {
+            result_ids.insert(id.to_string());
+        }
+    }
+
+    let mut dropped = 0_usize;
+    let mut kept = Vec::with_capacity(messages.len());
+
+    for msg in messages.into_iter() {
+        match msg.role {
+            MessageRole::Tool => {
+                if let Some(id) = msg.tool_call_id.as_deref() {
+                    // A tool_result whose tool_call_id has no matching
+                    // assistant tool_call would also be orphaned, but
+                    // we can only detect this if we also track call_ids
+                    // on assistant messages. Do that here.
+                    if result_has_matching_call(&kept, id) {
+                        kept.push(msg);
+                    } else {
+                        dropped += 1;
+                    }
+                } else {
+                    // Tool-role message with no id is malformed — drop.
+                    dropped += 1;
+                }
+            }
+            MessageRole::Assistant => {
+                let Some(calls) = msg.tool_calls.as_ref() else {
+                    kept.push(msg);
+                    continue;
+                };
+                if calls.is_empty() {
+                    kept.push(msg);
+                    continue;
+                }
+                let has_text = !msg.content.trim().is_empty();
+                let all_resolved = calls.iter().all(|call| {
+                    result_ids.contains(call.id.as_str())
+                        || retry_state
+                            .map(|state| state.contains_tool_call(&call.id))
+                            .unwrap_or(false)
+                });
+                if all_resolved {
+                    kept.push(msg);
+                } else if has_text {
+                    // Keep the text but strip the unresolved tool_calls
+                    // so the provider accepts the request.
+                    let mut stripped = msg;
+                    stripped.tool_calls = None;
+                    kept.push(stripped);
+                    dropped += 1;
+                } else {
+                    dropped += 1;
+                }
+            }
+            _ => kept.push(msg),
+        }
+    }
+
+    (kept, dropped)
+}
+
+/// Returns `true` when any already-kept assistant message has a tool_call
+/// with id == `id`. Used as the inverse check for orphaned tool results.
+fn result_has_matching_call(kept: &[Message], id: &str) -> bool {
+    kept.iter().any(|msg| {
+        matches!(msg.role, MessageRole::Assistant)
+            && msg
+                .tool_calls
+                .as_ref()
+                .map(|calls| calls.iter().any(|call| call.id == id))
+                .unwrap_or(false)
+    })
+}
+
+/// Pass 2: drop orphaned thinking-only assistant messages.
+///
+/// An assistant message is "thinking-only" when:
+///   - `reasoning_content` is `Some(non-empty)`.
+///   - `content.trim().is_empty()`.
+///   - `tool_calls` is None or empty.
+///
+/// Such messages are dropped EXCEPT when they are the last message in the
+/// transcript — that case represents an in-flight reasoning turn the harness
+/// will continue on resume.
+pub fn filter_orphaned_thinking_only_messages(messages: Vec<Message>) -> (Vec<Message>, usize) {
+    let total = messages.len();
+    let mut dropped = 0_usize;
+    let mut kept = Vec::with_capacity(total);
+
+    for (idx, msg) in messages.into_iter().enumerate() {
+        let is_tail = idx + 1 == total;
+        if !is_tail && is_thinking_only(&msg) {
+            dropped += 1;
+        } else {
+            kept.push(msg);
+        }
+    }
+
+    (kept, dropped)
+}
+
+fn is_thinking_only(msg: &Message) -> bool {
+    if !matches!(msg.role, MessageRole::Assistant) {
+        return false;
+    }
+    let reasoning = msg
+        .reasoning_content
+        .as_deref()
+        .map(|r| !r.trim().is_empty())
+        .unwrap_or(false);
+    if !reasoning {
+        return false;
+    }
+    let empty_content = msg.content.trim().is_empty();
+    let empty_calls = msg
+        .tool_calls
+        .as_ref()
+        .map(|calls| calls.is_empty())
+        .unwrap_or(true);
+    empty_content && empty_calls
+}
+
+/// Pass 3: drop assistant messages that carry no useful payload.
+///
+/// Criteria: role=Assistant AND `content.trim().is_empty()` AND no
+/// `tool_calls` AND no `reasoning_content`. The message contributes nothing
+/// to the transcript and some providers reject it outright.
+pub fn filter_whitespace_only_assistant_messages(messages: Vec<Message>) -> (Vec<Message>, usize) {
+    let mut dropped = 0_usize;
+    let mut kept = Vec::with_capacity(messages.len());
+
+    for msg in messages.into_iter() {
+        if is_whitespace_only_assistant(&msg) {
+            dropped += 1;
+        } else {
+            kept.push(msg);
+        }
+    }
+
+    (kept, dropped)
+}
+
+fn is_whitespace_only_assistant(msg: &Message) -> bool {
+    if !matches!(msg.role, MessageRole::Assistant) {
+        return false;
+    }
+    if !msg.content.trim().is_empty() {
+        return false;
+    }
+    let has_calls = msg
+        .tool_calls
+        .as_ref()
+        .map(|calls| !calls.is_empty())
+        .unwrap_or(false);
+    if has_calls {
+        return false;
+    }
+    let has_reasoning = msg
+        .reasoning_content
+        .as_deref()
+        .map(|r| !r.trim().is_empty())
+        .unwrap_or(false);
+    if has_reasoning {
+        return false;
+    }
+    true
+}
+
+/// Pass 4: collect content-replacement refs from tool results.
+///
+/// Scans every tool-role message for file paths. Heuristic: parse the tool
+/// result body as JSON and look for top-level `path` or `file` fields, OR
+/// fall back to a line-based scan for `path: <value>` / `file: <value>`.
+/// The output is a list of [`ReplacementStateRef`] with `content_hash:
+/// None` — M8.4 will populate hashes once the `FileStateCache` restore
+/// step is in place.
+pub fn reconstruct_content_replacement_state(messages: &[Message]) -> Vec<ReplacementStateRef> {
+    let mut refs = Vec::new();
+    let mut seen = HashSet::new();
+
+    for msg in messages {
+        if !matches!(msg.role, MessageRole::Tool) {
+            continue;
+        }
+
+        // First try structured parse: if content is JSON, look for known
+        // field names.
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&msg.content) {
+            extract_paths_from_json(&value, &mut |path| {
+                push_unique(&mut refs, &mut seen, path);
+            });
+        }
+
+        // Also fall back to line-based scan for tool results that emit
+        // plaintext like "wrote 12 bytes to <path>" or "read <path>".
+        for line in msg.content.lines() {
+            if let Some(path) = extract_path_from_line(line) {
+                push_unique(&mut refs, &mut seen, path);
+            }
+        }
+    }
+
+    refs
+}
+
+fn push_unique(refs: &mut Vec<ReplacementStateRef>, seen: &mut HashSet<String>, path: String) {
+    if path.is_empty() {
+        return;
+    }
+    if seen.insert(path.clone()) {
+        refs.push(ReplacementStateRef {
+            path: PathBuf::from(path),
+            content_hash: None,
+        });
+    }
+}
+
+fn extract_paths_from_json(value: &serde_json::Value, push: &mut dyn FnMut(String)) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map {
+                if matches!(key.as_str(), "path" | "file" | "file_path" | "filename") {
+                    if let serde_json::Value::String(s) = val {
+                        push(s.clone());
+                    }
+                }
+                extract_paths_from_json(val, push);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                extract_paths_from_json(item, push);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn extract_path_from_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    for prefix in ["path:", "file:", "wrote ", "read "] {
+        let Some(rest) = trimmed.strip_prefix(prefix) else {
+            continue;
+        };
+        let candidate = rest.trim().trim_matches('"').trim_matches('\'');
+        if candidate.contains(['/', '\\']) && candidate.len() < 512 {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+/// Internal result of the worktree existence + mtime bump helper.
+enum WorktreeStatus {
+    Present,
+    Missing,
+    BumpFailed { error: String },
+}
+
+/// Stat the worktree and, when present, touch a marker file inside it to
+/// bump the containing directory's mtime. The marker is written
+/// non-atomically — a concurrent resume is fine because both writes are
+/// idempotent (the file is overwritten with the current timestamp).
+///
+/// Returns [`WorktreeStatus::Missing`] if `root` does not exist (caller
+/// escalates to refuse resume). Returns [`WorktreeStatus::BumpFailed`] if
+/// the stat succeeds but writing the marker fails — non-fatal, logged as a
+/// report warning.
+fn check_and_bump_worktree(root: &Path) -> WorktreeStatus {
+    match std::fs::metadata(root) {
+        Ok(meta) if meta.is_dir() => bump_mtime_marker(root),
+        Ok(_) => {
+            warn!(path = %root.display(), "worktree root is not a directory");
+            WorktreeStatus::Missing
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => WorktreeStatus::Missing,
+        Err(error) => WorktreeStatus::BumpFailed {
+            error: error.to_string(),
+        },
+    }
+}
+
+fn bump_mtime_marker(root: &Path) -> WorktreeStatus {
+    let marker = root.join(RESUME_MTIME_MARKER);
+    let timestamp = Utc::now().to_rfc3339();
+    match std::fs::write(&marker, timestamp.as_bytes()) {
+        Ok(()) => WorktreeStatus::Present,
+        Err(error) => WorktreeStatus::BumpFailed {
+            error: error.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone, Utc};
+    use octos_core::{Message, MessageRole, ToolCall};
+    use tempfile::TempDir;
+
+    fn user(content: &str) -> Message {
+        Message {
+            role: MessageRole::User,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        }
+    }
+
+    fn assistant_text(content: &str) -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 1).unwrap(),
+        }
+    }
+
+    fn assistant_with_calls(content: &str, call_ids: &[&str]) -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: content.into(),
+            media: vec![],
+            tool_calls: Some(
+                call_ids
+                    .iter()
+                    .map(|id| ToolCall {
+                        id: (*id).to_string(),
+                        name: "shell".into(),
+                        arguments: serde_json::json!({}),
+                        metadata: None,
+                    })
+                    .collect(),
+            ),
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 2).unwrap(),
+        }
+    }
+
+    fn tool_result(tool_call_id: &str, body: &str) -> Message {
+        Message {
+            role: MessageRole::Tool,
+            content: body.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 3).unwrap(),
+        }
+    }
+
+    fn assistant_thinking_only(reasoning: &str) -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: Some(reasoning.into()),
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 4).unwrap(),
+        }
+    }
+
+    fn assistant_whitespace_only() -> Message {
+        Message {
+            role: MessageRole::Assistant,
+            content: "   \n\t ".into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 5).unwrap(),
+        }
+    }
+
+    #[test]
+    fn should_drop_tool_result_without_matching_tool_call() {
+        let messages = vec![
+            user("hello"),
+            assistant_text("hi"),
+            // Orphan: tool result with no matching tool_call in any
+            // assistant message.
+            tool_result("orphan-42", r#"{"output": "oops"}"#),
+            assistant_text("done"),
+        ];
+
+        let (filtered, dropped) = filter_unresolved_tool_uses(messages, None);
+
+        assert_eq!(dropped, 1, "orphan tool_result should bump dropped");
+        assert_eq!(filtered.len(), 3);
+        assert!(
+            !filtered.iter().any(|m| matches!(m.role, MessageRole::Tool)),
+            "the orphan tool_result should be gone"
+        );
+    }
+
+    #[test]
+    fn should_drop_tool_call_without_matching_result() {
+        let messages = vec![
+            user("run it"),
+            // Unresolved tool_call — no tool result follows; no text body
+            // so the whole assistant message should be dropped.
+            assistant_with_calls("", &["call-1"]),
+        ];
+
+        let (filtered, dropped) = filter_unresolved_tool_uses(messages, None);
+
+        assert_eq!(dropped, 1);
+        assert_eq!(filtered.len(), 1);
+        assert!(matches!(filtered[0].role, MessageRole::User));
+    }
+
+    #[test]
+    fn should_strip_tool_calls_but_keep_text_when_text_present() {
+        let messages = vec![
+            user("hi"),
+            // Unresolved tool_call, but assistant also wrote prose — keep
+            // the prose, strip the tool_calls so the provider accepts it.
+            assistant_with_calls("I started doing the thing.", &["call-x"]),
+        ];
+
+        let (filtered, dropped) = filter_unresolved_tool_uses(messages, None);
+
+        assert_eq!(dropped, 1, "counts the strip as a drop");
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[1].content, "I started doing the thing.");
+        assert!(filtered[1].tool_calls.is_none());
+    }
+
+    #[test]
+    fn should_preserve_tool_call_referenced_by_retry_state() {
+        let messages = vec![
+            user("run it"),
+            // Unresolved tool_call, but retry state says "pending — do
+            // not drop".
+            assistant_with_calls("", &["pending-1"]),
+        ];
+
+        let mut retry: HashSet<String> = HashSet::new();
+        retry.insert("pending-1".into());
+
+        let (filtered, dropped) =
+            filter_unresolved_tool_uses(messages, Some(&retry as &dyn RetryStateView));
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+        assert!(
+            filtered[1]
+                .tool_calls
+                .as_ref()
+                .map(|c| c.len() == 1 && c[0].id == "pending-1")
+                .unwrap_or(false)
+        );
+    }
+
+    #[test]
+    fn should_drop_orphan_thinking_only_message() {
+        let messages = vec![
+            user("huh"),
+            assistant_thinking_only("<think> ... </think>"),
+            // A real reply follows, so the thinking-only one is an orphan.
+            assistant_text("here is the answer"),
+        ];
+
+        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages);
+
+        assert_eq!(dropped, 1);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[1].content, "here is the answer");
+    }
+
+    #[test]
+    fn should_keep_trailing_thinking_only_message() {
+        // In-flight reasoning: session crashed mid-think. The tail
+        // thinking-only message represents state the harness will
+        // continue — keep it.
+        let messages = vec![
+            user("long one"),
+            assistant_thinking_only("still working on it ..."),
+        ];
+
+        let (filtered, dropped) = filter_orphaned_thinking_only_messages(messages);
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered[1].reasoning_content.is_some());
+    }
+
+    #[test]
+    fn should_drop_whitespace_only_assistant_message() {
+        let messages = vec![
+            user("hi"),
+            assistant_whitespace_only(),
+            assistant_text("oh hey"),
+        ];
+
+        let (filtered, dropped) = filter_whitespace_only_assistant_messages(messages);
+
+        assert_eq!(dropped, 1);
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[1].content, "oh hey");
+    }
+
+    #[test]
+    fn should_not_drop_user_whitespace_only() {
+        // Only assistant messages are subject to the whitespace filter —
+        // users can send whatever they want, we preserve.
+        let messages = vec![user("   "), assistant_text("weird")];
+
+        let (filtered, dropped) = filter_whitespace_only_assistant_messages(messages);
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn should_collect_content_replacement_refs_from_tool_results() {
+        let messages = vec![
+            user("read the file"),
+            assistant_with_calls("", &["call-a"]),
+            tool_result(
+                "call-a",
+                r#"{"path": "src/lib.rs", "contents": "fn main() {}"}"#,
+            ),
+            assistant_with_calls("", &["call-b"]),
+            tool_result("call-b", "wrote file\npath: docs/new.md\nbytes: 42\n"),
+        ];
+
+        let refs = reconstruct_content_replacement_state(&messages);
+
+        assert_eq!(refs.len(), 2, "two unique file paths recovered");
+        let paths: Vec<_> = refs.iter().map(|r| r.path.display().to_string()).collect();
+        assert!(paths.iter().any(|p| p == "src/lib.rs"));
+        assert!(paths.iter().any(|p| p == "docs/new.md"));
+        // content_hash is None — M8.4 stub.
+        assert!(refs.iter().all(|r| r.content_hash.is_none()));
+    }
+
+    #[test]
+    fn should_detect_missing_worktree() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("not-a-real-worktree");
+
+        let outcome = ResumePolicy::sanitize(vec![], None, Some(&missing));
+
+        match outcome {
+            Err(SanitizeError::WorktreeMissing { path, report }) => {
+                assert_eq!(path, missing);
+                assert!(report.worktree_missing);
+            }
+            other => panic!("expected WorktreeMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_bump_worktree_mtime_when_present() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+
+        let outcome =
+            ResumePolicy::sanitize(vec![user("hi")], None, Some(root)).expect("worktree present");
+
+        assert!(!outcome.report.worktree_missing);
+        let marker = root.join(RESUME_MTIME_MARKER);
+        assert!(marker.exists(), "marker file should exist after mtime bump");
+        let written = std::fs::read_to_string(&marker).unwrap();
+        assert!(
+            !written.trim().is_empty(),
+            "marker should contain a timestamp"
+        );
+    }
+
+    #[test]
+    fn should_report_zero_drops_for_clean_transcript() {
+        let messages = vec![
+            user("hello"),
+            assistant_with_calls("", &["call-1"]),
+            tool_result("call-1", r#"{"output": "ok"}"#),
+            assistant_text("all done"),
+        ];
+
+        let outcome = ResumePolicy::sanitize(messages, None, None).unwrap();
+
+        assert_eq!(outcome.report.unresolved_tool_uses_dropped, 0);
+        assert_eq!(outcome.report.orphan_thinking_dropped, 0);
+        assert_eq!(outcome.report.whitespace_only_dropped, 0);
+        assert_eq!(outcome.report.input_len, 4);
+        assert_eq!(outcome.report.output_len, 4);
+        assert!(!outcome.report.worktree_missing);
+        assert!(outcome.report.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_display_report_human_readable() {
+        let report = SessionSanitizeReport {
+            input_len: 10,
+            output_len: 6,
+            unresolved_tool_uses_dropped: 2,
+            orphan_thinking_dropped: 1,
+            whitespace_only_dropped: 1,
+            content_replacements_restored: 3,
+            worktree_missing: false,
+            warnings: vec!["one".into()],
+        };
+        let shown = report.to_string();
+        assert!(shown.contains("input_len=10"));
+        assert!(shown.contains("output_len=6"));
+        assert!(shown.contains("unresolved_tool=2"));
+        assert!(shown.contains("orphan_thinking=1"));
+        assert!(shown.contains("whitespace_only=1"));
+        assert!(shown.contains("worktree_missing=false"));
+    }
+
+    #[test]
+    fn should_sanitize_complex_transcript_end_to_end() {
+        let now = Utc::now();
+        let msgs = vec![
+            // User prompt.
+            Message {
+                timestamp: now,
+                ..user("task: refactor the widget")
+            },
+            // Assistant thinking + real reply.
+            Message {
+                timestamp: now + Duration::milliseconds(10),
+                ..assistant_thinking_only("let me think ...")
+            },
+            Message {
+                timestamp: now + Duration::milliseconds(20),
+                ..assistant_text("on it")
+            },
+            // Assistant tool_call that is resolved.
+            Message {
+                timestamp: now + Duration::milliseconds(30),
+                ..assistant_with_calls("", &["call-1"])
+            },
+            Message {
+                timestamp: now + Duration::milliseconds(40),
+                ..tool_result("call-1", r#"{"path": "widget.rs"}"#)
+            },
+            // Assistant tool_call UNRESOLVED (should be dropped).
+            Message {
+                timestamp: now + Duration::milliseconds(50),
+                ..assistant_with_calls("", &["call-ghost"])
+            },
+            // Whitespace-only assistant (should be dropped).
+            Message {
+                timestamp: now + Duration::milliseconds(60),
+                ..assistant_whitespace_only()
+            },
+            // Orphan thinking-only (should be dropped; not tail).
+            Message {
+                timestamp: now + Duration::milliseconds(70),
+                ..assistant_thinking_only("hmm")
+            },
+            // Final real reply (tail — preserved).
+            Message {
+                timestamp: now + Duration::milliseconds(80),
+                ..assistant_text("done refactoring")
+            },
+        ];
+
+        let outcome = ResumePolicy::sanitize(msgs, None, None).unwrap();
+
+        // unresolved=1, whitespace=1, orphan_thinking=2 (both thinking-only
+        // messages are non-tail once filtering starts — one appears mid-
+        // conversation, one appears just before the final reply).
+        assert_eq!(outcome.report.unresolved_tool_uses_dropped, 1);
+        assert_eq!(outcome.report.orphan_thinking_dropped, 2);
+        assert_eq!(outcome.report.whitespace_only_dropped, 1);
+        // One content-replacement ref from the resolved tool result.
+        assert_eq!(outcome.report.content_replacements_restored, 1);
+        // input was 9, output should be 9 - 4 = 5.
+        assert_eq!(outcome.report.input_len, 9);
+        assert_eq!(outcome.report.output_len, 5);
+        // The final real reply must be the tail.
+        assert_eq!(outcome.messages.last().unwrap().content, "done refactoring");
+    }
+
+    #[test]
+    fn should_flag_non_directory_worktree_as_missing() {
+        // Claude Code's worktree recovery treats a regular file at the
+        // configured path as "gone" because it can't be used as a
+        // worktree. We match that.
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("not-a-dir");
+        std::fs::write(&file_path, "hi").unwrap();
+
+        let outcome = ResumePolicy::sanitize(vec![user("hi")], None, Some(&file_path));
+
+        match outcome {
+            Err(SanitizeError::WorktreeMissing { path, .. }) => {
+                assert_eq!(path, file_path);
+            }
+            other => panic!("expected WorktreeMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_detect_whitespace_only_with_reasoning_not_dropped() {
+        // An assistant message with empty content but reasoning content
+        // is a thinking-only message, not whitespace-only. The
+        // whitespace filter must skip it.
+        let messages = vec![
+            user("hi"),
+            assistant_thinking_only("thinking ..."),
+            assistant_text("hi back"),
+        ];
+
+        let (filtered, dropped) = filter_whitespace_only_assistant_messages(messages);
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 3);
+    }
+
+    #[test]
+    fn should_ignore_retry_state_for_unknown_ids() {
+        // Retry state that references call IDs not actually in the
+        // transcript should be a no-op.
+        let messages = vec![user("hi"), assistant_text("hello")];
+
+        let mut retry: HashSet<String> = HashSet::new();
+        retry.insert("bogus".into());
+
+        let (filtered, dropped) =
+            filter_unresolved_tool_uses(messages, Some(&retry as &dyn RetryStateView));
+
+        assert_eq!(dropped, 0);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn should_handle_empty_transcript() {
+        let outcome = ResumePolicy::sanitize(vec![], None, None).unwrap();
+
+        assert_eq!(outcome.messages.len(), 0);
+        assert_eq!(outcome.report.input_len, 0);
+        assert_eq!(outcome.report.output_len, 0);
+    }
+}

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1120,6 +1120,50 @@ impl SessionHandle {
         &mut self.session
     }
 
+    /// Sanitize the loaded transcript via [`crate::ResumePolicy`] (M8.6).
+    ///
+    /// Runs the four filter passes described in `resume_policy`, replaces
+    /// `self.session.messages` with the sanitized list, and returns the
+    /// typed report so callers can log it or forward it to a harness event
+    /// sink. A missing worktree is reported via
+    /// [`crate::SanitizeError::WorktreeMissing`] — the session's in-memory
+    /// messages are NOT mutated in that case so callers retain the
+    /// original transcript for operator inspection.
+    ///
+    /// NOTE: this does not persist the sanitized transcript to disk. Call
+    /// [`Self::rewrite`] afterward if the caller wants the sanitized
+    /// version to survive a subsequent reload.
+    pub fn sanitize_loaded_messages(
+        &mut self,
+        retry_state: Option<&dyn crate::RetryStateView>,
+        workspace_root: Option<&Path>,
+    ) -> Result<
+        (
+            crate::SessionSanitizeReport,
+            Vec<crate::ReplacementStateRef>,
+        ),
+        crate::SanitizeError,
+    > {
+        // Clone so we can restore the original on the worktree-missing
+        // path without a partial-move hazard.
+        let messages = self.session.messages.clone();
+        match crate::ResumePolicy::sanitize(messages, retry_state, workspace_root) {
+            Ok(outcome) => {
+                self.session.messages = outcome.messages;
+                Ok((outcome.report, outcome.content_replacements))
+            }
+            Err(error) => {
+                let crate::SanitizeError::WorktreeMissing { report, .. } = &error;
+                warn!(
+                    key = %self.session.key,
+                    report = %report,
+                    "resume sanitize refused: worktree missing"
+                );
+                Err(error)
+            }
+        }
+    }
+
     /// Add a message to the session and persist it.
     pub async fn add_message(&mut self, message: Message) -> Result<()> {
         self.add_message_with_seq(message).await.map(|_| ())
@@ -2687,5 +2731,94 @@ mod tests {
         assert_eq!(child.0, "api:web-task-ledger#child-spawn-01%2Falpha%20beta");
         assert_eq!(child.base_key(), "api:web-task-ledger");
         assert_eq!(child.topic(), Some("child-spawn-01%2Falpha%20beta"));
+    }
+
+    /// M8.6: `sanitize_loaded_messages` replaces the session's in-memory
+    /// transcript with the cleaned-up version and returns the report. No
+    /// disk state is touched until the caller rewrites.
+    #[test]
+    fn should_sanitize_loaded_messages_in_place() {
+        use octos_core::ToolCall;
+
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "resume-test");
+        let mut handle = SessionHandle::open(tmp.path(), &key);
+
+        // Load an unresolved tool_call + a whitespace-only assistant
+        // message into the handle directly.
+        handle
+            .session
+            .messages
+            .push(make_message(MessageRole::User, "hi"));
+        handle.session.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: Some(vec![ToolCall {
+                id: "unresolved-1".into(),
+                name: "shell".into(),
+                arguments: serde_json::json!({}),
+                metadata: None,
+            }]),
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        });
+        handle.session.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: "   ".into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        });
+
+        let before = handle.session.messages.len();
+        let (report, refs) = handle
+            .sanitize_loaded_messages(None, None)
+            .expect("clean outcome — no workspace root");
+
+        assert_eq!(report.input_len, before);
+        assert_eq!(report.unresolved_tool_uses_dropped, 1);
+        assert_eq!(report.whitespace_only_dropped, 1);
+        assert_eq!(report.output_len, 1);
+        assert!(refs.is_empty());
+        // Handle was mutated in place.
+        assert_eq!(handle.session.messages.len(), 1);
+        assert_eq!(handle.session.messages[0].content, "hi");
+    }
+
+    /// M8.6: a missing worktree surfaces as `Err` and DOES NOT mutate the
+    /// session's in-memory transcript — callers can still log what was
+    /// loaded before deciding to refuse resume.
+    #[test]
+    fn should_preserve_messages_when_worktree_missing() {
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "resume-no-worktree");
+        let mut handle = SessionHandle::open(tmp.path(), &key);
+
+        handle
+            .session
+            .messages
+            .push(make_message(MessageRole::User, "hi"));
+        handle
+            .session
+            .messages
+            .push(make_message(MessageRole::Assistant, "there"));
+
+        let gone = tmp.path().join("ghost-worktree");
+        let before_count = handle.session.messages.len();
+
+        let outcome = handle.sanitize_loaded_messages(None, Some(&gone));
+
+        match outcome {
+            Err(crate::SanitizeError::WorktreeMissing { path, .. }) => {
+                assert_eq!(path, gone);
+            }
+            other => panic!("expected WorktreeMissing, got {other:?}"),
+        }
+        // Transcript is preserved.
+        assert_eq!(handle.session.messages.len(), before_count);
     }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1391,7 +1391,40 @@ impl ActorFactory {
         }
         // Create the per-actor session handle early so we can derive the
         // background task ledger path before any worker can mutate state.
-        let session_handle = SessionHandle::open(&self.data_dir, &session_key);
+        let mut session_handle = SessionHandle::open(&self.data_dir, &session_key);
+        // M8.6: sanitize the loaded transcript. Dropping unresolved tool
+        // calls, orphan thinking, and whitespace-only messages here
+        // prevents the provider from 400-ing on the first request after a
+        // resume. `retry_state` and `workspace_root` are None for
+        // top-level sessions today — sub-agent workstreams will thread
+        // them in when M8.7 lands.
+        match session_handle.sanitize_loaded_messages(None, None) {
+            Ok((report, refs)) => {
+                if report.input_len != report.output_len
+                    || report.content_replacements_restored > 0
+                    || !report.warnings.is_empty()
+                {
+                    info!(
+                        session = %session_key,
+                        report = %report,
+                        "resume sanitize applied"
+                    );
+                }
+                // TODO(M8.4): after FileStateCache lands, populate its
+                // entries from `refs` when the cache is non-empty
+                // post-load. The hand-off point is right here — we have
+                // the session key, the sanitized transcript, and the
+                // list of content-replacement refs.
+                let _ = refs;
+            }
+            Err(error) => {
+                warn!(
+                    session = %session_key,
+                    error = %error,
+                    "resume sanitize refused — continuing with original transcript"
+                );
+            }
+        }
         let task_state_path = session_handle.task_state_path();
         let session_handle = Arc::new(Mutex::new(session_handle));
         let session_policy_path = workspace_policy_path(&user_workspace);


### PR DESCRIPTION
## Summary

Closes runtime-v0.2 framing by adding the third of three workstreams (after M8.4 in flight and M8.5 landed in #548). Refs #541.

When octos reloads a session's JSONL transcript at startup or after a crash, the provider will 400 on unresolved tool calls, orphan thinking-only messages, or whitespace-only assistant messages — and sub-agent worktrees that were GC'd externally leave stale content-replacement state. `ResumePolicy` sanitizes the loaded `Vec<Message>` before the session actor picks it up and emits a typed `SessionSanitizeReport` via `HarnessEvent::SessionSanitized` for observability.

## Scope

**Four filter passes** (pure functions on `Vec<Message>`, order-preserving):

1. `filter_unresolved_tool_uses` — pairs assistant `tool_calls` with `Tool`-role results and drops orphans. Preserves calls pinned by a `RetryStateView`. When an assistant message has unresolved `tool_calls` AND non-empty text content, the tool_calls are stripped but the text is kept (provider will accept).
2. `filter_orphaned_thinking_only_messages` — drops assistant messages with `reasoning_content` but no content and no tool_calls, EXCEPT when they are the transcript tail (allow in-flight reasoning on resume).
3. `filter_whitespace_only_assistant_messages` — drops empty assistant messages with no tool calls or reasoning.
4. `reconstruct_content_replacement_state` — scans tool results for file paths (structured JSON + line heuristics) and returns `ReplacementStateRef` entries. `content_hash: None` for now.

**Worktree check + mtime bump**: when `workspace_root` is provided, stat the directory. Missing → `SanitizeError::WorktreeMissing` (caller refuses resume). Present → write a `.octos_resume_mtime` marker file with an RFC3339 timestamp to prevent stale-cleanup races (Claude Code issue #22355).

**Typed `SessionSanitizeReport`** with `input_len`, `output_len`, per-pass drop counts, `content_replacements_restored`, `worktree_missing`, `warnings`. Display impl for logging.

**Harness event**: `HarnessEvent::SessionSanitized` variant + `HarnessSessionSanitizedEvent` struct. ABI schema v1, `kind: "session_sanitized"`. `TaskSupervisor::apply_harness_event` accepts it as observability-only (no lifecycle mutation). Builder: `HarnessEvent::session_sanitized(session_id, task_id, workflow, &report)`.

**Wire-up**: `SessionHandle::sanitize_loaded_messages` mutates the session's in-memory transcript; `session_actor::spawn` calls it right after `SessionHandle::open`. Non-trivial reports (drops > 0 or warnings) log at info level; worktree-missing logs at warn and continues with the original transcript.

## M8.4 dependency

Stubbed per the task spec. `reconstruct_content_replacement_state` returns the file-path refs today with `content_hash: None`; the integration point is marked with a `TODO(M8.4)` comment in `session_actor.rs` where the refs would feed into `FileStateCache`. The follow-up PR after M8.4 merges will wire those refs into the cache and set real hashes.

## Tests

**23 total, all passing:**

- 18 in `octos-bus::resume_policy::tests` covering every required spec scenario plus edge cases (non-directory worktree, retry state with unknown ids, empty transcripts, whitespace-with-reasoning is not whitespace-only).
- 2 in `octos-bus::session::tests` for `SessionHandle::sanitize_loaded_messages` wiring — one sanitize in-place, one worktree-missing preserves messages.
- 3 in `octos-agent::harness_events::tests`: round-trip serialization, `worktree_missing` flag propagation, and end-to-end sink delivery via `HarnessEventSink::new` (verifies the sink pipeline routes the new variant to `TaskSupervisor`).

All 12 required test names from the spec are present by literal name (including `should_emit_session_sanitized_event_when_sink_configured` and `should_sanitize_complex_transcript_end_to_end`).

## Gates

```
cargo clippy -p octos-bus  --no-deps --all-targets -- -D warnings   # clean
cargo clippy -p octos-agent --no-deps --all-targets -- -D warnings  # clean
cargo test   -p octos-bus   --lib                                    # 149/149
cargo test   -p octos-agent --lib                                    # 983/983
cargo test   --workspace --no-fail-fast                              # 2336/2336
```

Pre-existing fmt issues remain in `crates/octos-cli/src/api/admin_setup.rs`, `auth_handlers.rs`, `commands/admin.rs`, `config.rs`, and `setup_state_store.rs` — none of which this PR touches. All files modified here are fmt-clean.

## Runtime-v0.2 status

- M8.5 (3-tier compaction) — landed in #548.
- M8.4 (FileStateCache) — in flight; this PR stubs the integration point.
- M8.6 (this PR) — closes v0.2 framing once M8.4 lands and the TODO wires up.

## Test plan

- [x] cargo test -p octos-bus --lib resume_policy (18/18)
- [x] cargo test -p octos-bus --lib (149/149)
- [x] cargo test -p octos-agent --lib (983/983)
- [x] cargo test --workspace --no-fail-fast (2336/2336)
- [x] cargo clippy on octos-bus/octos-agent clean
- [ ] Live resume-after-crash smoke once M8.4 lands and the TODO is wired.