### PR TITLE
ops: register voice clones from voice_profiles on deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,11 @@
 #   ./scripts/deploy.sh admin@10.0.1.50 --key ~/.ssh/id_ed25519 --init
 #   ./scripts/deploy.sh user@host --password s3cret --clone-from 1
 #   ./scripts/deploy.sh user@host --remote-bin /opt/octos/bin --remote-data /opt/octos/data
+#
+# Post-restart phase auto-registers voice clones from each profile's
+# voice_profiles/ dir into ~/.OminiX/models/voices.json. See
+# scripts/register-fleet-voices.sh to run that step on its own when
+# you only need to refresh voices without redeploying.
 set -euo pipefail
 
 # --- Built-in targets ---
@@ -955,6 +960,59 @@ echo "  ominix-api plist generated"'"'"
 
     echo "==> Starting launchd service..."
     ssh_target "$i" "launchctl load ~/Library/LaunchAgents/${PLIST}.plist"
+
+    # Register voice clones from voice_profiles dirs into ominix-api.
+    # OminiX-API only loads voices from ~/.OminiX/models/voices.json at
+    # startup; voice .wav files saved by mofa-fm are not auto-discovered.
+    # Without this step, fm_tts pre-validation rejects every clone voice
+    # because /v1/voices doesn't list it. See
+    # scripts/register-fleet-voices.sh for the standalone version.
+    if [[ "$SKIP_OMINIX" == false ]]; then
+        echo "==> Registering voice clones with ominix-api..."
+        ssh_target "$i" 'bash -c '"'"'
+            mkdir -p ~/.OminiX/models
+            python3 << "PYEOF"
+import json, os, glob, sys
+home = os.path.expanduser("~")
+path = os.path.join(home, ".OminiX/models/voices.json")
+if os.path.exists(path):
+    try:
+        cfg = json.loads(open(path).read())
+        if not isinstance(cfg, dict):
+            cfg = {}
+    except Exception as e:
+        print(f"warning: voices.json malformed ({e}); rewriting", file=sys.stderr)
+        cfg = {}
+else:
+    cfg = {}
+voices = cfg.get("voices") if isinstance(cfg.get("voices"), dict) else {}
+added = []
+for wav in sorted(glob.glob(os.path.join(home, ".octos/profiles/*/data/voice_profiles/*.wav"))):
+    name = os.path.splitext(os.path.basename(wav))[0]
+    if name in voices:
+        continue
+    voices[name] = {
+        "ref_audio": wav,
+        "ref_text": "",
+        "aliases": [],
+        "speed_factor": 1.0,
+    }
+    added.append(name)
+cfg.setdefault("default_voice", "vivian")
+cfg.setdefault("models_base_path", "~/.OminiX/models")
+cfg["voices"] = voices
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+shown = added if added else "(none)"
+print(f"  voices.json: {len(voices)} custom entries (added: {shown})")
+PYEOF
+            # Bounce ominix-api so the new voices.json is picked up.
+            launchctl kickstart -k "gui/$(id -u)/io.ominix.ominix-api" 2>/dev/null || \
+                (launchctl unload ~/Library/LaunchAgents/io.ominix.ominix-api.plist 2>/dev/null; \
+                 sleep 1; \
+                 launchctl load ~/Library/LaunchAgents/io.ominix.ominix-api.plist 2>/dev/null) || true
+        '"'"
+    fi
 
     echo "==> Verifying..."
     sleep 2

