### PR TITLE
fix(pipeline): plumb node_costs through tool result + SSE done event

### DIFF
--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -334,6 +334,7 @@ mod tests {
             files_to_send: vec![],
             streamed: false,
             messages: vec![],
+            tool_results: vec![],
         };
         let cloned = resp.clone();
         assert_eq!(cloned.content, "test");

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -47,14 +47,16 @@ use crate::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_cont
 ///
 /// Fields in order: the tool-result [`Message`], files the tool touched,
 /// files the tool wants auto-delivered to the user, optional sub-agent
-/// token usage, and a per-call `success` bit used by the serial scheduler
-/// to trigger the M8.8 error cascade.
+/// token usage, a per-call `success` bit used by the serial scheduler to
+/// trigger the M8.8 error cascade, and the optional structured side-channel
+/// metadata the tool surfaced (today: per-node cost rows from `run_pipeline`).
 type ToolCallResult = (
     Message,
     Vec<std::path::PathBuf>,
     Vec<std::path::PathBuf>,
     Option<TokenUsage>,
     bool,
+    Option<(String, serde_json::Value)>,
 );
 
 fn should_auto_send_tool_files(
@@ -195,6 +197,7 @@ impl Agent {
                             Vec::new(),
                             None,
                             false, // hook denial is a failure — cascade in serial mode
+                            None,
                         );
                     }
                     HookResult::Modified(new_args) => {
@@ -744,6 +747,7 @@ impl Agent {
                     Vec::new(),
                     None,
                     true, // spawn_only placeholder is reported as success
+                    None,
                 );
             }
 
