### PR TITLE
Thread committed_seq through SSE done event for live bubble ordering

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -840,7 +840,7 @@ impl Channel for ApiChannel {
                         }
                     }
                 }
-                let done = serde_json::json!({
+                let mut done = serde_json::json!({
                     "type": "done",
                     "content": "",
                     "model": msg.metadata.get("model").and_then(|v| v.as_str()).unwrap_or(""),
@@ -853,6 +853,13 @@ impl Channel for ApiChannel {
                     "duration_s": msg.metadata.get("duration_s").and_then(|v| v.as_u64()).unwrap_or(0),
                     "has_bg_tasks": has_bg,
                 });
+                // M8.10-A: thread the committed session sequence into the done
+                // event so live-streamed bubbles on the web client can populate
+                // `historySeq`. Optional — omitted when persist failed or the
+                // metadata key was not provided (legacy/error paths).
+                if let Some(seq) = msg.metadata.get("committed_seq").and_then(|v| v.as_u64()) {
+                    done["committed_seq"] = serde_json::Value::from(seq);
+                }
                 let _ = tx.send(done.to_string());
                 pending.remove(&msg.chat_id);
                 drop(pending);
@@ -3057,6 +3064,86 @@ mod tests {
             rx.recv().await,
             Err(broadcast::error::RecvError::Closed)
         ));
+    }
+
+    #[tokio::test]
+    async fn done_event_carries_committed_seq_when_message_persisted() {
+        // M8.10-A regression: the SSE `done` event must thread the committed
+        // session sequence back to the web client so live-streamed bubbles can
+        // populate `historySeq` and avoid floating to the end of the list.
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("test-chat-seq".into(), tx);
+        }
+
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "test-chat-seq".into(),
+            content: String::new(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "_completion": true,
+                "committed_seq": 42,
+                "tokens_in": 10,
+                "tokens_out": 5,
+            }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "done");
+        assert_eq!(parsed["committed_seq"], 42);
+    }
+
+    #[tokio::test]
+    async fn done_event_omits_committed_seq_when_persist_failed_or_skipped() {
+        // M8.10-A: when the server has no committed seq (e.g. persist failed
+        // or is skipped), the done event must NOT include `committed_seq` so
+        // legacy/error-path behaviour is preserved.
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("test-chat-noseq".into(), tx);
+        }
+
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "test-chat-noseq".into(),
+            content: String::new(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "_completion": true,
+                "tokens_in": 10,
+                "tokens_out": 5,
+            }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "done");
+        assert!(
+            parsed.get("committed_seq").is_none() || parsed["committed_seq"].is_null(),
+            "committed_seq must be omitted when missing from metadata, got: {parsed}"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -372,13 +372,24 @@ async fn chat_streaming(
                     "chat: streaming response complete"
                 );
 
-                // Save all conversation messages (user, assistant iterations, tool calls/results)
-                {
+                // Save all conversation messages (user, assistant iterations,
+                // tool calls/results). Capture the committed seq of the final
+                // assistant message so the SSE `done` event can thread it back
+                // to the web client (M8.10-A).
+                let assistant_committed_seq: Option<u64> = {
                     let mut sess = sessions.lock().await;
+                    let mut last_assistant_seq: Option<u64> = None;
                     for msg in &response.messages {
-                        let _ = sess.add_message(&session_key, msg.clone()).await;
+                        match sess.add_message_with_seq(&session_key, msg.clone()).await {
+                            Ok(seq) if msg.role == octos_core::MessageRole::Assistant => {
+                                last_assistant_seq = u64::try_from(seq).ok();
+                            }
+                            Ok(_) => {}
+                            Err(_) => {}
+                        }
                     }
-                }
+                    last_assistant_seq
+                };
 
                 // Send final done event (field names match what octos-web expects)
                 let provider_metadata = response.provider_metadata.clone();
@@ -400,7 +411,7 @@ async fn chat_streaming(
                         response.token_usage.output_tokens,
                     )
                 });
