### PR TITLE
Fix Linux test portability and lifecycle timeout cleanup

### DIFF
--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -1,5 +1,6 @@
 //! Plugin tool: wraps a plugin executable as a Tool.
 
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
@@ -573,7 +574,14 @@ impl Tool for PluginTool {
         // Write args to stdin
         if let Some(mut stdin) = child.stdin.take() {
             let data = serde_json::to_vec(&effective_args)?;
-            stdin.write_all(&data).await?;
+            if let Err(err) = stdin.write_all(&data).await {
+                // Some plugins do not read stdin at all and exit after writing a
+                // best-effort stdout result. Treat an early pipe close as
+                // non-fatal so fallback stdout parsing can still succeed.
+                if err.kind() != ErrorKind::BrokenPipe {
+                    return Err(err.into());
+                }
+            }
             // Drop stdin to signal EOF
         }
 

--- a/crates/octos-agent/src/prompts/worker.txt
+++ b/crates/octos-agent/src/prompts/worker.txt
@@ -1,4 +1,4 @@
-You are a Worker agent in the dora-octos system. Your role is to:
+You are a Worker agent in the octos system. Your role is to:
 
 1. EXECUTE: Complete the assigned task using available tools
 2. REPORT: Provide clear status updates

--- a/crates/octos-agent/src/tools/send_file.rs
+++ b/crates/octos-agent/src/tools/send_file.rs
@@ -454,9 +454,12 @@ mod tests {
     async fn test_base_dir_blocks_non_tmp_outside_path() {
         let base = tempfile::tempdir().unwrap();
 
-        // Create a file outside base_dir (but not in /tmp/) to test path validation.
-        // Use a second tempdir as the "outside" location so this works on all platforms.
-        let outside_dir = tempfile::tempdir().unwrap();
+        // Create a file outside base_dir and outside /tmp/, since /tmp/ is
+        // explicitly allowlisted for generated artifacts.
+        let outside_dir = tempfile::Builder::new()
+            .prefix("octos-send-file-outside-")
+            .tempdir_in(std::env::current_dir().unwrap())
+            .unwrap();
         let outside_file = outside_dir.path().join("secret.txt");
         std::fs::write(&outside_file, "secret").unwrap();
 

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -704,7 +704,10 @@ async fn test_06_send_file_sandbox_escape() {
     use octos_agent::tools::SendFileTool;
 
     let sandbox = TempDir::new().unwrap();
-    let outside = TempDir::new().unwrap();
+    let outside = tempfile::Builder::new()
+        .prefix("octos-pipeline-send-file-outside-")
+        .tempdir_in(std::env::current_dir().unwrap())
+        .unwrap();
 
     // Create a "secret" file outside the sandbox
     let secret = outside.path().join("credentials.json");

--- a/crates/octos-plugin/src/lifecycle.rs
+++ b/crates/octos-plugin/src/lifecycle.rs
@@ -539,10 +539,12 @@ impl LifecycleExecutor {
                 // error out before reaching child.kill() below.
                 #[cfg(unix)]
                 if let Some(pid) = pid {
-                    // `kill -9 -<pgid>` targets the whole group. Since
-                    // we called process_group(0), pid == pgid.
+                    // `kill -9 -- -<pgid>` targets the whole group. The `--`
+                    // is required so the negative pgid is not parsed as
+                    // another option by the `kill` CLI. Since we called
+                    // process_group(0), pid == pgid.
                     let _ = std::process::Command::new("kill")
-                        .args(["-9", &format!("-{pid}")])
+                        .args(["-9", "--", &format!("-{pid}")])
                         .status();
                 }
                 if let Err(e) = child.kill().await {
@@ -551,6 +553,18 @@ impl LifecycleExecutor {
                         step = step.label,
                         error = %e,
                         "failed to kill timed-out lifecycle step child"
+                    );
+                }
+                // Reap the direct child before returning. Without this, the
+                // shell wrapper can remain as a zombie briefly, which delays
+                // reparenting/reaping of background children enough to trip
+                // the lifecycle timeout contract test.
+                if let Err(e) = child.wait().await {
+                    tracing::warn!(
+                        phase = phase.as_str(),
+                        step = step.label,
+                        error = %e,
+                        "failed to reap timed-out lifecycle step child"
                     );
                 }
                 #[cfg(windows)]


### PR DESCRIPTION
## Summary
- tolerate `BrokenPipe` when plugin fallback tools exit without reading stdin
- update `send_file` tests to use paths outside both the sandbox/base dir and `/tmp`
- fix lifecycle timeout cleanup to kill the full Unix process group and reap the direct child

## Validation
- `cargo test -p octos-agent --lib tools::send_file::tests:: -- --nocapture`
- `cargo test -p octos-agent --lib plugins::tool::tests::execute_fallback_ -- --nocapture`
- `cargo test -p octos-pipeline --test ux_pipeline test_06_send_file_ -- --nocapture`
- `cargo test -p octos-plugin --test lifecycle_sandbox -- --nocapture`

Closes #562
