### PR TITLE
M8 W3: plugin protocol v2 + deep_search synthesis + deep_crawl cancel/cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,8 @@ scripts/deploy.sh
 !crates/platform-skills/**/SKILL.md
 # Crate-level developer documentation (SDK contracts, protocol specs)
 !crates/octos-plugin/docs/*.md
+# Crate test fixtures (sample reports, fake API payloads)
+!crates/app-skills/**/tests/fixtures/*.md
 # Harness M4.4 compat-gate fixture (SKILL.md + manifest.json must be tracked)
 !e2e/fixtures/compat-test-skill/SKILL.md
 !e2e/fixtures/compat-test-skill/manifest.json

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,8 @@ scripts/deploy.sh
 !crates/octos-agent/skills/**/SKILL.md
 !crates/app-skills/**/SKILL.md
 !crates/platform-skills/**/SKILL.md
+# Crate-level developer documentation (SDK contracts, protocol specs)
+!crates/octos-plugin/docs/*.md
 # Harness M4.4 compat-gate fixture (SKILL.md + manifest.json must be tracked)
 !e2e/fixtures/compat-test-skill/SKILL.md
 !e2e/fixtures/compat-test-skill/manifest.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "octos-core",
  "octos-llm",
  "octos-memory",
+ "octos-plugin",
  "redb",
  "regex",
  "reqwest 0.12.28",

--- a/crates/app-skills/deep-crawl/src/main.rs
+++ b/crates/app-skills/deep-crawl/src/main.rs
@@ -30,8 +30,7 @@ use url::Url;
 
 /// Set to 1 by the SIGTERM handler; the BFS loop and synchronous
 /// CDP-sender code paths poll this and exit early when set.
-static CANCELLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+static CANCELLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Pid of the Chrome child we launched. The handler kills this directly
 /// so chromium does not linger after the main task winds down.
@@ -998,7 +997,10 @@ async fn run() -> Output {
 
     while let Some((url, depth)) = queue.pop_front() {
         if cancelled() {
-            eprintln!("[deep_crawl] cancelled, stopping BFS at {} pages", results.len());
+            eprintln!(
+                "[deep_crawl] cancelled, stopping BFS at {} pages",
+                results.len()
+            );
             emit_v2_progress("cleanup", "cancellation requested", None);
             break;
         }
@@ -1019,11 +1021,7 @@ async fn run() -> Output {
         };
         emit_v2_progress(
             "crawling",
-            &format!(
-                "page {}/{} depth={depth}",
-                results.len() + 1,
-                max_pages
-            ),
+            &format!("page {}/{} depth={depth}", results.len() + 1, max_pages),
             progress_fraction,
         );
 

--- a/crates/app-skills/deep-crawl/src/main.rs
+++ b/crates/app-skills/deep-crawl/src/main.rs
@@ -9,7 +9,7 @@ use std::io::Read as _;
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
@@ -17,6 +17,30 @@ use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::Message;
 use url::Url;
+
+// ---------------------------------------------------------------------------
+// Cancellation (W3.D1)
+// ---------------------------------------------------------------------------
+//
+// Plugin protocol v2 contract: on SIGTERM the host gives us 10s to clean up
+// before SIGKILL. We track an in-process atomic that is set by the SIGTERM
+// handler, and the BFS loop checks it at every iteration. The Chrome child
+// pid is tracked so the handler can kill it directly even if the main task
+// is blocked in a CDP call.
+
+/// Set to 1 by the SIGTERM handler; the BFS loop and synchronous
+/// CDP-sender code paths poll this and exit early when set.
+static CANCELLED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Pid of the Chrome child we launched. The handler kills this directly
+/// so chromium does not linger after the main task winds down.
+/// 0 means "no child to kill".
+static CHROME_PID: AtomicI32 = AtomicI32::new(0);
+
+fn cancelled() -> bool {
+    CANCELLED.load(Ordering::Relaxed)
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -716,16 +740,96 @@ async fn crawl_single_page(
 }
 
 // ---------------------------------------------------------------------------
+// Plugin protocol v2 stderr emitters
+// ---------------------------------------------------------------------------
+
+/// Emit a v2 `progress` event on stderr.
+fn emit_v2_progress(stage: &str, message: &str, progress_fraction: Option<f64>) {
+    let event = serde_json::json!({
+        "type": "progress",
+        "stage": stage,
+        "message": message,
+        "progress": progress_fraction,
+    });
+    match serde_json::to_string(&event) {
+        Ok(line) => eprintln!("{line}"),
+        Err(_) => eprintln!("[{stage}] {message}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 #[tokio::main]
 async fn main() {
+    install_sigterm_handler();
     let result = run().await;
+    // Best-effort: kill chrome before we exit. Required when the timeout
+    // path didn't run (success exit) AND when the host SIGKILLs us before
+    // our drop runs.
+    cleanup_chrome();
     let output_json = serde_json::to_string(&result).unwrap_or_else(|_| {
         r#"{"output":"Internal serialization error","success":false}"#.to_string()
     });
     println!("{output_json}");
+}
+
+/// Install a SIGTERM handler that flips the [`CANCELLED`] atomic, kills
+/// the Chrome child, and exits within the host's 10s grace window.
+#[cfg(unix)]
+fn install_sigterm_handler() {
+    use tokio::signal::unix::{signal, SignalKind};
+    tokio::spawn(async {
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[deep_crawl] failed to install SIGTERM handler: {e}");
+                return;
+            }
+        };
+        if term.recv().await.is_some() {
+            CANCELLED.store(true, Ordering::Relaxed);
+            emit_v2_progress(
+                "cleanup",
+                "SIGTERM received, killing chrome and exiting",
+                None,
+            );
+            cleanup_chrome();
+            // 130 = 128 + SIGTERM(2). Stay well within the 10s budget.
+            std::process::exit(130);
+        }
+    });
+}
+
+#[cfg(not(unix))]
+fn install_sigterm_handler() {
+    // No SIGTERM on Windows; deep_crawl exits via host's TerminateProcess.
+}
+
+/// Kill the tracked Chrome child if any. Idempotent: safe to call from
+/// both the SIGTERM handler and the normal exit path.
+fn cleanup_chrome() {
+    let pid = CHROME_PID.swap(0, Ordering::Relaxed);
+    if pid <= 0 {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        // SIGKILL the chrome process. Best-effort — Chrome reaps on its
+        // own once the WS connection drops, but explicit kill is faster
+        // and matches the "no browser zombies" assertion in the test
+        // matrix.
+        let _ = std::process::Command::new("kill")
+            .args(["-9", &pid.to_string()])
+            .status();
+    }
+    #[cfg(windows)]
+    {
+        let _ = std::process::Command::new("taskkill")
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .status();
+    }
 }
 
 async fn run() -> Output {
@@ -800,6 +904,8 @@ async fn run() -> Output {
         }
     };
 
+    emit_v2_progress("init", "launching headless chrome", Some(0.05));
+
     // Launch Chrome
     let (mut child, port) = match launch_chrome(temp_dir.path()) {
         Ok(c) => c,
@@ -810,6 +916,11 @@ async fn run() -> Output {
             };
         }
     };
+
+    // Record pid so the SIGTERM handler can kill it directly.
+    if let Ok(pid) = i32::try_from(child.id()) {
+        CHROME_PID.store(pid, Ordering::Relaxed);
+    }
 
     // Connect to Chrome via CDP
     let ws_url = match get_ws_url(port).await {
@@ -879,8 +990,18 @@ async fn run() -> Output {
         "[deep_crawl] starting crawl: url={}, max_depth={max_depth}, max_pages={max_pages}, path_prefix={:?}",
         input.url, input.path_prefix
     );
+    emit_v2_progress(
+        "crawling",
+        &format!("starting BFS, max_pages={max_pages}, max_depth={max_depth}"),
+        Some(0.10),
+    );
 
     while let Some((url, depth)) = queue.pop_front() {
+        if cancelled() {
+            eprintln!("[deep_crawl] cancelled, stopping BFS at {} pages", results.len());
+            emit_v2_progress("cleanup", "cancellation requested", None);
+            break;
+        }
         if results.len() >= max_pages as usize {
             break;
         }
@@ -889,6 +1010,21 @@ async fn run() -> Output {
             "[deep_crawl] crawling [{}/{}] depth={depth}: {url}",
             results.len() + 1,
             max_pages
+        );
+        let progress_fraction = if max_pages > 0 {
+            // 0.10 reserved for init; cap progress under 0.95.
+            Some(0.10 + (results.len() as f64 / max_pages as f64) * 0.85)
+        } else {
+            None
+        };
+        emit_v2_progress(
+            "crawling",
+            &format!(
+                "page {}/{} depth={depth}",
+                results.len() + 1,
+                max_pages
+            ),
+            progress_fraction,
         );
 
         let mut crawled = crawl_single_page(&mut ws, &session_id, &url, PAGE_SETTLE_MS).await;
@@ -939,8 +1075,12 @@ async fn run() -> Output {
         results.push(crawled);
     }
 
-    // Shutdown browser
+    // Shutdown browser. The pid is also tracked in CHROME_PID so the
+    // SIGTERM handler can race us; clear our slot before kill so the
+    // double-kill from cleanup_chrome() is a noop in the success path.
+    emit_v2_progress("cleanup", "closing chrome", Some(0.97));
     let _ = ws.close(None).await;
+    CHROME_PID.store(0, Ordering::Relaxed);
     let _ = child.kill();
     let _ = child.wait();
 
@@ -1025,9 +1165,119 @@ async fn run() -> Output {
         results.len(),
         crawl_dir.display()
     );
+    emit_v2_progress(
+        "complete",
+        &format!("crawled {} pages", results.len()),
+        Some(1.0),
+    );
 
     Output {
         output,
         success: true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancelled_atomic_starts_unset() {
+        // Other tests in this module may set the atomic; reset before
+        // checking to keep this test deterministic regardless of
+        // execution order.
+        CANCELLED.store(false, Ordering::Relaxed);
+        assert!(!cancelled());
+        CANCELLED.store(true, Ordering::Relaxed);
+        assert!(cancelled());
+        CANCELLED.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn cleanup_chrome_is_idempotent_with_zero_pid() {
+        // No pid recorded → noop, must not panic.
+        CHROME_PID.store(0, Ordering::Relaxed);
+        cleanup_chrome();
+        cleanup_chrome();
+    }
+
+    #[test]
+    fn cleanup_chrome_clears_pid_after_call() {
+        // Use an obviously-invalid pid so the kill command no-ops on
+        // any sane host. The test asserts the slot is cleared so a
+        // second cleanup is a noop.
+        CHROME_PID.store(1, Ordering::Relaxed);
+        cleanup_chrome();
+        assert_eq!(CHROME_PID.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn normalize_url_strips_fragment_and_trailing_slash() {
+        assert_eq!(
+            normalize_url("https://example.com/page#frag"),
+            Some("https://example.com/page".to_string())
+        );
+        assert_eq!(
+            normalize_url("https://example.com/page/"),
+            Some("https://example.com/page".to_string())
+        );
+    }
+
+    #[test]
+    fn host_slug_replaces_dots_with_dashes() {
+        let url = Url::parse("https://www.example.com/").unwrap();
+        assert_eq!(host_slug(&url), "www-example-com");
+    }
+
+    #[test]
+    fn truncate_string_preserves_utf8_boundary() {
+        let s = "hello 你好 world".to_string();
+        let truncated = truncate_string(s, 7);
+        // No panic and result fits within budget.
+        assert!(truncated.len() <= 7 + "\n\n... (truncated)".len());
+        assert!(truncated.is_char_boundary(0));
+    }
+
+    #[test]
+    fn truncate_string_passes_through_short_strings() {
+        let s = "short".to_string();
+        assert_eq!(truncate_string(s, 1000), "short");
+    }
+
+    #[test]
+    fn is_bot_blocked_detects_known_strings() {
+        assert!(is_bot_blocked("Just a moment..."));
+        assert!(is_bot_blocked("Performing security verification"));
+        assert!(is_bot_blocked("Attention Required! | Cloudflare"));
+        assert!(!is_bot_blocked("Welcome to our site"));
+    }
+
+    #[test]
+    fn is_private_ip_blocks_loopback_and_private() {
+        let v4_loopback: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+        let v4_private: std::net::IpAddr = "10.0.0.1".parse().unwrap();
+        let v4_public: std::net::IpAddr = "8.8.8.8".parse().unwrap();
+        assert!(is_private_ip(v4_loopback));
+        assert!(is_private_ip(v4_private));
+        assert!(!is_private_ip(v4_public));
+    }
+
+    #[test]
+    fn emit_v2_progress_does_not_panic_on_unicode() {
+        // Catch any future serialization regression that would crash on
+        // non-ASCII content.
+        emit_v2_progress("crawling", "page 你好/世界", Some(0.5));
+    }
+
+    #[test]
+    fn page_slug_produces_deterministic_filename_for_same_url() {
+        let url = Url::parse("https://example.com/path/to/page").unwrap();
+        let slug = page_slug(&url, 5);
+        assert!(slug.starts_with("005_"));
+        assert!(slug.contains("path"));
     }
 }

--- a/crates/app-skills/deep-search/Cargo.toml
+++ b/crates/app-skills/deep-search/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util", "signal"] }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/app-skills/deep-search/Cargo.toml
+++ b/crates/app-skills/deep-search/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process", "io-util", "signal", "sync"] }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -37,10 +37,65 @@ fn default_depth() -> u8 {
     2
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 struct Output {
     output: String,
     success: bool,
+    /// Plugin-protocol-v2 summary. The host's
+    /// `SubAgentSummaryGenerator` consumes this to build the parent
+    /// agent's view of the call without re-running an LLM.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<ResultSummary>,
+    /// Plugin-protocol-v2 roll-up cost. Sums all internal LLM/API
+    /// spend incurred during this invocation. Per-call costs are also
+    /// emitted as stderr `cost` events for finer-grained ledger
+    /// attribution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost: Option<ResultCost>,
+    /// Files the host should auto-deliver to chat. Mirrors v1
+    /// behavior; we name the synthesized `_report.md` here so the
+    /// chat UI shows the report file, not the search-engine dump.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    files_to_send: Vec<String>,
+}
+
+/// v2 result summary: discriminator + headline + sources. Mirrors
+/// `octos_plugin::protocol_v2::ResultSummary` field-for-field. Avoids a
+/// dependency on `octos-plugin` from the standalone plugin binary
+/// (plugin binaries should be self-contained per the SDK contract).
+#[derive(Serialize, Deserialize, Default)]
+struct ResultSummary {
+    kind: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    headline: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    confidence: Option<f64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    sources: Vec<ResultSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rounds: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct ResultSource {
+    url: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    title: String,
+    #[serde(default)]
+    cited: bool,
+}
+
+/// v2 roll-up cost. Mirrors `octos_plugin::protocol_v2::ResultCost`.
+#[derive(Serialize, Deserialize, Default)]
+struct ResultCost {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    tokens_in: u32,
+    tokens_out: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    usd: Option<f64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -117,11 +172,20 @@ struct CrawledPage {
 
 #[tokio::main]
 async fn main() {
+    // Plugin-protocol-v2 SIGTERM handler (W3.C3): on SIGTERM we stop
+    // scheduling new work and exit cleanly within the 10-second host
+    // budget. We don't carry long-lived browsers in-process here
+    // (deep_crawl spawns its own), so the cleanup path is light: emit
+    // a final progress event, kill in-flight HTTP via dropping the
+    // client, and exit 130 (128 + SIGTERM=2).
+    install_sigterm_handler();
+
     let mut stdin_buf = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut stdin_buf) {
         print_output(&Output {
             output: format!("Failed to read stdin: {e}"),
             success: false,
+            ..Default::default()
         });
         return;
     }
@@ -132,6 +196,7 @@ async fn main() {
             print_output(&Output {
                 output: format!("Invalid input JSON: {e}"),
                 success: false,
+                ..Default::default()
             });
             return;
         }
@@ -165,8 +230,45 @@ async fn main() {
         Err(_) => print_output(&Output {
             output: format!("Deep search timed out after {}s", timeout.as_secs()),
             success: false,
+            ..Default::default()
         }),
     }
+}
+
+/// Install a SIGTERM handler that emits a final v2 progress event and
+/// exits with status 130 within the host's 10-second cancel budget.
+///
+/// On Windows there is no SIGTERM; the host falls back to job-object
+/// kill which doesn't run user code. The handler is therefore a no-op
+/// on Windows and the host's SIGKILL handles cleanup.
+#[cfg(unix)]
+fn install_sigterm_handler() {
+    use tokio::signal::unix::{signal, SignalKind};
+    tokio::spawn(async {
+        let mut term = match signal(SignalKind::terminate()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[deep_search] failed to install SIGTERM handler: {e}");
+                return;
+            }
+        };
+        if term.recv().await.is_some() {
+            // Best-effort final progress event so the operator sees
+            // why we're exiting in the chat UI.
+            emit_v2_progress(
+                "cleanup",
+                "SIGTERM received, shutting down deep_search",
+                None,
+            );
+            // 130 = 128 + SIGTERM(2). Convention for "killed by signal 2".
+            std::process::exit(130);
+        }
+    });
+}
+
+#[cfg(not(unix))]
+fn install_sigterm_handler() {
+    // No SIGTERM on Windows; deep_search exits via host SIGKILL.
 }
 
 async fn run_deep_search(
@@ -193,6 +295,7 @@ async fn run_deep_search(
         return Output {
             output: format!("Failed to create research directory: {e}"),
             success: false,
+            ..Default::default()
         };
     }
 
@@ -213,6 +316,7 @@ async fn run_deep_search(
         return Output {
             output: r1.output,
             success: false,
+            ..Default::default()
         };
     }
 
@@ -419,60 +523,101 @@ async fn run_deep_search(
     }
 
     // -----------------------------------------------------------------------
-    // Build structured report
+    // Synthesize an answer from the raw search dump + crawled excerpts.
+    //
+    // This is the W3.C1 "highest user-impact" change: instead of returning
+    // a wall of search snippets, we hand the corpus to an LLM and ask it
+    // to write a coherent multi-paragraph answer with `[N]` citations
+    // pointing at our `Sources` list. The LLM call is best-effort: if no
+    // API key is configured we fall back to the v1 behavior so the plugin
+    // still works in airgapped/dev setups.
     // -----------------------------------------------------------------------
     progress_simple(ProgressPhase::Synthesize, "Synthesizing report...");
+    emit_v2_progress("synthesizing", "Synthesizing report from sources...", Some(0.85));
+
+    let synthesis_input = SynthesisInput {
+        query,
+        rounds: search_queries.len(),
+        sources: saved_files
+            .iter()
+            .enumerate()
+            .map(|(i, (_, url, preview))| SynthesisSource {
+                index: i + 1,
+                url: url.clone(),
+                excerpt: preview.clone(),
+            })
+            .collect(),
+    };
+
+    let synthesis = synthesize(client, &synthesis_input).await;
+
     progress_simple(ProgressPhase::ReportBuild, "Building report...");
+    emit_v2_progress("building_report", "Assembling final document...", Some(0.95));
 
-    let mut report = String::new();
-    report.push_str(&format!("# Deep Research: {query}\n\n"));
-
-    // Overview section
-    report.push_str("## Overview\n\n");
-    report.push_str(&initial_answer);
-    report.push_str("\n\n");
-
-    // Source details with inline previews
-    report.push_str(&format!(
-        "## Sources ({} pages crawled)\n\n",
-        saved_files.len()
-    ));
-    for (i, (filename, url, preview)) in saved_files.iter().enumerate() {
-        report.push_str(&format!("### Source [{}]: {}\n", i + 1, url));
-        report.push_str(&format!(
-            "_Full content: {}/{}_\n\n",
-            dir.display(),
-            filename
-        ));
-        report.push_str(preview);
-        report.push_str("\n\n---\n\n");
-    }
-
-    // Search queries used
-    report.push_str("## Search Queries Used\n\n");
-    for (i, q) in search_queries.iter().enumerate() {
-        report.push_str(&format!("{}. {}\n", i + 1, q));
-    }
-    report.push('\n');
-
-    // Summary line
     let report_path = dir.join("_report.md");
-    report.push_str(&format!(
-        "\n---\n{} pages crawled across {} search rounds.\n\
-         Report saved to: {}\n",
-        saved_files.len(),
-        search_queries.len(),
-        report_path.display(),
-    ));
+    let report = build_report(
+        query,
+        synthesis.as_ref(),
+        &initial_answer,
+        &saved_files,
+        &search_queries,
+        &dir,
+        &report_path,
+    );
 
     // Save report
     let _ = fs::write(dir.join("_report.md"), &report);
 
     progress_simple_with_fraction(ProgressPhase::Completion, "Deep search complete", Some(1.0));
+    emit_v2_progress("complete", "Deep search complete", Some(1.0));
+
+    // Build the v2 result summary from the synthesis output (if any) so
+    // the parent agent can render a useful tool-call pill without
+    // re-parsing the report markdown.
+    let cited_indexes: HashSet<usize> = synthesis
+        .as_ref()
+        .map(|s| s.cited_indexes())
+        .unwrap_or_default();
+    let mut summary_sources = Vec::with_capacity(saved_files.len());
+    for (i, (_filename, url, _)) in saved_files.iter().enumerate() {
+        summary_sources.push(ResultSource {
+            url: url.clone(),
+            title: String::new(),
+            cited: cited_indexes.contains(&(i + 1)),
+        });
+    }
+    let summary = ResultSummary {
+        kind: "deep_research".to_string(),
+        headline: synthesis
+            .as_ref()
+            .map(|s| s.headline.clone())
+            .filter(|h| !h.is_empty())
+            .unwrap_or_else(|| {
+                format!(
+                    "Researched '{query}' across {} sources in {} rounds",
+                    saved_files.len(),
+                    search_queries.len()
+                )
+            }),
+        confidence: synthesis.as_ref().and_then(|s| s.confidence),
+        sources: summary_sources,
+        rounds: Some(search_queries.len() as u32),
+    };
+
+    let cost = synthesis.as_ref().map(|s| ResultCost {
+        provider: Some(s.provider.clone()),
+        model: Some(s.model.clone()),
+        tokens_in: s.tokens_in,
+        tokens_out: s.tokens_out,
+        usd: s.usd,
+    });
 
     Output {
         output: report,
         success: true,
+        summary: Some(summary),
+        cost,
+        files_to_send: vec![report_path.display().to_string()],
     }
 }
 
@@ -1990,6 +2135,512 @@ fn research_dir(slug: &str) -> PathBuf {
 }
 
 // ---------------------------------------------------------------------------
+// Report assembly (W3.C1)
+// ---------------------------------------------------------------------------
+
+/// Build the full markdown research report from the synthesis output and
+/// the raw crawled corpus.
+///
+/// Pure function: doesn't touch the filesystem or stderr, so it's easy to
+/// unit-test the structural guarantees ("must contain a `## Synthesis`
+/// section when synthesis is available", "must list all sources",
+/// "must end with the report path").
+fn build_report(
+    query: &str,
+    synthesis: Option<&SynthesisResult>,
+    initial_answer: &str,
+    saved_files: &[(String, String, String)],
+    search_queries: &[String],
+    dir: &Path,
+    report_path: &Path,
+) -> String {
+    let mut report = String::new();
+    report.push_str(&format!("# Deep Research: {query}\n\n"));
+
+    // Synthesis section — prose with citations, replaces the old "Overview".
+    match synthesis {
+        Some(syn) if !syn.synthesis.trim().is_empty() => {
+            if !syn.headline.is_empty() {
+                report.push_str(&format!("_{}_\n\n", syn.headline));
+            }
+            report.push_str("## Synthesis\n\n");
+            report.push_str(syn.synthesis.trim());
+            report.push_str("\n\n");
+            if let Some(conf) = syn.confidence {
+                report.push_str(&format!("_Self-reported confidence: {conf:.2}_\n\n"));
+            }
+        }
+        _ => {
+            // Fallback when no LLM is available or synthesis was empty:
+            // keep the v1 "Overview" but label it so it's clear we did
+            // NOT synthesize, and operators know the result is raw.
+            report.push_str("## Overview\n\n");
+            report.push_str(
+                "_LLM synthesis unavailable — showing raw search results below._\n\n",
+            );
+            report.push_str(initial_answer);
+            report.push_str("\n\n");
+        }
+    }
+
+    // Source details with inline previews. These are always present so
+    // the synthesis citations resolve to concrete URLs and the operator
+    // can verify each claim.
+    report.push_str(&format!(
+        "## Sources ({} pages crawled)\n\n",
+        saved_files.len()
+    ));
+    for (i, (filename, url, preview)) in saved_files.iter().enumerate() {
+        report.push_str(&format!("### Source [{}]: {}\n", i + 1, url));
+        report.push_str(&format!(
+            "_Full content: {}/{}_\n\n",
+            dir.display(),
+            filename
+        ));
+        report.push_str(preview);
+        report.push_str("\n\n---\n\n");
+    }
+
+    // Search queries used
+    report.push_str("## Search Queries Used\n\n");
+    for (i, q) in search_queries.iter().enumerate() {
+        report.push_str(&format!("{}. {}\n", i + 1, q));
+    }
+    report.push('\n');
+
+    // Summary footer — kept for v1 compatibility (the host's
+    // `Report saved to: ...` detector keys off this line).
+    report.push_str(&format!(
+        "\n---\n{} pages crawled across {} search rounds.\n\
+         Report saved to: {}\n",
+        saved_files.len(),
+        search_queries.len(),
+        report_path.display(),
+    ));
+
+    report
+}
+
+// ---------------------------------------------------------------------------
+// Synthesis (W3.C1)
+// ---------------------------------------------------------------------------
+
+/// Inputs to the synthesis LLM call: the original query plus the corpus of
+/// crawled excerpts the LLM should ground its answer on.
+struct SynthesisInput<'a> {
+    query: &'a str,
+    rounds: usize,
+    sources: Vec<SynthesisSource>,
+}
+
+struct SynthesisSource {
+    /// 1-based index used in `[N]` citations the LLM emits.
+    index: usize,
+    url: String,
+    excerpt: String,
+}
+
+/// Output of a successful synthesis call: prose with citations + metadata
+/// for the v2 result envelope.
+struct SynthesisResult {
+    /// Multi-paragraph synthesized answer with `[N]` citations.
+    synthesis: String,
+    /// Optional one-line headline. Used for the parent's tool-call pill.
+    headline: String,
+    /// Self-reported confidence in `[0, 1]`. Heuristic; the LLM is asked
+    /// to assess source quality and agreement.
+    confidence: Option<f64>,
+    /// Provider / model used. Reported in the v2 cost envelope.
+    provider: String,
+    model: String,
+    tokens_in: u32,
+    tokens_out: u32,
+    usd: Option<f64>,
+}
+
+impl SynthesisResult {
+    /// Extract the set of `[N]` citation indexes referenced in the prose.
+    fn cited_indexes(&self) -> HashSet<usize> {
+        let mut out = HashSet::new();
+        let bytes = self.synthesis.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'[' {
+                let mut j = i + 1;
+                while j < bytes.len() && bytes[j].is_ascii_digit() {
+                    j += 1;
+                }
+                if j > i + 1 && j < bytes.len() && bytes[j] == b']' {
+                    if let Ok(s) = std::str::from_utf8(&bytes[i + 1..j]) {
+                        if let Ok(n) = s.parse::<usize>() {
+                            out.insert(n);
+                        }
+                    }
+                    i = j + 1;
+                    continue;
+                }
+            }
+            i += 1;
+        }
+        out
+    }
+}
+
+/// Run the synthesis LLM call. Returns `None` when no API key is
+/// configured, the call fails, or the response is unusable. The deep_search
+/// flow falls back to the v1 raw-dump report in that case.
+async fn synthesize(client: &reqwest::Client, input: &SynthesisInput<'_>) -> Option<SynthesisResult> {
+    let (endpoint, api_key, model, provider) = resolve_synthesis_config()?;
+
+    let prompt = build_synthesis_prompt(input);
+    let prompt_chars = prompt.len();
+
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": SYNTHESIS_SYSTEM_PROMPT
+            },
+            {
+                "role": "user",
+                "content": prompt
+            }
+        ],
+        "max_tokens": 1500,
+        "temperature": 0.3,
+    });
+
+    let response = match client
+        .post(format!("{endpoint}/chat/completions"))
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .timeout(Duration::from_secs(60))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[synthesis] LLM call failed: {e}");
+            emit_v2_progress(
+                "synthesizing",
+                &format!("LLM call failed: {e}"),
+                None,
+            );
+            return None;
+        }
+    };
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        eprintln!("[synthesis] HTTP {status}: {}", truncate_utf8(&text, 300, ""));
+        emit_v2_progress(
+            "synthesizing",
+            &format!("LLM HTTP {status}"),
+            None,
+        );
+        return None;
+    }
+
+    let json: serde_json::Value = match response.json().await {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("[synthesis] failed to parse response: {e}");
+            return None;
+        }
+    };
+
+    let content = json["choices"][0]["message"]["content"]
+        .as_str()
+        .unwrap_or("")
+        .trim();
+    if content.is_empty() {
+        eprintln!("[synthesis] empty response");
+        return None;
+    }
+
+    // OpenAI-compatible providers return token usage under "usage".
+    let tokens_in = json["usage"]["prompt_tokens"].as_u64().unwrap_or(0) as u32;
+    let tokens_out = json["usage"]["completion_tokens"].as_u64().unwrap_or(0) as u32;
+    let usd = project_usd(&model, tokens_in, tokens_out);
+
+    let (synthesis_text, headline, confidence) = parse_synthesis_response(content);
+
+    // Emit a v2 cost event so the host can attribute spend.
+    emit_v2_cost(&provider, &model, tokens_in, tokens_out, usd);
+
+    eprintln!(
+        "[synthesis] ok: prompt_chars={} sources={} tokens_in={} tokens_out={} synthesis_chars={}",
+        prompt_chars,
+        input.sources.len(),
+        tokens_in,
+        tokens_out,
+        synthesis_text.len()
+    );
+
+    Some(SynthesisResult {
+        synthesis: synthesis_text,
+        headline,
+        confidence,
+        provider,
+        model,
+        tokens_in,
+        tokens_out,
+        usd,
+    })
+}
+
+/// System prompt for the synthesis call.
+///
+/// The output format is a strict 3-section markdown doc:
+/// 1. `## Headline` — one line summarizing the answer
+/// 2. `## Confidence` — numeric in `[0, 1]`
+/// 3. `## Synthesis` — multi-paragraph prose with `[N]` citations
+///
+/// We parse this in [`parse_synthesis_response`] so we can lift each piece
+/// into the v2 result envelope.
+const SYNTHESIS_SYSTEM_PROMPT: &str = "\
+You are a research analyst. You write grounded, cited answers from the source \
+material the user provides. Rules: (1) Every factual claim MUST end with one or \
+more `[N]` citations referencing the numbered sources. (2) Use multiple \
+paragraphs; do NOT bulletpoint the entire answer. (3) Acknowledge contradiction \
+between sources when present. (4) If the sources don't cover an aspect of the \
+question, say so explicitly rather than guess. (5) Output exactly three \
+sections, in this order:\n\n\
+## Headline\n\
+<one-line answer, no citations>\n\n\
+## Confidence\n\
+<a number from 0.0 to 1.0 reflecting source agreement and depth>\n\n\
+## Synthesis\n\
+<3-6 paragraphs of cited prose>\n";
+
+fn build_synthesis_prompt(input: &SynthesisInput<'_>) -> String {
+    let mut prompt = String::new();
+    prompt.push_str(&format!("Question: {}\n\n", input.query));
+    prompt.push_str(&format!(
+        "Researcher gathered {} sources across {} search rounds. Source excerpts \
+         (truncated):\n\n",
+        input.sources.len(),
+        input.rounds
+    ));
+    // Cap the excerpts so the prompt stays within reasonable LLM context.
+    // 1500 chars * 12 sources = 18k chars ≈ 4-5k tokens.
+    const PER_SOURCE_CHARS: usize = 1500;
+    const MAX_SOURCES: usize = 12;
+    for src in input.sources.iter().take(MAX_SOURCES) {
+        prompt.push_str(&format!("---\n[{}] {}\n", src.index, src.url));
+        let excerpt = if src.excerpt.len() > PER_SOURCE_CHARS {
+            truncate_utf8(&src.excerpt, PER_SOURCE_CHARS, "\n... (truncated)")
+        } else {
+            src.excerpt.clone()
+        };
+        prompt.push_str(&excerpt);
+        prompt.push_str("\n\n");
+    }
+    if input.sources.len() > MAX_SOURCES {
+        prompt.push_str(&format!(
+            "---\n(+ {} more sources omitted from this prompt for brevity; \
+             they are still listed in the final report.)\n",
+            input.sources.len() - MAX_SOURCES
+        ));
+    }
+    prompt.push_str(
+        "---\n\nWrite the answer. Cite each numbered source at least once if it \
+         is used. Sources you do not cite will not appear in the final summary.\n",
+    );
+    prompt
+}
+
+/// Parse the strict 3-section synthesis response.
+///
+/// Tolerant of section reordering and missing sections. The synthesis body
+/// is the section labeled `## Synthesis` (or, falling back, everything
+/// after the first heading we don't recognize).
+fn parse_synthesis_response(text: &str) -> (String, String, Option<f64>) {
+    let mut headline = String::new();
+    let mut confidence: Option<f64> = None;
+    let mut synthesis = String::new();
+    let mut current = SectionTag::None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("##") {
+            let label = rest.trim().to_lowercase();
+            current = match label.as_str() {
+                "headline" => SectionTag::Headline,
+                "confidence" => SectionTag::Confidence,
+                "synthesis" | "answer" | "report" => SectionTag::Synthesis,
+                _ => SectionTag::Other,
+            };
+            continue;
+        }
+        match current {
+            SectionTag::Headline if !trimmed.is_empty() && headline.is_empty() => {
+                headline = trimmed.to_string();
+            }
+            SectionTag::Confidence if confidence.is_none() && !trimmed.is_empty() => {
+                // Find the first run of digits/decimal/sign so we can
+                // tolerate prose like "Confidence: ~0.85 (high)" while
+                // still preserving negative signs (which we then clamp
+                // to 0).
+                let cleaned = trimmed
+                    .trim_matches(|c: char| !c.is_ascii_digit() && c != '.' && c != '-');
+                if let Ok(v) = cleaned.parse::<f64>() {
+                    confidence = Some(v.clamp(0.0, 1.0));
+                }
+            }
+            SectionTag::Synthesis => {
+                synthesis.push_str(line);
+                synthesis.push('\n');
+            }
+            _ => {}
+        }
+    }
+
+    let synthesis = synthesis.trim().to_string();
+    // Fallback: if we didn't find an explicit `## Synthesis` section, the
+    // whole text is treated as the synthesis. Keeps the renderer robust to
+    // model misbehavior.
+    let synthesis = if synthesis.is_empty() {
+        text.trim().to_string()
+    } else {
+        synthesis
+    };
+    (synthesis, headline, confidence)
+}
+
+#[derive(Clone, Copy)]
+enum SectionTag {
+    None,
+    Headline,
+    Confidence,
+    Synthesis,
+    Other,
+}
+
+/// Try env vars in priority order — prefer fast/cheap models.
+///
+/// Returns `(endpoint, api_key, model, provider)`.
+fn resolve_synthesis_config() -> Option<(String, String, String, String)> {
+    // Allow operators to override the model via env. Useful when the
+    // default for a provider is too slow or expensive for synthesis.
+    let model_override = std::env::var("DEEP_SEARCH_SYNTHESIS_MODEL").ok();
+
+    let configs: &[(&str, &str, &str, &str)] = &[
+        (
+            "DEEPSEEK_API_KEY",
+            "https://api.deepseek.com/v1",
+            "deepseek-chat",
+            "deepseek",
+        ),
+        (
+            "KIMI_API_KEY",
+            "https://api.moonshot.ai/v1",
+            "kimi-2.5",
+            "moonshot",
+        ),
+        (
+            "DASHSCOPE_API_KEY",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "qwen-plus",
+            "dashscope",
+        ),
+        (
+            "OPENAI_API_KEY",
+            "https://api.openai.com/v1",
+            "gpt-4o-mini",
+            "openai",
+        ),
+        (
+            "GEMINI_API_KEY",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+            "gemini-2.0-flash",
+            "google",
+        ),
+        (
+            "ANTHROPIC_API_KEY",
+            "https://api.anthropic.com/v1",
+            "claude-3-5-haiku-20241022",
+            "anthropic",
+        ),
+    ];
+    for &(env_var, endpoint, default_model, provider) in configs {
+        if let Ok(key) = std::env::var(env_var) {
+            if !key.is_empty() {
+                let model = model_override
+                    .clone()
+                    .unwrap_or_else(|| default_model.to_string());
+                return Some((
+                    endpoint.to_string(),
+                    key,
+                    model,
+                    provider.to_string(),
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Project a USD cost from token counts. Conservative estimate for the
+/// known small/cheap models. Returns `None` for unknown models so the
+/// host's pricing catalog can fill in (or operators can compute it
+/// post-hoc).
+fn project_usd(model: &str, tokens_in: u32, tokens_out: u32) -> Option<f64> {
+    let lower = model.to_lowercase();
+    let (input_per_million, output_per_million) = match lower.as_str() {
+        "deepseek-chat" | "deepseek-coder" => (0.27, 1.10),
+        m if m.starts_with("kimi") => (0.20, 0.80),
+        m if m.starts_with("qwen-plus") => (0.20, 0.60),
+        "gpt-4o-mini" => (0.15, 0.60),
+        "gemini-2.0-flash" | "gemini-1.5-flash" => (0.075, 0.30),
+        "claude-3-5-haiku-20241022" => (1.0, 5.0),
+        _ => return None,
+    };
+    let cost = (tokens_in as f64) * input_per_million / 1_000_000.0
+        + (tokens_out as f64) * output_per_million / 1_000_000.0;
+    Some(cost)
+}
+
+// ---------------------------------------------------------------------------
+// Plugin-protocol-v2 stderr events
+// ---------------------------------------------------------------------------
+
+/// Emit a v2 `progress` event on stderr. Best-effort: serialization is
+/// infallible for these small structs in practice; if it ever does fail
+/// we fall back to a legacy free-form line.
+fn emit_v2_progress(stage: &str, message: &str, progress: Option<f64>) {
+    let event = serde_json::json!({
+        "type": "progress",
+        "stage": stage,
+        "message": message,
+        "progress": progress,
+    });
+    match serde_json::to_string(&event) {
+        Ok(line) => eprintln!("{line}"),
+        Err(_) => eprintln!("[{stage}] {message}"),
+    }
+}
+
+/// Emit a v2 `cost` event on stderr.
+fn emit_v2_cost(provider: &str, model: &str, tokens_in: u32, tokens_out: u32, usd: Option<f64>) {
+    let event = serde_json::json!({
+        "type": "cost",
+        "provider": provider,
+        "model": model,
+        "tokens_in": tokens_in,
+        "tokens_out": tokens_out,
+        "usd": usd,
+    });
+    match serde_json::to_string(&event) {
+        Ok(line) => eprintln!("{line}"),
+        Err(_) => eprintln!("[cost] {provider}/{model} in={tokens_in} out={tokens_out}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Progress output (stderr for gateway to stream)
 // ---------------------------------------------------------------------------
 
@@ -2001,6 +2652,9 @@ fn progress(step: usize, total: usize, msg: &str) {
         Some((step as f64 / total as f64).min(0.95))
     };
     emit_progress_event(ProgressPhase::Search, msg, progress_fraction);
+    // Plugin-protocol-v2 mirror: structured event so downstream
+    // consumers don't have to scrape `[step/total] message`.
+    emit_v2_progress(ProgressPhase::Search.v2_stage(), msg, progress_fraction);
 }
 
 fn progress_simple(phase: ProgressPhase, msg: &str) {
@@ -2010,6 +2664,7 @@ fn progress_simple(phase: ProgressPhase, msg: &str) {
 fn progress_simple_with_fraction(phase: ProgressPhase, msg: &str, progress_fraction: Option<f64>) {
     eprintln!("[*] {msg}");
     emit_progress_event(phase, msg, progress_fraction);
+    emit_v2_progress(phase.v2_stage(), msg, progress_fraction);
 }
 
 #[derive(Copy, Clone)]
@@ -2029,6 +2684,19 @@ impl ProgressPhase {
             ProgressPhase::Synthesize => "synthesize",
             ProgressPhase::ReportBuild => "report_build",
             ProgressPhase::Completion => "completion",
+        }
+    }
+
+    /// Plugin-protocol-v2 stage label. Slightly different from the
+    /// internal harness phase name (which is preserved for backwards
+    /// compatibility with the existing harness sink schema).
+    fn v2_stage(self) -> &'static str {
+        match self {
+            ProgressPhase::Search => "searching",
+            ProgressPhase::Fetch => "fetching",
+            ProgressPhase::Synthesize => "synthesizing",
+            ProgressPhase::ReportBuild => "building_report",
+            ProgressPhase::Completion => "complete",
         }
     }
 }
@@ -2336,5 +3004,333 @@ mod tests {
         let actual = std::fs::read_to_string(&sink).unwrap();
         assert_eq!(actual, fixture);
         let _ = std::fs::remove_file(&sink);
+    }
+
+    // -------------------------------------------------------------------
+    // Synthesis (W3.C1) tests.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn parse_synthesis_response_extracts_three_sections() {
+        let raw = "## Headline\n\
+Foo is a programming language [1][2].\n\n\
+## Confidence\n\
+0.85\n\n\
+## Synthesis\n\
+Foo is a programming language used for systems programming [1]. It \
+emphasizes safety and performance [2].\n\n\
+A second paragraph explores tooling [3].\n";
+        let (synthesis, headline, confidence) = parse_synthesis_response(raw);
+        assert_eq!(headline, "Foo is a programming language [1][2].");
+        assert_eq!(confidence, Some(0.85));
+        assert!(synthesis.contains("systems programming [1]"));
+        assert!(synthesis.contains("A second paragraph"));
+        // Synthesis MUST NOT contain the headline or confidence lines.
+        assert!(
+            !synthesis.contains("## Headline"),
+            "synthesis leaked headline section"
+        );
+    }
+
+    #[test]
+    fn parse_synthesis_response_falls_back_when_no_sections() {
+        let raw = "Just a paragraph of text without explicit sections [1]. \
+And another sentence [2].";
+        let (synthesis, headline, confidence) = parse_synthesis_response(raw);
+        assert_eq!(headline, "");
+        assert_eq!(confidence, None);
+        assert!(synthesis.contains("[1]"));
+        assert!(synthesis.contains("[2]"));
+    }
+
+    #[test]
+    fn parse_synthesis_clamps_confidence() {
+        let raw = "## Confidence\n2.5\n## Synthesis\nbody";
+        let (_, _, confidence) = parse_synthesis_response(raw);
+        assert_eq!(confidence, Some(1.0));
+
+        let raw = "## Confidence\n-0.5\n## Synthesis\nbody";
+        let (_, _, confidence) = parse_synthesis_response(raw);
+        assert_eq!(confidence, Some(0.0));
+    }
+
+    #[test]
+    fn parse_synthesis_tolerates_renamed_sections() {
+        // Some models emit "## Answer" instead of "## Synthesis".
+        let raw = "## Headline\nshort\n\n## Answer\nThe real body [1].\n";
+        let (synthesis, headline, _) = parse_synthesis_response(raw);
+        assert_eq!(headline, "short");
+        assert!(synthesis.contains("real body"));
+    }
+
+    #[test]
+    fn cited_indexes_extracts_referenced_sources() {
+        let result = SynthesisResult {
+            synthesis: "Claim one [1]. Claim two [2][3]. Repeat [1] and [10].".to_string(),
+            headline: String::new(),
+            confidence: None,
+            provider: String::new(),
+            model: String::new(),
+            tokens_in: 0,
+            tokens_out: 0,
+            usd: None,
+        };
+        let cited = result.cited_indexes();
+        assert!(cited.contains(&1));
+        assert!(cited.contains(&2));
+        assert!(cited.contains(&3));
+        assert!(cited.contains(&10));
+        assert_eq!(cited.len(), 4); // [1] is deduplicated
+    }
+
+    #[test]
+    fn cited_indexes_ignores_non_numeric_brackets() {
+        let result = SynthesisResult {
+            synthesis: "Claim one [1]. Claim with [bracketed text]. Edge [99x] case.".to_string(),
+            headline: String::new(),
+            confidence: None,
+            provider: String::new(),
+            model: String::new(),
+            tokens_in: 0,
+            tokens_out: 0,
+            usd: None,
+        };
+        let cited = result.cited_indexes();
+        assert!(cited.contains(&1));
+        assert_eq!(cited.len(), 1);
+    }
+
+    #[test]
+    fn build_synthesis_prompt_caps_per_source_chars() {
+        let huge_excerpt = "x".repeat(5_000);
+        let input = SynthesisInput {
+            query: "test",
+            rounds: 1,
+            sources: vec![SynthesisSource {
+                index: 1,
+                url: "https://x".to_string(),
+                excerpt: huge_excerpt,
+            }],
+        };
+        let prompt = build_synthesis_prompt(&input);
+        // 1500 char cap + suffix → cap is enforced
+        assert!(prompt.contains("(truncated)"));
+    }
+
+    #[test]
+    fn build_synthesis_prompt_omits_sources_beyond_cap() {
+        let sources = (1..=20)
+            .map(|i| SynthesisSource {
+                index: i,
+                url: format!("https://x{i}"),
+                excerpt: format!("text {i}"),
+            })
+            .collect();
+        let input = SynthesisInput {
+            query: "test",
+            rounds: 1,
+            sources,
+        };
+        let prompt = build_synthesis_prompt(&input);
+        // Should mention 8 omitted (12 cap + 8 = 20)
+        assert!(
+            prompt.contains("8 more sources omitted"),
+            "got: {}",
+            &prompt[prompt.len().saturating_sub(300)..]
+        );
+        assert!(prompt.contains("https://x1"));
+        assert!(prompt.contains("https://x12"));
+        assert!(!prompt.contains("https://x13"));
+    }
+
+    #[test]
+    fn project_usd_handles_known_models() {
+        // Only check that costs are positive and roughly sane (sub-cent
+        // for typical synthesis sizes). Brittle pricing assertions are
+        // not the point — we want a sanity floor.
+        let cost = project_usd("deepseek-chat", 1000, 500).unwrap();
+        assert!(cost > 0.0);
+        assert!(cost < 0.01); // synthesis at 1k+500 should be sub-cent
+
+        let cost = project_usd("gpt-4o-mini", 1000, 500).unwrap();
+        assert!(cost > 0.0);
+    }
+
+    #[test]
+    fn project_usd_returns_none_for_unknown_model() {
+        assert!(project_usd("custom-private-model-v9", 100, 100).is_none());
+    }
+
+    #[test]
+    fn build_report_with_synthesis_includes_synthesis_section_and_sources() {
+        let saved = vec![
+            (
+                "01_a.md".to_string(),
+                "https://a.example/x".to_string(),
+                "Full text from a [1].".to_string(),
+            ),
+            (
+                "02_b.md".to_string(),
+                "https://b.example/y".to_string(),
+                "Full text from b [2].".to_string(),
+            ),
+        ];
+        let queries = vec!["topic".to_string(), "topic 2026".to_string()];
+        let syn = SynthesisResult {
+            synthesis: "Foo is widely used [1]. Bar is alternative [2].\n\n\
+A second paragraph elaborates on alternatives [2]."
+                .to_string(),
+            headline: "Foo and bar are alternatives".to_string(),
+            confidence: Some(0.85),
+            provider: "deepseek".to_string(),
+            model: "deepseek-chat".to_string(),
+            tokens_in: 1000,
+            tokens_out: 200,
+            usd: Some(0.0009),
+        };
+        let dir = std::path::PathBuf::from("/tmp/research/topic");
+        let report_path = dir.join("_report.md");
+        let report = build_report(
+            "topic",
+            Some(&syn),
+            "ignored when synthesis present",
+            &saved,
+            &queries,
+            &dir,
+            &report_path,
+        );
+
+        // Critical structural guarantees the test enforces:
+        assert!(report.starts_with("# Deep Research: topic\n\n"));
+        assert!(
+            report.contains("## Synthesis\n\nFoo is widely used [1]"),
+            "expected synthesis section with citations: {report}"
+        );
+        assert!(
+            report.contains("_Foo and bar are alternatives_"),
+            "expected italic headline: {report}"
+        );
+        assert!(
+            report.contains("_Self-reported confidence: 0.85_"),
+            "expected confidence line: {report}"
+        );
+        // Source listing must be present.
+        assert!(report.contains("### Source [1]: https://a.example/x"));
+        assert!(report.contains("### Source [2]: https://b.example/y"));
+        // No "LLM synthesis unavailable" disclaimer when synthesis IS available.
+        assert!(
+            !report.contains("LLM synthesis unavailable"),
+            "synthesis fallback leaked into successful path"
+        );
+        // Trailer with report path stays for v1 host compatibility.
+        assert!(report.contains("Report saved to: /tmp/research/topic/_report.md"));
+        // Multi-paragraph structure is preserved (we have a blank line in
+        // the synthesis input → there should be at least 4 newlines around
+        // the synthesis body).
+        let synthesis_section = report.split("## Sources").next().unwrap();
+        assert!(
+            synthesis_section.matches("\n\n").count() >= 3,
+            "synthesis should have multi-paragraph structure: {synthesis_section}"
+        );
+    }
+
+    #[test]
+    fn build_report_without_synthesis_falls_back_with_disclaimer() {
+        let saved = vec![(
+            "01_a.md".to_string(),
+            "https://a.example/x".to_string(),
+            "Snippet".to_string(),
+        )];
+        let queries = vec!["topic".to_string()];
+        let dir = std::path::PathBuf::from("/tmp/research/topic");
+        let report_path = dir.join("_report.md");
+        let report = build_report(
+            "topic",
+            None,
+            "Initial Bing dump:\n1. Result one",
+            &saved,
+            &queries,
+            &dir,
+            &report_path,
+        );
+        assert!(report.contains("## Overview"));
+        assert!(report.contains("LLM synthesis unavailable"));
+        assert!(report.contains("Initial Bing dump"));
+        assert!(report.contains("### Source [1]"));
+        assert!(!report.contains("## Synthesis"));
+    }
+
+    #[test]
+    fn build_report_with_empty_synthesis_falls_back() {
+        // If the LLM returns an empty body (rare but possible), the
+        // report should fall back to the raw initial answer rather than
+        // emit an empty synthesis section.
+        let syn = SynthesisResult {
+            synthesis: "   \n  ".to_string(),
+            headline: "Headline only".to_string(),
+            confidence: None,
+            provider: "x".to_string(),
+            model: "y".to_string(),
+            tokens_in: 0,
+            tokens_out: 0,
+            usd: None,
+        };
+        let report = build_report(
+            "topic",
+            Some(&syn),
+            "raw initial",
+            &[],
+            &["topic".to_string()],
+            std::path::Path::new("/tmp"),
+            std::path::Path::new("/tmp/_report.md"),
+        );
+        assert!(!report.contains("## Synthesis"));
+        assert!(report.contains("LLM synthesis unavailable"));
+        assert!(report.contains("raw initial"));
+    }
+
+    #[test]
+    fn output_serializes_v2_summary() {
+        let mut output = Output {
+            output: "report".to_string(),
+            success: true,
+            summary: Some(ResultSummary {
+                kind: "deep_research".to_string(),
+                headline: "5 sources answering test".to_string(),
+                confidence: Some(0.8),
+                sources: vec![ResultSource {
+                    url: "https://example.com".to_string(),
+                    title: "Example".to_string(),
+                    cited: true,
+                }],
+                rounds: Some(3),
+            }),
+            cost: Some(ResultCost {
+                provider: Some("deepseek".to_string()),
+                model: Some("deepseek-chat".to_string()),
+                tokens_in: 1024,
+                tokens_out: 256,
+                usd: Some(0.0034),
+            }),
+            files_to_send: vec!["/tmp/report.md".to_string()],
+        };
+        let json = serde_json::to_value(&output).unwrap();
+        assert_eq!(json["summary"]["kind"], "deep_research");
+        assert_eq!(json["summary"]["confidence"], 0.8);
+        assert_eq!(json["summary"]["sources"][0]["cited"], true);
+        assert_eq!(json["cost"]["tokens_in"], 1024);
+        assert_eq!(json["files_to_send"][0], "/tmp/report.md");
+
+        // Default-empty fields elide so existing v1 code keeps working.
+        output.summary = None;
+        output.cost = None;
+        output.files_to_send.clear();
+        let json = serde_json::to_value(&output).unwrap();
+        assert!(json.get("summary").is_none(), "summary should be omitted");
+        assert!(json.get("cost").is_none(), "cost should be omitted");
+        assert!(
+            json.get("files_to_send").is_none(),
+            "files_to_send should be omitted"
+        );
     }
 }

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -1284,11 +1284,49 @@ async fn brave_search(
 // Bing CDP Search (headless Chrome via deep-crawl binary)
 // ---------------------------------------------------------------------------
 
+/// Cap on the number of concurrent `deep_crawl` invocations (and thus
+/// concurrent headless Chromium processes) per `deep_search` invocation.
+///
+/// Pre-W3.D1 history: with `parallel_all_engines` + per-round retries,
+/// a single deep_search call could spawn 6+ Chromium processes at once,
+/// pegging memory on small VMs. The semaphore caps it at 3.
+///
+/// Operators can override via `DEEP_SEARCH_MAX_BROWSERS` (1..16). Useful
+/// when deep_search itself runs N times in parallel (e.g. swarm mode):
+/// the cap on the binary's own scope-internal concurrency stays at the
+/// configured value, so total chromiums = N × cap.
+fn max_browsers() -> usize {
+    std::env::var("DEEP_SEARCH_MAX_BROWSERS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|n| n.clamp(1, 16))
+        .unwrap_or(3)
+}
+
+fn browser_semaphore() -> &'static tokio::sync::Semaphore {
+    static SEMAPHORE: std::sync::OnceLock<tokio::sync::Semaphore> = std::sync::OnceLock::new();
+    SEMAPHORE.get_or_init(|| tokio::sync::Semaphore::new(max_browsers()))
+}
+
 /// Search Bing via headless Chrome. Calls the `deep_crawl` sibling binary
 /// to render the SERP, then extracts result links from the text output.
 /// No API key needed — just Chromium installed. Uses Bing instead of Google
 /// because Google CAPTCHAs automated requests from datacenter IPs.
+///
+/// W3.D1: gated by [`browser_semaphore`] so this binary cannot launch
+/// more than `DEEP_SEARCH_MAX_BROWSERS` concurrent chromiums.
 async fn bing_cdp_search(query: &str, count: u8) -> SearchResult {
+    // Acquire the semaphore before launching deep_crawl so we never
+    // exceed the configured cap on concurrent chromiums.
+    let _permit = match browser_semaphore().acquire().await {
+        Ok(p) => p,
+        Err(_) => {
+            return SearchResult {
+                output: "bing_cdp:browser semaphore closed".into(),
+                success: false,
+            };
+        }
+    };
     // Find deep_crawl binary: check sibling dir, cargo bin, and PATH
     let crawl_bin = {
         let candidates: Vec<std::path::PathBuf> = [
@@ -3287,6 +3325,75 @@ A second paragraph elaborates on alternatives [2]."
         assert!(!report.contains("## Synthesis"));
         assert!(report.contains("LLM synthesis unavailable"));
         assert!(report.contains("raw initial"));
+    }
+
+    #[test]
+    fn max_browsers_default_is_three() {
+        // Avoid clobbering a real env var the developer set.
+        let prev = std::env::var("DEEP_SEARCH_MAX_BROWSERS").ok();
+        // SAFETY: tests are single-threaded by default.
+        unsafe {
+            std::env::remove_var("DEEP_SEARCH_MAX_BROWSERS");
+        }
+        assert_eq!(max_browsers(), 3);
+        // Restore for other tests.
+        if let Some(v) = prev {
+            unsafe {
+                std::env::set_var("DEEP_SEARCH_MAX_BROWSERS", v);
+            }
+        }
+    }
+
+    #[test]
+    fn max_browsers_clamps_to_range() {
+        let prev = std::env::var("DEEP_SEARCH_MAX_BROWSERS").ok();
+        unsafe {
+            std::env::set_var("DEEP_SEARCH_MAX_BROWSERS", "0");
+        }
+        assert_eq!(max_browsers(), 1, "clamps zero to 1");
+        unsafe {
+            std::env::set_var("DEEP_SEARCH_MAX_BROWSERS", "100");
+        }
+        assert_eq!(max_browsers(), 16, "clamps high to 16");
+        unsafe {
+            std::env::set_var("DEEP_SEARCH_MAX_BROWSERS", "5");
+        }
+        assert_eq!(max_browsers(), 5, "passes through valid value");
+        unsafe {
+            std::env::set_var("DEEP_SEARCH_MAX_BROWSERS", "not-a-number");
+        }
+        assert_eq!(max_browsers(), 3, "falls back to default on parse fail");
+        // Cleanup.
+        unsafe {
+            std::env::remove_var("DEEP_SEARCH_MAX_BROWSERS");
+        }
+        if let Some(v) = prev {
+            unsafe {
+                std::env::set_var("DEEP_SEARCH_MAX_BROWSERS", v);
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn browser_semaphore_caps_concurrency() {
+        // The OnceLock-backed semaphore is initialized at first call.
+        // We can't read its capacity directly, but we can validate that
+        // permits decrement when held and that exceeding the cap blocks.
+        let sem = browser_semaphore();
+        let cap = sem.available_permits();
+        assert!((1..=16).contains(&cap), "cap must be in [1, 16], got {cap}");
+
+        // Hold the bindings so the permits are NOT dropped immediately.
+        let permit1 = sem.try_acquire().ok();
+        assert!(permit1.is_some(), "first acquire should succeed");
+        let after_one = sem.available_permits();
+        assert_eq!(
+            after_one, cap - 1,
+            "permit should decrement available count"
+        );
+        drop(permit1);
+        // Restored after drop.
+        assert_eq!(sem.available_permits(), cap);
     }
 
     #[test]

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -533,7 +533,11 @@ async fn run_deep_search(
     // still works in airgapped/dev setups.
     // -----------------------------------------------------------------------
     progress_simple(ProgressPhase::Synthesize, "Synthesizing report...");
-    emit_v2_progress("synthesizing", "Synthesizing report from sources...", Some(0.85));
+    emit_v2_progress(
+        "synthesizing",
+        "Synthesizing report from sources...",
+        Some(0.85),
+    );
 
     let synthesis_input = SynthesisInput {
         query,
@@ -552,7 +556,11 @@ async fn run_deep_search(
     let synthesis = synthesize(client, &synthesis_input).await;
 
     progress_simple(ProgressPhase::ReportBuild, "Building report...");
-    emit_v2_progress("building_report", "Assembling final document...", Some(0.95));
+    emit_v2_progress(
+        "building_report",
+        "Assembling final document...",
+        Some(0.95),
+    );
 
     let report_path = dir.join("_report.md");
     let report = build_report(
@@ -2213,9 +2221,7 @@ fn build_report(
             // keep the v1 "Overview" but label it so it's clear we did
             // NOT synthesize, and operators know the result is raw.
             report.push_str("## Overview\n\n");
-            report.push_str(
-                "_LLM synthesis unavailable — showing raw search results below._\n\n",
-            );
+            report.push_str("_LLM synthesis unavailable — showing raw search results below._\n\n");
             report.push_str(initial_answer);
             report.push_str("\n\n");
         }
@@ -2327,7 +2333,10 @@ impl SynthesisResult {
 /// Run the synthesis LLM call. Returns `None` when no API key is
 /// configured, the call fails, or the response is unusable. The deep_search
 /// flow falls back to the v1 raw-dump report in that case.
-async fn synthesize(client: &reqwest::Client, input: &SynthesisInput<'_>) -> Option<SynthesisResult> {
+async fn synthesize(
+    client: &reqwest::Client,
+    input: &SynthesisInput<'_>,
+) -> Option<SynthesisResult> {
     let (endpoint, api_key, model, provider) = resolve_synthesis_config()?;
 
     let prompt = build_synthesis_prompt(input);
@@ -2361,11 +2370,7 @@ async fn synthesize(client: &reqwest::Client, input: &SynthesisInput<'_>) -> Opt
         Ok(r) => r,
         Err(e) => {
             eprintln!("[synthesis] LLM call failed: {e}");
-            emit_v2_progress(
-                "synthesizing",
-                &format!("LLM call failed: {e}"),
-                None,
-            );
+            emit_v2_progress("synthesizing", &format!("LLM call failed: {e}"), None);
             return None;
         }
     };
@@ -2373,12 +2378,11 @@ async fn synthesize(client: &reqwest::Client, input: &SynthesisInput<'_>) -> Opt
     if !response.status().is_success() {
         let status = response.status();
         let text = response.text().await.unwrap_or_default();
-        eprintln!("[synthesis] HTTP {status}: {}", truncate_utf8(&text, 300, ""));
-        emit_v2_progress(
-            "synthesizing",
-            &format!("LLM HTTP {status}"),
-            None,
+        eprintln!(
+            "[synthesis] HTTP {status}: {}",
+            truncate_utf8(&text, 300, "")
         );
+        emit_v2_progress("synthesizing", &format!("LLM HTTP {status}"), None);
         return None;
     }
 
@@ -2523,8 +2527,8 @@ fn parse_synthesis_response(text: &str) -> (String, String, Option<f64>) {
                 // tolerate prose like "Confidence: ~0.85 (high)" while
                 // still preserving negative signs (which we then clamp
                 // to 0).
-                let cleaned = trimmed
-                    .trim_matches(|c: char| !c.is_ascii_digit() && c != '.' && c != '-');
+                let cleaned =
+                    trimmed.trim_matches(|c: char| !c.is_ascii_digit() && c != '.' && c != '-');
                 if let Ok(v) = cleaned.parse::<f64>() {
                     confidence = Some(v.clamp(0.0, 1.0));
                 }
@@ -2610,12 +2614,7 @@ fn resolve_synthesis_config() -> Option<(String, String, String, String)> {
                 let model = model_override
                     .clone()
                     .unwrap_or_else(|| default_model.to_string());
-                return Some((
-                    endpoint.to_string(),
-                    key,
-                    model,
-                    provider.to_string(),
-                ));
+                return Some((endpoint.to_string(), key, model, provider.to_string()));
             }
         }
     }
@@ -3388,7 +3387,8 @@ A second paragraph elaborates on alternatives [2]."
         assert!(permit1.is_some(), "first acquire should succeed");
         let after_one = sem.available_permits();
         assert_eq!(
-            after_one, cap - 1,
+            after_one,
+            cap - 1,
             "permit should decrement available count"
         );
         drop(permit1);

--- a/crates/app-skills/deep-search/tests/fixtures/sample_synthesized_report.md
+++ b/crates/app-skills/deep-search/tests/fixtures/sample_synthesized_report.md
@@ -1,0 +1,90 @@
+# Deep Research: Rust async runtimes in 2026
+
+_Tokio remains dominant, but smol and async-std competitors are converging on shared traits._
+
+## Synthesis
+
+The Rust async ecosystem in 2026 is characterized by tokio's continued
+dominance combined with a maturing trait surface that lets crates target
+multiple runtimes [1][2]. Tokio 1.50+ ships a stable `Spawn` trait via the
+`tokio-util` crate that the 2025 RFC #3727 standardized, easing migration
+between runtimes for library authors who previously had to feature-gate
+their code [1][3].
+
+Smol has carved a niche in embedded and `no_std` adjacent applications by
+offering a lighter scheduler footprint (~120 KiB vs tokio's ~600 KiB
+release binary) without sacrificing the executor primitives that
+`futures::stream` consumers need [4]. Sources note that smol's recent
+`smol-rt` crate added `tokio::task::spawn_blocking` compatibility, closing
+the last major API gap for typical web service workloads [2][4].
+
+A persistent friction point in 2025 was the lack of a stable cross-runtime
+timer trait. The `async_runtime_traits` crate from the rust-lang nursery
+addressed this in late 2025 by defining `Spawn`, `SpawnBlocking`, and
+`Sleep` traits that tokio, smol, and async-std all implement [3][5]. By
+mid-2026 the major web frameworks (axum, rocket, actix-web) had migrated
+their internal runtime references to these traits, allowing applications
+to select a runtime at the binary boundary rather than the framework
+boundary [5].
+
+Performance-wise, sources agree the differences between tokio and smol on
+typical web workloads are within noise margins [2][4]. The interesting
+performance work in 2026 is happening at the I/O reactor layer, where
+tokio's io_uring-backed `IoSubmit` API (gated behind the experimental
+`io-uring` feature) shows 15–30% lower syscall overhead under sustained
+high-fanout workloads compared to the epoll-backed default [1].
+
+_Self-reported confidence: 0.82_
+
+## Sources (5 pages crawled)
+
+### Source [1]: https://tokio.rs/blog/2026-mid-year
+_Full content: research/rust-async-runtimes-2026/01_tokio-rs.md_
+
+Tokio 1.50 brought a stable `Spawn` trait re-export from `tokio-util`...
+
+---
+
+### Source [2]: https://blog.smol.dev/state-of-smol-2026
+_Full content: research/rust-async-runtimes-2026/02_blog-smol-dev.md_
+
+We're proud to ship smol-rt as a drop-in compatibility layer with
+tokio's spawn_blocking semantics...
+
+---
+
+### Source [3]: https://github.com/rust-lang/rfcs/pull/3727
+_Full content: research/rust-async-runtimes-2026/03_github-com.md_
+
+RFC 3727 introduces stable Spawn/SpawnBlocking/Sleep traits to the
+async_runtime_traits crate so library authors can target executors
+abstractly...
+
+---
+
+### Source [4]: https://www.felipecrv.com/posts/async-rust-2026
+_Full content: research/rust-async-runtimes-2026/04_felipecrv-com.md_
+
+Microbenchmarks show tokio and smol within 5% of each other on
+canonical web workloads...
+
+---
+
+### Source [5]: https://github.com/tokio-rs/axum/pull/3010
+_Full content: research/rust-async-runtimes-2026/05_github-com.md_
+
+Migrate to async_runtime_traits::Spawn so axum applications can select
+a runtime at the binary level...
+
+---
+
+## Search Queries Used
+
+1. Rust async runtimes 2026
+2. Rust async runtimes 2026 latest
+3. Rust async runtimes Spawn trait
+4. tokio vs smol 2026
+
+---
+5 pages crawled across 4 search rounds.
+Report saved to: research/rust-async-runtimes-2026/_report.md

--- a/crates/app-skills/deep-search/tests/sample_report.rs
+++ b/crates/app-skills/deep-search/tests/sample_report.rs
@@ -1,0 +1,20 @@
+// Integration test that dumps a sample synthesized report to disk for
+// manual inspection. Run with:
+//
+//   cargo test -p deep-search --test sample_report dump_sample_synthesized_report -- --nocapture
+//
+// The resulting file lands in `target/sample_report.md`. Used by the W3
+// PR to demonstrate the C1 user-facing change.
+
+#[test]
+#[ignore = "demo-only: run with --ignored to dump a sample report"]
+fn dump_sample_synthesized_report() {
+    // We can't import private items from the deep-search bin, so this
+    // test reproduces the structural shape `build_report` emits using
+    // the same heading/citation conventions. Kept in lockstep with the
+    // unit test `build_report_with_synthesis_includes_synthesis_section_and_sources`.
+    let report = include_str!("fixtures/sample_synthesized_report.md");
+    let path = std::env::temp_dir().join("octos-w3-sample-report.md");
+    std::fs::write(&path, report).unwrap();
+    eprintln!("wrote sample synthesized report to: {}", path.display());
+}

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -11,6 +11,7 @@ octos-core = { workspace = true }
 octos-bus = { workspace = true }
 octos-memory = { workspace = true }
 octos-llm = { workspace = true }
+octos-plugin = { workspace = true }
 # codex-execpolicy = { workspace = true }  # Enable when codex builds
 # codex-file-search = { workspace = true }
 # codex-linux-sandbox = { workspace = true }

--- a/crates/octos-agent/src/harness_events.rs
+++ b/crates/octos-agent/src/harness_events.rs
@@ -105,6 +105,19 @@ fn register_sink_context(sink: String, context: HarnessEventSinkContext) {
     contexts.insert(sink, context);
 }
 
+/// Test-only wrapper around [`register_sink_context`] for crates that need
+/// to assert against a sink without booting a full [`HarnessEventSink`].
+#[doc(hidden)]
+pub fn attach_event_sink_context(sink: String, context: HarnessEventSinkContext) {
+    register_sink_context(sink, context);
+}
+
+/// Test-only wrapper around `unregister_sink_context`.
+#[doc(hidden)]
+pub fn detach_event_sink_context(sink: &str) {
+    unregister_sink_context(sink);
+}
+
 fn unregister_sink_context(sink: &str) {
     let mut contexts = sink_contexts().lock().unwrap_or_else(|e| e.into_inner());
     contexts.remove(sink);
@@ -131,6 +144,25 @@ pub fn write_event_to_sink(raw_sink: impl AsRef<str>, event: &HarnessEvent) -> s
     let json = serde_json::to_string(event)
         .map_err(|error| std::io::Error::other(format!("serialize harness event: {error}")))?;
     writeln!(file, "{json}")?;
+    file.flush()
+}
+
+/// Append a pre-serialized event line to a sink without round-tripping
+/// through the [`HarnessEvent`] validator.
+///
+/// Used by the plugin protocol-v2 shim, which builds events from the wire
+/// format on a hot reader path. Callers MUST pass a single well-formed
+/// JSON object; the writer adds a trailing newline.
+pub fn write_event_line_to_sink(
+    raw_sink: impl AsRef<str>,
+    line: &str,
+) -> std::io::Result<()> {
+    let path = sink_path_from_raw(raw_sink.as_ref());
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(file, "{line}")?;
     file.flush()
 }
 

--- a/crates/octos-agent/src/harness_events.rs
+++ b/crates/octos-agent/src/harness_events.rs
@@ -153,10 +153,7 @@ pub fn write_event_to_sink(raw_sink: impl AsRef<str>, event: &HarnessEvent) -> s
 /// Used by the plugin protocol-v2 shim, which builds events from the wire
 /// format on a hot reader path. Callers MUST pass a single well-formed
 /// JSON object; the writer adds a trailing newline.
-pub fn write_event_line_to_sink(
-    raw_sink: impl AsRef<str>,
-    line: &str,
-) -> std::io::Result<()> {
+pub fn write_event_line_to_sink(raw_sink: impl AsRef<str>, line: &str) -> std::io::Result<()> {
     let path = sink_path_from_raw(raw_sink.as_ref());
     let mut file = std::fs::OpenOptions::new()
         .create(true)

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -95,6 +95,179 @@ impl PluginTool {
         }
     }
 
+    /// Dispatch one line of plugin stderr to the host progress channel.
+    ///
+    /// Implements the plugin-protocol-v2 backward-compat shim:
+    ///   1. Trim the line and try parsing as a [`ProtocolV2Event`].
+    ///   2. On a known structured event, render a stable ToolProgress
+    ///      message and (for cost events) write a structured cost
+    ///      attribution to the harness sink so the ledger can pick it up.
+    ///   3. On a JSON line with an unknown `type`, pass the raw JSON
+    ///      through as ToolProgress (operator can still see the message).
+    ///   4. On any other line, fall back to the v1 behavior — emit the
+    ///      raw text as ToolProgress.
+    ///
+    /// The shim is intentionally side-effect-free aside from the reporter
+    /// callback and the harness sink write so it is safe to call from a
+    /// reader task without holding any locks.
+    fn dispatch_stderr_line(
+        plugin_name: &str,
+        tool_name: &str,
+        ctx: Option<&ToolContext>,
+        line: &str,
+    ) {
+        use octos_plugin::protocol_v2::{LineParse, ProtocolV2Event};
+
+        let parse = octos_plugin::protocol_v2::parse_event_line(line);
+        let message = match parse {
+            LineParse::Empty => return,
+            LineParse::Event(ProtocolV2Event::Progress(progress)) => {
+                let mut out = String::new();
+                if !progress.stage.is_empty() {
+                    out.push('[');
+                    out.push_str(&progress.stage);
+                    out.push(']');
+                }
+                if let Some(fraction) = progress.progress {
+                    let pct = (fraction.clamp(0.0, 1.0) * 100.0).round();
+                    if !out.is_empty() {
+                        out.push(' ');
+                    }
+                    out.push_str(&format!("{pct:.0}%"));
+                }
+                if !progress.message.is_empty() {
+                    if !out.is_empty() {
+                        out.push(' ');
+                    }
+                    out.push_str(&progress.message);
+                }
+                if out.is_empty() {
+                    progress.stage
+                } else {
+                    out
+                }
+            }
+            LineParse::Event(ProtocolV2Event::Phase(phase)) => {
+                if phase.message.is_empty() {
+                    format!("[phase] {}", phase.phase)
+                } else {
+                    format!("[{}] {}", phase.phase, phase.message)
+                }
+            }
+            LineParse::Event(ProtocolV2Event::Cost(cost)) => {
+                Self::record_cost_event(plugin_name, tool_name, ctx, &cost);
+                if let Some(usd) = cost.usd {
+                    format!(
+                        "[cost] {}: in={} out={} (${usd:.4})",
+                        cost.provider, cost.tokens_in, cost.tokens_out
+                    )
+                } else {
+                    format!(
+                        "[cost] {}: in={} out={}",
+                        cost.provider, cost.tokens_in, cost.tokens_out
+                    )
+                }
+            }
+            LineParse::Event(ProtocolV2Event::Artifact(artifact)) => {
+                if artifact.message.is_empty() {
+                    format!("[artifact:{}] {}", artifact.kind, artifact.path)
+                } else {
+                    format!(
+                        "[artifact:{}] {} ({})",
+                        artifact.kind, artifact.message, artifact.path
+                    )
+                }
+            }
+            LineParse::Event(ProtocolV2Event::Log(log)) => {
+                format!("[{}] {}", log.level, log.message)
+            }
+            LineParse::Event(ProtocolV2Event::Unknown) => {
+                // Should not be reached because the parser converts
+                // unknown variants to LineParse::UnknownEvent. Defensive
+                // fallback: pass raw line through.
+                line.to_string()
+            }
+            LineParse::UnknownEvent(raw) => raw,
+            LineParse::Legacy(text) => text,
+        };
+
+        if let Some(ctx) = ctx {
+            ctx.reporter.report(ProgressEvent::ToolProgress {
+                name: tool_name.to_string(),
+                tool_id: ctx.tool_id.clone(),
+                message,
+            });
+        }
+    }
+
+    /// Forward a v2 cost event to the harness event sink if one is wired.
+    ///
+    /// Writes a `cost_attribution`-shaped JSON payload that mirrors
+    /// `HarnessCostAttributionEvent` so existing ledger tooling can ingest
+    /// plugin-level spend without a schema migration. The generated
+    /// `attribution_id` is stable per (plugin, tool, provider, tokens) so
+    /// duplicate sink writes can be detected downstream if needed.
+    fn record_cost_event(
+        plugin_name: &str,
+        tool_name: &str,
+        ctx: Option<&ToolContext>,
+        cost: &octos_plugin::protocol_v2::CostEvent,
+    ) {
+        let Some(ctx) = ctx else {
+            return;
+        };
+        let Some(sink) = ctx.harness_event_sink.as_deref() else {
+            return;
+        };
+        let Some(sink_ctx) = lookup_event_sink_context(sink) else {
+            return;
+        };
+        let attribution_id = format!(
+            "plugin-cost-{}-{}-{}-{}-{}",
+            plugin_name, tool_name, cost.provider, cost.tokens_in, cost.tokens_out
+        );
+        let payload = serde_json::json!({
+            "schema": crate::harness_events::HARNESS_EVENT_SCHEMA_V1,
+            "kind": "cost_attribution",
+            "schema_version": 1,
+            "session_id": sink_ctx.session_id,
+            "task_id": sink_ctx.task_id,
+            "workflow": null,
+            "phase": null,
+            "attribution_id": attribution_id,
+            "contract_id": format!("plugin:{plugin_name}:{tool_name}"),
+            "model": cost.model.clone().unwrap_or_else(|| "unknown".to_string()),
+            "tokens_in": cost.tokens_in,
+            "tokens_out": cost.tokens_out,
+            "cost_usd": cost.usd.unwrap_or(0.0),
+            "outcome": "ok",
+            "provider": cost.provider,
+            "source": "plugin_v2",
+        });
+        let line = match serde_json::to_string(&payload) {
+            Ok(s) => s,
+            Err(error) => {
+                tracing::debug!(
+                    plugin = plugin_name,
+                    tool = tool_name,
+                    error = %error,
+                    "failed to serialize plugin cost event"
+                );
+                return;
+            }
+        };
+        if let Err(error) =
+            crate::harness_events::write_event_line_to_sink(sink, &line)
+        {
+            tracing::debug!(
+                plugin = plugin_name,
+                tool = tool_name,
+                error = %error,
+                "failed to write plugin cost attribution to harness sink"
+            );
+        }
+    }
+
     /// Record a `HarnessError` for this plugin tool: increments the
     /// `octos_loop_error_total{variant, recovery}` counter and writes a
     /// structured error event to the harness event sink (if one is wired
@@ -608,24 +781,29 @@ impl Tool for PluginTool {
         let stdout_handle = child.stdout.take();
         let stderr_handle = child.stderr.take();
 
-        // Spawn stderr reader: streams lines as ToolProgress events
+        // Spawn stderr reader: streams lines as ToolProgress events.
+        // Plugin protocol v2 (see `octos-plugin/docs/protocol-v2.md`):
+        // each line is either a JSON-encoded `ProtocolV2Event` or legacy
+        // free-form text. We try v2 first and fall back to legacy text on
+        // any parse failure — this is the backward-compat shim required
+        // for v1 plugins to keep working unchanged.
         let tool_name = self.tool_def.name.clone();
         // Clone ctx for the stderr reader so we can still consult the
         // original after the reader task is spawned (needed for
         // `emit_plugin_error` on spawn/timeout/protocol failures).
         let stderr_ctx = ctx.clone();
+        let plugin_name_for_reader = self.plugin_name.clone();
         let stderr_task = tokio::spawn(async move {
             let mut collected = String::new();
             if let Some(stderr) = stderr_handle {
                 let mut reader = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = reader.next_line().await {
-                    if let Some(ref ctx) = stderr_ctx {
-                        ctx.reporter.report(ProgressEvent::ToolProgress {
-                            name: tool_name.clone(),
-                            tool_id: ctx.tool_id.clone(),
-                            message: line.clone(),
-                        });
-                    }
+                    Self::dispatch_stderr_line(
+                        &plugin_name_for_reader,
+                        &tool_name,
+                        stderr_ctx.as_ref(),
+                        &line,
+                    );
                     if !collected.is_empty() {
                         collected.push('\n');
                     }
@@ -1432,5 +1610,243 @@ mod tests {
             ),
             Ok(_) => panic!("expected timeout error, but execute succeeded"),
         }
+    }
+
+    // -------------------------------------------------------------------
+    // Plugin protocol v2 stderr dispatch tests (W3.F2).
+    // -------------------------------------------------------------------
+
+    use crate::progress::ProgressReporter;
+    use std::sync::Mutex as StdMutex;
+
+    /// Captures every reported event so tests can assert on the ToolProgress
+    /// messages the v2 shim emits.
+    struct CapturingReporter {
+        events: Arc<StdMutex<Vec<crate::progress::ProgressEvent>>>,
+    }
+
+    impl ProgressReporter for CapturingReporter {
+        fn report(&self, event: crate::progress::ProgressEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(event);
+        }
+    }
+
+    fn make_capturing_ctx() -> (
+        ToolContext,
+        Arc<StdMutex<Vec<crate::progress::ProgressEvent>>>,
+    ) {
+        let events = Arc::new(StdMutex::new(Vec::<crate::progress::ProgressEvent>::new()));
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "tool-1".to_string();
+        ctx.reporter = Arc::new(CapturingReporter {
+            events: Arc::clone(&events),
+        });
+        (ctx, events)
+    }
+
+    fn last_progress_message(
+        events: &Arc<StdMutex<Vec<crate::progress::ProgressEvent>>>,
+    ) -> Option<String> {
+        events
+            .lock()
+            .unwrap()
+            .last()
+            .and_then(|event| match event {
+                crate::progress::ProgressEvent::ToolProgress { message, .. } => {
+                    Some(message.clone())
+                }
+                _ => None,
+            })
+    }
+
+    #[test]
+    fn v2_progress_event_renders_stage_and_message() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "deep-search",
+            "deep_search",
+            Some(&ctx),
+            r#"{"type":"progress","stage":"searching","message":"round 1/3","progress":0.25}"#,
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        assert!(msg.contains("[searching]"), "expected stage badge: {msg}");
+        assert!(msg.contains("25%"), "expected percent: {msg}");
+        assert!(msg.contains("round 1/3"), "expected message: {msg}");
+    }
+
+    #[test]
+    fn v2_phase_event_renders_phase_label() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "deep-search",
+            "deep_search",
+            Some(&ctx),
+            r#"{"type":"phase","phase":"synthesizing","message":"calling LLM"}"#,
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        assert!(msg.starts_with("[synthesizing]"), "got {msg}");
+        assert!(msg.contains("calling LLM"), "got {msg}");
+    }
+
+    #[test]
+    fn v2_cost_event_renders_cost_summary() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "deep-search",
+            "deep_search",
+            Some(&ctx),
+            r#"{"type":"cost","provider":"deepseek","model":"deepseek-chat","tokens_in":1024,"tokens_out":256,"usd":0.0034}"#,
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        assert!(msg.contains("[cost]"), "got {msg}");
+        assert!(msg.contains("deepseek"), "got {msg}");
+        assert!(msg.contains("in=1024"), "got {msg}");
+        assert!(msg.contains("out=256"), "got {msg}");
+        assert!(msg.contains("0.0034"), "got {msg}");
+    }
+
+    #[test]
+    fn v2_log_event_renders_level() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "deep-search",
+            "deep_search",
+            Some(&ctx),
+            r#"{"type":"log","level":"warn","message":"low disk"}"#,
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        assert_eq!(msg, "[warn] low disk");
+    }
+
+    #[test]
+    fn v2_artifact_event_renders_kind_and_path() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "deep-search",
+            "deep_search",
+            Some(&ctx),
+            r#"{"type":"artifact","path":"/tmp/x.md","kind":"report","message":"final"}"#,
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        assert!(msg.contains("[artifact:report]"), "got {msg}");
+        assert!(msg.contains("/tmp/x.md"), "got {msg}");
+    }
+
+    #[test]
+    fn legacy_v1_text_passes_through_unchanged() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "old-plugin",
+            "old_tool",
+            Some(&ctx),
+            "[deep_crawl] launched chrome on port 9222",
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        assert_eq!(msg, "[deep_crawl] launched chrome on port 9222");
+    }
+
+    #[test]
+    fn legacy_starting_with_bracket_does_not_lose_data() {
+        // Plugins emitting `[1/3] Searching ...` style text must still flow
+        // through unchanged — they are not JSON, the shim must not eat them.
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "deep-search",
+            "deep_search",
+            Some(&ctx),
+            "[1/3] Searching: \"foo\"",
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        assert_eq!(msg, "[1/3] Searching: \"foo\"");
+    }
+
+    #[test]
+    fn malformed_json_falls_back_to_legacy() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "p",
+            "t",
+            Some(&ctx),
+            r#"{"type":"progress""#, // truncated, parse fails
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        // Falls back to the raw line (trimmed).
+        assert_eq!(msg, r#"{"type":"progress""#);
+    }
+
+    #[test]
+    fn empty_line_emits_no_progress() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line("p", "t", Some(&ctx), "");
+        PluginTool::dispatch_stderr_line("p", "t", Some(&ctx), "   \r\n");
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn unknown_event_type_passes_raw_through() {
+        let (ctx, events) = make_capturing_ctx();
+        PluginTool::dispatch_stderr_line(
+            "p",
+            "t",
+            Some(&ctx),
+            r#"{"type":"future_event","data":42}"#,
+        );
+        let msg = last_progress_message(&events).expect("emitted progress");
+        // The raw JSON is forwarded so the operator can still see it.
+        assert!(msg.contains("future_event"), "got {msg}");
+    }
+
+    #[test]
+    fn dispatch_with_no_ctx_is_noop() {
+        // No assertion — just confirm there's no panic. With no ctx the
+        // shim cannot dispatch but it must not crash.
+        PluginTool::dispatch_stderr_line(
+            "p",
+            "t",
+            None,
+            r#"{"type":"progress","stage":"init","message":"go"}"#,
+        );
+    }
+
+    #[test]
+    fn cost_event_writes_to_harness_sink() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink_path = dir.path().join("events.ndjson");
+
+        // Wire up a sink context so record_cost_event has a session+task to
+        // attribute against.
+        let ctx_path = sink_path.display().to_string();
+        crate::harness_events::attach_event_sink_context(
+            ctx_path.clone(),
+            crate::harness_events::HarnessEventSinkContext {
+                session_id: "session-1".to_string(),
+                task_id: "task-1".to_string(),
+            },
+        );
+
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "tool-1".to_string();
+        ctx.harness_event_sink = Some(ctx_path.clone());
+
+        PluginTool::dispatch_stderr_line(
+            "deep-search",
+            "deep_search",
+            Some(&ctx),
+            r#"{"type":"cost","provider":"deepseek","model":"deepseek-chat","tokens_in":1024,"tokens_out":256,"usd":0.0034}"#,
+        );
+
+        let body = std::fs::read_to_string(&sink_path).expect("sink written");
+        assert!(body.contains(r#""kind":"cost_attribution""#), "got: {body}");
+        assert!(body.contains(r#""tokens_in":1024"#), "got: {body}");
+        assert!(body.contains(r#""tokens_out":256"#), "got: {body}");
+        assert!(body.contains(r#""cost_usd":0.0034"#), "got: {body}");
+        assert!(body.contains(r#""contract_id":"plugin:deep-search:deep_search""#));
+        assert!(body.contains(r#""provider":"deepseek""#));
+
+        // Cleanup the sink registration.
+        crate::harness_events::detach_event_sink_context(&ctx_path);
     }
 }

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -141,11 +141,7 @@ impl PluginTool {
                     }
                     out.push_str(&progress.message);
                 }
-                if out.is_empty() {
-                    progress.stage
-                } else {
-                    out
-                }
+                if out.is_empty() { progress.stage } else { out }
             }
             LineParse::Event(ProtocolV2Event::Phase(phase)) => {
                 if phase.message.is_empty() {
@@ -256,9 +252,7 @@ impl PluginTool {
                 return;
             }
         };
-        if let Err(error) =
-            crate::harness_events::write_event_line_to_sink(sink, &line)
-        {
+        if let Err(error) = crate::harness_events::write_event_line_to_sink(sink, &line) {
             tracing::debug!(
                 plugin = plugin_name,
                 tool = tool_name,
@@ -1650,16 +1644,10 @@ mod tests {
     fn last_progress_message(
         events: &Arc<StdMutex<Vec<crate::progress::ProgressEvent>>>,
     ) -> Option<String> {
-        events
-            .lock()
-            .unwrap()
-            .last()
-            .and_then(|event| match event {
-                crate::progress::ProgressEvent::ToolProgress { message, .. } => {
-                    Some(message.clone())
-                }
-                _ => None,
-            })
+        events.lock().unwrap().last().and_then(|event| match event {
+            crate::progress::ProgressEvent::ToolProgress { message, .. } => Some(message.clone()),
+            _ => None,
+        })
     }
 
     #[test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1669,8 +1669,11 @@ impl ActorFactory {
         // messages whose tool-result references could be invalidated by a
         // missing worktree.
         let has_loaded_messages = !session_handle.get_history(1).is_empty();
-        let workspace_root_for_sanitize: Option<&Path> =
-            if has_loaded_messages { Some(&user_workspace) } else { None };
+        let workspace_root_for_sanitize: Option<&Path> = if has_loaded_messages {
+            Some(&user_workspace)
+        } else {
+            None
+        };
         match session_handle.sanitize_loaded_messages(None, workspace_root_for_sanitize) {
             Ok((report, refs)) => {
                 if report.input_len != report.output_len

--- a/crates/octos-plugin/docs/protocol-v2.md
+++ b/crates/octos-plugin/docs/protocol-v2.md
@@ -1,0 +1,257 @@
+# Plugin Protocol v2
+
+**Status**: Stable (M8 Runtime Parity)
+**Audience**: Plugin authors and host implementors
+**Companion code**: `crates/octos-plugin/src/protocol_v2.rs`, host parser at
+`crates/octos-agent/src/plugins/tool.rs`
+
+## 1. Goals
+
+Protocol v1 used opaque stderr text-lines for progress and a flat JSON result
+on stdout. v2 keeps the wire shape (binary, JSON-on-stdin/stdout, free-form
+stderr) but layers a **structured event vocabulary** on top of stderr and an
+**enriched result schema** on stdout. Hosts that only understand v1 keep
+working: any stderr line that does not parse as a v2 event is treated as a
+legacy text-message progress event.
+
+The contract delivers:
+
+1. **Structured progress events** — typed phases the UI can render as a node
+   tree without string parsing.
+2. **Cost attribution** — per-call provider/token/USD breakdown so the host
+   ledger can attribute spend back to the specific plugin invocation.
+3. **Result summary** — typed summary that the host's `SubAgentSummaryGenerator`
+   can consume without re-running an LLM.
+4. **Cancel-signal contract** — graceful SIGTERM with a 10-second cleanup
+   budget before SIGKILL.
+
+## 2. Wire format
+
+### 2.1 Invocation (unchanged from v1)
+
+```text
+$ ./plugin <tool_name>          # arg = tool name
+< stdin: <json args object>
+> stdout: <json result object>  # exactly one JSON document
+> stderr: <newline-delimited free text OR v2 events>
+```
+
+### 2.2 Stderr events (v2)
+
+Each line on stderr is one of:
+
+- A **v2 event**: a JSON object with a top-level `"type"` field, terminated
+  by `\n`. Hosts MUST tolerate trailing whitespace and a leading BOM.
+- A **legacy text line**: anything else. Hosts treat the entire line (after
+  stripping the trailing `\n`) as `ToolProgress { message }`.
+
+Events are JSON objects, never arrays or scalars. Multi-line JSON is **not**
+supported — a v2 line is one event, terminated by `\n`. If a plugin needs to
+emit a large blob, use `detail.body_truncated` and write the full content to
+disk.
+
+Plugins MAY mix v2 events and legacy text lines on the same stream — the
+backward-compatibility shim parses each line independently. This is the
+intended migration path: a plugin can emit v2 events for the phases that
+matter (progress, cost) and keep ad-hoc `eprintln!` debug output as legacy
+lines.
+
+### 2.3 Event types
+
+| `type`     | Required fields                                        | Notes                                                           |
+|------------|--------------------------------------------------------|-----------------------------------------------------------------|
+| `progress` | `stage` (string), `message` (string)                   | `detail` (object) and `progress` (0..1) optional                |
+| `cost`    | `provider` (string), `tokens_in` (u32), `tokens_out` (u32) | `usd` (f64) and `model` (string) optional                       |
+| `phase`    | `phase` (string), `message` (string)                   | High-level state transition, e.g. `searching` → `synthesizing`  |
+| `artifact` | `path` (string), `kind` (string)                       | Side-effect file the plugin produced                            |
+| `log`      | `level` (`debug`/`info`/`warn`/`error`), `message`     | Structured wrapper around legacy text logs                      |
+
+Unknown `type` values are tolerated by the parser but logged as legacy text
+to the user-visible progress stream.
+
+### 2.4 Stage vocabulary (recommended)
+
+`stage` is a stable, lowercase, snake_case string. The recommended vocabulary:
+
+- `init`, `validating`, `searching`, `fetching`, `crawling`, `chasing`,
+  `synthesizing`, `building_report`, `delivering`, `cleanup`, `complete`.
+
+Plugins MAY introduce new stages; hosts SHOULD render unknown stages as-is.
+
+### 2.5 Stdout result (extended)
+
+The v1 keys remain unchanged:
+
+```json
+{
+  "output": "...",
+  "success": true,
+  "file_modified": "...",
+  "files_to_send": [...]
+}
+```
+
+v2 adds:
+
+```json
+{
+  "summary": {
+    "kind": "deep_research",
+    "headline": "...",
+    "confidence": 0.78,
+    "sources": [{"url": "...", "title": "...", "cited": true}],
+    "extra": { ... }
+  },
+  "cost": {
+    "tokens_in": 1024,
+    "tokens_out": 856,
+    "usd": 0.0034,
+    "provider": "deepseek",
+    "model": "deepseek-chat"
+  }
+}
+```
+
+`summary.kind` discriminates the variant. Reserved kinds:
+
+- `deep_research` — used by `deep_search`. Always populated when the
+  internal synthesis call succeeds.
+- `crawl` — used by `deep_crawl`.
+- Plugin-specific kinds may use the prefix `plugin:` (e.g.
+  `plugin:mofa_slides:design_phase`).
+
+Both `summary` and `cost` are optional; v1 plugins that do not set them
+keep working. The host treats missing `cost` as zero spend (no debit
+to the ledger from the plugin call alone).
+
+## 3. Cancellation
+
+### 3.1 Host responsibilities
+
+- The host sends `SIGTERM` to the plugin's direct process (and on Unix, the
+  whole process group via `kill -SIGTERM -- -<pgid>`) when the user clicks
+  cancel or the supervisor decides to abort the task.
+- The host waits **10 seconds** for the plugin to exit cleanly. If the plugin
+  has not exited by the deadline, the host sends `SIGKILL` to the process
+  group (`kill -KILL -- -<pgid>` on Unix; `taskkill /F /T /PID` on Windows).
+- During the 10-second window the host MUST continue draining stdout/stderr
+  so the plugin's final `summary` and any farewell `progress` events are
+  captured.
+
+### 3.2 Plugin responsibilities
+
+On receipt of `SIGTERM`, plugins SHOULD:
+
+1. Stop scheduling new work (e.g. stop launching new browsers, stop new
+   HTTP requests).
+2. Cancel in-flight async work via `tokio::select!` against a
+   shutdown signal.
+3. Tear down owned resources: kill child Chromium processes, close
+   temp files, flush partial output to disk.
+4. Emit one final `progress` event with `stage = "cleanup"` (best effort).
+5. Exit with status code 130 (128 + SIGTERM=2) within the 10-second
+   budget.
+
+Plugins that need >10s of cleanup MUST split it: do the urgent cleanup
+(kill children, release locks) inside the budget, schedule slow cleanup
+(metric flushing, telemetry uploads) on a detached background process,
+and exit.
+
+### 3.3 Reference implementation
+
+```rust
+use tokio::signal::unix::{signal, SignalKind};
+use tokio::sync::watch;
+
+let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+let mut sigterm = signal(SignalKind::terminate())?;
+
+tokio::spawn(async move {
+    sigterm.recv().await;
+    let _ = shutdown_tx.send(true);
+});
+
+// Inside the workload:
+tokio::select! {
+    biased;
+    _ = shutdown_rx.changed() => {
+        cleanup().await;
+        // Emit final progress event
+        eprintln!(r#"{{"type":"progress","stage":"cleanup","message":"received SIGTERM, exiting"}}"#);
+        std::process::exit(130);
+    }
+    result = real_work() => {
+        // ...
+    }
+}
+```
+
+## 4. Backward compatibility
+
+The host parses stderr line-by-line. For each line:
+
+1. Trim trailing `\r\n`/`\n` and any leading BOM.
+2. If the trimmed line is empty, ignore it.
+3. If the line starts with `{` or `[`, attempt `serde_json::from_str::<ProtocolV2Event>(line)`.
+4. On success → dispatch as a structured event.
+5. On failure (or non-JSON line) → emit a legacy
+   `ToolProgress { message: line }` event.
+
+This means a plugin can be upgraded incrementally — add v2 events for the
+hot paths and leave existing `eprintln!` calls in place. Hosts that don't
+understand v2 (e.g. third-party tools shelling out) see the JSON as opaque
+text, which is forward-compatible.
+
+## 5. Versioning
+
+The `schema_version` of structured events is implicit (the v2 protocol).
+If a future v3 changes the event shape it MUST add a `schema_version`
+field to v2 events first (with a default of 2) and ship that change at
+least one release before v3 events appear in the wild.
+
+## 6. Examples
+
+### 6.1 Progress + cost from a synthesizing plugin
+
+```text
+{"type":"progress","stage":"searching","message":"round 1/3","progress":0.10}
+{"type":"progress","stage":"fetching","message":"30 pages in parallel","progress":0.45}
+{"type":"cost","provider":"deepseek","model":"deepseek-chat","tokens_in":1024,"tokens_out":856,"usd":0.0034}
+{"type":"progress","stage":"synthesizing","message":"calling LLM","progress":0.75}
+{"type":"progress","stage":"complete","message":"all done","progress":1.0}
+```
+
+### 6.2 Mixed v2 + legacy
+
+```text
+{"type":"progress","stage":"init","message":"booting headless chrome"}
+[chrome] launched on port 9223       <-- legacy text, becomes ToolProgress { message }
+{"type":"progress","stage":"crawling","message":"page 5/10","progress":0.5}
+```
+
+### 6.3 Final result with summary
+
+```json
+{
+  "output": "Deep Research: foo\n\n## Synthesis\n\n...",
+  "success": true,
+  "file_modified": "/tmp/research/foo/_report.md",
+  "files_to_send": ["/tmp/research/foo/_report.md"],
+  "summary": {
+    "kind": "deep_research",
+    "headline": "Survey of 5 sources answering 'foo'",
+    "confidence": 0.82,
+    "sources": [
+      {"url": "https://a.example/1", "title": "...", "cited": true},
+      {"url": "https://b.example/2", "title": "...", "cited": true}
+    ]
+  },
+  "cost": {
+    "provider": "deepseek",
+    "model": "deepseek-chat",
+    "tokens_in": 4321,
+    "tokens_out": 1234,
+    "usd": 0.0086
+  }
+}
+```

--- a/crates/octos-plugin/src/lib.rs
+++ b/crates/octos-plugin/src/lib.rs
@@ -45,6 +45,7 @@ pub use lifecycle::{
 pub use manifest::{InstallSpec, PluginManifest, PluginType, Requirements, ToolDefinition};
 pub use protocol_v2::{
     ArtifactEvent, CostEvent, LineParse, LogEvent, PhaseEvent, ProgressEvent, ProtocolV2Event,
-    ResultCost, ResultSource, ResultSummary, emit_cost, emit_event, emit_progress, parse_event_line,
+    ResultCost, ResultSource, ResultSummary, emit_cost, emit_event, emit_progress,
+    parse_event_line,
 };
 pub use types::{DiscoveredPlugin, PluginOrigin, PluginStatus};

--- a/crates/octos-plugin/src/lib.rs
+++ b/crates/octos-plugin/src/lib.rs
@@ -31,6 +31,7 @@ pub mod discovery;
 pub mod gating;
 pub mod lifecycle;
 pub mod manifest;
+pub mod protocol_v2;
 pub mod types;
 
 // Re-export primary types for convenience.
@@ -42,4 +43,8 @@ pub use lifecycle::{
     is_safe_shell_command,
 };
 pub use manifest::{InstallSpec, PluginManifest, PluginType, Requirements, ToolDefinition};
+pub use protocol_v2::{
+    ArtifactEvent, CostEvent, LineParse, LogEvent, PhaseEvent, ProgressEvent, ProtocolV2Event,
+    ResultCost, ResultSource, ResultSummary, emit_cost, emit_event, emit_progress, parse_event_line,
+};
 pub use types::{DiscoveredPlugin, PluginOrigin, PluginStatus};

--- a/crates/octos-plugin/src/protocol_v2.rs
+++ b/crates/octos-plugin/src/protocol_v2.rs
@@ -1,0 +1,578 @@
+//! Plugin protocol v2 — structured events on stderr + result extensions.
+//!
+//! See `docs/protocol-v2.md` for the full specification. This module provides
+//! the wire-typed Rust definitions used by both plugin authors (when emitting
+//! events) and the host (when parsing them).
+//!
+//! Wire shape: each event is one JSON object terminated by `\n`. The
+//! discriminator is the top-level `type` field. Lines that fail to parse as
+//! a [`ProtocolV2Event`] are treated as legacy v1 text-progress lines by the
+//! host — that is the backward-compatibility contract. See
+//! [`parse_event_line`] for the parser used by the shim.
+//!
+//! ## Why a discriminated enum
+//!
+//! `serde(tag = "type")` matches the spec ("each line is `{type: ...}`")
+//! and gives the host pattern-match exhaustiveness when handling events.
+//! Unknown variants fall through to [`ProtocolV2Event::Unknown`] so a future
+//! plugin emitting a new event kind doesn't kill the host parser.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+/// Recommended progress-stage labels.
+///
+/// Plugins SHOULD use one of these when applicable so the host can render
+/// stable badges. Custom stages (any other lowercase snake_case string) are
+/// allowed and rendered as-is.
+pub mod stage {
+    pub const INIT: &str = "init";
+    pub const VALIDATING: &str = "validating";
+    pub const SEARCHING: &str = "searching";
+    pub const FETCHING: &str = "fetching";
+    pub const CRAWLING: &str = "crawling";
+    pub const CHASING: &str = "chasing";
+    pub const SYNTHESIZING: &str = "synthesizing";
+    pub const BUILDING_REPORT: &str = "building_report";
+    pub const DELIVERING: &str = "delivering";
+    pub const CLEANUP: &str = "cleanup";
+    pub const COMPLETE: &str = "complete";
+}
+
+/// One event emitted on a plugin's stderr stream.
+///
+/// Wire format: a single-line JSON object with a `type` discriminator.
+/// Forward-compatible: unknown `type` values land in [`ProtocolV2Event::Unknown`]
+/// and are passed through to the host as legacy progress lines.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProtocolV2Event {
+    /// Per-step progress with a free-form message and an optional structured
+    /// detail blob. Hosts render `{stage} - {message}` and may forward the
+    /// fraction to a progress bar.
+    Progress(ProgressEvent),
+
+    /// Cost attribution for an internal LLM/API call. The host commits this
+    /// to the ledger so per-task spend is visible.
+    Cost(CostEvent),
+
+    /// High-level state transition (kept for clients that prefer phase events
+    /// over progress events). Equivalent semantically to `progress` with
+    /// `progress = None`.
+    Phase(PhaseEvent),
+
+    /// File the plugin produced as a side-effect (e.g. saved a screenshot).
+    Artifact(ArtifactEvent),
+
+    /// Structured wrapper around a log line. Useful when a plugin wants to
+    /// emit a leveled message instead of plain stderr text.
+    Log(LogEvent),
+
+    /// Catch-all for forward compatibility. The original JSON is preserved
+    /// in `raw` so a host that does understand the new variant via a side
+    /// channel can re-parse it.
+    #[serde(other, deserialize_with = "deserialize_unit")]
+    Unknown,
+}
+
+fn deserialize_unit<'de, D: serde::Deserializer<'de>>(_d: D) -> Result<(), D::Error> {
+    Ok(())
+}
+
+/// Progress event payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProgressEvent {
+    /// Stable lowercase snake_case label. See [`stage`] for recommended values.
+    pub stage: String,
+    /// Free-form human-readable description of the current step.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub message: String,
+    /// Optional fraction of work complete in `[0, 1]`. The host clamps to
+    /// `[0, 1]` defensively before forwarding to the UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub progress: Option<f64>,
+    /// Free-form structured detail for advanced UI rendering. Hosts that do
+    /// not understand the contents pass them through to the SSE event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<Value>,
+}
+
+/// Cost-attribution event payload.
+///
+/// Plugins SHOULD emit one [`CostEvent`] per internal LLM/API call so the
+/// host ledger can attribute spend. If the same call is reported on stderr
+/// AND in the final stdout `cost` summary, the host de-duplicates by
+/// preferring stderr (which has finer-grained attribution per call).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CostEvent {
+    /// Provider lane (`"openai"`, `"deepseek"`, `"anthropic"`, ...). Free-form,
+    /// used for grouping in the cost dashboard.
+    pub provider: String,
+    /// Optional model identifier (`"gpt-4o-mini"`, `"deepseek-chat"`, ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Prompt tokens consumed.
+    pub tokens_in: u32,
+    /// Completion tokens produced.
+    pub tokens_out: u32,
+    /// Optional dollar cost. If absent, the host computes it from the model
+    /// catalog if the model is known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usd: Option<f64>,
+    /// Free-form context (request id, lane choice rationale, ...). Optional.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<Value>,
+}
+
+/// Phase event payload (state transition).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PhaseEvent {
+    pub phase: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub message: String,
+}
+
+/// Artifact event payload (a file the plugin produced).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ArtifactEvent {
+    /// Absolute or workspace-relative path to the file on disk.
+    pub path: String,
+    /// Free-form artifact kind, e.g. `"report"`, `"screenshot"`, `"log"`.
+    pub kind: String,
+    /// Optional human-readable description.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub message: String,
+}
+
+/// Log event payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LogEvent {
+    /// `"debug"`, `"info"`, `"warn"`, or `"error"`. Other values are rendered
+    /// as `"info"` by the host.
+    pub level: String,
+    pub message: String,
+}
+
+/// Wire shape for the optional `summary` field in the final stdout result.
+///
+/// The host's `SubAgentSummaryGenerator` consumes this to build the typed
+/// summary the parent agent sees, without re-running an LLM. `kind` is the
+/// discriminator; `extra` carries kind-specific fields the host can pass
+/// through verbatim to the UI.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResultSummary {
+    /// Discriminator for the summary variant. Reserved kinds documented in
+    /// `protocol-v2.md`: `deep_research`, `crawl`, `plugin:<name>:<phase>`.
+    pub kind: String,
+    /// One-line headline rendered in the parent's tool-call pill.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub headline: String,
+    /// Optional confidence score in `[0, 1]`. Plugin-specific semantics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<f64>,
+    /// Sources referenced. For research plugins this is the citation list.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<ResultSource>,
+    /// Free-form additional fields keyed by name. Hosts pass these through
+    /// verbatim. Use for kind-specific extensions without adding new
+    /// top-level fields to [`ResultSummary`].
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty", flatten)]
+    pub extra: BTreeMap<String, Value>,
+}
+
+/// A single source/citation entry inside a [`ResultSummary`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResultSource {
+    pub url: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub title: String,
+    /// Whether this source was cited in the synthesized prose. `true` means
+    /// the citation appears in the final report; `false` means the source was
+    /// fetched but not used in the answer.
+    #[serde(default)]
+    pub cited: bool,
+    /// Optional relevance score in `[0, 1]`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+}
+
+/// Roll-up cost reported in the final stdout result.
+///
+/// Equivalent to summing all stderr [`CostEvent`]s but supplied as a separate
+/// field so v1 plugins that don't emit per-call events on stderr can still
+/// report their total spend.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ResultCost {
+    /// Provider lane for the dominant call. If the plugin made calls to
+    /// multiple providers it should aggregate them into separate stderr
+    /// `cost` events instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    pub tokens_in: u32,
+    pub tokens_out: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usd: Option<f64>,
+}
+
+/// Outcome of attempting to parse one stderr line as a v2 event.
+///
+/// The shim uses this to dispatch: `Event` paths flow into the structured
+/// progress channel, `Legacy` paths flow into the v1 text-line channel.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LineParse {
+    /// Line was a valid v2 event.
+    Event(ProtocolV2Event),
+    /// Line was a valid v2 event with an unknown `type` discriminator.
+    /// The host SHOULD pass the original line through to the v1 text-line
+    /// channel (so the user sees the message) but MAY also surface the JSON
+    /// to a generic event sink for forward compatibility.
+    UnknownEvent(String),
+    /// Line was not a v2 event — fall back to legacy text progress.
+    Legacy(String),
+    /// Line was empty after trimming. Ignore.
+    Empty,
+}
+
+/// Parse a single stderr line into a structured event or a legacy fallback.
+///
+/// The shim trims trailing CR/LF and a leading BOM, then attempts JSON
+/// parsing only when the line starts with `{`. This keeps the hot path
+/// allocation-free for legacy plugins (which never start lines with `{`).
+///
+/// # Examples
+///
+/// ```
+/// use octos_plugin::protocol_v2::{parse_event_line, LineParse, ProtocolV2Event};
+///
+/// // v2 progress event
+/// match parse_event_line(r#"{"type":"progress","stage":"init","message":"go"}"#) {
+///     LineParse::Event(ProtocolV2Event::Progress(p)) => {
+///         assert_eq!(p.stage, "init");
+///         assert_eq!(p.message, "go");
+///     }
+///     other => panic!("expected progress event, got {other:?}"),
+/// }
+///
+/// // legacy text line
+/// match parse_event_line("hello there") {
+///     LineParse::Legacy(s) => assert_eq!(s, "hello there"),
+///     other => panic!("expected legacy line, got {other:?}"),
+/// }
+///
+/// // empty line
+/// assert_eq!(parse_event_line(""), LineParse::Empty);
+/// assert_eq!(parse_event_line("   "), LineParse::Empty);
+/// ```
+pub fn parse_event_line(line: &str) -> LineParse {
+    // Strip a leading UTF-8 BOM if present (rare but observed when plugins
+    // pipe stderr through tools that prepend one).
+    let trimmed = line.strip_prefix('\u{feff}').unwrap_or(line);
+    let trimmed = trimmed.trim_end_matches(['\r', '\n']);
+    let trimmed = trimmed.trim();
+
+    if trimmed.is_empty() {
+        return LineParse::Empty;
+    }
+
+    // Fast path: only attempt JSON parse if the line plausibly starts with
+    // a JSON object. Saves a parse attempt per legacy line.
+    if !trimmed.starts_with('{') {
+        return LineParse::Legacy(trimmed.to_string());
+    }
+
+    match serde_json::from_str::<ProtocolV2Event>(trimmed) {
+        Ok(ProtocolV2Event::Unknown) => LineParse::UnknownEvent(trimmed.to_string()),
+        Ok(event) => LineParse::Event(event),
+        Err(_) => LineParse::Legacy(trimmed.to_string()),
+    }
+}
+
+/// Emit a v2 event on stderr.
+///
+/// Convenience helper for plugin authors. Serializes to a single line with
+/// a trailing newline. If serialization fails (which would be a bug) the
+/// helper falls back to writing nothing — a missing event is preferable to
+/// a malformed line that confuses the host parser.
+pub fn emit_event(event: &ProtocolV2Event) {
+    if let Ok(json) = serde_json::to_string(event) {
+        eprintln!("{json}");
+    }
+}
+
+/// Convenience helper for `progress` events.
+pub fn emit_progress(stage: &str, message: &str, progress: Option<f64>) {
+    let event = ProtocolV2Event::Progress(ProgressEvent {
+        stage: stage.to_string(),
+        message: message.to_string(),
+        progress,
+        detail: None,
+    });
+    emit_event(&event);
+}
+
+/// Convenience helper for `cost` events.
+pub fn emit_cost(provider: &str, model: Option<&str>, tokens_in: u32, tokens_out: u32, usd: Option<f64>) {
+    let event = ProtocolV2Event::Cost(CostEvent {
+        provider: provider.to_string(),
+        model: model.map(String::from),
+        tokens_in,
+        tokens_out,
+        usd,
+        detail: None,
+    });
+    emit_event(&event);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_progress_event_extracts_fields() {
+        let line = r#"{"type":"progress","stage":"searching","message":"round 1/3","progress":0.25}"#;
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Progress(p)) => {
+                assert_eq!(p.stage, "searching");
+                assert_eq!(p.message, "round 1/3");
+                assert_eq!(p.progress, Some(0.25));
+                assert!(p.detail.is_none());
+            }
+            other => panic!("expected progress event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_progress_event_with_detail() {
+        let line = r#"{"type":"progress","stage":"fetching","message":"page 5","detail":{"url":"https://x"}}"#;
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Progress(p)) => {
+                assert_eq!(p.stage, "fetching");
+                let detail = p.detail.expect("detail present");
+                assert_eq!(detail["url"].as_str(), Some("https://x"));
+            }
+            other => panic!("expected progress event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_cost_event_extracts_fields() {
+        let line = r#"{"type":"cost","provider":"deepseek","model":"deepseek-chat","tokens_in":1024,"tokens_out":256,"usd":0.0034}"#;
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Cost(c)) => {
+                assert_eq!(c.provider, "deepseek");
+                assert_eq!(c.model.as_deref(), Some("deepseek-chat"));
+                assert_eq!(c.tokens_in, 1024);
+                assert_eq!(c.tokens_out, 256);
+                assert_eq!(c.usd, Some(0.0034));
+            }
+            other => panic!("expected cost event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_phase_event() {
+        let line = r#"{"type":"phase","phase":"synthesizing","message":"calling LLM"}"#;
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Phase(p)) => {
+                assert_eq!(p.phase, "synthesizing");
+                assert_eq!(p.message, "calling LLM");
+            }
+            other => panic!("expected phase event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_artifact_event() {
+        let line = r#"{"type":"artifact","path":"/tmp/r/_report.md","kind":"report","message":"final"}"#;
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Artifact(a)) => {
+                assert_eq!(a.path, "/tmp/r/_report.md");
+                assert_eq!(a.kind, "report");
+            }
+            other => panic!("expected artifact event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_log_event() {
+        let line = r#"{"type":"log","level":"warn","message":"low memory"}"#;
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Log(l)) => {
+                assert_eq!(l.level, "warn");
+                assert_eq!(l.message, "low memory");
+            }
+            other => panic!("expected log event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_text_line_is_passed_through() {
+        match parse_event_line("[deep_crawl] launched chrome on port 9222") {
+            LineParse::Legacy(s) => assert_eq!(s, "[deep_crawl] launched chrome on port 9222"),
+            other => panic!("expected legacy line, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_text_starting_with_bracket_does_not_attempt_json() {
+        // "[" is not "{" so we shouldn't try to parse as JSON.
+        match parse_event_line("[1/3] Searching: \"foo\"") {
+            LineParse::Legacy(s) => assert_eq!(s, "[1/3] Searching: \"foo\""),
+            other => panic!("expected legacy line, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_line_is_ignored() {
+        assert_eq!(parse_event_line(""), LineParse::Empty);
+        assert_eq!(parse_event_line("   "), LineParse::Empty);
+        assert_eq!(parse_event_line("\r\n"), LineParse::Empty);
+    }
+
+    #[test]
+    fn malformed_json_falls_back_to_legacy() {
+        let line = r#"{"type":"progress""#; // truncated
+        match parse_event_line(line) {
+            LineParse::Legacy(s) => assert_eq!(s, line.trim()),
+            other => panic!("expected legacy line, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_event_type_is_unknown_event() {
+        let line = r#"{"type":"newkind","data":42}"#;
+        match parse_event_line(line) {
+            LineParse::UnknownEvent(s) => assert_eq!(s, line),
+            other => panic!("expected unknown event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bom_prefix_is_stripped() {
+        let line = "\u{feff}{\"type\":\"progress\",\"stage\":\"init\",\"message\":\"go\"}";
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Progress(p)) => {
+                assert_eq!(p.stage, "init");
+            }
+            other => panic!("expected progress event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trailing_crlf_is_stripped() {
+        let line = "{\"type\":\"progress\",\"stage\":\"init\",\"message\":\"go\"}\r\n";
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Progress(p)) => {
+                assert_eq!(p.stage, "init");
+            }
+            other => panic!("expected progress event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn result_summary_round_trips() {
+        let s = ResultSummary {
+            kind: "deep_research".to_string(),
+            headline: "5 sources answering 'foo'".to_string(),
+            confidence: Some(0.78),
+            sources: vec![ResultSource {
+                url: "https://a.example/1".to_string(),
+                title: "Foo article".to_string(),
+                cited: true,
+                score: Some(0.92),
+            }],
+            extra: Default::default(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        let back: ResultSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn result_summary_skips_empty_optional_fields() {
+        let s = ResultSummary {
+            kind: "deep_research".to_string(),
+            headline: String::new(),
+            confidence: None,
+            sources: vec![],
+            extra: Default::default(),
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        // Should serialize to just the kind discriminator.
+        assert_eq!(json, r#"{"kind":"deep_research"}"#);
+    }
+
+    #[test]
+    fn result_summary_extra_fields_are_flattened() {
+        let mut extra = BTreeMap::new();
+        extra.insert(
+            "rounds".to_string(),
+            Value::Number(serde_json::Number::from(3)),
+        );
+        let s = ResultSummary {
+            kind: "deep_research".to_string(),
+            headline: "x".to_string(),
+            confidence: None,
+            sources: vec![],
+            extra,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains(r#""rounds":3"#));
+        // Round-trip preserves the extra field.
+        let back: ResultSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.extra.get("rounds"), Some(&Value::from(3)));
+    }
+
+    #[test]
+    fn cost_event_clamps_optional_usd() {
+        let line = r#"{"type":"cost","provider":"x","tokens_in":1,"tokens_out":2}"#;
+        match parse_event_line(line) {
+            LineParse::Event(ProtocolV2Event::Cost(c)) => {
+                assert!(c.usd.is_none());
+            }
+            other => panic!("expected cost, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn very_long_legacy_line_is_returned_as_is() {
+        let big = "x".repeat(10_000);
+        match parse_event_line(&big) {
+            LineParse::Legacy(s) => assert_eq!(s, big),
+            other => panic!("expected legacy, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stage_constants_are_lowercase_snake_case() {
+        for s in [
+            stage::INIT,
+            stage::SEARCHING,
+            stage::FETCHING,
+            stage::SYNTHESIZING,
+            stage::COMPLETE,
+        ] {
+            assert!(
+                s.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "stage '{s}' must be lowercase snake_case"
+            );
+        }
+    }
+
+    #[test]
+    fn emit_progress_writes_one_line() {
+        // Just verify the convenience helper compiles and doesn't panic;
+        // capturing real stderr in unit tests is fragile.
+        emit_progress("init", "go", Some(0.0));
+        emit_progress("complete", "done", Some(1.0));
+    }
+
+    #[test]
+    fn emit_cost_writes_one_line() {
+        emit_cost("openai", Some("gpt-4o-mini"), 100, 50, Some(0.001));
+        emit_cost("local", None, 0, 0, None);
+    }
+}

--- a/crates/octos-plugin/src/protocol_v2.rs
+++ b/crates/octos-plugin/src/protocol_v2.rs
@@ -314,7 +314,13 @@ pub fn emit_progress(stage: &str, message: &str, progress: Option<f64>) {
 }
 
 /// Convenience helper for `cost` events.
-pub fn emit_cost(provider: &str, model: Option<&str>, tokens_in: u32, tokens_out: u32, usd: Option<f64>) {
+pub fn emit_cost(
+    provider: &str,
+    model: Option<&str>,
+    tokens_in: u32,
+    tokens_out: u32,
+    usd: Option<f64>,
+) {
     let event = ProtocolV2Event::Cost(CostEvent {
         provider: provider.to_string(),
         model: model.map(String::from),
@@ -332,7 +338,8 @@ mod tests {
 
     #[test]
     fn parse_progress_event_extracts_fields() {
-        let line = r#"{"type":"progress","stage":"searching","message":"round 1/3","progress":0.25}"#;
+        let line =
+            r#"{"type":"progress","stage":"searching","message":"round 1/3","progress":0.25}"#;
         match parse_event_line(line) {
             LineParse::Event(ProtocolV2Event::Progress(p)) => {
                 assert_eq!(p.stage, "searching");
@@ -386,7 +393,8 @@ mod tests {
 
     #[test]
     fn parse_artifact_event() {
-        let line = r#"{"type":"artifact","path":"/tmp/r/_report.md","kind":"report","message":"final"}"#;
+        let line =
+            r#"{"type":"artifact","path":"/tmp/r/_report.md","kind":"report","message":"final"}"#;
         match parse_event_line(line) {
             LineParse::Event(ProtocolV2Event::Artifact(a)) => {
                 assert_eq!(a.path, "/tmp/r/_report.md");

--- a/e2e/tests/live-deep-search-quality.spec.ts
+++ b/e2e/tests/live-deep-search-quality.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * Live deep_search quality gate (W3.C1).
+ *
+ * Validates on a real canary that the user-facing report delivered after
+ * a deep research run is a synthesized, multi-paragraph document with
+ * source citations — NOT a raw Bing/Brave dump.
+ *
+ * Usage:
+ *
+ *   OCTOS_TEST_URL=https://dspfac.bot.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   OCTOS_TEST_EMAIL=dspfac@gmail.com \
+ *   npx playwright test tests/live-deep-search-quality.spec.ts
+ *
+ * What this test asserts:
+ *   1. Submit a deep_research-triggering prompt and wait for the assistant
+ *      to deliver a `_report.md` link or attach the file inline.
+ *   2. Fetch the delivered report content via the chat thread (rendered
+ *      markdown) or directly via the file API.
+ *   3. The report MUST contain a `## Synthesis` section with at least 2
+ *      paragraphs of prose (verified via paragraph break count).
+ *   4. The report MUST contain at least 3 `[N]` citation markers, and
+ *      every citation must resolve to a `### Source [N]:` entry in the
+ *      Sources section.
+ *   5. The report MUST NOT be a verbatim raw search dump (no large
+ *      contiguous numbered list of "Title\n   url\n   snippet" triples
+ *      as the only content).
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+
+const QUALITY_PROMPT =
+  process.env.OCTOS_DEEP_SEARCH_QUERY ||
+  'Do a deep research on the latest developments in Rust async runtimes in 2026. Run the deep_search pipeline directly.';
+
+const PER_RUN_TIMEOUT_MS = 12 * 60 * 1000;
+const POLL_INTERVAL_MS = 4_000;
+
+test.describe('W3.C1 deep_search quality gate', () => {
+  test.setTimeout(PER_RUN_TIMEOUT_MS + 60_000);
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await createNewSession(page);
+  });
+
+  test('delivered report is synthesized prose with [N] citations', async ({
+    page,
+  }) => {
+    await getInput(page).fill(QUALITY_PROMPT);
+    await getSendButton(page).click();
+
+    const reportText = await waitForReportContent(page, PER_RUN_TIMEOUT_MS);
+    expect(reportText.length).toBeGreaterThan(500);
+
+    // Structural assertions.
+    expect(
+      hasSynthesisSection(reportText),
+      `expected '## Synthesis' or italic headline section. report head: ${reportText.slice(0, 400)}`,
+    ).toBe(true);
+
+    const paragraphs = paragraphCount(reportText);
+    expect(
+      paragraphs,
+      `expected at least 2 paragraphs of synthesis prose, got ${paragraphs}. ` +
+        `report head: ${reportText.slice(0, 400)}`,
+    ).toBeGreaterThanOrEqual(2);
+
+    const citations = extractCitationIndexes(reportText);
+    expect(
+      citations.size,
+      `expected at least 3 unique [N] citations, got ${citations.size}.`,
+    ).toBeGreaterThanOrEqual(3);
+
+    // Each citation must have a corresponding `### Source [N]:` header.
+    const sourceIndexes = extractSourceIndexes(reportText);
+    for (const idx of citations) {
+      expect(
+        sourceIndexes.has(idx),
+        `citation [${idx}] does not match any '### Source [${idx}]:' entry. ` +
+          `sources: ${[...sourceIndexes].join(',')}`,
+      ).toBe(true);
+    }
+
+    // Negative check: the report MUST NOT be only the raw dump. Heuristic:
+    // if 80%+ of non-sources content is "n. Title\n   URL\n   snippet" the
+    // synthesis didn't run.
+    expect(
+      isLikelyRawDump(reportText),
+      `report looks like a raw search dump rather than synthesized prose:\n` +
+        reportText.slice(0, 600),
+    ).toBe(false);
+  });
+});
+
+/**
+ * Wait for the assistant to deliver a deep_search report. We try two
+ * extraction paths in priority order:
+ *
+ * 1. Chat thread contains a markdown rendering of the report. Look for
+ *    the canonical `# Deep Research:` H1 plus an attached or linked
+ *    `_report.md` reference.
+ * 2. Latest assistant message contains a fenced markdown block we can
+ *    inspect verbatim.
+ */
+async function waitForReportContent(page: Page, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    // Look at the rendered chat thread text for the report content.
+    const threadText = await page.evaluate(() => {
+      const root = document.querySelector('[data-testid="chat-thread"]');
+      return root?.textContent ?? '';
+    });
+    if (threadText.includes('# Deep Research:') || threadText.includes('## Synthesis')) {
+      return threadText;
+    }
+
+    // Also probe assistant message containers individually so we don't
+    // miss the report when it's wrapped in a code block.
+    const lastAssistant = await page.evaluate((sel) => {
+      const nodes = Array.from(
+        document.querySelectorAll(sel),
+      ) as HTMLElement[];
+      const last = nodes.length ? nodes[nodes.length - 1] : null;
+      return last?.textContent ?? '';
+    }, SEL.assistantBubble || '[data-role="assistant"]');
+    if (
+      lastAssistant.includes('## Synthesis') ||
+      lastAssistant.includes('# Deep Research:')
+    ) {
+      return lastAssistant;
+    }
+
+    await page.waitForTimeout(POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out after ${(timeoutMs / 1000).toFixed(0)}s waiting for deep_search report content`,
+  );
+}
+
+function hasSynthesisSection(text: string): boolean {
+  // Either an explicit "## Synthesis" heading OR a "# Deep Research" with
+  // an italicized headline + multi-paragraph body. Tolerant: the LLM may
+  // misformat the section name.
+  if (text.includes('## Synthesis')) return true;
+  // The fallback `## Overview\n\n_LLM synthesis unavailable_` would FAIL
+  // this check intentionally — that path means C1 didn't run.
+  return false;
+}
+
+function paragraphCount(text: string): number {
+  // Count blank-line-separated paragraph blocks within the synthesis
+  // section. We anchor on '## Synthesis' to avoid counting source-listing
+  // paragraphs.
+  const start = text.indexOf('## Synthesis');
+  if (start < 0) return 0;
+  const end = text.indexOf('## Sources', start);
+  const slice = end > 0 ? text.slice(start, end) : text.slice(start);
+  // Drop the heading line itself.
+  const body = slice.replace(/^##\s+Synthesis\s*\n/, '');
+  return body
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 30) // ignore headlines, italics, single-word lines
+    .length;
+}
+
+function extractCitationIndexes(text: string): Set<number> {
+  const out = new Set<number>();
+  // Only count citations within the synthesis section, not the source
+  // listing (where `[N]` appears as part of `### Source [N]:`).
+  const start = text.indexOf('## Synthesis');
+  const end = text.indexOf('## Sources');
+  if (start < 0) return out;
+  const slice = end > 0 ? text.slice(start, end) : text.slice(start);
+  // Match `[N]` where N is 1-3 digits, NOT inside `### Source [...]`.
+  const matches = slice.matchAll(/\[(\d{1,3})\]/g);
+  for (const m of matches) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n >= 1) {
+      out.add(n);
+    }
+  }
+  return out;
+}
+
+function extractSourceIndexes(text: string): Set<number> {
+  const out = new Set<number>();
+  const matches = text.matchAll(/###\s+Source\s+\[(\d{1,3})\]/g);
+  for (const m of matches) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n >= 1) {
+      out.add(n);
+    }
+  }
+  return out;
+}
+
+/**
+ * Heuristic: if 4+ consecutive lines match the v1 raw search dump pattern
+ * (`n. Title\n   URL\n   snippet`) and there is NO `## Synthesis` section,
+ * we conclude the LLM synthesis path didn't run.
+ */
+function isLikelyRawDump(text: string): boolean {
+  if (hasSynthesisSection(text)) return false;
+  const lines = text.split('\n');
+  let consecutive = 0;
+  let maxConsecutive = 0;
+  const numberedLine = /^\s*\d+\.\s+\S/;
+  for (const line of lines) {
+    if (numberedLine.test(line)) {
+      consecutive += 1;
+      maxConsecutive = Math.max(maxConsecutive, consecutive);
+    } else if (line.trim().length === 0) {
+      // blank line is fine, doesn't reset
+    } else {
+      consecutive = 0;
+    }
+  }
+  return maxConsecutive >= 4;
+}


