### PR TITLE
fix: handle LLM errors gracefully in interactive chat loop

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -415,7 +415,13 @@ impl ChatCommand {
             }
 
             // Process message
-            let response = agent.process_message(input, &history, vec![]).await?;
+            let response = match agent.process_message(input, &history, vec![]).await {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("{}: {e}", "Error".red().bold());
+                    continue;
+                }
+            };
 
             // Append to history
             history.push(Message {


### PR DESCRIPTION
## Summary

- Chat loop no longer crashes on LLM API errors (insufficient balance, rate limiting, network failures)
- Prints the error in red and continues the loop so users can retry without restarting

Fixes #557

## Test plan

- [ ] Configure a provider with insufficient balance, send a message — should print error and return to prompt
- [ ] Verify single-message mode (`octos chat -m "hello"`) still propagates errors normally
- [ ] Verify normal chat flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)