### PR TITLE
fix(deep-search): pass synthesis token via plugin args (S2)

### DIFF
--- a/crates/app-skills/deep-search/manifest.json
+++ b/crates/app-skills/deep-search/manifest.json
@@ -40,9 +40,32 @@
           "search_engine": {
             "type": "string",
             "description": "Preferred search engine: perplexity, duckduckgo, brave, you (default: auto-detect, prefers perplexity)"
+          },
+          "synthesis_config": {
+            "type": "object",
+            "description": "Synthesis LLM provider config injected by the host. When all four fields are populated, takes precedence over the legacy DEEPSEEK_API_KEY/etc env-var path. Operators should not set this directly — the host populates it from the agent's configured provider.",
+            "properties": {
+              "endpoint": {
+                "type": "string",
+                "description": "OpenAI-compatible base URL, e.g. https://api.deepseek.com/v1"
+              },
+              "api_key": {
+                "type": "string",
+                "description": "Bearer token for the synthesis provider. Never logged."
+              },
+              "model": {
+                "type": "string",
+                "description": "Model id to request (e.g. deepseek-chat). Overridable via DEEP_SEARCH_SYNTHESIS_MODEL env."
+              },
+              "provider": {
+                "type": "string",
+                "description": "Provider label used by the v2 cost envelope (e.g. deepseek)."
+              }
+            }
           }
         },
-        "required": ["query"]
+        "required": ["query"],
+        "x-octos-host-config-keys": ["synthesis_config"]
       }
     }
   ]

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -28,6 +28,34 @@ struct Input {
     /// Research depth: 1=quick (single search), 2=standard (3 rounds), 3=thorough (5 rounds).
     #[serde(default = "default_depth")]
     depth: u8,
+    /// Synthesis LLM provider config injected by the host (S2 plumbing).
+    ///
+    /// When present and complete, `resolve_synthesis_config` prefers this over
+    /// reading API keys from environment variables. This lets the host route
+    /// per-tenant or per-session credentials without requiring plist `EnvironmentVariables`.
+    #[serde(default)]
+    synthesis_config: Option<SynthesisConfig>,
+}
+
+/// Synthesis LLM provider config passed by the host.
+///
+/// Mirrors the `(endpoint, api_key, model, provider)` quadruple that
+/// [`resolve_synthesis_config`] used to read from environment variables. All
+/// fields are required for the args path to take precedence — partial configs
+/// fall through to the env-var path so the operator can still set defaults.
+#[derive(Deserialize, Clone, Debug)]
+struct SynthesisConfig {
+    /// OpenAI-compatible base URL, e.g. `https://api.deepseek.com/v1`.
+    endpoint: String,
+    /// Bearer token for the synthesis provider.
+    ///
+    /// Tokens MUST NOT be logged. Audit `tracing::*` and `eprintln!` paths
+    /// before adding new diagnostics.
+    api_key: String,
+    /// Model id to request (e.g. `deepseek-chat`).
+    model: String,
+    /// Provider label used by the v2 cost envelope (e.g. `deepseek`).
+    provider: String,
 }
 
 fn default_max_results() -> u8 {
@@ -221,6 +249,7 @@ async fn main() {
             max_results,
             depth,
             input.search_engine.as_deref(),
+            input.synthesis_config.as_ref(),
         ),
     )
     .await;
