### PR TITLE
M8.10 PR #5/5 (server): delete session_result primary-turn emissions (#627) [DRAFT — merge after fleet bake]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,16 @@ Splits long messages into channel-safe chunks (paragraph > newline > sentence > 
 
 JSONL persistence with LRU in-memory cache. Session forking (`/new` command) with parent_key tracking. Percent-encoded filenames with hash suffix on truncation (prevents collisions). File size limit: 10MB. Atomic write-then-rename for crash safety.
 
+#### Thread-by-cmid chat data model (M8.10, #627)
+
+Each user message roots a `Thread` keyed by its `client_message_id`. Assistant and tool messages bind to the thread via `response_to_client_message_id` (= `thread_id` from PR #2's SSE events). Conversations are an ordered list of threads sorted by `userMsg.timestamp`; within a thread, responses sort strictly by `intra_thread_seq`. The web client's `thread-store.ts` is the single chat data model — the legacy flat-list `message-store.ts` and the timestamp-primary `compareMessagesForDisplay` / `MAX_SAFE_INTEGER` fallback were deleted in PR #5.
+
+Server-side: every outbound message that produces an SSE event carries `thread_id` metadata (= the user message's cmid). The API channel (`octos-bus/src/api_channel.rs`) stamps `thread_id` on every wire payload (`token`, `replace`, `tool_start`, `tool_progress`, `tool_end`, `file`, `task_status`, `done`). PR #5 deleted the legacy user-message `session_result` event emissions for the primary, forced-background, and overflow paths — `thread_id` is now the routing key for both ordering and routing on every event. The remaining `_session_result` metadata routing in `api_channel.rs` is the durable late-binding fanout for assistant overflow replies, file-delivery commits, and background notifications, plus the SSE replay path (`/events/stream` since_seq).
+
+#### SSE protocol contract
+
+Every SSE event carries an optional `thread_id` field (string) — when present, it is the `client_message_id` of the user message rooting the thread the event belongs to. Web clients route streaming tokens, tool calls, file deliveries, and `done` events to the matching thread by `thread_id`. The `done` event additionally carries `committed_seq` (per-thread sequence assigned at persistence). See `crates/octos-cli/src/api/sse.rs` for the wire format.
+
 ### Hooks (`octos-agent/src/hooks.rs`)
 
 Lifecycle hook system for running shell commands at agent events. 4 events: `before_tool_call`, `after_tool_call`, `before_llm_call`, `after_llm_call`. Before-hooks can deny operations (exit code 1). Shell protocol: JSON payload on stdin, exit code semantics (0=allow, 1=deny, 2+=error). Circuit breaker auto-disables hooks after 3 consecutive failures (configurable via `HookExecutor::with_threshold()`). Commands use argv array (no shell interpretation). Environment sanitized via shared `BLOCKED_ENV_VARS`. Tilde expansion supports `~/` and `~username/`. Config: `hooks` array in config.json with `event`, `command`, `timeout_ms` (default 5000), `tool_filter`. Wired in chat.rs, gateway.rs, serve.rs. Hook changes trigger restart via config_watcher.

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -45,13 +45,13 @@ pub struct ChatRequest {
     pub media: Vec<String>,
     #[serde(default)]
     pub attach_only: bool,
-    /// Web-generated correlation id. Forwarded to the gateway so the
-    /// eventual `_session_result.response_to_client_message_id` matches
-    /// the web reducer's optimistic bubble (FA-12f).
-    ///
-    /// Also propagated onto the persisted user `Message` so the matching
-    /// `session_result` event lets the web client stamp the authoritative
-    /// `historySeq` onto its optimistic bubble.
+    /// Web-generated correlation id. Forwarded to the gateway so every
+    /// SSE event the streaming response produces carries `thread_id`
+    /// (= this cmid) and the web client routes streaming tokens to the
+    /// thread rooted at the optimistic user-message bubble (M8.10).
+    /// Also propagated onto the persisted user `Message` so the
+    /// thread-store can correlate replayed history rows back to the same
+    /// thread on reload.
     #[serde(default)]
     pub client_message_id: Option<String>,
 }
@@ -412,10 +412,8 @@ async fn chat_streaming(
 
     let message = req.message;
     let media = req.media;
-    let topic_for_event = req.topic.clone();
 
     // Spawn the agent task
-    let user_event_tx = tx.clone();
     tokio::spawn(async move {
         let result = request_agent
             .process_message(&message, &history, media)
@@ -438,16 +436,18 @@ async fn chat_streaming(
                 // so messages landed in `sessions/<encoded_full_key>.jsonl`
                 // while the actor wrote to `users/.../<topic>.jsonl`.
                 //
-                // Also tag the first user message with the client-supplied
+                // Tag the first user message with the client-supplied
                 // `client_message_id` so the persisted row carries it through
-                // the JSONL round-trip and emit a user-message session_result
-                // event so the web client can stamp the authoritative seq onto
-                // its optimistic bubble (M8.10-A user-message counterpart).
+                // the JSONL round-trip. M8.10 PR #5 dropped the user-message
+                // `session_result` event emission — every SSE event the
+                // streaming response produces is already tagged with
+                // `thread_id` (= the same cmid), so the web client routes
+                // streaming tokens to the right thread without a synthetic
+                // user-role result event.
                 //
                 // Capture the committed seq of the final assistant message
                 // so the SSE `done` event can thread it back to the web client
                 // (M8.10-A).
-                let mut user_message_seq_and_meta: Option<(usize, String, String)> = None;
                 let assistant_committed_seq: Option<u64> = {
                     let mut last_assistant_seq: Option<u64> = None;
                     let mut user_persisted = false;
@@ -460,26 +460,18 @@ async fn chat_streaming(
                                     to_save.client_message_id = Some(cmid.clone());
                                 }
                             }
-                            let timestamp = to_save.timestamp.to_rfc3339();
-                            let content_for_event = to_save.content.clone();
-                            match persist_chat_message_through_canonical(
+                            if let Err(error) = persist_chat_message_through_canonical(
                                 &sessions,
                                 &session_key,
                                 to_save,
                             )
                             .await
                             {
-                                Ok(seq) => {
-                                    user_message_seq_and_meta =
-                                        Some((seq, content_for_event, timestamp));
-                                }
-                                Err(error) => {
-                                    tracing::warn!(
-                                        session = %session_id,
-                                        error = %error,
-                                        "chat: failed to persist user message"
-                                    );
-                                }
+                                tracing::warn!(
+                                    session = %session_id,
+                                    error = %error,
+                                    "chat: failed to persist user message"
+                                );
                             }
                         } else {
                             let is_assistant = msg.role == MessageRole::Assistant;
@@ -500,34 +492,6 @@ async fn chat_streaming(
                     }
                     last_assistant_seq
                 };
-
-                // Emit a user-message session_result event so the web client
-                // can stamp the authoritative seq onto its optimistic bubble.
-                if let Some((seq, content, timestamp)) = user_message_seq_and_meta {
-                    let mut message_payload = serde_json::json!({
-                        "seq": seq,
-                        "role": "user",
-                        "content": content,
-                        "timestamp": timestamp,
-                    });
-                    if let Some(ref cmid) = client_message_id {
-                        if !cmid.is_empty() {
-                            message_payload
-                                .as_object_mut()
-                                .expect("json object")
-                                .insert(
-                                    "client_message_id".to_string(),
-                                    serde_json::Value::String(cmid.clone()),
-                                );
-                        }
-                    }
-                    let event = serde_json::json!({
-                        "type": "session_result",
-                        "topic": topic_for_event,
-                        "message": message_payload,
-                    });
-                    let _ = user_event_tx.send(event.to_string());
-                }
 
                 // Send final done event (field names match what octos-web expects)
                 let provider_metadata = response.provider_metadata.clone();

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3443,6 +3443,15 @@ impl SessionActor {
 
     /// Persist an assistant-visible background result and emit the matching
     /// committed session-result event metadata for the web/runtime surfaces.
+    ///
+    /// M8.10 PR #5 retained the `_session_result` metadata here (the only
+    /// late-binding case left in this file): background notifications are
+    /// emitted AFTER the originating turn's SSE stream has closed, so the
+    /// runtime needs the durable `broadcast_session_event` fanout in
+    /// `api_channel.rs` to deliver them to web watchers. The user-message
+    /// session_result emissions for primary, overflow, and forced-background
+    /// were deleted — those rode on the live SSE stream's `thread_id` and
+    /// no longer needed a separate result event. This one does.
     async fn deliver_background_notification(&self, content: String, media: Vec<String>) -> bool {
         let content = finalize_assistant_content(&self.session_key, &self.user_workspace, &content);
         let persisted = persist_assistant_message(
@@ -3715,78 +3724,28 @@ impl SessionActor {
             thread_id: None,
             timestamp: chrono::Utc::now(),
         };
-        let user_msg_timestamp = user_msg.timestamp;
-        let user_seq = {
+        // M8.10 PR #5: the forced-background user-message session_result
+        // emission is gone. PR #2's `thread_id` mechanism is now sufficient
+        // for both routing and ordering — the web client's thread store
+        // creates the bubble on send and binds streaming tokens by
+        // thread_id on every event the API channel emits. We still persist
+        // the user message so reload reconstructs the thread, but we don't
+        // need its committed seq to emit a result event.
+        {
             let mut handle = self.session_handle.lock().await;
             let session = handle.get_or_create();
             if session.summary.is_none() && !persisted_user_content.trim().is_empty() {
                 session.summary = Some(persisted_user_content.chars().take(100).collect());
             }
-            match handle.add_message_with_seq(user_msg).await {
-                Ok(seq) => Some(seq),
-                Err(error) => {
-                    warn!(session = %self.session_key, error = %error, "failed to persist user message for forced background workflow");
-                    None
-                }
-            }
-        };
-
-        // Restore the forced-background user-message session_result emission
-        // dropped by 14ac3f3a. Same reasoning as the overflow path: the web
-        // client needs a routing signal so the workflow's spawn_only progress
-        // events bind to this user message's bubble, not a stale primary.
-        // See #616.
-        if let Some(seq) = user_seq {
-            let mut session_result = serde_json::json!({
-                "seq": seq,
-                "role": "user",
-                "content": persisted_user_content.to_string(),
-                "timestamp": user_msg_timestamp.to_rfc3339(),
-                "media": Vec::<String>::new(),
-            });
-            if let Some(cmid) = client_message_id.as_deref() {
-                session_result.as_object_mut().expect("json object").insert(
-                    "client_message_id".to_string(),
-                    serde_json::Value::String(cmid.to_string()),
+            if let Err(error) = handle.add_message_with_seq(user_msg).await {
+                warn!(
+                    session = %self.session_key,
+                    error = %error,
+                    "failed to persist user message for forced background workflow"
                 );
             }
-            let mut metadata_obj = serde_json::Map::new();
-            if let Some(topic) = self.session_key.topic() {
-                metadata_obj.insert(
-                    "topic".to_string(),
-                    serde_json::Value::String(topic.to_string()),
-                );
-            }
-            metadata_obj.insert(
-                "_history_persisted".to_string(),
-                serde_json::Value::Bool(true),
-            );
-            metadata_obj.insert("_session_result".to_string(), session_result);
-            // M8.10 PR #2: tag the user-message session_result emission with
-            // thread_id so the API channel can stamp it on subsequent
-            // wire events for this turn.
-            if let Some(cmid) = client_message_id.as_deref() {
-                metadata_obj.insert(
-                    "thread_id".to_string(),
-                    serde_json::Value::String(cmid.to_string()),
-                );
-            }
-
-            let _ = send_outbound_with_timeout(
-                &self.session_key,
-                &self.out_tx,
-                OutboundMessage {
-                    channel: self.channel.clone(),
-                    chat_id: self.chat_id.clone(),
-                    content: String::new(),
-                    reply_to: None,
-                    media: vec![],
-                    metadata: serde_json::Value::Object(metadata_obj),
-                },
-                "user_message_session_result_forced_background",
-            )
-            .await;
         }
+
         let ack_content = workflow_ack;
         let persisted = persist_assistant_message(
             &self.session_handle,
@@ -3929,8 +3888,6 @@ impl SessionActor {
         // re-reference uploaded audio/files. Without this, attachments only
         // survived as TurnAttachmentContext for the current turn.
         let client_message_id = inbound_client_message_id(&inbound);
-        let persisted_user_content_for_event = persisted_user_content.clone();
-        let user_media_for_event = image_media.clone();
         let user_msg = Message {
             role: MessageRole::User,
             content: persisted_user_content,
@@ -3946,8 +3903,7 @@ impl SessionActor {
             thread_id: None,
             timestamp: chrono::Utc::now(),
         };
-        let user_msg_timestamp = user_msg.timestamp;
-        let user_seq = {
+        {
             let mut handle = self.session_handle.lock().await;
             // Auto-generate summary from first user message
             {
@@ -3957,17 +3913,13 @@ impl SessionActor {
                     session.summary = Some(summary);
                 }
             }
-            handle.add_message_with_seq(user_msg).await.ok()
-        };
-
-        // The web client sorts by Message.timestamp (timestamp-primary
-        // comparator) so optimistic bubbles slot in chronological order
-        // without needing a server seq round-trip. Seq is still captured for
-        // ledger integrity.
-        let _ = user_seq;
-        let _ = user_msg_timestamp;
-        let _ = persisted_user_content_for_event;
-        let _ = user_media_for_event;
+            // M8.10 PR #5: persist the user message but no longer emit a
+            // user-message session_result event — every SSE event for this
+            // turn carries `thread_id` (= client_message_id) so the web
+            // client routes streaming tokens to the optimistic bubble
+            // without needing a separate seq round-trip.
+            let _ = handle.add_message_with_seq(user_msg).await;
+        }
 
         // Get conversation history (now includes the user message we just saved)
         let history: Vec<Message> = {
@@ -4826,72 +4778,16 @@ impl SessionActor {
                 thread_id: None,
                 timestamp: user_msg_timestamp,
             };
-            let user_seq_for_overflow = {
+            let _user_seq_for_overflow = {
                 let mut handle = session_handle.lock().await;
                 handle.add_message_with_seq(user_msg).await.ok()
             };
 
-            // Restore the overflow user-message session_result emission that
-            // was removed by 14ac3f3a — without it the web client has no signal
-            // that user message B has a response slot, so streaming tokens for
-            // B's reply bind to A's bubble (or render nowhere). The
-            // timestamp-primary comparator handles ORDERING client-side; this
-            // session_result handles ROUTING server-side. The two are
-            // complementary, not exclusive. See #616. Channel-side fanout
-            // (api_channel.rs) only honours `_session_result` for the api
-            // channel; non-api adapters (telegram/etc) ignore it harmlessly.
-            if let Some(seq) = user_seq_for_overflow {
-                let mut session_result = serde_json::json!({
-                    "seq": seq,
-                    "role": "user",
-                    "content": content.clone(),
-                    "timestamp": user_msg_timestamp.to_rfc3339(),
-                    "media": Vec::<String>::new(),
-                });
-                if let Some(cmid) = overflow_client_message_id.as_deref() {
-                    session_result.as_object_mut().expect("json object").insert(
-                        "client_message_id".to_string(),
-                        serde_json::Value::String(cmid.to_string()),
-                    );
-                }
-                let mut metadata_obj = serde_json::Map::new();
-                if let Some(topic) = session_key.topic() {
-                    metadata_obj.insert(
-                        "topic".to_string(),
-                        serde_json::Value::String(topic.to_string()),
-                    );
-                }
-                metadata_obj.insert(
-                    "_history_persisted".to_string(),
-                    serde_json::Value::Bool(true),
-                );
-                metadata_obj.insert("_session_result".to_string(), session_result);
-                // M8.10 PR #2: tag the user-message session_result emission
-                // with thread_id so any SSE event the API channel emits in
-                // response (e.g. when this metadata path also wraps content
-                // into a `replace`) carries the right per-cmid routing key.
-                if let Some(cmid) = overflow_client_message_id.as_deref() {
-                    metadata_obj.insert(
-                        "thread_id".to_string(),
-                        serde_json::Value::String(cmid.to_string()),
-                    );
-                }
-
-                let _ = send_outbound_with_timeout(
-                    &session_key,
-                    &out_tx,
-                    OutboundMessage {
-                        channel: channel.clone(),
-                        chat_id: chat_id.clone(),
-                        content: String::new(),
-                        reply_to: None,
-                        media: vec![],
-                        metadata: serde_json::Value::Object(metadata_obj),
-                    },
-                    "user_message_session_result_overflow",
-                )
-                .await;
-            }
+            // M8.10 PR #5: the overflow user-message session_result emission
+            // is gone. The thread_id (= overflow user's cmid) is stamped on
+            // every SSE event this turn produces (replace, file, done) so
+            // the web client can route streaming tokens to the right bubble
+            // without a synthetic user-role result event.
 
             // Refresh the history snapshot so the overflow LLM sees the
             // primary turn's assistant reply if it has already landed. The
@@ -7519,21 +7415,15 @@ mod tests {
 
         // ── Phase 3: Collect all responses ──
         // We expect 2 user-facing responses: overflow answer + slow primary
-        // answer (in some order). Skip metadata-only outbounds (the
-        // user-message session_result emission added by #616 fix carries
-        // routing metadata in `_session_result` but no body).
+        // answer (in some order). Filter out metadata-only outbounds (the
+        // forced-background ack carries an empty content body alongside its
+        // _completion marker on the API channel).
         let mut responses = Vec::new();
         let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
         while responses.len() < 2 {
             match tokio::time::timeout_at(deadline, rx.recv()).await {
                 Ok(Some(msg)) => {
-                    let is_user_session_result = msg
-                        .metadata
-                        .get("_session_result")
-                        .and_then(|r| r.get("role"))
-                        .and_then(|v| v.as_str())
-                        == Some("user");
-                    if !is_user_session_result {
+                    if !msg.content.trim().is_empty() {
                         responses.push(msg.content);
                     }
                 }
@@ -7729,145 +7619,18 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
     }
 
-    /// #616 regression: the overflow USER message must emit `_session_result`
-    /// metadata so the web client can bind streaming response tokens to the
-    /// overflow user-message bubble. Without this signal, when a fast follow-up
-    /// arrives mid-primary-turn, the web client receives streaming tokens with
-    /// no way to route them to the second user's bubble — the response renders
-    /// nowhere (or worse, overwrites the primary's bubble).
-    ///
-    /// 14ac3f3a removed this emission on the assumption that timestamp-primary
-    /// sort handles ordering. True for ordering, false for routing — both
-    /// roles are needed and they're complementary, not exclusive.
-    #[tokio::test]
-    async fn should_emit_session_result_for_overflow_user_message() {
-        let dir = tempfile::TempDir::new().unwrap();
-
-        let agent_llm = Arc::new(DelayedMockProvider::new(
-            "agent",
-            vec![
-                (Duration::from_millis(200), make_response("warmup1")),
-                (Duration::from_millis(200), make_response("warmup2")),
-                (Duration::from_millis(200), make_response("warmup3")),
-                (Duration::from_millis(200), make_response("warmup4")),
-                (Duration::from_millis(200), make_response("warmup5")),
-                (Duration::from_secs(12), make_response("slow primary")),
-                (Duration::from_millis(400), make_response("overflow body")),
-                (Duration::from_millis(200), make_response("post-overflow")),
-            ],
-        ));
-        let router_a: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
-            "router-a",
-            vec![(Duration::from_millis(500), make_response("unused"))],
-        ));
-        let router_b: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
-            "router-b",
-            vec![(Duration::from_millis(500), make_response("unused"))],
-        ));
-
-        let (tx, mut rx, handle, _session_mgr) =
-            setup_speculative_actor(agent_llm, vec![router_a, router_b], &dir).await;
-
-        // Warmup so responsiveness baseline is established.
-        for i in 0..5 {
-            tx.send(make_inbound(&format!("warmup {i}"))).await.unwrap();
-            let _ = tokio::time::timeout(Duration::from_secs(5), rx.recv()).await;
-        }
-
-        // Slow primary.
-        tx.send(make_inbound("please run a big analysis"))
-            .await
-            .unwrap();
-
-        // Sleep past patience so the second prompt is served as overflow.
-        tokio::time::sleep(Duration::from_secs(11)).await;
-
-        // Fast follow-up with a known client_message_id so we can assert it
-        // round-trips on the session_result event. Construct the Inbound
-        // variant inline so we can set message_id (= client_message_id on the
-        // wire from api_channel.rs:1222 — see #616 audit).
-        let overflow_inbound = ActorMessage::Inbound {
-            message: InboundMessage {
-                channel: "cli".to_string(),
-                chat_id: "test".to_string(),
-                sender_id: "user".to_string(),
-                content: "the overflow user question".to_string(),
-                timestamp: chrono::Utc::now(),
-                media: vec![],
-                // Both fields carry client_message_id in production: api_channel
-                // sets metadata["client_message_id"] (which `inbound_client_message_id`
-                // reads) and message_id (which becomes overflow_reply_to). Mirror
-                // both so we exercise the same path.
-                metadata: serde_json::json!({
-                    "client_message_id": "client-msg-overflow-test",
-                }),
-                message_id: Some("client-msg-overflow-test".to_string()),
-            },
-            image_media: vec![],
-            attachment_media: vec![],
-            attachment_prompt: None,
-        };
-        tx.send(overflow_inbound).await.unwrap();
-
-        // Collect outbound until we see a user-role session_result (which is
-        // the overflow user-message emission we're asserting on).
-        let mut user_session_result: Option<serde_json::Value> = None;
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
-        while user_session_result.is_none() {
-            match tokio::time::timeout_at(deadline, rx.recv()).await {
-                Ok(Some(msg)) => {
-                    if let Some(result) = msg.metadata.get("_session_result") {
-                        if result.get("role").and_then(|v| v.as_str()) == Some("user") {
-                            user_session_result = Some(result.clone());
-                        }
-                    }
-                }
-                Ok(None) | Err(_) => break,
-            }
-        }
-
-        let result = user_session_result.unwrap_or_else(|| {
-            panic!("overflow user message must emit _session_result with role=user")
-        });
-
-        assert_eq!(
-            result.get("role").and_then(|v| v.as_str()),
-            Some("user"),
-            "role must be user"
-        );
-        assert!(
-            result.get("seq").and_then(|v| v.as_u64()).is_some(),
-            "session_result must include committed seq for the user message"
-        );
-        assert_eq!(
-            result.get("content").and_then(|v| v.as_str()),
-            Some("the overflow user question"),
-            "content must mirror the overflow user message"
-        );
-        assert_eq!(
-            result.get("client_message_id").and_then(|v| v.as_str()),
-            Some("client-msg-overflow-test"),
-            "client_message_id must round-trip from inbound — this is what the \
-             web client uses to bind subsequent streaming tokens to the \
-             overflow user bubble"
-        );
-        assert!(
-            result.get("timestamp").is_some(),
-            "session_result must include rfc3339 timestamp"
-        );
-
-        drop(tx);
-        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
-    }
-
     /// M8.10 PR #2 regression: every outbound message that fans out into
     /// SSE events on the API channel MUST carry `thread_id` metadata
     /// (= the user message's client_message_id) so the wire-side `done`,
-    /// `replace`, `file`, etc. payloads can be tagged. Drives the same
-    /// 2-POST rapid-succession pattern as
-    /// `should_emit_session_result_for_overflow_user_message` and asserts
-    /// that BOTH threads' outbound messages have thread_id populated and
-    /// match the expected user cmid for that message's logical thread.
+    /// `replace`, `file`, etc. payloads can be tagged. Asserts that BOTH
+    /// threads' outbound messages have thread_id populated and match the
+    /// expected user cmid for that message's logical thread.
+    ///
+    /// PR #5 deleted the legacy
+    /// `should_emit_session_result_for_overflow_user_message` test that
+    /// asserted on the user-role `_session_result` metadata: with thread_id
+    /// stamped on every event, the user-message session_result emission
+    /// is no longer needed and was removed.
     ///
     /// The whole point of M8.10 is that overflow stops being a special
     /// case — same code path, same events, just a different thread_id.
@@ -7979,27 +7742,18 @@ mod tests {
         }
 
         // Tag each outbound with the cmid of the thread it belongs to,
-        // identified by content fingerprint. Filter out warmup leftovers
-        // and unrelated metadata-only messages.
+        // identified by content fingerprint or by thread_id metadata
+        // (PR #5 removed the user-message _session_result emission, so
+        // thread_id is now the routing key on every event).
         let mut primary_outbounds: Vec<&OutboundMessage> = Vec::new();
         let mut overflow_outbounds: Vec<&OutboundMessage> = Vec::new();
         for msg in &outbounds {
-            // Match by user cmid first (covers user-message session_result
-            // emissions which echo the cmid).
-            let session_result_cmid = msg
-                .metadata
-                .get("_session_result")
-                .and_then(|sr| sr.get("client_message_id"))
-                .and_then(|v| v.as_str());
-            if session_result_cmid == Some(primary_cmid)
-                || msg.content.contains("primary thread reply")
-            {
+            let thread_id = msg.metadata.get("thread_id").and_then(|v| v.as_str());
+            if thread_id == Some(primary_cmid) || msg.content.contains("primary thread reply") {
                 primary_outbounds.push(msg);
                 continue;
             }
-            if session_result_cmid == Some(overflow_cmid)
-                || msg.content.contains("overflow thread reply")
-            {
+            if thread_id == Some(overflow_cmid) || msg.content.contains("overflow thread reply") {
                 overflow_outbounds.push(msg);
                 continue;
             }
@@ -8042,8 +7796,8 @@ mod tests {
         // bear the primary cmid. Overflow likewise.
         for msg in &primary_outbounds {
             // Filter to outbounds that produce SSE events: assistant reply
-            // (non-empty content) OR completion marker OR session_result
-            // user-message emission.
+            // (non-empty content) OR completion marker OR durable
+            // _session_result fanout for assistant overflow / file delivery.
             let is_sse_producing = !msg.content.trim().is_empty()
                 || msg.metadata.get("_completion").is_some()
                 || msg.metadata.get("_session_result").is_some();
@@ -8405,19 +8159,12 @@ mod tests {
         tx.send(make_inbound("quick question")).await.unwrap();
 
         // Collect responses — should get 2 (both overflow and primary).
-        // Skip metadata-only outbounds (the user-message session_result
-        // emission added by the #616 fix carries routing metadata in
-        // `_session_result` but no body).
+        // Skip metadata-only outbounds (forced-background acks emit an
+        // empty content body alongside their _completion marker).
         let mut responses = Vec::new();
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
-            let is_user_session_result = msg
-                .metadata
-                .get("_session_result")
-                .and_then(|r| r.get("role"))
-                .and_then(|v| v.as_str())
-                == Some("user");
-            if !is_user_session_result {
+            if !msg.content.trim().is_empty() {
                 responses.push(msg.content);
             }
         }


### PR DESCRIPTION
## Why this is the FINAL PR

This is the final cleanup step in the M8.10 thread-by-cmid chat data model rollout (issue #627). PRs #1-#4 staged `thread_id` end-to-end and proved it under live e2e coverage. This PR deletes the now-obsolete `session_result` user-message event emissions on all three primary-turn paths (primary, speculative overflow, forced-background). `thread_id` is now the only routing key the web client needs for both ordering and routing.

### M8.10 PR series

| # | Repo | PR | Status |
|---|------|----|---|
| 1 | octos | #628 — thread_id persistence | merged |
| 2 | octos | #629 — thread_id on every SSE event + committed_seq on done | merged |
| 3 | octos-web | [octos-web#53](https://github.com/octos-org/octos-web/pull/53) — web thread store behind feature flag | merged |
| 4 | octos-web | [octos-web#54](https://github.com/octos-org/octos-web/pull/54) — threaded chat renderer with tool-retry collapse | merged |
| 4-companion | octos | #630 — e2e specs for thread interleave + tool-retry collapse | merged |
| 5 | octos | this PR | draft |
| 5 | octos-web | [octos-web#55](https://github.com/octos-org/octos-web/pull/55) | draft |

## DO NOT MERGE UNTIL BAKE COMPLETE

**DO NOT merge until PR #4's flag has been on across all production minis for at least 7 calendar days with zero ordering-related bug reports.** Operator merges manually after confirming healthy fleet operation with the flag enabled. The companion octos-web PR must be merged in lockstep with this one — they form a single conceptual change.

## Summary

- `crates/octos-cli/src/session_actor.rs`:
  - Delete the user-message `session_result` emission for the forced-background workflow path.
  - Delete the user-message `session_result` emission for the speculative overflow path.
  - Clean up the dead locals on the primary path.
  - Delete the inline test `should_emit_session_result_for_overflow_user_message` (the thread_id-based assertion in `should_emit_thread_id_on_every_event_for_speculative_overflow_pair` already covers the overflow routing contract).
- `crates/octos-cli/src/api/handlers.rs`:
  - Delete the `/api/chat` user-message `session_result` event emission. The streaming SSE response already carries `thread_id` (= `client_message_id`) on every event.
- `CLAUDE.md`:
  - New "Thread-by-cmid chat data model" subsection under "Session Management" describing the new model, the thread_id wire contract, and the surviving late-binding `_session_result` cases.

## What was preserved

The `_session_result` metadata is retained for assistant-side late-binding, with justifying inline comments on each call site:

1. **`deliver_background_notification`** — background notifications are emitted AFTER the originating turn's SSE stream has closed, so the durable `broadcast_session_event` fanout in `api_channel.rs` is the only delivery path.
2. **Overflow assistant reply** — same reason: the overflow's reply may land after the primary's `_completion` removes `pending[chat_id]`, so the durable watchers fanout via `_session_result` metadata is the only way the web sees it.
3. **`api_channel.rs` replay/file-delivery** — the SSE replay loop and file-delivery committed media events still emit `type: "session_result"` SSE events; the web side consumes them through the standard history-merge path indexed by `response_to_client_message_id`. No call-site changes needed.

## Acceptance grep checks

```bash
$ grep -n "session_result" crates/octos-cli/src/session_actor.rs
# Only the late-binding edge cases remain (deliver_background_notification + overflow assistant reply), each with a justifying comment.
```

## Test plan

- [x] `cargo build --workspace --release --features "octos-cli/api,octos-cli/telegram"` — clean
- [x] `cargo test -p octos-cli --features "octos-cli/api,octos-cli/telegram" --lib` — 659 passed, 0 failed
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Live e2e specs against a daemon built from this branch:
  - [ ] live-msg-order
  - [ ] live-realtime-status
  - [ ] live-tool-progress
  - [ ] live-file-delivery
  - [ ] live-thread-interleave
  - [ ] live-tool-retry-collapse

## Issue closures

This PR closes #627 (M8.10 tracking), #575 (obsoleted by the thread-store), and #618 (subsumed: tool retries now collapse natively in the thread store).

## Post-merge checklist

- [ ] Confirm `grep "session_result" crates/octos-cli/src/session_actor.rs` returns only the late-binding edge cases.
- [ ] Confirm the e2e suite is green on the next nightly run.
- [ ] Watch fleet metrics for `octos_session_replay_total{kind=committed_session_result}` and `octos_thread_id_missing_total` — both should stay at baseline.
- [ ] Close #627, #575, #618 once both PRs are merged.

Closes #627. Closes #575. Closes #618.