### PR TITLE
Match default tool timeout to MAX_TOOL_TIMEOUT_SECS (1800s)

### DIFF
--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -138,10 +138,20 @@ mod tests {
         let cfg = AgentConfig::default();
         assert_eq!(cfg.max_iterations, 50);
         assert_eq!(cfg.max_tokens, None);
-        assert_eq!(cfg.max_timeout, Some(Duration::from_secs(600)));
+        assert_eq!(cfg.max_timeout, Some(Duration::from_secs(1800)));
         assert!(cfg.save_episodes);
-        assert_eq!(cfg.tool_timeout_secs, 600);
+        assert_eq!(cfg.tool_timeout_secs, 1800);
         assert!(cfg.worker_prompt.is_none());
+    }
+
+    #[test]
+    fn default_tool_timeout_matches_max_so_long_running_tools_have_room() {
+        // Long-running tools like run_pipeline can legitimately take up to MAX_TOOL_TIMEOUT_SECS.
+        // If DEFAULT < MAX, the LLM must remember to pass `timeout_secs` to use the headroom,
+        // and forgetting silently caps the call. Keep them equal so the default is the ceiling.
+        use super::super::{DEFAULT_TOOL_TIMEOUT_SECS, MAX_TOOL_TIMEOUT_SECS};
+        assert_eq!(DEFAULT_TOOL_TIMEOUT_SECS, MAX_TOOL_TIMEOUT_SECS);
+        assert_eq!(DEFAULT_TOOL_TIMEOUT_SECS, 1800);
     }
 
     // ---------- TokenTracker ----------

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -70,7 +70,10 @@ pub struct AgentConfig {
 }
 
 /// Default tool execution timeout in seconds.
-pub const DEFAULT_TOOL_TIMEOUT_SECS: u64 = 600;
+/// Matches `MAX_TOOL_TIMEOUT_SECS` so long-running tools like `run_pipeline`
+/// (default 1800s) are not silently capped when the LLM omits `timeout_secs`
+/// in the tool call.
+pub const DEFAULT_TOOL_TIMEOUT_SECS: u64 = 1800;
 /// Maximum tool timeout the LLM can request (30 minutes).
 pub const MAX_TOOL_TIMEOUT_SECS: u64 = 1800;
 /// Default session processing timeout in seconds.
@@ -81,7 +84,7 @@ impl Default for AgentConfig {
         Self {
             max_iterations: 50,
             max_tokens: None,
-            max_timeout: Some(std::time::Duration::from_secs(600)),
+            max_timeout: Some(std::time::Duration::from_secs(1800)),
             save_episodes: true,
             worker_prompt: None,
             tool_timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,


### PR DESCRIPTION
## Summary

`run_pipeline` accepts up to 1800s and `MAX_TOOL_TIMEOUT_SECS` is 1800s, but `DEFAULT_TOOL_TIMEOUT_SECS` and `AgentConfig::default().max_timeout` were 600s. When an LLM omits `timeout_secs` from a `run_pipeline` call, the agent silently capped it at 10 minutes, killing 5-way DynamicParallel pipelines that legitimately need ~15-20 min.

This bumps both defaults to 1800s so the documented pipeline ceiling actually applies. Production gateway already overrides these with `DEFAULT_SESSION_TIMEOUT_SECS = 1800` for `max_timeout` and `DEFAULT_TOOL_TIMEOUT_SECS` for `tool_timeout_secs`, so the practical effect is to match CLI-mode behavior with what the gateway has been doing all along.

## Behavior change

- `AgentConfig::default().max_timeout`: 600s → 1800s (idle-only check; never bites active loops)
- `AgentConfig::default().tool_timeout_secs`: 600s → 1800s
- A tool that wedges will now hold the agent for up to 30min instead of 10min. All long-running tools already have their own internal caps.

## Test plan

- [x] cargo test -p octos-agent --lib (1198 pass)
- [x] cargo test --workspace --lib (all crates green)
- [x] cargo build --workspace
- [x] cargo fmt --all -- --check
- [x] New regression test pins DEFAULT_TOOL_TIMEOUT_SECS == MAX_TOOL_TIMEOUT_SECS == 1800

🤖 Generated with [Claude Code](https://claude.com/claude-code)