### PR TITLE
test: replay-harness for thread_id binding correctness on JSONL fixtures

### DIFF
--- a/crates/octos-bus/tests/fixtures/jsonl/README.md
+++ b/crates/octos-bus/tests/fixtures/jsonl/README.md
@@ -1,0 +1,71 @@
+# JSONL Replay Fixtures
+
+This directory holds session JSONL fixtures replayed by the
+`jsonl_replay_thread_binding` integration test in
+`crates/octos-bus/tests/jsonl_replay_thread_binding.rs`.
+
+The harness asserts the thread_id binding invariant on every record:
+
+> `assistant.thread_id == originating_user.client_message_id`
+
+for every assistant + tool record. Originating user is determined as:
+
+1. The user record whose `client_message_id` matches the
+   `response_to_client_message_id` field on the assistant/tool record,
+   when present and pointing at a known user cmid.
+2. Otherwise, the most recent user record before this record.
+
+## Current fixtures
+
+- `issue-649-three-user-overflow.jsonl` — INTENTIONALLY broken. Mirrors
+  the production session `web-1777402538752` from issue #649, where the
+  deep-research tool result and final assistant for the stock query were
+  tagged with `cmid-3` (voices) instead of `cmid-2` (stock). The test
+  asserts this fixture exposes at least three violations at specific
+  record indices.
+
+- `correct-three-user-overflow.jsonl` — Same shape with correct
+  thread_id bindings. The test asserts zero violations.
+
+## Importing a real production session as a fixture
+
+After issue #649 is fixed and a re-run captures a clean JSONL on a mini,
+run:
+
+```bash
+scripts/import-session-fixture.sh <mini-host> <remote-jsonl-path> <local-fixture-name>
+# e.g.
+scripts/import-session-fixture.sh mini3 \
+  /var/lib/octos/sessions/web-1777402538752.jsonl \
+  fixed-three-user-overflow.jsonl
+```
+
+The script copies the JSONL into this directory. To wire the new
+fixture into the regression suite, add a corresponding `#[test]` to
+`jsonl_replay_thread_binding.rs` that calls `check_jsonl` on it and
+asserts whichever expectation applies (zero violations for a fixed
+session, or specific violations for a captured regression).
+
+## Schema expected by the harness
+
+Each line is a JSON object with at least these fields:
+
+- `role` — `"user"`, `"assistant"`, `"tool"`, or `"system"`.
+- `content` — string body.
+- `thread_id` — string (may be empty for legacy records).
+- `timestamp` — RFC3339 UTC, used for human-friendly violation reports.
+- `client_message_id` — required on `user` records.
+- `response_to_client_message_id` — optional on `assistant`/`tool`
+  records. Where present, must point to a `client_message_id` of a
+  preceding user record; this lets the harness disambiguate which
+  user message the assistant is actually replying to when other user
+  messages have arrived in the meantime.
+
+## Privacy
+
+Production sessions may contain user content. Before committing a
+fixture that originated from a real session, scrub PII and replace
+`content` strings with synthetic placeholders. The harness only cares
+about `role`, `thread_id`, `client_message_id`, and
+`response_to_client_message_id` — so content can safely be redacted to
+short summaries.

--- a/crates/octos-bus/tests/fixtures/jsonl/correct-three-user-overflow.jsonl
+++ b/crates/octos-bus/tests/fixtures/jsonl/correct-three-user-overflow.jsonl
@@ -1,0 +1,8 @@
+{"role":"user","content":"slow research","client_message_id":"cmid-1","thread_id":"cmid-1","timestamp":"2026-04-29T05:55:36Z"}
+{"role":"assistant","content":"backgrounded","thread_id":"cmid-1","response_to_client_message_id":"cmid-1","timestamp":"2026-04-29T05:55:36Z"}
+{"role":"user","content":"stock query","client_message_id":"cmid-2","thread_id":"cmid-2","timestamp":"2026-04-29T05:55:50Z"}
+{"role":"user","content":"voices","client_message_id":"cmid-3","thread_id":"cmid-3","timestamp":"2026-04-29T05:55:55Z"}
+{"role":"assistant","content":"empty","thread_id":"cmid-3","response_to_client_message_id":"cmid-3","timestamp":"2026-04-29T05:55:56Z"}
+{"role":"assistant","content":"voices answer","thread_id":"cmid-3","response_to_client_message_id":"cmid-3","timestamp":"2026-04-29T05:56:03Z"}
+{"role":"tool","content":"deep research stock","thread_id":"cmid-2","response_to_client_message_id":"cmid-2","timestamp":"2026-04-29T05:56:03Z"}
+{"role":"assistant","content":"stock answer","thread_id":"cmid-2","response_to_client_message_id":"cmid-2","timestamp":"2026-04-29T05:56:14Z"}

