### PR TITLE
fix(ci): unblock PR #600 by capping check-job parallel builds at 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    env:
+      # Cap parallel cargo build jobs at 2 so concurrent rustc/linker invocations
+      # do not exceed the 16GB ubuntu-latest runner budget. Linking the
+      # octos-agent --lib unit-test binary (78MB stripped, ~2GB+ peak rustc RSS
+      # against a 144MB rlib + chromiumoxide/lettre/etc.) at default parallelism
+      # was OOM-killing the runner during the `Test octos-agent (lib)` step,
+      # producing the "hosted runner lost communication with the server" error
+      # (~45min into the run before the runner died). Mirrors the existing
+      # CARGO_BUILD_JOBS="2" guard on check-arm and check-riscv, which already
+      # use this mitigation for the same 16GB memory budget.
+      CARGO_BUILD_JOBS: "2"
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

PR #600 (per-crate clippy shard) has been failing its own CI run at the **`Test octos-agent (lib)`** step with the canonical GitHub Actions OOM signature: "The hosted runner lost communication with the server." Last observed run [#24968089949](https://github.com/octos-org/octos/actions/runs/24968089949) ran for 53 minutes (~45min stuck on the OOM-ing step) before the runner died.

This PR adds the same mitigation already in place on `check-arm` and `check-riscv`: cap `CARGO_BUILD_JOBS` at 2 via job-level env on the `check` job.

## Root cause

`crates/octos-agent` is the workspace's heaviest crate: 70k LOC across 99 `#[cfg(test)]` inline modules. Linking its unit-test binary pulls a 144MB rlib plus the full dep closure (chromiumoxide, lettre, hyper, reqwest, redb, …). At default cargo parallelism on the ubuntu-latest 4-core / 16GB runner, peak rustc resident set crosses the runner's memory budget — kernel kills the runner agent, GitHub reports "lost communication with the server."

The prior `check` step that landed in PR #600 already shards clippy per crate to defuse the same OOM in the clippy phase. But the test phase still hit the same wall during `Test octos-agent (lib)` because cargo's default `-j` is uncapped on that job. Both `check-arm` and `check-riscv` already use `CARGO_BUILD_JOBS: "2"` for the same 16GB budget reason.

## Fix

`.github/workflows/ci.yml` — add to the `check` job:

```yaml
env:
  CARGO_BUILD_JOBS: "2"
```

with a comment block explaining the rationale and pointing at the existing arm/riscv guard. No weakening of `-D warnings`, no skipped tests, no changes to source code or test logic — strictly a runner budget knob.

## Verification

- `cargo test -p octos-agent --lib` → 1192 passed; 0 failed; 1 ignored locally
- `cargo clippy -p octos-agent --lib -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- YAML syntax validates

## Why this unblocks PR #600

PR #600's branch (`followup/ci-clippy-shard`) is currently behind `main`. Once this lands, PR #600 can rebase/merge `main`, the env block is inherited automatically by the per-crate-clippy-sharded `check` job, and the test phase peak RSS drops below the runner's 16GB budget.

## Test plan

- [ ] This PR's own CI `check` job completes (passes through `Test octos-agent (lib)` without OOM).
- [ ] PR #600 rebased on top of this commit completes its `check` job.