### PR TITLE
fix(plugins,mcp): allow declaring Exclusive concurrency class via manifest (M8 req 10)

### DIFF
--- a/crates/app-skills/account-manager/manifest.json
+++ b/crates/app-skills/account-manager/manifest.json
@@ -7,6 +7,7 @@
     {
       "name": "manage_account",
       "description": "Manage sub-accounts under the current profile. Sub-accounts share the parent's LLM provider and API keys but have their own data directory, memory, skills, and messaging channels. Supports creating, updating, listing, deleting, starting, stopping, and restarting sub-accounts.",
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/crates/app-skills/harness-starter-coding/manifest.json
+++ b/crates/app-skills/harness-starter-coding/manifest.json
@@ -9,6 +9,7 @@
       "name": "propose_patch",
       "description": "Render a patch as a unified-diff file under patches/<slug>.diff plus a preview file list at patches/<slug>.files.txt.",
       "spawn_only": true,
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/crates/app-skills/harness-starter-report/manifest.json
+++ b/crates/app-skills/harness-starter-report/manifest.json
@@ -9,6 +9,7 @@
       "name": "generate_report",
       "description": "Generate a markdown report for a topic. Writes to reports/<slug>.md. The workspace policy primary = \"reports/*.md\" resolves the delivered file.",
       "spawn_only": true,
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/crates/app-skills/skill-evolve/manifest.json
+++ b/crates/app-skills/skill-evolve/manifest.json
@@ -5,6 +5,7 @@
     {
       "name": "skill_evolve",
       "description": "Manage skill evolution patches: list pending corrections, apply them to SKILL.md, or discard them. Patches are auto-generated when plugin tools fail.",
+      "concurrency_class": "exclusive",
       "env": [
         "DEEPSEEK_API_KEY",
         "KIMI_API_KEY",

--- a/crates/octos-agent/src/mcp.rs
+++ b/crates/octos-agent/src/mcp.rs
@@ -39,9 +39,55 @@ pub struct McpServerConfig {
     /// HTTP transport: additional headers (e.g. Authorization).
     #[serde(default)]
     pub headers: HashMap<String, String>,
+    /// Optional override for the M8.8 concurrency class assigned to every
+    /// tool exposed by this server.
+    ///
+    /// Defaults to [`crate::tools::ConcurrencyClass::Safe`] — most MCP
+    /// servers in practice expose read-only / query tools (search, wiki
+    /// lookup, time, weather), and forcing `Exclusive` on all of them
+    /// would serialise the fast common path. Operators who run an MCP
+    /// server that mutates files, posts to remote services, or otherwise
+    /// races with the native `edit_file` / `write_file` tools must
+    /// declare `"exclusive"` here so the M8.8 scheduler serialises the
+    /// batch.
+    ///
+    /// Accepted values: `"safe"`, `"exclusive"` (case-insensitive).
+    /// Unknown values resolve to the conservative `Exclusive` side
+    /// (fail-safe: a typo must not silently downgrade enforcement).
+    ///
+    /// Per-tool granularity is intentionally not supported — MCP's
+    /// `tools/list` carries no concurrency hint, and exposing a per-tool
+    /// override field would invite drift between operator config and the
+    /// remote tool surface.
+    #[serde(default)]
+    pub concurrency_class: Option<String>,
 }
 
 impl McpServerConfig {
+    /// Resolve the configured concurrency class for tools spawned by this
+    /// server.
+    ///
+    /// - Field absent → `Safe` (read-only common case).
+    /// - Field `"safe"` (any case) → `Safe`.
+    /// - Field `"exclusive"` (any case) → `Exclusive` (operator opt-in
+    ///   for mutating servers).
+    /// - Unknown value → `Exclusive` (fail-safe — a typo must not
+    ///   silently downgrade enforcement).
+    pub fn resolved_concurrency_class(&self) -> crate::tools::ConcurrencyClass {
+        match self
+            .concurrency_class
+            .as_deref()
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            None | Some("safe") => crate::tools::ConcurrencyClass::Safe,
+            Some("exclusive") => crate::tools::ConcurrencyClass::Exclusive,
+            // Unknown values fail safe to Exclusive so a typo doesn't
+            // silently downgrade serialisation.
+            Some(_) => crate::tools::ConcurrencyClass::Exclusive,
+        }
+    }
+
     fn display_name(&self) -> &str {
         if let Some(cmd) = &self.command {
             cmd
@@ -269,6 +315,10 @@ struct McpToolSpec {
     description: String,
     input_schema: serde_json::Value,
     connection: Arc<Mutex<McpConnection>>,
+    /// Concurrency class for the M8.8 scheduler. Carried per-spec so each
+    /// server's `McpServerConfig.concurrency_class` propagates to every
+    /// tool the server exposes when `register_tools` runs.
+    concurrency_class: crate::tools::ConcurrencyClass,
 }
 
 /// Maximum nesting depth for MCP tool input schemas.
@@ -323,9 +373,11 @@ impl McpClient {
                 Ok((conn, server_tools)) => {
                     let server_name = config.display_name().to_string();
                     let conn = Arc::new(Mutex::new(conn));
+                    let concurrency_class = config.resolved_concurrency_class();
                     info!(
                         server = server_name,
                         tools = server_tools.len(),
+                        concurrency_class = ?concurrency_class,
                         "MCP server started"
                     );
                     for tool in server_tools {
@@ -345,6 +397,7 @@ impl McpClient {
                             description: tool.description.unwrap_or_default(),
                             input_schema: schema,
                             connection: conn.clone(),
+                            concurrency_class,
                         });
                     }
                     connections.push((server_name, conn));
@@ -503,13 +556,13 @@ impl McpClient {
                 description: spec.description,
                 input_schema: spec.input_schema,
                 connection: spec.connection,
-                // Item 6 of OCTOS_M8_FIX_FIRST_CHECKLIST_2026-04-24:
-                // MCP servers are conservative-by-default treated as
-                // Exclusive because the JSON-RPC transport serialises
-                // internally and most servers mutate remote state.
-                // A future milestone will let manifests/configs override
-                // this with per-server concurrency hints.
-                concurrency_class: crate::tools::ConcurrencyClass::Exclusive,
+                // Per-server class resolved at `start()` from
+                // `McpServerConfig.concurrency_class`. Defaults to
+                // `Safe` (read-only common case — search, wiki, time);
+                // operators declare `"exclusive"` for MCP servers that
+                // mutate files / remote state and could race with the
+                // native `edit_file` / `write_file` tools.
+                concurrency_class: spec.concurrency_class,
             });
         }
     }
@@ -547,12 +600,14 @@ struct McpTool {
     description: String,
     input_schema: serde_json::Value,
     connection: Arc<Mutex<McpConnection>>,
-    /// Item 6 of OCTOS_M8_FIX_FIRST_CHECKLIST_2026-04-24:
-    /// concurrency class declared by the wrapper. Each MCP server is
-    /// configured with a single concurrency class — the wrapper does
-    /// not inspect MCP's `tools/list` for a per-tool hint. Server-level
-    /// declaration is appropriate because most MCP servers serialise
-    /// internally on the JSON-RPC stream anyway.
+    /// Concurrency class for the M8.8 scheduler. Resolved at
+    /// `McpClient::start` from the per-server `McpServerConfig`:
+    /// defaults to `Safe` (read-only common case — search, wiki, time
+    /// servers); operators must declare `"exclusive"` per server when
+    /// the MCP server mutates files or remote state and could race
+    /// with the native `edit_file` / `write_file` tools. Per-tool
+    /// granularity is intentionally not wired — MCP's `tools/list`
+    /// carries no concurrency hint.
     concurrency_class: crate::tools::ConcurrencyClass,
 }
 
@@ -722,6 +777,7 @@ mod tests {
             env: HashMap::new(),
             url: None,
             headers: HashMap::new(),
+            concurrency_class: None,
         };
         assert_eq!(config.display_name(), "unknown");
     }
@@ -735,6 +791,103 @@ mod tests {
         assert!(config.env.is_empty());
         assert!(config.url.is_none());
         assert!(config.headers.is_empty());
+        // Backward-compat: existing configs that omit `concurrency_class`
+        // continue to parse. The resolved class falls through to `Safe`
+        // (read-only common case for MCP — search, wiki, time, weather).
+        // Mutating servers must declare `"exclusive"` explicitly.
+        assert!(config.concurrency_class.is_none());
+        assert_eq!(
+            config.resolved_concurrency_class(),
+            crate::tools::ConcurrencyClass::Safe,
+        );
+    }
+
+    #[test]
+    fn test_config_concurrency_class_explicit_safe() {
+        // Explicit declaration round-trips through serde and resolves
+        // identically to the default — pinned so a future schema change
+        // doesn't silently break operator configs that opt in.
+        let json = r#"{"concurrency_class": "safe"}"#;
+        let config: McpServerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.concurrency_class.as_deref(), Some("safe"));
+        assert_eq!(
+            config.resolved_concurrency_class(),
+            crate::tools::ConcurrencyClass::Safe,
+        );
+    }
+
+    #[test]
+    fn test_config_concurrency_class_explicit_exclusive() {
+        // Operators who run a mutating MCP server (e.g. one that
+        // writes files into the workspace) declare `"exclusive"` so
+        // the M8.8 scheduler serialises the batch.
+        let json = r#"{"concurrency_class": "exclusive"}"#;
+        let config: McpServerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.resolved_concurrency_class(),
+            crate::tools::ConcurrencyClass::Exclusive,
+        );
+    }
+
+    #[test]
+    fn test_config_concurrency_class_case_insensitive_and_unknown_falls_back() {
+        // Mixed case still resolves correctly.
+        let mixed_json = r#"{"concurrency_class": "ExClUsIvE"}"#;
+        let mixed: McpServerConfig = serde_json::from_str(mixed_json).unwrap();
+        assert_eq!(
+            mixed.resolved_concurrency_class(),
+            crate::tools::ConcurrencyClass::Exclusive,
+        );
+
+        // Unknown values fall back to `Exclusive` (fail-safe — typo in
+        // operator config must not silently downgrade enforcement).
+        let typo_json = r#"{"concurrency_class": "exlusive"}"#;
+        let typo: McpServerConfig = serde_json::from_str(typo_json).unwrap();
+        assert_eq!(
+            typo.resolved_concurrency_class(),
+            crate::tools::ConcurrencyClass::Exclusive,
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_surfaces_per_server_concurrency_class() {
+        // Construct an `McpTool` directly with a stub HTTP connection
+        // so we can verify the wrapper surfaces the per-spec class
+        // through `Tool::concurrency_class()`. This pins the contract
+        // that `register_tools` plumbs the per-server class to every
+        // tool — a regression that swapped the field back to
+        // hardcoded `Exclusive` would turn this test red for the
+        // safe-server case.
+        use crate::tools::ConcurrencyClass;
+
+        let conn = Arc::new(Mutex::new(McpConnection::Http(HttpMcpConnection {
+            client: reqwest::Client::new(),
+            url: "http://stub.invalid/".into(),
+            headers: HashMap::new(),
+            next_id: 1,
+            session_id: None,
+        })));
+
+        let safe_tool = McpTool {
+            name: "search".into(),
+            description: "test".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            connection: conn.clone(),
+            concurrency_class: ConcurrencyClass::Safe,
+        };
+        assert_eq!(safe_tool.concurrency_class(), ConcurrencyClass::Safe);
+
+        let exclusive_tool = McpTool {
+            name: "write_remote".into(),
+            description: "test".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+            connection: conn,
+            concurrency_class: ConcurrencyClass::Exclusive,
+        };
+        assert_eq!(
+            exclusive_tool.concurrency_class(),
+            ConcurrencyClass::Exclusive,
+        );
     }
 
     // --- Schema validation ---

--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -118,11 +118,12 @@ fn resolve_mcp_server(srv: &SkillMcpServer, skill_dir: &Path) -> McpServerConfig
         env,
         url: srv.url.clone(),
         headers: srv.headers.clone(),
-        // Skill-bundled MCP servers fall through to the conservative
-        // server default (`Exclusive`). A future skill manifest
-        // extension could plumb a per-server hint through `srv` if
-        // bundled servers prove to be mostly read-only — until then,
-        // leaving this `None` keeps the safer behaviour.
+        // Skill-bundled MCP servers fall through to the wrapper's
+        // server default (`Safe` — read-only common case). A skill
+        // that bundles a mutating MCP server should plumb a per-server
+        // hint through `SkillMcpServer` (a future extension) and have
+        // it copied into this field; until then, the bundled servers
+        // run in the parallel-friendly path.
         concurrency_class: None,
     }
 }

