### PR TITLE
Fix send_file sandbox test when worktree lives under /tmp/

### DIFF
--- a/crates/octos-agent/src/tools/send_file.rs
+++ b/crates/octos-agent/src/tools/send_file.rs
@@ -455,10 +455,25 @@ mod tests {
         let base = tempfile::tempdir().unwrap();
 
         // Create a file outside base_dir and outside /tmp/, since /tmp/ is
-        // explicitly allowlisted for generated artifacts.
+        // explicitly allowlisted for generated artifacts. Anchor the "outside"
+        // dir under the user's home directory so it's stable regardless of
+        // whether the worktree itself lives under /tmp/ (e.g. CI scratch dirs).
+        let canonical_tmp =
+            std::fs::canonicalize("/tmp").unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
+        let Some(home) = dirs::home_dir() else {
+            eprintln!("skipping test_base_dir_blocks_non_tmp_outside_path: no home dir");
+            return;
+        };
+        let canonical_home = std::fs::canonicalize(&home).unwrap_or(home);
+        if canonical_home.starts_with(&canonical_tmp) {
+            eprintln!(
+                "skipping test_base_dir_blocks_non_tmp_outside_path: $HOME is under /tmp/, no stable non-tmp location available"
+            );
+            return;
+        }
         let outside_dir = tempfile::Builder::new()
             .prefix("octos-send-file-outside-")
-            .tempdir_in(std::env::current_dir().unwrap())
+            .tempdir_in(&canonical_home)
             .unwrap();
         let outside_file = outside_dir.path().join("secret.txt");
         std::fs::write(&outside_file, "secret").unwrap();


### PR DESCRIPTION
## Summary
- Fixes pre-existing `octos-agent::tools::send_file::tests::test_base_dir_blocks_non_tmp_outside_path` failure on `main`.
- The previous portability fix (#563) anchored the "outside" tempdir under `current_dir()`. When the worktree is checked out under `/tmp/` (e.g. `/tmp/octos-fu2-sendfile`), `current_dir()` is also under `/tmp/`, so the file gets allowlisted by the production `/tmp/` rule and the negative assertion fails.
- Anchors the outside dir under `dirs::home_dir()` instead, which is stable across Linux and macOS regardless of where the worktree resides. Skips with a clear message if no home dir is available or `$HOME` itself canonicalizes under `/tmp/`.

## Root cause
On macOS, `/tmp` is a symlink to `/private/tmp`. The production validation calls `canonicalize("/tmp")` which resolves to `/private/tmp`, then accepts any file whose canonical path starts with that prefix. The previous test setup picked the "outside" location via `tempdir_in(current_dir())` to escape macOS's default `$TMPDIR` of `/var/folders/...`. But when the worktree is rooted under `/tmp/` (CI scratch dirs, agent worktrees, etc.), `current_dir()` canonicalizes to `/private/tmp/<worktree>/...` and the "outside" file ends up inside the allowlisted prefix — making the test assertion `assert!(!result.success)` fail.

## Fix
Use `dirs::home_dir()` (already in the workspace dependency tree, used by other modules in `octos-agent`) to anchor the outside directory. The user's home is stable across both supported platforms and does not overlap with `/tmp`. Defensive guards skip the test (rather than panic or misreport) if `$HOME` is unavailable or itself resolves under `/tmp/`.

## Sandbox enforcement is unchanged
- Production code (`SendFileTool::execute`) is untouched.
- The test still asserts `!result.success` AND that the error message contains `outside the allowed directory` — i.e. the same security invariant: a file outside both `base_dir` and `/tmp/` must be blocked. We just changed where we put the "outside" file so it's reliably outside `/tmp/` on the host where the test runs.

## Test plan
- [x] `cargo test -p octos-agent --lib send_file::tests::test_base_dir_blocks_non_tmp_outside_path` passes
- [x] All 15 `send_file::tests::*` pass
- [ ] `cargo test --workspace` — the host where I ran this had a 100% full system-data volume (`No space left on device`), which caused 22 unrelated failures (`tools::spawn::tests::*`, `tools::workspace_history::tests::*`, `workspace_git::tests::*`, `workspace_policy::tests::*`) — every failure traces to `os error 28` / `StorageFull`. Re-running on a host with free disk should yield 1182/1182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)