### PR TITLE
feat(appui): operator-configurable default session cwd

### DIFF
--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -800,6 +800,47 @@ impl Agent {
         self.sandbox_config.clone()
     }
 
+    /// Anchor the agent's tool registry to a workspace cwd.
+    ///
+    /// This is the Tier-2 hook used by the AppUi `session_tool_registry`
+    /// fallback chain in `octos serve`: when a client did not advertise
+    /// the `session.workspace_cwd.v1` capability and so cannot send its
+    /// own per-session cwd, the registry's `workspace_root()` becomes the
+    /// rebind target. Without this builder, the API agent's registry
+    /// always reports `None` and Tier-2 is dead.
+    ///
+    /// Mutates the registry in place when this builder owns the only
+    /// strong `Arc` (the typical post-`Agent::new` chain). If the `Arc`
+    /// is already shared, falls back to copying via `snapshot_excluding`
+    /// so we still anchor a fresh registry rather than silently dropping
+    /// the request.
+    ///
+    /// **Call ordering:** invoke this builder BEFORE
+    /// [`Self::wire_activate_tools`]. `wire_activate_tools` plants a
+    /// `Weak<ToolRegistry>` inside the `ActivateToolsTool` instance; if
+    /// this builder hits the fallback `snapshot_excluding(&[])` branch
+    /// (because the `Arc` was already shared by then), the Weak ref will
+    /// still point at the pre-copy registry and `ActivateToolsTool`
+    /// would observe a stale view. The current `serve.rs`/`session_actor`
+    /// flow calls `wire_activate_tools` strictly later (in
+    /// `session_actor.rs`), so this is fine; future refactors should
+    /// preserve that order or re-wire after copying.
+    pub fn with_workspace_root(mut self, cwd: PathBuf) -> Self {
+        if let Some(tools) = Arc::get_mut(&mut self.tools) {
+            tools.set_workspace_root(cwd);
+        } else {
+            // The Arc is already shared. Fall back to a deep copy so the
+            // new workspace_root still wins. ToolRegistry is intentionally
+            // not Clone, so use the existing snapshot helper which handles
+            // interior mutex state correctly. See call-ordering note
+            // above re: `wire_activate_tools`.
+            let mut copy = self.tools.snapshot_excluding(&[]);
+            copy.set_workspace_root(cwd);
+            self.tools = Arc::new(copy);
+        }
+        self
+    }
+
     /// Get a snapshot of the current system prompt.
     pub fn system_prompt_snapshot(&self) -> String {
         self.system_prompt

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -191,6 +191,17 @@ impl ToolRegistry {
         self.workspace_root.as_deref()
     }
 
+    /// Record a workspace cwd on this registry without re-creating the
+    /// cwd-bound tools. Used by the AppUi `session_tool_registry` Tier-2
+    /// fallback so an operator-configured default folder shows up in
+    /// `workspace_root()` and the per-session `rebind_cwd` path can pick
+    /// it up. The existing `rebind_cwd` API mints a fresh registry, which
+    /// is wasteful when we only want to update the recorded path on a
+    /// freshly-built registry; this setter mutates in place.
+    pub fn set_workspace_root(&mut self, cwd: PathBuf) {
+        self.workspace_root = Some(cwd);
+    }
+
     /// Register a background task and return its ID.
     pub fn register_task(&self, tool_name: &str, tool_call_id: &str) -> String {
         self.supervisor
@@ -1106,6 +1117,18 @@ mod cwd_isolation_tests {
             rebound_task.session_key.is_none(),
             "session key must be supplied by the new session actor, not inherited"
         );
+    }
+
+    #[test]
+    fn set_workspace_root_records_path_for_session_tool_registry_fallback() {
+        let mut reg = ToolRegistry::new();
+        assert!(
+            reg.workspace_root().is_none(),
+            "fresh registry must not advertise a workspace_root"
+        );
+        let cwd = std::path::PathBuf::from("/tmp/test-default-cwd");
+        reg.set_workspace_root(cwd.clone());
+        assert_eq!(reg.workspace_root(), Some(cwd.as_path()));
     }
 }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -5066,6 +5066,119 @@ mod tests {
         );
     }
 
