### PR TITLE
fix(pipeline): cache plugin loading across nodes to prevent SSE-window starvation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3792,6 +3792,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-test",

--- a/crates/octos-pipeline/Cargo.toml
+++ b/crates/octos-pipeline/Cargo.toml
@@ -28,3 +28,4 @@ workspace = true
 [dev-dependencies]
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
+sha2 = { workspace = true }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -13,10 +13,115 @@ use octos_memory::EpisodeStore;
 use tracing::{info, warn};
 
 use octos_agent::progress::{ProgressEvent, ProgressReporter};
-use octos_agent::tools::TOOL_CTX;
+use octos_agent::tools::{TOOL_CTX, Tool, ToolRegistry};
 
 use crate::condition;
 use crate::graph::{HandlerKind, NodeOutcome, OutcomeStatus, PipelineNode};
+
+/// Cached snapshot of plugin tools loaded from `plugin_dirs`.
+///
+/// Computed once per `CodergenHandler` instance and shared across every
+/// node execution via an `Arc`. Eliminates the per-node SHA-256
+/// verification + executable read that the loader would otherwise
+/// perform on every `execute()` call — for ~14 bundled plugins (each
+/// up to 100 MB) this used to cost 100 ms–seconds per node and starved
+/// the SSE window the chat UI / e2e tests inspect.
+///
+/// Field semantics:
+/// * `tools` — registered plugin tool `Arc`s (cheap to insert into a
+///   per-node [`ToolRegistry`]).
+/// * `tool_names` — passed to [`ToolRegistry::mark_as_plugin`] so
+///   downstream gates that check `is_plugin()` see the same labels
+///   pre-cache vs. post-cache.
+/// * `spawn_only` — `(name, optional_message)` pairs replayed via
+///   [`ToolRegistry::mark_spawn_only`]. The pipeline `execute` path
+///   then `clear_spawn_only`s these out, but the marking is preserved
+///   so behaviour is byte-for-byte identical to the legacy
+///   `PluginLoader::load_into` call.
+#[derive(Default)]
+pub(crate) struct CachedPluginRegistration {
+    pub(crate) tools: Vec<Arc<dyn Tool>>,
+    pub(crate) tool_names: Vec<String>,
+    pub(crate) spawn_only: Vec<(String, Option<String>)>,
+}
+
+impl CachedPluginRegistration {
+    /// Apply this cached registration onto a fresh per-node
+    /// [`ToolRegistry`]. Mirrors the ordering used by
+    /// [`octos_agent::PluginLoader::load_into_with_options`] so the
+    /// observable registry state is identical to the legacy code path.
+    pub(crate) fn apply_to(&self, registry: &mut ToolRegistry) {
+        for tool in &self.tools {
+            let name = tool.name().to_string();
+            registry.mark_as_plugin(&name);
+            registry.register_arc(tool.clone());
+        }
+        for (name, msg) in &self.spawn_only {
+            registry.mark_spawn_only(name, msg.clone());
+        }
+    }
+}
+
+/// Build the cached plugin registration by running the loader against a
+/// throw-away registry. Errors are downgraded to a warn (matching the
+/// legacy pipeline behaviour) and an empty registration is cached so
+/// the warning fires at most once per handler lifetime.
+fn build_cached_plugin_registration(plugin_dirs: &[PathBuf]) -> CachedPluginRegistration {
+    if plugin_dirs.is_empty() {
+        return CachedPluginRegistration::default();
+    }
+
+    let started = std::time::Instant::now();
+    let mut staging = ToolRegistry::new();
+    let load_result = octos_agent::PluginLoader::load_into(&mut staging, plugin_dirs, &[]);
+    let elapsed = started.elapsed();
+
+    let load_result = match load_result {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                error = %e,
+                plugin_dirs = ?plugin_dirs,
+                "plugin loading in pipeline handler — caching empty registration"
+            );
+            return CachedPluginRegistration::default();
+        }
+    };
+
+    // Pull each registered tool back out by name — `load_into` registers
+    // them via `register(...)` which stores them as `Arc<dyn Tool>` we
+    // can clone cheaply on every node hit.
+    let mut tools: Vec<Arc<dyn Tool>> = Vec::with_capacity(load_result.tool_names.len());
+    for name in &load_result.tool_names {
+        if let Some(tool) = staging.get_tool(name) {
+            tools.push(tool);
+        }
+    }
+
+    // Capture spawn_only names so per-node registries can replay the
+    // marking. We deliberately drop the custom messages here because
+    // the pipeline `execute` path immediately calls
+    // `tools.clear_spawn_only()` (the comment in `execute` explains
+    // why), so the message text is never observed downstream. Storing
+    // only the names keeps the cache copy lean.
+    let spawn_only: Vec<(String, Option<String>)> = staging
+        .spawn_only_tools()
+        .iter()
+        .map(|name| (name.clone(), None))
+        .collect();
+
+    info!(
+        tool_count = tools.len(),
+        elapsed_ms = elapsed.as_millis() as u64,
+        "cached pipeline plugin registration"
+    );
+
+    CachedPluginRegistration {
+        tools,
+        tool_names: load_result.tool_names,
+        spawn_only,
+    }
+}
 
 /// Reporter that bridges worker agent events to the parent pipeline's
 /// `report_progress` so they appear in the SSE stream.
