### PR TITLE
fix(swarm): enforce approval/policy/sandbox/env-allowlist parity across MCP+CLI+native backends (M7 req 7)

### DIFF
--- a/crates/octos-cli/src/api/swarm.rs
+++ b/crates/octos-cli/src/api/swarm.rs
@@ -891,20 +891,28 @@ impl SwarmEventSink for BroadcasterSwarmEventSink {
 /// The wired event sink forwards every `HarnessSwarmDispatchEvent`
 /// through [`BroadcasterSwarmEventSink`] so the dashboard's Live tab +
 /// the M7.8 live gate both see frames on `/api/events/harness`.
+///
+/// M7 req 7: callers MAY pass a [`octos_swarm::DispatchPolicy`] to wire
+/// the swarm-level approval / tool-policy / sandbox / env-allowlist
+/// gates. Pass `None` for the legacy unenforced behaviour (existing
+/// integration tests pre-fix) — production deployments should pass a
+/// real policy.
 pub async fn build_swarm_state(
     backend: Arc<dyn McpAgentBackend>,
     swarm_dir: impl Into<std::path::PathBuf>,
     cost_ledger: Arc<PersistentCostLedger>,
     broadcaster: Arc<super::SseBroadcaster>,
     sink_path: Option<String>,
+    dispatch_policy: Option<octos_swarm::DispatchPolicy>,
 ) -> eyre::Result<SwarmState> {
     let swarm_dir = swarm_dir.into();
     let sink: Arc<dyn SwarmEventSink> =
         Arc::new(BroadcasterSwarmEventSink::new(broadcaster, sink_path));
-    let swarm = Swarm::builder(backend, &swarm_dir)
-        .with_event_sink(sink)
-        .build()
-        .await?;
+    let mut builder = Swarm::builder(backend, &swarm_dir).with_event_sink(sink);
+    if let Some(policy) = dispatch_policy {
+        builder = builder.with_dispatch_policy(policy);
+    }
+    let swarm = builder.build().await?;
     Ok(SwarmState {
         swarm: Arc::new(swarm),
         cost_ledger,

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -1053,12 +1053,20 @@ impl ServeCommand {
                 .await
                 .wrap_err("failed to open persistent cost ledger for swarm")?,
         );
+        // M7 req 7: production-grade swarm dispatch policy. We default
+        // to a no-op policy (matches the pre-fix behaviour) so CLI
+        // callers without an explicit policy are not surprised by
+        // approval prompts. Operators that want enforcement should
+        // wire `DispatchPolicy` here (a follow-up PR will add a
+        // `--swarm-dispatch-policy <path>` flag — out of scope for the
+        // M7 req 7 close).
         let state = crate::api::build_swarm_state(
             backend,
             swarm_dir,
             cost_ledger,
             broadcaster,
             harness_sink,
+            None,
         )
         .await
         .wrap_err("failed to build swarm state")?;

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -44,6 +44,7 @@ use tracing::{debug, warn};
 
 use octos_agent::cost_ledger::{CostAccountant, CostAttributionEvent, project_cost_usd};
 
+use crate::gate::{DispatchPolicy, enforce_or_outcome};
 use crate::ledger::{CostLedger, NoopCostLedger, SwarmCostAttribution};
 use crate::persistence::{DispatchRecord, DispatchStore};
 use crate::result::{
@@ -173,6 +174,15 @@ pub struct Swarm {
     /// keeps the legacy pre-fix behaviour so integration tests and
     /// existing callers are unchanged.
     cost_budget: Option<SwarmCostBudget>,
+    /// M7 req 7: pre-dispatch policy gate. Closes the parity gap so
+    /// MCP/CLI/native backends honour the same approval, tool policy,
+    /// sandbox, and env-allowlist enforcement the native
+    /// [`octos_agent::tools::ToolRegistry::execute_with_context`] path
+    /// applies. Stored as an `Arc` so it can be cheaply cloned into the
+    /// per-subtask `JoinSet` without forcing the policy itself to be
+    /// `Clone`-cheap. A default policy (`is_noop()`) short-circuits the
+    /// gate so existing callers see no behavioural change.
+    dispatch_policy: Arc<DispatchPolicy>,
 }
 
 impl Swarm {
@@ -403,6 +413,7 @@ impl Swarm {
                 contract,
                 attempts,
                 self.cost_budget.as_ref(),
+                self.dispatch_policy.as_ref(),
             )
             .await;
             // Review A F-004: run per-subtask completion validators.
@@ -452,6 +463,7 @@ impl Swarm {
                 &contract,
                 attempts,
                 self.cost_budget.as_ref(),
+                self.dispatch_policy.as_ref(),
             )
             .await;
             // Review A F-004: run per-subtask completion validators. Pipeline
@@ -532,9 +544,16 @@ impl Swarm {
         let backend = Arc::clone(&self.backend);
         let contract = contracts[idx].clone();
         let budget = self.cost_budget.clone();
+        let policy = Arc::clone(&self.dispatch_policy);
         set.spawn(async move {
-            let outcome =
-                dispatch_with_budget(backend.as_ref(), &contract, attempts, budget.as_ref()).await;
+            let outcome = dispatch_with_budget(
+                backend.as_ref(),
+                &contract,
+                attempts,
+                budget.as_ref(),
+                policy.as_ref(),
+            )
+            .await;
             (idx, outcome)
         });
     }
@@ -615,6 +634,7 @@ pub struct SwarmBuilder {
     validator: Option<AggregateValidator>,
     event_sink: Arc<dyn SwarmEventSink>,
     cost_budget: Option<SwarmCostBudget>,
+    dispatch_policy: Arc<DispatchPolicy>,
 }
 
 impl SwarmBuilder {
@@ -626,6 +646,7 @@ impl SwarmBuilder {
             validator: None,
             event_sink: Arc::new(NoopSwarmEventSink),
             cost_budget: None,
+            dispatch_policy: Arc::new(DispatchPolicy::default()),
         }
     }
 
@@ -663,6 +684,18 @@ impl SwarmBuilder {
         self
     }
 
+    /// M7 req 7: wire a [`DispatchPolicy`] gate that runs before every
+    /// `McpAgentBackend::dispatch` call. Mirrors the gate sequence the
+    /// native [`octos_agent::tools::ToolRegistry::execute_with_context`]
+    /// path applies (tool policy, approval, sandbox, env allowlist) so
+    /// MCP/CLI/native backends are gated uniformly. Without this call
+    /// the swarm runs with the default no-op policy, preserving
+    /// pre-fix behaviour for existing callers.
+    pub fn with_dispatch_policy(mut self, policy: DispatchPolicy) -> Self {
+        self.dispatch_policy = Arc::new(policy);
+        self
+    }
+
     /// Open the redb ledger and return the usable [`Swarm`].
     pub async fn build(self) -> Result<Swarm> {
         let store = DispatchStore::open(&self.persistence_dir).await?;
@@ -673,6 +706,7 @@ impl SwarmBuilder {
             validator: self.validator,
             event_sink: self.event_sink,
             cost_budget: self.cost_budget,
+            dispatch_policy: self.dispatch_policy,
         })
     }
 }
@@ -686,12 +720,27 @@ impl SwarmBuilder {
 /// refunding the projected spend without a ledger write. Commit only
 /// fires when the subtask reached a `Completed` terminal status so
 /// retryable / terminal failures never inflate the ledger.
+///
+/// M7 req 7: the [`DispatchPolicy`] gate runs **first**, before any
+/// budget reservation or backend dispatch. A gate denial short-circuits
+/// the whole pipeline (no reservation taken, no backend touched, no
+/// ledger row written) and the synthesised [`SubtaskOutcome`] flows
+/// through the existing event/metrics path so the harness sees a
+/// `policy_denied` / `approval_denied` / `env_forbidden` /
+/// `sandbox_required` / `approval_unavailable` outcome label uniformly
+/// across stdio, HTTP, and any future CLI-style MCP backends.
 async fn dispatch_with_budget(
     backend: &dyn McpAgentBackend,
     contract: &ContractSpec,
     prior_attempts: u32,
     budget: Option<&SwarmCostBudget>,
+    policy: &DispatchPolicy,
 ) -> SubtaskOutcome {
+    if let Err(outcome) = enforce_or_outcome(policy, backend, contract, prior_attempts).await {
+        record_dispatch_gate_metric(backend.backend_label(), &outcome.last_dispatch_outcome);
+        return outcome;
+    }
+
     let Some(budget) = budget else {
         return dispatch_once(backend, contract, prior_attempts).await;
     };
@@ -839,6 +888,20 @@ fn record_swarm_metric(topology: &str, outcome: SwarmOutcomeKind) {
         "octos_swarm_dispatch_total",
         "topology" => topology.to_string(),
         "outcome" => outcome.as_str().to_string()
+    )
+    .increment(1);
+}
+
+/// M7 req 7: per-gate-denial counter. Surfaces approval/policy/sandbox/
+/// env-allowlist denials in the same metrics surface the dispatcher
+/// already feeds. Stable label set: `backend` (`"local"` / `"remote"`)
+/// and `outcome` (one of `policy_denied`, `approval_denied`,
+/// `approval_unavailable`, `env_forbidden`, `sandbox_required`).
+fn record_dispatch_gate_metric(backend: &str, outcome: &str) {
+    counter!(
+        "octos_swarm_dispatch_gate_denial_total",
+        "backend" => backend.to_string(),
+        "outcome" => outcome.to_string()
     )
     .increment(1);
 }

--- a/crates/octos-swarm/src/gate.rs
+++ b/crates/octos-swarm/src/gate.rs
@@ -1,0 +1,507 @@
+//! Pre-dispatch policy gate for [`Swarm::dispatch`](crate::Swarm::dispatch).
+//!
+//! Closes M7 requirement 7 (policy enforcement parity): every backend the
+//! swarm dispatches to — local stdio MCP, remote HTTP MCP, native sub-agent
+//! via [`octos_agent::tools::SpawnTool`] — is funnelled through
+//! [`crate::dispatcher::Swarm::dispatch_once`]. This module wires the same
+//! gates the native [`octos_agent::tools::ToolRegistry::execute_with_context`]
+//! path applies (tool policy, approval, sandbox, env allowlist) before any
+//! `McpAgentBackend::dispatch` call.
+//!
+//! The gate is **opt-in**: callers wire it via
+//! [`crate::SwarmBuilder::with_dispatch_policy`]. Without a configured
+//! policy the dispatcher's behaviour is unchanged so existing M7.1 callers
+//! and tests do not regress.
+//!
+//! ## Failure surfacing
+//!
+//! Each gate failure synthesises a [`crate::SubtaskOutcome`] with status
+//! `TerminalFailed` and a stable `last_dispatch_outcome` label. The label
+//! flows through the existing `octos_swarm_dispatch_total{topology,outcome}`
+//! counter and the typed
+//! [`octos_agent::HarnessEventPayload::SwarmDispatch`] event the harness
+//! observability channel consumes (M7 requirement 8 stays satisfied).
+//!
+//! Stable labels:
+//!
+//! - `policy_denied` — [`octos_agent::ToolPolicy`] denied the contract's
+//!   tool name. The `error` carries the policy reason
+//!   (`policy_deny` or `robot_tier_gate`).
+//! - `approval_denied` — the configured
+//!   [`octos_agent::ToolApprovalRequester`] returned
+//!   [`octos_agent::ToolApprovalDecision::Deny`].
+//! - `approval_unavailable` — approval is required but no requester was
+//!   wired. **Fail closed** — never fall through to dispatch.
+//! - `env_forbidden` — the contract's task carries an env key that fails
+//!   the dispatch policy's env allowlist (used by callers that pass env
+//!   through the task payload to the backend).
+//! - `sandbox_required` — the dispatch policy demands a sandboxed
+//!   backend but the wired backend does not self-report sandboxing.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use octos_agent::tools::mcp_agent::McpAgentBackend;
+use octos_agent::{
+    PolicyDecision, ToolApprovalDecision, ToolApprovalRequest, ToolApprovalRequester, ToolPolicy,
+};
+use tracing::warn;
+
+use crate::result::{SubtaskOutcome, SubtaskStatus};
+use crate::topology::ContractSpec;
+
+/// Configuration for the swarm dispatch policy gate.
+///
+/// Every field is independently optional so callers can opt into just the
+/// gates they need. An entirely default value is a no-op (matches the
+/// pre-fix dispatcher behaviour).
+#[derive(Clone, Default)]
+pub struct DispatchPolicy {
+    /// Tool policy evaluated against [`ContractSpec::tool_name`]. Deny
+    /// wins; an empty allow list permits every tool name not explicitly
+    /// denied (mirrors [`ToolPolicy`] semantics).
+    pub tool_policy: Option<ToolPolicy>,
+    /// When `true`, every dispatch must clear the approval gate before
+    /// the backend is called. The dispatch fails closed if no
+    /// [`ToolApprovalRequester`] is wired.
+    pub require_approval: bool,
+    /// Approval bridge used when [`Self::require_approval`] is true.
+    pub approval_requester: Option<Arc<dyn ToolApprovalRequester>>,
+    /// Env keys the dispatch is allowed to forward to the backend.
+    /// Inspected against the contract's task payload — if the task
+    /// carries an `env` object whose keys overlap any name **not** in
+    /// this allowlist, the dispatch is denied with `env_forbidden`.
+    /// `None` means env-checking is off (existing
+    /// [`octos_agent::tools::mcp_agent::StdioMcpAgent`] env handling
+    /// remains the only barrier). Names are matched case-insensitively
+    /// against the upper-cased form (mirrors
+    /// `subprocess_env::EnvAllowlist`).
+    pub env_allowlist: Option<HashSet<String>>,
+    /// When `true`, the wired backend must self-report as sandboxed. No
+    /// [`McpAgentBackend`] does today, so this field is provided for
+    /// forward compatibility — setting it true on a non-sandboxed
+    /// backend fails closed every time.
+    pub require_sandboxed: bool,
+}
+
+impl std::fmt::Debug for DispatchPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DispatchPolicy")
+            .field("tool_policy", &self.tool_policy)
+            .field("require_approval", &self.require_approval)
+            .field(
+                "approval_requester",
+                &self.approval_requester.as_ref().map(|_| "<requester>"),
+            )
+            .field("env_allowlist", &self.env_allowlist)
+            .field("require_sandboxed", &self.require_sandboxed)
+            .finish()
+    }
+}
+
+impl DispatchPolicy {
+    /// True if every gate is unset — the dispatcher can skip the
+    /// gate entirely.
+    pub fn is_noop(&self) -> bool {
+        self.tool_policy
+            .as_ref()
+            .is_none_or(|policy| policy.is_empty())
+            && !self.require_approval
+            && self.env_allowlist.is_none()
+            && !self.require_sandboxed
+    }
+}
+
+/// Outcome produced when a gate denies a dispatch. Folded directly into
+/// a [`SubtaskOutcome`] so the swarm result and harness event surface
+/// the failure with the same shape as backend failures.
+#[derive(Debug, Clone)]
+pub(crate) struct GateDenial {
+    pub last_dispatch_outcome: &'static str,
+    pub reason: String,
+}
+
+impl GateDenial {
+    fn into_outcome(self, contract: &ContractSpec, prior_attempts: u32) -> SubtaskOutcome {
+        SubtaskOutcome {
+            contract_id: contract.contract_id.clone(),
+            label: contract.label.clone(),
+            status: SubtaskStatus::TerminalFailed,
+            attempts: prior_attempts.saturating_add(1),
+            last_dispatch_outcome: self.last_dispatch_outcome.to_string(),
+            output: self.reason.clone(),
+            files_to_send: Vec::new(),
+            error: Some(self.reason),
+        }
+    }
+}
+
+/// Run every configured gate against `contract`. Returns `Ok(())` if the
+/// dispatch may proceed, otherwise the first failing gate's denial.
+///
+/// Gates run in this fixed order, so the surfaced failure matches the
+/// most-deterministic check first:
+///
+/// 1. Sandbox requirement (cheapest, config-only).
+/// 2. Tool policy (synchronous evaluator, no I/O).
+/// 3. Env allowlist (synchronous, inspects the task payload).
+/// 4. Approval (last; may block on user interaction).
+pub(crate) async fn enforce_dispatch_gates(
+    policy: &DispatchPolicy,
+    backend: &dyn McpAgentBackend,
+    contract: &ContractSpec,
+) -> std::result::Result<(), GateDenial> {
+    if policy.is_noop() {
+        return Ok(());
+    }
+
+    if policy.require_sandboxed && !backend_is_sandboxed(backend) {
+        return Err(GateDenial {
+            last_dispatch_outcome: "sandbox_required",
+            reason: format!(
+                "swarm dispatch requires a sandboxed backend; backend '{}' (endpoint '{}') is not sandboxed",
+                backend.backend_label(),
+                backend.endpoint_label()
+            ),
+        });
+    }
+
+    if let Some(ref tool_policy) = policy.tool_policy {
+        if let PolicyDecision::Deny { reason } = tool_policy.evaluate(&contract.tool_name) {
+            warn!(
+                contract_id = %contract.contract_id,
+                tool_name = %contract.tool_name,
+                deny_reason = reason,
+                "swarm dispatch denied by tool policy"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "policy_denied",
+                reason: format!(
+                    "tool '{}' denied by swarm dispatch policy ({})",
+                    contract.tool_name, reason
+                ),
+            });
+        }
+    }
+
+    if let Some(ref allowlist) = policy.env_allowlist {
+        if let Some(forbidden) = first_forbidden_env_key(&contract.task, allowlist) {
+            warn!(
+                contract_id = %contract.contract_id,
+                forbidden_key = %forbidden,
+                "swarm dispatch denied by env allowlist"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "env_forbidden",
+                reason: format!(
+                    "env variable '{forbidden}' is not in the swarm dispatch allowlist"
+                ),
+            });
+        }
+    }
+
+    if policy.require_approval {
+        let Some(ref requester) = policy.approval_requester else {
+            warn!(
+                contract_id = %contract.contract_id,
+                "swarm dispatch requires approval but no approver is wired"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "approval_unavailable",
+                reason: format!(
+                    "swarm dispatch policy requires approval but no requester is wired (contract '{}')",
+                    contract.contract_id
+                ),
+            });
+        };
+        let request = ToolApprovalRequest {
+            tool_id: contract.contract_id.clone(),
+            tool_name: contract.tool_name.clone(),
+            title: format!("Approve swarm dispatch for {}", contract.tool_name),
+            body: format!(
+                "Backend '{}' (endpoint '{}') will receive contract '{}'.",
+                backend.backend_label(),
+                backend.endpoint_label(),
+                contract.contract_id
+            ),
+            command: None,
+            cwd: None,
+        };
+        let decision = requester.request_approval(request).await;
+        if matches!(decision, ToolApprovalDecision::Deny) {
+            warn!(
+                contract_id = %contract.contract_id,
+                tool_name = %contract.tool_name,
+                "swarm dispatch denied by approval requester"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "approval_denied",
+                reason: format!(
+                    "swarm dispatch for tool '{}' denied by approval requester",
+                    contract.tool_name
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Helper for the dispatcher: enforce gates and synthesise a
+/// [`SubtaskOutcome`] on denial. Returns `Ok(())` if dispatch may
+/// proceed, otherwise the failure outcome to use in place of a backend
+/// dispatch.
+pub(crate) async fn enforce_or_outcome(
+    policy: &DispatchPolicy,
+    backend: &dyn McpAgentBackend,
+    contract: &ContractSpec,
+    prior_attempts: u32,
+) -> std::result::Result<(), SubtaskOutcome> {
+    match enforce_dispatch_gates(policy, backend, contract).await {
+        Ok(()) => Ok(()),
+        Err(denial) => Err(denial.into_outcome(contract, prior_attempts)),
+    }
+}
+
+fn backend_is_sandboxed(_backend: &dyn McpAgentBackend) -> bool {
+    // No `McpAgentBackend` implementation reports as sandboxed today.
+    // The trait does not expose an `is_sandboxed()` method, so callers
+    // that demand sandboxing must wire a backend that wraps the dispatch
+    // call site in their own isolation surface (Bubblewrap subprocess,
+    // Docker container, etc.). When the trait grows an `is_sandboxed()`
+    // method, this helper becomes the single switch-point.
+    false
+}
+
+fn first_forbidden_env_key(
+    task: &serde_json::Value,
+    allowlist: &HashSet<String>,
+) -> Option<String> {
+    let env = task.get("env")?.as_object()?;
+    for key in env.keys() {
+        let normalized = key.to_ascii_uppercase();
+        if !allowlist.contains(&normalized) {
+            return Some(key.clone());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use octos_agent::tools::mcp_agent::{DispatchOutcome, DispatchRequest, DispatchResponse};
+
+    struct StubBackend;
+
+    #[async_trait]
+    impl McpAgentBackend for StubBackend {
+        fn backend_label(&self) -> &'static str {
+            "local"
+        }
+        fn endpoint_label(&self) -> String {
+            "stub".into()
+        }
+        async fn dispatch(&self, _request: DispatchRequest) -> DispatchResponse {
+            DispatchResponse {
+                outcome: DispatchOutcome::Success,
+                output: String::new(),
+                files_to_send: Vec::new(),
+                error: None,
+            }
+        }
+    }
+
+    fn contract(id: &str, tool: &str) -> ContractSpec {
+        ContractSpec {
+            contract_id: id.into(),
+            tool_name: tool.into(),
+            task: serde_json::json!({}),
+            label: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn noop_policy_passes_every_dispatch() {
+        let policy = DispatchPolicy::default();
+        let backend = StubBackend;
+        let contract = contract("c1", "any_tool");
+        assert!(
+            enforce_dispatch_gates(&policy, &backend, &contract)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_policy_deny_blocks_dispatch() {
+        let tool_policy = ToolPolicy {
+            deny: vec!["forbidden".into()],
+            ..Default::default()
+        };
+        let policy = DispatchPolicy {
+            tool_policy: Some(tool_policy),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = contract("c1", "forbidden");
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "policy_denied");
+        assert!(denial.reason.contains("forbidden"));
+    }
+
+    #[tokio::test]
+    async fn tool_policy_allowlist_misses_block_dispatch() {
+        let policy = DispatchPolicy {
+            tool_policy: Some(ToolPolicy {
+                allow: vec!["allowed_tool".into()],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = contract("c1", "another_tool");
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "policy_denied");
+    }
+
+    #[tokio::test]
+    async fn approval_required_without_requester_fails_closed() {
+        let policy = DispatchPolicy {
+            require_approval: true,
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = contract("c1", "any_tool");
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "approval_unavailable");
+    }
+
+    #[tokio::test]
+    async fn approval_deny_blocks_dispatch() {
+        struct DenyRequester;
+
+        #[async_trait]
+        impl ToolApprovalRequester for DenyRequester {
+            async fn request_approval(&self, _: ToolApprovalRequest) -> ToolApprovalDecision {
+                ToolApprovalDecision::Deny
+            }
+        }
+
+        let policy = DispatchPolicy {
+            require_approval: true,
+            approval_requester: Some(Arc::new(DenyRequester)),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = contract("c1", "any_tool");
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "approval_denied");
+    }
+
+    #[tokio::test]
+    async fn approval_approve_passes_through() {
+        struct ApproveRequester;
+
+        #[async_trait]
+        impl ToolApprovalRequester for ApproveRequester {
+            async fn request_approval(&self, _: ToolApprovalRequest) -> ToolApprovalDecision {
+                ToolApprovalDecision::Approve
+            }
+        }
+
+        let policy = DispatchPolicy {
+            require_approval: true,
+            approval_requester: Some(Arc::new(ApproveRequester)),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = contract("c1", "any_tool");
+        assert!(
+            enforce_dispatch_gates(&policy, &backend, &contract)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn env_allowlist_rejects_forbidden_keys() {
+        let mut allowlist = HashSet::new();
+        allowlist.insert("OPENAI_API_KEY".to_string());
+
+        let policy = DispatchPolicy {
+            env_allowlist: Some(allowlist),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = ContractSpec {
+            contract_id: "c1".into(),
+            tool_name: "any".into(),
+            task: serde_json::json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}}),
+            label: None,
+        };
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "env_forbidden");
+        assert!(denial.reason.contains("LD_PRELOAD"));
+    }
+
+    #[tokio::test]
+    async fn env_allowlist_passes_allowed_keys() {
+        let mut allowlist = HashSet::new();
+        allowlist.insert("OPENAI_API_KEY".to_string());
+
+        let policy = DispatchPolicy {
+            env_allowlist: Some(allowlist),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = ContractSpec {
+            contract_id: "c1".into(),
+            tool_name: "any".into(),
+            task: serde_json::json!({"env": {"OPENAI_API_KEY": "sk-test"}}),
+            label: None,
+        };
+        assert!(
+            enforce_dispatch_gates(&policy, &backend, &contract)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn require_sandboxed_blocks_unsandboxed_backend() {
+        let policy = DispatchPolicy {
+            require_sandboxed: true,
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = contract("c1", "any_tool");
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "sandbox_required");
+    }
+
+    #[test]
+    fn is_noop_handles_default_and_empty_policy() {
+        assert!(DispatchPolicy::default().is_noop());
+        assert!(
+            DispatchPolicy {
+                tool_policy: Some(ToolPolicy::default()),
+                ..Default::default()
+            }
+            .is_noop()
+        );
+    }
+}

--- a/crates/octos-swarm/src/lib.rs
+++ b/crates/octos-swarm/src/lib.rs
@@ -79,6 +79,7 @@
 #![doc(html_root_url = "https://docs.rs/octos-swarm/0.1.0")]
 
 mod dispatcher;
+mod gate;
 mod ledger;
 mod persistence;
 mod result;
@@ -88,6 +89,7 @@ pub use dispatcher::{
     AggregateValidator, MAX_RETRY_ROUNDS, NoopSwarmEventSink, Swarm, SwarmBudget, SwarmBuilder,
     SwarmContext, SwarmCostBudget, SwarmEventSink, flatten_aggregate,
 };
+pub use gate::DispatchPolicy;
 pub use ledger::{CostLedger, NoopCostLedger, SwarmCostAttribution};
 pub use persistence::{DISPATCH_RECORD_SCHEMA_VERSION, DispatchRecord, DispatchStore};
 pub use result::{AggregateArtifact, SubtaskOutcome, SubtaskStatus, SwarmOutcomeKind, SwarmResult};

--- a/crates/octos-swarm/tests/swarm_dispatch_policy.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch_policy.rs
@@ -1,0 +1,546 @@
+//! Integration tests for the M7 req 7 dispatch policy gate.
+//!
+//! These tests stand in for the audit's `mcp_backend_respects_*` and
+//! `cli_backend_respects_*` cases. The swarm crate exposes a single
+//! [`octos_swarm::McpAgentBackend`] trait that every backend funnels
+//! through (stdio, HTTP, native sub-agent via SpawnTool), so a fake
+//! backend covers all three execution paths from the gate's
+//! perspective. Each test asserts:
+//!
+//! 1. The fake backend is **not** invoked when the gate denies
+//!    (`dispatch_count == 0`).
+//! 2. The synthesised [`octos_swarm::SubtaskOutcome`] carries a stable
+//!    `last_dispatch_outcome` label so the harness observability
+//!    channel renders the denial uniformly across topologies.
+//! 3. With a default (no-op) policy the existing tests' behaviour is
+//!    preserved (regression).
+
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use octos_agent::tools::mcp_agent::{
+    DispatchOutcome, DispatchRequest, DispatchResponse, McpAgentBackend,
+};
+use octos_agent::{ToolApprovalDecision, ToolApprovalRequest, ToolApprovalRequester, ToolPolicy};
+use octos_swarm::{
+    ContractSpec, DispatchPolicy, Swarm, SwarmBudget, SwarmContext, SwarmOutcomeKind, SwarmTopology,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Backend that counts dispatch calls and always succeeds. Used to
+/// prove the gate short-circuits before the backend is invoked.
+#[derive(Default)]
+struct CountingBackend {
+    counter: AtomicUsize,
+}
+
+impl CountingBackend {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+    fn count(&self) -> usize {
+        self.counter.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl McpAgentBackend for CountingBackend {
+    fn backend_label(&self) -> &'static str {
+        "local"
+    }
+    fn endpoint_label(&self) -> String {
+        "counting".to_string()
+    }
+    async fn dispatch(&self, _request: DispatchRequest) -> DispatchResponse {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        DispatchResponse {
+            outcome: DispatchOutcome::Success,
+            output: "ok".to_string(),
+            files_to_send: Vec::new(),
+            error: None,
+        }
+    }
+}
+
+/// HTTP-flavoured counting backend so we can prove the gate fires
+/// uniformly regardless of `backend_label()`. The audit treats `"local"`
+/// (stdio MCP) and `"remote"` (HTTP MCP) as separate execution paths,
+/// even though they share the same `McpAgentBackend` trait.
+#[derive(Default)]
+struct HttpCountingBackend {
+    counter: AtomicUsize,
+}
+
+impl HttpCountingBackend {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+    fn count(&self) -> usize {
+        self.counter.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl McpAgentBackend for HttpCountingBackend {
+    fn backend_label(&self) -> &'static str {
+        "remote"
+    }
+    fn endpoint_label(&self) -> String {
+        "https://example.com/mcp".to_string()
+    }
+    async fn dispatch(&self, _request: DispatchRequest) -> DispatchResponse {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        DispatchResponse {
+            outcome: DispatchOutcome::Success,
+            output: "ok".to_string(),
+            files_to_send: Vec::new(),
+            error: None,
+        }
+    }
+}
+
+fn ctx() -> SwarmContext {
+    SwarmContext {
+        session_id: "api:test-policy".into(),
+        task_id: "task-policy".into(),
+        workflow: Some("swarm_policy_test".into()),
+        phase: Some("dispatch".into()),
+    }
+}
+
+fn contract(id: &str, tool: &str) -> ContractSpec {
+    ContractSpec {
+        contract_id: id.into(),
+        tool_name: tool.into(),
+        task: serde_json::json!({"contract_id": id}),
+        label: Some(format!("c-{id}")),
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+/// AUDIT MAPPING: `mcp_backend_respects_tool_policy_deny` —
+/// MCP (local) backend dispatch must NOT execute when the tool policy
+/// denies the contract's tool name. The synthesised outcome uses the
+/// `policy_denied` label so the harness sees the denial uniformly.
+#[tokio::test]
+async fn local_mcp_backend_respects_tool_policy_deny() {
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let policy = DispatchPolicy {
+        tool_policy: Some(ToolPolicy {
+            deny: vec!["forbidden_tool".into()],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "policy-deny",
+            vec![contract("c1", "forbidden_tool")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(backend.count(), 0, "backend must NOT dispatch when denied");
+    assert_eq!(result.outcome, SwarmOutcomeKind::Failed);
+    let outcome = &result.per_task_outcomes[0];
+    assert_eq!(outcome.last_dispatch_outcome, "policy_denied");
+    assert!(outcome.error.as_deref().unwrap().contains("forbidden_tool"));
+}
+
+/// AUDIT MAPPING: equivalent of `cli_backend_respects_tool_policy_deny`
+/// — the same gate guards the remote/HTTP backend (which the swarm
+/// reaches via the same `McpAgentBackend` trait). The audit's "CLI
+/// backend" maps onto the `McpAgentBackend` trait because there is no
+/// separate CLI backend in the swarm crate today (the audit clarifies
+/// this in req 1's evidence: "The swarm dispatcher only knows about
+/// MCP backends").
+#[tokio::test]
+async fn remote_mcp_backend_respects_tool_policy_deny() {
+    let backend = HttpCountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let policy = DispatchPolicy {
+        tool_policy: Some(ToolPolicy {
+            allow: vec!["only_this_tool".into()],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "remote-policy-deny",
+            vec![contract("c1", "different_tool")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(backend.count(), 0);
+    assert_eq!(result.outcome, SwarmOutcomeKind::Failed);
+    assert_eq!(
+        result.per_task_outcomes[0].last_dispatch_outcome,
+        "policy_denied"
+    );
+}
+
+/// AUDIT MAPPING: `cli_backend_respects_approval_gate` —
+/// approval is required, no requester is wired -> dispatch must fail
+/// closed. The synthesised outcome uses `approval_unavailable` so
+/// operators can distinguish "no approver" from a user-issued deny.
+#[tokio::test]
+async fn approval_required_without_requester_fails_closed() {
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let policy = DispatchPolicy {
+        require_approval: true,
+        approval_requester: None,
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "approval-missing",
+            vec![contract("c1", "any_tool")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(backend.count(), 0);
+    assert_eq!(result.outcome, SwarmOutcomeKind::Failed);
+    assert_eq!(
+        result.per_task_outcomes[0].last_dispatch_outcome,
+        "approval_unavailable"
+    );
+}
+
+/// AUDIT MAPPING: extension of `cli_backend_respects_approval_gate` —
+/// approval requester returns Deny -> backend NOT dispatched.
+#[tokio::test]
+async fn approval_deny_blocks_dispatch() {
+    struct DenyRequester {
+        seen: Mutex<usize>,
+    }
+
+    #[async_trait]
+    impl ToolApprovalRequester for DenyRequester {
+        async fn request_approval(&self, _: ToolApprovalRequest) -> ToolApprovalDecision {
+            *self.seen.lock().unwrap() += 1;
+            ToolApprovalDecision::Deny
+        }
+    }
+
+    let requester = Arc::new(DenyRequester {
+        seen: Mutex::new(0),
+    });
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let policy = DispatchPolicy {
+        require_approval: true,
+        approval_requester: Some(requester.clone()),
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "approval-deny",
+            vec![contract("c1", "shell")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(*requester.seen.lock().unwrap(), 1);
+    assert_eq!(backend.count(), 0);
+    assert_eq!(
+        result.per_task_outcomes[0].last_dispatch_outcome,
+        "approval_denied"
+    );
+}
+
+/// AUDIT MAPPING: counterpart to the deny test — `Approve` lets the
+/// dispatch through and the backend is invoked exactly once.
+#[tokio::test]
+async fn approval_approve_lets_dispatch_through() {
+    struct ApproveRequester;
+
+    #[async_trait]
+    impl ToolApprovalRequester for ApproveRequester {
+        async fn request_approval(&self, _: ToolApprovalRequest) -> ToolApprovalDecision {
+            ToolApprovalDecision::Approve
+        }
+    }
+
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let policy = DispatchPolicy {
+        require_approval: true,
+        approval_requester: Some(Arc::new(ApproveRequester)),
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "approval-pass",
+            vec![contract("c1", "shell")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(backend.count(), 1);
+    assert_eq!(result.outcome, SwarmOutcomeKind::Success);
+}
+
+/// AUDIT MAPPING: `mcp_backend_respects_env_allowlist` — the gate
+/// inspects the contract's task payload for an `env` object whose keys
+/// are tested against the configured allowlist. Forbidden keys cause
+/// `env_forbidden` denial **before** the backend is touched.
+#[tokio::test]
+async fn env_allowlist_blocks_forbidden_keys() {
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let mut allowlist = HashSet::new();
+    allowlist.insert("OPENAI_API_KEY".to_string());
+
+    let policy = DispatchPolicy {
+        env_allowlist: Some(allowlist),
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    // Task carries a forbidden env key (LD_PRELOAD style injection).
+    let bad_contract = ContractSpec {
+        contract_id: "c1".into(),
+        tool_name: "any".into(),
+        task: serde_json::json!({
+            "contract_id": "c1",
+            "env": {"LD_PRELOAD": "/tmp/evil.so"},
+        }),
+        label: None,
+    };
+
+    let result = swarm
+        .dispatch(
+            "env-deny",
+            vec![bad_contract],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(backend.count(), 0);
+    assert_eq!(
+        result.per_task_outcomes[0].last_dispatch_outcome,
+        "env_forbidden"
+    );
+    assert!(
+        result.per_task_outcomes[0]
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("LD_PRELOAD")
+    );
+}
+
+/// `require_sandboxed: true` against an unsandboxed backend must fail
+/// closed. Today no `McpAgentBackend` self-reports as sandboxed, so the
+/// gate denies every dispatch when this flag is set — that's the
+/// conservative choice matching M7 req 7's safety bar (the audit notes
+/// the HTTP backend's remote sandbox is opaque to the parent).
+#[tokio::test]
+async fn require_sandboxed_blocks_unsandboxed_backend() {
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let policy = DispatchPolicy {
+        require_sandboxed: true,
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "sandbox-required",
+            vec![contract("c1", "shell")],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(1).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(backend.count(), 0);
+    assert_eq!(
+        result.per_task_outcomes[0].last_dispatch_outcome,
+        "sandbox_required"
+    );
+}
+
+/// AUDIT MAPPING: `native_backend_still_works_with_dispatch_gate_lifted`
+/// — regression: with no policy configured (default builder), the
+/// existing behaviour is unchanged. The backend dispatches normally,
+/// the result is `Success`, and the synthesised outcome carries the
+/// regular `success` label.
+#[tokio::test]
+async fn no_policy_preserves_legacy_behaviour() {
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "legacy",
+            vec![
+                contract("c1", "tool_a"),
+                contract("c2", "tool_b"),
+                contract("c3", "tool_c"),
+            ],
+            SwarmTopology::Parallel {
+                max_concurrency: NonZeroUsize::new(3).unwrap(),
+            },
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(backend.count(), 3);
+    assert_eq!(result.outcome, SwarmOutcomeKind::Success);
+    for outcome in &result.per_task_outcomes {
+        assert_eq!(outcome.last_dispatch_outcome, "success");
+    }
+}
+
+/// Sequential topology must abort on a gate denial just as it aborts on
+/// a backend `TerminalFailed`. This protects pipelines from poisoning
+/// downstream stages with a `policy_denied` upstream output.
+#[tokio::test]
+async fn sequential_aborts_on_gate_denial() {
+    let backend = CountingBackend::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let policy = DispatchPolicy {
+        tool_policy: Some(ToolPolicy {
+            deny: vec!["forbidden".into()],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let swarm = Swarm::builder(backend.clone(), dir.path())
+        .with_dispatch_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let result = swarm
+        .dispatch(
+            "seq-deny",
+            vec![
+                contract("c1", "ok_tool"),
+                contract("c2", "forbidden"),
+                contract("c3", "ok_tool"),
+            ],
+            SwarmTopology::Sequential,
+            SwarmBudget::default(),
+            ctx(),
+        )
+        .await
+        .unwrap();
+
+    // c1 dispatched (success), c2 denied (TerminalFailed -> sequential
+    // aborts), c3 never ran.
+    assert_eq!(backend.count(), 1);
+    assert_eq!(result.outcome, SwarmOutcomeKind::Aborted);
+    assert_eq!(
+        result.per_task_outcomes[1].last_dispatch_outcome,
+        "policy_denied"
+    );
+    assert_eq!(result.per_task_outcomes[2].last_dispatch_outcome, "not_run");
+}


### PR DESCRIPTION
## Summary

Closes the M7 requirement 7 gap (score 2/5 in the M6-M9 audit at `docs/m6-m9-audit-2026-04-30`): the swarm dispatcher routed work to MCP HTTP and CLI-style backends without the approval, tool policy, sandbox, and env-allowlist gates the native registry path applies via `ToolRegistry::execute_with_context`.

## The bug

When the swarm dispatcher routed a contract to its `McpAgentBackend` (stdio MCP, HTTP MCP, or native sub-agent dispatched through `SpawnTool`'s `agent_mcp` variant), the only pre-dispatch gate was the cost-budget reservation. None of the four safety checks the native `ToolRegistry::execute_with_context` path applies — tool policy, approval, sandbox, env allowlist — fired.

Audit evidence:
- `dispatcher.rs::dispatch_once` jumped straight from `ContractSpec` to `backend.dispatch(request)` with no policy pre-gate.
- HTTP MCP backend applied SSRF only.
- Stdio MCP backend's env allowlist was constructor-time, not per-dispatch.

## Design (Option A — single gate site)

Per the task plan I evaluated Option A vs Option B. Option A wins because:

1. The swarm has a single funnel: every topology (parallel/sequential/pipeline/fanout) routes through `dispatch_with_budget -> dispatch_once`. Adding the gate at `dispatch_with_budget`'s entry covers every backend without per-backend wrapping.
2. The `McpAgentBackend` trait is provider-agnostic, so a layered gate above it is structurally analogous to `ToolRegistry::execute_with_context` (one place enforces, everything else just executes).
3. Per-backend (Option B) would require touching every `McpAgentBackend` impl plus any future backend.

The new module is `crates/octos-swarm/src/gate.rs`. Gates run in this order (deterministic-first): sandbox requirement → tool policy → env allowlist → approval. Each denial synthesises a `SubtaskOutcome::TerminalFailed` with a stable `last_dispatch_outcome` label (`policy_denied`, `approval_denied`, `approval_unavailable`, `env_forbidden`, `sandbox_required`) so the existing harness event channel renders gate denials uniformly with backend failures (M7 req 8 stays satisfied). A new counter `octos_swarm_dispatch_gate_denial_total{backend, outcome}` is added.

The gate is **opt-in** via `SwarmBuilder::with_dispatch_policy(...)`. A default `DispatchPolicy::is_noop()` short-circuits enforcement so existing M7.1 callers and tests are unchanged. The CLI `build_swarm_state` helper now accepts an `Option<DispatchPolicy>` so production callers can wire policy without touching the swarm crate (codex review caught this — see "Codex findings" below).

## Tests

10 unit tests in `gate.rs` + 9 integration tests in `tests/swarm_dispatch_policy.rs`, exercising:

- `local_mcp_backend_respects_tool_policy_deny` — stdio MCP backend, policy `deny: ["forbidden_tool"]`; backend NOT dispatched; outcome `policy_denied`.
- `remote_mcp_backend_respects_tool_policy_deny` — HTTP MCP backend, policy `allow: ["only_this_tool"]`; backend NOT dispatched; outcome `policy_denied`.
- `approval_required_without_requester_fails_closed` — outcome `approval_unavailable`.
- `approval_deny_blocks_dispatch` — outcome `approval_denied`, requester invoked once, backend zero times.
- `approval_approve_lets_dispatch_through` — outcome `success`.
- `env_allowlist_blocks_forbidden_keys` — task carries `LD_PRELOAD`; outcome `env_forbidden`; backend zero dispatches.
- `require_sandboxed_blocks_unsandboxed_backend` — outcome `sandbox_required` (today's MCP backends never self-report sandboxing — fail closed by design).
- `sequential_aborts_on_gate_denial` — gate denial in middle of sequential pipeline aborts the topology, downstream stages stay `not_run`.
- `no_policy_preserves_legacy_behaviour` — regression: default builder with no policy keeps the existing behaviour (3 contracts succeed, 3 backend dispatches).

All 10 unit tests + 9 integration tests + 28 existing lib tests + 4 subtask contract tests + 10 swarm_dispatch tests = **61 swarm tests passing**. `cargo test -p octos-agent` also passes the full 1201-test suite. `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` are green.

## Codex findings

Codex (gpt-5.5) reviewed the diff (results in `/tmp/codex-swarm-policy.log`):

- All swarm dispatch sites covered (parallel/sequential/pipeline all funnel through `dispatch_with_budget`).
- Crafted MCP response cannot bypass the gate (denial returns before backend dispatch).
- All 4 gate types tested.
- Perf concern: high-fanout pipelines that demand approval will issue one async approval per subtask. This is inherent to the gate design — not a regression.
- **Medium finding addressed in this PR**: production CLI's `build_swarm_state` was building the swarm with no `with_dispatch_policy(...)` call. Fixed by plumbing an `Option<DispatchPolicy>` parameter through the helper; default `None` preserves legacy behaviour, follow-up PR can add a `--swarm-dispatch-policy` flag.

## Test plan

- [ ] Reviewer confirms the gate fires for every topology (parallel/sequential/pipeline/fanout)
- [ ] Reviewer confirms `last_dispatch_outcome` labels survive through `HarnessSwarmDispatchEvent`
- [ ] Reviewer confirms no double-gating (audit notes "don't double-gate" — the swarm gate is at `dispatch_with_budget`, the spawn-tool agent_mcp path applies the budget gate only and is **outside** the swarm crate, so no overlap)
- [ ] Reviewer agrees that adding a `--swarm-dispatch-policy` CLI flag is appropriate for a follow-up (out of scope for closing M7 req 7's structural gap)

DO NOT auto-merge.