### PR TITLE
test(m8.4): widen probe timeout for full-plugin profiles

### DIFF
--- a/e2e/tests/m8-runtime-invariants-live.spec.ts
+++ b/e2e/tests/m8-runtime-invariants-live.spec.ts
@@ -165,10 +165,15 @@ test.describe('M8.4 FileStateCache short-circuit', () => {
     // Probe what files the agent actually has visible. Combine assistant
     // text with the raw tool result so we see the list_dir output even
     // when the LLM paraphrases.
+    //
+    // Probe budget is intentionally generous (90s): on full-plugin profiles
+    // (e.g. bot's ~40 active tools) the first turn pays for the entire LLM
+    // tool-spec inventory, so the 45s cap previously misfired here despite
+    // FileStateCache wiring being correct end-to-end.
     const probe = await chatSSE(
       'List up to 10 files in your current working directory using the list_dir tool. Return only the names.',
       sid,
-      45_000,
+      90_000,
     );
     const probeMsgs = await getMessages(sid);
     const probeToolText = probeMsgs


### PR DESCRIPTION
## Summary

- The M8.4 FileStateCache short-circuit live spec was misfiring on full-plugin profiles (e.g. bot's ~40 active tools) because the **probe phase** had a 45s `chatSSE` budget. The first turn pays for the entire LLM tool-spec inventory, so 45s was too tight.
- FileStateCache wiring itself is verified correct end-to-end — this is a **test-side calibration fix only**.
- Widen the probe `maxWait` from 45s to 90s. The short-circuit assertion (`sawMarkerInTool || sawMarkerInAssistant || secondShorter`) at line 240+ is **unchanged**.

## Diff

```diff
-      45_000,
+      90_000,
```

Plus an explanatory comment block on the probe call.

## Test plan

- [ ] Re-run \`tests/m8-runtime-invariants-live.spec.ts\` against bot profile
- [ ] Confirm probe phase no longer hits the timeout cap
- [ ] Confirm M8.4 spec still asserts the cache short-circuit signal once the probe completes
- [ ] No-op for profiles where probe already completed inside 45s