### PR TITLE
M8.10 follow-up: per-turn thread_id binding survives sticky-map rotation (#649)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -235,6 +235,14 @@ impl Agent {
                 tools.mark_spawn_only_invoked();
                 let bg_supervisor = tools.supervisor();
                 let bg_reporter = reporter.clone();
+                // M8.10 follow-up (#649): snapshot the originating turn's
+                // thread_id NOW, before any other turn can swap reporters
+                // or rotate the api_channel sticky map. Late-arriving
+                // background results stamp this onto their OutboundMessage
+                // metadata so the wire-side SSE event lands under the
+                // correct turn even after subsequent unrelated user turns
+                // have advanced the per-chat sticky thread_id.
+                let bg_originating_thread_id = bg_reporter.thread_id().map(str::to_string);
                 // F004 B2: bridge supervised runtime-state transitions onto
                 // the per-request reporter so spawn_only tasks emit
                 // ToolProgress events keyed by `tool_call_id`. This is what
@@ -411,6 +419,7 @@ impl Agent {
                                             content: String::new(),
                                             kind: BackgroundResultKind::Notification,
                                             media: output_files.clone(),
+                                            originating_thread_id: bg_originating_thread_id.clone(),
                                         })
                                         .await
                                     } else {
@@ -439,6 +448,8 @@ impl Agent {
                                                     ),
                                                     kind: BackgroundResultKind::Notification,
                                                     media: vec![],
+                                                    originating_thread_id: bg_originating_thread_id
+                                                        .clone(),
                                                 })
                                                 .await;
                                             }
@@ -477,6 +488,7 @@ impl Agent {
                                             content,
                                             kind: BackgroundResultKind::Notification,
                                             media: vec![],
+                                            originating_thread_id: bg_originating_thread_id.clone(),
                                         })
                                         .await;
                                     }
@@ -499,6 +511,8 @@ impl Agent {
                                                 ),
                                                 kind: BackgroundResultKind::Notification,
                                                 media: vec![],
+                                                originating_thread_id: bg_originating_thread_id
+                                                    .clone(),
                                             })
                                             .await;
                                         }
@@ -534,6 +548,8 @@ impl Agent {
                                                 ),
                                                 kind: BackgroundResultKind::Notification,
                                                 media: vec![],
+                                                originating_thread_id: bg_originating_thread_id
+                                                    .clone(),
                                             })
                                             .await;
                                         }
@@ -633,6 +649,8 @@ impl Agent {
                                                 ),
                                                 kind: BackgroundResultKind::Notification,
                                                 media: vec![],
+                                                originating_thread_id: bg_originating_thread_id
+                                                    .clone(),
                                             })
                                             .await;
                                         }
@@ -659,6 +677,8 @@ impl Agent {
                                                         ),
                                                         kind: BackgroundResultKind::Notification,
                                                         media: vec![],
+                                                        originating_thread_id:
+                                                            bg_originating_thread_id.clone(),
                                                     })
                                                     .await;
                                                 }
@@ -679,6 +699,8 @@ impl Agent {
                                                         ),
                                                         kind: BackgroundResultKind::Notification,
                                                         media: vec![],
+                                                        originating_thread_id:
+                                                            bg_originating_thread_id.clone(),
                                                     })
                                                     .await;
                                                 }
@@ -702,6 +724,7 @@ impl Agent {
                                     content: format!("✗ {} failed: {}", bg_name, r.output),
                                     kind: BackgroundResultKind::Notification,
                                     media: vec![],
+                                    originating_thread_id: bg_originating_thread_id.clone(),
                                 })
                                 .await;
                             }
@@ -719,6 +742,7 @@ impl Agent {
                                     content: format!("✗ {} error: {}", bg_name, e),
                                     kind: BackgroundResultKind::Notification,
                                     media: vec![],
+                                    originating_thread_id: bg_originating_thread_id.clone(),
                                 })
                                 .await;
                             }