@@ -789,127 +793,142 @@ impl Agent {
 
             let duration = tool_start.elapsed();
 
-            let (content, tool_files_modified, tool_files_to_send, tool_tokens, tool_success) =
-                match result {
-                    Ok(tool_result) => {
+            let (
+                content,
+                tool_files_modified,
+                tool_files_to_send,
+                tool_tokens,
+                tool_success,
+                tool_structured_metadata,
+            ) = match result {
+                Ok(tool_result) => {
+                    debug!(
+                        tool = %tc_name,
+                        success = tool_result.success,
+                        duration_ms = duration.as_millis() as u64,
+                        "tool completed"
+                    );
+
+                    if let Some(ref file) = tool_result.file_modified {
+                        info!(tool = %tc_name, file = %file.display(), "file modified");
+                        reporter.report(ProgressEvent::FileModified {
+                            path: file.display().to_string(),
+                        });
+                    }
+
+                    if should_auto_send_tool_files(
+                        suppress_auto_send_files,
+                        explicit_send_file_requested,
+                        &tc_name,
+                    ) {
+                        // Auto-send files explicitly declared by the plugin via files_to_send.
+                        // No heuristic path detection — plugins must opt-in by including
+                        // "files_to_send": ["/path/to/file"] in their JSON output.
+                        let files: Vec<String> = tool_result
+                            .files_to_send
+                            .iter()
+                            .map(|p| p.to_string_lossy().to_string())
+                            .collect();
+
+                        for path_str in &files {
+                            info!(tool = %tc_name, file = %path_str, "auto-sending file to user");
+                            let send_args =
+                                serde_json::json!({"file_path": path_str, "tool_call_id": tc_id});
+                            match tools.execute("send_file", &send_args).await {
+                                Ok(r) if r.success => {
+                                    info!(tool = %tc_name, file = %path_str, "file auto-sent");
+                                }
+                                Ok(r) => {
+                                    warn!(tool = %tc_name, file = %path_str, error = %r.output, "auto-send failed");
+                                }
+                                Err(e) => {
+                                    warn!(tool = %tc_name, file = %path_str, error = %e, "auto-send failed");
+                                }
+                            }
+                        }
+                    } else if explicit_send_file_requested
+                        && tc_name != "send_file"
+                        && !tool_result.files_to_send.is_empty()
+                    {
                         debug!(
                             tool = %tc_name,
-                            success = tool_result.success,
-                            duration_ms = duration.as_millis() as u64,
-                            "tool completed"
+                            "skipping auto-send because the same model turn already issued send_file"
                         );
-
-                        if let Some(ref file) = tool_result.file_modified {
-                            info!(tool = %tc_name, file = %file.display(), "file modified");
-                            reporter.report(ProgressEvent::FileModified {
-                                path: file.display().to_string(),
-                            });
-                        }
-
-                        if should_auto_send_tool_files(
-                            suppress_auto_send_files,
-                            explicit_send_file_requested,
-                            &tc_name,
-                        ) {
-                            // Auto-send files explicitly declared by the plugin via files_to_send.
-                            // No heuristic path detection — plugins must opt-in by including
-                            // "files_to_send": ["/path/to/file"] in their JSON output.
-                            let files: Vec<String> = tool_result
-                                .files_to_send
-                                .iter()
-                                .map(|p| p.to_string_lossy().to_string())
-                                .collect();
-
-                            for path_str in &files {
-                                info!(tool = %tc_name, file = %path_str, "auto-sending file to user");
-                                let send_args = serde_json::json!({"file_path": path_str, "tool_call_id": tc_id});
-                                match tools.execute("send_file", &send_args).await {
-                                    Ok(r) if r.success => {
-                                        info!(tool = %tc_name, file = %path_str, "file auto-sent");
-                                    }
-                                    Ok(r) => {
-                                        warn!(tool = %tc_name, file = %path_str, error = %r.output, "auto-send failed");
-                                    }
-                                    Err(e) => {
-                                        warn!(tool = %tc_name, file = %path_str, error = %e, "auto-send failed");
-                                    }
-                                }
-                            }
-                        } else if explicit_send_file_requested
-                            && tc_name != "send_file"
-                            && !tool_result.files_to_send.is_empty()
-                        {
-                            debug!(
-                                tool = %tc_name,
-                                "skipping auto-send because the same model turn already issued send_file"
-                            );
-                        }
-
-                        let mut tool_files_modified = Vec::new();
-                        if let Some(file) = tool_result.file_modified.clone() {
-                            tool_files_modified.push(file);
-                        }
-                        let tool_files_to_send = tool_result.files_to_send.clone();
-
-                        let output_preview =
-                            octos_core::truncated_utf8(&tool_result.output, 200, "...");
-
-                        reporter.report(ProgressEvent::ToolCompleted {
-                            name: tc_name.clone(),
-                            tool_id: tc_id.clone(),
-                            success: tool_result.success,
-                            output_preview,
-                            duration,
-                        });
-
-                        let success = tool_result.success;
-                        (
-                            tool_result.output,
-                            tool_files_modified,
-                            tool_files_to_send,
-                            tool_result.tokens_used,
-                            success,
-                        )
                     }
-                    Err(e) => {
-                        // Classify the tool failure as a typed HarnessError.
-                        // Invariant #1 (#488): every raw tool error escape
-                        // must be routed through classification so the
-                        // metrics counter and the sink event both fire.
-                        let classified = HarnessError::classify_report(&e, Some(tc_name.as_str()));
-                        classified.record_metric();
-                        if let Some(sink) = harness_event_sink.as_deref() {
-                            if let Some(ctx) = lookup_event_sink_context(sink) {
-                                let event =
-                                    classified.to_event(ctx.session_id, ctx.task_id, None, None);
-                                if let Err(error) = write_event_to_sink(sink, &event) {
-                                    tracing::debug!(
-                                        error = %error,
-                                        "failed to write tool-failure harness error event"
-                                    );
-                                }
+
+                    let mut tool_files_modified = Vec::new();
+                    if let Some(file) = tool_result.file_modified.clone() {
+                        tool_files_modified.push(file);
+                    }
+                    let tool_files_to_send = tool_result.files_to_send.clone();
+
+                    let output_preview =
+                        octos_core::truncated_utf8(&tool_result.output, 200, "...");
+
+                    reporter.report(ProgressEvent::ToolCompleted {
+                        name: tc_name.clone(),
+                        tool_id: tc_id.clone(),
+                        success: tool_result.success,
+                        output_preview,
+                        duration,
+                    });
+
+                    let success = tool_result.success;
+                    (
+                        tool_result.output,
+                        tool_files_modified,
+                        tool_files_to_send,
+                        tool_result.tokens_used,
+                        success,
+                        tool_result.structured_metadata,
+                    )
+                }
+                Err(e) => {
+                    // Classify the tool failure as a typed HarnessError.
+                    // Invariant #1 (#488): every raw tool error escape
+                    // must be routed through classification so the
+                    // metrics counter and the sink event both fire.
+                    let classified = HarnessError::classify_report(&e, Some(tc_name.as_str()));
+                    classified.record_metric();
+                    if let Some(sink) = harness_event_sink.as_deref() {
+                        if let Some(ctx) = lookup_event_sink_context(sink) {
+                            let event =
+                                classified.to_event(ctx.session_id, ctx.task_id, None, None);
+                            if let Err(error) = write_event_to_sink(sink, &event) {
+                                tracing::debug!(
+                                    error = %error,
+                                    "failed to write tool-failure harness error event"
+                                );
                             }
                         }
-                        warn!(
-                            tool = %tc_name,
-                            error = %e,
-                            variant = classified.variant_name(),
-                            recovery = %classified.recovery_hint(),
-                            duration_ms = duration.as_millis() as u64,
-                            "tool failed"
-                        );
-
-                        reporter.report(ProgressEvent::ToolCompleted {
-                            name: tc_name.clone(),
-                            tool_id: tc_id.clone(),
-                            success: false,
-                            output_preview: e.to_string(),
-                            duration,
-                        });
-
-                        (format!("Error: {e}"), Vec::new(), Vec::new(), None, false)
                     }
-                };
+                    warn!(
+                        tool = %tc_name,
+                        error = %e,
+                        variant = classified.variant_name(),
+                        recovery = %classified.recovery_hint(),
+                        duration_ms = duration.as_millis() as u64,
+                        "tool failed"
+                    );
+
+                    reporter.report(ProgressEvent::ToolCompleted {
+                        name: tc_name.clone(),
+                        tool_id: tc_id.clone(),
+                        success: false,
+                        output_preview: e.to_string(),
+                        duration,
+                    });
+
+                    (
+                        format!("Error: {e}"),
+                        Vec::new(),
+                        Vec::new(),
+                        None,
+                        false,
+                        None,
+                    )
+                }
+            };
 
             // After-tool hook (fire-and-forget)
             if let Some(ref hooks) = hooks {
@@ -929,6 +948,11 @@ impl Agent {
             let content = octos_core::truncate_head_tail(&content, limit, 0.7);
             let content = crate::sanitize::sanitize_tool_output(&content);
 
+            // Pair the structured side-channel with the originating tool's
+            // call id so the session actor (which keys cost rows by
+            // tool_call_id) can match them on the SSE done event.
+            let structured_metadata = tool_structured_metadata.map(|meta| (tc_id.clone(), meta));
+
             (
                 Message {
                     role: MessageRole::Tool,
@@ -944,6 +968,7 @@ impl Agent {
                 tool_files_to_send,
                 tool_tokens,
                 tool_success,
+                structured_metadata,
             )
         })
     }
@@ -956,6 +981,7 @@ impl Agent {
         Vec<std::path::PathBuf>,
         Vec<std::path::PathBuf>,
         TokenUsage,
+        Vec<(String, serde_json::Value)>,
     )> {
         let tool_names: Vec<&str> = response
             .tool_calls
@@ -1056,7 +1082,7 @@ impl Agent {
                             timestamp: chrono::Utc::now(),
                         })
                         .collect();
-                    return Ok((messages, vec![], vec![], TokenUsage::default()));
+                    return Ok((messages, vec![], vec![], TokenUsage::default(), Vec::new()));
                 }
             }
         };
@@ -1064,7 +1090,7 @@ impl Agent {
         // Log completion of the tool batch.
         let result_sizes: Vec<usize> = results
             .iter()
-            .map(|(m, _, _, _, _)| m.content.len())
+            .map(|(m, _, _, _, _, _)| m.content.len())
             .collect();
         let total_result_bytes: usize = result_sizes.iter().sum();
         tracing::info!(
@@ -1080,8 +1106,17 @@ impl Agent {
         let mut files_modified = Vec::new();
         let mut files_to_send = Vec::new();
         let mut tokens_used = TokenUsage::default();
+        let mut structured_metadata: Vec<(String, serde_json::Value)> = Vec::new();
 
-        for (message, tool_files_modified, tool_files_to_send, tool_tokens, _success) in results {
+        for (
+            message,
+            tool_files_modified,
+            tool_files_to_send,
+            tool_tokens,
+            _success,
+            tool_structured_metadata,
+        ) in results
+        {
             messages.push(message);
             files_modified.extend(tool_files_modified);
             files_to_send.extend(tool_files_to_send);
@@ -1089,9 +1124,18 @@ impl Agent {
                 tokens_used.input_tokens += tokens.input_tokens;
                 tokens_used.output_tokens += tokens.output_tokens;
             }
+            if let Some(meta) = tool_structured_metadata {
+                structured_metadata.push(meta);
+            }
         }
 
-        Ok((messages, files_modified, files_to_send, tokens_used))
+        Ok((
+            messages,
+            files_modified,
+            files_to_send,
+            tokens_used,
+            structured_metadata,
+        ))
     }
 
     /// Serial dispatch for batches that contain at least one Exclusive tool (M8.8).
@@ -1168,6 +1212,7 @@ impl Agent {
                         Vec::new(),
                         None,
                         false,
+                        None,
                     )
                 }
             };
@@ -1208,6 +1253,7 @@ fn cancelled_result(tool_call: &octos_core::ToolCall) -> ToolCallResult {
         Vec::new(),
         None,
         false,
+        None,
     )
 }
 
@@ -1228,6 +1274,7 @@ fn panic_result(tool_call: &octos_core::ToolCall, reason: &str) -> ToolCallResul
         Vec::new(),
         None,
         false,
+        None,
     )
 }
 

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -646,6 +646,12 @@ impl Agent {
                 let config = self.chat_config();
                 let mut files_modified = Vec::new();
                 let mut files_to_send = Vec::new();
+                // Accumulate the structured side-channel metadata that tools
+                // surface during this turn (today: `node_costs` from
+                // `run_pipeline`). Threaded into every `ConversationResponse`
+                // built below so the session actor can plumb it into the SSE
+                // `done` event for the W1.G4 cost panel.
+                let mut tool_structured_metadata: Vec<(String, serde_json::Value)> = Vec::new();
                 let mut turn = LoopTurnState::new(Instant::now());
                 // M6.2: per-turn retry-bucket state machine. Lives alongside
                 // `LoopTurnState` rather than inside it so the file boundary
@@ -678,6 +684,7 @@ impl Agent {
                                 files_to_send,
                                 streamed: false,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
+                                tool_results: tool_structured_metadata.clone(),
                             });
                         }
                     }
