### PR TITLE
fix(e2e): drop cancel-button precondition from live-thread-interleave

### DIFF
--- a/e2e/tests/live-thread-interleave.spec.ts
+++ b/e2e/tests/live-thread-interleave.spec.ts
@@ -130,12 +130,16 @@ test.describe('Live thread interleave (M8.10 PR #4)', () => {
     await getSendButton(page).click();
     await expect.poll(() => countUserBubbles(page)).toBe(userBubblesBefore + 1);
 
-    // 2. Wait briefly so the slow request enters streaming state, then
-    //    send the fast question while slow is still in flight.
+    // 2. Wait briefly, then send the fast question. The slow Q may be
+    //    in active foreground streaming OR may have already spawned to
+    //    background — `deep_search` / `run_pipeline` are spawn_only, so
+    //    the foreground SSE turn ends with a "background started" ack
+    //    within ~2-3s and the cancel button disappears even though the
+    //    real research is still running. The threading invariant we
+    //    test below holds either way: each user message's responses
+    //    (including any later background-completion bubble) bind to
+    //    its own thread by clientMessageId.
     await page.waitForTimeout(SEND_GAP_MS);
-    await expect
-      .poll(() => page.locator(SEL.cancelButton).isVisible().catch(() => false))
-      .toBeTruthy();
 
     await getInput(page).fill(FAST_PROMPT);
     await getSendButton(page).click();


### PR DESCRIPTION
## Summary

- Removes the `expect.poll(cancel-button.isVisible).toBeTruthy()` precondition between Q1 and Q2 in `live-thread-interleave.spec.ts`.
- Updates the explanatory comment to document why the cancel button is not a reliable signal for the slow / spawn_only path.

## Why

The spec was 0✓ across the full regression on 2026-04-30 (mini1/mini3/mini4). The slow prompt (`"Use deep research to find the latest news about Rust language. Run the pipeline directly, don't ask. One paragraph."`) triggers a `spawn_only` / `run_pipeline` path: the foreground SSE turn ends with a "background started" ack within ~2-3s, finalizing the assistant message (`pendingAssistant.status = "complete"`, then nulled), which hides the cancel button.

The test waits `SEND_GAP_MS` (4 s) and then polls for cancel visibility for 5 s — the 9 s window opens entirely AFTER cancel has already disappeared, so the assertion times out 100% of the time.

Evidence in the same regression log: `live-browser` `deep_research` reports `streaming=false` at 3 s for an analogous prompt. The companion `live-overflow-thread-binding` spec uses the same prompt class and PASSES because it does not gate on the cancel button.

The threading invariants checked at the end of this test (DOM ordering, `data-thread-id` pairing, semantic slow-vs-fast text content) do not depend on observing foreground streaming mid-test, so removing the precondition keeps the test's intent intact.

## Validation

Ran in isolation against `https://dspfac.bot.ominix.io`:

```
[interleave] 0s: filled=2/2 streaming=true
new bubbles after both Qs: [
  { role: "user",      text: "Use deep research..." },
  { role: "assistant", text: "深度研究已在后台启动..." },
  { role: "user",      text: "1+1 等于几..." },
  { role: "assistant", text: "2\n\ndeepseek@..." }
]
1 passed (13.7s)
```

## Known follow-up (not in this PR)

The DOM dump shows the slow-thread ack bubble has `data-thread-id=""` (empty), while the fast-thread bubble has a populated id. This is because the slow `responses` only contain the spawn ack at this point, not the late background-completion result. The spec's own conditional check (`if (slowThreadIds.length > 0 && fastThreadIds.length > 0)`) tolerates this. A stronger spec would extend `waitForBothFinished` to wait for the ACTUAL late research result before asserting pairing — that would catch the #649 regression class more reliably. Filing as a follow-up rather than expanding scope here.

## Test plan

- [x] Spec passes in isolation against mini3 (dspfac.bot.ominix.io)
- [ ] Ride the next full regression to confirm it stays green across mini1/3/4