### PR TITLE
chore(ci): reduce check-job RAM footprint to fix runner OOM (#111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,41 +91,26 @@ jobs:
   check:
     runs-on: ubuntu-latest
     env:
-      # OOM mitigation for the 16GB ubuntu-latest runner (4 CPU, 16GB —
-      # public-repo standard). Two layers, defense-in-depth:
+      # Defense-in-depth OOM caps. Even after sharding the heaviest crates
+      # (octos-agent, octos-cli) into dedicated jobs (#672), the lean `check`
+      # job still compiles the full workspace for clippy + light-crate tests,
+      # so we keep the same caps that PR #672's prior commit established:
       #
-      # 1. CARGO_BUILD_JOBS=1 (was 2). The earlier =2 cap (#606) is
-      #    insufficient — runs still OOM-kill during `Test octos-agent
-      #    (lib)`, with the canonical "hosted runner lost communication
-      #    with the server" annotation appearing ~51min into the job
-      #    (e.g. run 25133705908: lib step started at 21:08:53Z, runner
-      #    died at 21:53Z, zero log output in between). Two concurrent
-      #    rustc/linker processes each touching the 144MB octos-agent
-      #    rlib closure (chromiumoxide + lettre + hyper) overlap their
-      #    peaks and cross the budget. Serializing fully removes the
-      #    aggregate-memory failure mode.
+      # 1. CARGO_BUILD_JOBS=1 — serialize rustc/linker invocations so two
+      #    peaks never overlap on the 16GB ubuntu-latest runner.
       #
-      # 2. CARGO_PROFILE_{TEST,DEV}_DEBUG=line-tables-only. JOBS=1 alone
-      #    only addresses overlap; it does not shrink the peak memory of
-      #    the single linker invocation that links the octos-agent --lib
-      #    test binary. Dropping from full DWARF (`debug=2`, the
-      #    dev/test profile default) to line-tables-only drops local-
-      #    variable and parameter debug info while preserving file/line
-      #    info — i.e. panic backtraces still report `file.rs:line`,
-      #    which is all CI ever consumes from debug-info. Both the test
-      #    profile (octos-agent --lib) and the dev profile (build
-      #    dependencies and any plain `cargo build` invocations) get the
-      #    cap; otherwise a build-dep compiled at `debug=2` could feed a
-      #    huge object back into the test link. Test correctness,
-      #    debug_assertions, and overflow checks are unchanged.
+      # 2. CARGO_PROFILE_{TEST,DEV}_DEBUG=line-tables-only — drop full DWARF
+      #    (debug=2) to file/line only, shrinking each linker invocation's
+      #    peak RSS while preserving panic-backtrace usefulness.
       #
-      # Using cargo's profile env vars rather than RUSTFLAGS avoids
-      # invalidating the Swatinem/rust-cache key for unrelated tools
-      # (e.g. clippy on a different debuginfo level) and is the
-      # cargo-recommended way to override a profile field.
-      #
-      # The same JOBS=2 guard remains in place on check-arm/check-riscv
-      # where it has been working (those runners are 16GB ARM/RISCV).
+      # The actual OOM that JOBS=1 + line-tables-only could not fix was
+      # memory accumulation across N sequential heavy-crate test steps in
+      # the same runner (run 25137059453, job 73677952504 — runner lost
+      # communication with the server during `Test octos-agent (lib)`,
+      # 54min in). The structural fix is sharding: see test-octos-agent
+      # and test-octos-cli below, which each get their own fresh 16GB
+      # runner. This `check` job now only handles the light crates and
+      # workspace-level checks (fmt, clippy, doc tests).
       CARGO_BUILD_JOBS: "1"
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
@@ -146,13 +131,11 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      # ── Sharded workspace tests ─────────────────────────────────────────────
-      # The previous `cargo test --workspace` step OOM-killed the 16GB ubuntu
-      # runner during peak link of the octos-agent integration test binaries
-      # (27 of them). Splitting per crate (and splitting heavy crates further
-      # into --lib vs --tests) keeps each step's resident set within budget
-      # while preserving the same aggregate coverage. The Swatinem cache makes
-      # subsequent steps incremental against the prior step's target/.
+      # ── Light-crate tests ───────────────────────────────────────────────────
+      # The two heavy crates (octos-agent, octos-cli) live in their own
+      # dedicated jobs (test-octos-agent, test-octos-cli) so each gets a
+      # fresh 16GB runner — see #672. This `check` job runs the remaining
+      # crates plus workspace-level checks.
 
       # Foundation crates (no internal deps, lib-only)
       - name: Test octos-core
@@ -180,22 +163,6 @@ jobs:
       - name: Test octos-swarm
         run: cargo test -p octos-swarm
 
-      # octos-agent: the heaviest crate. Library and integration test binaries
-      # are split so neither step pulls all 27 test binaries into memory at
-      # once during link.
-      - name: Test octos-agent (lib)
-        run: cargo test -p octos-agent --lib
-
-      - name: Test octos-agent (integration)
-        run: cargo test -p octos-agent --tests
-
-      # Top of the dep tree
-      - name: Test octos-cli (lib)
-        run: cargo test -p octos-cli --lib
-
-      - name: Test octos-cli (integration)
-        run: cargo test -p octos-cli --tests
-
       # Bundled harness starter skills (each has small lib + 1 smoke test)
       - name: Test harness starter skills
         run: |
@@ -208,19 +175,85 @@ jobs:
       - name: Doc tests
         run: cargo test --workspace --doc
 
-      # ── Targeted regression filters (already pre-existing) ──────────────────
-      - name: API feature tests
-        run: cargo test -p octos-cli --features api api::auth_handlers
-
-      - name: QoS adaptive/runtime catalog regressions
+      # ── Targeted regression filters that fit on the lean runner ─────────────
+      # The octos-llm-only regressions stay here (octos-llm already builds
+      # in this job for `Test octos-llm`). The octos-cli regressions and
+      # octos-agent regression test moved to their respective sharded jobs.
+      - name: QoS adaptive/runtime catalog regressions (octos-llm)
         run: |
           cargo test -p octos-llm test_qos_ranking_changes_lane_selection -- --nocapture
           cargo test -p octos-llm test_derive_cold_start_catalog_assigns_non_zero_scores -- --nocapture
           cargo test -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score -- --nocapture
-          cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
 
+  # ── Sharded heavy-crate test jobs ────────────────────────────────────────
+  # These crates each pull in a >100MB rlib closure (chromiumoxide, lettre,
+  # hyper, …) and link 27+ test binaries. Running them sequentially in the
+  # `check` job exhausted the 16GB ubuntu-latest runner mid-link (run
+  # 25137059453 — "hosted runner lost communication with the server" 54min
+  # in). Each crate now runs on its own fresh runner with its own cache.
+  #
+  # Cache keys are distinct (shared-key: octos-agent-tests / octos-cli-tests)
+  # so they don't fight the lean `check` job's default-keyed cache.
+
+  test-octos-agent:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_JOBS: "1"
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: octos-agent-tests
+
+      # Library and integration test binaries are split so neither step
+      # pulls all 27 octos-agent test binaries into memory at link time.
+      - name: Test octos-agent (lib)
+        run: cargo test -p octos-agent --lib
+
+      - name: Test octos-agent (integration)
+        run: cargo test -p octos-agent --tests
+
+      # Co-located here so it reuses this job's warm octos-agent build cache
+      # rather than triggering a cold rebuild in the lean `check` job.
       - name: activate_tools regression tests
         run: cargo test -p octos-agent --test activate_tools_regression -- --nocapture
+
+  test-octos-cli:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_BUILD_JOBS: "1"
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: octos-cli-tests
+
+      - name: Test octos-cli (lib)
+        run: cargo test -p octos-cli --lib
+
+      - name: Test octos-cli (integration)
+        run: cargo test -p octos-cli --tests
+
+      # Co-located here so they reuse this job's warm octos-cli build cache.
+      - name: API feature tests
+        run: cargo test -p octos-cli --features api api::auth_handlers
+
+      - name: gateway_runtime regression (octos-cli)
+        run: cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
 
   # Lightweight check that exercises the `matrix` feature gate. The default
   # `FEATURES` env above intentionally omits `matrix` to keep the main `check`
@@ -411,7 +444,7 @@ jobs:
   # ── Release artifact builds (main only) ──────────────────────────
   build-macos-arm:
     if: github.event_name == 'push'
-    needs: check
+    needs: [check, test-octos-agent, test-octos-cli]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -439,7 +472,7 @@ jobs:
 
   build-linux-x86:
     if: github.event_name == 'push'
-    needs: check
+    needs: [check, test-octos-agent, test-octos-cli]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -528,7 +561,7 @@ jobs:
 
   e2e-tool-regression:
     runs-on: macos-14
-    needs: check
+    needs: [check, test-octos-agent, test-octos-cli]
     # Run on pushes to main or when tool/sandbox/agent files change
     if: |
       github.event_name == 'push' ||
@@ -597,7 +630,7 @@ jobs:
 
   security:
     runs-on: macos-14
-    needs: check
+    needs: [check, test-octos-agent, test-octos-cli]
     # Only run when security-related files change
     if: |
       github.event_name == 'push' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,9 @@ jobs:
       # the same runner (run 25137059453, job 73677952504 — runner lost
       # communication with the server during `Test octos-agent (lib)`,
       # 54min in). The structural fix is sharding: see test-octos-agent
-      # and test-octos-cli below, which each get their own fresh 16GB
-      # runner. This `check` job now only handles the light crates and
-      # workspace-level checks (fmt, clippy, doc tests).
+      # (matrix: lib + integration) and test-octos-cli below, which each
+      # get their own fresh 16GB runner. This `check` job now only handles
+      # the light crates and workspace-level checks (fmt, clippy, doc tests).
       CARGO_BUILD_JOBS: "1"
       CARGO_PROFILE_TEST_DEBUG: line-tables-only
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
@@ -192,10 +192,26 @@ jobs:
   # 25137059453 — "hosted runner lost communication with the server" 54min
   # in). Each crate now runs on its own fresh runner with its own cache.
   #
-  # Cache keys are distinct (shared-key: octos-agent-tests / octos-cli-tests)
-  # so they don't fight the lean `check` job's default-keyed cache.
+  # octos-agent goes one step further: its lib + integration test compile
+  # phases EACH peak around the 16GB ceiling (run on PR #672 — integration
+  # step was cancelled after lib step's compile already used a chunk of
+  # RAM in the same runner). So lib and integration are split into two
+  # SEPARATE jobs (each fresh 16GB runner), via a matrix on `test-mode`.
+  #
+  # Cache keys are distinct (shared-key: octos-agent-tests-{lib,integration}
+  # / octos-cli-tests) so they don't fight the lean `check` job's
+  # default-keyed cache and don't fight each other.
 
   test-octos-agent:
+    strategy:
+      fail-fast: false
+      matrix:
+        # `lib` runs `--lib` only. `integration` runs `--tests` (every
+        # integration test binary, including activate_tools_regression).
+        # Splitting these onto separate runners means each gets a fresh
+        # 16GB allocation and neither inherits residual RAM from the
+        # other's compile phase.
+        test-mode: [lib, integration]
     runs-on: ubuntu-latest
     env:
       CARGO_BUILD_JOBS: "1"
@@ -210,19 +226,21 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: octos-agent-tests
+          shared-key: octos-agent-tests-${{ matrix.test-mode }}
 
-      # Library and integration test binaries are split so neither step
-      # pulls all 27 octos-agent test binaries into memory at link time.
       - name: Test octos-agent (lib)
+        if: matrix.test-mode == 'lib'
         run: cargo test -p octos-agent --lib
 
       - name: Test octos-agent (integration)
+        if: matrix.test-mode == 'integration'
         run: cargo test -p octos-agent --tests
 
-      # Co-located here so it reuses this job's warm octos-agent build cache
-      # rather than triggering a cold rebuild in the lean `check` job.
+      # Co-located in the integration job so it reuses the warm octos-agent
+      # integration test build cache (activate_tools_regression is itself an
+      # integration test binary). Skipped in the lib job.
       - name: activate_tools regression tests
+        if: matrix.test-mode == 'integration'
         run: cargo test -p octos-agent --test activate_tools_regression -- --nocapture
 
   test-octos-cli:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,16 +91,44 @@ jobs:
   check:
     runs-on: ubuntu-latest
     env:
-      # Cap parallel cargo build jobs at 2 so concurrent rustc/linker invocations
-      # do not exceed the 16GB ubuntu-latest runner budget. Linking the
-      # octos-agent --lib unit-test binary (78MB stripped, ~2GB+ peak rustc RSS
-      # against a 144MB rlib + chromiumoxide/lettre/etc.) at default parallelism
-      # was OOM-killing the runner during the `Test octos-agent (lib)` step,
-      # producing the "hosted runner lost communication with the server" error
-      # (~45min into the run before the runner died). Mirrors the existing
-      # CARGO_BUILD_JOBS="2" guard on check-arm and check-riscv, which already
-      # use this mitigation for the same 16GB memory budget.
-      CARGO_BUILD_JOBS: "2"
+      # OOM mitigation for the 16GB ubuntu-latest runner (4 CPU, 16GB —
+      # public-repo standard). Two layers, defense-in-depth:
+      #
+      # 1. CARGO_BUILD_JOBS=1 (was 2). The earlier =2 cap (#606) is
+      #    insufficient — runs still OOM-kill during `Test octos-agent
+      #    (lib)`, with the canonical "hosted runner lost communication
+      #    with the server" annotation appearing ~51min into the job
+      #    (e.g. run 25133705908: lib step started at 21:08:53Z, runner
+      #    died at 21:53Z, zero log output in between). Two concurrent
+      #    rustc/linker processes each touching the 144MB octos-agent
+      #    rlib closure (chromiumoxide + lettre + hyper) overlap their
+      #    peaks and cross the budget. Serializing fully removes the
+      #    aggregate-memory failure mode.
+      #
+      # 2. CARGO_PROFILE_{TEST,DEV}_DEBUG=line-tables-only. JOBS=1 alone
+      #    only addresses overlap; it does not shrink the peak memory of
+      #    the single linker invocation that links the octos-agent --lib
+      #    test binary. Dropping from full DWARF (`debug=2`, the
+      #    dev/test profile default) to line-tables-only drops local-
+      #    variable and parameter debug info while preserving file/line
+      #    info — i.e. panic backtraces still report `file.rs:line`,
+      #    which is all CI ever consumes from debug-info. Both the test
+      #    profile (octos-agent --lib) and the dev profile (build
+      #    dependencies and any plain `cargo build` invocations) get the
+      #    cap; otherwise a build-dep compiled at `debug=2` could feed a
+      #    huge object back into the test link. Test correctness,
+      #    debug_assertions, and overflow checks are unchanged.
+      #
+      # Using cargo's profile env vars rather than RUSTFLAGS avoids
+      # invalidating the Swatinem/rust-cache key for unrelated tools
+      # (e.g. clippy on a different debuginfo level) and is the
+      # cargo-recommended way to override a profile field.
+      #
+      # The same JOBS=2 guard remains in place on check-arm/check-riscv
+      # where it has been working (those runners are 16GB ARM/RISCV).
+      CARGO_BUILD_JOBS: "1"
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
         with:

--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -1107,7 +1107,10 @@ mod tests {
         let state = smtp_state(dir.path());
         let Json(body) = get_deployment_mode(State(state)).await.unwrap();
         assert_eq!(body.mode, "local");
-        assert!(!body.explicit, "implicit default must report explicit=false");
+        assert!(
+            !body.explicit,
+            "implicit default must report explicit=false"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -305,7 +305,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // First-run setup wizard
         .route("/api/admin/token/status", get(admin_setup::token_status))
         .route("/api/admin/token/rotate", post(admin_setup::rotate_token))
-        .route("/api/admin/token/email", post(admin_setup::post_token_email))
+        .route(
+            "/api/admin/token/email",
+            post(admin_setup::post_token_email),
+        )
         .route("/api/admin/setup/state", get(admin_setup::get_setup_state))
         .route("/api/admin/setup/step", post(admin_setup::post_setup_step))
         .route(


### PR DESCRIPTION
## Summary

The `check` job has been OOM-killing the 16GB ubuntu-latest runner during the `Test octos-agent (lib)` step on every workspace PR, despite the prior `CARGO_BUILD_JOBS=2` cap (#606). Recent runs (25133705908, 25133710641, 25134240576) all show the same signature: every per-crate test step up to and including `Test octos-swarm` succeeds, then `Test octos-agent (lib)` starts and produces no log output before the runner dies ~45 minutes later with the canonical *"hosted runner lost communication with the server"* annotation. ~51min wall per attempt, every PR red.

## Diagnosis

Linking `octos-agent --lib` is the heavy step: ~78MB stripped test binary, ~2GB+ peak rustc RSS, links a 144MB rlib closure including chromiumoxide, lettre, hyper, and the rest of the dep graph. At `CARGO_BUILD_JOBS=2`, two link peaks can overlap and cross the 16GB budget; serial steps elsewhere on the runner (build scripts, proc-macros) compound it.

Evidence (run 25133705908, job 73666399100):
- `Test octos-swarm` completed `2026-04-29T21:08:53Z` — success.
- `Test octos-agent (lib)` started `2026-04-29T21:08:53Z` — no further log output.
- Job killed `2026-04-29T21:53Z` (~45min later) with the runner-lost annotation.

## Fix (defense-in-depth, two layers)

1. **`CARGO_BUILD_JOBS=1`** — serialize cargo's rustc/linker invocations so two 2GB-RSS link peaks can never overlap.

2. **`CARGO_PROFILE_TEST_DEBUG=line-tables-only`** + **`CARGO_PROFILE_DEV_DEBUG=line-tables-only`** — drop from full DWARF (`debug=2`, the dev/test default) to line-tables-only. Local-variable and parameter debug info is dropped; file/line info is preserved, so panic backtraces still report `file.rs:line` (the only debug-info CI ever consumes). Both profiles are capped because `cargo test` may still feed dev-profile build dependencies into the final test link. `debug_assertions`, overflow checks, and panic semantics are all unchanged.

Using cargo's profile env vars (rather than `RUSTFLAGS=-C debuginfo=`) is more surgical: it does not affect rustc invocations cargo would otherwise compile without debug info, and avoids accidentally invalidating Swatinem/rust-cache keys for unrelated tooling.

The two layers complement each other:
- (1) addresses *aggregate* runner memory (no overlapping peaks).
- (2) addresses *per-process* peak (smaller DWARF in the rlib + final link).

The same `JOBS=2` guard remains on `check-arm` and `check-riscv` (also 16GB), where it has been working — those runners do not link the same x86_64 dep closure.

## Drift

Also includes a `cargo fmt --all` pass that picks up two stale formatting drift hunks in `octos-cli` (`admin_setup.rs` and `router.rs`). These would otherwise re-fail the `Check formatting` step on a future unrelated PR.

## Test plan

- [ ] This PR's own `check` run completes successfully (wall < 30min, no runner-lost annotation, all per-crate test steps green including `Test octos-agent (lib)` and `Test octos-cli (integration)`).
- [ ] Existing `check-arm` / `check-riscv` matrix jobs (gated on push, not PR) remain unaffected.
- [ ] Spot-check downstream `e2e-tool-regression` / `m9-protocol-e2e` / `security` jobs are not affected (they `needs: check` but otherwise share no env).

Refs internal task #111 (Shard CI workspace tests to unblock fleet OOM).