### PR TITLE
M8.8: Concurrent-safe vs exclusive scheduler (closes M8 family)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -1,10 +1,34 @@
 //! Tool execution: dispatching tool calls with hooks and timeout handling.
+//!
+//! # Batch admission (M8.8)
+//!
+//! Each turn of the agent loop receives a batch of tool calls from the LLM.
+//! Before M8.8 every call in a batch fired in parallel, which races when a
+//! mutating tool (shell, write_file, edit_file, diff_edit, save_memory) sits
+//! next to a reader in the same batch. The executor now consults
+//! [`crate::tools::Tool::concurrency_class`] for every call and picks one of
+//! two admission strategies:
+//!
+//! - **All-Safe batch** — the classic path. Every call is [`ConcurrencyClass::Safe`]
+//!   (read-only, side-effect-free). The executor spawns each call as a detached
+//!   task and aggregates via `futures::join_all`, preserving call order.
+//! - **Any-Exclusive batch** — new M8.8 path. At least one call reports
+//!   [`ConcurrencyClass::Exclusive`]. The executor runs calls serially in LLM
+//!   call order. On the first error (including hook denials and panics), the
+//!   remaining peers are skipped and each receives a synthetic
+//!   "cancelled due to sibling error" [`Message`] so the LLM still sees a
+//!   result for every `tool_call_id`.
+//!
+//! The split is pessimistic — a batch containing one Exclusive + four Safe
+//! tools still serializes the whole batch. An optimised "run Safe in parallel,
+//! then Exclusive in order" pipeline is explicitly deferred (see the M8.8 spec).
 
 use std::time::{Duration, Instant};
 
 use eyre::Result;
 use octos_core::{Message, MessageRole, TokenUsage};
 use octos_llm::ChatResponse;
+use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use super::{Agent, MAX_TOOL_TIMEOUT_SECS};
@@ -14,8 +38,24 @@ use crate::hooks::{HookEvent, HookPayload, HookResult};
 use crate::progress::ProgressEvent;
 use crate::task_supervisor::TaskRuntimeState;
 use crate::tools::spawn::{BackgroundResultKind, BackgroundResultPayload};
-use crate::tools::{TOOL_CTX, TURN_ATTACHMENT_CTX, ToolContext};
+use crate::tools::{ConcurrencyClass, TOOL_CTX, TURN_ATTACHMENT_CTX, ToolContext};
 use crate::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract};
