### PR TITLE
M8.10-C: loop-detector dedup

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -300,6 +300,22 @@ impl Agent {
         c
     }
 
+    /// Decide what to surface when the loop detector fires.
+    ///
+    /// First fire in a session-burst: returns the warning text and marks the
+    /// session as having warned. Subsequent fires within the same burst
+    /// (before the next `process_message` reset) return a terminal error so
+    /// the loop cannot keep emitting identical noise to the user.
+    pub(super) fn dedup_loop_warning(&self, warning: String) -> Result<String> {
+        if self.is_loop_detected_recently() {
+            return Err(eyre::eyre!(
+                "agent loop got stuck — please rephrase or simplify your request"
+            ));
+        }
+        self.mark_loop_detected_recently();
+        Ok(warning)
+    }
+
     /// Process a single message in conversation mode (chat/gateway).
     /// Takes the user's message, conversation history, and optional media paths.
     pub async fn process_message(
@@ -379,6 +395,7 @@ impl Agent {
                 TASK_REPORTER.scope(activity_reporter, async move {
                 // Reset per-run flags
                 self.tools.reset_spawn_only_invoked();
+                self.reset_loop_detected_recently();
 
                 // Build the system prompt via the shared helper in
                 // execution.rs so conversation + task loops compose the same
@@ -635,10 +652,16 @@ impl Agent {
                                             ),
                                         });
                                     }
+                                    // Single-fire-per-burst: first fire emits the
+                                    // warning; subsequent fires within the same
+                                    // burst (before the next process_message reset)
+                                    // surface a terminal error instead of repeating
+                                    // identical noise.
+                                    let warning_content = self.dedup_loop_warning(warning)?;
                                     // Don't execute the tools — break out with a message
                                     self.emit_cost_update(turn.total_usage(), &response.usage);
                                     return Ok(ConversationResponse {
-                                        content: warning,
+                                        content: warning_content,
                                         reasoning_content: None,
                                         provider_metadata: None,
                                         token_usage: turn.total_usage().clone(),
@@ -2834,5 +2857,162 @@ printf '{"output":"voice saved","success":true}\n'
         // large error payloads do not accidentally count as productive.
         let body = "failed to resolve target: ".to_string() + &"x".repeat(200);
         assert!(!is_productive_tool_message(&body));
+    }
+
+    /// Mock LLM that always returns the same shell tool call with the same
+    /// arguments, forcing the loop detector to fire on iteration 4.
+    struct AlwaysSameToolProvider;
+
+    #[async_trait]
+    impl LlmProvider for AlwaysSameToolProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<ChatResponse> {
+            Ok(ChatResponse {
+                content: None,
+                reasoning_content: None,
+                tool_calls: vec![ToolCall {
+                    id: "call_loop".to_string(),
+                    name: "read_file".to_string(),
+                    arguments: serde_json::json!({"path": "loopy.txt"}),
+                    metadata: None,
+                }],
+                stop_reason: StopReason::ToolUse,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    async fn build_agent_with_mock(dir: &std::path::Path) -> Agent {
+        let tools = ToolRegistry::with_builtins(dir);
+        let provider: Arc<dyn LlmProvider> = Arc::new(AlwaysSameToolProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.join("memory")).await.unwrap());
+        Agent::new(AgentId::new("loop-dedup"), provider, tools, memory)
+    }
+
+    #[tokio::test]
+    async fn dedup_loop_warning_returns_warning_on_first_fire() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent = build_agent_with_mock(dir.path()).await;
+
+        assert!(!agent.is_loop_detected_recently());
+        let result = agent.dedup_loop_warning("[LOOP DETECTED] cycle".to_string());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "[LOOP DETECTED] cycle");
+        assert!(agent.is_loop_detected_recently());
+    }
+
+    #[tokio::test]
+    async fn dedup_loop_warning_returns_terminal_error_on_second_fire() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent = build_agent_with_mock(dir.path()).await;
+
+        let first = agent.dedup_loop_warning("[LOOP DETECTED] one".to_string());
+        assert!(first.is_ok());
+        let second = agent.dedup_loop_warning("[LOOP DETECTED] two".to_string());
+        assert!(second.is_err());
+        let err = second.err().unwrap().to_string();
+        assert!(
+            err.contains("agent loop got stuck"),
+            "expected terminal error, got: {err}"
+        );
+        // Flag stays set after the terminal error so further fires keep
+        // returning terminal errors until the next process_message reset.
+        assert!(agent.is_loop_detected_recently());
+    }
+
+    #[tokio::test]
+    async fn dedup_loop_warning_resets_after_reset() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent = build_agent_with_mock(dir.path()).await;
+
+        agent
+            .dedup_loop_warning("[LOOP DETECTED]".to_string())
+            .unwrap();
+        assert!(agent.is_loop_detected_recently());
+        agent.reset_loop_detected_recently();
+        assert!(!agent.is_loop_detected_recently());
+
+        // After reset, a new fire returns a warning again (not terminal).
+        let again = agent.dedup_loop_warning("[LOOP DETECTED] again".to_string());
+        assert!(again.is_ok());
+    }
+
+    #[tokio::test]
+    async fn process_message_resets_loop_detected_flag_at_start() {
+        // Pre-set the flag, then run a process_message that does NOT trigger
+        // the loop detector. The reset at the start of process_message_inner
+        // should clear the flag before the turn runs, and since no loop fires
+        // the flag stays cleared at exit.
+        let dir = tempfile::tempdir().unwrap();
+        let provider: Arc<dyn LlmProvider> = Arc::new(ToolThenEndProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let mut tools = ToolRegistry::with_builtins(dir.path());
+        let echo_path = dir.path().join("audio.mp3");
+        std::fs::write(&echo_path, b"x").unwrap();
+        tools.register(FilesToSendOnlyTool {
+            file_path: echo_path,
+        });
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("reset-test"), provider, tools, memory);
+
+        agent.mark_loop_detected_recently();
+        assert!(agent.is_loop_detected_recently());
+
+        let _ = agent
+            .process_message("hi", &[], vec![])
+            .await
+            .expect("process_message should succeed");
+
+        assert!(
+            !agent.is_loop_detected_recently(),
+            "process_message should reset the loop_detected flag at start"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_message_fires_loop_warning_once_then_terminal_error() {
+        // Two consecutive process_message calls with the same looping LLM.
+        // Each call resets at start, so each should emit a warning (not a
+        // terminal error). This documents the cross-turn dedup behavior:
+        // dedup is intra-turn only because each new user message starts a
+        // fresh session-burst slot.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("loopy.txt"), b"x").unwrap();
+        let provider: Arc<dyn LlmProvider> = Arc::new(AlwaysSameToolProvider);
+        let tools = ToolRegistry::with_builtins(dir.path());
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("burst"), provider, tools, memory).with_config(
+            crate::AgentConfig {
+                max_iterations: 30,
+                save_episodes: false,
+                ..Default::default()
+            },
+        );
+
+        let first = agent.process_message("loop please", &[], vec![]).await;
+        // Either the loop warning surfaced, or the recover_shell_retry path
+        // returned. Both terminate cleanly without an Err.
+        assert!(first.is_ok(), "first call should not error");
+        // Flag set after first warning.
+        assert!(agent.is_loop_detected_recently());
+
+        let second = agent.process_message("loop again", &[], vec![]).await;
+        // Reset at start of process_message clears the flag, so a brand-new
+        // burst is allowed and emits a warning (Ok), not a terminal Err.
+        assert!(second.is_ok(), "second call should not error after reset");
     }
 }

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -16,7 +16,7 @@ mod streaming;
 mod turn_state;
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU32};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 
 use octos_core::{AgentId, Message, TokenUsage};
