### PR TITLE
fix(e2e): live-slides-site case bug + skill-presence precondition

### DIFF
--- a/e2e/tests/live-slides-site.spec.ts
+++ b/e2e/tests/live-slides-site.spec.ts
@@ -21,7 +21,106 @@ import {
   SEL,
 } from './live-browser-helpers';
 
+const AUTH_TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
+const PROFILE_ID = process.env.OCTOS_PROFILE || 'dspfac';
+const BASE_URL = process.env.OCTOS_TEST_URL || 'http://localhost:3000';
+
+// The canonical skill names in mofa-org/mofa-skills are hyphenated:
+// `mofa-slides` and `mofa-site` (singular). The dashboard's installed-skill
+// listing returns these exact names.
+const REQUIRED_SLIDES_SKILLS = ['mofa-slides'] as const;
+const REQUIRED_SITE_SKILLS = ['mofa-site'] as const;
+
 test.setTimeout(600_000);
+
+/**
+ * Tri-state result of probing `/api/admin/profiles/{profile}/skills`:
+ *  - `present`: API responded and the named skill is installed.
+ *  - `missing`: API responded and the named skill is NOT installed.
+ *  - `unknown`: the API call itself failed (network, 401, 5xx). We don't
+ *    know whether the skill is present, so we shouldn't quietly mark the
+ *    test as missing-skill-skip.
+ *
+ * The slides + site flows depend on `mofa_slides` and `mofa_sites` being
+ * pre-provisioned on the target host. Tenant state has historically drifted
+ * across the mini fleet (mini2 had them, mini1/3/4 did not), so we gate
+ * execution on actual API state rather than assuming. Distinguishing
+ * `missing` from `unknown` is important: the former is environment drift the
+ * operator can fix by installing, the latter is an infra problem (probably
+ * auth or daemon down) that a separate inventory gate should catch.
+ */
+type SkillProbe =
+  | { state: 'present' | 'missing' }
+  | { state: 'unknown'; reason: string };
+
+async function probeSkill(skillName: string): Promise<SkillProbe> {
+  let resp: Response;
+  try {
+    resp = await fetch(
+      `${BASE_URL}/api/admin/profiles/${PROFILE_ID}/skills`,
+      {
+        headers: {
+          Authorization: `Bearer ${AUTH_TOKEN}`,
+          'X-Profile-Id': PROFILE_ID,
+        },
+      },
+    );
+  } catch (err) {
+    return {
+      state: 'unknown',
+      reason: `network error: ${(err as Error)?.message || String(err)}`,
+    };
+  }
+  if (!resp.ok) {
+    return { state: 'unknown', reason: `HTTP ${resp.status} ${resp.statusText}` };
+  }
+  const data = await resp.json().catch(() => null);
+  const entries = Array.isArray(data)
+    ? data
+    : Array.isArray((data as { skills?: unknown })?.skills)
+      ? (data as { skills: unknown[] }).skills
+      : [];
+  for (const entry of entries) {
+    const name =
+      typeof (entry as { name?: unknown })?.name === 'string'
+        ? (entry as { name: string }).name
+        : '';
+    if (name === skillName) return { state: 'present' };
+  }
+  return { state: 'missing' };
+}
+
+async function skipIfSkillsMissing(required: readonly string[]): Promise<void> {
+  const probes = await Promise.all(
+    required.map(async (name) => ({ name, probe: await probeSkill(name) })),
+  );
+  const missing = probes.filter((p) => p.probe.state === 'missing');
+  const unknown = probes.filter((p) => p.probe.state === 'unknown');
+
+  if (missing.length > 0) {
+    const names = missing.map((p) => p.name).join(', ');
+    test.skip(
+      true,
+      `Skipping: required skill(s) "${names}" not installed for profile "${PROFILE_ID}" on ${BASE_URL}. ` +
+        `This is an environment prerequisite for this live acceptance flow, not an app assertion. ` +
+        `Install via POST /api/admin/profiles/${PROFILE_ID}/skills (repo: mofa-org/mofa-skills/<name>), then re-run.`,
+    );
+  }
+
+  if (unknown.length > 0) {
+    // We couldn't verify presence at all. Don't pretend the skill is missing
+    // — the underlying call failed. Skip with a distinct, infra-flavoured
+    // reason so a separate inventory gate (or the operator) can act on it.
+    const detail = unknown
+      .map((p) => `${p.name} (${(p.probe as { reason: string }).reason})`)
+      .join(', ');
+    test.skip(
+      true,
+      `Skipping: cannot verify required skill(s) for profile "${PROFILE_ID}" on ${BASE_URL}: ${detail}. ` +
+        `In prod/canary this should fail the required-skills inventory gate.`,
+    );
+  }
+}
 
 async function collectPreviewUrls(page: Page): Promise<string[]> {
   const text = await getAssistantMessageText(page);
@@ -178,6 +277,8 @@ test.describe('Live deliverable flows', () => {
   });
 
   test('slides flow renders one final deck artifact after reload', async ({ page }) => {
+    await skipIfSkillsMissing(REQUIRED_SLIDES_SKILLS);
+
     const deckSlug = `browser-deck-${Date.now().toString(36)}`;
 
     await sendAndWait(page, `/new slides ${deckSlug}`, {
@@ -247,6 +348,8 @@ test.describe('Live deliverable flows', () => {
   test('site flow renders a built preview page and survives reload', async ({
     page,
   }) => {
+    await skipIfSkillsMissing(REQUIRED_SITE_SKILLS);
+
     let initResult = await sendAndWait(page, '/new site astro', {
       label: 'site-init',
       maxWait: 90_000,
@@ -284,13 +387,18 @@ test.describe('Live deliverable flows', () => {
       );
 
       expect(body).toContain('Browser Site Acceptance');
-      expect(body).toContain('Live preview');
+      // The Astro template ships "Live Preview" (TitleCase). The
+      // `waitForPreviewBody` helper above normalises via `.toLowerCase()`
+      // before matching, so a bare `toContain('Live preview')` (lowercase)
+      // would race with that helper and fail on TitleCase. Match
+      // case-insensitively here so the assertion mirrors the helper.
+      expect(body.toLowerCase()).toContain('live preview');
 
       await previewPage.reload({ waitUntil: 'networkidle' });
       const reloadedBody =
         (await previewPage.locator('body').innerText().catch(() => '')) || '';
       expect(reloadedBody).toContain('Browser Site Acceptance');
-      expect(reloadedBody).toContain('Live preview');
+      expect(reloadedBody.toLowerCase()).toContain('live preview');
     } finally {
       await previewPage.close();
     }


### PR DESCRIPTION
## Summary

- **Case-sensitivity bug**: `e2e/tests/live-slides-site.spec.ts` lines 287/293 asserted `body.toContain('Live preview')` (lowercase) but the Astro template ships `Live Preview` (TitleCase). The `waitForPreviewBody` helper above normalises via `.toLowerCase()` and advances, so the bare assertions raced and failed. Match case-insensitively so the assertion mirrors the helper.
- **Tenant-state drift gate**: add a tri-state precondition that probes `/api/admin/profiles/{profile}/skills` and uses `test.skip(...)` when `mofa-slides` / `mofa-site` are missing. The probe distinguishes `present` / `missing` / `unknown` so an API failure isn't silently miscategorised as a missing-skill skip — codex 2nd-opinion flagged that and recommended the tri-state shape.
- **Provisioning**: the canonical names in `mofa-org/mofa-skills` are hyphenated (`mofa-slides`, `mofa-site` — singular). Verified inventory across the mini fleet:
  - mini1 (`dspfac.crew.ominix.io`): already had both
  - mini2 (`dspfac.bot.ominix.io`): already had both
  - mini3 (`dspfac.octos.ominix.io`): already had both
  - mini4 (`dspfac.river.ominix.io`): missing both — installed via `POST /api/admin/profiles/dspfac/skills` with `repo: mofa-org/mofa-skills/mofa-slides` and `mofa-org/mofa-skills/mofa-site`. Both returned `{"installed": [...], "ok": true}` and now appear in the inventory.

The user's task brief referenced `mofa_slides` / `mofa_sites` (underscore, plural); the actual names are hyphenated and singular. The spec uses the correct hyphenated form.

## Test plan

- [x] `npx playwright test --list tests/live-slides-site.spec.ts` lists both tests cleanly (parses)
- [x] All four minis return `mofa-slides` and `mofa-site` from `GET /api/admin/profiles/dspfac/skills` post-provision
- [ ] Run the spec end-to-end against a canary mini (skip path is now infra-resilient; happy path is unchanged)
- [ ] Confirm the skip reason fires correctly when the skill is intentionally removed

## Codex 2nd opinion

Pre-push, codex reviewed the `test.skip` approach (log at `/tmp/codex-slides-site.log`). Verdict:
1. Skip is the right call for this acceptance spec; missing-skill is environment drift, not an app regression.
2. Make the precondition tri-state (`present` / `missing` / `unknown`) — implemented.
3. Sharper skip reasons that distinguish missing-from-environment vs. cannot-verify — implemented.