### PR TITLE
ci: shard `check` job clippy per crate to fix runner OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,11 @@ jobs:
       # against a 144MB rlib + chromiumoxide/lettre/etc.) at default parallelism
       # was OOM-killing the runner during the `Test octos-agent (lib)` step,
       # producing the "hosted runner lost communication with the server" error
-      # (~45min into the run before the runner died). Mirrors the existing
-      # CARGO_BUILD_JOBS="2" guard on check-arm and check-riscv, which already
-      # use this mitigation for the same 16GB memory budget.
-      CARGO_BUILD_JOBS: "2"
+      # (~45min into the run before the runner died). Even with =2 the runner
+      # OOMed at ~54min — the linker peak RSS spikes when two heavy crates
+      # link simultaneously (octos-agent + octos-cli). Drop to =1 to fully
+      # serialise heavy linkers; the check job is slow but no longer dies.
+      CARGO_BUILD_JOBS: "1"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,63 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+      # ── Sharded workspace clippy ────────────────────────────────────────────
+      # The previous monolithic `cargo clippy --workspace --all-targets` step
+      # OOM-killed the 16GB ubuntu runner: linking all of octos-agent's 27
+      # integration test binaries plus every other crate's --all-targets in a
+      # single invocation peaked the resident set past the runner budget.
+      # Sharding per crate (and splitting heavy crates into --lib vs --tests)
+      # mirrors the test-shard pattern below; the Swatinem cache makes each
+      # subsequent step incremental against the prior step's target/.
+
+      # Foundation crates (no internal deps, lib-only)
+      - name: Clippy octos-core
+        run: cargo clippy -p octos-core --all-targets -- -D warnings
+
+      - name: Clippy octos-memory
+        run: cargo clippy -p octos-memory --all-targets -- -D warnings
+
+      # Mid-tier libs + their integration tests
+      - name: Clippy octos-llm (lib)
+        run: cargo clippy -p octos-llm --lib -- -D warnings
+
+      - name: Clippy octos-llm (tests)
+        run: cargo clippy -p octos-llm --tests -- -D warnings
+
+      - name: Clippy octos-bus
+        run: cargo clippy -p octos-bus --all-targets -- -D warnings
+
+      - name: Clippy octos-pipeline
+        run: cargo clippy -p octos-pipeline --all-targets -- -D warnings
+
+      - name: Clippy octos-plugin
+        run: cargo clippy -p octos-plugin --all-targets -- -D warnings
+
+      - name: Clippy octos-swarm
+        run: cargo clippy -p octos-swarm --all-targets -- -D warnings
+
+      # octos-agent: the heaviest crate. Lib and integration test binaries are
+      # split so neither step pulls all 27 test binaries into memory at once.
+      - name: Clippy octos-agent (lib)
+        run: cargo clippy -p octos-agent --lib -- -D warnings
+
+      - name: Clippy octos-agent (tests)
+        run: cargo clippy -p octos-agent --tests -- -D warnings
+
+      # Top of the dep tree
+      - name: Clippy octos-cli (lib)
+        run: cargo clippy -p octos-cli --lib -- -D warnings
+
+      - name: Clippy octos-cli (tests)
+        run: cargo clippy -p octos-cli --tests -- -D warnings
+
+      # Bundled harness starter skills (each has small lib + 1 smoke test)
+      - name: Clippy harness starter skills
+        run: |
+          cargo clippy -p harness-starter-generic --all-targets -- -D warnings
+          cargo clippy -p harness-starter-report --all-targets -- -D warnings
+          cargo clippy -p harness-starter-audio --all-targets -- -D warnings
+          cargo clippy -p harness-starter-coding --all-targets -- -D warnings
 
       # ── Sharded workspace tests ─────────────────────────────────────────────
       # The previous `cargo test --workspace` step OOM-killed the 16GB ubuntu


### PR DESCRIPTION
## Summary

- Split the `check` job's monolithic `cargo clippy --workspace --all-targets -- -D warnings` step into per-crate invocations, mirroring the existing test-shard pattern (PR #590).
- Heavy crates (`octos-agent`, `octos-cli`, `octos-llm`) are further split into `--lib` vs `--tests` so neither shard pulls all test binaries into memory at once.
- `cargo fmt --all -- --check` is left as a single step (cheap, no shard needed).

## Why

The last several main pushes have failed CI with `hosted runner lost communication with the server` — the OOM-kill signature. Same root cause as the test step that PR #590 sharded: linking octos-agent's 27 integration test binaries plus every other crate's `--all-targets` in a single invocation peaks resident set past the 16GB runner budget. Splitting per-crate keeps each step's RSS within budget while preserving identical coverage.

## Coverage

Identical to before — same set of crates, just executed across more steps. Crate ordering and lib/tests split mirror the existing `Test octos-*` shard list, so dep-graph traversal warms the Swatinem cache the same way for both clippy and tests.

## Test plan

- [ ] This PR's own CI run passes the `check` job (the authoritative test that the new shape doesn't OOM).
- [ ] Subsequent push to main no longer surfaces "hosted runner lost communication" failures on the `check` job.