### PR TITLE
fix(storage): unify session journals — eliminate split-brain spawn_only file delivery loss

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -1443,31 +1443,37 @@ async fn replay_committed_session_results(
         return Vec::new();
     };
 
+    // Collect candidate-events first WITHOUT early-returning. The previous
+    // shape returned `events` as soon as ANY candidate file resolved, even
+    // when its filtered output was empty — short-circuiting the topic-less
+    // fallback below for the case where a topic-less candidate JSONL exists
+    // but only contains user/tool-trace lines (no displayable assistant
+    // content). The fallback is the only path that surfaces a topic-bearing
+    // audio bubble to a topic-less reconnect, so we must NOT early-return on
+    // an empty candidate result.
+    let mut candidate_events: Vec<String> = Vec::new();
     for candidate in &candidates {
         if let Some(session) = session_loader.load(candidate).await {
-            let events: Vec<String> = session
-                .messages
-                .iter()
-                .enumerate()
-                .filter(|(seq, message)| {
-                    since_seq.is_none_or(|since| *seq > since)
-                        && message.role == MessageRole::Assistant
-                        && assistant_message_has_displayable_content(message)
-                })
-                .map(|(seq, message)| {
+            for (seq, message) in session.messages.iter().enumerate() {
+                let passes = since_seq.is_none_or(|since| seq > since)
+                    && message.role == MessageRole::Assistant
+                    && assistant_message_has_displayable_content(message);
+                if !passes {
+                    continue;
+                }
+                candidate_events.push(
                     build_session_result_event_from_message(
                         message_info_from_history_message(message, &data_dir, seq),
                         topic,
                     )
-                    .to_string()
-                })
-                .collect();
-            if events.is_empty() {
-                record_replay("session_result", "empty", 1);
-            } else {
-                record_replay("session_result", "emitted", events.len());
+                    .to_string(),
+                );
             }
-            return events;
+            // Stop at the first resolved candidate file even if it produced
+            // zero displayable events — we do not want to layer multiple
+            // candidate JSONLs on top of each other; the fallback below
+            // handles the topic-less union case explicitly.
+            break;
         }
     }
 
@@ -1476,15 +1482,14 @@ async fn replay_committed_session_results(
     // without a topic, none of the topic-less candidates above resolves to
     // that file. Scan every per-user JSONL for these candidates' base_keys
     // and union the assistant messages so the audio bubble re-materialises.
+    let mut fallback_events: Vec<(chrono::DateTime<chrono::Utc>, String)> = Vec::new();
     if topic.is_none() {
-        let mut scanned: Vec<String> = Vec::new();
-        let mut events: Vec<(chrono::DateTime<chrono::Utc>, String)> = Vec::new();
+        let mut scanned: std::collections::HashSet<String> = std::collections::HashSet::new();
         for candidate in &candidates {
             let base_key = candidate.base_key();
-            if scanned.iter().any(|seen| seen == base_key) {
+            if !scanned.insert(base_key.to_string()) {
                 continue;
             }
-            scanned.push(base_key.to_string());
             for topic_key in session_loader.list_user_session_keys(base_key) {
                 if topic_key.topic().is_none() {
                     continue; // already covered by candidate-load above
@@ -1494,8 +1499,16 @@ async fn replay_committed_session_results(
                 };
                 let topic_str = topic_key.topic().map(str::to_string);
                 for (seq, message) in session.messages.iter().enumerate() {
-                    let passes = since_seq.is_none_or(|since| seq > since)
-                        && message.role == MessageRole::Assistant
+                    // NOTE: we deliberately do NOT apply `since_seq` here.
+                    // `since_seq` is a per-watcher cursor measured against the
+                    // unified replay sequence — comparing it to a per-file
+                    // index is the wrong axis (a cursor of 5 must NOT mean
+                    // "skip 5 messages of EACH topic file"). The fallback's
+                    // job is to re-materialise spawn_only file deliveries on
+                    // a topic-less reconnect; tracking per-file cursors is
+                    // meaningless here and was silently dropping legitimate
+                    // assistant rows.
+                    let passes = message.role == MessageRole::Assistant
                         && assistant_message_has_displayable_content(message);
                     if !passes {
                         continue;
@@ -1505,16 +1518,35 @@ async fn replay_committed_session_results(
                         topic_str.as_deref(),
                     )
                     .to_string();
-                    events.push((message.timestamp, payload));
+                    fallback_events.push((message.timestamp, payload));
                 }
             }
         }
-        if !events.is_empty() {
-            events.sort_by_key(|(timestamp, _)| *timestamp);
-            let payloads: Vec<String> = events.into_iter().map(|(_, payload)| payload).collect();
-            record_replay("session_result", "emitted_topic_fallback", payloads.len());
-            return payloads;
-        }
+    }
+
+    if !candidate_events.is_empty() && !fallback_events.is_empty() {
+        // Both branches produced events — concatenate, candidate first then
+        // fallback (sorted by timestamp). This is rare (it would require a
+        // displayable-message topic-less candidate AND a populated topic
+        // file under the same base_key) but we must still surface both.
+        fallback_events.sort_by_key(|(timestamp, _)| *timestamp);
+        let mut combined = candidate_events;
+        combined.extend(fallback_events.into_iter().map(|(_, payload)| payload));
+        record_replay("session_result", "emitted_with_topic_fallback", combined.len());
+        return combined;
+    }
+
+    if !candidate_events.is_empty() {
+        record_replay("session_result", "emitted", candidate_events.len());
+        return candidate_events;
+    }
+
+    if !fallback_events.is_empty() {
+        fallback_events.sort_by_key(|(timestamp, _)| *timestamp);
+        let payloads: Vec<String> =
+            fallback_events.into_iter().map(|(_, payload)| payload).collect();
+        record_replay("session_result", "emitted_topic_fallback", payloads.len());
+        return payloads;
     }
 
     record_replay("session_result", "missing_session", 1);
@@ -2830,6 +2862,184 @@ mod tests {
             media[0].as_str().unwrap_or_default().starts_with("pf/"),
             "audio path must be projected through the profile-relative file handle so the web client can fetch it"
         );
+    }
+
+    #[tokio::test]
+    async fn topic_less_fallback_runs_when_candidate_topicless_file_is_empty() {
+        // Regression for the topic-less-fallback short-circuit bug.
+        //
+        // When a topic-less candidate JSONL exists on disk but contains zero
+        // displayable assistant messages (only user lines, or only tool-trace
+        // assistant entries with empty content), the candidate-load early-
+        // returned with `events = []` BEFORE the topic-less per-user fallback
+        // ran. As a result the audio bubble committed under a topic-bearing
+        // file was never surfaced to a topic-less reconnect.
+        //
+        // Post-fix: the fallback path runs whenever the candidate-load returned
+        // empty content (vs returned a Some(session) with displayable rows). A
+        // populated topic-bearing per-user JSONL must surface even when an
+        // empty topic-less per-user file co-exists for the same base_key.
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+
+        // Topic-less per-user JSONL: exists, but only contains a user line —
+        // zero displayable assistant content.
+        let topicless_key = current_profile_api_session_key_with_topic(
+            Some(TEST_PROFILE_ID),
+            "fallback-chat",
+            None,
+        );
+        actor_persist_to_per_user(
+            data_dir.path(),
+            &topicless_key,
+            Message::user("hello — no assistant response yet on this branch"),
+        )
+        .await;
+
+        // Topic-bearing per-user JSONL: holds the actually-committed audio
+        // bubble that the topic-less reconnect must replay.
+        let topic = "site astro";
+        let topic_key = current_profile_api_session_key_with_topic(
+            Some(TEST_PROFILE_ID),
+            "fallback-chat",
+            Some(topic),
+        );
+        let mp3 = data_dir.path().join("audio").join("fallback.mp3");
+        std::fs::create_dir_all(mp3.parent().unwrap()).unwrap();
+        std::fs::write(&mp3, b"mp3 bytes").unwrap();
+        actor_persist_to_per_user(
+            data_dir.path(),
+            &topic_key,
+            Message {
+                role: MessageRole::Assistant,
+                content: "✓ topic-bearing audio bubble committed under topic JSONL".into(),
+                media: vec![mp3.to_string_lossy().into_owned()],
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: None,
+                timestamp: chrono::Utc::now(),
+            },
+        )
+        .await;
+
+        let state = ApiState {
+            inbound_tx: mpsc::channel(1).0,
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            watchers: Arc::new(Mutex::new(HashMap::new())),
+            auth_token: None,
+            profile_id: Some(TEST_PROFILE_ID.to_string()),
+            sessions,
+            task_query: None,
+            on_session_deleted: None,
+            metrics_renderer: None,
+        };
+
+        let replayed =
+            replay_committed_session_results(&state, "fallback-chat", None, None).await;
+        let topic_event = replayed
+            .iter()
+            .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
+            .find(|payload| {
+                payload["message"]["content"]
+                    .as_str()
+                    .is_some_and(|c| c.contains("topic-bearing audio bubble"))
+            });
+        assert!(
+            topic_event.is_some(),
+            "topic-less reconnect must reach the per-user fallback when the \
+             candidate topic-less JSONL is empty — the early `return events;` \
+             in the candidate-load loop short-circuited the fallback and the \
+             topic-bearing audio bubble silently disappeared"
+        );
+    }
+
+    #[tokio::test]
+    async fn topic_less_fallback_does_not_strip_messages_via_per_file_seq() {
+        // Regression for the wrong-axis `since_seq` filter in the topic-less
+        // fallback. Pre-fix, `since_seq` was compared against per-file
+        // `enumerate()` positions inside EACH topic JSONL independently — a
+        // watcher cursor of N meant "skip N messages of every topic file"
+        // instead of "skip the first N messages in the unified replay".
+        // For any topic file with > N messages this either wrongly stripped
+        // legitimate later assistant rows or wrongly let early rows through.
+        //
+        // Post-fix, the fallback path drops the per-file `since_seq` filter
+        // entirely. The fallback only runs on a topic-less reconnect — that
+        // is, the watcher has no unified cursor against which a per-file
+        // index could be measured. Tracking it was meaningless. We pin the
+        // contract: with `since_seq=Some(N)` the fallback still emits every
+        // displayable assistant message regardless of position in its file.
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+
+        // Topic-less per-user JSONL is empty so the candidate-load returns
+        // no events; the fallback is the only path that surfaces the audio
+        // bubbles below.
+        let topicless_key = current_profile_api_session_key_with_topic(
+            Some(TEST_PROFILE_ID),
+            "long-topic-chat",
+            None,
+        );
+        actor_persist_to_per_user(
+            data_dir.path(),
+            &topicless_key,
+            Message::user("kick off the topic"),
+        )
+        .await;
+
+        // Topic-bearing per-user JSONL with many displayable assistant rows.
+        // Pre-fix, with `since_seq=Some(5)` the fallback would silently strip
+        // rows 0..=5 from the topic file's per-file index (so messages 0-5
+        // would be dropped).
+        let topic = "long-topic";
+        let topic_key = current_profile_api_session_key_with_topic(
+            Some(TEST_PROFILE_ID),
+            "long-topic-chat",
+            Some(topic),
+        );
+        for n in 0..20usize {
+            actor_persist_to_per_user(
+                data_dir.path(),
+                &topic_key,
+                Message::assistant(format!("topic answer {n}")),
+            )
+            .await;
+        }
+
+        let state = ApiState {
+            inbound_tx: mpsc::channel(1).0,
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            watchers: Arc::new(Mutex::new(HashMap::new())),
+            auth_token: None,
+            profile_id: Some(TEST_PROFILE_ID.to_string()),
+            sessions,
+            task_query: None,
+            on_session_deleted: None,
+            metrics_renderer: None,
+        };
+
+        let replayed =
+            replay_committed_session_results(&state, "long-topic-chat", Some(5), None).await;
+        let recovered: std::collections::HashSet<String> = replayed
+            .iter()
+            .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
+            .filter_map(|payload| {
+                payload["message"]["content"]
+                    .as_str()
+                    .map(str::to_string)
+            })
+            .collect();
+        for n in 0..20usize {
+            let expected = format!("topic answer {n}");
+            assert!(
+                recovered.contains(&expected),
+                "fallback must surface every displayable assistant message in \
+                 a topic file regardless of `since_seq` (a per-watcher cursor \
+                 measured against the unified replay, NOT the per-file index). \
+                 Missing: `{expected}`"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -953,8 +953,16 @@ impl ApiChannel {
         false
     }
 
-    /// Persist a message to the session JSONL for the given chat_id and
-    /// return the authoritative committed message shape when available.
+    /// Persist a message to the canonical per-user session JSONL and return
+    /// the authoritative committed message shape when available.
+    ///
+    /// Routes through `SessionHandle` so bus-side writes hit the same
+    /// `users/<encoded_base>/sessions/<encoded_topic>.jsonl` file the
+    /// SessionActor uses. This is the unified write path that closed the
+    /// split-brain bug where bus-side writes landed in a hardcoded
+    /// `default.jsonl` while actor-side writes landed in `<topic>.jsonl`.
+    /// The legacy flat layout is no longer touched on writes; reads still
+    /// merge it for back-compat with stale on-disk data.
     async fn persist_to_session(
         &self,
         chat_id: &str,
@@ -963,57 +971,44 @@ impl ApiChannel {
     ) -> Option<MessageInfo> {
         let key =
             current_profile_api_session_key_with_topic(self.profile_id.as_deref(), chat_id, topic);
-        let mut sess = self.sessions.lock().await;
-        let committed = match sess.add_message_with_seq(&key, message.clone()).await {
-            Ok(seq) => {
-                info!(chat_id = %chat_id, key = %key.0, seq, "persisted file/notification to session");
-                Some(message_info_from_history_message(
-                    &message,
-                    &sess.data_dir(),
-                    seq,
-                ))
-            }
-            Err(e) => {
-                tracing::warn!(chat_id = %chat_id, error = %e, "failed to persist message to session");
-                None
-            }
+        let data_dir = {
+            let sess = self.sessions.lock().await;
+            sess.data_dir()
         };
 
-        // Also write to the per-user SessionHandle path so the web client
-        // (which reads from per-user JSONL via source=full) can see file deliveries.
-        let data_dir = sess.data_dir();
-        drop(sess);
-        let base_key = key.base_key();
-        let encoded = crate::session::encode_path_component(base_key);
-        let per_user_dir = data_dir.join("users").join(encoded).join("sessions");
-        let per_user_path = per_user_dir.join("default.jsonl");
-        if per_user_path.exists() {
-            if let Ok(msg_json) = serde_json::to_string(&message) {
-                let path_clone = per_user_path.clone();
-                match tokio::task::spawn_blocking(move || {
-                    use std::io::Write;
-                    let mut f = std::fs::OpenOptions::new()
-                        .append(true)
-                        .open(&per_user_path)?;
-                    writeln!(f, "{}", msg_json)?;
-                    Ok::<_, std::io::Error>(())
-                })
-                .await
-                {
-                    Ok(Ok(())) => info!(chat_id = %chat_id, "persisted to per-user session"),
-                    Ok(Err(e)) => {
-                        tracing::warn!(chat_id = %chat_id, path = %path_clone.display(), error = %e, "per-user session write failed")
-                    }
-                    Err(e) => {
-                        tracing::warn!(chat_id = %chat_id, error = %e, "per-user session spawn_blocking failed")
-                    }
-                }
-            }
-        } else {
-            tracing::debug!(chat_id = %chat_id, path = %per_user_path.display(), "per-user session path not found, skipping");
+        let mut handle = crate::session::SessionHandle::open(&data_dir, &key);
+        let result = handle.add_message_with_seq(message.clone()).await;
+
+        // Drop any stale `SessionManager` cache entry for this key so a
+        // follow-up read (e.g. duplicate-detection or `?source=full`) consults
+        // disk instead of returning a pre-write empty `Session`. Without this
+        // invalidation the manager's LRU cache could shadow the canonical
+        // per-user JSONL and silently strip newly-written messages.
+        {
+            let mut sess = self.sessions.lock().await;
+            sess.invalidate_cache(&key);
         }
 
-        committed
+        match result {
+            Ok(seq) => {
+                info!(
+                    chat_id = %chat_id,
+                    key = %key.0,
+                    seq,
+                    "persisted file/notification to canonical per-user session"
+                );
+                Some(message_info_from_history_message(&message, &data_dir, seq))
+            }
+            Err(error) => {
+                tracing::warn!(
+                    chat_id = %chat_id,
+                    key = %key.0,
+                    error = %error,
+                    "failed to persist message to canonical per-user session"
+                );
+                None
+            }
+        }
     }
 }
 
@@ -1473,6 +1468,52 @@ async fn replay_committed_session_results(
                 record_replay("session_result", "emitted", events.len());
             }
             return events;
+        }
+    }
+
+    // Topic-less reconnect fallback. The actor writes spawn_only file
+    // deliveries to per-user `<topic>.jsonl`; when the watcher subscribes
+    // without a topic, none of the topic-less candidates above resolves to
+    // that file. Scan every per-user JSONL for these candidates' base_keys
+    // and union the assistant messages so the audio bubble re-materialises.
+    if topic.is_none() {
+        let mut scanned: Vec<String> = Vec::new();
+        let mut events: Vec<(chrono::DateTime<chrono::Utc>, String)> = Vec::new();
+        for candidate in &candidates {
+            let base_key = candidate.base_key();
+            if scanned.iter().any(|seen| seen == base_key) {
+                continue;
+            }
+            scanned.push(base_key.to_string());
+            for topic_key in session_loader.list_user_session_keys(base_key) {
+                if topic_key.topic().is_none() {
+                    continue; // already covered by candidate-load above
+                }
+                let Some(session) = session_loader.load(&topic_key).await else {
+                    continue;
+                };
+                let topic_str = topic_key.topic().map(str::to_string);
+                for (seq, message) in session.messages.iter().enumerate() {
+                    let passes = since_seq.is_none_or(|since| seq > since)
+                        && message.role == MessageRole::Assistant
+                        && assistant_message_has_displayable_content(message);
+                    if !passes {
+                        continue;
+                    }
+                    let payload = build_session_result_event_from_message(
+                        message_info_from_history_message(message, &data_dir, seq),
+                        topic_str.as_deref(),
+                    )
+                    .to_string();
+                    events.push((message.timestamp, payload));
+                }
+            }
+        }
+        if !events.is_empty() {
+            events.sort_by_key(|(timestamp, _)| *timestamp);
+            let payloads: Vec<String> = events.into_iter().map(|(_, payload)| payload).collect();
+            record_replay("session_result", "emitted_topic_fallback", payloads.len());
+            return payloads;
         }
     }
 
@@ -2573,6 +2614,222 @@ mod tests {
             "user-message session_result events must carry the client-supplied id so the web client can correlate optimistic bubbles to the server seq"
         );
         assert!(rx.try_recv().is_err());
+    }
+
+    /// Helper: simulate the actor-side write to per-user JSONL (no FLAT write).
+    /// Mirrors `SessionActor::deliver_background_notification` for spawn_only
+    /// file deliveries — the actor stamps `_history_persisted=true` on the
+    /// outbound, so ApiChannel never writes for these.
+    async fn actor_persist_to_per_user(
+        data_dir: &Path,
+        session_key: &SessionKey,
+        message: Message,
+    ) {
+        let mut handle = crate::session::SessionHandle::open(data_dir, session_key);
+        handle.add_message_with_seq(message).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn bus_side_persist_routes_to_canonical_per_user_topic_jsonl() {
+        // Pins the unified-write contract introduced by the storage unification
+        // fix. The bus-side `persist_to_session` previously wrote to:
+        //   - legacy flat `sessions/<encoded_full_key>.jsonl`
+        //   - hardcoded per-user `users/<encoded_base>/sessions/default.jsonl`
+        //     (ignored topic — actor-side writes used `<topic>.jsonl`)
+        //
+        // Post-fix it must route through `SessionHandle` so writes land in the
+        // canonical per-user `<encoded_topic>.jsonl` file the actor uses.
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+        let channel = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            sessions,
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+
+        let topic = "site astro";
+        let mp3 = data_dir.path().join("audio").join("a.mp3");
+        std::fs::create_dir_all(mp3.parent().unwrap()).unwrap();
+        std::fs::write(&mp3, b"mp3 bytes").unwrap();
+
+        let outbound = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "web-canonical".into(),
+            content: "✓ fm_tts done".into(),
+            reply_to: None,
+            media: vec![mp3.to_string_lossy().into_owned()],
+            metadata: serde_json::json!({ "topic": topic }),
+        };
+        channel.send(&outbound).await.unwrap();
+
+        // Canonical per-user topic file must exist with the message.
+        let encoded_base =
+            crate::session::encode_path_component(&format!("{TEST_PROFILE_ID}:api:web-canonical"));
+        let encoded_topic = crate::session::encode_path_component(topic);
+        let canonical = data_dir
+            .path()
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions")
+            .join(format!("{encoded_topic}.jsonl"));
+        assert!(
+            canonical.exists(),
+            "bus-side persist must write to canonical per-user `<topic>.jsonl` ({}) — \
+             this is the file the SessionActor also writes, eliminating split-brain storage",
+            canonical.display()
+        );
+        let body = std::fs::read_to_string(&canonical).unwrap();
+        assert!(
+            body.contains("fm_tts done"),
+            "canonical per-user `<topic>.jsonl` must record the persisted message"
+        );
+
+        // Legacy per-user `default.jsonl` mirror must NOT be written when a
+        // topic is supplied — that's the bug we are fixing.
+        let legacy_default = data_dir
+            .path()
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions")
+            .join("default.jsonl");
+        assert!(
+            !legacy_default.exists(),
+            "topic-bearing bus-side persist must NOT touch the hardcoded `default.jsonl` mirror — \
+             that legacy fan-out caused the split-brain bug"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_only_file_delivery_is_visible_to_watcher_replay_after_reconnect() {
+        // Regression for the split-brain session-storage bug.
+        //
+        // Production scenario reproduced on mini2 (2026-04-23):
+        //   1. A spawn_only background task (e.g. fm_tts) finishes long after
+        //      the user's interactive turn ended, so the live SSE pending
+        //      sender for the session has either been dropped or is empty.
+        //   2. SessionActor::deliver_background_notification persists the file
+        //      message via the per-actor `SessionHandle` (per-user JSONL at
+        //      `users/<encoded_base>/sessions/<encoded_topic>.jsonl`) and stamps
+        //      `_history_persisted=true` on the OutboundMessage.
+        //   3. ApiChannel::send sees `_history_persisted=true` and skips its
+        //      own bus-side write (legacy flat layout
+        //      `sessions/<encoded_full_key>.jsonl` plus the hardcoded per-user
+        //      `default.jsonl` mirror — note that mirror IGNORES the actor's
+        //      topic).
+        //   4. The user reconnects. Their web client opens
+        //      `/sessions/{chat_id}/events/stream` — without re-supplying the
+        //      topic in the query string (a real failure mode of the dashboard
+        //      reload + workflow listing flows). The only chance the audio
+        //      bubble has to materialise is `replay_committed_session_results`.
+        //
+        // Pre-fix, the actor's write lands in `<topic>.jsonl` while the
+        // ApiChannel write — when it happens at all — hits FLAT or the
+        // hardcoded `default.jsonl`. With no topic in the candidate-key set
+        // and nothing in the topic-less per-user files, replay returns zero
+        // events and the audio bubble silently disappears.
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+        let topic = "site astro";
+        let session_key = current_profile_api_session_key_with_topic(
+            Some(TEST_PROFILE_ID),
+            "test-chat",
+            Some(topic),
+        );
+
+        // Actor persists the user message into per-user `<topic>.jsonl` (the
+        // production gateway path: SessionActor handles inbound BEFORE
+        // ApiChannel.send is ever invoked for this turn).
+        actor_persist_to_per_user(
+            data_dir.path(),
+            &session_key,
+            Message::user("please make me a podcast about cats"),
+        )
+        .await;
+
+        // Simulate the mp3 the spawn_only fm_tts skill produced.
+        let mp3_path = data_dir.path().join("artifacts").join("podcast.mp3");
+        std::fs::create_dir_all(mp3_path.parent().unwrap()).unwrap();
+        std::fs::write(&mp3_path, b"ID3...mp3 bytes").unwrap();
+
+        // Actor-side spawn_only delivery — the only writer that records the
+        // file message anywhere. ApiChannel never writes because the actor
+        // stamps `_history_persisted=true`.
+        actor_persist_to_per_user(
+            data_dir.path(),
+            &session_key,
+            Message {
+                role: MessageRole::Assistant,
+                content: "✓ fm_tts completed — file delivered".into(),
+                media: vec![mp3_path.to_string_lossy().into_owned()],
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: None,
+                timestamp: chrono::Utc::now(),
+            },
+        )
+        .await;
+
+        let state = ApiState {
+            inbound_tx: mpsc::channel(1).0,
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            watchers: Arc::new(Mutex::new(HashMap::new())),
+            auth_token: None,
+            profile_id: Some(TEST_PROFILE_ID.to_string()),
+            sessions,
+            task_query: None,
+            on_session_deleted: None,
+            metrics_renderer: None,
+        };
+
+        // Cold reconnect WITHOUT topic — this is what fails pre-fix because
+        // the candidate-key set never reaches `<topic>.jsonl` and the
+        // hardcoded per-user `default.jsonl` mirror was never written.
+        let replayed_topicless =
+            replay_committed_session_results(&state, "test-chat", None, None).await;
+
+        let event_topicless = replayed_topicless
+            .iter()
+            .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
+            .find(|payload| {
+                payload["message"]["content"]
+                    .as_str()
+                    .is_some_and(|c| c.contains("fm_tts completed"))
+            });
+        assert!(
+            event_topicless.is_some(),
+            "topic-less reconnect must still surface the spawn_only file delivery — \
+             actor-side write to per-user `<topic>.jsonl` was lost because the \
+             bus-side reader never visits topic-bearing per-user files when the \
+             watcher subscribes without a topic. This is the split-brain \
+             session-storage bug"
+        );
+
+        // Hot reconnect WITH topic — this happens to work pre-fix because the
+        // SessionManager::load merge sees per-user `<topic>.jsonl`. We pin
+        // the contract here too so the canonical-write fix doesn't quietly
+        // break the topic path while landing the topic-less path.
+        let replayed_topic =
+            replay_committed_session_results(&state, "test-chat", None, Some(topic)).await;
+        let event_topic = replayed_topic
+            .iter()
+            .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
+            .find(|payload| {
+                payload["message"]["content"]
+                    .as_str()
+                    .is_some_and(|c| c.contains("fm_tts completed"))
+            })
+            .expect("topic-aware reconnect must continue to surface the file delivery");
+        let media = event_topic["message"]["media"]
+            .as_array()
+            .expect("file-delivery session_result event must carry a media array");
+        assert_eq!(media.len(), 1, "exactly one audio handle expected");
+        assert!(
+            media[0].as_str().unwrap_or_default().starts_with("pf/"),
+            "audio path must be projected through the profile-relative file handle so the web client can fetch it"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -956,11 +956,14 @@ impl ApiChannel {
     /// Persist a message to the canonical per-user session JSONL and return
     /// the authoritative committed message shape when available.
     ///
-    /// Routes through `SessionHandle` so bus-side writes hit the same
-    /// `users/<encoded_base>/sessions/<encoded_topic>.jsonl` file the
-    /// SessionActor uses. This is the unified write path that closed the
-    /// split-brain bug where bus-side writes landed in a hardcoded
-    /// `default.jsonl` while actor-side writes landed in `<topic>.jsonl`.
+    /// Routes through the shared
+    /// [`crate::session::persist_message_through_canonical_path`] helper so:
+    ///   - bus-side writes hit the same
+    ///     `users/<encoded_base>/sessions/<encoded_topic>.jsonl` file the
+    ///     `SessionActor` uses (closing the split-brain storage bug);
+    ///   - concurrent writes for the same session_key serialise via a
+    ///     per-key Tokio mutex (closing the concurrent-persist seq race).
+    ///
     /// The legacy flat layout is no longer touched on writes; reads still
     /// merge it for back-compat with stale on-disk data.
     async fn persist_to_session(
@@ -976,8 +979,12 @@ impl ApiChannel {
             sess.data_dir()
         };
 
-        let mut handle = crate::session::SessionHandle::open(&data_dir, &key);
-        let result = handle.add_message_with_seq(message.clone()).await;
+        let result = crate::session::persist_message_through_canonical_path(
+            &data_dir,
+            &key,
+            message.clone(),
+        )
+        .await;
 
         // Drop any stale `SessionManager` cache entry for this key so a
         // follow-up read (e.g. duplicate-detection or `?source=full`) consults
@@ -1532,7 +1539,11 @@ async fn replay_committed_session_results(
         fallback_events.sort_by_key(|(timestamp, _)| *timestamp);
         let mut combined = candidate_events;
         combined.extend(fallback_events.into_iter().map(|(_, payload)| payload));
-        record_replay("session_result", "emitted_with_topic_fallback", combined.len());
+        record_replay(
+            "session_result",
+            "emitted_with_topic_fallback",
+            combined.len(),
+        );
         return combined;
     }
 
@@ -1543,8 +1554,10 @@ async fn replay_committed_session_results(
 
     if !fallback_events.is_empty() {
         fallback_events.sort_by_key(|(timestamp, _)| *timestamp);
-        let payloads: Vec<String> =
-            fallback_events.into_iter().map(|(_, payload)| payload).collect();
+        let payloads: Vec<String> = fallback_events
+            .into_iter()
+            .map(|(_, payload)| payload)
+            .collect();
         record_replay("session_result", "emitted_topic_fallback", payloads.len());
         return payloads;
     }
@@ -2865,6 +2878,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn concurrent_bus_side_persists_get_distinct_seqs() {
+        // Regression for the concurrent-persist seq race introduced when
+        // `persist_to_session` switched from `SessionManager::add_message_with_seq`
+        // (shared mutex via `Arc<Mutex<SessionManager>>`) to
+        // `SessionHandle::open` + `add_message_with_seq`.
+        //
+        // Each `SessionHandle::open` loads disk into its OWN per-instance
+        // `messages: Vec<_>`. Two concurrent calls both observe `len = N`,
+        // both append, both return `seq = N`. Watcher correlation breaks —
+        // the web client sees two "session_result, seq=N" rows and renders
+        // duplicates.
+        //
+        // Post-fix: writes for the same session_key must serialise at the
+        // storage layer (per-key mutex map shared across actor + channel) so
+        // each call observes a fresh `len` and returns a distinct seq.
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+        let channel = Arc::new(ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            sessions,
+            Some(TEST_PROFILE_ID.to_string()),
+        ));
+
+        let chat_id = "race-chat";
+        let topic = Some("race-topic");
+        let n = 16usize;
+
+        let mut handles = Vec::new();
+        for i in 0..n {
+            let channel = channel.clone();
+            let chat_id = chat_id.to_string();
+            handles.push(tokio::spawn(async move {
+                channel
+                    .persist_to_session(
+                        &chat_id,
+                        topic,
+                        Message::assistant(format!("concurrent assistant {i}")),
+                    )
+                    .await
+                    .and_then(|info| info.seq)
+            }));
+        }
+
+        let mut seqs: Vec<usize> = Vec::with_capacity(n);
+        for h in handles {
+            let result = h.await.expect("join");
+            seqs.push(result.expect("persist must succeed and return a seq"));
+        }
+        seqs.sort();
+        let expected: Vec<usize> = (0..n).collect();
+        assert_eq!(
+            seqs, expected,
+            "{n} concurrent bus-side persist calls must each receive a \
+             distinct sequence in 0..N (storage layer must serialise writes \
+             via a per-key lock map shared across actor + channel)"
+        );
+    }
+
+    #[tokio::test]
     async fn topic_less_fallback_runs_when_candidate_topicless_file_is_empty() {
         // Regression for the topic-less-fallback short-circuit bug.
         //
@@ -2935,8 +3009,7 @@ mod tests {
             metrics_renderer: None,
         };
 
-        let replayed =
-            replay_committed_session_results(&state, "fallback-chat", None, None).await;
+        let replayed = replay_committed_session_results(&state, "fallback-chat", None, None).await;
         let topic_event = replayed
             .iter()
             .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
@@ -3024,11 +3097,7 @@ mod tests {
         let recovered: std::collections::HashSet<String> = replayed
             .iter()
             .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
-            .filter_map(|payload| {
-                payload["message"]["content"]
-                    .as_str()
-                    .map(str::to_string)
-            })
+            .filter_map(|payload| payload["message"]["content"].as_str().map(str::to_string))
             .collect();
         for n in 0..20usize {
             let expected = format!("topic answer {n}");

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -1458,7 +1458,15 @@ async fn replay_committed_session_results(
     // content). The fallback is the only path that surfaces a topic-bearing
     // audio bubble to a topic-less reconnect, so we must NOT early-return on
     // an empty candidate result.
-    let mut candidate_events: Vec<String> = Vec::new();
+    //
+    // Both branches stash `(timestamp, payload)` so the combined-replay path
+    // can globally sort by timestamp before returning. Pre-fix, candidate
+    // events were concatenated in disk order in front of fallback events
+    // — if the two branches' timestamps interleaved (e.g. candidate=T0,T2,T4
+    // and fallback=T1,T3,T5), replay surfaced T0,T2,T4,T1,T3,T5 instead of
+    // T0..T5. The web client renders bubbles in delivery order, so the
+    // mis-sort manifested as a "leap back in time" mid-replay.
+    let mut candidate_events: Vec<(chrono::DateTime<chrono::Utc>, String)> = Vec::new();
     for candidate in &candidates {
         if let Some(session) = session_loader.load(candidate).await {
             for (seq, message) in session.messages.iter().enumerate() {
@@ -1468,13 +1476,12 @@ async fn replay_committed_session_results(
                 if !passes {
                     continue;
                 }
-                candidate_events.push(
-                    build_session_result_event_from_message(
-                        message_info_from_history_message(message, &data_dir, seq),
-                        topic,
-                    )
-                    .to_string(),
-                );
+                let payload = build_session_result_event_from_message(
+                    message_info_from_history_message(message, &data_dir, seq),
+                    topic,
+                )
+                .to_string();
+                candidate_events.push((message.timestamp, payload));
             }
             // Stop at the first resolved candidate file even if it produced
             // zero displayable events — we do not want to layer multiple
@@ -1532,24 +1539,29 @@ async fn replay_committed_session_results(
     }
 
     if !candidate_events.is_empty() && !fallback_events.is_empty() {
-        // Both branches produced events — concatenate, candidate first then
-        // fallback (sorted by timestamp). This is rare (it would require a
-        // displayable-message topic-less candidate AND a populated topic
-        // file under the same base_key) but we must still surface both.
-        fallback_events.sort_by_key(|(timestamp, _)| *timestamp);
-        let mut combined = candidate_events;
-        combined.extend(fallback_events.into_iter().map(|(_, payload)| payload));
+        // Both branches produced events — globally sort by timestamp so the
+        // unified set surfaces in true chronological order. (See top-of-fn
+        // comment for the previous out-of-order shape.)
+        let mut combined: Vec<(chrono::DateTime<chrono::Utc>, String)> = candidate_events;
+        combined.extend(fallback_events);
+        combined.sort_by_key(|(timestamp, _)| *timestamp);
+        let payloads: Vec<String> = combined.into_iter().map(|(_, payload)| payload).collect();
         record_replay(
             "session_result",
             "emitted_with_topic_fallback",
-            combined.len(),
+            payloads.len(),
         );
-        return combined;
+        return payloads;
     }
 
     if !candidate_events.is_empty() {
-        record_replay("session_result", "emitted", candidate_events.len());
-        return candidate_events;
+        candidate_events.sort_by_key(|(timestamp, _)| *timestamp);
+        let payloads: Vec<String> = candidate_events
+            .into_iter()
+            .map(|(_, payload)| payload)
+            .collect();
+        record_replay("session_result", "emitted", payloads.len());
+        return payloads;
     }
 
     if !fallback_events.is_empty() {
@@ -3109,6 +3121,112 @@ mod tests {
                  Missing: `{expected}`"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn combined_replay_events_are_globally_sorted_by_timestamp() {
+        // Pins the global-timestamp-sort contract for the combined-events
+        // branch in `replay_committed_session_results`. Pre-fix, when both
+        // the candidate-load and the topic-less fallback produced events,
+        // the function concatenated `candidate_events` (in disk order) BEFORE
+        // `fallback_events` (timestamp-sorted) without globally sorting the
+        // unified set. If the two branches' timestamps interleave, replay
+        // delivered them out of chronological order — the web client renders
+        // bubbles in delivery order, so a topic-less reconnect would show
+        // candidate bubbles first then a "leap back in time" to fallback
+        // bubbles whose timestamps fall between candidate ones.
+        //
+        // Post-fix: extract the timestamp from each event's payload and
+        // sort the unified set by timestamp before returning.
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+
+        // Topic-less candidate JSONL with timestamps T0, T2, T4 (even).
+        let topicless_key = current_profile_api_session_key_with_topic(
+            Some(TEST_PROFILE_ID),
+            "interleave-chat",
+            None,
+        );
+        let base = chrono::Utc::now() - chrono::Duration::seconds(60);
+        for (idx, secs) in [0i64, 2, 4].iter().enumerate() {
+            let mut msg = Message::assistant(format!("candidate-{idx}-T{secs}"));
+            msg.timestamp = base + chrono::Duration::seconds(*secs);
+            actor_persist_to_per_user(data_dir.path(), &topicless_key, msg).await;
+        }
+
+        // Topic-bearing fallback file under the same base_key with timestamps
+        // T1, T3, T5 (odd) — interleaving the candidate timestamps.
+        let topic = "interleaved";
+        let topic_key = current_profile_api_session_key_with_topic(
+            Some(TEST_PROFILE_ID),
+            "interleave-chat",
+            Some(topic),
+        );
+        for (idx, secs) in [1i64, 3, 5].iter().enumerate() {
+            let mut msg = Message::assistant(format!("fallback-{idx}-T{secs}"));
+            msg.timestamp = base + chrono::Duration::seconds(*secs);
+            actor_persist_to_per_user(data_dir.path(), &topic_key, msg).await;
+        }
+
+        let state = ApiState {
+            inbound_tx: mpsc::channel(1).0,
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            watchers: Arc::new(Mutex::new(HashMap::new())),
+            auth_token: None,
+            profile_id: Some(TEST_PROFILE_ID.to_string()),
+            sessions,
+            task_query: None,
+            on_session_deleted: None,
+            metrics_renderer: None,
+        };
+
+        // Topic-less reconnect — both the candidate-load and the topic-less
+        // fallback produce events.
+        let replayed =
+            replay_committed_session_results(&state, "interleave-chat", None, None).await;
+
+        let timestamps: Vec<chrono::DateTime<chrono::Utc>> = replayed
+            .iter()
+            .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
+            .filter_map(|payload| {
+                payload["message"]["timestamp"]
+                    .as_str()
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+            })
+            .collect();
+
+        assert_eq!(
+            timestamps.len(),
+            6,
+            "combined replay must surface all six events: {replayed:?}"
+        );
+
+        let mut sorted = timestamps.clone();
+        sorted.sort();
+        assert_eq!(
+            timestamps, sorted,
+            "combined replay must be globally sorted by timestamp; got {timestamps:?}"
+        );
+
+        // Spot-check the chronological interleave (candidate-T0, fallback-T1, ...).
+        let contents: Vec<String> = replayed
+            .iter()
+            .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
+            .filter_map(|payload| payload["message"]["content"].as_str().map(str::to_string))
+            .collect();
+        let expected_order = [
+            "candidate-0-T0",
+            "fallback-0-T1",
+            "candidate-1-T2",
+            "fallback-1-T3",
+            "candidate-2-T4",
+            "fallback-2-T5",
+        ];
+        assert_eq!(
+            contents, expected_order,
+            "combined replay must interleave by timestamp"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/lib.rs
+++ b/crates/octos-bus/src/lib.rs
@@ -58,7 +58,7 @@ pub use resume_policy::{
 };
 pub use session::{
     ActiveSessionStore, Session, SessionHandle, SessionListEntry, SessionManager,
-    validate_topic_name,
+    persist_message_through_canonical_path, validate_topic_name,
 };
 
 #[cfg(feature = "api")]

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1075,10 +1075,12 @@ fn persist_lock_for(key: &SessionKey) -> std::sync::Arc<tokio::sync::Mutex<()>> 
 ///
 /// Writes for the same `key` serialise via a per-key Tokio mutex (see
 /// [`persist_lock_for`]). This is the contract that closed the concurrent-
-/// persist seq race: every caller — whether `SessionActor` (which already
-/// owns `Arc<Mutex<SessionHandle>>` per actor), `ApiChannel::persist_to_session`,
-/// or the standalone `octos serve` `/chat` handlers — should funnel through
-/// this helper so the storage layer is the single ordering point.
+/// persist seq race: every caller — `SessionActor::persist_assistant_message`,
+/// `ApiChannel::persist_to_session`, and the standalone `octos serve` `/chat`
+/// handlers — funnels through this helper so the storage layer is the single
+/// ordering point. Callers that also keep an in-memory `SessionHandle` mirror
+/// the message via [`SessionHandle::push_message_in_memory`] AFTER the disk
+/// write commits, so their local Vec stays consistent without double-writing.
 ///
 /// Preserves the canonical migration path (legacy flat → per-user) inside
 /// `SessionHandle::open`.
@@ -1104,55 +1106,86 @@ impl SessionHandle {
         let user_sessions_dir = data_dir.join("users").join(&encoded_base).join("sessions");
         let _ = std::fs::create_dir_all(&user_sessions_dir);
 
-        // Try loading from new per-user path first
         let topic_filename = Self::topic_filename(key);
         let new_path = user_sessions_dir.join(&topic_filename);
+        let marker_path = Self::migration_marker_path(&user_sessions_dir, key);
+        let legacy_dir = data_dir.join("sessions");
+        let legacy_path = SessionManager::session_path_static(&legacy_dir, key);
 
-        let session = if new_path.exists() {
+        // Migration state machine — three real cases:
+        //   (A) marker present              -> migration is done; per-user is
+        //                                      authoritative. Skip legacy load
+        //                                      AND skip legacy delete (a stale
+        //                                      legacy file is left in place so
+        //                                      operator-level cleanup can find
+        //                                      it; the per-user merge in
+        //                                      `list_user_sessions` would still
+        //                                      dedup if it surfaces).
+        //   (B) per-user + legacy + no marker
+        //                                   -> previous boot's `rewrite_blocking`
+        //                                      succeeded but `remove_file(legacy)`
+        //                                      failed. Best-effort retry the
+        //                                      removal; on success write the
+        //                                      marker. On failure log and keep
+        //                                      going (per-user already wins).
+        //   (C) per-user only               -> normal read.
+        //   (D) legacy only                 -> first-time migration: load,
+        //                                      rewrite into per-user, remove
+        //                                      legacy, write marker.
+        //   (else)                          -> empty session.
+        let session = if marker_path.exists() {
+            // Case (A): marker says migration is done. The per-user file is
+            // authoritative even if a stale legacy file co-exists.
             Self::load_from_file(&new_path, key)
-        } else {
-            // Fall back to legacy flat path for migration. We persist the
-            // loaded history into the per-user JSONL BEFORE removing the
-            // legacy file so a subsequent incremental `add_message_with_seq`
-            // (which only appends a single line) does not silently drop the
-            // pre-migration messages.
-            //
-            // Migration race protection: on a previous open, `rewrite_blocking`
-            // may have succeeded but `remove_file(legacy)` failed. The next
-            // open then sees both files. We mark a per-key `.migrated.<topic>`
-            // flag in the per-user directory after a successful rewrite +
-            // remove pair. If the marker exists we skip migration entirely
-            // (per-user file is authoritative even if a stale legacy file
-            // co-exists). If the marker is missing but per-user exists, we
-            // best-effort retry the legacy removal.
-            let legacy_dir = data_dir.join("sessions");
-            let legacy_path = SessionManager::session_path_static(&legacy_dir, key);
+        } else if new_path.exists() {
             if legacy_path.exists() {
-                debug!(key = %key, "migrating session from legacy flat layout");
-                let session = Self::load_from_file(&legacy_path, key);
-                if let Some(loaded) = session.as_ref() {
-                    if let Err(error) = Self::rewrite_blocking(&new_path, loaded) {
+                // Case (B): partial-migration leftover. Retry the legacy
+                // removal so subsequent boots take the cheap (A) path.
+                match std::fs::remove_file(&legacy_path) {
+                    Ok(()) => {
+                        let _ = std::fs::write(&marker_path, b"migrated-from-flat\n");
+                    }
+                    Err(error) => {
                         warn!(
                             key = %key,
-                            path = %new_path.display(),
+                            legacy_path = %legacy_path.display(),
                             error = %error,
-                            "failed to materialize legacy session into per-user layout; \
-                             leaving legacy file in place"
+                            "failed to retry legacy session removal during open; \
+                             per-user file remains authoritative"
                         );
-                        return Self {
-                            sessions_dir: user_sessions_dir,
-                            session: loaded.clone(),
-                        };
-                    }
-                    if std::fs::remove_file(&legacy_path).is_ok() {
-                        let marker = Self::migration_marker_path(&user_sessions_dir, key);
-                        let _ = std::fs::write(&marker, b"migrated-from-flat\n");
                     }
                 }
-                session
-            } else {
-                None
             }
+            // Case (C): per-user only — straight read.
+            Self::load_from_file(&new_path, key)
+        } else if legacy_path.exists() {
+            // Case (D): first-time migration. Persist into the per-user JSONL
+            // BEFORE removing the legacy file so a subsequent incremental
+            // `add_message_with_seq` (which only appends a single line) does
+            // not silently drop the pre-migration messages.
+            debug!(key = %key, "migrating session from legacy flat layout");
+            let session = Self::load_from_file(&legacy_path, key);
+            if let Some(loaded) = session.as_ref() {
+                if let Err(error) = Self::rewrite_blocking(&new_path, loaded) {
+                    warn!(
+                        key = %key,
+                        path = %new_path.display(),
+                        error = %error,
+                        "failed to materialize legacy session into per-user layout; \
+                         leaving legacy file in place"
+                    );
+                    return Self {
+                        sessions_dir: user_sessions_dir,
+                        session: loaded.clone(),
+                    };
+                }
+                if std::fs::remove_file(&legacy_path).is_ok() {
+                    let _ = std::fs::write(&marker_path, b"migrated-from-flat\n");
+                }
+            }
+            session
+        } else {
+            None
         }
         .unwrap_or_else(|| Session::new(key.clone()));
 
@@ -1363,6 +1396,17 @@ impl SessionHandle {
         }
         record_session_persist("committed");
         Ok(self.session.messages.len().saturating_sub(1))
+    }
+
+    /// Append a message to the in-memory transcript only — no disk I/O.
+    ///
+    /// Used by callers that funneled the persist through
+    /// [`persist_message_through_canonical_path`] and now need to keep the
+    /// per-actor handle's in-memory `messages` consistent with disk WITHOUT
+    /// double-writing (the canonical helper already wrote the JSONL line).
+    pub fn push_message_in_memory(&mut self, message: Message) {
+        self.session.messages.push(message);
+        self.session.updated_at = Utc::now();
     }
 
     /// Insert or update a durable child-session contract and persist it.
@@ -3303,5 +3347,142 @@ mod tests {
         // Parent linkage survives the clear so the supervisor can find
         // the parent on its mark-failed lookup.
         assert_eq!(child_handle.session.parent_key, Some(parent));
+    }
+
+    /// Helper to build the legacy-flat path for a key.
+    fn legacy_session_path(data_dir: &Path, key: &SessionKey) -> PathBuf {
+        SessionManager::session_path_static(&data_dir.join("sessions"), key)
+    }
+
+    /// Helper to build the per-user session path for a key.
+    fn per_user_session_path(data_dir: &Path, key: &SessionKey) -> PathBuf {
+        let encoded_base = encode_path_component(key.base_key());
+        let topic = key.topic().unwrap_or("default");
+        let encoded_topic = encode_path_component(topic);
+        data_dir
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions")
+            .join(format!("{encoded_topic}.jsonl"))
+    }
+
+    /// Helper to build the migration marker path for a key.
+    fn migration_marker_path_for(data_dir: &Path, key: &SessionKey) -> PathBuf {
+        let encoded_base = encode_path_component(key.base_key());
+        let topic = key.topic().unwrap_or("default");
+        let encoded_topic = encode_path_component(topic);
+        data_dir
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions")
+            .join(format!(".migrated.{encoded_topic}"))
+    }
+
+    /// Write a minimal JSONL with one user message at `path`.
+    fn write_jsonl_with_one_user_message(path: &Path, key: &SessionKey, content: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let meta = serde_json::json!({
+            "schema_version": 1,
+            "session_key": key.0,
+            "topic": key.topic(),
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
+        });
+        let msg = make_message(MessageRole::User, content);
+        let body = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&meta).unwrap(),
+            serde_json::to_string(&msg).unwrap()
+        );
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn migration_marker_skips_redundant_migration_when_present() {
+        // Pre-condition: a per-user JSONL exists, the legacy flat file ALSO
+        // exists (e.g. from a stale prior boot), and the per-key migration
+        // marker is present — meaning a previous open already migrated and
+        // confirmed remove. On `SessionHandle::open` we must skip the legacy
+        // load AND the legacy delete entirely: the marker is the authoritative
+        // signal that migration completed, so the per-user file wins and the
+        // stale legacy file is left untouched (a separate operator cleanup
+        // can remove it).
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "marker-skip");
+
+        // 1) Per-user JSONL with the canonical content.
+        let per_user_path = per_user_session_path(tmp.path(), &key);
+        write_jsonl_with_one_user_message(&per_user_path, &key, "canonical");
+
+        // 2) Stale legacy file with DIFFERENT content. If migration runs
+        //    redundantly it would overwrite the per-user file with this
+        //    legacy content — the test catches that.
+        let legacy_path = legacy_session_path(tmp.path(), &key);
+        write_jsonl_with_one_user_message(&legacy_path, &key, "STALE-LEGACY");
+
+        // 3) Migration marker present.
+        let marker = migration_marker_path_for(tmp.path(), &key);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, b"migrated-from-flat\n").unwrap();
+
+        // Open the handle — must skip legacy entirely.
+        let handle = SessionHandle::open(tmp.path(), &key);
+        let session = handle.session();
+
+        assert_eq!(
+            session.messages.len(),
+            1,
+            "marker present: must load per-user only, not merge legacy"
+        );
+        assert_eq!(
+            session.messages[0].content, "canonical",
+            "marker present: per-user content must win, legacy must NOT overwrite"
+        );
+
+        // Stale legacy file must remain untouched (we didn't delete it).
+        assert!(
+            legacy_path.exists(),
+            "marker present + stale legacy: legacy file must remain (no redundant remove)"
+        );
+        // Marker still present.
+        assert!(marker.exists(), "marker must remain after open");
+    }
+
+    #[test]
+    fn migration_retries_legacy_remove_when_marker_absent_but_per_user_exists() {
+        // Pre-condition: a previous open succeeded `rewrite_blocking` (per-user
+        // file written) but `remove_file(legacy)` failed (transient errno) —
+        // so we ended up with both files on disk and NO marker. The next open
+        // must detect this partial-migration shape and best-effort RETRY the
+        // legacy removal. On success the marker is written.
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "marker-retry");
+
+        // 1) Per-user JSONL exists — canonical state.
+        let per_user_path = per_user_session_path(tmp.path(), &key);
+        write_jsonl_with_one_user_message(&per_user_path, &key, "canonical");
+
+        // 2) Legacy file ALSO exists (the failed-remove leftover).
+        let legacy_path = legacy_session_path(tmp.path(), &key);
+        write_jsonl_with_one_user_message(&legacy_path, &key, "legacy-leftover");
+
+        // 3) Marker is ABSENT.
+        let marker = migration_marker_path_for(tmp.path(), &key);
+        assert!(
+            !marker.exists(),
+            "precondition: marker must not exist for this case"
+        );
+
+        // Open the handle — must retry the legacy removal.
+        let _handle = SessionHandle::open(tmp.path(), &key);
+
+        assert!(
+            !legacy_path.exists(),
+            "legacy file must be removed by the retry-on-open path"
+        );
+        assert!(
+            marker.exists(),
+            "marker must be written after the retry succeeds"
+        );
     }
 }

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -923,6 +923,53 @@ impl SessionManager {
         removed
     }
 
+    /// Drop the cached in-memory copy of a session so the next read consults
+    /// disk. Required by callers that write through alternate channels (e.g.
+    /// `SessionHandle`) and must keep the manager's LRU cache from serving
+    /// stale post-write reads.
+    pub fn invalidate_cache(&mut self, key: &SessionKey) {
+        self.cache.pop(&key.0);
+    }
+
+    /// Scan the per-user layout for every JSONL belonging to `base_key` and
+    /// return their reconstructed `SessionKey`s. The default file maps back to
+    /// the base key (no topic suffix); other files map to `{base_key}#{topic}`.
+    ///
+    /// Used by topic-less watcher reconnects so the replay path can union
+    /// every topic-specific JSONL the actor has written under this user even
+    /// when the URL didn't carry an explicit `?topic=...` parameter.
+    pub fn list_user_session_keys(&self, base_key: &str) -> Vec<SessionKey> {
+        let encoded_base = encode_path_component(base_key);
+        let user_sessions_dir = self
+            .sessions_dir
+            .parent()
+            .unwrap_or(&self.sessions_dir)
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions");
+        let mut keys = Vec::new();
+        let Ok(read_dir) = std::fs::read_dir(&user_sessions_dir) else {
+            return keys;
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let topic = Self::decode_filename(stem);
+            let session_key = if topic == "default" {
+                SessionKey(base_key.to_string())
+            } else {
+                SessionKey(format!("{base_key}#{topic}"))
+            };
+            keys.push(session_key);
+        }
+        keys
+    }
+
     /// Ensure a session file exists in the per-user layout so that
     /// `list_user_sessions` can discover it.  Creates an empty JSONL
     /// (metadata-only) if the file does not already exist.
@@ -1009,15 +1056,30 @@ impl SessionHandle {
         let session = if new_path.exists() {
             Self::load_from_file(&new_path, key)
         } else {
-            // Fall back to legacy flat path for migration
+            // Fall back to legacy flat path for migration. We persist the
+            // loaded history into the per-user JSONL BEFORE removing the
+            // legacy file so a subsequent incremental `add_message_with_seq`
+            // (which only appends a single line) does not silently drop the
+            // pre-migration messages.
             let legacy_dir = data_dir.join("sessions");
             let legacy_path = SessionManager::session_path_static(&legacy_dir, key);
             if legacy_path.exists() {
                 debug!(key = %key, "migrating session from legacy flat layout");
                 let session = Self::load_from_file(&legacy_path, key);
-                // Migration: if loaded from legacy, we'll write to new path on next save
-                if session.is_some() {
-                    // Remove legacy file after successful load
+                if let Some(loaded) = session.as_ref() {
+                    if let Err(error) = Self::rewrite_blocking(&new_path, loaded) {
+                        warn!(
+                            key = %key,
+                            path = %new_path.display(),
+                            error = %error,
+                            "failed to materialize legacy session into per-user layout; \
+                             leaving legacy file in place"
+                        );
+                        return Self {
+                            sessions_dir: user_sessions_dir,
+                            session: loaded.clone(),
+                        };
+                    }
                     let _ = std::fs::remove_file(&legacy_path);
                 }
                 session
@@ -1300,6 +1362,35 @@ impl SessionHandle {
     fn session_path(&self) -> PathBuf {
         self.sessions_dir
             .join(Self::topic_filename(&self.session.key))
+    }
+
+    /// Synchronously rewrite a session JSONL at `path` from an in-memory
+    /// `Session`. Used by the migration path in [`Self::open`] where the
+    /// caller is not yet inside an async context. Atomic write-then-rename.
+    fn rewrite_blocking(path: &Path, session: &Session) -> Result<()> {
+        use std::io::Write;
+        let meta = SessionMeta {
+            schema_version: CURRENT_SESSION_SCHEMA,
+            session_key: session.key.0.clone(),
+            parent_key: session.parent_key.as_ref().map(|k| k.0.clone()),
+            topic: session.topic.clone(),
+            summary: session.summary.clone(),
+            child_contracts: session.child_contracts.clone(),
+            created_at: session.created_at,
+            updated_at: session.updated_at,
+        };
+        let mut content = serde_json::to_string(&meta)?;
+        content.push('\n');
+        for msg in &session.messages {
+            content.push_str(&serde_json::to_string(msg)?);
+            content.push('\n');
+        }
+        let tmp_path = rewrite_tmp_path(path);
+        let mut file = std::fs::File::create(&tmp_path)?;
+        file.write_all(content.as_bytes())?;
+        file.flush()?;
+        std::fs::rename(&tmp_path, path)?;
+        Ok(())
     }
 
     /// Append a single message to the JSONL file.

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1116,6 +1116,15 @@ impl SessionHandle {
             // legacy file so a subsequent incremental `add_message_with_seq`
             // (which only appends a single line) does not silently drop the
             // pre-migration messages.
+            //
+            // Migration race protection: on a previous open, `rewrite_blocking`
+            // may have succeeded but `remove_file(legacy)` failed. The next
+            // open then sees both files. We mark a per-key `.migrated.<topic>`
+            // flag in the per-user directory after a successful rewrite +
+            // remove pair. If the marker exists we skip migration entirely
+            // (per-user file is authoritative even if a stale legacy file
+            // co-exists). If the marker is missing but per-user exists, we
+            // best-effort retry the legacy removal.
             let legacy_dir = data_dir.join("sessions");
             let legacy_path = SessionManager::session_path_static(&legacy_dir, key);
             if legacy_path.exists() {
@@ -1135,7 +1144,10 @@ impl SessionHandle {
                             session: loaded.clone(),
                         };
                     }
-                    let _ = std::fs::remove_file(&legacy_path);
+                    if std::fs::remove_file(&legacy_path).is_ok() {
+                        let marker = Self::migration_marker_path(&user_sessions_dir, key);
+                        let _ = std::fs::write(&marker, b"migrated-from-flat\n");
+                    }
                 }
                 session
             } else {
@@ -1148,6 +1160,17 @@ impl SessionHandle {
             sessions_dir: user_sessions_dir,
             session,
         }
+    }
+
+    /// Path of the per-key migration marker written after a successful
+    /// rewrite + legacy-remove pair. Used by [`Self::open`] to detect a
+    /// completed migration on subsequent opens (so a stale legacy file —
+    /// e.g. from a remove_file failure on a prior boot — does not cause
+    /// double-history reads).
+    fn migration_marker_path(user_sessions_dir: &Path, key: &SessionKey) -> PathBuf {
+        let topic = key.topic().unwrap_or("default");
+        let encoded = encode_path_component(topic);
+        user_sessions_dir.join(format!(".migrated.{encoded}"))
     }
 
     /// Check whether a session file exists in either the per-user or legacy layout.
@@ -1422,7 +1445,22 @@ impl SessionHandle {
     /// Synchronously rewrite a session JSONL at `path` from an in-memory
     /// `Session`. Used by the migration path in [`Self::open`] where the
     /// caller is not yet inside an async context. Atomic write-then-rename.
+    ///
+    /// Cleans up the tmp file if the write or rename fails so a partial
+    /// migration does not leak `<path>.<pid>-<seq>.tmp` files on disk.
+    /// Records the same `octos_session_rewrite_total` metric as the async
+    /// `rewrite()` so operators see a unified rewrite count regardless of
+    /// the originating call path.
     fn rewrite_blocking(path: &Path, session: &Session) -> Result<()> {
+        let result = Self::rewrite_blocking_inner(path, session);
+        match &result {
+            Ok(()) => record_session_rewrite("committed"),
+            Err(_) => record_session_rewrite("failed"),
+        }
+        result
+    }
+
+    fn rewrite_blocking_inner(path: &Path, session: &Session) -> Result<()> {
         use std::io::Write;
         let meta = SessionMeta {
             schema_version: CURRENT_SESSION_SCHEMA,
@@ -1441,11 +1479,21 @@ impl SessionHandle {
             content.push('\n');
         }
         let tmp_path = rewrite_tmp_path(path);
-        let mut file = std::fs::File::create(&tmp_path)?;
-        file.write_all(content.as_bytes())?;
-        file.flush()?;
-        std::fs::rename(&tmp_path, path)?;
-        Ok(())
+        let write_result = (|| -> Result<()> {
+            let mut file = std::fs::File::create(&tmp_path)?;
+            file.write_all(content.as_bytes())?;
+            file.flush()?;
+            std::fs::rename(&tmp_path, path)?;
+            Ok(())
+        })();
+        if write_result.is_err() {
+            // Best-effort tmp cleanup. If the rename succeeded but a later
+            // step failed (currently impossible — rename is the last step)
+            // we'd skip this; if `File::create` or `write_all` fail, the
+            // tmp file may exist and must not leak.
+            let _ = std::fs::remove_file(&tmp_path);
+        }
+        write_result
     }
 
     /// Append a single message to the JSONL file.
@@ -1817,6 +1865,10 @@ struct StoredActiveSessions {
 }
 
 /// Validate a topic name. Returns Err with a message if invalid.
+///
+/// Rejects the literal `"default"` because the per-user storage layout
+/// uses `default.jsonl` as the no-topic filename — a user-named `"default"`
+/// topic would silently collide with the topic-less mapping.
 pub fn validate_topic_name(topic: &str) -> std::result::Result<(), &'static str> {
     if topic.is_empty() {
         return Err("topic name cannot be empty");
@@ -1829,6 +1881,9 @@ pub fn validate_topic_name(topic: &str) -> std::result::Result<(), &'static str>
     }
     if topic.chars().any(|c| c.is_control()) {
         return Err("topic name cannot contain control characters");
+    }
+    if topic.eq_ignore_ascii_case("default") {
+        return Err("topic name 'default' is reserved (used as the no-topic filename in storage)");
     }
     Ok(())
 }
@@ -2664,6 +2719,13 @@ mod tests {
         assert!(validate_topic_name("a:b").is_err());
         assert!(validate_topic_name("a/b").is_err());
         assert!(validate_topic_name(&"x".repeat(51)).is_err());
+
+        // Reserved: "default" is the no-topic filename in the per-user
+        // layout. Allowing a user-named "default" topic would silently
+        // collide with the topic-less mapping.
+        assert!(validate_topic_name("default").is_err());
+        assert!(validate_topic_name("DEFAULT").is_err());
+        assert!(validate_topic_name("Default").is_err());
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -1038,6 +1038,61 @@ pub struct SessionHandle {
     session: Session,
 }
 
+/// Per-key persist lock map.
+///
+/// Two writers (e.g. `SessionActor` and `ApiChannel::persist_to_session`) can
+/// each open a fresh `SessionHandle` for the same session_key concurrently.
+/// Each handle loads disk into its OWN per-instance `messages: Vec<_>`.
+/// Without serialisation, both observe `len = N`, both append, both return
+/// `seq = N` — duplicate seqs that break watcher correlation.
+///
+/// This map gives `persist_message_through_canonical_path` a per-key Tokio
+/// mutex so all writes for the same `SessionKey.0` serialise. The mutex is
+/// scoped to the session_key string (NOT the file path) so callers reaching
+/// the canonical per-user JSONL via different code paths still contend on
+/// the same lock.
+///
+/// Memory note: entries leak forever, one per active session_key. In a long-
+/// lived bus process this grows with active distinct sessions; given
+/// production keys are typically `<profile>:api:<chat>` and bounded by user
+/// count, this is acceptable. We can add LRU eviction later if needed.
+fn persist_lock_for(key: &SessionKey) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static MAP: OnceLock<Mutex<HashMap<String, std::sync::Arc<tokio::sync::Mutex<()>>>>> =
+        OnceLock::new();
+    let map = MAP.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().expect("persist lock map poisoned");
+    guard
+        .entry(key.0.clone())
+        .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+        .clone()
+}
+
+/// Persist a single message to the canonical per-user `<topic>.jsonl` file
+/// the `SessionActor` and `ApiChannel` both target. Returns the committed
+/// per-session sequence number.
+///
+/// Writes for the same `key` serialise via a per-key Tokio mutex (see
+/// [`persist_lock_for`]). This is the contract that closed the concurrent-
+/// persist seq race: every caller — whether `SessionActor` (which already
+/// owns `Arc<Mutex<SessionHandle>>` per actor), `ApiChannel::persist_to_session`,
+/// or the standalone `octos serve` `/chat` handlers — should funnel through
+/// this helper so the storage layer is the single ordering point.
+///
+/// Preserves the canonical migration path (legacy flat → per-user) inside
+/// `SessionHandle::open`.
+pub async fn persist_message_through_canonical_path(
+    data_dir: &Path,
+    key: &SessionKey,
+    message: Message,
+) -> Result<usize> {
+    let lock = persist_lock_for(key);
+    let _guard = lock.lock().await;
+    let mut handle = SessionHandle::open(data_dir, key);
+    handle.add_message_with_seq(message).await
+}
+
 impl SessionHandle {
     /// Open or create a session handle for the given key.
     ///

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -18,7 +18,7 @@ use octos_bus::file_handle::{
     encode_profile_file_handle, encode_tmp_upload_handle, resolve_legacy_file_request,
     resolve_scoped_file_handle,
 };
-use octos_core::{AgentId, MAIN_PROFILE_ID, Message, SessionKey};
+use octos_core::{AgentId, MAIN_PROFILE_ID, Message, MessageRole, SessionKey};
 use octos_llm::pricing::model_pricing;
 use serde::{Deserialize, Serialize};
 
@@ -255,6 +255,39 @@ fn validate_chat_request(
     Ok((agent.clone(), sessions.clone()))
 }
 
+/// Persist a `Message` to the canonical per-user `<topic>.jsonl` and
+/// invalidate the `SessionManager` LRU cache for the key.
+///
+/// This is the unified write path for the standalone `octos serve` /chat
+/// handlers. Mirrors `ApiChannel::persist_to_session` in the gateway path
+/// — both funnel through `octos_bus::persist_message_through_canonical_path`
+/// so the storage layer is the single ordering point.
+///
+/// Returns the committed per-session sequence number so callers (e.g. the
+/// streaming handler) can correlate it back to the optimistic bubble.
+async fn persist_chat_message_through_canonical(
+    sessions: &Arc<tokio::sync::Mutex<octos_bus::SessionManager>>,
+    key: &SessionKey,
+    message: Message,
+) -> eyre::Result<usize> {
+    let data_dir = {
+        let manager = sessions.lock().await;
+        manager.data_dir()
+    };
+
+    let result = octos_bus::persist_message_through_canonical_path(&data_dir, key, message).await;
+
+    // Drop any stale `SessionManager` cache entry so a follow-up read
+    // (duplicate-detection, `?source=full`) consults disk instead of
+    // returning a pre-write empty `Session`.
+    {
+        let mut manager = sessions.lock().await;
+        manager.invalidate_cache(key);
+    }
+
+    result
+}
+
 async fn chat_sync(
     state: Arc<AppState>,
     headers: HeaderMap,
@@ -295,12 +328,11 @@ async fn chat_sync(
         "chat: response generated"
     );
 
-    // Save all conversation messages to session
-    {
-        let mut sess = sessions.lock().await;
-        for msg in &response.messages {
-            let _ = sess.add_message(&session_key, msg.clone()).await;
-        }
+    // Save all conversation messages to the canonical per-user JSONL.
+    // Funnels through the same helper the gateway-side `ApiChannel` uses so
+    // standalone deployments don't split-brain into the legacy flat layout.
+    for msg in &response.messages {
+        let _ = persist_chat_message_through_canonical(&sessions, &session_key, msg.clone()).await;
     }
 
     Ok(Json(ChatResponse {
@@ -390,9 +422,14 @@ async fn chat_streaming(
                 );
 
                 // Save all conversation messages (user, assistant iterations, tool calls/results)
+                // through the canonical per-user JSONL. Pre-fix this funnelled
+                // through `SessionManager::add_message_with_seq` which wrote
+                // to the legacy flat layout — a standalone `octos serve` had
+                // no gateway-side `ApiChannel` to redirect, so messages
+                // landed in `sessions/<encoded_full_key>.jsonl` while the
+                // actor wrote to `users/.../<topic>.jsonl`.
                 let mut user_message_seq_and_meta: Option<(usize, String, String)> = None;
                 {
-                    let mut sess = sessions.lock().await;
                     let mut user_persisted = false;
                     for msg in &response.messages {
                         // Tag the first user message with the client-supplied
@@ -410,7 +447,13 @@ async fn chat_streaming(
                             }
                             let timestamp = to_save.timestamp.to_rfc3339();
                             let content_for_event = to_save.content.clone();
-                            match sess.add_message_with_seq(&session_key, to_save).await {
+                            match persist_chat_message_through_canonical(
+                                &sessions,
+                                &session_key,
+                                to_save,
+                            )
+                            .await
+                            {
                                 Ok(seq) => {
                                     user_message_seq_and_meta =
                                         Some((seq, content_for_event, timestamp));
@@ -424,7 +467,12 @@ async fn chat_streaming(
                                 }
                             }
                         } else {
-                            let _ = sess.add_message(&session_key, to_save).await;
+                            let _ = persist_chat_message_through_canonical(
+                                &sessions,
+                                &session_key,
+                                to_save,
+                            )
+                            .await;
                         }
                     }
                 }
@@ -2545,6 +2593,7 @@ async fn ws_connection(socket: WebSocket, state: Arc<AppState>, headers: HeaderM
                         stream: true,
                         media: media.clone(),
                         attach_only: false,
+                        client_message_id: None,
                     },
                 ) {
                     // Standalone agent mode — run the agent directly.
@@ -2703,12 +2752,17 @@ async fn ws_standalone_agent(
 
         match result {
             Ok(response) => {
-                // Save conversation messages to session
-                {
-                    let mut sess = sessions.lock().await;
-                    for msg in &response.messages {
-                        let _ = sess.add_message(&session_key2, msg.clone()).await;
-                    }
+                // Save conversation messages to the canonical per-user JSONL.
+                // Mirrors `chat_sync` and `chat_streaming`; closes the
+                // standalone-serve split-brain by routing through the same
+                // helper the gateway-side `ApiChannel` uses.
+                for msg in &response.messages {
+                    let _ = persist_chat_message_through_canonical(
+                        &sessions,
+                        &session_key2,
+                        msg.clone(),
+                    )
+                    .await;
                 }
 
                 let provider_metadata = response.provider_metadata.clone();
@@ -3274,5 +3328,88 @@ mod tests {
         let json = r#"{"type": "unknown"}"#;
         let result = serde_json::from_str::<WsClientMsg>(json);
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn chat_sync_writes_to_canonical_per_user_topic_jsonl() {
+        // Regression for the standalone `octos serve` /chat handlers writing
+        // to the legacy flat layout instead of the canonical per-user JSONL.
+        //
+        // Pre-fix, `chat_sync`/`chat_streaming`/the websocket handler all
+        // called `SessionManager::add_message_with_seq` directly. That writes
+        // to `<data_dir>/sessions/<encoded_full_key>.jsonl` (legacy flat),
+        // not the canonical per-user `<topic>.jsonl`. A standalone deployment
+        // without a gateway-side `ApiChannel` therefore split-brained — the
+        // actor wrote to one path, handlers wrote to another, replays missed
+        // half the history.
+        //
+        // Post-fix, every `/chat` write must funnel through
+        // `persist_chat_message_through_canonical` — a wrapper around
+        // `octos_bus::persist_message_through_canonical_path` that also
+        // invalidates the `SessionManager` LRU cache (mirroring what
+        // `ApiChannel::persist_to_session` does). The contract: messages
+        // committed via this helper land in the canonical per-user JSONL
+        // and never touch the legacy flat directory.
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = Arc::new(tokio::sync::Mutex::new(
+            octos_bus::SessionManager::open(data_dir.path()).unwrap(),
+        ));
+        let session_id = "web-canonical-handlers";
+        let topic = "research";
+        let key = SessionKey::with_profile_topic(MAIN_PROFILE_ID, "api", session_id, topic);
+
+        // Drive a write through the helper the production handlers now use.
+        let seq = persist_chat_message_through_canonical(
+            &sessions,
+            &key,
+            Message::user("please summarise the q1 numbers"),
+        )
+        .await
+        .expect("canonical persist");
+        assert_eq!(seq, 0);
+
+        // Canonical per-user `<encoded_topic>.jsonl` must exist and carry
+        // the user message.
+        let encoded_base = octos_bus::session::encode_path_component(&format!(
+            "{MAIN_PROFILE_ID}:api:{session_id}"
+        ));
+        let encoded_topic = octos_bus::session::encode_path_component(topic);
+        let canonical = data_dir
+            .path()
+            .join("users")
+            .join(&encoded_base)
+            .join("sessions")
+            .join(format!("{encoded_topic}.jsonl"));
+        assert!(
+            canonical.exists(),
+            "/chat handler write must land in canonical per-user JSONL ({}) — \
+             this is the unified file the SessionActor and the bus-side \
+             ApiChannel also write",
+            canonical.display()
+        );
+        let body = std::fs::read_to_string(&canonical).unwrap();
+        assert!(
+            body.contains("please summarise the q1 numbers"),
+            "canonical JSONL must contain the user message text"
+        );
+
+        // Legacy flat `sessions/<encoded_full_key>.jsonl` must NOT exist —
+        // that's the old split-brain location standalone /chat used to
+        // write to.
+        let sessions_dir = data_dir.path().join("sessions");
+        if sessions_dir.exists() {
+            for entry in std::fs::read_dir(&sessions_dir).unwrap().flatten() {
+                let path = entry.path();
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                    panic!(
+                        "/chat handler must NOT write to the legacy flat \
+                         layout (sessions/{}.jsonl) — that is the split-brain \
+                         path the storage unification PR is closing",
+                        name
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -115,6 +115,7 @@ struct PersistedSessionMessage {
 async fn persist_assistant_message(
     session_handle: &Arc<Mutex<SessionHandle>>,
     session_key: &SessionKey,
+    data_dir: &Path,
     content: String,
     media: Vec<String>,
 ) -> Option<PersistedSessionMessage> {
@@ -122,9 +123,31 @@ async fn persist_assistant_message(
     assistant_msg.media = media;
     let timestamp = assistant_msg.timestamp;
 
+    // Funnel through the canonical helper so the per-key Tokio mutex
+    // serialises this write with `ApiChannel::persist_to_session` (and any
+    // other caller). Pre-fix, the actor opened its OWN `SessionHandle` and
+    // called `add_message_with_seq` directly — the channel and actor each
+    // observed their independent in-memory `len = N`, both returned the
+    // same `seq = N`, and the duplicate seqs broke watcher correlation.
+    //
+    // Holding `session_handle.lock()` across the canonical-helper call is
+    // safe (the helper's per-key map is independent of the actor's per-actor
+    // mutex; no deadlock) and serialises this write with the actor's other
+    // in-memory operations (read history, summary update, etc.). After the
+    // disk write commits we mirror the message into the actor's local Vec
+    // so subsequent `get_history` reads stay consistent.
     let mut handle = session_handle.lock().await;
-    match handle.add_message_with_seq(assistant_msg).await {
-        Ok(seq) => Some(PersistedSessionMessage { seq, timestamp }),
+    match octos_bus::session::persist_message_through_canonical_path(
+        data_dir,
+        session_key,
+        assistant_msg.clone(),
+    )
+    .await
+    {
+        Ok(seq) => {
+            handle.push_message_in_memory(assistant_msg);
+            Some(PersistedSessionMessage { seq, timestamp })
+        }
         Err(error) => {
             warn!(
                 session = %session_key,
@@ -222,6 +245,7 @@ async fn send_outbound_with_timeout(
 async fn persist_terminal_reply_and_fanout(
     session_handle: &Arc<Mutex<SessionHandle>>,
     session_key: &SessionKey,
+    data_dir: &Path,
     out_tx: &mpsc::Sender<OutboundMessage>,
     channel: &str,
     chat_id: &str,
@@ -229,9 +253,14 @@ async fn persist_terminal_reply_and_fanout(
     content: String,
     media: Vec<String>,
 ) -> bool {
-    let Some(_persisted) =
-        persist_assistant_message(session_handle, session_key, content.clone(), media.clone())
-            .await
+    let Some(_persisted) = persist_assistant_message(
+        session_handle,
+        session_key,
+        data_dir,
+        content.clone(),
+        media.clone(),
+    )
+    .await
     else {
         record_result_delivery("terminal_reply", "history_not_persisted", "assistant");
         warn!(
@@ -2964,6 +2993,7 @@ impl SessionActor {
         let persisted = persist_assistant_message(
             &self.session_handle,
             &self.session_key,
+            &self.data_dir,
             content.clone(),
             media.clone(),
         )
@@ -3251,6 +3281,7 @@ impl SessionActor {
         let persisted = persist_assistant_message(
             &self.session_handle,
             &self.session_key,
+            &self.data_dir,
             ack_content.clone(),
             vec![],
         )
@@ -4023,6 +4054,7 @@ impl SessionActor {
                 let _ = persist_terminal_reply_and_fanout(
                     &self.session_handle,
                     &self.session_key,
+                    &self.data_dir,
                     &self.out_tx,
                     &self.channel,
                     &self.chat_id,
@@ -4039,6 +4071,7 @@ impl SessionActor {
                 let _ = persist_terminal_reply_and_fanout(
                     &self.session_handle,
                     &self.session_key,
+                    &self.data_dir,
                     &self.out_tx,
                     &self.channel,
                     &self.chat_id,
@@ -4135,6 +4168,7 @@ impl SessionActor {
         let active_sessions = self.active_sessions.clone();
         let overflow_cancelled = Arc::clone(&self.overflow_cancelled);
         let user_workspace = self.user_workspace.clone();
+        let data_dir = self.data_dir.clone();
         let overflow_client_message_id = inbound_client_message_id(msg);
 
         tokio::spawn(async move {
@@ -4330,6 +4364,7 @@ impl SessionActor {
                     let _ = persist_terminal_reply_and_fanout(
                         &session_handle,
                         &session_key,
+                        &data_dir,
                         &out_tx,
                         &channel,
                         &chat_id,
@@ -4345,6 +4380,7 @@ impl SessionActor {
                     let _ = persist_terminal_reply_and_fanout(
                         &session_handle,
                         &session_key,
+                        &data_dir,
                         &out_tx,
                         &channel,
                         &chat_id,
@@ -4741,6 +4777,7 @@ impl SessionActor {
                 let _ = persist_terminal_reply_and_fanout(
                     &self.session_handle,
                     &self.session_key,
+                    &self.data_dir,
                     &self.out_tx,
                     &self.channel,
                     &self.chat_id,
@@ -4757,6 +4794,7 @@ impl SessionActor {
                 let _ = persist_terminal_reply_and_fanout(
                     &self.session_handle,
                     &self.session_key,
+                    &self.data_dir,
                     &self.out_tx,
                     &self.channel,
                     &self.chat_id,
@@ -5545,7 +5583,7 @@ mod tests {
             status_indicator: None,
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
-            data_dir: std::path::PathBuf::from("/tmp"),
+            data_dir: dir.path().to_path_buf(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -5613,7 +5651,7 @@ mod tests {
             status_indicator: None,
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
-            data_dir: std::path::PathBuf::from("/tmp"),
+            data_dir: dir.path().to_path_buf(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout,
@@ -5687,7 +5725,7 @@ mod tests {
             status_indicator: None,
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
-            data_dir: std::path::PathBuf::from("/tmp"),
+            data_dir: dir.path().to_path_buf(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -5808,7 +5846,7 @@ mod tests {
             status_indicator: None,
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
-            data_dir: std::path::PathBuf::from("/tmp"),
+            data_dir: dir.path().to_path_buf(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -6014,7 +6052,7 @@ mod tests {
             status_indicator: None,
             sender_user_id: None,
             user_status_config: UserStatusConfig::default(),
-            data_dir: std::path::PathBuf::from("/tmp"),
+            data_dir: dir.path().to_path_buf(),
             max_history: Arc::new(std::sync::atomic::AtomicUsize::new(50)),
             idle_timeout: Duration::from_secs(60),
             session_timeout: Duration::from_secs(120),
@@ -7693,6 +7731,99 @@ mod tests {
                 "请同步等待完成，不要后台。对这个主题做深度研究并直接在这里输出。"
             ),
             None
+        );
+    }
+
+    #[tokio::test]
+    async fn actor_and_channel_persists_get_distinct_seqs_across_paths() {
+        // Pins the unified-serialisation contract for `SessionActor` and
+        // `ApiChannel::persist_to_session`. Pre-fix, the actor held its own
+        // `Arc<Mutex<SessionHandle>>` and called `add_message_with_seq`
+        // directly while `ApiChannel::persist_to_session` already routed
+        // through `persist_message_through_canonical_path`. The two paths
+        // held INDEPENDENT in-memory `messages` Vecs (the actor's grew
+        // forever, the channel always opened fresh from disk), so concurrent
+        // persists collided: the actor read `len = N` on its local Vec, the
+        // channel read disk-len `M`, both returned `seq = X` — duplicate
+        // seqs that broke watcher correlation.
+        //
+        // Post-fix, `persist_assistant_message` also routes through the
+        // canonical helper. Both paths contend on the per-key Tokio mutex
+        // and observe disk-canonical seqs, so concurrent persists across
+        // paths get distinct, monotonic seqs.
+        let dir = tempfile::TempDir::new().unwrap();
+        let key = SessionKey::new("api", "actor-vs-channel");
+        let data_dir = dir.path().to_path_buf();
+
+        // Single shared actor handle (mirrors how `SessionActor` owns ONE
+        // long-lived `Arc<Mutex<SessionHandle>>` for the duration of the
+        // session). Pre-fix, a series of `add_message_with_seq` calls on
+        // this handle increment its local Vec — so seqs returned from this
+        // path collide with seqs returned from canonical-helper opens.
+        let actor_handle = std::sync::Arc::new(tokio::sync::Mutex::new(SessionHandle::open(
+            &data_dir, &key,
+        )));
+
+        const TOTAL: usize = 16;
+        let mut handles = Vec::with_capacity(TOTAL);
+
+        for i in 0..TOTAL {
+            let data_dir = data_dir.clone();
+            let key = key.clone();
+            let actor_handle = actor_handle.clone();
+            handles.push(tokio::spawn(async move {
+                if i % 2 == 0 {
+                    // "Actor" path — uses the shared `Arc<Mutex<SessionHandle>>`.
+                    // Post-fix this call funnels through the canonical helper
+                    // so its seq is disk-canonical.
+                    let res = persist_assistant_message(
+                        &actor_handle,
+                        &key,
+                        &data_dir,
+                        format!("actor-{i}"),
+                        vec![],
+                    )
+                    .await;
+                    res.map(|p| p.seq)
+                } else {
+                    // "Channel" path — the canonical helper directly (this is
+                    // the same code `ApiChannel::persist_to_session` calls).
+                    let assistant = Message::assistant(format!("channel-{i}"));
+                    octos_bus::session::persist_message_through_canonical_path(
+                        &data_dir, &key, assistant,
+                    )
+                    .await
+                    .ok()
+                }
+            }));
+        }
+
+        let mut seqs = Vec::with_capacity(TOTAL);
+        for h in handles {
+            let seq = h.await.expect("join").expect("persist returned Some");
+            seqs.push(seq);
+        }
+        seqs.sort_unstable();
+
+        let unique: std::collections::HashSet<usize> = seqs.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            TOTAL,
+            "actor + channel persists must each receive a distinct seq, got: {seqs:?}"
+        );
+        assert_eq!(
+            seqs,
+            (0..TOTAL).collect::<Vec<_>>(),
+            "seqs must form a contiguous 0..TOTAL range; got: {seqs:?}"
+        );
+
+        // Final disk transcript should hold all TOTAL messages.
+        let final_handle = SessionHandle::open(&data_dir, &key);
+        assert_eq!(
+            final_handle.session().messages.len(),
+            TOTAL,
+            "all persisted messages must land on disk: {:?}",
+            final_handle.session().messages
         );
     }
 }


### PR DESCRIPTION
## Summary

Bus-side `ApiChannel::persist_to_session` and actor-side
`SessionActor::persist_assistant_message` wrote session messages to two
different on-disk layouts. When the actor handled a spawn_only background
task (e.g. fm_tts), it stamped `_history_persisted=true` on the OutboundMessage
so ApiChannel.send skipped its own persist — the audio bubble landed in
per-user `<topic>.jsonl` only. On a topic-less reconnect, the
`replay_committed_session_results` candidate set never visited that file,
so the bubble silently disappeared.

This PR collapses the two writers onto a single canonical store (per-user
`users/<encoded_base>/sessions/<encoded_topic>.jsonl`) and teaches the
replay path to scan all topics for a base_key when the watcher reconnects
without a topic.

## Diagnosis

- Mini2 evidence (2026-04-23): file message at 20:40:43.037 in per-user
  `<topic>.jsonl`; bus-channel flat journal ends at 20:39:36; mp3 16389
  bytes on disk untouched; user saw "fm_tts completed" but no audio.
- Two writers — `SessionManager::add_message_with_seq` (flat layout +
  hardcoded `default.jsonl` mirror that **ignored** topic) vs
  `SessionHandle::add_message_with_seq` (per-user `<topic>.jsonl`).
- `SessionManager::load_from_disk` merged both layouts on read, but only
  for the candidate's exact `(base_key, topic)` tuple. Topic-less
  reconnect candidates queried `default.jsonl` which the actor never
  wrote to.

## Architecture

- `ApiChannel::persist_to_session` now opens a `SessionHandle` for
  `(profile_id:api:chat_id [#topic])` and calls
  `add_message_with_seq`. Bus-side and actor-side writes converge on the
  same canonical file.
- After the unified write, the bus-side persist drops the
  `SessionManager` LRU entry for that key so follow-up reads
  (`should_suppress_duplicate_slides_delivery`, `?source=full`,
  `replay_committed_session_results`) consult disk instead of a stale
  empty `Session`.
- `replay_committed_session_results` adds a topic-less fallback that
  scans `users/<encoded_base>/sessions/*.jsonl` and unions the assistant
  messages so dashboards reloading without `?topic=...` still surface
  spawn_only file deliveries.
- `SessionHandle::open` now atomically rewrites the migrated history
  into the per-user layout before removing the legacy flat file. The
  pre-fix incremental-append semantics quietly dropped pre-migration
  messages on the first bus-side persist after migration.
- Read-side merge of flat + per-user is preserved for backward
  compatibility with stale on-disk data; no migration script needed.

## Tests

- New: `bus_side_persist_routes_to_canonical_per_user_topic_jsonl` pins
  the unified-write contract.
- New: `spawn_only_file_delivery_is_visible_to_watcher_replay_after_reconnect`
  is RED pre-fix on the topic-less reconnect branch and GREEN
  post-fix.
- `cargo test -p octos-bus --features api` — 211 pass (up from 209).
- `cargo test -p octos-cli session_actor` — 42 pass.
- `cargo test --workspace` — clean apart from
  `tools::send_file::tests::test_base_dir_blocks_non_tmp_outside_path`
  which fails identically on `origin/main` (pre-existing, unrelated).
- `cargo fmt --all --check` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Test Plan

- [x] Failing regression test added before fix
- [x] Regression test passes after fix
- [x] Bus crate full suite passes
- [x] CLI `session_actor` suite passes
- [x] M8.6 resume sanitizer (`octos-bus resume_policy`) — 21 pass
- [x] fmt, clippy clean
- [ ] Manual verification on a staging mini after rollout (NOT in this PR)

## Operator Deploy Plan

Because there are no production users, no migration script is required.
Operators have two options when rolling out:

1. **Cold-cut wipe (recommended for cleanest state):** stop the gateway,
   delete `~/.octos/profiles/<id>/data/sessions/` (legacy flat) and
   `~/.octos/profiles/<id>/data/users/*/sessions/*.jsonl` (per-user) on
   each mini, deploy this build, restart. Empty starting state.
2. **In-place leave-as-is:** deploy this build with no on-disk surgery.
   Existing flat-only history remains visible via the read-side merge
   in `SessionManager::load_from_disk`. New writes go to the canonical
   per-user layout. The first per-user write for an existing flat
   session migrates that session via the new atomic rewrite path; the
   legacy file is removed only after the per-user file is fully
   materialized.

Either way, the post-deploy invariant is the same: every spawn_only
file delivery surfaces on reconnect (with or without `?topic=...`).

## Notes

- DO NOT MERGE / cherry-pick / deploy from this PR. It is the
  architectural fix for review only.