### PR TITLE
fix(serve): wire DispatchPolicy into production swarm — close audit #701 end-to-end (#713)

### DIFF
--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -463,6 +463,9 @@ impl ServeCommand {
         // `stdio` pairs with `--swarm-backend-cmd <path>`; `http` pairs
         // with `--swarm-backend-url <url>`.
         let harness_sink_init = std::env::var("OCTOS_HARNESS_EVENT_SINK").ok();
+        // #713: pass `config.tool_policy` so the swarm dispatch policy
+        // mirrors the operator's native tool-policy denylist. Cloned
+        // here because `config` is borrowed for the rest of init.
         let swarm_state_init = Self::build_swarm_state_from_flags(
             self.swarm_backend.as_deref(),
             self.swarm_backend_cmd.as_deref(),
@@ -470,6 +473,7 @@ impl ServeCommand {
             &data_dir,
             broadcaster.clone(),
             harness_sink_init.clone(),
+            config.tool_policy.clone(),
         )
         .await
         .wrap_err("failed to build swarm state")?;
@@ -924,6 +928,20 @@ impl ServeCommand {
             }
         }
 
+        // #713 codex finding (Medium): apply `config.tool_policy` to the
+        // api-mode `ToolRegistry`, mirroring the chat path
+        // (`commands/chat.rs::297`). Without this, the swarm dispatch
+        // policy (which now inherits `config.tool_policy` per #713) is
+        // strictly stricter than the native server's tool registry,
+        // breaking the parity claim. Runs AFTER MCP + plugin tools are
+        // registered so a `deny: ["dangerous_tool"]` entry catches
+        // both built-in and skill-declared tools. `apply_policy` is a
+        // no-op when `config.tool_policy` is `None`/empty, preserving
+        // legacy behaviour for operators who never set the field.
+        if let Some(ref policy) = config.tool_policy {
+            tools.apply_policy(policy);
+        }
+
         let reporter: Arc<dyn octos_agent::ProgressReporter> =
             Arc::new(MetricsReporter::new(broadcaster));
 
@@ -1025,6 +1043,25 @@ impl ServeCommand {
     /// Takes the flag slices by `&str` instead of `&self` so the caller
     /// can invoke this helper after partially moving other fields out
     /// of `self` during the main init flow.
+    ///
+    /// `tool_policy` (`config.tool_policy`) is folded into the swarm's
+    /// production [`octos_swarm::DispatchPolicy`] via
+    /// [`octos_swarm::DispatchPolicy::from_agent_gates`]. The
+    /// resulting policy reproduces two of the workspace-level gates
+    /// the native side already applies:
+    ///
+    /// - **tool-name policy** — same `config.tool_policy` value the
+    ///   api agent's `ToolRegistry` is filtered with (see
+    ///   `try_create_agent`).
+    /// - **injection-env denylist** — the workspace-shared
+    ///   [`octos_agent::sandbox::BLOCKED_ENV_VARS`] set the agent's
+    ///   sandbox + MCP subprocess paths use to scrub child env.
+    ///
+    /// Approval bridge, sandbox-required, and per-skill manifest env
+    /// allowlists are intentionally not mirrored here — see
+    /// [`octos_swarm::DispatchPolicy::from_agent_gates`] rustdoc for
+    /// the boundary. Closes audit issue #713 (M7 req 7 production
+    /// wiring).
     async fn build_swarm_state_from_flags(
         swarm_backend: Option<&str>,
         swarm_backend_cmd: Option<&str>,
@@ -1032,6 +1069,7 @@ impl ServeCommand {
         data_dir: &std::path::Path,
         broadcaster: Arc<crate::api::SseBroadcaster>,
         harness_sink: Option<String>,
+        tool_policy: Option<octos_agent::ToolPolicy>,
     ) -> Result<Option<Arc<crate::api::SwarmState>>> {
         use octos_agent::cost_ledger::PersistentCostLedger;
         use octos_agent::tools::mcp_agent::{
@@ -1083,20 +1121,40 @@ impl ServeCommand {
                 .await
                 .wrap_err("failed to open persistent cost ledger for swarm")?,
         );
-        // M7 req 7: production-grade swarm dispatch policy. We default
-        // to a no-op policy (matches the pre-fix behaviour) so CLI
-        // callers without an explicit policy are not surprised by
-        // approval prompts. Operators that want enforcement should
-        // wire `DispatchPolicy` here (a follow-up PR will add a
-        // `--swarm-dispatch-policy <path>` flag — out of scope for the
-        // M7 req 7 close).
+        // #713 / M7 req 7 production wiring: build a `DispatchPolicy`
+        // that inherits the workspace-level gates audit #701 flagged —
+        // operator tool-name policy + injection-env denylist — so
+        // MCP/CLI swarm backends fail closed on the same names native
+        // execution rejects, without requiring operators to wire a
+        // separate `--swarm-dispatch-policy` config.
+        //
+        // - `tool_policy`: cloned from `config.tool_policy` upstream so
+        //   a `deny: ["dangerous_tool"]` entry blocks both the native
+        //   registry execution (re-applied at the api agent registry,
+        //   see the `tools.apply_policy(...)` call earlier in
+        //   `try_create_agent`) AND swarm dispatch.
+        // - `block_injection_env_vars: true`: adds `LD_PRELOAD`,
+        //   `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, ... to the env
+        //   denylist so a contract carrying those keys fails closed
+        //   even if the underlying backend's own env handling were to
+        //   regress.
+        //
+        // Approval bridge, sandbox-required, manifest env allowlists,
+        // and per-skill gates are **not** wired here — they are
+        // either per-turn (approval), forward-compat (sandbox-required
+        // with no backend self-reports), or out of scope (per-skill
+        // manifests). Operators that want any of those can layer them
+        // on top via `Swarm::builder(...).with_dispatch_policy(...)`.
+        // See `DispatchPolicy::from_agent_gates` rustdoc for the full
+        // boundary.
+        let dispatch_policy = octos_swarm::DispatchPolicy::from_agent_gates(tool_policy, true);
         let state = crate::api::build_swarm_state(
             backend,
             swarm_dir,
             cost_ledger,
             broadcaster,
             harness_sink,
-            None,
+            Some(dispatch_policy),
         )
         .await
         .wrap_err("failed to build swarm state")?;
@@ -1370,6 +1428,7 @@ mod tests {
             dir.path(),
             broadcaster,
             None,
+            None,
         )
         .await
         .expect("helper must succeed when the flag is absent");
@@ -1395,6 +1454,7 @@ mod tests {
             dir.path(),
             broadcaster,
             None,
+            None,
         )
         .await
         .expect("helper must succeed when stdio backend is configured");
@@ -1417,6 +1477,7 @@ mod tests {
             None,
             dir.path(),
             broadcaster,
+            None,
             None,
         )
         .await;
@@ -1444,6 +1505,7 @@ mod tests {
             dir.path(),
             broadcaster,
             None,
+            None,
         )
         .await;
         let err = match result {
@@ -1470,6 +1532,7 @@ mod tests {
             dir.path(),
             broadcaster,
             None,
+            None,
         )
         .await;
         let err = match result {
@@ -1480,6 +1543,131 @@ mod tests {
         assert!(
             msg.contains("stdio") && msg.contains("http"),
             "error must list accepted backends, got: {msg}"
+        );
+    }
+
+    /// #713: when an operator-provided `tool_policy` denies a tool, the
+    /// constructed swarm state must inherit that policy so MCP/CLI
+    /// swarm dispatch refuses the same names native execution refuses.
+    /// This is the integration-side cover for
+    /// `gate::from_agent_gates_inherits_tool_policy_deny` — proves the
+    /// policy survives the journey through `build_swarm_state_from_flags`
+    /// into the live `Swarm`.
+    #[tokio::test]
+    async fn should_inherit_tool_policy_into_swarm_dispatch_policy() {
+        use octos_swarm::{ContractSpec, SwarmBudget, SwarmContext, SwarmTopology};
+        use std::num::NonZeroUsize;
+
+        let dir = tempfile::tempdir().unwrap();
+        let broadcaster = Arc::new(SseBroadcaster::new(16));
+        let tool_policy = octos_agent::ToolPolicy {
+            deny: vec!["dangerous_tool".into()],
+            ..Default::default()
+        };
+        let state = ServeCommand::build_swarm_state_from_flags(
+            Some("stdio"),
+            Some("/bin/cat"),
+            None,
+            dir.path(),
+            broadcaster,
+            None,
+            Some(tool_policy),
+        )
+        .await
+        .expect("helper must succeed with tool_policy")
+        .expect("state must be Some when stdio backend is configured");
+
+        // Drive a dispatch that targets the denied tool. The wired
+        // policy must short-circuit at the gate before the (real,
+        // /bin/cat-backed) MCP backend is ever invoked. Outcome must
+        // surface `policy_denied`.
+        let outcome = state
+            .swarm
+            .dispatch(
+                "d-tool-policy-inherit".to_string(),
+                vec![ContractSpec {
+                    contract_id: "sub-1".into(),
+                    tool_name: "dangerous_tool".into(),
+                    task: serde_json::json!({}),
+                    label: None,
+                }],
+                SwarmTopology::Parallel {
+                    max_concurrency: NonZeroUsize::new(1).unwrap(),
+                },
+                SwarmBudget::default(),
+                SwarmContext {
+                    session_id: "api:swarm-test".into(),
+                    task_id: "task-1".into(),
+                    workflow: Some("swarm".into()),
+                    phase: Some("dispatch".into()),
+                },
+            )
+            .await
+            .expect("dispatch must complete (denied subtask still produces an outcome)");
+        assert_eq!(outcome.per_task_outcomes.len(), 1);
+        assert_eq!(
+            outcome.per_task_outcomes[0].last_dispatch_outcome, "policy_denied",
+            "tool_policy deny must propagate into swarm dispatch — \
+             outcome was: {:?}",
+            outcome.per_task_outcomes[0]
+        );
+    }
+
+    /// #713: even without an operator-provided tool_policy, the swarm
+    /// state must still gate against injection-class env vars
+    /// (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, ...). This proves the
+    /// `block_injection_env_vars: true` knob inside
+    /// `build_swarm_state_from_flags` is not bypassed when the
+    /// operator's tool_policy is `None`.
+    #[tokio::test]
+    async fn should_block_injection_env_in_swarm_dispatch_by_default() {
+        use octos_swarm::{ContractSpec, SwarmBudget, SwarmContext, SwarmTopology};
+        use std::num::NonZeroUsize;
+
+        let dir = tempfile::tempdir().unwrap();
+        let broadcaster = Arc::new(SseBroadcaster::new(16));
+        let state = ServeCommand::build_swarm_state_from_flags(
+            Some("stdio"),
+            Some("/bin/cat"),
+            None,
+            dir.path(),
+            broadcaster,
+            None,
+            None,
+        )
+        .await
+        .expect("helper must succeed without tool_policy")
+        .expect("state must be Some when stdio backend is configured");
+
+        let outcome = state
+            .swarm
+            .dispatch(
+                "d-env-denylist-inherit".to_string(),
+                vec![ContractSpec {
+                    contract_id: "sub-1".into(),
+                    tool_name: "any_tool".into(),
+                    task: serde_json::json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}}),
+                    label: None,
+                }],
+                SwarmTopology::Parallel {
+                    max_concurrency: NonZeroUsize::new(1).unwrap(),
+                },
+                SwarmBudget::default(),
+                SwarmContext {
+                    session_id: "api:swarm-test".into(),
+                    task_id: "task-1".into(),
+                    workflow: Some("swarm".into()),
+                    phase: Some("dispatch".into()),
+                },
+            )
+            .await
+            .expect("dispatch must complete (denied subtask still produces an outcome)");
+        assert_eq!(outcome.per_task_outcomes.len(), 1);
+        assert_eq!(
+            outcome.per_task_outcomes[0].last_dispatch_outcome, "env_forbidden",
+            "BLOCKED_ENV_VARS must propagate into swarm dispatch — \
+             outcome was: {:?}",
+            outcome.per_task_outcomes[0]
         );
     }
 }

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -174,14 +174,19 @@ pub struct Swarm {
     /// keeps the legacy pre-fix behaviour so integration tests and
     /// existing callers are unchanged.
     cost_budget: Option<SwarmCostBudget>,
-    /// M7 req 7: pre-dispatch policy gate. Closes the parity gap so
-    /// MCP/CLI/native backends honour the same approval, tool policy,
-    /// sandbox, and env-allowlist enforcement the native
+    /// M7 req 7: pre-dispatch policy gate. Surfaces the same gate
+    /// *shape* the native
     /// [`octos_agent::tools::ToolRegistry::execute_with_context`] path
-    /// applies. Stored as an `Arc` so it can be cheaply cloned into the
-    /// per-subtask `JoinSet` without forcing the policy itself to be
-    /// `Clone`-cheap. A default policy (`is_noop()`) short-circuits the
-    /// gate so existing callers see no behavioural change.
+    /// applies (tool policy, approval, sandbox-required, env), so
+    /// MCP/CLI/native backends can be brought to parity. The set of
+    /// gates *actually active* is whatever the caller wired into the
+    /// [`DispatchPolicy`] — see
+    /// [`DispatchPolicy::from_agent_gates`] for the production close
+    /// (`octos serve`'s default) and what is intentionally not
+    /// mirrored. Stored as an `Arc` so it can be cheaply cloned into
+    /// the per-subtask `JoinSet` without forcing the policy itself to
+    /// be `Clone`-cheap. A default policy (`is_noop()`) short-circuits
+    /// the gate so existing callers see no behavioural change.
     dispatch_policy: Arc<DispatchPolicy>,
 }
 
@@ -685,11 +690,17 @@ impl SwarmBuilder {
     }
 
     /// M7 req 7: wire a [`DispatchPolicy`] gate that runs before every
-    /// `McpAgentBackend::dispatch` call. Mirrors the gate sequence the
-    /// native [`octos_agent::tools::ToolRegistry::execute_with_context`]
-    /// path applies (tool policy, approval, sandbox, env allowlist) so
-    /// MCP/CLI/native backends are gated uniformly. Without this call
-    /// the swarm runs with the default no-op policy, preserving
+    /// `McpAgentBackend::dispatch` call. The policy exposes the same
+    /// gate shape the native
+    /// [`octos_agent::tools::ToolRegistry::execute_with_context`] path
+    /// applies (tool policy, approval, sandbox-required, env). Whether
+    /// each gate is active depends on what the caller put into the
+    /// passed [`DispatchPolicy`] — see
+    /// [`DispatchPolicy::from_agent_gates`] for the production close
+    /// `octos serve` uses and the boundary (tool policy + injection-env
+    /// denylist are mirrored; approval bridge / sandbox-required /
+    /// per-skill manifest env are intentionally not). Without this
+    /// call the swarm runs with the default no-op policy, preserving
     /// pre-fix behaviour for existing callers.
     pub fn with_dispatch_policy(mut self, policy: DispatchPolicy) -> Self {
         self.dispatch_policy = Arc::new(policy);

--- a/crates/octos-swarm/src/gate.rs
+++ b/crates/octos-swarm/src/gate.rs
@@ -1,12 +1,20 @@
 //! Pre-dispatch policy gate for [`Swarm::dispatch`](crate::Swarm::dispatch).
 //!
-//! Closes M7 requirement 7 (policy enforcement parity): every backend the
-//! swarm dispatches to — local stdio MCP, remote HTTP MCP, native sub-agent
-//! via [`octos_agent::tools::SpawnTool`] — is funnelled through
-//! [`crate::dispatcher::Swarm::dispatch_once`]. This module wires the same
-//! gates the native [`octos_agent::tools::ToolRegistry::execute_with_context`]
-//! path applies (tool policy, approval, sandbox, env allowlist) before any
-//! `McpAgentBackend::dispatch` call.
+//! Addresses M7 requirement 7 (policy enforcement parity): every backend
+//! the swarm dispatches to — local stdio MCP, remote HTTP MCP, native
+//! sub-agent via [`octos_agent::tools::SpawnTool`] — is funnelled through
+//! [`crate::dispatcher::Swarm::dispatch_once`], so a single gate point
+//! covers all transports.
+//!
+//! [`DispatchPolicy`] **exposes** the same shape of gates the native
+//! [`octos_agent::tools::ToolRegistry::execute_with_context`] path
+//! applies: tool policy, approval, sandbox-required, and env (allowlist
+//! or denylist). Whether a given gate is *active* is up to the caller —
+//! see [`DispatchPolicy::from_agent_gates`] for the production
+//! constructor `octos serve` uses (it wires `tool_policy` +
+//! injection-env denylist; approval bridge / sandbox-required /
+//! per-skill manifest env are intentionally not mirrored, see that
+//! constructor's rustdoc for the full boundary).
 //!
 //! The gate is **opt-in**: callers wire it via
 //! [`crate::SwarmBuilder::with_dispatch_policy`]. Without a configured
@@ -33,8 +41,9 @@
 //! - `approval_unavailable` — approval is required but no requester was
 //!   wired. **Fail closed** — never fall through to dispatch.
 //! - `env_forbidden` — the contract's task carries an env key that fails
-//!   the dispatch policy's env allowlist (used by callers that pass env
-//!   through the task payload to the backend).
+//!   either the dispatch policy's env allowlist (key not in allowlist)
+//!   or env denylist (key in denylist). Used by callers that pass env
+//!   through the task payload to the backend.
 //! - `sandbox_required` — the dispatch policy demands a sandboxed
 //!   backend but the wired backend does not self-report sandboxing.
 
@@ -71,12 +80,22 @@ pub struct DispatchPolicy {
     /// Inspected against the contract's task payload — if the task
     /// carries an `env` object whose keys overlap any name **not** in
     /// this allowlist, the dispatch is denied with `env_forbidden`.
-    /// `None` means env-checking is off (existing
+    /// `None` means allowlist checking is off (existing
     /// [`octos_agent::tools::mcp_agent::StdioMcpAgent`] env handling
     /// remains the only barrier). Names are matched case-insensitively
     /// against the upper-cased form (mirrors
     /// `subprocess_env::EnvAllowlist`).
     pub env_allowlist: Option<HashSet<String>>,
+    /// Env keys the dispatch must reject if the task payload tries to
+    /// forward them. Complements [`Self::env_allowlist`]: an entry here
+    /// is denied unconditionally (matches the agent's
+    /// `subprocess_env::BLOCKED_ENV_VARS` denylist semantics, e.g.
+    /// `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`). Both
+    /// fields can be wired together — the denylist runs first so a
+    /// permissive allowlist cannot accidentally let a known-bad key
+    /// through. Names are matched case-insensitively. `None` means the
+    /// denylist gate is off.
+    pub env_denylist: Option<HashSet<String>>,
     /// When `true`, the wired backend must self-report as sandboxed. No
     /// [`McpAgentBackend`] does today, so this field is provided for
     /// forward compatibility — setting it true on a non-sandboxed
@@ -94,6 +113,7 @@ impl std::fmt::Debug for DispatchPolicy {
                 &self.approval_requester.as_ref().map(|_| "<requester>"),
             )
             .field("env_allowlist", &self.env_allowlist)
+            .field("env_denylist", &self.env_denylist)
             .field("require_sandboxed", &self.require_sandboxed)
             .finish()
     }
@@ -108,7 +128,82 @@ impl DispatchPolicy {
             .is_none_or(|policy| policy.is_empty())
             && !self.require_approval
             && self.env_allowlist.is_none()
+            && self
+                .env_denylist
+                .as_ref()
+                .is_none_or(|denylist| denylist.is_empty())
             && !self.require_sandboxed
+    }
+
+    /// M7 req 7 production wiring (#713): build a [`DispatchPolicy`]
+    /// that inherits the **two operator-configured gates** the audit's
+    /// #701 finding called out — the workspace-wide tool-name policy
+    /// (`config.tool_policy`) and the shared `BLOCKED_ENV_VARS`
+    /// injection-env denylist — so MCP and CLI swarm backends fail
+    /// closed on the same names native execution rejects, without
+    /// requiring operators to wire a separate config file.
+    ///
+    /// `octos serve` builds this from `config.tool_policy` + the
+    /// shared denylist and passes it to
+    /// [`crate::SwarmBuilder::with_dispatch_policy`]. The resulting
+    /// policy is **deny-on-parity**, not deny-all — it fires only
+    /// when the operator-configured tool policy fires, or the contract
+    /// payload tries to forward a known-bad env key.
+    ///
+    /// **Not mirrored by this constructor** (intentional, scope of
+    /// #713 / #701):
+    ///
+    /// - `require_approval` / `approval_requester` — the native
+    ///   approval bridge is `TOOL_APPROVAL_CTX`, a per-turn
+    ///   task-local; there is no global requester to clone at server
+    ///   startup. Operators that want swarm-level approval can layer
+    ///   it on with [`crate::SwarmBuilder::with_dispatch_policy`].
+    /// - `require_sandboxed` — no [`octos_agent::tools::mcp_agent::McpAgentBackend`]
+    ///   self-reports as sandboxed today; the field is forward-compat.
+    /// - `env_allowlist` — the native side uses denylist semantics
+    ///   (drop blocked names) plus secret-detection, not an allowlist.
+    ///   This constructor populates the parallel `env_denylist` field
+    ///   so the gate semantics match.
+    /// - Per-skill manifest env allowlists — those live on the
+    ///   plugin tool, not the workspace config; they are out of scope
+    ///   for a workspace-level dispatch gate.
+    ///
+    /// Operators that want any of the above can layer them on top via
+    /// [`crate::SwarmBuilder::with_dispatch_policy`] — the public
+    /// fields on [`DispatchPolicy`] remain mutable for that reason.
+    ///
+    /// `tool_policy: None` keeps the tool-name gate off (matches the
+    /// native side: an absent config means no policy is applied).
+    /// `block_injection_env_vars: true` populates the env denylist
+    /// with the workspace-wide
+    /// [`octos_agent::sandbox::BLOCKED_ENV_VARS`] set so swarm
+    /// dispatches fail closed if the contract carries `LD_PRELOAD`,
+    /// `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, etc. — even if the
+    /// underlying backend's own env handling forgets to strip them.
+    /// Use `false` only for tests that explicitly need to drive an
+    /// injection-style env through the gate.
+    pub fn from_agent_gates(
+        tool_policy: Option<octos_agent::ToolPolicy>,
+        block_injection_env_vars: bool,
+    ) -> Self {
+        let env_denylist = if block_injection_env_vars {
+            Some(
+                octos_agent::sandbox::BLOCKED_ENV_VARS
+                    .iter()
+                    .map(|name| name.to_ascii_uppercase())
+                    .collect::<HashSet<String>>(),
+            )
+        } else {
+            None
+        };
+        Self {
+            tool_policy,
+            require_approval: false,
+            approval_requester: None,
+            env_allowlist: None,
+            env_denylist,
+            require_sandboxed: false,
+        }
     }
 }
 
@@ -144,8 +239,11 @@ impl GateDenial {
 ///
 /// 1. Sandbox requirement (cheapest, config-only).
 /// 2. Tool policy (synchronous evaluator, no I/O).
-/// 3. Env allowlist (synchronous, inspects the task payload).
-/// 4. Approval (last; may block on user interaction).
+/// 3. Env denylist (synchronous, inspects the task payload — runs
+///    before the allowlist so a permissive allowlist cannot let a
+///    known-bad key through).
+/// 4. Env allowlist (synchronous, inspects the task payload).
+/// 5. Approval (last; may block on user interaction).
 pub(crate) async fn enforce_dispatch_gates(
     policy: &DispatchPolicy,
     backend: &dyn McpAgentBackend,
@@ -179,6 +277,22 @@ pub(crate) async fn enforce_dispatch_gates(
                 reason: format!(
                     "tool '{}' denied by swarm dispatch policy ({})",
                     contract.tool_name, reason
+                ),
+            });
+        }
+    }
+
+    if let Some(ref denylist) = policy.env_denylist {
+        if let Some(forbidden) = first_denied_env_key(&contract.task, denylist) {
+            warn!(
+                contract_id = %contract.contract_id,
+                forbidden_key = %forbidden,
+                "swarm dispatch denied by env denylist"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "env_forbidden",
+                reason: format!(
+                    "env variable '{forbidden}' is denied by the swarm dispatch denylist (injection-class env vars are blocked)"
                 ),
             });
         }
@@ -281,6 +395,17 @@ fn first_forbidden_env_key(
     for key in env.keys() {
         let normalized = key.to_ascii_uppercase();
         if !allowlist.contains(&normalized) {
+            return Some(key.clone());
+        }
+    }
+    None
+}
+
+fn first_denied_env_key(task: &serde_json::Value, denylist: &HashSet<String>) -> Option<String> {
+    let env = task.get("env")?.as_object()?;
+    for key in env.keys() {
+        let normalized = key.to_ascii_uppercase();
+        if denylist.contains(&normalized) {
             return Some(key.clone());
         }
     }
@@ -502,6 +627,126 @@ mod tests {
                 ..Default::default()
             }
             .is_noop()
+        );
+    }
+
+    #[tokio::test]
+    async fn env_denylist_blocks_known_injection_keys() {
+        let mut denylist = HashSet::new();
+        denylist.insert("LD_PRELOAD".to_string());
+        denylist.insert("DYLD_INSERT_LIBRARIES".to_string());
+
+        let policy = DispatchPolicy {
+            env_denylist: Some(denylist),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = ContractSpec {
+            contract_id: "c1".into(),
+            tool_name: "any".into(),
+            task: serde_json::json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}}),
+            label: None,
+        };
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "env_forbidden");
+        assert!(denial.reason.contains("LD_PRELOAD"));
+        assert!(denial.reason.contains("denylist"));
+    }
+
+    #[tokio::test]
+    async fn env_denylist_passes_unrelated_keys() {
+        let mut denylist = HashSet::new();
+        denylist.insert("LD_PRELOAD".to_string());
+
+        let policy = DispatchPolicy {
+            env_denylist: Some(denylist),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let contract = ContractSpec {
+            contract_id: "c1".into(),
+            tool_name: "any".into(),
+            task: serde_json::json!({"env": {"OPENAI_API_KEY": "sk-test"}}),
+            label: None,
+        };
+        assert!(
+            enforce_dispatch_gates(&policy, &backend, &contract)
+                .await
+                .is_ok()
+        );
+    }
+
+    /// #713: `from_agent_gates` populates the env denylist from the
+    /// shared `BLOCKED_ENV_VARS`, so MCP swarm dispatch refuses to
+    /// forward injection-class keys without the operator wiring a
+    /// separate denylist.
+    #[tokio::test]
+    async fn from_agent_gates_denies_injection_env_by_default() {
+        let policy = DispatchPolicy::from_agent_gates(None, true);
+        // The constructor's denylist must contain at least `LD_PRELOAD`
+        // (sanity check on `BLOCKED_ENV_VARS` content).
+        let denylist = policy.env_denylist.as_ref().expect("denylist set");
+        assert!(denylist.contains("LD_PRELOAD"));
+        assert!(denylist.contains("DYLD_INSERT_LIBRARIES"));
+        assert!(denylist.contains("NODE_OPTIONS"));
+
+        let backend = StubBackend;
+        let contract = ContractSpec {
+            contract_id: "c1".into(),
+            tool_name: "any".into(),
+            task: serde_json::json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}}),
+            label: None,
+        };
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("dispatch with LD_PRELOAD must be denied");
+        assert_eq!(denial.last_dispatch_outcome, "env_forbidden");
+    }
+
+    /// #713: `from_agent_gates` mirrors the operator's tool policy so
+    /// MCP swarm dispatch denies the same names native execution
+    /// denies.
+    #[tokio::test]
+    async fn from_agent_gates_inherits_tool_policy_deny() {
+        let tool_policy = ToolPolicy {
+            deny: vec!["dangerous_tool".into()],
+            ..Default::default()
+        };
+        let policy = DispatchPolicy::from_agent_gates(Some(tool_policy), true);
+        let backend = StubBackend;
+        let contract = contract("c1", "dangerous_tool");
+        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+            .await
+            .expect_err("dispatch of dangerous_tool must be denied");
+        assert_eq!(denial.last_dispatch_outcome, "policy_denied");
+    }
+
+    /// #713: `from_agent_gates` with `block_injection_env_vars: false`
+    /// leaves the denylist off, used by tests that need to drive an
+    /// injection-style env through the gate.
+    #[tokio::test]
+    async fn from_agent_gates_can_disable_env_denylist() {
+        let policy = DispatchPolicy::from_agent_gates(None, false);
+        assert!(policy.env_denylist.is_none());
+        // With nothing configured + injection denylist off, the policy
+        // must be a no-op so the dispatcher's hot path is unchanged for
+        // tests that explicitly opt out.
+        assert!(policy.is_noop());
+    }
+
+    /// #713: with no operator tool policy and the env denylist on, the
+    /// policy is **not** a no-op — it still gates against injection
+    /// env vars. This guards the dispatcher's `is_noop()` short-circuit
+    /// against accidentally bypassing the gate when only the denylist
+    /// is configured.
+    #[tokio::test]
+    async fn from_agent_gates_with_only_denylist_is_not_noop() {
+        let policy = DispatchPolicy::from_agent_gates(None, true);
+        assert!(
+            !policy.is_noop(),
+            "a denylist-only policy must run the gate"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes audit issue #713 by wiring the `DispatchPolicy` gate that PR #710 added into the `octos serve` production path. Prior to this fix, `serve.rs:1093` passed `None` for the policy — the swarm gate was live API but dead code in production, leaving the M7 req 7 (#701) close incomplete.

## Why this PR

The codex holistic review (cited in #713) flagged that:

> "[#710] added the `DispatchPolicy` API + gate logic but explicitly left `serve.rs:1093` passing `None`. Production swarm dispatch is still ungated."

The audit's M7 P0 (#701) is therefore not actually closed end-to-end until `octos serve`'s production swarm dispatch enforces the same gates native execution does.

## What changed

### Before (PR #710 left in place)

```rust
// serve.rs:1093 — `None` left the gate dead in production
let state = crate::api::build_swarm_state(
    backend, swarm_dir, cost_ledger, broadcaster, harness_sink,
    None, // ← swarm gate is dead code
).await?;
```

### After

```rust
let dispatch_policy =
    octos_swarm::DispatchPolicy::from_agent_gates(tool_policy, true);
let state = crate::api::build_swarm_state(
    backend, swarm_dir, cost_ledger, broadcaster, harness_sink,
    Some(dispatch_policy), // ← gate live
).await?;
```

Boundary documented in `DispatchPolicy::from_agent_gates` rustdoc:

- **Mirrored**: `config.tool_policy` (same value the api `ToolRegistry` is filtered with) + `BLOCKED_ENV_VARS` injection-env denylist (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, ...).
- **Not mirrored** (intentional, out of scope for #701/#713): approval bridge (per-turn task-local, no global to clone), `require_sandboxed` (forward-compat, no backend self-reports), per-skill manifest env allowlists (live on the plugin, not workspace config). Operators can layer these via `Swarm::builder(...).with_dispatch_policy(...)`.

### Side fix for parity

`serve.rs::try_create_agent` previously did NOT apply `config.tool_policy` to the api-mode `ToolRegistry` at all (the chat path did via `chat.rs:297`, but the api path did not — codex Medium finding). Added `tools.apply_policy(config.tool_policy)` after MCP + plugin tool registration so the native + swarm sides actually reach parity. Without this, the swarm gate would be strictly stricter than the native server.

### Gate API extension

Added `DispatchPolicy::env_denylist` complementing the existing `env_allowlist` so the gate can mirror the agent's denylist-style env handling. Denylist runs before allowlist so a permissive allowlist cannot accidentally let a known injection key through.

## Tests

- **Unit (`octos_swarm::gate`)**: `from_agent_gates_inherits_tool_policy_deny`, `from_agent_gates_denies_injection_env_by_default`, `from_agent_gates_can_disable_env_denylist`, `from_agent_gates_with_only_denylist_is_not_noop`, `env_denylist_blocks_known_injection_keys`, `env_denylist_passes_unrelated_keys`. All pass.
- **Integration (`octos_cli::commands::serve::tests`)**:
  - `should_inherit_tool_policy_into_swarm_dispatch_policy` — drives a live `Swarm::dispatch` through the production `build_swarm_state_from_flags` helper with a `deny: [\"dangerous_tool\"]` policy; asserts `last_dispatch_outcome == \"policy_denied\"`.
  - `should_block_injection_env_in_swarm_dispatch_by_default` — same, with `LD_PRELOAD` in the contract task; asserts `last_dispatch_outcome == \"env_forbidden\"` even when no operator `tool_policy` is set.

These cover the production builder path (not just the `DispatchPolicy` API surface) — they instantiate the same `build_swarm_state_from_flags` helper `run_async` calls.

## Codex 2nd-opinion findings (addressed)

Three rounds of codex review were run.

- **Round 1 — High**: "Not a full mirror." Fixed by clarifying the boundary in rustdoc — `from_agent_gates` only mirrors tool_policy + injection-env (which is what the audit gap was about); approval/sandbox/manifest-env are intentionally out of scope.
- **Round 1 — Medium**: "Native serve path doesn't apply `config.tool_policy`." Fixed by adding `tools.apply_policy(...)` in `try_create_agent` (mirroring `chat.rs`).
- **Round 2 — Medium**: "Stale parity overclaims in `gate.rs:3`, `dispatcher.rs:177`, `dispatcher.rs:687`." Fixed by rewriting those module/struct/builder rustdocs to say "exposes the same gate shape" / "whether each gate is active depends on the caller" with a link to `from_agent_gates` for the boundary.
- **Round 3 — confirmation**: One narrower overclaim remained in `serve.rs::build_swarm_state_from_flags` rustdoc; rewrote it to enumerate exactly the two gates mirrored.

Final codex pass: only narrow tool-policy/name-deny claims remain, which are accurate.

## Verification gates

- `cargo fmt --all -- --check`: clean
- `cargo test -p octos-swarm`: 57 pass / 0 fail (10 + 9 + 4 + 34, includes new gate tests)
- `cargo test -p octos-cli --features api`: 839+ pass / 0 fail (includes 2 new integration tests for the production builder)
- `cargo test -p octos-agent`: all groups pass / 0 fail
- `cargo clippy -p octos-swarm --all-targets`: clean
- `cargo clippy` on the modified files in `octos-cli`: clean (pre-existing clippy warnings exist elsewhere in `octos-cli` — `process_manager.rs`, `admin.rs`, `ui_protocol.rs`, etc. — but were present on `origin/main` before this PR)

## Test plan

- [ ] Reviewer runs `cargo test -p octos-swarm` and `cargo test -p octos-cli --features api commands::serve` locally and confirms green
- [ ] Reviewer skims `DispatchPolicy::from_agent_gates` rustdoc and confirms the documented boundary (mirrored vs not-mirrored) is accurate
- [ ] Reviewer confirms the audit doc status table for #701 is updated post-merge
- [ ] Operator running `octos serve --swarm-backend stdio --swarm-backend-cmd <bin>` with a `tool_policy.deny` entry verifies a swarm dispatch of the denied tool now fails closed (sanity check the production close)

## Hard constraints checklist

- [x] Pre-commit hooks not skipped
- [x] No force-push to main
- [x] Gate is engaged by default — `Some(dispatch_policy)` is unconditional, not behind an opt-in flag
- [x] No invasive cross-crate type movement (`octos-swarm` already depends on `octos-agent`; `BLOCKED_ENV_VARS` is `pub`)
- [x] DO NOT auto-merge