@@ -277,6 +306,7 @@ async fn run_deep_search(
     max_results: u8,
     depth: u8,
     engine: Option<&str>,
+    synthesis_config: Option<&SynthesisConfig>,
 ) -> Output {
     let max_rounds = match depth {
         1 => 1,
@@ -553,7 +583,7 @@ async fn run_deep_search(
             .collect(),
     };
 
-    let synthesis = synthesize(client, &synthesis_input).await;
+    let synthesis = synthesize(client, &synthesis_input, synthesis_config).await;
 
     progress_simple(ProgressPhase::ReportBuild, "Building report...");
     emit_v2_progress(
@@ -2336,8 +2366,9 @@ impl SynthesisResult {
 async fn synthesize(
     client: &reqwest::Client,
     input: &SynthesisInput<'_>,
+    args_config: Option<&SynthesisConfig>,
 ) -> Option<SynthesisResult> {
-    let (endpoint, api_key, model, provider) = resolve_synthesis_config()?;
+    let (endpoint, api_key, model, provider) = resolve_synthesis_config(args_config)?;
 
     let prompt = build_synthesis_prompt(input);
     let prompt_chars = prompt.len();
@@ -2562,12 +2593,47 @@ enum SectionTag {
     Other,
 }
 
-/// Try env vars in priority order — prefer fast/cheap models.
+/// Resolve synthesis provider config: prefer host-injected args over env.
+///
+/// S2 plumbing: when the host populates `Input::synthesis_config`, we use it
+/// directly so secrets stay in the agent's typed config instead of operator
+/// plists. When it's missing or incomplete (any of the four fields blank), we
+/// fall back to environment variables in the legacy priority order. This
+/// preserves backward compat with operators who still set `DEEPSEEK_API_KEY`
+/// in the launchd plist.
 ///
 /// Returns `(endpoint, api_key, model, provider)`.
-fn resolve_synthesis_config() -> Option<(String, String, String, String)> {
-    // Allow operators to override the model via env. Useful when the
-    // default for a provider is too slow or expensive for synthesis.
+///
+/// Tokens MUST NOT be logged. The function only emits a `provider` label on
+/// success so debugging the resolution path doesn't leak credentials.
+fn resolve_synthesis_config(
+    args_config: Option<&SynthesisConfig>,
+) -> Option<(String, String, String, String)> {
+    // Args path: take everything from the host-injected struct when all four
+    // fields are non-empty. Allow operators to still override the model via
+    // env even when the args path is used — keeps the
+    // `DEEP_SEARCH_SYNTHESIS_MODEL` knob meaningful.
+    if let Some(cfg) = args_config {
+        if !cfg.endpoint.is_empty()
+            && !cfg.api_key.is_empty()
+            && !cfg.model.is_empty()
+            && !cfg.provider.is_empty()
+        {
+            let model = std::env::var("DEEP_SEARCH_SYNTHESIS_MODEL")
+                .ok()
+                .filter(|m| !m.is_empty())
+                .unwrap_or_else(|| cfg.model.clone());
+            eprintln!("[synthesis] using host-injected provider: {}", cfg.provider);
+            return Some((
+                cfg.endpoint.clone(),
+                cfg.api_key.clone(),
+                model,
+                cfg.provider.clone(),
+            ));
+        }
+    }
+
+    // Env path: legacy fallback for operators who haven't migrated to S2.
     let model_override = std::env::var("DEEP_SEARCH_SYNTHESIS_MODEL").ok();
 
     let configs: &[(&str, &str, &str, &str)] = &[
@@ -2920,6 +2986,195 @@ mod tests {
         let input: Input = serde_json::from_str(json).unwrap();
         assert_eq!(input.depth, 3);
         assert_eq!(input.search_engine.as_deref(), Some("perplexity"));
+    }
+
+    // ---- S2: synthesis_config plumbing ---------------------------------
+    //
+    // These tests share process-wide env-var state, so they serialize on a
+    // local mutex. Every test snapshots the env keys it touches before the
+    // case and restores them on exit so no test leaks into another.
+
+    /// Mutex serializing synthesis-config env tests in this module.
+    fn synthesis_env_lock() -> &'static std::sync::Mutex<()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// All synthesis-related env keys that the resolver consults.
+    /// We snapshot+restore these so concurrently-running test orderings stay safe.
+    const SYNTHESIS_ENV_KEYS: &[&str] = &[
+        "DEEPSEEK_API_KEY",
+        "KIMI_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "DEEP_SEARCH_SYNTHESIS_MODEL",
+    ];
+
+    fn snapshot_synthesis_env() -> Vec<(&'static str, Option<String>)> {
+        SYNTHESIS_ENV_KEYS
+            .iter()
+            .map(|k| (*k, std::env::var(k).ok()))
+            .collect()
+    }
+
+    fn clear_synthesis_env() {
+        for key in SYNTHESIS_ENV_KEYS {
+            // SAFETY: tests serialize on `synthesis_env_lock()`.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+
+    fn restore_synthesis_env(snapshot: Vec<(&'static str, Option<String>)>) {
+        for (key, value) in snapshot {
+            // SAFETY: tests serialize on `synthesis_env_lock()`.
+            match value {
+                Some(v) => unsafe { std::env::set_var(key, v) },
+                None => unsafe { std::env::remove_var(key) },
+            }
+        }
+    }
+
+    #[test]
+    fn test_input_deserialization_with_synthesis_config() {
+        let json = r#"{
+            "query": "test",
+            "synthesis_config": {
+                "endpoint": "https://api.example.com/v1",
+                "api_key": "sk-host-injected",
+                "model": "deepseek-chat",
+                "provider": "deepseek"
+            }
+        }"#;
+        let input: Input = serde_json::from_str(json).unwrap();
+        let cfg = input.synthesis_config.expect("synthesis_config parsed");
+        assert_eq!(cfg.endpoint, "https://api.example.com/v1");
+        assert_eq!(cfg.api_key, "sk-host-injected");
+        assert_eq!(cfg.model, "deepseek-chat");
+        assert_eq!(cfg.provider, "deepseek");
+    }
+
+    #[test]
+    fn test_synthesis_config_args_path_takes_precedence_over_env() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let snapshot = snapshot_synthesis_env();
+        clear_synthesis_env();
+        // Set BOTH a real env key (would normally win) and pass an args
+        // config: args must take precedence, leaving env untouched.
+        // SAFETY: test holds `synthesis_env_lock` for the duration of the case.
+        unsafe { std::env::set_var("DEEPSEEK_API_KEY", "from-env") };
+
+        let args = SynthesisConfig {
+            endpoint: "https://api.host-injected.example/v1".to_string(),
+            api_key: "from-args".to_string(),
+            model: "host-model".to_string(),
+            provider: "host-provider".to_string(),
+        };
+        let resolved = resolve_synthesis_config(Some(&args)).expect("resolves");
+        assert_eq!(resolved.0, "https://api.host-injected.example/v1");
+        assert_eq!(resolved.1, "from-args");
+        assert_eq!(resolved.2, "host-model");
+        assert_eq!(resolved.3, "host-provider");
+
+        restore_synthesis_env(snapshot);
+    }
+
+    #[test]
+    fn test_synthesis_config_args_path_with_no_env() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let snapshot = snapshot_synthesis_env();
+        clear_synthesis_env();
+
+        let args = SynthesisConfig {
+            endpoint: "https://api.example.com/v1".to_string(),
+            api_key: "sk-args-only".to_string(),
+            model: "args-model".to_string(),
+            provider: "args-provider".to_string(),
+        };
+        let resolved = resolve_synthesis_config(Some(&args)).expect("resolves from args");
+        assert_eq!(resolved.1, "sk-args-only");
+        assert_eq!(resolved.3, "args-provider");
+
+        restore_synthesis_env(snapshot);
+    }
+
+    #[test]
+    fn test_synthesis_config_falls_back_to_env_when_args_missing() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let snapshot = snapshot_synthesis_env();
+        clear_synthesis_env();
+        // SAFETY: test holds `synthesis_env_lock` for the duration of the case.
+        unsafe { std::env::set_var("KIMI_API_KEY", "kimi-from-env") };
+
+        let resolved = resolve_synthesis_config(None).expect("env path resolves");
+        assert_eq!(resolved.0, "https://api.moonshot.ai/v1");
+        assert_eq!(resolved.1, "kimi-from-env");
+        assert_eq!(resolved.3, "moonshot");
+
+        restore_synthesis_env(snapshot);
+    }
+
+    #[test]
+    fn test_synthesis_config_falls_back_to_env_when_args_incomplete() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let snapshot = snapshot_synthesis_env();
+        clear_synthesis_env();
+        // SAFETY: test holds `synthesis_env_lock` for the duration of the case.
+        unsafe { std::env::set_var("OPENAI_API_KEY", "openai-from-env") };
+
+        // Args missing api_key → fall through to env.
+        let args = SynthesisConfig {
+            endpoint: "https://api.example.com/v1".to_string(),
+            api_key: "".to_string(),
+            model: "some-model".to_string(),
+            provider: "some-provider".to_string(),
+        };
+        let resolved = resolve_synthesis_config(Some(&args)).expect("env path resolves");
+        assert_eq!(resolved.1, "openai-from-env");
+        assert_eq!(resolved.3, "openai");
+
+        restore_synthesis_env(snapshot);
+    }
+
+    #[test]
+    fn test_synthesis_config_returns_none_when_neither_set() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let snapshot = snapshot_synthesis_env();
+        clear_synthesis_env();
+
+        assert!(resolve_synthesis_config(None).is_none());
+        // Empty args also falls through to none.
+        let empty_args = SynthesisConfig {
+            endpoint: "".to_string(),
+            api_key: "".to_string(),
+            model: "".to_string(),
+            provider: "".to_string(),
+        };
+        assert!(resolve_synthesis_config(Some(&empty_args)).is_none());
+
+        restore_synthesis_env(snapshot);
+    }
+
+    #[test]
+    fn test_synthesis_model_env_override_applies_to_args_path() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let snapshot = snapshot_synthesis_env();
+        clear_synthesis_env();
+        // SAFETY: test holds `synthesis_env_lock` for the duration of the case.
+        unsafe { std::env::set_var("DEEP_SEARCH_SYNTHESIS_MODEL", "override-model") };
+
+        let args = SynthesisConfig {
+            endpoint: "https://api.example.com/v1".to_string(),
+            api_key: "sk-args".to_string(),
+            model: "default-from-args".to_string(),
+            provider: "deepseek".to_string(),
+        };
+        let resolved = resolve_synthesis_config(Some(&args)).expect("resolves");
+        assert_eq!(resolved.2, "override-model");
+
+        restore_synthesis_env(snapshot);
     }
 
     #[test]

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -105,7 +105,7 @@ pub use hooks::{
 };
 pub use mcp::{McpClient, McpServerConfig};
 pub use permissions::{InvalidSafetyTier, SafetyTier};
-pub use plugins::{PluginLoadResult, PluginLoader};
+pub use plugins::{PluginLoadOptions, PluginLoadResult, PluginLoader, SynthesisConfig};
 pub use progress::{ConsoleReporter, ProgressEvent, ProgressReporter, SilentReporter};
 pub use prompt_layer::PromptLayerBuilder;
 pub use provider_tools::{ProviderToolsets, ToolAdjustment};

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -14,7 +14,7 @@ use crate::tools::{Tool, ToolRegistry};
 
 use super::extras::{SkillExtras, resolve_extras};
 use super::manifest::{PluginManifest, PluginToolDef};
-use super::tool::PluginTool;
+use super::tool::{PluginTool, SynthesisConfig};
 
 const MAX_EXECUTABLE_SIZE: u64 = 100_000_000;
 const GENERATIVE_SKILL_ENV_ALLOWLIST: &[&str] = &[
@@ -41,6 +41,21 @@ pub struct PluginLoadResult {
     pub hooks: Vec<HookConfig>,
     /// Prompt fragments read from skill directories.
     pub prompt_fragments: Vec<String>,
+}
+
+/// Optional knobs for plugin loading beyond `extra_env` and `work_dir`.
+///
+/// Add new fields here when introducing host→plugin config injection so the
+/// existing `load_into` and `load_into_with_work_dir` signatures stay stable
+/// for callers that don't need the new functionality.
+#[derive(Debug, Default, Clone)]
+pub struct PluginLoadOptions<'a> {
+    /// Per-process working directory for plugin executions.
+    pub work_dir: Option<&'a Path>,
+    /// Synthesis LLM provider config injected into plugin args for tools that
+    /// opt in via `x-octos-host-config-keys: ["synthesis_config"]`. Tools
+    /// without the opt-in never receive this struct.
+    pub synthesis_config: Option<SynthesisConfig>,
 }
 
 impl PluginLoadResult {
@@ -82,6 +97,28 @@ impl PluginLoader {
         extra_env: &[(String, String)],
         work_dir: Option<&Path>,
     ) -> Result<PluginLoadResult> {
+        Self::load_into_with_options(
+            registry,
+            dirs,
+            extra_env,
+            PluginLoadOptions {
+                work_dir,
+                synthesis_config: None,
+            },
+        )
+    }
+
+    /// Full-featured loader that accepts arbitrary [`PluginLoadOptions`].
+    ///
+    /// New host-controlled config (e.g. `synthesis_config`) is plumbed
+    /// through here so older `load_into` callers keep working without
+    /// signature churn.
+    pub fn load_into_with_options(
+        registry: &mut ToolRegistry,
+        dirs: &[PathBuf],
+        extra_env: &[(String, String)],
+        options: PluginLoadOptions<'_>,
+    ) -> Result<PluginLoadResult> {
         let mut result = PluginLoadResult::default();
 
         for dir in dirs {
@@ -101,7 +138,7 @@ impl PluginLoader {
                     continue;
                 }
 
-                match Self::load_plugin_with_work_dir(&path, extra_env, work_dir) {
+                match Self::load_plugin_with_options(&path, extra_env, options.clone()) {
                     Ok((tools, extras)) => {
                         let n = tools.len();
                         let spawn_only = extras.spawn_only_tools.clone();
@@ -172,6 +209,25 @@ impl PluginLoader {
         extra_env: &[(String, String)],
         work_dir: Option<&Path>,
     ) -> Result<(Vec<PluginTool>, SkillExtras)> {
+        Self::load_plugin_with_options(
+            plugin_dir,
+            extra_env,
+            PluginLoadOptions {
+                work_dir,
+                synthesis_config: None,
+            },
+        )
+    }
+
+    /// Full-featured single-plugin loader that accepts arbitrary
+    /// [`PluginLoadOptions`].
+    pub fn load_plugin_with_options(
+        plugin_dir: &Path,
+        extra_env: &[(String, String)],
+        options: PluginLoadOptions<'_>,
+    ) -> Result<(Vec<PluginTool>, SkillExtras)> {
+        let work_dir = options.work_dir;
+        let synthesis_config = options.synthesis_config;
         let manifest_path = plugin_dir.join("manifest.json");
         let content = std::fs::read_to_string(&manifest_path)
             .map_err(|e| eyre::eyre!("no manifest.json: {e}"))?;
@@ -309,6 +365,14 @@ impl PluginLoader {
                     .with_timeout(timeout);
                 if let Some(dir) = work_dir {
                     tool = tool.with_work_dir(dir.to_path_buf());
+                }
+                // S2 plumbing: attach synthesis_config when the tool's
+                // manifest opts in. The runtime check inside
+                // `prepare_effective_args` is what gates injection — wiring
+                // it onto every tool is harmless because the gate keys off
+                // `accepts_host_config_key`.
+                if let Some(cfg) = synthesis_config.clone() {
+                    tool = tool.with_synthesis_config(cfg);
                 }
                 tool
             })
@@ -1033,5 +1097,119 @@ edition = "2021"
         let verified = plugin_dir.join(".perm-plugin_verified");
         let mode = std::fs::metadata(&verified).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_into_with_options_attaches_synthesis_config_to_opted_in_plugins() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("research-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        // Manifest opts in via x-octos-host-config-keys.
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            r#"{
+              "name": "research-plugin",
+              "version": "1.0",
+              "tools": [{
+                "name": "deep_search",
+                "description": "Research",
+                "input_schema": {
+                  "type": "object",
+                  "properties": {"query": {"type": "string"}},
+                  "x-octos-host-config-keys": ["synthesis_config"]
+                }
+              }]
+            }"#,
+        )
+        .unwrap();
+        let exec_path = plugin_dir.join("research-plugin");
+        std::fs::write(
+            &exec_path,
+            "#!/bin/sh\necho '{\"output\": \"ok\", \"success\": true}'",
+        )
+        .unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let cfg = SynthesisConfig {
+            endpoint: "https://api.example.com/v1".to_string(),
+            api_key: "sk-loader-test".to_string(),
+            model: "test-model".to_string(),
+            provider: "test-provider".to_string(),
+        };
+
+        let (tools, _extras) = PluginLoader::load_plugin_with_options(
+            &plugin_dir,
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: Some(cfg),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(tools.len(), 1);
+        // Inject through prepare_effective_args to verify the loader propagated
+        // the config into the constructed PluginTool.
+        let prepared = tools[0].prepare_effective_args(&serde_json::json!({"query": "x"}), None);
+        assert_eq!(prepared["synthesis_config"]["api_key"], "sk-loader-test");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_into_with_options_skips_synthesis_config_for_non_opted_in_plugins() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("other-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        // No x-octos-host-config-keys → should not receive synthesis_config.
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            r#"{
+              "name": "other-plugin",
+              "version": "1.0",
+              "tools": [{
+                "name": "innocuous",
+                "description": "Does not need credentials",
+                "input_schema": {"type": "object"}
+              }]
+            }"#,
+        )
+        .unwrap();
+        let exec_path = plugin_dir.join("other-plugin");
+        std::fs::write(
+            &exec_path,
+            "#!/bin/sh\necho '{\"output\": \"ok\", \"success\": true}'",
+        )
+        .unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let cfg = SynthesisConfig {
+            endpoint: "https://api.example.com/v1".to_string(),
+            api_key: "sk-must-not-leak".to_string(),
+            model: "test-model".to_string(),
+            provider: "test-provider".to_string(),
+        };
+
+        let (tools, _extras) = PluginLoader::load_plugin_with_options(
+            &plugin_dir,
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: Some(cfg),
+            },
+        )
+        .unwrap();
+        assert_eq!(tools.len(), 1);
+        let prepared = tools[0].prepare_effective_args(&serde_json::json!({}), None);
+        assert!(
+            prepared.get("synthesis_config").is_none(),
+            "non-opted-in plugin must not see synthesis_config: {prepared}"
+        );
     }
 }

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -130,6 +130,34 @@ pub struct PluginToolDef {
     pub concurrency_class: Option<String>,
 }
 
+impl PluginToolDef {
+    /// Whether this tool's input schema declares it accepts host-injected
+    /// config under the named key (e.g. `"synthesis_config"`).
+    ///
+    /// Schema lookup: the manifest may either list the key under
+    /// `input_schema["x-octos-host-config-keys"]` (a string array) or define
+    /// it as a property in `input_schema["properties"]`. Either form is
+    /// sufficient — having the key in `properties` is what the plugin
+    /// actually parses; the `x-octos-host-config-keys` extension is the
+    /// explicit opt-in signal so other plugins don't accidentally receive
+    /// secrets they didn't declare.
+    pub fn accepts_host_config_key(&self, key: &str) -> bool {
+        let schema = &self.input_schema;
+        // Explicit opt-in via x-octos-host-config-keys.
+        if let Some(keys) = schema
+            .get("x-octos-host-config-keys")
+            .and_then(|v| v.as_array())
+        {
+            for k in keys {
+                if k.as_str() == Some(key) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
 /// Binary download info for a specific platform.
 #[derive(Debug, Clone, Deserialize)]
 pub struct BinaryDownload {
@@ -198,6 +226,42 @@ mod tests {
             manifest.tools[0].env,
             vec!["SMTP_PASSWORD".to_string(), "OPENAI_API_KEY".to_string()]
         );
+    }
+
+    #[test]
+    fn accepts_host_config_key_returns_false_when_extension_absent() {
+        let json = r#"{
+            "name": "p",
+            "version": "1",
+            "tools": [{
+                "name": "t",
+                "description": "d",
+                "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}
+            }]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(!manifest.tools[0].accepts_host_config_key("synthesis_config"));
+    }
+
+    #[test]
+    fn accepts_host_config_key_honours_extension_array() {
+        let json = r#"{
+            "name": "p",
+            "version": "1",
+            "tools": [{
+                "name": "deep_search",
+                "description": "Research",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                    "x-octos-host-config-keys": ["synthesis_config"]
+                }
+            }]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.tools[0].accepts_host_config_key("synthesis_config"));
+        // Other keys still rejected — explicit opt-in only.
+        assert!(!manifest.tools[0].accepts_host_config_key("smtp_config"));
     }
 
     #[test]

--- a/crates/octos-agent/src/plugins/mod.rs
+++ b/crates/octos-agent/src/plugins/mod.rs
@@ -10,6 +10,6 @@ pub mod manifest;
 pub mod tool;
 
 pub use extras::{SkillExtras, resolve_extras};
-pub use loader::{PluginLoadResult, PluginLoader};
+pub use loader::{PluginLoadOptions, PluginLoadResult, PluginLoader};
 pub use manifest::{PluginManifest, PluginToolDef};
-pub use tool::PluginTool;
+pub use tool::{PluginTool, SynthesisConfig};

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -21,6 +21,49 @@ use crate::tools::{TOOL_CTX, Tool, ToolContext, ToolResult};
 
 use super::manifest::PluginToolDef;
 
+/// Synthesis LLM provider config injected into plugin args.
+///
+/// S2 plumbing: octos passes this struct under `synthesis_config` in the JSON
+/// args (alongside `query`, `depth`, etc.) when the plugin's manifest opts in
+/// via `x-octos-host-config-keys: ["synthesis_config"]`. Plugins that haven't
+/// declared the key never see this struct, so secrets stay scoped to the
+/// plugins that asked for them.
+///
+/// Token MUST NOT be logged. Audit `tracing::*` and `eprintln!` paths before
+/// adding diagnostics that touch this struct.
+#[derive(Clone, Debug)]
+pub struct SynthesisConfig {
+    /// OpenAI-compatible base URL (e.g. `https://api.deepseek.com/v1`).
+    pub endpoint: String,
+    /// Bearer token for the synthesis provider.
+    pub api_key: String,
+    /// Model id to request (e.g. `deepseek-chat`).
+    pub model: String,
+    /// Provider label for the v2 cost envelope (e.g. `deepseek`).
+    pub provider: String,
+}
+
+impl SynthesisConfig {
+    /// Whether all four fields are populated. Partial configs are dropped at
+    /// the inject site so the plugin's env-fallback still works.
+    pub fn is_complete(&self) -> bool {
+        !self.endpoint.is_empty()
+            && !self.api_key.is_empty()
+            && !self.model.is_empty()
+            && !self.provider.is_empty()
+    }
+
+    /// Encode the config as a JSON object suitable for inlining into plugin args.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "endpoint": self.endpoint,
+            "api_key": self.api_key,
+            "model": self.model,
+            "provider": self.provider,
+        })
+    }
+}
+
 /// A tool backed by a plugin executable.
 ///
 /// Protocol: write JSON args to stdin, read JSON result from stdout.
@@ -38,6 +81,10 @@ pub struct PluginTool {
     work_dir: Option<PathBuf>,
     /// Execution timeout.
     timeout: Duration,
+    /// S2 plumbing: synthesis LLM provider config to inject into plugin args.
+    /// Only honoured when the tool's manifest opts in via
+    /// `x-octos-host-config-keys: ["synthesis_config"]`.
+    synthesis_config: Option<SynthesisConfig>,
 }
 
 impl PluginTool {
@@ -53,6 +100,7 @@ impl PluginTool {
             extra_env: vec![],
             work_dir: None,
             timeout: Self::DEFAULT_TIMEOUT,
+            synthesis_config: None,
         }
     }
 
@@ -81,6 +129,14 @@ impl PluginTool {
         self
     }
 
+    /// S2 plumbing: set the synthesis LLM provider config injected into the
+    /// plugin's args. Only honoured when the tool's manifest opts in via
+    /// `x-octos-host-config-keys: ["synthesis_config"]`.
+    pub fn with_synthesis_config(mut self, cfg: SynthesisConfig) -> Self {
+        self.synthesis_config = Some(cfg);
+        self
+    }
+
     /// Create a copy of this plugin tool with a different work directory.
     /// Used to give each user session its own workspace for plugin output.
     pub fn clone_with_work_dir(&self, work_dir: PathBuf) -> Self {
@@ -92,6 +148,7 @@ impl PluginTool {
             extra_env: self.extra_env.clone(),
             work_dir: Some(work_dir),
             timeout: self.timeout,
+            synthesis_config: self.synthesis_config.clone(),
         }
     }
 
@@ -366,7 +423,7 @@ impl PluginTool {
         serde_json::Value::Object(rewritten)
     }
 
-    fn prepare_effective_args(
+    pub(crate) fn prepare_effective_args(
         &self,
         args: &serde_json::Value,
         ctx: Option<&ToolContext>,
@@ -421,6 +478,32 @@ impl PluginTool {
                         serde_json::Value::String(format!("slides_{ts}.pptx")),
                     );
                     tracing::info!("injected default 'out' for mofa_slides");
+                }
+            }
+        }
+
+        // S2 plumbing: inject synthesis_config when the manifest opts in via
+        // `x-octos-host-config-keys: ["synthesis_config"]` and the host has a
+        // configured `SynthesisConfig`. The plugin still falls back to env if
+        // the LLM happens to skip injection. NOTE: tokens MUST NOT be logged
+        // — emit only the provider label.
+        if self.tool_def.accepts_host_config_key("synthesis_config") {
+            if let Some(cfg) = self.synthesis_config.as_ref() {
+                if cfg.is_complete() {
+                    if let Some(obj) = effective_args.as_object_mut() {
+                        // Don't override an explicitly-provided synthesis_config.
+                        // (The LLM should never set this, but we defend in depth
+                        // so a misbehaving caller can't be silently overwritten.)
+                        if !obj.contains_key("synthesis_config") {
+                            obj.insert("synthesis_config".into(), cfg.to_json());
+                            tracing::info!(
+                                plugin = %self.plugin_name,
+                                tool = %self.tool_def.name,
+                                provider = %cfg.provider,
+                                "injected synthesis_config into plugin args"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -1258,6 +1341,136 @@ mod tests {
 
         assert_eq!(prepared["audio_path"], "/workspace/voice.ogg");
         assert_eq!(prepared["file_path"], "/workspace/report.pdf");
+    }
+
+    fn deep_search_def_with_opt_in() -> PluginToolDef {
+        PluginToolDef {
+            name: "deep_search".to_string(),
+            description: "Deep research".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "synthesis_config": {"type": "object"}
+                },
+                "x-octos-host-config-keys": ["synthesis_config"]
+            }),
+            spawn_only: false,
+            env: vec![],
+            spawn_only_message: None,
+            concurrency_class: None,
+        }
+    }
+
+    fn full_synthesis_config() -> SynthesisConfig {
+        SynthesisConfig {
+            endpoint: "https://api.deepseek.com/v1".to_string(),
+            api_key: "sk-host-injected".to_string(),
+            model: "deepseek-chat".to_string(),
+            provider: "deepseek".to_string(),
+        }
+    }
+
+    #[test]
+    fn synthesis_config_is_complete_only_when_all_fields_populated() {
+        let cfg = full_synthesis_config();
+        assert!(cfg.is_complete());
+
+        let mut partial = cfg.clone();
+        partial.api_key.clear();
+        assert!(!partial.is_complete());
+
+        let mut partial = cfg.clone();
+        partial.endpoint.clear();
+        assert!(!partial.is_complete());
+    }
+
+    #[test]
+    fn prepare_effective_args_injects_synthesis_config_when_opted_in() {
+        let tool = PluginTool::new(
+            "deep-search".into(),
+            deep_search_def_with_opt_in(),
+            PathBuf::from("/bin/true"),
+        )
+        .with_synthesis_config(full_synthesis_config());
+
+        let prepared = tool.prepare_effective_args(&json!({"query": "AI policy"}), None);
+        let cfg = &prepared["synthesis_config"];
+        assert_eq!(cfg["endpoint"], "https://api.deepseek.com/v1");
+        assert_eq!(cfg["api_key"], "sk-host-injected");
+        assert_eq!(cfg["model"], "deepseek-chat");
+        assert_eq!(cfg["provider"], "deepseek");
+    }
+
+    #[test]
+    fn prepare_effective_args_skips_synthesis_config_when_manifest_does_not_opt_in() {
+        // Same tool but without the x-octos-host-config-keys extension.
+        let mut def = deep_search_def_with_opt_in();
+        def.input_schema = json!({
+            "type": "object",
+            "properties": {"query": {"type": "string"}}
+        });
+        let tool = PluginTool::new("plug".into(), def, PathBuf::from("/bin/true"))
+            .with_synthesis_config(full_synthesis_config());
+
+        let prepared = tool.prepare_effective_args(&json!({"query": "AI policy"}), None);
+        assert!(
+            prepared.get("synthesis_config").is_none(),
+            "tools without opt-in must not receive synthesis_config: {prepared}",
+        );
+    }
+
+    #[test]
+    fn prepare_effective_args_skips_synthesis_config_when_host_did_not_set_one() {
+        let tool = PluginTool::new(
+            "deep-search".into(),
+            deep_search_def_with_opt_in(),
+            PathBuf::from("/bin/true"),
+        );
+
+        let prepared = tool.prepare_effective_args(&json!({"query": "AI policy"}), None);
+        assert!(prepared.get("synthesis_config").is_none());
+    }
+
+    #[test]
+    fn prepare_effective_args_skips_synthesis_config_when_partial() {
+        let mut cfg = full_synthesis_config();
+        cfg.api_key.clear(); // Partial → fall through to env path.
+        let tool = PluginTool::new(
+            "deep-search".into(),
+            deep_search_def_with_opt_in(),
+            PathBuf::from("/bin/true"),
+        )
+        .with_synthesis_config(cfg);
+
+        let prepared = tool.prepare_effective_args(&json!({"query": "AI policy"}), None);
+        assert!(prepared.get("synthesis_config").is_none());
+    }
+
+    #[test]
+    fn prepare_effective_args_does_not_overwrite_explicit_synthesis_config() {
+        // Defense in depth: if a caller already set synthesis_config (e.g. a
+        // unit test or a future LLM-controlled override), don't silently
+        // replace it.
+        let tool = PluginTool::new(
+            "deep-search".into(),
+            deep_search_def_with_opt_in(),
+            PathBuf::from("/bin/true"),
+        )
+        .with_synthesis_config(full_synthesis_config());
+
+        let prepared = tool.prepare_effective_args(
+            &json!({
+                "query": "AI policy",
+                "synthesis_config": {"api_key": "caller-supplied"}
+            }),
+            None,
+        );
+        assert_eq!(prepared["synthesis_config"]["api_key"], "caller-supplied");
+        assert!(
+            prepared["synthesis_config"].get("endpoint").is_none(),
+            "host config must not be merged into caller-supplied synthesis_config",
+        );
     }
 
     /// Write a script to a file and make it executable, with fsync to avoid ETXTBSY

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -30,7 +30,8 @@ use tracing::{info, warn};
 use super::build_system_prompt;
 use super::message_preprocessing;
 use super::profile_factory::{
-    ProfileActorFactoryBuilder, build_plugin_env, profile_plugin_env, profile_search_provider_keys,
+    ProfileActorFactoryBuilder, build_plugin_env, build_synthesis_config, profile_plugin_env,
+    profile_search_provider_keys,
 };
 use super::{account_handler, adapters, skills_handler};
 use super::{build_profiled_session_key, resolve_dispatch_profile_id};
@@ -649,11 +650,18 @@ impl GatewayRuntime {
             }
             plugin_result = octos_agent::PluginLoadResult::default();
             if !plugin_dirs.is_empty() {
-                match octos_agent::PluginLoader::load_into_with_work_dir(
+                // S2 plumbing: pass the agent's current provider config so
+                // plugins like deep_search can synthesize via host-injected
+                // args instead of the operator's plist `EnvironmentVariables`.
+                let synthesis_config = build_synthesis_config(&config, &provider_name);
+                match octos_agent::PluginLoader::load_into_with_options(
                     &mut tools,
                     &plugin_dirs,
                     &plugin_env,
-                    Some(&plugin_work_dir),
+                    octos_agent::PluginLoadOptions {
+                        work_dir: Some(&plugin_work_dir),
+                        synthesis_config,
+                    },
                 ) {
                     Ok(result) => plugin_result = result,
                     Err(e) => warn!("plugin loading failed: {e}"),
@@ -1211,24 +1219,22 @@ impl GatewayRuntime {
                     }
                 })),
                 #[cfg(feature = "api")]
-                task_relaunch: Some(Arc::new(
-                    move |task_id: &str, from_node: Option<&str>| {
-                        let opts = octos_agent::RelaunchOpts {
-                            from_node: from_node.map(str::to_string),
-                        };
-                        match task_relaunch_store.relaunch_task(task_id, opts) {
-                            Ok(new_task_id) => {
-                                octos_bus::TaskRelaunchOutcome::Relaunched { new_task_id }
-                            }
-                            Err(octos_agent::TaskRelaunchError::NotFound) => {
-                                octos_bus::TaskRelaunchOutcome::NotFound
-                            }
-                            Err(octos_agent::TaskRelaunchError::StillActive) => {
-                                octos_bus::TaskRelaunchOutcome::StillActive
-                            }
+                task_relaunch: Some(Arc::new(move |task_id: &str, from_node: Option<&str>| {
+                    let opts = octos_agent::RelaunchOpts {
+                        from_node: from_node.map(str::to_string),
+                    };
+                    match task_relaunch_store.relaunch_task(task_id, opts) {
+                        Ok(new_task_id) => {
+                            octos_bus::TaskRelaunchOutcome::Relaunched { new_task_id }
                         }
-                    },
-                )),
+                        Err(octos_agent::TaskRelaunchError::NotFound) => {
+                            octos_bus::TaskRelaunchOutcome::NotFound
+                        }
+                        Err(octos_agent::TaskRelaunchError::StillActive) => {
+                            octos_bus::TaskRelaunchOutcome::StillActive
+                        }
+                    }
+                })),
                 #[cfg(feature = "api")]
                 metrics_handle: metrics_handle.clone(),
                 #[cfg(not(feature = "api"))]

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -403,6 +403,68 @@ pub(crate) fn build_plugin_env(
     env
 }
 
+/// S2 plumbing: build a synthesis-LLM provider config from the agent's
+/// current `Config`.
+///
+/// Used to populate plugin args (e.g. `deep_search`'s `synthesis_config`) so
+/// the plugin no longer needs to read `DEEPSEEK_API_KEY` / etc. from the
+/// process environment. Returns `None` when:
+///   1. No API key can be resolved for the active provider, OR
+///   2. We can't determine an OpenAI-compatible base URL for the provider.
+///
+/// Tokens MUST NOT be logged. We log only the provider name on success.
+pub(crate) fn build_synthesis_config(
+    config: &crate::config::Config,
+    provider_name: &str,
+) -> Option<octos_agent::SynthesisConfig> {
+    // Resolve base URL (config override > registry default).
+    let base_url = config.base_url.clone().or_else(|| {
+        octos_llm::registry::lookup(provider_name)
+            .and_then(|e| e.default_base_url)
+            .map(String::from)
+    })?;
+
+    // Resolve API key via auth store / env.
+    let api_key = config.get_api_key(provider_name).ok()?;
+    if api_key.is_empty() {
+        return None;
+    }
+
+    // Resolve model: default to the configured model, else fall back to a
+    // sensible per-provider default that matches the registry catalog.
+    let model = config
+        .model
+        .clone()
+        .or_else(|| {
+            octos_llm::registry::lookup(provider_name)
+                .and_then(|e| e.default_model)
+                .map(String::from)
+        })
+        .unwrap_or_else(|| match provider_name {
+            "deepseek" => "deepseek-chat".to_string(),
+            "openai" => "gpt-4o-mini".to_string(),
+            "gemini" | "google" => "gemini-2.0-flash".to_string(),
+            "dashscope" | "qwen" => "qwen-plus".to_string(),
+            "moonshot" | "kimi" => "kimi-2.5".to_string(),
+            "anthropic" => "claude-3-5-haiku-20241022".to_string(),
+            _ => "gpt-4o-mini".to_string(),
+        });
+
+    info!(
+        provider = %provider_name,
+        endpoint = %base_url,
+        model = %model,
+        "built synthesis_config for plugin injection"
+    );
+
+    Some(octos_agent::SynthesisConfig {
+        endpoint: base_url,
+        api_key,
+        model,
+        provider: provider_name.to_string(),
+    })
+}
+
 pub(super) struct ProfileActorFactoryBuilder {
     pub(super) profile_store: Arc<crate::profiles::ProfileStore>,
     pub(super) project_dir: PathBuf,
@@ -528,11 +590,17 @@ impl ProfileActorFactoryBuilder {
             );
             let plugin_dirs = crate::skills_scope::build_account_plugin_dirs(&profile_data_dir);
             if !plugin_dirs.is_empty() {
-                match octos_agent::PluginLoader::load_into_with_work_dir(
+                // S2 plumbing: pass profile-scoped synthesis config so per-tenant
+                // routing of synthesis credentials works.
+                let synthesis_config = build_synthesis_config(&profile_config, &provider_name);
+                match octos_agent::PluginLoader::load_into_with_options(
                     &mut tools,
                     &plugin_dirs,
                     &plugin_env,
-                    Some(&plugin_work_dir),
+                    octos_agent::PluginLoadOptions {
+                        work_dir: Some(&plugin_work_dir),
+                        synthesis_config,
+                    },
                 ) {
                     Ok(result) => {
                         child_plugin_prompt_fragments = result.prompt_fragments;
@@ -854,5 +922,67 @@ mod tests {
         assert!(env.contains(&("PPT_TEMPLATE_DIR".to_string(), "/templates".to_string())));
         assert!(env.contains(&("PPT_DEFAULT_THEME".to_string(), "nb-pro".to_string())));
         assert!(!env.iter().any(|(key, _)| key == "CUSTOM_SECRET_KEY"));
+    }
+
+    /// Mutex serializing build_synthesis_config env tests in this module.
+    fn synthesis_env_lock() -> &'static std::sync::Mutex<()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn build_synthesis_config_returns_full_struct_when_all_pieces_resolve() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let prev_key = std::env::var("OPENAI_API_KEY").ok();
+        // SAFETY: serialized by `synthesis_env_lock`; tests are single-threaded
+        // for env-mutation purposes via the lock above.
+        unsafe { std::env::set_var("OPENAI_API_KEY", "sk-test-build-synth") };
+
+        let config = crate::config::Config {
+            provider: Some("openai".to_string()),
+            model: Some("gpt-4o-mini".to_string()),
+            ..Default::default()
+        };
+        let cfg = build_synthesis_config(&config, "openai").expect("resolves");
+        assert_eq!(cfg.provider, "openai");
+        assert_eq!(cfg.api_key, "sk-test-build-synth");
+        assert_eq!(cfg.model, "gpt-4o-mini");
+        assert!(cfg.endpoint.contains("openai"));
+
+        // SAFETY: serialized by `synthesis_env_lock`.
+        match prev_key {
+            Some(v) => unsafe { std::env::set_var("OPENAI_API_KEY", v) },
+            None => unsafe { std::env::remove_var("OPENAI_API_KEY") },
+        }
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn build_synthesis_config_returns_none_without_api_key() {
+        let _guard = synthesis_env_lock().lock().unwrap();
+        let prev_key = std::env::var("OPENAI_API_KEY").ok();
+        // SAFETY: serialized by `synthesis_env_lock`.
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+
+        let config = crate::config::Config {
+            provider: Some("openai".to_string()),
+            model: Some("gpt-4o-mini".to_string()),
+            ..Default::default()
+        };
+        // Without an API key the helper must return None so the plugin
+        // falls back to its env path. We verify this by ensuring the helper
+        // never accidentally returns a placeholder/empty key.
+        let cfg = build_synthesis_config(&config, "openai");
+        assert!(
+            cfg.is_none(),
+            "must not synthesize a partial config when API key is unresolvable"
+        );
+
+        // SAFETY: serialized by `synthesis_env_lock`.
+        if let Some(v) = prev_key {
+            unsafe { std::env::set_var("OPENAI_API_KEY", v) };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Plugin (deep-search) reads `synthesis_config` from JSON args first, falls back to env vars for backward compat. Tokens never logged.
- Host (`octos-agent`) injects `synthesis_config` only into plugins whose manifest opts in via `x-octos-host-config-keys: ["synthesis_config"]`. Other plugins never receive the token.
- New `build_synthesis_config()` helper in `octos-cli` builds the struct from the agent's active provider config; wired through both `gateway_runtime` and `profile_factory` so per-tenant routing works.

## Why this change
Today operators set `DEEPSEEK_API_KEY` in `/Library/LaunchDaemons/io.octos.serve.plist` and the manifest's env allowlist forwards it. Problems:
- Per-mini operational config; doesn't survive a fresh bootstrap.
- Secret in the plist file under `/Library/LaunchDaemons/`.
- Same key forwarded to every plugin invocation regardless of caller.
- No per-tenant or per-user routing.

S2 makes the token octos-controlled and scoped to the plugins that explicitly opt in.

## Schema
```json
{
  "endpoint": "https://api.deepseek.com/v1",
  "api_key": "sk-...",
  "model": "deepseek-chat",
  "provider": "deepseek"
}
```
All four fields are required for the args path to win; partial configs fall through to the legacy env-var path so the operator's existing plist still works while migrations are in flight.

## Opt-in mechanism
Plugins declare which host-injected keys they accept via a JSON-schema extension:
```json
"x-octos-host-config-keys": ["synthesis_config"]
```
Tools without this extension never see the struct — defense against accidental token leakage to other plugins.

## Backward compat
- Manifest's existing env allowlist (`DEEPSEEK_API_KEY`, `KIMI_API_KEY`, etc.) stays so operators with legacy plists keep working.
- `resolve_synthesis_config()` still falls through to the env-var priority chain when args are missing or incomplete.
- `test_synthesis_config_args_path_takes_precedence_over_env` verifies args wins when both are present.
- `test_synthesis_config_falls_back_to_env_when_args_missing` verifies env fallback.
- `test_synthesis_config_falls_back_to_env_when_args_incomplete` verifies partial args fall through.

## Security
- Tokens MUST NOT be logged. Audited `tracing::*` and `eprintln!` paths around the resolver and the host injector. Only provider labels appear in diagnostics.
- `DEEPSEEK_API_KEY` etc. are not in `BLOCKED_ENV_VARS` (verified in `crates/octos-agent/src/sandbox/mod.rs:26`).
- Defense in depth: caller-supplied `synthesis_config` in args is never silently overwritten by the host. If a future call already provides one, the host backs off.

## Tests
Plugin (38 tests, 7 new):
- `test_input_deserialization_with_synthesis_config`
- `test_synthesis_config_args_path_takes_precedence_over_env`
- `test_synthesis_config_args_path_with_no_env`
- `test_synthesis_config_falls_back_to_env_when_args_missing`
- `test_synthesis_config_falls_back_to_env_when_args_incomplete`
- `test_synthesis_config_returns_none_when_neither_set`
- `test_synthesis_model_env_override_applies_to_args_path`

Host (`octos-agent`: 1191 lib tests pass; 9 new):
- `accepts_host_config_key_returns_false_when_extension_absent`
- `accepts_host_config_key_honours_extension_array`
- `synthesis_config_is_complete_only_when_all_fields_populated`
- `prepare_effective_args_injects_synthesis_config_when_opted_in`
- `prepare_effective_args_skips_synthesis_config_when_manifest_does_not_opt_in`
- `prepare_effective_args_skips_synthesis_config_when_host_did_not_set_one`
- `prepare_effective_args_skips_synthesis_config_when_partial`
- `prepare_effective_args_does_not_overwrite_explicit_synthesis_config`
- `load_into_with_options_attaches_synthesis_config_to_opted_in_plugins`
- `load_into_with_options_skips_synthesis_config_for_non_opted_in_plugins`

Host (`octos-cli`: 313 lib tests pass; 2 new):
- `build_synthesis_config_returns_full_struct_when_all_pieces_resolve`
- `build_synthesis_config_returns_none_without_api_key`

## Notes for the reviewer
- The plugin's `Input` and `SynthesisConfig` deliberately mirror the host's `octos_agent::SynthesisConfig` field-for-field but are independent types — plugin binaries are self-contained per the SDK contract, so we don't depend on `octos-agent` from the deep-search crate.
- The host helper falls back to per-provider model defaults when neither the agent's config nor the registry yields one. This keeps the args path useful even when only a key is configured.
- Sister plugins (e.g. `deep-crawl` if/when it grows synthesis) get host-injection for free by adding the same `x-octos-host-config-keys` schema extension to their manifest.

## Test plan
- [x] `cargo test -p deep-search` — 38 pass, 0 fail.
- [x] `cargo test -p octos-agent --lib -- --skip tools::send_file::tests::test_base_dir_blocks_non_tmp_outside_path` — 1191 pass, 0 fail. The skipped test is a pre-existing failure on the `220b3044` base (zero diff in send_file.rs).
- [x] `cargo test -p octos-cli --lib` — 313 pass, 0 fail.
- [x] `cargo clippy -p deep-search -p octos-agent -p octos-cli` — clean, no warnings.
- [x] `cargo build -p deep-search --release` — clean release build.
- [ ] Manual test: with env unset and args populated, synthesis fires; with neither set, fallback v1 raw-dump report renders. Recommend the orchestrator runs this end-to-end on a mini before merge.