### PR TITLE
feat(ui_protocol): emit UiProtocolCapabilities in SessionOpened (closes #720)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -171,6 +171,17 @@ Current M9 sandbox-parity decision:
   diagnostic fields the `turn/interrupt` handler has been emitting since the
   protocol shipped. The typed contract is now equivalent to the wire shape;
   the canonical minimal `{ "interrupted": <bool> }` response is preserved.
+- The additive `capabilities` field on `SessionOpened` (carrying the
+  negotiated `UiProtocolCapabilities` payload) is governed by accepted
+  [UPCR-2026-007](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md).
+  That UPCR closes M9 harness audit gap #720 by emitting the negotiated
+  method/notification/feature surface in-band so clients no longer have
+  to read the spec doc to know which `X-Octos-Ui-Features` tokens the
+  server honours. The field is the in-band counterpart to the
+  capability-negotiation rules in this section: `supported_features` is
+  the intersection of the client's `X-Octos-Ui-Features` request with
+  the server's known feature registry; absent header falls back to the
+  first-server-slice default.
 
 ## 5. Identity Model
 
@@ -269,6 +280,19 @@ Optional result fields from accepted `UPCR-2026-003`:
   Canonical server-approved workspace root for the session. Clients should use
   it for display/status and must not infer approval from the requested `cwd`
   alone.
+
+Required result fields from accepted `UPCR-2026-007`:
+
+- `capabilities`
+  Negotiated `UiProtocolCapabilities` payload. Always present. Carries the
+  protocol version, capability schema version, server-advertised method and
+  notification sets, and the `supported_features` subset honoured for this
+  session. When the client did not send `X-Octos-Ui-Features`, the field
+  echoes the server's first-server-slice default so a discovery-aware client
+  can still learn the surface in-band. When the client sent feature tokens,
+  `supported_features` is the intersection of the request with the server's
+  known feature registry — the server never advertises a flag the client did
+  not request.
 
 ### `turn/start`
 
@@ -530,7 +554,8 @@ Marks the start of one client-visible turn. This creates the turn lifecycle boun
 
 Carries the opened-session notification and optional cursor baseline. The
 notification payload shares the `SessionOpened` shape used by
-`SessionOpenResult.opened`.
+`SessionOpenResult.opened`, including the required `capabilities` field
+from accepted `UPCR-2026-007` (see § 7).
 
 Optional pane fields from accepted `UPCR-2026-002`:
 

--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -292,7 +292,11 @@ Required result fields from accepted `UPCR-2026-007`:
   can still learn the surface in-band. When the client sent feature tokens,
   `supported_features` is the intersection of the request with the server's
   known feature registry — the server never advertises a flag the client did
-  not request.
+  not request. Capability-gated methods (`task/list`, `task/cancel`,
+  `task/restart_from_node` behind `harness.task_control.v1`) appear in
+  `supported_methods` only when their gating feature is in the negotiated
+  `supported_features`, so the advertised method set always agrees with the
+  callable surface.
 
 ### `turn/start`
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -6040,13 +6040,31 @@ mod tests {
         assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
         assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
         assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
-        // Method/notification surface stays intact so the client can still
-        // see what the server advertises in-band.
+        // Unconditional methods stay advertised so the client can still
+        // see what the server offers in-band.
         assert!(
             capabilities
                 .supported_methods
                 .iter()
                 .any(|method| method == octos_core::ui_protocol::methods::SESSION_OPEN)
+        );
+        // Capability-gated methods (task-control RPCs behind
+        // harness.task_control.v1) must not leak when the gating feature
+        // is not in the negotiated set — otherwise the client would call
+        // them and the server would reject with method_not_supported.
+        assert!(
+            !capabilities
+                .supported_methods
+                .iter()
+                .any(|method| method == octos_core::ui_protocol::methods::TASK_LIST),
+            "task/list must be gated by harness.task_control.v1"
+        );
+        assert!(
+            !capabilities
+                .supported_methods
+                .iter()
+                .any(|method| method == octos_core::ui_protocol::methods::TASK_CANCEL),
+            "task/cancel must be gated by harness.task_control.v1"
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -28,12 +28,13 @@ use octos_core::ui_protocol::{
     TaskRestartFromNodeResult, TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent,
     ToolCompletedEvent, ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent,
     TurnId, TurnInterruptParams, TurnInterruptResult, TurnStartParams,
-    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UiArtifactPaneItem, UiArtifactPaneSnapshot,
-    UiCommand, UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot,
-    UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent,
-    UiProgressMetadata, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot, approval_cancelled_reasons,
-    approval_kinds, progress_kinds,
+    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiCursor, UiFileMutationNotice,
+    UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot,
+    UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities,
+    UiWorkspacePaneEntry, UiWorkspacePaneSnapshot, approval_cancelled_reasons, approval_kinds,
+    progress_kinds,
 };
 use octos_core::{AgentId, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId};
 use serde::Serialize;
@@ -475,6 +476,14 @@ struct ConnectionUiFeatures {
     typed_approvals: bool,
     pane_snapshots: bool,
     session_workspace_cwd: bool,
+    harness_task_control: bool,
+    /// `true` when the client sent at least one feature token via the
+    /// `X-Octos-Ui-Features` header or the `ui_feature` / `ui_features`
+    /// query parameter (UPCR-2026-007). Distinguishes "no header at all"
+    /// (where the server falls back to advertising the full first-slice in
+    /// `SessionOpened.capabilities`) from "header sent with all-unknown
+    /// tokens" (where the negotiated `supported_features` is empty).
+    header_present: bool,
 }
 
 impl ConnectionUiFeatures {
@@ -487,8 +496,68 @@ impl ConnectionUiFeatures {
                 query,
                 UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
             ),
+            harness_task_control: has_ui_feature(
+                headers,
+                query,
+                UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+            ),
+            header_present: has_any_ui_feature_token(headers, query),
         }
     }
+
+    /// Build the `UiProtocolCapabilities` payload to advertise on
+    /// `SessionOpened` per UPCR-2026-007 § 4 capability negotiation. When
+    /// the client sent no feature header at all, the server returns the
+    /// `first_server_slice` default so clients can still discover the
+    /// surface in-band. When the client sent at least one feature token,
+    /// the server returns the intersection of requested features with the
+    /// known feature registry — clients see exactly which of their
+    /// requests were honoured and never receive a flag they did not ask
+    /// for.
+    fn negotiated_capabilities(self) -> UiProtocolCapabilities {
+        if !self.header_present {
+            return UiProtocolCapabilities::first_server_slice();
+        }
+        let mut requested: Vec<&str> = Vec::with_capacity(4);
+        if self.typed_approvals {
+            requested.push(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1);
+        }
+        if self.pane_snapshots {
+            requested.push(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1);
+        }
+        if self.session_workspace_cwd {
+            requested.push(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1);
+        }
+        if self.harness_task_control {
+            requested.push(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1);
+        }
+        UiProtocolCapabilities::for_negotiated_features(requested)
+    }
+}
+
+/// True when the client sent any non-empty `X-Octos-Ui-Features` token
+/// through the header or the URL query. Used by UPCR-2026-007 to
+/// distinguish "no negotiation attempted" from "negotiation attempted with
+/// no honoured tokens".
+fn has_any_ui_feature_token(headers: &HeaderMap, query: Option<&str>) -> bool {
+    let header_has_token = headers
+        .get(UI_FEATURES_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split([',', ' '])
+                .any(|candidate| !candidate.trim().is_empty())
+        });
+    if header_has_token {
+        return true;
+    }
+    query
+        .unwrap_or_default()
+        .split('&')
+        .filter_map(|pair| pair.split_once('='))
+        .filter(|(key, _)| matches!(*key, "ui_feature" | "ui_features" | "x-octos-ui-features"))
+        .flat_map(|(_, value)| value.split([',', ' ']))
+        .any(|candidate| !candidate.trim().is_empty())
 }
 
 fn has_ui_feature(headers: &HeaderMap, query: Option<&str>, feature: &str) -> bool {
@@ -1388,12 +1457,17 @@ async fn open_session_result(
     let panes = features
         .pane_snapshots
         .then(|| build_pane_snapshot(&data_dir, &params.session_id, workspace_root.as_deref()));
+    // UPCR-2026-007: advertise the negotiated capability set in-band so
+    // clients don't have to rely on out-of-band knowledge of which feature
+    // tokens the server honours.
+    let capabilities = features.negotiated_capabilities();
     let opened_event = ledger.append_notification(UiNotification::SessionOpened(SessionOpened {
         session_id: params.session_id,
         active_profile_id,
         workspace_root: workspace_root.map(|path| path.to_string_lossy().to_string()),
         cursor: None,
         panes,
+        capabilities,
     }));
     let UiProtocolLedgerEvent::Notification(UiNotification::SessionOpened(opened)) =
         opened_event.event.clone()
@@ -4238,6 +4312,8 @@ mod tests {
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                harness_task_control: false,
+                header_present: true,
             },
         );
         assert_eq!(
@@ -4281,6 +4357,8 @@ mod tests {
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                harness_task_control: false,
+                header_present: true,
             },
         );
 
@@ -4527,6 +4605,8 @@ mod tests {
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                harness_task_control: false,
+                header_present: true,
             },
         );
         let cwd = typed
