### PR TITLE
fix(rapid-fire): per-turn thread_id capture survives concurrent chat streams (#649 follow-up)

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -5119,6 +5119,181 @@ mod tests {
         assert_eq!(parsed["thread_id"], "cmid-explicit-A");
     }
 
+    /// #649 follow-up (rapid-fire): when 5 chat streams interleave on the
+    /// same chat_id, each turn's stream forwarder must call `send_with_id`
+    /// with its OWN cmid in metadata so subsequent `edit_message` /
+    /// `send_raw_sse` calls can recover the right thread.
+    ///
+    /// Pre-fix the stream forwarder built outbound metadata containing only
+    /// `streaming: true` and let `send_with_id` fall back to the sticky
+    /// map. Under rapid-fire (Q1..Q5 lining up on the same session before
+    /// any of them finishes), the sticky map has rotated to the LAST
+    /// request's cmid by the time Q1's first chunk reaches the channel —
+    /// so Q1's encoded message_id captures Q5's cmid and every subsequent
+    /// streaming `token` / `replace` for Q1 mis-routes to Q5's bubble on
+    /// the web client. This drives that exact ordering and asserts each
+    /// turn's encoded message_id carries its OWN thread_id when supplied
+    /// explicitly via the OutboundMessage metadata.
+    #[tokio::test]
+    async fn send_with_id_uses_explicit_metadata_thread_id_over_sticky() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, _rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("chat-rapid-fire".into(), tx);
+        }
+
+        // Five rapid-fire `handle_chat`-equivalent sticky rotations: the
+        // PRODUCTION race is each new request pinning sticky to its own
+        // cmid before any earlier turn has produced its first stream
+        // chunk. By the time Q1's stream forwarder calls `send_with_id`,
+        // sticky already holds Q5's cmid.
+        for cmid in ["cmid-A", "cmid-B", "cmid-C", "cmid-D", "cmid-E"] {
+            ch.remember_thread_id("chat-rapid-fire", Some(cmid)).await;
+        }
+
+        // Q1's stream forwarder calls `send_with_id` with metadata that
+        // EXPLICITLY carries Q1's cmid (the post-fix shape). The encoded
+        // message_id must capture cmid-A — NOT the sticky's cmid-E.
+        let q1 = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "chat-rapid-fire".into(),
+            content: "first chunk for Q1".into(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "streaming": true,
+                "thread_id": "cmid-A",
+            }),
+        };
+        let q1_msg_id = ch
+            .send_with_id(&q1)
+            .await
+            .unwrap()
+            .expect("send_with_id always returns Some");
+        let (_, q1_decoded) = decode_sse_message_id(&q1_msg_id);
+        assert_eq!(
+            q1_decoded.as_deref(),
+            Some("cmid-A"),
+            "Q1's encoded message_id must capture its OWN cmid, not the sticky's last value (cmid-E). Got: {q1_msg_id}"
+        );
+
+        // Q3 lands next, also with explicit metadata. Same expectation —
+        // Q3's encoded id must reflect Q3's cmid even though sticky still
+        // points elsewhere.
+        let q3 = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "chat-rapid-fire".into(),
+            content: "first chunk for Q3".into(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "streaming": true,
+                "thread_id": "cmid-C",
+            }),
+        };
+        let q3_msg_id = ch
+            .send_with_id(&q3)
+            .await
+            .unwrap()
+            .expect("send_with_id always returns Some");
+        let (_, q3_decoded) = decode_sse_message_id(&q3_msg_id);
+        assert_eq!(
+            q3_decoded.as_deref(),
+            Some("cmid-C"),
+            "Q3's encoded message_id must capture its OWN cmid even with concurrent sticky rotations. Got: {q3_msg_id}"
+        );
+    }
+
+    /// #649 follow-up (rapid-fire): drive an end-to-end interleaved
+    /// 5-turn rapid-fire scenario through `send` and assert each turn's
+    /// `replace` event carries its OWN cmid when the OutboundMessage
+    /// metadata supplies one explicitly. This exercises the path the
+    /// stream forwarder takes for non-first chunks (the inner `send` call
+    /// from `send_with_id`).
+    #[tokio::test]
+    async fn rapid_fire_streaming_chunks_carry_per_turn_thread_id() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("chat-rapid".into(), tx);
+        }
+
+        // Simulate `handle_chat` rotating sticky to the LATEST cmid as
+        // each rapid-fire request arrives.
+        for cmid in ["cmid-A", "cmid-B", "cmid-C", "cmid-D", "cmid-E"] {
+            ch.remember_thread_id("chat-rapid", Some(cmid)).await;
+        }
+
+        // Each turn's first chunk arrives via `send` with explicit
+        // thread_id metadata. The `replace` event emitted on the wire
+        // must be tagged with that cmid, NOT the latest sticky value.
+        let cases = [
+            ("cmid-A", "Q1 reply"),
+            ("cmid-B", "Q2 reply"),
+            ("cmid-C", "Q3 reply"),
+            ("cmid-D", "Q4 reply"),
+        ];
+        for (cmid, content) in &cases {
+            let msg = OutboundMessage {
+                channel: "api".into(),
+                chat_id: "chat-rapid".into(),
+                content: (*content).into(),
+                reply_to: None,
+                media: vec![],
+                metadata: serde_json::json!({
+                    "streaming": true,
+                    "thread_id": cmid,
+                }),
+            };
+            ch.send(&msg).await.unwrap();
+            // Reset last_content so each turn's chunk emits as a `replace`,
+            // not a delta `token` (the production stream forwarder calls
+            // `send_with_id` first which clears last_content; we mimic that
+            // by clearing it inline here).
+            ch.last_content.lock().await.remove("chat-rapid");
+        }
+
+        // Drain wire events and verify each carries its OWN cmid.
+        let mut events: Vec<serde_json::Value> = Vec::new();
+        while let Ok(payload) = rx.try_recv() {
+            events.push(serde_json::from_str(&payload).unwrap());
+        }
+        let replaces: Vec<&serde_json::Value> =
+            events.iter().filter(|e| e["type"] == "replace").collect();
+        assert_eq!(
+            replaces.len(),
+            cases.len(),
+            "expected {} replace events, got {}: {:?}",
+            cases.len(),
+            replaces.len(),
+            events,
+        );
+        for ((expected_cmid, expected_text), event) in cases.iter().zip(replaces.iter()) {
+            assert_eq!(
+                event["text"], *expected_text,
+                "replace event text mismatch: {event}"
+            );
+            assert_eq!(
+                event["thread_id"], *expected_cmid,
+                "replace event for {expected_text} mis-tagged. Expected {expected_cmid}, got: {event}"
+            );
+        }
+    }
+
     /// Pre-cmid clients send messages with no thread_id metadata. The wire
     /// schema must remain backwards-compatible: events emitted in this
     /// case must NOT include a `thread_id` field at all.

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4137,6 +4137,14 @@ impl SessionActor {
                     self.session_key.clone(),
                     self.sender_user_id.clone(),
                     op_updater,
+                    // #649 follow-up (rapid-fire): forward THIS turn's
+                    // cmid so the forwarder stamps every `send_with_id` /
+                    // `edit_message` outbound with it. Concurrent overflow
+                    // turns each get their OWN forwarder + their OWN
+                    // cmid — under rapid-fire 5 turns that prevents the
+                    // shared sticky map from collapsing them onto one
+                    // bubble.
+                    client_message_id.clone(),
                 )))
             } else {
                 drop(stream_rx);
@@ -5075,6 +5083,13 @@ impl SessionActor {
                     session_key.clone(),
                     sender_user_id.clone(),
                     op_updater,
+                    // #649 follow-up (rapid-fire): each overflow turn
+                    // captures its OWN cmid up front so its stream
+                    // forwarder stamps every outbound with it. Without
+                    // this, 5 concurrent rapid-fire overflow forwarders
+                    // fight over the shared sticky map and collapse onto
+                    // the bubble of whichever turn arrived last.
+                    overflow_client_message_id.clone(),
                 )))
             } else {
                 drop(stream_rx);
@@ -5484,6 +5499,9 @@ impl SessionActor {
                     self.session_key.clone(),
                     self.sender_user_id.clone(),
                     op_updater,
+                    // #649 follow-up (rapid-fire): forward this turn's
+                    // cmid so streaming chunks stamp it on the wire.
+                    client_message_id.clone(),
                 )))
             } else {
                 drop(stream_rx);

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -296,6 +296,16 @@ async fn is_session_active(
 /// `active_sessions` + `session_key` — used to check if this session is currently
 /// active before sending/editing channel messages. When inactive, all direct
 /// channel operations are skipped to prevent cross-session message leaks.
+///
+/// `thread_id` — #649 follow-up (rapid-fire): the originating turn's
+/// `client_message_id`, captured ONCE at forwarder construction. Every
+/// `send_with_id` / `edit_message` call this forwarder issues stamps the
+/// outbound metadata with this value so the channel does not have to
+/// fall back to the per-chat sticky map. Under rapid-fire 5 concurrent
+/// turns, sticky has rotated to the LATEST cmid by the time an earlier
+/// turn produces its first chunk — pre-fix that earlier chunk's encoded
+/// message_id captured the rotated value and every subsequent edit
+/// inherited the wrong thread_id, collapsing 4 turns onto one bubble.
 #[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub async fn run_stream_forwarder(
     mut rx: mpsc::UnboundedReceiver<StreamProgressEvent>,
@@ -307,6 +317,7 @@ pub async fn run_stream_forwarder(
     session_key: SessionKey,
     sender_user_id: Option<String>,
     operation_updater: Option<Arc<dyn Fn(&str) + Send + Sync>>,
+    thread_id: Option<String>,
 ) -> StreamResult {
     let mut buffer = String::new();
     let mut message_id: Option<String> = None;
@@ -377,6 +388,7 @@ pub async fn run_stream_forwarder(
                             &mut message_id,
                             &mut no_edit_support,
                             sender_user_id.as_deref(),
+                            thread_id.as_deref(),
                         )
                         .await;
                         last_edit = Instant::now();
@@ -399,6 +411,7 @@ pub async fn run_stream_forwarder(
                             &mut message_id,
                             &mut no_edit_support,
                             sender_user_id.as_deref(),
+                            thread_id.as_deref(),
                         )
                         .await;
                     }
@@ -425,6 +438,7 @@ pub async fn run_stream_forwarder(
                             &mut message_id,
                             &mut no_edit_support,
                             sender_user_id.as_deref(),
+                            thread_id.as_deref(),
                         )
                         .await;
                     }
@@ -451,6 +465,7 @@ pub async fn run_stream_forwarder(
                                 &mut message_id,
                                 &mut no_edit_support,
                                 sender_user_id.as_deref(),
+                                thread_id.as_deref(),
                             )
                             .await;
                         }
