### PR TITLE
ci: unblock fleet by fmt --all + typos allowlist (abd, mis)

### DIFF
--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -412,9 +412,9 @@ pub async fn post_smtp(
 
     let path = require_config_path(&state)?;
     crate::config::write_mutation(&path, |value| {
-        let obj = value.as_object_mut().ok_or_else(|| {
-            eyre::eyre!("config.json root is not a JSON object")
-        })?;
+        let obj = value
+            .as_object_mut()
+            .ok_or_else(|| eyre::eyre!("config.json root is not a JSON object"))?;
         let auth = obj
             .entry("dashboard_auth".to_string())
             .or_insert_with(|| serde_json::json!({}));
@@ -851,7 +851,10 @@ mod tests {
         // password_env should be backfilled when missing.
         let raw = std::fs::read_to_string(dir.path().join("config.json")).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert_eq!(parsed["dashboard_auth"]["smtp"]["password_env"], "SMTP_PASSWORD");
+        assert_eq!(
+            parsed["dashboard_auth"]["smtp"]["password_env"],
+            "SMTP_PASSWORD"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -2180,12 +2180,8 @@ mod tests {
             broadcaster: Arc::new(crate::api::SseBroadcaster::new(8)),
             started_at: chrono::Utc::now(),
             auth_token: Some("bootstrap-token".into()),
-            admin_token_store: Arc::new(crate::admin_token_store::AdminTokenStore::new(
-                dir.path(),
-            )),
-            setup_state_store: Arc::new(crate::setup_state_store::SetupStateStore::new(
-                dir.path(),
-            )),
+            admin_token_store: Arc::new(crate::admin_token_store::AdminTokenStore::new(dir.path())),
+            setup_state_store: Arc::new(crate::setup_state_store::SetupStateStore::new(dir.path())),
             metrics_handle: None,
             profile_store: Some(profile_store.clone()),
             process_manager: None,

--- a/crates/octos-cli/src/commands/admin.rs
+++ b/crates/octos-cli/src/commands/admin.rs
@@ -248,10 +248,7 @@ impl Executable for AdminCommand {
                 let data_dir = super::resolve_data_dir(data_dir)?;
                 let store = AdminTokenStore::new(&data_dir);
                 if !yes {
-                    print!(
-                        "Reset admin token at {}? [y/N]: ",
-                        store.path().display()
-                    );
+                    print!("Reset admin token at {}? [y/N]: ", store.path().display());
                     std::io::stdout().flush().ok();
                     let mut input = String::new();
                     std::io::stdin().read_line(&mut input)?;

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -719,8 +719,7 @@ where
     mutate(&mut value)?;
     let body = serde_json::to_string_pretty(&value)?;
     let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, &body)
-        .wrap_err_with(|| format!("failed to write {}", tmp.display()))?;
+    std::fs::write(&tmp, &body).wrap_err_with(|| format!("failed to write {}", tmp.display()))?;
     std::fs::rename(&tmp, path)
         .wrap_err_with(|| format!("failed to rename into {}", path.display()))?;
     Ok(())

--- a/crates/octos-cli/src/setup_state_store.rs
+++ b/crates/octos-cli/src/setup_state_store.rs
@@ -141,7 +141,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let store = SetupStateStore::new(dir.path());
         store.update_last_step(1).unwrap();
-        let mode = std::fs::metadata(store.path()).unwrap().permissions().mode() & 0o777;
+        let mode = std::fs::metadata(store.path())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(mode, 0o600);
     }
 }

--- a/typos.toml
+++ b/typos.toml
@@ -33,6 +33,10 @@ iz = "iz"
 ot = "ot"
 # Rust TUI library name
 ratatui = "ratatui"
+# English prefix "mis-" (misclassification, miscount, etc.)
+mis = "mis"
+# Constant-time equality test fixture (intentionally 1-byte diff from "abc")
+abd = "abd"
 
 [files]
 extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
## Why

The PR audit this afternoon found that ~every open PR (M8 family #546-#556, release trains #534/#46, ops fixes #549/#550/#559/#552, et al) is blocked on two mechanical CI jobs failing on `main`:

- `check` — `cargo fmt --all -- --check` diffs in 5 files nobody touched recently:
  - `crates/octos-cli/src/api/admin_setup.rs`
  - `crates/octos-cli/src/api/auth_handlers.rs`
  - `crates/octos-cli/src/commands/admin.rs`
  - `crates/octos-cli/src/config.rs`
  - `crates/octos-cli/src/setup_state_store.rs`
- `typos` — two false positives:
  - `abd` — test fixture in `crates/octos-agent/src/mcp_server.rs:870` (`constant_time_eq("abc", "abd")`), intentionally 1 char off.
  - `mis` — English prefix in `crates/octos-agent/src/harness_events.rs:506` ("mis-classification").

Each individual PR author can't fix this in their own PR (fmt drift lives on main already; typos rule lives in `typos.toml`).

## What

- `cargo fmt --all` pass.
- Extend `typos.toml` `[default.extend-words]` with `abd` + `mis`.

## Expected effect

Merging this onto `main` retros all 20+ blocked PRs to green (after rebase / automatic recheck) in one shot.

## Test plan

- [x] `cargo fmt --all -- --check` — clean after this PR.
- [x] `typos` — clean after this PR.
- [ ] Post-merge: spot-check one of the M8 PRs re-runs CI green.