### PR TITLE
fix(plugins): mark harness-starter-audio/generic exclusive + plugin concurrency_class fail-closed (closes #718)

### DIFF
--- a/crates/app-skills/deep-crawl/manifest.json
+++ b/crates/app-skills/deep-crawl/manifest.json
@@ -8,6 +8,7 @@
     {
       "name": "deep_crawl",
       "description": "Recursively crawl a website using a headless browser (CDP). Renders JavaScript, follows same-origin links via BFS, extracts text from each page, and saves results to disk. Ideal for JS-rendered SPAs and documentation sites.",
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/crates/app-skills/deep-search/manifest.json
+++ b/crates/app-skills/deep-search/manifest.json
@@ -8,6 +8,7 @@
     {
       "name": "deep_search",
       "description": "Perform deep multi-round web research on a topic. Searches from multiple angles (follow-up queries, time-qualified, controversy), fetches all pages in parallel, chases most-referenced external sources, and produces a structured research report saved to disk. The report file path is printed at the end of the output.",
+      "concurrency_class": "exclusive",
       "entrypoint": "target/release/deep-search",
       "env": [
         "SERPER_API_KEY",

--- a/crates/app-skills/harness-starter-audio/manifest.json
+++ b/crates/app-skills/harness-starter-audio/manifest.json
@@ -9,6 +9,7 @@
       "name": "synthesize_clip",
       "description": "Synthesize a short WAV clip for a label. Writes to audio/<slug>.wav. Replace with a real TTS/render engine when adapting the starter.",
       "spawn_only": true,
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/crates/app-skills/harness-starter-audio/tests/harness_smoke.rs
+++ b/crates/app-skills/harness-starter-audio/tests/harness_smoke.rs
@@ -20,6 +20,29 @@ fn manifest_parses_and_declares_synthesize_clip_tool() {
 }
 
 #[test]
+fn harness_starter_audio_manifest_declares_exclusive_concurrency() {
+    // Issue #718: `synthesize_clip` writes `audio/<slug>.wav`, so it
+    // must declare `concurrency_class = "exclusive"` to serialise
+    // against sibling mutating tools in the same batch. Without this
+    // field the M8.8 scheduler defaults to `Safe` and silently permits
+    // parallel writes — same gap PR #711 closed for the other bundled
+    // mutating skills (harness-starter-coding, harness-starter-report,
+    // account-manager, skill-evolve).
+    let manifest = PluginManifest::from_file(&crate_root().join("manifest.json"))
+        .expect("manifest.json must parse");
+    let tool = manifest
+        .tools
+        .iter()
+        .find(|t| t.name == "synthesize_clip")
+        .expect("synthesize_clip tool present");
+    assert_eq!(
+        tool.concurrency_class.as_deref(),
+        Some("exclusive"),
+        "synthesize_clip writes audio/<slug>.wav and must declare concurrency_class=exclusive",
+    );
+}
+
+#[test]
 fn workspace_policy_declares_primary_audio_with_size_validator() {
     let raw = std::fs::read_to_string(crate_root().join("workspace-policy.toml"))
         .expect("policy readable");

--- a/crates/app-skills/harness-starter-generic/manifest.json
+++ b/crates/app-skills/harness-starter-generic/manifest.json
@@ -9,6 +9,7 @@
       "name": "produce_artifact",
       "description": "Produce a single text artifact under output/. The workspace policy primary = \"output/artifact-*.txt\" resolves the delivered file.",
       "spawn_only": true,
+      "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/crates/app-skills/harness-starter-generic/tests/harness_smoke.rs
+++ b/crates/app-skills/harness-starter-generic/tests/harness_smoke.rs
@@ -37,6 +37,28 @@ fn manifest_parses_and_declares_spawn_only_tool() {
 }
 
 #[test]
+fn harness_starter_generic_manifest_declares_exclusive_concurrency() {
+    // Issue #718: `produce_artifact` writes `output/artifact-*.txt`, so
+    // it must declare `concurrency_class = "exclusive"` to serialise
+    // against sibling mutating tools in the same batch. Without this
+    // field the M8.8 scheduler defaults to `Safe` and silently permits
+    // parallel writes — same gap PR #711 closed for the other bundled
+    // mutating skills (harness-starter-coding, harness-starter-report,
+    // account-manager, skill-evolve).
+    let manifest = PluginManifest::from_file(&manifest_path()).expect("manifest.json must parse");
+    let tool = manifest
+        .tools
+        .iter()
+        .find(|t| t.name == "produce_artifact")
+        .expect("produce_artifact tool present");
+    assert_eq!(
+        tool.concurrency_class.as_deref(),
+        Some("exclusive"),
+        "produce_artifact writes output/artifact-*.txt and must declare concurrency_class=exclusive",
+    );
+}
+
+#[test]
 fn workspace_policy_parses_and_declares_primary_artifact() {
     let raw =
         std::fs::read_to_string(policy_path()).expect("workspace-policy.toml must be readable");

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -406,11 +406,14 @@ impl PluginLoader {
                     );
                     return None;
                 }
-                // Codex review #1: warn (don't reject) on unknown
-                // concurrency_class so authors notice typos like
-                // `"exclusive "` (trailing space → silently Safe). The
-                // runtime trim added in tool.rs handles the trim case;
-                // this surface keeps unknown literals visible.
+                // Codex review #1 + issue #718: warn (don't reject) on
+                // unknown concurrency_class so authors notice typos like
+                // `"exclusive "` (trailing space → silently Safe) or
+                // `"exclusve"`. The runtime resolver in tool.rs now
+                // fails-closed to Exclusive on Unknown — matches MCP's
+                // `resolved_concurrency_class`. This warn keeps the
+                // misconfiguration visible even though it is no longer
+                // a silent downgrade.
                 if let ConcurrencyClassClassification::Unknown(raw) =
                     def.classify_concurrency_class()
                 {
@@ -418,7 +421,7 @@ impl PluginLoader {
                         plugin = %plugin_name,
                         tool = %def.name,
                         concurrency_class = %raw,
-                        "manifest declares unknown concurrency_class; falling back to Safe"
+                        "manifest declares unknown concurrency_class; falling back to Exclusive (fail-closed)"
                     );
                 }
                 let manifest_risk = def.risk.clone();

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -221,9 +221,10 @@ impl PluginToolDef {
     /// Returns the trimmed/lowercased `concurrency_class` literal if it is
     /// recognised. Returns `None` for missing values; returns
     /// `Some("unknown:...")` for declared-but-unrecognised values so the
-    /// loader can warn without rejecting (silent fallback to Safe is the
-    /// existing behavior — we don't want to break a manifest that
-    /// declares e.g. `"safe"` even though Safe is the default).
+    /// loader can warn without rejecting (the runtime resolver in
+    /// `PluginTool::concurrency_class` fails-closed to Exclusive on
+    /// Unknown — see issue #718 — so a typo still serialises execution
+    /// even before the operator notices the warn log).
     ///
     /// Recognised: `exclusive`, `safe`. Anything else (including
     /// `"medium"`, `"highly-exclusive"`, ...) is reported as unknown so
@@ -256,7 +257,8 @@ pub enum ConcurrencyClassClassification {
     /// can reject Unset for mutating tools while keeping explicit Safe.
     Safe,
     /// Declared but unrecognised. Carries the original raw value for
-    /// diagnostic logging. Runtime behavior falls back to Safe.
+    /// diagnostic logging. Runtime behavior fails-closed to Exclusive
+    /// (see issue #718 — matches MCP's `resolved_concurrency_class`).
     Unknown(String),
 }
 

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -715,6 +715,12 @@ impl Tool for PluginTool {
         // plugin author marks the tool as `"exclusive"` (e.g. it
         // mutates shared state, posts to a remote service, or writes
         // to disk) the M8.8 scheduler serialises it against siblings.
+        //
+        // Issue #718 follow-up: align with `McpServerConfig::resolved_concurrency_class`
+        // — unknown literals fail-closed to `Exclusive` so a typo like
+        // `"exclusve"` does not silently permit parallel writes. The
+        // loader already emits a `warn!` on `Unknown` so misconfigurations
+        // are visible; this resolver is the runtime safety net.
         match self
             .tool_def
             .concurrency_class
@@ -723,8 +729,10 @@ impl Tool for PluginTool {
             .map(str::to_ascii_lowercase)
             .as_deref()
         {
+            None | Some("") | Some("safe") => super::super::tools::ConcurrencyClass::Safe,
             Some("exclusive") => super::super::tools::ConcurrencyClass::Exclusive,
-            _ => super::super::tools::ConcurrencyClass::Safe,
+            // Unknown values fail-safe to Exclusive — matches MCP behavior.
+            Some(_) => super::super::tools::ConcurrencyClass::Exclusive,
         }
     }
 
@@ -2467,12 +2475,30 @@ mod tests {
     }
 
     #[test]
-    fn concurrency_class_unknown_falls_back_to_safe() {
+    fn plugin_unknown_concurrency_class_falls_back_to_exclusive() {
+        // Issue #718 follow-up: align with MCP's
+        // `McpServerConfig::resolved_concurrency_class`. The previous
+        // behavior was fail-open (unknown → Safe), which silently
+        // permitted parallel writes when a manifest author typoed
+        // `"exclusve"`. After the fix, unknown literals fail-closed to
+        // Exclusive — same behavior as MCP — so a typo still serialises
+        // execution.
         let mut def = make_tool_def("excl_tool", "exclusive");
         def.concurrency_class = Some("highly-exclusive".to_string());
         let tool = PluginTool::new("p".into(), def, PathBuf::from("/bin/echo"));
-        let class = tool.concurrency_class();
-        assert!(matches!(class, crate::tools::ConcurrencyClass::Safe));
+        assert!(matches!(
+            tool.concurrency_class(),
+            crate::tools::ConcurrencyClass::Exclusive,
+        ));
+
+        // The exact typo called out in #718.
+        let mut typo_def = make_tool_def("typo_tool", "exclusive");
+        typo_def.concurrency_class = Some("exclusve".to_string());
+        let typo_tool = PluginTool::new("p".into(), typo_def, PathBuf::from("/bin/echo"));
+        assert!(matches!(
+            typo_tool.concurrency_class(),
+            crate::tools::ConcurrencyClass::Exclusive,
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

Closes #718. Three gaps caught by codex audit after PR #711:

1. **harness-starter-audio**: `synthesize_clip` writes `audio/<slug>.wav` but manifest lacked `concurrency_class: "exclusive"`. Default fell through to `Safe`, allowing parallel-write races against sibling mutating tools in the same M8.8 batch.
2. **harness-starter-generic**: `produce_artifact` writes `output/artifact-*.txt` with the same gap.
3. **Plugin runtime resolver was fail-open vs. MCP**. After PR #711, MCP unknown `concurrency_class` -> `Exclusive` (fail-closed). Plugin unknown -> `Safe`. A typo like `"exclusve"` therefore silently permitted parallel writes for plugin tools while MCP correctly serialised them.

Codex 2nd-opinion flagged two more first-party plugins that write files but lack the field — included in this PR:
- `deep-search` (`deep_search`, writes a research report to disk)
- `deep-crawl` (`deep_crawl`, writes per-page text + index)

`pipeline-guard` writes `pipeline_models.json` but ships with `tools: []` (hook-only) so it is not exposed to the scheduler — no field needed.

## Changes

Manifests (4 x +1 line, all gain `"concurrency_class": "exclusive"`):
- `crates/app-skills/harness-starter-audio/manifest.json`
- `crates/app-skills/harness-starter-generic/manifest.json`
- `crates/app-skills/deep-search/manifest.json`
- `crates/app-skills/deep-crawl/manifest.json`

Plugin parser fail-closed:
- `crates/octos-agent/src/plugins/tool.rs`: runtime `Tool::concurrency_class` now matches MCP's `McpServerConfig::resolved_concurrency_class` — `None` / `""` / `"safe"` -> `Safe`; `"exclusive"` -> `Exclusive`; anything else -> `Exclusive` (fail-closed). The trim from PR #711 (codex review #1) is preserved so `"exclusive "` still resolves to `Exclusive` instead of `Unknown`.
- `crates/octos-agent/src/plugins/loader.rs`: warn message says "falling back to Exclusive (fail-closed)".
- `crates/octos-agent/src/plugins/manifest.rs`: doc comments updated.

Tests:
- `harness_starter_audio_manifest_declares_exclusive_concurrency` (asserts the manifest field)
- `harness_starter_generic_manifest_declares_exclusive_concurrency` (asserts the manifest field)
- `plugin_unknown_concurrency_class_falls_back_to_exclusive` (replaces the previous `*_falls_back_to_safe`; exercises both `"highly-exclusive"` and the exact `"exclusve"` typo from the audit)

Diff: 9 files changed, 94 insertions, 14 deletions.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p octos-agent plugins` — 101 passed (includes new fail-closed test)
- [x] `cargo test -p octos-agent --tests` — all green
- [x] `cargo test -p harness-starter-audio -p harness-starter-generic` — all green (includes 2 new manifest tests)
- [x] `cargo test -p deep-search -p deep-crawl` — all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] All 4 modified manifests parse via `python3 -m json.tool`
- [x] Codex 2nd-opinion review captured at `/tmp/codex-718.log`; broader-mutating-tool catch (deep-search, deep-crawl) was acted on; trim asymmetry deemed intentional (stricter, not less safe)