### PR TITLE
feat(ui_protocol): task/cancel + task/list + task/restart_from_node (closes #704)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -362,18 +362,23 @@ Result fields:
 
 Errors follow the v1 taxonomy (see § 10):
 
-- `unknown_session` when the requested session is not active and has no
-  tracked tasks
 - `runtime_unavailable` with `data.kind = "runtime_unavailable"` when the
   server has no task supervisor wired
+
+A `task/list` request for an inactive or unknown session returns an empty
+`tasks` array rather than `unknown_session`, matching how the
+`SessionTaskQueryStore` snapshot already handles missing supervisors.
 
 ### `task/cancel`
 
 Capability-gated by accepted `UPCR-2026-005`. Maps to
-`TaskSupervisor::cancel(task_id)` and preserves the cancel-race guard from
-PR #709 — once a task transitions to `cancelled`, later runtime state
-transitions cannot overwrite it, so a re-entrant cancel is observably
-idempotent.
+`TaskSupervisor::cancel(task_id)` (via `SessionTaskQueryStore::cancel_task`,
+which dispatches to the owning supervisor) and preserves the cancel-race
+guard from PR #709: once a task transitions to `cancelled`, later runtime
+state transitions cannot overwrite it. Re-entrant cancel of an
+already-terminal task surfaces as the `task_already_terminal` error rather
+than a second success — the supervisor *state* is the idempotent invariant,
+not the wire response.
 
 Purpose:
 
@@ -382,8 +387,9 @@ Purpose:
 Minimum params:
 
 - `task_id`
-- `session_id` — required for session-scope validation; omitting it returns
-  `invalid_params` so clients cannot cross-cancel tasks across sessions
+- `session_id` — wire-optional but validated as required at handler time;
+  omitting it returns `invalid_params` so clients cannot cross-cancel tasks
+  across sessions
 - optional `profile_id` — forwarded to the connection-profile validator
 
 Result fields:
@@ -397,9 +403,13 @@ Errors follow the v1 taxonomy (see § 10):
 - `unknown_task` when the supervisor has no task with that id, or the task is
   scoped to a different session than the request
 - `invalid_params` with `data.kind = "task_already_terminal"` when applied to
-  a task already in a terminal state
-- `permission_denied` when the connection profile does not match the
-  requested session/profile
+  a task already in a terminal state (including a task that was already
+  cancelled)
+- `invalid_params` (with the existing `expected_profile_id` /
+  `actual_profile_id` data fields) when the connection profile does not match
+  the requested `session_id` or `profile_id`. The taxonomy reuses
+  `validate_session_scope`, which the rest of the AppUi command surface
+  already returns as `invalid_params` for profile mismatches
 
 ### `task/restart_from_node`
 
@@ -418,8 +428,8 @@ Minimum params:
 - `task_id`
 - optional `node_id` — pipeline node id to resume from; forwarded to
   `RelaunchOpts.from_node`
-- `session_id` — required for session-scope validation, same rule as
-  `task/cancel`
+- `session_id` — wire-optional but validated as required at handler time,
+  same rule as `task/cancel`
 - optional `profile_id` — forwarded to the connection-profile validator
 
 Result fields:
@@ -435,6 +445,9 @@ Errors follow the v1 taxonomy (see § 10):
   scoped to a different session than the request
 - `invalid_params` with `data.kind = "task_still_active"` when applied to a
   non-terminal task
+- `invalid_params` (with the same `expected_profile_id` / `actual_profile_id`
+  data fields documented for `task/cancel`) when the connection profile does
+  not match the requested `session_id` or `profile_id`
 
 ## 8. Event Semantics
 

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -152,6 +152,12 @@ Current M9 sandbox-parity decision:
   [UPCR-2026-004](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_004_TASK_RUNTIME_CANCELLED.md).
   That UPCR carries the `task_supervisor` cancellation lifecycle through to
   the wire so cancelled tasks no longer fall back to `Running` in the UI.
+- The additive `task/list`, `task/cancel`, and `task/restart_from_node`
+  command methods are governed by accepted
+  [UPCR-2026-005](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_005_TASK_CONTROL_RPCS.md).
+  That UPCR closes M9 harness audit gap #704 by giving clients first-class
+  AppUi RPCs for the supervisor's `cancel` / `relaunch` / task-snapshot
+  primitives, gated behind the `harness.task_control.v1` feature flag.
 
 ## 5. Identity Model
 
@@ -192,6 +198,9 @@ Commands:
 - `approval/respond`
 - `diff/preview/get`
 - `task/output/read`
+- `task/list` (capability-gated, accepted `UPCR-2026-005`)
+- `task/cancel` (capability-gated, accepted `UPCR-2026-005`)
+- `task/restart_from_node` (capability-gated, accepted `UPCR-2026-005`)
 
 Notifications:
 
@@ -326,6 +335,106 @@ Minimum params:
 - `task_id`
 - optional `cursor`
 - optional `limit_bytes`
+
+### `task/list`
+
+Capability-gated by accepted `UPCR-2026-005`. Servers expose it only when
+`harness.task_control.v1` is advertised in `UiProtocolCapabilities`.
+
+Purpose:
+
+- enumerate tasks the runtime tracks for one session, with one entry per task
+  including lifecycle/runtime state, optional child-session linkage, and output
+  cursors. Primary consumer is the `/ps`-style task panel.
+
+Minimum params:
+
+- `session_id`
+- optional `topic` — sub-topic suffix appended as `<session>#<topic>` for
+  grouping; the server falls back to the bare session if omitted or empty
+
+Result fields:
+
+- `session_id` and optional `topic` echoed from the request
+- `tasks` — array of task snapshots; each entry's `state` is the canonical
+  `TaskRuntimeState` (the same enum as `task/updated`), so cancelled tasks
+  surface as `cancelled` per accepted `UPCR-2026-004`
+
+Errors follow the v1 taxonomy (see § 10):
+
+- `unknown_session` when the requested session is not active and has no
+  tracked tasks
+- `runtime_unavailable` with `data.kind = "runtime_unavailable"` when the
+  server has no task supervisor wired
+
+### `task/cancel`
+
+Capability-gated by accepted `UPCR-2026-005`. Maps to
+`TaskSupervisor::cancel(task_id)` and preserves the cancel-race guard from
+PR #709 — once a task transitions to `cancelled`, later runtime state
+transitions cannot overwrite it, so a re-entrant cancel is observably
+idempotent.
+
+Purpose:
+
+- cancel a single tracked task and return its final wire state
+
+Minimum params:
+
+- `task_id`
+- `session_id` — required for session-scope validation; omitting it returns
+  `invalid_params` so clients cannot cross-cancel tasks across sessions
+- optional `profile_id` — forwarded to the connection-profile validator
+
+Result fields:
+
+- `task_id` echoed from the request
+- `status` — canonical `TaskRuntimeState` value; cancelled tasks surface as
+  `cancelled` per accepted `UPCR-2026-004`
+
+Errors follow the v1 taxonomy (see § 10):
+
+- `unknown_task` when the supervisor has no task with that id, or the task is
+  scoped to a different session than the request
+- `invalid_params` with `data.kind = "task_already_terminal"` when applied to
+  a task already in a terminal state
+- `permission_denied` when the connection profile does not match the
+  requested session/profile
+
+### `task/restart_from_node`
+
+Capability-gated by accepted `UPCR-2026-005`. Maps to
+`TaskSupervisor::relaunch(task_id, opts)` for operator-triggered relaunch of a
+previously failed or terminal task, optionally beginning from a specific
+pipeline node.
+
+Purpose:
+
+- relaunch a tracked task from a chosen node and return the supervisor-assigned
+  successor task id
+
+Minimum params:
+
+- `task_id`
+- optional `node_id` — pipeline node id to resume from; forwarded to
+  `RelaunchOpts.from_node`
+- `session_id` — required for session-scope validation, same rule as
+  `task/cancel`
+- optional `profile_id` — forwarded to the connection-profile validator
+
+Result fields:
+
+- `original_task_id` echoed from the request
+- `new_task_id` — supervisor-assigned id of the relaunched successor
+- optional `from_node` — echoed when the supervisor accepted the requested
+  node
+
+Errors follow the v1 taxonomy (see § 10):
+
+- `unknown_task` when the supervisor has no task with that id, or the task is
+  scoped to a different session than the request
+- `invalid_params` with `data.kind = "task_still_active"` when applied to a
+  non-terminal task
 
 ## 8. Event Semantics
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15,7 +15,7 @@ use axum::extract::State;
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
 use axum::http::{HeaderMap, Uri};
 use axum::response::Response;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use futures::{SinkExt, StreamExt};
 use octos_agent::{Agent, ToolApprovalDecision, ToolApprovalRequest};
 use octos_core::ui_protocol::{
@@ -23,17 +23,19 @@ use octos_core::ui_protocol::{
     ApprovalDecidedEvent, ApprovalDecision, ApprovalId, ApprovalRenderHints,
     ApprovalRequestedEvent, ApprovalTypedDetails, InputItem, MessageDeltaEvent, OutputCursor,
     ReplayLossyEvent, RpcError, RpcErrorResponse, RpcRequest, RpcResponse, SessionOpenParams,
-    SessionOpenResult, SessionOpened, TaskOutputDeltaEvent, TaskRuntimeState as UiTaskRuntimeState,
-    TaskUpdatedEvent, ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent,
-    TurnErrorEvent, TurnId, TurnInterruptParams, TurnStartParams,
-    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UiArtifactPaneItem, UiArtifactPaneSnapshot,
-    UiCommand, UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot,
-    UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent,
-    UiProgressMetadata, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot, approval_cancelled_reasons,
-    approval_kinds, progress_kinds,
+    SessionOpenResult, SessionOpened, TaskCancelParams, TaskCancelResult, TaskListEntry,
+    TaskListParams, TaskListResult, TaskOutputDeltaEvent, TaskRestartFromNodeParams,
+    TaskRestartFromNodeResult, TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent,
+    ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent,
+    TurnId, TurnInterruptParams, TurnStartParams, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiCursor, UiFileMutationNotice,
+    UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot,
+    UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata, UiWorkspacePaneEntry,
+    UiWorkspacePaneSnapshot, approval_cancelled_reasons, approval_kinds, progress_kinds,
 };
 use octos_core::{AgentId, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId};
+use serde::Serialize;
 use serde_json::{Value, json};
 use tokio::sync::{Mutex as TokioMutex, mpsc, oneshot};
 use tokio::task::AbortHandle;
@@ -85,7 +87,6 @@ const INTERRUPT_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 /// traffic. Tunable per session size.
 const WS_WRITER_CHANNEL_CAPACITY: usize = 1024;
 const APPROVAL_CANCELLED_REASON_REQUEST_SEND_FAILED: &str = "request_send_failed";
-
 type WsSink = futures::stream::SplitSink<WebSocket, WsMessage>;
 type SharedActiveTurns = Arc<tokio::sync::Mutex<HashMap<SessionKey, ActiveTurn>>>;
 type SharedConnectionTurns = Arc<tokio::sync::Mutex<HashMap<SessionKey, TurnId>>>;
@@ -1132,6 +1133,15 @@ async fn ui_protocol_connection(
             UiCommand::TaskOutputRead(params) => {
                 handle_task_output_read(&ws, &state, connection_profile_id, id, params).await;
             }
+            UiCommand::TaskList(params) => {
+                handle_task_list(&ws, &state, connection_profile_id, id, params).await;
+            }
+            UiCommand::TaskCancel(params) => {
+                handle_task_cancel(&ws, &state, connection_profile_id, id, params).await;
+            }
+            UiCommand::TaskRestartFromNode(params) => {
+                handle_task_restart_from_node(&ws, &state, connection_profile_id, id, params).await;
+            }
         }
     }
 
@@ -1154,13 +1164,6 @@ fn parse_rpc_request(text: &str) -> Result<RpcRequest<Value>, RpcError> {
 }
 
 fn route_rpc_command(request: RpcRequest<Value>) -> Result<UiCommand, RpcError> {
-    if !request.is_jsonrpc_v2() {
-        return Err(RpcError::invalid_request(format!(
-            "unsupported JSON-RPC version: {}",
-            request.jsonrpc
-        )));
-    }
-
     let command = UiCommand::from_rpc_request(request)?;
     if !ui_protocol_server_supported_methods().contains(&command.method()) {
         return Err(RpcError::method_not_supported(command.method()));
@@ -1168,8 +1171,8 @@ fn route_rpc_command(request: RpcRequest<Value>) -> Result<UiCommand, RpcError> 
     Ok(command)
 }
 
-fn ui_protocol_server_supported_methods() -> &'static [&'static str] {
-    octos_core::ui_protocol::UI_PROTOCOL_FIRST_SERVER_METHODS
+fn ui_protocol_server_supported_methods() -> Vec<&'static str> {
+    octos_core::ui_protocol::UI_PROTOCOL_FIRST_SERVER_METHODS.to_vec()
 }
 
 fn frame_too_large_error() -> RpcError {
@@ -2383,6 +2386,341 @@ async fn handle_task_output_read(
         },
         Err(error) => {
             let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_task_list(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
+    id: String,
+    params: TaskListParams,
+) {
+    let query_session_id =
+        session_key_with_optional_topic(&params.session_id, params.topic.as_deref());
+    if let Err(error) = validate_session_scope(&query_session_id, None, connection_profile_id) {
+        let _ = send_rpc_error(ws, Some(id), error);
+        return;
+    }
+
+    match task_list_snapshot(state, &query_session_id) {
+        Ok(tasks) => {
+            let result = TaskListResult {
+                session_id: params.session_id,
+                topic: params.topic,
+                tasks,
+            };
+            send_serialized_rpc_result(ws, id, octos_core::ui_protocol::methods::TASK_LIST, result);
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_task_cancel(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
+    id: String,
+    params: TaskCancelParams,
+) {
+    let Some(session_id) = params.session_id.as_ref() else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params("task/cancel requires session_id for scoped cancellation"),
+        );
+        return;
+    };
+    if let Err(error) = validate_session_scope(
+        session_id,
+        params.profile_id.as_deref(),
+        connection_profile_id,
+    ) {
+        let _ = send_rpc_error(ws, Some(id), error);
+        return;
+    }
+
+    let store = match task_query_store_or_error(state) {
+        Ok(store) => store,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+    let task_id = params.task_id.clone();
+    match ensure_task_in_session(state, session_id, &task_id).and_then(|()| {
+        store
+            .cancel_task(&task_id.to_string())
+            .map_err(|error| task_cancel_rpc_error(&task_id, error))
+    }) {
+        Ok(()) => {
+            let result = TaskCancelResult {
+                task_id,
+                status: UiTaskRuntimeState::Cancelled,
+            };
+            send_serialized_rpc_result(
+                ws,
+                id,
+                octos_core::ui_protocol::methods::TASK_CANCEL,
+                result,
+            );
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_task_restart_from_node(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
+    id: String,
+    params: TaskRestartFromNodeParams,
+) {
+    let Some(session_id) = params.session_id.as_ref() else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(
+                "task/restart_from_node requires session_id for scoped restart",
+            ),
+        );
+        return;
+    };
+    if let Err(error) = validate_session_scope(
+        session_id,
+        params.profile_id.as_deref(),
+        connection_profile_id,
+    ) {
+        let _ = send_rpc_error(ws, Some(id), error);
+        return;
+    }
+
+    let store = match task_query_store_or_error(state) {
+        Ok(store) => store,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+    let task_id = params.task_id.clone();
+    let from_node = params.node_id.clone();
+    let opts = octos_agent::RelaunchOpts {
+        from_node: from_node.clone(),
+    };
+    match ensure_task_in_session(state, session_id, &task_id).and_then(|()| {
+        store
+            .relaunch_task(&task_id.to_string(), opts)
+            .map_err(|error| task_relaunch_rpc_error(&task_id, error))
+    }) {
+        Ok(new_task_id) => {
+            let new_task_id = match new_task_id.parse::<TaskId>() {
+                Ok(task_id) => task_id,
+                Err(error) => {
+                    let _ = send_rpc_error(
+                        ws,
+                        Some(id),
+                        RpcError::internal_error(format!(
+                            "task supervisor returned an invalid relaunched task id: {error}"
+                        )),
+                    );
+                    return;
+                }
+            };
+            let result = TaskRestartFromNodeResult {
+                original_task_id: task_id,
+                new_task_id,
+                from_node,
+            };
+            send_serialized_rpc_result(
+                ws,
+                id,
+                octos_core::ui_protocol::methods::TASK_RESTART_FROM_NODE,
+                result,
+            );
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+fn send_serialized_rpc_result<T: Serialize>(
+    ws: &WsConnection,
+    id: String,
+    method: &str,
+    result: T,
+) {
+    match serde_json::to_value(result) {
+        Ok(result) => {
+            let _ = send_rpc_result(ws, id, result);
+        }
+        Err(error) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::internal_error(format!("failed to serialize {method} result: {error}")),
+            );
+        }
+    }
+}
+
+fn task_query_store_or_error(
+    state: &Arc<AppState>,
+) -> Result<&crate::session_actor::SessionTaskQueryStore, RpcError> {
+    state.task_query_store.as_ref().ok_or_else(|| {
+        RpcError::runtime_not_ready("task supervisor not wired for AppUI task commands")
+            .with_data(json!({ "kind": "runtime_unavailable" }))
+    })
+}
+
+fn task_list_snapshot(
+    state: &Arc<AppState>,
+    session_id: &SessionKey,
+) -> Result<Vec<TaskListEntry>, RpcError> {
+    let store = task_query_store_or_error(state)?;
+    match store.query_json(&session_id.to_string()) {
+        Value::Array(tasks) => tasks
+            .into_iter()
+            .map(task_list_entry_from_value)
+            .collect::<Result<Vec<_>, _>>(),
+        _ => Err(RpcError::internal_error(
+            "task supervisor query returned a non-array task snapshot",
+        )),
+    }
+}
+
+fn session_key_with_optional_topic(session_id: &SessionKey, topic: Option<&str>) -> SessionKey {
+    let Some(topic) = topic.map(str::trim).filter(|topic| !topic.is_empty()) else {
+        return session_id.clone();
+    };
+    SessionKey(format!("{}#{topic}", session_id.base_key()))
+}
+
+#[derive(serde::Deserialize)]
+struct TaskListProjection {
+    id: TaskId,
+    #[serde(default)]
+    tool_name: String,
+    #[serde(default)]
+    tool_call_id: String,
+    #[serde(default)]
+    parent_session_key: Option<SessionKey>,
+    #[serde(default)]
+    child_session_key: Option<SessionKey>,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    lifecycle_state: String,
+    #[serde(default)]
+    runtime_state: String,
+    #[serde(default)]
+    child_terminal_state: Option<String>,
+    #[serde(default)]
+    child_join_state: Option<String>,
+    #[serde(default)]
+    child_joined_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    child_failure_action: Option<String>,
+    #[serde(default)]
+    runtime_detail: Option<Value>,
+    #[serde(default)]
+    workflow_kind: Option<String>,
+    #[serde(default)]
+    current_phase: Option<String>,
+    started_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    #[serde(default)]
+    completed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    output_files: Vec<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    session_key: Option<SessionKey>,
+}
+
+fn task_list_entry_from_value(value: Value) -> Result<TaskListEntry, RpcError> {
+    let projected: TaskListProjection = serde_json::from_value(value)
+        .map_err(|error| RpcError::internal_error(format!("invalid task snapshot: {error}")))?;
+    let state = ui_task_state_from_label(&projected.lifecycle_state)
+        .or_else(|| ui_task_state_from_label(&projected.runtime_state))
+        .or_else(|| ui_task_state_from_label(&projected.status))
+        .unwrap_or(UiTaskRuntimeState::Running);
+
+    Ok(TaskListEntry {
+        id: projected.id,
+        tool_name: projected.tool_name,
+        tool_call_id: projected.tool_call_id,
+        state,
+        status: projected.status,
+        lifecycle_state: projected.lifecycle_state,
+        runtime_state: projected.runtime_state,
+        parent_session_key: projected.parent_session_key,
+        child_session_key: projected.child_session_key,
+        child_terminal_state: projected.child_terminal_state,
+        child_join_state: projected.child_join_state,
+        child_joined_at: projected.child_joined_at,
+        child_failure_action: projected.child_failure_action,
+        runtime_detail: projected.runtime_detail,
+        workflow_kind: projected.workflow_kind,
+        current_phase: projected.current_phase,
+        started_at: projected.started_at,
+        updated_at: projected.updated_at,
+        completed_at: projected.completed_at,
+        output_files: projected.output_files,
+        error: projected.error,
+        session_key: projected.session_key,
+    })
+}
+
+fn ui_task_state_from_label(label: &str) -> Option<UiTaskRuntimeState> {
+    match label {
+        "pending" | "queued" | "spawned" => Some(UiTaskRuntimeState::Pending),
+        "running" | "executing_tool" | "resolving_outputs" | "verifying_outputs"
+        | "delivering_outputs" | "cleaning_up" | "verifying" => Some(UiTaskRuntimeState::Running),
+        "completed" | "ready" => Some(UiTaskRuntimeState::Completed),
+        "failed" => Some(UiTaskRuntimeState::Failed),
+        "cancelled" | "canceled" => Some(UiTaskRuntimeState::Cancelled),
+        _ => None,
+    }
+}
+
+fn ensure_task_in_session(
+    state: &Arc<AppState>,
+    session_id: &SessionKey,
+    task_id: &TaskId,
+) -> Result<(), RpcError> {
+    if task_list_snapshot(state, session_id)?
+        .iter()
+        .any(|task| &task.id == task_id)
+    {
+        Ok(())
+    } else {
+        Err(RpcError::unknown_task_id(task_id))
+    }
+}
+
+fn task_cancel_rpc_error(task_id: &TaskId, error: octos_agent::TaskCancelError) -> RpcError {
+    match error {
+        octos_agent::TaskCancelError::NotFound => RpcError::unknown_task_id(task_id),
+        octos_agent::TaskCancelError::AlreadyTerminal => {
+            RpcError::invalid_params("task is already terminal")
+                .with_data(json!({ "kind": "task_already_terminal" }))
+        }
+    }
+}
+
+fn task_relaunch_rpc_error(task_id: &TaskId, error: octos_agent::TaskRelaunchError) -> RpcError {
+    match error {
+        octos_agent::TaskRelaunchError::NotFound => RpcError::unknown_task_id(task_id),
+        octos_agent::TaskRelaunchError::StillActive => {
+            RpcError::invalid_params("task is still active; cancel it before relaunching")
+                .with_data(json!({ "kind": "task_still_active" }))
         }
     }
 }
@@ -4099,6 +4437,24 @@ mod tests {
                 preview_id: decoded_preview_id,
             }) if decoded_session_id == session_id && decoded_preview_id == preview_id
         ));
+
+        let task_id = TaskId::new();
+        let task_cancel = RpcRequest::new(
+            "task-cancel",
+            methods::TASK_CANCEL,
+            json!({
+                "session_id": session_id.clone(),
+                "task_id": task_id.clone(),
+            }),
+        );
+        assert!(matches!(
+            route_rpc_command(task_cancel).expect("task/cancel routes"),
+            UiCommand::TaskCancel(TaskCancelParams {
+                session_id: Some(decoded_session_id),
+                task_id: decoded_task_id,
+                ..
+            }) if decoded_session_id == session_id && decoded_task_id == task_id
+        ));
     }
 
     #[test]
@@ -4157,6 +4513,30 @@ mod tests {
                     "task_id": task_id.clone(),
                 }),
             ),
+            RpcRequest::new(
+                "task-list",
+                methods::TASK_LIST,
+                json!({
+                    "session_id": session_id.clone(),
+                }),
+            ),
+            RpcRequest::new(
+                "task-cancel",
+                methods::TASK_CANCEL,
+                json!({
+                    "session_id": session_id.clone(),
+                    "task_id": task_id.clone(),
+                }),
+            ),
+            RpcRequest::new(
+                "task-restart",
+                methods::TASK_RESTART_FROM_NODE,
+                json!({
+                    "session_id": session_id.clone(),
+                    "task_id": task_id.clone(),
+                    "node_id": "design",
+                }),
+            ),
         ] {
             let method = request.method.clone();
             assert!(
@@ -4166,6 +4546,127 @@ mod tests {
             let command = route_rpc_command(request).expect("server-supported method routes");
             assert_eq!(command.method(), method);
         }
+    }
+
+    fn appui_task_state_with_running_task(
+        session_id: &SessionKey,
+    ) -> (Arc<AppState>, Arc<octos_agent::TaskSupervisor>, TaskId) {
+        let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
+        let task_id = supervisor.register(
+            "run_pipeline",
+            "call-appui-task",
+            Some(&session_id.to_string()),
+        );
+        supervisor.mark_running(&task_id);
+        let parsed_task_id = task_id
+            .parse::<TaskId>()
+            .expect("supervisor task id is UUID");
+
+        let store = crate::session_actor::SessionTaskQueryStore::default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        store.register(session_id, &supervisor, tmp.path());
+        let state = Arc::new(AppState {
+            task_query_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+        (state, supervisor, parsed_task_id)
+    }
+
+    async fn recv_rpc_json(rx: &mut mpsc::Receiver<WsMessage>) -> Value {
+        match rx.recv().await.expect("rpc frame") {
+            WsMessage::Text(text) => serde_json::from_str(text.as_str()).expect("json frame"),
+            other => panic!("expected text frame, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn appui_task_list_returns_runtime_snapshot() {
+        let session_id = SessionKey("local:test".into());
+        let (state, _supervisor, task_id) = appui_task_state_with_running_task(&session_id);
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_task_list(
+            &ws,
+            &state,
+            None,
+            "task-list-1".into(),
+            TaskListParams {
+                session_id: session_id.clone(),
+                topic: None,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], "task-list-1");
+        assert_eq!(frame["result"]["session_id"], session_id.to_string());
+        let tasks = frame["result"]["tasks"].as_array().expect("tasks array");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0]["id"], task_id.to_string());
+        assert_eq!(tasks[0]["status"], "running");
+        assert_eq!(tasks[0]["state"], "running");
+    }
+
+    #[tokio::test]
+    async fn appui_task_cancel_uses_supervisor_cancel_path() {
+        let session_id = SessionKey("local:test".into());
+        let (state, supervisor, task_id) = appui_task_state_with_running_task(&session_id);
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_task_cancel(
+            &ws,
+            &state,
+            None,
+            "task-cancel-1".into(),
+            TaskCancelParams {
+                task_id: task_id.clone(),
+                session_id: Some(session_id.clone()),
+                profile_id: None,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], "task-cancel-1");
+        assert_eq!(frame["result"]["task_id"], task_id.to_string());
+        assert_eq!(frame["result"]["status"], "cancelled");
+        let task = supervisor
+            .get_task(&task_id.to_string())
+            .expect("task remains queryable");
+        assert_eq!(task.status, octos_agent::TaskStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn appui_task_restart_from_node_uses_relaunch_path() {
+        let session_id = SessionKey("local:test".into());
+        let (state, supervisor, task_id) = appui_task_state_with_running_task(&session_id);
+        supervisor.mark_failed(&task_id.to_string(), "ready to relaunch".into());
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_task_restart_from_node(
+            &ws,
+            &state,
+            None,
+            "task-restart-1".into(),
+            TaskRestartFromNodeParams {
+                task_id: task_id.clone(),
+                node_id: Some("design".into()),
+                session_id: Some(session_id),
+                profile_id: None,
+            },
+        )
+        .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], "task-restart-1");
+        assert_eq!(frame["result"]["original_task_id"], task_id.to_string());
+        assert_eq!(frame["result"]["from_node"], "design");
+        let new_task_id = frame["result"]["new_task_id"]
+            .as_str()
+            .expect("new task id");
+        assert_ne!(new_task_id, task_id.to_string());
+        let successor = supervisor.get_task(new_task_id).expect("successor task");
+        assert_eq!(successor.tool_name, "run_pipeline");
     }
 
     #[test]

--- a/crates/octos-core/src/app_ui.rs
+++ b/crates/octos-core/src/app_ui.rs
@@ -8,8 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::ui_protocol::{
     self, ApprovalRespondParams, ApprovalScopesListParams, DiffPreviewGetParams, SessionOpenParams,
-    TaskOutputReadParams, TaskRuntimeState, TurnId, TurnInterruptParams, TurnStartParams,
-    UiCommand, UiNotification, UiProgressEvent, methods,
+    TaskCancelParams, TaskListParams, TaskOutputReadParams, TaskRestartFromNodeParams,
+    TaskRuntimeState, TurnId, TurnInterruptParams, TurnStartParams, UiCommand, UiNotification,
+    UiProgressEvent, methods,
 };
 use crate::{Message, SessionKey, TaskId};
 
@@ -23,6 +24,9 @@ pub type AppUiInterruptTurn = TurnInterruptParams;
 pub type AppUiRespondApproval = ApprovalRespondParams;
 pub type AppUiListApprovalScopes = ApprovalScopesListParams;
 pub type AppUiGetDiffPreview = DiffPreviewGetParams;
+pub type AppUiListTasks = TaskListParams;
+pub type AppUiCancelTask = TaskCancelParams;
+pub type AppUiRestartTaskFromNode = TaskRestartFromNodeParams;
 pub type AppUiReadTaskOutput = TaskOutputReadParams;
 pub type AppUiBackendEvent = UiNotification;
 pub type AppUiProgress = UiProgressEvent;
@@ -105,6 +109,9 @@ pub enum AppUiCommand {
     RespondApproval(AppUiRespondApproval),
     ListApprovalScopes(AppUiListApprovalScopes),
     GetDiffPreview(AppUiGetDiffPreview),
+    ListTasks(AppUiListTasks),
+    CancelTask(AppUiCancelTask),
+    RestartTaskFromNode(AppUiRestartTaskFromNode),
     ReadTaskOutput(AppUiReadTaskOutput),
 }
 
@@ -117,6 +124,9 @@ impl AppUiCommand {
             Self::RespondApproval(_) => methods::APPROVAL_RESPOND,
             Self::ListApprovalScopes(_) => methods::APPROVAL_SCOPES_LIST,
             Self::GetDiffPreview(_) => methods::DIFF_PREVIEW_GET,
+            Self::ListTasks(_) => methods::TASK_LIST,
+            Self::CancelTask(_) => methods::TASK_CANCEL,
+            Self::RestartTaskFromNode(_) => methods::TASK_RESTART_FROM_NODE,
             Self::ReadTaskOutput(_) => methods::TASK_OUTPUT_READ,
         }
     }
@@ -133,6 +143,9 @@ impl AppUiCommand {
             Self::RespondApproval(params) => UiCommand::ApprovalRespond(params),
             Self::ListApprovalScopes(params) => UiCommand::ApprovalScopesList(params),
             Self::GetDiffPreview(params) => UiCommand::DiffPreviewGet(params),
+            Self::ListTasks(params) => UiCommand::TaskList(params),
+            Self::CancelTask(params) => UiCommand::TaskCancel(params),
+            Self::RestartTaskFromNode(params) => UiCommand::TaskRestartFromNode(params),
             Self::ReadTaskOutput(params) => UiCommand::TaskOutputRead(params),
         }
     }
@@ -274,6 +287,51 @@ mod tests {
         assert_eq!(
             UiCommand::from(command).method(),
             methods::APPROVAL_SCOPES_LIST
+        );
+    }
+
+    #[test]
+    fn app_command_surface_covers_harness_task_control() {
+        let session_id = SessionKey("local:test".into());
+        let task_id = TaskId::new();
+
+        let list = AppUiCommand::ListTasks(AppUiListTasks {
+            session_id: session_id.clone(),
+            topic: Some("default".into()),
+        });
+        assert_eq!(list.method(), methods::TASK_LIST);
+        assert_eq!(
+            list.first_server_result_kind(),
+            Some(AppUiCommandResultKind::TaskList)
+        );
+        assert_eq!(UiCommand::from(list).method(), methods::TASK_LIST);
+
+        let cancel = AppUiCommand::CancelTask(AppUiCancelTask {
+            task_id: task_id.clone(),
+            session_id: Some(session_id.clone()),
+            profile_id: Some("coding".into()),
+        });
+        assert_eq!(cancel.method(), methods::TASK_CANCEL);
+        assert_eq!(
+            cancel.first_server_result_kind(),
+            Some(AppUiCommandResultKind::TaskCancel)
+        );
+        assert_eq!(UiCommand::from(cancel).method(), methods::TASK_CANCEL);
+
+        let restart = AppUiCommand::RestartTaskFromNode(AppUiRestartTaskFromNode {
+            task_id,
+            node_id: Some("node-1".into()),
+            session_id: Some(session_id),
+            profile_id: None,
+        });
+        assert_eq!(restart.method(), methods::TASK_RESTART_FROM_NODE);
+        assert_eq!(
+            restart.first_server_result_kind(),
+            Some(AppUiCommandResultKind::TaskRestartFromNode)
+        );
+        assert_eq!(
+            UiCommand::from(restart).method(),
+            methods::TASK_RESTART_FROM_NODE
         );
     }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3,7 +3,9 @@
 //! This module intentionally captures only the first protocol slice needed to
 //! align client and server work. A first WebSocket server slice now handles
 //! session open, turn start, turn interrupt, approval, diff preview, and
-//! task-output read requests.
+//! task-output read requests. The full protocol model also defines harness
+//! task-control requests so clients can target a stable AppUI contract while
+//! backend support lands behind capabilities.
 
 use crate::{SessionKey, TaskId};
 use chrono::{DateTime, Utc};
@@ -34,6 +36,9 @@ pub const UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1: &str = "pane.snapshots.v1";
 
 /// Feature flag for UPCR-2026-003 per-session workspace cwd requests.
 pub const UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1: &str = "session.workspace_cwd.v1";
+
+/// Feature flag for harness task registry/control commands.
+pub const UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1: &str = "harness.task_control.v1";
 
 pub mod approval_kinds {
     pub const COMMAND: &str = "command";
@@ -561,6 +566,9 @@ pub mod methods {
     pub const APPROVAL_RESPOND: &str = "approval/respond";
     pub const APPROVAL_SCOPES_LIST: &str = "approval/scopes/list";
     pub const DIFF_PREVIEW_GET: &str = "diff/preview/get";
+    pub const TASK_LIST: &str = "task/list";
+    pub const TASK_CANCEL: &str = "task/cancel";
+    pub const TASK_RESTART_FROM_NODE: &str = "task/restart_from_node";
     pub const TASK_OUTPUT_READ: &str = "task/output/read";
 
     pub const TURN_STARTED: &str = "turn/started";
@@ -600,6 +608,9 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::APPROVAL_RESPOND,
     methods::APPROVAL_SCOPES_LIST,
     methods::DIFF_PREVIEW_GET,
+    methods::TASK_LIST,
+    methods::TASK_CANCEL,
+    methods::TASK_RESTART_FROM_NODE,
     methods::TASK_OUTPUT_READ,
 ];
 
@@ -625,7 +636,18 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
 ];
 
 /// Request methods currently handled by the first server/runtime slice.
-pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = UI_PROTOCOL_COMMAND_METHODS;
+pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
+    methods::SESSION_OPEN,
+    methods::TURN_START,
+    methods::TURN_INTERRUPT,
+    methods::APPROVAL_RESPOND,
+    methods::APPROVAL_SCOPES_LIST,
+    methods::DIFF_PREVIEW_GET,
+    methods::TASK_LIST,
+    methods::TASK_CANCEL,
+    methods::TASK_RESTART_FROM_NODE,
+    methods::TASK_OUTPUT_READ,
+];
 
 /// Protocol methods known but not implemented by the first server/runtime slice.
 pub const UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS: &[&str] = &[];
@@ -688,6 +710,7 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
             UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
             UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
         ])
     }
 