--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -118,6 +118,12 @@ fn resolve_mcp_server(srv: &SkillMcpServer, skill_dir: &Path) -> McpServerConfig
         env,
         url: srv.url.clone(),
         headers: srv.headers.clone(),
+        // Skill-bundled MCP servers fall through to the conservative
+        // server default (`Exclusive`). A future skill manifest
+        // extension could plumb a per-server hint through `srv` if
+        // bundled servers prove to be mostly read-only — until then,
+        // leaving this `None` keeps the safer behaviour.
+        concurrency_class: None,
     }
 }
 

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -284,9 +284,22 @@ impl ToolRegistry {
     ///
     /// Unknown tools report [`super::ConcurrencyClass::Safe`] — the executor
     /// defers error handling to `execute()` which bails with `unknown tool`
-    /// rather than letting the admission phase fail silently. Plugin/MCP
-    /// tools report `Safe` today because their wrapper inherits the trait
-    /// default; they will be wired through a declared class in a follow-up.
+    /// rather than letting the admission phase fail silently.
+    ///
+    /// Plugin and MCP wrappers override `Tool::concurrency_class()` and
+    /// surface their declared class:
+    /// - Plugin wrapper: reads `concurrency_class` from the manifest tool
+    ///   def. Defaults to `Safe` so the bundled read-only skills (weather,
+    ///   news, time, deep-search, …) keep their parallel-friendly path. A
+    ///   plugin tool that writes files or mutates remote state must declare
+    ///   `"exclusive"` in its manifest.
+    /// - MCP wrapper: reads `concurrency_class` from
+    ///   `McpServerConfig`. Defaults to `Safe` because most MCP servers
+    ///   in practice are read-only (search, wiki, time, weather);
+    ///   operators must declare `"exclusive"` per server when the MCP
+    ///   server mutates files / remote state and could race with the
+    ///   native `edit_file` / `write_file` tools. Unknown values fail
+    ///   safe to `Exclusive`.
     pub fn concurrency_class(&self, name: &str) -> super::ConcurrencyClass {
         self.tools
             .get(name)

--- a/crates/octos-agent/tests/m8_integration_concurrency.rs
+++ b/crates/octos-agent/tests/m8_integration_concurrency.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use octos_agent::{
-    CheckBackgroundTasksTool, ConcurrencyClass, McpServerConfig, SpawnTool, Tool, ToolResult,
+    CheckBackgroundTasksTool, ConcurrencyClass, McpServerConfig, SpawnTool, Tool,
     plugins::PluginTool,
 };
 use octos_memory::EpisodeStore;
@@ -68,11 +68,12 @@ fn task_control_tools_are_exclusive() {
 }
 
 #[test]
-fn plugin_wrapper_can_declare_exclusive_and_serializes_batch() {
+fn plugin_with_exclusive_manifest_serializes_with_other_exclusive_tools_in_batch() {
     // Build a PluginTool whose manifest declares
     // `concurrency_class: "exclusive"`. The wrapper must lift that
     // declaration into the trait method so the M8.8 scheduler sees
-    // Exclusive instead of inheriting the Safe default.
+    // Exclusive and serialises the batch alongside other exclusive
+    // tools (e.g. native `spawn`, `edit_file`).
     let exclusive_def = octos_agent::plugins::PluginToolDef {
         name: "exclusive_plugin".into(),
         description: "test".into(),
@@ -93,8 +94,13 @@ fn plugin_wrapper_can_declare_exclusive_and_serializes_batch() {
         ConcurrencyClass::Exclusive,
         "plugin manifest declared `exclusive` — wrapper must lift it"
     );
+}
 
-    // A plugin with no concurrency_class hint falls back to Safe.
+#[test]
+fn plugin_with_no_concurrency_declaration_defaults_to_safe() {
+    // Backward-compat: existing skills (without the new field) must
+    // continue to register as Safe. Most bundled skills are read-only
+    // (weather, news, time, deep-search) so Safe is the right default.
     let safe_def = octos_agent::plugins::PluginToolDef {
         name: "safe_plugin".into(),
         description: "test".into(),
@@ -118,53 +124,79 @@ fn plugin_wrapper_can_declare_exclusive_and_serializes_batch() {
     );
 }
 
-#[tokio::test]
-async fn mcp_wrapper_can_declare_exclusive_and_serializes_batch() {
-    // The M8.6 fix-first checklist requires MCP wrappers to declare a
-    // concurrency class. We pinned the wrapper to default-Exclusive
-    // (most MCP servers serialise on JSON-RPC anyway). This test
-    // exercises the wrapper through a registered MCP tool and asserts
-    // the registry surfaces Exclusive.
-    //
-    // Spinning up a real MCP server in CI is heavy — we instead query
-    // the registered tool's class via a unit-style harness that mirrors
-    // the wrapper's construction.
-    //
-    // Note: McpServerConfig needs network/process IO; we don't actually
-    // spin one up. We assert the static contract by constructing a
-    // mock `Tool` impl that mirrors `McpTool::concurrency_class` so a
-    // future change to McpTool's policy turns this red.
-    struct MockMcpExclusive;
-    #[async_trait]
-    impl Tool for MockMcpExclusive {
-        fn name(&self) -> &str {
-            "mcp_mock"
-        }
-        fn description(&self) -> &str {
-            "test"
-        }
-        fn input_schema(&self) -> serde_json::Value {
-            serde_json::json!({"type": "object"})
-        }
-        fn concurrency_class(&self) -> ConcurrencyClass {
-            // Mirror the policy in `McpTool::concurrency_class` —
-            // Exclusive by default until a per-server override lands.
-            ConcurrencyClass::Exclusive
-        }
-        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
-            Ok(ToolResult::default())
-        }
-    }
-    let mock = MockMcpExclusive;
-    assert_eq!(
-        mock.concurrency_class(),
-        ConcurrencyClass::Exclusive,
-        "MCP wrapper default policy must be Exclusive — JSON-RPC \
-         transport serialises and most servers mutate remote state"
+#[test]
+fn mcp_wrapper_defaults_to_safe_when_metadata_absent() {
+    // M8 req 10: legacy operator configs that pre-date the
+    // `concurrency_class` field must keep parsing. The resolved class
+    // falls through to `Safe` because most MCP servers in practice
+    // are read-only (search, wiki, time, weather) and forcing
+    // Exclusive on all of them would serialise the fast common path.
+    // Operators who run mutating MCP servers declare `"exclusive"`
+    // explicitly — see `mcp_wrapper_exclusive_opt_in_propagates`.
+    let config: McpServerConfig = serde_json::from_str(r#"{"command": "/bin/true"}"#).unwrap();
+    assert!(
+        config.concurrency_class.is_none(),
+        "field is optional and absent in legacy configs"
     );
+    assert_eq!(
+        config.resolved_concurrency_class(),
+        ConcurrencyClass::Safe,
+        "MCP defaults to Safe for the read-only common case"
+    );
+}
 
-    // Document the McpServerConfig name so a future grep finds it.
-    let _ = std::any::type_name::<McpServerConfig>();
+#[test]
+fn existing_app_skills_continue_to_register_after_field_addition() {
+    // M8 req 10 backward-compat gate: bundled skills shipped with
+    // older `manifest.json` files (no `concurrency_class` key on
+    // either tool defs or mcpServers entries) must keep parsing and
+    // registering exactly as before. This pins the JSON-shape
+    // contract for both wrappers.
+    let legacy_plugin: octos_agent::plugins::PluginToolDef = serde_json::from_str(
+        r#"{"name": "weather", "description": "lookup", "input_schema": {"type": "object"}}"#,
+    )
+    .unwrap();
+    assert!(legacy_plugin.concurrency_class.is_none());
+
+    let legacy_mcp: McpServerConfig =
+        serde_json::from_str(r#"{"command": "/bin/true", "args": ["--mcp"]}"#).unwrap();
+    assert!(legacy_mcp.concurrency_class.is_none());
+    assert_eq!(
+        legacy_mcp.resolved_concurrency_class(),
+        ConcurrencyClass::Safe,
+        "legacy configs resolve to Safe — read-only common case"
+    );
+}
+
+#[test]
+fn mcp_wrapper_exclusive_opt_in_propagates() {
+    // Operators who run a mutating MCP server (one that writes files
+    // into the workspace, posts to a remote service, etc.) declare
+    // `"exclusive"` so the M8.8 scheduler serialises the batch and
+    // prevents racing with the native `edit_file` / `write_file`
+    // tools.
+    let config: McpServerConfig =
+        serde_json::from_str(r#"{"command": "/bin/true", "concurrency_class": "exclusive"}"#)
+            .unwrap();
+    assert_eq!(
+        config.resolved_concurrency_class(),
+        ConcurrencyClass::Exclusive,
+        "operator-declared `exclusive` lifts to Exclusive enforcement"
+    );
+}
+
+#[test]
+fn mcp_unknown_concurrency_value_falls_back_to_exclusive() {
+    // Typos must not silently downgrade enforcement. Unknown values
+    // resolve to the safe-side default.
+    let config: McpServerConfig =
+        serde_json::from_str(r#"{"command": "/bin/true", "concurrency_class": "exlusive"}"#)
+            .unwrap();
+    assert_eq!(
+        config.resolved_concurrency_class(),
+        ConcurrencyClass::Exclusive,
+        "typo'd values must fall back to Exclusive — fail-safe"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/platform-skills/voice/manifest.json
+++ b/crates/platform-skills/voice/manifest.json
@@ -27,6 +27,7 @@
     {
       "name": "voice_synthesize",
       "description": "Synthesize speech from text. Uses Qwen3-TTS when ominix-api is running (high quality, emotion/style control, speed adjustment). Falls back to macOS built-in Say command when ominix-api is unavailable. Produces a WAV/MP3 audio file. After generating, use send_file to deliver the audio to the user. NOTE: This tool only supports preset voices. For voice cloning or custom voice profiles, use mofa-fm (fm_tts).",
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -70,6 +71,7 @@
     {
       "name": "download_model",
       "description": "Download a model from the catalog to the local machine. Use list_models first to see available model IDs. Downloads can take several minutes for large models.",
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -84,6 +86,7 @@
     {
       "name": "load_model",
       "description": "Load a downloaded model into GPU memory for inference. The model must already be downloaded locally.",
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -102,6 +105,7 @@
     {
       "name": "unload_model",
       "description": "Unload a model from GPU memory to free resources.",
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/e2e/fixtures/compat-test-skill/manifest.json
+++ b/e2e/fixtures/compat-test-skill/manifest.json
@@ -9,6 +9,7 @@
     {
       "name": "summarize_text",
       "description": "Read a text file and write a compact summary. Returns the summary file as a deliverable artifact.",
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Audit citation

`/tmp/m8-audit.md` Req 10: MCP/plugin tool wrappers default to `Safe`
regardless of whether the underlying operation mutates files. Score 3/5.
The race the audit calls out:

> A user could call `write_file` (via MCP) and `edit_file` (native, Exclusive)
> in the same batch -> executor sees both as Safe -> runs parallel -> unsafe race
> on same file.

## Gap

- Plugin manifest already had `concurrency_class: Option<String>` and the
  wrapper read it (`crates/octos-agent/src/plugins/tool.rs:705`). This PR
  documents the contract and adds the audit's missing-test gates.
- MCP wrapper hardcoded `Exclusive` for every server -- operators had no way
  to declare a read-only server (search, wiki) so the M8.8 scheduler always
  serialised them.
- Several bundled / fixture skills (`compat-test-skill`, `harness-starter-coding`,
  `harness-starter-report`, `account-manager`, `skill-evolve`,
  `voice_synthesize`, `download_model`, `load_model`, `unload_model`) write
  files or mutate state but did not declare a concurrency class -- silently
  classified as `Safe` (race-vulnerable).

## Design

**Default `Safe`, opt-in `Exclusive`** -- per the brief at handoff. Trade-off
documented:

- Pro: Most MCP servers and bundled skills in practice are read-only (search,
  wiki, time, weather) -- Safe-default keeps the parallel fast path.
- Con: A new mutating MCP server must declare `"exclusive"` or it races with
  native `edit_file` / `write_file`. Mitigated by:
  1. Backward compat: every shipped mutating skill in this repo now declares
     `"exclusive"` (commit 2).
  2. Fail-safe parsing: an unknown / typo'd value resolves to `Exclusive`
     (e.g. `"exlusive"` -> `Exclusive`) so a typo cannot silently downgrade
     enforcement.

Codex review preferred `Exclusive` as the default (more conservative).
Following the brief's explicit instruction here; if reviewers want to flip
the default, the change is a 2-line tweak in `McpServerConfig::resolved_concurrency_class`
plus updating the test names.

**Why not auto-promote `risk: "high"` to Exclusive?** Risk is an *approval*
signal (whether the user must confirm), not a *concurrency* signal. A
read-only `web_fetch` could be `risk: "high"` (reads sensitive URLs) but
still parallel-safe. The two axes are kept orthogonal.

**Why no per-tool granularity for MCP?** MCP's `tools/list` carries no
concurrency hint and exposing a per-tool override field would invite drift
between operator config and the remote tool surface. Server-level
declaration is the right abstraction.

## Files

Commit 1 -- wrapper plumbing & tests:
- `crates/octos-agent/src/mcp.rs` -- `McpServerConfig.concurrency_class: Option<String>`,
  `resolved_concurrency_class()`, plumbed into `McpToolSpec` -> `McpTool`.
- `crates/octos-agent/src/plugins/extras.rs` -- pass `concurrency_class: None`
  for skill-bundled MCP servers.
- `crates/octos-agent/src/tools/registry.rs` -- refresh stale doc comment that
  claimed plugin/MCP wrappers inherit Safe via the trait default.
- `crates/octos-agent/tests/m8_integration_concurrency.rs` -- 6 named tests.

Commit 2 -- bundled skill manifest migration:
- `e2e/fixtures/compat-test-skill/manifest.json`
- `crates/app-skills/{account-manager,harness-starter-coding,harness-starter-report,skill-evolve}/manifest.json`
- `crates/platform-skills/voice/manifest.json`

## Tests

```
test plugin_with_exclusive_manifest_serializes_with_other_exclusive_tools_in_batch ... ok
test plugin_with_no_concurrency_declaration_defaults_to_safe ... ok
test mcp_wrapper_defaults_to_safe_when_metadata_absent ... ok
test mcp_wrapper_exclusive_opt_in_propagates ... ok
test mcp_unknown_concurrency_value_falls_back_to_exclusive ... ok
test existing_app_skills_continue_to_register_after_field_addition ... ok
test mixed_batch_with_spawn_serializes ... ok
test task_control_tools_are_exclusive ... ok
```

Plus inline unit tests for `McpServerConfig::resolved_concurrency_class()`
parsing (Safe/Exclusive/case-insensitive/unknown-falls-back-to-Exclusive)
and an `McpTool` constructor smoke test that verifies the wrapper surfaces
the per-server class.

## Verification gates

- `cargo fmt --all -- --check` -- clean
- `cargo test -p octos-agent --tests` -- 35 binaries pass, all green
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean

## Codex 2nd-opinion findings

Recorded at `/tmp/codex-mcp-concurrency.log`. Key disagreements:

1. **Default direction** -- codex preferred `Exclusive` default; we kept `Safe`
   per brief. Trade-off documented above.
2. **Stale comment in `extras.rs`** -- fixed in commit 2.
3. **Existing fixtures with mutating tools** -- codex caught these
   (`compat-test-skill`, `harness-starter-coding`); migrated all of them to
   declare `"exclusive"` in commit 2.
4. **No `ReadOnly`/`Idempotent` enum variants needed** -- agreed; binary
   Safe/Exclusive is the audit's contract.

## Test plan

- [ ] Reviewer agrees with `Safe` default direction (or requests flip; trivial change)
- [ ] CI green on the six new integration tests
- [ ] Operators with mutating MCP servers add `"concurrency_class": "exclusive"` to their config

DO NOT auto-merge.