--- a/crates/octos-bus/tests/fixtures/jsonl/issue-649-three-user-overflow.jsonl
+++ b/crates/octos-bus/tests/fixtures/jsonl/issue-649-three-user-overflow.jsonl
@@ -1,0 +1,8 @@
+{"role":"user","content":"slow research","client_message_id":"cmid-1","thread_id":"cmid-1","timestamp":"2026-04-29T05:55:36Z"}
+{"role":"assistant","content":"backgrounded","thread_id":"","response_to_client_message_id":"cmid-1","timestamp":"2026-04-29T05:55:36Z"}
+{"role":"user","content":"stock query","client_message_id":"cmid-2","thread_id":"cmid-2","timestamp":"2026-04-29T05:55:50Z"}
+{"role":"user","content":"voices","client_message_id":"cmid-3","thread_id":"cmid-3","timestamp":"2026-04-29T05:55:55Z"}
+{"role":"assistant","content":"empty","thread_id":"cmid-3","response_to_client_message_id":"cmid-3","timestamp":"2026-04-29T05:55:56Z"}
+{"role":"assistant","content":"voices answer","thread_id":"cmid-3","response_to_client_message_id":"cmid-3","timestamp":"2026-04-29T05:56:03Z"}
+{"role":"tool","content":"deep research stock","thread_id":"cmid-3","response_to_client_message_id":"cmid-2","timestamp":"2026-04-29T05:56:03Z"}
+{"role":"assistant","content":"stock answer","thread_id":"cmid-3","response_to_client_message_id":"cmid-2","timestamp":"2026-04-29T05:56:14Z"}