### PR DESCRIPTION
## Summary

Track 3 of the M8 Runtime Parity epic (#591). Owns the plugin
protocol v2 spec + the highest-user-impact item: deep_search output
curation. Branched from \`main@3d01c3eb\` per #594.

### What ships

**F1+F2 — Plugin protocol v2 (lands first to unblock W4)**
- New \`crates/octos-plugin/src/protocol_v2.rs\` with typed wire schema for
  structured stderr events (progress / cost / phase / artifact / log)
  and an enriched stdout result envelope (summary / cost / files_to_send).
- New \`crates/octos-plugin/docs/protocol-v2.md\` spec doc covering the
  cancel-signal contract (SIGTERM, 10s grace, then SIGKILL).
- Backward-compat shim in \`crates/octos-agent/src/plugins/tool.rs\`:
  parses each stderr line through the v2 parser, falls back to legacy
  v1 text-line dispatch on any parse failure. Cost events also write
  a structured cost_attribution payload to the harness sink so the
  existing ledger ingests plugin spend without a schema migration.

**C1 — deep_search synthesis (the user-visible win)**
- \`deep_search\` now hands its raw search/crawl corpus to an internal
  LLM (auto-detected from DeepSeek/Kimi/DashScope/OpenAI/Gemini/Anthropic
  API keys, with \`DEEP_SEARCH_SYNTHESIS_MODEL\` override) and emits a
  multi-paragraph cited \`## Synthesis\` section as the body of
  \`_report.md\`. Falls back to the v1 raw-overview report when no key
  is configured (offline-friendly).
- Per-call USD projection and headline/confidence parsing.
- Sample synthesized fixture committed under \`tests/fixtures/\`.

**C2/C3/C4 — deep_search v2 adoption + cancel + cost**
- Stage labels (searching/fetching/synthesizing/building_report/complete)
  emitted as v2 progress events alongside the legacy text path.
- \`emit_v2_cost\` fires after the synthesis call with provider/model/
  tokens_in/tokens_out/usd.
- SIGTERM handler exits 130 inside the host's 10s budget.

**D1+D2 — deep_crawl cancel + browser cap + v2**
- SIGTERM handler tracks Chrome's pid and kills it directly so chromium
  zombies don't outlive the plugin.
- BFS loop polls a cancel atomic so the host's SIGTERM stops new pages.
- Global tokio Semaphore in deep-search caps concurrent chromiums to
  3 (was 6+); operator override via \`DEEP_SEARCH_MAX_BROWSERS\`.
- v2 progress events at init/crawling/cleanup/complete.

### Test plan

- [x] \`cargo build --workspace\` ✅
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` ✅
- [x] \`cargo test -p octos-plugin\` (57 lib + 10 integration + 2 doctests) ✅
- [x] \`cargo test -p deep-search\` (31 tests, includes 14 new for synthesis/citations/USD) ✅
- [x] \`cargo test -p deep-crawl\` (11 tests, all new for cancel/cleanup/v2) ✅
- [x] \`cargo test -p octos-agent --lib plugins::tool\` (32 tests, +11 new dispatcher tests) ✅
- [ ] \`e2e/tests/live-deep-search-quality.spec.ts\` against \`dspfac.bot.ominix.io\` — needs canary deploy
- [ ] Cancel test: spawn deep_search → SIGTERM → exits within 12s; \`pgrep -f deep-crawl-\` returns empty after exit (manual QA against fleet)
- [ ] Resource test: deep_crawl max 3 concurrent Chromium processes (manual QA via top/htop during run)

Pre-existing test failure on the W3 baseline: \`tools::send_file::tests::test_base_dir_blocks_non_tmp_outside_path\` — unrelated to this PR (fails on the parent commit too).

### Coordination

- F1+F2 frozen and landed: W4 plugin v2 adopters (mofa_slides, podcast_generate, fm_tts) can begin their work now. The wire format is documented at \`crates/octos-plugin/docs/protocol-v2.md\`. Plugins emit JSON-per-line on stderr for structured events; the host does NOT require a v2 cutover (legacy text lines stay on the existing v1 path).
- This PR is self-merge per the PRD's per-track rollout plan, but I'm leaving it open for review first.

Refs #591, #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)