@@ -138,6 +243,12 @@ pub struct CodergenHandler {
     /// the same summary generator drives periodic LLM digests for any
     /// background task the worker triggers.
     host_context: crate::host_context::PipelineHostContext,
+    /// Backend bug #1 fix: cached snapshot of the plugin-tool registry
+    /// produced from `plugin_dirs`. Lazily populated on the first node
+    /// `execute()` (or test warm-up call) so all subsequent nodes skip
+    /// the SHA-256 verification + 100 MB executable read that would
+    /// otherwise re-run on every node and starve the SSE window.
+    plugin_cache: Arc<OnceLock<Arc<CachedPluginRegistration>>>,
 }
 
 impl CodergenHandler {
@@ -159,6 +270,7 @@ impl CodergenHandler {
             compaction_workspace: None,
             compaction_llm_provider: None,
             host_context: crate::host_context::PipelineHostContext::default(),
+            plugin_cache: Arc::new(OnceLock::new()),
         }
     }
 
@@ -195,6 +307,9 @@ impl CodergenHandler {
 
     pub fn with_plugin_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         self.plugin_dirs = dirs;
+        // Backend bug #1: reset the plugin-load cache when dirs change
+        // so a builder reordering can't end up with a stale cached set.
+        self.plugin_cache = Arc::new(OnceLock::new());
         self
     }
 
@@ -254,6 +369,39 @@ impl CodergenHandler {
         self.compaction_workspace.is_some()
     }
 
+    /// Lazily build (or return the already-built) plugin-tool cache.
+    ///
+    /// Backend bug #1 fix — collapses the per-node SHA-256 verification and
+    /// 100 MB-bounded executable read into a single up-front scan.
+    ///
+    /// The returned `Arc<CachedPluginRegistration>` is shared across every
+    /// node in the same pipeline run, and via `Arc<OnceLock>` across every
+    /// `Arc<dyn Handler>` clone of the same handler instance.
+    ///
+    /// First-call latency equals the legacy load cost (SHA-256 plus
+    /// `.<name>_verified` write). Subsequent calls reduce to a single atomic
+    /// load and an `Arc::clone`.
+    fn cached_plugin_registration(&self) -> Arc<CachedPluginRegistration> {
+        self.plugin_cache
+            .get_or_init(|| Arc::new(build_cached_plugin_registration(&self.plugin_dirs)))
+            .clone()
+    }
+
+    /// Doc-hidden test accessor — populates the plugin cache so tests
+    /// can assert that subsequent loads do NOT re-touch disk.
+    #[doc(hidden)]
+    pub fn warm_plugin_cache_for_test(&self) {
+        let _ = self.cached_plugin_registration();
+    }
+
+    /// Doc-hidden test accessor — exposes the cached plugin tool names.
+    /// Used by the regression test for backend bug #1 to confirm the
+    /// cached registration is stable across calls.
+    #[doc(hidden)]
+    pub fn cached_plugin_tool_names_for_test(&self) -> Vec<String> {
+        self.cached_plugin_registration().tool_names.clone()
+    }
+
     /// Resolve LLM provider for a node, following SpawnTool pattern.
     ///
     /// When a model is explicitly specified and a `ProviderRouter` is available,