@@ -700,6 +723,7 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
             UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
             UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
         ]);
         capabilities.unsupported = UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS
             .iter()
@@ -809,6 +833,9 @@ pub enum UiResultKind {
     ApprovalRespond,
     ApprovalScopesList,
     DiffPreviewGet,
+    TaskList,
+    TaskCancel,
+    TaskRestartFromNode,
     TaskOutputRead,
     UnsupportedCapability,
 }
@@ -821,6 +848,9 @@ pub fn first_server_result_kind_for_method(method: &str) -> Option<UiResultKind>
         methods::APPROVAL_RESPOND => Some(UiResultKind::ApprovalRespond),
         methods::APPROVAL_SCOPES_LIST => Some(UiResultKind::ApprovalScopesList),
         methods::DIFF_PREVIEW_GET => Some(UiResultKind::DiffPreviewGet),
+        methods::TASK_LIST => Some(UiResultKind::TaskList),
+        methods::TASK_CANCEL => Some(UiResultKind::TaskCancel),
+        methods::TASK_RESTART_FROM_NODE => Some(UiResultKind::TaskRestartFromNode),
         methods::TASK_OUTPUT_READ => Some(UiResultKind::TaskOutputRead),
         _ => None,
     }
@@ -1021,6 +1051,95 @@ pub struct TaskOutputReadParams {
     pub limit_bytes: Option<u64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskListParams {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskCancelParams {
+    pub task_id: TaskId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<SessionKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskRestartFromNodeParams {
+    pub task_id: TaskId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<SessionKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskListResult {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    #[serde(default)]
+    pub tasks: Vec<TaskListEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskListEntry {
+    pub id: TaskId,
+    pub tool_name: String,
+    pub tool_call_id: String,
+    pub state: TaskRuntimeState,
+    pub status: String,
+    pub lifecycle_state: String,
+    pub runtime_state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_session_key: Option<SessionKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_session_key: Option<SessionKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_terminal_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_join_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_joined_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_failure_action: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_detail: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_phase: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_files: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_key: Option<SessionKey>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskCancelResult {
+    pub task_id: TaskId,
+    pub status: TaskRuntimeState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskRestartFromNodeResult {
+    pub original_task_id: TaskId,
+    pub new_task_id: TaskId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_node: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DiffPreviewGetStatus {
@@ -1171,6 +1290,9 @@ pub enum UiCommand {
     ApprovalRespond(ApprovalRespondParams),
     ApprovalScopesList(ApprovalScopesListParams),
     DiffPreviewGet(DiffPreviewGetParams),
+    TaskList(TaskListParams),
+    TaskCancel(TaskCancelParams),
+    TaskRestartFromNode(TaskRestartFromNodeParams),
     TaskOutputRead(TaskOutputReadParams),
 }
 
@@ -1183,6 +1305,9 @@ impl UiCommand {
             Self::ApprovalRespond(_) => methods::APPROVAL_RESPOND,
             Self::ApprovalScopesList(_) => methods::APPROVAL_SCOPES_LIST,
             Self::DiffPreviewGet(_) => methods::DIFF_PREVIEW_GET,
+            Self::TaskList(_) => methods::TASK_LIST,
+            Self::TaskCancel(_) => methods::TASK_CANCEL,
+            Self::TaskRestartFromNode(_) => methods::TASK_RESTART_FROM_NODE,
             Self::TaskOutputRead(_) => methods::TASK_OUTPUT_READ,
         }
     }
@@ -1199,6 +1324,9 @@ impl UiCommand {
             Self::ApprovalRespond(params) => serde_json::to_value(params),
             Self::ApprovalScopesList(params) => serde_json::to_value(params),
             Self::DiffPreviewGet(params) => serde_json::to_value(params),
+            Self::TaskList(params) => serde_json::to_value(params),
+            Self::TaskCancel(params) => serde_json::to_value(params),
+            Self::TaskRestartFromNode(params) => serde_json::to_value(params),
             Self::TaskOutputRead(params) => serde_json::to_value(params),
         }?;
 
@@ -1227,6 +1355,11 @@ impl UiCommand {
                 Ok(Self::ApprovalScopesList(decode_params(method, params)?))
             }
             methods::DIFF_PREVIEW_GET => Ok(Self::DiffPreviewGet(decode_params(method, params)?)),
+            methods::TASK_LIST => Ok(Self::TaskList(decode_params(method, params)?)),
+            methods::TASK_CANCEL => Ok(Self::TaskCancel(decode_params(method, params)?)),
+            methods::TASK_RESTART_FROM_NODE => {
+                Ok(Self::TaskRestartFromNode(decode_params(method, params)?))
+            }
             methods::TASK_OUTPUT_READ => Ok(Self::TaskOutputRead(decode_params(method, params)?)),
             _ => Err(RpcError::method_not_found(method)),
         }
@@ -1395,6 +1528,9 @@ pub enum UiRpcResult {
     ApprovalRespond(ApprovalRespondResult),
     ApprovalScopesList(ApprovalScopesListResult),
     DiffPreviewGet(DiffPreviewGetResult),
+    TaskList(TaskListResult),
+    TaskCancel(TaskCancelResult),
+    TaskRestartFromNode(TaskRestartFromNodeResult),
     TaskOutputRead(TaskOutputReadResult),
     UnsupportedCapability(UnsupportedCapabilityResult),
 }
@@ -1408,6 +1544,9 @@ impl UiRpcResult {
             Self::ApprovalRespond(_) => UiResultKind::ApprovalRespond,
             Self::ApprovalScopesList(_) => UiResultKind::ApprovalScopesList,
             Self::DiffPreviewGet(_) => UiResultKind::DiffPreviewGet,
+            Self::TaskList(_) => UiResultKind::TaskList,
+            Self::TaskCancel(_) => UiResultKind::TaskCancel,
+            Self::TaskRestartFromNode(_) => UiResultKind::TaskRestartFromNode,
             Self::TaskOutputRead(_) => UiResultKind::TaskOutputRead,
             Self::UnsupportedCapability(_) => UiResultKind::UnsupportedCapability,
         }
@@ -1421,6 +1560,9 @@ impl UiRpcResult {
             Self::ApprovalRespond(_) => Some(methods::APPROVAL_RESPOND),
             Self::ApprovalScopesList(_) => Some(methods::APPROVAL_SCOPES_LIST),
             Self::DiffPreviewGet(_) => Some(methods::DIFF_PREVIEW_GET),
+            Self::TaskList(_) => Some(methods::TASK_LIST),
+            Self::TaskCancel(_) => Some(methods::TASK_CANCEL),
+            Self::TaskRestartFromNode(_) => Some(methods::TASK_RESTART_FROM_NODE),
             Self::TaskOutputRead(_) => Some(methods::TASK_OUTPUT_READ),
             Self::UnsupportedCapability(result) => Some(result.unsupported.method.as_str()),
         }
@@ -1434,6 +1576,9 @@ impl UiRpcResult {
             Self::ApprovalRespond(result) => serde_json::to_value(result),
             Self::ApprovalScopesList(result) => serde_json::to_value(result),
             Self::DiffPreviewGet(result) => serde_json::to_value(result),
+            Self::TaskList(result) => serde_json::to_value(result),
+            Self::TaskCancel(result) => serde_json::to_value(result),
+            Self::TaskRestartFromNode(result) => serde_json::to_value(result),
             Self::TaskOutputRead(result) => serde_json::to_value(result),
             Self::UnsupportedCapability(result) => serde_json::to_value(result),
         }
@@ -1466,6 +1611,11 @@ impl UiRpcResult {
                 Ok(Self::ApprovalScopesList(decode_result(method, result)?))
             }
             methods::DIFF_PREVIEW_GET => Ok(Self::DiffPreviewGet(decode_result(method, result)?)),
+            methods::TASK_LIST => Ok(Self::TaskList(decode_result(method, result)?)),
+            methods::TASK_CANCEL => Ok(Self::TaskCancel(decode_result(method, result)?)),
+            methods::TASK_RESTART_FROM_NODE => {
+                Ok(Self::TaskRestartFromNode(decode_result(method, result)?))
+            }
             methods::TASK_OUTPUT_READ => Ok(Self::TaskOutputRead(decode_result(method, result)?)),
             _ => Err(RpcError::method_not_found(method)),
         }
@@ -2279,6 +2429,10 @@ mod tests {
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
+        assert!(capabilities.supports_method(methods::TASK_LIST));
+        assert!(capabilities.supports_method(methods::TASK_CANCEL));
+        assert!(capabilities.supports_method(methods::TASK_RESTART_FROM_NODE));
         assert!(capabilities.unsupported.is_empty());
 
         let json = serde_json::to_string(&capabilities).expect("serialize capabilities");
@@ -2309,6 +2463,19 @@ mod tests {
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1));
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
+        assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
+    }
+
+    #[test]
+    fn full_protocol_capabilities_advertise_harness_task_control() {
+        let capabilities = UiProtocolCapabilities::full_protocol();
+
+        assert!(capabilities.supports_method(methods::TASK_LIST));
+        assert!(capabilities.supports_method(methods::TASK_CANCEL));
+        assert!(capabilities.supports_method(methods::TASK_RESTART_FROM_NODE));
+        assert!(capabilities.supports_method(methods::TASK_OUTPUT_READ));
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
+        assert!(capabilities.unsupported.is_empty());
     }
 
     #[test]
@@ -2422,6 +2589,10 @@ mod tests {
             UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
             "session.workspace_cwd.v1"
         );
+        assert_eq!(
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+            "harness.task_control.v1"
+        );
 
         assert_eq!(
             UI_PROTOCOL_COMMAND_METHODS,
@@ -2432,6 +2603,9 @@ mod tests {
                 "approval/respond",
                 "approval/scopes/list",
                 "diff/preview/get",
+                "task/list",
+                "task/cancel",
+                "task/restart_from_node",
                 "task/output/read",
             ]
         );
@@ -2459,9 +2633,20 @@ mod tests {
         );
         assert_eq!(
             UI_PROTOCOL_FIRST_SERVER_METHODS,
-            UI_PROTOCOL_COMMAND_METHODS
+            &[
+                "session/open",
+                "turn/start",
+                "turn/interrupt",
+                "approval/respond",
+                "approval/scopes/list",
+                "diff/preview/get",
+                "task/list",
+                "task/cancel",
+                "task/restart_from_node",
+                "task/output/read",
+            ]
         );
-        assert_eq!(UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS, &[] as &[&str]);
+        assert!(UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS.is_empty());
     }
 
     #[test]
@@ -2488,6 +2673,9 @@ mod tests {
                     "approval/respond",
                     "approval/scopes/list",
                     "diff/preview/get",
+                    "task/list",
+                    "task/cancel",
+                    "task/restart_from_node",
                     "task/output/read"
                 ],
                 "supported_notifications": [
@@ -2512,7 +2700,8 @@ mod tests {
                 "supported_features": [
                     "approval.typed.v1",
                     "pane.snapshots.v1",
-                    "session.workspace_cwd.v1"
+                    "session.workspace_cwd.v1",
+                    "harness.task_control.v1"
                 ]
             })
         );
@@ -3011,6 +3200,62 @@ mod tests {
     }
 
     #[test]
+    fn task_control_commands_build_and_parse_json_rpc_requests() {
+        let session_id = SessionKey("local:demo".into());
+        let task_id = TaskId(Uuid::from_u128(42));
+
+        let list = UiCommand::TaskList(TaskListParams {
+            session_id: session_id.clone(),
+            topic: Some("default".into()),
+        });
+        assert_eq!(list.method(), methods::TASK_LIST);
+        let list_wire = list
+            .clone()
+            .into_rpc_request("task-list")
+            .expect("serialize task/list");
+        assert_eq!(list_wire.method, methods::TASK_LIST);
+        assert_eq!(list_wire.params["session_id"], json!("local:demo"));
+        assert_eq!(
+            UiCommand::from_rpc_request(list_wire).expect("decode task/list"),
+            list
+        );
+
+        let cancel = UiCommand::TaskCancel(TaskCancelParams {
+            task_id: task_id.clone(),
+            session_id: Some(session_id.clone()),
+            profile_id: Some("coding".into()),
+        });
+        assert_eq!(cancel.method(), methods::TASK_CANCEL);
+        let cancel_wire = cancel
+            .clone()
+            .into_rpc_request("task-cancel")
+            .expect("serialize task/cancel");
+        assert_eq!(cancel_wire.params["task_id"], json!(task_id));
+        assert_eq!(cancel_wire.params["profile_id"], json!("coding"));
+        assert_eq!(
+            UiCommand::from_rpc_request(cancel_wire).expect("decode task/cancel"),
+            cancel
+        );
+
+        let restart = UiCommand::TaskRestartFromNode(TaskRestartFromNodeParams {
+            task_id: TaskId(Uuid::from_u128(43)),
+            node_id: Some("node-7".into()),
+            session_id: Some(session_id),
+            profile_id: None,
+        });
+        assert_eq!(restart.method(), methods::TASK_RESTART_FROM_NODE);
+        let restart_wire = restart
+            .clone()
+            .into_rpc_request("task-restart")
+            .expect("serialize task/restart_from_node");
+        assert_eq!(restart_wire.params["node_id"], json!("node-7"));
+        assert_eq!(
+            UiCommand::from_rpc_request(restart_wire).expect("decode task/restart_from_node"),
+            restart
+        );
+    }
+
+    #[test]
     fn typed_rpc_results_map_from_methods_and_round_trip() {
         let opened = SessionOpened {
             session_id: SessionKey("local:demo".into()),
@@ -3105,6 +3350,18 @@ mod tests {
             first_server_result_kind_for_method(methods::DIFF_PREVIEW_GET),
             Some(UiResultKind::DiffPreviewGet)
         );
+        assert_eq!(
+            first_server_result_kind_for_method(methods::TASK_LIST),
+            Some(UiResultKind::TaskList)
+        );
+        assert_eq!(
+            first_server_result_kind_for_method(methods::TASK_CANCEL),
+            Some(UiResultKind::TaskCancel)
+        );
+        assert_eq!(
+            first_server_result_kind_for_method(methods::TASK_RESTART_FROM_NODE),
+            Some(UiResultKind::TaskRestartFromNode)
+        );
 
         let preview_id = PreviewId::new();
         let diff_result = UiRpcResult::DiffPreviewGet(DiffPreviewGetResult {
@@ -3140,6 +3397,93 @@ mod tests {
             UiRpcResult::from_method_and_result(methods::DIFF_PREVIEW_GET, value)
                 .expect("decode diff/preview/get result"),
             diff_result
+        );
+
+        let started_at = DateTime::parse_from_rfc3339("2026-04-30T12:00:00Z")
+            .expect("parse started_at")
+            .with_timezone(&Utc);
+        let updated_at = DateTime::parse_from_rfc3339("2026-04-30T12:01:00Z")
+            .expect("parse updated_at")
+            .with_timezone(&Utc);
+        let list_task_id = TaskId(Uuid::from_u128(44));
+        let task_list = UiRpcResult::TaskList(TaskListResult {
+            session_id: SessionKey("local:demo".into()),
+            topic: Some("default".into()),
+            tasks: vec![TaskListEntry {
+                id: list_task_id.clone(),
+                tool_name: "spawn_only_runner".into(),
+                tool_call_id: "call-1".into(),
+                state: TaskRuntimeState::Running,
+                status: "running".into(),
+                lifecycle_state: "running".into(),
+                runtime_state: "executing_tool".into(),
+                parent_session_key: Some(SessionKey("local:demo".into())),
+                child_session_key: Some(SessionKey("local:demo#child-1".into())),
+                child_terminal_state: None,
+                child_join_state: None,
+                child_joined_at: None,
+                child_failure_action: None,
+                runtime_detail: Some(json!({ "current_phase": "coding" })),
+                workflow_kind: Some("coding".into()),
+                current_phase: Some("coding".into()),
+                started_at,
+                updated_at,
+                completed_at: None,
+                output_files: vec!["octos-file://task-output".into()],
+                error: None,
+                session_key: Some(SessionKey("local:demo".into())),
+            }],
+        });
+        assert_eq!(task_list.kind(), UiResultKind::TaskList);
+        assert_eq!(task_list.method(), Some(methods::TASK_LIST));
+        let value = task_list
+            .clone()
+            .into_result_value()
+            .expect("serialize task/list result");
+        assert_eq!(value["tasks"][0]["id"], json!(list_task_id));
+        assert_eq!(value["tasks"][0]["state"], json!("running"));
+        assert_eq!(
+            UiRpcResult::from_method_and_result(methods::TASK_LIST, value)
+                .expect("decode task/list result"),
+            task_list
+        );
+
+        let cancel_result = UiRpcResult::TaskCancel(TaskCancelResult {
+            task_id: TaskId(Uuid::from_u128(45)),
+            status: TaskRuntimeState::Cancelled,
+        });
+        assert_eq!(cancel_result.kind(), UiResultKind::TaskCancel);
+        assert_eq!(cancel_result.method(), Some(methods::TASK_CANCEL));
+        let value = cancel_result
+            .clone()
+            .into_result_value()
+            .expect("serialize task/cancel result");
+        assert_eq!(value["status"], json!("cancelled"));
+        assert_eq!(
+            UiRpcResult::from_method_and_result(methods::TASK_CANCEL, value)
+                .expect("decode task/cancel result"),
+            cancel_result
+        );
+
+        let restart_result = UiRpcResult::TaskRestartFromNode(TaskRestartFromNodeResult {
+            original_task_id: TaskId(Uuid::from_u128(46)),
+            new_task_id: TaskId(Uuid::from_u128(47)),
+            from_node: Some("node-7".into()),
+        });
+        assert_eq!(restart_result.kind(), UiResultKind::TaskRestartFromNode);
+        assert_eq!(
+            restart_result.method(),
+            Some(methods::TASK_RESTART_FROM_NODE)
+        );
+        let value = restart_result
+            .clone()
+            .into_result_value()
+            .expect("serialize task/restart_from_node result");
+        assert_eq!(value["from_node"], json!("node-7"));
+        assert_eq!(
+            UiRpcResult::from_method_and_result(methods::TASK_RESTART_FROM_NODE, value)
+                .expect("decode task/restart_from_node result"),
+            restart_result
         );
 
         let task_result = UiRpcResult::TaskOutputRead(TaskOutputReadResult {

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_005_TASK_CONTROL_RPCS.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_005_TASK_CONTROL_RPCS.md
@@ -48,12 +48,13 @@ them piecemeal would require three UPCRs for one logical contract addition.
 
 ## Change Type
 
-Additive method/notification.
+Additive method.
 
-Three new JSON-RPC command methods on the existing AppUi v1alpha1 protocol. No
-existing method, notification, required field, enum variant, or capability flag
-is modified. One additive feature flag (`harness.task_control.v1`) is added so
-clients can negotiate availability.
+Three new JSON-RPC command methods on the existing AppUi v1alpha1 protocol.
+No new notifications are added. No existing method, notification, required
+field, enum variant, or capability flag is modified. One additive feature
+flag (`harness.task_control.v1`) is added so clients can negotiate
+availability.
 
 ## Wire Contract
 
@@ -142,10 +143,13 @@ Params:
 ```
 
 - `task_id` (required): the task to cancel.
-- `session_id` (required for v1alpha1): scopes the cancel to one session and
-  enables the same `validate_session_scope` check used by other AppUi commands.
-  An absent `session_id` is rejected with `invalid_params` so clients cannot
-  cross-cancel tasks across sessions.
+- `session_id` (wire-optional, validated as required at handler time): scopes
+  the cancel to one session and enables the same `validate_session_scope`
+  check used by other AppUi commands. The wire schema keeps the field
+  optional to match the existing v1 pattern of using `serde(default,
+  skip_serializing_if = "Option::is_none")` for cross-session-shaped
+  identifiers; the handler rejects an absent `session_id` with
+  `invalid_params` so clients cannot cross-cancel tasks across sessions.
 - `profile_id` (optional): forwarded to the connection-profile validator.
 
 Result:
@@ -160,7 +164,10 @@ Result:
 - `status` is the canonical `TaskRuntimeState` value `cancelled` (governed by
   accepted `UPCR-2026-004`). The server preserves the cancel-race guard from
   PR #709: once a task is `Cancelled`, later runtime state transitions cannot
-  overwrite it, so a re-entrant cancel is observably idempotent.
+  overwrite the supervisor's stored state. A re-cancel of an already-terminal
+  task surfaces as `invalid_params` with `data.kind = "task_already_terminal"`
+  rather than a second `cancelled` success — the supervisor *state* is the
+  idempotent invariant, not the wire response.
 
 ### `task/restart_from_node`
 
@@ -184,7 +191,8 @@ Params:
 - `task_id` (required): the task to relaunch.
 - `node_id` (optional): pipeline node id to resume from. Forwarded to
   `RelaunchOpts.from_node`.
-- `session_id` (required for v1alpha1): same scoping rule as `task/cancel`.
+- `session_id` (wire-optional, validated as required at handler time): same
+  scoping rule as `task/cancel`.
 - `profile_id` (optional): forwarded to the connection-profile validator.
 
 Result:
@@ -211,16 +219,25 @@ The new commands return errors from the existing v1 taxonomy
 - `invalid_params` — params failed structural validation. Includes:
   - missing `session_id` on `task/cancel` / `task/restart_from_node`,
   - `task_already_terminal` (cancel applied to a task already in a terminal
-    state) — returned with `data.kind = "task_already_terminal"`,
+    state, including a task that was already cancelled) — returned with
+    `data.kind = "task_already_terminal"`,
   - `task_still_active` (relaunch applied to a non-terminal task) — returned
-    with `data.kind = "task_still_active"`.
-- `permission_denied` — connection profile does not match the requested
-  session/profile (existing `validate_session_scope` rule).
+    with `data.kind = "task_still_active"`,
+  - profile-scope mismatches surfaced through the existing
+    `validate_session_scope` helper. Carries the same
+    `expected_profile_id` / `actual_profile_id` data fields the rest of the
+    AppUi command surface already returns; this UPCR keeps the existing
+    convention rather than introducing a new `permission_denied` channel for
+    the same case.
 - `runtime_unavailable` — server has no `task_query_store` wired for this
   deployment (e.g. lite/embedded build). Returned with
   `data.kind = "runtime_unavailable"`.
 - `internal_error` — supervisor produced a non-array snapshot or returned an
   unparseable task id (defensive; should not occur in practice).
+
+A `task/list` request for an inactive or unknown session returns an empty
+`tasks` array rather than `unknown_session`, matching how the existing
+`SessionTaskQueryStore` snapshot already handles missing supervisors.
 
 No new error categories are introduced.
 

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_005_TASK_CONTROL_RPCS.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_005_TASK_CONTROL_RPCS.md
@@ -1,0 +1,309 @@
+# Octos UI Protocol Change Request: Task Control RPCs
+
+## Header
+
+- Request id: `UPCR-2026-005`
+- Title: Add `task/list`, `task/cancel`, `task/restart_from_node` RPC commands
+- Author: M9 harness audit follow-up (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related M issue: `#704` (M9 req 9 P2 from
+  [OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md](OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md))
+
+## Summary
+
+This change request adds three additive JSON-RPC command methods to the AppUi
+protocol so harness clients can control the runtime task registry without
+falling back to REST: `task/list` (enumerate tasks for a session), `task/cancel`
+(cancel a running task by id), and `task/restart_from_node` (operator-triggered
+relaunch from a specific pipeline node). The methods wrap the stable
+`TaskSupervisor` primitives already used by the REST surface and the agent's
+internal cancel/relaunch lifecycle. The change is purely additive: no existing
+method, payload, enum variant, capability bit, or protocol identifier is
+modified.
+
+## Motivation
+
+The M6-M9 harness audit (`docs/OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md` § M9
+req 9) flagged that `task/cancel` was missing from the `UiCommand` enum. Slash
+commands such as `/stop` against a background task and `/ps` against the task
+registry had no canonical AppUi RPC entry point and were forced to either
+short-circuit to REST or skip the UX entirely. The audit assigned this gap
+priority **P2** and tracked it as issue `#704`.
+
+`TaskSupervisor` already exposes `cancel(task_id)` and `relaunch(task_id, opts)`
+as stable in-process primitives, and the supervisor enforces the cancel-race
+guard added in PR #709 — once a task transitions to `Cancelled`, later
+state-transition attempts are no-ops, so a re-entrant cancel cannot overwrite a
+terminal state. The agent runtime also exposes a
+`SessionTaskQueryStore` that returns a JSON snapshot of all tasks scoped to a
+session. Lifting these three primitives to first-class AppUi RPCs preserves the
+existing semantics and removes the REST detour.
+
+`task/list` and `task/restart_from_node` are bundled into the same UPCR because
+they consume the same supervisor surface, share the same session-scoping rules,
+and together form the minimum command set the `/ps` slash command needs. Adding
+them piecemeal would require three UPCRs for one logical contract addition.
+
+## Change Type
+
+Additive method/notification.
+
+Three new JSON-RPC command methods on the existing AppUi v1alpha1 protocol. No
+existing method, notification, required field, enum variant, or capability flag
+is modified. One additive feature flag (`harness.task_control.v1`) is added so
+clients can negotiate availability.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Capability payload: `UiProtocolCapabilities` (new feature flag entry,
+  full-protocol method-set entry)
+- Capability feature registry: `harness.task_control.v1`
+- Command method: `task/list` (new)
+- Command method: `task/cancel` (new)
+- Command method: `task/restart_from_node` (new)
+- Command params: `TaskListParams`, `TaskCancelParams`,
+  `TaskRestartFromNodeParams` (new)
+- Command results: `TaskListResult`, `TaskCancelResult`,
+  `TaskRestartFromNodeResult` (new)
+
+No existing command method, notification, params, results, or enum variants
+are modified by this UPCR.
+
+### `task/list`
+
+Purpose:
+
+- Enumerate tasks the runtime tracks for a session, with one entry per task
+  including lifecycle state, runtime state, optional child-session linkage, and
+  output cursors. Primary consumer: the `/ps`-style task panel.
+
+Params:
+
+```json
+{
+  "session_id": "local:demo",
+  "topic": "default"
+}
+```
+
+- `session_id` (required): canonical session identifier.
+- `topic` (optional): sub-topic suffix appended as `<session>#<topic>` for
+  grouping; the server falls back to the bare session if omitted or empty.
+
+Result:
+
+```json
+{
+  "session_id": "local:demo",
+  "topic": "default",
+  "tasks": [
+    {
+      "id": "01900000-0000-7000-8000-000000000001",
+      "tool_name": "spawn_only_runner",
+      "tool_call_id": "call-1",
+      "state": "running",
+      "status": "running",
+      "lifecycle_state": "running",
+      "runtime_state": "executing_tool",
+      "parent_session_key": "local:demo",
+      "child_session_key": "local:demo#child-1",
+      "started_at": "2026-04-30T12:00:00Z",
+      "updated_at": "2026-04-30T12:01:00Z",
+      "output_files": ["octos-file://task-output"]
+    }
+  ]
+}
+```
+
+- `tasks[].state` is the canonical wire enum `TaskRuntimeState` (the same enum
+  used by `task/updated`), derived from the supervisor's `lifecycle_state` /
+  `runtime_state` / `status` snapshot. Optional fields follow the existing
+  `task/updated` shape and are omitted when empty.
+
+### `task/cancel`
+
+Purpose:
+
+- Cancel a single task in the supervisor and return its final wire state. Maps
+  directly to `TaskSupervisor::cancel(task_id)`.
+
+Params:
+
+```json
+{
+  "task_id": "01900000-0000-7000-8000-000000000001",
+  "session_id": "local:demo",
+  "profile_id": "coding"
+}
+```
+
+- `task_id` (required): the task to cancel.
+- `session_id` (required for v1alpha1): scopes the cancel to one session and
+  enables the same `validate_session_scope` check used by other AppUi commands.
+  An absent `session_id` is rejected with `invalid_params` so clients cannot
+  cross-cancel tasks across sessions.
+- `profile_id` (optional): forwarded to the connection-profile validator.
+
+Result:
+
+```json
+{
+  "task_id": "01900000-0000-7000-8000-000000000001",
+  "status": "cancelled"
+}
+```
+
+- `status` is the canonical `TaskRuntimeState` value `cancelled` (governed by
+  accepted `UPCR-2026-004`). The server preserves the cancel-race guard from
+  PR #709: once a task is `Cancelled`, later runtime state transitions cannot
+  overwrite it, so a re-entrant cancel is observably idempotent.
+
+### `task/restart_from_node`
+
+Purpose:
+
+- Operator-triggered relaunch of a previously failed or terminal task,
+  optionally beginning from a specific pipeline node. Maps to
+  `TaskSupervisor::relaunch(task_id, RelaunchOpts { from_node })`.
+
+Params:
+
+```json
+{
+  "task_id": "01900000-0000-7000-8000-000000000001",
+  "node_id": "design",
+  "session_id": "local:demo",
+  "profile_id": "coding"
+}
+```
+
+- `task_id` (required): the task to relaunch.
+- `node_id` (optional): pipeline node id to resume from. Forwarded to
+  `RelaunchOpts.from_node`.
+- `session_id` (required for v1alpha1): same scoping rule as `task/cancel`.
+- `profile_id` (optional): forwarded to the connection-profile validator.
+
+Result:
+
+```json
+{
+  "original_task_id": "01900000-0000-7000-8000-000000000001",
+  "new_task_id": "01900000-0000-7000-8000-000000000002",
+  "from_node": "design"
+}
+```
+
+- `new_task_id` is the supervisor-assigned id of the relaunched successor.
+- `from_node` echoes the requested node when the supervisor accepted it.
+
+## Error Model
+
+The new commands return errors from the existing v1 taxonomy
+([§ 10](../api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md)):
+
+- `unknown_task` — supervisor has no task with that `task_id`, or the task is
+  scoped to a different session than the request. Returned as `RpcError`
+  category `unknown_task`.
+- `invalid_params` — params failed structural validation. Includes:
+  - missing `session_id` on `task/cancel` / `task/restart_from_node`,
+  - `task_already_terminal` (cancel applied to a task already in a terminal
+    state) — returned with `data.kind = "task_already_terminal"`,
+  - `task_still_active` (relaunch applied to a non-terminal task) — returned
+    with `data.kind = "task_still_active"`.
+- `permission_denied` — connection profile does not match the requested
+  session/profile (existing `validate_session_scope` rule).
+- `runtime_unavailable` — server has no `task_query_store` wired for this
+  deployment (e.g. lite/embedded build). Returned with
+  `data.kind = "runtime_unavailable"`.
+- `internal_error` — supervisor produced a non-array snapshot or returned an
+  unparseable task id (defensive; should not occur in practice).
+
+No new error categories are introduced.
+
+## Compatibility
+
+- Old clients that never request `harness.task_control.v1` and never send
+  `task/list` / `task/cancel` / `task/restart_from_node` are unaffected.
+- Old servers that have not implemented these methods reject incoming
+  `task/*` requests with the existing `method_not_supported` error
+  (`UI_PROTOCOL_FIRST_SERVER_METHODS` membership check).
+- No new protocol identifier is required because all three methods are
+  additive.
+- Clients that exhaustively match on `UiCommand` or `UiResultKind` and have not
+  been recompiled against the new enum variants will fail to deserialize a
+  message carrying one of the new methods. This is the standard
+  forward-compatibility behaviour for any added method, acknowledged by
+  spec § 4.1.
+- The cancel-race guard from PR #709 (terminal `Cancelled` cannot be
+  overwritten) is preserved end-to-end: `task/cancel` simply lifts the
+  supervisor's existing cancel call onto the wire.
+
+## Capability Negotiation
+
+New feature flag:
+
+- `harness.task_control.v1`
+
+Servers advertise it through `UiProtocolCapabilities.supported_features`. The
+flag is included in `UiProtocolCapabilities::full_protocol()` and in the first
+server slice's supported method set. Clients that want to depend on the new
+methods should request the feature through the existing
+`X-Octos-Ui-Features` header or the `ui_feature` / `ui_features` query
+parameters.
+
+If a client sends a `task/*` method to a server that does not advertise the
+feature, the server returns the existing `method_not_supported` error.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `task_control_commands_build_and_parse_json_rpc_requests` — round-trips
+    `task/list`, `task/cancel`, `task/restart_from_node` requests through the
+    JSON-RPC envelope.
+  - `typed_rpc_results_map_from_methods_and_round_trip` — extended with
+    `TaskListResult`, `TaskCancelResult`, `TaskRestartFromNodeResult` golden
+    coverage.
+  - `full_protocol_capabilities_advertise_harness_task_control` — asserts the
+    new feature flag and methods are advertised in `full_protocol()`.
+  - Capability-set golden tests updated to include the new methods and the
+    `harness.task_control.v1` feature literal.
+- `crates/octos-core/src/app_ui.rs`:
+  - `app_command_surface_covers_harness_task_control` — exercises the
+    `AppUiCommand` adapter for all three methods.
+- `crates/octos-cli/src/api/ui_protocol.rs`:
+  - `appui_task_list_returns_runtime_snapshot` — verifies the handler returns
+    the supervisor snapshot for a session.
+  - `appui_task_cancel_uses_supervisor_cancel_path` — verifies the handler
+    routes to `TaskSupervisor::cancel` and reports `cancelled`.
+  - `appui_task_restart_from_node_uses_relaunch_path` — verifies the handler
+    routes to `TaskSupervisor::relaunch` and emits a fresh `new_task_id`.
+  - Routing tests extended with `task/list`, `task/cancel`,
+    `task/restart_from_node` requests.
+
+## Rollout Plan
+
+1. Land the protocol constants, params/result types, command/result enums,
+   capability flag, and golden tests in `octos-core`.
+2. Land the server handlers (`handle_task_list`, `handle_task_cancel`,
+   `handle_task_restart_from_node`), the `SessionTaskQueryStore` projection,
+   and the routing tests in `octos-cli`.
+3. Update this spec to reference UPCR-2026-005 from § 7.
+4. Follow-up: TUI `/ps` slash command surface (separate change, tracked under
+   #704 follow-ups) consumes the new methods.
+
+No client renegotiation is required for clients that do not consume the new
+methods.
+
+## Decision
+
+Accepted by: M9 harness audit follow-up (coding-green).
+
+Decision notes: Accepted as the minimum additive contract change to close
+audit issue #704 (M9 req 9 P2). The three methods wrap stable supervisor
+primitives, preserve the PR #709 cancel-race guard, and reuse the existing
+v1 error taxonomy. TUI-side `/ps` UX remains a follow-up; this UPCR scopes
+only the wire contract.


### PR DESCRIPTION
## Summary

Adds 3 new RPC commands to UI Protocol v1, closing audit issue #704 (M9 req 9 P2 from `docs/OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md`):

- `task/cancel` — wraps `TaskSupervisor::cancel(task_id)` (via `SessionTaskQueryStore::cancel_task`, which dispatches to the owning supervisor). Gives `/stop` and similar UX surfaces a real protocol method, replacing REST fallback.
- `task/list` — enumerates tasks; primary consumer is the `/ps`-style task panel.
- `task/restart_from_node` — operator-triggered relaunch from a specific pipeline node, consumes existing `TaskSupervisor::relaunch`.

## Audit gap closed

This PR closes #704. The TUI `/ps` slash command surface that was the *other* part of M9 req 9 is **TUI-side work** and remains a follow-up — this PR adds the protocol method TUI will call.

## UPCR

`UPCR-2026-005` filed and accepted in this PR (additive method-name additions to UI Protocol v1; backward-compatible per v1's "unknown methods may be ignored" rule). New feature flag `harness.task_control.v1`.

## Quality

- `cargo fmt --check` clean
- `cargo test -p octos-core ui_protocol` — 39/39 pass (golden tests stay green; new round-trip tests added)
- `cargo test -p octos-cli api::ui_protocol --features api` — 168/168 pass (3 new async handler tests)
- `cargo test -p octos-agent task_supervisor` — 65/65 pass; verifies the cancel-race guard from PR #709 is preserved (`mark_*_after_cancel_does_not_overwrite_cancelled_*`)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `./scripts/check-ui-protocol-upcr.sh` — clean

## Codex 2nd-opinion review

Codex flagged 4 doc/spec inconsistencies between UPCR-2026-005 prose and the actual handler:

1. `session_id` documented as required but kept `Option<SessionKey>` in the wire struct — addressed by clarifying the wire schema keeps it optional per v1 convention and the handler validates it as required (matching `validate_session_scope` pattern).
2. `task/list` documented `unknown_session` for inactive sessions — addressed: implementation returns empty `tasks` array, spec/UPCR now reflect that.
3. Profile mismatches documented as `permission_denied` — addressed: `validate_session_scope` already returns `invalid_params` with `expected_profile_id` / `actual_profile_id`; spec/UPCR aligned.
4. Re-cancel idempotency wording — addressed: clarified the supervisor *state* (PR #709 guard) is the idempotent invariant; the wire response surfaces a re-cancel as `task_already_terminal` rather than a second `cancelled` success.

All addressed in commit `6384ae2d` (doc-only alignment, no code changes). Codex P2 suggestion to add a regression test asserting `mark_completed` after `cancel_task` does not overwrite the cancelled state is already covered by the supervisor-level golden tests (`crates/octos-agent/src/task_supervisor.rs::mark_completed_after_cancel_does_not_overwrite_cancelled_state` and siblings).

## Backward compatibility

Additive only. Existing clients that don't request these methods are unaffected. Per spec § 4 ("clients should treat unknown fields as ignorable"), older clients can keep operating against this server.

## Test plan

- [ ] CI green
- [ ] Manual: open AppUi session, spawn a long task, call `task/list` from a test client; confirm task appears with stable ID
- [ ] Manual: call `task/cancel` against a running task; confirm response carries `status: "cancelled"` and supervisor preserves the state across follow-up `mark_*` calls
- [ ] Manual: call `task/restart_from_node` against a failed pipeline; confirm new task ID emitted in result + supervisor records relaunch