--- a/crates/octos-agent/src/progress.rs
+++ b/crates/octos-agent/src/progress.rs
@@ -141,6 +141,16 @@ pub enum ProgressEvent {
 pub trait ProgressReporter: Send + Sync {
     /// Called when a progress event occurs.
     fn report(&self, event: ProgressEvent);
+
+    /// M8.10 follow-up (#649): the per-turn `thread_id` (typically the user
+    /// message's `client_message_id`) bound to this reporter. Tools that
+    /// spawn long-running background work read this so the late-arriving
+    /// completion can be stamped with the originating turn's id rather than
+    /// inheriting whatever the per-chat sticky map currently holds.
+    /// Default is `None` — silent / console reporters don't track threads.
+    fn thread_id(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// Default reporter that does nothing (silent mode).

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -74,6 +74,13 @@ pub struct BackgroundResultPayload {
     pub content: String,
     pub kind: BackgroundResultKind,
     pub media: Vec<String>,
+    /// M8.10 follow-up (#649): the user message's `client_message_id` that
+    /// originated this background task. Carries through to the late-arriving
+    /// outbound's `metadata.thread_id` so the API channel can stamp SSE
+    /// events with the originating turn — NOT whatever the per-chat sticky
+    /// map happens to hold when the background task finally finalises.
+    /// `None` for legacy callers and tests that don't track origination.
+    pub originating_thread_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2249,6 +2256,15 @@ impl Tool for SpawnTool {
             // background child task so the detached child inherits the same
             // compaction + validator contracts the sync spawn path honours.
             let child_workspace_policy = parent_workspace_policy.clone();
+            // M8.10 follow-up (#649): snapshot the originating turn's
+            // thread_id (= user message's client_message_id) at spawn
+            // time so the late-arriving terminal payload can stamp it
+            // onto the OutboundMessage metadata. Without this snapshot
+            // the payload would inherit whatever the per-chat sticky
+            // map happens to hold when the background task finalises,
+            // which after fast-follow-up turns is the WRONG turn's
+            // thread_id (cf. live mini3 trace, 2026-04-29).
+            let originating_thread_id = ctx.reporter.thread_id().map(str::to_string);
             // M8 Runtime Parity W2.B1: capture parent caches into the
             // detached background closure so the bg child Agent gets the
             // same FileStateCache + Router + SummaryGenerator as the sync
@@ -2869,6 +2885,7 @@ impl Tool for SpawnTool {
                         content: content.clone(),
                         kind: result_kind,
                         media: result_media.clone(),
+                        originating_thread_id: originating_thread_id.clone(),
                     },
                 )
                 .await
@@ -3798,6 +3815,7 @@ PY
             content: "done".to_string(),
             kind: BackgroundResultKind::Notification,
             media: vec!["/tmp/output.mp3".to_string()],
+            originating_thread_id: None,
         };
 
         assert!(deliver_background_result(Some(sender), payload.clone()).await);

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -963,8 +963,15 @@ impl Channel for ApiChannel {
                 let sess = self.sessions.lock().await;
                 sess.data_dir()
             };
-            if let Some(event) = build_session_result_event(result, &data_dir, None, topic) {
+            if let Some(mut event) = build_session_result_event(result, &data_dir, None, topic) {
                 record_result_delivery("session_result_event", "metadata", "session_result");
+                // M8.10 follow-up (#649): tag the wire-side session_result
+                // with the resolved thread_id so the web client routes it
+                // under the originating bubble. Without this, late-arriving
+                // background results (deep_research, spawn_only completions)
+                // appear under whichever turn happens to hold the sticky
+                // thread_id, NOT the turn that actually launched them.
+                inject_thread_id(&mut event, thread_id.as_deref());
                 self.broadcast_session_event(&msg.chat_id, topic, event)
                     .await;
             }
@@ -3502,6 +3509,137 @@ mod tests {
         assert_eq!(media.len(), 1);
         assert!(media[0].as_str().unwrap().starts_with("pf/"));
         assert!(rx.try_recv().is_err());
+    }
+
+    /// M8.10 follow-up (#649) regression: when the api_channel sticky map
+    /// has rotated through three turns (A → B → C) and a long-running
+    /// background task originating in turn A finally finalises, the wire
+    /// event MUST carry turn A's thread_id (sourced from explicit
+    /// metadata) and NOT the most-recent sticky value (turn C).
+    ///
+    /// Reproduces the live mini3 trace (2026-04-29, session
+    /// `web-1777402538752-zn7jfr`) where the deep_research turn's late
+    /// output landed under the voices turn's bubble — the bug this PR
+    /// fixes.
+    #[tokio::test]
+    async fn late_tool_result_for_overflow_turn_keeps_originating_thread_id_under_3_user_race() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            sessions,
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("test-race-chat".into(), tx);
+        }
+
+        // Simulate the production scenario: 3 user turns rotate the
+        // sticky map A → B → C as their first SSE events go out. We
+        // drive the rotation directly by calling `remember_thread_id`
+        // (the same hook every `send`/`send_with_id` uses).
+        ch.remember_thread_id("test-race-chat", Some("cmid-A-deep-research"))
+            .await;
+        ch.remember_thread_id("test-race-chat", Some("cmid-B-stocks"))
+            .await;
+        ch.remember_thread_id("test-race-chat", Some("cmid-C-voices"))
+            .await;
+        // After this, the sticky map points at C — the WRONG thread for
+        // a late-arriving turn-A result.
+
+        // Now turn A's background task finally finalises. It carries
+        // `thread_id=cmid-A-deep-research` in OutboundMessage metadata
+        // (the fix). The api_channel must honour this explicit metadata
+        // INSTEAD of falling through to the sticky map.
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "test-race-chat".into(),
+            content: "Deep research report on space exploration".into(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "_history_persisted": true,
+                "thread_id": "cmid-A-deep-research",
+                "_session_result": {
+                    "seq": 9,
+                    "role": "assistant",
+                    "content": "Deep research report on space exploration",
+                    "timestamp": "2026-04-29T05:56:03Z",
+                    "media": [],
+                    "thread_id": "cmid-A-deep-research",
+                }
+            }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "session_result");
+        assert_eq!(
+            parsed.get("thread_id").and_then(|v| v.as_str()),
+            Some("cmid-A-deep-research"),
+            "wire-side session_result MUST be tagged with the turn A cmid \
+             carried explicitly in OutboundMessage metadata; the sticky \
+             map (which now points at turn C) must NOT win. Got: {parsed}"
+        );
+        assert_eq!(
+            parsed["message"].get("thread_id").and_then(|v| v.as_str()),
+            Some("cmid-A-deep-research"),
+            "the embedded message body must also carry the originating \
+             thread_id so the web client renders it under the right bubble \
+             (the v2 thread-store keys off `message.thread_id`)"
+        );
+    }
+
+    /// M8.10 follow-up (#649) regression: explicit `thread_id` in
+    /// OutboundMessage metadata MUST win over the sticky map for the
+    /// `replace`/wire-side text path too. This pins the contract that
+    /// `outbound_thread_id(metadata)` is consulted BEFORE
+    /// `sticky_thread_id(chat_id)` in `send()`.
+    #[tokio::test]
+    async fn explicit_metadata_thread_id_wins_over_sticky_for_replace_event() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let sessions = test_sessions_in(data_dir.path());
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            sessions,
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("test-explicit-chat".into(), tx);
+        }
+
+        // Sticky map says C.
+        ch.remember_thread_id("test-explicit-chat", Some("cmid-sticky-C"))
+            .await;
+
+        // Outbound carries A explicitly.
+        let msg = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "test-explicit-chat".into(),
+            content: "originating turn A reply".into(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({ "thread_id": "cmid-explicit-A" }),
+        };
+        ch.send(&msg).await.unwrap();
+
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(parsed["type"], "replace");
+        assert_eq!(
+            parsed.get("thread_id").and_then(|v| v.as_str()),
+            Some("cmid-explicit-A"),
+            "explicit metadata.thread_id must outrank the sticky map; got {parsed}"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -1107,7 +1107,10 @@ mod tests {
         let state = smtp_state(dir.path());
         let Json(body) = get_deployment_mode(State(state)).await.unwrap();
         assert_eq!(body.mode, "local");
-        assert!(!body.explicit, "implicit default must report explicit=false");
+        assert!(
+            !body.explicit,
+            "implicit default must report explicit=false"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -305,7 +305,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // First-run setup wizard
         .route("/api/admin/token/status", get(admin_setup::token_status))
         .route("/api/admin/token/rotate", post(admin_setup::rotate_token))
-        .route("/api/admin/token/email", post(admin_setup::post_token_email))
+        .route(
+            "/api/admin/token/email",
+            post(admin_setup::post_token_email),
+        )
         .route("/api/admin/setup/state", get(admin_setup::get_setup_state))
         .route("/api/admin/setup/step", post(admin_setup::post_setup_step))
         .route(

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -970,6 +970,7 @@ async fn dispatch_background_result_to_actor(
             content: payload.content,
             kind: payload.kind,
             media: payload.media,
+            originating_thread_id: payload.originating_thread_id,
             ack: Some(ack_tx),
         }),
     )
@@ -1250,6 +1251,13 @@ pub enum ActorMessage {
         kind: BackgroundResultKind,
         /// Media files attached to this terminal background result.
         media: Vec<String>,
+        /// M8.10 follow-up (#649): the user message's `client_message_id`
+        /// from the turn that originated this background task. Stamped onto
+        /// the outbound's `metadata.thread_id` so wire-side SSE events land
+        /// under the originating bubble even after subsequent unrelated user
+        /// turns have rotated the per-chat sticky thread_id. `None` for
+        /// legacy callers and tests that pre-date #649.
+        originating_thread_id: Option<String>,
         /// Completion acknowledgment for durable persistence.
         ack: Option<oneshot::Sender<bool>>,
     },
@@ -2692,10 +2700,17 @@ impl SessionActor {
                             content,
                             kind,
                             media,
+                            originating_thread_id,
                             ack,
                         }) => {
                             let persisted = self
-                                .handle_background_result(&task_label, &content, kind, media)
+                                .handle_background_result(
+                                    &task_label,
+                                    &content,
+                                    kind,
+                                    media,
+                                    originating_thread_id,
+                                )
                                 .await;
                             if let Some(ack) = ack {
                                 let _ = ack.send(persisted);
@@ -3320,10 +3335,17 @@ impl SessionActor {
                             content,
                             kind,
                             media,
+                            originating_thread_id,
                             ack,
                         }) => {
                             let persisted = self
-                                .handle_background_result(&task_label, &content, kind, media)
+                                .handle_background_result(
+                                    &task_label,
+                                    &content,
+                                    kind,
+                                    media,
+                                    originating_thread_id,
+                                )
                                 .await;
                             if let Some(ack) = ack {
                                 let _ = ack.send(persisted);
@@ -3397,10 +3419,17 @@ impl SessionActor {
                             content,
                             kind,
                             media,
+                            originating_thread_id,
                             ack,
                         }) => {
                             let persisted = self
-                                .handle_background_result(&task_label, &content, kind, media)
+                                .handle_background_result(
+                                    &task_label,
+                                    &content,
+                                    kind,
+                                    media,
+                                    originating_thread_id,
+                                )
                                 .await;
                             if let Some(ack) = ack {
                                 let _ = ack.send(persisted);
@@ -3443,7 +3472,19 @@ impl SessionActor {
 
     /// Persist an assistant-visible background result and emit the matching
     /// committed session-result event metadata for the web/runtime surfaces.
-    async fn deliver_background_notification(&self, content: String, media: Vec<String>) -> bool {
+    ///
+    /// M8.10 follow-up (#649): `originating_thread_id` is the
+    /// `client_message_id` of the user message that started the background
+    /// task. When present it is stamped onto the OutboundMessage metadata
+    /// so the api_channel routes the wire-side SSE event under the correct
+    /// turn — even when subsequent unrelated user turns have rotated the
+    /// per-chat sticky thread_id.
+    async fn deliver_background_notification(
+        &self,
+        content: String,
+        media: Vec<String>,
+        originating_thread_id: Option<String>,
+    ) -> bool {
         let content = finalize_assistant_content(&self.session_key, &self.user_workspace, &content);
         let persisted = persist_assistant_message(
             &self.session_handle,
@@ -3467,7 +3508,7 @@ impl SessionActor {
             return false;
         };
 
-        let metadata = serde_json::json!({
+        let mut metadata = serde_json::json!({
             "topic": self.session_key.topic(),
             "_history_persisted": true,
             "_session_result": {
@@ -3478,6 +3519,30 @@ impl SessionActor {
                 "media": media.clone(),
             }
         });
+
+        // M8.10 follow-up (#649): stamp `thread_id` onto the OutboundMessage
+        // metadata so the api_channel resolves it via the explicit-metadata
+        // path (NOT the per-chat sticky-map fallback). Without this stamp,
+        // a deep_research / spawn_only result that completes after later
+        // user turns inherits the WRONG turn's thread_id from the sticky
+        // map (cf. live mini3 trace, 2026-04-29).
+        if let Some(tid) = originating_thread_id.as_deref() {
+            if let Some(obj) = metadata.as_object_mut() {
+                obj.insert(
+                    "thread_id".to_string(),
+                    serde_json::Value::String(tid.to_string()),
+                );
+                if let Some(sr) = obj
+                    .get_mut("_session_result")
+                    .and_then(|v| v.as_object_mut())
+                {
+                    sr.insert(
+                        "thread_id".to_string(),
+                        serde_json::Value::String(tid.to_string()),
+                    );
+                }
+            }
+        }
 
         let _ = send_outbound_with_timeout(
             &self.session_key,
@@ -3503,15 +3568,16 @@ impl SessionActor {
         content: &str,
         kind: BackgroundResultKind,
         media: Vec<String>,
+        originating_thread_id: Option<String>,
     ) -> bool {
         if kind == BackgroundResultKind::Notification {
-            self.deliver_background_notification(content.to_string(), media)
+            self.deliver_background_notification(content.to_string(), media, originating_thread_id)
                 .await
         } else {
             let report_message = self
                 .prepare_background_report_result(task_label, content)
                 .await;
-            self.deliver_background_notification(report_message, Vec::new())
+            self.deliver_background_notification(report_message, Vec::new(), originating_thread_id)
                 .await
         }
     }
@@ -4191,10 +4257,17 @@ impl SessionActor {
                             content,
                             kind,
                             media,
+                            originating_thread_id,
                             ack,
                         }) => {
                             let persisted = self
-                                .handle_background_result(&task_label, &content, kind, media)
+                                .handle_background_result(
+                                    &task_label,
+                                    &content,
+                                    kind,
+                                    media,
+                                    originating_thread_id,
+                                )
                                 .await;
                             if let Some(ack) = ack {
                                 let _ = ack.send(persisted);
@@ -8495,6 +8568,7 @@ mod tests {
             content: "Background research completed with 5 findings.".to_string(),
             kind: BackgroundResultKind::Report,
             media: vec![],
+            originating_thread_id: None,
             ack: None,
         })
         .await
@@ -8572,6 +8646,7 @@ mod tests {
             content: "Background research completed with 5 findings.".to_string(),
             kind: BackgroundResultKind::Report,
             media: vec![],
+            originating_thread_id: None,
             ack: None,
         })
         .await
@@ -8644,6 +8719,7 @@ mod tests {
             content: String::new(),
             kind: BackgroundResultKind::Notification,
             media: vec![media_path.to_string_lossy().to_string()],
+            originating_thread_id: None,
             ack: Some(ack_tx),
         })
         .await
@@ -8678,6 +8754,134 @@ mod tests {
         let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
     }
 
+    /// M8.10 follow-up (#649) regression: when a `BackgroundResult` carries
+    /// an `originating_thread_id` (the user message's `client_message_id`
+    /// from the turn that started the background task), the OutboundMessage
+    /// the actor emits MUST stamp that id onto the metadata so the
+    /// api_channel routes the wire-side SSE event under the originating
+    /// turn — NOT whatever the per-chat sticky map currently holds.
+    ///
+    /// Drives the production scenario from mini3 (2026-04-29): three user
+    /// turns rotate the sticky map, then a long-running deep_research
+    /// background task originating in turn A finally finalises. Pre-fix,
+    /// the OutboundMessage metadata lacked thread_id and the sticky map
+    /// (now pointing at turn C) won; post-fix, the explicit metadata
+    /// thread_id always pins the result to turn A.
+    #[tokio::test]
+    async fn late_tool_result_for_overflow_turn_keeps_originating_thread_id_under_3_user_race() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // No active turn: the actor is idle, simulating "background task
+        // finalises long after the originating turn ended". This is the
+        // exact production failure mode.
+        let agent_llm = Arc::new(DelayedMockProvider::new("agent", vec![]));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let originating_cmid = "cmid-A-deep-research-originator";
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        tx.send(ActorMessage::BackgroundResult {
+            task_label: "deep_research".to_string(),
+            content: "Deep research report on space exploration.".to_string(),
+            kind: BackgroundResultKind::Report,
+            media: vec![],
+            originating_thread_id: Some(originating_cmid.to_string()),
+            ack: Some(ack_tx),
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), ack_rx)
+                .await
+                .expect("ack timeout")
+                .expect("actor ack"),
+            "background result must be persisted"
+        );
+
+        let outbound = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("outbound timeout")
+            .expect("outbound message");
+
+        // The OutboundMessage metadata MUST carry thread_id at the top
+        // level so api_channel's `outbound_thread_id(&msg.metadata)` lookup
+        // returns Some(originating_cmid) and bypasses the sticky-map
+        // fallback. This is the contract the bug fix relies on.
+        assert_eq!(
+            outbound.metadata.get("thread_id").and_then(|v| v.as_str()),
+            Some(originating_cmid),
+            "OutboundMessage metadata must carry the originating turn's \
+             thread_id so api_channel resolves it via the explicit-metadata \
+             path; got metadata = {}",
+            outbound.metadata,
+        );
+
+        // The embedded `_session_result` ALSO carries thread_id so the
+        // wire-side session_result event the api_channel emits has it
+        // baked into the message body the web client renders. The v2
+        // thread-store keys off `message.thread_id` for routing.
+        assert_eq!(
+            outbound
+                .metadata
+                .get("_session_result")
+                .and_then(|sr| sr.get("thread_id"))
+                .and_then(|v| v.as_str()),
+            Some(originating_cmid),
+            "embedded _session_result must also carry thread_id so the web \
+             client renders the late result under the originating bubble; \
+             got metadata = {}",
+            outbound.metadata,
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// M8.10 follow-up (#649): when no `originating_thread_id` is supplied
+    /// (legacy callers, pre-fix BackgroundResult senders), the
+    /// OutboundMessage metadata must NOT carry a `thread_id` field. This
+    /// pins the wire-compat property: callers without a tracked origin
+    /// continue to fall through to the api_channel sticky-map fallback,
+    /// not surface a phantom empty/null thread_id that would mis-route.
+    #[tokio::test]
+    async fn legacy_background_result_without_originating_thread_id_omits_metadata_thread_id() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new("agent", vec![]));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        tx.send(ActorMessage::BackgroundResult {
+            task_label: "legacy_task".to_string(),
+            content: "Legacy result with no origin tracking.".to_string(),
+            kind: BackgroundResultKind::Report,
+            media: vec![],
+            originating_thread_id: None,
+            ack: Some(ack_tx),
+        })
+        .await
+        .unwrap();
+
+        let _ = tokio::time::timeout(Duration::from_secs(2), ack_rx).await;
+        let outbound = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("outbound timeout")
+            .expect("outbound message");
+
+        assert!(
+            outbound.metadata.get("thread_id").is_none(),
+            "legacy callers (originating_thread_id=None) must NOT populate \
+             metadata.thread_id — sticky map fallback handles wire compat. \
+             got metadata = {}",
+            outbound.metadata,
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
     #[tokio::test]
     async fn test_background_notification_ack_stays_persisted_when_live_fanout_is_closed() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -8692,6 +8896,7 @@ mod tests {
             content: "Background research completed.".to_string(),
             kind: BackgroundResultKind::Report,
             media: vec![],
+            originating_thread_id: None,
             ack: Some(ack_tx),
         })
         .await

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -83,6 +83,10 @@ fn inject_thread_id(value: &mut serde_json::Value, thread_id: Option<&str>) {
 }
 
 impl ProgressReporter for ChannelStreamReporter {
+    fn thread_id(&self) -> Option<&str> {
+        self.thread_id.as_deref()
+    }
+
     fn report(&self, event: ProgressEvent) {
         let thread_id = self.thread_id.as_deref();
         let mapped = match event {

--- a/e2e/tests/live-overflow-thread-binding.spec.ts
+++ b/e2e/tests/live-overflow-thread-binding.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * M8.10 follow-up (#649) live e2e: overflow thread-binding under 3-user race.
+ *
+ * Regression for the production trace observed on mini3 (2026-04-29,
+ * session `web-1777402538752-zn7jfr`):
+ *
+ *   05:55:36 user      tid=A  深度搜索一下中国的探月工程 clep
+ *   05:55:50 user      tid=B  今日股市如何
+ *   05:55:55 user      tid=C  你有哪些内置语音
+ *   05:56:03 tool      tid=C  # Deep Research: 今日股市行情 ... ← BUG
+ *   05:56:14 assistant tid=C  搜索未找到 ... 2026 年 4 月 29 日 ... ← BUG
+ *
+ * Pre-fix: a long-running spawn_only / background task started in turn A
+ * inherits whatever the api_channel sticky map currently holds when it
+ * finalises — which after a fast 3-user follow-up is turn C's thread_id.
+ * The web client then renders A's late result under C's bubble; A's user
+ * bubble appears with NO assistant response.
+ *
+ * Post-fix (this PR): the BackgroundResultPayload carries
+ * `originating_thread_id` snapshotted at spawn time, and
+ * `deliver_background_notification` stamps it onto the OutboundMessage
+ * metadata so api_channel resolves the thread via the explicit-metadata
+ * path, NOT the sticky-map fallback.
+ *
+ * What this spec drives:
+ *  - 3 user messages within a ≤5s window: Q1 (slow / spawning),
+ *    Q2 (fast — stocks-style), Q3 (fast — voices-style).
+ *  - Wait for ALL responses + tool outputs to land.
+ *  - Assert each user's bubble has its own assistant response paired
+ *    correctly via `data-thread-id`.
+ *  - Assert NO bubble is empty / orphaned.
+ *
+ * Required env:
+ *   OCTOS_TEST_URL=https://dspfac.octos.ominix.io
+ *   OCTOS_AUTH_TOKEN=octos-admin-2026
+ *   OCTOS_PROFILE=dspfac
+ *
+ * NEVER point at mini5 — that host is reserved for coding-green tests.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  SEL,
+  countAssistantBubbles,
+  countUserBubbles,
+  createNewSession,
+  getInput,
+  getSendButton,
+  login,
+} from './live-browser-helpers';
+
+// Q1 is the SLOW / SPAWNING question. We use a deep_research-style
+// prompt so the agent hands the work off to a background subagent —
+// that's the path #649 fixes.
+const Q1_PROMPT =
+  process.env.OCTOS_OVERFLOW_Q1_PROMPT ||
+  '深度搜索一下中国的探月工程 CLEP，给我一份简短的研究报告。直接执行流程，不要确认。';
+
+// Q2 fires DURING Q1's processing window. A fast factual question —
+// triggers the speculative-overflow path on the session actor.
+const Q2_PROMPT =
+  process.env.OCTOS_OVERFLOW_Q2_PROMPT || '今日股市如何？只需一句概要。';
+
+// Q3 fires immediately after Q2. Another fast factual — drives the
+// sticky map to rotate to a third value before Q1's background result
+// finalises.
+const Q3_PROMPT =
+  process.env.OCTOS_OVERFLOW_Q3_PROMPT || '你有哪些内置语音？只列出名称。';
+
+const FLAG_KEY = 'octos_thread_store_v2';
+
+const Q_GAP_MS = 1_500; // ≤5s total window: 1.5s × 2 ≈ 3s
+const SLOW_MAX_WAIT_MS = 8 * 60 * 1000; // 8 minutes — deep_research can be slow
+const STABLE_OBSERVATIONS = 3;
+
+async function enableThreadStoreV2(page: Page) {
+  await page.addInitScript((key) => {
+    localStorage.setItem(key, '1');
+  }, FLAG_KEY);
+}
+
+async function getOrderedBubbles(page: Page) {
+  return page.evaluate(() => {
+    const nodes = document.querySelectorAll(
+      "[data-testid='user-message'], [data-testid='assistant-message']",
+    );
+    return Array.from(nodes).map((el, i) => ({
+      index: i,
+      role:
+        el.getAttribute('data-testid') === 'user-message' ? 'user' : 'assistant',
+      threadId: el.getAttribute('data-thread-id') || '',
+      text: ((el as HTMLElement).innerText || '').trim().slice(0, 600),
+    }));
+  });
+}
+
+async function waitForAllFinished(
+  page: Page,
+  expectedAssistantCount: number,
+  maxWaitMs: number,
+) {
+  const start = Date.now();
+  let lastFilled = 0;
+  let stable = 0;
+  while (Date.now() - start < maxWaitMs) {
+    const isStreaming = await page
+      .locator(SEL.cancelButton)
+      .isVisible()
+      .catch(() => false);
+    const filled = await page.evaluate((sel) => {
+      const bubbles = document.querySelectorAll(sel);
+      return Array.from(bubbles).filter((el) => {
+        const text = ((el as HTMLElement).innerText || '').trim();
+        return text.length > 4;
+      }).length;
+    }, SEL.assistantMessage);
+
+    if (filled >= expectedAssistantCount && !isStreaming) {
+      stable += 1;
+      if (stable >= STABLE_OBSERVATIONS) return filled;
+    } else {
+      stable = 0;
+    }
+
+    if (filled !== lastFilled) {
+      const elapsed = ((Date.now() - start) / 1000).toFixed(0);
+      console.log(
+        `  [overflow-binding] ${elapsed}s: filled=${filled}/${expectedAssistantCount} streaming=${isStreaming}`,
+      );
+      lastFilled = filled;
+    }
+    await page.waitForTimeout(3_000);
+  }
+  return lastFilled;
+}
+
+test.describe('Live overflow thread binding (M8.10 follow-up #649)', () => {
+  test.setTimeout(SLOW_MAX_WAIT_MS + 60_000);
+
+  test('3-user fast follow-up keeps each bubble paired with its own assistant', async ({
+    page,
+  }) => {
+    await enableThreadStoreV2(page);
+    await login(page);
+    await createNewSession(page);
+
+    const userBubblesBefore = await countUserBubbles(page);
+    const assistantBubblesBefore = await countAssistantBubbles(page);
+
+    // Q1 — slow / spawning.
+    await getInput(page).fill(Q1_PROMPT);
+    await getSendButton(page).click();
+    await expect.poll(() => countUserBubbles(page)).toBe(userBubblesBefore + 1);
+    console.log('[overflow-binding] Q1 sent (slow / spawning)');
+
+    // Q2 — fast follow-up DURING Q1's processing.
+    await page.waitForTimeout(Q_GAP_MS);
+    await getInput(page).fill(Q2_PROMPT);
+    await getSendButton(page).click();
+    await expect.poll(() => countUserBubbles(page)).toBe(userBubblesBefore + 2);
+    console.log('[overflow-binding] Q2 sent (fast — stocks-style)');
+
+    // Q3 — second fast follow-up. Now the sticky map has rotated A→B→C.
+    await page.waitForTimeout(Q_GAP_MS);
+    await getInput(page).fill(Q3_PROMPT);
+    await getSendButton(page).click();
+    await expect.poll(() => countUserBubbles(page)).toBe(userBubblesBefore + 3);
+    console.log('[overflow-binding] Q3 sent (fast — voices-style)');
+
+    // Wait for ALL three threads to finalise. Q1 may take minutes
+    // because deep_research runs a background subagent; Q2 and Q3
+    // finish quickly. The slow Q1 is the one whose late result tests
+    // the fix.
+    const assistantsExpected = assistantBubblesBefore + 3;
+    const filled = await waitForAllFinished(
+      page,
+      assistantsExpected,
+      SLOW_MAX_WAIT_MS,
+    );
+    expect(
+      filled,
+      `Only ${filled}/${assistantsExpected} assistant bubbles completed within ${SLOW_MAX_WAIT_MS}ms`,
+    ).toBeGreaterThanOrEqual(assistantsExpected);
+
+    // Pull the bubble order from the DOM and assert pairing.
+    const bubbles = await getOrderedBubbles(page);
+    const newBubbles = bubbles.slice(
+      userBubblesBefore + assistantBubblesBefore,
+    );
+    console.log('new bubbles after 3 Qs:', JSON.stringify(newBubbles, null, 2));
+
+    // Identify the three user-bubble indices in render order.
+    const userIndices = newBubbles
+      .map((b, i) => (b.role === 'user' ? i : -1))
+      .filter((i) => i >= 0);
+    expect(
+      userIndices,
+      `Expected exactly 3 user bubbles in the new region, got ${userIndices.length}; bubbles: ${JSON.stringify(newBubbles)}`,
+    ).toHaveLength(3);
+
+    // Each user bubble must have ≥1 NON-EMPTY assistant bubble paired
+    // with it. "Paired" = appears AFTER this user bubble and BEFORE
+    // the next user bubble (or end of list).
+    for (let k = 0; k < userIndices.length; k++) {
+      const userIdx = userIndices[k];
+      const nextIdx =
+        k + 1 < userIndices.length ? userIndices[k + 1] : newBubbles.length;
+      const between = newBubbles.slice(userIdx + 1, nextIdx);
+      const filledAssistants = between.filter(
+        (b) => b.role === 'assistant' && b.text.trim().length > 0,
+      );
+      expect(
+        filledAssistants.length,
+        `User bubble #${k + 1} (text="${newBubbles[userIdx].text.slice(0, 80)}") has no paired non-empty assistant bubble. Bubbles between this user and the next: ${JSON.stringify(between)}`,
+      ).toBeGreaterThan(0);
+    }
+
+    // Per-thread thread_id assertion: each user bubble's thread_id (if
+    // emitted) must MATCH the thread_id of every assistant bubble paired
+    // with it. The bug pre-fix is that turn A's late background result
+    // gets stamped with turn C's thread_id, so its assistant bubbles end
+    // up under turn C — different `data-thread-id` from turn A's user
+    // bubble. The renderer skips threads whose user bubble has no
+    // matching assistant data-thread-id, leaving turn A's bubble empty
+    // (the production symptom).
+    for (let k = 0; k < userIndices.length; k++) {
+      const userIdx = userIndices[k];
+      const userTid = newBubbles[userIdx].threadId;
+      if (!userTid) {
+        // Older renderer / no thread_id surfaced — skip this check.
+        continue;
+      }
+      const nextIdx =
+        k + 1 < userIndices.length ? userIndices[k + 1] : newBubbles.length;
+      const between = newBubbles.slice(userIdx + 1, nextIdx);
+      const assistants = between.filter((b) => b.role === 'assistant');
+      const matchingAssistant = assistants.find((b) => b.threadId === userTid);
+      expect(
+        matchingAssistant,
+        `User #${k + 1} (thread_id="${userTid}", text="${newBubbles[userIdx].text.slice(0, 80)}") has NO assistant bubble with matching thread_id. Adjacent assistants: ${JSON.stringify(assistants)}. This is the #649 bug shape: late background result inherited the wrong thread_id from the sticky map.`,
+      ).toBeDefined();
+    }
+
+    // No "orphaned" assistant bubble: every assistant bubble in the new
+    // region must come AFTER one of our three user bubbles. (A bubble
+    // appearing BEFORE the first user index would be an orphan from
+    // a prior session bleed; a bubble whose thread_id matches none of
+    // the three user thread_ids would be a misrouted bubble.)
+    const userThreadIds = userIndices
+      .map((i) => newBubbles[i].threadId)
+      .filter((t) => t && t.length > 0);
+    if (userThreadIds.length === userIndices.length) {
+      // All user bubbles surfaced thread_ids — we can do strong routing.
+      const assistantBubblesNew = newBubbles.filter(
+        (b) => b.role === 'assistant' && b.text.trim().length > 0,
+      );
+      for (const ab of assistantBubblesNew) {
+        if (!ab.threadId) continue; // older builds may not surface tid
+        expect(
+          userThreadIds,
+          `Assistant bubble (thread_id="${ab.threadId}", text="${ab.text.slice(0, 80)}") routes to a thread that has NO user bubble in this turn. This is exactly the #649 misrouting symptom. New user thread_ids: ${JSON.stringify(userThreadIds)}`,
+        ).toContain(ab.threadId);
+      }
+    }
+  });
+});


### PR DESCRIPTION
closes #649
relates to #627

## Summary

Stamps the originating thread_id on background results to fix the 3-user-overflow race where late-arriving deep_research results would inherit the wrong thread_id from the sticky-map. Per-turn thread_id binding now survives sticky-map rotation.

## Detail

Sticky-map-per-chat_id assumes one turn at a time. Real production hits 3-user-overflow scenarios where late-arriving deep_research results inherit whatever the sticky map currently holds — which is the most recent turn's thread_id, NOT the originating turn's.

Fix: spawn-task and background-completion paths now carry thread_id explicitly in OutboundMessage metadata, sourced from the originating user message's cmid. The sticky map is a fallback only when explicit thread_id is absent.

New inline test reproduces the 3-user race. New e2e spec `live-overflow-thread-binding.spec.ts` asserts each bubble pairs correctly under realistic user timing.

## Test plan

- [x] `cargo build --workspace --tests`
- [x] `cargo test -p octos-bus` (179 unit + 2 replay-harness tests pass)
- [ ] `live-overflow-thread-binding.spec.ts` against mini3 after deploy
- [ ] `live-overflow-stress.spec.ts` (PR #657) against mini3 after deploy