+
+/// Per-tool-call result returned from the in-process dispatcher. Kept as a
+/// tuple so the aggregation path can reuse today's `futures::join_all` style
+/// fan-in without an intermediate struct.
+///
+/// Fields in order: the tool-result [`Message`], files the tool touched,
+/// files the tool wants auto-delivered to the user, optional sub-agent
+/// token usage, and a per-call `success` bit used by the serial scheduler
+/// to trigger the M8.8 error cascade.
+type ToolCallResult = (
+    Message,
+    Vec<std::path::PathBuf>,
+    Vec<std::path::PathBuf>,
+    Option<TokenUsage>,
+    bool,
+);
 
 fn should_auto_send_tool_files(
     suppress_auto_send_files: bool,
@@ -46,447 +86,77 @@ pub(super) fn compose_system_prompt(agent: &Agent) -> String {
 }
 
 impl Agent {
-    pub(super) async fn execute_tools(
+    /// Spawn a single tool call as a detached `tokio::spawn` task.
+    ///
+    /// The returned [`JoinHandle`] yields the per-call [`ToolCallResult`]:
+    /// tool-output [`Message`], modified file paths, files-to-send paths, and
+    /// optional sub-agent [`TokenUsage`]. This is the worker used by both
+    /// dispatch strategies in [`Agent::execute_tools`] — parallel (Safe) runs
+    /// many in flight via `join_all`; serial (any-Exclusive) spawns one,
+    /// awaits it, then spawns the next.
+    ///
+    /// `explicit_send_file_requested` is a per-batch fact (true when the same
+    /// LLM turn already issued a `send_file`), so the caller computes it once
+    /// and passes it in; it is used to decide whether to auto-deliver each
+    /// tool's `files_to_send`.
+    ///
+    /// SAFETY / COMPAT: the task body is byte-identical to the pre-M8.8
+    /// inline closure in `execute_tools` — the only change is that the
+    /// closure is now reachable from two call sites.
+    fn spawn_tool_task(
         &self,
-        response: &ChatResponse,
-    ) -> Result<(
-        Vec<Message>,
-        Vec<std::path::PathBuf>,
-        Vec<std::path::PathBuf>,
-        TokenUsage,
-    )> {
-        // Log parallel tool execution details
-        let tool_names: Vec<&str> = response
-            .tool_calls
-            .iter()
-            .map(|tc| tc.name.as_str())
-            .collect();
-        let explicit_send_file_requested =
-            response.tool_calls.iter().any(|tc| tc.name == "send_file");
-        tracing::info!(
-            parallel_tools = response.tool_calls.len(),
-            tool_names = %tool_names.join(", "),
-            "executing tools in parallel"
-        );
+        tool_call: &octos_core::ToolCall,
+        explicit_send_file_requested: bool,
+        turn_attachment_ctx: &crate::tools::TurnAttachmentContext,
+    ) -> JoinHandle<ToolCallResult> {
+        // Clone Arc-wrapped fields so the spawned task is 'static
+        let tools = self.tools.clone();
+        let reporter = self.reporter();
+        let hooks = self.hooks.clone();
+        let hook_ctx = self.hook_ctx();
+        let suppress_auto_send_files = self.config.suppress_auto_send_files;
+        let tc_name = tool_call.name.clone();
+        let tc_id = tool_call.id.clone();
+        let tc_args = tool_call.arguments.clone();
+        let attachment_ctx = turn_attachment_ctx.clone();
+        let harness_event_sink = self.harness_event_sink.clone();
 
-        let turn_attachment_ctx = TURN_ATTACHMENT_CTX
-            .try_with(|ctx| ctx.clone())
-            .unwrap_or_default();
+        tokio::spawn(async move {
+            let tool_start = Instant::now();
+            debug!(tool = %tc_name, tool_id = %tc_id, "executing tool");
 
-        // Spawn each tool as a separate tokio task so that if the agent-level
-        // timeout fires, the tasks keep running and can perform their own cleanup
-        // (e.g., browser tool kills Chrome, spawn tool finishes gracefully).
-        // Without tokio::spawn, timeout would drop the futures mid-flight,
-        // orphaning child processes (Chrome, shell commands, etc.).
-        let handles: Vec<_> = response
-            .tool_calls
-            .iter()
-            .map(|tool_call| {
-                // Clone Arc-wrapped fields so the spawned task is 'static
-                let tools = self.tools.clone();
-                let reporter = self.reporter();
-                let hooks = self.hooks.clone();
-                let hook_ctx = self.hook_ctx();
-                let suppress_auto_send_files = self.config.suppress_auto_send_files;
-                let tc_name = tool_call.name.clone();
-                let tc_id = tool_call.id.clone();
-                let tc_args = tool_call.arguments.clone();
-                let attachment_ctx = turn_attachment_ctx.clone();
-                let harness_event_sink = self.harness_event_sink.clone();
+            reporter.report(ProgressEvent::ToolStarted {
+                name: tc_name.clone(),
+                tool_id: tc_id.clone(),
+            });
 
-                tokio::spawn(async move {
-                    let tool_start = Instant::now();
-                    debug!(tool = %tc_name, tool_id = %tc_id, "executing tool");
-
-                    reporter.report(ProgressEvent::ToolStarted {
-                        name: tc_name.clone(),
-                        tool_id: tc_id.clone(),
-                    });
-
-                    // Before-tool hook: may deny or modify args
-                    let mut effective_args = tc_args.clone();
-                    if let Some(ref hooks) = hooks {
-                        let payload = HookPayload::before_tool(
-                            &tc_name,
-                            tc_args.clone(),
-                            &tc_id,
-                            hook_ctx.as_ref(),
-                        );
-                        match hooks.run(HookEvent::BeforeToolCall, &payload).await {
-                            HookResult::Deny(reason) => {
-                                tracing::warn!(
-                                    tool = %tc_name,
-                                    reason = %reason,
-                                    "before_tool_call hook denied"
-                                );
-                                let deny_msg = if reason.is_empty() {
-                                    format!("[HOOK DENIED] Tool '{}' was blocked by a lifecycle hook. Do not retry.", tc_name)
-                                } else {
-                                    format!("[HOOK DENIED] Tool '{}' was blocked: {}. Do not retry.", tc_name, reason)
-                                };
-                                return (
-                                    Message {
-                                        role: MessageRole::Tool,
-                                        content: deny_msg,
-                                        media: vec![],
-                                        tool_calls: None,
-                                        tool_call_id: Some(tc_id),
-                                        reasoning_content: None,
-                                        timestamp: chrono::Utc::now(),
-                                    },
-                                    Vec::new(),
-                                    Vec::new(),
-                                    None,
-                                );
-                            }
-                            HookResult::Modified(new_args) => {
-                                tracing::info!(
-                                    tool = %tc_name,
-                                    "hook modified tool arguments"
-                                );
-                                effective_args = new_args;
-                            }
-                            _ => {}
-                        }
-                    }
-
-                    // Auto-background spawn_only tools: run the tool in a background
-                    // tokio task and return immediately. The tool's files_to_send
-                    // auto-delivers the result to the user. No subagent LLM needed.
-                    if tools.is_spawn_only(&tc_name) {
-                        tracing::info!(
+            // Before-tool hook: may deny or modify args
+            let mut effective_args = tc_args.clone();
+            if let Some(ref hooks) = hooks {
+                let payload =
+                    HookPayload::before_tool(&tc_name, tc_args.clone(), &tc_id, hook_ctx.as_ref());
+                match hooks.run(HookEvent::BeforeToolCall, &payload).await {
+                    HookResult::Deny(reason) => {
+                        tracing::warn!(
                             tool = %tc_name,
-                            "running spawn_only tool in background"
+                            reason = %reason,
+                            "before_tool_call hook denied"
                         );
-                        let bg_tools = tools.clone();
-                        let bg_name = tc_name.clone();
-                        let bg_args = effective_args.clone();
-                        let bg_sender = tools.background_result_sender();
-                        let bg_tc_id = tc_id.clone();
-                        let task_id = tools.register_task(&tc_name, &tc_id);
-                        tools.mark_spawn_only_invoked();
-                        let bg_supervisor = tools.supervisor();
-                        let bg_reporter = reporter.clone();
-                        let bg_attachment_ctx = attachment_ctx.clone();
-                        tokio::spawn(async move {
-                            bg_supervisor.mark_running(&task_id);
-                            let bg_started_at = std::time::SystemTime::now();
-
-                            // Helper to create TOOL_CTX for plugin stderr progress streaming.
-                            // Base it on the zero-value context so M8.x placeholder fields
-                            // carry their default-populated values.
-                            let make_ctx = || ToolContext {
-                                tool_id: bg_tc_id.clone(),
-                                reporter: bg_reporter.clone(),
-                                harness_event_sink: harness_event_sink.clone(),
-                                attachment_paths: bg_attachment_ctx.attachment_paths.clone(),
-                                audio_attachment_paths: bg_attachment_ctx
-                                    .audio_attachment_paths
-                                    .clone(),
-                                file_attachment_paths: bg_attachment_ctx
-                                    .file_attachment_paths
-                                    .clone(),
-                                ..ToolContext::zero()
-                            };
-
-                            let mut result = TOOL_CTX
-                                .scope(make_ctx(), bg_tools.execute(&bg_name, &bg_args))
-                                .await;
-
-                            // Retry once on transient failure (e.g. ominix-api restart)
-                            if let Ok(ref r) = result {
-                                if !r.success && (r.output.contains("error sending request") || r.output.contains("connection refused")) {
-                                    tracing::warn!(tool = %bg_name, "spawn_only tool failed (transient), retrying in 5s");
-                                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                                    result = TOOL_CTX.scope(make_ctx(), bg_tools.execute(&bg_name, &bg_args)).await;
-                                }
-                            }
-
-                            match result {
-                                Ok(r) if r.success => {
-                                    tracing::info!(
-                                        tool = %bg_name,
-                                        success = true,
-                                        "spawn_only background tool completed"
-                                    );
-                                    match enforce_spawn_task_contract(
-                                        &bg_tools,
-                                        &bg_name,
-                                        &bg_tc_id,
-                                        &r.files_to_send,
-                                        bg_started_at,
-                                        Some((&bg_supervisor, &task_id)),
-                                    )
-                                    .await
-                                    {
-                                        SpawnTaskContractResult::Satisfied { output_files } => {
-                                            let result_persisted = if let Some(ref sender) = bg_sender
-                                            {
-                                                sender(BackgroundResultPayload {
-                                                    task_label: bg_name.clone(),
-                                                    content: String::new(),
-                                                    kind: BackgroundResultKind::Notification,
-                                                    media: output_files.clone(),
-                                                })
-                                                .await
-                                            } else {
-                                                false
-                                            };
-
-                                            if result_persisted {
-                                                bg_supervisor
-                                                    .mark_completed(&task_id, output_files.clone());
-                                            } else {
-                                                let err_msg = format!(
-                                                    "verified outputs for {} but failed to persist background result",
-                                                    bg_name
-                                                );
-                                                tracing::warn!(
-                                                    tool = %bg_name,
-                                                    files = ?output_files,
-                                                    "background result persistence failed after contract verification"
-                                                );
-                                                bg_supervisor.mark_failed(&task_id, err_msg);
-                                            }
-                                        }
-                                        SpawnTaskContractResult::Failed {
-                                            error,
-                                            notify_user,
-                                        } => {
-                                            tracing::warn!(
-                                                tool = %bg_name,
-                                                error = %error,
-                                                "workspace contract rejected spawn_only result"
-                                            );
-                                            bg_supervisor.mark_failed(&task_id, error.clone());
-                                            if let Some(ref sender) = bg_sender {
-                                                let content = match notify_user {
-                                                    Some(message) => {
-                                                        format!("✗ {}: {}", message, error)
-                                                    }
-                                                    None => {
-                                                        format!("✗ {} failed: {}", bg_name, error)
-                                                    }
-                                                };
-                                                let _ = sender(BackgroundResultPayload {
-                                                    task_label: bg_name.clone(),
-                                                    content,
-                                                    kind: BackgroundResultKind::Notification,
-                                                    media: vec![],
-                                                })
-                                                .await;
-                                            }
-                                        }
-                                        SpawnTaskContractResult::NotConfigured { required, reason } => {
-                                            if required {
-                                                let err_msg = reason.unwrap_or_else(|| {
-                                                    format!(
-                                                        "workspace contract is required for {} but not configured",
-                                                        bg_name
-                                                    )
-                                                });
-                                                bg_supervisor.mark_failed(&task_id, err_msg.clone());
-                                                if let Some(ref sender) = bg_sender {
-                                                    let _ = sender(BackgroundResultPayload {
-                                                        task_label: bg_name.clone(),
-                                                        content: format!(
-                                                            "✗ {} failed: {}",
-                                                            bg_name, err_msg
-                                                        ),
-                                                        kind: BackgroundResultKind::Notification,
-                                                        media: vec![],
-                                                    })
-                                                    .await;
-                                                }
-                                                return;
-                                            }
-
-                                            if r.files_to_send.is_empty() {
-                                                let err_msg = format!(
-                                                    "completed with no output (stdout: {})",
-                                                    r.output.chars().take(200).collect::<String>()
-                                                );
-                                                tracing::warn!(
-                                                    tool = %bg_name,
-                                                    "spawn_only tool produced no files"
-                                                );
-                                                bg_supervisor.mark_failed(&task_id, err_msg);
-                                                if let Some(ref sender) = bg_sender {
-                                                    let _ = sender(BackgroundResultPayload {
-                                                        task_label: bg_name.clone(),
-                                                        content: format!(
-                                                            "✗ {} failed: no output files produced",
-                                                            bg_name
-                                                        ),
-                                                        kind: BackgroundResultKind::Notification,
-                                                        media: vec![],
-                                                    })
-                                                    .await;
-                                                }
-                                                return;
-                                            }
-
-                                            bg_supervisor.mark_runtime_state(
-                                                &task_id,
-                                                TaskRuntimeState::DeliveringOutputs,
-                                                Some(format!("deliver outputs for {}", bg_name)),
-                                            );
-                                            let mut sent_files = Vec::new();
-                                            let mut delivery_failed = false;
-                                            for file_path in &r.files_to_send {
-                                                let path_str =
-                                                    file_path.to_string_lossy().to_string();
-                                                tracing::info!(
-                                                    tool = %bg_name,
-                                                    file = %path_str,
-                                                    "background auto-sending file"
-                                                );
-                                                let send_args = serde_json::json!({
-                                                    "file_path": path_str,
-                                                    "tool_call_id": bg_tc_id
-                                                });
-                                                let mut delivered = false;
-                                                for attempt in 0..3 {
-                                                    match bg_tools.execute("send_file", &send_args).await {
-                                                        Ok(sr) if sr.success => {
-                                                            tracing::info!(
-                                                                tool = %bg_name,
-                                                                file = %path_str,
-                                                                "background file sent"
-                                                            );
-                                                            sent_files.push(path_str.clone());
-                                                            delivered = true;
-                                                            break;
-                                                        }
-                                                        Ok(sr) => {
-                                                            tracing::warn!(
-                                                                tool = %bg_name,
-                                                                file = %path_str,
-                                                                attempt,
-                                                                error = %sr.output,
-                                                                "background file send failed"
-                                                            );
-                                                        }
-                                                        Err(e) => {
-                                                            tracing::warn!(
-                                                                tool = %bg_name,
-                                                                file = %path_str,
-                                                                attempt,
-                                                                error = %e,
-                                                                "background file send failed"
-                                                            );
-                                                        }
-                                                    }
-                                                    if attempt < 2 {
-                                                        tokio::time::sleep(
-                                                            std::time::Duration::from_secs(3),
-                                                        )
-                                                        .await;
-                                                    }
-                                                }
-                                                if !delivered {
-                                                    delivery_failed = true;
-                                                    tracing::error!(
-                                                        tool = %bg_name,
-                                                        file = %path_str,
-                                                        "file delivery failed after 3 attempts"
-                                                    );
-                                                }
-                                            }
-                                            if delivery_failed || sent_files.len() != r.files_to_send.len() {
-                                                let err_msg = format!(
-                                                    "completed but file delivery failed ({}/{})",
-                                                    sent_files.len(),
-                                                    r.files_to_send.len()
-                                                );
-                                                bg_supervisor.mark_failed(&task_id, err_msg.clone());
-                                                if let Some(ref sender) = bg_sender {
-                                                    let _ = sender(BackgroundResultPayload {
-                                                        task_label: bg_name.clone(),
-                                                        content: format!(
-                                                            "✗ {} failed: {}",
-                                                            bg_name, err_msg
-                                                        ),
-                                                        kind: BackgroundResultKind::Notification,
-                                                        media: vec![],
-                                                    })
-                                                    .await;
-                                                }
-                                            } else {
-                                                bg_supervisor
-                                                    .mark_completed(&task_id, sent_files.clone());
-                                                let file_info = format!(
-                                                    " ({})",
-                                                    sent_files
-                                                        .iter()
-                                                        .map(|f| f.rsplit('/').next().unwrap_or(f))
-                                                        .collect::<Vec<_>>()
-                                                        .join(", ")
-                                                );
-                                                if let Some(ref sender) = bg_sender {
-                                                    let _ = sender(BackgroundResultPayload {
-                                                        task_label: bg_name.clone(),
-                                                        content: format!(
-                                                            "✓ {} completed{}",
-                                                            bg_name, file_info
-                                                        ),
-                                                        kind: BackgroundResultKind::Notification,
-                                                        media: vec![],
-                                                    })
-                                                    .await;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                Ok(r) => {
-                                    tracing::warn!(
-                                        tool = %bg_name,
-                                        error = %r.output,
-                                        "spawn_only background tool failed"
-                                    );
-                                    bg_supervisor.mark_failed(&task_id, r.output.clone());
-                                    // Notify session of failure
-                                    if let Some(ref sender) = bg_sender {
-                                        let _ = sender(BackgroundResultPayload {
-                                            task_label: bg_name.clone(),
-                                            content: format!("✗ {} failed: {}", bg_name, r.output),
-                                            kind: BackgroundResultKind::Notification,
-                                            media: vec![],
-                                        })
-                                        .await;
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        tool = %bg_name,
-                                        error = %e,
-                                        "spawn_only background tool error"
-                                    );
-                                    bg_supervisor.mark_failed(&task_id, e.to_string());
-                                    if let Some(ref sender) = bg_sender {
-                                        let _ = sender(BackgroundResultPayload {
-                                            task_label: bg_name.clone(),
-                                            content: format!("✗ {} error: {}", bg_name, e),
-                                            kind: BackgroundResultKind::Notification,
-                                            media: vec![],
-                                        })
-                                        .await;
-                                    }
-                                }
-                            }
-                        });
-                        reporter.report(ProgressEvent::ToolCompleted {
-                            name: tc_name.clone(),
-                            tool_id: tc_id.clone(),
-                            success: true,
-                            output_preview: "Running in background — audio will be sent when ready.".into(),
-                            duration: tool_start.elapsed(),
-                        });
+                        let deny_msg = if reason.is_empty() {
+                            format!(
+                                "[HOOK DENIED] Tool '{}' was blocked by a lifecycle hook. Do not retry.",
+                                tc_name
+                            )
+                        } else {
+                            format!(
+                                "[HOOK DENIED] Tool '{}' was blocked: {}. Do not retry.",
+                                tc_name, reason
+                            )
+                        };
                         return (
                             Message {
                                 role: MessageRole::Tool,
-                                content: tools.spawn_only_message(&tc_name),
+                                content: deny_msg,
                                 media: vec![],
                                 tool_calls: None,
                                 tool_call_id: Some(tc_id),
@@ -496,203 +166,579 @@ impl Agent {
                             Vec::new(),
                             Vec::new(),
                             None,
+                            false, // hook denial is a failure — cascade in serial mode
                         );
                     }
+                    HookResult::Modified(new_args) => {
+                        tracing::info!(
+                            tool = %tc_name,
+                            "hook modified tool arguments"
+                        );
+                        effective_args = new_args;
+                    }
+                    _ => {}
+                }
+            }
 
-                    let ctx = ToolContext {
-                        tool_id: tc_id.clone(),
-                        reporter: reporter.clone(),
+            // Auto-background spawn_only tools: run the tool in a background
+            // tokio task and return immediately. The tool's files_to_send
+            // auto-delivers the result to the user. No subagent LLM needed.
+            if tools.is_spawn_only(&tc_name) {
+                tracing::info!(
+                    tool = %tc_name,
+                    "running spawn_only tool in background"
+                );
+                let bg_tools = tools.clone();
+                let bg_name = tc_name.clone();
+                let bg_args = effective_args.clone();
+                let bg_sender = tools.background_result_sender();
+                let bg_tc_id = tc_id.clone();
+                let task_id = tools.register_task(&tc_name, &tc_id);
+                tools.mark_spawn_only_invoked();
+                let bg_supervisor = tools.supervisor();
+                let bg_reporter = reporter.clone();
+                let bg_attachment_ctx = attachment_ctx.clone();
+                tokio::spawn(async move {
+                    bg_supervisor.mark_running(&task_id);
+                    let bg_started_at = std::time::SystemTime::now();
+
+                    // Helper to create TOOL_CTX for plugin stderr progress streaming.
+                    // Base it on the zero-value context so M8.x placeholder fields
+                    // carry their default-populated values.
+                    let make_ctx = || ToolContext {
+                        tool_id: bg_tc_id.clone(),
+                        reporter: bg_reporter.clone(),
                         harness_event_sink: harness_event_sink.clone(),
-                        attachment_paths: attachment_ctx.attachment_paths.clone(),
-                        audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
-                        file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),
+                        attachment_paths: bg_attachment_ctx.attachment_paths.clone(),
+                        audio_attachment_paths: bg_attachment_ctx.audio_attachment_paths.clone(),
+                        file_attachment_paths: bg_attachment_ctx.file_attachment_paths.clone(),
                         ..ToolContext::zero()
                     };
-                    // Thread the typed context into execute_with_context. Legacy tools
-                    // whose trait impl only overrides `execute` still work via the
-                    // default delegation path; migrated tools read the typed fields.
-                    // TOOL_CTX is still scoped for plugin tools that read the task-local.
-                    let result = TOOL_CTX
-                        .scope(
-                            ctx.clone(),
-                            tools.execute_with_context(&ctx, &tc_name, &effective_args),
-                        )
+
+                    let mut result = TOOL_CTX
+                        .scope(make_ctx(), bg_tools.execute(&bg_name, &bg_args))
                         .await;
 
-                    let duration = tool_start.elapsed();
-
-                    let (
-                        content,
-                        tool_files_modified,
-                        tool_files_to_send,
-                        tool_tokens,
-                        tool_success,
-                    ) = match result {
-                        Ok(tool_result) => {
-                            debug!(
-                                tool = %tc_name,
-                                success = tool_result.success,
-                                duration_ms = duration.as_millis() as u64,
-                                "tool completed"
-                            );
-
-                            if let Some(ref file) = tool_result.file_modified {
-                                info!(tool = %tc_name, file = %file.display(), "file modified");
-                                reporter.report(ProgressEvent::FileModified {
-                                    path: file.display().to_string(),
-                                });
-                            }
-
-                            if should_auto_send_tool_files(
-                                suppress_auto_send_files,
-                                explicit_send_file_requested,
-                                &tc_name,
-                            ) {
-                                // Auto-send files explicitly declared by the plugin via files_to_send.
-                                // No heuristic path detection — plugins must opt-in by including
-                                // "files_to_send": ["/path/to/file"] in their JSON output.
-                                let files: Vec<String> = tool_result.files_to_send
-                                    .iter()
-                                    .map(|p| p.to_string_lossy().to_string())
-                                    .collect();
-
-                                for path_str in &files {
-                                    info!(tool = %tc_name, file = %path_str, "auto-sending file to user");
-                                    let send_args = serde_json::json!({"file_path": path_str, "tool_call_id": tc_id});
-                                    match tools.execute("send_file", &send_args).await {
-                                        Ok(r) if r.success => {
-                                            info!(tool = %tc_name, file = %path_str, "file auto-sent");
-                                        }
-                                        Ok(r) => {
-                                            warn!(tool = %tc_name, file = %path_str, error = %r.output, "auto-send failed");
-                                        }
-                                        Err(e) => {
-                                            warn!(tool = %tc_name, file = %path_str, error = %e, "auto-send failed");
-                                        }
-                                    }
-                                }
-                            } else if explicit_send_file_requested
-                                && tc_name != "send_file"
-                                && !tool_result.files_to_send.is_empty()
-                            {
-                                debug!(
-                                    tool = %tc_name,
-                                    "skipping auto-send because the same model turn already issued send_file"
-                                );
-                            }
-
-                            let mut tool_files_modified = Vec::new();
-                            if let Some(file) = tool_result.file_modified.clone() {
-                                tool_files_modified.push(file);
-                            }
-                            let tool_files_to_send = tool_result.files_to_send.clone();
-
-                            let output_preview =
-                                octos_core::truncated_utf8(&tool_result.output, 200, "...");
-
-                            reporter.report(ProgressEvent::ToolCompleted {
-                                name: tc_name.clone(),
-                                tool_id: tc_id.clone(),
-                                success: tool_result.success,
-                                output_preview,
-                                duration,
-                            });
-
-                            let success = tool_result.success;
-                            (
-                                tool_result.output,
-                                tool_files_modified,
-                                tool_files_to_send,
-                                tool_result.tokens_used,
-                                success,
-                            )
+                    // Retry once on transient failure (e.g. ominix-api restart)
+                    if let Ok(ref r) = result {
+                        if !r.success
+                            && (r.output.contains("error sending request")
+                                || r.output.contains("connection refused"))
+                        {
+                            tracing::warn!(tool = %bg_name, "spawn_only tool failed (transient), retrying in 5s");
+                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                            result = TOOL_CTX
+                                .scope(make_ctx(), bg_tools.execute(&bg_name, &bg_args))
+                                .await;
                         }
-                        Err(e) => {
-                            // Classify the tool failure as a typed HarnessError.
-                            // Invariant #1 (#488): every raw tool error escape
-                            // must be routed through classification so the
-                            // metrics counter and the sink event both fire.
-                            let classified =
-                                HarnessError::classify_report(&e, Some(tc_name.as_str()));
-                            classified.record_metric();
-                            if let Some(sink) = harness_event_sink.as_deref() {
-                                if let Some(ctx) = lookup_event_sink_context(sink) {
-                                    let event = classified.to_event(
-                                        ctx.session_id,
-                                        ctx.task_id,
-                                        None,
-                                        None,
-                                    );
-                                    if let Err(error) = write_event_to_sink(sink, &event) {
-                                        tracing::debug!(
-                                            error = %error,
-                                            "failed to write tool-failure harness error event"
-                                        );
-                                    }
-                                }
-                            }
-                            warn!(
-                                tool = %tc_name,
-                                error = %e,
-                                variant = classified.variant_name(),
-                                recovery = %classified.recovery_hint(),
-                                duration_ms = duration.as_millis() as u64,
-                                "tool failed"
-                            );
-
-                            reporter.report(ProgressEvent::ToolCompleted {
-                                name: tc_name.clone(),
-                                tool_id: tc_id.clone(),
-                                success: false,
-                                output_preview: e.to_string(),
-                                duration,
-                            });
-
-                            (
-                                format!("Error: {e}"),
-                                Vec::new(),
-                                Vec::new(),
-                                None,
-                                false,
-                            )
-                        }
-                    };
-
-                    // After-tool hook (fire-and-forget)
-                    if let Some(ref hooks) = hooks {
-                        let payload = HookPayload::after_tool(
-                            &tc_name,
-                            &tc_id,
-                            octos_core::truncated_utf8(&content, 500, "..."),
-                            tool_success,
-                            duration.as_millis() as u64,
-                            hook_ctx.as_ref(),
-                        );
-                        let _ = hooks.run(HookEvent::AfterToolCall, &payload).await;
                     }
 
-                    // Per-tool output truncation with head/tail split
-                    let limit = octos_core::tool_output_limit(&tc_name);
-                    let content = octos_core::truncate_head_tail(&content, limit, 0.7);
-                    let content = crate::sanitize::sanitize_tool_output(&content);
+                    match result {
+                        Ok(r) if r.success => {
+                            tracing::info!(
+                                tool = %bg_name,
+                                success = true,
+                                "spawn_only background tool completed"
+                            );
+                            match enforce_spawn_task_contract(
+                                &bg_tools,
+                                &bg_name,
+                                &bg_tc_id,
+                                &r.files_to_send,
+                                bg_started_at,
+                                Some((&bg_supervisor, &task_id)),
+                            )
+                            .await
+                            {
+                                SpawnTaskContractResult::Satisfied { output_files } => {
+                                    let result_persisted = if let Some(ref sender) = bg_sender {
+                                        sender(BackgroundResultPayload {
+                                            task_label: bg_name.clone(),
+                                            content: String::new(),
+                                            kind: BackgroundResultKind::Notification,
+                                            media: output_files.clone(),
+                                        })
+                                        .await
+                                    } else {
+                                        false
+                                    };
 
-                    (
-                        Message {
-                            role: MessageRole::Tool,
-                            content,
-                            media: vec![],
-                            tool_calls: None,
-                            tool_call_id: Some(tc_id),
-                            reasoning_content: None,
-                            timestamp: chrono::Utc::now(),
-                        },
-                        tool_files_modified,
-                        tool_files_to_send,
-                        tool_tokens,
-                    )
-                })
-            })
+                                    if result_persisted {
+                                        bg_supervisor
+                                            .mark_completed(&task_id, output_files.clone());
+                                    } else {
+                                        let err_msg = format!(
+                                            "verified outputs for {} but failed to persist background result",
+                                            bg_name
+                                        );
+                                        tracing::warn!(
+                                            tool = %bg_name,
+                                            files = ?output_files,
+                                            "background result persistence failed after contract verification"
+                                        );
+                                        bg_supervisor.mark_failed(&task_id, err_msg);
+                                    }
+                                }
+                                SpawnTaskContractResult::Failed { error, notify_user } => {
+                                    tracing::warn!(
+                                        tool = %bg_name,
+                                        error = %error,
+                                        "workspace contract rejected spawn_only result"
+                                    );
+                                    bg_supervisor.mark_failed(&task_id, error.clone());
+                                    if let Some(ref sender) = bg_sender {
+                                        let content = match notify_user {
+                                            Some(message) => {
+                                                format!("✗ {}: {}", message, error)
+                                            }
+                                            None => {
+                                                format!("✗ {} failed: {}", bg_name, error)
+                                            }
+                                        };
+                                        let _ = sender(BackgroundResultPayload {
+                                            task_label: bg_name.clone(),
+                                            content,
+                                            kind: BackgroundResultKind::Notification,
+                                            media: vec![],
+                                        })
+                                        .await;
+                                    }
+                                }
+                                SpawnTaskContractResult::NotConfigured { required, reason } => {
+                                    if required {
+                                        let err_msg = reason.unwrap_or_else(|| {
+                                            format!(
+                                                "workspace contract is required for {} but not configured",
+                                                bg_name
+                                            )
+                                        });
+                                        bg_supervisor.mark_failed(&task_id, err_msg.clone());
+                                        if let Some(ref sender) = bg_sender {
+                                            let _ = sender(BackgroundResultPayload {
+                                                task_label: bg_name.clone(),
+                                                content: format!(
+                                                    "✗ {} failed: {}",
+                                                    bg_name, err_msg
+                                                ),
+                                                kind: BackgroundResultKind::Notification,
+                                                media: vec![],
+                                            })
+                                            .await;
+                                        }
+                                        return;
+                                    }
+
+                                    if r.files_to_send.is_empty() {
+                                        let err_msg = format!(
+                                            "completed with no output (stdout: {})",
+                                            r.output.chars().take(200).collect::<String>()
+                                        );
+                                        tracing::warn!(
+                                            tool = %bg_name,
+                                            "spawn_only tool produced no files"
+                                        );
+                                        bg_supervisor.mark_failed(&task_id, err_msg);
+                                        if let Some(ref sender) = bg_sender {
+                                            let _ = sender(BackgroundResultPayload {
+                                                task_label: bg_name.clone(),
+                                                content: format!(
+                                                    "✗ {} failed: no output files produced",
+                                                    bg_name
+                                                ),
+                                                kind: BackgroundResultKind::Notification,
+                                                media: vec![],
+                                            })
+                                            .await;
+                                        }
+                                        return;
+                                    }
+
+                                    bg_supervisor.mark_runtime_state(
+                                        &task_id,
+                                        TaskRuntimeState::DeliveringOutputs,
+                                        Some(format!("deliver outputs for {}", bg_name)),
+                                    );
+                                    let mut sent_files = Vec::new();
+                                    let mut delivery_failed = false;
+                                    for file_path in &r.files_to_send {
+                                        let path_str = file_path.to_string_lossy().to_string();
+                                        tracing::info!(
+                                            tool = %bg_name,
+                                            file = %path_str,
+                                            "background auto-sending file"
+                                        );
+                                        let send_args = serde_json::json!({
+                                            "file_path": path_str,
+                                            "tool_call_id": bg_tc_id
+                                        });
+                                        let mut delivered = false;
+                                        for attempt in 0..3 {
+                                            match bg_tools.execute("send_file", &send_args).await {
+                                                Ok(sr) if sr.success => {
+                                                    tracing::info!(
+                                                        tool = %bg_name,
+                                                        file = %path_str,
+                                                        "background file sent"
+                                                    );
+                                                    sent_files.push(path_str.clone());
+                                                    delivered = true;
+                                                    break;
+                                                }
+                                                Ok(sr) => {
+                                                    tracing::warn!(
+                                                        tool = %bg_name,
+                                                        file = %path_str,
+                                                        attempt,
+                                                        error = %sr.output,
+                                                        "background file send failed"
+                                                    );
+                                                }
+                                                Err(e) => {
+                                                    tracing::warn!(
+                                                        tool = %bg_name,
+                                                        file = %path_str,
+                                                        attempt,
+                                                        error = %e,
+                                                        "background file send failed"
+                                                    );
+                                                }
+                                            }
+                                            if attempt < 2 {
+                                                tokio::time::sleep(std::time::Duration::from_secs(
+                                                    3,
+                                                ))
+                                                .await;
+                                            }
+                                        }
+                                        if !delivered {
+                                            delivery_failed = true;
+                                            tracing::error!(
+                                                tool = %bg_name,
+                                                file = %path_str,
+                                                "file delivery failed after 3 attempts"
+                                            );
+                                        }
+                                    }
+                                    if delivery_failed || sent_files.len() != r.files_to_send.len()
+                                    {
+                                        let err_msg = format!(
+                                            "completed but file delivery failed ({}/{})",
+                                            sent_files.len(),
+                                            r.files_to_send.len()
+                                        );
+                                        bg_supervisor.mark_failed(&task_id, err_msg.clone());
+                                        if let Some(ref sender) = bg_sender {
+                                            let _ = sender(BackgroundResultPayload {
+                                                task_label: bg_name.clone(),
+                                                content: format!(
+                                                    "✗ {} failed: {}",
+                                                    bg_name, err_msg
+                                                ),
+                                                kind: BackgroundResultKind::Notification,
+                                                media: vec![],
+                                            })
+                                            .await;
+                                        }
+                                    } else {
+                                        bg_supervisor.mark_completed(&task_id, sent_files.clone());
+                                        let file_info = format!(
+                                            " ({})",
+                                            sent_files
+                                                .iter()
+                                                .map(|f| f.rsplit('/').next().unwrap_or(f))
+                                                .collect::<Vec<_>>()
+                                                .join(", ")
+                                        );
+                                        if let Some(ref sender) = bg_sender {
+                                            let _ = sender(BackgroundResultPayload {
+                                                task_label: bg_name.clone(),
+                                                content: format!(
+                                                    "✓ {} completed{}",
+                                                    bg_name, file_info
+                                                ),
+                                                kind: BackgroundResultKind::Notification,
+                                                media: vec![],
+                                            })
+                                            .await;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Ok(r) => {
+                            tracing::warn!(
+                                tool = %bg_name,
+                                error = %r.output,
+                                "spawn_only background tool failed"
+                            );
+                            bg_supervisor.mark_failed(&task_id, r.output.clone());
+                            // Notify session of failure
+                            if let Some(ref sender) = bg_sender {
+                                let _ = sender(BackgroundResultPayload {
+                                    task_label: bg_name.clone(),
+                                    content: format!("✗ {} failed: {}", bg_name, r.output),
+                                    kind: BackgroundResultKind::Notification,
+                                    media: vec![],
+                                })
+                                .await;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                tool = %bg_name,
+                                error = %e,
+                                "spawn_only background tool error"
+                            );
+                            bg_supervisor.mark_failed(&task_id, e.to_string());
+                            if let Some(ref sender) = bg_sender {
+                                let _ = sender(BackgroundResultPayload {
+                                    task_label: bg_name.clone(),
+                                    content: format!("✗ {} error: {}", bg_name, e),
+                                    kind: BackgroundResultKind::Notification,
+                                    media: vec![],
+                                })
+                                .await;
+                            }
+                        }
+                    }
+                });
+                reporter.report(ProgressEvent::ToolCompleted {
+                    name: tc_name.clone(),
+                    tool_id: tc_id.clone(),
+                    success: true,
+                    output_preview: "Running in background — audio will be sent when ready.".into(),
+                    duration: tool_start.elapsed(),
+                });
+                return (
+                    Message {
+                        role: MessageRole::Tool,
+                        content: tools.spawn_only_message(&tc_name),
+                        media: vec![],
+                        tool_calls: None,
+                        tool_call_id: Some(tc_id),
+                        reasoning_content: None,
+                        timestamp: chrono::Utc::now(),
+                    },
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                    true, // spawn_only placeholder is reported as success
+                );
+            }
+
+            let ctx = ToolContext {
+                tool_id: tc_id.clone(),
+                reporter: reporter.clone(),
+                harness_event_sink: harness_event_sink.clone(),
+                attachment_paths: attachment_ctx.attachment_paths.clone(),
+                audio_attachment_paths: attachment_ctx.audio_attachment_paths.clone(),
+                file_attachment_paths: attachment_ctx.file_attachment_paths.clone(),
+                ..ToolContext::zero()
+            };
+            // Thread the typed context into execute_with_context. Legacy tools
+            // whose trait impl only overrides `execute` still work via the
+            // default delegation path; migrated tools read the typed fields.
+            // TOOL_CTX is still scoped for plugin tools that read the task-local.
+            let result = TOOL_CTX
+                .scope(
+                    ctx.clone(),
+                    tools.execute_with_context(&ctx, &tc_name, &effective_args),
+                )
+                .await;
+
+            let duration = tool_start.elapsed();
+
+            let (content, tool_files_modified, tool_files_to_send, tool_tokens, tool_success) =
+                match result {
+                    Ok(tool_result) => {
+                        debug!(
+                            tool = %tc_name,
+                            success = tool_result.success,
+                            duration_ms = duration.as_millis() as u64,
+                            "tool completed"
+                        );
+
+                        if let Some(ref file) = tool_result.file_modified {
+                            info!(tool = %tc_name, file = %file.display(), "file modified");
+                            reporter.report(ProgressEvent::FileModified {
+                                path: file.display().to_string(),
+                            });
+                        }
+
+                        if should_auto_send_tool_files(
+                            suppress_auto_send_files,
+                            explicit_send_file_requested,
+                            &tc_name,
+                        ) {
+                            // Auto-send files explicitly declared by the plugin via files_to_send.
+                            // No heuristic path detection — plugins must opt-in by including
+                            // "files_to_send": ["/path/to/file"] in their JSON output.
+                            let files: Vec<String> = tool_result
+                                .files_to_send
+                                .iter()
+                                .map(|p| p.to_string_lossy().to_string())
+                                .collect();
+
+                            for path_str in &files {
+                                info!(tool = %tc_name, file = %path_str, "auto-sending file to user");
+                                let send_args = serde_json::json!({"file_path": path_str, "tool_call_id": tc_id});
+                                match tools.execute("send_file", &send_args).await {
+                                    Ok(r) if r.success => {
+                                        info!(tool = %tc_name, file = %path_str, "file auto-sent");
+                                    }
+                                    Ok(r) => {
+                                        warn!(tool = %tc_name, file = %path_str, error = %r.output, "auto-send failed");
+                                    }
+                                    Err(e) => {
+                                        warn!(tool = %tc_name, file = %path_str, error = %e, "auto-send failed");
+                                    }
+                                }
+                            }
+                        } else if explicit_send_file_requested
+                            && tc_name != "send_file"
+                            && !tool_result.files_to_send.is_empty()
+                        {
+                            debug!(
+                                tool = %tc_name,
+                                "skipping auto-send because the same model turn already issued send_file"
+                            );
+                        }
+
+                        let mut tool_files_modified = Vec::new();
+                        if let Some(file) = tool_result.file_modified.clone() {
+                            tool_files_modified.push(file);
+                        }
+                        let tool_files_to_send = tool_result.files_to_send.clone();
+
+                        let output_preview =
+                            octos_core::truncated_utf8(&tool_result.output, 200, "...");
+
+                        reporter.report(ProgressEvent::ToolCompleted {
+                            name: tc_name.clone(),
+                            tool_id: tc_id.clone(),
+                            success: tool_result.success,
+                            output_preview,
+                            duration,
+                        });
+
+                        let success = tool_result.success;
+                        (
+                            tool_result.output,
+                            tool_files_modified,
+                            tool_files_to_send,
+                            tool_result.tokens_used,
+                            success,
+                        )
+                    }
+                    Err(e) => {
+                        // Classify the tool failure as a typed HarnessError.
+                        // Invariant #1 (#488): every raw tool error escape
+                        // must be routed through classification so the
+                        // metrics counter and the sink event both fire.
+                        let classified = HarnessError::classify_report(&e, Some(tc_name.as_str()));
+                        classified.record_metric();
+                        if let Some(sink) = harness_event_sink.as_deref() {
+                            if let Some(ctx) = lookup_event_sink_context(sink) {
+                                let event =
+                                    classified.to_event(ctx.session_id, ctx.task_id, None, None);
+                                if let Err(error) = write_event_to_sink(sink, &event) {
+                                    tracing::debug!(
+                                        error = %error,
+                                        "failed to write tool-failure harness error event"
+                                    );
+                                }
+                            }
+                        }
+                        warn!(
+                            tool = %tc_name,
+                            error = %e,
+                            variant = classified.variant_name(),
+                            recovery = %classified.recovery_hint(),
+                            duration_ms = duration.as_millis() as u64,
+                            "tool failed"
+                        );
+
+                        reporter.report(ProgressEvent::ToolCompleted {
+                            name: tc_name.clone(),
+                            tool_id: tc_id.clone(),
+                            success: false,
+                            output_preview: e.to_string(),
+                            duration,
+                        });
+
+                        (format!("Error: {e}"), Vec::new(), Vec::new(), None, false)
+                    }
+                };
+
+            // After-tool hook (fire-and-forget)
+            if let Some(ref hooks) = hooks {
+                let payload = HookPayload::after_tool(
+                    &tc_name,
+                    &tc_id,
+                    octos_core::truncated_utf8(&content, 500, "..."),
+                    tool_success,
+                    duration.as_millis() as u64,
+                    hook_ctx.as_ref(),
+                );
+                let _ = hooks.run(HookEvent::AfterToolCall, &payload).await;
+            }
+
+            // Per-tool output truncation with head/tail split
+            let limit = octos_core::tool_output_limit(&tc_name);
+            let content = octos_core::truncate_head_tail(&content, limit, 0.7);
+            let content = crate::sanitize::sanitize_tool_output(&content);
+
+            (
+                Message {
+                    role: MessageRole::Tool,
+                    content,
+                    media: vec![],
+                    tool_calls: None,
+                    tool_call_id: Some(tc_id),
+                    reasoning_content: None,
+                    timestamp: chrono::Utc::now(),
+                },
+                tool_files_modified,
+                tool_files_to_send,
+                tool_tokens,
+                tool_success,
+            )
+        })
+    }
+
+    pub(super) async fn execute_tools(
+        &self,
+        response: &ChatResponse,
+    ) -> Result<(
+        Vec<Message>,
+        Vec<std::path::PathBuf>,
+        Vec<std::path::PathBuf>,
+        TokenUsage,
+    )> {
+        let tool_names: Vec<&str> = response
+            .tool_calls
+            .iter()
+            .map(|tc| tc.name.as_str())
             .collect();
+        let explicit_send_file_requested =
+            response.tool_calls.iter().any(|tc| tc.name == "send_file");
+
+        // M8.8 — classify the batch and pick an admission strategy.
+        let any_exclusive = response
+            .tool_calls
+            .iter()
+            .any(|tc| self.tools.concurrency_class(&tc.name) == ConcurrencyClass::Exclusive);
+
+        tracing::info!(
+            parallel_tools = response.tool_calls.len(),
+            tool_names = %tool_names.join(", "),
+            dispatch = if any_exclusive { "serial" } else { "parallel" },
+            "executing tool batch"
+        );
+
+        let turn_attachment_ctx = TURN_ATTACHMENT_CTX
+            .try_with(|ctx| ctx.clone())
+            .unwrap_or_default();
 
         // Let the LLM specify per-tool timeout via `timeout_secs` in tool call args.
         // Use the max of all requested timeouts, clamped to MAX_TOOL_TIMEOUT_SECS.
@@ -710,35 +756,40 @@ impl Agent {
             self.config.tool_timeout_secs
         };
         let tool_timeout = Duration::from_secs(tool_timeout_secs);
-        let results: Vec<_> =
+
+        let results: Vec<ToolCallResult> = if any_exclusive {
+            // Serial admission: run each tool in LLM call order, bail out of
+            // the remaining calls if any one errors and emit synthetic
+            // "cancelled" results so the LLM still sees every tool_call_id.
+            self.execute_serial_batch(
+                response,
+                explicit_send_file_requested,
+                &turn_attachment_ctx,
+                tool_timeout,
+                tool_timeout_secs,
+            )
+            .await
+        } else {
+            // Parallel admission — today's behaviour. Spawn every tool call
+            // as a detached task and join them.
+            let handles: Vec<_> = response
+                .tool_calls
+                .iter()
+                .map(|tool_call| {
+                    self.spawn_tool_task(
+                        tool_call,
+                        explicit_send_file_requested,
+                        &turn_attachment_ctx,
+                    )
+                })
+                .collect();
+
             match tokio::time::timeout(tool_timeout, futures::future::join_all(handles)).await {
-                Ok(results) => {
-                    // Unwrap JoinHandle results -- panics in tool tasks become errors
-                    results
-                        .into_iter()
-                        .zip(response.tool_calls.iter())
-                        .map(|(r, tc)| {
-                            r.unwrap_or_else(|e| {
-                                // Task panicked -- return error with tool_call_id so
-                                // the LLM knows which tool failed.
-                                (
-                                    Message {
-                                        role: MessageRole::Tool,
-                                        content: format!("Tool '{}' panicked: {e}", tc.name),
-                                        media: vec![],
-                                        tool_calls: None,
-                                        tool_call_id: Some(tc.id.clone()),
-                                        reasoning_content: None,
-                                        timestamp: chrono::Utc::now(),
-                                    },
-                                    Vec::new(),
-                                    Vec::new(),
-                                    None,
-                                )
-                            })
-                        })
-                        .collect()
-                }
+                Ok(results) => results
+                    .into_iter()
+                    .zip(response.tool_calls.iter())
+                    .map(|(r, tc)| r.unwrap_or_else(|e| panic_result(tc, &e.to_string())))
+                    .collect(),
                 Err(_) => {
                     tracing::error!(
                         timeout_secs = tool_timeout_secs,
@@ -746,12 +797,10 @@ impl Agent {
                         tools = %tool_names.join(", "),
                         "tool execution timed out -- spawned tasks continue running for cleanup"
                     );
-                    // Note: spawned tasks are NOT aborted -- they continue running so
-                    // tools can perform their own cleanup (browser kills Chrome, etc.).
-                    // They will eventually complete via their own internal timeouts.
-                    let mut messages = Vec::with_capacity(response.tool_calls.len());
-                    for tc in &response.tool_calls {
-                        messages.push(Message {
+                    let messages = response
+                        .tool_calls
+                        .iter()
+                        .map(|tc| Message {
                             role: MessageRole::Tool,
                             content: format!(
                                 "Tool '{}' timed out after {} seconds",
@@ -762,29 +811,34 @@ impl Agent {
                             tool_call_id: Some(tc.id.clone()),
                             reasoning_content: None,
                             timestamp: chrono::Utc::now(),
-                        });
-                    }
+                        })
+                        .collect();
                     return Ok((messages, vec![], vec![], TokenUsage::default()));
                 }
-            };
+            }
+        };
 
-        // Log completion of all parallel tools
-        let result_sizes: Vec<usize> = results.iter().map(|(m, _, _, _)| m.content.len()).collect();
+        // Log completion of the tool batch.
+        let result_sizes: Vec<usize> = results
+            .iter()
+            .map(|(m, _, _, _, _)| m.content.len())
+            .collect();
         let total_result_bytes: usize = result_sizes.iter().sum();
         tracing::info!(
             parallel_tools = results.len(),
+            dispatch = if any_exclusive { "serial" } else { "parallel" },
             result_sizes = %result_sizes.iter().map(|s| s.to_string()).collect::<Vec<_>>().join(", "),
             total_result_bytes,
-            "all parallel tools completed"
+            "all tools in batch completed"
         );
 
-        // Aggregate results -- join_all preserves input order.
+        // Aggregate results -- order is preserved by both dispatch paths.
         let mut messages = Vec::with_capacity(results.len());
         let mut files_modified = Vec::new();
         let mut files_to_send = Vec::new();
         let mut tokens_used = TokenUsage::default();
 
-        for (message, tool_files_modified, tool_files_to_send, tool_tokens) in results {
+        for (message, tool_files_modified, tool_files_to_send, tool_tokens, _success) in results {
             messages.push(message);
             files_modified.extend(tool_files_modified);
             files_to_send.extend(tool_files_to_send);
@@ -796,6 +850,139 @@ impl Agent {
 
         Ok((messages, files_modified, files_to_send, tokens_used))
     }
+
+    /// Serial dispatch for batches that contain at least one Exclusive tool (M8.8).
+    ///
+    /// Each tool call runs to completion before the next one is spawned. If
+    /// any call's result message reports a failure (success=false), every
+    /// remaining peer is skipped and receives a synthetic "cancelled due to
+    /// sibling error" [`Message`] so the LLM sees a 1:1 mapping from its
+    /// `tool_call_id`s to results.
+    ///
+    /// The batch-level timeout is enforced per call by wrapping the
+    /// single-call [`JoinHandle`] in `tokio::time::timeout`. A timeout on any
+    /// one call fails that call and cascades to its peers the same way a
+    /// regular error does.
+    async fn execute_serial_batch(
+        &self,
+        response: &ChatResponse,
+        explicit_send_file_requested: bool,
+        turn_attachment_ctx: &crate::tools::TurnAttachmentContext,
+        tool_timeout: Duration,
+        tool_timeout_secs: u64,
+    ) -> Vec<ToolCallResult> {
+        let mut results: Vec<ToolCallResult> = Vec::with_capacity(response.tool_calls.len());
+        let mut cancelled = false;
+
+        for (idx, tool_call) in response.tool_calls.iter().enumerate() {
+            if cancelled {
+                let skipped = response.tool_calls.len() - idx;
+                tracing::info!(
+                    tool = %tool_call.name,
+                    tool_id = %tool_call.id,
+                    skipped_peers = skipped,
+                    "cancelling remaining tool call in serial batch after sibling error"
+                );
+                results.push(cancelled_result(tool_call));
+                continue;
+            }
+
+            let handle =
+                self.spawn_tool_task(tool_call, explicit_send_file_requested, turn_attachment_ctx);
+
+            let outcome = match tokio::time::timeout(tool_timeout, handle).await {
+                Ok(Ok(r)) => r,
+                Ok(Err(e)) => {
+                    tracing::warn!(
+                        tool = %tool_call.name,
+                        error = %e,
+                        "serial tool task panicked"
+                    );
+                    panic_result(tool_call, &e.to_string())
+                }
+                Err(_) => {
+                    tracing::error!(
+                        timeout_secs = tool_timeout_secs,
+                        tool = %tool_call.name,
+                        tool_id = %tool_call.id,
+                        "serial tool execution timed out"
+                    );
+                    (
+                        Message {
+                            role: MessageRole::Tool,
+                            content: format!(
+                                "Tool '{}' timed out after {} seconds",
+                                tool_call.name, tool_timeout_secs
+                            ),
+                            media: vec![],
+                            tool_calls: None,
+                            tool_call_id: Some(tool_call.id.clone()),
+                            reasoning_content: None,
+                            timestamp: chrono::Utc::now(),
+                        },
+                        Vec::new(),
+                        Vec::new(),
+                        None,
+                        false,
+                    )
+                }
+            };
+
+            // The per-call success bit (the 5-th tuple element) drives the
+            // cascade. Every failure path in `spawn_tool_task` — tool error,
+            // hook denial, panic, timeout — sets it to `false`, so we do not
+            // need to peek at the message content.
+            let failed = !outcome.4;
+            results.push(outcome);
+            if failed {
+                cancelled = true;
+            }
+        }
+
+        results
+    }
+}
+
+/// Build a synthetic tool-result message for a peer that was cancelled after
+/// a sibling tool errored in a serial (M8.8) batch.
+fn cancelled_result(tool_call: &octos_core::ToolCall) -> ToolCallResult {
+    (
+        Message {
+            role: MessageRole::Tool,
+            content: format!(
+                "Tool '{}' cancelled due to earlier sibling error in the same batch. Re-issue this call on the next turn if still needed.",
+                tool_call.name
+            ),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tool_call.id.clone()),
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        },
+        Vec::new(),
+        Vec::new(),
+        None,
+        false,
+    )
+}
+
+/// Build a tool-result message describing a panic inside a spawned tool task.
+fn panic_result(tool_call: &octos_core::ToolCall, reason: &str) -> ToolCallResult {
+    (
+        Message {
+            role: MessageRole::Tool,
+            content: format!("Tool '{}' panicked: {}", tool_call.name, reason),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tool_call.id.clone()),
+            reasoning_content: None,
+            timestamp: chrono::Utc::now(),
+        },
+        Vec::new(),
+        Vec::new(),
+        None,
+        false,
+    )
 }
 
 #[cfg(test)]

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -102,7 +102,7 @@ pub use task_supervisor::{
 };
 pub use tools::{
     ActivateToolsTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,
-    CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConfigureToolTool,
+    CheckBackgroundTasksTool, CheckWorkspaceContractTool, ConcurrencyClass, ConfigureToolTool,
     DEFAULT_DISPATCH_TIMEOUT_SECS, DEFAULT_HTTP_CONNECT_TIMEOUT_SECS,
     DEFAULT_HTTP_READ_TIMEOUT_SECS, DELEGATED_DENY_GROUP, DELEGATION_METRIC, DeepSearchTool,
     DelegateTool, DelegationEvent, DelegationOutcome, DepthBudget, DiffEditTool, DispatchOutcome,

--- a/crates/octos-agent/src/tools/diff_edit.rs
+++ b/crates/octos-agent/src/tools/diff_edit.rs
@@ -7,7 +7,7 @@ use eyre::{Result, WrapErr};
 use serde::Deserialize;
 use tracing::warn;
 
-use super::{Tool, ToolResult};
+use super::{ConcurrencyClass, Tool, ToolResult};
 
 /// Tool for editing files via unified diff format with fuzzy matching.
 pub struct DiffEditTool {
@@ -41,6 +41,12 @@ impl Tool for DiffEditTool {
 
     fn tags(&self) -> &[&str] {
         &["fs", "code"]
+    }
+
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        // diff_edit writes back to disk after applying the patch — the same
+        // race hazard as write_file / edit_file. Serialize. See M8.8.
+        ConcurrencyClass::Exclusive
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -325,6 +331,15 @@ fn matches_at(lines: &[String], pattern: &[&str], start: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn diff_edit_tool_is_exclusive() {
+        // diff_edit writes back after applying the patch — same race hazard
+        // as write_file; must serialize (M8.8).
+        let dir = tempfile::tempdir().unwrap();
+        let tool = DiffEditTool::new(dir.path());
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Exclusive);
+    }
 
     #[test]
     fn test_parse_simple_diff() {

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -7,7 +7,7 @@ use eyre::{Result, WrapErr};
 use serde::Deserialize;
 use tracing::warn;
 
-use super::{Tool, ToolResult};
+use super::{ConcurrencyClass, Tool, ToolResult};
 
 /// Tool for editing files via string replacement.
 pub struct EditFileTool {
@@ -43,6 +43,12 @@ impl Tool for EditFileTool {
 
     fn tags(&self) -> &[&str] {
         &["fs", "code"]
+    }
+
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        // edit_file rewrites a file in place — same race hazard as
+        // write_file. Serialize the whole batch. See M8.8.
+        ConcurrencyClass::Exclusive
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -143,6 +149,15 @@ impl Tool for EditFileTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn edit_file_tool_is_exclusive() {
+        // edit_file rewrites the target file; parallel read_file would race
+        // on in-flight content, so it must serialize (M8.8).
+        let dir = tempfile::tempdir().unwrap();
+        let tool = EditFileTool::new(dir.path());
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Exclusive);
+    }
 
     #[tokio::test]
     async fn test_edit_file_basic_replacement() {

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -231,6 +231,35 @@ pub enum ToolProgress {
     Intermediate { summary: String },
 }
 
+/// Concurrency class of a tool — controls how the executor admits tool calls
+/// into a parallel batch (M8.8).
+///
+/// The executor unconditionally ran every tool call in parallel before M8.8.
+/// This was unsafe in the presence of mutating tools: a `shell && rm foo`
+/// dispatched concurrently with `read_file foo/x` could race and return
+/// inconsistent observations to the LLM. Claude Code's
+/// `StreamingToolExecutor.ts` classifies tools via `isConcurrencySafe()` —
+/// this mirrors that pattern at the trait surface.
+///
+/// Admission policy (implemented in `agent::execution`):
+/// - If every call in the batch is [`ConcurrencyClass::Safe`], the batch
+///   dispatches in parallel (today's behaviour).
+/// - If *any* call is [`ConcurrencyClass::Exclusive`], the entire batch runs
+///   serially in call order. A single error from an exclusive call cancels
+///   the remaining peers so the LLM sees the cascade instead of continuing
+///   to mutate state on a doomed path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConcurrencyClass {
+    /// Read-only / side-effect-free. Can run in parallel with any other
+    /// `Safe` tool call without observable interference.
+    #[default]
+    Safe,
+    /// Mutating or stateful (writes files, spawns shells, updates memory).
+    /// Must run serialized: no other tool call runs concurrently while an
+    /// `Exclusive` call is in-flight.
+    Exclusive,
+}
+
 /// Result of executing a tool.
 #[derive(Default)]
 pub struct ToolResult {
@@ -312,6 +341,17 @@ pub trait Tool: Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any {
         // Default: no downcasting. Override in tools that need it.
         &()
+    }
+
+    /// Concurrency class for parallel-batch admission (M8.8).
+    ///
+    /// The default is [`ConcurrencyClass::Safe`] so pre-M8.8 tools keep their
+    /// parallel-friendly behaviour. Mutating or stateful tools override this
+    /// and return [`ConcurrencyClass::Exclusive`] — see each tool's doc for
+    /// rationale. The executor (in `agent::execution`) uses the class to
+    /// decide whether a batch may fan out in parallel or must serialize.
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        ConcurrencyClass::Safe
     }
 }
 
@@ -991,5 +1031,54 @@ mod tool_context_tests {
         // tool_id is empty because ToolContext::zero() carries no id.
         assert!(result.output.starts_with("tool_id=;"));
         assert_eq!(tool.with_ctx_calls.load(Ordering::SeqCst), 1);
+    }
+
+    // ---------- M8.8 concurrency-class tests ----------
+
+    struct ExclusiveStubTool;
+
+    #[async_trait]
+    impl Tool for ExclusiveStubTool {
+        fn name(&self) -> &str {
+            "exclusive_stub"
+        }
+        fn description(&self) -> &str {
+            "stub"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({})
+        }
+        async fn execute(&self, _args: &Value) -> Result<ToolResult> {
+            Ok(ToolResult::default())
+        }
+        fn concurrency_class(&self) -> ConcurrencyClass {
+            ConcurrencyClass::Exclusive
+        }
+    }
+
+    #[test]
+    fn default_concurrency_class_is_safe() {
+        // A tool that does not override the default must report Safe so that
+        // unmigrated tools keep pre-M8.8 parallel-friendly behaviour.
+        let tool = LegacyTool::new();
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Safe);
+        let ctx_tool = ContextAwareTool::new();
+        assert_eq!(ctx_tool.concurrency_class(), ConcurrencyClass::Safe);
+    }
+
+    #[test]
+    fn override_returns_exclusive() {
+        // A tool that opts into Exclusive must be reported as Exclusive.
+        let tool = ExclusiveStubTool;
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Exclusive);
+    }
+
+    #[test]
+    fn concurrency_class_is_copy_eq_default() {
+        // The enum exposes Copy + Eq + Default as contracted by the M8.8 spec.
+        let a: ConcurrencyClass = ConcurrencyClass::default();
+        let b = a; // Copy
+        assert_eq!(a, b);
+        assert_eq!(ConcurrencyClass::default(), ConcurrencyClass::Safe);
     }
 }

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -187,6 +187,17 @@ impl Tool for ReadFileTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::ConcurrencyClass;
+
+    #[test]
+    fn read_file_tool_is_safe() {
+        // read_file is read-only and side-effect-free — the M8.8 default
+        // class is Safe so the executor can parallel-dispatch it with other
+        // Safe tools.
+        let dir = tempfile::tempdir().unwrap();
+        let tool = ReadFileTool::new(dir.path());
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Safe);
+    }
 
     #[tokio::test]
     async fn test_read_file_basic() {

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -252,6 +252,20 @@ impl ToolRegistry {
         self.tools.get(name).cloned()
     }
 
+    /// Look up the concurrency class of a registered tool (M8.8).
+    ///
+    /// Unknown tools report [`super::ConcurrencyClass::Safe`] — the executor
+    /// defers error handling to `execute()` which bails with `unknown tool`
+    /// rather than letting the admission phase fail silently. Plugin/MCP
+    /// tools report `Safe` today because their wrapper inherits the trait
+    /// default; they will be wired through a declared class in a follow-up.
+    pub fn concurrency_class(&self, name: &str) -> super::ConcurrencyClass {
+        self.tools
+            .get(name)
+            .map(|t| t.concurrency_class())
+            .unwrap_or_default()
+    }
+
     /// Get tool specifications for the LLM, filtered by provider policy if set.
     /// Results are cached and invalidated when the registry is mutated.
     pub fn specs(&self) -> Vec<ToolSpec> {

--- a/crates/octos-agent/src/tools/save_memory.rs
+++ b/crates/octos-agent/src/tools/save_memory.rs
@@ -7,7 +7,7 @@ use eyre::{Result, WrapErr};
 use octos_memory::MemoryStore;
 use serde::Deserialize;
 
-use super::{Tool, ToolResult};
+use super::{ConcurrencyClass, Tool, ToolResult};
 
 /// Tool that saves or updates entity pages in the memory bank.
 pub struct SaveMemoryTool {
@@ -53,6 +53,12 @@ impl Tool for SaveMemoryTool {
          IMPORTANT: When updating an existing entity, first use `recall_memory` to \
          load the current content, then MERGE new information into it before saving. \
          Never discard existing facts — add to or update them."
+    }
+
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        // save_memory writes the memory bank. A parallel recall_memory could
+        // observe a half-written entity. Serialize the whole batch. See M8.8.
+        ConcurrencyClass::Exclusive
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -189,6 +195,19 @@ mod tests {
     }
 
     // --- Tool metadata ---
+
+    #[test]
+    fn save_memory_tool_is_exclusive() {
+        // save_memory writes the memory bank; parallel recall_memory could
+        // read half-written content. Serialize the whole batch (M8.8).
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let store = rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            Arc::new(MemoryStore::open(dir.path()).await.unwrap())
+        });
+        let tool = SaveMemoryTool::new(store);
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Exclusive);
+    }
 
     #[test]
     fn tool_metadata() {

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -10,7 +10,7 @@ use eyre::{Result, WrapErr};
 use serde::Deserialize;
 use tokio::time::timeout;
 
-use super::{Tool, ToolResult};
+use super::{ConcurrencyClass, Tool, ToolResult};
 use crate::policy::{CommandPolicy, Decision, SafePolicy};
 use crate::sandbox::{NoSandbox, Sandbox};
 use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
@@ -157,6 +157,14 @@ impl Tool for ShellTool {
 
     fn tags(&self) -> &[&str] {
         &["runtime", "code"]
+    }
+
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        // Shell commands can mutate the filesystem or spawn long-lived
+        // processes. Running them in parallel with other tool calls races
+        // observable state (e.g. `shell: rm foo` vs `read_file foo/x`), so
+        // shell serializes the whole batch. See M8.8.
+        ConcurrencyClass::Exclusive
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -344,6 +352,14 @@ impl Tool for ShellTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shell_tool_is_exclusive() {
+        // Shell must serialize relative to peers (M8.8) — a mutating command
+        // should never race with a parallel read_file on the same path.
+        let tool = ShellTool::new(std::env::temp_dir());
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Exclusive);
+    }
 
     #[tokio::test]
     async fn test_timeout_clamped_to_max() {

--- a/crates/octos-agent/src/tools/web_fetch.rs
+++ b/crates/octos-agent/src/tools/web_fetch.rs
@@ -273,6 +273,15 @@ fn extract_text(html: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::ConcurrencyClass;
+
+    #[test]
+    fn web_fetch_tool_is_safe() {
+        // web_fetch retrieves remote data; it does not mutate local state
+        // so it keeps the M8.8 default Safe class and can parallel-dispatch.
+        let tool = WebFetchTool::new();
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Safe);
+    }
 
     #[test]
     fn test_extract_text() {

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -7,7 +7,7 @@ use eyre::{Result, WrapErr};
 use serde::Deserialize;
 use tracing::warn;
 
-use super::{Tool, ToolResult};
+use super::{ConcurrencyClass, Tool, ToolResult};
 
 /// Tool for writing/creating files.
 pub struct WriteFileTool {
@@ -42,6 +42,13 @@ impl Tool for WriteFileTool {
 
     fn tags(&self) -> &[&str] {
         &["fs", "code"]
+    }
+
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        // Writing to disk mutates state visible to every other tool. If a
+        // parallel `read_file` targets the same path we'd hand the LLM a
+        // torn view. Serialize the whole batch. See M8.8.
+        ConcurrencyClass::Exclusive
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -112,6 +119,15 @@ impl Tool for WriteFileTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn write_file_tool_is_exclusive() {
+        // write_file mutates disk visible to other tools in the batch,
+        // so it must serialize (M8.8).
+        let dir = tempfile::tempdir().unwrap();
+        let tool = WriteFileTool::new(dir.path());
+        assert_eq!(tool.concurrency_class(), ConcurrencyClass::Exclusive);
+    }
 
     #[tokio::test]
     async fn test_write_file_creates_new() {

--- a/crates/octos-agent/tests/concurrent_scheduler.rs
+++ b/crates/octos-agent/tests/concurrent_scheduler.rs
@@ -1,0 +1,600 @@
+//! M8.8 concurrent-safe vs exclusive scheduler integration tests.
+//!
+//! Drives the `Agent` loop through a mock LLM with scripted tool-call batches
+//! and observes the executor's admission decisions via probe tools that
+//! record start/end timestamps on a shared log. The tests assert on two
+//! invariants:
+//!
+//! 1. A batch composed entirely of [`ConcurrencyClass::Safe`] tools runs in
+//!    parallel (the last start precedes the first end — i.e. windows
+//!    overlap).
+//! 2. A batch that contains *any* [`ConcurrencyClass::Exclusive`] tool runs
+//!    each call serially in LLM call order (every start strictly follows the
+//!    previous end).
+//!
+//! A third test triggers an error cascade: the first Exclusive call fails
+//! and the remaining peers receive a synthetic "cancelled" tool-result
+//! message without being dispatched.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_agent::{Agent, AgentConfig, ConcurrencyClass, Tool, ToolRegistry, ToolResult};
+use octos_core::{AgentId, Message, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+/// Per-call timing record captured by [`ProbeTool`].
+#[derive(Clone, Debug)]
+struct CallSpan {
+    name: String,
+    /// Monotonic microseconds from [`std::time::Instant`] against a shared
+    /// epoch — used to reason about overlap without making assertions about
+    /// wall-clock time.
+    started_us: u128,
+    ended_us: u128,
+}
+
+#[derive(Default)]
+struct CallLog {
+    epoch: Option<std::time::Instant>,
+    spans: Vec<CallSpan>,
+}
+
+impl CallLog {
+    fn new() -> Arc<Mutex<Self>> {
+        Arc::new(Mutex::new(Self::default()))
+    }
+
+    fn epoch(&mut self) -> std::time::Instant {
+        *self.epoch.get_or_insert_with(std::time::Instant::now)
+    }
+
+    fn push(&mut self, span: CallSpan) {
+        self.spans.push(span);
+    }
+
+    fn snapshot(&self) -> Vec<CallSpan> {
+        self.spans.clone()
+    }
+}
+
+/// Instrumented tool that sleeps for a fixed interval to expose the
+/// executor's dispatch strategy (overlap vs serialisation).
+struct ProbeTool {
+    name: &'static str,
+    class: ConcurrencyClass,
+    /// Duration each call sleeps before returning.
+    sleep: Duration,
+    /// Whether this call should return a failed [`ToolResult`].
+    should_fail: bool,
+    log: Arc<Mutex<CallLog>>,
+}
+
+impl ProbeTool {
+    fn new(
+        name: &'static str,
+        class: ConcurrencyClass,
+        sleep: Duration,
+        log: Arc<Mutex<CallLog>>,
+    ) -> Self {
+        Self {
+            name,
+            class,
+            sleep,
+            should_fail: false,
+            log,
+        }
+    }
+
+    fn with_failure(mut self, fail: bool) -> Self {
+        self.should_fail = fail;
+        self
+    }
+}
+
+#[async_trait]
+impl Tool for ProbeTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn description(&self) -> &str {
+        "probe"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        self.class
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        let started_us = {
+            let mut log = self.log.lock().unwrap();
+            let epoch = log.epoch();
+            epoch.elapsed().as_micros()
+        };
+
+        tokio::time::sleep(self.sleep).await;
+
+        let ended_us = {
+            let log = self.log.lock().unwrap();
+            log.epoch.expect("epoch set at start").elapsed().as_micros()
+        };
+
+        {
+            let mut log = self.log.lock().unwrap();
+            log.push(CallSpan {
+                name: self.name.to_string(),
+                started_us,
+                ended_us,
+            });
+        }
+
+        if self.should_fail {
+            Ok(ToolResult {
+                output: format!("{} deliberate failure", self.name),
+                success: false,
+                ..Default::default()
+            })
+        } else {
+            Ok(ToolResult {
+                output: format!("{} ok", self.name),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+}
+
+/// Mock LLM provider that returns scripted responses in FIFO order.
+struct MockLlm {
+    responses: Mutex<Vec<ChatResponse>>,
+}
+
+impl MockLlm {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MockLlm {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            eyre::bail!("MockLlm: no more scripted responses");
+        }
+        Ok(responses.remove(0))
+    }
+
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+    fn model_id(&self) -> &str {
+        "mock-m88"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+fn tool_use_response(calls: Vec<ToolCall>) -> ChatResponse {
+    ChatResponse {
+        content: None,
+        reasoning_content: None,
+        tool_calls: calls,
+        stop_reason: StopReason::ToolUse,
+        usage: TokenUsage {
+            input_tokens: 100,
+            output_tokens: 10,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn end_turn(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.to_string()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage {
+            input_tokens: 50,
+            output_tokens: 20,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn tc(id: &str, name: &str) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        name: name.into(),
+        arguments: serde_json::json!({}),
+        metadata: None,
+    }
+}
+
+/// Build an agent configured with the supplied probe tools. The registry
+/// keeps only the probe tools (built-ins would clutter the call log).
+async fn make_agent(probes: Vec<ProbeTool>, responses: Vec<ChatResponse>, dir: &TempDir) -> Agent {
+    let llm: Arc<dyn LlmProvider> = Arc::new(MockLlm::new(responses));
+    let mut tools = ToolRegistry::new();
+    for probe in probes {
+        tools.register(probe);
+    }
+    let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
+    Agent::new(AgentId::new("m88-test"), llm, tools, memory).with_config(AgentConfig {
+        save_episodes: false,
+        ..Default::default()
+    })
+}
+
+#[tokio::test]
+async fn executor_dispatches_all_safe_in_parallel() {
+    // Three Safe probes each sleep 200ms. If dispatch is parallel the entire
+    // batch completes in ~200ms (overlapping windows). If it serialises
+    // accidentally the total would be ~600ms. We assert overlap directly via
+    // timestamps rather than wall-clock so the test is flake-resistant.
+    let dir = TempDir::new().unwrap();
+    let log = CallLog::new();
+    let probes = vec![
+        ProbeTool::new(
+            "safe_a",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(200),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "safe_b",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(200),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "safe_c",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(200),
+            log.clone(),
+        ),
+    ];
+    let responses = vec![
+        tool_use_response(vec![
+            tc("call_1", "safe_a"),
+            tc("call_2", "safe_b"),
+            tc("call_3", "safe_c"),
+        ]),
+        end_turn("done"),
+    ];
+    let agent = make_agent(probes, responses, &dir).await;
+
+    let resp = agent
+        .process_message("fan out reads", &[], vec![])
+        .await
+        .expect("agent loop must succeed");
+    assert_eq!(resp.content, "done");
+
+    let spans = log.lock().unwrap().snapshot();
+    assert_eq!(spans.len(), 3);
+
+    // At least two spans must overlap — the max start time must precede the
+    // min end time. This is equivalent to "the windows intersect".
+    let max_start = spans.iter().map(|s| s.started_us).max().unwrap();
+    let min_end = spans.iter().map(|s| s.ended_us).min().unwrap();
+    assert!(
+        max_start < min_end,
+        "safe batch did not overlap: max_start={}us min_end={}us spans={:?}",
+        max_start,
+        min_end,
+        spans
+    );
+}
+
+#[tokio::test]
+async fn executor_dispatches_exclusive_serially_in_call_order() {
+    // Three Exclusive probes must run one at a time in the order the LLM
+    // emitted them. We verify that every span starts *at or after* its
+    // predecessor's end and that the LLM call order is preserved.
+    let dir = TempDir::new().unwrap();
+    let log = CallLog::new();
+    let probes = vec![
+        ProbeTool::new(
+            "excl_a",
+            ConcurrencyClass::Exclusive,
+            Duration::from_millis(50),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "excl_b",
+            ConcurrencyClass::Exclusive,
+            Duration::from_millis(50),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "excl_c",
+            ConcurrencyClass::Exclusive,
+            Duration::from_millis(50),
+            log.clone(),
+        ),
+    ];
+    let responses = vec![
+        tool_use_response(vec![
+            tc("call_1", "excl_a"),
+            tc("call_2", "excl_b"),
+            tc("call_3", "excl_c"),
+        ]),
+        end_turn("serialized"),
+    ];
+    let agent = make_agent(probes, responses, &dir).await;
+
+    let resp = agent
+        .process_message("serial mutations", &[], vec![])
+        .await
+        .expect("agent loop must succeed");
+    assert_eq!(resp.content, "serialized");
+
+    let spans = log.lock().unwrap().snapshot();
+    assert_eq!(spans.len(), 3);
+
+    // Order-preserved: the log is appended in finish order, which equals
+    // start order under serialisation.
+    assert_eq!(
+        spans.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+        vec!["excl_a", "excl_b", "excl_c"]
+    );
+    // Each subsequent span must start no earlier than the prior one ended.
+    for pair in spans.windows(2) {
+        assert!(
+            pair[1].started_us >= pair[0].ended_us,
+            "exclusive batch was not serialized: {:?}",
+            spans
+        );
+    }
+}
+
+#[tokio::test]
+async fn executor_serializes_mixed_batch_when_any_exclusive() {
+    // One Exclusive + two Safe must serialize the WHOLE batch per the M8.8
+    // admission rule ("if any Exclusive, run the whole batch serially").
+    let dir = TempDir::new().unwrap();
+    let log = CallLog::new();
+    let probes = vec![
+        ProbeTool::new(
+            "excl_x",
+            ConcurrencyClass::Exclusive,
+            Duration::from_millis(50),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "safe_y",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(50),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "safe_z",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(50),
+            log.clone(),
+        ),
+    ];
+    let responses = vec![
+        tool_use_response(vec![
+            tc("call_1", "excl_x"),
+            tc("call_2", "safe_y"),
+            tc("call_3", "safe_z"),
+        ]),
+        end_turn("mixed-ok"),
+    ];
+    let agent = make_agent(probes, responses, &dir).await;
+
+    let resp = agent
+        .process_message("mixed batch", &[], vec![])
+        .await
+        .expect("agent loop must succeed");
+    assert_eq!(resp.content, "mixed-ok");
+
+    let spans = log.lock().unwrap().snapshot();
+    assert_eq!(spans.len(), 3);
+
+    // No two spans may overlap; each start >= previous end.
+    for pair in spans.windows(2) {
+        assert!(
+            pair[1].started_us >= pair[0].ended_us,
+            "mixed batch was not serialized: {:?}",
+            spans
+        );
+    }
+}
+
+#[tokio::test]
+async fn executor_cancels_siblings_after_exclusive_tool_error() {
+    // First Exclusive tool fails; the remaining two must not execute. Each
+    // cancelled peer gets a synthetic "cancelled" tool-result message so the
+    // LLM sees every tool_call_id. The spans log records exactly ONE probe
+    // invocation (the failing first call).
+    let dir = TempDir::new().unwrap();
+    let log = CallLog::new();
+    let probes = vec![
+        ProbeTool::new(
+            "excl_bad",
+            ConcurrencyClass::Exclusive,
+            Duration::from_millis(20),
+            log.clone(),
+        )
+        .with_failure(true),
+        ProbeTool::new(
+            "safe_peer1",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(20),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "safe_peer2",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(20),
+            log.clone(),
+        ),
+    ];
+    let responses = vec![
+        tool_use_response(vec![
+            tc("call_1", "excl_bad"),
+            tc("call_2", "safe_peer1"),
+            tc("call_3", "safe_peer2"),
+        ]),
+        end_turn("post-cascade"),
+    ];
+    let agent = make_agent(probes, responses, &dir).await;
+
+    let resp = agent
+        .process_message("cascade test", &[], vec![])
+        .await
+        .expect("agent loop must succeed (cancellation is not an error)");
+    assert_eq!(resp.content, "post-cascade");
+
+    // Only the failing probe actually ran.
+    let spans = log.lock().unwrap().snapshot();
+    assert_eq!(spans.len(), 1, "only the failing probe should execute");
+    assert_eq!(spans[0].name, "excl_bad");
+}
+
+#[tokio::test]
+async fn executor_preserves_tool_call_ids_across_cascade() {
+    // Every tool_call_id issued by the LLM must appear in the result
+    // messages, whether the call executed or was cancelled. This is what
+    // the LLM relies on to correlate responses with its outstanding calls.
+    use octos_agent::ProgressEvent;
+
+    // Collect tool-completion events to verify each call_id roundtrips.
+    #[derive(Default)]
+    struct Collector {
+        events: Mutex<Vec<(String, String, bool)>>, // (name, tool_id, success)
+    }
+    impl octos_agent::ProgressReporter for Collector {
+        fn report(&self, event: ProgressEvent) {
+            if let ProgressEvent::ToolCompleted {
+                name,
+                tool_id,
+                success,
+                ..
+            } = event
+            {
+                self.events.lock().unwrap().push((name, tool_id, success));
+            }
+        }
+    }
+
+    let dir = TempDir::new().unwrap();
+    let log = CallLog::new();
+    let probes = vec![
+        ProbeTool::new(
+            "excl_fail",
+            ConcurrencyClass::Exclusive,
+            Duration::from_millis(10),
+            log.clone(),
+        )
+        .with_failure(true),
+        ProbeTool::new(
+            "safe_late_a",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(10),
+            log.clone(),
+        ),
+        ProbeTool::new(
+            "safe_late_b",
+            ConcurrencyClass::Safe,
+            Duration::from_millis(10),
+            log.clone(),
+        ),
+    ];
+    let responses = vec![
+        tool_use_response(vec![
+            tc("call_alpha", "excl_fail"),
+            tc("call_beta", "safe_late_a"),
+            tc("call_gamma", "safe_late_b"),
+        ]),
+        end_turn("ok"),
+    ];
+    let reporter = Arc::new(Collector::default());
+    let agent = make_agent(probes, responses, &dir)
+        .await
+        .with_reporter(reporter.clone());
+
+    let resp = agent
+        .process_message("id roundtrip", &[], vec![])
+        .await
+        .expect("agent loop must succeed");
+
+    // 1) The reporter saw the failing probe's ToolCompleted event with the
+    //    original call_id preserved.
+    let events = reporter.events.lock().unwrap().clone();
+    assert!(
+        events
+            .iter()
+            .any(|(name, id, _)| name == "excl_fail" && id == "call_alpha"),
+        "expected a ToolCompleted for the failing call_alpha; saw {:?}",
+        events
+    );
+
+    // 2) Every LLM-issued tool_call_id must appear exactly once among the
+    //    tool-result messages — whether the call executed or was cancelled.
+    //    This is the invariant the LLM relies on to close its outstanding
+    //    tool_uses: missing an id would leave the conversation in an
+    //    unresolvable state on the next turn.
+    let tool_msgs: Vec<&Message> = resp
+        .messages
+        .iter()
+        .filter(|m| m.role == octos_core::MessageRole::Tool)
+        .collect();
+    let ids: Vec<&str> = tool_msgs
+        .iter()
+        .filter_map(|m| m.tool_call_id.as_deref())
+        .collect();
+    assert!(
+        ids.contains(&"call_alpha"),
+        "missing call_alpha in {:?}",
+        ids
+    );
+    assert!(
+        ids.contains(&"call_beta"),
+        "missing cancelled call_beta in {:?}",
+        ids
+    );
+    assert!(
+        ids.contains(&"call_gamma"),
+        "missing cancelled call_gamma in {:?}",
+        ids
+    );
+
+    // 3) The two cancelled peers must carry a "cancelled" marker in their
+    //    content so the LLM can distinguish them from an ordinary failure.
+    let find = |id: &str| -> &str {
+        tool_msgs
+            .iter()
+            .find(|m| m.tool_call_id.as_deref() == Some(id))
+            .expect("result for id")
+            .content
+            .as_str()
+    };
+    assert!(
+        find("call_beta").contains("cancelled"),
+        "call_beta result should mark cancellation; got {}",
+        find("call_beta")
+    );
+    assert!(
+        find("call_gamma").contains("cancelled"),
+        "call_gamma result should mark cancellation; got {}",
+        find("call_gamma")
+    );
+}


### PR DESCRIPTION
Closes the last M8-family workstream. Refs #543 / docs/OCTOS_RUNTIME_FAMILY_PLAN_2026-04-23.md.

## Summary

- Adds `ConcurrencyClass::{Safe, Exclusive}` and a `Tool::concurrency_class` trait method defaulting to `Safe`. Unmigrated tools keep pre-M8.8 parallel-friendly behaviour.
- Agent executor classifies every batch up front. All-Safe batches fan out via `futures::join_all` (today's behaviour); any-Exclusive batches run each call serially in LLM call order.
- Serial dispatch cascades the first error (tool bail, hook denial, panic, timeout) across peers. Skipped peers get a synthetic `"Tool 'X' cancelled due to earlier sibling error..."` tool-result message so every `tool_call_id` round-trips.
- Refactored `execute_tools` to reuse a single `spawn_tool_task` helper from both dispatch paths — no behavioural change on the parallel side.

## Tools moved to `Exclusive`

| Tool | Why |
| --- | --- |
| `ShellTool` | spawns processes, mutates FS |
| `WriteFileTool` | writes to disk |
| `EditFileTool` | rewrites file contents |
| `DiffEditTool` | writes back after patching |
| `SaveMemoryTool` | updates memory bank |

Everything else — `ReadFileTool`, `WebFetchTool`, `WebSearchTool`, `GrepTool`, `GlobTool`, `ListDirTool`, plugin/MCP wrappers — stays on the `Safe` default.

## Admission rule

Per the spec, this PR ships the **simple / pessimistic** rule: if any call in a batch is `Exclusive`, the whole batch serializes. The optimised Safe-parallel + Exclusive-serial split is a follow-up.

## Cascade behaviour

When an Exclusive batch hits a failure on call N:
- calls 1..N execute and record real tool-results,
- call N records its actual failure message,
- calls N+1..end are never dispatched; each receives a synthetic `Tool '<name>' cancelled due to earlier sibling error in the same batch. Re-issue this call on the next turn if still needed.` message keyed to its original `tool_call_id`.

No reporter events are emitted for cancelled peers — they exist only as tool-result messages visible to the LLM on the next turn.

## Test coverage (15 new tests)

Unit tests in `tools/`:
- `default_concurrency_class_is_safe`, `override_returns_exclusive`, `concurrency_class_is_copy_eq_default`
- `shell_tool_is_exclusive`, `write_file_tool_is_exclusive`, `edit_file_tool_is_exclusive`, `diff_edit_tool_is_exclusive`, `save_memory_tool_is_exclusive`
- `read_file_tool_is_safe`, `web_fetch_tool_is_safe`

Integration tests in `tests/concurrent_scheduler.rs`:
- `executor_dispatches_all_safe_in_parallel` — timestamp windows overlap
- `executor_dispatches_exclusive_serially_in_call_order` — each start >= prior end
- `executor_serializes_mixed_batch_when_any_exclusive` — 1 Exclusive + 2 Safe all serial
- `executor_cancels_siblings_after_exclusive_tool_error` — only the failing probe executes
- `executor_preserves_tool_call_ids_across_cascade` — every id round-trips through messages

## Gates

- `cargo fmt -p octos-agent -- --check` — clean
- `cargo clippy -p octos-agent --no-deps --all-targets -- -D warnings` — clean
- `cargo test -p octos-agent --lib` — 997 passed, 1 ignored
- `cargo test --workspace --no-fail-fast` — all green

Pre-existing `cargo fmt --all -- --check` diffs in `octos-cli/` (6 files, pre-M8.1 state of `feature/m8.1-typed-tool-context`) are untouched by this PR.

## M8 family status

With M8.8 shipped the M8 family is **8/8 complete**:

- [x] M8.1 typed `ToolContext`
- [x] M8.2 agent-definition manifest
- [x] M8.3 profile system
- [x] M8.4 file-state cache
- [x] M8.5 three-tier compaction
- [x] M8.6 structured resume
- [x] M8.7 disk-output agent summary
- [x] M8.8 concurrent-safe vs exclusive scheduler (this PR)

Octos is now properly framed as a runtime with coding as the default profile per the runtime-family plan.