### PR TITLE
fix(progress-gate): align fixture phases + populate progress + raise timeout

### DIFF
--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -120,6 +120,18 @@ struct WorkflowMetadata {
     allowed_tools: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     terminal_output: Option<WorkflowTerminalOutputPolicy>,
+    /// Coarse progress fraction in [0.0, 1.0] for this phase. Populated
+    /// on every workflow_runtime-driven `mark_runtime_state` so the
+    /// dashboard `runtime_detail.progress` field is non-null even for
+    /// workflows whose internal tools (e.g. `run_pipeline`) do not emit
+    /// per-event `HarnessEvent::progress`. Increments roughly with phase
+    /// transitions: 0.05 at workflow start (`research`/initial phase),
+    /// 0.95 when the runtime advances to `deliver_result`. The
+    /// task_supervisor's [`mark_completed`] path lets the lifecycle
+    /// state speak for terminal completion; we do not synthesize a
+    /// 1.0 sentinel here to avoid stepping on real progress events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    progress: Option<f64>,
 }
 
 fn is_retryable_child_failure(text: &str) -> bool {
@@ -851,6 +863,32 @@ fn should_deliver_output_files(files: &[PathBuf]) -> bool {
 
 fn encode_workflow_detail(workflow: &WorkflowMetadata) -> Option<String> {
     serde_json::to_string(workflow).ok()
+}
+
+/// Coarse progress fraction (0.0–1.0) the workflow_runtime path attaches
+/// to `runtime_detail.progress` for a given phase. The runtime owns only
+/// two phases per workflow family — the initial phase (`research` /
+/// `design` / `scaffold` / etc.) and `deliver_result` after artifacts
+/// pass validation — so the curve is deliberately coarse: the runtime
+/// stamps a small starting value at spawn and a near-terminal value at
+/// the deliver_result transition. Finer-grained values come from the
+/// inner tools (e.g. `deep_search` inside `run_pipeline`) emitting
+/// `HarnessEvent::progress`, which `task_supervisor::apply_harness_event`
+/// folds into the same `runtime_detail.progress` field.
+///
+/// Without this seed, `runtime_detail.progress` is `null` for the entire
+/// initial phase of any workflow whose internal tools do not emit per-event
+/// progress, which the e2e live-progress gate spec relies on being non-null.
+fn workflow_phase_progress(phase: &str) -> f64 {
+    match phase {
+        "deliver_result" => 0.95,
+        "verify_outputs" | "verify_contract" => 0.9,
+        // The initial workflow_runtime phase is family-specific
+        // (`research`, `design`, `scaffold`, ...) — treat any non-terminal
+        // phase as "just started" so the runtime advertises a non-null
+        // progress value rather than `null`.
+        _ => 0.05,
+    }
 }
 
 fn workflow_artifact_matches_kind(path: &Path, kind: &str) -> bool {
@@ -2270,10 +2308,21 @@ impl Tool for SpawnTool {
                 {
                     supervisor.mark_running(task_id);
                     if let Some(workflow) = workflow_metadata.as_ref() {
+                        // Seed `runtime_detail.progress` with a small non-null
+                        // value at workflow start. Without this, dashboards
+                        // (and the e2e live-progress gate) see
+                        // `runtime_detail.progress == null` for the entire
+                        // initial phase on workflows that drive a
+                        // `run_pipeline` graph rather than emitting their
+                        // own `HarnessEvent::progress`. The deep_search
+                        // built-in still overwrites this with finer values
+                        // (~0.1, 0.4, 0.8, 1.0) as the pipeline cycles.
+                        let mut start = workflow.clone();
+                        start.progress = Some(workflow_phase_progress(&start.current_phase));
                         supervisor.mark_runtime_state(
                             task_id,
                             crate::task_supervisor::TaskRuntimeState::ExecutingTool,
-                            encode_workflow_detail(workflow),
+                            encode_workflow_detail(&start),
                         );
                     }
                 }
@@ -2603,6 +2652,7 @@ impl Tool for SpawnTool {
                     ) {
                         let mut deliver = workflow.clone();
                         deliver.current_phase = "deliver_result".to_string();
+                        deliver.progress = Some(workflow_phase_progress("deliver_result"));
                         supervisor.mark_runtime_state(
                             task_id,
                             crate::task_supervisor::TaskRuntimeState::DeliveringOutputs,
@@ -3338,6 +3388,7 @@ mod tests {
                 forbid_intermediate_files: true,
                 required_artifact_kind: "audio".to_string(),
             }),
+            progress: None,
         };
 
         let files_to_send = vec![
@@ -3365,6 +3416,7 @@ mod tests {
                 forbid_intermediate_files: true,
                 required_artifact_kind: "audio".to_string(),
             }),
+            progress: None,
         };
 
         let files_modified = vec![
@@ -3390,6 +3442,7 @@ mod tests {
                 forbid_intermediate_files: true,
                 required_artifact_kind: "audio".to_string(),
             }),
+            progress: None,
         };
 
         let error = resolve_background_terminal_files(temp.path(), &[], &[], Some(&workflow))
@@ -3409,6 +3462,7 @@ mod tests {
                 forbid_intermediate_files: true,
                 required_artifact_kind: "presentation".to_string(),
             }),
+            progress: None,
         };
 
         let files_to_send = vec![
@@ -3434,6 +3488,7 @@ mod tests {
                 forbid_intermediate_files: true,
                 required_artifact_kind: "site".to_string(),
             }),
