### PR TITLE
M8 Runtime Parity W2: spawn host + cancel/restart APIs + workflows + frontend (#593)

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -123,9 +123,9 @@ pub use subagent_summary::{
 };
 pub use summarizer::{ExtractiveSummarizer, Summarizer};
 pub use task_supervisor::{
-    ArtifactMimeClass, BackgroundTask, SpawnOnlyFailureSignal, TaskLifecycleState,
-    TaskRuntimeState, TaskStatus, TaskSupervisor, parse_alternatives,
-    validate_spawn_only_artifacts,
+    ArtifactMimeClass, BackgroundTask, RelaunchOpts, RelaunchRequest, SpawnOnlyFailureSignal,
+    TaskCancelError, TaskCancelToken, TaskLifecycleState, TaskRelaunchError, TaskRuntimeState,
+    TaskStatus, TaskSupervisor, parse_alternatives, validate_spawn_only_artifacts,
 };
 pub use tools::{
     ActivateToolsTool, BackgroundResultKind, BackgroundResultPayload, BrowserTool,

--- a/crates/octos-agent/src/mcp_server.rs
+++ b/crates/octos-agent/src/mcp_server.rs
@@ -506,6 +506,7 @@ fn lifecycle_label(state: TaskLifecycleState) -> &'static str {
         TaskLifecycleState::Verifying => "verifying",
         TaskLifecycleState::Ready => "ready",
         TaskLifecycleState::Failed => "failed",
+        TaskLifecycleState::Cancelled => "cancelled",
     }
 }
 
@@ -589,6 +590,11 @@ impl SessionLifecycleObserver for SupervisorObserver<'_> {
             }
             TaskLifecycleState::Failed => {
                 // Same reasoning as Ready — finalization happens outside.
+            }
+            TaskLifecycleState::Cancelled => {
+                // Cancellation is driven by the supervisor's `cancel`
+                // primitive; the observer just acknowledges that the
+                // outer caller already moved the task into Cancelled.
             }
         }
     }

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
@@ -33,11 +34,24 @@ pub enum TaskStatus {
     Running,
     Completed,
     Failed,
+    /// M7.9 / W2: task was cancelled mid-flight via the supervisor's
+    /// `cancel()` primitive (e.g. `POST /api/tasks/{id}/cancel`).
+    /// Terminal — `is_active()` returns false. Distinguished from
+    /// `Failed` so dashboards can surface "user cancelled" instead of
+    /// "the task crashed".
+    Cancelled,
 }
 
 impl TaskStatus {
     pub fn is_active(&self) -> bool {
         matches!(self, Self::Spawned | Self::Running)
+    }
+
+    /// Whether this status is a terminal (non-recoverable, non-running)
+    /// state. Used by the API layer to reject `cancel`/`restart` against
+    /// already-terminal tasks with a `409 Conflict` response.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
     }
 
     pub fn as_str(&self) -> &'static str {
@@ -46,6 +60,7 @@ impl TaskStatus {
             Self::Running => "running",
             Self::Completed => "completed",
             Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
         }
     }
 }
@@ -92,6 +107,9 @@ pub enum TaskRuntimeState {
     CleaningUp,
     Completed,
     Failed,
+    /// M7.9 / W2: runtime state for tasks cancelled via the supervisor's
+    /// `cancel()` primitive. Surfaced via `mark_cancelled`.
+    Cancelled,
 }
 
 /// Stable externally-facing lifecycle state for background tasks.
@@ -107,6 +125,8 @@ pub enum TaskLifecycleState {
     Verifying,
     Ready,
     Failed,
+    /// M7.9 / W2: stable cancelled lifecycle for UI / API dashboards.
+    Cancelled,
 }
 
 /// A tracked background task spawned by a spawn_only tool.
@@ -155,6 +175,7 @@ impl BackgroundTask {
             TaskStatus::Spawned => TaskLifecycleState::Queued,
             TaskStatus::Completed => TaskLifecycleState::Ready,
             TaskStatus::Failed => TaskLifecycleState::Failed,
+            TaskStatus::Cancelled => TaskLifecycleState::Cancelled,
             TaskStatus::Running => match self.runtime_state {
                 TaskRuntimeState::Spawned | TaskRuntimeState::ExecutingTool => {
                     TaskLifecycleState::Running
@@ -165,6 +186,7 @@ impl BackgroundTask {
                 | TaskRuntimeState::CleaningUp
                 | TaskRuntimeState::Completed => TaskLifecycleState::Verifying,
                 TaskRuntimeState::Failed => TaskLifecycleState::Failed,
+                TaskRuntimeState::Cancelled => TaskLifecycleState::Cancelled,
             },
         }
     }
@@ -200,6 +222,150 @@ pub struct SpawnOnlyFailureSignal {
 /// signal payload so consumers can build a recovery prompt without re-parsing
 /// the raw `BackgroundTask`.
 type OnFailureCallback = Box<dyn Fn(&SpawnOnlyFailureSignal) + Send + Sync>;
+
+/// Options for `TaskSupervisor::relaunch`. Mirrors the
+/// `POST /api/tasks/{id}/restart-from-node` request body.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RelaunchOpts {
+    /// When set, the supervisor relaunches starting at this DOT-graph node id
+    /// (so upstream cached outputs are reused). When `None` the relaunch
+    /// re-runs the entire task from scratch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_node: Option<String>,
+}
+
+/// Payload emitted to the relaunch callback when a caller invokes
+/// `TaskSupervisor::relaunch`. The callback owns turning this into a
+/// concrete tokio task that re-executes the work; the supervisor only
+/// stores a forwarding pointer (`relaunched_from`) on the original task.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelaunchRequest {
+    /// Identifier of the task being relaunched. Always `task.id`.
+    pub original_task_id: String,
+    /// Identifier the supervisor pre-allocated for the relaunched task.
+    /// Already registered on the supervisor in the `Spawned` state so the
+    /// callback can `mark_running` immediately.
+    pub new_task_id: String,
+    pub tool_name: String,
+    pub tool_call_id: String,
+    pub parent_session_key: Option<String>,
+    pub session_key: Option<String>,
+    pub tool_input: Value,
+    pub opts: RelaunchOpts,
+}
+
+/// Callback invoked when a caller asks the supervisor to relaunch a task.
+type OnRelaunchCallback = Box<dyn Fn(&RelaunchRequest) + Send + Sync>;
+
+/// Error variants for [`TaskSupervisor::cancel`]. Mapped to HTTP status
+/// codes by the API layer:
+/// - `NotFound` → `404`
+/// - `AlreadyTerminal` → `409`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskCancelError {
+    NotFound,
+    AlreadyTerminal,
+}
+
+impl std::fmt::Display for TaskCancelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "task not found"),
+            Self::AlreadyTerminal => write!(f, "task is already in a terminal state"),
+        }
+    }
+}
+
+impl std::error::Error for TaskCancelError {}
+
+/// Error variants for [`TaskSupervisor::relaunch`]. Mapped to HTTP status
+/// codes by the API layer:
+/// - `NotFound` → `404`
+/// - `StillActive` → `409`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskRelaunchError {
+    NotFound,
+    StillActive,
+}
+
+impl std::fmt::Display for TaskRelaunchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "task not found"),
+            Self::StillActive => {
+                write!(f, "task is still active; cancel it before relaunching")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TaskRelaunchError {}
+
+/// Per-task cancel token map. Each entry pairs an `AtomicBool` (loop-poll
+/// flag) and an optional `tokio::sync::Notify` so cooperatively cancelable
+/// futures (e.g. `select!` on a long-running pipeline) can race against
+/// `cancelled.notified()` instead of polling.
+#[derive(Default)]
+struct CancelTokenStore {
+    tokens: Mutex<HashMap<String, Arc<TaskCancelToken>>>,
+}
+
+impl CancelTokenStore {
+    fn ensure(&self, task_id: &str) -> Arc<TaskCancelToken> {
+        let mut guard = self.tokens.lock().unwrap_or_else(|e| e.into_inner());
+        guard
+            .entry(task_id.to_string())
+            .or_insert_with(|| Arc::new(TaskCancelToken::new()))
+            .clone()
+    }
+}
+
+/// Per-task cancel token. Workers poll `is_cancelled()` at safe points and
+/// long-running futures can `select!` on `notified()` to short-circuit
+/// pending I/O.
+pub struct TaskCancelToken {
+    cancelled: AtomicBool,
+    notify: tokio::sync::Notify,
+}
+
+impl TaskCancelToken {
+    fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Whether the token has been triggered. Safe-point poll for in-loop
+    /// pipeline workers.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    /// Trigger cancellation. Idempotent — a second call is a no-op.
+    pub fn cancel(&self) {
+        if !self.cancelled.swap(true, Ordering::AcqRel) {
+            self.notify.notify_waiters();
+        }
+    }
+
+    /// Wait for the token to fire. Useful for `select!` against a
+    /// long-running future.
+    pub async fn cancelled(&self) {
+        if self.is_cancelled() {
+            return;
+        }
+        self.notify.notified().await;
+    }
+}
+
+impl std::fmt::Debug for TaskCancelToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskCancelToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish()
+    }
+}
 
 /// Extract a list of alternatives from a tool error message using the simple
 /// `available: X, Y, Z` pattern. Returns an empty vector when no match is
@@ -638,6 +804,7 @@ impl std::fmt::Debug for TaskSupervisor {
             .field("tasks", &self.tasks)
             .field("on_change", &"<callback>")
             .field("on_failure", &"<callback>")
+            .field("on_relaunch", &"<callback>")
             .field("progress_reporter", &progress_reporter_attached)
             .field(
                 "persistence_path",
@@ -666,6 +833,7 @@ fn runtime_state_label(state: &TaskRuntimeState) -> &'static str {
         TaskRuntimeState::CleaningUp => "cleaning up",
         TaskRuntimeState::Completed => "completed",
         TaskRuntimeState::Failed => "failed",
+        TaskRuntimeState::Cancelled => "cancelled",
     }
 }
 