@@ -308,12 +456,15 @@ impl Handler for CodergenHandler {
         // Build tool registry (same pattern as SpawnTool sync, spawn.rs:269-278)
         let mut tools = octos_agent::ToolRegistry::with_builtins(&self.working_dir);
 
-        // Load plugin tools (app-skills like deep-search, deep-crawl, etc.)
+        // Backend bug #1: load plugin tools from a process-shared cache.
+        // The cache is populated on the first node's execute() call (or
+        // via the test warm-up accessor) so subsequent nodes skip the
+        // SHA-256 verification + executable read that used to add
+        // 100 ms–seconds of per-node latency, starving the SSE window
+        // the chat UI / e2e tests inspect.
         if !self.plugin_dirs.is_empty() {
-            if let Err(e) = octos_agent::PluginLoader::load_into(&mut tools, &self.plugin_dirs, &[])
-            {
-                warn!("plugin loading in pipeline handler: {e}");
-            }
+            let cached = self.cached_plugin_registration();
+            cached.apply_to(&mut tools);
         }
 
         // Filter out empty tool names (from tools="" in DOT)

--- a/crates/octos-pipeline/tests/plugin_load_cache.rs
+++ b/crates/octos-pipeline/tests/plugin_load_cache.rs
@@ -1,0 +1,255 @@
+//! Backend bug #1 — pipeline plugin-load caching.
+//!
+//! The `CodergenHandler::execute` path used to call
+//! `PluginLoader::load_into` for every node, re-reading and SHA-256
+//! verifying every plugin executable on the runtime thread. With ~14
+//! bundled plugins (each up to 100 MB) this added 100 ms–seconds of
+//! latency per node which starved the SSE window the chat UI / e2e
+//! tests inspect. The fix loads plugins once per `CodergenHandler` and
+//! shares them via an `Arc<OnceLock>`-backed cache.
+//!
+//! These tests assert the cached behaviour: the verified-bytes sibling
+//! file is written exactly once across N node executions, and the
+//! cached registration vector exposes the same set of plugin tools on
+//! repeat calls.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use octos_pipeline::CodergenHandler;
+use sha2::{Digest, Sha256};
+
+#[allow(dead_code)]
+struct MockProvider;
+
+#[async_trait::async_trait]
+impl octos_llm::LlmProvider for MockProvider {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        Ok(octos_llm::ChatResponse {
+            content: Some("ok".into()),
+            tool_calls: vec![],
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage::default(),
+            reasoning_content: None,
+            provider_index: None,
+        })
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+    fn model_id(&self) -> &str {
+        "mock-1"
+    }
+}
+
+async fn temp_episode_store() -> Arc<octos_memory::EpisodeStore> {
+    let dir = tempfile::tempdir().unwrap();
+    Arc::new(octos_memory::EpisodeStore::open(dir.path()).await.unwrap())
+}
+
+/// Create a sham plugin under `plugins_root` named `name`. The plugin
+/// has a manifest declaring a single tool, a tiny shell-script
+/// executable, and a sha256 entry pointing at the executable bytes so
+/// the loader's hash verification path is exercised.
+fn create_stub_plugin(plugins_root: &Path, name: &str) -> PathBuf {
+    let plugin_dir = plugins_root.join(name);
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+
+    let exec_content = format!("#!/bin/sh\necho '{{\"output\":\"ok-{name}\",\"success\":true}}'\n");
+    let exec_bytes = exec_content.as_bytes();
+    let hash = format!("{:x}", Sha256::digest(exec_bytes));
+
+    let manifest = format!(
+        r#"{{
+            "name": "{name}",
+            "version": "1.0.0",
+            "sha256": "{hash}",
+            "tools": [{{
+                "name": "{tool_name}",
+                "description": "stub tool from plugin {name}"
+            }}]
+        }}"#,
+        tool_name = name.replace('-', "_"),
+    );
+    std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+
+    let exec_path = plugin_dir.join(name);
+    std::fs::write(&exec_path, exec_bytes).unwrap();
+    std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    plugin_dir
+}
+
+/// Acceptance — the cached-plugin path writes the verified-bytes sibling
+/// exactly once across many invocations, even when several plugin dirs
+/// are configured. This is the per-node-spawn cost the bug report
+/// flagged: prior to caching every node re-read + re-hashed every
+/// plugin and re-wrote `.<name>_verified` files, so the mtime advanced
+/// on every node execution.
+#[tokio::test]
+async fn pipeline_plugin_load_is_cached_across_nodes() {
+    let plugins_root = tempfile::tempdir().unwrap();
+    let working_dir = tempfile::tempdir().unwrap();
+
+    // Two stub plugins so the test exercises a multi-dir scan.
+    create_stub_plugin(plugins_root.path(), "stub-alpha");
+    create_stub_plugin(plugins_root.path(), "stub-beta");
+
+    let handler = CodergenHandler::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        working_dir.path().to_path_buf(),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .with_plugin_dirs(vec![plugins_root.path().to_path_buf()]);
+
+    // First load — verified files get written.
+    handler.warm_plugin_cache_for_test();
+
+    let alpha_verified = plugins_root.path().join("stub-alpha/.stub-alpha_verified");
+    let beta_verified = plugins_root.path().join("stub-beta/.stub-beta_verified");
+    assert!(
+        alpha_verified.exists(),
+        "first load should have written {}",
+        alpha_verified.display()
+    );
+    assert!(
+        beta_verified.exists(),
+        "first load should have written {}",
+        beta_verified.display()
+    );
+
+    let alpha_mtime_1 = std::fs::metadata(&alpha_verified)
+        .unwrap()
+        .modified()
+        .unwrap();
+    let beta_mtime_1 = std::fs::metadata(&beta_verified)
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    // Sleep long enough that a fresh write would advance mtime past the
+    // filesystem's resolution. macOS HFS+/APFS typically resolves to 1 ns
+    // but Linux on tmpfs can round to 1 s — sleep a full second to make
+    // any second `write` visible.
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+    // Second + third loads — these would re-write the verified files
+    // under the old (uncached) code path. With caching they must NOT.
+    handler.warm_plugin_cache_for_test();
+    handler.warm_plugin_cache_for_test();
+
+    let alpha_mtime_2 = std::fs::metadata(&alpha_verified)
+        .unwrap()
+        .modified()
+        .unwrap();
+    let beta_mtime_2 = std::fs::metadata(&beta_verified)
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    assert_eq!(
+        alpha_mtime_1, alpha_mtime_2,
+        "stub-alpha verified file must NOT be re-written on subsequent loads",
+    );
+    assert_eq!(
+        beta_mtime_1, beta_mtime_2,
+        "stub-beta verified file must NOT be re-written on subsequent loads",
+    );
+}
+
+/// Basic exposure check — the cached plugin tool names match what the
+/// loader produced (one tool per stub plugin). Mirrors the parity
+/// assertion that a node's per-execution registry sees the same
+/// plugin tools regardless of which node order it runs in.
+#[tokio::test]
+async fn cached_plugin_registration_exposes_loaded_tools() {
+    let plugins_root = tempfile::tempdir().unwrap();
+    let working_dir = tempfile::tempdir().unwrap();
+    create_stub_plugin(plugins_root.path(), "stub-alpha");
+    create_stub_plugin(plugins_root.path(), "stub-beta");
+
+    let handler = CodergenHandler::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        working_dir.path().to_path_buf(),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .with_plugin_dirs(vec![plugins_root.path().to_path_buf()]);
+
+    let names_first = handler.cached_plugin_tool_names_for_test();
+    let names_second = handler.cached_plugin_tool_names_for_test();
+
+    assert_eq!(
+        names_first, names_second,
+        "cached registration must be stable across calls"
+    );
+    assert!(names_first.contains(&"stub_alpha".to_string()));
+    assert!(names_first.contains(&"stub_beta".to_string()));
+}
+
+/// Empty plugin_dirs is a fast path — the cache resolves to an empty
+/// registration without filesystem work.
+#[tokio::test]
+async fn empty_plugin_dirs_is_a_no_op_fast_path() {
+    let working_dir = tempfile::tempdir().unwrap();
+    let handler = CodergenHandler::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        working_dir.path().to_path_buf(),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    );
+    assert!(handler.cached_plugin_tool_names_for_test().is_empty());
+}
+
+/// Measurement guard — the second cached load must complete in under
+/// 50 ms even with several plugins configured. The brief calls out
+/// 100 ms–seconds per node under the legacy uncached path, so this
+/// threshold gives us 2× headroom while leaving a clear regression
+/// signal if the cache ever stops working.
+#[tokio::test]
+async fn cached_load_is_at_least_an_order_of_magnitude_faster() {
+    let plugins_root = tempfile::tempdir().unwrap();
+    let working_dir = tempfile::tempdir().unwrap();
+    // Eight stub plugins — keep the test fast in CI but exercise enough
+    // surface that the per-load cost is observable.
+    for i in 0..8 {
+        create_stub_plugin(plugins_root.path(), &format!("stub-{i}"));
+    }
+
+    let handler = CodergenHandler::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        working_dir.path().to_path_buf(),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .with_plugin_dirs(vec![plugins_root.path().to_path_buf()]);
+
+    // First load — full cost.
+    let cold_start = std::time::Instant::now();
+    handler.warm_plugin_cache_for_test();
+    let cold_elapsed = cold_start.elapsed();
+
+    // Second load — must be effectively free.
+    let warm_start = std::time::Instant::now();
+    handler.warm_plugin_cache_for_test();
+    let warm_elapsed = warm_start.elapsed();
+
+    eprintln!(
+        "cold={cold_elapsed:?} warm={warm_elapsed:?} ratio={:.0}x",
+        cold_elapsed.as_nanos() as f64 / (warm_elapsed.as_nanos().max(1) as f64)
+    );
+
+    assert!(
+        warm_elapsed < std::time::Duration::from_millis(50),
+        "cached load should complete in <50 ms (got {warm_elapsed:?})"
+    );
+}


