### PR TITLE
fix(gemini): strip x-* schema extension keys to stop HTTP 400

### DIFF
--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -593,6 +593,14 @@ fn sanitize_schema_recursive(value: &mut serde_json::Value, depth: usize) {
         obj.remove("$ref");
         obj.remove("$id");
 
+        // Gemini's tool API rejects unknown field names with HTTP 400
+        // ("Unknown name <field>"), even for the conventional `x-*` JSON
+        // Schema vendor-extension namespace. Strip them before the schema
+        // reaches the wire so host-only metadata (e.g. octos's
+        // `x-octos-host-config-keys` on the deep-search manifest) doesn't
+        // crash plan_and_search workers when routing lands on Gemini.
+        obj.retain(|k, _| !k.starts_with("x-"));
+
         // Gemini requires `items` to have a type when present.
         // Replace empty `"items": {}` with `"items": {"type": "string"}`.
         if let Some(items) = obj.get("items") {
@@ -802,6 +810,29 @@ mod tests {
         assert!(schema.get("$ref").is_none());
         assert!(schema.get("$id").is_none());
         assert_eq!(schema["type"], "object");
+    }
+
+    #[test]
+    fn test_sanitize_strips_x_extension_keys() {
+        // Pins the fix for the deep-search → Gemini 400 regression where
+        // `x-octos-host-config-keys` in input_schema crashed plan_and_search
+        // workers. Gemini's tool API rejects unknown field names (including
+        // the conventional `x-*` extension namespace) with HTTP 400.
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "synthesis_config": {"type": "object"},
+                "query": {"type": "string"}
+            },
+            "x-octos-host-config-keys": ["synthesis_config"],
+            "x-some-other-extension": {"nested": true}
+        });
+        sanitize_schema_for_gemini(&mut schema);
+        assert!(schema.get("x-octos-host-config-keys").is_none());
+        assert!(schema.get("x-some-other-extension").is_none());
+        // Non-x-prefixed fields preserved.
+        assert!(schema.get("type").is_some());
+        assert!(schema.get("properties").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the root cause of the \`live-thread-interleave:207\` soak failure where deep_research's \`plan_and_search\` workers were crashing with HTTP 400 \"Unknown name x-octos-host-config-keys\" whenever the routing lottery landed on \`gemini/gemini-3.1-pro-preview\`. After 200 retries the supervisor's child fanout cap tripped and no \`report.md\` was produced — the slow Q in the test showed only the spawn-ack with no research content.

## Why specifically Gemini

| Provider | Behavior on unknown \`x-*\` JSON Schema extension keys |
|---|---|
| OpenAI / OpenAI-compatible | silently accepted |
| Anthropic | silently accepted |
| OpenRouter | silently accepted |
| **Gemini** | **HTTP 400 \"Unknown name <field>\"** |

\`x-*\` is the conventional JSON Schema vendor-extension namespace, designed to be ignored by validators that don't recognize it. Gemini's tool API validates strictly against its OpenAPI 3.0 subset and rejects unknown keys.

The \`x-octos-host-config-keys\` field on the deep-search manifest is octos-internal metadata that tells the host runtime "extract these keys from tool args and pass as host-side synthesis config" — it's never meant for the model to see. But it lived inside \`input_schema\` because that's the only blob exposed on the manifest, so it leaked through to Gemini.

## Fix

\`crates/octos-llm/src/gemini.rs\` — \`sanitize_schema_recursive\` already strips \`additionalProperties / \$schema / \$ref / \$id\` to make schemas Gemini-acceptable. Extends with:

\`\`\`rust
obj.retain(|k, _| !k.starts_with(\"x-\"));
\`\`\`

One-liner, plus a high-fidelity unit test \`test_sanitize_strips_x_extension_keys\` that pins the exact deep-search regression scenario.

## Considered but skipped

Architectural alternative: move \`x-octos-host-config-keys\` out of \`input_schema\` into a sibling manifest field (host metadata vs model schema separation). Decided against for now — codebase has exactly 1 \`x-*\` extension in 1 manifest. \"Don't refactor for hypothetical futures\" (CLAUDE.md). If we add a second host-config extension and it hits the same trap with a different provider, *that's* the moment to refactor.

## Verification

- \`cargo fmt --all -- --check\` — clean
- \`cargo test -p octos-llm --lib\` — **270 passed, 0 failed, 3 ignored** (including 6 sanitize tests)

## Test plan

- [ ] CI green
- [ ] After deploy: re-run \`live-thread-interleave\` soak against mini3; expect green when routing lands on Gemini