@@ -851,6 +858,7 @@ impl Agent {
                                 files_to_send,
                                 streamed,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
+                                tool_results: tool_structured_metadata.clone(),
                             });
                         }
                         StopReason::ToolUse => {
@@ -883,6 +891,7 @@ impl Agent {
                                                 &messages,
                                                 history.len(),
                                             ),
+                                            tool_results: tool_structured_metadata.clone(),
                                         });
                                     }
                                     // Single-fire-per-burst: first fire emits the
@@ -905,6 +914,7 @@ impl Agent {
                                             &messages,
                                             history.len(),
                                         ),
+                                        tool_results: tool_structured_metadata.clone(),
                                     });
                                 }
                             }
@@ -917,6 +927,7 @@ impl Agent {
                                     &mut turn,
                                     &mut retry_state,
                                     tracker,
+                                    Some(&mut tool_structured_metadata),
                                 )
                                 .await
                             {
@@ -957,6 +968,7 @@ impl Agent {
                                         &messages,
                                         history.len(),
                                     ),
+                                    tool_results: tool_structured_metadata.clone(),
                                 });
                             }
 
@@ -993,6 +1005,7 @@ impl Agent {
                                     files_to_send,
                                     streamed,
                                     messages: LoopTurnState::new_messages(&messages, history.len()),
+                                    tool_results: tool_structured_metadata.clone(),
                                 });
                             }
                         }
@@ -1009,6 +1022,7 @@ impl Agent {
                                 files_to_send,
                                 streamed,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
+                                tool_results: tool_structured_metadata.clone(),
                             });
                         }
                         StopReason::ContentFiltered => {
@@ -1031,6 +1045,7 @@ impl Agent {
                                 files_to_send,
                                 streamed,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
+                                tool_results: tool_structured_metadata.clone(),
                             });
                         }
                     }