@@ -5803,6 +5883,8 @@ mod tests {
                 typed_approvals: false,
                 pane_snapshots: true,
                 session_workspace_cwd: false,
+                harness_task_control: false,
+                header_present: true,
             },
             SessionOpenParams {
                 session_id: session_id.clone(),
@@ -5865,6 +5947,106 @@ mod tests {
         assert_eq!(
             error.data.as_ref().and_then(|data| data.get("kind")),
             Some(&json!("feature_required"))
+        );
+    }
+
+    // ----- UPCR-2026-007: capability advertisement on `SessionOpened` -----
+
+    #[tokio::test]
+    async fn session_open_result_advertises_full_protocol_when_no_header() {
+        // Client sent no `X-Octos-Ui-Features` request — server returns
+        // the `first_server_slice` baseline so a discovery-aware client
+        // can learn the surface in-band per UPCR-2026-007.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = UiProtocolLedger::new(16);
+        let approvals = PendingApprovalStore::default();
+        let session_id = SessionKey("local:caps-default".into());
+
+        let outcome = open_session_result(
+            &state,
+            &ledger,
+            &approvals,
+            None,
+            ConnectionUiFeatures::default(),
+            SessionOpenParams {
+                session_id,
+                profile_id: None,
+                cwd: None,
+                after: None,
+            },
+        )
+        .await
+        .expect("open session without feature header");
+
+        let capabilities = &outcome.result.opened.capabilities;
+        assert_eq!(
+            capabilities,
+            &UiProtocolCapabilities::first_server_slice(),
+            "no header => server falls back to first_server_slice"
+        );
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1));
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
+    }
+
+    #[tokio::test]
+    async fn session_open_result_advertises_intersection_when_header_subset() {
+        // Client requested only `pane.snapshots.v1` — server returns
+        // capabilities with that single feature and never leaks flags the
+        // client did not negotiate (UPCR-2026-007 § 4 capability
+        // negotiation).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = UiProtocolLedger::new(16);
+        let approvals = PendingApprovalStore::default();
+        let session_id = SessionKey("local:caps-subset".into());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(features.header_present);
+        assert!(features.pane_snapshots);
+        assert!(!features.typed_approvals);
+
+        let outcome = open_session_result(
+            &state,
+            &ledger,
+            &approvals,
+            None,
+            features,
+            SessionOpenParams {
+                session_id,
+                profile_id: None,
+                cwd: None,
+                after: None,
+            },
+        )
+        .await
+        .expect("open session with feature header subset");
+
+        let capabilities = &outcome.result.opened.capabilities;
+        assert_eq!(
+            capabilities.supported_features,
+            vec![UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1.to_owned()],
+            "intersection must be exactly the features the client asked for"
+        );
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
+        // Method/notification surface stays intact so the client can still
+        // see what the server advertises in-band.
+        assert!(
+            capabilities
+                .supported_methods
+                .iter()
+                .any(|method| method == octos_core::ui_protocol::methods::SESSION_OPEN)
         );
     }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -52,6 +52,25 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
 ];
 
