### PR TITLE
feat(ui_protocol): type reason + ack_timeout on TurnInterruptResult (closes #721)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -164,6 +164,13 @@ Current M9 sandbox-parity decision:
   That UPCR closes M9 harness audit gap #707 by giving clients a single
   wire-level boolean for snapshot vs. live-tail semantics, independent of the
   open `source` enum and the free-form `limitations[]` registry.
+- The additive `reason`, `terminal_state`, and `ack_timeout` optional fields
+  on `TurnInterruptResult` are governed by accepted
+  [UPCR-2026-008](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_008_TURN_INTERRUPT_TYPED_FIELDS.md).
+  That UPCR closes M9 protocol-as-contract audit issue #721 by codifying the
+  diagnostic fields the `turn/interrupt` handler has been emitting since the
+  protocol shipped. The typed contract is now equivalent to the wire shape;
+  the canonical minimal `{ "interrupted": <bool> }` response is preserved.
 
 ## 5. Identity Model
 
@@ -296,6 +303,32 @@ Behavior:
 
 - if the turn is still running, server stops it and emits terminal state
 - if already completed, behavior should be idempotent and explicit
+
+Minimum result fields:
+
+- `interrupted` (`bool`)
+  `true` iff the server stopped the turn (or the turn had already been
+  interrupted). `false` iff the interrupt was declined or the turn was
+  already in a non-`interrupted` terminal state.
+
+Optional result fields from accepted `UPCR-2026-008`:
+
+- `reason` (`string`)
+  Non-terminal diagnostic explanation when `interrupted` is `false`. String
+  registry; initial value: `turn_id_mismatch`. Future values must be
+  registered via UPCR.
+- `terminal_state` (`string`)
+  Set when interrupt was sent against a turn that had already reached a
+  terminal state. String registry; values: `completed`, `errored`,
+  `interrupted`. Future values must be registered via UPCR.
+- `ack_timeout` (`bool`)
+  Set to `true` only when the server captured the interrupt and emitted the
+  wire-side terminal event but could not confirm client receipt within the
+  ack window. The interrupt itself is captured (`interrupted` is `true`);
+  only client-side receipt is uncertain. Omitted otherwise.
+
+The canonical minimal wire shape is preserved: when no diagnostic fields
+apply, the result is `{ "interrupted": <bool> }`.
 
 ### `approval/respond`
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -27,12 +27,13 @@ use octos_core::ui_protocol::{
     TaskListParams, TaskListResult, TaskOutputDeltaEvent, TaskRestartFromNodeParams,
     TaskRestartFromNodeResult, TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent,
     ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent,
-    TurnId, TurnInterruptParams, TurnStartParams, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
-    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
-    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiCursor, UiFileMutationNotice,
-    UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot,
-    UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata, UiWorkspacePaneEntry,
-    UiWorkspacePaneSnapshot, approval_cancelled_reasons, approval_kinds, progress_kinds,
+    TurnId, TurnInterruptParams, TurnInterruptResult, TurnStartParams,
+    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UiArtifactPaneItem, UiArtifactPaneSnapshot,
+    UiCommand, UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot,
+    UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent,
+    UiProgressMetadata, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot, approval_cancelled_reasons,
+    approval_kinds, progress_kinds,
 };
 use octos_core::{AgentId, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId};
 use serde::Serialize;
@@ -2103,21 +2104,22 @@ async fn handle_turn_interrupt(
             let _ = send_rpc_error(ws, Some(id), unknown_turn_error(&params.turn_id));
         }
         InterruptOutcome::Mismatch => {
-            let _ = send_rpc_result(
+            // Codified by accepted UPCR-2026-008: typed `reason` field on
+            // `TurnInterruptResult`. String registry value `turn_id_mismatch`.
+            let _ = send_typed_interrupt_result(
                 ws,
                 id,
-                json!({ "interrupted": false, "reason": "turn_id_mismatch" }),
+                TurnInterruptResult::declined("turn_id_mismatch"),
             );
         }
         InterruptOutcome::AlreadyTerminal(reason) => {
             let interrupted = matches!(reason, TerminalReason::Interrupted);
-            let _ = send_rpc_result(
+            // Codified by accepted UPCR-2026-008: typed `terminal_state` field
+            // on `TurnInterruptResult`. Values come from `TerminalReason`.
+            let _ = send_typed_interrupt_result(
                 ws,
                 id,
-                json!({
-                    "interrupted": interrupted,
-                    "terminal_state": reason.as_str(),
-                }),
+                TurnInterruptResult::already_terminal(reason.as_str(), interrupted),
             );
         }
         InterruptOutcome::AlreadyInterrupting => {
@@ -2125,7 +2127,7 @@ async fn handle_turn_interrupt(
             // awaiting ack. The terminal event is already guaranteed to be
             // emitted exactly once. Idempotent: report the same response shape
             // as the original caller will.
-            let _ = send_rpc_result(ws, id, json!({ "interrupted": true }));
+            let _ = send_typed_interrupt_result(ws, id, TurnInterruptResult::interrupted_ok());
         }
         InterruptOutcome::Captured { ack_rx } => {
             // State is now `Interrupting { ack }`; the turn task is wired to
@@ -2135,19 +2137,37 @@ async fn handle_turn_interrupt(
             // emission and could lose the wire-side event.
             let result = tokio::time::timeout(INTERRUPT_ACK_TIMEOUT, ack_rx).await;
             let payload = match result {
-                Ok(Ok(())) => json!({ "interrupted": true }),
+                Ok(Ok(())) => TurnInterruptResult::interrupted_ok(),
                 Ok(Err(_)) => {
                     // Sender dropped without ack — the task panicked or was
                     // cancelled before reaching the terminal arm. The state
                     // remains `Interrupting`; report timeout-style result so
                     // the caller knows the wire-side terminal is uncertain.
-                    json!({ "interrupted": true, "ack_timeout": true })
+                    // Codified by accepted UPCR-2026-008.
+                    TurnInterruptResult::ack_timed_out()
                 }
-                Err(_) => json!({ "interrupted": true, "ack_timeout": true }),
+                Err(_) => TurnInterruptResult::ack_timed_out(),
             };
-            let _ = send_rpc_result(ws, id, payload);
+            let _ = send_typed_interrupt_result(ws, id, payload);
         }
     }
+}
+
+/// Serialize a typed `TurnInterruptResult` and dispatch via `send_rpc_result`.
+///
+/// Falls back to a hand-built minimal result if serialization fails. The
+/// fallback path should be unreachable in practice — `TurnInterruptResult`
+/// has no field that can fail to serialize — but keeping the call infallible
+/// on the wire avoids leaving the caller without a response on a defensive
+/// path.
+fn send_typed_interrupt_result(
+    ws: &WsConnection,
+    id: String,
+    result: TurnInterruptResult,
+) -> Result<(), SendError> {
+    let value = serde_json::to_value(&result)
+        .unwrap_or_else(|_| json!({ "interrupted": result.interrupted }));
+    send_rpc_result(ws, id, value)
 }
 
 #[derive(Debug)]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1513,14 +1513,98 @@ impl TurnStartResult {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Typed result for `turn/interrupt`.
+///
+/// `interrupted` is the canonical boolean response. The three optional
+/// fields (`reason`, `terminal_state`, `ack_timeout`) carry diagnostic
+/// information the server has historically emitted via raw `json!` and are
+/// codified here under accepted `UPCR-2026-008`.
+///
+/// String registry for `reason` (when `interrupted` is `false`):
+/// - `turn_id_mismatch` — the turn_id sent does not match the active turn for
+///   the session.
+/// - `<terminal_state>` — set by `terminal_state` instead; `reason` stays
+///   `None` for the already-terminal case.
+///
+/// Future `reason` values must be added via a follow-up UPCR.
+///
+/// `terminal_state` is set when interrupt was sent against a turn that had
+/// already reached a terminal state. Values come from the server's terminal
+/// state enum and currently include `completed`, `errored`, and
+/// `interrupted`.
+///
+/// `ack_timeout` is set to `Some(true)` when the server captured the
+/// interrupt but could not confirm the wire-side terminal event was received
+/// within the ack window. It is omitted otherwise.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnInterruptResult {
     pub interrupted: bool,
+    /// Diagnostic reason when `interrupted` is `false` and the server has a
+    /// non-terminal explanation (e.g., `turn_id_mismatch`). String registry;
+    /// future values must be registered via UPCR.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Set when interrupt was sent against a turn that had already reached a
+    /// terminal state. Carries the terminal state name (`completed`,
+    /// `errored`, `interrupted`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_state: Option<String>,
+    /// `Some(true)` when the interrupt was captured but the wire-side ack of
+    /// the terminal event timed out. Indicates the server did finish the
+    /// interrupt but could not confirm client receipt within the ack window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ack_timeout: Option<bool>,
 }
 
 impl TurnInterruptResult {
+    /// Bare constructor preserved for back-compat: callers passing only the
+    /// boolean see no behavioural change.
     pub fn new(interrupted: bool) -> Self {
-        Self { interrupted }
+        Self {
+            interrupted,
+            reason: None,
+            terminal_state: None,
+            ack_timeout: None,
+        }
+    }
+
+    /// Successful interrupt of a running turn — the typical happy-path
+    /// response.
+    pub fn interrupted_ok() -> Self {
+        Self::new(true)
+    }
+
+    /// Interrupt declined with a diagnostic reason (e.g.,
+    /// `turn_id_mismatch`).
+    pub fn declined(reason: impl Into<String>) -> Self {
+        Self {
+            interrupted: false,
+            reason: Some(reason.into()),
+            terminal_state: None,
+            ack_timeout: None,
+        }
+    }
+
+    /// Interrupt against a turn that was already terminal. `interrupted` is
+    /// `true` only when the prior terminal was itself `interrupted`.
+    pub fn already_terminal(terminal_state: impl Into<String>, interrupted: bool) -> Self {
+        Self {
+            interrupted,
+            reason: None,
+            terminal_state: Some(terminal_state.into()),
+            ack_timeout: None,
+        }
+    }
+
+    /// Interrupt was captured but the wire-side ack timed out. Server still
+    /// emitted the terminal event; client just couldn't be confirmed.
+    pub fn ack_timed_out() -> Self {
+        Self {
+            interrupted: true,
+            reason: None,
+            terminal_state: None,
+            ack_timeout: Some(true),
+        }
     }
 }
 
@@ -3533,6 +3617,99 @@ mod tests {
             UiRpcResult::from_method_and_result(methods::TASK_OUTPUT_READ, value)
                 .expect("decode task/output/read result"),
             task_result
+        );
+    }
+
+    /// Golden: minimal `interrupted: true` round-trip omits the optional
+    /// diagnostic fields (`reason`, `terminal_state`, `ack_timeout`) so the
+    /// canonical happy-path wire shape is preserved.
+    #[test]
+    fn turn_interrupt_result_minimal_omits_optional_fields() {
+        let result = UiRpcResult::TurnInterrupt(TurnInterruptResult::interrupted_ok());
+        let value = result
+            .clone()
+            .into_result_value()
+            .expect("serialize turn/interrupt result");
+        assert_eq!(value, json!({ "interrupted": true }));
+        assert_eq!(
+            UiRpcResult::from_method_and_result(methods::TURN_INTERRUPT, value)
+                .expect("decode turn/interrupt result"),
+            result
+        );
+    }
+
+    /// Golden: declined interrupt with a `reason` string round-trips through
+    /// serde without dropping the diagnostic field.
+    #[test]
+    fn turn_interrupt_result_round_trips_with_reason() {
+        let result = UiRpcResult::TurnInterrupt(TurnInterruptResult::declined("turn_id_mismatch"));
+        let value = result
+            .clone()
+            .into_result_value()
+            .expect("serialize turn/interrupt result");
+        assert_eq!(
+            value,
+            json!({ "interrupted": false, "reason": "turn_id_mismatch" })
+        );
+        assert_eq!(
+            UiRpcResult::from_method_and_result(methods::TURN_INTERRUPT, value)
+                .expect("decode turn/interrupt result"),
+            result
+        );
+    }
+
+    /// Golden: already-terminal interrupt round-trips with `terminal_state`
+    /// and an `interrupted` boolean derived from the prior terminal state.
+    #[test]
+    fn turn_interrupt_result_round_trips_with_terminal_state() {
+        let result =
+            UiRpcResult::TurnInterrupt(TurnInterruptResult::already_terminal("completed", false));
+        let value = result
+            .clone()
+            .into_result_value()
+            .expect("serialize turn/interrupt result");
+        assert_eq!(
+            value,
+            json!({ "interrupted": false, "terminal_state": "completed" })
+        );
+        assert_eq!(
+            UiRpcResult::from_method_and_result(methods::TURN_INTERRUPT, value)
+                .expect("decode turn/interrupt result"),
+            result
+        );
+    }
+
+    /// Golden: ack-timed-out interrupt round-trips with `ack_timeout: true`
+    /// and `interrupted: true` (server captured the interrupt; only client
+    /// receipt of the terminal event is uncertain).
+    #[test]
+    fn turn_interrupt_result_round_trips_with_ack_timeout() {
+        let result = UiRpcResult::TurnInterrupt(TurnInterruptResult::ack_timed_out());
+        let value = result
+            .clone()
+            .into_result_value()
+            .expect("serialize turn/interrupt result");
+        assert_eq!(value, json!({ "interrupted": true, "ack_timeout": true }));
+        assert_eq!(
+            UiRpcResult::from_method_and_result(methods::TURN_INTERRUPT, value)
+                .expect("decode turn/interrupt result"),
+            result
+        );
+    }
+
+    /// Spec: unknown optional fields on a `turn/interrupt` result must not
+    /// break decode for clients on this version (forward-compat).
+    #[test]
+    fn turn_interrupt_result_decodes_with_unknown_fields_ignored() {
+        let value = json!({
+            "interrupted": true,
+            "future_extension": "x"
+        });
+        let decoded = UiRpcResult::from_method_and_result(methods::TURN_INTERRUPT, value)
+            .expect("decode turn/interrupt result with unknown field");
+        assert_eq!(
+            decoded,
+            UiRpcResult::TurnInterrupt(TurnInterruptResult::interrupted_ok())
         );
     }
 

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_008_TURN_INTERRUPT_TYPED_FIELDS.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_008_TURN_INTERRUPT_TYPED_FIELDS.md
@@ -1,0 +1,209 @@
+# Octos UI Protocol Change Request: Typed Diagnostic Fields on `TurnInterruptResult`
+
+## Header
+
+- Request id: `UPCR-2026-008`
+- Title: Add typed `reason`, `terminal_state`, and `ack_timeout` optional
+  fields to `TurnInterruptResult`
+- Author: M9 protocol-as-contract audit follow-up (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related issue: `#721` (server emits ad-hoc JSON fields beyond the typed
+  `TurnInterruptResult { interrupted: bool }`)
+
+## Summary
+
+This change request codifies three optional diagnostic fields that the
+`turn/interrupt` handler in `crates/octos-cli/src/api/ui_protocol.rs` has been
+emitting via raw `serde_json::json!` since the AppUi protocol shipped:
+
+- `reason: String` — non-terminal explanation when `interrupted` is `false`
+  (e.g., `turn_id_mismatch`).
+- `terminal_state: String` — the prior terminal state when interrupt is
+  applied to an already-terminal turn (`completed` / `errored` /
+  `interrupted`).
+- `ack_timeout: bool` — set to `true` when the server captured the interrupt
+  but could not confirm the wire-side terminal event was acknowledged within
+  the ack window.
+
+All three fields already cross the wire today; only the typed contract
+(`TurnInterruptResult` in `crates/octos-core/src/ui_protocol.rs`) was lagging.
+This UPCR brings the type up to the existing wire shape so the contract is
+honest. No semantic change.
+
+## Motivation
+
+Audit issue `#721` flagged the drift: the server's `handle_turn_interrupt`
+handler emits four distinct response shapes via raw `json!()`, but the typed
+result advertised by `octos-core` is the single-field
+`TurnInterruptResult { interrupted: bool }`. The drift is exactly the kind of
+silent wire/type divergence the protocol-as-contract rule is meant to
+prevent. Specifically, the handler emits:
+
+- `{ "interrupted": false, "reason": "turn_id_mismatch" }`
+- `{ "interrupted": <bool>, "terminal_state": "completed"|"errored"|"interrupted" }`
+- `{ "interrupted": true }`
+- `{ "interrupted": true, "ack_timeout": true }`
+
+Of these, only the third matches the typed result. The first, second, and
+fourth carry diagnostic information clients have already been free to read
+because the v1 contract stipulates that unknown fields must be ignored.
+Codifying them in the typed result lets typed clients consume the diagnostic
+fields safely without re-parsing the raw `Value`.
+
+## Change Type
+
+Additive optional fields on an existing typed RPC result.
+
+`TurnInterruptResult` gains three fields, each marked
+`#[serde(default, skip_serializing_if = "Option::is_none")]` so the canonical
+minimal wire shape `{ "interrupted": <bool> }` is unchanged for the typical
+cases where the diagnostic fields are absent. No new method, notification,
+enum variant, capability flag, feature, or protocol identifier is introduced.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Result type: `TurnInterruptResult` (extended with three optional fields)
+
+No existing field is renamed, removed, or made required. The typed
+constructor `TurnInterruptResult::new(interrupted: bool)` is preserved and
+fills the new fields with `None`, so all existing callers continue to
+produce the canonical `{ "interrupted": <bool> }` wire shape.
+
+### `TurnInterruptResult` (extended)
+
+Result of `turn/interrupt`:
+
+```json
+{ "interrupted": true }
+```
+
+```json
+{ "interrupted": false, "reason": "turn_id_mismatch" }
+```
+
+```json
+{ "interrupted": false, "terminal_state": "completed" }
+```
+
+```json
+{ "interrupted": true, "ack_timeout": true }
+```
+
+Field descriptions:
+
+- `interrupted` (required, `bool`): canonical interrupt acknowledgement.
+  `true` iff the server stopped the turn (or the turn had already been
+  interrupted). `false` iff the interrupt was declined or the turn was
+  already in a non-`interrupted` terminal state.
+- `reason` (optional, `string`): non-terminal diagnostic explanation when
+  `interrupted` is `false`. String registry with initial value:
+  - `turn_id_mismatch` — the `turn_id` sent does not match the active turn
+    for the session.
+- `terminal_state` (optional, `string`): set when the interrupt was sent
+  against a turn that had already reached a terminal state. String registry,
+  values matching the server's `TerminalReason` enum:
+  - `completed`
+  - `errored`
+  - `interrupted`
+- `ack_timeout` (optional, `bool`): set to `true` only when the server
+  captured the interrupt and emitted the wire-side terminal event but could
+  not confirm that the client received the terminal within the server's ack
+  window. The interrupt itself is still considered captured (`interrupted`
+  is `true`); only client-side receipt is uncertain. Omitted otherwise.
+
+`reason` and `terminal_state` are mutually exclusive in practice (the server
+only sets `terminal_state` for already-terminal turns and `reason` for
+non-terminal declines), but the wire contract does not forbid both being
+present in future revisions; clients should accept either, neither, or both.
+
+Future `reason` and `terminal_state` registry values must be added via a
+follow-up UPCR.
+
+## Error Model
+
+This UPCR does not introduce or modify any RPC error category. The existing
+`unknown_turn` error continues to be the response when the server has no
+record of the requested `turn_id`. The new optional fields are carried only
+on the success result.
+
+## Compatibility
+
+- Old clients that ignore unknown fields per spec § 4 see no behavioural
+  change. The minimal `{ "interrupted": <bool> }` canonical shape is
+  preserved for every case where the diagnostic fields are `None`.
+- Old servers that have not yet been recompiled against the new type
+  continue to emit the same wire shapes via `json!` (this UPCR does not
+  delete the raw-`json!` code path until the typed-builder migration lands).
+- New typed clients can deserialize the result directly into the extended
+  `TurnInterruptResult` and read `reason`, `terminal_state`, and
+  `ack_timeout` for diagnostic UX without re-parsing the raw `Value`.
+- The handler in `crates/octos-cli/src/api/ui_protocol.rs` is migrated to
+  the typed `TurnInterruptResult` constructors (`interrupted_ok`,
+  `declined`, `already_terminal`, `ack_timed_out`) so the wire emission and
+  the typed contract are produced from a single source.
+- No new protocol identifier or capability flag is required because the
+  change is additive and `Option::is_none` is the v1 idiom for additive
+  optional fields.
+
+## Capability Negotiation
+
+No new capability flag. v1 forward-compat (unknown fields ignored) is
+sufficient for additive optional result fields.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `turn_interrupt_result_minimal_omits_optional_fields` — golden:
+    `interrupted: true` only, with no diagnostic fields, round-trips through
+    serde and produces the canonical `{ "interrupted": true }` wire shape.
+  - `turn_interrupt_result_round_trips_with_reason` — golden: declined
+    interrupt with `reason: Some("turn_id_mismatch")` round-trips.
+  - `turn_interrupt_result_round_trips_with_terminal_state` — golden:
+    already-terminal interrupt with `terminal_state: Some("completed")`
+    round-trips.
+  - `turn_interrupt_result_round_trips_with_ack_timeout` — golden:
+    ack-timed-out interrupt with `ack_timeout: Some(true)` round-trips.
+  - `turn_interrupt_result_decodes_with_unknown_fields_ignored` — forward
+    compat: a result with an extra unknown field decodes cleanly.
+  - The pre-existing
+    `typed_rpc_results_map_from_methods_and_round_trip` test continues to
+    pass because the canonical `{ "interrupted": false }` wire shape is
+    preserved for `TurnInterruptResult::new(false)`.
+
+## Rollout Plan
+
+1. Land the typed result extension and the four named constructors on
+   `TurnInterruptResult` in `octos-core` (this PR).
+2. Migrate the four `handle_turn_interrupt` emission sites in `octos-cli`
+   from raw `serde_json::json!` to the typed constructors, dispatched
+   through a single `send_typed_interrupt_result` helper (this PR).
+3. Update the spec § 7 entry for `turn/interrupt` to reference
+   `UPCR-2026-008` (this PR).
+4. Follow-up: harness clients that currently re-parse the raw `Value` to
+   surface `reason` / `terminal_state` / `ack_timeout` may switch to the
+   typed result. Tracked separately if/when needed.
+
+No client renegotiation is required.
+
+## Decision
+
+Accepted by: M9 protocol-as-contract audit follow-up (coding-green).
+
+Decision notes: Accepted as the minimum additive contract change to close
+audit issue `#721`. The fields have already been on the wire since the
+AppUi protocol shipped; this UPCR only brings the typed contract up to the
+existing wire shape so the protocol-as-contract rule holds end-to-end.
+
+## Out-of-scope follow-ups
+
+- The `terminal_state` value strings (`completed`, `errored`,
+  `interrupted`) match the server's internal `TerminalReason` enum and are
+  not yet shared with `octos-core`. A future UPCR may promote
+  `TerminalReason` to a typed enum on the wire if more values are added.
+- The `reason` registry is intentionally minimal in this UPCR
+  (`turn_id_mismatch` only). Future declined-interrupt explanations require
+  an extension UPCR.


### PR DESCRIPTION
## Summary

- Closes audit issue #721: server emits ad-hoc JSON fields (`reason`,
  `terminal_state`, `ack_timeout`) beyond the typed
  `TurnInterruptResult { interrupted: bool }`.
- Extend `TurnInterruptResult` in `crates/octos-core/src/ui_protocol.rs`
  with three additive optional fields (`#[serde(default,
  skip_serializing_if = "Option::is_none")]`), preserving the canonical
  minimal `{ "interrupted": <bool> }` wire shape.
- Migrate the 4 `handle_turn_interrupt` emission sites in
  `crates/octos-cli/src/api/ui_protocol.rs` from raw `serde_json::json!`
  to the typed `TurnInterruptResult` constructors via a single
  `send_typed_interrupt_result` helper.
- Add accepted **UPCR-2026-008** at
  `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_008_TURN_INTERRUPT_TYPED_FIELDS.md`
  governing the additive fields. Update spec § 4 + § 7 to reference it.

### Drift cited (before)

| `crates/octos-cli/src/api/ui_protocol.rs` line | Emission |
|---|---|
| 2102 | `json!({ "interrupted": false, "reason": "turn_id_mismatch" })` |
| 2110-2113 | `json!({ "interrupted": <bool>, "terminal_state": reason.as_str() })` |
| 2121 | `json!({ "interrupted": true })` |
| 2137-2139 | `json!({ "interrupted": true, "ack_timeout": true })` |

All four sites now use the typed `TurnInterruptResult::{declined, already_terminal, interrupted_ok, ack_timed_out}` constructors.

### Codex 2nd-opinion findings

- (1) No additional raw `json!()` emissions for `turn/interrupt` beyond
  the cited sites; helper now contains the only fallback `json!` which
  is unreachable (defensive).
- (2) No e2e or fixture asserts on the OLD raw shape — e2e
  (`e2e/tests/m9-protocol-turn-interrupt.spec.ts`) only reads the
  `interrupted` field. Pre-existing core minimal-shape test still passes.
- (3) UPCR-2026-008 shape matches UPCR-2026-005 skeleton. No new
  capability flag (additive optional fields).
- (4) Line 2112's `terminal_state` is on the **RPC result** (not an
  event payload). `TurnCompletedEvent` / `TurnErrorEvent` have no such
  field. Codified accordingly.

