### PR TITLE
backport(M8.9): Runtime failure recovery (auto re-engage LLM on spawn_only failures)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ scripts/deploy.sh
 !docs/SANDBOX.md
 !docs/SECURITY_ARCHITECTURE.md
 !docs/OCTOS_ROBOTICS_PR270_RP06_NOTE.md
+!docs/OCTOS_FAILURE_MODES_INVENTORY.md
 
 # mdBook documentation site (EN + ZH)
 !book/book.toml

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -216,7 +216,8 @@ impl Agent {
                 let bg_args = effective_args.clone();
                 let bg_sender = tools.background_result_sender();
                 let bg_tc_id = tc_id.clone();
-                let task_id = tools.register_task(&tc_name, &tc_id);
+                let task_id =
+                    tools.register_task_with_input(&tc_name, &tc_id, Some(effective_args.clone()));
                 tools.mark_spawn_only_invoked();
                 let bg_supervisor = tools.supervisor();
                 let bg_reporter = reporter.clone();

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -123,8 +123,9 @@ pub use subagent_summary::{
 };
 pub use summarizer::{ExtractiveSummarizer, Summarizer};
 pub use task_supervisor::{
-    ArtifactMimeClass, BackgroundTask, TaskLifecycleState, TaskRuntimeState, TaskStatus,
-    TaskSupervisor, validate_spawn_only_artifacts,
+    ArtifactMimeClass, BackgroundTask, SpawnOnlyFailureSignal, TaskLifecycleState,
+    TaskRuntimeState, TaskStatus, TaskSupervisor, parse_alternatives,
+    validate_spawn_only_artifacts,
 };
 pub use tools::{
     ActivateToolsTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,

--- a/crates/octos-agent/src/prompts/worker.txt
+++ b/crates/octos-agent/src/prompts/worker.txt
@@ -19,6 +19,10 @@ Guidelines:
 - When the user shares preferences, personal info, or important project facts, proactively save them to the memory bank using `save_memory`
 - If `web_search` returns an all-providers-exhausted / quota error (rare), the tool already rotates providers internally — do NOT retry with identical args; instead inform the user or try a different query phrasing.
 
+Failure recovery:
+- If a tool call fails, read the error message carefully. If it suggests alternatives (e.g. "use fm_voice_save to register this voice first", "available voices: vivian, serena, ..."), offer those alternatives to the user OR try the safest suggested alternative yourself. Don't just report failure to the user without offering a path forward.
+- A `[system-internal]` message in the conversation means the runtime is informing you about a background failure that already surfaced to the user as a terminal notice. Acknowledge the failure briefly and propose a concrete next step — never restate the raw error and stop there.
+
 Output structure (for background tasks):
 - Start with a one-line summary of the result
 - Follow with details, findings, or code changes

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -142,6 +142,10 @@ pub struct BackgroundTask {
     /// Session that owns this task (for per-session filtering).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_key: Option<String>,
+    /// Original tool arguments — preserved so failure-recovery flows can
+    /// surface the exact input the LLM passed when offering alternatives.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_input: Option<Value>,
 }
 
 impl BackgroundTask {
@@ -167,6 +171,66 @@ impl BackgroundTask {
 
 /// Callback invoked when a task's status changes.
 type OnChangeCallback = Box<dyn Fn(&BackgroundTask) + Send + Sync>;
+
+/// Payload emitted when a `spawn_only` background task transitions to
+/// `Failed`. Consumers (e.g. the session actor) use this to schedule a
+/// synthetic recovery turn so the LLM can re-engage with an actionable
+/// error and offer alternatives instead of leaving the user stuck on a
+/// terminal-only failure notification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpawnOnlyFailureSignal {
+    /// Background task identifier (matches `BackgroundTask::id`).
+    pub task_id: String,
+    /// Tool that failed (e.g. `fm_tts`).
+    pub tool_name: String,
+    /// The original tool arguments passed by the LLM when invoking the tool.
+    /// May be `Value::Null` if the input was not captured for this task.
+    pub tool_input: Value,
+    /// The textual error reported by the tool, contract validator, or wrapper.
+    pub error_message: String,
+    /// Best-effort list of alternatives extracted from the error text via the
+    /// `available: X, Y, Z` pattern. Empty when no alternatives were detected.
+    pub suggested_alternatives: Vec<String>,
+    /// Owning session, when the failed task is bound to one.
+    pub parent_session_key: Option<String>,
+}
+
+/// Callback invoked when a `spawn_only` task fails. Receives the structured
+/// signal payload so consumers can build a recovery prompt without re-parsing
+/// the raw `BackgroundTask`.
+type OnFailureCallback = Box<dyn Fn(&SpawnOnlyFailureSignal) + Send + Sync>;
+
+/// Extract a list of alternatives from a tool error message using the simple
+/// `available: X, Y, Z` pattern. Returns an empty vector when no match is
+/// found so callers can fall back to surfacing the raw error text.
+///
+/// This is intentionally conservative — we only handle the canonical
+/// "available: ..." phrasing emitted by the fm_tts/voice-skill family. More
+/// aggressive parsing belongs in the failure-modes inventory follow-up.
+pub fn parse_alternatives(error_text: &str) -> Vec<String> {
+    // Use a literal scan rather than a regex so we don't pull in a fresh
+    // dependency or risk pathological backtracking. The marker is
+    // case-insensitive and matched anywhere in the message.
+    let needle = "available:";
+    let lower = error_text.to_lowercase();
+    let Some(start) = lower.find(needle) else {
+        return Vec::new();
+    };
+    let tail = &error_text[start + needle.len()..];
+
+    // Stop at the first sentence boundary so we don't grab the entire
+    // remainder of the error message. Newlines and periods both terminate
+    // the alternatives clause.
+    let stop = tail.find(['\n', '.', ';']).unwrap_or(tail.len());
+    let clause = &tail[..stop];
+
+    clause
+        .split(',')
+        .map(|item| item.trim().trim_matches(['"', '\'']))
+        .filter(|item| !item.is_empty())
+        .map(|item| item.to_string())
+        .collect()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PersistedTaskRecord {
@@ -567,6 +631,7 @@ impl std::fmt::Debug for TaskSupervisor {
         f.debug_struct("TaskSupervisor")
             .field("tasks", &self.tasks)
             .field("on_change", &"<callback>")
+            .field("on_failure", &"<callback>")
             .field(
                 "persistence_path",
                 &self
@@ -587,6 +652,7 @@ impl std::fmt::Debug for TaskSupervisor {
 pub struct TaskSupervisor {
     tasks: Arc<Mutex<HashMap<String, BackgroundTask>>>,
     on_change: Arc<Mutex<Option<OnChangeCallback>>>,
+    on_failure: Arc<Mutex<Option<OnFailureCallback>>>,
     persistence_path: Arc<Mutex<Option<PathBuf>>>,
 }
 
@@ -602,6 +668,7 @@ impl TaskSupervisor {
         Self {
             tasks: Arc::new(Mutex::new(HashMap::new())),
             on_change: Arc::new(Mutex::new(None)),
+            on_failure: Arc::new(Mutex::new(None)),
             persistence_path: Arc::new(Mutex::new(None)),
         }
     }
@@ -656,6 +723,19 @@ impl TaskSupervisor {
         *guard = Some(Box::new(cb));
     }
 
+    /// Set a callback that fires only when a `spawn_only` task transitions to
+    /// `Failed`. This is the M8.9 hook the session actor uses to enqueue a
+    /// synthetic recovery turn. The callback is only invoked once per failed
+    /// task — re-marking a task as failed (or any subsequent state change)
+    /// will not re-fire the signal.
+    pub fn set_on_failure_signal(
+        &self,
+        cb: impl Fn(&SpawnOnlyFailureSignal) + Send + Sync + 'static,
+    ) {
+        let mut guard = self.on_failure.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(Box::new(cb));
+    }
+
     /// Register a new background task. Returns the generated task ID.
     pub fn register(
         &self,
@@ -673,6 +753,30 @@ impl TaskSupervisor {
         tool_call_id: &str,
         session_key: Option<&str>,
         task_ledger_path: Option<&str>,
+    ) -> String {
+        self.register_full(tool_name, tool_call_id, session_key, task_ledger_path, None)
+    }
+
+    /// Register a new background task with optional ledger-path lineage and
+    /// the original tool input. The tool input is preserved so failure
+    /// signals can include it without re-walking the message history.
+    pub fn register_with_input(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        session_key: Option<&str>,
+        tool_input: Option<Value>,
+    ) -> String {
+        self.register_full(tool_name, tool_call_id, session_key, None, tool_input)
+    }
+
+    fn register_full(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        session_key: Option<&str>,
+        task_ledger_path: Option<&str>,
+        tool_input: Option<Value>,
     ) -> String {
         let id = TaskId::new().to_string();
         let derived_child_session_key = session_key.map(|parent| format!("{parent}#child-{id}"));
@@ -702,6 +806,7 @@ impl TaskSupervisor {
             output_files: Vec::new(),
             error: None,
             session_key: session_key.map(|s| s.to_string()),
+            tool_input,
         };
         let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
         tasks.insert(id.clone(), task);
@@ -716,6 +821,16 @@ impl TaskSupervisor {
             },
         );
         id
+    }
+
+    /// Attach (or replace) the tool input for an already-registered task.
+    /// Useful when the task is registered eagerly and the args become
+    /// available later in the spawn pipeline.
+    pub fn set_tool_input(&self, task_id: &str, tool_input: Value) {
+        let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(task) = tasks.get_mut(task_id) {
+            task.tool_input = Some(tool_input);
+        }
     }
 
     /// Mark a task as running.
@@ -828,24 +943,55 @@ impl TaskSupervisor {
     }
 
     /// Mark a task as failed with an error message.
+    ///
+    /// On the FIRST transition from a non-`Failed` status to `Failed`, also
+    /// emits a `SpawnOnlyFailureSignal` so listeners (e.g. the session
+    /// actor) can schedule a recovery turn. Re-marking an already-failed
+    /// task is a no-op for the failure signal — this guarantees at most one
+    /// recovery attempt per task even if multiple paths report the failure.
     pub fn mark_failed(&self, task_id: &str, error: String) {
-        let snapshot = {
+        let (snapshot, was_already_failed) = {
             let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(task) = tasks.get_mut(task_id) {
+                let already_failed = task.status == TaskStatus::Failed;
                 task.status = TaskStatus::Failed;
                 task.runtime_state = TaskRuntimeState::Failed;
                 task.updated_at = Utc::now();
                 task.completed_at = Some(Utc::now());
                 task.error = Some(error);
-                Some(task.clone())
+                (Some(task.clone()), already_failed)
             } else {
-                None
+                (None, false)
             }
         };
         if let Some(ref task) = snapshot {
             self.persist_snapshot(task);
             self.notify_change(task);
+            if !was_already_failed {
+                self.notify_failure(task);
+            }
         }
+    }
+
+    /// Emit a `SpawnOnlyFailureSignal` for a freshly-failed task, if a
+    /// failure callback has been registered. The error_message is taken
+    /// from the task's `error` field (set immediately before this call).
+    fn notify_failure(&self, task: &BackgroundTask) {
+        let guard = self.on_failure.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(cb) = guard.as_ref() else {
+            return;
+        };
+        let error_message = task.error.clone().unwrap_or_default();
+        let suggested_alternatives = parse_alternatives(&error_message);
+        let signal = SpawnOnlyFailureSignal {
+            task_id: task.id.clone(),
+            tool_name: task.tool_name.clone(),
+            tool_input: task.tool_input.clone().unwrap_or(Value::Null),
+            error_message,
+            suggested_alternatives,
+            parent_session_key: task.parent_session_key.clone(),
+        };
+        cb(&signal);
     }
 
     /// Record the child-session contract outcome for a task.
@@ -1796,6 +1942,197 @@ mod tests {
         );
     }
 
+    // ── M8.9: spawn_only failure recovery signals ───────────────────────────
+
+    use std::sync::Mutex as StdMutex;
+
+    fn collect_failure_signals(
+        supervisor: &TaskSupervisor,
+    ) -> Arc<StdMutex<Vec<SpawnOnlyFailureSignal>>> {
+        let collected = Arc::new(StdMutex::new(Vec::new()));
+        let captured = Arc::clone(&collected);
+        supervisor.set_on_failure_signal(move |signal| {
+            captured
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(signal.clone());
+        });
+        collected
+    }
+
+    #[test]
+    fn should_emit_failure_signal_when_spawn_only_task_status_becomes_failed() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register_with_input(
+            "fm_tts",
+            "call-1",
+            Some("api:session"),
+            Some(serde_json::json!({"voice": "yangmi", "text": "hi"})),
+        );
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(
+            &task_id,
+            "voice 'yangmi' not registered. available: vivian, serena, longxiang".to_string(),
+        );
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(signals.len(), 1, "expected exactly one failure signal");
+        let signal = &signals[0];
+        assert_eq!(signal.task_id, task_id);
+        assert_eq!(signal.tool_name, "fm_tts");
+        assert_eq!(signal.parent_session_key.as_deref(), Some("api:session"));
+        assert!(
+            signal
+                .error_message
+                .contains("voice 'yangmi' not registered")
+        );
+        assert_eq!(
+            signal.suggested_alternatives,
+            vec![
+                "vivian".to_string(),
+                "serena".to_string(),
+                "longxiang".to_string()
+            ]
+        );
+        assert_eq!(signal.tool_input["voice"], "yangmi");
+    }
+
+    #[test]
+    fn should_not_emit_signal_on_successful_completion() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-2", None);
+        supervisor.mark_running(&task_id);
+        supervisor.mark_completed(&task_id, vec!["/tmp/out.mp3".to_string()]);
+
+        assert!(
+            collected.lock().unwrap().is_empty(),
+            "completion must not emit failure signal"
+        );
+    }
+
+    #[test]
+    fn should_not_emit_signal_on_transient_running_state() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-3", None);
+        supervisor.mark_running(&task_id);
+        supervisor.mark_runtime_state(
+            &task_id,
+            TaskRuntimeState::DeliveringOutputs,
+            Some("send_file".into()),
+        );
+
+        assert!(
+            collected.lock().unwrap().is_empty(),
+            "transient state changes must not emit failure signal"
+        );
+    }
+
+    #[test]
+    fn should_only_emit_failure_signal_once_per_task() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-4", None);
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(&task_id, "first failure".to_string());
+        // re-marking should NOT re-fire the signal — guards against runaway
+        // recovery loops if multiple paths report the same failure.
+        supervisor.mark_failed(&task_id, "second failure".to_string());
+        supervisor.mark_failed(&task_id, "third failure".to_string());
+
+        assert_eq!(
+            collected.lock().unwrap().len(),
+            1,
+            "subsequent failures must not re-fire the signal"
+        );
+    }
+
+    #[test]
+    fn should_capture_tool_input_in_failure_signal() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let input = serde_json::json!({
+            "voice": "yangmi",
+            "text": "hello world",
+            "format": "mp3",
+        });
+        let task_id = supervisor.register_with_input("fm_tts", "call-5", None, Some(input.clone()));
+        supervisor.mark_failed(&task_id, "internal error".to_string());
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].tool_input, input);
+    }
+
+    #[test]
+    fn parse_alternatives_handles_canonical_pattern() {
+        let alts = parse_alternatives(
+            "voice 'yangmi' not registered. available: vivian, serena, longxiang.",
+        );
+        assert_eq!(alts, vec!["vivian", "serena", "longxiang"]);
+    }
+
+    #[test]
+    fn parse_alternatives_returns_empty_when_no_marker() {
+        let alts = parse_alternatives("connection refused after 3 retries");
+        assert!(alts.is_empty());
+    }
+
+    #[test]
+    fn parse_alternatives_strips_quotes_and_whitespace() {
+        let alts = parse_alternatives(r#"available: "alice", 'bob' , charlie"#);
+        assert_eq!(alts, vec!["alice", "bob", "charlie"]);
+    }
+
+    #[test]
+    fn should_set_tool_input_after_registration() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-6", None);
+        supervisor.set_tool_input(&task_id, serde_json::json!({"voice": "yangmi"}));
+        supervisor.mark_failed(&task_id, "voice missing".to_string());
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].tool_input["voice"], "yangmi");
+    }
+
+    #[test]
+    fn should_not_enqueue_second_recovery_for_same_task_id() {
+        // Spec-named alias of should_only_emit_failure_signal_once_per_task —
+        // codifies that the supervisor-level dedup is what guarantees the
+        // session actor never sees a second hint for the same task id.
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-dedup", None);
+        supervisor.mark_failed(&task_id, "first".to_string());
+        supervisor.mark_failed(&task_id, "second".to_string());
+        assert_eq!(collected.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn should_include_parsed_alternatives_from_error_text() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-alts", None);
+        supervisor.mark_failed(
+            &task_id,
+            "voice missing. available: vivian, serena, longxiang.".to_string(),
+        );
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(
+            signals[0].suggested_alternatives,
+            vec![
+                "vivian".to_string(),
+                "serena".to_string(),
+                "longxiang".to_string(),
+            ]
+        );
+    }
+
     #[test]
     fn should_accept_valid_wav_with_real_audio() {
         let dir = tempfile::tempdir().unwrap();
@@ -1916,5 +2253,34 @@ mod tests {
         std::fs::write(&clip, build_flac(2048)).unwrap();
 
         validate_spawn_only_artifacts(&[clip]).expect("fLaC magic must pass");
+    }
+
+    #[test]
+    fn should_include_tool_name_and_input_in_recovery_prompt() {
+        // Asserts the supervisor exposes both the tool name and the input
+        // on the SpawnOnlyFailureSignal so the session actor can build the
+        // recovery prompt without re-walking the message history.
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let input = serde_json::json!({"voice": "yangmi", "text": "hello"});
+        let task_id =
+            supervisor.register_with_input("fm_tts", "call-prompt", None, Some(input.clone()));
+        supervisor.mark_failed(&task_id, "voice missing".to_string());
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].tool_name, "fm_tts");
+        assert_eq!(signals[0].tool_input, input);
+    }
+
+    #[test]
+    fn should_emit_failure_signal_with_null_tool_input_when_unset() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-7", None);
+        supervisor.mark_failed(&task_id, "boom".to_string());
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].tool_input, Value::Null);
     }
 }

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -197,6 +197,23 @@ impl ToolRegistry {
             .register(tool_name, tool_call_id, self.session_key.as_deref())
     }
 