+    /// Minimal stub LLM provider for tests that build an `Agent` but never
+    /// actually call out to a model. `session_tool_registry` only inspects
+    /// the agent's tool registry and sandbox config — it never drives the
+    /// LLM — so a `chat` panic guard is enough.
+    struct StubLlm;
+
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for StubLlm {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            unreachable!("StubLlm should not be invoked by session_tool_registry tests")
+        }
+
+        fn context_window(&self) -> u32 {
+            128_000
+        }
+
+        fn model_id(&self) -> &str {
+            "stub"
+        }
+
+        fn provider_name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    /// Tier-2 of the AppUi `session_tool_registry` fallback chain: when a
+    /// session has no entry in `session_workspaces()` and the operator
+    /// configured `appui.default_session_cwd`, the API agent's recorded
+    /// `workspace_root` is used. This locks down the behavior added by
+    /// `Agent::with_workspace_root` + `serve.rs` wire-up.
+    #[tokio::test]
+    async fn session_tool_registry_uses_agent_workspace_root_as_tier2_fallback() {
+        let workspace = tempfile::tempdir().expect("workspace dir");
+        let memory_dir = tempfile::tempdir().expect("memory dir");
+        let memory = Arc::new(
+            octos_memory::EpisodeStore::open(memory_dir.path())
+                .await
+                .expect("open memory"),
+        );
+        let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(StubLlm);
+        let tools = octos_agent::ToolRegistry::with_builtins(workspace.path());
+
+        let agent = octos_agent::Agent::new(AgentId::new("api-test"), llm, tools, memory)
+            .with_workspace_root(workspace.path().to_path_buf());
+
+        // Use a unique session_id so we don't collide with other tests on
+        // the process-global `session_workspaces()` store.
+        let session_id = SessionKey("local:tier2-fallback-test".into());
+
+        let (registry, root) =
+            session_tool_registry(&agent, &session_id).expect("session_tool_registry");
+
+        let root = root.expect("Tier-2 must populate workspace_root");
+        assert_eq!(
+            std::fs::canonicalize(&root).expect("canonicalize"),
+            std::fs::canonicalize(workspace.path()).expect("canonicalize"),
+            "Tier-2 fallback should pick up the agent's recorded workspace_root"
+        );
+        assert!(
+            registry.workspace_root().is_some(),
+            "rebound registry must record the workspace_root"
+        );
+    }
+
+    /// Tier-1 (capability-gated client-sent cwd via `session_workspaces`)
+    /// MUST take precedence over Tier-2 (operator default). This prevents
+    /// the operator default from clobbering octos-tui's per-session picker.
+    ///
+    /// `session_filesystem_profile_for_workspace` requires the requested
+    /// cwd to live under `tools.workspace_root()`. Since
+    /// `with_workspace_root` overwrites the registry's recorded root, we
+    /// anchor the agent at the operator-default folder (Tier-2) and put
+    /// the client-sent cwd as a subdir of it. If Tier-1 wins, the
+    /// resulting workspace_root is the subdir, not the parent.
+    #[tokio::test]
+    async fn session_tool_registry_tier1_wins_over_tier2_default() {
+        let tier2_default = tempfile::tempdir().expect("tier2 default dir");
+        let tier1_subdir = tier2_default.path().join("tier1-client-cwd");
+        std::fs::create_dir_all(&tier1_subdir).expect("tier1 subdir");
+
+        let memory_dir = tempfile::tempdir().expect("memory dir");
+        let memory = Arc::new(
+            octos_memory::EpisodeStore::open(memory_dir.path())
+                .await
+                .expect("open memory"),
+        );
+        let llm: Arc<dyn octos_llm::LlmProvider> = Arc::new(StubLlm);
+        let tools = octos_agent::ToolRegistry::with_builtins(tier2_default.path());
+
+        let agent = octos_agent::Agent::new(AgentId::new("api-test"), llm, tools, memory)
+            // Tier-2: operator-configured default cwd.
+            .with_workspace_root(tier2_default.path().to_path_buf());
+
+        // Tier-1: client-sent cwd recorded in `session_workspaces`.
+        let session_id = SessionKey("local:tier1-wins-test".into());
+        session_workspaces().set(session_id.clone(), tier1_subdir.clone());
+
+        let (_registry, root) =
+            session_tool_registry(&agent, &session_id).expect("session_tool_registry");
+
+        let root = root.expect("workspace_root must be set");
+        assert_eq!(
+            std::fs::canonicalize(&root).expect("canonicalize"),
+            std::fs::canonicalize(&tier1_subdir).expect("canonicalize"),
+            "Tier-1 (client-sent cwd) must win over Tier-2 (operator default)"
+        );
+    }
+
     #[test]
     fn pane_snapshot_prefers_approved_session_workspace_root() {
         let data_dir = tempfile::tempdir().expect("data dir");

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -967,6 +967,36 @@ impl ServeCommand {
             // read paths).
             .with_sandbox_config(config.sandbox.clone());
 
+        // Tier-2 of the AppUi `session_tool_registry` fallback chain: when
+        // operators set `appui.default_session_cwd` in `config.json`, anchor
+        // the API agent's tool registry to that path so clients without the
+        // `session.workspace_cwd.v1` capability (e.g. octos-app, which sends
+        // `cwd: None`) inherit the folder transparently. Tier-1
+        // (capability-gated client-sent cwds) still wins for clients that
+        // do advertise it, e.g. octos-tui.
+        //
+        // We do not canonicalize here — the path is recorded as-is on the
+        // tool registry and reused verbatim by `session_tool_registry`'s
+        // rebind path. Operators must use absolute paths; tilde (`~`) is
+        // not expanded. A `warn!` log on a missing/non-directory path
+        // surfaces config drift early without aborting startup, since the
+        // path may be created later (or may live under a network mount
+        // that mounts asynchronously).
+        if let Some(cwd) = config.appui.default_session_cwd.as_ref() {
+            if !cwd.is_dir() {
+                tracing::warn!(
+                    cwd = %cwd.display(),
+                    "appui.default_session_cwd does not point at an existing directory; \
+                     sessions will fail authorization until it is created",
+                );
+            }
+            agent = agent.with_workspace_root(cwd.clone());
+            tracing::info!(
+                cwd = %cwd.display(),
+                "appui: anchoring api agent to operator-configured default cwd",
+            );
+        }
+
         // Inject skill prompt fragments
         for fragment in &plugin_result.prompt_fragments {
             agent.append_system_prompt(fragment);

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -180,6 +180,37 @@ pub struct Config {
     /// (preserves pre-M6.6 routing behavior).
     #[serde(default)]
     pub content_routing: Option<octos_llm::RoutingConfig>,
+
+    /// AppUi (octos-app, octos-tui, etc.) session defaults applied by the
+    /// API agent inside `octos serve`. Operators can anchor every AppUi
+    /// session that does not advertise the `session.workspace_cwd.v1`
+    /// capability to a chosen folder via `appui.default_session_cwd`,
+    /// so clients like octos-app — which sends `cwd: None` — get a
+    /// useful workspace root transparently. Capability-gated client-sent
+    /// cwds (Tier-1 of `session_tool_registry`) still take precedence.
+    #[serde(default)]
+    pub appui: AppUiConfig,
+}
+
+/// AppUi session defaults applied by `octos serve`'s API agent.
+///
+/// All fields are optional; an empty `[appui]` section preserves the
+/// historical behavior (no server-side default cwd, every session falls
+/// through Tier-3 of the `session_tool_registry` chain unchanged).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct AppUiConfig {
+    /// Optional default workspace cwd for AppUi sessions. When set, every
+    /// `session/open` call against this server falls back to this cwd
+    /// (Tier-2 of `session_tool_registry`'s fallback chain) when the
+    /// client does not advertise `session.workspace_cwd.v1` and send its
+    /// own cwd. Capability-gated client-sent cwds (Tier-1) take precedence.
+    ///
+    /// Use absolute paths. Tilde (`~`) is not expanded — operators who
+    /// prefer a home-relative path should resolve it before writing
+    /// `config.json`.
+    #[serde(default)]
+    pub default_session_cwd: Option<PathBuf>,
 }
 
 /// Top-level credential-pool configuration for `chat` / `serve`. Mirrors

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1474,6 +1474,7 @@ pub(crate) fn config_from_profile(
         // `profile.config` directly when needed.
         credential_pool: None,
         content_routing: profile.config.content_routing.clone(),
+        appui: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Why

`session_tool_registry()` in `crates/octos-cli/src/api/ui_protocol.rs` already had a Tier-1/Tier-2/Tier-3 fallback for the per-session cwd, but Tier-2 (`base_tools.workspace_root()`) was dead — nothing was setting `workspace_root` on the API agent's tool registry. This PR adds that knob.

With `appui.default_session_cwd` set, every AppUi session whose client did not advertise the `session.workspace_cwd.v1` capability inherits an operator-chosen folder. octos-app (which sends `cwd: None`) gets a useful chat workspace transparently; octos-tui keeps its per-session picker via Tier-1.

This is a server-side-only change. Protocol-as-contract: clients are not touched and the `octos-core` `ui_protocol` golden tests stay green.

## Summary

- New `AppUiConfig.default_session_cwd: Option<PathBuf>` on top-level `Config` (with a typed `[appui]` section and `deny_unknown_fields`)
- New `ToolRegistry::set_workspace_root(PathBuf)` for in-place mutation (avoids the heavier `rebind_cwd` clone)
- New `Agent::with_workspace_root(PathBuf)` builder using `Arc::get_mut` with a `snapshot_excluding(&[])` fallback for the shared-Arc case
- `serve.rs` wire-up immediately after `with_sandbox_config`, with a `warn!` log when the configured path is not an existing directory
- Tier-1 (client-sent cwd via `session_workspaces`) > Tier-2 (operator default) > Tier-3 (no rebind) — preserved by the existing `or_else` chain

## Codex 2nd-opinion

Run on the staged diff. Findings:

1. Tier precedence: confirmed correct — `session_workspaces().get(...).or_else(|| base_tools.workspace_root()...)` keeps Tier-1 first.
2. `Arc::get_mut` safety: safe in the current `serve.rs`/`session_actor.rs` call order. Codex flagged that the fallback branch could leave a stale `Weak<ToolRegistry>` ref inside an already-wired `ActivateToolsTool` — addressed with a doc comment on `with_workspace_root` documenting the call-ordering constraint (`with_workspace_root` must run before `wire_activate_tools`, which is the case today).
3. Sandbox interaction: no read-allow path expansion needed; sandbox wrappers already allow the runtime cwd. The relevant authorization is the registry's `workspace_root`, which we already update.
4. Missing test scenarios: added a `warn!` for non-existent paths so operators see config drift early. Tier-2 path canonicalization deferred — Tier-1's `canonical_existing_dir` is gated on the `session.workspace_cwd.v1` capability and not a fair comparison; operators are documented to pass absolute paths.

## Tests

- `crates/octos-agent/src/tools/registry.rs` — unit test `set_workspace_root_records_path_for_session_tool_registry_fallback` verifying the in-place setter.
- `crates/octos-cli/src/api/ui_protocol.rs` — two integration tests:
  - `session_tool_registry_uses_agent_workspace_root_as_tier2_fallback` — Tier-2 engages when `session_workspaces` has no entry.
  - `session_tool_registry_tier1_wins_over_tier2_default` — Tier-1 wins over Tier-2 when both are set (defends against the operator default clobbering octos-tui's picker).

## Verification gates passed

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p octos-core ui_protocol` — 37 passed (golden contract preserved)
- [x] `cargo test -p octos-cli --lib --features api api::ui_protocol` — 156 passed
- [x] `cargo test -p octos-agent` — 1202 lib + every integration suite green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Test plan

- [ ] Set `appui.default_session_cwd = "/Users/me/foo"` in `~/.octos/config.json`, restart `octos serve`
- [ ] Connect from a client without the `session.workspace_cwd.v1` capability (e.g. octos-app); confirm `session/open` response carries `workspace_root: "/Users/me/foo"`
- [ ] Run a shell command in that session; confirm the working directory is `/Users/me/foo`
- [ ] Connect from octos-tui (which advertises `session.workspace_cwd.v1`) and pass a different per-session cwd; confirm Tier-1 wins and the chosen cwd is used
- [ ] Set the config to a non-existent path; confirm the `warn!` log fires at startup but the daemon stays up