-                let done = serde_json::json!({
+                let mut done = serde_json::json!({
                     "type": "done",
                     "content": response.content,
                     "model": provider_metadata.as_ref().map(|meta| meta.display_label()),
@@ -411,6 +422,9 @@ async fn chat_streaming(
                     "tokens_out": response.token_usage.output_tokens,
                     "session_cost": session_cost,
                 });
+                if let Some(seq) = assistant_committed_seq {
+                    done["committed_seq"] = serde_json::Value::from(seq);
+                }
                 let _ = tx.send(done.to_string());
             }
             Err(e) => {
@@ -2638,13 +2652,23 @@ async fn ws_standalone_agent(
 
         match result {
             Ok(response) => {
-                // Save conversation messages to session
-                {
+                // Save conversation messages to session. Capture the committed
+                // seq of the final assistant message so the WebSocket-bridged
+                // `done` event can thread it back to the web client (M8.10-A).
+                let assistant_committed_seq: Option<u64> = {
                     let mut sess = sessions.lock().await;
+                    let mut last_assistant_seq: Option<u64> = None;
                     for msg in &response.messages {
-                        let _ = sess.add_message(&session_key2, msg.clone()).await;
+                        match sess.add_message_with_seq(&session_key2, msg.clone()).await {
+                            Ok(seq) if msg.role == octos_core::MessageRole::Assistant => {
+                                last_assistant_seq = u64::try_from(seq).ok();
+                            }
+                            Ok(_) => {}
+                            Err(_) => {}
+                        }
                     }
-                }
+                    last_assistant_seq
+                };
 
                 let provider_metadata = response.provider_metadata.clone();
                 let model_id = provider_metadata
@@ -2665,7 +2689,7 @@ async fn ws_standalone_agent(
                         response.token_usage.output_tokens,
                     )
                 });
-                let done = serde_json::json!({
+                let mut done = serde_json::json!({
                     "type": "done",
                     "content": response.content,
                     "model": provider_metadata.as_ref().map(|meta| meta.display_label()),
@@ -2676,6 +2700,9 @@ async fn ws_standalone_agent(
                     "tokens_out": response.token_usage.output_tokens,
                     "session_cost": session_cost,
                 });
+                if let Some(seq) = assistant_committed_seq {
+                    done["committed_seq"] = serde_json::Value::from(seq);
+                }
                 let _ = tx.send(done.to_string());
             }
             Err(e) => {

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3733,7 +3733,7 @@ impl SessionActor {
                 );
             }
         }
-        let completion_meta = match &agent_result {
+        let mut completion_meta = match &agent_result {
             Ok(Ok(cr)) => {
                 info!(session = %self.session_key, messages = cr.messages.len(), content_len = cr.content.len(), bg_tasks, "agent completed, saving messages");
                 let provider_metadata = cr.provider_metadata.clone();
@@ -3790,6 +3790,7 @@ impl SessionActor {
                 // Save tool calls, tool results, and assistant reply to history.
                 // Skip the first message (user msg) — we already saved it before
                 // spawning to maintain chronological ordering.
+                let mut assistant_committed_seq: Option<u64> = None;
                 {
                     let mut handle = self.session_handle.lock().await;
                     let messages_to_save = if !conv_response.messages.is_empty()
@@ -3819,8 +3820,18 @@ impl SessionActor {
                             reasoning_content: conv_response.reasoning_content.clone(),
                             timestamp: chrono::Utc::now(),
                         };
-                        if let Err(e) = handle.add_message(assistant_msg).await {
-                            warn!(session = %self.session_key, error = %e, "failed to persist assistant reply");
+                        // M8.10-A: capture the committed seq so the SSE `done`
+                        // event can thread it back to the web client. The
+                        // assistant timestamp is `Utc::now()` (newer than any
+                        // tool message) so the post-sort position matches the
+                        // append index returned here.
+                        match handle.add_message_with_seq(assistant_msg).await {
+                            Ok(seq) => {
+                                assistant_committed_seq = u64::try_from(seq).ok();
+                            }
+                            Err(e) => {
+                                warn!(session = %self.session_key, error = %e, "failed to persist assistant reply");
+                            }
                         }
                     }
 
@@ -3840,6 +3851,16 @@ impl SessionActor {
                     .await
                     {
                         warn!("session compaction failed: {e}");
+                    }
+                }
+
+                // M8.10-A: thread the committed assistant seq into the
+                // completion_meta so the SSE done event can carry it back to
+                // the web client. Live-streamed bubbles use this to populate
+                // their `historySeq` and stay in chronological order.
+                if let Some(seq) = assistant_committed_seq {
+                    if let Some(map) = completion_meta.as_object_mut() {
+                        map.insert("committed_seq".to_string(), serde_json::Value::from(seq));
                     }
                 }
 
@@ -7517,6 +7538,81 @@ mod tests {
             assert!(user_messages.contains(&"msg-b"));
             assert!(user_messages.contains(&"msg-c"));
         }
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// M8.10-A: the primary-turn `_completion` OutboundMessage MUST carry
+    /// `committed_seq` so the API channel can thread it onto the SSE `done`
+    /// event. Without this, web clients can't populate `historySeq` on
+    /// live-streamed bubbles and they float to the end of the list.
+    #[tokio::test]
+    async fn primary_turn_completion_metadata_includes_committed_seq() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Single fast reply so the primary turn completes quickly and emits
+        // `_completion` metadata.
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(
+                Duration::from_millis(50),
+                make_response("primary turn reply"),
+            )],
+        ));
+        let router_a: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "router-a",
+            vec![(Duration::from_millis(500), make_response("unused"))],
+        ));
+        let router_b: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "router-b",
+            vec![(Duration::from_millis(500), make_response("unused"))],
+        ));
+
+        let status_channel: Arc<dyn octos_bus::Channel> = Arc::new(FakeSseChannel::new("api"));
+        let (tx, mut rx, handle, _session_mgr) = setup_speculative_actor_with_indicator(
+            agent_llm,
+            vec![router_a, router_b],
+            status_channel,
+            "api",
+            &dir,
+        )
+        .await;
+
+        tx.send(make_inbound_api("hello", "api")).await.unwrap();
+
+        // Drain until we see the primary-turn `_completion` marker.
+        let mut completion: Option<OutboundMessage> = None;
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout_at(deadline, rx.recv()).await {
+                Ok(Some(msg)) => {
+                    if msg.metadata.get("_completion").is_some() {
+                        completion = Some(msg);
+                        break;
+                    }
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        let completion =
+            completion.expect("expected a `_completion` OutboundMessage from primary turn");
+        let seq = completion
+            .metadata
+            .get("committed_seq")
+            .and_then(|v| v.as_u64())
+            .unwrap_or_else(|| {
+                panic!(
+                    "primary-turn _completion metadata must carry `committed_seq`; got {}",
+                    completion.metadata
+                )
+            });
+        // Seq is a position index — must point past the user message (seq 0).
+        assert!(
+            seq >= 1,
+            "committed_seq must reference the persisted assistant slot, got {seq}"
+        );
 
         drop(tx);
         let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;


### PR DESCRIPTION
## Summary

- M8.10-A (Problem A): live-streamed assistant bubbles never received an authoritative historySeq, so `compareMessagesForDisplay` ranked them via `Number.MAX_SAFE_INTEGER` and they migrated to the end of the list when newer seq'd messages arrived (the "reappearing" bug observed on mini2).
- Three call sites now thread the committed seq into the SSE `done` event:
  - `session_actor.rs` primary turn captures the seq from `add_message_with_seq` and stamps it into `completion_meta`.
  - `api_channel.rs` copies `committed_seq` from completion metadata onto the `done` event JSON. Optional — omitted when persist failed or on legacy/error paths.
  - `handlers.rs` (POST /chat + WebSocket bridge) switches from `add_message` to `add_message_with_seq`, captures the last assistant seq, and emits it on the done event.
- Web companion PR: octos-org/octos-web#fix/m8-10a-populate-history-seq-on-done.

Issue: octos-org/octos#575 (Problem A).

## Test plan

- [x] `cargo test -p octos-bus --features api done_event` — new tests `done_event_carries_committed_seq_when_message_persisted` and `done_event_omits_committed_seq_when_persist_failed_or_skipped` pass.
- [x] `cargo test -p octos-cli --lib primary_turn_completion_metadata_includes_committed_seq` — full session_actor flow asserts `committed_seq` is on the `_completion` OutboundMessage.
- [x] `cargo test -p octos-cli --lib session` — all 63 session tests still pass (no regressions).
- [x] `cargo test -p octos-bus --features api` — all 181 octos-bus tests still pass.
- [x] `cargo build --workspace` clean.
- [x] `cargo fmt -p octos-bus -p octos-cli -- --check` clean for the touched files.
- [ ] After merge: deploy to mini2, run a chat turn, observe SSE `done` carries `committed_seq` and the bubble stays in chronological order across follow-up turns.