@@ -489,6 +504,7 @@ pub async fn run_stream_forwarder(
                             &mut message_id,
                             &mut no_edit_support,
                             sender_user_id.as_deref(),
+                            thread_id.as_deref(),
                         )
                         .await;
                     }
@@ -521,6 +537,7 @@ pub async fn run_stream_forwarder(
                         &mut message_id,
                         &mut no_edit_support,
                         sender_user_id.as_deref(),
+                        thread_id.as_deref(),
                     )
                     .await;
                     last_edit = Instant::now();
@@ -545,6 +562,7 @@ pub async fn run_stream_forwarder(
                                 &mut message_id,
                                 &mut no_edit_support,
                                 sender_user_id.as_deref(),
+                                thread_id.as_deref(),
                             )
                             .await;
                         }
@@ -582,6 +600,7 @@ pub async fn run_stream_forwarder(
                 &mut message_id,
                 &mut no_edit_support,
                 sender_user_id.as_deref(),
+                thread_id.as_deref(),
             )
             .await;
         }
@@ -598,6 +617,7 @@ pub async fn run_stream_forwarder(
 /// If `send_with_id` returns `None` (channel doesn't support message editing),
 /// sets `no_edit_support` to true so the caller stops attempting to stream.
 /// The final reply will go through the normal `out_tx` path instead.
+#[allow(clippy::too_many_arguments)]
 async fn flush_to_channel(
     channel: &Arc<dyn Channel>,
     chat_id: &str,
@@ -605,6 +625,7 @@ async fn flush_to_channel(
     message_id: &mut Option<String>,
     no_edit_support: &mut bool,
     sender_user_id: Option<&str>,
+    thread_id: Option<&str>,
 ) {
     do_flush(
         channel,
@@ -614,6 +635,7 @@ async fn flush_to_channel(
         no_edit_support,
         false,
         sender_user_id,
+        thread_id,
     )
     .await;
 }
@@ -622,6 +644,7 @@ async fn flush_to_channel(
 ///
 /// Channels that need special finalization (e.g. WeCom `finish: true`) will
 /// receive this via `Channel::finish_stream()`.
+#[allow(clippy::too_many_arguments)]
 async fn finish_flush_to_channel(
     channel: &Arc<dyn Channel>,
     chat_id: &str,
@@ -629,6 +652,7 @@ async fn finish_flush_to_channel(
     message_id: &mut Option<String>,
     no_edit_support: &mut bool,
     sender_user_id: Option<&str>,
+    thread_id: Option<&str>,
 ) {
     // Preserve the asserted virtual-user identity when the final flush is the
     // first send; otherwise Matrix falls back to the main bot user.
@@ -640,10 +664,12 @@ async fn finish_flush_to_channel(
         no_edit_support,
         true,
         sender_user_id,
+        thread_id,
     )
     .await;
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn do_flush(
     channel: &Arc<dyn Channel>,
     chat_id: &str,
@@ -652,6 +678,7 @@ async fn do_flush(
     no_edit_support: &mut bool,
     finish: bool,
     sender_user_id: Option<&str>,
+    thread_id: Option<&str>,
 ) {
     if let Some(mid) = message_id.as_ref() {
         let result = if finish {
@@ -664,15 +691,34 @@ async fn do_flush(
         }
     } else {
         // Send new message and capture its ID
+        //
+        // #649 follow-up (rapid-fire): stamp the originating turn's
+        // `thread_id` into the outbound metadata so the API channel's
+        // `send_with_id` captures THIS turn's cmid into the encoded
+        // message_id rather than falling back to the per-chat sticky
+        // map (which has been rotated by every concurrent rapid-fire
+        // request that arrived between this turn's bind and first chunk).
+        let mut metadata = match sender_user_id {
+            Some(uid) => {
+                serde_json::json!({ METADATA_SENDER_USER_ID: uid, "streaming": true })
+            }
+            None => serde_json::json!({ "streaming": true }),
+        };
+        if let Some(tid) = thread_id.filter(|s| !s.is_empty()) {
+            if let Some(map) = metadata.as_object_mut() {
+                map.insert(
+                    "thread_id".to_string(),
+                    serde_json::Value::String(tid.to_string()),
+                );
+            }
+        }
         let msg = OutboundMessage {
             channel: channel.name().to_string(),
             chat_id: chat_id.to_string(),
             content: text.to_string(),
             reply_to: None,
             media: vec![],
-            metadata: sender_user_id
-                .map(|uid| serde_json::json!({ METADATA_SENDER_USER_ID: uid, "streaming": true }))
-                .unwrap_or_else(|| serde_json::json!({ "streaming": true })),
+            metadata,
         };
         match channel.send_with_id(&msg).await {
             Ok(Some(mid)) => {
@@ -889,6 +935,7 @@ mod tests {
             &mut message_id,
             &mut no_edit_support,
             Some("@bot_mybot:localhost"),
+            None,
         )
         .await;
 
@@ -917,6 +964,7 @@ mod tests {
             &mut message_id,
             &mut no_edit_support,
             Some("@bot_mybot:localhost"),
+            None,
         )
         .await;
 
@@ -928,6 +976,139 @@ mod tests {
                 .get(METADATA_SENDER_USER_ID)
                 .and_then(|v| v.as_str()),
             Some("@bot_mybot:localhost")
+        );
+    }
+
+    /// #649 follow-up (rapid-fire): the streaming path must stamp the
+    /// originating turn's `thread_id` into the OutboundMessage metadata
+    /// every time `do_flush` opens a new bubble via `send_with_id`. Pre-fix
+    /// the metadata was `{streaming: true}` only, so under rapid-fire the
+    /// API channel's `send_with_id` fell back to the per-chat sticky map
+    /// (rotated to the LATEST cmid by every concurrent `handle_chat`
+    /// arrival) and 4 of 5 turns mis-tagged onto a single bubble.
+    ///
+    /// This test drives the exact pre-fix shape (per-turn `thread_id`
+    /// captured at forwarder construction) and asserts the wire-side
+    /// outbound carries it. Pre-fix the assert fails — the metadata only
+    /// has `streaming: true`. Post-fix the assert passes.
+    #[tokio::test]
+    async fn flush_to_channel_stamps_outbound_with_thread_id() {
+        let mock = Arc::new(MockChannel::default());
+        let channel: Arc<dyn Channel> = mock.clone();
+        let mut message_id = None;
+        let mut no_edit_support = false;
+
+        flush_to_channel(
+            &channel,
+            "chat-rapid-fire",
+            "first chunk",
+            &mut message_id,
+            &mut no_edit_support,
+            None,
+            Some("cmid-A"),
+        )
+        .await;
+
+        let sent = mock.sent.lock().await;
+        let first = sent
+            .first()
+            .expect("stream message should be sent through send_with_id");
+        assert_eq!(
+            first.metadata.get("thread_id").and_then(|v| v.as_str()),
+            Some("cmid-A"),
+            "outbound metadata must carry the per-turn thread_id so \
+             ApiChannel does not fall back to the rotated sticky map. \
+             Got metadata: {}",
+            first.metadata
+        );
+    }
+
+    /// #649 follow-up (rapid-fire): same property for the FINAL flush
+    /// path (StreamDone). The final outbound also goes through
+    /// `send_with_id` when the bubble was never opened, so it must
+    /// stamp `thread_id`.
+    #[tokio::test]
+    async fn finish_flush_to_channel_stamps_outbound_with_thread_id() {
+        let mock = Arc::new(MockChannel::default());
+        let channel: Arc<dyn Channel> = mock.clone();
+        let mut message_id = None;
+        let mut no_edit_support = false;
+
+        finish_flush_to_channel(
+            &channel,
+            "chat-rapid-fire",
+            "final chunk",
+            &mut message_id,
+            &mut no_edit_support,
+            None,
+            Some("cmid-E"),
+        )
+        .await;
+
+        let sent = mock.sent.lock().await;
+        let first = sent
+            .first()
+            .expect("final stream message should be sent through send_with_id");
+        assert_eq!(
+            first.metadata.get("thread_id").and_then(|v| v.as_str()),
+            Some("cmid-E"),
+            "final-flush outbound metadata must carry the per-turn thread_id"
+        );
+    }
+
+    /// Backwards-compat: when `thread_id` is None or empty, the outbound
+    /// metadata MUST NOT include a `thread_id` field so non-API channels
+    /// (Matrix, Telegram, …) and pre-cmid clients keep observing the
+    /// pre-fix wire shape.
+    #[tokio::test]
+    async fn flush_omits_thread_id_when_unbound() {
+        let mock = Arc::new(MockChannel::default());
+        let channel: Arc<dyn Channel> = mock.clone();
+        let mut message_id = None;
+        let mut no_edit_support = false;
+
+        flush_to_channel(
+            &channel,
+            "chat-legacy",
+            "hello",
+            &mut message_id,
+            &mut no_edit_support,
+            None,
+            None,
+        )
+        .await;
+
+        let sent = mock.sent.lock().await;
+        let first = sent.first().expect("stream message should be sent");
+        assert!(
+            first.metadata.get("thread_id").is_none(),
+            "thread_id field must be absent when forwarder has no bound id, got {}",
+            first.metadata
+        );
+
+        // Also verify empty-string thread_id is treated as absent (legacy
+        // pre-cmid clients send `client_message_id: ""` on some paths).
+        drop(sent);
+        let mock2 = Arc::new(MockChannel::default());
+        let channel2: Arc<dyn Channel> = mock2.clone();
+        let mut message_id2 = None;
+        let mut no_edit_support2 = false;
+        flush_to_channel(
+            &channel2,
+            "chat-legacy-empty",
+            "hello",
+            &mut message_id2,
+            &mut no_edit_support2,
+            None,
+            Some(""),
+        )
+        .await;
+        let sent2 = mock2.sent.lock().await;
+        let first2 = sent2.first().expect("stream message should be sent");
+        assert!(
+            first2.metadata.get("thread_id").is_none(),
+            "empty-string thread_id must be treated as absent, got {}",
+            first2.metadata
         );
     }
 }


### PR DESCRIPTION
## Summary

- Under rapid-fire 5 chat streams interleaving on the same `chat_id`, the streaming text path (`stream_reporter::do_flush`) built `OutboundMessage` metadata containing only `{streaming: true}`. `ApiChannel::send_with_id` then fell back to the per-chat sticky thread_id map, which `handle_chat` had rotated to whatever request arrived last — collapsing 4 of 5 turns onto a single web bubble (assistant outputs `2`, `4`, `6`, `8`, `10` all tagged `thread_id=E`, the last turn's cmid).
- Fix: thread the originating turn's `client_message_id` through `run_stream_forwarder` -> `flush_to_channel` / `finish_flush_to_channel` -> `do_flush`, and stamp it into `OutboundMessage.metadata` before the first `send_with_id`. `ApiChannel::send_with_id` already prefers explicit metadata `thread_id` over sticky, so this closes the rapid-fire window without touching api_channel logic. Each `tokio::spawn` captures its own owned `Option<String>` so concurrent forwarders cannot race.
- Backwards compat preserved: when `thread_id` is None or empty, the wire-side `OutboundMessage` metadata stays `{streaming: true}` (no `thread_id` field). Verified by `flush_omits_thread_id_when_unbound`.

## Codex 2nd opinion

Codex (logged at `/tmp/codex-rapid-fire-fix.log`) verdict:
> Your fix shape is correct for the cmid collapse bug. Passing the owned `Option<String>` into each `tokio::spawn` gives every forwarder its own immutable turn id, and `do_flush` now puts that id into `OutboundMessage.metadata` before the first `send_with_id`. Then `ApiChannel::send_with_id` resolves explicit metadata before sticky, so the encoded SSE message id gets the right thread.
>
> I would not solve this by delaying sticky-map rotation until the previous turn finishes. Sticky is a fallback for legacy/unbound events; it cannot be the source of truth for concurrent same-chat streams. Explicit per-turn metadata is the right boundary.

Codex flagged a **separate** bug class as a follow-up: `ApiChannel::last_content` is keyed only by `chat_id`, so under concurrent same-chat streams, `edit_message`'s delta computation can mis-emit a `token` event derived from another turn's previous content (when one turn's content happens to be a prefix of another's). That is a different defect (delta computation, not thread_id routing) and is not addressed here per the "don't iterate forever" guidance — it deserves its own PR keying `last_content` by `(chat_id, thread_id)` or by synthetic `message_id`.

## Test plan

- [x] `cargo build --workspace --tests` passes
- [x] `cargo clippy -p octos-cli -p octos-bus --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p octos-cli` (326 passed)
- [x] `cargo test -p octos-bus --features api` (259 passed)
- [x] New regression tests:
  - `octos-cli::stream_reporter::tests::flush_to_channel_stamps_outbound_with_thread_id`
  - `octos-cli::stream_reporter::tests::finish_flush_to_channel_stamps_outbound_with_thread_id`
  - `octos-cli::stream_reporter::tests::flush_omits_thread_id_when_unbound`
  - `octos-bus::api_channel::tests::send_with_id_uses_explicit_metadata_thread_id_over_sticky`
  - `octos-bus::api_channel::tests::rapid_fire_streaming_chunks_carry_per_turn_thread_id`
- [ ] Mini3 soak with `rapid-fire-five-fast` scenario shows each Q gets its own thread_id end-to-end