--- a/crates/octos-bus/tests/jsonl_replay_thread_binding.rs
+++ b/crates/octos-bus/tests/jsonl_replay_thread_binding.rs
@@ -1,0 +1,198 @@
+//! Replay harness for thread_id binding correctness on JSONL session fixtures.
+//!
+//! The invariant under test:
+//!   `assistant.thread_id == originating_user.client_message_id`
+//! for every assistant + tool record in a session JSONL.
+//!
+//! Originating user is determined as:
+//!   1. The user record whose `client_message_id` matches the
+//!      `response_to_client_message_id` field on the assistant/tool record,
+//!      when that field is present and non-empty.
+//!   2. Otherwise, the most recent user record before this record.
+//!
+//! Today's M8.10 fix cycle (#629 -> #635 -> #637 -> #649) repeatedly missed
+//! variations of the same bug class. The production JSONL had the answer all
+//! along: record #6+7 in session `web-1777402538752` were tagged with the
+//! wrong thread_id, but no test parsed the JSONL. This harness replays JSONL
+//! fixtures so the next regression is caught at `cargo test` time.
+//!
+//! See `tests/fixtures/jsonl/README.md` for how to import a real production
+//! session JSONL as a new regression fixture.
+//!
+//! Tracking: #649 (immediate bug), #654 (generative property tests umbrella).
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+#[derive(Debug)]
+#[allow(dead_code)] // fields are read via Debug formatting for test reports
+struct ThreadBindingViolation {
+    record_index: usize,
+    role: String,
+    timestamp: String,
+    expected_thread_id: String,
+    actual_thread_id: String,
+    response_to_client_message_id: Option<String>,
+    content_preview: String,
+}
+
+/// Parse a JSONL fixture and return every record that violates the
+/// thread_id binding invariant.
+fn check_jsonl(path: &Path) -> Vec<ThreadBindingViolation> {
+    let body = fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("fixture {} should exist: {}", path.display(), e));
+    let records: Vec<Value> = body
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str(l).unwrap_or_else(|e| {
+                panic!("invalid JSON in {}: {} -- line: {}", path.display(), e, l)
+            })
+        })
+        .collect();
+
+    // First pass: collect every user-cmid we know about so we can validate
+    // that response_to_client_message_id targets a real user record.
+    let known_user_cmids: HashSet<String> = records
+        .iter()
+        .filter(|r| r["role"].as_str() == Some("user"))
+        .filter_map(|r| r["client_message_id"].as_str().map(|s| s.to_string()))
+        .collect();
+
+    let mut violations = Vec::new();
+    let mut current_user_cmid: Option<String> = None;
+
+    for (i, r) in records.iter().enumerate() {
+        let role = r["role"].as_str().unwrap_or("");
+        let actual_tid = r["thread_id"].as_str().unwrap_or("").to_string();
+        let timestamp = r["timestamp"].as_str().unwrap_or("").to_string();
+        let content_preview: String = r["content"]
+            .as_str()
+            .unwrap_or("")
+            .chars()
+            .take(60)
+            .collect();
+        let rtcmid = r["response_to_client_message_id"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        match role {
+            "user" => {
+                if let Some(cmid) = r["client_message_id"].as_str() {
+                    current_user_cmid = Some(cmid.to_string());
+                    // User records: thread_id should equal their own cmid.
+                    if actual_tid != cmid {
+                        violations.push(ThreadBindingViolation {
+                            record_index: i,
+                            role: role.to_string(),
+                            timestamp,
+                            expected_thread_id: cmid.to_string(),
+                            actual_thread_id: actual_tid,
+                            response_to_client_message_id: rtcmid,
+                            content_preview,
+                        });
+                    }
+                }
+            }
+            "assistant" | "tool" => {
+                // Prefer explicit response_to_client_message_id when it
+                // points at a known user. Otherwise fall back to the most
+                // recent user cmid in the stream.
+                let expected = rtcmid
+                    .clone()
+                    .filter(|c| known_user_cmids.contains(c))
+                    .or_else(|| current_user_cmid.clone());
+
+                if let Some(expected) = expected {
+                    if actual_tid != expected {
+                        violations.push(ThreadBindingViolation {
+                            record_index: i,
+                            role: role.to_string(),
+                            timestamp,
+                            expected_thread_id: expected,
+                            actual_thread_id: actual_tid,
+                            response_to_client_message_id: rtcmid,
+                            content_preview,
+                        });
+                    }
+                }
+            }
+            // System / other roles are not subject to the invariant.
+            _ => {}
+        }
+    }
+
+    violations
+}
+
+fn fixture_path(name: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/jsonl")
+        .join(name)
+}
+
+#[test]
+fn issue_649_fixture_violates_invariant_until_fixed() {
+    let path = fixture_path("issue-649-three-user-overflow.jsonl");
+    let violations = check_jsonl(&path);
+
+    assert!(
+        !violations.is_empty(),
+        "Issue #649 fixture should expose at least one thread_id binding violation"
+    );
+
+    eprintln!(
+        "Issue #649 fixture surfaced {} violation(s):",
+        violations.len()
+    );
+    for v in &violations {
+        eprintln!("  {:?}", v);
+    }
+
+    // Three known production violations the fixture mirrors:
+    //   record 1: assistant for slow-research has empty thread_id
+    //   record 6: deep-research tool result tagged cmid-3 instead of cmid-2
+    //   record 7: stock answer assistant tagged cmid-3 instead of cmid-2
+    assert!(
+        violations.len() >= 3,
+        "Expected at least 3 violations from issue-649 fixture, got {}: {:?}",
+        violations.len(),
+        violations
+    );
+
+    let by_index: std::collections::HashMap<usize, &ThreadBindingViolation> =
+        violations.iter().map(|v| (v.record_index, v)).collect();
+
+    let v1 = by_index
+        .get(&1)
+        .expect("record 1 (assistant for slow-research) should be flagged");
+    assert_eq!(v1.expected_thread_id, "cmid-1");
+    assert_eq!(v1.actual_thread_id, "");
+
+    let v6 = by_index
+        .get(&6)
+        .expect("record 6 (deep-research tool) should be flagged");
+    assert_eq!(v6.expected_thread_id, "cmid-2");
+    assert_eq!(v6.actual_thread_id, "cmid-3");
+
+    let v7 = by_index
+        .get(&7)
+        .expect("record 7 (stock answer) should be flagged");
+    assert_eq!(v7.expected_thread_id, "cmid-2");
+    assert_eq!(v7.actual_thread_id, "cmid-3");
+}
+
+#[test]
+fn correct_three_user_overflow_passes() {
+    let path = fixture_path("correct-three-user-overflow.jsonl");
+    let violations = check_jsonl(&path);
+    assert!(
+        violations.is_empty(),
+        "Correct fixture should have zero thread_id binding violations, got: {:?}",
+        violations
+    );
+}