+            progress: None,
         };
 
         let files_to_send = vec![
@@ -3459,12 +3514,46 @@ mod tests {
                 forbid_intermediate_files: true,
                 required_artifact_kind: "presentation".to_string(),
             }),
+            progress: None,
         };
 
         let policy = build_subagent_tool_policy(workflow.allowed_tools.clone(), Some(&workflow));
 
         assert!(policy.deny.contains(&"spawn".to_string()));
         assert!(policy.deny.contains(&"send_file".to_string()));
+    }
+
+    #[test]
+    fn workflow_phase_progress_is_coarse_but_non_null_and_monotonic() {
+        // Initial phases of every workflow family — research_runtime path
+        // names them differently per family; the helper must seed a small
+        // non-null fraction for each so `runtime_detail.progress` is never
+        // null on the first phase transition.
+        for initial_phase in &["research", "design", "scaffold", "outline"] {
+            let value = workflow_phase_progress(initial_phase);
+            assert!(
+                value > 0.0 && value <= 0.5,
+                "initial phase {initial_phase} should map to a small non-null fraction, got {value}"
+            );
+        }
+
+        // The terminal-ish phases must produce values strictly greater
+        // than initial-phase values so the dashboard sees forward motion.
+        let initial = workflow_phase_progress("research");
+        let verifying = workflow_phase_progress("verify_outputs");
+        let deliver = workflow_phase_progress("deliver_result");
+        assert!(
+            verifying > initial,
+            "verify_outputs ({verifying}) must exceed initial ({initial})"
+        );
+        assert!(
+            deliver > verifying,
+            "deliver_result ({deliver}) must exceed verify_outputs ({verifying})"
+        );
+        assert!(
+            deliver < 1.0,
+            "deliver_result ({deliver}) must stay strictly under 1.0 — terminal completion is signalled by lifecycle state, not by a synthesized progress sentinel"
+        );
     }
 
     #[test]
@@ -3635,6 +3724,7 @@ PY
                 forbid_intermediate_files: true,
                 required_artifact_kind: "presentation".to_string(),
             }),
+            progress: None,
         };
 
         let selected = resolve_contract_terminal_files(&repo_root, Some(&workflow))
@@ -3667,6 +3757,7 @@ PY
                 forbid_intermediate_files: true,
                 required_artifact_kind: "site".to_string(),
             }),
+            progress: None,
         };
 
         let error = resolve_contract_terminal_files(&repo_root, Some(&workflow)).unwrap_err();
@@ -3767,6 +3858,39 @@ PY
             detail.get("workflow_kind").and_then(|v| v.as_str()) == Some("research_podcast")
                 && detail.get("current_phase").and_then(|v| v.as_str()) == Some("deliver_result")
         }));
+
+        // The workflow_runtime path must seed `progress` on every phase
+        // transition so dashboards (and the e2e live-progress gate) never
+        // see `runtime_detail.progress == null` for workflows whose
+        // internal tools do not emit per-event progress. The exact values
+        // are coarse — a small starting fraction at the initial phase and
+        // a near-terminal fraction once `deliver_result` is reached.
+        let initial_progress = details
+            .iter()
+            .find(|detail| detail.get("current_phase").and_then(|v| v.as_str()) == Some("research"))
+            .and_then(|detail| detail.get("progress"))
+            .and_then(|v| v.as_f64())
+            .expect("research phase must populate progress");
+        assert!(
+            (0.0..=0.5).contains(&initial_progress),
+            "research-phase progress should be small but non-null, got {initial_progress}"
+        );
+        let deliver_progress = details
+            .iter()
+            .find(|detail| {
+                detail.get("current_phase").and_then(|v| v.as_str()) == Some("deliver_result")
+            })
+            .and_then(|detail| detail.get("progress"))
+            .and_then(|v| v.as_f64())
+            .expect("deliver_result phase must populate progress");
+        assert!(
+            (0.85..=1.0).contains(&deliver_progress),
+            "deliver_result progress should be near-terminal, got {deliver_progress}"
+        );
+        assert!(
+            deliver_progress > initial_progress,
+            "progress must monotonically advance from research ({initial_progress}) to deliver_result ({deliver_progress})"
+        );
 
         let script =
             std::fs::read_to_string(&script_seen).expect("podcast_generate should receive script");