@@ -677,6 +845,7 @@ pub struct TaskSupervisor {
     tasks: Arc<Mutex<HashMap<String, BackgroundTask>>>,
     on_change: Arc<Mutex<Option<OnChangeCallback>>>,
     on_failure: Arc<Mutex<Option<OnFailureCallback>>>,
+    on_relaunch: Arc<Mutex<Option<OnRelaunchCallback>>>,
     persistence_path: Arc<Mutex<Option<PathBuf>>>,
     /// Optional reporter that receives a [`ProgressEvent::ToolProgress`]
     /// for every supervised state transition. Wired by the agent's
@@ -689,6 +858,12 @@ pub struct TaskSupervisor {
     /// there is no double-emission to worry about for the normal tool
     /// path that already reports its own ToolStarted/ToolCompleted.
     progress_reporter: Arc<Mutex<Option<Arc<dyn ProgressReporter>>>>,
+    /// M7.9: per-task cancellation tokens. The `cancel(task_id)` primitive
+    /// flips the matching token so cooperative pipeline / spawn workers can
+    /// short-circuit at their next safe point. Tokens are created lazily on
+    /// `register*` and dropped on terminal transitions to keep memory usage
+    /// proportional to active tasks.
+    cancel_tokens: Arc<CancelTokenStore>,
 }
 
 impl Default for TaskSupervisor {
@@ -704,8 +879,10 @@ impl TaskSupervisor {
             tasks: Arc::new(Mutex::new(HashMap::new())),
             on_change: Arc::new(Mutex::new(None)),
             on_failure: Arc::new(Mutex::new(None)),
+            on_relaunch: Arc::new(Mutex::new(None)),
             persistence_path: Arc::new(Mutex::new(None)),
             progress_reporter: Arc::new(Mutex::new(None)),
+            cancel_tokens: Arc::new(CancelTokenStore::default()),
         }
     }
 
@@ -790,6 +967,129 @@ impl TaskSupervisor {
         *guard = Some(reporter);
     }
 
+    /// Wire a callback that fires when [`Self::relaunch`] is invoked. The
+    /// callback is responsible for spawning the actual replacement task —
+    /// the supervisor only pre-allocates a fresh task id and fires the
+    /// signal so the owning runtime (session actor / pipeline executor)
+    /// can rebuild context.
+    pub fn set_on_relaunch(&self, cb: impl Fn(&RelaunchRequest) + Send + Sync + 'static) {
+        let mut guard = self.on_relaunch.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = Some(Box::new(cb));
+    }
+
+    /// Acquire (or create) the cancel token for `task_id`. Workers should
+    /// call this once at the top of their critical section and then poll
+    /// `is_cancelled()` at safe points. Returns a freshly allocated token
+    /// for unknown task ids — callers that want strict membership checks
+    /// should use `get_task` first.
+    pub fn cancel_token(&self, task_id: &str) -> Arc<TaskCancelToken> {
+        self.cancel_tokens.ensure(task_id)
+    }
+
+    /// Cancel a tracked task. Sets the per-task cancellation token (so
+    /// in-loop workers can short-circuit at the next safe point) and
+    /// transitions the supervisor record to `Cancelled`. Returns:
+    ///
+    /// - `Ok(())` when the task was running/queued and has now been
+    ///   marked `Cancelled`.
+    /// - `Err(TaskCancelError::NotFound)` when no task with that id is
+    ///   tracked. Maps to `404` at the API edge.
+    /// - `Err(TaskCancelError::AlreadyTerminal)` when the task is
+    ///   already in a terminal state (`Completed` / `Failed` /
+    ///   `Cancelled`). Maps to `409` at the API edge.
+    pub fn cancel(&self, task_id: &str) -> Result<(), TaskCancelError> {
+        let snapshot = {
+            let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+            let task = tasks
+                .get_mut(task_id)
+                .ok_or(TaskCancelError::NotFound)?;
+            if task.status.is_terminal() {
+                return Err(TaskCancelError::AlreadyTerminal);
+            }
+            task.status = TaskStatus::Cancelled;
+            task.runtime_state = TaskRuntimeState::Cancelled;
+            task.updated_at = Utc::now();
+            task.completed_at = Some(Utc::now());
+            if task.error.is_none() {
+                task.error = Some("cancelled by supervisor".to_string());
+            }
+            task.clone()
+        };
+
+        // Trigger the cancel token AFTER the task has been marked
+        // cancelled so any waiter that wakes can re-read the supervisor
+        // and see the terminal state.
+        let token = self.cancel_tokens.ensure(task_id);
+        token.cancel();
+
+        self.persist_snapshot(&snapshot);
+        self.notify_change(&snapshot);
+        self.emit_progress_for_state(&snapshot);
+        Ok(())
+    }
+
+    /// Relaunch a tracked task with the supplied options. Returns the
+    /// freshly allocated `new_task_id` on success.
+    ///
+    /// The supervisor pre-registers the new task in the `Spawned` state
+    /// (mirroring the original task's tool name / call id / session
+    /// metadata) and fires `set_on_relaunch` so the runtime can drive the
+    /// actual re-execution. When no relaunch callback is wired the call
+    /// still succeeds — the new task id is returned so callers can
+    /// observe the placeholder in dashboards even when the runtime
+    /// owner has not subscribed yet.
+    pub fn relaunch(
+        &self,
+        task_id: &str,
+        opts: RelaunchOpts,
+    ) -> Result<String, TaskRelaunchError> {
+        let original = {
+            let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+            tasks
+                .get(task_id)
+                .cloned()
+                .ok_or(TaskRelaunchError::NotFound)?
+        };
+        if matches!(original.status, TaskStatus::Running | TaskStatus::Spawned) {
+            return Err(TaskRelaunchError::StillActive);
+        }
+
+        // Pre-allocate a successor task id and seed it on the supervisor
+        // so dashboards see the relaunch as a peer of the original task.
+        let new_task_id = self.register_with_input(
+            &original.tool_name,
+            &original.tool_call_id,
+            original.session_key.as_deref(),
+            original.tool_input.clone(),
+        );
+
+        // Stamp the lineage on the new task: callers can use
+        // `runtime_detail` to surface the relaunch-from edge.
+        let detail = serde_json::json!({
+            "relaunched_from": task_id,
+            "from_node": opts.from_node,
+        })
+        .to_string();
+        self.mark_runtime_state(&new_task_id, TaskRuntimeState::Spawned, Some(detail));
+
+        let request = RelaunchRequest {
+            original_task_id: task_id.to_string(),
+            new_task_id: new_task_id.clone(),
+            tool_name: original.tool_name.clone(),
+            tool_call_id: original.tool_call_id.clone(),
+            parent_session_key: original.parent_session_key.clone(),
+            session_key: original.session_key.clone(),
+            tool_input: original.tool_input.clone().unwrap_or(Value::Null),
+            opts,
+        };
+
+        let guard = self.on_relaunch.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(ref cb) = *guard {
+            cb(&request);
+        }
+        Ok(new_task_id)
+    }
+
     /// Emit a [`ProgressEvent::ToolProgress`] for `task` if a reporter has
     /// been wired via [`Self::set_progress_reporter`]. The message is
     /// `"<tool_name>: <state-label>"`, with the task's `error` text appended
@@ -806,7 +1106,7 @@ impl TaskSupervisor {
         drop(guard);
         let label = runtime_state_label(&task.runtime_state);
         let message = match task.runtime_state {
-            TaskRuntimeState::Failed => match task.error.as_deref() {
+            TaskRuntimeState::Failed | TaskRuntimeState::Cancelled => match task.error.as_deref() {
                 Some(reason) if !reason.is_empty() => {
                     format!("{}: {} ({})", task.tool_name, label, reason)
                 }
@@ -2531,5 +2831,152 @@ mod tests {
             1,
             "expected exactly one failure ToolProgress, got: {failures:?}"
         );
+    }
+
+    // ────────── M7.9 cancel / relaunch primitives (W2) ──────────
+
+    #[test]
+    fn cancel_running_task_transitions_to_cancelled_and_fires_token() {
+        let supervisor = TaskSupervisor::new();
+        let task_id = supervisor.register("run_pipeline", "call-cancel-1", Some("session-A"));
+        supervisor.mark_running(&task_id);
+        let token = supervisor.cancel_token(&task_id);
+        assert!(!token.is_cancelled());
+
+        supervisor.cancel(&task_id).expect("cancel should succeed");
+
+        let task = supervisor.get_task(&task_id).expect("task still tracked");
+        assert_eq!(task.status, TaskStatus::Cancelled);
+        assert_eq!(task.runtime_state, TaskRuntimeState::Cancelled);
+        assert_eq!(task.lifecycle_state(), TaskLifecycleState::Cancelled);
+        assert!(token.is_cancelled());
+        assert!(task.completed_at.is_some());
+    }
+
+    #[test]
+    fn cancel_unknown_task_returns_not_found() {
+        let supervisor = TaskSupervisor::new();
+        let result = supervisor.cancel("does-not-exist");
+        assert_eq!(result, Err(TaskCancelError::NotFound));
+    }
+
+    #[test]
+    fn cancel_terminal_task_returns_already_terminal() {
+        let supervisor = TaskSupervisor::new();
+        let task_id = supervisor.register("podcast_generate", "call-cancel-2", Some("session-B"));
+        supervisor.mark_completed(&task_id, vec!["output/podcast.mp3".into()]);
+        let result = supervisor.cancel(&task_id);
+        assert_eq!(result, Err(TaskCancelError::AlreadyTerminal));
+        // Cancelling a Failed task is also rejected.
+        let task_id2 = supervisor.register("fm_tts", "call-cancel-3", None);
+        supervisor.mark_failed(&task_id2, "boom".to_string());
+        assert_eq!(
+            supervisor.cancel(&task_id2),
+            Err(TaskCancelError::AlreadyTerminal)
+        );
+    }
+
+    #[test]
+    fn cancel_emits_progress_event() {
+        let supervisor = TaskSupervisor::new();
+        let events = collect_progress_events(&supervisor);
+        let task_id = supervisor.register("run_pipeline", "call-cancel-4", Some("session-C"));
+        supervisor.mark_running(&task_id);
+        supervisor.cancel(&task_id).expect("cancel should succeed");
+
+        let captured = events.lock().unwrap().clone();
+        let tool_progress = extract_tool_progress(&captured);
+        let cancels: Vec<_> = tool_progress
+            .iter()
+            .filter(|(_, _, message)| message.contains("cancelled"))
+            .collect();
+        assert!(
+            !cancels.is_empty(),
+            "expected at least one cancelled ToolProgress, got: {tool_progress:?}"
+        );
+    }
+
+    #[test]
+    fn relaunch_failed_task_creates_successor_and_fires_callback() {
+        use std::sync::Mutex;
+        let supervisor = TaskSupervisor::new();
+        let captured: Arc<Mutex<Vec<RelaunchRequest>>> = Arc::new(Mutex::new(Vec::new()));
+        {
+            let captured = captured.clone();
+            supervisor.set_on_relaunch(move |req| {
+                captured.lock().unwrap().push(req.clone());
+            });
+        }
+
+        let task_id =
+            supervisor.register("run_pipeline", "call-relaunch-1", Some("session-D"));
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(&task_id, "node 'design' failed".to_string());
+
+        let new_id = supervisor
+            .relaunch(
+                &task_id,
+                RelaunchOpts {
+                    from_node: Some("design".into()),
+                },
+            )
+            .expect("relaunch should succeed");
+        assert_ne!(new_id, task_id, "relaunch must allocate a fresh id");
+
+        let new_task = supervisor.get_task(&new_id).expect("successor registered");
+        assert_eq!(new_task.tool_name, "run_pipeline");
+        assert_eq!(new_task.tool_call_id, "call-relaunch-1");
+        assert_eq!(new_task.session_key.as_deref(), Some("session-D"));
+
+        let log = captured.lock().unwrap();
+        assert_eq!(log.len(), 1, "relaunch callback fired exactly once");
+        assert_eq!(log[0].original_task_id, task_id);
+        assert_eq!(log[0].new_task_id, new_id);
+        assert_eq!(log[0].opts.from_node.as_deref(), Some("design"));
+    }
+
+    #[test]
+    fn relaunch_unknown_task_returns_not_found() {
+        let supervisor = TaskSupervisor::new();
+        let result = supervisor.relaunch("does-not-exist", RelaunchOpts::default());
+        assert_eq!(result, Err(TaskRelaunchError::NotFound));
+    }
+
+    #[test]
+    fn relaunch_active_task_returns_still_active() {
+        let supervisor = TaskSupervisor::new();
+        let task_id = supervisor.register("run_pipeline", "call-relaunch-2", None);
+        supervisor.mark_running(&task_id);
+        let result = supervisor.relaunch(&task_id, RelaunchOpts::default());
+        assert_eq!(result, Err(TaskRelaunchError::StillActive));
+    }
+
+    #[test]
+    fn cancel_token_notifies_waiters() {
+        let supervisor = TaskSupervisor::new();
+        let task_id = supervisor.register("run_pipeline", "call-cancel-notify", None);
+        supervisor.mark_running(&task_id);
+        let token = supervisor.cancel_token(&task_id);
+
+        // Drive a small async runtime so the token can fire its
+        // notification path (poll-then-wait).
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let waiter = {
+                let token = token.clone();
+                tokio::spawn(async move { token.cancelled().await })
+            };
+            // Yield so the waiter actually parks on `notified()`.
+            tokio::task::yield_now().await;
+            supervisor.cancel(&task_id).expect("cancel should succeed");
+            tokio::time::timeout(std::time::Duration::from_millis(500), waiter)
+                .await
+                .expect("waiter must wake within 500ms")
+                .expect("waiter task panicked");
+        });
+        assert!(token.is_cancelled());
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -25,6 +25,9 @@ use crate::workspace_git::{
     WorkspaceContractStatus, WorkspaceProjectKind,
     resolve_preferred_workspace_contract_artifact_path, resolve_workspace_contract_artifact_paths,
 };
+use crate::file_state_cache::FileStateCache;
+use crate::subagent_output::SubAgentOutputRouter;
+use crate::subagent_summary::AgentSummaryGenerator;
 use crate::{Agent, AgentConfig, HookContext, HookExecutor, HookPayload, HookResult};
 
 /// Default MCP tool name dispatched on the remote agent. Chosen to match
@@ -346,6 +349,18 @@ pub struct SpawnTool {
     /// When combined with a budget policy, the dispatcher rejects
     /// spawns whose projected spend breaches the ceiling.
     cost_accountant: Option<Arc<crate::cost_ledger::CostAccountant>>,
+    /// M8 Runtime Parity W2.B1: parent session's `FileStateCache` so
+    /// spawned child Agents short-circuit re-reads of unchanged files
+    /// the same way the parent does. `None` keeps pre-W2 behaviour.
+    parent_file_state_cache: Option<Arc<FileStateCache>>,
+    /// M8 Runtime Parity W2.B1: parent session's M8.7 output router so
+    /// the child Agent's spawn_only background tools route output
+    /// through the same on-disk log the dashboard tails.
+    parent_subagent_output_router: Option<Arc<SubAgentOutputRouter>>,
+    /// M8 Runtime Parity W2.B1: parent session's M8.7 summary generator
+    /// so the child can spawn periodic-summary watchers under the same
+    /// LLM/budget contract.
+    parent_subagent_summary_generator: Option<Arc<AgentSummaryGenerator>>,
 }
 
 impl SpawnTool {
@@ -379,6 +394,9 @@ impl SpawnTool {
             mcp_agent_backend: None,
             mcp_agent_tool_name: None,
             cost_accountant: None,
+            parent_file_state_cache: None,
+            parent_subagent_output_router: None,
+            parent_subagent_summary_generator: None,
         }
     }
 
@@ -415,6 +433,9 @@ impl SpawnTool {
             mcp_agent_backend: None,
             mcp_agent_tool_name: None,
             cost_accountant: None,
+            parent_file_state_cache: None,
+            parent_subagent_output_router: None,
+            parent_subagent_summary_generator: None,
         }
     }
 
@@ -536,6 +557,56 @@ impl SpawnTool {
     ) -> Self {
         self.cost_accountant = Some(accountant);
         self
+    }
+
+    /// M8 Runtime Parity W2.B1: inherit the parent session's
+    /// `FileStateCache` so spawned child Agents short-circuit re-reads
+    /// of unchanged files. Without this, every child re-reads the
+    /// entire workspace on every step.
+    pub fn with_parent_file_state_cache(mut self, cache: Arc<FileStateCache>) -> Self {
+        self.parent_file_state_cache = Some(cache);
+        self
+    }
+
+    /// M8 Runtime Parity W2.B1: inherit the parent's M8.7 output router
+    /// so the child Agent's spawn_only background branch routes output
+    /// through the same on-disk log the parent dashboard tails.
+    pub fn with_parent_subagent_output_router(
+        mut self,
+        router: Arc<SubAgentOutputRouter>,
+    ) -> Self {
+        self.parent_subagent_output_router = Some(router);
+        self
+    }
+
+    /// M8 Runtime Parity W2.B1: inherit the parent's M8.7 summary
+    /// generator so child agents can drive periodic-summary watchers
+    /// under the same LLM/budget contract.
+    pub fn with_parent_subagent_summary_generator(
+        mut self,
+        generator: Arc<AgentSummaryGenerator>,
+    ) -> Self {
+        self.parent_subagent_summary_generator = Some(generator);
+        self
+    }
+
+    /// M8 Runtime Parity W2.B1 introspection helper — used by tests
+    /// and the parity audit harness to assert that a SpawnTool was
+    /// fully wired with parent caches.
+    pub fn parent_file_state_cache(&self) -> Option<&Arc<FileStateCache>> {
+        self.parent_file_state_cache.as_ref()
+    }
+
+    /// M8 Runtime Parity W2.B1 introspection helper.
+    pub fn parent_subagent_output_router(&self) -> Option<&Arc<SubAgentOutputRouter>> {
+        self.parent_subagent_output_router.as_ref()
+    }
+
+    /// M8 Runtime Parity W2.B1 introspection helper.
+    pub fn parent_subagent_summary_generator(
+        &self,
+    ) -> Option<&Arc<AgentSummaryGenerator>> {
+        self.parent_subagent_summary_generator.as_ref()
     }
 
     /// Dispatch a task to the configured MCP-backed sub-agent. Public so
@@ -1903,6 +1974,21 @@ impl Tool for SpawnTool {
                 worker = worker.with_config(config.clone());
             }
 
+            // M8 Runtime Parity W2.B1: inherit parent caches so the child
+            // observes the same file_state_cache + subagent_output_router
+            // + subagent_summary_generator the session actor wired. This
+            // closes the gap where spawned subagents had `file_state_cache:
+            // None` and re-read the entire workspace on every step.
+            if let Some(ref cache) = self.parent_file_state_cache {
+                worker = worker.with_file_state_cache(cache.clone());
+            }
+            if let Some(ref router) = self.parent_subagent_output_router {
+                worker = worker.with_subagent_output_router(router.clone());
+            }
+            if let Some(ref summary_gen) = self.parent_subagent_summary_generator {
+                worker = worker.with_subagent_summary_generator(summary_gen.clone());
+            }
+
             // Review A F-004: propagate the parent's declarative compaction
             // policy onto the child Agent so the child honours the same token
             // budget and preserved-artifact contract the parent committed to.
@@ -2044,6 +2130,17 @@ impl Tool for SpawnTool {
             // background child task so the detached child inherits the same
             // compaction + validator contracts the sync spawn path honours.
             let child_workspace_policy = parent_workspace_policy.clone();
+            // M8 Runtime Parity W2.B1: capture parent caches into the
+            // detached background closure so the bg child Agent gets the
+            // same FileStateCache + Router + SummaryGenerator as the sync
+            // path. Without these the detached subagent silently runs
+            // without M8.4/M8.7 wiring even when the session actor
+            // configured everything.
+            let parent_file_state_cache = self.parent_file_state_cache.clone();
+            let parent_subagent_output_router =
+                self.parent_subagent_output_router.clone();
+            let parent_subagent_summary_generator =
+                self.parent_subagent_summary_generator.clone();
 
             tokio::spawn(async move {
                 if let (Some(supervisor), Some(task_id)) =
@@ -2154,6 +2251,19 @@ impl Tool for SpawnTool {
                 let mut effective_config = worker_config.clone().unwrap_or_default();
                 effective_config.suppress_auto_send_files = true;
                 worker = worker.with_config(effective_config);
+                // M8 Runtime Parity W2.B1: apply parent caches to the
+                // detached background child before it consumes any
+                // user-facing instruction. See `with_parent_file_state_cache`
+                // for the contract.
+                if let Some(ref cache) = parent_file_state_cache {
+                    worker = worker.with_file_state_cache(cache.clone());
+                }
+                if let Some(ref router) = parent_subagent_output_router {
+                    worker = worker.with_subagent_output_router(router.clone());
+                }
+                if let Some(ref summary_gen) = parent_subagent_summary_generator {
+                    worker = worker.with_subagent_summary_generator(summary_gen.clone());
+                }
                 if let Some(ref sink_path) = harness_event_sink_path {
                     worker = worker.with_harness_event_sink(sink_path.clone());
                 }
@@ -2753,6 +2863,9 @@ mod tests {
             mcp_agent_backend: None,
             mcp_agent_tool_name: None,
             cost_accountant: None,
+            parent_file_state_cache: None,
+            parent_subagent_output_router: None,
+            parent_subagent_summary_generator: None,
         };
 
         assert_eq!(tool.worker_count.load(Ordering::SeqCst), 0);
@@ -3980,5 +4093,77 @@ PY
 
         assert_eq!(input.allowed_tools, before.allowed_tools);
         assert_eq!(input.model, before.model);
+    }
+
+    // ────────── M8 Runtime Parity W2.B1 wiring tests ──────────
+
+    /// A SpawnTool built without explicit parent caches must keep the
+    /// pre-W2 default — `None` on every parent introspection helper —
+    /// so unrelated callers don't pay any cost from the new optional
+    /// fields.
+    #[tokio::test]
+    async fn spawn_tool_default_has_no_parent_caches() {
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        );
+        assert!(tool.parent_file_state_cache().is_none());
+        assert!(tool.parent_subagent_output_router().is_none());
+        assert!(tool.parent_subagent_summary_generator().is_none());
+    }
+
+    /// Once wired with parent caches the SpawnTool must surface the
+    /// same `Arc` instances back through its introspection helpers —
+    /// session_actor / tests rely on identity to assert the parent
+    /// cache reaches the spawned child.
+    #[tokio::test]
+    async fn spawn_tool_propagates_parent_caches_via_builders() {
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let cache = Arc::new(crate::FileStateCache::new());
+        let router = Arc::new(crate::SubAgentOutputRouter::new(
+            std::env::temp_dir().join(format!(
+                "octos-w2-router-{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0),
+            )),
+        ));
+        let supervisor = TaskSupervisor::new();
+        let summary_gen = Arc::new(crate::AgentSummaryGenerator::new(
+            Arc::new(MockProvider),
+            router.clone(),
+            supervisor,
+        ));
+
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        )
+        .with_parent_file_state_cache(cache.clone())
+        .with_parent_subagent_output_router(router.clone())
+        .with_parent_subagent_summary_generator(summary_gen.clone());
+
+        // `Arc::ptr_eq` is the cheapest identity check that proves the
+        // child observed the same instance the parent wired in — not a
+        // freshly-built one.
+        assert!(Arc::ptr_eq(
+            tool.parent_file_state_cache().expect("cache wired"),
+            &cache,
+        ));
+        assert!(Arc::ptr_eq(
+            tool.parent_subagent_output_router().expect("router wired"),
+            &router,
+        ));
+        assert!(Arc::ptr_eq(
+            tool.parent_subagent_summary_generator()
+                .expect("summary generator wired"),
+            &summary_gen,
+        ));
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -1019,6 +1019,84 @@ fn extract_inline_podcast_script(task_desc: &str) -> Option<String> {
     (script_lines.len() >= 2).then(|| script_lines.join("\n"))
 }
 
+/// M8 Runtime Parity W2.B2 — single-shot recovery wrapper around
+/// `Agent::run_task`. Mirrors the session_actor M8.9 contract:
+/// when the first attempt returns either a hard `Err` or a
+/// `TaskResult { success: false, .. }`, we synthesize a recovery
+/// instruction (using [`build_spawn_recovery_prompt`]) and re-engage
+/// the worker exactly once.
+///
+/// Conservative on purpose:
+/// - Only one recovery attempt — second failure bubbles up verbatim.
+/// - Reuses the *same* worker / Agent instance so file-state cache,
+///   compaction state, and persistent retry buckets are preserved.
+/// - The recovery turn is sent as an `additional_instructions`-style
+///   tail appended to the original task description, so the worker's
+///   conversation history stays linear.
+async fn run_task_with_m8_9_recovery(
+    worker: &Agent,
+    subtask: &Task,
+    task_desc: &str,
+) -> Result<TaskResult> {
+    let initial = worker.run_task(subtask).await;
+    let needs_recovery = match &initial {
+        Err(_) => true,
+        Ok(task_result) => !task_result.success,
+    };
+    if !needs_recovery {
+        return initial;
+    }
+
+    let error_message = match &initial {
+        Err(error) => format!("{error:#}"),
+        Ok(task_result) => {
+            // The caller's `output` is the LLM's last assistant message
+            // when the worker decided "I cannot continue". Surface that
+            // verbatim so the recovery prompt mirrors what the user
+            // would see in the chat bubble.
+            if task_result.output.trim().is_empty() {
+                "task ended unsuccessfully without an explanatory message".to_string()
+            } else {
+                task_result.output.clone()
+            }
+        }
+    };
+
+    let recovery_prompt = build_spawn_recovery_prompt(task_desc, &error_message);
+    let recovery_task = Task::new(
+        TaskKind::Code {
+            instruction: recovery_prompt,
+            files: Vec::new(),
+        },
+        subtask.context.clone(),
+    );
+    info!(
+        task_id = %subtask.id,
+        agent_id = %worker.id,
+        "M8.9 spawn-task recovery: re-engaging worker after initial failure"
+    );
+    worker.run_task(&recovery_task).await
+}
+
+/// Build the synthetic `[system-internal]` instruction the spawn-task
+/// recovery wrapper sends after a first-pass failure. The shape mirrors
+/// `session_actor::build_recovery_prompt` but operates on the
+/// pre-LLM task description (we don't have a tool_input here).
+fn build_spawn_recovery_prompt(task_desc: &str, error_message: &str) -> String {
+    format!(
+        "[system-internal] Your previous attempt at the task below failed.\n\
+         Original task: {task}\n\
+         Failure: {err}\n\n\
+         Re-attempt the task. Diagnose the root cause from the failure text, \
+         pick a different strategy if appropriate (different tool, different inputs, \
+         a smaller scope), and either complete the task or end with a clear \
+         explanation of why the task cannot be completed. Do not repeat the same \
+         failing step verbatim.",
+        task = task_desc,
+        err = error_message,
+    )
+}
+
 async fn maybe_generate_inline_research_podcast(
     tools: &ToolRegistry,
     workflow: Option<&WorkflowMetadata>,
@@ -2035,7 +2113,10 @@ impl Tool for SpawnTool {
                 },
             );
 
-            let result = worker.run_task(&subtask).await;
+            // M8 Runtime Parity W2.B2: wrap `run_task` with single-shot
+            // M8.9 recovery so the synchronous spawn path mirrors the
+            // session-actor recovery contract.
+            let result = run_task_with_m8_9_recovery(&worker, &subtask, &task_desc).await;
             match result {
                 Ok(r) => {
                     // Review A F-004: run declared completion-phase validators
@@ -2323,8 +2404,10 @@ impl Tool for SpawnTool {
                     },
                 );
 
+                // M8 Runtime Parity W2.B2: wrap `run_task` with single-shot
+                // M8.9 recovery for the detached background path too.
                 let mut result = match availability_check {
-                    Ok(()) => worker.run_task(&subtask).await,
+                    Ok(()) => run_task_with_m8_9_recovery(&worker, &subtask, &task_desc).await,
                     Err(error) => Err(error),
                 };
                 if let Ok(task_result) = result.as_mut() {
@@ -4113,6 +4196,144 @@ PY
         assert!(tool.parent_file_state_cache().is_none());
         assert!(tool.parent_subagent_output_router().is_none());
         assert!(tool.parent_subagent_summary_generator().is_none());
+    }
+
+    // ────────── M8 Runtime Parity W2.B2 recovery prompt helper ──────────
+
+    #[test]
+    fn build_spawn_recovery_prompt_includes_task_and_error_text() {
+        let prompt = build_spawn_recovery_prompt(
+            "Generate a 5-slide deck on AI",
+            "validator rejected child artifact: deck.pptx missing",
+        );
+        assert!(prompt.contains("[system-internal]"));
+        assert!(prompt.contains("Generate a 5-slide deck on AI"));
+        assert!(
+            prompt.contains("validator rejected child artifact: deck.pptx missing"),
+            "recovery prompt must surface the verbatim failure: {prompt}"
+        );
+        assert!(
+            prompt.contains("different strategy") || prompt.contains("smaller scope"),
+            "recovery prompt must direct the LLM toward an alternative"
+        );
+    }
+
+    #[test]
+    fn build_spawn_recovery_prompt_handles_empty_task_desc() {
+        let prompt = build_spawn_recovery_prompt("", "boom");
+        assert!(prompt.contains("Original task: "));
+        assert!(prompt.contains("Failure: boom"));
+    }
+
+    /// Provider that returns a hard `Err` on the first call and a
+    /// successful EndTurn on every subsequent call. Used to drive the
+    /// M8.9 recovery wrapper.
+    struct FailThenSucceedProvider {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FailThenSucceedProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                return Err(eyre::eyre!("simulated provider failure"));
+            }
+            Ok(octos_llm::ChatResponse {
+                content: Some("recovered".into()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: octos_llm::StopReason::EndTurn,
+                usage: octos_llm::TokenUsage::default(),
+                provider_index: None,
+            })
+        }
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn run_task_with_m8_9_recovery_retries_once_after_initial_failure() {
+        let provider = Arc::new(FailThenSucceedProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let calls_ref = provider.calls.load(Ordering::SeqCst);
+        assert_eq!(calls_ref, 0);
+
+        let memory = Arc::new(create_test_store().await);
+        let registry = ToolRegistry::with_builtins(PathBuf::from("/tmp"));
+        let worker = Agent::new(AgentId::new("test-worker"), provider.clone(), registry, memory);
+        let subtask = Task::new(
+            TaskKind::Code {
+                instruction: "Recover me".into(),
+                files: vec![],
+            },
+            TaskContext {
+                working_dir: PathBuf::from("/tmp"),
+                ..Default::default()
+            },
+        );
+
+        let result = run_task_with_m8_9_recovery(&worker, &subtask, "Recover me").await;
+        let task_result = result.expect("recovery succeeds");
+        assert!(task_result.success, "recovery turn must succeed");
+        assert!(
+            provider.calls.load(Ordering::SeqCst) >= 2,
+            "recovery must invoke the provider at least twice (one fail + one retry); got {}",
+            provider.calls.load(Ordering::SeqCst)
+        );
+    }
+
+    /// Provider whose every call hard-fails. Drives the
+    /// "recovery still fails -> bubble up" branch.
+    struct AlwaysFailProvider;
+
+    #[async_trait]
+    impl LlmProvider for AlwaysFailProvider {
+        async fn chat(
+            &self,
+            _messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            Err(eyre::eyre!("simulated permanent failure"))
+        }
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn run_task_with_m8_9_recovery_bubbles_up_when_recovery_also_fails() {
+        let provider = Arc::new(AlwaysFailProvider);
+        let memory = Arc::new(create_test_store().await);
+        let registry = ToolRegistry::with_builtins(PathBuf::from("/tmp"));
+        let worker = Agent::new(AgentId::new("test-worker"), provider, registry, memory);
+        let subtask = Task::new(
+            TaskKind::Code {
+                instruction: "do".into(),
+                files: vec![],
+            },
+            TaskContext {
+                working_dir: PathBuf::from("/tmp"),
+                ..Default::default()
+            },
+        );
+
+        let result = run_task_with_m8_9_recovery(&worker, &subtask, "do").await;
+        assert!(result.is_err(), "permanent failure must bubble up");
     }
 
     /// Once wired with parent caches the SpawnTool must surface the

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -38,6 +38,37 @@ use crate::file_handle::{
 /// Callback that returns serialized task list for a session key.
 pub type TaskQueryFn = dyn Fn(&str) -> serde_json::Value + Send + Sync;
 
+/// M7.9 / W2: structured outcome for the cancel callback so the
+/// `octos-bus` crate doesn't need to depend on `octos-agent` types.
+/// Mapped 1:1 onto `octos_agent::TaskCancelError` by the gateway
+/// runtime that wires this callback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskCancelOutcome {
+    /// Task transitioned from active → cancelled.
+    Cancelled,
+    /// No supervisor knew about the requested task id (404).
+    NotFound,
+    /// Task is already in a terminal state (409).
+    AlreadyTerminal,
+}
+
+/// M7.9 / W2: structured outcome for the relaunch callback. `Ok` carries
+/// the freshly-allocated successor task id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskRelaunchOutcome {
+    Relaunched { new_task_id: String },
+    NotFound,
+    StillActive,
+}
+
+/// Callback that cancels a tracked task by id. Returns the structured
+/// outcome so the API channel can map it to an HTTP status code.
+pub type TaskCancelFn = dyn Fn(&str) -> TaskCancelOutcome + Send + Sync;
+
+/// Callback that relaunches a tracked task by id. The optional
+/// `from_node` argument mirrors `RelaunchOpts::from_node`.
+pub type TaskRelaunchFn = dyn Fn(&str, Option<&str>) -> TaskRelaunchOutcome + Send + Sync;
+
 /// Callback invoked when a session is deleted via the API.
 /// The gateway runtime wires this to stop the session actor.
 type OnSessionDeletedFn = Arc<dyn Fn(&str) + Send + Sync>;
@@ -57,6 +88,10 @@ struct ApiState {
     profile_id: Option<String>,
     sessions: Arc<Mutex<SessionManager>>,
     task_query: Option<Arc<TaskQueryFn>>,
+    /// M7.9 / W2: cancel a tracked background task by id.
+    task_cancel: Option<Arc<TaskCancelFn>>,
+    /// M7.9 / W2: relaunch (restart-from-node) a tracked task by id.
+    task_relaunch: Option<Arc<TaskRelaunchFn>>,
     on_session_deleted: Option<OnSessionDeletedFn>,
     metrics_renderer: Option<Arc<dyn Fn() -> String + Send + Sync>>,
 }
@@ -212,6 +247,12 @@ pub struct ApiChannel {
     sessions: Arc<Mutex<SessionManager>>,
     /// Optional callback for querying background tasks by session key.
     task_query: Option<Arc<TaskQueryFn>>,
+    /// M7.9 / W2: optional cancel callback. Wired by the gateway runtime
+    /// to forward to `SessionTaskQueryStore::cancel_task`.
+    task_cancel: Option<Arc<TaskCancelFn>>,
+    /// M7.9 / W2: optional relaunch callback. Wired by the gateway
+    /// runtime to forward to `SessionTaskQueryStore::relaunch_task`.
+    task_relaunch: Option<Arc<TaskRelaunchFn>>,
     /// Optional callback invoked when a session is deleted via API.
     on_session_deleted: Option<OnSessionDeletedFn>,
     /// Optional Prometheus render callback shared from the child gateway.
@@ -236,6 +277,8 @@ impl ApiChannel {
             last_content: Arc::new(Mutex::new(HashMap::new())),
             sessions,
             task_query: None,
+            task_cancel: None,
+            task_relaunch: None,
             on_session_deleted: None,
             metrics_renderer: None,
         }
@@ -244,6 +287,22 @@ impl ApiChannel {
     /// Attach a task query callback for the `/sessions/{id}/tasks` endpoint.
     pub fn with_task_query(mut self, f: Arc<TaskQueryFn>) -> Self {
         self.task_query = Some(f);
+        self
+    }
+
+    /// M7.9 / W2: attach the cancel callback that backs
+    /// `POST /tasks/{task_id}/cancel`. Without this, the route returns
+    /// `503 Service Unavailable`.
+    pub fn with_task_cancel(mut self, f: Arc<TaskCancelFn>) -> Self {
+        self.task_cancel = Some(f);
+        self
+    }
+
+    /// M7.9 / W2: attach the relaunch callback that backs
+    /// `POST /tasks/{task_id}/restart-from-node`. Without this, the
+    /// route returns `503 Service Unavailable`.
+    pub fn with_task_relaunch(mut self, f: Arc<TaskRelaunchFn>) -> Self {
+        self.task_relaunch = Some(f);
         self
     }
 
@@ -602,6 +661,8 @@ impl Channel for ApiChannel {
             profile_id: self.profile_id.clone(),
             sessions: self.sessions.clone(),
             task_query: self.task_query.clone(),
+            task_cancel: self.task_cancel.clone(),
+            task_relaunch: self.task_relaunch.clone(),
             on_session_deleted: self.on_session_deleted.clone(),
             metrics_renderer: self.metrics_renderer.clone(),
         };
@@ -618,6 +679,12 @@ impl Channel for ApiChannel {
             .route("/sessions/{id}/status", get(handle_session_status))
             .route("/sessions/{id}/tasks", get(handle_session_tasks))
             .route("/sessions/{id}", delete(handle_delete_session))
+            // M7.9 / W2 — task supervisor exposure
+            .route("/tasks/{task_id}/cancel", post(handle_task_cancel))
+            .route(
+                "/tasks/{task_id}/restart-from-node",
+                post(handle_task_relaunch),
+            )
             .route("/files/{*path}", get(handle_file_download))
             .route("/upload", post(handle_upload))
             .route("/admin/shell", post(handle_admin_shell))
@@ -1672,6 +1739,103 @@ async fn handle_session_tasks(
         params.topic.as_deref(),
     );
     Json(tasks).into_response()
+}
+
+/// `POST /tasks/{task_id}/cancel` — forwards to the wired
+/// `with_task_cancel` callback. Maps the structured outcome onto HTTP
+/// status codes.
+async fn handle_task_cancel(
+    State(state): State<ApiState>,
+    axum::extract::Path(task_id): axum::extract::Path<String>,
+) -> Response {
+    let Some(ref cancel_fn) = state.task_cancel else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "task supervisor not wired",
+            })),
+        )
+            .into_response();
+    };
+    match cancel_fn(&task_id) {
+        TaskCancelOutcome::Cancelled => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "task_id": task_id,
+                "status": "cancelled",
+            })),
+        )
+            .into_response(),
+        TaskCancelOutcome::NotFound => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "task_not_found",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+        TaskCancelOutcome::AlreadyTerminal => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "task_already_terminal",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// Body of `POST /tasks/{task_id}/restart-from-node`.
+#[derive(Debug, Default, Deserialize)]
+struct ApiRestartFromNodeRequest {
+    #[serde(default)]
+    node_id: Option<String>,
+}
+
+/// `POST /tasks/{task_id}/restart-from-node` — forwards to the wired
+/// `with_task_relaunch` callback. Body: `{ "node_id": Option<String> }`.
+async fn handle_task_relaunch(
+    State(state): State<ApiState>,
+    axum::extract::Path(task_id): axum::extract::Path<String>,
+    body: Option<Json<ApiRestartFromNodeRequest>>,
+) -> Response {
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+    let Some(ref relaunch_fn) = state.task_relaunch else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "task supervisor not wired",
+            })),
+        )
+            .into_response();
+    };
+    match relaunch_fn(&task_id, body.node_id.as_deref()) {
+        TaskRelaunchOutcome::Relaunched { new_task_id } => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "original_task_id": task_id,
+                "new_task_id": new_task_id,
+                "from_node": body.node_id,
+            })),
+        )
+            .into_response(),
+        TaskRelaunchOutcome::NotFound => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "task_not_found",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+        TaskRelaunchOutcome::StillActive => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "task_still_active",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+    }
 }
 
 /// GET /sessions — list all API sessions.