+    /// Register a background task and capture the original tool input so
+    /// failure-recovery flows (M8.9) can reference it without re-walking
+    /// the message history.
+    pub fn register_task_with_input(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        tool_input: Option<serde_json::Value>,
+    ) -> String {
+        self.supervisor.register_with_input(
+            tool_name,
+            tool_call_id,
+            self.session_key.as_deref(),
+            tool_input,
+        )
+    }
+
     /// Return the number of currently active background tasks.
     pub fn bg_task_count(&self) -> u32 {
         self.supervisor.task_count() as u32

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -853,6 +853,40 @@ async fn dispatch_background_result_to_actor(
     }
 }
 
+/// Build the synthetic `[system-internal]` recovery prompt that the
+/// session actor enqueues when a `spawn_only` task transitions to
+/// `Failed` (M8.9). The prompt frames the failure for the LLM and asks
+/// it to offer a path forward — alternatives parsed from the error, or
+/// a safer fallback the model can attempt itself.
+pub(crate) fn build_recovery_prompt(signal: &octos_agent::SpawnOnlyFailureSignal) -> String {
+    let alternatives_block = if signal.suggested_alternatives.is_empty() {
+        String::new()
+    } else {
+        let list = signal
+            .suggested_alternatives
+            .iter()
+            .map(|alt| format!("- {alt}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("\nDetected alternatives:\n{list}\n")
+    };
+    let input_block = if signal.tool_input.is_null() {
+        String::new()
+    } else {
+        let pretty = serde_json::to_string(&signal.tool_input).unwrap_or_else(|_| "{}".into());
+        format!("\nOriginal input: {pretty}")
+    };
+    format!(
+        "[system-internal] Your previous `{tool}` call failed.\n\
+         Error: {err}{input}{alts}\n\
+         Respond to the user with a path forward — offer the alternatives, or try the safest one yourself if appropriate. Do not just report failure.",
+        tool = signal.tool_name,
+        err = signal.error_message,
+        input = input_block,
+        alts = alternatives_block,
+    )
+}
+
 fn git_turn_summary(content: &str) -> String {
     let compact = content.split_whitespace().collect::<Vec<_>>().join(" ");
     if compact.is_empty() {
@@ -1057,6 +1091,18 @@ pub enum ActorMessage {
     TaskStatusChanged {
         /// Serialized JSON of the BackgroundTask.
         task_json: String,
+    },
+    /// Synthetic recovery turn enqueued by the spawn_only failure-signal
+    /// callback (M8.9). Drives the LLM to re-engage on a failed background
+    /// task with the actionable error and (optionally parsed) alternatives.
+    RecoveryHint {
+        /// Task ID that triggered the recovery (used for de-duplication).
+        task_id: String,
+        /// Tool that failed — surfaced verbatim in the synthetic prompt.
+        tool_name: String,
+        /// Best-effort prompt body. Already framed as `[system-internal]` so
+        /// the LLM treats it as runtime guidance, not a user turn.
+        prompt: String,
     },
     /// Cancel the current operation.
     Cancel,
@@ -1771,6 +1817,21 @@ impl ActorFactory {
             }
         });
 
+        // Wire supervisor on_failure_signal callback (M8.9): when a
+        // spawn_only task transitions to Failed, enqueue a synthetic
+        // recovery turn so the LLM can offer alternatives or take a
+        // recovery action instead of leaving the user with only a
+        // terminal failure notification.
+        let recovery_tx = tx.clone();
+        supervisor.set_on_failure_signal(move |signal| {
+            let prompt = build_recovery_prompt(signal);
+            let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
+                task_id: signal.task_id.clone(),
+                tool_name: signal.tool_name.clone(),
+                prompt,
+            });
+        });
+
         let cron_tool_ref = if let Some(ref cron_service) = self.cron_service {
             let cron_tool = Arc::new(CronTool::with_context(
                 cron_service.clone(),
@@ -1980,6 +2041,7 @@ impl ActorFactory {
             active_sessions: self.active_sessions.clone(),
             user_workspace: user_workspace.clone(),
             cron_tool: cron_tool_ref,
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
         };
 
         // Spawn the outbound forwarding task — buffers messages from inactive sessions
@@ -2144,6 +2206,10 @@ struct SessionActor {
     user_workspace: std::path::PathBuf,
     /// Per-session cron tool reference — updated with channel/chat_id on each message.
     cron_tool: Option<Arc<CronTool>>,
+    /// Set of `task_id`s that have already triggered an automatic recovery
+    /// turn (M8.9). Caps recovery at one attempt per task so a recovery
+    /// turn that itself fails cannot ignite a runaway loop.
+    recovered_tasks: Arc<StdMutex<std::collections::HashSet<String>>>,
 }
 
 impl SessionActor {
@@ -2230,6 +2296,35 @@ impl SessionActor {
             .get_active_topic(base_key)
             .to_string();
         my_topic == active_topic
+    }
+
+    /// Reserve a recovery slot for a task. Returns `true` if this is the
+    /// first recovery for the given task ID and the caller should proceed,
+    /// `false` if a recovery has already been triggered (and the second
+    /// signal should be dropped). Cap is one recovery attempt per task —
+    /// see M8.9.
+    fn claim_recovery_slot(&self, task_id: &str) -> bool {
+        let mut guard = self
+            .recovered_tasks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        guard.insert(task_id.to_string())
+    }
+
+    /// Build a synthetic `InboundMessage` carrying the recovery prompt so
+    /// the existing inbound pipeline (history persistence, agent loop)
+    /// runs unchanged.
+    fn synthetic_recovery_inbound(&self, prompt: String) -> InboundMessage {
+        InboundMessage {
+            channel: self.channel.clone(),
+            sender_id: "octos-runtime".to_string(),
+            chat_id: self.chat_id.clone(),
+            content: prompt,
+            timestamp: chrono::Utc::now(),
+            media: vec![],
+            metadata: serde_json::json!({ "_recovery_turn": true }),
+            message_id: None,
+        }
     }
 
     async fn run(mut self) {
@@ -2361,6 +2456,41 @@ impl SessionActor {
                                     "_task_status": task_json
                                 }),
                             }).await;
+                        }
+                        Some(ActorMessage::RecoveryHint {
+                            task_id,
+                            tool_name,
+                            prompt,
+                        }) => {
+                            // Cap recovery at one attempt per task to avoid
+                            // runaway loops if the recovery turn itself
+                            // fails. Subsequent failures from the same task
+                            // ID are silently dropped here.
+                            if !self.claim_recovery_slot(&task_id) {
+                                debug!(
+                                    session = %self.session_key,
+                                    task_id,
+                                    tool_name,
+                                    "skipping duplicate recovery hint"
+                                );
+                                continue;
+                            }
+                            debug!(
+                                session = %self.session_key,
+                                task_id,
+                                tool_name,
+                                "enqueueing synthetic recovery turn"
+                            );
+                            let synthetic = self.synthetic_recovery_inbound(prompt);
+                            let final_attachment_media = self
+                                .copy_media_to_workspace(Vec::new());
+                            self.process_inbound(
+                                synthetic,
+                                Vec::new(),
+                                final_attachment_media,
+                                None,
+                            )
+                            .await;
                         }
                         Some(ActorMessage::Cancel) => {
                             debug!(session = %self.session_key, "cancel requested");
@@ -2944,6 +3074,21 @@ impl SessionActor {
                         Ok(ActorMessage::TaskStatusChanged { .. }) => {
                             // Ignore in drain — status is pushed via the main loop
                         }
+                        Ok(ActorMessage::RecoveryHint {
+                            task_id, tool_name, ..
+                        }) => {
+                            // Drain context: a turn is already running. The
+                            // claim guarantees we won't try to recover this
+                            // task again later. Trace and drop — the LLM
+                            // will see the failure via TaskStatusChanged.
+                            debug!(
+                                session = %self.session_key,
+                                task_id,
+                                tool_name,
+                                "dropping recovery hint received during drain"
+                            );
+                            self.claim_recovery_slot(&task_id);
+                        }
                         Ok(ActorMessage::Cancel) => {
                             self.cancelled.store(true, Ordering::Release);
                             break;
@@ -3005,6 +3150,21 @@ impl SessionActor {
                         }
                         Ok(ActorMessage::TaskStatusChanged { .. }) => {
                             // Ignore in drain — status is pushed via the main loop
+                        }
+                        Ok(ActorMessage::RecoveryHint {
+                            task_id, tool_name, ..
+                        }) => {
+                            // Drain context: a turn is already running. The
+                            // claim guarantees we won't try to recover this
+                            // task again later. Trace and drop — the LLM
+                            // will see the failure via TaskStatusChanged.
+                            debug!(
+                                session = %self.session_key,
+                                task_id,
+                                tool_name,
+                                "dropping recovery hint received during drain"
+                            );
+                            self.claim_recovery_slot(&task_id);
                         }
                         Ok(ActorMessage::Cancel) => {
                             self.cancelled.store(true, Ordering::Release);
@@ -3711,6 +3871,20 @@ impl SessionActor {
                                     "_task_status": task_json
                                 }),
                             }).await;
+                        }
+                        Some(ActorMessage::RecoveryHint { task_id, tool_name, .. }) => {
+                            // Speculative-overflow context: the primary
+                            // turn is already running. Reserve the slot
+                            // (so we don't try again later) and drop the
+                            // hint — the failure will be visible via
+                            // TaskStatusChanged.
+                            debug!(
+                                session = %self.session_key,
+                                task_id,
+                                tool_name,
+                                "dropping recovery hint during speculative overflow"
+                            );
+                            self.claim_recovery_slot(&task_id);
                         }
                         Some(ActorMessage::Cancel) => {
                             self.cancelled.store(true, Ordering::Release);
@@ -5686,6 +5860,7 @@ mod tests {
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
             user_workspace: dir.path().join("workspace"),
             cron_tool: None,
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
         };
 
         let handle = tokio::spawn(actor.run());
@@ -5754,6 +5929,7 @@ mod tests {
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
             user_workspace: dir.path().join("workspace"),
             cron_tool: None,
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
         };
 
         let handle = tokio::spawn(actor.run());
@@ -5828,6 +6004,7 @@ mod tests {
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
             user_workspace: dir.path().join("workspace"),
             cron_tool: None,
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
         };
 
         let handle = tokio::spawn(actor.run());
@@ -5949,6 +6126,7 @@ mod tests {
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
             user_workspace: dir.path().join("workspace"),
             cron_tool: None,
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
         };
 
         let handle = tokio::spawn(actor.run());
@@ -6066,6 +6244,7 @@ mod tests {
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
             user_workspace: dir.path().join("workspace"),
             cron_tool: Some(cron_tool),
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
         };
 
         let handle = tokio::spawn(actor.run());
@@ -6155,6 +6334,7 @@ mod tests {
             active_sessions: Arc::new(RwLock::new(ActiveSessionStore::open(dir.path()).unwrap())),
             user_workspace: dir.path().join("workspace"),
             cron_tool: None,
+            recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
         };
 
         let handle = tokio::spawn(actor.run());
@@ -8175,5 +8355,278 @@ mod tests {
             elapsed.as_millis()
         );
         assert_eq!(snapshot.len(), 2);
+    }
+
+    // ── M8.9: Runtime failure recovery ─────────────────────────────────────
+
+    #[test]
+    fn recovery_prompt_includes_tool_name_and_error() {
+        let signal = octos_agent::SpawnOnlyFailureSignal {
+            task_id: "task-1".into(),
+            tool_name: "fm_tts".into(),
+            tool_input: serde_json::json!({"voice": "yangmi"}),
+            error_message: "voice 'yangmi' not registered".into(),
+            suggested_alternatives: vec![],
+            parent_session_key: Some("api:test".into()),
+        };
+        let prompt = build_recovery_prompt(&signal);
+        assert!(prompt.starts_with("[system-internal]"));
+        assert!(prompt.contains("fm_tts"));
+        assert!(prompt.contains("voice 'yangmi' not registered"));
+        assert!(prompt.contains("path forward"));
+    }
+
+    #[test]
+    fn recovery_prompt_includes_alternatives_block_when_present() {
+        let signal = octos_agent::SpawnOnlyFailureSignal {
+            task_id: "task-2".into(),
+            tool_name: "fm_tts".into(),
+            tool_input: serde_json::Value::Null,
+            error_message: "voice missing".into(),
+            suggested_alternatives: vec!["vivian".into(), "serena".into(), "longxiang".into()],
+            parent_session_key: None,
+        };
+        let prompt = build_recovery_prompt(&signal);
+        assert!(prompt.contains("Detected alternatives"));
+        assert!(prompt.contains("- vivian"));
+        assert!(prompt.contains("- serena"));
+        assert!(prompt.contains("- longxiang"));
+    }
+
+    #[test]
+    fn recovery_prompt_omits_alternatives_block_when_empty() {
+        let signal = octos_agent::SpawnOnlyFailureSignal {
+            task_id: "task-3".into(),
+            tool_name: "fm_tts".into(),
+            tool_input: serde_json::Value::Null,
+            error_message: "internal error".into(),
+            suggested_alternatives: vec![],
+            parent_session_key: None,
+        };
+        let prompt = build_recovery_prompt(&signal);
+        assert!(!prompt.contains("Detected alternatives"));
+    }
+
+    #[test]
+    fn recovery_prompt_includes_tool_input_when_set() {
+        let signal = octos_agent::SpawnOnlyFailureSignal {
+            task_id: "task-4".into(),
+            tool_name: "fm_tts".into(),
+            tool_input: serde_json::json!({"voice": "yangmi", "text": "hello"}),
+            error_message: "voice missing".into(),
+            suggested_alternatives: vec![],
+            parent_session_key: None,
+        };
+        let prompt = build_recovery_prompt(&signal);
+        assert!(prompt.contains("Original input"));
+        assert!(prompt.contains("yangmi"));
+    }
+
+    #[tokio::test]
+    async fn should_enqueue_synthetic_recovery_turn_with_error_message() {
+        // End-to-end: a RecoveryHint pushed onto the inbox should drive a
+        // primary turn whose user/system content includes the recovery
+        // prompt, so the LLM (mock here) sees and responds to it.
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(
+                Duration::from_millis(50),
+                make_response("acknowledging recovery"),
+            )],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm.clone(), QueueMode::Followup, None, false, &dir).await;
+
+        let prompt = build_recovery_prompt(&octos_agent::SpawnOnlyFailureSignal {
+            task_id: "task-rh-1".into(),
+            tool_name: "fm_tts".into(),
+            tool_input: serde_json::json!({"voice": "yangmi"}),
+            error_message: "voice 'yangmi' not registered. available: vivian, serena.".into(),
+            suggested_alternatives: vec!["vivian".into(), "serena".into()],
+            parent_session_key: Some("cli:test".into()),
+        });
+        tx.send(ActorMessage::RecoveryHint {
+            task_id: "task-rh-1".into(),
+            tool_name: "fm_tts".into(),
+            prompt,
+        })
+        .await
+        .unwrap();
+
+        let mut responses = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+            if responses.len() >= 1 {
+                break;
+            }
+        }
+        assert!(
+            responses
+                .iter()
+                .any(|c| c.contains("acknowledging recovery")),
+            "expected LLM to produce recovery response, got: {:?}",
+            responses
+        );
+
+        // Verify the synthetic recovery prompt actually landed in history.
+        let session_handle = SessionHandle::open(dir.path(), &SessionKey::new("cli", "test"));
+        let session = session_handle.session();
+        let recovery_user_msgs: Vec<_> = session
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == MessageRole::User
+                    && m.content.contains("[system-internal]")
+                    && m.content.contains("fm_tts")
+            })
+            .collect();
+        assert_eq!(
+            recovery_user_msgs.len(),
+            1,
+            "expected exactly one recovery prompt in history, got: {:?}",
+            session.messages
+        );
+        assert!(
+            recovery_user_msgs[0].content.contains("vivian"),
+            "recovery prompt should include parsed alternatives"
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    #[tokio::test]
+    async fn should_not_enqueue_second_recovery_for_same_task_id() {
+        // Two RecoveryHints for the same task_id — only the first should
+        // produce a recovery turn. The second is silently dropped via the
+        // recovered_tasks claim slot.
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![
+                (Duration::from_millis(50), make_response("first recovery")),
+                (Duration::from_millis(50), make_response("second recovery")),
+            ],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let prompt1 = "[system-internal] first recovery prompt".to_string();
+        let prompt2 = "[system-internal] second recovery prompt".to_string();
+        tx.send(ActorMessage::RecoveryHint {
+            task_id: "task-dup".into(),
+            tool_name: "fm_tts".into(),
+            prompt: prompt1,
+        })
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        tx.send(ActorMessage::RecoveryHint {
+            task_id: "task-dup".into(),
+            tool_name: "fm_tts".into(),
+            prompt: prompt2,
+        })
+        .await
+        .unwrap();
+
+        let mut responses = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+        }
+        // Only the first recovery should have driven an LLM turn.
+        let first_seen = responses.iter().any(|c| c.contains("first recovery"));
+        let second_seen = responses.iter().any(|c| c.contains("second recovery"));
+        assert!(
+            first_seen,
+            "first recovery should have run: {:?}",
+            responses
+        );
+        assert!(
+            !second_seen,
+            "second recovery should have been suppressed: {:?}",
+            responses
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    #[tokio::test]
+    async fn supervisor_failure_signal_generates_recovery_actor_message_end_to_end() {
+        // Full integration: install the failure-signal callback we set up
+        // in spawn(), trigger mark_failed, and assert the actor enqueues
+        // and processes a RecoveryHint.
+        use octos_agent::TaskSupervisor;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::from_millis(50), make_response("recovery-handled"))],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        // Mirror the spawn() wiring: a TaskSupervisor whose failure signal
+        // dispatches a RecoveryHint into the actor inbox.
+        let supervisor = TaskSupervisor::new();
+        let recovery_tx = tx.clone();
+        supervisor.set_on_failure_signal(move |signal| {
+            let prompt = build_recovery_prompt(signal);
+            let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
+                task_id: signal.task_id.clone(),
+                tool_name: signal.tool_name.clone(),
+                prompt,
+            });
+        });
+        let task_id = supervisor.register_with_input(
+            "fm_tts",
+            "call-int-1",
+            Some("cli:test"),
+            Some(serde_json::json!({"voice": "yangmi", "text": "hi"})),
+        );
+        supervisor.mark_failed(
+            &task_id,
+            "voice 'yangmi' not registered. available: vivian, serena.".into(),
+        );
+
+        let mut responses = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+            if responses.iter().any(|r| r.contains("recovery-handled")) {
+                break;
+            }
+        }
+        assert!(
+            responses.iter().any(|c| c.contains("recovery-handled")),
+            "expected recovery turn to drive an LLM response, got: {:?}",
+            responses
+        );
+
+        let session_handle = SessionHandle::open(dir.path(), &SessionKey::new("cli", "test"));
+        let session = session_handle.session();
+        let prompt_present = session.messages.iter().any(|m| {
+            m.role == MessageRole::User
+                && m.content.contains("[system-internal]")
+                && m.content.contains("fm_tts")
+                && m.content.contains("vivian")
+        });
+        assert!(
+            prompt_present,
+            "synthetic recovery prompt should be in session history: {:?}",
+            session.messages
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
     }
 }

