### PR TITLE
task #89: orphan-task reaper + skip live-progress-gate Test 1 (Bug A)

### DIFF
--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -486,6 +486,23 @@ fn record_child_session_orphan(reason: &'static str) {
     .increment(1);
 }
 
+/// Returns true if the given runtime_state is a terminal state. The
+/// non-terminal complement is the set of states that, on supervisor
+/// restart, indicate an orphaned task whose owning worker is gone.
+///
+/// `Completed`, `Failed`, and `Cancelled` are terminal: the worker has
+/// already driven the task to a final state and persisted the outcome.
+/// Anything else (`Spawned`, `ExecutingTool`, `ResolvingOutputs`,
+/// `VerifyingOutputs`, `DeliveringOutputs`, `CleaningUp`) means the
+/// owning worker was mid-flight when the runtime stopped, so on restart
+/// the task is an orphan with no live actor behind it.
+fn is_terminal_runtime_state(state: &TaskRuntimeState) -> bool {
+    matches!(
+        state,
+        TaskRuntimeState::Completed | TaskRuntimeState::Failed | TaskRuntimeState::Cancelled
+    )
+}
+
 fn record_workflow_phase_transition(workflow_kind: &str, from_phase: &str, to_phase: &str) {
     counter!(
         "octos_workflow_phase_transition_total",
@@ -952,6 +969,23 @@ impl TaskSupervisor {
     }
 
     /// Enable append-only persistence for task snapshots and restore existing state.
+    ///
+    /// At the end of replay, sweeps the in-memory map for any task whose
+    /// `runtime_state` is non-terminal (anything other than `Completed`,
+    /// `Failed`, or `Cancelled`). Those tasks are orphans — the worker
+    /// process that owned them died across the restart, so no live actor
+    /// will ever drive them to a terminal state. They are marked
+    /// `Failed("orphaned across restart")` via the standard `mark_failed`
+    /// path so the JSONL ledger gets a proper terminal entry and re-loading
+    /// is idempotent. The `octos_orphaned_tasks_reaped_total` counter is
+    /// incremented per reaped task.
+    ///
+    /// This handles startup-time orphans only: at this point in startup no
+    /// new work has been scheduled yet, so any non-terminal runtime_state
+    /// definitionally has no live worker. In-flight orphans inside a
+    /// long-running supervisor (worker hangs / crashes silently while the
+    /// supervisor itself stays alive) are NOT addressed here — that needs
+    /// a heartbeat-based reaper, which is a follow-up if observed.
     pub fn enable_persistence(&self, path: impl Into<PathBuf>) -> std::io::Result<usize> {
         let path = path.into();
         if let Some(parent) = path.parent() {
@@ -990,6 +1024,26 @@ impl TaskSupervisor {
         };
         for task in snapshots {
             self.persist_snapshot(&task);
+        }
+
+        // Sweep orphans: any task whose runtime_state is non-terminal at
+        // this point has no live worker behind it (we are still in startup,
+        // no new work has been scheduled yet). Mark them Failed via the
+        // standard mark_failed path so the JSONL ledger gets a proper
+        // terminal entry and re-loading is idempotent.
+        let orphans: Vec<String> = {
+            let tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+            tasks
+                .values()
+                .filter(|task| !is_terminal_runtime_state(&task.runtime_state))
+                .map(|task| task.id.clone())
+                .collect()
+        };
+        for task_id in &orphans {
+            self.mark_failed(task_id, "orphaned across restart".to_string());
+        }
+        if !orphans.is_empty() {
+            counter!("octos_orphaned_tasks_reaped_total").increment(orphans.len() as u64);
         }
 
         Ok(self.tasks.lock().unwrap_or_else(|e| e.into_inner()).len())
@@ -2157,7 +2211,16 @@ mod tests {
         assert_eq!(detail["workflow_kind"], "deep_research");
         assert_eq!(detail["current_phase"], "fetch");
         assert_eq!(detail["progress_message"], "Fetching 4 pages");
-        assert_eq!(task.status, TaskStatus::Running);
+        // Across restart, the in-flight task has no live worker — the orphan
+        // reaper marks it Failed so callers observe a clean terminal state.
+        // The harness progress detail still survives so operators can inspect
+        // where the task was when the runtime died.
+        assert_eq!(task.status, TaskStatus::Failed);
+        assert_eq!(
+            task.error.as_deref(),
+            Some("orphaned across restart"),
+            "orphan reaper must record a stable error message"
+        );
     }
 
     #[test]
@@ -2270,8 +2333,18 @@ mod tests {
         let tasks = restored.get_all_tasks();
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].id, task_id);
-        assert_eq!(tasks[0].status, TaskStatus::Running);
-        assert_eq!(tasks[0].runtime_state, TaskRuntimeState::ResolvingOutputs);
+        // The orphan reaper marks non-terminal tasks Failed at startup —
+        // their owning workers are gone. Metadata (lineage, ledger path,
+        // last-known runtime_detail) is preserved for operator diagnosis.
+        assert_eq!(tasks[0].status, TaskStatus::Failed);
+        assert_eq!(tasks[0].runtime_state, TaskRuntimeState::Failed);
+        assert_eq!(
+            tasks[0].error.as_deref(),
+            Some("orphaned across restart"),
+            "orphan reaper must mark restored running tasks Failed"
+        );
+        // runtime_detail (the last live progress payload) survives the
+        // reap so operators can see where the task was when the worker died.
         assert_eq!(
             tasks[0].runtime_detail.as_deref(),
             Some("collecting evidence")
@@ -3294,5 +3367,114 @@ mod tests {
             id.is_empty(),
             "legacy register must return empty-string sentinel when refused"
         );
+    }
+
+    #[test]
+    fn enable_persistence_reaps_orphan_running_tasks_at_startup() {
+        // The bug: when the runtime crashes mid-task, the JSONL ledger has a
+        // non-terminal entry for the in-flight task (Running / ResolvingOutputs
+        // / etc) but no Completed/Failed event. On restart, the supervisor
+        // restored that state verbatim — leaving the task forever
+        // non-terminal because no live worker is backing it anymore.
+        //
+        // The fix: after replay, any task whose runtime_state is non-terminal
+        // is reaped — marked Failed("orphaned across restart") — so callers
+        // observing the supervisor see a clean state.
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let ledger_path = dir.path().join("tasks.jsonl");
+
+        // Phase 1: simulate a previous run that registered two tasks. Task A
+        // is left mid-flight (Running). Task B reached terminal Completed.
+        let supervisor = TaskSupervisor::new();
+        supervisor.enable_persistence(&ledger_path).unwrap();
+        let task_a =
+            supervisor.register_with_lineage("deep_search", "call-a", Some("api:session"), None);
+        supervisor.mark_running(&task_a);
+        let task_b =
+            supervisor.register_with_lineage("fm_tts", "call-b", Some("api:session"), None);
+        supervisor.mark_completed(&task_b, vec!["/tmp/voice.mp3".to_string()]);
+        // Drop the first supervisor — its in-flight worker for task_a is gone.
+        drop(supervisor);
+
+        // Phase 2: a fresh supervisor replays the ledger and must reap the
+        // orphaned non-terminal task.
+        let restored = TaskSupervisor::new();
+        restored.enable_persistence(&ledger_path).unwrap();
+
+        let reaped = restored
+            .get_task(&task_a)
+            .expect("orphan task must still be tracked after reap");
+        assert_eq!(
+            reaped.status,
+            TaskStatus::Failed,
+            "orphan task must be marked Failed at startup"
+        );
+        assert_eq!(reaped.runtime_state, TaskRuntimeState::Failed);
+        let error = reaped.error.as_deref().unwrap_or("");
+        assert!(
+            error.contains("orphaned") || error.contains("restart"),
+            "orphan task error must mention orphan/restart, got {error:?}"
+        );
+        assert!(
+            reaped.completed_at.is_some(),
+            "orphan task must have a completed_at timestamp"
+        );
+
+        let surviving = restored
+            .get_task(&task_b)
+            .expect("completed task must still be tracked after reap");
+        assert_eq!(
+            surviving.status,
+            TaskStatus::Completed,
+            "terminal tasks must not be reaped"
+        );
+        assert_eq!(surviving.runtime_state, TaskRuntimeState::Completed);
+
+        // Idempotency: a third supervisor replaying the same ledger must see
+        // task_a already terminal (because the reaper appended a Failed event).
+        let restored_again = TaskSupervisor::new();
+        restored_again.enable_persistence(&ledger_path).unwrap();
+        let reread = restored_again
+            .get_task(&task_a)
+            .expect("orphan task still tracked on second replay");
+        assert_eq!(reread.status, TaskStatus::Failed);
+        let reread_error = reread.error.as_deref().unwrap_or("");
+        assert!(
+            reread_error.contains("orphaned") || reread_error.contains("restart"),
+            "orphan task error must persist across replay, got {reread_error:?}"
+        );
+        // The completed task is unaffected on replay.
+        let reread_b = restored_again
+            .get_task(&task_b)
+            .expect("completed task still tracked on second replay");
+        assert_eq!(reread_b.status, TaskStatus::Completed);
+
+        // Cancelled tasks must also be respected as terminal — they should
+        // not be reaped a second time. Add a cancelled task to the ledger,
+        // reload, and assert the cancellation survives.
+        let cancel_supervisor = restored_again;
+        let task_c = cancel_supervisor.register_with_lineage(
+            "run_pipeline",
+            "call-c",
+            Some("api:session"),
+            None,
+        );
+        cancel_supervisor.mark_running(&task_c);
+        cancel_supervisor
+            .cancel(&task_c)
+            .expect("cancel should succeed");
+        drop(cancel_supervisor);
+        let final_reload = TaskSupervisor::new();
+        final_reload.enable_persistence(&ledger_path).unwrap();
+        let cancelled = final_reload
+            .get_task(&task_c)
+            .expect("cancelled task still tracked after reload");
+        assert_eq!(
+            cancelled.status,
+            TaskStatus::Cancelled,
+            "cancelled tasks must not be reaped"
+        );
+        assert_eq!(cancelled.runtime_state, TaskRuntimeState::Cancelled);
     }
 }

--- a/e2e/tests/live-progress-gate.spec.ts
+++ b/e2e/tests/live-progress-gate.spec.ts
@@ -460,7 +460,16 @@ test.describe('M4.1A live progress gate', () => {
     await createNewSession(page);
   });
 
-  test('deep research emits live progress through every required phase', async ({
+  // Skipped pending Bug A (issue #580): the built-in `DeepSearchTool`
+  // at crates/octos-agent/src/tools/deep_search.rs emits 4 phases
+  // (search/fetch/report_build/completion) but this fixture demands 5
+  // including `synthesize`. The bundled skill binary at
+  // crates/app-skills/deep-search/src/main.rs emits all 5, but the
+  // profile factory registers the built-in tool AFTER the plugin so
+  // the built-in overrides. Re-enable once the built-in tool either
+  // gets a `synthesize` phase or the plugin registration order is
+  // flipped to take precedence.
+  test.skip('deep research emits live progress through every required phase', async ({
     page,
   }) => {
     await submitPrompt(page, DEEP_RESEARCH_PROMPT);


### PR DESCRIPTION
## Summary

Closes the M4.1A live-progress-gate task tracking work that PRs #581
and #582 had open. Both prior PRs were branched off pre-M7.9 / pre-M8
main and could not be cleanly rebased — a rebase would have reverted
thousands of lines of cancel/restart/M8-parity work that has since
landed. This PR redoes the focused fixes atop current `main`.

## Changes

### Commit 1 — `fix(task-supervisor): reap orphan tasks across restart`

Sweep at the end of `TaskSupervisor::enable_persistence` for any task
whose `runtime_state` is non-terminal. Those tasks are orphans — the
worker that owned them is gone, so no live actor will drive them to a
terminal state. Each is marked `Failed("orphaned across restart")` via
the standard `mark_failed` path (so the JSONL ledger gets a proper
terminal entry and replay is idempotent). A new
`is_terminal_runtime_state` helper unifies the terminal/non-terminal
split. Counter `octos_orphaned_tasks_reaped_total` increments per reap.

Treats `Completed`, `Failed`, AND `Cancelled` as terminal — the latter
is new since PR #581 was authored (M7.9 / W2 cancel primitive).

Pre-existing tests `should_persist_harness_progress_event_for_replay`
and `should_restore_running_task_state_after_restart` previously encoded
the buggy contract; updated to assert the new orphan-reaped semantics.
Lineage / ledger-path / last-known runtime_detail are still preserved
for operator diagnosis. New TDD test
`enable_persistence_reaps_orphan_running_tasks_at_startup` covers the
full bug scenario including idempotency on third replay and that
`Cancelled` tasks are not reaped a second time.

Caveat (carried from #581): handles startup-time orphans only. In-flight
orphans inside a long-running supervisor (worker hangs / crashes silently
while the supervisor itself stays alive) need a heartbeat-based reaper;
follow-up if the orphan rate is observed nontrivial.

### Commit 2 — `e2e: skip live-progress-gate Test 1 pending Bug A`

Mark Test 1 (`deep research emits live progress through every required
phase`) as `test.skip` with a documented reason pointing at issue #580.
The built-in `DeepSearchTool` emits 4 phases; the M4.1A fixture demands
5; the bundled skill emits all 5 but the gateway profile factory
registers the built-in AFTER the plugin so the built-in overrides.

Test 2 (`progress state persists across session switch and browser
reload`) — left active. Its blocker (orphan-task reaper, formerly Bug B)
is fixed in commit 1.

Test 3 (task API + SSE phase truth) — left active, has always been
able to pass.

## Bug status

- **Bug A** — phase ladder (4 vs 5). Tracked at issue #580 (already
  filed). Fix is to add a `synthesize` step to the built-in tool, OR
  flip the gateway profile factory's tool-registration order so the
  bundled plugin takes precedence. Not in scope here.
- **Bug B** — orphan-task reaper. Fixed in commit 1 of this PR.

## Test summary

```
cargo test -p octos-agent --lib                         1193 passed; 0 failed; 1 ignored
cargo test -p octos-agent --lib task_supervisor         57 passed; 0 failed
cargo fmt --all -- --check                              clean
cargo clippy -p octos-agent --all-targets -- -D warnings clean
npx playwright test live-progress-gate.spec.ts --list   3 tests detected (Test 1 skipped)
```

## Supersedes

- Closes #581 (orphan-task reaper) — branch was unrebasable; logic
  redone in commit 1.
- Closes #582 (skip M4.1A live-progress-gate) — branch was unrebasable;
  scope narrowed to Test 1 only because Bug B is now fixed.

## Test plan

- [ ] CI workspace tests stay green
- [ ] Playwright `live-progress-gate.spec.ts` reports Test 1 as skipped,
      Tests 2 and 3 as passing on the canary
- [ ] After issue #580 lands, revert the `test.skip` to `test` in
      `live-progress-gate.spec.ts` Test 1