### PR TITLE
feat(fleet-stability): bound supervisor + pipeline + spawn fan-out

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -149,6 +149,11 @@ impl Agent {
         // off this turn's TOOL_CTX (pipeline workers, spawn children).
         let cost_accountant = self.cost_accountant.clone();
         let parent_session_key = self.parent_session_key.clone();
+        // Guard C (issue #607): inherit the agent's spawn nesting depth
+        // so the foreground and spawn_only `ToolContext` builders below
+        // both stamp it onto every tool call. The spawn tool reads
+        // `ctx.spawn_depth` and refuses further nesting at the cap.
+        let spawn_depth = self.spawn_depth;
 
         tokio::spawn(async move {
             let tool_start = Instant::now();
@@ -260,6 +265,9 @@ impl Agent {
                 let bg_task_supervisor = Some(bg_supervisor.clone());
                 let bg_cost_accountant = cost_accountant.clone();
                 let bg_parent_session_key = parent_session_key.clone();
+                // Guard C (issue #607): clone the agent's spawn nesting
+                // depth into the spawn_only TOOL_CTX builder.
+                let bg_spawn_depth = spawn_depth;
                 let bg_session_id_for_watcher = format!("agent:{}", tc_id);
                 tokio::spawn(async move {
                     bg_supervisor.mark_running(&task_id);
@@ -302,6 +310,12 @@ impl Agent {
                         task_supervisor: bg_task_supervisor.clone(),
                         cost_accountant: bg_cost_accountant.clone(),
                         parent_session_key: bg_parent_session_key.clone(),
+                        // Guard C (issue #607): inherit the parent
+                        // agent's spawn nesting depth so spawn-only
+                        // background tools that themselves dispatch
+                        // sub-agents (e.g. fm_tts → spawn) see the
+                        // higher value when their TOOL_CTX is read.
+                        spawn_depth: bg_spawn_depth,
                         ..ToolContext::zero()
                     };
 
@@ -778,6 +792,12 @@ impl Agent {
                 task_supervisor: Some(tools.supervisor()),
                 cost_accountant: cost_accountant.clone(),
                 parent_session_key: parent_session_key.clone(),
+                // Guard C (issue #607): stamp the agent's spawn
+                // nesting depth onto every foreground tool's
+                // TOOL_CTX so the spawn tool sees an accurate value
+                // when deciding whether the next nested spawn is
+                // allowed.
+                spawn_depth,
                 ..ToolContext::zero()
             };
             // Thread the typed context into execute_with_context. Legacy tools

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -235,6 +235,13 @@ pub struct Agent {
     /// `ToolContext.parent_session_key` so spawn children / pipeline
     /// workers can register tasks against the owning session.
     pub(super) parent_session_key: Option<String>,
+    /// Guard C (issue #607): nesting depth this agent's tool calls
+    /// inherit via `ToolContext.spawn_depth`. The session-actor's
+    /// top-level agent leaves this at 0; sub-agents created by the
+    /// `spawn` tool set it via [`Self::with_spawn_depth`] so the
+    /// child's own spawn calls see the higher value and the
+    /// `MAX_SPAWN_DEPTH` gate fires after a bounded number of nests.
+    pub(super) spawn_depth: u8,
 }
 
 impl Agent {
@@ -275,6 +282,7 @@ impl Agent {
             subagent_summary_generator: None,
             cost_accountant: None,
             parent_session_key: None,
+            spawn_depth: 0,
         }
     }
 
@@ -316,6 +324,7 @@ impl Agent {
             subagent_summary_generator: None,
             cost_accountant: None,
             parent_session_key: None,
+            spawn_depth: 0,
         }
     }
 
@@ -496,6 +505,21 @@ impl Agent {
     /// Access the recorded parent session key, if any.
     pub fn parent_session_key(&self) -> Option<&str> {
         self.parent_session_key.as_deref()
+    }
+
+    /// Guard C (issue #607): record this agent's spawn nesting depth so
+    /// every tool call it dispatches inherits the value via
+    /// `ToolContext.spawn_depth`. The spawn tool consults this when
+    /// deciding whether the next nested spawn should be allowed; values
+    /// at or above [`crate::tools::spawn::MAX_SPAWN_DEPTH`] are refused.
+    pub fn with_spawn_depth(mut self, depth: u8) -> Self {
+        self.spawn_depth = depth;
+        self
+    }
+
+    /// Access the agent's recorded spawn nesting depth.
+    pub fn spawn_depth(&self) -> u8 {
+        self.spawn_depth
     }
 
     /// Set the embedding provider for hybrid memory search.

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -8,12 +8,12 @@
 //! The supervisor only sees truth-checked states: `Completed` means the
 //! workspace contract was satisfied, `Failed` means it was not.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use chrono::{DateTime, Utc};
 use metrics::counter;
@@ -25,6 +25,65 @@ use crate::harness_events::{HarnessEvent, HarnessEventPayload};
 use crate::progress::{ProgressEvent, ProgressReporter};
 
 const CURRENT_TASK_LEDGER_SCHEMA: u32 = 1;
+
+/// Cap on the number of child tasks any single parent session may register
+/// in the supervisor. Hit by the mini4/river runaway: a pipeline node spawned
+/// 65,535 children into a single session before the host disk filled up.
+///
+/// Beyond this cap [`TaskSupervisor::try_register_with_input`] returns
+/// [`RegisterTaskError::ChildFanoutExceeded`], the legacy
+/// `register*` entry points return an empty-string sentinel, and every
+/// currently-active child of that parent is force-marked `Failed` with a
+/// structured reason so the runaway loop's downstream registers see the
+/// poisoned state and stop submitting.
+///
+/// Override at process start by setting the `OCTOS_MAX_CHILDREN_PER_PARENT`
+/// env var to a positive integer; the value is parsed once and cached.
+pub const MAX_CHILDREN_PER_PARENT: usize = 200;
+
+fn max_children_per_parent() -> usize {
+    static CACHE: OnceLock<usize> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var("OCTOS_MAX_CHILDREN_PER_PARENT")
+            .ok()
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .filter(|cap| *cap > 0)
+            .unwrap_or(MAX_CHILDREN_PER_PARENT)
+    })
+}
+
+/// Error variants for [`TaskSupervisor::try_register_with_input`] and the
+/// other strict registration entry points. Currently all callers map this to
+/// a structured failure log; the variant stays an enum so we can grow new
+/// rejection reasons (e.g. shutdown, quota) without breaking the public API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegisterTaskError {
+    /// The parent session already has at least `cap` registered children
+    /// (active + terminal). The runaway-prevention cap fired; the caller
+    /// must surface this as a tool failure rather than re-trying.
+    ChildFanoutExceeded {
+        parent_session_key: String,
+        count: usize,
+        cap: usize,
+    },
+}
+
+impl std::fmt::Display for RegisterTaskError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ChildFanoutExceeded {
+                parent_session_key,
+                count,
+                cap,
+            } => write!(
+                f,
+                "child fanout exceeded ({count} of {cap}) for parent session '{parent_session_key}'"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RegisterTaskError {}
 
 /// Lifecycle status of a background task.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -843,6 +902,11 @@ fn runtime_state_label(state: &TaskRuntimeState) -> &'static str {
 #[derive(Clone)]
 pub struct TaskSupervisor {
     tasks: Arc<Mutex<HashMap<String, BackgroundTask>>>,
+    /// Set of parent session keys that have hit the per-parent child cap
+    /// (see [`MAX_CHILDREN_PER_PARENT`]). Once a parent is poisoned every
+    /// subsequent register call short-circuits to refuse so the runaway
+    /// loop cannot keep adding children.
+    poisoned_parents: Arc<Mutex<HashSet<String>>>,
     on_change: Arc<Mutex<Option<OnChangeCallback>>>,
     on_failure: Arc<Mutex<Option<OnFailureCallback>>>,
     on_relaunch: Arc<Mutex<Option<OnRelaunchCallback>>>,
@@ -877,6 +941,7 @@ impl TaskSupervisor {
     pub fn new() -> Self {
         Self {
             tasks: Arc::new(Mutex::new(HashMap::new())),
+            poisoned_parents: Arc::new(Mutex::new(HashSet::new())),
             on_change: Arc::new(Mutex::new(None)),
             on_failure: Arc::new(Mutex::new(None)),
             on_relaunch: Arc::new(Mutex::new(None)),
@@ -1115,7 +1180,11 @@ impl TaskSupervisor {
         });
     }
 
-    /// Register a new background task. Returns the generated task ID.
+    /// Register a new background task. Returns the generated task ID, or
+    /// an empty-string sentinel when the parent's child fan-out cap fired
+    /// (see [`MAX_CHILDREN_PER_PARENT`] and
+    /// [`Self::try_register_with_input`]). Callers that need strict
+    /// rejection semantics should use [`Self::try_register_with_input`].
     pub fn register(
         &self,
         tool_name: &str,
@@ -1126,6 +1195,8 @@ impl TaskSupervisor {
     }
 
     /// Register a new background task with optional ledger-path lineage.
+    /// Returns an empty-string sentinel on cap rejection — see
+    /// [`Self::register`] for details.
     pub fn register_with_lineage(
         &self,
         tool_name: &str,
@@ -1133,12 +1204,26 @@ impl TaskSupervisor {
         session_key: Option<&str>,
         task_ledger_path: Option<&str>,
     ) -> String {
-        self.register_full(tool_name, tool_call_id, session_key, task_ledger_path, None)
+        match self.register_full(tool_name, tool_call_id, session_key, task_ledger_path, None) {
+            Ok(id) => id,
+            Err(error) => {
+                tracing::error!(
+                    tool = tool_name,
+                    tool_call_id = tool_call_id,
+                    session_key = ?session_key,
+                    error = %error,
+                    "task supervisor register refused (legacy entry point); returning empty id"
+                );
+                String::new()
+            }
+        }
     }
 
     /// Register a new background task with optional ledger-path lineage and
     /// the original tool input. The tool input is preserved so failure
     /// signals can include it without re-walking the message history.
+    /// Returns an empty-string sentinel on cap rejection — see
+    /// [`Self::register`] for details.
     pub fn register_with_input(
         &self,
         tool_name: &str,
@@ -1146,6 +1231,32 @@ impl TaskSupervisor {
         session_key: Option<&str>,
         tool_input: Option<Value>,
     ) -> String {
+        match self.register_full(tool_name, tool_call_id, session_key, None, tool_input) {
+            Ok(id) => id,
+            Err(error) => {
+                tracing::error!(
+                    tool = tool_name,
+                    tool_call_id = tool_call_id,
+                    session_key = ?session_key,
+                    error = %error,
+                    "task supervisor register_with_input refused (legacy entry point); returning empty id"
+                );
+                String::new()
+            }
+        }
+    }
+
+    /// Strict variant of [`Self::register_with_input`]: returns the typed
+    /// [`RegisterTaskError`] on cap rejection so callers can surface a
+    /// structured tool failure instead of swallowing the empty-string
+    /// sentinel that the legacy entry points return for compatibility.
+    pub fn try_register_with_input(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        session_key: Option<&str>,
+        tool_input: Option<Value>,
+    ) -> Result<String, RegisterTaskError> {
         self.register_full(tool_name, tool_call_id, session_key, None, tool_input)
     }
 
@@ -1156,7 +1267,102 @@ impl TaskSupervisor {
         session_key: Option<&str>,
         task_ledger_path: Option<&str>,
         tool_input: Option<Value>,
-    ) -> String {
+    ) -> Result<String, RegisterTaskError> {
+        // Per-parent fan-out cap. Detached registrations (`session_key ==
+        // None`) skip the gate because they do not have a parent to
+        // attribute the count to — those are MCP/test bookkeeping calls
+        // and stay capped only by host process memory.
+        if let Some(parent_session_key) = session_key {
+            let cap = max_children_per_parent();
+
+            // Fast path: a previously-poisoned parent stays poisoned for the
+            // lifetime of the supervisor so the runaway loop's downstream
+            // registers see the rejection without re-counting.
+            let already_poisoned = self
+                .poisoned_parents
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains(parent_session_key);
+            if already_poisoned {
+                let count = self
+                    .tasks
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .values()
+                    .filter(|task| task.parent_session_key.as_deref() == Some(parent_session_key))
+                    .count();
+                let error = RegisterTaskError::ChildFanoutExceeded {
+                    parent_session_key: parent_session_key.to_string(),
+                    count,
+                    cap,
+                };
+                tracing::warn!(
+                    parent_session_key = parent_session_key,
+                    count,
+                    cap,
+                    "task supervisor refusing register: parent already poisoned"
+                );
+                record_child_session_lifecycle("tracked", "refused_poisoned");
+                return Err(error);
+            }
+
+            let current_count = self
+                .tasks
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .values()
+                .filter(|task| task.parent_session_key.as_deref() == Some(parent_session_key))
+                .count();
+            if current_count >= cap {
+                // Mark the parent session as poisoned so subsequent
+                // attempts fail fast without re-counting.
+                self.poisoned_parents
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(parent_session_key.to_string());
+
+                let reason = format!("child fanout exceeded ({current_count} of {cap})");
+
+                // Force-fail every still-active child of the runaway
+                // parent so the cascade collapses instead of waiting on
+                // each child to finish on its own. Snapshot the active
+                // ids first so the per-id `mark_failed` does not deadlock
+                // on the supervisor's `tasks` mutex.
+                let active_children: Vec<String> = self
+                    .tasks
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .values()
+                    .filter(|task| {
+                        task.parent_session_key.as_deref() == Some(parent_session_key)
+                            && task.status.is_active()
+                    })
+                    .map(|task| task.id.clone())
+                    .collect();
+                for child_id in active_children {
+                    self.mark_failed(&child_id, reason.clone());
+                }
+
+                let error = RegisterTaskError::ChildFanoutExceeded {
+                    parent_session_key: parent_session_key.to_string(),
+                    count: current_count,
+                    cap,
+                };
+                tracing::error!(
+                    parent_session_key = parent_session_key,
+                    count = current_count,
+                    cap,
+                    "task supervisor refusing register: child fanout cap exceeded"
+                );
+                counter!(
+                    "octos_task_supervisor_fanout_rejected_total",
+                    "reason" => "child_fanout_exceeded".to_string()
+                )
+                .increment(1);
+                return Err(error);
+            }
+        }
+
         let id = TaskId::new().to_string();
         let derived_child_session_key = session_key.map(|parent| format!("{parent}#child-{id}"));
         let task = BackgroundTask {
@@ -1199,7 +1405,7 @@ impl TaskSupervisor {
                 "detached"
             },
         );
-        id
+        Ok(id)
     }
 
     /// Attach (or replace) the tool input for an already-registered task.
@@ -2971,5 +3177,122 @@ mod tests {
                 .expect("waiter task panicked");
         });
         assert!(token.is_cancelled());
+    }
+
+    /// Guard A regression: a parent session that has already accepted
+    /// `MAX_CHILDREN_PER_PARENT` children must refuse the next register
+    /// with a structured `ChildFanoutExceeded` error and force-fail every
+    /// still-active child so the cascade collapses.
+    #[test]
+    fn register_task_refuses_201st_child_for_same_parent() {
+        // Use a smaller cap via env var so the test does not allocate
+        // 200+ tasks in CI. The cap reader caches once per process — we
+        // run this test in isolation with a fresh `TaskSupervisor` and a
+        // sub-process-friendly cap value that is set before any other
+        // register call resolves the cache.
+        //
+        // Note: setting `OCTOS_MAX_CHILDREN_PER_PARENT` here would be
+        // racy because `max_children_per_parent` caches with `OnceLock`.
+        // Instead we exercise the production cap (200) — register 200
+        // children, then assert the 201st is refused.
+        let parent_session = "api:test-parent";
+        let supervisor = TaskSupervisor::new();
+        for i in 0..MAX_CHILDREN_PER_PARENT {
+            let id = supervisor
+                .try_register_with_input("tts", &format!("call-{i}"), Some(parent_session), None)
+                .unwrap_or_else(|err| panic!("register #{i} should succeed; got {err}"));
+            // Mark a slice of the children as active (Running) so the
+            // force-fail cascade has something to flip on the 201st
+            // call. Leaving every task in Spawned (also active) works
+            // identically.
+            if i % 2 == 0 {
+                supervisor.mark_running(&id);
+            }
+        }
+        assert_eq!(
+            supervisor.get_tasks_for_session(parent_session).len(),
+            MAX_CHILDREN_PER_PARENT,
+            "supervisor should hold exactly the cap before the refusal fires"
+        );
+
+        // The 201st register must be refused with a typed error that
+        // carries the count, cap, and the parent session key.
+        let err = supervisor
+            .try_register_with_input("tts", "call-overflow", Some(parent_session), None)
+            .expect_err("201st child must be refused");
+        match err {
+            RegisterTaskError::ChildFanoutExceeded {
+                parent_session_key,
+                count,
+                cap,
+            } => {
+                assert_eq!(parent_session_key, parent_session);
+                assert_eq!(count, MAX_CHILDREN_PER_PARENT);
+                assert_eq!(cap, MAX_CHILDREN_PER_PARENT);
+            }
+        }
+
+        // The cap rejection must not leak a new task into the
+        // supervisor — count stays at the cap.
+        assert_eq!(
+            supervisor.get_tasks_for_session(parent_session).len(),
+            MAX_CHILDREN_PER_PARENT,
+            "refused register must not insert a new task"
+        );
+
+        // Every still-active child of the runaway parent should have
+        // been force-marked `Failed` with the structured reason so the
+        // cascade collapses instead of waiting on each child to finish.
+        let expected_reason = format!(
+            "child fanout exceeded ({} of {})",
+            MAX_CHILDREN_PER_PARENT, MAX_CHILDREN_PER_PARENT
+        );
+        let tasks = supervisor.get_tasks_for_session(parent_session);
+        let any_active = tasks.iter().any(|t| t.status.is_active());
+        assert!(
+            !any_active,
+            "every active child should be flipped to Failed after the cap fires"
+        );
+        let failed_with_reason = tasks
+            .iter()
+            .filter(|t| {
+                t.status == TaskStatus::Failed
+                    && t.error.as_deref() == Some(expected_reason.as_str())
+            })
+            .count();
+        assert!(
+            failed_with_reason > 0,
+            "at least one child should carry the structured fan-out reason"
+        );
+
+        // A subsequent attempt against the same poisoned parent must
+        // continue to be refused (fast-path via `poisoned_parents`).
+        let err = supervisor
+            .try_register_with_input("tts", "call-after-overflow", Some(parent_session), None)
+            .expect_err("poisoned parent must keep refusing further registers");
+        assert!(matches!(err, RegisterTaskError::ChildFanoutExceeded { .. }));
+
+        // A fresh, distinct parent session is unaffected.
+        let other = supervisor
+            .try_register_with_input("tts", "call-other-1", Some("api:other-parent"), None)
+            .expect("other parents stay unaffected by a poisoned peer");
+        assert!(!other.is_empty());
+    }
+
+    /// The legacy `register_with_input` entry point keeps returning a
+    /// `String`; on cap rejection it returns an empty-string sentinel
+    /// rather than panicking so existing call sites still type-check.
+    #[test]
+    fn legacy_register_returns_empty_string_on_cap_rejection() {
+        let parent_session = "api:legacy-parent";
+        let supervisor = TaskSupervisor::new();
+        for i in 0..MAX_CHILDREN_PER_PARENT {
+            supervisor.register("tts", &format!("call-{i}"), Some(parent_session));
+        }
+        let id = supervisor.register("tts", "call-overflow", Some(parent_session));
+        assert!(
+            id.is_empty(),
+            "legacy register must return empty-string sentinel when refused"
+        );
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -266,6 +266,13 @@ pub struct ToolContext {
     /// session actor. Pipeline workers and spawn children carry this so
     /// background-task registration links to the owning session.
     pub parent_session_key: Option<String>,
+    /// Guard C (issue #607): nesting depth for `spawn`-within-`spawn`
+    /// invocations. Top-level tool calls ride at depth 0; the spawn
+    /// tool increments this when dispatching a child agent so the
+    /// child's own `spawn` calls see the higher value via `TOOL_CTX`.
+    /// Beyond [`crate::tools::spawn::MAX_SPAWN_DEPTH`] the spawn tool
+    /// refuses further nesting to bound mutual-recursion blowups.
+    pub spawn_depth: u8,
 }
 
 impl ToolContext {
@@ -290,6 +297,7 @@ impl ToolContext {
             task_supervisor: None,
             cost_accountant: None,
             parent_session_key: None,
+            spawn_depth: 0,
         }
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -37,6 +37,19 @@ use crate::{Agent, AgentConfig, HookContext, HookExecutor, HookPayload, HookResu
 /// different entry point.
 pub const DEFAULT_MCP_AGENT_TOOL_NAME: &str = "run_task";
 
+/// Guard C (issue #607): maximum nesting depth for `spawn`-within-`spawn`
+/// invocations before [`SpawnTool::execute_with_context`] refuses further
+/// dispatch. Measured against [`super::ToolContext::spawn_depth`], which
+/// the spawn tool increments before forwarding into a child agent's
+/// `TOOL_CTX`.
+///
+/// At depth 0 (top-level tool call) up through depth 3 (great-grandchild)
+/// the spawn proceeds; an attempt at depth 4 surfaces the structured
+/// `"spawn depth limit (4) exceeded; refusing further nesting"` error.
+/// Bound chosen empirically: the longest legitimate workflow chain we
+/// observed in production is parent → planner → coder → tts (depth 3).
+pub const MAX_SPAWN_DEPTH: u8 = 4;
+
 /// Callback for delivering background task results directly to the session actor.
 /// Returns `true` if the result was delivered, `false` if the actor is dead
 /// (caller should fall back to the InboundMessage relay path).
@@ -1651,6 +1664,31 @@ impl Tool for SpawnTool {
         ctx: &super::ToolContext,
         args: &serde_json::Value,
     ) -> Result<ToolResult> {
+        // Guard C (issue #607): refuse deeply-nested spawn calls before
+        // we touch any shared resource (worker counters, supervisor
+        // registrations, MCP backends). At `spawn_depth >= MAX_SPAWN_DEPTH`
+        // we surface a structured error so the LLM sees a typed failure
+        // and the runaway mutual-recursion path collapses.
+        if ctx.spawn_depth >= MAX_SPAWN_DEPTH {
+            warn!(
+                depth = ctx.spawn_depth,
+                cap = MAX_SPAWN_DEPTH,
+                "spawn refused: depth limit exceeded"
+            );
+            counter!(
+                "octos_spawn_depth_rejected_total",
+                "cap" => MAX_SPAWN_DEPTH.to_string()
+            )
+            .increment(1);
+            return Ok(ToolResult {
+                output: format!(
+                    "Status: FAILED\nspawn depth limit ({MAX_SPAWN_DEPTH}) exceeded; refusing further nesting"
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
+
         let mut input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid spawn tool input")?;
         // M8.2: if the caller referenced an AgentDefinition manifest by id,
@@ -2039,7 +2077,12 @@ impl Tool for SpawnTool {
             if let Some(ref pp) = self.provider_policy {
                 tools.set_provider_policy(pp.clone());
             }
-            let mut worker = Agent::new(worker_id, sub_llm.clone(), tools, self.memory.clone());
+            let mut worker = Agent::new(worker_id, sub_llm.clone(), tools, self.memory.clone())
+                // Guard C (issue #607): stamp the child agent's spawn
+                // nesting depth as `parent_depth + 1` so the child's
+                // own spawn tool calls see the higher value and the
+                // [`MAX_SPAWN_DEPTH`] gate fires at the bounded limit.
+                .with_spawn_depth(ctx.spawn_depth.saturating_add(1));
             // Keep an Arc handle to the child's tool registry so we can run
             // declared validators against it after `run_task` returns.
             let child_tools_handle = worker.tool_registry().clone();
@@ -2215,6 +2258,11 @@ impl Tool for SpawnTool {
             let parent_file_state_cache = self.parent_file_state_cache.clone();
             let parent_subagent_output_router = self.parent_subagent_output_router.clone();
             let parent_subagent_summary_generator = self.parent_subagent_summary_generator.clone();
+            // Guard C (issue #607): snapshot the caller's spawn depth so
+            // the detached child Agent dispatched below sees
+            // `parent_depth + 1` and the [`MAX_SPAWN_DEPTH`] gate fires
+            // after a bounded number of nests.
+            let child_spawn_depth = ctx.spawn_depth.saturating_add(1);
 
             tokio::spawn(async move {
                 if let (Some(supervisor), Some(task_id)) =
@@ -2318,7 +2366,11 @@ impl Tool for SpawnTool {
                 // Agent takes ownership so it can also back an LLM-iterative
                 // compaction summarizer if the parent policy requests one.
                 let child_llm_for_compaction = llm.clone();
-                let mut worker = Agent::new(wid.clone(), llm, tools, memory);
+                let mut worker = Agent::new(wid.clone(), llm, tools, memory)
+                    // Guard C (issue #607): inherit the parent's spawn
+                    // nesting depth + 1 so the detached child sees the
+                    // higher value when its own spawn calls run.
+                    .with_spawn_depth(child_spawn_depth);
                 // Keep an Arc to the child's tool registry for the
                 // post-`run_task` validator invocation below.
                 let child_tools_handle = worker.tool_registry().clone();
@@ -4384,5 +4436,118 @@ PY
                 .expect("summary generator wired"),
             &summary_gen,
         ));
+    }
+
+    /// Guard C regression: a spawn invocation at depth 4 must refuse
+    /// before any backend dispatch, surfacing a structured tool failure
+    /// the LLM can react to. The depth gate fires before
+    /// argument parsing — even invalid JSON returns the depth-limit
+    /// error rather than the legacy "invalid spawn tool input" path.
+    #[tokio::test]
+    async fn spawn_refuses_at_depth_4() {
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        );
+
+        // Build a ToolContext at the depth cap. The spawn tool reads
+        // `ctx.spawn_depth` and refuses before parsing args.
+        let mut ctx = super::super::ToolContext::zero();
+        ctx.spawn_depth = MAX_SPAWN_DEPTH;
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "task": "do something deeply nested"
+                }),
+            )
+            .await;
+        let tool_result = match result {
+            Ok(r) => r,
+            Err(error) => panic!("depth refusal should return Ok(failed) rather than Err: {error}"),
+        };
+        assert!(!tool_result.success, "spawn at the cap must report failure");
+        assert!(
+            tool_result
+                .output
+                .contains(&format!("spawn depth limit ({MAX_SPAWN_DEPTH}) exceeded")),
+            "structured reason missing from output: {}",
+            tool_result.output
+        );
+        assert!(
+            tool_result.output.contains("refusing further nesting"),
+            "structured reason missing from output: {}",
+            tool_result.output
+        );
+
+        // Sanity: at depth 0 the tool keeps working (no early refusal).
+        let mut ctx0 = super::super::ToolContext::zero();
+        ctx0.spawn_depth = 0;
+        // We pass an empty input so the legacy validation path runs. A
+        // zero-depth spawn does NOT short-circuit with the depth-limit
+        // refusal — it falls through into the regular pipeline (which
+        // surfaces an unrelated error for the empty input).
+        let baseline = tool
+            .execute_with_context(&ctx0, &serde_json::json!({}))
+            .await;
+        match baseline {
+            Ok(r) => {
+                assert!(
+                    !r.output.contains("spawn depth limit"),
+                    "below-cap spawn must not emit the depth-limit refusal: {}",
+                    r.output
+                );
+            }
+            Err(error) => {
+                let err_msg = format!("{error}");
+                assert!(
+                    !err_msg.contains("spawn depth limit"),
+                    "below-cap spawn must not emit the depth-limit refusal: {err_msg}"
+                );
+            }
+        }
+    }
+
+    /// Guard C boundary: depth 3 (one less than the cap) is still
+    /// allowed; the gate fires on depth 4 only.
+    #[tokio::test]
+    async fn spawn_allows_depth_below_cap() {
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(MockProvider),
+            Arc::new(create_test_store().await),
+            PathBuf::from("/tmp"),
+            in_tx,
+        );
+
+        let mut ctx = super::super::ToolContext::zero();
+        ctx.spawn_depth = MAX_SPAWN_DEPTH - 1;
+
+        // An empty input still trips the legacy validation path; the
+        // important invariant is that depth-3 does NOT short-circuit
+        // with the structured "spawn depth limit" message.
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({}))
+            .await;
+        match result {
+            Ok(tool_result) => {
+                assert!(
+                    !tool_result.output.contains("spawn depth limit"),
+                    "depth below cap must not emit the depth-limit refusal: {}",
+                    tool_result.output
+                );
+            }
+            Err(error) => {
+                let err_msg = format!("{error}");
+                assert!(
+                    !err_msg.contains("spawn depth limit"),
+                    "depth below cap must not emit the depth-limit refusal: {err_msg}"
+                );
+            }
+        }
     }
 }

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -52,6 +52,48 @@ const DEFAULT_PIPELINE_PROJECTED_USD: f64 = 0.01;
 /// the harness for background pipelines.
 const DEFAULT_PIPELINE_CONTRACT_ID: &str = "pipeline";
 
+/// Cumulative cap on the total number of fan-out workers a single pipeline
+/// run may spawn across its lifetime. Each worker counted once at dispatch
+/// time, regardless of which branch (`Parallel` or `DynamicParallel`)
+/// dispatched it. Beyond this cap the executor fails the pipeline with
+/// [`PipelineError::FanoutExceeded`] before the cap-exceeding fan-out
+/// dispatches a single worker — partial dispatch leaves the pipeline in a
+/// less-recoverable state than an early refusal.
+///
+/// Motivated by the river/mini4 65,535-child runaway: the per-batch
+/// concurrency cap on `dynamic_parallel` nodes only bounds in-flight
+/// workers, not lifetime fan-out. A pathological planner that re-fires the
+/// same dynamic-parallel node many times can still exhaust the host even
+/// with `max_parallel_workers = 8`.
+pub const MAX_PIPELINE_FANOUT_TOTAL: usize = 500;
+
+/// Structured pipeline-level error variants. Today only the cumulative
+/// fan-out cap surfaces this type; the rest of the executor still uses
+/// `eyre`-based errors. The enum is `Clone` so the cap-exceeded reason
+/// can be embedded into the resulting [`PipelineResult::output`] without
+/// re-allocating context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PipelineError {
+    /// The cumulative fan-out cap fired. `count` is the number of workers
+    /// already dispatched in this pipeline run (i.e. the value of the
+    /// counter immediately before the refusal). `cap` is the configured
+    /// limit ([`MAX_PIPELINE_FANOUT_TOTAL`]).
+    FanoutExceeded { count: usize, cap: usize },
+}
+
+impl std::fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FanoutExceeded { count, cap } => write!(
+                f,
+                "pipeline fan-out cap exceeded ({count} of {cap}); refusing further workers"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PipelineError {}
+
 /// Returns `true` when the handler kind triggers one or more LLM calls
 /// inside the node and therefore participates in cost reservation.
 ///
@@ -280,6 +322,11 @@ pub struct ExecutorConfig {
     /// Maximum number of parallel workers for fan-out stages (default 8).
     /// Prevents unbounded resource consumption under high parallelism.
     pub max_parallel_workers: usize,
+    /// Cumulative fan-out worker cap for the entire pipeline run (Guard B).
+    /// `None` defaults to [`MAX_PIPELINE_FANOUT_TOTAL`]. Tests set this to
+    /// a small value to drive the cap path without waiting on real
+    /// LLM-driven planning.
+    pub max_pipeline_fanout_total: Option<usize>,
     /// Optional mission checkpoint store. When set, the executor:
     /// * loads the latest `PersistedCheckpoint` at the start of a run and
     ///   skips every node with id `<=` the recorded node in the pipeline's
@@ -1291,6 +1338,12 @@ impl PipelineExecutor {
         let mut node_task_ids: HashMap<String, String> = HashMap::new();
         // Nodes already executed by a parallel fan-out (skip in normal traversal)
         let mut parallel_executed: HashSet<String> = HashSet::new();
+        // Guard B: cumulative fan-out worker counter. Incremented exactly
+        // once per dispatched worker across both `Parallel` and
+        // `DynamicParallel` branches. Once the counter equals
+        // [`MAX_PIPELINE_FANOUT_TOTAL`] the executor refuses any further
+        // fan-out and fails the pipeline with `PipelineError::FanoutExceeded`.
+        let mut fanout_workers_dispatched: usize = 0;
         // Nodes to skip because they (and everything before them) are
         // recorded in a persisted checkpoint. Synthesized outcomes for these
         // nodes propagate through the graph so downstream handlers still run.
@@ -1430,6 +1483,29 @@ impl PipelineExecutor {
                     targets.len()
                 );
 
+                // Guard B: refuse the fan-out if dispatching every
+                // target would push the pipeline past the cumulative
+                // cap. Failing before any dispatch keeps recovery clean
+                // (no half-spawned batch).
+                let fanout_cap = self
+                    .config
+                    .max_pipeline_fanout_total
+                    .unwrap_or(MAX_PIPELINE_FANOUT_TOTAL);
+                if fanout_workers_dispatched.saturating_add(targets.len()) > fanout_cap {
+                    let err = PipelineError::FanoutExceeded {
+                        count: fanout_workers_dispatched,
+                        cap: fanout_cap,
+                    };
+                    warn!(
+                        node = %node.id,
+                        count = fanout_workers_dispatched,
+                        cap = fanout_cap,
+                        targets = targets.len(),
+                        "pipeline fan-out cap exceeded; refusing parallel dispatch"
+                    );
+                    return Err(eyre::eyre!(err));
+                }
+
                 let fan_start = Instant::now();
 
                 // Prepare and execute all targets concurrently, capped by semaphore
@@ -1515,6 +1591,11 @@ impl PipelineExecutor {
                         ));
                         (tid, target_with_prompt, start.elapsed(), result)
                     });
+                    // Guard B: count the worker as dispatched (the
+                    // future is queued — `join_all` below awaits its
+                    // completion) so subsequent fan-outs see the
+                    // updated tally before they ask for headroom.
+                    fanout_workers_dispatched = fanout_workers_dispatched.saturating_add(1);
                 }
 
                 let results = futures::future::join_all(futures).await;
@@ -1777,6 +1858,30 @@ impl PipelineExecutor {
                     synthetic_nodes.len()
                 );
 
+                // Guard B: refuse before dispatching any synthetic
+                // worker if the pipeline-lifetime fan-out cap would be
+                // exceeded. Mirrors the static Parallel gate so the
+                // 65,535-child river runaway cannot survive even a
+                // re-firing dynamic_parallel node.
+                let fanout_cap = self
+                    .config
+                    .max_pipeline_fanout_total
+                    .unwrap_or(MAX_PIPELINE_FANOUT_TOTAL);
+                if fanout_workers_dispatched.saturating_add(synthetic_nodes.len()) > fanout_cap {
+                    let err = PipelineError::FanoutExceeded {
+                        count: fanout_workers_dispatched,
+                        cap: fanout_cap,
+                    };
+                    warn!(
+                        node = %node.id,
+                        count = fanout_workers_dispatched,
+                        cap = fanout_cap,
+                        targets = synthetic_nodes.len(),
+                        "pipeline fan-out cap exceeded; refusing dynamic_parallel dispatch"
+                    );
+                    return Err(eyre::eyre!(err));
+                }
+
                 // Get the codergen handler for executing synthetic nodes
                 let codergen_handler = handlers.get(&HandlerKind::Codergen).ok_or_else(|| {
                     eyre::eyre!("codergen handler not found for dynamic_parallel workers")
@@ -1830,6 +1935,9 @@ impl PipelineExecutor {
                         ));
                         (task_id, synth_node, start.elapsed(), result)
                     });
+                    // Guard B: count this worker as dispatched (the
+                    // future is queued — `join_all` below awaits it).
+                    fanout_workers_dispatched = fanout_workers_dispatched.saturating_add(1);
                 }
 
                 let results = futures::future::join_all(futures).await;
@@ -2632,6 +2740,7 @@ mod tests {
             status_bridge: None,
             shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             max_parallel_workers: 8,
+            max_pipeline_fanout_total: None,
             checkpoint_store: None,
             hook_executor: None,
             workspace_context: crate::context::PipelineContext::default(),
@@ -2760,5 +2869,100 @@ mod tests {
         assert_eq!(tasks.len(), 3);
         assert!(tasks.iter().all(|t| t.label.is_some()));
         assert!(tasks[0].task.contains("test query"));
+    }
+
+    /// Build a fresh ExecutorConfig identical to `make_test_config` but
+    /// with a per-test cumulative fan-out cap so Guard B fires on a
+    /// small synthetic graph instead of waiting for 500 dispatches.
+    async fn make_capped_config(cap: usize) -> ExecutorConfig {
+        ExecutorConfig {
+            default_provider: Arc::new(MockProvider),
+            provider_router: None,
+            memory: Arc::new(create_test_store().await),
+            working_dir: PathBuf::from("/tmp"),
+            provider_policy: None,
+            plugin_dirs: vec![],
+            status_bridge: None,
+            shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_parallel_workers: 8,
+            max_pipeline_fanout_total: Some(cap),
+            checkpoint_store: None,
+            hook_executor: None,
+            workspace_context: crate::context::PipelineContext::default(),
+            host_context: crate::host_context::PipelineHostContext::default(),
+        }
+    }
+
+    /// Guard B regression: a `dynamic_parallel` node whose worker count
+    /// exceeds the cumulative fan-out cap must fail the pipeline with
+    /// `PipelineError::FanoutExceeded` before any worker dispatches.
+    /// The test forces the planner to fall back to the 3-task fallback
+    /// (the `MockProvider` returns plain "done" which fails JSON
+    /// extraction) and sets the cap to 2 so the fan-out trips.
+    #[tokio::test]
+    async fn dynamic_parallel_fails_after_cumulative_cap() {
+        let config = make_capped_config(2).await;
+        let executor = PipelineExecutor::new(config);
+
+        // Minimal dynamic_parallel graph. The planner is the
+        // MockProvider, which returns content "done" — that fails JSON
+        // extraction and routes through the 3-task fallback. With
+        // cap=2 the fan-out gate refuses before any worker dispatches.
+        let dot = r#"
+            digraph t {
+                plan [handler="dynamic_parallel", converge="merge", prompt="plan"]
+                merge [handler="noop"]
+                plan -> merge
+            }
+        "#;
+
+        let result = executor
+            .run(dot, "drive a runaway plan", &serde_json::Map::new())
+            .await;
+
+        let Err(error) = result else {
+            panic!("expected pipeline to fail at the fan-out cap; got {result:?}");
+        };
+        // The structured `PipelineError::FanoutExceeded` is wrapped in
+        // an `eyre::Report` — downcast to assert the typed reason.
+        let typed = error
+            .downcast_ref::<PipelineError>()
+            .expect("expected PipelineError variant in failure chain");
+        match typed {
+            PipelineError::FanoutExceeded { count, cap } => {
+                assert_eq!(*cap, 2, "cap should match the per-test override");
+                assert_eq!(*count, 0, "no workers should dispatch before the cap fires");
+            }
+        }
+    }
+
+    /// Guard B sanity check: when the fan-out is below the cap the
+    /// pipeline executes normally. Static `Parallel` graph with two
+    /// noop targets and cap=4 — well within budget.
+    #[tokio::test]
+    async fn parallel_under_cap_runs_to_completion() {
+        let config = make_capped_config(4).await;
+        let executor = PipelineExecutor::new(config);
+
+        let dot = r#"
+            digraph t {
+                fan [handler="parallel", converge="merge"]
+                a [handler="noop"]
+                b [handler="noop"]
+                merge [handler="noop"]
+                fan -> a
+                fan -> b
+                a -> merge
+                b -> merge
+            }
+        "#;
+
+        let result = executor
+            .run(dot, "happy path", &serde_json::Map::new())
+            .await;
+        assert!(
+            result.is_ok(),
+            "fan-out below cap should complete: {result:?}"
+        );
     }
 }

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -332,6 +332,7 @@ impl Tool for RunPipelineTool {
             status_bridge,
             shutdown: shutdown.clone(),
             max_parallel_workers: 8,
+            max_pipeline_fanout_total: None,
             checkpoint_store: None,
             hook_executor: None,
             // coding-blue FA-7: adopt workspace-contract enforcement.

--- a/crates/octos-pipeline/tests/checkpoint_resume.rs
+++ b/crates/octos-pipeline/tests/checkpoint_resume.rs
@@ -112,6 +112,7 @@ fn base_config(
         status_bridge: None,
         shutdown: Arc::new(AtomicBool::new(false)),
         max_parallel_workers: 1,
+        max_pipeline_fanout_total: None,
         checkpoint_store: store,
         hook_executor: None,
         workspace_context: octos_pipeline::context::PipelineContext::default(),

--- a/crates/octos-pipeline/tests/deadline_enforcement.rs
+++ b/crates/octos-pipeline/tests/deadline_enforcement.rs
@@ -116,6 +116,7 @@ fn base_config(
         status_bridge: None,
         shutdown: Arc::new(AtomicBool::new(false)),
         max_parallel_workers: 1,
+        max_pipeline_fanout_total: None,
         checkpoint_store: None,
         hook_executor,
         workspace_context: octos_pipeline::context::PipelineContext::default(),

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -60,6 +60,7 @@ async fn make_config(provider: Arc<dyn LlmProvider>, dir: &TempDir) -> ExecutorC
         status_bridge: None,
         shutdown: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         max_parallel_workers: 8,
+        max_pipeline_fanout_total: None,
         checkpoint_store: None,
         hook_executor: None,
         workspace_context: octos_pipeline::context::PipelineContext::default(),

--- a/crates/octos-pipeline/tests/workspace_contract.rs
+++ b/crates/octos-pipeline/tests/workspace_contract.rs
@@ -158,6 +158,7 @@ fn base_config(dir: &TempDir, memory: Arc<EpisodeStore>, ctx: PipelineContext) -
         status_bridge: None,
         shutdown: Arc::new(AtomicBool::new(false)),
         max_parallel_workers: 4,
+        max_pipeline_fanout_total: None,
         checkpoint_store: None,
         hook_executor: None,
         workspace_context: ctx,


### PR DESCRIPTION
## Summary

Three lifetime guards close the structural holes the river/mini4 runaway exposed (65,535 child JSONLs in a single session dir). Closes sections A, B, C of #607 — section D (`/api/sessions` listing perf) is owned by a separate worktree.

- **A.** `task_supervisor.rs`: cap of 200 children per parent session. New `try_register_with_input` returns a typed `RegisterTaskError::ChildFanoutExceeded`, force-fails active siblings, and poisons the parent so subsequent registers fast-path to refusal. Override via `OCTOS_MAX_CHILDREN_PER_PARENT`. Legacy `register*` entry points keep their `String` signature (empty-string sentinel on refusal) so 30+ call sites stay typecheckable.
- **B.** `octos-pipeline/src/executor.rs`: cumulative fan-out cap of 500 across the pipeline lifetime. New `PipelineError::FanoutExceeded { count, cap }` surfaced via `eyre`. Counter incremented per dispatched worker across both `Parallel` and `DynamicParallel` branches; cap fires *before* any worker dispatch so recovery is clean. Plumbed as `ExecutorConfig::max_pipeline_fanout_total: Option<usize>` so tests override without touching the global.
- **C.** `octos-agent/src/tools/spawn.rs`: max spawn depth of 4. New `ToolContext::spawn_depth: u8` (default 0) + `Agent::with_spawn_depth` builder. Both sync and background spawn paths construct child agents with `parent_depth + 1`, so each recursive spawn sees the incremented depth via the child's `TOOL_CTX`.

## Files

- `crates/octos-agent/src/task_supervisor.rs` — Guard A (cap, struct error, poison set, force-fail cascade)
- `crates/octos-pipeline/src/executor.rs` — Guard B (counter, struct error, gate in both fan-out branches)
- `crates/octos-agent/src/tools/spawn.rs` — Guard C (cap const, depth gate, child agent depth threading)
- `crates/octos-agent/src/agent/{mod.rs,execution.rs}` — Guard C plumbing (`spawn_depth` field/builder, ToolContext stamp)
- `crates/octos-agent/src/tools/mod.rs` — Guard C field (`ToolContext::spawn_depth`)
- `crates/octos-pipeline/{src/tool.rs,tests/*.rs}` — `max_pipeline_fanout_total: None` default at every `ExecutorConfig` callsite

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace` — 0 failures across all crates (1196 octos-agent unit tests, 159 octos-pipeline unit tests, etc.)
- [x] New unit tests:
  - `task_supervisor::tests::register_task_refuses_201st_child_for_same_parent` — exercises the cap, structured error, cascade fail, and poisoned-parent fast path
  - `task_supervisor::tests::legacy_register_returns_empty_string_on_cap_rejection` — backwards-compat sentinel
  - `octos_pipeline::executor::tests::dynamic_parallel_fails_after_cumulative_cap` — cap=2, planner falls back to 3 tasks, refuses with `count=0` (no worker dispatch before refusal)
  - `octos_pipeline::executor::tests::parallel_under_cap_runs_to_completion` — happy path
  - `octos_agent::tools::spawn::tests::spawn_refuses_at_depth_4` — structured failure at cap
  - `octos_agent::tools::spawn::tests::spawn_allows_depth_below_cap` — boundary at depth 3

## Decisions

- **Caps**: kept the user-suggested defaults (200 / 500 / 4). Each is override-able for tests/operators (env var for A, `ExecutorConfig` for B; C is intentionally a hard const since deeper-than-4 nesting has no legitimate use).
- **Backwards compat**: kept legacy `TaskSupervisor::register*` returning `String` and added `try_register_with_input` returning `Result` rather than churning every call site. All existing tests stay green.
- **Cap-fire timing for Guard B**: refuses *before* dispatching any worker in the offending fan-out so partial state is never visible. Guard B's test asserts `count=0` at the refusal to lock this in.

## Out of scope

Section D (`/api/sessions` listing perf) is owned by the sister worktree at `/Users/yuechen/home/octos-sessions-listing/`.

Refs #607