--- a/docs/OCTOS_FAILURE_MODES_INVENTORY.md
+++ b/docs/OCTOS_FAILURE_MODES_INVENTORY.md
@@ -1,0 +1,43 @@
+# Octos Failure Modes Inventory
+
+Living catalogue of how the runtime handles each class of failure.
+Update this file whenever a new failure class is discovered or an
+existing recovery path changes.
+
+## Conventions
+
+- Each row is a single observable failure class.
+- "Trigger" is the smallest reproducible signal (error code, log line,
+  protocol event) that the failure has occurred.
+- "Recovery path" names the runtime component that owns the response
+  and the PR/milestone where it shipped.
+- "Tested?" links to a test name (or notes a gap).
+- "Owner" is the stewarding workstream — usually the originating
+  engineer, sometimes a long-lived module.
+
+## Inventory
+
+| Failure class                          | Trigger                                                                                                | Recovery path                                                                                                                                          | Tested?                                                                                                                                       | Owner                  |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| Sync tool error                        | Tool returns `ToolResult { success: false, .. }` or panics, surfaced as `Tool` message in the loop      | Tool-use loop in `octos-agent/src/agent/loop_runner.rs` injects the failure as a `Tool` message; the LLM sees it on the next turn                       | Yes — `agent::tests::*tool_error*` plus integration tests in `tools/` modules                                                                  | octos-agent (existing) |
+| Spawn_only task `Failed`               | `TaskSupervisor::mark_failed` fires for a `spawn_only` background task                                  | M8.9: `SpawnOnlyFailureSignal` → session actor enqueues a `RecoveryHint` → synthetic `[system-internal]` turn re-engages the LLM with alternatives      | Yes — `task_supervisor::tests::should_emit_failure_signal_*`, `session_actor::tests::supervisor_failure_signal_generates_recovery_actor_message_end_to_end` | M8.9                   |
+| Network partition                      | LLM provider request returns `reqwest::Error` (timeout, connection reset)                              | `RetryProvider` exponential backoff (`octos-llm/src/retry.rs`); falls through to `ProviderChain` failover                                                | Yes — retry + chain integration tests in `octos-llm`                                                                                          | octos-llm (existing)   |
+| Provider 429 / 5xx                     | HTTP 429 or 5xx surface from any LLM endpoint                                                          | `RetryProvider` retries → `ProviderChain` failover → `AdaptiveRouter` lane scoring + circuit breakers                                                  | Yes — provider chain test suite                                                                                                               | octos-llm (existing)   |
+| LLM returns empty content              | Model returns empty `content` and no tool calls                                                        | Loop emits a synthetic stub assistant message; parent flow receives a non-empty terminal reply                                                          | Yes — `agent::tests::stub_*`                                                                                                                  | octos-agent (existing) |
+| Silent voice substitution              | OminiX-API silently swaps an unknown voice for the default one                                          | OminiX-API now returns `404` for unknown voices; `fm_tts` pre-validates voice IDs; `task_supervisor` content-checks the produced audio (PR #12, #48, #559) | Yes — fm_tts unit tests + e2e voice-skill specs                                                                                               | voice-skill            |
+| Partial file output                    | Spawn_only tool reports success but emits a truncated/empty payload                                     | `task_supervisor` size + content validation rejects the artifact and routes through the `Failed` path so M8.9 picks it up (PR #550, #559)               | Yes — workspace-contract suite                                                                                                                | task-supervisor        |
+| Session crash mid-turn                 | Process exits while a turn is in flight                                                                 | M8.6 structured resume pipeline replays the last committed turn from JSONL on next session boot                                                          | Yes — M8.6 resume integration tests                                                                                                           | M8.6                   |
+| Overflow history stale                 | Speculative-overflow path consumes a stale window of conversation history                              | In-flight `a89c7fd1` snapshots primary history at speculative-spawn time and pins it for the overflow worker                                            | Pending — tracking in `a89c7fd1`                                                                                                              | runtime                |
+| Recovery turn itself fails             | The recovery turn enqueued by M8.9 produces another spawn_only failure                                  | M8.9 caps recovery at one attempt per task; subsequent failure signals for the same `task_id` are silently dropped                                       | Yes — `session_actor::tests::recovery_hint_only_fires_once_for_same_task_id`, `task_supervisor::tests::should_only_emit_failure_signal_once_per_task` | M8.9                   |
+
+## Adding a new failure class
+
+When a new class is discovered:
+
+1. Add a row above with the trigger, recovery path (or "TBD"), and a
+   test reference.
+2. If recovery is missing, file an issue and link it from this table.
+3. After the recovery ships, update the row in the same PR.
+
+This file is the canonical surface area for failure-mode reviews. Skip
+no rows — silent partial coverage is what M8.9 was created to close.


### PR DESCRIPTION
## Summary

Backports M8.9 (commit 4f8542b8 from release/coding-blue) to main. M8.9 adds an automatic recovery turn when a spawn_only background task transitions to Failed — the LLM gets a synthetic prompt with the failure details and suggested alternatives so the user is never left stuck.

## Resolution notes

- main has restructured execution.rs into a `spawn_tool_task` method (post-M8.8 reconciliation). The cherry-pick's inline-closure form was removed and the M8.9 change (`register_task` → `register_task_with_input`) was applied surgically to the canonical site at line 219.
- The session_actor.rs cherry-pick brings in F-015 fields (`persistent_retry_state`, `retry_state_path`) that are NOT M8.9 — they are from a separate review-A commit. Those fields were stripped from each of 7 SessionActor struct sites; only `recovered_tasks: Arc<StdMutex<HashSet>>` (the actual M8.9 field) is added.
- `setup_speculative_actor_with_indicator` and `make_inbound_api` test helpers from the cherry-pick were dropped (they support FA-12d which was already excluded from PR #587).

## Verification

- cargo build -p octos-cli --features api: clean
- cargo build -p octos-agent: clean
- cargo test -p octos-cli --features api --lib: 580 passed (up from 573 — M8.9 adds 7 new); 3 pre-existing main failures unchanged
- cargo test -p octos-agent --lib: 1146 passed (up from 1133 — M8.9 adds 13 new); 1 pre-existing main failure
- cargo fmt --all -- --check: clean
- cargo clippy -p octos-agent -- -D warnings: clean

## Test plan

- [ ] CI green (or admin-merge under fleet-wide infra-OOM rationale)