### PR TITLE
M8.10 PR #4 companion: e2e specs for thread interleave + tool-retry collapse (#627)

### DIFF
--- a/e2e/tests/live-thread-interleave.spec.ts
+++ b/e2e/tests/live-thread-interleave.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * M8.10 PR #4 live e2e: thread-by-cmid interleave.
+ *
+ * Validates that when a slow question and a fast question are sent in
+ * quick succession, the rendered DOM pairs each question with its own
+ * answer, regardless of which one finishes first on the wire.
+ *
+ * Old (broken) flat-list rendering would interleave: e.g. user1, user2,
+ * assistant1's progress events split across both bubbles, then assistant2,
+ * then assistant1's final text — pairing breaks. The new thread-by-cmid
+ * renderer (octos-web PR #4 / octos-org/octos#627) anchors each response
+ * to its origin user message via `responseToClientMessageId`.
+ *
+ * The new renderer is BEHIND the feature flag
+ * `localStorage.octos_thread_store_v2 = '1'`. This spec sets that flag
+ * before any messages are sent.
+ *
+ * Required env:
+ *   OCTOS_TEST_URL=https://dspfac.bot.ominix.io
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026
+ *   OCTOS_PROFILE=dspfac
+ *
+ * NEVER point at mini5 — that host is reserved for coding-green tests.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+
+const SLOW_PROMPT =
+  process.env.OCTOS_INTERLEAVE_SLOW_PROMPT ||
+  'Use deep research to find the latest news about Rust language. ' +
+    "Run the pipeline directly, don't ask. One paragraph.";
+const FAST_PROMPT =
+  process.env.OCTOS_INTERLEAVE_FAST_PROMPT || '1+1 等于几？只回答数字。';
+
+const SLOW_HINT_RE = /rust|news|research|pipeline|update/i;
+const FAST_HINT_RE = /\b2\b|二|两/;
+
+const FLAG_KEY = 'octos_thread_store_v2';
+
+const SLOW_MAX_WAIT_MS = 6 * 60 * 1000; // 6 minutes
+const FAST_MAX_WAIT_MS = 90 * 1000; // 90s
+const SEND_GAP_MS = 4_000; // ≤10s window between slow send and fast send
+
+async function enableThreadStoreV2(page: Page) {
+  await page.addInitScript((key) => {
+    localStorage.setItem(key, '1');
+  }, FLAG_KEY);
+}
+
+async function getOrderedBubbles(page: Page) {
+  return page.evaluate(() => {
+    const nodes = document.querySelectorAll(
+      "[data-testid='user-message'], [data-testid='assistant-message']",
+    );
+    return Array.from(nodes).map((el, i) => ({
+      index: i,
+      role:
+        el.getAttribute('data-testid') === 'user-message' ? 'user' : 'assistant',
+      threadId: el.getAttribute('data-thread-id') || '',
+      text: ((el as HTMLElement).innerText || '').trim().slice(0, 400),
+    }));
+  });
+}
+
+async function waitForBothFinished(
+  page: Page,
+  expectedAssistantCount: number,
+  maxWaitMs: number,
+) {
+  const start = Date.now();
+  let lastFilled = 0;
+  let stable = 0;
+  while (Date.now() - start < maxWaitMs) {
+    const isStreaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible()
+      .catch(() => false);
+    const filled = await page.evaluate((sel) => {
+      const bubbles = document.querySelectorAll(sel);
+      return Array.from(bubbles).filter((el) => {
+        const text = ((el as HTMLElement).innerText || '').trim();
+        return text.length > 8;
+      }).length;
+    }, SEL.assistantMessage);
+
+    if (filled >= expectedAssistantCount && !isStreaming) {
+      stable += 1;
+      if (stable >= 2) return filled;
+    } else {
+      stable = 0;
+    }
+
+    if (filled !== lastFilled) {
+      const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+      console.log(
+        `  [interleave] ${elapsed}s: filled=${filled}/${expectedAssistantCount} streaming=${isStreaming}`,
+      );
+      lastFilled = filled;
+    }
+    await page.waitForTimeout(3_000);
+  }
+  return lastFilled;
+}
+
+test.describe('Live thread interleave (M8.10 PR #4)', () => {
+  test.setTimeout(SLOW_MAX_WAIT_MS + FAST_MAX_WAIT_MS + 60_000);
+
+  test('slow Q + fast Q pair correctly with thread-store-v2 flag on', async ({
+    page,
+  }) => {
+    await enableThreadStoreV2(page);
+    await login(page);
+    await createNewSession(page);
+
+    const userBubblesBefore = await countUserBubbles(page);
+    const assistantBubblesBefore = await countAssistantBubbles(page);
+
+    // 1. Send slow question first.
+    await getInput(page).fill(SLOW_PROMPT);
+    await getSendButton(page).click();
+    await expect.poll(() => countUserBubbles(page)).toBe(userBubblesBefore + 1);
+
+    // 2. Wait briefly so the slow request enters streaming state, then
+    //    send the fast question while slow is still in flight.
+    await page.waitForTimeout(SEND_GAP_MS);
+    await expect
+      .poll(() => page.locator(SEL.cancelButton).isVisible().catch(() => false))
+      .toBeTruthy();
+
+    await getInput(page).fill(FAST_PROMPT);
+    await getSendButton(page).click();
+    await expect.poll(() => countUserBubbles(page)).toBe(userBubblesBefore + 2);
+
+    // 3. Wait until both answers are complete.
+    const assistantsExpected = assistantBubblesBefore + 2;
+    const filled = await waitForBothFinished(
+      page,
+      assistantsExpected,
+      SLOW_MAX_WAIT_MS,
+    );
+    expect(
+      filled,
+      `Only ${filled}/${assistantsExpected} assistant bubbles completed within ${SLOW_MAX_WAIT_MS}ms`,
+    ).toBeGreaterThanOrEqual(assistantsExpected);
+
+    // 4. Pull the bubble order from the DOM and assert pairing.
+    //    Expected pattern (thread-by-cmid):
+    //       [user_slow][assistant_slow ...][user_fast][assistant_fast ...]
+    //    The slow thread was sent first, so it appears first in the thread
+    //    list (sort key = userMsg.timestamp). Each user is followed by its
+    //    own assistant response, regardless of arrival order on the wire.
+    const bubbles = await getOrderedBubbles(page);
+    const newBubbles = bubbles.slice(
+      userBubblesBefore + assistantBubblesBefore,
+    );
+    console.log('new bubbles after both Qs:', JSON.stringify(newBubbles, null, 2));
+
+    // The first new bubble should be the slow user.
+    expect(newBubbles.length).toBeGreaterThanOrEqual(4);
+    expect(newBubbles[0].role).toBe('user');
+
+    // Find the indices of user / assistant pairs.
+    const userIndices = newBubbles
+      .map((b, i) => (b.role === 'user' ? i : -1))
+      .filter((i) => i >= 0);
+    expect(userIndices).toHaveLength(2);
+
+    // Slow user is at [0]. Its assistant must come BEFORE the fast user.
+    const fastUserIdx = userIndices[1];
+    expect(fastUserIdx).toBeGreaterThan(0);
+
+    // There must be at least one assistant bubble between slow user and
+    // fast user that contains some recognizable slow-prompt content.
+    const between = newBubbles.slice(1, fastUserIdx);
+    const slowAssistantBetween = between.filter(
+      (b) => b.role === 'assistant' && b.text.length > 0,
+    );
+    expect(
+      slowAssistantBetween.length,
+      `Expected at least one slow-thread assistant bubble between users; got ${between.length} bubbles between: ${JSON.stringify(between)}`,
+    ).toBeGreaterThan(0);
+
+    // After the fast user, there must be the fast assistant.
+    const after = newBubbles.slice(fastUserIdx + 1);
+    const fastAssistantAfter = after.filter(
+      (b) => b.role === 'assistant' && b.text.length > 0,
+    );
+    expect(
+      fastAssistantAfter.length,
+      `Expected at least one fast-thread assistant bubble after the fast user; got ${after.length} bubbles after: ${JSON.stringify(after)}`,
+    ).toBeGreaterThan(0);
+
+    // Pairing sanity: each thread's assistant bubble carries
+    // data-thread-id matching its parent user. The renderer (PR #4) sets
+    // data-thread-id on assistant-message elements. If absent (older
+    // build), skip this check rather than fail.
+    const slowThreadIds = slowAssistantBetween
+      .map((b) => b.threadId)
+      .filter((tid) => tid.length > 0);
+    const fastThreadIds = fastAssistantAfter
+      .map((b) => b.threadId)
+      .filter((tid) => tid.length > 0);
+    if (slowThreadIds.length > 0 && fastThreadIds.length > 0) {
+      // The slow thread id and fast thread id must differ — pairing intact.
+      expect(slowThreadIds[0]).not.toBe(fastThreadIds[0]);
+    }
+
+    // Soft semantic check: the slow assistant's text should NOT include
+    // any "1+1=2" content (that's the fast Q's answer). If it does, the
+    // wires got crossed.
+    const slowText = slowAssistantBetween.map((b) => b.text).join(' ');
+    const fastText = fastAssistantAfter.map((b) => b.text).join(' ');
+    if (FAST_HINT_RE.test(slowText) && !SLOW_HINT_RE.test(slowText)) {
+      throw new Error(
+        `BROKEN PAIRING: slow assistant text contains fast-Q answer marker but no slow-Q content. slow="${slowText.slice(0, 200)}" fast="${fastText.slice(0, 200)}"`,
+      );
+    }
+  });
+});

--- a/e2e/tests/live-tool-retry-collapse.spec.ts
+++ b/e2e/tests/live-tool-retry-collapse.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * M8.10 PR #4 live e2e: tool-retry collapse.
+ *
+ * Validates that when an LLM retries the same tool with bad args (e.g. 6×
+ * weather pills before settling on the right call), the rendered UI
+ * collapses retries into a SINGLE tool-call-bubble that carries a retry
+ * counter — not N duplicate pills.
+ *
+ * Implements the assertion described in the M8.10 plan: send a Chinese-
+ * city weather prompt that historically caused 3+ tool retries; assert
+ * exactly one `data-testid="tool-call-bubble"` for the tool with
+ * `data-tool-call-retry-count >= 1`.
+ *
+ * The test is allowed to skip if the LLM happens to nail the call on the
+ * first attempt — retryCount === 0 on the only bubble means there's no
+ * retry behavior to validate, but the renderer is correct (no extra
+ * pills appeared). We assert the absence of duplicate pills regardless.
+ *
+ * The new renderer is BEHIND the feature flag
+ * `localStorage.octos_thread_store_v2 = '1'`. This spec sets that flag
+ * before any messages are sent.
+ *
+ * NEVER point at mini5 — that host is reserved for coding-green tests.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+
+const FLAG_KEY = 'octos_thread_store_v2';
+
+const RETRY_PROMPT =
+  process.env.OCTOS_RETRY_PROMPT ||
+  '北京今天的天气怎么样？请使用工具查询。';
+
+const TOOL_CALL_BUBBLE = "[data-testid='tool-call-bubble']";
+const RETRY_BADGE = "[data-testid='tool-call-retry-badge']";
+
+const MAX_WAIT_FOR_FINAL_MS = 4 * 60 * 1000; // 4 minutes
+const MAX_WAIT_FOR_TOOL_CALL_MS = 90 * 1000;
+
+async function enableThreadStoreV2(page: Page) {
+  await page.addInitScript((key) => {
+    localStorage.setItem(key, '1');
+  }, FLAG_KEY);
+}
+
+async function waitForCompletion(page: Page, maxWaitMs: number) {
+  const start = Date.now();
+  let stable = 0;
+  while (Date.now() - start < maxWaitMs) {
+    const isStreaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible()
+      .catch(() => false);
+    if (!isStreaming) {
+      stable += 1;
+      if (stable >= 2) return true;
+    } else {
+      stable = 0;
+    }
+    await page.waitForTimeout(2_500);
+  }
+  return false;
+}
+
+interface ToolCallBubbleSnapshot {
+  index: number;
+  toolCallId: string;
+  retryCount: number;
+  name: string;
+  threadId: string;
+}
+
+async function snapshotToolCallBubbles(page: Page): Promise<ToolCallBubbleSnapshot[]> {
+  return page.evaluate((sel) => {
+    const nodes = document.querySelectorAll(sel);
+    return Array.from(nodes).map((el, i) => {
+      const parentAssistant = el.closest("[data-testid='assistant-message']");
+      const text = ((el as HTMLElement).innerText || '').trim();
+      // First non-empty whitespace-separated token = tool name (the
+      // renderer puts `<tool-name><retry-badge>` on the first line).
+      const firstLine = text.split(/\n/)[0] || '';
+      const tokenMatch = firstLine.match(/^([A-Za-z0-9_.-]+)/);
+      return {
+        index: i,
+        toolCallId: el.getAttribute('data-tool-call-id') || '',
+        retryCount: Number(
+          el.getAttribute('data-tool-call-retry-count') ?? '0',
+        ),
+        name: tokenMatch ? tokenMatch[1] : '',
+        threadId: parentAssistant?.getAttribute('data-thread-id') || '',
+      };
+    });
+  }, TOOL_CALL_BUBBLE);
+}
+
+test.describe('Live tool-retry collapse (M8.10 PR #4)', () => {
+  test.setTimeout(MAX_WAIT_FOR_FINAL_MS + 60_000);
+
+  test(
+    'multiple retries of the same tool collapse into one bubble with retry counter',
+    async ({ page }) => {
+      await enableThreadStoreV2(page);
+      await login(page);
+      await createNewSession(page);
+
+      const userBubblesBefore = await countUserBubbles(page);
+      const assistantBubblesBefore = await countAssistantBubbles(page);
+
+      await getInput(page).fill(RETRY_PROMPT);
+      await getSendButton(page).click();
+
+      // 1) User bubble appears.
+      await expect.poll(() => countUserBubbles(page)).toBe(userBubblesBefore + 1);
+
+      // 2) Assistant bubble materializes.
+      await expect
+        .poll(() => countAssistantBubbles(page), {
+          timeout: 30_000,
+          intervals: [1_000, 2_000, 3_000],
+        })
+        .toBeGreaterThanOrEqual(assistantBubblesBefore + 1);
+
+      // 3) At least one tool-call bubble must appear within the wait window.
+      await expect
+        .poll(() => page.locator(TOOL_CALL_BUBBLE).count(), {
+          timeout: MAX_WAIT_FOR_TOOL_CALL_MS,
+          intervals: [2_000, 3_000, 5_000],
+        })
+        .toBeGreaterThan(0);
+
+      // 4) Wait for completion (streaming finishes).
+      const finished = await waitForCompletion(page, MAX_WAIT_FOR_FINAL_MS);
+      expect(finished, 'Stream did not finish within the test window').toBeTruthy();
+
+      // 5) Snapshot all tool-call bubbles. Group by name — for any name
+      //    appearing more than once we have a duplicate-pill regression.
+      const bubbles = await snapshotToolCallBubbles(page);
+      console.log(
+        'tool-call bubbles after completion:',
+        JSON.stringify(bubbles, null, 2),
+      );
+
+      const byName = new Map<string, ToolCallBubbleSnapshot[]>();
+      for (const b of bubbles) {
+        if (!b.name) continue;
+        const list = byName.get(b.name) ?? [];
+        list.push(b);
+        byName.set(b.name, list);
+      }
+
+      // The CRITICAL assertion: no duplicate-pill regressions. Each
+      // distinct tool name must appear in at most ONE bubble — retries
+      // collapse into the same bubble and bump retryCount.
+      for (const [name, list] of byName.entries()) {
+        expect(
+          list.length,
+          `Tool "${name}" rendered ${list.length} bubbles (broken duplicate-pill regression). Bubbles: ${JSON.stringify(list)}`,
+        ).toBe(1);
+      }
+
+      // 6) If any bubble has retryCount >= 1, the retry-collapse path
+      //    actually fired. If retryCount === 0 across all bubbles, the
+      //    LLM happened to nail the args on the first try — skip the
+      //    retry-counter assertion in that case but keep the
+      //    no-duplicate-pills check above.
+      const maxRetry = bubbles.reduce(
+        (acc, b) => (b.retryCount > acc ? b.retryCount : acc),
+        0,
+      );
+      console.log(
+        `tool-retry-collapse: total bubbles=${bubbles.length}, maxRetryCount=${maxRetry}`,
+      );
+
+      if (maxRetry === 0) {
+        test.info().annotations.push({
+          type: 'note',
+          description:
+            'LLM nailed the tool args on the first try; retry-counter path not exercised. ' +
+            'No-duplicate-pill check still passed.',
+        });
+        // Soft-skip is fine — retry-collapse is a tolerance for flaky LLM
+        // arg generation; the renderer's retry-counter UI is then unused
+        // for this run but provably present (badge selector exists).
+        return;
+      }
+
+      // 7) When retryCount >= 1, the retry badge must be visible.
+      const badgeCount = await page.locator(RETRY_BADGE).count();
+      expect(
+        badgeCount,
+        `retryCount=${maxRetry} but no retry-badge rendered`,
+      ).toBeGreaterThan(0);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Two new live e2e specs that exercise the M8.10 (revised) thread-by-cmid chat data model — the invariants that motivated the redesign.

- `e2e/tests/live-thread-interleave.spec.ts` — sends a slow research question, then a fast question while the slow one is still in flight; asserts the rendered DOM pairs each user with its own assistant response regardless of arrival order on the wire.
- `e2e/tests/live-tool-retry-collapse.spec.ts` — drives a Chinese-city weather prompt that historically caused 3+ tool retries; asserts exactly **one** `[data-testid="tool-call-bubble"]` per distinct tool name, with a `data-tool-call-retry-count` >= 1 and the retry badge visible. Retry-counter check soft-skips when the LLM nails args on the first try.

Both specs set `localStorage.octos_thread_store_v2 = '1'` before login so they exercise the new threaded renderer (octos-org/octos-web#54). They do NOT replace existing live specs — they extend coverage to the speculative-queue and tool-retry scenarios the previous specs missed.

## Cross-references

- Tracking issue: #627
- Companion octos-web PR: octos-org/octos-web#54
- PR #1 (#628), #2 (#629), #3 (octos-org/octos-web#53) merged.

## Test plan

- [x] `npx playwright test --list live-thread-interleave live-tool-retry-collapse` lists both specs (verified locally).
- [ ] Run against canary once octos-web PR #54 is deployed:
  - `OCTOS_TEST_URL=https://dspfac.bot.ominix.io npx playwright test live-thread-interleave live-tool-retry-collapse`
- [ ] NEVER point at mini5 (coding-green territory).

These specs do NOT block merging — they validate behavior already shipped behind a feature flag that's default-off.