### PR TITLE
fix(spawn_only): apply ToolPolicy at intercept site + re-apply after ActorFactory registration

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -221,6 +221,49 @@ impl Agent {
             // tokio task and return immediately. The tool's files_to_send
             // auto-delivers the result to the user. No subagent LLM needed.
             if tools.is_spawn_only(&tc_name) {
+                // PR #688 follow-up — MEDIUM #3: enforce the registry's
+                // provider policy at the spawn_only intercept site, BEFORE
+                // `tokio::spawn`. Without this, a denied stale tool call is
+                // silently spawned and only fails async inside the
+                // background task — the foreground turn observes a fake
+                // "started successfully" and the deny is invisible to the
+                // LLM. Mirror the deny behaviour of the foreground path
+                // (registry.rs `execute_with_context`) so the LLM sees one
+                // synthetic Tool message and stops retrying.
+                if let Some(policy) = tools.provider_policy() {
+                    if let crate::tools::policy::PolicyDecision::Deny { reason } =
+                        policy.evaluate(&tc_name)
+                    {
+                        tracing::warn!(
+                            tool = %tc_name,
+                            reason = %reason,
+                            "provider policy denied spawn_only tool at intercept"
+                        );
+                        let deny_msg = format!(
+                            "[POLICY DENIED] Tool '{}' is blocked by provider policy ({}). Do not retry.",
+                            tc_name, reason
+                        );
+                        return (
+                            Message {
+                                role: MessageRole::Tool,
+                                content: deny_msg,
+                                media: vec![],
+                                tool_calls: None,
+                                tool_call_id: Some(tc_id),
+                                reasoning_content: None,
+                                client_message_id: None,
+                                thread_id: None,
+                                timestamp: chrono::Utc::now(),
+                            },
+                            Vec::new(),
+                            Vec::new(),
+                            None,
+                            false, // policy denial is a failure — cascade in serial mode
+                            None,
+                        );
+                    }
+                }
+
                 tracing::info!(
                     tool = %tc_name,
                     "running spawn_only tool in background"

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -336,8 +336,34 @@ impl ToolRegistry {
     }
 
     /// Retain only tools whose names satisfy the predicate.
+    ///
+    /// Also prunes parallel side state (`spawn_only`,
+    /// `spawn_only_messages`, `deferred`) for any names that were
+    /// dropped. Without this, stale entries survive an `apply_policy`
+    /// deny and produce confusing downstream behaviour:
+    ///
+    /// - A stale `spawn_only` marker fools the agent's spawn_only
+    ///   intercept in `execution.rs` into treating an evicted tool as
+    ///   background-eligible. The intercept falls through to
+    ///   `bg_tools.execute_with_context` which fails async because the
+    ///   tool itself is gone from the registry — so the foreground turn
+    ///   observes a fake "started successfully". See PR #688 follow-up
+    ///   MEDIUM #3.
+    /// - A stale `deferred` entry would let `activate_tools` /
+    ///   `has_deferred()` advertise a name that was already evicted by
+    ///   policy. See PR #688 follow-up codex review (round 2).
     pub fn retain(&mut self, f: impl Fn(&str) -> bool) {
         self.tools.retain(|name, _| f(name));
+        self.spawn_only.retain(|name| self.tools.contains_key(name));
+        self.spawn_only_messages
+            .retain(|name, _| self.tools.contains_key(name));
+        // Stale `deferred` entries are interior-mutable; lock and prune
+        // here so a subsequent `activate(...)` cannot resurrect a tool
+        // that policy has already removed.
+        {
+            let mut deferred = self.deferred.lock().unwrap_or_else(|e| e.into_inner());
+            deferred.retain(|name| self.tools.contains_key(name));
+        }
         self.invalidate_cache();
     }
 

--- a/crates/octos-agent/tests/spawn_only_policy_gate.rs
+++ b/crates/octos-agent/tests/spawn_only_policy_gate.rs
@@ -1,0 +1,403 @@
+//! Tests for the spawn_only ToolPolicy gate.
+//!
+//! Origin: PR #688 (run_pipeline → spawn_only) shipped two latent bypasses:
+//!
+//! - **MEDIUM #3**: the spawn_only intercept site in
+//!   `crates/octos-agent/src/agent/execution.rs` runs BEFORE the registry's
+//!   provider-policy check. A denied stale tool call was silently
+//!   `tokio::spawn`ed; the deny only surfaced async, inside the background
+//!   task. The foreground turn observed a fake "started successfully" and
+//!   the LLM had no signal to stop retrying.
+//!
+//! - **MEDIUM #4**: the gateway / session ActorFactory path registers
+//!   `run_pipeline` AFTER the base `tool_policy` was applied, so a
+//!   `tool_policy.deny: ["run_pipeline"]` configured globally was ignored
+//!   on gateway-spawned actors. (The CLI `chat.rs` path does not have this
+//!   bug because it applies policy AFTER mark_spawn_only.)
+//!
+//! These tests pin Option A: a synchronous policy check at the spawn_only
+//! intercept (covers MEDIUM #3) and the re-application of `tool_policy`
+//! after `mark_spawn_only` registration (covered separately in
+//! `octos-cli`'s session_actor tests; here we cover the registry-level
+//! contract that makes that re-application meaningful).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use octos_agent::tools::ToolPolicy;
+use octos_agent::{Agent, AgentConfig, Tool, ToolRegistry, ToolResult};
+use octos_core::{AgentId, Message, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+// =========================================================================
+// Test infra
+// =========================================================================
+
+struct ScriptedLlm {
+    responses: std::sync::Mutex<Vec<ChatResponse>>,
+}
+
+impl ScriptedLlm {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: std::sync::Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ScriptedLlm {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        let mut r = self.responses.lock().unwrap();
+        if r.is_empty() {
+            eyre::bail!("ScriptedLlm: no more responses");
+        }
+        Ok(r.remove(0))
+    }
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+    fn model_id(&self) -> &str {
+        "policy-test"
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+/// Tool that records every invocation. Used as a probe to assert the
+/// spawn_only intercept did NOT actually run the tool when policy denies.
+struct CountingTool {
+    name: &'static str,
+    invocations: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl Tool for CountingTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+    fn description(&self) -> &str {
+        "spawn_only probe"
+    }
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+    async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(ToolResult {
+            output: format!("{} ran\n", self.name),
+            success: true,
+            ..Default::default()
+        })
+    }
+}
+
+fn tool_use(calls: Vec<ToolCall>) -> ChatResponse {
+    ChatResponse {
+        content: None,
+        reasoning_content: None,
+        tool_calls: calls,
+        stop_reason: StopReason::ToolUse,
+        usage: TokenUsage {
+            input_tokens: 50,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn end_turn(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.into()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage {
+            input_tokens: 5,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn tc(id: &str, name: &str) -> ToolCall {
+    ToolCall {
+        id: id.into(),
+        name: name.into(),
+        arguments: serde_json::json!({}),
+        metadata: None,
+    }
+}
+
+// =========================================================================
+// MEDIUM #3: spawn_only intercept must enforce provider policy.
+//
+// Setup:
+//   - Register a tool "blocked_bg".
+//   - Mark it spawn_only.
+//   - Set a provider_policy that denies it.
+//   - Script the LLM to call it once.
+//
+// Expected:
+//   - The agent's foreground turn returns a synthetic Tool message tagged
+//     "[POLICY DENIED]" — visible to the LLM in the same turn.
+//   - The tool's `execute` body is NEVER invoked. Without the fix the tool
+//     runs in `tokio::spawn` and only fails async after the foreground
+//     turn already accepted the spawn.
+// =========================================================================
+
+#[tokio::test]
+async fn policy_denies_run_pipeline_via_spawn_only_path() {
+    let memory_dir = TempDir::new().unwrap();
+
+    let invocations = Arc::new(AtomicU32::new(0));
+    let probe = CountingTool {
+        name: "blocked_bg",
+        invocations: invocations.clone(),
+    };
+
+    let mut tools = ToolRegistry::new();
+    tools.register(probe);
+    tools.mark_spawn_only("blocked_bg", None);
+
+    // Deny the spawn_only tool via provider policy.
+    let policy = ToolPolicy {
+        deny: vec!["blocked_bg".to_string()],
+        ..Default::default()
+    };
+    tools.set_provider_policy(policy);
+
+    let memory = Arc::new(
+        EpisodeStore::open(memory_dir.path().join(".octos"))
+            .await
+            .unwrap(),
+    );
+
+    let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlm::new(vec![
+        tool_use(vec![tc("call-1", "blocked_bg")]),
+        end_turn("done"),
+    ]));
+
+    let agent = Agent::new(AgentId::new("policy-spawn-only"), llm, tools, memory).with_config(
+        AgentConfig {
+            save_episodes: false,
+            suppress_auto_send_files: true,
+            ..Default::default()
+        },
+    );
+
+    let response = agent
+        .process_message("kick blocked spawn_only", &[], vec![])
+        .await
+        .expect("agent loop should not error on policy deny");
+
+    // The foreground turn must surface the deny synchronously: there is a
+    // Tool message in the turn's outbound messages tagged with the
+    // [POLICY DENIED] marker the intercept produces.
+    let denied = response.messages.iter().any(|m| {
+        matches!(m.role, octos_core::MessageRole::Tool)
+            && m.content.contains("[POLICY DENIED]")
+            && m.content.contains("blocked_bg")
+    });
+    assert!(
+        denied,
+        "expected a synchronous [POLICY DENIED] Tool message; got: {:#?}",
+        response.messages
+    );
+
+    // Settle any spurious background tasks (there should be none).
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // The tool body must NEVER have been invoked. Without the policy gate
+    // at the intercept site this assertion fails because the spawn_only
+    // branch fires `tokio::spawn` before checking the policy.
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        0,
+        "spawn_only tool body must not run when provider policy denies it"
+    );
+}
+
+// =========================================================================
+// Companion: confirm the registry's apply_policy correctly removes a
+// spawn_only-marked tool when invoked AFTER mark_spawn_only.
+//
+// This is the registry-level contract that the session_actor.rs
+// re-application (PR #688 follow-up MEDIUM #4 fix) depends on:
+//   `apply_policy` must drop a denied tool even if it was already marked
+//   spawn_only — otherwise the re-application after run_pipeline
+//   registration would be a no-op.
+// =========================================================================
+
+#[test]
+fn apply_policy_after_mark_spawn_only_removes_denied_tool() {
+    let probe = CountingTool {
+        name: "lateral_pipeline",
+        invocations: Arc::new(AtomicU32::new(0)),
+    };
+
+    let mut tools = ToolRegistry::new();
+    tools.register(probe);
+    tools.mark_spawn_only("lateral_pipeline", None);
+
+    // Sanity: tool is registered before policy.
+    assert!(tools.get("lateral_pipeline").is_some());
+
+    // Mirror the session_actor.rs re-application: apply a deny-list
+    // policy AFTER the spawn_only-marked tool was registered.
+    let policy = ToolPolicy {
+        deny: vec!["lateral_pipeline".to_string()],
+        ..Default::default()
+    };
+    tools.apply_policy(&policy);
+
+    // The tool must be evicted by apply_policy regardless of its
+    // spawn_only marker. Without this, MEDIUM #4's re-application after
+    // ActorFactory registration would not remove `run_pipeline`.
+    assert!(
+        tools.get("lateral_pipeline").is_none(),
+        "apply_policy must drop a denied tool even when spawn_only"
+    );
+
+    // Codex review (PR #688 follow-up): `apply_policy` must ALSO clean
+    // up the parallel `spawn_only` marker. Otherwise a stale call to
+    // the now-evicted tool would still trip the spawn_only intercept in
+    // `execution.rs`, fall through to the background `tokio::spawn`,
+    // and only fail async — exactly the "fake started" pattern the
+    // policy gate is meant to prevent.
+    assert!(
+        !tools.is_spawn_only("lateral_pipeline"),
+        "apply_policy must also drop the spawn_only marker for evicted tools"
+    );
+}
+
+// =========================================================================
+// MEDIUM #4 + codex follow-up: stale spawn_only call after `apply_policy`.
+//
+// Setup:
+//   - Register a tool, mark it spawn_only.
+//   - `apply_policy` denies it (this is the gateway/session_actor path
+//     where `run_pipeline` was registered first then policy applied).
+//   - Script the LLM to call the now-removed tool (a stale call).
+//
+// Expected:
+//   - The spawn_only marker has been cleaned up (no fake "background
+//     started" message).
+//   - The tool body is never invoked.
+//   - The agent loop returns an "unknown tool" error message rather
+//     than spawning an async task that fails later.
+// =========================================================================
+
+#[tokio::test]
+async fn apply_policy_then_stale_call_fails_synchronously_not_async() {
+    let memory_dir = TempDir::new().unwrap();
+
+    let invocations = Arc::new(AtomicU32::new(0));
+    let probe = CountingTool {
+        name: "stale_pipeline",
+        invocations: invocations.clone(),
+    };
+
+    let mut tools = ToolRegistry::new();
+    tools.register(probe);
+    tools.mark_spawn_only("stale_pipeline", None);
+
+    // Mirror the session_actor.rs MEDIUM #4 fix: `apply_policy` runs
+    // AFTER the spawn_only-marked tool was registered. The fix in
+    // `retain` must clean up both the tool AND the spawn_only marker.
+    let policy = ToolPolicy {
+        deny: vec!["stale_pipeline".to_string()],
+        ..Default::default()
+    };
+    tools.apply_policy(&policy);
+
+    let memory = Arc::new(
+        EpisodeStore::open(memory_dir.path().join(".octos"))
+            .await
+            .unwrap(),
+    );
+
+    let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlm::new(vec![
+        tool_use(vec![tc("call-stale", "stale_pipeline")]),
+        end_turn("done"),
+    ]));
+
+    let agent =
+        Agent::new(AgentId::new("policy-stale"), llm, tools, memory).with_config(AgentConfig {
+            save_episodes: false,
+            suppress_auto_send_files: true,
+            ..Default::default()
+        });
+
+    let response = agent
+        .process_message("call stale tool", &[], vec![])
+        .await
+        .expect("agent loop must not error");
+
+    // Settle any spurious background tasks (there should be none).
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // The tool body must NEVER have been invoked. Without the `retain`
+    // fix the stale spawn_only marker survives, the intercept fires,
+    // and the tool runs in `tokio::spawn` (then fails async).
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        0,
+        "stale spawn_only call must not invoke the (denied) tool body"
+    );
+
+    // Codex review (round 2): also verify the LLM saw a real synchronous
+    // failure for the call (unknown-tool / error), NOT a fake
+    // "Pipeline started in background" success message. The exact
+    // wording of the spawn_only success message is "Pipeline started in
+    // background" — its presence here would mean the intercept fooled
+    // the foreground turn.
+    // The agent loop normalises tool_call_ids ("call-stale" gets a
+    // "call_" prefix); match by tool_call_id suffix to stay robust.
+    let tool_msg = response
+        .messages
+        .iter()
+        .find(|m| {
+            matches!(m.role, octos_core::MessageRole::Tool)
+                && m.tool_call_id
+                    .as_deref()
+                    .is_some_and(|id| id.contains("call-stale"))
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "a Tool message for call-stale must exist; got messages: {:#?}",
+                response.messages
+            )
+        });
+    assert!(
+        !tool_msg.content.contains("started in background"),
+        "stale call must not produce a fake 'started in background' \
+         message; got: {}",
+        tool_msg.content
+    );
+    // The reply must look like a synchronous failure (unknown tool,
+    // policy denial, or registry error). We accept any of these
+    // markers so the assertion is robust to minor rewording.
+    let looks_like_error = tool_msg.content.contains("unknown tool")
+        || tool_msg.content.contains("[POLICY DENIED]")
+        || tool_msg.content.contains("error")
+        || tool_msg.content.contains("denied");
+    assert!(
+        looks_like_error,
+        "stale spawn_only call must surface a synchronous error to the \
+         LLM; got: {}",
+        tool_msg.content
+    );
+}

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1049,6 +1049,21 @@ impl GatewayRuntime {
             tools.register(octos_agent::ActivateToolsTool::new());
         }
 
+        // PR #688 follow-up — codex finding (post-MEDIUM #4):
+        // re-apply tool_policy AFTER all base-registry tools have been
+        // registered. The first pass at line ~684 above ran before
+        // `ManageSkillsTool`, `SynthesizeResearchTool`,
+        // `RecallMemoryTool`, `SaveMemoryTool`, `SwitchModelTool`, and
+        // `ActivateToolsTool` were registered, so a `tool_policy.deny`
+        // entry targeting any of those names was silently bypassed at
+        // the base level. The per-session re-apply in
+        // `ActorFactory::spawn` is still required for `run_pipeline`
+        // (which is registered later still); this second pass plugs the
+        // base-registry leak so the snapshot itself is consistent.
+        if let Some(ref policy) = config.tool_policy {
+            tools.apply_policy(policy);
+        }
+
         // Create the base tool registry snapshot (excludes session-specific tools)
         let tool_registry_factory = Arc::new(SnapshotToolRegistryFactory::new(tools));
 
@@ -1102,6 +1117,13 @@ impl GatewayRuntime {
             cwd: cwd.clone(),
             sandbox_config: sandbox_config.clone(),
             provider_policy: provider_policy_for_factory,
+            // PR #688 follow-up — MEDIUM #4: pass the global tool_policy
+            // through so `ActorFactory::spawn` can re-apply it AFTER the
+            // per-session `run_pipeline` registration. Without this, a
+            // policy deny of `run_pipeline` configured via `tool_policy`
+            // is silently bypassed because the base registry's
+            // `apply_policy` ran before `run_pipeline` was registered.
+            tool_policy: config.tool_policy.clone(),
             worker_prompt: worker_prompt_for_factory,
             provider_router: provider_router_for_factory,
             embedder: create_embedder(&config).map(|e| e as Arc<dyn octos_llm::EmbeddingProvider>),

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -759,6 +759,17 @@ impl ProfileActorFactoryBuilder {
                 tools.register(octos_agent::ActivateToolsTool::new());
             }
 
+            // PR #688 follow-up — codex finding: re-apply tool_policy
+            // AFTER all base-registry tools have been registered. The
+            // first pass at line ~648 ran before `ActivateToolsTool`
+            // (and any other late-registered base tools) existed, so a
+            // `tool_policy.deny` entry targeting them was bypassed at
+            // the base level. Per-session re-apply in
+            // `ActorFactory::spawn` still covers `run_pipeline`.
+            if let Some(ref policy) = profile_config.tool_policy {
+                tools.apply_policy(policy);
+            }
+
             struct ChildPipelineToolFactory {
                 llm: Arc<dyn LlmProvider>,
                 memory: Arc<octos_memory::EpisodeStore>,
@@ -841,6 +852,13 @@ impl ProfileActorFactoryBuilder {
             cwd: self.cwd.clone(),
             sandbox_config: effective_profile.config.sandbox.clone(),
             provider_policy,
+            // PR #688 follow-up — MEDIUM #4: thread the profile's
+            // `tool_policy` so `ActorFactory::spawn` re-applies it AFTER
+            // per-session `run_pipeline` registration. The non-admin
+            // branch above already applied it to the base registry, but
+            // per-session tools registered later (notably the spawn_only
+            // pipeline tool) bypass that initial pass.
+            tool_policy: profile_config.tool_policy.clone(),
             worker_prompt,
             provider_router,
             embedder: create_embedder(&profile_config)

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1652,6 +1652,15 @@ pub struct ActorFactory {
     pub sandbox_config: octos_agent::SandboxConfig,
     /// Provider policy for SpawnTool and PipelineTool.
     pub provider_policy: Option<ToolPolicy>,
+    /// Global `tool_policy` from config. The base registry has this applied
+    /// at construction time, but per-session tools (notably `run_pipeline`)
+    /// are registered later by [`ActorFactory::spawn`]. Re-applying after
+    /// per-session registration ensures globally denied tools cannot slip
+    /// in through the per-session registration path. See PR #688 follow-up
+    /// (MEDIUM #4): `gateway_runtime.rs` calls `apply_policy` BEFORE the
+    /// `ActorFactory` adds `run_pipeline`, so without this re-application
+    /// the global deny is bypassed for spawn_only-marked tools.
+    pub tool_policy: Option<ToolPolicy>,
     /// Worker system prompt for SpawnTool subagents.
     pub worker_prompt: Option<String>,
     /// Provider router for SpawnTool and PipelineTool.
@@ -2115,6 +2124,18 @@ impl ActorFactory {
                         .to_string(),
                 ),
             );
+        }
+
+        // PR #688 follow-up — MEDIUM #4: re-apply the global tool_policy
+        // AFTER the per-session pipeline tool was registered. The base
+        // registry already had `apply_policy` invoked during construction
+        // (in `gateway_runtime.rs`), but `run_pipeline` is only registered
+        // here at session-spawn time. Without this second pass, a config
+        // `tool_policy.deny: ["run_pipeline"]` is silently ignored on
+        // gateway-spawned actors. Mirrors the chat.rs pattern that already
+        // applies policy AFTER registering the pipeline tool.
+        if let Some(ref policy) = self.tool_policy {
+            tools.apply_policy(policy);
         }
 
         // Defer rarely-used per-session tools to keep active tool count low
@@ -9942,6 +9963,7 @@ mod tests {
             cwd: dir.path().to_path_buf(),
             sandbox_config: octos_agent::SandboxConfig::default(),
             provider_policy: None,
+            tool_policy: None,
             worker_prompt: None,
             provider_router: None,
             embedder: None,


### PR DESCRIPTION
## Summary

Address codex's 2 MEDIUM findings from the PR #688 (run_pipeline -> spawn_only) review, plus 2 follow-up findings from a 2nd-opinion codex pass on this fix.

### MEDIUM #3 — spawn_only intercept bypassed provider policy
The spawn_only intercept in `crates/octos-agent/src/agent/execution.rs:223` runs BEFORE the registry's provider-policy check at `tools/registry.rs:691`. A denied tool was silently `tokio::spawn`ed and the deny only surfaced async inside the background task. The foreground turn observed a fake "Pipeline started in background" success and the LLM had no signal to stop retrying.

**Fix:** synchronous `provider_policy.evaluate(...)` check at the top of the spawn_only branch — returns a `[POLICY DENIED]` Tool message (mirrors the hook-denial pattern) before any `tokio::spawn`. Matches the deny semantics of `execute_with_context`.

### MEDIUM #4 — `tool_policy` applied before late tool registrations
`gateway_runtime.rs:684` applied `tool_policy` to the base registry, but several tools were registered AFTER:
- per-session: `run_pipeline` (registered in `session_actor.rs:2110` by `ActorFactory::spawn`)
- base-late: `ManageSkillsTool`, `SynthesizeResearchTool`, `RecallMemoryTool`, `SaveMemoryTool`, `SwitchModelTool`, `ActivateToolsTool`

A `tool_policy.deny` entry targeting any of those was silently bypassed.

**Fix:**
- thread `tool_policy: Option<ToolPolicy>` through `ActorFactory` and re-apply it in `ActorFactory::spawn` AFTER per-session `run_pipeline` registration
- add a second `apply_policy` pass at the bottom of `gateway_runtime.rs` and `profile_factory.rs` so the BASE registry snapshot is consistent

### Codex round-2 follow-ups (also addressed in this PR)

- **`apply_policy` left stale `spawn_only` markers** — fixed: `ToolRegistry::retain` now prunes `spawn_only`, `spawn_only_messages`, and `deferred` for any names that no longer exist in `tools`. Otherwise a stale spawn_only marker would still trip the intercept after policy removed the tool.
- **Test weakness** — strengthened the stale-call regression test to also assert the LLM saw a real synchronous failure (not a fake "started in background" success) AND that no background invocation happened.

## Tests

`crates/octos-agent/tests/spawn_only_policy_gate.rs`:
- `policy_denies_run_pipeline_via_spawn_only_path` — provider policy deny is observed synchronously by the foreground turn; tool body never runs.
- `apply_policy_after_mark_spawn_only_removes_denied_tool` — registry contract: `apply_policy` drops the tool AND its spawn_only marker.
- `apply_policy_then_stale_call_fails_synchronously_not_async` — stale call to a denied spawn_only tool surfaces a sync error to the LLM rather than a fake "background started" success.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p octos-agent` (1201 + others, all green)
- [x] `cargo test -p octos-cli --features api` (822 + others, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] codex 2nd-opinion review (round 1 + round 2 findings addressed)