### PR TITLE
feat(ui_protocol): is_snapshot_projection field on task/output/read result (closes #707)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -158,6 +158,12 @@ Current M9 sandbox-parity decision:
   That UPCR closes M9 harness audit gap #704 by giving clients first-class
   AppUi RPCs for the supervisor's `cancel` / `relaunch` / task-snapshot
   primitives, gated behind the `harness.task_control.v1` feature flag.
+- The additive `is_snapshot_projection: bool` field on the
+  `task/output/read` result is governed by accepted
+  [UPCR-2026-006](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_006_TASK_OUTPUT_SNAPSHOT_PROJECTION.md).
+  That UPCR closes M9 harness audit gap #707 by giving clients a single
+  wire-level boolean for snapshot vs. live-tail semantics, independent of the
+  open `source` enum and the free-form `limitations[]` registry.
 
 ## 5. Identity Model
 
@@ -335,6 +341,38 @@ Minimum params:
 - `task_id`
 - optional `cursor`
 - optional `limit_bytes`
+
+Result fields (subset relevant to this spec; see `TaskOutputReadResult` for
+the full struct):
+
+- `source` — open snake_case enum identifying the read source. Today's
+  runtime always emits `runtime_projection`; future sources (e.g. a
+  disk-routed stdout/stderr stream) will introduce additional variants.
+  Clients MUST NOT switch on this enum to decide whether the cursor is a
+  stable byte-stream offset or an advisory snapshot offset; use
+  `is_snapshot_projection` for that.
+- `cursor` / `next_cursor` — byte offsets into the returned text window.
+  When `is_snapshot_projection` is `true` the offsets are interpreted within
+  the snapshot served by this response; when it is `false` the offsets are
+  stable positions in the live byte stream the source exposes (see
+  `is_snapshot_projection` below).
+- `live_tail_supported: bool` — whether the read *source* has a live-tail
+  mode (i.e. whether `task/output/delta` notifications can be expected for
+  the same task). Today's `runtime_projection` source always reports
+  `false`.
+- `is_snapshot_projection: bool` — required, governed by accepted
+  [UPCR-2026-006](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_006_TASK_OUTPUT_SNAPSHOT_PROJECTION.md).
+  When `true`, the response was projected from a point-in-time snapshot of
+  the task ledger; `cursor` / `next_cursor` are advisory across reads
+  because a fresh `task/output/read` may project a different snapshot.
+  When `false`, the response was sourced from a live byte-monotonic stream
+  and `next_cursor` is a stable resume offset. Today's runtime always emits
+  `is_snapshot_projection: true`.
+- `limitations` — free-form list of `{ code, message }` entries describing
+  source-specific caveats (e.g. `live_tail_unavailable`,
+  `disk_output_unavailable`). Clients MUST NOT rely on specific `code`
+  values as a contract for snapshot vs. live-tail semantics; that contract
+  is carried by `is_snapshot_projection`.
 
 ### `task/list`
 

--- a/crates/octos-cli/src/api/ui_protocol_task_output.rs
+++ b/crates/octos-cli/src/api/ui_protocol_task_output.rs
@@ -162,6 +162,11 @@ fn project_task_output(
         truncated: window.end_offset < text.len(),
         complete: window.end_offset >= text.len(),
         live_tail_supported: false,
+        // Audit issue #707 / accepted UPCR-2026-006: today's runtime serves
+        // every `task/output/read` from a snapshot of the task ledger, not a
+        // live disk-routed stdout/stderr stream. When the disk-routed source
+        // ships, that constructor will set this to `false`.
+        is_snapshot_projection: true,
         task_status,
         runtime_state,
         lifecycle_state,
@@ -511,6 +516,10 @@ mod tests {
 
         assert_eq!(value["source"], json!("runtime_projection"));
         assert_eq!(value["live_tail_supported"], json!(false));
+        // Audit issue #707 / accepted UPCR-2026-006: the wire result must
+        // expose snapshot-projection truth as a boolean clients can switch on
+        // without parsing the human-facing `limitations[]` strings.
+        assert_eq!(value["is_snapshot_projection"], json!(true));
         assert_eq!(value["complete"], json!(true));
         assert!(value["total_bytes"].as_u64().unwrap() >= value["bytes_read"].as_u64().unwrap());
         assert_eq!(

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1270,6 +1270,13 @@ pub struct TaskOutputReadResult {
     pub truncated: bool,
     pub complete: bool,
     pub live_tail_supported: bool,
+    /// True when this read came from snapshot projection rather than a live
+    /// disk-routed output stream. Clients should treat the cursor returned
+    /// alongside `is_snapshot_projection: true` as advisory: a fresh read may
+    /// produce a different snapshot, since the underlying data is the latest
+    /// task ledger entry rather than a position in a monotonic byte stream.
+    /// Governed by accepted `UPCR-2026-006` (audit issue #707, M9 req 7).
+    pub is_snapshot_projection: bool,
     pub task_status: String,
     pub runtime_state: String,
     pub lifecycle_state: String,
@@ -2841,6 +2848,7 @@ mod tests {
             truncated: false,
             complete: true,
             live_tail_supported: false,
+            is_snapshot_projection: true,
             task_status: "completed".into(),
             runtime_state: "completed".into(),
             lifecycle_state: "completed".into(),
@@ -2870,6 +2878,7 @@ mod tests {
                     "truncated": false,
                     "complete": true,
                     "live_tail_supported": false,
+                    "is_snapshot_projection": true,
                     "task_status": "completed",
                     "runtime_state": "completed",
                     "lifecycle_state": "completed",
@@ -3498,6 +3507,7 @@ mod tests {
             truncated: false,
             complete: true,
             live_tail_supported: false,
+            is_snapshot_projection: true,
             task_status: "failed".into(),
             runtime_state: "delivering_outputs".into(),
             lifecycle_state: "completed".into(),
@@ -3514,6 +3524,11 @@ mod tests {
             .expect("serialize task/output/read result");
         assert_eq!(value["source"], json!("runtime_projection"));
         assert_eq!(value["next_cursor"]["offset"], json!(4));
+        // Audit issue #707 / accepted UPCR-2026-006: clients must be able to
+        // distinguish a snapshot projection read from a (future) live-tail
+        // read on the wire, not just by inferring it from `live_tail_supported
+        // == false` or the `runtime_projection` source label.
+        assert_eq!(value["is_snapshot_projection"], json!(true));
         assert_eq!(
             UiRpcResult::from_method_and_result(methods::TASK_OUTPUT_READ, value)
                 .expect("decode task/output/read result"),

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_006_TASK_OUTPUT_SNAPSHOT_PROJECTION.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_006_TASK_OUTPUT_SNAPSHOT_PROJECTION.md
@@ -1,0 +1,228 @@
+# Octos UI Protocol Change Request: Task Output Snapshot-Projection Flag
+
+## Header
+
+- Request id: `UPCR-2026-006`
+- Title: Add `is_snapshot_projection: bool` to `task/output/read` result
+- Author: M9 harness audit follow-up (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related M issue: `#707` (M9 req 7 P3 from
+  [OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md](OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md))
+
+## Summary
+
+This change request adds a single additive boolean field
+`is_snapshot_projection` to the `TaskOutputReadResult` payload returned by the
+`task/output/read` JSON-RPC command. The field tells clients whether the read
+was projected from the task ledger snapshot (the only mode the runtime
+currently supports) or sourced from a live disk-routed stdout/stderr stream
+(the mode targeted by the M8.7 disk-routed output work). The change is purely
+additive: no existing field, method, notification, enum variant, capability
+flag, or protocol identifier is modified.
+
+## Motivation
+
+The M6-M9 harness audit (`docs/OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md` § M9
+req 7) flagged that the wire payload for `task/output/read` did not expose
+whether the cursor semantics were backed by a real live byte stream or by a
+snapshot projection. The audit assigned this gap priority **P3** and tracked
+it as issue `#707`.
+
+Today's runtime (`crates/octos-cli/src/api/ui_protocol_task_output.rs:3`)
+states explicitly:
+
+> The current runtime persists task snapshots, not disk-routed stdout/stderr
+> streams. This module exposes a typed, cursorable projection of that
+> snapshot data and reports whether this read source itself can be
+> live-tailed.
+
+The result already carries:
+
+- `source: TaskOutputReadSource` — currently the single variant
+  `runtime_projection`.
+- `live_tail_supported: bool` — currently always `false` for the projection
+  source.
+- `limitations: Vec<TaskOutputReadLimitation>` — a human-readable list whose
+  entries include `live_tail_unavailable` and `disk_output_unavailable`.
+
+Clients can *infer* "this is a snapshot, not a live stream" from these signals
+today, but only by enumerating the `runtime_projection` source label or by
+parsing the `limitations[]` strings. Neither is a stable contract:
+
+1. `source` is an open `serde(rename_all = "snake_case")` enum that may grow
+   new variants (e.g. `disk_routed`, `mcp_streamed`). A client that switches
+   on `source == "runtime_projection"` to decide whether the cursor is
+   advisory will silently break the moment a second projection-style source
+   ships.
+2. `limitations[].code` is a free-form string registry; the spec § 7 minimum
+   contract for `task/output/read` does not pin a specific limitation code as
+   the snapshot indicator.
+3. `live_tail_supported` answers a different question — whether the *source*
+   has a live-tail mode at all, not whether *this particular response* came
+   from a snapshot. A future source might be live-tail-capable in general yet
+   serve a single response from a snapshot fallback (e.g. on reconnect).
+
+The audit therefore requires a single, dedicated boolean that says exactly:
+"this response was projected from a snapshot; cursors are advisory." That is
+the contract `is_snapshot_projection` carries.
+
+The semantic contract attached to the new field:
+
+- `is_snapshot_projection: true` means the `text` window was drawn from a
+  point-in-time projection of the task ledger snapshot. The `cursor` and
+  `next_cursor` advance through the bytes of that projection, but a fresh
+  `task/output/read` request may project a different snapshot (the task
+  ledger may have advanced; runtime detail or output_files may have changed).
+  Clients must treat the cursor as advisory across reads and must not assume
+  that `next_cursor` from an earlier read still points to a valid offset in
+  a later snapshot.
+- `is_snapshot_projection: false` means the `text` window was drawn from a
+  live disk-routed (or otherwise byte-monotonic) source. `next_cursor` is a
+  stable offset that a follow-up read can resume from.
+
+## Change Type
+
+Additive field on result payload.
+
+A new required boolean field on the existing `TaskOutputReadResult` struct
+returned by the `task/output/read` JSON-RPC command. No method, notification,
+enum variant, capability flag, or protocol identifier is modified.
+
+## Wire Contract
+
+Affected existing wire surface — strictly additive:
+
+- Command result: `TaskOutputReadResult`
+
+### Before
+
+```json
+{
+  "session_id": "local:demo",
+  "task_id": "01900000-0000-7000-8000-000000000001",
+  "source": "runtime_projection",
+  "cursor": { "offset": 0 },
+  "next_cursor": { "offset": 6 },
+  "text": "output",
+  "bytes_read": 6,
+  "total_bytes": 6,
+  "truncated": false,
+  "complete": true,
+  "live_tail_supported": false,
+  "task_status": "completed",
+  "runtime_state": "completed",
+  "lifecycle_state": "completed",
+  "limitations": [
+    { "code": "snapshot_projection", "message": "served from task snapshot" }
+  ]
+}
+```
+
+### After
+
+```json
+{
+  "session_id": "local:demo",
+  "task_id": "01900000-0000-7000-8000-000000000001",
+  "source": "runtime_projection",
+  "cursor": { "offset": 0 },
+  "next_cursor": { "offset": 6 },
+  "text": "output",
+  "bytes_read": 6,
+  "total_bytes": 6,
+  "truncated": false,
+  "complete": true,
+  "live_tail_supported": false,
+  "is_snapshot_projection": true,
+  "task_status": "completed",
+  "runtime_state": "completed",
+  "lifecycle_state": "completed",
+  "limitations": [
+    { "code": "snapshot_projection", "message": "served from task snapshot" }
+  ]
+}
+```
+
+The new field is required and serialized verbatim alongside
+`live_tail_supported`. The Rust struct keeps the field as a plain
+`pub is_snapshot_projection: bool` (no `serde(default)`), matching the
+existing pattern for `live_tail_supported`, `truncated`, `complete`, and
+other wire-visible truth booleans on this result.
+
+## Compatibility
+
+- Old clients that deserialize unknown fields permissively (i.e. follow spec
+  § 4 "unknown fields MUST be ignored") continue to work. The added field is
+  ignored without affecting their handling of the cursor, text, or
+  limitations.
+- Old clients that exhaustively enumerate fields and reject unknown ones
+  must add the field to their deserializer on the next protocol-types
+  update. This is the standard forward-compatibility behaviour for any
+  added field, acknowledged by spec § 4.
+- Old servers that have not adopted the new field cannot satisfy the new
+  required-field shape. Servers in this repository all flow through the
+  shared `project_task_output` constructor and therefore set the field in
+  one place; downstream forks must add the field at construction time.
+- No capability flag is required because the field is additive on an
+  existing result and the wire shape (`TaskOutputReadResult` is a single
+  JSON object) is unchanged.
+- The field is a strict refinement of information already implied by
+  `source == "runtime_projection"` plus `limitations[].code` membership of
+  `live_tail_unavailable`/`snapshot_projection`. Servers that emit those
+  signals correctly today will set `is_snapshot_projection: true` for the
+  same reads.
+
+## Capability Negotiation
+
+None. The field is additive on an existing result and does not require a
+feature flag.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `representative_payload_round_trip_v1` — extended with
+    `is_snapshot_projection: true` on the literal `task/output/read` golden
+    payload.
+  - `typed_rpc_results_map_from_methods_and_round_trip` — extended with an
+    explicit assertion that the wire object carries
+    `"is_snapshot_projection": true` for `runtime_projection` results.
+- `crates/octos-cli/src/api/ui_protocol_task_output.rs`:
+  - `runtime_projection_serializes_stable_live_tail_metadata` — extended
+    with a wire-shape assertion that `value["is_snapshot_projection"] ==
+    true`. The handler's `project_task_output` always sets the field to
+    `true` until a non-snapshot source ships.
+- `e2e/tests/m9-protocol-task-output-read.spec.ts`:
+  - `initial read + follow-up read advance by task/output cursor` — extended
+    with an explicit assertion that `first.is_snapshot_projection === true`
+    and `first.live_tail_supported === false`.
+
+## Rollout Plan
+
+1. Land the field on `TaskOutputReadResult`, the in-handler default
+   (`is_snapshot_projection: true`), the golden-test updates, and the e2e
+   client type/test updates in this PR.
+2. Update this spec § 7 `task/output/read` block to reference UPCR-2026-006
+   and document the field's contract.
+3. Follow-up: once the M8.7 disk-routed task stdout/stderr work ships, the
+   disk-routed constructor will set `is_snapshot_projection: false` and the
+   matching `live_tail_supported: true`. That follow-up does not require a
+   new UPCR — the field is already accepted on the wire by this UPCR.
+
+No client renegotiation is required for clients that follow the spec's
+"unknown fields MUST be ignored" rule. Clients that want to render the
+"this is a stale snapshot" hint in their UI should adopt the field on
+their next protocol-types update.
+
+## Decision
+
+Accepted by: M9 harness audit follow-up (coding-green).
+
+Decision notes: Accepted as the minimum additive contract change to close
+audit issue #707 (M9 req 7 P3). The new field gives clients a single,
+stable wire-level signal for snapshot vs. live-tail semantics that does
+not depend on enumerating an open `source` enum or parsing free-form
+`limitations[]` strings. The field is required so servers cannot
+accidentally omit it and so clients can rely on it without an
+"unspecified means false" fallback.

--- a/e2e/lib/m9-ws-client.ts
+++ b/e2e/lib/m9-ws-client.ts
@@ -94,6 +94,11 @@ export interface TaskOutputReadResult {
   truncated: boolean;
   complete: boolean;
   live_tail_supported: boolean;
+  // Audit issue #707 / accepted UPCR-2026-006: true when the result was
+  // projected from the task ledger snapshot rather than a live disk-routed
+  // output stream. Cursors returned alongside `is_snapshot_projection: true`
+  // are advisory; a fresh read may produce a different snapshot.
+  is_snapshot_projection: boolean;
   task_status: string;
   runtime_state: string;
   lifecycle_state: string;

--- a/e2e/tests/m9-protocol-task-output-read.spec.ts
+++ b/e2e/tests/m9-protocol-task-output-read.spec.ts
@@ -132,6 +132,11 @@ test.describe("M9 protocol — task/output/read", () => {
       expect(first.session_id).toBe(sid);
       expect(first.task_id).toBe(taskId);
       expect(first.source).toBe("runtime_projection");
+      // Audit issue #707 / accepted UPCR-2026-006: clients must be able to
+      // distinguish snapshot projection from a (future) live-tail read on the
+      // wire without parsing limitations[] strings.
+      expect(first.is_snapshot_projection).toBe(true);
+      expect(first.live_tail_supported).toBe(false);
       expect(first.cursor.offset).toBe(0);
       expect(first.next_cursor.offset).toBeGreaterThan(first.cursor.offset);
       expect(Buffer.byteLength(first.text, "utf8")).toBe(first.bytes_read);


### PR DESCRIPTION
## Summary

Adds a single required boolean `is_snapshot_projection` to the
`TaskOutputReadResult` payload returned by `task/output/read`, closing
M9 harness audit issue #707 (M9 req 7 P3).

- New required field `is_snapshot_projection: bool` on
  `TaskOutputReadResult` (`crates/octos-core/src/ui_protocol.rs`). Plain
  `bool` with no `serde(default)`, matching the existing
  `live_tail_supported` / `truncated` / `complete` patterns.
- The CLI handler `project_task_output`
  (`crates/octos-cli/src/api/ui_protocol_task_output.rs`) sets
  `is_snapshot_projection: true` for every read, since today's runtime
  exclusively serves snapshot projections of the task ledger.
- New UPCR-2026-006 (`docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_006_TASK_OUTPUT_SNAPSHOT_PROJECTION.md`)
  documents the additive contract: `true` means cursors are advisory
  across reads (a fresh `task/output/read` may project a different
  snapshot); `false` means cursors are stable resume offsets in a live
  byte-monotonic source. The field is intentionally separate from
  `source` (open enum, may grow new variants) and from
  `limitations[].code` (free-form registry).
- Spec § 7 `task/output/read` block documents the field and references
  UPCR-2026-006. The introduction list of accepted UPCRs is extended
  with UPCR-2026-006.
- Golden tests in `crates/octos-core/src/ui_protocol.rs` and
  `crates/octos-cli/src/api/ui_protocol_task_output.rs` pin the wire
  shape (`"is_snapshot_projection": true`).
- E2E client type (`e2e/lib/m9-ws-client.ts`) and the
  `m9-protocol-task-output-read.spec.ts` round-trip test extended with
  the new field.

The change is purely additive: no existing field, method, notification,
enum variant, capability flag, or protocol identifier is modified.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p octos-core ui_protocol` (39 passed)
- [x] `cargo test -p octos-cli api::ui_protocol --features api` (168 passed)
- [x] `cargo test --workspace` (no real failures; flaky
  `process_manager::tests::should_report_free_port_as_available` passes
  in isolation, unrelated to this change)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/check-ui-protocol-upcr.sh` (UPCR coverage detected)
- [x] codex 2nd-opinion review (one wording nit on cursor description in
  spec § 7 fixed before commit)
- [ ] e2e `m9-protocol-task-output-read.spec.ts` round-trip in CI
- [ ] downstream client codegen / TS type updates pick up the new field

## Audit & UPCR references

- Audit issue: #707 (M9 req 7 P3 from
  `docs/OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md`)
- New UPCR: `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_006_TASK_OUTPUT_SNAPSHOT_PROJECTION.md`
- Spec section: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 7
  `task/output/read`

DO NOT auto-merge.