### PR TITLE
fix(ui_protocol): inherit sandbox on cwd rebind + add Cancelled task state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,11 @@ scripts/deploy.sh
 !docs/m8-runtime-parity-prd.md
 !docs/m8-runtime-contract.md
 !docs/m8-runtime-migration-runbook.md
+# UI Protocol change requests (UPCR) — required by check-ui-protocol-upcr.sh
+# whenever protocol-visible code changes; listed in
+# api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md.
+!docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_TEMPLATE.md
+!docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md
 
 # mdBook documentation site (EN + ZH)
 !book/book.toml

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -147,6 +147,11 @@ Current M9 sandbox-parity decision:
   [UPCR-2026-003](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_003_SESSION_WORKSPACE_CWD.md).
   That UPCR authorizes launch/open-time workspace binding only; in-session cwd
   mutation UX or persistent cwd approval policy requires a future accepted UPCR.
+- The additive `cancelled` variant on `TaskRuntimeState` (used by the
+  `task/updated` notification) is governed by accepted
+  [UPCR-2026-004](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_004_TASK_RUNTIME_CANCELLED.md).
+  That UPCR carries the `task_supervisor` cancellation lifecycle through to
+  the wire so cancelled tasks no longer fall back to `Running` in the UI.
 
 ## 5. Identity Model
 

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -245,6 +245,16 @@ pub struct Agent {
     /// child's own spawn calls see the higher value and the
     /// `MAX_SPAWN_DEPTH` gate fires after a bounded number of nests.
     pub(super) spawn_depth: u8,
+    /// M9 review fix (HIGH #1): the effective [`crate::sandbox::SandboxConfig`]
+    /// that built this agent's `ShellTool` sandbox. Recorded so per-session
+    /// callers (notably the AppUi `session_tool_registry` rebind path) can
+    /// re-create a sandbox that inherits the running server's policy
+    /// (mode, network, read paths, profile) instead of silently dropping
+    /// back to `SandboxConfig::default()` and disabling features like
+    /// `npm install` that need network or specific read paths.
+    /// `None` keeps legacy behaviour — callers that don't track the sandbox
+    /// config (chat, gateway, tests) get the previous default.
+    pub(super) sandbox_config: Option<crate::sandbox::SandboxConfig>,
 }
 
 impl Agent {
@@ -286,6 +296,7 @@ impl Agent {
             cost_accountant: None,
             parent_session_key: None,
             spawn_depth: 0,
+            sandbox_config: None,
         }
     }
 
@@ -328,6 +339,7 @@ impl Agent {
             cost_accountant: None,
             parent_session_key: None,
             spawn_depth: 0,
+            sandbox_config: None,
         }
     }
 