Codex flagged two stale prose issues during review (doc-comment said
"two optional fields" instead of three; UPCR claimed `terminal_state`
also lived on an event payload — false). Both fixed before push.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p octos-core ui_protocol` — 44 passed (5 new tests added)
- [x] `cargo test -p octos-cli --features api ui_protocol` — 168 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `./scripts/check-ui-protocol-upcr.sh` — UPCR coverage detected
- [ ] No e2e regression for `m9-protocol-turn-interrupt` (typed builder
      preserves canonical `{ "interrupted": <bool> }` for happy path)

### New tests

- `turn_interrupt_result_minimal_omits_optional_fields` — golden:
  canonical wire shape preserved when no diagnostic fields apply.
- `turn_interrupt_result_round_trips_with_reason` — `reason: "turn_id_mismatch"`.
- `turn_interrupt_result_round_trips_with_terminal_state` — `terminal_state: "completed"`.
- `turn_interrupt_result_round_trips_with_ack_timeout` — `ack_timeout: true`.
- `turn_interrupt_result_decodes_with_unknown_fields_ignored` — forward-compat.

## Notes

- **DO NOT auto-merge.**
- Wire shape change governed by accepted UPCR-2026-008.
- v1 forward-compat (unknown fields ignored) means older clients see no
  change; new typed clients get diagnostic fields without re-parsing the
  raw `Value`.