### PR TITLE
fix(api): /api/sessions enumerates only top-level sessions, skip child fanout

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -1848,11 +1848,17 @@ async fn handle_task_relaunch(
 }
 
 /// GET /sessions — list all API sessions.
+///
+/// Backed by `list_top_level_sessions` so internal `child-*` spawn fanouts
+/// and `*.tasks` ledger sidecars are skipped at the directory walk. The
+/// generic `list_sessions` is O(N) over every JSONL on disk and was
+/// observed to hang 30s+ on a user dir with 65k+ child JSONLs (river /
+/// mini4) — see issue #607 §D.
 async fn handle_list_sessions(State(state): State<ApiState>) -> Response {
     let sess = state.sessions.lock().await;
     let mut seen = std::collections::HashSet::new();
     let list: Vec<SessionInfo> = sess
-        .list_sessions()
+        .list_top_level_sessions()
         .into_iter()
         .filter_map(|(id, count)| {
             let chat_id = api_chat_id_from_session_key(&id)?.to_string();

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -324,12 +324,39 @@ impl SessionManager {
         self
     }
 
-    /// List all sessions (ID + message count) from disk.
+    /// List all sessions (ID + message count) from disk, including internal
+    /// runtime topics (`child-*`, `*.tasks`).
     ///
     /// Scans both the legacy flat layout (`sessions/*.jsonl`) and the per-user
     /// layout (`users/{base_key}/sessions/{topic}.jsonl`).
     /// Counts lines efficiently using `BufRead` to avoid loading entire files.
+    ///
+    /// Use [`Self::list_top_level_sessions`] for the user-facing listing path:
+    /// the all-inclusive walk is O(N) over every JSONL on disk and becomes a
+    /// hard bottleneck once spawn-fanout sessions accumulate (one user dir
+    /// observed in the wild had 65k+ `child-*.jsonl` siblings, each
+    /// line-counted by [`Self::count_lines`], hanging `/api/sessions` for
+    /// 30 s+).
     pub fn list_sessions(&self) -> Vec<(String, usize)> {
+        self.list_sessions_inner(false)
+    }
+
+    /// List only top-level sessions — those whose topic is empty (the
+    /// canonical `default.jsonl` per user dir) or a user-facing topic such
+    /// as `research`. Internal runtime topics (`child-*` spawn fanouts and
+    /// `*.tasks` background-task ledgers) are skipped at the directory walk,
+    /// before any line counting, so the cost stays O(top-level sessions)
+    /// regardless of how many child sessions a parent has accumulated.
+    ///
+    /// This is the helper that should back the user-facing
+    /// `GET /api/sessions` path. Child sessions are surfaced only when an
+    /// individual session's history is explicitly opened via
+    /// `/api/sessions/{id}/messages`.
+    pub fn list_top_level_sessions(&self) -> Vec<(String, usize)> {
+        self.list_sessions_inner(true)
+    }
+
+    fn list_sessions_inner(&self, skip_internal_topics: bool) -> Vec<(String, usize)> {
         let mut seen = std::collections::HashSet::new();
         let mut result = Vec::new();
 
@@ -339,8 +366,11 @@ impl SessionManager {
                 let path = entry.path();
                 if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
                     if let Some(name) = path.file_stem().and_then(|n| n.to_str()) {
-                        let count = Self::count_lines(&path);
                         let decoded = Self::decode_filename(name);
+                        if skip_internal_topics && Self::is_internal_session_key(&decoded) {
+                            continue;
+                        }
+                        let count = Self::count_lines(&path);
                         if seen.insert(decoded.clone()) {
                             result.push((decoded, count));
                         }
@@ -378,6 +408,14 @@ impl SessionManager {
                             None => continue,
                         };
                         let topic = Self::decode_filename(topic_encoded);
+                        if skip_internal_topics && Self::is_internal_session_topic(&topic) {
+                            // Skip child-* and *.tasks files BEFORE counting
+                            // lines: line counting opens every file, and on
+                            // user dirs with tens of thousands of spawn
+                            // children the cumulative I/O blocks the
+                            // /api/sessions handler for tens of seconds.
+                            continue;
+                        }
                         // Reconstruct the full session key
                         let session_key = if topic == "default" {
                             base_key.clone()
@@ -394,6 +432,21 @@ impl SessionManager {
         }
 
         result
+    }
+
+    /// True for runtime-internal topics that should never appear in the
+    /// user-facing session listing (`child-*` spawn fanouts and `*.tasks`
+    /// background-task ledger sidecars).
+    fn is_internal_session_topic(topic: &str) -> bool {
+        topic.starts_with("child-") || topic == "default.tasks" || topic.ends_with(".tasks")
+    }
+
+    /// True for full session keys (legacy flat layout, encoded as
+    /// `{base}#{topic}` after decoding) whose topic is internal.
+    fn is_internal_session_key(decoded_key: &str) -> bool {
+        decoded_key
+            .split_once('#')
+            .is_some_and(|(_, topic)| Self::is_internal_session_topic(topic))
     }
 
     /// Count lines in a JSONL session file, skipping oversized files.
@@ -2623,6 +2676,126 @@ mod tests {
         assert_eq!(sessions.len(), 1);
         // Should return decoded key, not percent-encoded filename
         assert_eq!(sessions[0].0, "feishu:oc_abc123");
+    }
+
+    /// Issue #607 §D: `/api/sessions` hung 30 s+ on a user dir with 65 535
+    /// `child-*.jsonl` siblings because the listing iterated every JSONL.
+    /// `list_top_level_sessions` must skip `child-*` and `*.tasks` files at
+    /// the directory walk so the cost stays O(top-level sessions).
+    #[tokio::test]
+    async fn list_top_level_sessions_skips_child_jsonl() {
+        let tmp = TempDir::new().unwrap();
+        let mut mgr = SessionManager::open(tmp.path()).unwrap();
+        let parent = SessionKey::new("api", "web-parent");
+
+        // 1 top-level session.
+        mgr.add_message(&parent, make_message(MessageRole::User, "parent"))
+            .await
+            .unwrap();
+
+        // 100 child sessions written via the same canonical handle code path
+        // production uses (so the test exercises real filename encoding).
+        for i in 0..100 {
+            let child = child_session_key(&parent, &format!("task-{i:03}"));
+            mgr.add_message(&child, make_message(MessageRole::Assistant, "child"))
+                .await
+                .unwrap();
+        }
+
+        // The all-inclusive walk reflects every jsonl on disk (1 parent +
+        // 100 children).
+        let all = mgr.list_sessions();
+        assert_eq!(all.len(), 101, "internal walk should include children");
+
+        // The user-facing listing must surface only the top-level session.
+        let top = mgr.list_top_level_sessions();
+        assert_eq!(
+            top.len(),
+            1,
+            "list_top_level_sessions must skip child-* fanouts; got {top:?}"
+        );
+        assert_eq!(top[0].0, "api:web-parent");
+    }
+
+    /// Sidecar `*.tasks.jsonl` ledgers (e.g. `default.tasks.jsonl`) are an
+    /// internal runtime detail and must never appear in the user-facing
+    /// listing.
+    #[test]
+    fn list_top_level_sessions_skips_tasks_sidecar_jsonl() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = SessionManager::open(tmp.path()).unwrap();
+
+        // Construct a per-user dir directly so we can drop in both a
+        // top-level `default.jsonl` and an internal `default.tasks.jsonl`
+        // without having to drive the task-ledger writers in this unit.
+        let user_dir = tmp.path().join("users/api%3Aweb-tasks/sessions");
+        std::fs::create_dir_all(&user_dir).unwrap();
+
+        let meta = serde_json::json!({
+            "schema_version": 1,
+            "session_key": "api:web-tasks",
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
+        });
+        std::fs::write(
+            user_dir.join("default.jsonl"),
+            format!("{}\n", serde_json::to_string(&meta).unwrap()),
+        )
+        .unwrap();
+        // Sidecar — must be ignored.
+        std::fs::write(
+            user_dir.join("default.tasks.jsonl"),
+            "{\"task_id\":\"t-1\",\"state\":\"queued\"}\n",
+        )
+        .unwrap();
+
+        let top = mgr.list_top_level_sessions();
+        let ids: Vec<&str> = top.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["api:web-tasks"], "got {top:?}");
+    }
+
+    /// Regression guard for the O(N) hang. With 5 000 synthetic
+    /// `child-*.jsonl` files on disk, `list_top_level_sessions` must stay
+    /// well under the 500 ms bound — the original `list_sessions`
+    /// `count_lines`-per-file loop blew past 30 s in the wild on a dir
+    /// 13× larger.
+    #[test]
+    fn list_top_level_sessions_is_fast_with_many_child_jsonls() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = SessionManager::open(tmp.path()).unwrap();
+
+        let user_dir = tmp.path().join("users/api%3Aweb-river/sessions");
+        std::fs::create_dir_all(&user_dir).unwrap();
+
+        // Top-level session.
+        std::fs::write(
+            user_dir.join("default.jsonl"),
+            "{\"schema_version\":1,\"session_key\":\"api:web-river\",\
+             \"created_at\":\"2024-01-01T00:00:00Z\",\
+             \"updated_at\":\"2024-01-01T00:00:00Z\"}\n",
+        )
+        .unwrap();
+
+        // Synthetic spawn fanout.
+        const FANOUT: usize = 5_000;
+        for i in 0..FANOUT {
+            std::fs::write(
+                user_dir.join(format!("child-task-{i:05}.jsonl")),
+                "{\"schema_version\":1}\n{\"role\":\"assistant\",\"content\":\"x\"}\n",
+            )
+            .unwrap();
+        }
+
+        let start = std::time::Instant::now();
+        let top = mgr.list_top_level_sessions();
+        let elapsed = start.elapsed();
+
+        assert_eq!(top.len(), 1, "only top-level session should surface");
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "list_top_level_sessions took {elapsed:?} for {FANOUT} child files; \
+             the per-file count_lines fallback regressed",
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -646,16 +646,26 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>, headers: HeaderMa
     if let Some(sessions) = &state.sessions {
         let sess = sessions.lock().await;
         let prefix = format!("{}:api:", api_profile_id_from_headers(&state, &headers));
-        all.extend(sess.list_sessions().into_iter().filter_map(|(id, count)| {
-            let chat_id = id.strip_prefix(&prefix)?;
-            if is_internal_api_session_id(chat_id) {
-                return None;
-            }
-            Some(SessionInfo {
-                id: chat_id.to_string(),
-                message_count: count,
-            })
-        }));
+        // Use `list_top_level_sessions` (skips `child-*` and `*.tasks` at the
+        // directory walk) so a user dir with tens of thousands of spawn
+        // children does not turn this listing into an O(N) hang. The
+        // `is_internal_api_session_id` belt-and-suspenders check is kept for
+        // legacy entries that might slip through (e.g. flat layout files
+        // pre-dating the encoder rules).
+        all.extend(
+            sess.list_top_level_sessions()
+                .into_iter()
+                .filter_map(|(id, count)| {
+                    let chat_id = id.strip_prefix(&prefix)?;
+                    if is_internal_api_session_id(chat_id) {
+                        return None;
+                    }
+                    Some(SessionInfo {
+                        id: chat_id.to_string(),
+                        message_count: count,
+                    })
+                }),
+        );
     }
 
     // Also fetch from gateway if available.
@@ -3451,6 +3461,71 @@ mod tests {
             .collect();
 
         assert_eq!(ids, vec!["web-123"]);
+    }
+
+    /// Issue #607 §D regression: river / mini4 hung 30 s+ on
+    /// `GET /api/sessions` because one user dir had 65 535
+    /// `child-*.jsonl` files that the listing iterated. The handler must
+    /// stay well under 500 ms with a synthetic spawn fanout in place.
+    #[tokio::test]
+    async fn list_sessions_is_fast_with_many_child_jsonl_files() {
+        let data_dir = tempfile::tempdir().unwrap();
+
+        // Lay down the per-user dir for `_main:api:web-river` directly so the
+        // test does not have to drive 10 000 SessionHandle writes (~30 s on
+        // its own and not what we are measuring).
+        let encoded_base = "_main%3Aapi%3Aweb-river";
+        let user_dir = data_dir
+            .path()
+            .join("users")
+            .join(encoded_base)
+            .join("sessions");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        std::fs::write(
+            user_dir.join("default.jsonl"),
+            "{\"schema_version\":1,\"session_key\":\"_main:api:web-river\",\
+             \"created_at\":\"2024-01-01T00:00:00Z\",\
+             \"updated_at\":\"2024-01-01T00:00:00Z\"}\n",
+        )
+        .unwrap();
+
+        const FANOUT: usize = 10_000;
+        for i in 0..FANOUT {
+            std::fs::write(
+                user_dir.join(format!("child-task-{i:05}.jsonl")),
+                "{\"schema_version\":1}\n{\"role\":\"assistant\",\"content\":\"x\"}\n",
+            )
+            .unwrap();
+        }
+
+        let sessions = std::sync::Arc::new(tokio::sync::Mutex::new(
+            octos_bus::SessionManager::open(data_dir.path()).unwrap(),
+        ));
+        let state = std::sync::Arc::new(AppState {
+            sessions: Some(sessions),
+            ..AppState::empty_for_tests()
+        });
+
+        let start = std::time::Instant::now();
+        let response = list_sessions(State(state), HeaderMap::new()).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let listed: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        let ids: Vec<&str> = listed
+            .iter()
+            .filter_map(|entry| entry.get("id").and_then(|id| id.as_str()))
+            .collect();
+        assert_eq!(ids, vec!["web-river"], "child fanout must not surface");
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "list_sessions took {elapsed:?} for {FANOUT} child jsonls; \
+             #607 §D regression — the user-facing handler must not iterate child fanouts",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Refs https://github.com/octos-org/octos/issues/607 §D — river (mini4) hung 30s+ on `GET /api/sessions` because one user-session dir had 65,535+ child JSONL files; the listing handler walked every `*.jsonl` and called `count_lines` on each (O(N) over total session JSONLs).
- Adds `SessionManager::list_top_level_sessions()` which filters `child-*` and `*.tasks` files at the directory walk, before any line counting. Wires both the standalone `/api/sessions` handler (`octos-cli`) and the gateway `/sessions` handler (`octos-bus::api_channel`) to it. The original `list_sessions()` is kept for callers that need the full enumeration (admin paths). Listing is now O(top-level sessions per user dir) regardless of spawn-fanout depth.
- Child sessions surface only when the individual session is opened via `/api/sessions/{id}/messages`, matching the issue's stated goal.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` — full pass (no failures); my changes add 3 new bus-side tests + 1 handler-side test.
- [x] `cargo test -p octos-cli --features api --lib api::handlers::tests` — all 51 handler tests pass, including:
      - `list_sessions_is_fast_with_many_child_jsonl_files` (10,000 child JSONL fixture, <500 ms bound)
      - `list_sessions_hides_internal_runtime_sessions_from_standalone_store` (existing behavior preserved)
- [x] `cargo test -p octos-bus list_top_level_sessions` — all three new tests pass (skip child, skip task sidecar, 5k-file <500 ms perf bound)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean for default features. (Pre-existing baseline `clippy -p octos-cli --features api` errors in `admin.rs` test code are unchanged — same 34 errors with and without this branch's changes; outside the scope of this fix.)
- [ ] Live test post-deploy: time `/api/sessions` on the minis. Goal: <1 s on every mini including river.

## Notes

The runaway child fanout in the wild is preserved as `/tmp/runaway-session-archive-*` on mini4 if a fixture inspired by its real shape is wanted later.