@@ -763,6 +775,29 @@ impl Agent {
     /// Get a clone of the agent config.
     pub fn agent_config(&self) -> AgentConfig {
         self.config.clone()
+    }
+
+    /// Record the effective [`crate::sandbox::SandboxConfig`] that built this
+    /// agent's `ShellTool` sandbox.
+    ///
+    /// Callers that need to recreate a sandbox for a per-session
+    /// [`crate::tools::ToolRegistry::rebind_cwd`] (e.g. AppUi session cwd
+    /// binding) can read it back via [`Self::sandbox_config`] and pass it to
+    /// [`crate::sandbox::create_sandbox`] so the new shell tool inherits
+    /// network access, read-allow paths, profile name, and mode from the
+    /// running server's configuration instead of falling back to
+    /// `SandboxConfig::default()`.
+    pub fn with_sandbox_config(mut self, sandbox: crate::sandbox::SandboxConfig) -> Self {
+        self.sandbox_config = Some(sandbox);
+        self
+    }
+
+    /// Return the recorded effective [`crate::sandbox::SandboxConfig`], if
+    /// any was supplied via [`Self::with_sandbox_config`]. `None` keeps
+    /// pre-M9 behaviour — callers should fall back to
+    /// `SandboxConfig::default()` only when this is `None`.
+    pub fn sandbox_config(&self) -> Option<crate::sandbox::SandboxConfig> {
+        self.sandbox_config.clone()
     }
 
     /// Get a snapshot of the current system prompt.

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1398,7 +1398,18 @@ fn session_tool_registry(
 
     session_filesystem_profile_for_workspace(base_tools.as_ref(), &workspace_root)
         .map_err(|error| error.message)?;
-    let sandbox = octos_agent::sandbox::create_sandbox(&octos_agent::SandboxConfig::default());
+    // M9 review fix (HIGH #1): inherit the effective sandbox config from
+    // `base_agent` so per-session shell tools keep the running server's
+    // sandbox policy (mode, network, read-allow paths, profile) instead of
+    // silently falling back to `SandboxConfig::default()` which disables
+    // network and overrides read paths — that fallback was the root cause
+    // of "backend cannot install npm" reports on AppUi sessions.
+    // Falls back to `SandboxConfig::default()` only when the agent was built
+    // without recording its sandbox config (legacy/test paths).
+    let sandbox_config = base_agent
+        .sandbox_config()
+        .unwrap_or_else(octos_agent::SandboxConfig::default);
+    let sandbox = octos_agent::sandbox::create_sandbox(&sandbox_config);
     let rebound = base_tools.rebind_cwd(&workspace_root, sandbox);
 
     Ok((Arc::new(rebound), Some(workspace_root)))

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -181,12 +181,34 @@ fn map_task_updated(context: &ProgressMappingContext, event: &Value) -> UiProgre
 
     let title =
         string_field(event, &["title", "tool", "tool_name"]).unwrap_or_else(|| "Task".into());
-    let state = string_field(
+    // M9 review fix MEDIUM #4: distinguish "no state field at all" (legacy
+    // task_started events) from "state field present but unrecognised".
+    // The former keeps the historical default of `Running` so legacy callers
+    // continue to render correctly. The latter emits a `warning` notification
+    // — the previous unwrap_or fallback masked typos and unmapped terminal
+    // states (notably `cancelled` before this PR) by reporting them as
+    // running, so adding a recognised variant would only fix one symptom and
+    // the next future state would regress the same way.
+    let raw_state = string_field(
         event,
         &["state", "lifecycle_state", "status", "runtime_state"],
-    )
-    .and_then(|state| ui_task_runtime_state(&state))
-    .unwrap_or(UiTaskRuntimeState::Running);
+    );
+    let state = match raw_state.as_deref() {
+        Some(raw) => match ui_task_runtime_state(raw) {
+            Some(state) => state,
+            None => {
+                return UiProgressMapping::warning(
+                    context,
+                    "invalid_progress",
+                    format!(
+                        "task_updated progress event has unrecognised lifecycle state `{raw}`; \
+                         dropping notification to avoid rendering it as still running",
+                    ),
+                );
+            }
+        },
+        None => UiTaskRuntimeState::Running,
+    };
 
     UiProgressMapping::notifications(vec![UiNotification::TaskUpdated(TaskUpdatedEvent {
         session_id: context.session_id.clone(),
@@ -449,6 +471,13 @@ fn ui_task_runtime_state(state: &str) -> Option<UiTaskRuntimeState> {
         | "delivering_outputs" | "cleaning_up" | "verifying" => Some(UiTaskRuntimeState::Running),
         "completed" | "ready" => Some(UiTaskRuntimeState::Completed),
         "failed" => Some(UiTaskRuntimeState::Failed),
+        // M9 review fix (MEDIUM #4) — governed by accepted UPCR-2026-004.
+        // The agent emits `TaskLifecycleState::Cancelled` (snake_case
+        // `"cancelled"`) for tasks cancelled via the supervisor's `cancel()`
+        // primitive (e.g. `POST /api/tasks/{id}/cancel`). The US-spelling
+        // alias `"canceled"` is accepted defensively because some upstream
+        // sources spell it that way.
+        "cancelled" | "canceled" => Some(UiTaskRuntimeState::Cancelled),
         _ => None,
     }
 }
@@ -755,6 +784,72 @@ mod tests {
         assert_eq!(updated.title, "deep_search");
         assert_eq!(updated.state, UiTaskRuntimeState::Running);
         assert_eq!(updated.runtime_detail.as_deref(), Some("checking outputs"));
+    }
+
+    #[test]
+    fn ui_protocol_progress_warns_on_unknown_task_state_instead_of_silently_running() {
+        // M9 review fix MEDIUM #4: codex 2nd-opinion finding — the old
+        // `unwrap_or(UiTaskRuntimeState::Running)` fallback masked future
+        // unmapped terminal states (e.g. before this PR, `cancelled` rendered
+        // as still running). With a recognised state list, an unrecognised
+        // lifecycle string now emits a structured `invalid_progress` warning
+        // instead of synthesising a misleading `Running` notification.
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "task_updated",
+                "task_id": "01900000-0000-7000-8000-000000000004",
+                "title": "spawn_only_runner",
+                "state": "definitely_not_a_real_lifecycle_state"
+            }),
+        );
+
+        assert!(
+            mapping.notifications.is_empty(),
+            "unrecognised lifecycle state must not synthesise a TaskUpdated notification",
+        );
+        let warning = mapping
+            .warning
+            .expect("expected invalid_progress warning for unknown lifecycle state");
+        assert_eq!(warning.code, "invalid_progress");
+        assert!(
+            warning
+                .message
+                .contains("definitely_not_a_real_lifecycle_state"),
+            "warning should surface the offending raw state string, got: {}",
+            warning.message,
+        );
+    }
+
+    #[test]
+    fn ui_protocol_progress_maps_cancelled_task_state_to_cancelled_variant() {
+        // M9 review fix (MEDIUM #4) — governed by accepted UPCR-2026-004.
+        // Before this fix the `"cancelled"` lifecycle state did not match any
+        // variant of `UiTaskRuntimeState` and the unwrap_or fallback rendered
+        // the task as still `Running`. Now the mapper recognises both the
+        // canonical British spelling and the US-spelling alias.
+        for spelling in ["cancelled", "canceled"] {
+            let mapping = map_progress_json(
+                &context(),
+                &json!({
+                    "type": "task_updated",
+                    "task_id": "01900000-0000-7000-8000-000000000003",
+                    "title": "spawn_only_runner",
+                    "state": spelling,
+                    "runtime_detail": "user cancelled"
+                }),
+            );
+
+            let [UiNotification::TaskUpdated(updated)] = mapping.notifications.as_slice() else {
+                panic!("expected task updated notification for spelling={spelling}");
+            };
+            assert_eq!(
+                updated.state,
+                UiTaskRuntimeState::Cancelled,
+                "spelling {spelling} should map to Cancelled, not fall back to Running",
+            );
+            assert_eq!(updated.runtime_detail.as_deref(), Some("user cancelled"));
+        }
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -958,7 +958,14 @@ impl ServeCommand {
             .with_reporter(reporter)
             .with_file_state_cache(file_state_cache)
             .with_subagent_output_router(subagent_output_router)
-            .with_subagent_summary_generator(subagent_summary_generator);
+            .with_subagent_summary_generator(subagent_summary_generator)
+            // M9 review fix (HIGH #1): record the effective sandbox config so
+            // the AppUi `session_tool_registry` rebind path inherits the
+            // running server's sandbox policy when re-creating the per-session
+            // ShellTool sandbox, instead of silently dropping back to
+            // `SandboxConfig::default()` (which disables network and overrides
+            // read paths).
+            .with_sandbox_config(config.sandbox.clone());
 
         // Inject skill prompt fragments
         for fragment in &plugin_result.prompt_fragments {

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2070,6 +2070,13 @@ pub enum TaskRuntimeState {
     Running,
     Completed,
     Failed,
+    /// M9 review fix (MEDIUM #4) — governed by accepted UPCR-2026-004:
+    /// background tasks cancelled mid-flight (e.g. via the
+    /// `POST /api/tasks/{id}/cancel` endpoint) emit lifecycle state
+    /// `cancelled` from the agent's `TaskLifecycleState`. Without this
+    /// variant the AppUi mapper fell back to `Running` and rendered
+    /// cancelled tasks as still running. Wire form: `"cancelled"`.
+    Cancelled,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2683,6 +2690,36 @@ mod tests {
                             "message": "served from task snapshot"
                         }
                     ]
+                }
+            })
+        );
+
+        // M9 review fix MEDIUM #4 (UPCR-2026-004): pin the literal wire form
+        // for `task/updated` carrying the new `cancelled` lifecycle state so a
+        // future rename of the variant or a serializer regression that drops
+        // the snake_case shape is caught by the representative-payload golden
+        // gate, not just by the variant-level round-trip tests at the bottom
+        // of this module.
+        let task_cancelled = UiNotification::TaskUpdated(TaskUpdatedEvent {
+            session_id: SessionKey("local:demo".into()),
+            task_id: task_id.clone(),
+            title: "spawn_only_runner".into(),
+            state: TaskRuntimeState::Cancelled,
+            runtime_detail: Some("user cancelled".into()),
+        })
+        .into_rpc_notification()
+        .expect("serialize task/updated cancelled");
+        assert_eq!(
+            serde_json::to_value(task_cancelled).expect("task/updated cancelled json"),
+            json!({
+                "jsonrpc": "2.0",
+                "method": "task/updated",
+                "params": {
+                    "session_id": "local:demo",
+                    "task_id": task_id,
+                    "title": "spawn_only_runner",
+                    "state": "cancelled",
+                    "runtime_detail": "user cancelled"
                 }
             })
         );
@@ -3842,5 +3879,38 @@ mod tests {
                 .any(|method| method == methods::APPROVAL_CANCELLED),
             "approval/cancelled must be advertised so clients can render it",
         );
+    }
+
+    // ----- M9 review fix MEDIUM #4 (UPCR-2026-004): Cancelled task state -----
+
+    #[test]
+    fn task_runtime_state_cancelled_round_trips_as_snake_case_cancelled() {
+        // Wire form must be exactly `"cancelled"` so the agent's
+        // `TaskLifecycleState::Cancelled` (also `snake_case`-serialized as
+        // `"cancelled"`) flows through the protocol mapper without falling
+        // back to `Running`. UPCR-2026-004 promises `"cancelled"` (the British
+        // spelling) as the wire literal.
+        let value = serde_json::to_value(TaskRuntimeState::Cancelled).expect("serialize Cancelled");
+        assert_eq!(value, json!("cancelled"));
+        let parsed: TaskRuntimeState = serde_json::from_value(value).expect("round-trip Cancelled");
+        assert_eq!(parsed, TaskRuntimeState::Cancelled);
+    }
+
+    #[test]
+    fn task_updated_event_round_trips_with_cancelled_state() {
+        let event = UiNotification::TaskUpdated(TaskUpdatedEvent {
+            session_id: SessionKey("local:demo".into()),
+            task_id: TaskId(Uuid::from_u128(7)),
+            title: "spawn_only_runner".into(),
+            state: TaskRuntimeState::Cancelled,
+            runtime_detail: Some("user cancelled".into()),
+        });
+        let rpc = event
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize task/updated cancelled");
+        let decoded =
+            UiNotification::from_rpc_notification(rpc).expect("deserialize task/updated cancelled");
+        assert_eq!(decoded, event);
     }
 }

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_004_TASK_RUNTIME_CANCELLED.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_004_TASK_RUNTIME_CANCELLED.md
@@ -1,0 +1,148 @@
+# Octos UI Protocol Change Request: Task Runtime Cancelled State
+
+## Header
+
+- Request id: `UPCR-2026-004`
+- Title: Add `cancelled` variant to `TaskRuntimeState`
+- Author: M9 review fixes (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related M issue: `M9` review (issue #687)
+
+## Summary
+
+This change request adds the `cancelled` variant to the
+`TaskRuntimeState` wire enum so the AppUi protocol can faithfully represent
+background tasks that were cancelled mid-flight by
+`POST /api/tasks/{id}/cancel` and the agent's `TaskSupervisor::cancel`
+primitive. The variant is purely additive and does not change any existing
+serialization, method, or capability bit.
+
+## Motivation
+
+The agent's `TaskLifecycleState` enum already carries a `Cancelled` terminal
+variant (added in M7.9 / W2) and emits it as the snake_case literal
+`"cancelled"` whenever a tracked spawn-only task is cancelled before it
+reaches `Completed` or `Failed`. The AppUi wire enum
+`TaskRuntimeState` had only four variants — `Pending`, `Running`,
+`Completed`, `Failed` — so the `ui_task_runtime_state` mapper in
+`crates/octos-cli/src/api/ui_protocol_progress.rs` could not match the
+`"cancelled"` literal. The `unwrap_or(UiTaskRuntimeState::Running)` fallback
+caused cancelled tasks to render as still running indefinitely in the UI.
+
+This UPCR adds the missing variant so the cancel signal is preserved end-to-end
+on the wire, eliminating a class of "stuck running" bugs without rewriting any
+existing message field.
+
+## Change Type
+
+Additive enum variant.
+
+A new `cancelled` variant on the existing `TaskRuntimeState` enum used by the
+`task/updated` notification payload `TaskUpdatedEvent.state`. No method,
+notification, required field, capability flag, or protocol identifier
+changes.
+
+## Wire Contract
+
+Affected existing wire surface:
+
+- Notification method: `task/updated`
+- Notification payload field: `TaskUpdatedEvent.state`
+- Wire enum: `TaskRuntimeState`
+
+### Before
+
+`TaskRuntimeState` accepts the snake_case literals:
+
+- `"pending"`
+- `"running"`
+- `"completed"`
+- `"failed"`
+
+### After
+
+`TaskRuntimeState` additionally accepts the snake_case literal:
+
+- `"cancelled"` (canonical wire form, matches British spelling used by the
+  agent's `TaskLifecycleState::Cancelled` and `TaskStatus::Cancelled`
+  serializers)
+
+### Example wire payload
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "task/updated",
+  "params": {
+    "session_id": "local:demo",
+    "task_id": "01900000-0000-7000-8000-000000000003",
+    "title": "spawn_only_runner",
+    "state": "cancelled",
+    "runtime_detail": "user cancelled"
+  }
+}
+```
+
+The mapper additionally accepts the US spelling `"canceled"` defensively, but
+the canonical wire form emitted by the server is the British `"cancelled"`.
+
+## Compatibility
+
+- Old clients that exhaustively match on `TaskRuntimeState` and have not been
+  recompiled against the new variant will fail to deserialize a `task/updated`
+  notification carrying `state: "cancelled"`. This is the standard
+  forward-compatibility behaviour for any added enum variant, and is
+  acknowledged by the protocol spec (§4 — clients must not assume unknown
+  enum variants are impossible forever).
+- Clients that deserialize `TaskRuntimeState` permissively or use a closed
+  string enum with an `Unknown` fallback continue to work unchanged.
+- Old servers that do not emit `"cancelled"` continue to be valid wire
+  producers.
+- No capability flag is required because the variant is additive on an
+  existing field. Servers that have not adopted the variant simply do not
+  emit it; the old behaviour (cancelled tasks reported as `running`) was
+  already the observable bug, and the field-level upgrade fixes it
+  per-server.
+- No new protocol identifier is needed.
+
+## Capability Negotiation
+
+None. The variant is additive and does not require a feature flag because
+the wire shape (`TaskUpdatedEvent.state` is a single string) is unchanged.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `task_runtime_state_cancelled_round_trips_as_snake_case_cancelled` — asserts
+    the wire literal is exactly `"cancelled"`.
+  - `task_updated_event_round_trips_with_cancelled_state` — asserts a full
+    `task/updated` notification round-trips through the JSON-RPC envelope.
+- `crates/octos-cli/src/api/ui_protocol_progress.rs`:
+  - `ui_protocol_progress_maps_cancelled_task_state_to_cancelled_variant`
+    — asserts the mapper returns `Cancelled` for both `"cancelled"` and
+    `"canceled"` and no longer falls back to `Running`.
+
+## Rollout Plan
+
+This UPCR ships in the same PR that:
+
+1. Adds the variant to `TaskRuntimeState` in `octos-core`.
+2. Updates the mapper in `octos-cli/src/api/ui_protocol_progress.rs` to
+   recognise `"cancelled"` and `"canceled"`.
+3. Adds the round-trip tests above.
+
+No new wire surface is added; no client renegotiation is required. Clients
+that consume `task/updated` and want to render the cancelled state explicitly
+should adopt the new variant on their next protocol-types update.
+
+## Decision
+
+Accepted by: M9 review fixes (coding-green local).
+
+Decision notes: The variant is the smallest possible change that preserves an
+existing terminal state across the wire. The cancelled lifecycle was already
+modelled in the agent (`TaskLifecycleState::Cancelled`), the supervisor
+(`TaskStatus::Cancelled`), and the UI (`UiTaskRuntimeState::Running` fallback
+masked it). Adding the variant restores end-to-end fidelity.


### PR DESCRIPTION
## Summary

Two M9 milestone review findings (#687) addressed in one PR.

### HIGH #1 — sandbox config silently reset on AppUi cwd rebind

**Site:** `crates/octos-cli/src/api/ui_protocol.rs:1399-1402` (pre-fix).

`session_tool_registry()` was constructing `SandboxConfig::default()` for every AppUi per-session ToolRegistry rebind, silently dropping the running server's actual sandbox policy (mode, network access, read-allow paths, profile). Default disables network and overrides read paths, which directly causes the "backend cannot install npm" reports on AppUi sessions.

**Fix:** thread `SandboxConfig` through `Agent` via a new optional field, builder `with_sandbox_config()`, and getter `sandbox_config()`. `serve.rs` records `config.sandbox.clone()` on the api agent; `session_tool_registry()` reads it back and falls back to `SandboxConfig::default()` only when the agent was built without recording one (chat / gateway / tests). No surface change for those callers.

### MEDIUM #4 — Cancelled task state falls back to Running

**Sites:**
- `crates/octos-core/src/ui_protocol.rs:2068` — `TaskRuntimeState` enum lacks `Cancelled`.
- `crates/octos-cli/src/api/ui_protocol_progress.rs:189` — mapper falls back to `Running` for unrecognised states.

Agent's `TaskLifecycleState::Cancelled` (M7.9/W2) serializes as `"cancelled"`. The mapper returned `None` and `unwrap_or(Running)` rendered cancelled tasks as still running.

**Fix:** add `Cancelled` to the wire enum (additive — see UPCR status below), recognise `"cancelled"` + US-spelling `"canceled"`, and address codex's 2nd-opinion finding by splitting the fallback: state field absent → legacy `Running` (preserves `task_started` rendering); state present-but-unrecognised → structured `invalid_progress` warning notification, no synthetic `TaskUpdated`. The previous unconditional `Running` fallback masked future unmapped terminal states the same way.

### Unknown-state fallback decision

The previous behaviour was "any unknown state -> Running". This PR treats:
- **state field absent** -> default to `Running` for legacy compat (e.g. `task_started` events that don't carry a lifecycle string).
- **state field present but unrecognised** -> emit `invalid_progress` warning notification instead of fabricating a `Running` view.

This makes the previous bug class (cancelled silently rendered as running) impossible for any future unmapped terminal state without protocol awareness.

## UPCR status

`UPCR-2026-004` (`docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_004_TASK_RUNTIME_CANCELLED.md`) is included in this PR, marked `accepted`, covering the additive `cancelled` variant. Spec section 4.1 cross-references it. `scripts/check-ui-protocol-upcr.sh` passes (covered by both UPCR file and spec edit).

`.gitignore` allowlists `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md` and `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_TEMPLATE.md` so future UPCRs can land alongside protocol code.

## Codex 2nd-opinion summary

Codex confirmed sandbox inheritance is correct (no aliasing). Two findings flagged, both addressed in this PR:
- MEDIUM: unknown task state still silently became `running`. Fixed via the warning-instead-of-fallback split above + new regression test.
- LOW: golden payload coverage for `task/updated` cancelled was missing the literal wire form. Fixed by adding a `state: "cancelled"` assertion inside `ui_protocol_v1_representative_wire_payloads_are_golden`.

## Test plan

Automated:
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p octos-core ui_protocol` (37 passed, including 2 new round-trip + 1 literal golden)
- [x] `cargo test -p octos-cli api::ui_protocol --features api` (154 passed, including 2 new tests)
- [x] `cargo test -p octos-agent` (all suites pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `scripts/check-ui-protocol-upcr.sh`

Manual (unblocks ship):
- [ ] Run `octos serve` with a non-default `sandbox.allow_network = true` config; open an AppUi session against a workspace dir; run a tool that requires network (e.g. `npm install`) and confirm it succeeds where it failed before.
- [ ] In the same AppUi session, spawn a background task, call `POST /api/tasks/{id}/cancel`, observe that the UI surfaces the task in `cancelled` state (not `running`).

## Hard constraints honoured

- No pre-commit hook bypass (no active hooks installed).
- No force-push / no main push.
- Not auto-merging.