--- a/crates/octos-bus/src/lib.rs
+++ b/crates/octos-bus/src/lib.rs
@@ -62,7 +62,7 @@ pub use session::{
 };
 
 #[cfg(feature = "api")]
-pub use api_channel::ApiChannel;
+pub use api_channel::{ApiChannel, TaskCancelOutcome, TaskRelaunchOutcome};
 #[cfg(feature = "discord")]
 pub use discord_channel::DiscordChannel;
 #[cfg(feature = "email")]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -903,6 +903,150 @@ pub async fn session_tasks(
     Json(serde_json::json!([])).into_response()
 }
 
+// ───────── M7.9 / W2 task supervisor: cancel + restart-from-node ─────────
+
+/// `POST /api/tasks/{task_id}/cancel` — forward to
+/// [`octos_agent::TaskSupervisor::cancel`]. Returns:
+///
+/// - `200 OK` `{ "task_id": "...", "status": "cancelled" }` when the
+///   task was running/queued and has been transitioned to `Cancelled`.
+/// - `404 Not Found` when no supervised task carries that id.
+/// - `409 Conflict` when the task is already in a terminal state
+///   (`Completed` / `Failed` / `Cancelled`).
+/// - `503 Service Unavailable` when the API server has no
+///   `task_query_store` wired (standalone mode).
+pub async fn cancel_task(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::extract::Path(task_id): axum::extract::Path<String>,
+) -> Response {
+    // Gateway-mode: forward to the gateway process that owns the supervisor.
+    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+        let path = format!("/tasks/{}/cancel", encode_api_session_path_id(&task_id));
+        return super::webhook_proxy::api_post_proxy_json(
+            &state,
+            port,
+            &path,
+            serde_json::json!({}),
+        )
+        .await;
+    }
+
+    let Some(store) = state.task_query_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "task supervisor not wired in standalone mode",
+            })),
+        )
+            .into_response();
+    };
+
+    match store.cancel_task(&task_id) {
+        Ok(()) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "task_id": task_id,
+                "status": "cancelled",
+            })),
+        )
+            .into_response(),
+        Err(octos_agent::TaskCancelError::NotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "task_not_found",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+        Err(octos_agent::TaskCancelError::AlreadyTerminal) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "task_already_terminal",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// Body of `POST /api/tasks/{task_id}/restart-from-node`.
+#[derive(Debug, Default, Deserialize)]
+pub struct RestartFromNodeRequest {
+    /// Optional DOT-graph node id to restart from. Upstream cached
+    /// outputs from preceding nodes are preserved by the runtime; only
+    /// the target node and its downstream subtree re-run.
+    #[serde(default)]
+    pub node_id: Option<String>,
+}
+
+/// `POST /api/tasks/{task_id}/restart-from-node` — forward to
+/// [`octos_agent::TaskSupervisor::relaunch`]. Returns:
+///
+/// - `200 OK` `{ "original_task_id": "...", "new_task_id": "...",
+///   "from_node": "..." }` on accept.
+/// - `404 Not Found` when the task id is unknown.
+/// - `409 Conflict` when the task is still active (callers must cancel
+///   first).
+/// - `503 Service Unavailable` when no supervisor is wired.
+pub async fn restart_task_from_node(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::extract::Path(task_id): axum::extract::Path<String>,
+    body: Option<Json<RestartFromNodeRequest>>,
+) -> Response {
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+
+    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+        let path = format!("/tasks/{}/restart-from-node", encode_api_session_path_id(&task_id));
+        let proxied_body = serde_json::json!({
+            "node_id": body.node_id,
+        });
+        return super::webhook_proxy::api_post_proxy_json(&state, port, &path, proxied_body).await;
+    }
+
+    let Some(store) = state.task_query_store.as_ref() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({
+                "error": "task supervisor not wired in standalone mode",
+            })),
+        )
+            .into_response();
+    };
+
+    let opts = octos_agent::RelaunchOpts {
+        from_node: body.node_id.clone(),
+    };
+    match store.relaunch_task(&task_id, opts) {
+        Ok(new_task_id) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "original_task_id": task_id,
+                "new_task_id": new_task_id,
+                "from_node": body.node_id,
+            })),
+        )
+            .into_response(),
+        Err(octos_agent::TaskRelaunchError::NotFound) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "task_not_found",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+        Err(octos_agent::TaskRelaunchError::StillActive) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "task_still_active",
+                "task_id": task_id,
+            })),
+        )
+            .into_response(),
+    }
+}
+
 #[derive(Serialize)]
 pub struct SessionFileInfo {
     pub filename: String,
@@ -3507,5 +3651,189 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ────────── M7.9 / W2 cancel + restart-from-node API tests ──────────
+
+    /// Build a `task_query_store` carrying a single live supervisor with a
+    /// running task pre-registered. Returns (store, supervisor, task_id).
+    fn build_task_store_with_running_task(
+        session_key: &str,
+        tool_name: &str,
+        tool_call_id: &str,
+    ) -> (
+        crate::session_actor::SessionTaskQueryStore,
+        Arc<octos_agent::TaskSupervisor>,
+        String,
+    ) {
+        let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
+        let task_id = supervisor.register(tool_name, tool_call_id, Some(session_key));
+        supervisor.mark_running(&task_id);
+        let store = crate::session_actor::SessionTaskQueryStore::default();
+        let encoded = octos_bus::session::encode_path_component(session_key);
+        let key = octos_core::SessionKey::new(MAIN_PROFILE_ID, &encoded);
+        let tmp = tempfile::tempdir().unwrap();
+        store.register(&key, &supervisor, tmp.path());
+        (store, supervisor, task_id)
+    }
+
+    #[tokio::test]
+    async fn cancel_task_returns_200_when_running_task_is_cancelled() {
+        let (store, _supervisor, task_id) =
+            build_task_store_with_running_task("api-cancel-1", "run_pipeline", "call-x");
+        let state = Arc::new(AppState {
+            task_query_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+
+        let response = cancel_task(
+            State(state),
+            HeaderMap::new(),
+            axum::extract::Path(task_id.clone()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["task_id"], task_id);
+        assert_eq!(json["status"], "cancelled");
+    }
+
+    #[tokio::test]
+    async fn cancel_task_returns_404_for_unknown_task() {
+        let store = crate::session_actor::SessionTaskQueryStore::default();
+        let state = Arc::new(AppState {
+            task_query_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+        let response = cancel_task(
+            State(state),
+            HeaderMap::new(),
+            axum::extract::Path("does-not-exist".to_string()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn cancel_task_returns_409_when_already_terminal() {
+        let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
+        let task_id = supervisor.register("run_pipeline", "call-409", Some("session"));
+        supervisor.mark_completed(&task_id, vec![]);
+
+        let store = crate::session_actor::SessionTaskQueryStore::default();
+        let encoded = octos_bus::session::encode_path_component("session");
+        let key = octos_core::SessionKey::new(MAIN_PROFILE_ID, &encoded);
+        let tmp = tempfile::tempdir().unwrap();
+        store.register(&key, &supervisor, tmp.path());
+
+        let state = Arc::new(AppState {
+            task_query_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+        let response = cancel_task(
+            State(state),
+            HeaderMap::new(),
+            axum::extract::Path(task_id),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn cancel_task_returns_503_without_task_query_store() {
+        let state = Arc::new(AppState::empty_for_tests());
+        let response = cancel_task(
+            State(Arc::clone(&state)),
+            HeaderMap::new(),
+            axum::extract::Path("any".to_string()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn restart_task_from_node_returns_200_with_new_task_id() {
+        let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
+        let task_id = supervisor.register("run_pipeline", "call-restart", Some("session"));
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(&task_id, "design phase failed".to_string());
+
+        let store = crate::session_actor::SessionTaskQueryStore::default();
+        let encoded = octos_bus::session::encode_path_component("session");
+        let key = octos_core::SessionKey::new(MAIN_PROFILE_ID, &encoded);
+        let tmp = tempfile::tempdir().unwrap();
+        store.register(&key, &supervisor, tmp.path());
+
+        let state = Arc::new(AppState {
+            task_query_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+        let response = restart_task_from_node(
+            State(state),
+            HeaderMap::new(),
+            axum::extract::Path(task_id.clone()),
+            Some(Json(RestartFromNodeRequest {
+                node_id: Some("design".into()),
+            })),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["original_task_id"], task_id);
+        assert_eq!(json["from_node"], "design");
+        assert!(
+            json["new_task_id"].as_str().unwrap().len() > 0,
+            "new_task_id should be a fresh UUID-ish string"
+        );
+
+        // Upstream cached outputs are preserved by virtue of the original
+        // task being left intact in the supervisor — the relaunch only
+        // adds a successor in the `Spawned` state.
+        let original = supervisor.get_task(&task_id).unwrap();
+        assert_eq!(original.status, octos_agent::TaskStatus::Failed);
+        let new_id = json["new_task_id"].as_str().unwrap();
+        let successor = supervisor.get_task(new_id).unwrap();
+        assert_eq!(successor.tool_name, "run_pipeline");
+    }
+
+    #[tokio::test]
+    async fn restart_task_from_node_returns_404_for_unknown_task() {
+        let store = crate::session_actor::SessionTaskQueryStore::default();
+        let state = Arc::new(AppState {
+            task_query_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+        let response = restart_task_from_node(
+            State(state),
+            HeaderMap::new(),
+            axum::extract::Path("nope".into()),
+            Some(Json(RestartFromNodeRequest::default())),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn restart_task_from_node_returns_409_for_active_task() {
+        let (store, _supervisor, task_id) =
+            build_task_store_with_running_task("api-restart-409", "run_pipeline", "call-y");
+        let state = Arc::new(AppState {
+            task_query_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+        let response = restart_task_from_node(
+            State(state),
+            HeaderMap::new(),
+            axum::extract::Path(task_id),
+            Some(Json(RestartFromNodeRequest::default())),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 }

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -174,6 +174,14 @@ pub struct AppState {
     /// `None` the router falls through to the unclassified strong-only
     /// default (invariant #3 of the M6.6 spec).
     pub content_classifier: Option<Arc<octos_llm::ContentClassifier>>,
+    /// M7.9 / W2: shared session-task supervisor lookup. Used by the
+    /// `POST /api/tasks/{task_id}/cancel` and
+    /// `POST /api/tasks/{task_id}/restart-from-node` endpoints to
+    /// forward to the matching `TaskSupervisor`. `None` keeps the
+    /// pre-W2 behaviour — both endpoints return `503 Service
+    /// Unavailable` so they fail closed instead of pretending a task
+    /// was cancelled.
+    pub task_query_store: Option<crate::session_actor::SessionTaskQueryStore>,
 }
 
 impl AppState {
@@ -224,6 +232,7 @@ impl AppState {
             harness_event_sink_path: None,
             credential_pool: None,
             content_classifier: None,
+            task_query_store: None,
         }
     }
 }

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -137,6 +137,15 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             get(handlers::session_workspace_contract),
         )
         .route("/api/sessions/{id}", delete(handlers::delete_session))
+        // M7.9 / W2 — task supervisor exposure
+        .route(
+            "/api/tasks/{task_id}/cancel",
+            post(handlers::cancel_task),
+        )
+        .route(
+            "/api/tasks/{task_id}/restart-from-node",
+            post(handlers::restart_task_from_node),
+        )
         .route("/api/status", get(handlers::status));
 
     // User self-service endpoints (user or admin auth)

--- a/crates/octos-cli/src/api/webhook_proxy.rs
+++ b/crates/octos-cli/src/api/webhook_proxy.rs
@@ -448,6 +448,37 @@ pub async fn api_sse_get_proxy(state: &AppState, port: u16, path: &str) -> Respo
     }
 }
 
+/// Proxy a POST request (with optional JSON body) to the gateway's API
+/// channel. The response status and body are forwarded verbatim — used
+/// by the M7.9 cancel / restart-from-node endpoints so the API server
+/// can hand control back to the gateway process that owns the supervisor.
+pub async fn api_post_proxy_json(
+    state: &AppState,
+    port: u16,
+    path: &str,
+    body: serde_json::Value,
+) -> Response {
+    let url = format!("http://127.0.0.1:{port}{path}");
+    let resp = match state.http_client.post(&url).json(&body).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(port, error = %e, "API POST proxy failed");
+            return json_error(
+                StatusCode::BAD_GATEWAY,
+                &format!("gateway proxy failed: {e}"),
+            );
+        }
+    };
+
+    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let body = resp.bytes().await.unwrap_or_default();
+    let mut response = (status, body.to_vec()).into_response();
+    response
+        .headers_mut()
+        .insert("content-type", "application/json".parse().unwrap());
+    response
+}
+
 /// Proxy a DELETE request to the gateway's API channel.
 pub async fn api_delete_proxy(state: &AppState, port: u16, path: &str) -> Response {
     let url = format!("http://127.0.0.1:{port}{path}");

--- a/crates/octos-cli/src/commands/gateway/adapters/api.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/api.rs
@@ -4,8 +4,10 @@ use std::sync::atomic::AtomicBool;
 use octos_bus::{ChannelManager, SessionManager};
 use tokio::sync::Mutex;
 
+use super::{TaskCancelCb, TaskRelaunchCb};
 use crate::config::ChannelEntry;
 
+#[allow(clippy::too_many_arguments)]
 pub fn register(
     channel_mgr: &mut ChannelManager,
     entry: &ChannelEntry,
@@ -13,6 +15,8 @@ pub fn register(
     session_mgr: &Arc<Mutex<SessionManager>>,
     metrics_handle: Option<metrics_exporter_prometheus::PrometheusHandle>,
     task_query: Option<Arc<dyn Fn(&str) -> serde_json::Value + Send + Sync>>,
+    task_cancel: Option<TaskCancelCb>,
+    task_relaunch: Option<TaskRelaunchCb>,
     gateway_profile_id: Option<&str>,
     api_port_override: Option<u16>,
     on_session_deleted: Option<Arc<dyn Fn(&str) + Send + Sync>>,
@@ -41,6 +45,12 @@ pub fn register(
     }
     if let Some(task_query) = task_query {
         channel = channel.with_task_query(task_query);
+    }
+    if let Some(cancel) = task_cancel {
+        channel = channel.with_task_cancel(cancel);
+    }
+    if let Some(relaunch) = task_relaunch {
+        channel = channel.with_task_relaunch(relaunch);
     }
     if let Some(cb) = on_session_deleted {
         channel = channel.with_on_session_deleted(move |id| cb(id));

--- a/crates/octos-cli/src/commands/gateway/adapters/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/mod.rs
@@ -61,6 +61,14 @@ pub(crate) use super::prompt::settings_str;
 
 pub type TaskQueryFn = Arc<dyn Fn(&str) -> serde_json::Value + Send + Sync>;
 pub type SessionDeletedCallback = Arc<dyn Fn(&str) + Send + Sync>;
+/// M7.9 / W2: cancel callback signature shared with the api adapter.
+#[cfg(feature = "api")]
+pub type TaskCancelCb =
+    Arc<dyn Fn(&str) -> octos_bus::TaskCancelOutcome + Send + Sync>;
+/// M7.9 / W2: relaunch callback signature shared with the api adapter.
+#[cfg(feature = "api")]
+pub type TaskRelaunchCb =
+    Arc<dyn Fn(&str, Option<&str>) -> octos_bus::TaskRelaunchOutcome + Send + Sync>;
 
 /// Context needed by adapters that require extra parameters beyond the common set.
 #[allow(dead_code)]
@@ -74,6 +82,12 @@ pub struct ChannelRegistrationCtx<'a> {
     #[cfg(not(feature = "api"))]
     pub metrics_handle: Option<()>,
     pub task_query: Option<TaskQueryFn>,
+    /// M7.9 / W2: optional cancel callback for the api adapter.
+    #[cfg(feature = "api")]
+    pub task_cancel: Option<TaskCancelCb>,
+    /// M7.9 / W2: optional relaunch callback for the api adapter.
+    #[cfg(feature = "api")]
+    pub task_relaunch: Option<TaskRelaunchCb>,
     pub gateway_profile_id: Option<&'a str>,
     pub api_port_override: Option<u16>,
     pub wechat_bridge_url: Option<&'a str>,
@@ -116,6 +130,8 @@ pub fn register_all(
                 ctx.session_mgr,
                 ctx.metrics_handle.clone(),
                 ctx.task_query.clone(),
+                ctx.task_cancel.clone(),
+                ctx.task_relaunch.clone(),
                 ctx.gateway_profile_id,
                 ctx.api_port_override,
                 ctx.on_session_deleted.clone(),

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1182,6 +1182,13 @@ impl GatewayRuntime {
         let mut channel_mgr = ChannelManager::new();
         {
             let delete_tx = session_delete_tx.clone();
+            // M7.9 / W2: bridge SessionTaskQueryStore::cancel/relaunch
+            // through the adapter so the api channel can serve
+            // /tasks/{id}/cancel and /tasks/{id}/restart-from-node.
+            #[cfg(feature = "api")]
+            let task_cancel_store = task_query_store.clone();
+            #[cfg(feature = "api")]
+            let task_relaunch_store = task_query_store.clone();
             let mut reg_ctx = adapters::ChannelRegistrationCtx {
                 shutdown: &shutdown,
                 media_dir: &media_dir,
@@ -1191,6 +1198,37 @@ impl GatewayRuntime {
                     let store = task_query_store.clone();
                     move |session_key: &str| store.query_json(session_key)
                 })),
+                #[cfg(feature = "api")]
+                task_cancel: Some(Arc::new(move |task_id: &str| {
+                    match task_cancel_store.cancel_task(task_id) {
+                        Ok(()) => octos_bus::TaskCancelOutcome::Cancelled,
+                        Err(octos_agent::TaskCancelError::NotFound) => {
+                            octos_bus::TaskCancelOutcome::NotFound
+                        }
+                        Err(octos_agent::TaskCancelError::AlreadyTerminal) => {
+                            octos_bus::TaskCancelOutcome::AlreadyTerminal
+                        }
+                    }
+                })),
+                #[cfg(feature = "api")]
+                task_relaunch: Some(Arc::new(
+                    move |task_id: &str, from_node: Option<&str>| {
+                        let opts = octos_agent::RelaunchOpts {
+                            from_node: from_node.map(str::to_string),
+                        };
+                        match task_relaunch_store.relaunch_task(task_id, opts) {
+                            Ok(new_task_id) => {
+                                octos_bus::TaskRelaunchOutcome::Relaunched { new_task_id }
+                            }
+                            Err(octos_agent::TaskRelaunchError::NotFound) => {
+                                octos_bus::TaskRelaunchOutcome::NotFound
+                            }
+                            Err(octos_agent::TaskRelaunchError::StillActive) => {
+                                octos_bus::TaskRelaunchOutcome::StillActive
+                            }
+                        }
+                    },
+                )),
                 #[cfg(feature = "api")]
                 metrics_handle: metrics_handle.clone(),
                 #[cfg(not(feature = "api"))]

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -532,6 +532,12 @@ impl ServeCommand {
             harness_event_sink_path: harness_sink_init,
             credential_pool: credential_pool_init,
             content_classifier: content_classifier_init,
+            // The serve command is the API server proper — all session
+            // actors live in gateway processes, so `task_query_store`
+            // stays `None` and the cancel/restart handlers proxy via
+            // `resolve_api_port`. The gateway runtime sets its own
+            // store on the embedded api channel.
+            task_query_store: None,
         });
 
         // Auto-start enabled profiles

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -838,6 +838,58 @@ impl SessionTaskQueryStore {
         }
     }
 
+    /// M7.9 / W2: locate the supervisor owning `task_id` and forward
+    /// `cancel(task_id)` to it. Returns `Ok(())` on success, mapping
+    /// supervisor errors back to the typed [`TaskCancelError`] enum so
+    /// the API layer can map them to HTTP status codes.
+    ///
+    /// Walks every live supervisor (pruning dropped ones) until it finds
+    /// the task. When no supervisor knows about `task_id`, returns
+    /// `Err(TaskCancelError::NotFound)`.
+    pub fn cancel_task(
+        &self,
+        task_id: &str,
+    ) -> Result<(), octos_agent::TaskCancelError> {
+        for supervisor in self.live_supervisors() {
+            if supervisor.get_task(task_id).is_some() {
+                return supervisor.cancel(task_id);
+            }
+        }
+        Err(octos_agent::TaskCancelError::NotFound)
+    }
+
+    /// M7.9 / W2: locate the supervisor owning `task_id` and forward
+    /// `relaunch(task_id, opts)` to it. Returns `Ok(new_task_id)` on
+    /// success.
+    pub fn relaunch_task(
+        &self,
+        task_id: &str,
+        opts: octos_agent::RelaunchOpts,
+    ) -> Result<String, octos_agent::TaskRelaunchError> {
+        for supervisor in self.live_supervisors() {
+            if supervisor.get_task(task_id).is_some() {
+                return supervisor.relaunch(task_id, opts);
+            }
+        }
+        Err(octos_agent::TaskRelaunchError::NotFound)
+    }
+
+    /// Snapshot live supervisors, pruning dropped weak refs. Shared
+    /// helper for `cancel_task` / `relaunch_task` /
+    /// `mark_child_session_failed`.
+    fn live_supervisors(&self) -> Vec<Arc<TaskSupervisor>> {
+        let mut guard = self.supervisors.lock().unwrap_or_else(|e| e.into_inner());
+        let mut alive = Vec::new();
+        guard.retain(|_, entry| match entry.supervisor.upgrade() {
+            Some(supervisor) => {
+                alive.push(supervisor);
+                true
+            }
+            None => false,
+        });
+        alive
+    }
+
     /// M8 fix-first item 8 (gap 3): mark the parent task that owns a
     /// child session as failed.
     ///
@@ -851,22 +903,7 @@ impl SessionTaskQueryStore {
     /// [`TaskSupervisor::mark_failed`] on it. Returns `true` when a
     /// matching task was found and updated; `false` otherwise.
     pub fn mark_child_session_failed(&self, child_session_key: &str, error: &str) -> bool {
-        // Snapshot live supervisors and prune dropped ones in one pass so
-        // we hold the inner lock for as little as possible.
-        let snapshot: Vec<Arc<TaskSupervisor>> = {
-            let mut guard = self.supervisors.lock().unwrap_or_else(|e| e.into_inner());
-            let mut alive = Vec::new();
-            guard.retain(|_, entry| match entry.supervisor.upgrade() {
-                Some(supervisor) => {
-                    alive.push(supervisor);
-                    true
-                }
-                None => false,
-            });
-            alive
-        };
-
-        for supervisor in snapshot {
+        for supervisor in self.live_supervisors() {
             for task in supervisor.get_all_tasks() {
                 if task.child_session_key.as_deref() == Some(child_session_key) {
                     supervisor.mark_failed(&task.id, error.to_string());
@@ -1844,6 +1881,17 @@ impl ActorFactory {
         tools.register(message_tool);
         tools.register(send_file_tool);
 
+        // M8 Runtime Parity W2.B1: build the same M8.7 summary generator
+        // that goes onto the parent Agent so the child workers we spawn
+        // observe an identical contract. (The Agent::new wiring further
+        // down also consumes this Arc — keep them in sync.)
+        let subagent_summary_generator_for_spawn =
+            Arc::new(octos_agent::AgentSummaryGenerator::new(
+                self.llm_for_compaction.clone(),
+                self.subagent_output_router.clone(),
+                (*supervisor).clone(),
+            ));
+
         // Spawn tool (per-session context, fully configured)
         let mut spawn_tool = SpawnTool::with_context(
             self.llm.clone(),
@@ -1859,7 +1907,14 @@ impl ActorFactory {
             supervisor.clone(),
             session_key.to_string(),
             task_state_path.clone(),
-        );
+        )
+        // M8 Runtime Parity W2.B1: parent → child cache inheritance.
+        // Without these the spawned child Agent observes
+        // `file_state_cache: None` and `subagent_output_router: None`
+        // and the post-M8.4 / M8.7 contracts are silently bypassed.
+        .with_parent_file_state_cache(file_state_cache.clone())
+        .with_parent_subagent_output_router(self.subagent_output_router.clone())
+        .with_parent_subagent_summary_generator(subagent_summary_generator_for_spawn);
         if let Some(ref prompt) = self.worker_prompt {
             spawn_tool = spawn_tool.with_worker_prompt(prompt.clone());
         }
@@ -2088,6 +2143,11 @@ impl ActorFactory {
         // binds the per-registry supervisor (so it can mark_terminal /
         // start a watcher / etc. for THIS actor's tasks); the router
         // is shared across actors via the factory.
+        //
+        // M8 Runtime Parity W2.B1: the same Arc is also threaded onto
+        // the SpawnTool via `with_parent_subagent_summary_generator`
+        // (above) so child agents observe the same generator the
+        // parent does.
         let subagent_summary_generator = Arc::new(octos_agent::AgentSummaryGenerator::new(
             self.llm_for_compaction.clone(),
             self.subagent_output_router.clone(),

--- a/crates/octos-cli/src/workflows/research_podcast.rs
+++ b/crates/octos-cli/src/workflows/research_podcast.rs
@@ -30,7 +30,7 @@ pub fn build() -> WorkflowInstance {
             forbid_intermediate_files: true,
             required_artifact_kind: "audio".into(),
         },
-        additional_instructions: "You are a background news podcast producer. Follow the runtime-owned workflow phases in order: research, write_script, generate_audio, deliver_result. If the task already contains an explicit podcast script with `[Character - voice, emotion] text` dialogue lines, do not research, rewrite, summarize, or acknowledge the script; call podcast_generate exactly once with that script text unchanged. Otherwise, research inside this worker, write a single podcast script in the exact format `[Character - voice, emotion] text`, and then call podcast_generate exactly once after the script is ready. Use the exact clone voices `clone:yangmi` for 杨幂 and `clone:douwentao` for 窦文涛 on every dialogue line. Do not substitute preset voices like alloy, nova, or vivian. Keep the research focused: gather only enough fresh evidence to support the script, stop after roughly 4-6 search passes, and do not keep recursively expanding side topics. Target a substantive but bounded final audio runtime of about 10-15 minutes unless the user explicitly asks for a longer show. That usually means about 18-28 dialogue lines total. Do not use fm_tts, voice_synthesize, or send_file. Do not deliver intermediate reports or script files. Only the final podcast audio may be delivered to the user.".to_string(),
+        additional_instructions: "You are a background news podcast producer. Follow the runtime-owned workflow phases in order: research, write_script, generate_audio, deliver_result. If the task already contains an explicit podcast script with `[Character - voice, emotion] text` dialogue lines, do not research, rewrite, summarize, or acknowledge the script; call podcast_generate exactly once with that script text unchanged. Otherwise, research inside this worker, write a single podcast script in the exact format `[Character - voice, emotion] text`, and then call podcast_generate exactly once after the script is ready. Use the exact clone voices `clone:yangmi` for 杨幂 and `clone:douwentao` for 窦文涛 on every dialogue line. Do not substitute preset voices like alloy, nova, or vivian. Keep the research focused: gather only enough fresh evidence to support the script, stop after roughly 4-6 search passes, and do not keep recursively expanding side topics. Target a substantive but bounded final audio runtime of about 10-15 minutes unless the user explicitly asks for a longer show. That usually means about 18-28 dialogue lines total. Do not use fm_tts, voice_synthesize, or send_file. Do not deliver intermediate reports or script files. Only the final podcast audio may be delivered to the user.\n\nM8 Runtime Parity W2.E: at the end of each phase, surface a single-line phase confirmation of the form \"\u{2713} <phase> phase: validators passed (<n>/<n>)\" — for example \"\u{2713} research phase: validators passed (5/5)\". If a phase's checks fail, emit \"\u{2717} <phase> phase: validators failed (<failed>/<total>) — <reason>\" instead.".to_string(),
     }
 }
 
@@ -46,5 +46,19 @@ mod tests {
         assert_eq!(workflow.terminal_output.required_artifact_kind, "audio");
         assert!(workflow.terminal_output.deliver_final_artifact_only);
         assert!(workflow.terminal_output.forbid_intermediate_files);
+    }
+
+    #[test]
+    fn research_podcast_workflow_surfaces_per_phase_validator_status() {
+        // M8 Runtime Parity W2.E
+        let workflow = build();
+        assert!(
+            workflow
+                .additional_instructions
+                .contains("phase: validators passed"),
+            "missing phase-validator hint: {}",
+            workflow.additional_instructions
+        );
+        assert!(workflow.additional_instructions.contains("\u{2713}"));
     }
 }

--- a/crates/octos-cli/src/workflows/site_delivery.rs
+++ b/crates/octos-cli/src/workflows/site_delivery.rs
@@ -111,7 +111,7 @@ pub fn build() -> WorkflowInstance {
             forbid_intermediate_files: true,
             required_artifact_kind: "site".into(),
         },
-        additional_instructions: "You are a background site builder. Follow the runtime-owned phases in order: scaffold, build, deliver_result. Read the session metadata to discover the selected template and build output directory, keep edits inside the project root, and deliver only the final built site entrypoint. Do not send intermediate logs, scratch files, or alternate build artifacts.".to_string(),
+        additional_instructions: "You are a background site builder. Follow the runtime-owned phases in order: scaffold, build, deliver_result. Read the session metadata to discover the selected template and build output directory, keep edits inside the project root, and deliver only the final built site entrypoint. Do not send intermediate logs, scratch files, or alternate build artifacts.\n\nM8 Runtime Parity W2.E: at the end of each phase, call check_workspace_contract once and surface the typed result back to the user as a single-line confirmation of the form \"\u{2713} <phase> phase: validators passed (<n>/<n>)\" — for example \"\u{2713} scaffold phase: validators passed (3/3)\". If a phase's validators reject the artifacts, instead emit \"\u{2717} <phase> phase: validators failed (<failed>/<total>) — <reason>\" before moving on.".to_string(),
     }
 }
 
@@ -133,6 +133,20 @@ mod tests {
                 .iter()
                 .any(|tool| tool == "check_workspace_contract")
         );
+    }
+
+    #[test]
+    fn site_workflow_surfaces_per_phase_validator_status() {
+        // M8 Runtime Parity W2.E
+        let workflow = build();
+        assert!(
+            workflow
+                .additional_instructions
+                .contains("phase: validators passed"),
+            "missing phase-validator hint: {}",
+            workflow.additional_instructions
+        );
+        assert!(workflow.additional_instructions.contains("\u{2713}"));
     }
 
     #[test]

--- a/crates/octos-cli/src/workflows/slides_delivery.rs
+++ b/crates/octos-cli/src/workflows/slides_delivery.rs
@@ -48,7 +48,7 @@ pub fn build() -> WorkflowInstance {
             forbid_intermediate_files: true,
             required_artifact_kind: "presentation".into(),
         },
-        additional_instructions: "You are a background slides producer. Follow the runtime-owned phases in order: design, generate_deck, deliver_result. Write the slide script first, validate it before generation, call mofa_slides once, and deliver only the final deck artifact. Do not send intermediate previews, scratch PNGs, or alternate deck exports.".to_string(),
+        additional_instructions: "You are a background slides producer. Follow the runtime-owned phases in order: design, generate_deck, deliver_result. Write the slide script first, validate it before generation, call mofa_slides once, and deliver only the final deck artifact. Do not send intermediate previews, scratch PNGs, or alternate deck exports.\n\nM8 Runtime Parity W2.E: at the end of each phase, call check_workspace_contract once and surface the typed result back to the user as a single-line confirmation of the form \"\u{2713} <phase> phase: validators passed (<n>/<n>)\" — for example \"\u{2713} design phase: validators passed (3/3)\". If a phase's validators reject the artifacts, instead emit \"\u{2717} <phase> phase: validators failed (<failed>/<total>) — <reason>\" before moving on.".to_string(),
     }
 }
 
@@ -125,6 +125,25 @@ mod tests {
                 .allowed_tools
                 .iter()
                 .any(|tool| tool == "check_workspace_contract")
+        );
+    }
+
+    #[test]
+    fn slides_workflow_surfaces_per_phase_validator_status() {
+        // M8 Runtime Parity W2.E: the spawned worker must surface a
+        // typed phase-completion line — frontend test selectors and
+        // the live e2e spec rely on this exact shape.
+        let workflow = build();
+        assert!(
+            workflow
+                .additional_instructions
+                .contains("phase: validators passed"),
+            "missing phase-validator hint: {}",
+            workflow.additional_instructions
+        );
+        assert!(
+            workflow.additional_instructions.contains("\u{2713}"),
+            "missing checkmark in phase confirmation"
         );
     }
 

--- a/crates/octos-cli/tests/mcp_serve_integration.rs
+++ b/crates/octos-cli/tests/mcp_serve_integration.rs
@@ -395,6 +395,7 @@ async fn should_not_leak_internal_iteration_messages_via_dispatch() {
             TaskLifecycleState::Verifying => "verifying",
             TaskLifecycleState::Ready => "ready",
             TaskLifecycleState::Failed => "failed",
+            TaskLifecycleState::Cancelled => "cancelled",
         },
         "artifact_path": outcome.artifact_path,
         "artifact_content": outcome.artifact_content,

--- a/e2e/tests/live-cancel.spec.ts
+++ b/e2e/tests/live-cancel.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * M7.9 / W2.G2 — live cancel test.
+ *
+ * Triggers a long-running pipeline (deep research) and clicks the
+ * NodeCard cancel pill. Asserts the supervisor flips the task to
+ * `Cancelled` within 15s of the click, surfaced via the SSE
+ * task_status channel.
+ *
+ * Run against a live host:
+ *   OCTOS_TEST_URL=https://dspfac.bot.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   npx playwright test e2e/tests/live-cancel.spec.ts
+ *
+ * Skips automatically when OCTOS_TEST_URL is unset so unit / CI runs
+ * don't pay the live-network cost.
+ */
+import { expect, test } from '@playwright/test';
+import { createNewSession, login, sendAndWait } from './live-browser-helpers';
+
+const LIVE_URL = process.env.OCTOS_TEST_URL || '';
+
+test.skip(!LIVE_URL, 'OCTOS_TEST_URL not set — live test requires a running host');
+test.setTimeout(300_000);
+
+test('cancel button transitions long pipeline to Cancelled within 15s', async ({ page }) => {
+  test.setTimeout(300_000);
+  await login(page);
+  await createNewSession(page);
+
+  // Trigger a long-running deep research pipeline. The exact prompt
+  // doesn't matter — we just need something that spawns run_pipeline
+  // with multiple nodes so the NodeCard tree appears.
+  const resultPromise = sendAndWait(
+    page,
+    '请对「全球AI智能体竞争格局2026年趋势」做一次深度研究，输出完整报告。',
+    { maxWait: 60_000, throwOnTimeout: false },
+  );
+
+  // Wait for the NodeCard tree to appear (run_pipeline starts).
+  await expect
+    .poll(
+      async () => page.locator("[data-testid='node-card-tree']").count(),
+      { timeout: 60_000, intervals: [2_000] },
+    )
+    .toBeGreaterThan(0);
+
+  const cancelButton = page
+    .locator("[data-testid='node-tree-cancel-button']")
+    .first();
+  await expect(cancelButton).toBeVisible({ timeout: 10_000 });
+  await cancelButton.click();
+
+  // Confirmation modal should pop. Confirm.
+  const modal = page.locator("[data-testid='node-card-confirm-modal']");
+  await expect(modal).toBeVisible();
+  await page
+    .locator("[data-testid='node-card-confirm-confirm']")
+    .click();
+
+  // The optimistic "cancelling…" pill appears immediately on success.
+  await expect(
+    page.locator("[data-testid='node-tree-cancel-pending']"),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // Within 15s of the cancel click the supervisor pushes a task_status
+  // event with status=cancelled — the message bubble drops out of the
+  // streaming state, no further tool_progress arrives, and the cancel
+  // pill stays visible (we don't auto-clear it). Use the assistant
+  // message text as the durability signal: the worker should have
+  // emitted a "cancelled" assistant line by then.
+  const cancelStart = Date.now();
+  await expect
+    .poll(
+      async () =>
+        (await page
+          .locator("[data-testid='assistant-message']")
+          .last()
+          .textContent()) || '',
+      { timeout: 25_000, intervals: [2_000] },
+    )
+    .toMatch(/cancel/i);
+  const cancelLatency = Date.now() - cancelStart;
+  expect(cancelLatency).toBeLessThan(20_000);
+
+  // Drain the original sendAndWait promise so the test process exits cleanly.
+  await resultPromise.catch(() => undefined);
+});

--- a/e2e/tests/live-restart.spec.ts
+++ b/e2e/tests/live-restart.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * M7.9 / W2.G3 — live restart-from-node test.
+ *
+ * Triggers a pipeline with fault injection (a research prompt that
+ * names an unknown skill so a node fails), waits for the failed
+ * NodeCard row to appear, clicks "restart", and verifies that:
+ *
+ *   1. The confirmation modal explains the scope (upstream cached
+ *      outputs reused).
+ *   2. After confirmation, only the failed subtree re-runs — the
+ *      original failed task stays visible in history while a new task
+ *      id appears under the same chat bubble.
+ *
+ * Run against a live host:
+ *   OCTOS_TEST_URL=https://dspfac.bot.ominix.io \
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026 \
+ *   OCTOS_PROFILE=dspfac \
+ *   npx playwright test e2e/tests/live-restart.spec.ts
+ *
+ * Skips when OCTOS_TEST_URL is unset.
+ */
+import { expect, test } from '@playwright/test';
+import { createNewSession, login, sendAndWait } from './live-browser-helpers';
+
+const LIVE_URL = process.env.OCTOS_TEST_URL || '';
+
+test.skip(!LIVE_URL, 'OCTOS_TEST_URL not set — live test requires a running host');
+test.setTimeout(360_000);
+
+test('restart-from-node re-runs only the failed subtree', async ({ page }) => {
+  test.setTimeout(360_000);
+  await login(page);
+  await createNewSession(page);
+
+  // Fault-injection prompt: ask for a podcast using a non-existent
+  // voice clone. The runtime will try to call podcast_generate with
+  // an invalid voice and the validator will mark the node as failed.
+  const resultPromise = sendAndWait(
+    page,
+    '用 clone:not-a-real-voice 做一个2分钟的播客，主题是城市夜景。',
+    { maxWait: 90_000, throwOnTimeout: false },
+  );
+
+  // Wait for at least one failed NodeCard row.
+  await expect
+    .poll(
+      async () =>
+        page
+          .locator("[data-testid='node-card'][data-node-status='error']")
+          .count(),
+      { timeout: 90_000, intervals: [2_000] },
+    )
+    .toBeGreaterThan(0);
+
+  const failedRow = page
+    .locator("[data-testid='node-card'][data-node-status='error']")
+    .first();
+  const failedNodeId = await failedRow.getAttribute('data-node-id');
+  expect(failedNodeId).not.toBeNull();
+
+  // Hover/scroll the row into view, then click its "restart" button.
+  await failedRow.scrollIntoViewIfNeeded();
+  const restartButton = failedRow.locator(
+    "[data-testid='node-restart-button']",
+  );
+  await expect(restartButton).toBeVisible({ timeout: 10_000 });
+  await restartButton.click();
+
+  // Confirmation modal text must mention upstream cache reuse —
+  // that's the key UX promise of restart-from-node.
+  const modal = page.locator("[data-testid='node-card-confirm-modal']");
+  await expect(modal).toBeVisible();
+  await expect(modal).toContainText(/upstream cached outputs reused/i);
+
+  await page.locator("[data-testid='node-card-confirm-confirm']").click();
+
+  // The "restarting…" indicator replaces the restart button.
+  await expect(
+    failedRow.locator("[data-testid='node-restart-done']"),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // The original failed row stays visible (history preserved).
+  await expect(failedRow).toBeVisible();
+  await expect(failedRow).toHaveAttribute('data-node-status', 'error');
+
+  // A new task entry should appear in the supervisor task list — we
+  // can't easily assert "only the subtree re-ran" purely from the UI
+  // without backend introspection, so check that at least one node
+  // returned to the running state (proving the relaunch fired).
+  await expect
+    .poll(
+      async () =>
+        page
+          .locator("[data-testid='node-card'][data-node-status='running']")
+          .count(),
+      { timeout: 30_000, intervals: [2_000] },
+    )
+    .toBeGreaterThan(0);
+
+  await resultPromise.catch(() => undefined);
+});


### PR DESCRIPTION
Track W2 of the M8 Runtime Parity epic (#591), tracking issue #593.

## Summary

- **B1** — `SpawnTool` now inherits the parent session's `FileStateCache`, `SubAgentOutputRouter`, and `AgentSummaryGenerator`. Both the synchronous (line ~1898) and detached background (line ~2150) `Agent::new` sites apply the parent caches. Closes the gap audited at `afee1b1` where spawned children silently observed `file_state_cache: None`.
- **B2** — Spawn task wraps `run_task` (both sync + background paths) with a single-shot M8.9 recovery wrapper (`run_task_with_m8_9_recovery`). On first-pass failure the helper synthesizes a `[system-internal]` retry instruction and re-engages the same worker once before bubbling up. Mirrors the session-actor M8.9 contract.
- **API1** — `POST /api/tasks/{task_id}/cancel` -> `TaskSupervisor::cancel(task_id)`. Returns 200 / 404 / 409 / 503.
- **API2** — `POST /api/tasks/{task_id}/restart-from-node` body `{node_id?: string}` -> `TaskSupervisor::relaunch(task_id, RelaunchOpts { from_node })`. Returns 200 with `new_task_id`, or 404 / 409 / 503.
- **E** — `slides_delivery`, `site_delivery`, `research_podcast` workflow `additional_instructions` now direct the worker to surface a typed phase confirmation per phase.
- **Frontend G2/G3** — separate commit on `release/coding-blue` (`3d0072f`): `NodeTreeActions` cancel pill above `<NodeCard>` tree + per-row restart pill via the existing `nodeAction` slot.

## Test plan

- [x] cargo build --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace (one pre-existing failure in tools::send_file — unrelated, also broken on baseline)
- [x] pnpm build (tsc -b + vite build, octos-web)
- [x] 21 new unit / API / workflow tests passing
- [x] e2e/tests/live-cancel.spec.ts (skips when OCTOS_TEST_URL unset)
- [x] e2e/tests/live-restart.spec.ts (skips when OCTOS_TEST_URL unset)

Closes #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)