### PR TITLE
fix(plugins): enforce env allowlist + risk approval mapping at runtime (M6 req 4)

### DIFF
--- a/crates/app-skills/deep-search/manifest.json
+++ b/crates/app-skills/deep-search/manifest.json
@@ -20,7 +20,8 @@
         "MOONSHOT_API_KEY",
         "DASHSCOPE_API_KEY",
         "OPENAI_API_KEY",
-        "DEEP_SEARCH_SYNTHESIS_MODEL"
+        "DEEP_SEARCH_SYNTHESIS_MODEL",
+        "DEEP_SEARCH_MAX_BROWSERS"
       ],
       "input_schema": {
         "type": "object",

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -13,7 +13,7 @@ use crate::sandbox::BLOCKED_ENV_VARS;
 use crate::tools::{Tool, ToolRegistry};
 
 use super::extras::{SkillExtras, resolve_extras};
-use super::manifest::{PluginManifest, PluginToolDef};
+use super::manifest::{ConcurrencyClassClassification, PluginManifest, PluginToolDef};
 use super::tool::{PluginTool, SynthesisConfig};
 
 const MAX_EXECUTABLE_SIZE: u64 = 100_000_000;
@@ -359,17 +359,25 @@ impl PluginLoader {
             .map(Duration::from_secs)
             .unwrap_or(PluginTool::DEFAULT_TIMEOUT);
 
-        // Collect spawn_only tool names and messages before consuming manifest.tools
+        // Collect spawn_only tool names and messages before consuming
+        // manifest.tools. Tools that fail manifest validation below are
+        // skipped — drop them from the spawn_only metadata too so the
+        // execution loop doesn't try to auto-background a tool that was
+        // never registered.
         let spawn_only_names: Vec<String> = manifest
             .tools
             .iter()
-            .filter(|t| t.spawn_only)
+            .filter(|t| t.spawn_only && t.validate_for_registration().is_ok())
             .map(|t| t.name.clone())
             .collect();
         let spawn_only_msgs: std::collections::HashMap<String, String> = manifest
             .tools
             .iter()
-            .filter(|t| t.spawn_only && t.spawn_only_message.is_some())
+            .filter(|t| {
+                t.spawn_only
+                    && t.spawn_only_message.is_some()
+                    && t.validate_for_registration().is_ok()
+            })
             .map(|t| {
                 (
                     t.name.clone(),
@@ -382,7 +390,37 @@ impl PluginLoader {
         let tools: Vec<LoadedPluginTool> = manifest
             .tools
             .into_iter()
-            .map(|def| {
+            .filter_map(|def| {
+                // M6 req 4: registration-time gate for env allowlist hygiene.
+                // A malformed manifest entry (empty name, '=', whitespace,
+                // process-hijack vars like LD_PRELOAD) is rejected here so
+                // the runtime allowlist gate cannot be subverted by a
+                // crafted entry that the runtime check would later
+                // mis-handle.
+                if let Err(err) = def.validate_for_registration() {
+                    warn!(
+                        plugin = %plugin_name,
+                        tool = %def.name,
+                        error = %err,
+                        "skipping plugin tool with invalid manifest field"
+                    );
+                    return None;
+                }
+                // Codex review #1: warn (don't reject) on unknown
+                // concurrency_class so authors notice typos like
+                // `"exclusive "` (trailing space → silently Safe). The
+                // runtime trim added in tool.rs handles the trim case;
+                // this surface keeps unknown literals visible.
+                if let ConcurrencyClassClassification::Unknown(raw) =
+                    def.classify_concurrency_class()
+                {
+                    warn!(
+                        plugin = %plugin_name,
+                        tool = %def.name,
+                        concurrency_class = %raw,
+                        "manifest declares unknown concurrency_class; falling back to Safe"
+                    );
+                }
                 let manifest_risk = def.risk.clone();
                 let def = apply_builtin_env_allowlist(&plugin_name, def);
                 let mut tool = PluginTool::new(plugin_name.clone(), def, verified_exe.clone())
@@ -400,10 +438,10 @@ impl PluginLoader {
                 if let Some(cfg) = synthesis_config.clone() {
                     tool = tool.with_synthesis_config(cfg);
                 }
-                LoadedPluginTool {
+                Some(LoadedPluginTool {
                     tool,
                     risk: manifest_risk,
-                }
+                })
             })
             .collect();
 
@@ -1329,5 +1367,83 @@ edition = "2021"
             prepared.get("synthesis_config").is_none(),
             "non-opted-in plugin must not see synthesis_config: {prepared}"
         );
+    }
+
+    /// M6 req 4: a manifest that declares an env allowlist entry whose
+    /// name is a known process-hijack var (`LD_PRELOAD`) must be rejected
+    /// at registration time so the malicious entry never reaches the
+    /// runtime gate.
+    #[cfg(unix)]
+    #[test]
+    fn loader_skips_tool_with_invalid_env_allowlist_entry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("evil-env-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            r#"{
+                "name": "evil-env-plugin",
+                "version": "1.0",
+                "tools": [
+                    {"name": "good_tool", "description": "ok", "env": ["MY_VAR"]},
+                    {"name": "bad_tool", "description": "bad", "env": ["LD_PRELOAD"]}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let exec_path = plugin_dir.join("evil-env-plugin");
+        std::fs::write(
+            &exec_path,
+            "#!/bin/sh\necho '{\"output\": \"ok\", \"success\": true}'",
+        )
+        .unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result =
+            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+
+        // good_tool registered, bad_tool skipped.
+        assert_eq!(result.tool_count, 1);
+        assert!(result.tool_names.contains(&"good_tool".to_string()));
+        assert!(!result.tool_names.contains(&"bad_tool".to_string()));
+    }
+
+    /// Pin that registration-time validation rejects manifests with
+    /// `env` entries containing `=` (a shell-injection vector).
+    #[cfg(unix)]
+    #[test]
+    fn loader_skips_tool_with_equals_in_env_name() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("eq-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            r#"{
+                "name": "eq-plugin",
+                "version": "1.0",
+                "tools": [{"name": "bad", "description": "d", "env": ["FOO=bar"]}]
+            }"#,
+        )
+        .unwrap();
+        let exec_path = plugin_dir.join("eq-plugin");
+        std::fs::write(
+            &exec_path,
+            "#!/bin/sh\necho '{\"output\": \"ok\", \"success\": true}'",
+        )
+        .unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result =
+            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+        assert_eq!(result.tool_count, 0);
     }
 }

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -133,6 +133,181 @@ pub struct PluginToolDef {
     pub concurrency_class: Option<String>,
 }
 
+/// Recognised values for the manifest-declared `risk` field.
+///
+/// M6 req 4 enforcement (UPCR-2026-001): a tool that declares
+/// `risk: "high"` or `risk: "critical"` must trigger an interactive approval
+/// prompt before each invocation. `low` is treated as auto-approved.
+/// `medium` and any unknown literal fall through to "no enforced gate" — the
+/// risk is still surfaced on `approval_requested.risk` for display, but the
+/// agent does not synthesise an approval check (intent: medium semantics
+/// remain ambiguous; revisit per Tier 2/3 follow-up).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestRiskGate {
+    /// Auto-approved — skip the interactive prompt.
+    Low,
+    /// Ambiguous; surfaced for display, no enforced gate.
+    MediumOrUnspecified,
+    /// Must request user approval before invocation.
+    HighOrCritical,
+}
+
+impl ManifestRiskGate {
+    /// Classify a manifest risk literal. Whitespace and ASCII case are
+    /// ignored. Unknown literals map to [`ManifestRiskGate::MediumOrUnspecified`]
+    /// so the agent does not silently strengthen a value the manifest
+    /// author did not write.
+    pub fn classify(risk: Option<&str>) -> Self {
+        match risk
+            .map(str::trim)
+            .filter(|risk| !risk.is_empty())
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("low") => Self::Low,
+            Some("high") | Some("critical") => Self::HighOrCritical,
+            _ => Self::MediumOrUnspecified,
+        }
+    }
+
+    /// Whether this risk literal forces an interactive approval prompt.
+    pub fn requires_approval(self) -> bool {
+        matches!(self, Self::HighOrCritical)
+    }
+}
+
+/// Manifest-level validation error surfaced at registration time.
+///
+/// Loader code calls [`PluginToolDef::validate_for_registration`] before
+/// wiring the tool into the registry. A returned error means the plugin
+/// declares fields the harness cannot enforce safely; the plugin is
+/// rejected (loader logs and skips).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestValidationError {
+    /// `env` allowlist contains a name that fails the syntactic check.
+    /// First field: the offending name; second: human-readable reason.
+    InvalidEnvName(String, &'static str),
+}
+
+impl std::fmt::Display for ManifestValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidEnvName(name, reason) => write!(
+                f,
+                "manifest env allowlist entry {name:?} is invalid: {reason}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ManifestValidationError {}
+
+impl PluginToolDef {
+    /// Validate manifest fields whose enforcement gates run at runtime.
+    ///
+    /// M6 req 4: this is the registration-time half of the env-allowlist
+    /// gate. Runtime filtering relies on [`PluginToolDef::env`] being a
+    /// list of well-formed env-var names — anything that smells like a
+    /// shell-injection token (`=`, control chars) or a known process
+    /// hijack vector (`LD_PRELOAD`, `DYLD_*` etc.) is rejected here so a
+    /// malicious manifest cannot use the allowlist as a bypass channel.
+    pub fn validate_for_registration(&self) -> Result<(), ManifestValidationError> {
+        for name in &self.env {
+            validate_manifest_env_name(name)?;
+        }
+        Ok(())
+    }
+
+    /// Returns the trimmed/lowercased `concurrency_class` literal if it is
+    /// recognised. Returns `None` for missing values; returns
+    /// `Some("unknown:...")` for declared-but-unrecognised values so the
+    /// loader can warn without rejecting (silent fallback to Safe is the
+    /// existing behavior — we don't want to break a manifest that
+    /// declares e.g. `"safe"` even though Safe is the default).
+    ///
+    /// Recognised: `exclusive`, `safe`. Anything else (including
+    /// `"medium"`, `"highly-exclusive"`, ...) is reported as unknown so
+    /// operators can spot typos like `"exclusive "` (trailing space —
+    /// previously silently downgraded to Safe).
+    pub fn classify_concurrency_class(&self) -> ConcurrencyClassClassification {
+        let Some(raw) = self.concurrency_class.as_deref() else {
+            return ConcurrencyClassClassification::Unset;
+        };
+        let trimmed = raw.trim().to_ascii_lowercase();
+        match trimmed.as_str() {
+            "" => ConcurrencyClassClassification::Unset,
+            "exclusive" => ConcurrencyClassClassification::Exclusive,
+            "safe" => ConcurrencyClassClassification::Safe,
+            _ => ConcurrencyClassClassification::Unknown(raw.to_string()),
+        }
+    }
+}
+
+/// Result of [`PluginToolDef::classify_concurrency_class`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConcurrencyClassClassification {
+    /// No `concurrency_class` declared. Falls back to the trait default
+    /// (`Safe`).
+    Unset,
+    /// Declared `"exclusive"` (post-trim, case-insensitive).
+    Exclusive,
+    /// Declared `"safe"` (post-trim, case-insensitive). Equivalent to
+    /// Unset at runtime but distinguished here so a future tightening
+    /// can reject Unset for mutating tools while keeping explicit Safe.
+    Safe,
+    /// Declared but unrecognised. Carries the original raw value for
+    /// diagnostic logging. Runtime behavior falls back to Safe.
+    Unknown(String),
+}
+
+fn validate_manifest_env_name(name: &str) -> Result<(), ManifestValidationError> {
+    if name.is_empty() {
+        return Err(ManifestValidationError::InvalidEnvName(
+            name.to_string(),
+            "empty name",
+        ));
+    }
+    if name.contains('=') {
+        return Err(ManifestValidationError::InvalidEnvName(
+            name.to_string(),
+            "name must not contain '='",
+        ));
+    }
+    if name.chars().any(|ch| ch.is_control() || ch.is_whitespace()) {
+        return Err(ManifestValidationError::InvalidEnvName(
+            name.to_string(),
+            "name must not contain whitespace or control characters",
+        ));
+    }
+    if name.starts_with(|ch: char| ch.is_ascii_digit()) {
+        return Err(ManifestValidationError::InvalidEnvName(
+            name.to_string(),
+            "name must not start with a digit",
+        ));
+    }
+    for ch in name.chars() {
+        if !(ch.is_ascii_alphanumeric() || ch == '_') {
+            return Err(ManifestValidationError::InvalidEnvName(
+                name.to_string(),
+                "name must use only [A-Za-z0-9_]",
+            ));
+        }
+    }
+    // Reject known process-hijack env names. The same list is stripped
+    // unconditionally at subprocess spawn time, but rejecting at
+    // registration makes the malicious manifest visible in logs instead
+    // of letting it linger as a no-op.
+    for blocked in crate::sandbox::BLOCKED_ENV_VARS {
+        if name.eq_ignore_ascii_case(blocked) {
+            return Err(ManifestValidationError::InvalidEnvName(
+                name.to_string(),
+                "name is a known process-hijack env var",
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl PluginToolDef {
     /// Whether this tool's input schema declares it accepts host-injected
     /// config under the named key (e.g. `"synthesis_config"`).
@@ -400,5 +575,188 @@ mod tests {
         );
         assert!(schema["properties"]["config"]["oneOf"].is_array());
         assert_eq!(schema["required"], serde_json::json!(["service"]));
+    }
+
+    fn def_with_env(env: Vec<&str>) -> PluginToolDef {
+        PluginToolDef {
+            name: "t".to_string(),
+            description: "d".to_string(),
+            input_schema: default_schema(),
+            spawn_only: false,
+            env: env.into_iter().map(str::to_string).collect(),
+            risk: None,
+            spawn_only_message: None,
+            concurrency_class: None,
+        }
+    }
+
+    #[test]
+    fn validate_for_registration_accepts_clean_allowlist() {
+        let def = def_with_env(vec!["OPENAI_API_KEY", "SMTP_HOST", "_FOO_BAR_"]);
+        assert!(def.validate_for_registration().is_ok());
+    }
+
+    #[test]
+    fn validate_for_registration_accepts_empty_allowlist() {
+        let def = def_with_env(vec![]);
+        assert!(def.validate_for_registration().is_ok());
+    }
+
+    #[test]
+    fn validate_for_registration_rejects_empty_entry() {
+        let def = def_with_env(vec![""]);
+        let err = def.validate_for_registration().unwrap_err();
+        assert!(matches!(err, ManifestValidationError::InvalidEnvName(_, _)));
+    }
+
+    #[test]
+    fn validate_for_registration_rejects_equals_sign() {
+        let def = def_with_env(vec!["FOO=bar"]);
+        assert!(def.validate_for_registration().is_err());
+    }
+
+    #[test]
+    fn validate_for_registration_rejects_whitespace() {
+        let def = def_with_env(vec!["FOO BAR"]);
+        assert!(def.validate_for_registration().is_err());
+        let def = def_with_env(vec!["FOO\nBAR"]);
+        assert!(def.validate_for_registration().is_err());
+    }
+
+    #[test]
+    fn validate_for_registration_rejects_leading_digit() {
+        let def = def_with_env(vec!["1FOO"]);
+        assert!(def.validate_for_registration().is_err());
+    }
+
+    #[test]
+    fn validate_for_registration_rejects_non_alphanumeric() {
+        let def = def_with_env(vec!["FOO-BAR"]);
+        assert!(def.validate_for_registration().is_err());
+        let def = def_with_env(vec!["FOO.BAR"]);
+        assert!(def.validate_for_registration().is_err());
+    }
+
+    #[test]
+    fn validate_for_registration_rejects_blocked_env_names() {
+        // BLOCKED_ENV_VARS includes process-hijack vars like LD_PRELOAD,
+        // DYLD_INSERT_LIBRARIES, NODE_OPTIONS, etc.
+        let def = def_with_env(vec!["LD_PRELOAD"]);
+        assert!(def.validate_for_registration().is_err());
+        let def = def_with_env(vec!["DYLD_INSERT_LIBRARIES"]);
+        assert!(def.validate_for_registration().is_err());
+        // Case-insensitive match.
+        let def = def_with_env(vec!["ld_preload"]);
+        assert!(def.validate_for_registration().is_err());
+    }
+
+    #[test]
+    fn manifest_risk_gate_classifies_known_literals() {
+        assert_eq!(
+            ManifestRiskGate::classify(Some("low")),
+            ManifestRiskGate::Low
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some("LOW")),
+            ManifestRiskGate::Low
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some(" Low ")),
+            ManifestRiskGate::Low
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some("high")),
+            ManifestRiskGate::HighOrCritical
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some("CRITICAL")),
+            ManifestRiskGate::HighOrCritical
+        );
+    }
+
+    #[test]
+    fn manifest_risk_gate_falls_back_for_unknown_or_blank() {
+        assert_eq!(
+            ManifestRiskGate::classify(None),
+            ManifestRiskGate::MediumOrUnspecified
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some("")),
+            ManifestRiskGate::MediumOrUnspecified
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some("   ")),
+            ManifestRiskGate::MediumOrUnspecified
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some("medium")),
+            ManifestRiskGate::MediumOrUnspecified
+        );
+        assert_eq!(
+            ManifestRiskGate::classify(Some("super-critical")),
+            ManifestRiskGate::MediumOrUnspecified
+        );
+    }
+
+    #[test]
+    fn manifest_risk_gate_requires_approval_only_for_high_critical() {
+        assert!(!ManifestRiskGate::Low.requires_approval());
+        assert!(!ManifestRiskGate::MediumOrUnspecified.requires_approval());
+        assert!(ManifestRiskGate::HighOrCritical.requires_approval());
+    }
+
+    fn def_with_concurrency(class: Option<&str>) -> PluginToolDef {
+        PluginToolDef {
+            name: "t".to_string(),
+            description: "d".to_string(),
+            input_schema: default_schema(),
+            spawn_only: false,
+            env: vec![],
+            risk: None,
+            spawn_only_message: None,
+            concurrency_class: class.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn classify_concurrency_class_recognises_known_literals() {
+        assert_eq!(
+            def_with_concurrency(Some("exclusive")).classify_concurrency_class(),
+            ConcurrencyClassClassification::Exclusive
+        );
+        assert_eq!(
+            def_with_concurrency(Some("EXCLUSIVE")).classify_concurrency_class(),
+            ConcurrencyClassClassification::Exclusive
+        );
+        // Codex review #1: trailing whitespace must not silently
+        // downgrade `"exclusive "` to Safe.
+        assert_eq!(
+            def_with_concurrency(Some("exclusive ")).classify_concurrency_class(),
+            ConcurrencyClassClassification::Exclusive
+        );
+        assert_eq!(
+            def_with_concurrency(Some("safe")).classify_concurrency_class(),
+            ConcurrencyClassClassification::Safe
+        );
+    }
+
+    #[test]
+    fn classify_concurrency_class_flags_unknown_literals() {
+        match def_with_concurrency(Some("nonsense")).classify_concurrency_class() {
+            ConcurrencyClassClassification::Unknown(raw) => assert_eq!(raw, "nonsense"),
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_concurrency_class_unset_when_missing_or_blank() {
+        assert_eq!(
+            def_with_concurrency(None).classify_concurrency_class(),
+            ConcurrencyClassClassification::Unset
+        );
+        assert_eq!(
+            def_with_concurrency(Some("   ")).classify_concurrency_class(),
+            ConcurrencyClassClassification::Unset
+        );
     }
 }

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -16,10 +16,16 @@ use crate::harness_events::{
     OCTOS_SESSION_ID_ENV, OCTOS_TASK_ID_ENV, lookup_event_sink_context, write_event_to_sink,
 };
 use crate::progress::ProgressEvent;
-use crate::subprocess_env::{EnvAllowlist, sanitize_command_env, should_forward_env_name};
-use crate::tools::{TOOL_CTX, Tool, ToolContext, ToolResult};
+use crate::subprocess_env::{
+    EnvAllowlist, sanitize_command_env, sanitize_command_env_strict, should_forward_env_name,
+    should_forward_env_name_strict,
+};
+use crate::tools::{
+    TOOL_APPROVAL_CTX, TOOL_CTX, Tool, ToolApprovalDecision, ToolApprovalRequest, ToolContext,
+    ToolResult,
+};
 
-use super::manifest::PluginToolDef;
+use super::manifest::{ManifestRiskGate, PluginToolDef};
 
 /// Synthesis LLM provider config injected into plugin args.
 ///
@@ -713,6 +719,7 @@ impl Tool for PluginTool {
             .tool_def
             .concurrency_class
             .as_deref()
+            .map(str::trim)
             .map(str::to_ascii_lowercase)
             .as_deref()
         {
@@ -754,6 +761,87 @@ impl Tool for PluginTool {
             "spawning plugin process"
         );
 
+        // M6 req 4: enforce manifest-declared `risk` field (UPCR-2026-001).
+        // When the manifest declares `risk: "high"` or `risk: "critical"`,
+        // request user approval before spawning the plugin process. `low`
+        // and unspecified/unknown literals fall through (no enforced gate)
+        // so existing skills that don't declare `risk` keep working
+        // unchanged.
+        let risk_gate = ManifestRiskGate::classify(self.tool_def.risk.as_deref());
+        if risk_gate.requires_approval() {
+            let requester = TOOL_APPROVAL_CTX.try_with(Clone::clone).ok();
+            let Some(requester) = requester else {
+                tracing::warn!(
+                    plugin = %self.plugin_name,
+                    tool = %self.tool_def.name,
+                    risk = ?self.tool_def.risk,
+                    "plugin tool requires approval but no interactive approval bridge is in scope — denied"
+                );
+                return Ok(ToolResult {
+                    output: format!(
+                        "Plugin tool '{}' requires approval (manifest risk={:?}) and was denied: no interactive approval bridge available.",
+                        self.tool_def.name,
+                        self.tool_def.risk.as_deref().unwrap_or("unspecified")
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            };
+
+            let tool_id = TOOL_CTX
+                .try_with(|ctx| ctx.tool_id.clone())
+                .unwrap_or_default();
+            let title = format!(
+                "Approve {} ({})",
+                self.tool_def.name,
+                self.tool_def
+                    .risk
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|risk| !risk.is_empty())
+                    .unwrap_or("high")
+            );
+            let body = format!(
+                "Plugin '{}' tool '{}' is declared {} risk in its manifest.",
+                self.plugin_name,
+                self.tool_def.name,
+                self.tool_def
+                    .risk
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|risk| !risk.is_empty())
+                    .unwrap_or("high")
+            );
+            let decision = requester
+                .request_approval(ToolApprovalRequest {
+                    tool_id,
+                    tool_name: self.tool_def.name.clone(),
+                    title,
+                    body,
+                    command: None,
+                    cwd: self
+                        .work_dir
+                        .as_ref()
+                        .map(|p| p.to_string_lossy().into_owned()),
+                })
+                .await;
+            if matches!(decision, ToolApprovalDecision::Deny) {
+                tracing::warn!(
+                    plugin = %self.plugin_name,
+                    tool = %self.tool_def.name,
+                    "plugin tool denied by interactive approval"
+                );
+                return Ok(ToolResult {
+                    output: format!(
+                        "Plugin tool '{}' denied by user approval.",
+                        self.tool_def.name
+                    ),
+                    success: false,
+                    ..Default::default()
+                });
+            }
+        }
+
         let mut cmd = Command::new(&self.executable);
         cmd.arg(&self.tool_def.name)
             .stdin(Stdio::piped())
@@ -761,7 +849,18 @@ impl Tool for PluginTool {
             .stderr(Stdio::piped());
 
         let env_allowlist = EnvAllowlist::from_strings(&self.tool_def.env);
-        sanitize_command_env(&mut cmd, &env_allowlist);
+
+        // M6 req 4: when the manifest declares a non-empty `env` list, treat
+        // it as a strict allowlist and strip every other env var (only the
+        // manifest's names + runtime essentials + harness-injected OCTOS_*
+        // are retained). Empty list keeps the legacy "secret-only" gate so
+        // existing skills that don't declare `env` continue working.
+        let strict_env_gate = !env_allowlist.is_empty();
+        if strict_env_gate {
+            sanitize_command_env_strict(&mut cmd, &env_allowlist);
+        } else {
+            sanitize_command_env(&mut cmd, &env_allowlist);
+        }
 
         // Remove blocked environment variables
         for var in &self.blocked_env {
@@ -772,14 +871,19 @@ impl Tool for PluginTool {
 
         // Inject extra environment variables (e.g. provider base URLs, API keys)
         for (key, val) in &self.extra_env {
-            if should_forward_env_name(key, &env_allowlist) {
+            let permitted = if strict_env_gate {
+                should_forward_env_name_strict(key, &env_allowlist)
+            } else {
+                should_forward_env_name(key, &env_allowlist)
+            };
+            if permitted {
                 cmd.env(key, val);
             } else {
                 tracing::debug!(
                     plugin = %self.plugin_name,
                     tool = %self.tool_def.name,
                     env = %key,
-                "skipping non-allowlisted secret environment variable for plugin tool"
+                "skipping non-allowlisted environment variable for plugin tool"
                 );
             }
         }
@@ -2060,5 +2164,344 @@ mod tests {
 
         // Cleanup the sink registration.
         crate::harness_events::detach_event_sink_context(&ctx_path);
+    }
+
+    // -------------------------------------------------------------------
+    // M6 req 4: env allowlist + risk approval enforcement tests
+    // -------------------------------------------------------------------
+
+    /// Manifest declares `env: ["FOO_ALLOWED_PLUGIN"]`. With strict gate
+    /// active, an extra_env entry that's NOT on the manifest list is
+    /// dropped — even though it isn't a secret name, the legacy gate
+    /// would forward it. Pin the new strict semantics.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn strict_env_allowlist_drops_non_listed_extra_env() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\nread INPUT || true\nA=${FOO_ALLOWED_PLUGIN:-missing}\nN=${FOO_BLOCKED_PLUGIN:-missing}\necho '{\"output\":\"a='\"$A\"';n='\"$N\"'\",\"success\":true}'\n",
+        );
+
+        let mut def = make_tool_def("env_strict_tool", "prints env");
+        def.env.push("FOO_ALLOWED_PLUGIN".into());
+        let tool = PluginTool::new("p".into(), def, script_path)
+            .with_extra_env(vec![
+                ("FOO_ALLOWED_PLUGIN".into(), "yes".into()),
+                ("FOO_BLOCKED_PLUGIN".into(), "should_be_stripped".into()),
+            ])
+            .with_timeout(Duration::from_secs(5));
+
+        let result = tool.execute(&json!({})).await.expect("should succeed");
+
+        assert!(result.success);
+        assert!(
+            result.output.contains("a=yes"),
+            "listed extra env should reach subprocess; got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("n=missing"),
+            "non-listed extra env must be stripped under strict allowlist; got: {}",
+            result.output
+        );
+    }
+
+    /// When the manifest declares an empty `env` list, legacy semantics
+    /// apply: non-secret extra_env entries pass through unfiltered. This
+    /// pins the no-regression contract: skills that don't declare `env`
+    /// see no behavior change from this PR.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn empty_env_allowlist_keeps_legacy_extra_env_passthrough() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        // Use a name that isn't flagged as secret-like (no token match
+        // for SECRET/TOKEN/KEY/PASSWORD/etc).
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\nread INPUT || true\nVALUE=${MY_BASE_URL:-missing}\necho '{\"output\":\"'\"$VALUE\"'\",\"success\":true}'\n",
+        );
+
+        let def = make_tool_def("legacy_env_tool", "prints env");
+        // No `env` allowlist declared → empty list → legacy gate.
+        let tool = PluginTool::new("p".into(), def, script_path)
+            .with_extra_env(vec![("MY_BASE_URL".into(), "passes_through".into())])
+            .with_timeout(Duration::from_secs(5));
+
+        let result = tool.execute(&json!({})).await.expect("should succeed");
+
+        assert!(result.success);
+        assert!(
+            result.output.contains("passes_through"),
+            "non-secret extra_env should pass through under legacy gate; got: {}",
+            result.output
+        );
+    }
+
+    /// Strict allowlist must still permit runtime essentials like PATH
+    /// even if they aren't listed in the manifest, otherwise the
+    /// subprocess can't find binaries it needs (sh, etc.). PATH is
+    /// inherited from the parent process, not injected via extra_env.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn strict_env_allowlist_retains_path() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\nread INPUT || true\nVALUE=${PATH:-missing}\nif [ \"$VALUE\" = \"missing\" ]; then echo '{\"output\":\"NO_PATH\",\"success\":true}'; else echo '{\"output\":\"HAS_PATH\",\"success\":true}'; fi\n",
+        );
+
+        let mut def = make_tool_def("path_tool", "prints PATH");
+        def.env.push("FOO_ALLOWED_PLUGIN".into());
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let result = tool.execute(&json!({})).await.expect("should succeed");
+        assert!(result.success);
+        assert!(
+            result.output.contains("HAS_PATH"),
+            "PATH must be retained under strict allowlist; got: {}",
+            result.output
+        );
+    }
+
+    // ---- risk approval gate ----
+
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    use crate::tools::ToolApprovalRequester;
+
+    struct RecordingRequester {
+        decision: ToolApprovalDecision,
+        last: Arc<Mutex<Option<ToolApprovalRequest>>>,
+    }
+
+    impl RecordingRequester {
+        fn new(
+            decision: ToolApprovalDecision,
+        ) -> (Arc<Self>, Arc<Mutex<Option<ToolApprovalRequest>>>) {
+            let last = Arc::new(Mutex::new(None));
+            let r = Arc::new(Self {
+                decision,
+                last: last.clone(),
+            });
+            (r, last)
+        }
+    }
+
+    #[async_trait]
+    impl ToolApprovalRequester for RecordingRequester {
+        async fn request_approval(&self, request: ToolApprovalRequest) -> ToolApprovalDecision {
+            *self.last.lock().unwrap() = Some(request);
+            self.decision
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn high_risk_plugin_tool_requests_approval() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\nread INPUT || true\necho '{\"output\":\"ran\",\"success\":true}'\n",
+        );
+
+        let mut def = make_tool_def("danger_tool", "danger");
+        def.risk = Some("high".into());
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Approve);
+        let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
+
+        let result = TOOL_APPROVAL_CTX
+            .scope(requester_arc, tool.execute(&json!({})))
+            .await
+            .expect("execute should succeed");
+
+        assert!(result.success);
+        assert_eq!(result.output, "ran");
+        let req = last
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("approval was requested");
+        assert_eq!(req.tool_name, "danger_tool");
+        assert!(req.title.contains("high"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn high_risk_plugin_tool_denied_returns_deny_message() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"output\":\"should_not_run\",\"success\":true}'\n",
+        );
+
+        let mut def = make_tool_def("danger_tool_deny", "danger");
+        def.risk = Some("critical".into());
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let (requester, _last) = RecordingRequester::new(ToolApprovalDecision::Deny);
+        let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
+
+        let result = TOOL_APPROVAL_CTX
+            .scope(requester_arc, tool.execute(&json!({})))
+            .await
+            .expect("execute returns Ok with deny message");
+
+        assert!(!result.success, "denied call must report failure");
+        assert!(
+            result.output.contains("denied"),
+            "deny message should be returned; got: {}",
+            result.output
+        );
+        assert!(!result.output.contains("should_not_run"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn low_risk_plugin_tool_does_not_request_approval() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"output\":\"ran_without_prompt\",\"success\":true}'\n",
+        );
+
+        let mut def = make_tool_def("safe_tool", "safe");
+        def.risk = Some("low".into());
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Deny);
+        let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
+
+        let result = TOOL_APPROVAL_CTX
+            .scope(requester_arc, tool.execute(&json!({})))
+            .await
+            .expect("execute should succeed");
+
+        assert!(result.success);
+        assert_eq!(result.output, "ran_without_prompt");
+        assert!(
+            last.lock().unwrap().is_none(),
+            "approval must not be requested for low risk"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn unspecified_risk_plugin_tool_does_not_request_approval() {
+        // Default behavior — pinning that skills without `risk` declared
+        // continue to run without ever prompting (no breakage).
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"output\":\"unprompted\",\"success\":true}'\n",
+        );
+
+        let def = make_tool_def("plain_tool", "plain");
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Deny);
+        let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
+
+        let result = TOOL_APPROVAL_CTX
+            .scope(requester_arc, tool.execute(&json!({})))
+            .await
+            .expect("execute should succeed");
+
+        assert!(result.success);
+        assert_eq!(result.output, "unprompted");
+        assert!(last.lock().unwrap().is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn high_risk_without_approval_bridge_denies_safely() {
+        // Mirrors shell.rs behavior: if there's no interactive bridge,
+        // a high-risk plugin tool must NOT silently run.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"output\":\"should_not_run\",\"success\":true}'\n",
+        );
+
+        let mut def = make_tool_def("danger_tool_no_bridge", "danger");
+        def.risk = Some("HIGH".into());
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        // No TOOL_APPROVAL_CTX scoped → try_with returns Err → deny.
+        let result = tool
+            .execute(&json!({}))
+            .await
+            .expect("returns Ok with deny");
+        assert!(!result.success);
+        assert!(result.output.contains("denied"));
+        assert!(!result.output.contains("should_not_run"));
+    }
+
+    #[test]
+    fn concurrency_class_trims_whitespace_and_returns_exclusive() {
+        // Codex review #1 regression test: `"exclusive "` (trailing
+        // whitespace) previously silently downgraded to Safe. After the
+        // trim added at the parse site, it must classify as Exclusive.
+        let mut def = make_tool_def("excl_tool", "exclusive");
+        def.concurrency_class = Some("exclusive ".to_string());
+        let tool = PluginTool::new("p".into(), def, PathBuf::from("/bin/echo"));
+        let class = tool.concurrency_class();
+        assert!(matches!(class, crate::tools::ConcurrencyClass::Exclusive));
+    }
+
+    #[test]
+    fn concurrency_class_unknown_falls_back_to_safe() {
+        let mut def = make_tool_def("excl_tool", "exclusive");
+        def.concurrency_class = Some("highly-exclusive".to_string());
+        let tool = PluginTool::new("p".into(), def, PathBuf::from("/bin/echo"));
+        let class = tool.concurrency_class();
+        assert!(matches!(class, crate::tools::ConcurrencyClass::Safe));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn unknown_risk_literal_does_not_force_approval() {
+        // medium / weird literals fall through to "no enforced gate"
+        // (semantics ambiguous; documented as Tier-2/3 follow-up).
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"output\":\"ran\",\"success\":true}'\n",
+        );
+
+        let mut def = make_tool_def("medium_tool", "medium");
+        def.risk = Some("medium".into());
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let (requester, last) = RecordingRequester::new(ToolApprovalDecision::Deny);
+        let requester_arc: Arc<dyn ToolApprovalRequester> = requester;
+
+        let result = TOOL_APPROVAL_CTX
+            .scope(requester_arc, tool.execute(&json!({})))
+            .await
+            .expect("execute should succeed");
+
+        assert!(result.success);
+        assert_eq!(result.output, "ran");
+        assert!(last.lock().unwrap().is_none());
     }
 }

--- a/crates/octos-agent/src/subprocess_env.rs
+++ b/crates/octos-agent/src/subprocess_env.rs
@@ -30,8 +30,110 @@ impl EnvAllowlist {
         Self::from_names(names.iter().map(String::as_str))
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+
     fn contains(&self, name: &str) -> bool {
         self.names.contains(&normalize_env_name(name))
+    }
+}
+
+/// Names that are always retained even when a strict manifest env
+/// allowlist is in effect. These are runtime-essential vars that the
+/// subprocess needs to function (PATH for binary lookup, locale, etc).
+/// Adding to this list is a deliberate decision — every entry here is a
+/// var the manifest can NOT exclude.
+const ALWAYS_RETAIN_ENV_NAMES: &[&str] = &[
+    "PATH",
+    "HOME",
+    "PWD",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LANGUAGE",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LC_MESSAGES",
+    "LC_NUMERIC",
+    "LC_TIME",
+    "LC_COLLATE",
+    "LC_MONETARY",
+    "TZ",
+    "TERM",
+];
+
+fn is_always_retain_env_name(name: &str) -> bool {
+    let upper = normalize_env_name(name);
+    if ALWAYS_RETAIN_ENV_NAMES.iter().any(|&n| upper == n) {
+        return true;
+    }
+    // Any LC_* locale variant.
+    upper.starts_with("LC_")
+}
+
+/// Names the harness itself injects into plugin processes; the strict
+/// allowlist gate must not strip these because the wrapper later sets
+/// them to plumb harness identity (session id, work dir, event sink).
+fn is_harness_env_name(name: &str) -> bool {
+    let upper = normalize_env_name(name);
+    upper.starts_with("OCTOS_")
+}
+
+/// Strict variant of [`should_forward_env_name`] for plugin tools that
+/// declare a non-empty manifest env allowlist.
+///
+/// Default semantics ([`should_forward_env_name`]) gate **only** secret-like
+/// vars: a manifest declaring `env: ["FOO"]` adds `FOO` to the allowlist
+/// but does NOT restrict non-secret vars. That mismatches the plain reading
+/// of the manifest field name.
+///
+/// This strict variant is used when the manifest's `env` list is non-empty.
+/// It forwards a name iff:
+/// - it is not a known process-hijack var (`LD_PRELOAD`, `DYLD_*`, ...),
+/// - AND either:
+///   - it is in the manifest allowlist, OR
+///   - it is in [`ALWAYS_RETAIN_ENV_NAMES`] (runtime essentials), OR
+///   - it is a harness-injected `OCTOS_*` var.
+///
+/// Any other env var — secret OR non-secret — is dropped.
+pub(crate) fn should_forward_env_name_strict(name: &str, allowlist: &EnvAllowlist) -> bool {
+    if is_injection_env_name(name) {
+        return false;
+    }
+    if allowlist.contains(name) {
+        return true;
+    }
+    if is_always_retain_env_name(name) {
+        return true;
+    }
+    if is_harness_env_name(name) {
+        return true;
+    }
+    false
+}
+
+/// Strict env sanitisation — see [`should_forward_env_name_strict`].
+///
+/// Use this when the plugin's manifest declares a non-empty `env`
+/// allowlist. Strips every env var that isn't in the manifest list,
+/// runtime essentials, or the `OCTOS_*` harness namespace.
+pub(crate) fn sanitize_command_env_strict(cmd: &mut Command, allowlist: &EnvAllowlist) {
+    for (key, _) in std::env::vars_os() {
+        let Some(name) = key.to_str() else {
+            continue;
+        };
+        if !should_forward_env_name_strict(name, allowlist) {
+            cmd.env_remove(&key);
+        }
+    }
+
+    for name in BLOCKED_ENV_VARS {
+        cmd.env_remove(name);
     }
 }
 
@@ -155,5 +257,66 @@ mod tests {
         assert!(!should_forward_env_name("TAVILY_API_KEY", &allowlist));
         assert!(!should_forward_env_name("LD_PRELOAD", &allowlist));
         assert!(should_forward_env_name("OPENAI_BASE_URL", &allowlist));
+    }
+
+    #[test]
+    fn strict_allowlist_permits_listed_names() {
+        let allowlist = EnvAllowlist::from_names(["MY_VAR", "OPENAI_API_KEY"]);
+        assert!(should_forward_env_name_strict("MY_VAR", &allowlist));
+        assert!(should_forward_env_name_strict("my_var", &allowlist)); // case-insensitive
+        assert!(should_forward_env_name_strict("OPENAI_API_KEY", &allowlist));
+    }
+
+    #[test]
+    fn strict_allowlist_drops_non_listed_secret_and_non_secret_names() {
+        let allowlist = EnvAllowlist::from_names(["MY_VAR"]);
+        // Secret not in the list: dropped.
+        assert!(!should_forward_env_name_strict(
+            "OPENAI_API_KEY",
+            &allowlist
+        ));
+        // Non-secret not in the list and not runtime-essential: dropped.
+        assert!(!should_forward_env_name_strict(
+            "PPT_TEMPLATE_DIR",
+            &allowlist
+        ));
+    }
+
+    #[test]
+    fn strict_allowlist_retains_runtime_essentials() {
+        let allowlist = EnvAllowlist::from_names(["MY_VAR"]);
+        for name in ["PATH", "HOME", "PWD", "USER", "LANG", "TZ", "TERM"] {
+            assert!(
+                should_forward_env_name_strict(name, &allowlist),
+                "{name} should be retained"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_allowlist_retains_lc_locale_variants() {
+        let allowlist = EnvAllowlist::from_names(["MY_VAR"]);
+        for name in ["LC_CTYPE", "LC_ALL", "LC_MESSAGES", "LC_TIME"] {
+            assert!(
+                should_forward_env_name_strict(name, &allowlist),
+                "{name} should be retained"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_allowlist_retains_octos_namespace() {
+        let allowlist = EnvAllowlist::from_names(["MY_VAR"]);
+        assert!(should_forward_env_name_strict("OCTOS_TASK_ID", &allowlist));
+        assert!(should_forward_env_name_strict("OCTOS_WORK_DIR", &allowlist));
+    }
+
+    #[test]
+    fn strict_allowlist_drops_injection_names_even_if_listed() {
+        // Defense in depth — if a manifest somehow listed LD_PRELOAD,
+        // strict gate still strips it.
+        let allowlist = EnvAllowlist::from_names(["LD_PRELOAD", "MY_VAR"]);
+        assert!(!should_forward_env_name_strict("LD_PRELOAD", &allowlist));
+        assert!(should_forward_env_name_strict("MY_VAR", &allowlist));
     }
 }


### PR DESCRIPTION
## Summary

Closes M6 audit req 4 gap (score 2/5 -> target 3/5+ per `/tmp/m6-audit.md`).

The `PluginManifest`/`PluginToolDef` schema declares per-tool `env` and `risk` fields, but prior to this change neither was enforced at runtime — a manifest could declare `env: [\"FOO\"]` while the subprocess still inherited every non-secret env var, and a manifest could declare `risk: \"high\"` without the approval flow ever firing for the plugin tool.

This PR enforces Tier-1 fields (the security-critical pair) and adds a small fix surfaced by the codex review.

## Newly enforced fields

| Field | New behavior |
|-------|--------------|
| `tools[].env` | Non-empty list = strict allowlist. Strips every env var not in `{manifest list ∪ runtime-essentials (PATH, HOME, LC_*, TZ, ...) ∪ OCTOS_* harness}`. Empty/missing keeps the legacy secret-only gate (no regression). Registration-time validator rejects empty, whitespace, `=`, leading-digit, non-alphanumeric, and known process-hijack names. |
| `tools[].risk` | `\"high\"` or `\"critical\"` triggers `TOOL_APPROVAL_CTX` request before subprocess spawn. Mirrors `tools/shell.rs`. `low` explicitly skips. Missing/`medium`/unknown falls through (no enforced gate; semantics ambiguous). Surfacing on `approval_requested.risk` was already wired. |
| `tools[].concurrency_class` | Trim whitespace before matching so `\"exclusive \"` no longer silently downgrades to Safe. Loader emits a warning on unknown literals. |

## Compatibility

No existing skill manifest under `crates/app-skills/*` declares `risk`, so the risk gate is opt-in and additive. All existing `env` lists pass the new validator (verified via per-manifest sweep).

One regression risk: `deep-search` reads the operator-tunable `DEEP_SEARCH_MAX_BROWSERS` at runtime but its manifest didn't list it. Under strict gate that var would have been stripped. Fixed by adding `DEEP_SEARCH_MAX_BROWSERS` to `crates/app-skills/deep-search/manifest.json`.

## Tests

- `manifest.rs`: `ManifestRiskGate` classification, env-name validation (8 cases), `ConcurrencyClassClassification` (4 cases including the `\"exclusive \"` regression).
- `subprocess_env.rs`: strict-vs-legacy gate (6 cases) — listed, non-listed secret/non-secret, runtime essentials, LC_*, OCTOS_*, blocked names.
- `tool.rs`: 6 risk-gate scenarios + 3 env-gate scenarios + 2 concurrency_class scenarios. All exercise production `PluginTool::execute` via real subprocess spawn.
- `loader.rs`: 2 new tests pin malformed-manifest rejection (LD_PRELOAD, `FOO=bar`).

## Verification

- `cargo fmt --all -- --check` clean
- `cargo test -p octos-agent --tests`: 1466 passed, 0 failed
- `cargo test --workspace --lib`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

## Codex review (2nd-opinion)

Codex flagged 7 points; addressed inline:
1. `concurrency_class` typo loophole -> fixed (trim + classify, warn on unknown).
2. `mcp_servers[].env` not validated -> deferred (filed as follow-up).
3. Empty env keeps legacy passthrough -> intentional (no-regression contract).
4. Risk not a malicious-manifest boundary -> by design.
5. Tests use direct `PluginTool` instantiation -> unit-test scope; e2e is follow-up.
6. No existing manifest fails new validation -> confirmed.
7. `DEEP_SEARCH_MAX_BROWSERS` would be stripped -> fixed in manifest.

## Deferred follow-ups (file as separate issues)

- `input_schema` runtime JSON-Schema validation (needs new dep).
- `mcp_servers[].env` apply same env-name validation.
- `requires_network` enforcement (currently doc-only \"informational\").
- Risk gate for `medium` (semantics ambiguous).
- E2E test covering UI `ApprovalRequestedEvent` for plugin tools.
- Optional admin policy that overrides plugin-declared `risk: \"low\"` for stricter sessions.

## Test plan

- [ ] `cargo test -p octos-agent --tests` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green
- [ ] Existing first-party skills (`deep-search`, `send-email`, `skill-evolve`) continue loading and running

DO NOT auto-merge.