### PR DESCRIPTION
## Summary
- `CodergenHandler::execute` re-read + SHA-256 verified every bundled plugin (up to ~100 MB each, ~14 plugins) on **every** pipeline node, costing 100 ms–seconds of synchronous I/O per node and starving the SSE window so the chat UI / e2e tests only saw node 1.
- The handler now lazily loads plugin tools once per instance into an `Arc<OnceLock<Arc<CachedPluginRegistration>>>` cache. Per-node `execute` clones the cached `Arc<dyn Tool>` handles into a fresh `ToolRegistry` and replays `mark_as_plugin` + `mark_spawn_only` so observable registry state is identical to the legacy path.
- Warm-path latency drops from millisecond-to-second range to ~83 ns (>20,000x faster on the in-tree measurement guard). First-node cost is unchanged.

## Approach
Option A (cache-and-share) — implemented in `crates/octos-pipeline/src/handler.rs`:
- New private `CachedPluginRegistration` holds `Vec<Arc<dyn Tool>>`, `Vec<String>` plugin names, and `Vec<(String, Option<String>)>` spawn_only markers.
- `build_cached_plugin_registration` runs the loader against a throw-away `ToolRegistry`, harvests the registered Arcs, and downgrades load errors to a `warn!` that fires once per handler.
- `cached_plugin_registration()` populates the `OnceLock` on first call; `apply_to(&mut registry)` replays the cached state into the per-node registry.
- `with_plugin_dirs(dirs)` resets the cache so builder reordering can't keep a stale set.

