### PR TITLE
e2e/stress: catch thread_id binding bugs under realistic 3-5 user overflow

### DIFF
--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -1107,7 +1107,10 @@ mod tests {
         let state = smtp_state(dir.path());
         let Json(body) = get_deployment_mode(State(state)).await.unwrap();
         assert_eq!(body.mode, "local");
-        assert!(!body.explicit, "implicit default must report explicit=false");
+        assert!(
+            !body.explicit,
+            "implicit default must report explicit=false"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -305,7 +305,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // First-run setup wizard
         .route("/api/admin/token/status", get(admin_setup::token_status))
         .route("/api/admin/token/rotate", post(admin_setup::rotate_token))
-        .route("/api/admin/token/email", post(admin_setup::post_token_email))
+        .route(
+            "/api/admin/token/email",
+            post(admin_setup::post_token_email),
+        )
         .route("/api/admin/setup/state", get(admin_setup::get_setup_state))
         .route("/api/admin/setup/step", post(admin_setup::post_setup_step))
         .route(

--- a/e2e/tests/live-mofa-full-flow.spec.ts
+++ b/e2e/tests/live-mofa-full-flow.spec.ts
@@ -1,0 +1,385 @@
+/**
+ * MoFA full-flow live e2e: install → exercise → remove.
+ *
+ * Walks through the complete lifecycle of MoFA skills against a live
+ * dashboard:
+ *
+ *   1. Login + navigate to the profile's skill page.
+ *   2. Install the `mofa-cli` skill (and any siblings) for the profile.
+ *      If the skill is already installed, remove it first to force a
+ *      fresh install path.
+ *   3. Open a fresh chat session with the v2 thread-store flag on.
+ *   4. Exercise every MoFA-related feature in succession, collecting
+ *      proof-of-delivery from the DOM:
+ *        a. Builtin-voice TTS (vivian)            — fast, ~10s
+ *        b. Cloned-voice TTS (yangmi)             — fast, ~15s, requires
+ *           a registered voice clone in OminiX
+ *        c. MoFA podcast (research_podcast)       — slow, 3-5 min
+ *        d. MoFA slide deck (slides_delivery)     — slow, 3-5 min
+ *        e. MoFA site preview                     — slow, 3-5 min
+ *      Each step asserts the assistant bubble paired with the user
+ *      message contains an expected artifact marker.
+ *   5. Navigate back to the skill page and remove the skill. Verify
+ *      it's gone from the DOM.
+ *
+ * Required env:
+ *   OCTOS_TEST_URL=https://dspfac.crew.ominix.io
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026
+ *   OCTOS_PROFILE=dspfac
+ *
+ * Optional env:
+ *   OCTOS_MOFA_INSTALL_SOURCE  default: mofa-org/mofa-skills/mofa-cli
+ *   OCTOS_MOFA_SKILL_NAME      default: mofa-cli
+ *   OCTOS_MOFA_BUILTIN_VOICE   default: vivian
+ *   OCTOS_MOFA_CLONED_VOICE    default: yangmi
+ *   OCTOS_MOFA_SKIP_INSTALL=1  reuse an already-installed skill
+ *   OCTOS_MOFA_SKIP_REMOVE=1   leave skill installed for later runs
+ *
+ * NEVER point at mini5 — that host is reserved for coding-green.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+
+const AUTH_TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
+const PROFILE_ID = process.env.OCTOS_PROFILE || 'dspfac';
+const INSTALL_SOURCE =
+  process.env.OCTOS_MOFA_INSTALL_SOURCE || 'mofa-org/mofa-skills/mofa-cli';
+const SKILL_NAME = process.env.OCTOS_MOFA_SKILL_NAME || 'mofa-cli';
+const BUILTIN_VOICE = process.env.OCTOS_MOFA_BUILTIN_VOICE || 'vivian';
+const CLONED_VOICE = process.env.OCTOS_MOFA_CLONED_VOICE || 'yangmi';
+const SKIP_INSTALL = process.env.OCTOS_MOFA_SKIP_INSTALL === '1';
+const SKIP_REMOVE = process.env.OCTOS_MOFA_SKIP_REMOVE === '1';
+
+const FLAG_KEY = 'octos_thread_store_v2';
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function skillNameLocator(page: Page, skillName: string) {
+  return page.getByText(new RegExp(`^${escapeRegExp(skillName)}$`)).first();
+}
+
+function removeButtonForSkill(page: Page, skillName: string) {
+  return page
+    .locator('div.flex.items-center.justify-between')
+    .filter({ has: skillNameLocator(page, skillName) })
+    .getByRole('button', { name: /Remove|Removing/i })
+    .first();
+}
+
+async function loginToDashboard(page: Page) {
+  await page.addInitScript(
+    ({ token, profile, flagKey }) => {
+      localStorage.setItem('octos_session_token', token);
+      localStorage.setItem('octos_auth_token', token);
+      localStorage.setItem('selected_profile', profile);
+      localStorage.setItem(flagKey, '1');
+    },
+    { token: AUTH_TOKEN, profile: PROFILE_ID, flagKey: FLAG_KEY },
+  );
+
+  await page.goto(`/admin/profile/${PROFILE_ID}/skills`, {
+    waitUntil: 'networkidle',
+  });
+
+  if (page.url().includes('/admin/login') || page.url().includes('/login')) {
+    const tokenTab = page.getByRole('button', {
+      name: /Login with admin token/i,
+    });
+    if (await tokenTab.isVisible().catch(() => false)) {
+      await tokenTab.click();
+    }
+    await page.getByLabel('Admin token').fill(AUTH_TOKEN);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForURL(/\/admin(\/|$)/, { timeout: 20_000 });
+    await page.goto(`/admin/profile/${PROFILE_ID}/skills`, {
+      waitUntil: 'networkidle',
+    });
+  }
+
+  await expect(
+    page.getByRole('heading', { name: 'Skills', exact: true }),
+  ).toBeVisible({ timeout: 20_000 });
+}
+
+async function removeSkillIfPresent(
+  page: Page,
+  skillName: string,
+): Promise<boolean> {
+  const skill = skillNameLocator(page, skillName);
+  const present = await skill.isVisible().catch(() => false);
+  if (!present) return false;
+
+  const deleteResponse = page.waitForResponse(
+    (resp) =>
+      resp.request().method() === 'DELETE' &&
+      resp.url().includes(`/api/admin/profiles/${PROFILE_ID}/skills/${skillName}`),
+    { timeout: 180_000 },
+  );
+
+  page.once('dialog', (dialog) => dialog.accept());
+  await removeButtonForSkill(page, skillName).click();
+
+  const resp = await deleteResponse;
+  expect(resp.ok()).toBeTruthy();
+  await expect(skill).toHaveCount(0, { timeout: 30_000 });
+  return true;
+}
+
+async function installSkillFresh(page: Page) {
+  // Force a fresh install: if the skill is already installed, remove
+  // first so the install path is the same as a brand-new profile.
+  const wasPreinstalled = await removeSkillIfPresent(page, SKILL_NAME);
+  console.log(`mofa-flow: preinstalled_removed=${wasPreinstalled}`);
+
+  const sourceInput = page.getByPlaceholder(
+    /octos-org\/system-skills, https:\/\/host\/org\/repo\.git, or \.\/skills\/my-skill/i,
+  );
+  await sourceInput.fill(INSTALL_SOURCE);
+
+  const installResponse = page.waitForResponse(
+    (resp) =>
+      resp.request().method() === 'POST' &&
+      resp.url().includes(`/api/admin/profiles/${PROFILE_ID}/skills`),
+    { timeout: 300_000 },
+  );
+
+  await page.getByRole('button', { name: 'Install' }).click();
+  const installResp = await installResponse;
+  expect(installResp.ok()).toBeTruthy();
+
+  const installJson = await installResp.json();
+  console.log(`mofa-flow: install_response=${JSON.stringify(installJson)}`);
+  expect(Array.isArray(installJson.installed)).toBeTruthy();
+  expect(installJson.installed).toContain(SKILL_NAME);
+
+  await expect(
+    page.locator('span').filter({ hasText: /^Error:/ }),
+  ).toHaveCount(0, { timeout: 5_000 });
+
+  await expect(skillNameLocator(page, SKILL_NAME)).toBeVisible({
+    timeout: 180_000,
+  });
+}
+
+interface FeatureStep {
+  name: string;
+  prompt: string;
+  expected_markers: string[];
+  // Per-step wait window for the assistant to finalise. Slow MoFA
+  // operations (podcast / slides / sites) can take several minutes;
+  // fast TTS settles in under a minute.
+  timeout_ms: number;
+}
+
+const FEATURES: FeatureStep[] = [
+  {
+    name: 'tts-builtin',
+    prompt: `用 ${BUILTIN_VOICE} 说一段：今天是个好日子，让我们开始吧`,
+    expected_markers: [
+      BUILTIN_VOICE,
+      'audio',
+      '.wav',
+      '.mp3',
+      '语音',
+      '好日子',
+    ],
+    timeout_ms: 90_000,
+  },
+  {
+    name: 'tts-cloned',
+    prompt: `用 ${CLONED_VOICE} 念这段：我是你的数字助理`,
+    expected_markers: [
+      CLONED_VOICE,
+      'audio',
+      '.wav',
+      '.mp3',
+      '数字',
+      '助理',
+    ],
+    timeout_ms: 120_000,
+  },
+  {
+    name: 'mofa-podcast',
+    prompt: '生成一个关于AI智能体平台的FM播客 (research_podcast)',
+    expected_markers: [
+      'podcast',
+      '播客',
+      'episode',
+      'audio',
+      '.mp3',
+      '智能体',
+    ],
+    timeout_ms: 600_000,
+  },
+  {
+    name: 'mofa-slides',
+    prompt: '生成一个关于 AI 智能体技术发展的幻灯片 (mofa slides, full deck)',
+    expected_markers: [
+      'slides',
+      '幻灯片',
+      '.pptx',
+      'deck',
+      'pptx',
+      'slide',
+    ],
+    timeout_ms: 600_000,
+  },
+  {
+    name: 'mofa-sites',
+    prompt: '生成一个产品介绍网站 (mofa sites, full site preview)',
+    expected_markers: [
+      'site',
+      '网站',
+      'preview',
+      'preview/',
+      '.html',
+      'index',
+    ],
+    timeout_ms: 600_000,
+  },
+];
+
+async function waitForAssistantText(
+  page: Page,
+  expectedAssistantCount: number,
+  maxWaitMs: number,
+  label: string,
+): Promise<string> {
+  const start = Date.now();
+  let lastFilled = 0;
+  let stable = 0;
+  while (Date.now() - start < maxWaitMs) {
+    const isStreaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible()
+      .catch(() => false);
+    const filled = await page.evaluate((sel) => {
+      const bubbles = document.querySelectorAll(sel);
+      return Array.from(bubbles).filter((el) => {
+        const text = ((el as HTMLElement).innerText || '').trim();
+        return text.length > 1;
+      }).length;
+    }, SEL.assistantMessage);
+
+    if (filled >= expectedAssistantCount && !isStreaming) {
+      stable += 1;
+      if (stable >= 2) {
+        const lastText = await page.evaluate((sel) => {
+          const bubbles = document.querySelectorAll(sel);
+          if (!bubbles.length) return '';
+          const last = bubbles[bubbles.length - 1] as HTMLElement;
+          return (last.innerText || '').trim();
+        }, SEL.assistantMessage);
+        return lastText;
+      }
+    } else {
+      stable = 0;
+    }
+
+    if (filled !== lastFilled) {
+      const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+      console.log(
+        `  [${label}] ${elapsed}s: filled=${filled}/${expectedAssistantCount} streaming=${isStreaming}`,
+      );
+      lastFilled = filled;
+    }
+    await page.waitForTimeout(3_000);
+  }
+  return '';
+}
+
+test.describe('MoFA full-flow: install → exercise → remove', () => {
+  test.setTimeout(2_400_000); // 40 min — install + 5 features (~5 min slow ops × 3) + remove
+
+  test('install mofa skill, exercise all features, then remove', async ({
+    page,
+  }) => {
+    // -- Phase 1: dashboard login + install ----------------------------
+    await loginToDashboard(page);
+
+    if (!SKIP_INSTALL) {
+      await installSkillFresh(page);
+    } else {
+      console.log('mofa-flow: SKIP_INSTALL=1, expecting skill already present');
+      await expect(skillNameLocator(page, SKILL_NAME)).toBeVisible({
+        timeout: 30_000,
+      });
+    }
+
+    // -- Phase 2: switch to chat, run every MoFA feature ---------------
+    await login(page); // ensures /chat is open with the right session/profile
+    await createNewSession(page);
+
+    const failures: string[] = [];
+
+    for (let i = 0; i < FEATURES.length; i++) {
+      const step = FEATURES[i];
+      const userBefore = await countUserBubbles(page);
+      const assistantBefore = await countAssistantBubbles(page);
+
+      await getInput(page).fill(step.prompt);
+      await getSendButton(page).click();
+      await expect
+        .poll(() => countUserBubbles(page), { timeout: 30_000 })
+        .toBe(userBefore + 1);
+      console.log(`mofa-flow: sent "${step.name}" prompt`);
+
+      const lastText = await waitForAssistantText(
+        page,
+        assistantBefore + 1,
+        step.timeout_ms,
+        step.name,
+      );
+
+      const lower = lastText.toLowerCase();
+      const matched = step.expected_markers.some((m) =>
+        lower.includes(m.toLowerCase()),
+      );
+      if (!matched) {
+        failures.push(
+          `${step.name}: assistant text did not contain any expected marker [${step.expected_markers.join(', ')}]. Got "${lastText.slice(0, 200)}"`,
+        );
+        console.log(`mofa-flow: FAIL ${step.name} — text="${lastText.slice(0, 120)}"`);
+      } else {
+        console.log(`mofa-flow: OK ${step.name}`);
+      }
+    }
+
+    // -- Phase 3: remove the skill -------------------------------------
+    if (!SKIP_REMOVE) {
+      await page.goto(`/admin/profile/${PROFILE_ID}/skills`, {
+        waitUntil: 'networkidle',
+      });
+      await expect(skillNameLocator(page, SKILL_NAME)).toBeVisible({
+        timeout: 30_000,
+      });
+      const removed = await removeSkillIfPresent(page, SKILL_NAME);
+      expect(
+        removed,
+        `Expected skill "${SKILL_NAME}" to be present and removable`,
+      ).toBeTruthy();
+      console.log(`mofa-flow: skill removed`);
+    } else {
+      console.log('mofa-flow: SKIP_REMOVE=1, leaving skill installed');
+    }
+
+    // Surface any feature failures last so the install/remove gates the
+    // skill state cleanly even when one feature regresses.
+    expect(
+      failures,
+      `MoFA feature failures:\n  - ${failures.join('\n  - ')}`,
+    ).toEqual([]);
+  });
+});

--- a/e2e/tests/live-overflow-stress.spec.ts
+++ b/e2e/tests/live-overflow-stress.spec.ts
@@ -198,6 +198,51 @@ const SCENARIOS: Scenario[] = [
     timeout_ms: 720_000,
   },
   {
+    // Heavy soaking test focused on MoFA deliverable artifacts: a
+    // generated slide deck, a generated website preview, and an FM
+    // podcast — the three slowest spawn_only flows in the platform.
+    // Each takes ~3-8 min to finalise. Two simple questions interleaved
+    // keep the sticky-map rotating during the long settle window.
+    //
+    // Catches binding races where the delivered artifact (a .pptx, a
+    // /preview/* HTML page, an .mp3) attaches to the wrong user
+    // bubble — this is the failure mode users notice first because the
+    // artifact is visibly mis-paired in the chat history.
+    name: 'mofa-deliverables-soak',
+    messages: [
+      {
+        gap_ms: 0,
+        text: '生成一个关于 AI 智能体技术发展的幻灯片 (mofa slides, full deck)',
+        expected_in_response: [
+          'slides', '幻灯片', '.pptx', 'deck', 'slide', 'pptx',
+        ],
+      },
+      {
+        gap_ms: 8000,
+        text: '生成一个产品介绍网站 (mofa sites, full site preview)',
+        expected_in_response: [
+          'site', 'preview', '网站', 'preview/', '.html', 'index',
+        ],
+      },
+      {
+        gap_ms: 4000,
+        text: '1+1 = ?',
+        expected_in_response: ['2', '两', '二'],
+      },
+      {
+        gap_ms: 5000,
+        text: '做一个关于AI发展的FM播客 (mofa podcast)',
+        expected_in_response: ['podcast', 'audio', '.mp3', 'episode', '播客'],
+      },
+      {
+        gap_ms: 4000,
+        text: '今天日期是？',
+        expected_in_response: ['2026', 'date', '日期', '月', 'april'],
+      },
+    ],
+    timeout_ms: 900_000,
+  },
+  {
     // Normal-paced 10-message session (30s gaps). Catches sticky-map
     // staleness that only surfaces after the cache has rotated many
     // times; each turn is well-separated so any drift across turns

--- a/e2e/tests/live-overflow-stress.spec.ts
+++ b/e2e/tests/live-overflow-stress.spec.ts
@@ -14,6 +14,13 @@
  * sticky map; a 10-message normal-pacing session catches stale-state
  * accumulation that only shows up after the cache warms.
  *
+ * The `media-mix-soak-five-skills` scenario is the canonical soaking
+ * test — 5 different spawn_only skills (builtin-voice TTS, cloned-voice
+ * TTS, news-digest + TTS, deep research, FM podcast) all running in
+ * parallel. Each finalises asynchronously, putting sustained pressure
+ * on the sticky-map. This mirrors the realistic "user opens the app
+ * and tries many features at once" load.
+ *
  * Each scenario sends multiple messages within a short window, waits for
  * all responses to land, then verifies that the assistant response BELOW
  * each user bubble in DOM order matches the prompt by content.
@@ -144,6 +151,51 @@ const SCENARIOS: Scenario[] = [
       },
     ],
     timeout_ms: 480_000,
+  },
+  {
+    // Soaking test: 5 different media-producing skills running in
+    // parallel. Each is spawn_only and finalises asynchronously,
+    // putting sustained pressure on the sticky-map across multiple
+    // thread rotations for the duration of the slowest tool
+    // (typically deep_research at 3-5 min). Mirrors the canonical
+    // "real user trying many features at once" load — builtin-voice
+    // TTS, cloned-voice TTS, news-digest + TTS, deep research, and
+    // an FM-style podcast.
+    //
+    // Pre-#649: at least one bubble orphans because late-arriving
+    // spawn_only results collide with the rotated sticky-map.
+    // Post-fix: all five thread_ids are stamped at spawn time, so
+    // late finalises bind correctly regardless of which slot the
+    // sticky-map currently holds.
+    name: 'media-mix-soak-five-skills',
+    messages: [
+      {
+        gap_ms: 0,
+        text: '用 vivian 说一段：今天是个好日子，让我们开始吧',
+        expected_in_response: ['vivian', 'audio', '.wav', '.mp3', '语音', '好日子'],
+      },
+      {
+        gap_ms: 8000,
+        text: '用 yangmi 念这段：我是你的数字助理',
+        expected_in_response: ['yangmi', 'audio', '.wav', '.mp3', '数字', '助理'],
+      },
+      {
+        gap_ms: 6000,
+        text: '总结一下今日科技新闻并用 vivian 朗读 (news digest + tts)',
+        expected_in_response: ['news', '新闻', 'tech', '科技', 'audio', '.mp3'],
+      },
+      {
+        gap_ms: 5000,
+        text: '深度搜索今日Rust语言进展 (deep search)',
+        expected_in_response: ['rust', 'research', 'language', '语言', 'news'],
+      },
+      {
+        gap_ms: 5000,
+        text: '做一个关于AI智能体平台的FM播客 (mofa podcast)',
+        expected_in_response: ['podcast', 'audio', '.mp3', 'episode', '播客', '智能体'],
+      },
+    ],
+    timeout_ms: 720_000,
   },
   {
     // Normal-paced 10-message session (30s gaps). Catches sticky-map
@@ -336,10 +388,11 @@ function assertPairing(
 }
 
 test.describe('M8.10 stress: thread_id binding under realistic 3-10 user overflow', () => {
-  // 900_000 (15 min) covers the longest scenario: long-session-ten-messages
-  // sends 10 msgs with 30s gaps (= 270s send time) plus a settle window for
-  // the last response, plus playwright fixture overhead.
-  test.setTimeout(900_000);
+  // 1_200_000 (20 min) covers the longest scenario:
+  // media-mix-soak-five-skills runs 5 spawn_only skills in parallel and
+  // waits for the slowest (deep_research / podcast) to finalise — typically
+  // 5-12 min wall, plus playwright fixture overhead and the 24s send window.
+  test.setTimeout(1_200_000);
 
   for (const scenario of SCENARIOS) {
     test(`stress scenario: ${scenario.name}`, async ({ page }) => {

--- a/e2e/tests/live-overflow-stress.spec.ts
+++ b/e2e/tests/live-overflow-stress.spec.ts
@@ -1,0 +1,336 @@
+/**
+ * M8.10 stress test: thread_id binding under realistic 3-5 user overflow.
+ *
+ * Existing live-thread-interleave.spec.ts only sends 2 messages with a
+ * fixed 1.5s gap. Real users (issue #649) send 3-5 messages with random
+ * gaps and at least one slow tool. The narrow scope kept letting
+ * variations of the thread_id binding bug ship to production
+ * (#629 -> #635 -> #637 -> #649).
+ *
+ * Each scenario sends multiple messages within a short window, waits for
+ * all responses to land, then verifies that the assistant response BELOW
+ * each user bubble in DOM order matches the prompt by content.
+ *
+ * Required env:
+ *   OCTOS_TEST_URL=https://dspfac.octos.ominix.io   (mini3, pre-#649)
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026
+ *   OCTOS_PROFILE=dspfac
+ *
+ * Behind the same v2 flag as live-thread-interleave: the new thread-by-cmid
+ * renderer is gated by `localStorage.octos_thread_store_v2 = '1'`.
+ *
+ * NEVER point at mini5 — that host is reserved for coding-green tests.
+ *
+ * EXPECTED behavior:
+ *   - On daemons without #649 fix: at least one scenario (typically
+ *     `slow-research-then-fast-questions`) FAILS, because a late-arriving
+ *     slow tool result gets bound to the wrong thread.
+ *   - After #649 deploys: all scenarios PASS. This becomes a regression
+ *     check for the entire 3-5 user overflow class.
+ *
+ * Tracking: M8.10 follow-up issue #654 (generative property tests).
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+
+const FLAG_KEY = 'octos_thread_store_v2';
+
+interface ScenarioMessage {
+  gap_ms: number;
+  text: string;
+  expected_in_response: string[];
+}
+
+interface Scenario {
+  name: string;
+  messages: ScenarioMessage[];
+  timeout_ms: number;
+}
+
+const SCENARIOS: Scenario[] = [
+  {
+    name: 'slow-research-then-fast-questions',
+    messages: [
+      {
+        gap_ms: 0,
+        text:
+          'Use deep research to find latest Rust news. Run pipeline directly. One paragraph.',
+        expected_in_response: ['rust', 'research', 'language', 'news'],
+      },
+      {
+        gap_ms: 5000,
+        text: 'What is 1 + 1?',
+        expected_in_response: ['2', '两', '二'],
+      },
+      {
+        gap_ms: 4000,
+        text: '你有哪些内置语音',
+        expected_in_response: ['vivian', 'serena', 'voice', '语音', 'tts'],
+      },
+    ],
+    timeout_ms: 240_000,
+  },
+  {
+    name: 'three-fast-then-one-slow',
+    messages: [
+      {
+        gap_ms: 0,
+        text: '今天日期是多少？',
+        expected_in_response: ['2026', 'date', '日期', '月', 'april'],
+      },
+      {
+        gap_ms: 2000,
+        text: '北京天气怎么样？',
+        expected_in_response: ['beijing', '北京', 'weather', '天气', 'temperature'],
+      },
+      {
+        gap_ms: 1500,
+        text: '搜索一下今日Rust相关新闻 (deep search)',
+        expected_in_response: ['rust', 'news', '新闻', 'language'],
+      },
+    ],
+    timeout_ms: 300_000,
+  },
+  {
+    name: 'rapid-fire-five-fast',
+    messages: [
+      { gap_ms: 0, text: '1+1 = ?', expected_in_response: ['2', '两', '二'] },
+      { gap_ms: 800, text: '2+2 = ?', expected_in_response: ['4', '四'] },
+      { gap_ms: 800, text: '3+3 = ?', expected_in_response: ['6', '六'] },
+      { gap_ms: 800, text: '4+4 = ?', expected_in_response: ['8', '八'] },
+      { gap_ms: 800, text: '5+5 = ?', expected_in_response: ['10', '十'] },
+    ],
+    timeout_ms: 180_000,
+  },
+];
+
+async function enableThreadStoreV2(page: Page) {
+  await page.addInitScript((key) => {
+    localStorage.setItem(key, '1');
+  }, FLAG_KEY);
+}
+
+interface OrderedBubble {
+  index: number;
+  role: 'user' | 'assistant';
+  threadId: string;
+  text: string;
+}
+
+async function getOrderedBubbles(page: Page): Promise<OrderedBubble[]> {
+  return page.evaluate(() => {
+    const nodes = document.querySelectorAll(
+      "[data-testid='user-message'], [data-testid='assistant-message']",
+    );
+    return Array.from(nodes).map((el, i) => ({
+      index: i,
+      role:
+        el.getAttribute('data-testid') === 'user-message'
+          ? ('user' as const)
+          : ('assistant' as const),
+      threadId: el.getAttribute('data-thread-id') || '',
+      text: ((el as HTMLElement).innerText || '').trim(),
+    }));
+  });
+}
+
+async function waitForAllAssistantsFilled(
+  page: Page,
+  expectedAssistantCount: number,
+  maxWaitMs: number,
+  label: string,
+): Promise<number> {
+  const start = Date.now();
+  let lastFilled = 0;
+  let stable = 0;
+  while (Date.now() - start < maxWaitMs) {
+    const isStreaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible()
+      .catch(() => false);
+    const filled = await page.evaluate((sel) => {
+      const bubbles = document.querySelectorAll(sel);
+      return Array.from(bubbles).filter((el) => {
+        const text = ((el as HTMLElement).innerText || '').trim();
+        return text.length > 1;
+      }).length;
+    }, SEL.assistantMessage);
+
+    if (filled >= expectedAssistantCount && !isStreaming) {
+      stable += 1;
+      if (stable >= 2) return filled;
+    } else {
+      stable = 0;
+    }
+
+    if (filled !== lastFilled) {
+      const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+      console.log(
+        `  [${label}] ${elapsed}s: filled=${filled}/${expectedAssistantCount} streaming=${isStreaming}`,
+      );
+      lastFilled = filled;
+    }
+    await page.waitForTimeout(3_000);
+  }
+  return lastFilled;
+}
+
+function assertPairing(
+  scenario: Scenario,
+  newBubbles: OrderedBubble[],
+): { violations: string[]; debug: string } {
+  const violations: string[] = [];
+
+  // Walk the bubble list, picking out user bubbles in order.
+  const userIndices: number[] = [];
+  for (let i = 0; i < newBubbles.length; i++) {
+    if (newBubbles[i].role === 'user') userIndices.push(i);
+  }
+
+  if (userIndices.length < scenario.messages.length) {
+    violations.push(
+      `Expected ${scenario.messages.length} user bubbles, found ${userIndices.length}`,
+    );
+  }
+
+  // Track thread-id collisions: each user bubble's paired assistant should
+  // have a unique thread-id (when the renderer exposes it).
+  const seenThreadIds = new Set<string>();
+
+  for (let i = 0; i < scenario.messages.length; i++) {
+    const userIdx = userIndices[i];
+    if (userIdx === undefined) {
+      violations.push(`User bubble ${i} not found in DOM`);
+      continue;
+    }
+    const userBubble = newBubbles[userIdx];
+    const userPrompt = scenario.messages[i].text;
+
+    // Look at substrings to handle whitespace / formatting changes.
+    const promptShort = userPrompt.slice(0, 12).replace(/\s+/g, '').toLowerCase();
+    const userTextNorm = userBubble.text.replace(/\s+/g, '').toLowerCase();
+    if (!userTextNorm.includes(promptShort.slice(0, 6))) {
+      violations.push(
+        `User bubble ${i} text "${userBubble.text.slice(0, 60)}" doesn't contain prompt prefix "${userPrompt.slice(0, 30)}"`,
+      );
+    }
+
+    // Find the next assistant bubble after this user that has any text.
+    // Stop scanning when we hit the next user bubble (that's a different
+    // thread).
+    const nextUserIdx =
+      i + 1 < userIndices.length ? userIndices[i + 1] : newBubbles.length;
+    let assistantBubble: OrderedBubble | undefined;
+    for (let j = userIdx + 1; j < nextUserIdx; j++) {
+      const b = newBubbles[j];
+      if (b.role === 'assistant' && b.text.length > 0) {
+        assistantBubble = b;
+        break;
+      }
+    }
+
+    if (!assistantBubble) {
+      violations.push(
+        `User ${i} ("${userPrompt.slice(0, 30)}"): no paired assistant response found between this user and the next user`,
+      );
+      continue;
+    }
+
+    // Track thread-id uniqueness when available.
+    if (assistantBubble.threadId) {
+      if (seenThreadIds.has(assistantBubble.threadId)) {
+        violations.push(
+          `User ${i}: assistant thread_id "${assistantBubble.threadId}" already used by an earlier thread (binding collision)`,
+        );
+      }
+      seenThreadIds.add(assistantBubble.threadId);
+    }
+
+    // Content-match check: at least one expected marker must appear in the
+    // assistant's text. Markers are lowercased for case-insensitive match.
+    const assistantTextLower = assistantBubble.text.toLowerCase();
+    const markers = scenario.messages[i].expected_in_response;
+    const matched = markers.some((mark) =>
+      assistantTextLower.includes(mark.toLowerCase()),
+    );
+    if (!matched) {
+      violations.push(
+        `User ${i} ("${userPrompt.slice(0, 30)}"): assistant response "${assistantBubble.text.slice(0, 120)}" does not contain any expected marker [${markers.join(', ')}]`,
+      );
+    }
+  }
+
+  const debug = JSON.stringify(
+    newBubbles.map((b) => ({
+      role: b.role,
+      threadId: b.threadId,
+      text: b.text.slice(0, 80),
+    })),
+    null,
+    2,
+  );
+  return { violations, debug };
+}
+
+test.describe('M8.10 stress: thread_id binding under realistic 3-5 user overflow', () => {
+  test.setTimeout(420_000);
+
+  for (const scenario of SCENARIOS) {
+    test(`stress scenario: ${scenario.name}`, async ({ page }) => {
+      await enableThreadStoreV2(page);
+      await login(page);
+      await createNewSession(page);
+
+      const userBefore = await countUserBubbles(page);
+      const assistantBefore = await countAssistantBubbles(page);
+
+      // Send every message with the configured gap in front of it.
+      for (let i = 0; i < scenario.messages.length; i++) {
+        const m = scenario.messages[i];
+        if (m.gap_ms > 0) await page.waitForTimeout(m.gap_ms);
+        await getInput(page).fill(m.text);
+        await getSendButton(page).click();
+        await expect
+          .poll(() => countUserBubbles(page), { timeout: 30_000 })
+          .toBe(userBefore + i + 1);
+      }
+
+      // Wait for all assistant bubbles to settle.
+      const expectedAssistants = assistantBefore + scenario.messages.length;
+      const filled = await waitForAllAssistantsFilled(
+        page,
+        expectedAssistants,
+        scenario.timeout_ms,
+        scenario.name,
+      );
+      expect(
+        filled,
+        `Only ${filled}/${expectedAssistants} assistant bubbles completed within ${scenario.timeout_ms / 1000}s`,
+      ).toBeGreaterThanOrEqual(expectedAssistants);
+
+      // Pull all bubbles from the DOM, slice off pre-existing ones, and
+      // verify pairing against expected content per user prompt.
+      const allBubbles = await getOrderedBubbles(page);
+      const newBubbles = allBubbles.slice(userBefore + assistantBefore);
+      const { violations, debug } = assertPairing(scenario, newBubbles);
+
+      if (violations.length > 0) {
+        console.log(`[${scenario.name}] DOM dump:`, debug);
+      }
+      expect(
+        violations,
+        `Pairing violations in scenario "${scenario.name}":\n  - ${violations.join('\n  - ')}\n\nDOM:\n${debug}`,
+      ).toEqual([]);
+    });
+  }
+});

--- a/e2e/tests/live-overflow-stress.spec.ts
+++ b/e2e/tests/live-overflow-stress.spec.ts
@@ -1,11 +1,18 @@
 /**
- * M8.10 stress test: thread_id binding under realistic 3-5 user overflow.
+ * M8.10 stress test: thread_id binding under realistic 3-10 user overflow.
  *
  * Existing live-thread-interleave.spec.ts only sends 2 messages with a
- * fixed 1.5s gap. Real users (issue #649) send 3-5 messages with random
+ * fixed 1.5s gap. Real users (issue #649) send 3-10 messages with random
  * gaps and at least one slow tool. The narrow scope kept letting
  * variations of the thread_id binding bug ship to production
  * (#629 -> #635 -> #637 -> #649).
+ *
+ * The 7- and 10-message scenarios were added to catch sticky-map drift
+ * across many turn rotations: a fast-only 5-message rapid-fire test
+ * exercises one rotation pattern; mixing slow tools at both ends of a
+ * 7-message run exercises spawn-time AND finalise-time pressure on the
+ * sticky map; a 10-message normal-pacing session catches stale-state
+ * accumulation that only shows up after the cache warms.
  *
  * Each scenario sends multiple messages within a short window, waits for
  * all responses to land, then verifies that the assistant response BELOW
@@ -81,7 +88,7 @@ const SCENARIOS: Scenario[] = [
     timeout_ms: 240_000,
   },
   {
-    name: 'three-fast-then-one-slow',
+    name: 'two-fast-then-one-slow',
     messages: [
       {
         gap_ms: 0,
@@ -111,6 +118,52 @@ const SCENARIOS: Scenario[] = [
       { gap_ms: 800, text: '5+5 = ?', expected_in_response: ['10', '十'] },
     ],
     timeout_ms: 180_000,
+  },
+  {
+    // Slow + 5 fast + slow (7 user msgs). The trailing slow operation
+    // exercises sticky-map pressure at finalise-time after 5 rotations,
+    // which is the failure window most likely to be missed by the
+    // 5-message rapid-fire scenario.
+    name: 'seven-messages-mixed-pacing',
+    messages: [
+      {
+        gap_ms: 0,
+        text:
+          'Use deep research to find latest Rust language news. Run pipeline directly. One paragraph.',
+        expected_in_response: ['rust', 'research', 'language', 'news'],
+      },
+      { gap_ms: 4000, text: '1+1 = ?', expected_in_response: ['2', '两', '二'] },
+      { gap_ms: 1200, text: '2+2 = ?', expected_in_response: ['4', '四'] },
+      { gap_ms: 1200, text: '3+3 = ?', expected_in_response: ['6', '六'] },
+      { gap_ms: 1200, text: '4+4 = ?', expected_in_response: ['8', '八'] },
+      { gap_ms: 1200, text: '5+5 = ?', expected_in_response: ['10', '十'] },
+      {
+        gap_ms: 3000,
+        text: '搜索一下今天的天气情况 (deep search)',
+        expected_in_response: ['weather', '天气', 'temperature', '温度', 'forecast'],
+      },
+    ],
+    timeout_ms: 480_000,
+  },
+  {
+    // Normal-paced 10-message session (30s gaps). Catches sticky-map
+    // staleness that only surfaces after the cache has rotated many
+    // times; each turn is well-separated so any drift across turns
+    // shows as a binding collision or content-mismatch in the DOM.
+    name: 'long-session-ten-messages',
+    messages: [
+      { gap_ms: 0, text: '1+1 = ?', expected_in_response: ['2', '两', '二'] },
+      { gap_ms: 30000, text: '2+2 = ?', expected_in_response: ['4', '四'] },
+      { gap_ms: 30000, text: '3+3 = ?', expected_in_response: ['6', '六'] },
+      { gap_ms: 30000, text: '4+4 = ?', expected_in_response: ['8', '八'] },
+      { gap_ms: 30000, text: '5+5 = ?', expected_in_response: ['10', '十'] },
+      { gap_ms: 30000, text: '6+6 = ?', expected_in_response: ['12', '十二'] },
+      { gap_ms: 30000, text: '7+7 = ?', expected_in_response: ['14', '十四'] },
+      { gap_ms: 30000, text: '8+8 = ?', expected_in_response: ['16', '十六'] },
+      { gap_ms: 30000, text: '9+9 = ?', expected_in_response: ['18', '十八'] },
+      { gap_ms: 30000, text: '10+10 = ?', expected_in_response: ['20', '二十'] },
+    ],
+    timeout_ms: 480_000,
   },
 ];
 
@@ -282,8 +335,11 @@ function assertPairing(
   return { violations, debug };
 }
 
-test.describe('M8.10 stress: thread_id binding under realistic 3-5 user overflow', () => {
-  test.setTimeout(420_000);
+test.describe('M8.10 stress: thread_id binding under realistic 3-10 user overflow', () => {
+  // 900_000 (15 min) covers the longest scenario: long-session-ten-messages
+  // sends 10 msgs with 30s gaps (= 270s send time) plus a settle window for
+  // the last response, plus playwright fixture overhead.
+  test.setTimeout(900_000);
 
   for (const scenario of SCENARIOS) {
     test(`stress scenario: ${scenario.name}`, async ({ page }) => {


### PR DESCRIPTION
## Summary

- Adds `e2e/tests/live-overflow-stress.spec.ts` to catch the class of `thread_id` binding bugs that keep slipping past existing M8.10 specs.
- Three scenarios send 3-5 user messages within a short window, with at least one slow background tool, then verify each user bubble's paired assistant response (in DOM order) matches the prompt by content.
- Initially expected to FAIL on pre-#649 daemons (especially the `slow-research-then-fast-questions` scenario); becomes a regression check after #649 deploys.

## Why

`live-thread-interleave.spec.ts` only models 2 messages with a fixed 1.5s gap. The narrow scope kept letting variations of the same `thread_id` binding bug ship to production: #629 -> #635 -> #637 -> #649. Real users (issue #649 reproducer) send 3-5 messages with random gaps, where a late-arriving slow tool result was bound to the wrong thread.

## Scenarios

- `slow-research-then-fast-questions` -- mirrors the production session that produced #649 (deep_research + 2 fast questions inside ~14s). Expected to fail on pre-#649 daemons.
- `three-fast-then-one-slow` -- fast questions first, then a deep-search at the tail; verifies the same correctness invariant when the slow message arrives last.
- `rapid-fire-five-fast` -- 5 fast prompts in 4s; pure user-overflow stress, no slow tool. Smoke-tests basic queueing.

## Validation

Manual run against `https://dspfac.bot.ominix.io` (mini2; daemon at `8a4e4f1d`, the same pre-#649 version as mini3):

- `slow-research-then-fast-questions` FAILED -- only 2/3 assistant bubbles completed within 240s. The slow-research thread did not pair correctly with its user. Reproduces #649.
- `rapid-fire-five-fast` FAILED -- only 4/5 assistant bubbles completed. One user prompt remained orphaned, consistent with a thread_id binding loss.

The user originally specified mini3 (`dspfac.octos.ominix.io`) for validation, but mini3's per-tenant build only exposes Email-OTP login and the helper falls through to a 15s timeout. The post-#650 helper (`6db87b03`) auto-rotates the admin token and would unblock that path; once this branch lands on top of post-#650 main, the spec runs against mini3 directly without a helper change.

After #649 deploys, all three scenarios should pass and this becomes a regression guard for the entire 3-5-user overflow class.

## Tracking

- Closes the regression-protection gap behind #629 / #635 / #637 / #649.
- M8.10 follow-up #654 (generative property tests) tracks the next layer of invariant coverage.

## Test plan

- [x] Spec file added at `e2e/tests/live-overflow-stress.spec.ts` (336 lines).
- [x] `npx playwright test live-overflow-stress.spec.ts --list` shows all 3 scenarios.
- [x] Scenario `slow-research-then-fast-questions` fails on pre-#649 daemon (validated against mini2 at `8a4e4f1d`).
- [x] Scenario `rapid-fire-five-fast` fails on pre-#649 daemon (one orphan).
- [x] Existing `live-thread-interleave.spec.ts` continues to compile and lists.
- [ ] Re-run after #649 deploys; all scenarios should pass.