@@ -155,6 +155,12 @@ pub struct Agent {
     pub(super) harness_event_sink: Option<String>,
     /// Shutdown signal.
     pub(super) shutdown: Arc<AtomicBool>,
+    /// Tracks whether the LOOP DETECTED warning has already fired in the
+    /// current session-burst. Reset at the start of each `process_message`
+    /// invocation; if a second loop fire happens within the same turn (e.g.
+    /// re-engagement before the turn ends), the duplicate warning is replaced
+    /// by a terminal error so the loop cannot keep emitting identical noise.
+    pub(super) loop_detected_recently: Arc<AtomicBool>,
     /// Optional per-session runtime limits for tool rounds and per-tool calls.
     pub(super) session_limits: Option<SessionLimits>,
     /// Mutable usage tracked against `session_limits`.
@@ -197,6 +203,7 @@ impl Agent {
             hook_context: std::sync::Mutex::new(None),
             harness_event_sink: None,
             shutdown: Arc::new(AtomicBool::new(false)),
+            loop_detected_recently: Arc::new(AtomicBool::new(false)),
             session_limits: None,
             session_usage: std::sync::Mutex::new(SessionUsage::default()),
             realtime: None,
@@ -228,6 +235,7 @@ impl Agent {
             hook_context: std::sync::Mutex::new(None),
             harness_event_sink: None,
             shutdown: Arc::new(AtomicBool::new(false)),
+            loop_detected_recently: Arc::new(AtomicBool::new(false)),
             session_limits: None,
             session_usage: std::sync::Mutex::new(SessionUsage::default()),
             realtime: None,
@@ -492,5 +500,23 @@ impl Agent {
             .read()
             .unwrap_or_else(|e| e.into_inner())
             .clone()
+    }
+
+    /// Whether the loop-detector warning has fired since the last reset.
+    /// Exposed for tests so they can verify single-fire-per-burst semantics.
+    pub fn is_loop_detected_recently(&self) -> bool {
+        self.loop_detected_recently.load(Ordering::Acquire)
+    }
+
+    /// Clear the "loop detected recently" flag.
+    /// Called at the start of each `process_message` turn so a new user
+    /// message starts with a clean slate.
+    pub(super) fn reset_loop_detected_recently(&self) {
+        self.loop_detected_recently.store(false, Ordering::Release);
+    }
+
+    /// Mark the loop-detector warning as having just fired.
+    pub(super) fn mark_loop_detected_recently(&self) {
+        self.loop_detected_recently.store(true, Ordering::Release);
     }
 }


### PR DESCRIPTION
## Summary

Implements M8.10-C from #575 (Problem C): the LOOP DETECTED warning fires at most once per session-burst instead of emitting identical noise on every re-engagement.

- Adds `loop_detected_recently: Arc<AtomicBool>` on `Agent` (mirrors the `shutdown` field pattern).
- New `dedup_loop_warning` helper: first fire returns the warning text and sets the flag; subsequent fires within the same burst return `Err(eyre!("agent loop got stuck - please rephrase or simplify your request"))` so the loop cannot keep emitting identical noise.
- Flag resets at the top of every `process_message_inner` invocation so each new user message starts clean.
- Per-turn `LoopDetector::new(12)` left untouched; dedup is a separate session-level layer on top.

Option A (session-scoped single-fire on `Agent`). Option B was unnecessary because the only callers needed the existing `Result<ConversationResponse>` return type.

## Test plan

- [x] `cargo test -p octos-agent` - 846 unit + integration tests pass (5 new)
- [x] `cargo test -p octos-cli` - 257 + 17 tests pass
- [x] `cargo fmt --all -- --check`
- [x] Five new tests:
  - `dedup_loop_warning_returns_warning_on_first_fire`
  - `dedup_loop_warning_returns_terminal_error_on_second_fire`
  - `dedup_loop_warning_resets_after_reset`
  - `process_message_resets_loop_detected_flag_at_start`
  - `process_message_fires_loop_warning_once_then_terminal_error`

Refs #575 Problem C.