### PR TITLE
fix(e2e): migrate dashboard-nav specs to use ensureAdminTokenRotated (#650 follow-up)

### DIFF
--- a/e2e/tests/live-browser-helpers.ts
+++ b/e2e/tests/live-browser-helpers.ts
@@ -61,11 +61,20 @@ export async function ensureAdminTokenRotated(
             },
             body: JSON.stringify({ new_token: STRONG_ADMIN_TOKEN }),
           });
-          if (!rotateResp.ok && rotateResp.status !== 409) {
-            const text = await rotateResp.text().catch(() => '');
-            throw new Error(
-              `failed to rotate admin token: ${rotateResp.status} ${text}`,
-            );
+          if (!rotateResp.ok) {
+            // Cross-worker race: another Playwright worker process may have
+            // rotated first, which leaves us with a 401 (current bootstrap
+            // token now invalid) or a 409 (token store already populated).
+            // In both cases, probe with STRONG_ADMIN_TOKEN; if it works,
+            // the other worker rotated to the same target and we're done.
+            const fallbackStatus = await probe(STRONG_ADMIN_TOKEN);
+            if (fallbackStatus) return STRONG_ADMIN_TOKEN;
+            if (rotateResp.status !== 409) {
+              const text = await rotateResp.text().catch(() => '');
+              throw new Error(
+                `failed to rotate admin token: ${rotateResp.status} ${text}`,
+              );
+            }
           }
           return STRONG_ADMIN_TOKEN;
         }

--- a/e2e/tests/live-mofa-skills.spec.ts
+++ b/e2e/tests/live-mofa-skills.spec.ts
@@ -54,7 +54,18 @@ async function loginToDashboard(page: Page) {
       await tokenTab.click();
     }
     await page.getByLabel('Admin token').fill(effectiveToken);
-    await page.getByRole('button', { name: 'Login' }).click();
+    // `getByRole('button', { name: 'Login' })` matches *both* the submit
+    // button and the "Login with email instead" toggle button (Playwright's
+    // accessible-name match is substring-by-default), tripping strict mode.
+    // PR #625 added `data-testid="login-button"` on the submit button — use
+    // it directly and fall back to the type=submit + exact "Login" text for
+    // older deployed bundles.
+    await page
+      .locator(
+        "[data-testid='login-button'], button[type='submit']:text-is('Login')",
+      )
+      .first()
+      .click();
     await page.waitForURL(/\/admin(\/|$)/, { timeout: 20_000 });
     await page.goto(`/admin/profile/${PROFILE_ID}/skills`, { waitUntil: 'networkidle' });
   }


### PR DESCRIPTION
## Summary

PR #650 added `ensureAdminTokenRotated()` and partially migrated `live-mofa-skills.spec.ts`. Two follow-ups remained that this PR addresses:

- **Login selector strict-mode collision.** `live-mofa-skills.spec.ts` clicked `getByRole('button', { name: 'Login' })`, which Playwright resolves by substring on the accessible name. That matches both the real submit button and the `Login with email instead` toggle button rendered by `LoginPage.tsx`, tripping strict-mode and failing every dashboard-navigating run. Tighten to `data-testid='login-button'` (the testid added in PR #625) with a scoped `button[type='submit']:text-is('Login')` fallback for older deployed bundles.

- **Cross-worker rotation race.** `ensureAdminTokenRotated()` memoises the rotation inside one Node process, but Playwright's default multi-worker mode runs the helper concurrently across worker processes. Two workers can both observe `rotated:false`, both `POST /api/admin/token/rotate`, and one will see `401` (its bootstrap bearer was just invalidated by the other) or `409` (record already exists). Today we only swallow `409`. Now we probe `STRONG_ADMIN_TOKEN` on any non-OK rotate response — if another worker rotated to the same target, the probe succeeds and we share its result, otherwise we surface the original failure.

`live-mofa-full-flow.spec.ts` from PR #657 isn't on `main` yet, so this PR doesn't touch it. The same migration should be applied when #657 lands.

## Fleet rotation state

The 4 fleet minis were stuck in bootstrap mode (`rotated:false`) before this PR's verification run, breaking `live-mofa-skills.spec.ts` and any future dashboard-navigating spec. They are now rotated with the same `STRONG_ADMIN_TOKEN` (`Octos-E2E-Strong-Token-2026-XYZ-123!`) the helper uses, so subsequent runs go through the steady-state path:

| Mini | Host | Before | After (old bearer / new bearer on /api/auth/me) |
| ---- | ---- | ------ | ----------------------------------------------- |
| mini1 | dspfac.crew  | rotated:false | 401 / 200 |
| mini2 | dspfac.bot   | rotated:false | 401 / 200 |
| mini3 | dspfac.octos | rotated:false | 401 / 200 |
| mini4 | dspfac.river | rotated:false | 401 / 200 |

(mini5 is reserved for the coding-green branch and was not touched.)

## Test plan

- [x] `npx playwright test --list tests/live-mofa-skills.spec.ts` parses with the tightened selector.
- [x] `npx playwright test --list` parses for all 92 tests across 26 files (no upstream consumer of the helper broken).
- [x] `cargo fmt --all` clean (no Rust touched in this PR; the unrelated `admin_setup.rs` + `router.rs` fmt drift is owned by PR #667).
- [ ] Re-run `live-mofa-skills.spec.ts` against `dspfac.crew` end-to-end after merge — exercises both the steady-state rotation path (`STRONG_ADMIN_TOKEN` probe) and the tightened Login selector if the SPA bounces through `/admin/login`.
- [ ] Verify multi-worker behaviour with `npx playwright test --workers=4 tests/live-mofa-skills.spec.ts` against a freshly-reset bootstrap host (only relevant once a fresh canary lands).