@@ -1252,6 +1267,7 @@ impl Agent {
                                 &mut turn,
                                 &mut retry_state,
                                 None,
+                                None,
                             )
                             .await
                         {
@@ -1341,6 +1357,7 @@ impl Agent {
         turn: &mut LoopTurnState,
         retry_state: &mut LoopRetryState,
         tracker: Option<&TokenTracker>,
+        tool_structured_metadata: Option<&mut Vec<(String, serde_json::Value)>>,
     ) -> Result<()> {
         // Fix tool_call IDs -- some models (e.g. qwen via dashscope) generate
         // duplicate or empty IDs which downstream providers reject with 400.
@@ -1406,16 +1423,21 @@ impl Agent {
         let mut tool_files = Vec::new();
         let mut tool_send_files = Vec::new();
         let mut tool_tokens = TokenUsage::default();
+        let mut tool_metadata: Vec<(String, serde_json::Value)> = Vec::new();
         for batch in tool_batches {
             let mut batch_response = limited_response.clone();
             batch_response.tool_calls = batch.to_vec();
-            let (batch_messages, batch_files, batch_send_files, batch_tokens) =
+            let (batch_messages, batch_files, batch_send_files, batch_tokens, batch_metadata) =
                 self.execute_tools(&batch_response).await?;
             tool_messages.extend(batch_messages);
             tool_files.extend(batch_files);
             tool_send_files.extend(batch_send_files);
             tool_tokens.input_tokens += batch_tokens.input_tokens;
             tool_tokens.output_tokens += batch_tokens.output_tokens;
+            tool_metadata.extend(batch_metadata);
+        }
+        if let Some(sink) = tool_structured_metadata {
+            sink.extend(tool_metadata);
         }
 
         let merged = merge_tool_messages_in_order(

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -107,6 +107,12 @@ pub struct ConversationResponse {
     /// tool results). Includes the user message at the front. Callers should
     /// persist these to session history so subsequent calls see the full context.
     pub messages: Vec<Message>,
+    /// Structured side-channel metadata surfaced by tools that ran during
+    /// this conversation, keyed by `tool_call_id`. Used today for per-node
+    /// cost rows from `run_pipeline` (`{"node_costs": [...]}`); the session
+    /// actor pulls these into the SSE `done` event so the W1.G4 cost panel
+    /// can render real per-node attribution. Empty when no tool opted in.
+    pub tool_results: Vec<(String, serde_json::Value)>,
 }
 
 /// Shared atomic counters for real-time token tracking (used by status indicators).

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1000,9 +1000,7 @@ impl TaskSupervisor {
     pub fn cancel(&self, task_id: &str) -> Result<(), TaskCancelError> {
         let snapshot = {
             let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
-            let task = tasks
-                .get_mut(task_id)
-                .ok_or(TaskCancelError::NotFound)?;
+            let task = tasks.get_mut(task_id).ok_or(TaskCancelError::NotFound)?;
             if task.status.is_terminal() {
                 return Err(TaskCancelError::AlreadyTerminal);
             }
@@ -1038,11 +1036,7 @@ impl TaskSupervisor {
     /// still succeeds — the new task id is returned so callers can
     /// observe the placeholder in dashboards even when the runtime
     /// owner has not subscribed yet.
-    pub fn relaunch(
-        &self,
-        task_id: &str,
-        opts: RelaunchOpts,
-    ) -> Result<String, TaskRelaunchError> {
+    pub fn relaunch(&self, task_id: &str, opts: RelaunchOpts) -> Result<String, TaskRelaunchError> {
         let original = {
             let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
             tasks
@@ -2908,8 +2902,7 @@ mod tests {
             });
         }
 
-        let task_id =
-            supervisor.register("run_pipeline", "call-relaunch-1", Some("session-D"));
+        let task_id = supervisor.register("run_pipeline", "call-relaunch-1", Some("session-D"));
         supervisor.mark_running(&task_id);
         supervisor.mark_failed(&task_id, "node 'design' failed".to_string());
 

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -368,6 +368,13 @@ pub struct ToolResult {
     pub files_to_send: Vec<PathBuf>,
     /// Tokens used by this tool (for subagent tools).
     pub tokens_used: Option<TokenUsage>,
+    /// Optional structured side-channel for tool-specific metadata the host
+    /// wants to surface beyond plain output text. Used today for per-node
+    /// cost rows from `run_pipeline` (`{"node_costs": [...]}`); the session
+    /// actor pulls this back into the SSE `done` event so the W1.G4 cost
+    /// panel can render real per-node attribution. Absent (`None`) for
+    /// every tool that does not opt in — keeps legacy callers byte-identical.
+    pub structured_metadata: Option<serde_json::Value>,
 }
 
 /// Trait for implementing tools.

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -19,15 +19,15 @@ use super::mcp_agent::{
     build_backend_from_config, build_dispatch_event_payload, dispatch_with_metrics,
 };
 use super::{Tool, ToolPolicy, ToolRegistry, ToolResult};
+use crate::file_state_cache::FileStateCache;
 use crate::harness_events::{HarnessEvent, HarnessEventSink, write_event_to_sink};
+use crate::subagent_output::SubAgentOutputRouter;
+use crate::subagent_summary::AgentSummaryGenerator;
 use crate::task_supervisor::TaskSupervisor;
 use crate::workspace_git::{
     WorkspaceContractStatus, WorkspaceProjectKind,
     resolve_preferred_workspace_contract_artifact_path, resolve_workspace_contract_artifact_paths,
 };
-use crate::file_state_cache::FileStateCache;
-use crate::subagent_output::SubAgentOutputRouter;
-use crate::subagent_summary::AgentSummaryGenerator;
 use crate::{Agent, AgentConfig, HookContext, HookExecutor, HookPayload, HookResult};
 
 /// Default MCP tool name dispatched on the remote agent. Chosen to match
@@ -571,10 +571,7 @@ impl SpawnTool {
     /// M8 Runtime Parity W2.B1: inherit the parent's M8.7 output router
     /// so the child Agent's spawn_only background branch routes output
     /// through the same on-disk log the parent dashboard tails.
-    pub fn with_parent_subagent_output_router(
-        mut self,
-        router: Arc<SubAgentOutputRouter>,
-    ) -> Self {
+    pub fn with_parent_subagent_output_router(mut self, router: Arc<SubAgentOutputRouter>) -> Self {
         self.parent_subagent_output_router = Some(router);
         self
     }
@@ -603,9 +600,7 @@ impl SpawnTool {
     }
 
     /// M8 Runtime Parity W2.B1 introspection helper.
-    pub fn parent_subagent_summary_generator(
-        &self,
-    ) -> Option<&Arc<AgentSummaryGenerator>> {
+    pub fn parent_subagent_summary_generator(&self) -> Option<&Arc<AgentSummaryGenerator>> {
         self.parent_subagent_summary_generator.as_ref()
     }
 
@@ -2218,10 +2213,8 @@ impl Tool for SpawnTool {
             // without M8.4/M8.7 wiring even when the session actor
             // configured everything.
             let parent_file_state_cache = self.parent_file_state_cache.clone();
-            let parent_subagent_output_router =
-                self.parent_subagent_output_router.clone();
-            let parent_subagent_summary_generator =
-                self.parent_subagent_summary_generator.clone();
+            let parent_subagent_output_router = self.parent_subagent_output_router.clone();
+            let parent_subagent_summary_generator = self.parent_subagent_summary_generator.clone();
 
             tokio::spawn(async move {
                 if let (Some(supervisor), Some(task_id)) =
@@ -4271,7 +4264,12 @@ PY
 
         let memory = Arc::new(create_test_store().await);
         let registry = ToolRegistry::with_builtins(PathBuf::from("/tmp"));
-        let worker = Agent::new(AgentId::new("test-worker"), provider.clone(), registry, memory);
+        let worker = Agent::new(
+            AgentId::new("test-worker"),
+            provider.clone(),
+            registry,
+            memory,
+        );
         let subtask = Task::new(
             TaskKind::Code {
                 instruction: "Recover me".into(),
@@ -4344,15 +4342,15 @@ PY
     async fn spawn_tool_propagates_parent_caches_via_builders() {
         let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
         let cache = Arc::new(crate::FileStateCache::new());
-        let router = Arc::new(crate::SubAgentOutputRouter::new(
-            std::env::temp_dir().join(format!(
+        let router = Arc::new(crate::SubAgentOutputRouter::new(std::env::temp_dir().join(
+            format!(
                 "octos-w2-router-{}",
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_nanos())
                     .unwrap_or(0),
-            )),
-        ));
+            ),
+        )));
         let supervisor = TaskSupervisor::new();
         let summary_gen = Arc::new(crate::AgentSummaryGenerator::new(
             Arc::new(MockProvider),

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -934,6 +934,15 @@ impl Channel for ApiChannel {
                 if let Some(seq) = msg.metadata.get("committed_seq").and_then(|v| v.as_u64()) {
                     done["committed_seq"] = serde_json::Value::from(seq);
                 }
+                // Bug 3 / W1.G4 cost panel — forward the per-node cost rows
+                // that the session actor pulled out of
+                // `ToolResult.structured_metadata` from `run_pipeline`. The
+                // CostBreakdown panel reads this array off the `done` event.
+                if let Some(node_costs) = msg.metadata.get("node_costs").cloned() {
+                    if !node_costs.as_array().map(|a| a.is_empty()).unwrap_or(true) {
+                        done["node_costs"] = node_costs;
+                    }
+                }
                 let _ = tx.send(done.to_string());
                 pending.remove(&msg.chat_id);
                 drop(pending);

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -558,6 +558,19 @@ async fn chat_streaming(
                 if let Some(seq) = assistant_committed_seq {
                     done["committed_seq"] = serde_json::Value::from(seq);
                 }
+                // Bug 3 / W1.G4 cost panel — flatten per-node cost rows from
+                // tool results' structured side-channel into the SSE done
+                // event so the dashboard CostBreakdown panel can render
+                // real per-node attribution from `run_pipeline` runs.
+                let mut all_node_costs: Vec<serde_json::Value> = Vec::new();
+                for (_tool_call_id, meta) in &response.tool_results {
+                    if let Some(arr) = meta.get("node_costs").and_then(|v| v.as_array()) {
+                        all_node_costs.extend(arr.iter().cloned());
+                    }
+                }
+                if !all_node_costs.is_empty() {
+                    done["node_costs"] = serde_json::Value::Array(all_node_costs);
+                }
                 let _ = tx.send(done.to_string());
             }
             Err(e) => {
@@ -998,7 +1011,10 @@ pub async fn restart_task_from_node(
     let body = body.map(|Json(b)| b).unwrap_or_default();
 
     if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
-        let path = format!("/tasks/{}/restart-from-node", encode_api_session_path_id(&task_id));
+        let path = format!(
+            "/tasks/{}/restart-from-node",
+            encode_api_session_path_id(&task_id)
+        );
         let proxied_body = serde_json::json!({
             "node_id": body.node_id,
         });
@@ -2990,6 +3006,19 @@ async fn ws_standalone_agent(
                 if let Some(seq) = assistant_committed_seq {
                     done["committed_seq"] = serde_json::Value::from(seq);
                 }
+                // Bug 3 / W1.G4 cost panel — flatten per-node cost rows from
+                // tool results' structured side-channel into the SSE done
+                // event so the dashboard CostBreakdown panel can render
+                // real per-node attribution from `run_pipeline` runs.
+                let mut all_node_costs: Vec<serde_json::Value> = Vec::new();
+                for (_tool_call_id, meta) in &response.tool_results {
+                    if let Some(arr) = meta.get("node_costs").and_then(|v| v.as_array()) {
+                        all_node_costs.extend(arr.iter().cloned());
+                    }
+                }
+                if !all_node_costs.is_empty() {
+                    done["node_costs"] = serde_json::Value::Array(all_node_costs);
+                }
                 let _ = tx.send(done.to_string());
             }
             Err(e) => {
@@ -3733,12 +3762,8 @@ mod tests {
             task_query_store: Some(store),
             ..AppState::empty_for_tests()
         });
-        let response = cancel_task(
-            State(state),
-            HeaderMap::new(),
-            axum::extract::Path(task_id),
-        )
-        .await;
+        let response =
+            cancel_task(State(state), HeaderMap::new(), axum::extract::Path(task_id)).await;
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -138,10 +138,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/sessions/{id}", delete(handlers::delete_session))
         // M7.9 / W2 — task supervisor exposure
-        .route(
-            "/api/tasks/{task_id}/cancel",
-            post(handlers::cancel_task),
-        )
+        .route("/api/tasks/{task_id}/cancel", post(handlers::cancel_task))
         .route(
             "/api/tasks/{task_id}/restart-from-node",
             post(handlers::restart_task_from_node),

--- a/crates/octos-cli/src/commands/gateway/adapters/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/adapters/mod.rs
@@ -63,8 +63,7 @@ pub type TaskQueryFn = Arc<dyn Fn(&str) -> serde_json::Value + Send + Sync>;
 pub type SessionDeletedCallback = Arc<dyn Fn(&str) + Send + Sync>;
 /// M7.9 / W2: cancel callback signature shared with the api adapter.
 #[cfg(feature = "api")]
-pub type TaskCancelCb =
-    Arc<dyn Fn(&str) -> octos_bus::TaskCancelOutcome + Send + Sync>;
+pub type TaskCancelCb = Arc<dyn Fn(&str) -> octos_bus::TaskCancelOutcome + Send + Sync>;
 /// M7.9 / W2: relaunch callback signature shared with the api adapter.
 #[cfg(feature = "api")]
 pub type TaskRelaunchCb =

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -444,6 +444,28 @@ fn record_retry(reason: &'static str) {
     counter!("octos_retry_total", "reason" => reason.to_string()).increment(1);
 }
 
+/// Collect per-node cost rows from a turn's tool-result side-channel
+/// metadata into a flat array suitable for the SSE `done` event.
+///
+/// Bug 3 / W1.G4 — tools (today: `run_pipeline`) surface per-node cost
+/// rows via `ToolResult.structured_metadata` keyed under `"node_costs"`.
+/// The session actor walks every tool result and concatenates the rows so
+/// the dashboard CostBreakdown panel sees one cost row per pipeline node
+/// regardless of how many `run_pipeline` calls fired during the turn.
+///
+/// Returns an empty vector when no tool surfaced cost rows — the caller
+/// only writes the `node_costs` key on the SSE event when this is
+/// non-empty so legacy clients keep their byte-for-byte payload shape.
+fn collect_node_costs(tool_results: &[(String, serde_json::Value)]) -> Vec<serde_json::Value> {
+    let mut all_node_costs: Vec<serde_json::Value> = Vec::new();
+    for (_tool_call_id, meta) in tool_results {
+        if let Some(arr) = meta.get("node_costs").and_then(|v| v.as_array()) {
+            all_node_costs.extend(arr.iter().cloned());
+        }
+    }
+    all_node_costs
+}
+
 fn record_result_delivery(path: &'static str, outcome: &'static str, kind: &'static str) {
     counter!(
         "octos_result_delivery_total",
@@ -846,10 +868,7 @@ impl SessionTaskQueryStore {
     /// Walks every live supervisor (pruning dropped ones) until it finds
     /// the task. When no supervisor knows about `task_id`, returns
     /// `Err(TaskCancelError::NotFound)`.
-    pub fn cancel_task(
-        &self,
-        task_id: &str,
-    ) -> Result<(), octos_agent::TaskCancelError> {
+    pub fn cancel_task(&self, task_id: &str) -> Result<(), octos_agent::TaskCancelError> {
         for supervisor in self.live_supervisors() {
             if supervisor.get_task(task_id).is_some() {
                 return supervisor.cancel(task_id);
@@ -4261,7 +4280,14 @@ impl SessionActor {
                 let session_cost = model_id.as_deref().and_then(model_pricing).map(|pricing| {
                     pricing.cost(cr.token_usage.input_tokens, cr.token_usage.output_tokens)
                 });
-                serde_json::json!({
+                // Bug 3 / W1.G4 cost panel — collect per-node cost rows that
+                // tools (today: `run_pipeline`) surfaced through their
+                // `ToolResult.structured_metadata` side-channel. Without this
+                // accumulator the data was being silently dropped between
+                // the tool boundary and the SSE `done` event, leaving the
+                // dashboard's CostBreakdown panel data-blind in production.
+                let all_node_costs = collect_node_costs(&cr.tool_results);
+                let mut meta_obj = serde_json::json!({
                     "_completion": true,
                     "model": model_label,
                     "provider": provider_metadata.as_ref().map(|meta| meta.provider.clone()),
@@ -4273,7 +4299,16 @@ impl SessionActor {
                     "duration_s": llm_latency.as_secs_f64().round() as u64,
                     "has_bg_tasks": had_bg_tasks,
                     "bg_tasks": bg_task_details,
-                })
+                });
+                if !all_node_costs.is_empty() {
+                    if let Some(map) = meta_obj.as_object_mut() {
+                        map.insert(
+                            "node_costs".to_string(),
+                            serde_json::Value::Array(all_node_costs),
+                        );
+                    }
+                }
+                meta_obj
             }
             Ok(Err(e)) => {
                 warn!(session = %self.session_key, error = %e, "agent returned error");
@@ -5578,6 +5613,97 @@ mod tests {
         assert_eq!(
             strip_invoke_tags("a<invoke name=\"cron\" args='{}' />b"),
             "ab"
+        );
+    }
+
+    /// Gap 3.2 — when a tool surfaced `node_costs` via
+    /// `ToolResult.structured_metadata`, `process_inbound`'s metadata
+    /// builder must concatenate every row across tool results so the
+    /// SSE `done` event carries the per-node cost array. Tested through
+    /// the same `collect_node_costs` helper `process_inbound` calls.
+    #[test]
+    fn collect_node_costs_concatenates_rows_from_multiple_tool_results() {
+        let tool_results = vec![
+            (
+                "call_pipeline_1".to_string(),
+                serde_json::json!({
+                    "node_costs": [
+                        {"node_id": "draft",  "tokens_in": 320, "tokens_out": 110, "actual_usd": 0.0008},
+                        {"node_id": "refine", "tokens_in": 540, "tokens_out": 220, "actual_usd": 0.0032},
+                    ]
+                }),
+            ),
+            (
+                "call_pipeline_2".to_string(),
+                serde_json::json!({
+                    "node_costs": [
+                        {"node_id": "synthesize", "tokens_in": 720, "tokens_out": 410, "actual_usd": 0.0091}
+                    ]
+                }),
+            ),
+        ];
+
+        let collected = collect_node_costs(&tool_results);
+        assert_eq!(collected.len(), 3, "rows from both pipelines must merge");
+        assert_eq!(
+            collected[0].get("node_id").and_then(|v| v.as_str()),
+            Some("draft")
+        );
+        assert_eq!(
+            collected[2].get("node_id").and_then(|v| v.as_str()),
+            Some("synthesize")
+        );
+    }
+
+    /// When no tool produced cost rows, the helper returns an empty vector
+    /// so the calling code can omit the `node_costs` key from the SSE
+    /// payload entirely (legacy clients see byte-identical events).
+    #[test]
+    fn collect_node_costs_returns_empty_when_no_tool_surfaced_metadata() {
+        let tool_results: Vec<(String, serde_json::Value)> = Vec::new();
+        assert!(collect_node_costs(&tool_results).is_empty());
+
+        let unrelated = vec![(
+            "call_other_tool".to_string(),
+            serde_json::json!({"some_other_key": "value"}),
+        )];
+        assert!(collect_node_costs(&unrelated).is_empty());
+    }
+
+    /// End-to-end shape — drop the helper output into the same
+    /// `completion_meta` builder shape used by `process_inbound` and
+    /// confirm the SSE payload carries `node_costs`.
+    #[test]
+    fn completion_meta_carries_node_costs_when_tool_results_have_metadata() {
+        let tool_results = vec![(
+            "call_pipeline_1".to_string(),
+            serde_json::json!({
+                "node_costs": [
+                    {"node_id": "draft", "tokens_in": 320, "tokens_out": 110, "actual_usd": 0.0008}
+                ]
+            }),
+        )];
+
+        let collected = collect_node_costs(&tool_results);
+        let mut meta = serde_json::json!({
+            "_completion": true,
+            "tokens_in": 320,
+            "tokens_out": 110,
+        });
+        if !collected.is_empty() {
+            meta.as_object_mut().unwrap().insert(
+                "node_costs".to_string(),
+                serde_json::Value::Array(collected),
+            );
+        }
+        let arr = meta
+            .get("node_costs")
+            .and_then(|v| v.as_array())
+            .expect("completion_meta must carry node_costs once a tool surfaced rows");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(
+            arr[0].get("node_id").and_then(|v| v.as_str()),
+            Some("draft")
         );
     }
 

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -2189,8 +2189,7 @@ impl PipelineExecutor {
                             supervisor.mark_completed(&task_id, files);
                         }
                         OutcomeStatus::Fail | OutcomeStatus::Error => {
-                            supervisor
-                                .mark_failed(&task_id, format!("node {} failed", node.id));
+                            supervisor.mark_failed(&task_id, format!("node {} failed", node.id));
                         }
                         OutcomeStatus::Skipped => {
                             // Treat as completed-with-no-output so the

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -20,9 +20,9 @@ use crate::graph::{HandlerKind, NodeOutcome, OutcomeStatus, PipelineNode};
 
 /// Reporter that bridges worker agent events to the parent pipeline's
 /// `report_progress` so they appear in the SSE stream.
-struct PipelineNodeReporter {
-    node_id: String,
-    model: String,
+pub(crate) struct PipelineNodeReporter {
+    pub(crate) node_id: String,
+    pub(crate) model: String,
 }
 
 impl ProgressReporter for PipelineNodeReporter {
@@ -56,6 +56,25 @@ impl ProgressReporter for PipelineNodeReporter {
                 format!(
                     "{} [{}]: response received (iteration {})",
                     self.node_id, self.model, iteration
+                )
+            }
+            // Bug 3 / Gap 3.3 — per-node cost updates from inner agents must
+            // reach the parent SSE stream. The legacy `_ => return` arm
+            // swallowed these silently, leaving the W1.G4 CostBreakdown
+            // panel data-blind. Forward as a structured progress message
+            // the chat UI can render alongside the per-node tree.
+            ProgressEvent::CostUpdate {
+                session_input_tokens,
+                session_output_tokens,
+                response_cost,
+                ..
+            } => {
+                let cost_label = response_cost
+                    .map(|c| format!("${c:.4}"))
+                    .unwrap_or_else(|| "$?".to_string());
+                format!(
+                    "{}: tokens {}+{}, {}",
+                    self.node_id, session_input_tokens, session_output_tokens, cost_label
                 )
             }
             _ => return,
@@ -718,5 +737,112 @@ impl Handler for NoopHandler {
             token_usage: TokenUsage::default(),
             files_modified: vec![],
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    use octos_agent::progress::{ProgressEvent, ProgressReporter};
+    use octos_agent::tools::{TOOL_CTX, ToolContext};
+
+    /// Capture reporter that stores every event so tests can assert which
+    /// pieces of progress reached the parent SSE stream.
+    struct CapturingReporter {
+        events: Arc<Mutex<Vec<ProgressEvent>>>,
+    }
+
+    impl ProgressReporter for CapturingReporter {
+        fn report(&self, event: ProgressEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    /// Gap 3.3 — `PipelineNodeReporter::report` must forward
+    /// `ProgressEvent::CostUpdate` events through
+    /// `crate::executor::report_progress` instead of swallowing them via
+    /// the `_ => return` arm. This is the bridge that lets per-node cost
+    /// updates from inner-agent loops reach the parent SSE stream so the
+    /// W1.G4 CostBreakdown panel can render them inline with the node tree.
+    #[tokio::test]
+    async fn pipeline_node_reporter_forwards_cost_update_to_parent_sse() {
+        let captured = Arc::new(Mutex::new(Vec::<ProgressEvent>::new()));
+        let parent_reporter: Arc<dyn ProgressReporter> = Arc::new(CapturingReporter {
+            events: captured.clone(),
+        });
+
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call_test".to_string();
+        ctx.reporter = parent_reporter;
+
+        let node_reporter = PipelineNodeReporter {
+            node_id: "draft".to_string(),
+            model: "claude-sonnet".to_string(),
+        };
+
+        // Scope TOOL_CTX so report_progress() can find the parent reporter,
+        // then dispatch a CostUpdate event the way an inner Agent would.
+        TOOL_CTX
+            .scope(ctx, async {
+                node_reporter.report(ProgressEvent::CostUpdate {
+                    session_input_tokens: 320,
+                    session_output_tokens: 110,
+                    response_cost: Some(0.0008),
+                    session_cost: Some(0.0008),
+                });
+            })
+            .await;
+
+        let events = captured.lock().unwrap();
+        let forwarded = events
+            .iter()
+            .find_map(|e| match e {
+                ProgressEvent::ToolProgress { name, message, .. } if name == "run_pipeline" => {
+                    Some(message.clone())
+                }
+                _ => None,
+            })
+            .expect("CostUpdate must be forwarded as a ToolProgress event on the parent reporter");
+        assert!(
+            forwarded.contains("draft"),
+            "forwarded message should reference the originating node_id"
+        );
+        assert!(
+            forwarded.contains("320") && forwarded.contains("110"),
+            "forwarded message should carry the per-node token totals; got {forwarded:?}"
+        );
+    }
+
+    /// Sanity check — the existing event arms still forward as before so
+    /// the new CostUpdate arm is purely additive.
+    #[tokio::test]
+    async fn pipeline_node_reporter_still_forwards_thinking_events() {
+        let captured = Arc::new(Mutex::new(Vec::<ProgressEvent>::new()));
+        let parent_reporter: Arc<dyn ProgressReporter> = Arc::new(CapturingReporter {
+            events: captured.clone(),
+        });
+
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "call_test".to_string();
+        ctx.reporter = parent_reporter;
+
+        let node_reporter = PipelineNodeReporter {
+            node_id: "refine".to_string(),
+            model: "claude-haiku".to_string(),
+        };
+
+        TOOL_CTX
+            .scope(ctx, async {
+                node_reporter.report(ProgressEvent::Thinking { iteration: 1 });
+            })
+            .await;
+
+        let events = captured.lock().unwrap();
+        assert!(events.iter().any(|e| matches!(
+            e,
+            ProgressEvent::ToolProgress { name, .. } if name == "run_pipeline"
+        )));
     }
 }

--- a/crates/octos-pipeline/src/lib.rs
+++ b/crates/octos-pipeline/src/lib.rs
@@ -45,12 +45,12 @@ pub use handler::{
     CodergenHandler, GateHandler, Handler, HandlerRegistry, NoopHandler, ShellHandler,
 };
 pub use host_context::PipelineHostContext;
-pub use recovery::{RecoveryDecision, RecoveryOutcome, recover_node};
 pub use human_gate::{HumanInputProvider, HumanInputType, HumanRequest, HumanResponse};
 pub use manager::{
     ChildExecutor, ChildResult, ChildSpec, ManagerOutcome, PipelineManager, SupervisionStrategy,
 };
 pub use parser::parse_dot;
+pub use recovery::{RecoveryDecision, RecoveryOutcome, recover_node};
 pub use run_dir::{NodeStatus, PipelineRunSummary, RunDir};
 pub use server::{
     CancelRequest, PipelineServer, RunStatus, RunStatusResponse, SubmitRequest, SubmitResponse,

--- a/crates/octos-pipeline/src/recovery.rs
+++ b/crates/octos-pipeline/src/recovery.rs
@@ -100,13 +100,9 @@ pub fn classify_outcome(
     match outcome.status {
         OutcomeStatus::Pass => RecoveryDecision::Pass,
         OutcomeStatus::Skipped => RecoveryDecision::Terminal,
-        OutcomeStatus::Fail | OutcomeStatus::Error => {
-            RecoveryDecision::Retryable(Box::new(RetryableSignal::from_outcome(
-                node,
-                outcome,
-                input.clone(),
-            )))
-        }
+        OutcomeStatus::Fail | OutcomeStatus::Error => RecoveryDecision::Retryable(Box::new(
+            RetryableSignal::from_outcome(node, outcome, input.clone()),
+        )),
     }
 }
 
@@ -249,11 +245,7 @@ mod tests {
 
     #[async_trait]
     impl Handler for FailThenPass {
-        async fn execute(
-            &self,
-            node: &PipelineNode,
-            _ctx: &HandlerContext,
-        ) -> Result<NodeOutcome> {
+        async fn execute(&self, node: &PipelineNode, _ctx: &HandlerContext) -> Result<NodeOutcome> {
             let n = self.attempts.fetch_add(1, Ordering::SeqCst);
             if n == 0 {
                 Ok(NodeOutcome {

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -407,6 +407,12 @@ impl Tool for RunPipelineTool {
         // Also set files_to_send so the execution loop auto-delivers
         let files_to_send = report_file.iter().filter(|p| p.exists()).cloned().collect();
 
+        // Surface per-node cost attribution in the structured side-channel so
+        // the session actor can pull it back into the SSE `done` event for the
+        // W1.G4 cost panel. The data was being silently dropped at the tool
+        // boundary before we extended `ToolResult` with `structured_metadata`.
+        let structured_metadata = node_costs_metadata(&result.node_costs);
+
         Ok(ToolResult {
             output: format!(
                 "{}\n\n---\nPipeline execution summary:\n{summary}\nTotal: {} input + {} output tokens",
@@ -416,7 +422,25 @@ impl Tool for RunPipelineTool {
             tokens_used: Some(result.token_usage),
             file_modified: report_file,
             files_to_send,
+            structured_metadata,
         })
+    }
+}
+
+/// Project a non-empty slice of [`NodeCost`] rows into the
+/// `ToolResult.structured_metadata` shape the session actor consumes.
+///
+/// Returns `None` when there are no cost rows so the side-channel stays
+/// absent for legacy callers (no accountant / no LLM-call nodes); returns
+/// `Some({"node_costs": [...]})` otherwise. Lifted out so tests can assert
+/// the projection without standing up a full pipeline run.
+fn node_costs_metadata(rows: &[crate::executor::NodeCost]) -> Option<serde_json::Value> {
+    if rows.is_empty() {
+        None
+    } else {
+        Some(serde_json::json!({
+            "node_costs": rows,
+        }))
     }
 }
 
@@ -453,4 +477,77 @@ fn sanitize_dot(dot: &str) -> String {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::NodeCost;
+
+    /// Gap 3.1 — when a pipeline run reports per-node cost rows, the tool
+    /// surfaces them in `ToolResult.structured_metadata` under the
+    /// `"node_costs"` key so the session actor can project them onto the
+    /// SSE `done` event for the W1.G4 CostBreakdown panel.
+    #[test]
+    fn node_costs_metadata_emits_node_costs_array_for_multi_node_pipeline() {
+        let rows = vec![
+            NodeCost {
+                node_id: "draft".into(),
+                model: Some("anthropic/claude-haiku".into()),
+                reserved_usd: 0.0010,
+                actual_usd: 0.0008,
+                tokens_in: 320,
+                tokens_out: 110,
+                committed: true,
+            },
+            NodeCost {
+                node_id: "refine".into(),
+                model: Some("anthropic/claude-sonnet".into()),
+                reserved_usd: 0.0040,
+                actual_usd: 0.0032,
+                tokens_in: 540,
+                tokens_out: 220,
+                committed: true,
+            },
+        ];
+
+        let meta = node_costs_metadata(&rows).expect("multi-node pipeline must surface metadata");
+        let arr = meta
+            .get("node_costs")
+            .and_then(|v| v.as_array())
+            .expect("structured_metadata must carry a `node_costs` array");
+        assert_eq!(arr.len(), 2, "one row per pipeline node");
+        assert_eq!(
+            arr[0].get("node_id").and_then(|v| v.as_str()),
+            Some("draft")
+        );
+        assert_eq!(
+            arr[1].get("node_id").and_then(|v| v.as_str()),
+            Some("refine")
+        );
+        assert!(
+            arr[0]
+                .get("tokens_in")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+                > 0,
+            "tokens_in must be threaded through the projection"
+        );
+        assert!(
+            arr[0]
+                .get("actual_usd")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0)
+                > 0.0,
+            "actual_usd must be threaded through the projection"
+        );
+    }
+
+    /// When a pipeline runs without an accountant attached, no per-node cost
+    /// rows are produced; the side-channel stays absent so legacy callers
+    /// observe byte-identical behaviour.
+    #[test]
+    fn node_costs_metadata_returns_none_for_empty_rows() {
+        assert!(node_costs_metadata(&[]).is_none());
+    }
 }

--- a/crates/octos-pipeline/tests/m8_parity.rs
+++ b/crates/octos-pipeline/tests/m8_parity.rs
@@ -23,11 +23,7 @@ use octos_pipeline::{CodergenHandler, HandlerRegistry};
 
 async fn temp_episode_store() -> Arc<octos_memory::EpisodeStore> {
     let dir = tempfile::tempdir().unwrap();
-    Arc::new(
-        octos_memory::EpisodeStore::open(dir.path())
-            .await
-            .unwrap(),
-    )
+    Arc::new(octos_memory::EpisodeStore::open(dir.path()).await.unwrap())
 }
 
 #[allow(dead_code)]
@@ -89,8 +85,7 @@ async fn host_context_with_cache_and_supervisor() -> (
 /// session's `FileStateCache`.
 #[tokio::test]
 async fn pipeline_worker_handler_carries_file_state_cache_from_host() {
-    let (host, _cache, _sup, _acct, _ledger_dir) =
-        host_context_with_cache_and_supervisor().await;
+    let (host, _cache, _sup, _acct, _ledger_dir) = host_context_with_cache_and_supervisor().await;
     let codergen = CodergenHandler::new(
         Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
         temp_episode_store().await,
@@ -223,7 +218,9 @@ async fn handler_registry_default_with_codergen_carrying_host_context() {
         Arc::new(codergen) as Arc<dyn octos_pipeline::Handler>,
     );
     assert!(
-        registry.get(&octos_pipeline::HandlerKind::Codergen).is_some(),
+        registry
+            .get(&octos_pipeline::HandlerKind::Codergen)
+            .is_some(),
         "Codergen handler should resolve out of the registry"
     );
 }

--- a/e2e/tests/live-pipeline-cost.spec.ts
+++ b/e2e/tests/live-pipeline-cost.spec.ts
@@ -87,13 +87,26 @@ async function chatSSE(message: string, sessionId: string, maxWait = 150_000) {
 }
 
 function findToken(events: SseEvent[], key: 'input_tokens' | 'output_tokens'): number {
+  // Accept BOTH the OpenAI-style `input_tokens`/`output_tokens` shape AND
+  // the octos SSE `done` event's `tokens_in`/`tokens_out` shape. The done
+  // event today emits `tokens_in`/`tokens_out` (matched by `api_channel.rs`
+  // and `handlers.rs`); rather than rename keys broadly (which would touch
+  // every existing W4 assertion), the test accepts both vocabularies so
+  // it asserts the data path end-to-end without a global rename.
+  const aliasKey = key === 'input_tokens' ? 'tokens_in' : 'tokens_out';
   let total = 0;
   for (const e of events) {
     if (typeof e[key] === 'number') {
       total += e[key] as number;
     }
+    if (typeof e[aliasKey] === 'number') {
+      total += e[aliasKey] as number;
+    }
     if (e.usage && typeof (e.usage as Record<string, unknown>)[key] === 'number') {
       total += (e.usage as Record<string, number>)[key];
+    }
+    if (e.usage && typeof (e.usage as Record<string, unknown>)[aliasKey] === 'number') {
+      total += (e.usage as Record<string, number>)[aliasKey];
     }
     if (Array.isArray(e.node_costs)) {
       for (const row of e.node_costs as Array<Record<string, unknown>>) {


### PR DESCRIPTION
## Summary

Closes Bug 3 (W1.G4 cost panel data-blind in production). Three distinct gaps were dropping per-node cost data on the path from `run_pipeline` to the dashboard's CostBreakdown SSE consumer:

- **Gap 3.1 — `ToolResult` had no slot for tool-specific metadata.** `RunPipelineTool::execute` already computed `result.node_costs` but the surrounding `ToolResult` had no field for it; the data was dropped at the tool boundary. Added `structured_metadata: Option<serde_json::Value>` to `ToolResult`, populated by `RunPipelineTool` with `{"node_costs": [...]}`. Threaded through `ToolCallResult` in execution.rs and into a new `ConversationResponse.tool_results: Vec<(String, serde_json::Value)>` accumulator keyed by `tool_call_id`.
- **Gap 3.2 — `completion_meta` did not include `node_costs`.** `process_inbound` walks `cr.tool_results`, plucks every `node_costs` array, and adds the concatenated rows to `completion_meta`. The API channel (`api_channel.rs`) and direct chat handler (`handlers.rs`) both forward the array onto the SSE `done` event.
- **Gap 3.3 — `PipelineNodeReporter` swallowed `CostUpdate`.** The reporter's `_ => return` arm hid every event other than the four it explicitly matched, including `ProgressEvent::CostUpdate`. Added an explicit arm that formats per-node tokens + USD and forwards through `crate::executor::report_progress`.

## Decisions

- **`structured_metadata` vs dedicated field**: chose the generic `Option<serde_json::Value>` slot per the spec sketch — keeps the door open for other tools to surface side-channel data without further `ToolResult` changes.
- **Test fix vs key rename**: kept the SSE done event keys at `tokens_in`/`tokens_out` (consistent with existing `api_channel.rs` and `handlers.rs`) and updated the e2e test's `findToken` to accept both vocabularies. Renaming would have touched every existing W4 assertion for no architectural gain.

## Tests

- 7 new unit tests, all passing:
  - `octos-pipeline::tool::tests::node_costs_metadata_emits_node_costs_array_for_multi_node_pipeline`
  - `octos-pipeline::tool::tests::node_costs_metadata_returns_none_for_empty_rows`
  - `octos-pipeline::handler::tests::pipeline_node_reporter_forwards_cost_update_to_parent_sse`
  - `octos-pipeline::handler::tests::pipeline_node_reporter_still_forwards_thinking_events`
  - `octos-cli::session_actor::tests::collect_node_costs_concatenates_rows_from_multiple_tool_results`
  - `octos-cli::session_actor::tests::collect_node_costs_returns_empty_when_no_tool_surfaced_metadata`
  - `octos-cli::session_actor::tests::completion_meta_carries_node_costs_when_tool_results_have_metadata`
- `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all clean.
- Full `cargo test --workspace` passes 2300+ tests with one pre-existing failure (`test_06_send_file_sandbox_escape` in `octos-pipeline::tests::ux_pipeline`) that reproduces on unmodified `main` — unrelated to this PR.

## Test plan

- [ ] Deploy to a canary mini and run `e2e/tests/live-pipeline-cost.spec.ts` end-to-end against live SSE
- [ ] Confirm the dashboard CostBreakdown panel renders per-node rows for a `run_pipeline` invocation
- [ ] Verify legacy callers (no accountant attached, no `run_pipeline` in turn) still see byte-identical SSE `done` events without a `node_costs` key