--- a/scripts/register-fleet-voices.sh
+++ b/scripts/register-fleet-voices.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Register voice clones with ominix-api on each fleet host.
+#
+# OminiX-API's voice registry is in-memory at startup (loaded from
+# ~/.OminiX/models/voices.json). Voice .wav files saved by mofa-fm
+# under ~/.octos/profiles/<profile>/data/voice_profiles/ are NOT
+# auto-discovered by ominix-api; if voices.json is missing those
+# names, every clone request hits mofa-fm's pre-validation and fails
+# with "voice 'X' is not registered on ominix-api".
+#
+# This script writes voices.json on the remote host so /v1/voices
+# enumerates every saved voice profile, then nudges the daemon to
+# pick up the change. It's idempotent: existing entries are kept
+# (operators can hand-tune ref_text/aliases without losing them).
+#
+# Run as part of post-deploy by invoking ./scripts/deploy.sh, or
+# directly when fixing a single host:
+#
+#   ./scripts/register-fleet-voices.sh           # all minis (skips mini5)
+#   ./scripts/register-fleet-voices.sh 1         # mini1 only
+#   ./scripts/register-fleet-voices.sh user@host --password <pw>
+#
+# Mini5 is reserved for coding-green local testing — the script
+# refuses to touch it unless --force-mini5 is set.
+set -euo pipefail
+
+# --- Built-in targets (mirror deploy.sh) ---
+HOST_1="cloud@69.194.3.128"; PW_1="zjsgf128"
+HOST_2="cloud@69.194.3.129"; PW_2="vbasx129"
+HOST_3="cloud@69.194.3.203"; PW_3="b_KPfpN7Ge2ggxF-"
+HOST_4="cloud@69.194.3.66";  PW_4=""        # key auth
+HOST_5="cloud@69.194.3.19";  PW_5="zjsgf19"
+
+FORCE_MINI5=false
+TARGETS=()
+CUSTOM_PW=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --password) CUSTOM_PW="$2"; shift 2 ;;
+        --force-mini5) FORCE_MINI5=true; shift ;;
+        all)
+            TARGETS+=("1" "2" "3" "4")
+            shift ;;
+        1|2|3|4)
+            TARGETS+=("$1")
+            shift ;;
+        5)
+            if [[ "$FORCE_MINI5" == true ]]; then
+                TARGETS+=("5")
+            else
+                echo "ERROR: mini5 is reserved for coding-green; pass --force-mini5 to override" >&2
+                exit 2
+            fi
+            shift ;;
+        -h|--help)
+            awk '/^#!/{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+            exit 0 ;;
+        *)
+            # Treat as user@host
+            TARGETS+=("custom:$1")
+            shift ;;
+    esac
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+    TARGETS=("1" "2" "3" "4")
+fi
+
+# Remote script: scans voice_profiles dirs and merges into voices.json.
+# Idempotent — does not overwrite existing entries.
+REMOTE_SCRIPT='
+set -e
+mkdir -p ~/.OminiX/models
+python3 << "PYEOF"
+import json, os, glob, sys
+home = os.path.expanduser("~")
+path = os.path.join(home, ".OminiX/models/voices.json")
+if os.path.exists(path):
+    try:
+        cfg = json.loads(open(path).read())
+        if not isinstance(cfg, dict):
+            cfg = {}
+    except Exception as e:
+        print(f"warning: existing voices.json was malformed ({e}); rewriting", file=sys.stderr)
+        cfg = {}
+else:
+    cfg = {}
+voices = cfg.get("voices") if isinstance(cfg.get("voices"), dict) else {}
+added = []
+for wav in sorted(glob.glob(os.path.join(home, ".octos/profiles/*/data/voice_profiles/*.wav"))):
+    name = os.path.splitext(os.path.basename(wav))[0]
+    if name in voices:
+        # keep operator-tuned entries
+        continue
+    voices[name] = {
+        "ref_audio": wav,
+        "ref_text": "",
+        "aliases": [],
+        "speed_factor": 1.0,
+    }
+    added.append(name)
+cfg.setdefault("default_voice", "vivian")
+cfg.setdefault("models_base_path", "~/.OminiX/models")
+cfg["voices"] = voices
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+shown = added if added else "(none)"
+print(f"voices.json: {len(voices)} custom entries; added this run: {shown}")
+PYEOF
+
+# Nudge ominix-api so /v1/voices reflects the new file.
+# voices.json is loaded once at startup, so we need to bounce the
+# daemon. Kickstart -k restarts under launchd if the agent is loaded.
+if launchctl print "gui/$(id -u)/io.ominix.ominix-api" >/dev/null 2>&1; then
+    launchctl kickstart -k "gui/$(id -u)/io.ominix.ominix-api" 2>/dev/null || true
+elif launchctl list | grep -q io.ominix.ominix-api; then
+    launchctl unload ~/Library/LaunchAgents/io.ominix.ominix-api.plist 2>/dev/null || true
+    sleep 1
+    launchctl load ~/Library/LaunchAgents/io.ominix.ominix-api.plist 2>/dev/null || true
+fi
+
+# Wait for /v1/voices to come back (max 20s).
+for i in $(seq 1 20); do
+    sleep 1
+    body=$(curl -sf --max-time 2 http://localhost:8080/v1/voices 2>/dev/null || true)
+    if [ -n "$body" ]; then
+        echo "/v1/voices ready after ${i}s"
+        echo "$body" | python3 -c "import json, sys; d=json.load(sys.stdin); names=[v[\"name\"] for v in d[\"voices\"]]; print(\"  voices:\", \", \".join(names))"
+        exit 0
+    fi
+done
+echo "WARNING: ominix-api did not return /v1/voices within 20s" >&2
+exit 1
+'
+
+run_one() {
+    local label="$1" host="$2" pw="$3"
+    echo
+    echo "=== $label ($host) ==="
+    if [[ -n "$pw" ]]; then
+        sshpass -p "$pw" ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            -o PreferredAuthentications=password,keyboard-interactive \
+            "$host" "$REMOTE_SCRIPT"
+    else
+        ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+            "$host" "$REMOTE_SCRIPT"
+    fi
+}
+
+EXIT_CODE=0
+for t in "${TARGETS[@]}"; do
+    case "$t" in
+        custom:*)
+            host="${t#custom:}"
+            run_one "$host" "$host" "$CUSTOM_PW" || EXIT_CODE=$?
+            ;;
+        1) run_one "mini1" "$HOST_1" "$PW_1" || EXIT_CODE=$? ;;
+        2) run_one "mini2" "$HOST_2" "$PW_2" || EXIT_CODE=$? ;;
+        3) run_one "mini3" "$HOST_3" "$PW_3" || EXIT_CODE=$? ;;
+        4) run_one "mini4" "$HOST_4" "$PW_4" || EXIT_CODE=$? ;;
+        5) run_one "mini5" "$HOST_5" "$PW_5" || EXIT_CODE=$? ;;
+    esac
+done
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Closes the deploy-time gap that lets `~/.OminiX/models/voices.json` drift from each profile's `voice_profiles/*.wav` and breaks every `fm_tts(voice=<clone>)` call after an ominix-api restart.