CWD-rebind risk flagged in the brief did not materialise — the existing pipeline path passes `work_dir = None` to `PluginLoader::load_into` (no per-node rebinding happens today), so caching the loaded tools is byte-for-byte equivalent.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo clippy -p octos-pipeline --all-targets -- -D warnings`
- [x] `rustfmt --check` on touched files
- [x] `cargo test -p octos-pipeline --test plugin_load_cache` — 4/4 passing
- [x] `cargo test -p octos-pipeline` — 188 passing, 1 pre-existing failure (`test_06_send_file_sandbox_escape`) unrelated to this change (also fails on `0c1098e4`)
- [x] `cargo test -p octos-agent --lib` — 1192 passing
- [ ] Deploy + e2e `live-pipeline-cards.spec.ts` to confirm node ≥2 ids surface in SSE under full plugin load (left for orchestrator)

## Measurement
With 8 stub plugins under tempfs:
```
cold=1.868167ms warm=83ns ratio=22508x
```
Real bundled plugins are larger and on potentially-cold disk, so the cold path can hit hundreds of milliseconds; the warm path stays in the nanosecond range either way. The new test `cached_load_is_at_least_an_order_of_magnitude_faster` enforces a 50 ms ceiling on the warm path so a regression would fail loudly.

## Files
- `crates/octos-pipeline/src/handler.rs` — cache machinery + helper methods + `execute` call-site swap
- `crates/octos-pipeline/tests/plugin_load_cache.rs` — 4 new tests (caching parity, mtime stability, empty fast path, latency guard)
- `crates/octos-pipeline/Cargo.toml`, `Cargo.lock` — `sha2` dev-dependency for hash-fixture stub plugins

## Risk
Low. Changes are confined to one handler; no public API changes; the cache reset on `with_plugin_dirs` keeps builder behaviour intact; load failures still log a warn (just once instead of per-node).