### PR TITLE
fix(gateway): MAIN_PROFILE_ID import for matrix feature compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,29 @@ jobs:
       - name: activate_tools regression tests
         run: cargo test -p octos-agent --test activate_tools_regression -- --nocapture
 
+  # Lightweight check that exercises the `matrix` feature gate. The default
+  # `FEATURES` env above intentionally omits `matrix` to keep the main `check`
+  # job lean, but the Dockerfile and several release configurations enable it.
+  # Without this job, feature-gated compile errors (e.g. an identifier referenced
+  # only inside `#[cfg(feature = "matrix")]`) slip past PR CI and only surface
+  # during docker builds. Keep this job intentionally tiny: `cargo check` only,
+  # no tests, no clippy — its sole job is to catch the feature-gated compile.
+  check-matrix:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_JOBS: "2"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: matrix-feature
+
+      - name: Check octos-cli with matrix feature
+        run: cargo check -p octos-cli --no-default-features --features api,telegram,discord,slack,whatsapp,feishu,email,matrix
+
   check-arm:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04-arm

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -50,6 +50,9 @@ use crate::session_actor::{
 use crate::status_layers::StatusComposer;
 
 #[cfg(feature = "matrix")]
+use octos_core::MAIN_PROFILE_ID;
+
+#[cfg(feature = "matrix")]
 use super::matrix_integration::*;
 
 const PROFILE_PROMPT_CACHE_CAP: usize = 128;


### PR DESCRIPTION
## Summary

- The matrix-gated `GatewayBotManager` setup at `crates/octos-cli/src/commands/gateway/gateway_runtime.rs:1282` referenced `MAIN_PROFILE_ID` without an import. `gateway/mod.rs` imports it via plain `use` (not `pub use`), so submodules cannot pick it up through the parent path. Default CI's `FEATURES` env omits `matrix`, so the broken compile slipped past PR review and only surfaced when the Dockerfile (which enables `matrix`) built from main.
- Fix: add `use octos_core::MAIN_PROFILE_ID;` directly in `gateway_runtime.rs`, gated on `feature = "matrix"` so it does not warn when matrix is disabled.
- Add a small `check-matrix` CI job that runs `cargo check -p octos-cli --no-default-features --features api,...,matrix` so this class of feature-gated compile bug is caught on every PR rather than at docker-build time. Job is intentionally tiny (no tests, no clippy) — its sole purpose is exercising the feature gate.

Surfaced by the audit on PR #527 (kept open with explanation; this PR does not close #527).

## Reproduce (before fix)

```
cargo check -p octos-cli --features api,telegram,discord,slack,whatsapp,feishu,email,matrix --no-default-features
```

```
error[E0425]: cannot find value `MAIN_PROFILE_ID` in this scope
   --> crates/octos-cli/src/commands/gateway/gateway_runtime.rs:1282:48
```

## Test plan

- [x] `cargo check -p octos-cli --features api,telegram,discord,slack,whatsapp,feishu,email,matrix --no-default-features` — passes after fix
- [x] `cargo check --workspace` (default features) — passes
- [x] `cargo check --workspace --all-features` — passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI: new `check-matrix` job exercises the matrix feature on every PR going forward

Note: `cargo test -p octos-cli --features api,matrix --lib` has pre-existing test-fixture drift in `gateway/mod.rs::tests` (struct field renames in `ProfileConfig`, missing builder fields in `ProfileActorFactoryBuilder`) — those errors are present on main without this fix and are out of scope here. Library code (the actual matrix feature surface) compiles fine with the fix.