+/// Returns the feature flag that gates `method` per spec § 7 capability
+/// negotiation, or `None` if the method is unconditionally available.
+///
+/// Used by [`UiProtocolCapabilities::for_negotiated_features`] so the
+/// negotiated `supported_methods` only advertises capability-gated methods
+/// when their gating feature is also in the negotiated `supported_features`
+/// set. Without this gate a client that did not request
+/// `harness.task_control.v1` would see `task/list` / `task/cancel` /
+/// `task/restart_from_node` in the response and then receive
+/// `method_not_supported` errors when it tried to call them.
+fn method_capability_gate(method: &str) -> Option<&'static str> {
+    match method {
+        methods::TASK_LIST | methods::TASK_CANCEL | methods::TASK_RESTART_FROM_NODE => {
+            Some(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1)
+        }
+        _ => None,
+    }
+}
+
 pub mod approval_kinds {
     pub const COMMAND: &str = "command";
     pub const DIFF: &str = "diff";
@@ -745,13 +764,22 @@ impl UiProtocolCapabilities {
     }
 
     /// Build a server-side capabilities payload reflecting the negotiated
-    /// feature set per spec § 4 (UPCR-2026-007). The advertised method and
-    /// notification surfaces are always the first-server-slice baseline so
-    /// clients can discover them in-band; `supported_features` is the
+    /// feature set per spec § 4 (UPCR-2026-007). `supported_features` is the
     /// intersection of `requested` (typically from `X-Octos-Ui-Features`)
-    /// with the server's known feature registry, preserving the order of the
-    /// registry. Unknown feature names in `requested` are dropped — the
+    /// with the server's known feature registry, preserving the order of
+    /// the registry. Unknown feature names in `requested` are dropped — the
     /// server does not advertise capabilities it cannot honour.
+    ///
+    /// Method-level capability gates honour the same intersection: methods
+    /// that spec § 7 marks as capability-gated (e.g. `task/list`,
+    /// `task/cancel`, `task/restart_from_node` behind
+    /// `harness.task_control.v1`) appear in `supported_methods` only when
+    /// the gating feature is in the negotiated set. The spec contract is
+    /// "servers expose it only when the feature flag is advertised", so
+    /// the advertised method set must agree with the advertised feature
+    /// set — otherwise a client that did not negotiate `harness.task_control.v1`
+    /// would still see the methods in the response and make calls the
+    /// server would then reject with `method_not_supported`.
     pub fn for_negotiated_features<I, S>(requested: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -761,15 +789,30 @@ impl UiProtocolCapabilities {
             .into_iter()
             .map(|feature| feature.as_ref().to_owned())
             .collect();
-        let mut capabilities = Self::new(
-            UI_PROTOCOL_FIRST_SERVER_METHODS,
-            UI_PROTOCOL_NOTIFICATION_METHODS,
-        );
-        capabilities.supported_features = UI_PROTOCOL_KNOWN_FEATURES
+        let supported_features: Vec<String> = UI_PROTOCOL_KNOWN_FEATURES
             .iter()
             .filter(|feature| requested.iter().any(|requested| requested == **feature))
             .map(|feature| (*feature).to_owned())
             .collect();
+        let supported_methods: Vec<String> = UI_PROTOCOL_FIRST_SERVER_METHODS
+            .iter()
+            .filter(|method| {
+                method_capability_gate(method).is_none_or(|gating_feature| {
+                    supported_features
+                        .iter()
+                        .any(|advertised| advertised == gating_feature)
+                })
+            })
+            .map(|method| (*method).to_owned())
+            .collect();
+        let mut capabilities = Self {
+            version: UiProtocolVersion::current(),
+            capabilities_schema_version: UI_PROTOCOL_CAPABILITIES_SCHEMA_VERSION,
+            supported_methods,
+            supported_notifications: string_list(UI_PROTOCOL_NOTIFICATION_METHODS),
+            supported_features,
+            unsupported: Vec::new(),
+        };
         capabilities.unsupported = UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS
             .iter()
             .map(|method| {
@@ -2802,6 +2845,12 @@ mod tests {
         assert!(capabilities.supported_features.is_empty());
         assert!(capabilities.supports_method(methods::SESSION_OPEN));
         assert!(capabilities.supports_method(methods::TURN_START));
+        // Capability-gated methods MUST NOT leak when their gating feature
+        // is not in the negotiated set — otherwise a client would call
+        // them and receive `method_not_supported`.
+        assert!(!capabilities.supports_method(methods::TASK_LIST));
+        assert!(!capabilities.supports_method(methods::TASK_CANCEL));
+        assert!(!capabilities.supports_method(methods::TASK_RESTART_FROM_NODE));
     }
 
     #[test]
@@ -2820,6 +2869,32 @@ mod tests {
         assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
         assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
         assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
+        // Task-control methods are gated by harness.task_control.v1 — they
+        // must not appear in the advertised method set when the gating
+        // feature is not negotiated.
+        assert!(!capabilities.supports_method(methods::TASK_LIST));
+        assert!(!capabilities.supports_method(methods::TASK_CANCEL));
+        assert!(!capabilities.supports_method(methods::TASK_RESTART_FROM_NODE));
+        // Unconditional methods stay present.
+        assert!(capabilities.supports_method(methods::SESSION_OPEN));
+        assert!(capabilities.supports_method(methods::TURN_START));
+        assert!(capabilities.supports_method(methods::TASK_OUTPUT_READ));
+    }
+
+    #[test]
+    fn negotiated_capabilities_advertise_task_control_methods_when_feature_requested() {
+        // Pre-condition for the gating change: when the client *did*
+        // request `harness.task_control.v1`, the server's negotiated
+        // method set includes the task-control RPCs so the spec § 7
+        // "expose only when feature flag is advertised" rule is honoured
+        // bidirectionally.
+        let capabilities = UiProtocolCapabilities::for_negotiated_features([
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+        ]);
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
+        assert!(capabilities.supports_method(methods::TASK_LIST));
+        assert!(capabilities.supports_method(methods::TASK_CANCEL));
+        assert!(capabilities.supports_method(methods::TASK_RESTART_FROM_NODE));
     }
 
     #[test]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -40,6 +40,18 @@ pub const UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1: &str = "session.workspac
 /// Feature flag for harness task registry/control commands.
 pub const UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1: &str = "harness.task_control.v1";
 
+/// Server-known feature registry. Used by
+/// [`UiProtocolCapabilities::for_negotiated_features`] (UPCR-2026-007) to
+/// intersect a client's `X-Octos-Ui-Features` request with the names the
+/// server actually honours. The order is the canonical advertisement order
+/// surfaced through `supported_features`.
+pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
+    UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+];
+
 pub mod approval_kinds {
     pub const COMMAND: &str = "command";
     pub const DIFF: &str = "diff";
@@ -719,12 +731,45 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FIRST_SERVER_METHODS,
             UI_PROTOCOL_NOTIFICATION_METHODS,
         )
-        .with_supported_features([
-            UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
-            UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
-            UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
-            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
-        ]);
+        .with_supported_features(UI_PROTOCOL_KNOWN_FEATURES.iter().copied());
+        capabilities.unsupported = UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS
+            .iter()
+            .map(|method| {
+                UnsupportedCapabilityReport::method(
+                    *method,
+                    "not implemented by the first server runtime slice",
+                )
+            })
+            .collect();
+        capabilities
+    }
+
+    /// Build a server-side capabilities payload reflecting the negotiated
+    /// feature set per spec § 4 (UPCR-2026-007). The advertised method and
+    /// notification surfaces are always the first-server-slice baseline so
+    /// clients can discover them in-band; `supported_features` is the
+    /// intersection of `requested` (typically from `X-Octos-Ui-Features`)
+    /// with the server's known feature registry, preserving the order of the
+    /// registry. Unknown feature names in `requested` are dropped — the
+    /// server does not advertise capabilities it cannot honour.
+    pub fn for_negotiated_features<I, S>(requested: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let requested: Vec<String> = requested
+            .into_iter()
+            .map(|feature| feature.as_ref().to_owned())
+            .collect();
+        let mut capabilities = Self::new(
+            UI_PROTOCOL_FIRST_SERVER_METHODS,
+            UI_PROTOCOL_NOTIFICATION_METHODS,
+        );
+        capabilities.supported_features = UI_PROTOCOL_KNOWN_FEATURES
+            .iter()
+            .filter(|feature| requested.iter().any(|requested| requested == **feature))
+            .map(|feature| (*feature).to_owned())
+            .collect();
         capabilities.unsupported = UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS
             .iter()
             .map(|method| {
@@ -1489,6 +1534,23 @@ pub struct SessionOpened {
     pub cursor: Option<UiCursor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub panes: Option<UiPaneSnapshot>,
+    /// Server-supported features negotiated for this session per spec § 4
+    /// capability negotiation (UPCR-2026-007). Carries the protocol version,
+    /// schema version, supported method/notification sets, and the negotiated
+    /// `supported_features` intersection of the client's
+    /// `X-Octos-Ui-Features` request with the server's known feature
+    /// registry. Clients without the header receive the server's
+    /// `first_server_slice` default so they can still discover the surface
+    /// in-band.
+    ///
+    /// Older clients that don't expect the field continue to ignore it per
+    /// spec § 4 ("clients should treat unknown fields as ignorable"). Older
+    /// serialized payloads (e.g. ledger replays from before the field
+    /// existed) decode successfully because `UiProtocolCapabilities` itself
+    /// fills missing optional members with `serde(default)`; the field uses
+    /// `serde(default)` for forward compatibility.
+    #[serde(default = "UiProtocolCapabilities::first_server_slice")]
+    pub capabilities: UiProtocolCapabilities,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2652,6 +2714,7 @@ mod tests {
                 }),
                 limitations: Vec::new(),
             }),
+            capabilities: UiProtocolCapabilities::first_server_slice(),
         };
 
         let wire = serde_json::to_value(&opened).expect("serialize session/open panes");
@@ -2666,6 +2729,97 @@ mod tests {
         let decoded: SessionOpened =
             serde_json::from_value(wire).expect("deserialize session/open panes");
         assert_eq!(decoded, opened);
+    }
+
+    // ----- UPCR-2026-007: capability advertisement on `SessionOpened` -----
+
+    #[test]
+    fn session_open_result_includes_capabilities_field() {
+        // Golden: `SessionOpened` serializes a `capabilities` payload that
+        // covers protocol version, method/notification surface, and the
+        // negotiated feature set so clients can discover the contract
+        // in-band per spec § 4 / UPCR-2026-007.
+        let opened = SessionOpened {
+            session_id: SessionKey("local:demo".into()),
+            active_profile_id: None,
+            workspace_root: None,
+            cursor: None,
+            panes: None,
+            capabilities: UiProtocolCapabilities::first_server_slice(),
+        };
+        let wire = serde_json::to_value(&opened).expect("serialize SessionOpened");
+        let capabilities = wire
+            .get("capabilities")
+            .expect("SessionOpened must serialize a capabilities field");
+        assert_eq!(capabilities["version"]["protocol"], json!(UI_PROTOCOL_V1));
+        assert_eq!(
+            capabilities["capabilities_schema_version"],
+            json!(UI_PROTOCOL_CAPABILITIES_SCHEMA_VERSION)
+        );
+        assert!(
+            capabilities["supported_methods"]
+                .as_array()
+                .expect("supported_methods array")
+                .iter()
+                .any(|method| method == &json!(methods::SESSION_OPEN))
+        );
+        let supported_features = capabilities["supported_features"]
+            .as_array()
+            .expect("supported_features array");
+        for feature in UI_PROTOCOL_KNOWN_FEATURES {
+            assert!(
+                supported_features
+                    .iter()
+                    .any(|advertised| advertised == &json!(*feature)),
+                "first_server_slice must advertise {feature}"
+            );
+        }
+
+        // Older payloads (e.g. ledger replays from before the field
+        // existed) decode successfully because the field carries
+        // `serde(default = "first_server_slice")`.
+        let legacy = json!({
+            "session_id": "local:demo",
+        });
+        let decoded: SessionOpened =
+            serde_json::from_value(legacy).expect("legacy SessionOpened decode");
+        assert_eq!(
+            decoded.capabilities,
+            UiProtocolCapabilities::first_server_slice()
+        );
+    }
+
+    #[test]
+    fn negotiated_capabilities_advertise_full_protocol_when_no_features_requested() {
+        // No header => `for_negotiated_features([])` returns the
+        // first-slice baseline with an empty `supported_features` so the
+        // server does not silently advertise flags the client did not ask
+        // for. The no-header fallback handled by callers is the
+        // `first_server_slice` default; this test pins the empty-request
+        // intersection contract.
+        let none: [&str; 0] = [];
+        let capabilities = UiProtocolCapabilities::for_negotiated_features(none);
+        assert!(capabilities.supported_features.is_empty());
+        assert!(capabilities.supports_method(methods::SESSION_OPEN));
+        assert!(capabilities.supports_method(methods::TURN_START));
+    }
+
+    #[test]
+    fn negotiated_capabilities_intersect_requested_with_known_features() {
+        // Client asked only for pane snapshots — the server returns just
+        // that feature, never leaking the typed-approval / cwd / task-
+        // control flags the client did not negotiate.
+        let capabilities = UiProtocolCapabilities::for_negotiated_features([
+            UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
+            "made.up.feature.v9",
+        ]);
+        assert_eq!(
+            capabilities.supported_features,
+            vec![UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1.to_owned()]
+        );
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
     }
 
     #[test]
@@ -3359,6 +3513,7 @@ mod tests {
                 seq: 42,
             }),
             panes: None,
+            capabilities: UiProtocolCapabilities::first_server_slice(),
         };
 
         let session_result = UiRpcResult::SessionOpen(SessionOpenResult::new(opened));
@@ -3889,6 +4044,7 @@ mod tests {
             workspace_root: None,
             cursor: Some(opened_cursor.clone()),
             panes: None,
+            capabilities: UiProtocolCapabilities::first_server_slice(),
         });
 
         let opened_wire = opened

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md
@@ -1,0 +1,250 @@
+# Octos UI Protocol Change Request: SessionOpened Capability Advertisement
+
+## Header
+
+- Request id: `UPCR-2026-007`
+- Title: Emit `UiProtocolCapabilities` on `SessionOpened` so clients can
+  discover server features in-band
+- Author: M9 harness audit follow-up (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related M issue: `#720` (M9 audit gap — `SessionOpened` had no
+  `capabilities` payload, so clients had to read the spec doc to know
+  which `X-Octos-Ui-Features` tokens the server actually honours)
+
+## Summary
+
+This change request adds a required `capabilities` field to the
+`SessionOpened` payload (shared by the `session/open` RPC result and the
+`session/open` notification) so clients can discover the server's
+negotiated method set, notification set, schema versions, and the
+honoured subset of their `X-Octos-Ui-Features` request without an
+out-of-band spec lookup.
+
+The shape is the existing `UiProtocolCapabilities` value, already
+constructed for the runtime advertisement APIs in `octos-core`. The
+field is **always emitted** by the server; the wire payload itself is a
+strict superset of the previous one. Older clients that ignore unknown
+fields per spec § 4 continue to work; older serialized payloads (e.g.
+ledger replays from before the field existed) decode successfully
+because the field carries `serde(default = "first_server_slice")`.
+
+## Motivation
+
+Spec § 4 already defines capability negotiation as part of the protocol
+contract, and the WebSocket connection parser in
+`crates/octos-cli/src/api/ui_protocol.rs` reads
+`X-Octos-Ui-Features` (and the `ui_feature` / `ui_features` query
+parameters) on every connection. But the `SessionOpened` payload — the
+first lifecycle frame after `session/open` — never echoes back which
+features the server understood. As a result:
+
+- New clients have to hard-code feature tokens taken from the spec doc.
+  They cannot ask the server "what are you actually willing to honour
+  for this session?" until they probe each method individually and
+  observe an `unsupported_capability` error.
+- Servers that drop a feature flag (e.g. due to a missing dependency in
+  a slim build) cannot signal that to the client until a downstream RPC
+  fails.
+- Replays of historical sessions cannot be inspected for "which
+  capability slice did this client and server land on?" because the
+  ledger event is silent on it.
+
+Since `SessionOpened` is already on the critical path for every
+session, attaching the negotiated capability snapshot to it closes the
+gap with one additive field instead of an extra round-trip RPC.
+
+## Change Type
+
+Additive required field on an existing payload.
+
+`SessionOpened.capabilities: UiProtocolCapabilities` is added to the
+shared payload used by:
+
+- the `session/open` RPC `SessionOpenResult.opened`
+- the `session/open` notification (same `SessionOpened` shape, sent
+  through the event ledger)
+
+No method, notification, enum variant, capability flag, or protocol
+identifier is changed. No existing field is removed or repurposed. The
+`UiProtocolCapabilities` struct itself is unchanged.
+
+## Wire Contract
+
+Affected existing wire surface:
+
+- Payload: `SessionOpened`
+  - new field: `capabilities` (required, always emitted)
+
+The added field is a `UiProtocolCapabilities` object with the existing
+shape:
+
+```json
+{
+  "version": {
+    "protocol": "octos-ui/v1alpha1",
+    "schema_version": 1,
+    "jsonrpc": "2.0"
+  },
+  "capabilities_schema_version": 2,
+  "supported_methods": [
+    "session/open",
+    "turn/start",
+    "turn/interrupt",
+    "approval/respond",
+    "approval/scopes/list",
+    "diff/preview/get",
+    "task/list",
+    "task/cancel",
+    "task/restart_from_node",
+    "task/output/read"
+  ],
+  "supported_notifications": [
+    "session/open",
+    "turn/started",
+    "turn/completed",
+    "turn/error",
+    "message/delta",
+    "tool/started",
+    "tool/progress",
+    "tool/completed",
+    "approval/requested",
+    "approval/auto_resolved",
+    "approval/decided",
+    "approval/cancelled",
+    "task/updated",
+    "task/output/delta",
+    "progress/updated",
+    "warning",
+    "protocol/replay_lossy"
+  ],
+  "supported_features": [
+    "pane.snapshots.v1"
+  ]
+}
+```
+
+### Negotiation Semantics
+
+`capabilities.supported_methods` and
+`capabilities.supported_notifications` are the server's first-slice
+baseline so a discovery-aware client can learn the surface in-band even
+when it never sent `X-Octos-Ui-Features`.
+
+`capabilities.supported_features` is computed from the client's
+`X-Octos-Ui-Features` header (or `ui_feature` / `ui_features` query
+param):
+
+1. **No header sent** → server returns
+   `UiProtocolCapabilities::first_server_slice()` (full known feature
+   set). Existing clients that don't yet know to negotiate still see
+   what the server can do.
+2. **Header sent with feature tokens** → server returns the
+   intersection of requested features with the server-known feature
+   registry (`UI_PROTOCOL_KNOWN_FEATURES`). The server **never** leaks a
+   feature flag the client did not ask for; clients see exactly which
+   of their requests were honoured.
+3. **Unknown tokens in the header** → silently dropped from the
+   response (server does not advertise capabilities it cannot honour).
+
+The intersection logic lives behind the new
+`UiProtocolCapabilities::for_negotiated_features` builder in
+`octos-core` and behind a `ConnectionUiFeatures::negotiated_capabilities`
+helper in `octos-cli` so it stays in one place across handlers.
+
+## Compatibility
+
+- Old clients that ignore unknown fields per spec § 4 continue to work
+  unchanged. The TS interface in `e2e/lib/m9-ws-client.ts` already uses
+  `unknown` for the pane field and will treat `capabilities` the same
+  way.
+- Old serialized payloads (ledger replays from before the field
+  existed) decode successfully because the field carries
+  `serde(default = "UiProtocolCapabilities::first_server_slice")`. A
+  replayed `SessionOpened` from an older binary surfaces the
+  first-slice default for the missing field, which is the same payload
+  a fresh open with no header would receive — preserving the
+  "unspecified ⇒ default" invariant.
+- Old servers that have not adopted the field continue to emit a
+  `SessionOpened` without `capabilities`. Clients deserializing such a
+  payload through the new schema get the `first_server_slice` default;
+  no breakage.
+- Existing `UiProtocolLedger` replays continue to work because the
+  ledger stores the JSON wire form, and the new schema decodes both old
+  and new shapes.
+- The `ConnectionUiFeatures` struct gains two private fields
+  (`harness_task_control: bool`, `header_present: bool`) used by the
+  negotiation helper. Both fields default to `false` (matches the
+  pre-UPCR "no header sent" semantics) so existing tests that build the
+  struct via `Default::default()` continue to work.
+- No new protocol identifier is required because the change is
+  additive.
+
+## Capability Negotiation
+
+None. UPCR-2026-007 *is the in-band capability negotiation surface*; it
+does not introduce a new feature flag of its own. The field is
+unconditionally present so a client can rely on its existence (and on
+the `serde` default for legacy replays) without first negotiating
+anything.
+
+The set of feature flags advertised through
+`capabilities.supported_features` is governed by the existing per-flag
+UPCRs (`UPCR-2026-001`, `UPCR-2026-002`, `UPCR-2026-003`,
+`UPCR-2026-005`).
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `session_open_result_includes_capabilities_field` — golden: the
+    serialized `SessionOpened` carries a `capabilities` payload with
+    `version`, `capabilities_schema_version`, `supported_methods`, and
+    every flag in `UI_PROTOCOL_KNOWN_FEATURES`. Also asserts a legacy
+    payload without the field decodes via the `serde` default.
+  - `negotiated_capabilities_advertise_full_protocol_when_no_features_requested`
+    — empty request returns the first-slice baseline with an empty
+    `supported_features`.
+  - `negotiated_capabilities_intersect_requested_with_known_features` —
+    a request containing a known feature plus an unknown token returns
+    only the known feature; never leaks unrequested flags.
+- `crates/octos-cli/src/api/ui_protocol.rs`:
+  - `session_open_result_advertises_full_protocol_when_no_header` —
+    `open_session_result()` with `ConnectionUiFeatures::default()`
+    returns `first_server_slice()` capabilities.
+  - `session_open_result_advertises_intersection_when_header_subset` —
+    a client requesting only `pane.snapshots.v1` receives a session
+    payload whose `supported_features` is exactly that one entry, and
+    the method/notification surface stays intact for in-band
+    discovery.
+
+## Rollout Plan
+
+This UPCR ships in the same PR that:
+
+1. Adds `UI_PROTOCOL_KNOWN_FEATURES` and the
+   `UiProtocolCapabilities::for_negotiated_features` builder to
+   `octos-core`.
+2. Adds the required `capabilities` field to `SessionOpened` with
+   `serde(default = "first_server_slice")` for backward compatibility.
+3. Wires `ConnectionUiFeatures` to track `header_present` and
+   `harness_task_control`, and exposes `negotiated_capabilities()`.
+4. Populates `SessionOpened.capabilities` in `open_session_result`.
+5. Updates `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 4 and § 7 to
+   reference UPCR-2026-007 and document the field semantics.
+
+No client renegotiation is required. Clients that want to gate UI on
+the negotiated set can read the field on their next protocol-types
+update.
+
+## Decision
+
+Accepted by: M9 harness audit follow-up (coding-green).
+
+Decision notes: Accepted as the minimum additive change to close audit
+issue #720. The field ships the existing `UiProtocolCapabilities`
+shape, reuses the existing `X-Octos-Ui-Features` header as the
+negotiation channel, and never leaks a feature the client did not
+request. The required-field-with-`serde(default)` choice keeps wire
+compatibility with older binaries and ledger replays while pinning the
+field as a stable surface new clients can rely on.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md
@@ -127,10 +127,13 @@ shape:
 
 ### Negotiation Semantics
 
-`capabilities.supported_methods` and
-`capabilities.supported_notifications` are the server's first-slice
-baseline so a discovery-aware client can learn the surface in-band even
-when it never sent `X-Octos-Ui-Features`.
+`capabilities.supported_notifications` is always the first-slice
+baseline so a discovery-aware client can learn the event surface
+in-band even when it never sent `X-Octos-Ui-Features`. Notifications
+are not capability-gated at the wire level (the server may simply not
+emit a given notification if the underlying feature is off; a client
+that doesn't request a feature won't react to notifications it doesn't
+know about).
 
 `capabilities.supported_features` is computed from the client's
 `X-Octos-Ui-Features` header (or `ui_feature` / `ui_features` query
@@ -142,11 +145,28 @@ param):
    what the server can do.
 2. **Header sent with feature tokens** → server returns the
    intersection of requested features with the server-known feature
-   registry (`UI_PROTOCOL_KNOWN_FEATURES`). The server **never** leaks a
-   feature flag the client did not ask for; clients see exactly which
+   registry (`UI_PROTOCOL_KNOWN_FEATURES`). The server **never** leaks
+   a feature flag the client did not ask for; clients see exactly which
    of their requests were honoured.
 3. **Unknown tokens in the header** → silently dropped from the
    response (server does not advertise capabilities it cannot honour).
+
+`capabilities.supported_methods` follows the same intersection so the
+advertised method set agrees with the advertised feature set. Methods
+that spec § 7 marks as capability-gated (`task/list`, `task/cancel`,
+`task/restart_from_node` behind `harness.task_control.v1`) appear in
+`supported_methods` only when the gating feature is present in the
+negotiated `supported_features`. Without this, a client that did not
+negotiate `harness.task_control.v1` would see the methods in the
+response, call them, and receive `method_not_supported` from the same
+server it just learnt the methods from. With the gate, advertised
+surface ⇔ callable surface.
+
+Methods without a capability gate (`session/open`, `turn/start`,
+`turn/interrupt`, `approval/respond`, `approval/scopes/list`,
+`diff/preview/get`, `task/output/read`) are unconditionally advertised
+so discovery still works for clients that never send any feature
+header.
 
 The intersection logic lives behind the new
 `UiProtocolCapabilities::for_negotiated_features` builder in
@@ -156,9 +176,12 @@ helper in `octos-cli` so it stays in one place across handlers.
 ## Compatibility
 
 - Old clients that ignore unknown fields per spec § 4 continue to work
-  unchanged. The TS interface in `e2e/lib/m9-ws-client.ts` already uses
-  `unknown` for the pane field and will treat `capabilities` the same
-  way.
+  unchanged. The TS interface in `e2e/lib/m9-ws-client.ts` does not
+  declare a `capabilities` member yet; structural-typing TypeScript
+  consumers will simply see the extra field as untyped and ignore it.
+  Future client updates can add an explicit `capabilities?: unknown` (or
+  a typed `UiProtocolCapabilities` shape) when they are ready to consume
+  the negotiated set.
 - Old serialized payloads (ledger replays from before the field
   existed) decode successfully because the field carries
   `serde(default = "UiProtocolCapabilities::first_server_slice")`. A
@@ -207,7 +230,15 @@ UPCRs (`UPCR-2026-001`, `UPCR-2026-002`, `UPCR-2026-003`,
     `supported_features`.
   - `negotiated_capabilities_intersect_requested_with_known_features` —
     a request containing a known feature plus an unknown token returns
-    only the known feature; never leaks unrequested flags.
+    only the known feature; never leaks unrequested flags. Also pins
+    that capability-gated methods (`task/list`, `task/cancel`,
+    `task/restart_from_node`) are excluded from `supported_methods`
+    when their gating feature is not requested.
+  - `negotiated_capabilities_advertise_task_control_methods_when_feature_requested`
+    — when the client *does* request `harness.task_control.v1`, the
+    advertised method set includes the task-control RPCs so the spec
+    § 7 "expose only when feature flag is advertised" rule is honoured
+    bidirectionally.
 - `crates/octos-cli/src/api/ui_protocol.rs`:
   - `session_open_result_advertises_full_protocol_when_no_header` —
     `open_session_result()` with `ConnectionUiFeatures::default()`

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md
@@ -78,7 +78,10 @@ Affected existing wire surface:
   - new field: `capabilities` (required, always emitted)
 
 The added field is a `UiProtocolCapabilities` object with the existing
-shape:
+shape. Example: a client that requested only `pane.snapshots.v1` via
+`X-Octos-Ui-Features` receives the negotiated payload below — the
+task-control RPCs are excluded from `supported_methods` because their
+gating feature `harness.task_control.v1` was not in the request:
 
 ```json
 {
@@ -95,9 +98,6 @@ shape:
     "approval/respond",
     "approval/scopes/list",
     "diff/preview/get",
-    "task/list",
-    "task/cancel",
-    "task/restart_from_node",
     "task/output/read"
   ],
   "supported_notifications": [
@@ -124,6 +124,12 @@ shape:
   ]
 }
 ```
+
+A client that sends no `X-Octos-Ui-Features` header receives the full
+`first_server_slice` payload instead — `supported_methods` includes
+the task-control RPCs and `supported_features` includes every name in
+`UI_PROTOCOL_KNOWN_FEATURES` — so it can still discover the surface in
+one round-trip.
 
 ### Negotiation Semantics
 
@@ -279,3 +285,19 @@ negotiation channel, and never leaks a feature the client did not
 request. The required-field-with-`serde(default)` choice keeps wire
 compatibility with older binaries and ledger replays while pinning the
 field as a stable surface new clients can rely on.
+
+### Out of Scope
+
+- **Runtime-side enforcement of `harness.task_control.v1`.** This UPCR
+  gates *advertisement*: a client that did not request the feature does
+  not see the methods in `supported_methods`. The
+  `handle_task_list` / `handle_task_cancel` /
+  `handle_task_restart_from_node` handlers in
+  `crates/octos-cli/src/api/ui_protocol.rs` still accept the calls
+  regardless of `ConnectionUiFeatures.harness_task_control`. A
+  well-behaved client that consults `supported_methods` will not call
+  them, but a malformed client could still hit the handler. Wiring
+  runtime rejection (returning `method_not_supported` when the feature
+  is not negotiated) is a follow-up tracked separately — it requires
+  threading the negotiated set through every command dispatcher and is
+  larger than the scope this UPCR closes.


### PR DESCRIPTION
## Summary

Closes audit issue #720: `SessionOpened` never echoed back the negotiated capability set, so clients had to read the spec doc to know which `X-Octos-Ui-Features` tokens the server actually honoured.

- Adds a required `capabilities: UiProtocolCapabilities` field to `SessionOpened` (used by both `SessionOpenResult.opened` and the `session/open` notification). `serde(default = "first_server_slice")` keeps backward compatibility with older serialized payloads (ledger replays, older binaries).
- New `UiProtocolCapabilities::for_negotiated_features` builder intersects the client's `X-Octos-Ui-Features` request with the server's known feature registry. Method-set is gated by the same intersection — capability-gated methods (`task/list`, `task/cancel`, `task/restart_from_node` behind `harness.task_control.v1`) appear in `supported_methods` only when the gating feature is negotiated, so advertised surface == callable surface.
- Spec § 4 (Versioning), § 7 (`session/open` Command Semantics), § 8 (`session/open` notification) cross-reference [UPCR-2026-007](docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_007_SESSION_OPEN_CAPABILITIES.md).
- UPCR-2026-007 follows the UPCR-2026-005 shape with status `accepted`. Out-of-scope: runtime-side enforcement (this UPCR gates advertisement; runtime rejection is a separate follow-up documented in the UPCR).

## Negotiation rules

- **No header sent** => server returns `first_server_slice()` (full known set) so discovery-aware clients learn the surface in-band.
- **Header sent** => `supported_features` is the intersection with `UI_PROTOCOL_KNOWN_FEATURES`. `supported_methods` is filtered by `method_capability_gate`. Server never advertises a flag the client did not request.
- **Unknown tokens** => silently dropped.

## Codex 2nd-opinion

Two rounds of review caught:
1. Method-set leak (`task/list` etc. advertised when `harness.task_control.v1` was not negotiated) -> fixed in commit 2 with `method_capability_gate`.
2. Stale example payload in the UPCR doc -> fixed in commit 3.

Final review verified the gate maps only task-control methods, no other capability-gated RPCs were missed (`approval/scopes/list`, `diff/preview/get`, `task/output/read` are unconditional per spec § 7), and noted the runtime-routing follow-up which is documented as out-of-scope.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p octos-core ui_protocol` => 43 passed (includes 3 new round-trip + intersection tests)
- [x] `cargo test -p octos-cli api::ui_protocol --features api` => 170 passed (includes 2 new handler tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `./scripts/check-ui-protocol-upcr.sh` reports UPCR coverage
- [ ] e2e harness regression smoke (manual)

DO NOT auto-merge.