### PR TITLE
chore: cargo fmt drift in api/admin_setup + api/router

### DIFF
--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -1107,7 +1107,10 @@ mod tests {
         let state = smtp_state(dir.path());
         let Json(body) = get_deployment_mode(State(state)).await.unwrap();
         assert_eq!(body.mode, "local");
-        assert!(!body.explicit, "implicit default must report explicit=false");
+        assert!(
+            !body.explicit,
+            "implicit default must report explicit=false"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -305,7 +305,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // First-run setup wizard
         .route("/api/admin/token/status", get(admin_setup::token_status))
         .route("/api/admin/token/rotate", post(admin_setup::rotate_token))
-        .route("/api/admin/token/email", post(admin_setup::post_token_email))
+        .route(
+            "/api/admin/token/email",
+            post(admin_setup::post_token_email),
+        )
         .route("/api/admin/setup/state", get(admin_setup::get_setup_state))
         .route("/api/admin/setup/step", post(admin_setup::post_setup_step))
         .route(


### PR DESCRIPTION
## Summary

Pure `cargo fmt --all` output. Two long single-line statements on `main` are out of rustfmt compliance, so every other in-flight PR has to absorb the same trivial fix to pass the `cargo fmt --all -- --check` CI gate. This PR fixes them on `main` directly so that work doesn't keep getting duplicated.

Files touched (8 lines total):

- `crates/octos-cli/src/api/admin_setup.rs:1107` — wrap `assert!(!body.explicit, "...")` across multiple lines
- `crates/octos-cli/src/api/router.rs:305` — wrap `.route("/api/admin/token/email", post(...))` across multiple lines

No semantic change — rustfmt operates on syntax only.

## Test plan

- [x] `cargo fmt --all` produced exactly these two file changes (no other drift)
- [x] `cargo fmt --all -- --check` passes after the commit
- [ ] CI green