--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -1107,7 +1107,10 @@ mod tests {
         let state = smtp_state(dir.path());
         let Json(body) = get_deployment_mode(State(state)).await.unwrap();
         assert_eq!(body.mode, "local");
-        assert!(!body.explicit, "implicit default must report explicit=false");
+        assert!(
+            !body.explicit,
+            "implicit default must report explicit=false"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -305,7 +305,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // First-run setup wizard
         .route("/api/admin/token/status", get(admin_setup::token_status))
         .route("/api/admin/token/rotate", post(admin_setup::rotate_token))
-        .route("/api/admin/token/email", post(admin_setup::post_token_email))
+        .route(
+            "/api/admin/token/email",
+            post(admin_setup::post_token_email),
+        )
         .route("/api/admin/setup/state", get(admin_setup::get_setup_state))
         .route("/api/admin/setup/step", post(admin_setup::post_setup_step))
         .route(

--- a/e2e/fixtures/m4-1a-progress-expected.json
+++ b/e2e/fixtures/m4-1a-progress-expected.json
@@ -1,5 +1,5 @@
 {
-  "$schema_doc": "Expected phase ladder for the M4.1A live release gate (issue #474). This is authoritative for the validate-m4-1a-live.sh script and the e2e live-progress-gate specs. Keep field names in sync with crates/octos-agent/src/harness_events.rs and crates/app-skills/deep-search/src/main.rs.",
+  "$schema_doc": "Expected phase ladder for the M4.1A live release gate (issue #474). This is authoritative for the validate-m4-1a-live.sh script and the e2e live-progress-gate specs. Keep field names in sync with crates/octos-agent/src/harness_events.rs, crates/octos-agent/src/tools/deep_search.rs, and crates/octos-cli/src/workflows/research_report.rs. The live deep_research workflow uses the run_pipeline path (not the standalone deep-search skill binary), so phases come from a mix of: (a) the workflow runtime — `research` (initial) and `deliver_result` (after artifacts are produced), and (b) the deep_search built-in tool invoked by the pipeline graph — `search`, `synthesize`, `completion`. The legacy `fetch` and `report_build` phases were emitted only by the standalone deep-search skill binary, which is not on the live run_pipeline path; they remain in this fixture as observability hints (`must_appear: false`) for backwards compatibility with older skill-binary code paths.",
   "schema": "octos.harness.event.v1",
   "kind": "progress",
   "workflow": "deep_research",
@@ -30,14 +30,26 @@
   ],
   "required_phases": [
     {
-      "phase": "search",
+      "phase": "research",
       "min_progress": 0.0,
       "max_progress": 0.95,
       "must_appear": true
     },
     {
+      "phase": "search",
+      "must_appear": true
+    },
+    {
+      "phase": "synthesize",
+      "must_appear": true
+    },
+    {
       "phase": "completion",
-      "min_progress": 0.99,
+      "must_appear": true
+    },
+    {
+      "phase": "deliver_result",
+      "min_progress": 0.9,
       "max_progress": 1.0,
       "must_appear": true
     },
@@ -46,25 +58,16 @@
       "must_appear": false
     },
     {
-      "phase": "synthesize",
-      "must_appear": false
-    },
-    {
       "phase": "report_build",
-      "must_appear": false
-    },
-    {
-      "phase": "research",
       "must_appear": false
     }
   ],
   "phase_order": [
     "research",
     "search",
-    "fetch",
     "synthesize",
-    "report_build",
-    "completion"
+    "completion",
+    "deliver_result"
   ],
   "runtime_detail_fields": [
     "schema",
@@ -108,16 +111,17 @@
     "deep_research": "Do a deep research on the latest Rust programming language developments in 2026. Run the pipeline directly, don't ask me to choose."
   },
   "limits": {
-    "per_run_timeout_seconds": 600,
+    "per_run_timeout_seconds": 1200,
     "poll_interval_seconds": 5,
     "min_progress_events": 3,
     "max_duplicate_sessions": 0
   },
   "notes": [
-    "A deep_research run MUST emit progress events for every phase in `required_phases` before the task transitions to `ready`.",
-    "`phase_order` is the canonical ordering; the monotonic check allows repeats but never a backward jump.",
+    "A deep_research run MUST emit progress events for every phase in `required_phases` whose `must_appear` is true before the task transitions to `ready`.",
+    "`phase_order` is the canonical ordering; the monotonic check allows repeats but never a backward jump. `research` is the initial workflow_runtime phase, then the run_pipeline graph cycles `search`/`synthesize`/`completion` (potentially multiple passes), and finally the workflow_runtime advances to `deliver_result` once artifacts pass validation.",
     "Field names mirror the canonical ABI: `progress` (not `progress_fraction`) in the HarnessEvent struct. Skills that still emit `progress_fraction` are acceptable as an aliased rendering; validators consume whichever the runtime exposes in `runtime_detail.progress`.",
     "The `ui_selectors` map is the source of truth for the e2e live-progress-gate spec; keep it synchronized with crates/octos-cli/static/app.js.",
-    "This fixture is consumed by both scripts/validate-m4-1a-live.sh and e2e/tests/live-progress-gate.spec.ts."
+    "This fixture is consumed by both scripts/validate-m4-1a-live.sh and e2e/tests/live-progress-gate.spec.ts.",
+    "`per_run_timeout_seconds` is sized for a real deep_research run: roughly 4-10 minutes of pipeline work plus stack reload overhead on freshly redeployed minis."
   ]
 }


### PR DESCRIPTION
## Summary

Three coupled fixes so `e2e/tests/live-progress-gate.spec.ts` passes against a real fleet running the current deep_research workflow.

### 1. Fixture realignment (`e2e/fixtures/m4-1a-progress-expected.json`)

Old required phases were `search,fetch,synthesize,report_build,completion`. But:

- `fetch` and `report_build` are emitted **only** by the standalone deep-search skill binary (`crates/app-skills/deep-search/src/main.rs`).
- The live `deep_research` workflow takes the `run_pipeline` path (see `crates/octos-cli/src/workflows/research_report.rs`), which never invokes that binary.
- The phases the live workflow actually emits are: `research` (workflow_runtime initial) → `search` / `synthesize` / `completion` (deep_search built-in cycles inside the pipeline graph) → `deliver_result` (workflow_runtime terminal).

New `required_phases` track what the live workflow emits. `fetch` / `report_build` stay in the fixture as `must_appear: false` for backwards compatibility with older skill-binary code paths.

### 2. Timeout bump

`per_run_timeout_seconds` 600 → 1200. A real `deep_research` run is 4-10 minutes of pipeline work plus stack-reload overhead on freshly redeployed minis. 600s was too tight and was the proximate cause of false-negative failures during the 4-mini sweep.

### 3. Server: populate `runtime_detail.progress` on the workflow_runtime path

Before this PR, `runtime_detail.progress` was always `null` on the workflow_runtime path because `spawn.rs` encoded `WorkflowMetadata` without a `progress` field. The deep_search built-in tool's per-event progress (0.1 / 0.4 / 0.8 / 1.0) only flowed through `task_supervisor::apply_harness_event` from `HarnessEvent::progress`, leaving every workflow whose internal tools didn't emit those events with a perpetually-null progress field.

This PR:

- Adds `progress: Option<f64>` to `WorkflowMetadata` (`crates/octos-agent/src/tools/spawn.rs`).
- Adds a `workflow_phase_progress()` helper that returns coarse fractions per phase: `0.05` for initial phases, `0.9` for verifying, `0.95` for `deliver_result`. Deliberately does NOT synthesize a `1.0` sentinel — terminal completion is signalled by the lifecycle state, not a magic progress value, so we don't step on the inner tools' real progress events.
- Populates `progress` at the two workflow_runtime emission sites: when the task starts (initial phase) and when the runtime advances to `deliver_result` after artifact validation.
- Adds two unit tests:
  - `workflow_phase_progress_is_coarse_but_non_null_and_monotonic`
  - extends `test_background_spawn_persists_workflow_phase_transitions` to assert `progress` is populated and monotonically increases from research to deliver_result

Inner-tool `HarnessEvent::progress` events still overwrite this seed via `task_supervisor::apply_harness_event` → `runtime_detail_value`, so finer-grained progress from `deep_search` is preserved.

### Misc

The PR also picks up two pre-existing `rustfmt` drifts in `crates/octos-cli/src/api/{admin_setup,router}.rs` that `cargo fmt --all` flags on a clean `main` checkout. They are unrelated but had to be reformatted to keep `cargo fmt --all -- --check` green.

Refs task #89 (Bug A) and the 4-mini sweep findings.

## Test plan

- [x] `cargo build --workspace --tests` (clean)
- [x] `cargo clippy -p octos-cli --all-targets -- -D warnings` (clean)
- [x] `cargo clippy -p octos-agent --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo test -p octos-cli` (323+ passed, 0 failed)
- [x] `cargo test -p octos-agent` (1199+ passed, 0 failed; new tests `workflow_phase_progress_is_coarse_but_non_null_and_monotonic` + extended `test_background_spawn_persists_workflow_phase_transitions` pass)
- [ ] Run `live-progress-gate.spec.ts` against `dspfac.crew.ominix.io` once a build with this PR is deployed there