--- a/scripts/import-session-fixture.sh
+++ b/scripts/import-session-fixture.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Import a production session JSONL as a regression fixture for the
+# `jsonl_replay_thread_binding` harness.
+#
+# Usage:
+#   scripts/import-session-fixture.sh <mini-host> <remote-jsonl-path> <local-fixture-name>
+#
+# Example:
+#   scripts/import-session-fixture.sh mini3 \
+#     /var/lib/octos/sessions/web-1777402538752.jsonl \
+#     fixed-three-user-overflow.jsonl
+#
+# The fixture lands in:
+#   crates/octos-bus/tests/fixtures/jsonl/<local-fixture-name>
+#
+# After import, scrub PII from `content` fields if needed, and add a
+# corresponding `#[test]` to crates/octos-bus/tests/jsonl_replay_thread_binding.rs
+# wiring the fixture into the regression suite.
+
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <mini-host> <remote-jsonl-path> <local-fixture-name>" >&2
+  exit 2
+fi
+
+REMOTE_HOST="$1"
+REMOTE_PATH="$2"
+LOCAL_NAME="$3"
+
+# Resolve the fixtures directory relative to the repo root, regardless of
+# where the script is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIXTURES_DIR="${REPO_ROOT}/crates/octos-bus/tests/fixtures/jsonl"
+
+if [[ ! -d "${FIXTURES_DIR}" ]]; then
+  echo "fixtures dir not found: ${FIXTURES_DIR}" >&2
+  exit 1
+fi
+
+# Reject path traversal and odd filenames; we only allow plain
+# alphanumeric / dash / underscore / dot fixture names ending in .jsonl.
+if [[ ! "${LOCAL_NAME}" =~ ^[A-Za-z0-9._-]+\.jsonl$ ]]; then
+  echo "local-fixture-name must match [A-Za-z0-9._-]+\\.jsonl, got: ${LOCAL_NAME}" >&2
+  exit 1
+fi
+
+DEST="${FIXTURES_DIR}/${LOCAL_NAME}"
+
+echo "Importing ${REMOTE_HOST}:${REMOTE_PATH}"
+echo "       -> ${DEST}"
+
+# scp -p preserves modification times so we have a record of when the
+# session was captured on the production host.
+scp -p "${REMOTE_HOST}:${REMOTE_PATH}" "${DEST}"
+
+# Sanity-check: each line should parse as JSON and have a `role` field.
+python3 - "${DEST}" <<'PY'
+import json, sys
+path = sys.argv[1]
+n = 0
+with open(path, "r", encoding="utf-8") as f:
+    for i, line in enumerate(f, 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError as e:
+            sys.exit(f"line {i}: invalid JSON: {e}")
+        if "role" not in r:
+            sys.exit(f"line {i}: missing 'role'")
+        n += 1
+print(f"ok: {n} records parsed")
+PY
+
+cat <<EOF
+
+Imported. Next steps:
+  1. Scrub PII from \`content\` fields if needed (the harness only reads
+     role, thread_id, client_message_id, response_to_client_message_id).
+  2. Add a #[test] in crates/octos-bus/tests/jsonl_replay_thread_binding.rs
+     that calls check_jsonl on this fixture and asserts the expectation.
+  3. Run: cargo test -p octos-bus --test jsonl_replay_thread_binding
+EOF


### PR DESCRIPTION
## Summary

- New integration test `crates/octos-bus/tests/jsonl_replay_thread_binding.rs` parses session JSONL fixtures and asserts the invariant `assistant.thread_id == originating_user.client_message_id` on every assistant + tool record. Originating user is the record matched by `response_to_client_message_id` when present, else the most recent prior user message.
- Two hand-written fixtures: `issue-649-three-user-overflow.jsonl` (intentionally broken, mirrors session `web-1777402538752`) and `correct-three-user-overflow.jsonl` (correct shape). The test asserts the broken fixture surfaces three specific violations at record indices 1, 6, 7 with concrete expected vs actual thread_ids; the correct fixture is asserted clean.
- `scripts/import-session-fixture.sh` copies a session JSONL off a remote mini into the fixtures dir and validates JSON well-formedness, so future production JSONLs (including the post-#649 fix capture from mini3) can become regression fixtures with one command.
- `crates/octos-bus/tests/fixtures/jsonl/README.md` documents the schema, current fixtures, the import flow, and PII scrubbing guidance.

Today's M8.10 cycle (#629 -> #635 -> #637 -> #649) repeatedly missed variations of the same bug class. The production JSONL had the answer all along; no test was parsing it. This harness fills that gap and gives us a place to drop captured sessions as new regression fixtures going forward.

## Test plan

- [x] `cargo test -p octos-bus --test jsonl_replay_thread_binding` passes (2 tests).
- [x] `cargo clippy -p octos-bus --tests --no-deps` clean.
- [x] `cargo fmt -p octos-bus -- --check` clean.
- [x] `bash -n scripts/import-session-fixture.sh` clean; running with no args prints usage.
- [ ] After #649 lands, capture a re-run JSONL on mini3 with `scripts/import-session-fixture.sh` and add it as a third "passes" fixture.

Refs: #649, #654.