### PR TITLE
M8.10 PR #2/5: thread_id on every SSE event + committed_seq on done (#627)

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -576,6 +576,54 @@ fn build_task_status_event(task: serde_json::Value, topic: Option<&str>) -> serd
     })
 }
 
+/// M8.10 PR #2: insert `thread_id` into a JSON object payload (in place).
+/// No-op when `thread_id` is `None` or the value is not an object.
+fn inject_thread_id(value: &mut serde_json::Value, thread_id: Option<&str>) {
+    if let (Some(tid), Some(obj)) = (thread_id, value.as_object_mut()) {
+        obj.insert(
+            "thread_id".to_string(),
+            serde_json::Value::String(tid.to_string()),
+        );
+    }
+}
+
+/// Read the `thread_id` (if any) from outbound metadata. Empty strings are
+/// treated as absent.
+fn outbound_thread_id(metadata: &serde_json::Value) -> Option<String> {
+    metadata
+        .get("thread_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Sentinel that delimits the chat_id and the thread_id inside the synthetic
+/// message_id returned by `ApiChannel::send_with_id`. ASCII unit separator
+/// (0x1F) was chosen because it cannot appear inside JSON string content
+/// without explicit escaping, so it cannot collide with a legitimate
+/// thread_id payload.
+const SSE_THREAD_DELIM: char = '\u{1F}';
+
+/// Encode a synthetic SSE message_id that round-trips both the chat_id and
+/// the bound thread_id. Decoded back in `edit_message` to tag streaming
+/// `token`/`replace` events with the right thread.
+fn encode_sse_message_id(chat_id: &str, thread_id: Option<&str>) -> String {
+    match thread_id {
+        Some(tid) if !tid.is_empty() => format!("sse-{chat_id}{SSE_THREAD_DELIM}{tid}"),
+        _ => format!("sse-{chat_id}"),
+    }
+}
+
+/// Decode an `(chat_id, thread_id)` pair from a synthetic SSE message_id.
+/// Returns the bare chat_id and `None` when the legacy single-segment
+/// encoding is used.
+fn decode_sse_message_id(message_id: &str) -> (&str, Option<&str>) {
+    match message_id.split_once(SSE_THREAD_DELIM) {
+        Some((bare, tid)) => (bare, Some(tid).filter(|s| !s.is_empty())),
+        None => (message_id, None),
+    }
+}
+
 fn compatibility_tool_name_for_task(task: &serde_json::Value) -> Option<&'static str> {
     match task.get("tool_name").and_then(|value| value.as_str()) {
         Some("Direct TTS") => Some("fm_tts"),
@@ -717,6 +765,12 @@ impl Channel for ApiChannel {
         let session_result = msg.metadata.get("_session_result").cloned();
 
         let topic = msg.metadata.get("topic").and_then(|v| v.as_str());
+        // M8.10 PR #2: every SSE event the channel emits below is tagged
+        // with this thread_id (the user message's client_message_id) when
+        // present. Speculative-overflow + forced-background paths set this
+        // to the overflow user's cmid so two concurrent threads on the same
+        // chat_id can be demultiplexed by web clients.
+        let thread_id = outbound_thread_id(&msg.metadata);
 
         if !msg.media.is_empty() {
             if !history_already_persisted
@@ -830,7 +884,7 @@ impl Channel for ApiChannel {
                         .get("tool_call_id")
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
-                    let event = serde_json::json!({
+                    let mut event = serde_json::json!({
                         "type": "file",
                         "path": response_path_for_session_file(&data_dir, Path::new(persisted_path))
                             .unwrap_or_else(|| persisted_path.clone()),
@@ -838,6 +892,7 @@ impl Channel for ApiChannel {
                         "caption": msg.content,
                         "tool_call_id": tool_call_id,
                     });
+                    inject_thread_id(&mut event, thread_id.as_deref());
                     let _ = tx.send(event.to_string());
                 }
             }
@@ -846,10 +901,11 @@ impl Channel for ApiChannel {
 
         // Task status change — push raw JSON through SSE
         if let Some(task_json) = msg.metadata.get("_task_status").and_then(|v| v.as_str()) {
-            let event = build_task_status_event(
+            let mut event = build_task_status_event(
                 serde_json::from_str::<serde_json::Value>(task_json).unwrap_or_default(),
                 topic,
             );
+            inject_thread_id(&mut event, thread_id.as_deref());
             self.broadcast_session_event(&msg.chat_id, topic, event)
                 .await;
             return Ok(());
@@ -910,7 +966,8 @@ impl Channel for ApiChannel {
                             &msg.chat_id,
                             topic,
                         );
-                        for event in build_bg_task_tool_start_events(&tasks) {
+                        for mut event in build_bg_task_tool_start_events(&tasks) {
+                            inject_thread_id(&mut event, thread_id.as_deref());
                             let _ = tx.send(event.to_string());
                         }
                     }
@@ -944,16 +1001,18 @@ impl Channel for ApiChannel {
                         done["node_costs"] = node_costs;
                     }
                 }
+                inject_thread_id(&mut done, thread_id.as_deref());
                 let _ = tx.send(done.to_string());
                 pending.remove(&msg.chat_id);
                 drop(pending);
                 self.last_content.lock().await.remove(&msg.chat_id);
             } else if !msg.content.is_empty() {
                 // Regular message — send as replace event (full text replacement).
-                let event = serde_json::json!({
+                let mut event = serde_json::json!({
                     "type": "replace",
                     "text": msg.content,
                 });
+                inject_thread_id(&mut event, thread_id.as_deref());
                 if tx.send(event.to_string()).is_err() {
                     pending.remove(&msg.chat_id);
                 }
@@ -968,18 +1027,27 @@ impl Channel for ApiChannel {
         self.send(msg).await?;
         // Return a dummy ID so the stream forwarder uses edit_message() for
         // subsequent updates instead of calling send_with_id() again.
-        Ok(Some(format!("sse-{}", msg.chat_id)))
+        //
+        // M8.10 PR #2: encode the bound thread_id into the message_id so
+        // subsequent `edit_message` calls can tag streaming `token`/`replace`
+        // events with the correct thread (two concurrent threads on the
+        // same chat_id is the speculative-overflow case).
+        let thread_id = outbound_thread_id(&msg.metadata);
+        Ok(Some(encode_sse_message_id(
+            &msg.chat_id,
+            thread_id.as_deref(),
+        )))
     }
 
-    async fn edit_message(
-        &self,
-        chat_id: &str,
-        _message_id: &str,
-        new_content: &str,
-    ) -> Result<()> {
+    async fn edit_message(&self, chat_id: &str, message_id: &str, new_content: &str) -> Result<()> {
         if new_content.is_empty() {
             return Ok(());
         }
+        // M8.10 PR #2: recover the thread_id encoded into `send_with_id`'s
+        // synthetic message_id so streaming `token`/`replace` events can be
+        // demultiplexed by web clients running multiple in-flight threads
+        // against the same chat_id.
+        let (_, thread_id) = decode_sse_message_id(message_id);
         let pending = self.pending.lock().await;
         if let Some(tx) = pending.get(chat_id) {
             let mut last = self.last_content.lock().await;
@@ -990,19 +1058,21 @@ impl Channel for ApiChannel {
             if !prev.is_empty() && new_content.starts_with(prev) {
                 let delta = &new_content[prev.len()..];
                 if !delta.is_empty() {
-                    let event = serde_json::json!({
+                    let mut event = serde_json::json!({
                         "type": "token",
                         "text": delta,
                     });
+                    inject_thread_id(&mut event, thread_id);
                     let _ = tx.send(event.to_string());
                 }
             } else {
                 // Content changed non-incrementally (tool progress replaced, etc.)
                 // Send full replacement.
-                let event = serde_json::json!({
+                let mut event = serde_json::json!({
                     "type": "replace",
                     "text": new_content,
                 });
+                inject_thread_id(&mut event, thread_id);
                 let _ = tx.send(event.to_string());
             }
             last.insert(chat_id.to_string(), new_content.to_string());
@@ -2289,6 +2359,45 @@ mod tests {
     use tower::util::ServiceExt;
 
     const TEST_PROFILE_ID: &str = "dspfac";
+
+    /// M8.10 PR #2: the synthetic SSE message_id round-trips through
+    /// encode → decode without losing the bound thread_id. This is the
+    /// thread that lets `edit_message` recover the cmid for its
+    /// streaming `token`/`replace` payloads.
+    #[test]
+    fn sse_message_id_roundtrips_chat_id_and_thread_id() {
+        let encoded = encode_sse_message_id("chat-A", Some("cmid-T-1"));
+        let (chat, tid) = decode_sse_message_id(&encoded);
+        assert_eq!(chat, "sse-chat-A");
+        assert_eq!(tid, Some("cmid-T-1"));
+    }
+
+    #[test]
+    fn sse_message_id_omits_thread_id_when_unbound() {
+        let encoded = encode_sse_message_id("chat-A", None);
+        assert_eq!(encoded, "sse-chat-A");
+        let (chat, tid) = decode_sse_message_id(&encoded);
+        assert_eq!(chat, "sse-chat-A");
+        assert_eq!(tid, None);
+    }
+
+    #[test]
+    fn outbound_thread_id_extracts_string_from_metadata() {
+        let m = serde_json::json!({"thread_id": "cmid-T"});
+        assert_eq!(outbound_thread_id(&m).as_deref(), Some("cmid-T"));
+    }
+
+    #[test]
+    fn outbound_thread_id_treats_empty_string_as_absent() {
+        let m = serde_json::json!({"thread_id": ""});
+        assert!(outbound_thread_id(&m).is_none());
+    }
+
+    #[test]
+    fn outbound_thread_id_returns_none_when_absent() {
+        let m = serde_json::json!({});
+        assert!(outbound_thread_id(&m).is_none());
+    }
 
     fn test_sessions_in(data_dir: &Path) -> Arc<Mutex<SessionManager>> {
         Arc::new(Mutex::new(SessionManager::open(data_dir).unwrap()))
@@ -4092,6 +4201,173 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
         assert_eq!(parsed["type"], "done");
         assert_eq!(parsed["committed_seq"], 42);
+    }
+
+    /// M8.10 PR #2: every SSE event the API channel emits MUST include
+    /// `thread_id` (sourced from `OutboundMessage.metadata.thread_id`) so
+    /// web clients with multiple in-flight threads on the same chat_id
+    /// can route streamed events to the right per-thread bubble.
+    #[tokio::test]
+    async fn done_event_includes_thread_id_from_metadata() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("test-chat-tid".into(), tx);
+        }
+
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "test-chat-tid".into(),
+            content: String::new(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "_completion": true,
+                "committed_seq": 11,
+                "thread_id": "cmid-thread-Z",
+                "tokens_in": 0,
+                "tokens_out": 0,
+            }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "done");
+        assert_eq!(parsed["committed_seq"], 11);
+        assert_eq!(parsed["thread_id"], "cmid-thread-Z");
+    }
+
+    /// M8.10 PR #2: the wire-side `replace` event emitted by `send`
+    /// (non-streaming assistant content) must carry thread_id.
+    #[tokio::test]
+    async fn replace_event_includes_thread_id_from_metadata() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("test-chat-replace".into(), tx);
+        }
+
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "test-chat-replace".into(),
+            content: "hello world".into(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "thread_id": "cmid-thread-R",
+            }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "replace");
+        assert_eq!(parsed["text"], "hello world");
+        assert_eq!(parsed["thread_id"], "cmid-thread-R");
+    }
+
+    /// M8.10 PR #2: streaming `token` and `replace` events emitted via
+    /// `edit_message` must carry thread_id encoded into the synthetic
+    /// message_id returned by `send_with_id`. This is the key handshake
+    /// that lets two concurrent threads on the same chat_id be
+    /// demultiplexed by web clients.
+    #[tokio::test]
+    async fn edit_message_token_event_includes_thread_id_decoded_from_message_id() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("chat-edit".into(), tx);
+        }
+
+        // Step 1: send_with_id encodes thread_id into the message_id
+        let initial = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "chat-edit".into(),
+            content: "Hi".into(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "thread_id": "cmid-thread-EDIT",
+            }),
+        };
+        let message_id = ch.send_with_id(&initial).await.unwrap().unwrap();
+        // Drain the initial replace event from send().
+        let _ = rx.recv().await.unwrap();
+
+        // Step 2: edit_message decodes thread_id back from message_id and
+        // tags the streaming `token`/`replace` payload with it.
+        ch.edit_message("chat-edit", &message_id, "Hi there")
+            .await
+            .unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        // The delta comparison sees prev="Hi" and new starts with "Hi", so
+        // it emits a `token` for the suffix.
+        assert_eq!(parsed["type"], "token");
+        assert_eq!(parsed["text"], " there");
+        assert_eq!(parsed["thread_id"], "cmid-thread-EDIT");
+    }
+
+    /// Pre-cmid clients send messages with no thread_id metadata. The wire
+    /// schema must remain backwards-compatible: events emitted in this
+    /// case must NOT include a `thread_id` field at all.
+    #[tokio::test]
+    async fn done_event_omits_thread_id_when_metadata_absent() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("test-chat-no-tid".into(), tx);
+        }
+
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "test-chat-no-tid".into(),
+            content: String::new(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "_completion": true,
+            }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "done");
+        assert!(
+            parsed.get("thread_id").is_none(),
+            "thread_id field must be absent when metadata didn't carry one"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -373,10 +373,16 @@ async fn chat_streaming(
         session.get_history(50).to_vec()
     };
 
-    // Create per-request channel and reporter
+    // Create per-request channel and reporter.
+    //
+    // M8.10 PR #2: bind the user message's `client_message_id` to the
+    // reporter so every emitted SSE payload carries `thread_id`. The
+    // standalone `serve` mode shares a single chat_id across turns, but
+    // each turn gets a fresh ChannelReporter scoped to its cmid.
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let client_message_id = req.client_message_id.clone();
     let reporter: Arc<dyn octos_agent::ProgressReporter> = Arc::new(MetricsReporter::new(
-        Arc::new(ChannelReporter::new(tx.clone())),
+        Arc::new(ChannelReporter::new(tx.clone()).with_thread_id(client_message_id.clone())),
     ));
 
     // Build per-request agent sharing resources with the base agent
@@ -406,7 +412,6 @@ async fn chat_streaming(
 
     let message = req.message;
     let media = req.media;
-    let client_message_id = req.client_message_id;
     let topic_for_event = req.topic.clone();
 
     // Spawn the agent task
@@ -557,6 +562,14 @@ async fn chat_streaming(
                 });
                 if let Some(seq) = assistant_committed_seq {
                     done["committed_seq"] = serde_json::Value::from(seq);
+                }
+                // M8.10 PR #2: tag the done event with thread_id so the web
+                // client can route the committed_seq onto the right per-cmid
+                // bubble.
+                if let Some(ref tid) = client_message_id {
+                    if !tid.is_empty() {
+                        done["thread_id"] = serde_json::Value::String(tid.clone());
+                    }
                 }
                 // Bug 3 / W1.G4 cost panel — flatten per-node cost rows from
                 // tool results' structured side-channel into the SSE done

--- a/crates/octos-cli/src/api/sse.rs
+++ b/crates/octos-cli/src/api/sse.rs
@@ -33,7 +33,12 @@ impl SseBroadcaster {
 
 impl ProgressReporter for SseBroadcaster {
     fn report(&self, event: ProgressEvent) {
-        let json = match serde_json::to_string(&event_to_json(&event)) {
+        // Broadcaster is process-wide and not turn-scoped, so it cannot
+        // resolve a thread_id without further plumbing. Per-request
+        // [`ChannelReporter`] consumers receive the field via their
+        // turn-bound thread_id; broadcaster subscribers are debug-only
+        // and tolerate the absence.
+        let json = match serde_json::to_string(&event_to_json(&event, None)) {
             Ok(j) => j,
             Err(_) => return,
         };
@@ -44,19 +49,34 @@ impl ProgressReporter for SseBroadcaster {
 
 /// Per-request reporter that sends serialized SSE events through an mpsc channel.
 /// Used by the streaming POST /api/chat handler to isolate events per request.
+///
+/// M8.10 PR #2: optionally carries a `thread_id` (the user message's
+/// `client_message_id`) so every emitted SSE payload is tagged with the
+/// thread it belongs to. When unset, the field is omitted (legacy clients
+/// continue to ignore it).
 pub(crate) struct ChannelReporter {
     tx: tokio::sync::mpsc::UnboundedSender<String>,
+    thread_id: Option<String>,
 }
 
 impl ChannelReporter {
     pub fn new(tx: tokio::sync::mpsc::UnboundedSender<String>) -> Self {
-        Self { tx }
+        Self {
+            tx,
+            thread_id: None,
+        }
+    }
+
+    /// Bind a `thread_id` to every payload this reporter emits.
+    pub fn with_thread_id(mut self, thread_id: Option<String>) -> Self {
+        self.thread_id = thread_id.filter(|s| !s.is_empty());
+        self
     }
 }
 
 impl ProgressReporter for ChannelReporter {
     fn report(&self, event: ProgressEvent) {
-        let json = match serde_json::to_string(&event_to_json(&event)) {
+        let json = match serde_json::to_string(&event_to_json(&event, self.thread_id.as_deref())) {
             Ok(j) => j,
             Err(_) => return,
         };
@@ -64,8 +84,14 @@ impl ProgressReporter for ChannelReporter {
     }
 }
 
-pub(crate) fn event_to_json(event: &ProgressEvent) -> serde_json::Value {
-    match event {
+/// Serialize a [`ProgressEvent`] to a JSON SSE payload. When `thread_id` is
+/// `Some`, every payload is tagged with the thread it belongs to.
+///
+/// M8.10 PR #2: strictly additive — clients that don't know `thread_id`
+/// silently ignore the field. When `thread_id` is `None`, the field is
+/// omitted from the payload entirely.
+pub(crate) fn event_to_json(event: &ProgressEvent, thread_id: Option<&str>) -> serde_json::Value {
+    let mut value = match event {
         ProgressEvent::ToolStarted { name, tool_id } => {
             serde_json::json!({
                 "type": "tool_start",
@@ -127,7 +153,14 @@ pub(crate) fn event_to_json(event: &ProgressEvent) -> serde_json::Value {
             debug!("unmapped SSE progress event: {other:?}");
             serde_json::json!({"type": "other"})
         }
+    };
+    if let (Some(tid), Some(obj)) = (thread_id, value.as_object_mut()) {
+        obj.insert(
+            "thread_id".to_string(),
+            serde_json::Value::String(tid.to_string()),
+        );
     }
+    value
 }
 
 #[cfg(test)]
@@ -141,7 +174,7 @@ mod tests {
             name: "shell".into(),
             tool_id: "t1".into(),
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "tool_start");
         assert_eq!(json["tool"], "shell");
         assert_eq!(json["tool_call_id"], "t1");
@@ -156,7 +189,7 @@ mod tests {
             output_preview: "contents".into(),
             duration: Duration::from_millis(42),
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "tool_end");
         assert_eq!(json["tool"], "read_file");
         assert_eq!(json["tool_call_id"], "t2");
@@ -172,7 +205,7 @@ mod tests {
             output_preview: "error".into(),
             duration: Duration::from_secs(1),
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["success"], false);
     }
 
@@ -183,7 +216,7 @@ mod tests {
             tool_id: "call_00_XXX".into(),
             message: "plan_and_search_task_3 [...]: running deep_search".into(),
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "tool_progress");
         assert_eq!(json["tool"], "run_pipeline");
         assert_eq!(json["tool_call_id"], "call_00_XXX");
@@ -199,7 +232,7 @@ mod tests {
             text: "Hello".into(),
             iteration: 1,
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "token");
         assert_eq!(json["text"], "Hello");
     }
@@ -207,7 +240,7 @@ mod tests {
     #[test]
     fn event_to_json_stream_done() {
         let event = ProgressEvent::StreamDone { iteration: 2 };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "stream_end");
     }
 
@@ -219,7 +252,7 @@ mod tests {
             response_cost: Some(0.001),
             session_cost: Some(0.005),
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "cost_update");
         assert_eq!(json["input_tokens"], 100);
         assert_eq!(json["output_tokens"], 50);
@@ -234,7 +267,7 @@ mod tests {
             response_cost: None,
             session_cost: None,
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "cost_update");
         assert!(json["session_cost"].is_null());
     }
@@ -242,7 +275,7 @@ mod tests {
     #[test]
     fn event_to_json_thinking() {
         let event = ProgressEvent::Thinking { iteration: 3 };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "thinking");
         assert_eq!(json["iteration"], 3);
     }
@@ -253,7 +286,7 @@ mod tests {
             content: "answer".into(),
             iteration: 1,
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "response");
         assert_eq!(json["iteration"], 1);
     }
@@ -263,8 +296,98 @@ mod tests {
         let event = ProgressEvent::TaskStarted {
             task_id: "abc".into(),
         };
-        let json = event_to_json(&event);
+        let json = event_to_json(&event, None);
         assert_eq!(json["type"], "other");
+    }
+
+    /// M8.10 PR #2: every SSE payload tagged with the bound thread_id so
+    /// the web client can route to the right per-cmid thread bubble.
+    #[test]
+    fn event_to_json_includes_thread_id_when_provided() {
+        let cases: &[(ProgressEvent, &str)] = &[
+            (
+                ProgressEvent::ToolStarted {
+                    name: "shell".into(),
+                    tool_id: "t1".into(),
+                },
+                "tool_start",
+            ),
+            (
+                ProgressEvent::ToolCompleted {
+                    name: "shell".into(),
+                    tool_id: "t1".into(),
+                    success: true,
+                    output_preview: "ok".into(),
+                    duration: Duration::from_millis(1),
+                },
+                "tool_end",
+            ),
+            (
+                ProgressEvent::ToolProgress {
+                    name: "shell".into(),
+                    tool_id: "t1".into(),
+                    message: "step".into(),
+                },
+                "tool_progress",
+            ),
+            (
+                ProgressEvent::StreamChunk {
+                    text: "x".into(),
+                    iteration: 0,
+                },
+                "token",
+            ),
+            (ProgressEvent::StreamDone { iteration: 0 }, "stream_end"),
+            (
+                ProgressEvent::CostUpdate {
+                    session_input_tokens: 0,
+                    session_output_tokens: 0,
+                    response_cost: None,
+                    session_cost: None,
+                },
+                "cost_update",
+            ),
+            (ProgressEvent::Thinking { iteration: 0 }, "thinking"),
+            (
+                ProgressEvent::Response {
+                    content: "c".into(),
+                    iteration: 0,
+                },
+                "response",
+            ),
+        ];
+
+        for (event, expected_type) in cases {
+            let json = event_to_json(event, Some("cmid-T-thread"));
+            assert_eq!(json["type"], *expected_type);
+            assert_eq!(
+                json.get("thread_id").and_then(|v| v.as_str()),
+                Some("cmid-T-thread"),
+                "event with type `{expected_type}` missing thread_id field, got {json}",
+            );
+        }
+    }
+
+    #[test]
+    fn event_to_json_omits_thread_id_when_absent() {
+        let json = event_to_json(&ProgressEvent::Thinking { iteration: 0 }, None);
+        assert!(
+            json.get("thread_id").is_none(),
+            "thread_id must be absent when caller passes None, got {json}"
+        );
+    }
+
+    #[test]
+    fn channel_reporter_with_thread_id_tags_emitted_payloads() {
+        use tokio::sync::mpsc;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelReporter::new(tx).with_thread_id(Some("cmid-route-XYZ".to_string()));
+
+        reporter.report(ProgressEvent::Thinking { iteration: 0 });
+        let raw = rx.try_recv().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(parsed["type"], "thinking");
+        assert_eq!(parsed["thread_id"], "cmid-route-XYZ");
     }
 
     #[test]

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -371,6 +371,10 @@ async fn send_outbound_with_timeout(
     }
 }
 
+/// M8.10 PR #2: optional `thread_id` is the user message's
+/// client_message_id. When present, the outbound the helper emits is
+/// tagged with `thread_id` metadata so the API channel can stamp SSE
+/// payloads with the correct per-cmid routing key.
 #[allow(clippy::too_many_arguments)]
 async fn persist_terminal_reply_and_fanout(
     session_handle: &Arc<Mutex<SessionHandle>>,
@@ -382,6 +386,7 @@ async fn persist_terminal_reply_and_fanout(
     reply_to: Option<String>,
     content: String,
     media: Vec<String>,
+    thread_id: Option<&str>,
 ) -> bool {
     let Some(_persisted) = persist_assistant_message(
         session_handle,
@@ -400,6 +405,18 @@ async fn persist_terminal_reply_and_fanout(
         return false;
     };
 
+    let mut metadata = serde_json::json!({});
+    if let Some(tid) = thread_id {
+        if !tid.is_empty() {
+            if let Some(map) = metadata.as_object_mut() {
+                map.insert(
+                    "thread_id".to_string(),
+                    serde_json::Value::String(tid.to_string()),
+                );
+            }
+        }
+    }
+
     send_outbound_with_timeout(
         session_key,
         out_tx,
@@ -409,7 +426,7 @@ async fn persist_terminal_reply_and_fanout(
             content,
             reply_to,
             media,
-            metadata: serde_json::json!({}),
+            metadata,
         },
         "terminal_reply",
     )
@@ -3744,6 +3761,15 @@ impl SessionActor {
                 serde_json::Value::Bool(true),
             );
             metadata_obj.insert("_session_result".to_string(), session_result);
+            // M8.10 PR #2: tag the user-message session_result emission with
+            // thread_id so the API channel can stamp it on subsequent
+            // wire events for this turn.
+            if let Some(cmid) = client_message_id.as_deref() {
+                metadata_obj.insert(
+                    "thread_id".to_string(),
+                    serde_json::Value::String(cmid.to_string()),
+                );
+            }
 
             let _ = send_outbound_with_timeout(
                 &self.session_key,
@@ -3770,6 +3796,22 @@ impl SessionActor {
         )
         .await;
 
+        // M8.10 PR #2: tag the forced-background ack and the trailing
+        // _completion with the user's cmid so the SSE events the API
+        // channel emits carry thread_id back to the web client. Same
+        // events as the speculative path — just a different thread.
+        let mut ack_metadata = serde_json::json!({
+            "_history_persisted": persisted,
+            "spawn_output": spawn_result.output,
+        });
+        if let Some(ref tid) = client_message_id {
+            if let Some(map) = ack_metadata.as_object_mut() {
+                map.insert(
+                    "thread_id".to_string(),
+                    serde_json::Value::String(tid.clone()),
+                );
+            }
+        }
         let _ = self
             .out_tx
             .send(OutboundMessage {
@@ -3778,10 +3820,7 @@ impl SessionActor {
                 content: ack_content,
                 reply_to,
                 media: vec![],
-                metadata: serde_json::json!({
-                    "_history_persisted": persisted,
-                    "spawn_output": spawn_result.output,
-                }),
+                metadata: ack_metadata,
             })
             .await;
 
@@ -3794,6 +3833,19 @@ impl SessionActor {
                 .map(|task| sanitize_task_for_response(&self.data_dir, &task))
                 .collect::<Vec<_>>();
 
+            let mut completion_metadata = serde_json::json!({
+                "_completion": true,
+                "has_bg_tasks": !bg_tasks.is_empty(),
+                "bg_tasks": bg_tasks,
+            });
+            if let Some(ref tid) = client_message_id {
+                if let Some(map) = completion_metadata.as_object_mut() {
+                    map.insert(
+                        "thread_id".to_string(),
+                        serde_json::Value::String(tid.clone()),
+                    );
+                }
+            }
             let _ = self
                 .out_tx
                 .send(OutboundMessage {
@@ -3802,11 +3854,7 @@ impl SessionActor {
                     content: String::new(),
                     reply_to: None,
                     media: vec![],
-                    metadata: serde_json::json!({
-                        "_completion": true,
-                        "has_bg_tasks": !bg_tasks.is_empty(),
-                        "bg_tasks": bg_tasks,
-                    }),
+                    metadata: completion_metadata,
                 })
                 .await;
         }
@@ -3945,11 +3993,18 @@ impl SessionActor {
             )
         });
 
-        // Set up progressive streaming reporter
+        // Set up progressive streaming reporter.
+        //
+        // M8.10 PR #2: bind the user message's `client_message_id` to the
+        // reporter so every emitted SSE payload (token, tool_start, ...)
+        // carries `thread_id`. Speculative overflow + forced-background paths
+        // construct their own reporter with their own cmid below — the same
+        // event types flow through, just tagged with a different thread_id.
         let (stream_tx, stream_rx) = tokio::sync::mpsc::unbounded_channel();
-        let reporter = Arc::new(crate::stream_reporter::ChannelStreamReporter::new(
-            stream_tx.clone(),
-        ));
+        let reporter = Arc::new(
+            crate::stream_reporter::ChannelStreamReporter::new(stream_tx.clone())
+                .with_thread_id(client_message_id.clone()),
+        );
         self.agent.set_reporter(reporter);
 
         // Wire adaptive router status callback to forward through the stream channel.
@@ -4583,6 +4638,18 @@ impl SessionActor {
                     };
 
                     if !streamed {
+                        // M8.10 PR #2: tag the assistant reply with the
+                        // turn's thread_id so the API channel can stamp
+                        // it onto the SSE `replace` event it emits.
+                        let mut reply_metadata = serde_json::json!({});
+                        if let Some(ref tid) = client_message_id {
+                            if let Some(map) = reply_metadata.as_object_mut() {
+                                map.insert(
+                                    "thread_id".to_string(),
+                                    serde_json::Value::String(tid.clone()),
+                                );
+                            }
+                        }
                         let _ = self
                             .out_tx
                             .send(OutboundMessage {
@@ -4591,7 +4658,7 @@ impl SessionActor {
                                 content: display_content,
                                 reply_to: inbound_message_id.clone(),
                                 media: vec![],
-                                metadata: serde_json::json!({}),
+                                metadata: reply_metadata,
                             })
                             .await;
                     }
@@ -4610,6 +4677,7 @@ impl SessionActor {
                     inbound_message_id.clone(),
                     content,
                     vec![],
+                    client_message_id.as_deref(),
                 )
                 .await;
             }
@@ -4627,6 +4695,7 @@ impl SessionActor {
                     inbound_message_id.clone(),
                     content,
                     vec![],
+                    client_message_id.as_deref(),
                 )
                 .await;
             }
@@ -4640,6 +4709,19 @@ impl SessionActor {
         // This must happen AFTER the agent finishes, so it has had a chance to
         // observe the shutdown signal during its iteration loop.
         self.cancelled.store(false, Ordering::Release);
+
+        // M8.10 PR #2: tag the completion event with this turn's thread_id
+        // (= the user message's client_message_id) so ApiChannel can stamp
+        // it onto the SSE `done` payload. Applied uniformly across success,
+        // error, and timeout branches above.
+        if let Some(ref tid) = client_message_id {
+            if let Some(map) = completion_meta.as_object_mut() {
+                map.insert(
+                    "thread_id".to_string(),
+                    serde_json::Value::String(tid.clone()),
+                );
+            }
+        }
 
         // Send completion marker so the API channel can close the SSE stream.
         if self.channel == "api" {
@@ -4780,6 +4862,16 @@ impl SessionActor {
                     serde_json::Value::Bool(true),
                 );
                 metadata_obj.insert("_session_result".to_string(), session_result);
+                // M8.10 PR #2: tag the user-message session_result emission
+                // with thread_id so any SSE event the API channel emits in
+                // response (e.g. when this metadata path also wraps content
+                // into a `replace`) carries the right per-cmid routing key.
+                if let Some(cmid) = overflow_client_message_id.as_deref() {
+                    metadata_obj.insert(
+                        "thread_id".to_string(),
+                        serde_json::Value::String(cmid.to_string()),
+                    );
+                }
 
                 let _ = send_outbound_with_timeout(
                     &session_key,
@@ -4853,9 +4945,16 @@ impl SessionActor {
             });
 
             // ── Per-overflow stream reporter (own chat bubble) ──────────────
+            //
+            // M8.10 PR #2: tag every SSE payload emitted by this reporter
+            // with the overflow user's cmid so the web client can route
+            // streaming tokens to the right per-thread bubble. This is the
+            // critical bit that makes overflow stop being a special case —
+            // same code path, same events, just a different thread_id.
             let (stream_tx, stream_rx) = tokio::sync::mpsc::unbounded_channel();
             let overflow_reporter: Arc<dyn octos_agent::ProgressReporter> = Arc::new(
-                crate::stream_reporter::ChannelStreamReporter::new(stream_tx),
+                crate::stream_reporter::ChannelStreamReporter::new(stream_tx)
+                    .with_thread_id(overflow_client_message_id.clone()),
             );
 
             // Spawn stream forwarder — edits its OWN message, not the primary's
@@ -5054,6 +5153,19 @@ impl SessionActor {
                         } else {
                             reply
                         };
+                        // M8.10 PR #2: tag the overflow assistant reply
+                        // with the overflow user's cmid so any wire events
+                        // ApiChannel emits (replace, file, …) carry the
+                        // correct thread_id. The done event for the overflow
+                        // is the primary completion's done — that one is
+                        // tagged with the primary's cmid, so an overflow
+                        // can render before the primary completes.
+                        if let Some(ref tid) = overflow_client_message_id {
+                            metadata.insert(
+                                "thread_id".to_string(),
+                                serde_json::Value::String(tid.clone()),
+                            );
+                        }
                         let _ = out_tx
                             .send(OutboundMessage {
                                 channel: channel.clone(),
@@ -5079,6 +5191,7 @@ impl SessionActor {
                         overflow_reply_to.clone(),
                         content,
                         vec![],
+                        overflow_client_message_id.as_deref(),
                     )
                     .await;
                 }
@@ -5095,6 +5208,7 @@ impl SessionActor {
                         overflow_reply_to.clone(),
                         content,
                         vec![],
+                        overflow_client_message_id.as_deref(),
                     )
                     .await;
                 }
@@ -5127,6 +5241,11 @@ impl SessionActor {
     ) {
         // Capture the platform message ID for reply threading
         let inbound_message_id = inbound.message_id.clone();
+        // M8.10 PR #2: capture the user's client_message_id so every
+        // OutboundMessage we emit (assistant reply, _completion, errors)
+        // carries `thread_id` metadata. The API channel reads it back to
+        // tag SSE payloads with the right per-cmid thread.
+        let client_message_id = inbound_client_message_id(&inbound);
 
         // Acquire concurrency permit
         let _permit = match self.semaphore.acquire().await {
@@ -5492,6 +5611,18 @@ impl SessionActor {
                     };
 
                     if !streamed {
+                        // M8.10 PR #2: tag the assistant reply with the
+                        // turn's thread_id so the API channel can stamp
+                        // it onto the SSE `replace` event it emits.
+                        let mut reply_metadata = serde_json::json!({});
+                        if let Some(ref tid) = client_message_id {
+                            if let Some(map) = reply_metadata.as_object_mut() {
+                                map.insert(
+                                    "thread_id".to_string(),
+                                    serde_json::Value::String(tid.clone()),
+                                );
+                            }
+                        }
                         let _ = self
                             .out_tx
                             .send(OutboundMessage {
@@ -5500,7 +5631,7 @@ impl SessionActor {
                                 content: display_content,
                                 reply_to: inbound_message_id.clone(),
                                 media: vec![],
-                                metadata: serde_json::json!({}),
+                                metadata: reply_metadata,
                             })
                             .await;
                     }
@@ -5519,6 +5650,7 @@ impl SessionActor {
                     inbound_message_id.clone(),
                     content,
                     vec![],
+                    client_message_id.as_deref(),
                 )
                 .await;
             }
@@ -5536,6 +5668,7 @@ impl SessionActor {
                     inbound_message_id.clone(),
                     content,
                     vec![],
+                    client_message_id.as_deref(),
                 )
                 .await;
             }
@@ -5550,6 +5683,17 @@ impl SessionActor {
 
         // Send completion marker so the API channel can close the SSE stream.
         if self.channel == "api" {
+            // M8.10 PR #2: tag the completion with the turn's thread_id
+            // so ApiChannel stamps it onto the SSE `done` payload.
+            let mut completion_metadata = serde_json::json!({"_completion": true});
+            if let Some(ref tid) = client_message_id {
+                if let Some(map) = completion_metadata.as_object_mut() {
+                    map.insert(
+                        "thread_id".to_string(),
+                        serde_json::Value::String(tid.clone()),
+                    );
+                }
+            }
             let _ = self
                 .out_tx
                 .send(OutboundMessage {
@@ -5558,7 +5702,7 @@ impl SessionActor {
                     content: String::new(),
                     reply_to: None,
                     media: vec![],
-                    metadata: serde_json::json!({"_completion": true}),
+                    metadata: completion_metadata,
                 })
                 .await;
         }
@@ -7705,6 +7849,210 @@ mod tests {
             result.get("timestamp").is_some(),
             "session_result must include rfc3339 timestamp"
         );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// M8.10 PR #2 regression: every outbound message that fans out into
+    /// SSE events on the API channel MUST carry `thread_id` metadata
+    /// (= the user message's client_message_id) so the wire-side `done`,
+    /// `replace`, `file`, etc. payloads can be tagged. Drives the same
+    /// 2-POST rapid-succession pattern as
+    /// `should_emit_session_result_for_overflow_user_message` and asserts
+    /// that BOTH threads' outbound messages have thread_id populated and
+    /// match the expected user cmid for that message's logical thread.
+    ///
+    /// The whole point of M8.10 is that overflow stops being a special
+    /// case — same code path, same events, just a different thread_id.
+    #[tokio::test]
+    async fn should_emit_thread_id_on_every_event_for_speculative_overflow_pair() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![
+                (Duration::from_millis(200), make_response("warmup1")),
+                (Duration::from_millis(200), make_response("warmup2")),
+                (Duration::from_millis(200), make_response("warmup3")),
+                (Duration::from_millis(200), make_response("warmup4")),
+                (Duration::from_millis(200), make_response("warmup5")),
+                (
+                    Duration::from_secs(12),
+                    make_response("primary thread reply"),
+                ),
+                (
+                    Duration::from_millis(400),
+                    make_response("overflow thread reply"),
+                ),
+                (Duration::from_millis(200), make_response("post-overflow")),
+            ],
+        ));
+        let router_a: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "router-a",
+            vec![(Duration::from_millis(500), make_response("unused"))],
+        ));
+        let router_b: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "router-b",
+            vec![(Duration::from_millis(500), make_response("unused"))],
+        ));
+
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_speculative_actor(agent_llm, vec![router_a, router_b], &dir).await;
+
+        // Warmup so responsiveness baseline is established.
+        for i in 0..5 {
+            tx.send(make_inbound(&format!("warmup {i}"))).await.unwrap();
+            let _ = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
+        }
+
+        // Primary (slow) prompt with its own cmid.
+        let primary_cmid = "cmid-primary-thread-A";
+        let primary_inbound = ActorMessage::Inbound {
+            message: InboundMessage {
+                channel: "cli".to_string(),
+                chat_id: "test".to_string(),
+                sender_id: "user".to_string(),
+                content: "primary slow prompt".to_string(),
+                timestamp: chrono::Utc::now(),
+                media: vec![],
+                metadata: serde_json::json!({
+                    "client_message_id": primary_cmid,
+                }),
+                message_id: Some(primary_cmid.to_string()),
+            },
+            image_media: vec![],
+            attachment_media: vec![],
+            attachment_prompt: None,
+        };
+        tx.send(primary_inbound).await.unwrap();
+
+        // Sleep past patience so the second prompt is served as overflow.
+        tokio::time::sleep(Duration::from_secs(11)).await;
+
+        // Overflow follow-up with a DIFFERENT cmid.
+        let overflow_cmid = "cmid-overflow-thread-B";
+        let overflow_inbound = ActorMessage::Inbound {
+            message: InboundMessage {
+                channel: "cli".to_string(),
+                chat_id: "test".to_string(),
+                sender_id: "user".to_string(),
+                content: "overflow follow-up".to_string(),
+                timestamp: chrono::Utc::now(),
+                media: vec![],
+                metadata: serde_json::json!({
+                    "client_message_id": overflow_cmid,
+                }),
+                message_id: Some(overflow_cmid.to_string()),
+            },
+            image_media: vec![],
+            attachment_media: vec![],
+            attachment_prompt: None,
+        };
+        tx.send(overflow_inbound).await.unwrap();
+
+        // Collect outbound messages until both replies have arrived.
+        let mut outbounds: Vec<OutboundMessage> = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout_at(deadline, rx.recv()).await {
+                Ok(Some(msg)) => {
+                    outbounds.push(msg);
+                    let primary_reply = outbounds
+                        .iter()
+                        .any(|m| m.content.contains("primary thread reply"));
+                    let overflow_reply = outbounds
+                        .iter()
+                        .any(|m| m.content.contains("overflow thread reply"));
+                    if primary_reply && overflow_reply {
+                        break;
+                    }
+                }
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        // Tag each outbound with the cmid of the thread it belongs to,
+        // identified by content fingerprint. Filter out warmup leftovers
+        // and unrelated metadata-only messages.
+        let mut primary_outbounds: Vec<&OutboundMessage> = Vec::new();
+        let mut overflow_outbounds: Vec<&OutboundMessage> = Vec::new();
+        for msg in &outbounds {
+            // Match by user cmid first (covers user-message session_result
+            // emissions which echo the cmid).
+            let session_result_cmid = msg
+                .metadata
+                .get("_session_result")
+                .and_then(|sr| sr.get("client_message_id"))
+                .and_then(|v| v.as_str());
+            if session_result_cmid == Some(primary_cmid)
+                || msg.content.contains("primary thread reply")
+            {
+                primary_outbounds.push(msg);
+                continue;
+            }
+            if session_result_cmid == Some(overflow_cmid)
+                || msg.content.contains("overflow thread reply")
+            {
+                overflow_outbounds.push(msg);
+                continue;
+            }
+        }
+
+        assert!(
+            !primary_outbounds.is_empty(),
+            "expected at least one outbound for the primary thread, got outbounds = {:?}",
+            outbounds
+                .iter()
+                .map(|m| (m.content.as_str(), m.metadata.clone()))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            !overflow_outbounds.is_empty(),
+            "expected at least one outbound for the overflow thread, got outbounds = {:?}",
+            outbounds
+                .iter()
+                .map(|m| (m.content.as_str(), m.metadata.clone()))
+                .collect::<Vec<_>>()
+        );
+
+        // Helper: assert that an outbound's metadata.thread_id matches
+        // the expected cmid for its logical thread. Skip outbounds that
+        // are pure-content (no metadata fan-out), since those don't go
+        // through the API channel's SSE wrapping.
+        fn assert_thread_id(msg: &OutboundMessage, expected_cmid: &str) {
+            let actual = msg.metadata.get("thread_id").and_then(|v| v.as_str());
+            assert_eq!(
+                actual,
+                Some(expected_cmid),
+                "outbound for thread `{expected_cmid}` is missing thread_id metadata; \
+                 content = {:?}, metadata = {}",
+                msg.content,
+                msg.metadata,
+            );
+        }
+
+        // Every primary-thread outbound that carries fanout metadata must
+        // bear the primary cmid. Overflow likewise.
+        for msg in &primary_outbounds {
+            // Filter to outbounds that produce SSE events: assistant reply
+            // (non-empty content) OR completion marker OR session_result
+            // user-message emission.
+            let is_sse_producing = !msg.content.trim().is_empty()
+                || msg.metadata.get("_completion").is_some()
+                || msg.metadata.get("_session_result").is_some();
+            if is_sse_producing {
+                assert_thread_id(msg, primary_cmid);
+            }
+        }
+        for msg in &overflow_outbounds {
+            let is_sse_producing = !msg.content.trim().is_empty()
+                || msg.metadata.get("_completion").is_some()
+                || msg.metadata.get("_session_result").is_some();
+            if is_sse_producing {
+                assert_thread_id(msg, overflow_cmid);
+            }
+        }
 
         drop(tx);
         let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -43,18 +43,48 @@ pub enum StreamProgressEvent {
 ///
 /// Because `ProgressReporter::report()` is synchronous, we use `unbounded_send()`
 /// which never blocks. The receiving async task handles actual channel I/O.
+///
+/// M8.10 PR #2: every emitted SSE payload includes `thread_id` (the
+/// client_message_id of the user message that owns this turn). Reporters are
+/// constructed per-turn so the thread_id is bound for the reporter's lifetime.
+/// When `thread_id` is `None`, the field is omitted (preserves wire compat for
+/// non-API channels and pre-cmid clients).
 pub struct ChannelStreamReporter {
     tx: mpsc::UnboundedSender<StreamProgressEvent>,
+    thread_id: Option<String>,
 }
 
 impl ChannelStreamReporter {
     pub fn new(tx: mpsc::UnboundedSender<StreamProgressEvent>) -> Self {
-        Self { tx }
+        Self {
+            tx,
+            thread_id: None,
+        }
+    }
+
+    /// Bind a `thread_id` (typically the user message's `client_message_id`)
+    /// to every SSE payload this reporter emits.
+    pub fn with_thread_id(mut self, thread_id: Option<String>) -> Self {
+        self.thread_id = thread_id.filter(|s| !s.is_empty());
+        self
+    }
+}
+
+/// Insert the bound `thread_id` into a JSON object payload (if any). Mutates
+/// the value in place. No-op when `thread_id` is `None` or the value is not
+/// an object.
+fn inject_thread_id(value: &mut serde_json::Value, thread_id: Option<&str>) {
+    if let (Some(tid), Some(obj)) = (thread_id, value.as_object_mut()) {
+        obj.insert(
+            "thread_id".to_string(),
+            serde_json::Value::String(tid.to_string()),
+        );
     }
 }
 
 impl ProgressReporter for ChannelStreamReporter {
     fn report(&self, event: ProgressEvent) {
+        let thread_id = self.thread_id.as_deref();
         let mapped = match event {
             ProgressEvent::StreamChunk { text, iteration } => {
                 StreamProgressEvent::Chunk { text, iteration }
@@ -67,13 +97,14 @@ impl ProgressReporter for ChannelStreamReporter {
                 ref tool_id,
             } => {
                 // Also send raw SSE for web client status indicators
+                let mut payload = serde_json::json!({
+                    "type": "tool_start",
+                    "tool": name,
+                    "tool_call_id": tool_id,
+                });
+                inject_thread_id(&mut payload, thread_id);
                 let _ = self.tx.send(StreamProgressEvent::RawSse {
-                    json: serde_json::json!({
-                        "type": "tool_start",
-                        "tool": name,
-                        "tool_call_id": tool_id,
-                    })
-                    .to_string(),
+                    json: payload.to_string(),
                 });
                 StreamProgressEvent::ToolStarted { name: name.clone() }
             }
@@ -83,14 +114,15 @@ impl ProgressReporter for ChannelStreamReporter {
                 success,
                 ..
             } => {
+                let mut payload = serde_json::json!({
+                    "type": "tool_end",
+                    "tool": name,
+                    "tool_call_id": tool_id,
+                    "success": success,
+                });
+                inject_thread_id(&mut payload, thread_id);
                 let _ = self.tx.send(StreamProgressEvent::RawSse {
-                    json: serde_json::json!({
-                        "type": "tool_end",
-                        "tool": name,
-                        "tool_call_id": tool_id,
-                        "success": success,
-                    })
-                    .to_string(),
+                    json: payload.to_string(),
                 });
                 StreamProgressEvent::ToolCompleted {
                     name: name.clone(),
@@ -102,14 +134,15 @@ impl ProgressReporter for ChannelStreamReporter {
                 ref tool_id,
                 ref message,
             } => {
+                let mut payload = serde_json::json!({
+                    "type": "tool_progress",
+                    "tool": name,
+                    "tool_call_id": tool_id,
+                    "message": message,
+                });
+                inject_thread_id(&mut payload, thread_id);
                 let _ = self.tx.send(StreamProgressEvent::RawSse {
-                    json: serde_json::json!({
-                        "type": "tool_progress",
-                        "tool": name,
-                        "tool_call_id": tool_id,
-                        "message": message,
-                    })
-                    .to_string(),
+                    json: payload.to_string(),
                 });
                 StreamProgressEvent::ToolProgress {
                     name: name.clone(),
@@ -120,26 +153,37 @@ impl ProgressReporter for ChannelStreamReporter {
             ProgressEvent::FileModified { path } => StreamProgressEvent::FileWritten { path },
             ProgressEvent::StreamRetry { .. } => StreamProgressEvent::BufferReset,
             // Forward discrete progress events as raw SSE JSON for the web client.
-            ProgressEvent::Thinking { iteration } => StreamProgressEvent::RawSse {
-                json: serde_json::json!({"type": "thinking", "iteration": iteration}).to_string(),
-            },
-            ProgressEvent::Response { iteration, .. } => StreamProgressEvent::RawSse {
-                json: serde_json::json!({"type": "response", "iteration": iteration}).to_string(),
-            },
+            ProgressEvent::Thinking { iteration } => {
+                let mut payload = serde_json::json!({"type": "thinking", "iteration": iteration});
+                inject_thread_id(&mut payload, thread_id);
+                StreamProgressEvent::RawSse {
+                    json: payload.to_string(),
+                }
+            }
+            ProgressEvent::Response { iteration, .. } => {
+                let mut payload = serde_json::json!({"type": "response", "iteration": iteration});
+                inject_thread_id(&mut payload, thread_id);
+                StreamProgressEvent::RawSse {
+                    json: payload.to_string(),
+                }
+            }
             ProgressEvent::CostUpdate {
                 session_input_tokens,
                 session_output_tokens,
                 session_cost,
                 ..
-            } => StreamProgressEvent::RawSse {
-                json: serde_json::json!({
+            } => {
+                let mut payload = serde_json::json!({
                     "type": "cost_update",
                     "input_tokens": session_input_tokens,
                     "output_tokens": session_output_tokens,
                     "session_cost": session_cost,
-                })
-                .to_string(),
-            },
+                });
+                inject_thread_id(&mut payload, thread_id);
+                StreamProgressEvent::RawSse {
+                    json: payload.to_string(),
+                }
+            }
             _ => return,
         };
         let _ = self.tx.send(mapped);
@@ -708,6 +752,97 @@ mod tests {
 
         let event = rx.try_recv().unwrap();
         assert!(matches!(event, StreamProgressEvent::BufferReset));
+    }
+
+    /// M8.10 PR #2: every raw SSE payload emitted by the reporter must
+    /// include a `thread_id` field equal to the bound cmid. Drives every
+    /// variant that produces a `RawSse` event to confirm none are missed.
+    #[test]
+    fn should_inject_thread_id_into_every_raw_sse_event() {
+        use octos_agent::progress::ProgressEvent;
+        use std::time::Duration;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter =
+            ChannelStreamReporter::new(tx).with_thread_id(Some("cmid-thread-A".to_string()));
+
+        reporter.report(ProgressEvent::ToolStarted {
+            name: "shell".into(),
+            tool_id: "t1".into(),
+        });
+        reporter.report(ProgressEvent::ToolCompleted {
+            name: "shell".into(),
+            tool_id: "t1".into(),
+            success: true,
+            output_preview: "ok".into(),
+            duration: Duration::from_millis(5),
+        });
+        reporter.report(ProgressEvent::ToolProgress {
+            name: "shell".into(),
+            tool_id: "t1".into(),
+            message: "step 1".into(),
+        });
+        reporter.report(ProgressEvent::Thinking { iteration: 0 });
+        reporter.report(ProgressEvent::Response {
+            content: "answer".into(),
+            iteration: 1,
+        });
+        reporter.report(ProgressEvent::CostUpdate {
+            session_input_tokens: 10,
+            session_output_tokens: 20,
+            response_cost: None,
+            session_cost: None,
+        });
+
+        let mut raw_payloads: Vec<String> = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let StreamProgressEvent::RawSse { json } = event {
+                raw_payloads.push(json);
+            }
+        }
+
+        // ToolStarted, ToolCompleted, ToolProgress emit RawSse + a typed
+        // mapped event each, so 6 reports → 6 RawSse JSON payloads.
+        assert_eq!(
+            raw_payloads.len(),
+            6,
+            "expected 6 RawSse payloads, got {}: {:?}",
+            raw_payloads.len(),
+            raw_payloads
+        );
+        for json in &raw_payloads {
+            let parsed: serde_json::Value = serde_json::from_str(json)
+                .unwrap_or_else(|e| panic!("payload `{json}` failed to parse: {e}"));
+            assert_eq!(
+                parsed.get("thread_id").and_then(|v| v.as_str()),
+                Some("cmid-thread-A"),
+                "payload `{json}` missing `thread_id` field",
+            );
+        }
+    }
+
+    /// When the reporter is constructed without a thread_id (or with an
+    /// empty string), payloads must NOT carry a `thread_id` field. This
+    /// preserves wire compatibility with non-API channels and pre-cmid
+    /// clients that expect the field to be absent.
+    #[test]
+    fn should_omit_thread_id_when_not_bound() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        reporter.report(ProgressEvent::Thinking { iteration: 0 });
+
+        if let StreamProgressEvent::RawSse { json } = rx.try_recv().unwrap() {
+            let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert!(
+                parsed.get("thread_id").is_none(),
+                "thread_id field must be absent when reporter has no bound id, got {parsed}"
+            );
+        } else {
+            panic!("expected RawSse for Thinking event");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Strictly additive SSE wire-format change for the M8.10 thread-by-cmid chat data model. Every SSE payload now carries `thread_id` (= the current turn's user-message `client_message_id`) so web clients with multiple in-flight threads on the same `chat_id` can demultiplex streamed events into the right per-thread bubble. The `done` event additionally carries `committed_seq`, the per-thread sequence number the just-finalized assistant message will hold in storage.

Tracking issue: #627. Runs in parallel with PR #1 (`m810/01-persistence`) and predates PR #3 (web-side wiring).

## Event-by-event mapping

| SSE event | Source | thread_id source |
|-----------|--------|------------------|
| `token`, `replace` (streaming text) | `ApiChannel::edit_message` | decoded from synthetic `message_id` returned by `send_with_id` |
| `replace` (final assistant text) | `ApiChannel::send` (non-empty content) | `OutboundMessage.metadata[\"thread_id\"]` |
| `tool_start`, `tool_end`, `tool_progress` | `ChannelStreamReporter::report` -> `RawSse` | reporter bound to cmid via `with_thread_id` |
| `thinking`, `response`, `cost_update`, `stream_end` | `ChannelStreamReporter::report` -> `RawSse` | reporter bound to cmid |
| `file` | `ApiChannel::send` (media path) | `OutboundMessage.metadata[\"thread_id\"]` |
| `task_status` | `ApiChannel::send` (task_status metadata) | `OutboundMessage.metadata[\"thread_id\"]` |
| `done` (+ new `committed_seq`) | `ApiChannel::send` (`_completion`) | `OutboundMessage.metadata[\"thread_id\"]` |
| `done` (standalone `serve` mode) | `chat_streaming` handler | `req.client_message_id` |

The synthetic SSE `message_id` returned by `ApiChannel::send_with_id` now encodes the bound thread_id (`sse-<chat_id>\u{1F}<thread_id>`) so subsequent `edit_message` calls can recover the cmid for streaming `token`/`replace` events. ASCII unit separator chosen because it cannot appear in JSON string content without escaping.

## No special path for overflow / forced-background

Speculative overflow and forced-background paths emit the SAME events through the SAME code paths — only the bound `thread_id` differs (overflow user's cmid vs primary's cmid). The whole point of M8.10 is that overflow stops being a special case.

- Per-turn `ChannelStreamReporter::with_thread_id(cmid)` carries the routing key for the lifetime of one turn.
- Per-overflow reporter binds the overflow user's cmid; primary reporter binds the primary user's cmid.
- Both write to the same channel; the wire-side `thread_id` lets the web client demultiplex.

## Strictly additive

- Existing `session_result` emissions remain unchanged (deleted in PR #5 after bake).
- When the reporter has no bound thread_id (legacy/CLI paths), the field is omitted entirely from the wire payload — pre-cmid clients silently ignore it.
- `committed_seq` on `done` is omitted when the assistant message could not be persisted (matches existing M8.10-A behaviour).

## Test plan

- [x] \`cargo test -p octos-cli --features api --lib\` -> 659/659 pass
- [x] \`cargo test -p octos-cli --features api --lib stream_reporter\` -> 9/9 pass (includes new \`should_inject_thread_id_into_every_raw_sse_event\` + \`should_omit_thread_id_when_not_bound\`)
- [x] \`cargo test -p octos-cli --features api --lib api::sse\` -> 15/15 pass (includes new thread_id tests)
- [x] \`cargo test -p octos-cli --features api --lib should_emit_thread_id_on_every_event_for_speculative_overflow_pair\` -> passes (drives the 2-POST overflow pattern)
- [x] \`cargo build --workspace --release --features \"octos-cli/api,octos-cli/telegram\"\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` -> only pre-existing warnings (no new lints from this PR)

## What this PR does NOT do

- Does NOT touch persistence (PR #1 territory).
- Does NOT modify any web-side code (PR #3 territory).
- Does NOT remove existing \`session_result\` emissions (PR #5 territory after bake).