- New `scripts/register-fleet-voices.sh` — idempotent walker that merges every host's saved voice profiles into `voices.json` and bounces `io.ominix.ominix-api` so the registry reloads. Built-in mini1/mini2/mini3/mini4 plus custom hosts; mini5 is gated behind `--force-mini5` (reserved for coding-green local testing).
- `scripts/deploy.sh` runs the same logic as a post-restart phase whenever `--skip-ominix` is not set.

Tracking issue #652 captures the durable fix (startup directory scan in ominix-api itself).

## Verification

- Ran `scripts/register-fleet-voices.sh 1`: yangmi + douwentao now appear in `/v1/voices` on mini1.
- mini2 same. mini3 picks up its 14 saved voices (yangmi included). mini4 has no profiles yet — script reports "(none)" and exits clean.
- mini5 untouched (no `voices.json`, default empty registry).
- Re-ran failing e2e: `live-browser.spec.ts:286 "short TTS success"` against `https://dspfac.crew.ominix.io` — passes (17.4s).

## Test plan

- [x] `bash -n scripts/deploy.sh && bash -n scripts/register-fleet-voices.sh`
- [x] `scripts/register-fleet-voices.sh 1` registers and verifies via `/v1/voices`
- [x] `live-browser.spec.ts` short-TTS spec passes on mini1
- [ ] Next deploy run on mini2-4 picks up new voices automatically (verified manually for now; deploy path will exercise on next release)

Tracking: M8.10 follow-up.