### PR TITLE
docs(api): add server/app/tui feature requirements + allowlist api/*.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,11 @@ scripts/deploy.sh
 !docs/m8-runtime-migration-runbook.md
 !docs/OCTOS_HARNESS_ENGINEERING_REQUIREMENTS_M6_M9.md
 !docs/OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md
+# Canonical product/engineering spec docs under api/. The UI Protocol v1
+# spec (api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md) was tracked manually before
+# this rule existed; the server/app/tui feature-requirement specs added
+# 2026-04-30 follow the same convention.
+!api/*.md
 # UI Protocol change requests (UPCR) — required by check-ui-protocol-upcr.sh
 # whenever protocol-visible code changes; listed in
 # api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md.

--- a/api/OCTOS_APP_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_APP_FEATURE_REQUIREMENTS.md
@@ -1,0 +1,236 @@
+# Octos App Feature Requirements
+
+Status: proposed test contract.
+Owner: octos-app.
+Applies to: native Makepad desktop client, transport, store, renderer, coding
+workspace, content/studio surfaces, and AppUI integration.
+
+## Purpose
+
+This document defines the feature requirements that `octos-app` must satisfy to
+serve as the production native client for Octos. It is the desktop-client
+counterpart to the server and TUI requirements documents in this directory.
+
+The app must provide a richer visual and multi-pane experience than the TUI
+while preserving the same AppUI contract. The app must not depend on private
+server behavior, raw logs, or one-off REST shortcuts for interactive runtime
+truth.
+
+## Product Principles
+
+- `octos-app` is an AppUI client first. Interactive runtime state comes from
+  shared `octos-core` AppUI/UI Protocol types.
+- REST is allowed for cold snapshots, file bytes, content libraries, and legacy
+  compatibility. It must not replace AppUI for live turns, approvals, task
+  lifecycle, diff previews, or task output.
+- The store is the source of UI truth inside the app. Transport events fold into
+  reducer state before widgets render.
+- The app must degrade gracefully when capabilities are absent and must ignore
+  unknown future capabilities and enum values where the shared protocol permits.
+- UI decisions must support long-running coding sessions: many turns, many
+  approvals, many tool calls, reconnects, and background tasks.
+- Secrets and auth tokens must never appear in rendered UI, logs intended for
+  users, crash summaries, or copied diagnostics.
+
+## Requirement Matrix
+
+| ID | Requirement | Priority | Acceptance Criteria | Verification |
+|---|---|---:|---|---|
+| APP-001 | Native app shell | P0 | App launches to a usable shell with chat, navigation, connection state, profile/session context, and no placeholder-only landing page. | app smoke test |
+| APP-002 | AppUI transport | P0 | WebSocket JSON-RPC transport sends and receives shared AppUI commands/results/notifications using `octos-core` types. | transport contract tests |
+| APP-003 | Capability negotiation | P0 | App requests and parses supported AppUI features including typed approvals, pane snapshots, workspace cwd, task output, and future task-control features when available. Unknown features are ignored safely. | transport unit tests |
+| APP-004 | Session open | P0 | App opens sessions with session id, profile id, auth token, optional cursor, and workspace cwd when configured. Invalid open errors surface clearly. | live/protocol smoke |
+| APP-005 | Workspace cwd | P0 | App passes server-side workspace cwd for coding sessions and displays effective workspace root or typed rejection. | store/integration test |
+| APP-006 | Reconnect and replay | P0 | App persists cursor per session, reconnects with `session/open { after }`, applies replay in order, handles cursor invalid/lossy replay by rehydrating snapshot state. | transport fault tests |
+| APP-007 | Store reducer authority | P0 | All protocol notifications fold through `octos-app-store`; widgets do not mutate protocol truth directly. | reducer tests and code review |
+| APP-008 | Chat stream | P0 | `message/delta` renders live assistant text; terminal turn events commit/clear live state without duplicating content after reconnect. | store tests |
+| APP-009 | User prompt ordering | P0 | User prompts appear in chat before assistant/tool output they triggered. Queued prompts remain visually distinct from sent turns. | reducer/UI snapshot |
+| APP-010 | Turn control | P0 | App can send `turn/start` and `turn/interrupt`; interruption status distinguishes no-active-turn, requested, interrupted, and failed. | transport/store tests |
+| APP-011 | Approval cards | P0 | Typed approval requests render as command, diff, filesystem, network, sandbox escalation, or generic fallback cards with risk and clear decision controls. | UI snapshot tests |
+| APP-012 | Approval response | P0 | Approve once, approve scoped/session, and deny send `approval/respond` with correct id/session/scope. Retry/stale errors render as decided/expired, not as pending. | contract tests |
+| APP-013 | Approval lifecycle | P0 | `approval/decided`, `approval/auto_resolved`, and `approval/cancelled` update queue/history and remove actionable pending approvals. | store tests |
+| APP-014 | Diff preview | P0 | Diff approvals and file mutation previews can fetch and render `diff/preview/get` results with file list, hunks, additions/removals, renames, truncation/limitations when present. | UI/render tests |
+| APP-015 | Coding workspace | P0 | Coding screen shows approval queue/history, task dock, preview pane, command/network/filesystem/diff/output detail, and connection/task status. | app snapshot |
+| APP-016 | Task dock | P0 | Task list renders task id/title/state/progress/output availability. Cancelled/completed/failed/running states are visually distinct. | store/render tests |
+| APP-017 | Task output read | P0 | App can request `task/output/read`, preserve output cursor per task, append `task/output/delta`, cap buffers, and avoid duplicate output after reconnect. | store + transport tests |
+| APP-018 | Task control readiness | P1 | When server advertises task-control support, app exposes list/cancel/restart affordances through AppUI. When absent, controls are hidden or disabled with explanation. | capability tests |
+| APP-019 | Tool cards | P0 | Tool lifecycle renders command/tool cards with name, arguments or command, status, duration, output preview, error/success state, and expandable details. | UI snapshot |
+| APP-020 | Progress and status | P0 | Progress events update visible working state, file mutation status, retry/cost summaries, and warnings without flooding chat with low-value event rows. | reducer tests |
+| APP-021 | Pane snapshots | P1 | App hydrates workspace, artifacts, and git panes from `session/open.panes` when supported and falls back to REST/snapshot sources when absent. | protocol fixture |
+| APP-022 | Content viewer | P1 | App opens generated content and artifacts using appropriate viewers for image album, markdown, audio, video, generic files, and external OS open fallback. | UI tests |
+| APP-023 | Studio surfaces | P2 | Slides/sites/research producer screens use the same transport/store patterns and declare their server dependencies explicitly. | workstream tests |
+| APP-024 | Auth and profile | P0 | App stores auth safely, sends bearer/profile headers, supports profile switching, handles 401/403 by entering auth-required state, and redacts secrets. | auth tests |
+| APP-025 | Connection state | P0 | UI shows connected, connecting, reconnecting, offline, auth failed, and protocol error states. Connection state is folded into store and visible globally. | store/UI tests |
+| APP-026 | Error handling | P0 | Typed AppUI errors map to user-actionable messages. Unknown errors preserve code/kind without panics. | error fixture tests |
+| APP-027 | Replay lossy | P0 | `protocol/replay_lossy` creates a visible rehydrate warning and triggers or offers snapshot rehydrate. | reducer test |
+| APP-028 | Forward compatibility | P0 | Unknown capabilities, unknown approval kinds, future task states, and additive payload fields do not crash decode or rendering. | fuzz/serde tests |
+| APP-029 | Markdown rendering | P0 | Chat and content markdown render headings, lists, code, tables, links, images where supported, and CJK text without unsafe HTML/script execution. | render tests |
+| APP-030 | Layout responsiveness | P0 | Main shell, chat, coding workspace, approval cards, task dock, and preview panes adapt to desktop window sizes without overlapping controls. | pixel/widget snapshots |
+| APP-031 | Accessibility basics | P1 | Keyboard navigation covers core actions, focus state is visible, clickable controls have text labels/tooltips, and color is not the only state indicator. | manual + widget tests |
+| APP-032 | Performance | P1 | 50 approvals, 500 messages, long tool output, and large task lists remain responsive with virtualized or bounded rendering. | stress tests |
+| APP-033 | Persistence | P1 | Local app state persists sessions, cursor, selected profile, UI preferences, and safe drafts without persisting secrets in plaintext. | persistence tests |
+| APP-034 | Build and packaging | P0 | App builds on supported platforms, has reproducible release profile, and CI runs store/transport/app checks. | CI |
+| APP-035 | Observability | P1 | App records sanitized telemetry for connection failures, protocol errors, approval failures, task output failures, and panics. | telemetry tests |
+| APP-036 | Client parity | P0 | App behavior remains protocol-compatible with `octos-tui` for core flows: session, turns, approvals, diffs, tasks, replay, cwd, and errors. | shared fixture tests |
+
+## Major Interaction Flows
+
+### 1. App Launch And Session Open
+
+Precondition: user starts the native app with a configured server endpoint.
+
+Expected flow:
+
+1. App loads local preferences and auth/profile configuration.
+2. App connects to the AppUI WebSocket and sends `session/open`.
+3. App requests supported capabilities and workspace cwd when configured.
+4. Store folds `session/open` result, pane snapshots, and connection state.
+5. Shell renders chat/coding/content navigation with visible connection status.
+
+### 2. Coding Chat Turn
+
+Precondition: session is open and connected.
+
+Expected flow:
+
+1. User submits prompt from chat or coding screen.
+2. Store records the user message before assistant/tool output.
+3. App sends `turn/start`.
+4. Live assistant text streams through `message/delta`.
+5. Tool lifecycle, progress, task updates, approvals, and diff previews update
+   structured UI surfaces.
+6. Terminal turn event commits or fails the turn and clears active working
+   state.
+
+### 3. Approval Review
+
+Precondition: server emits `approval/requested`.
+
+Expected flow:
+
+1. Pending approval appears in queue and, when relevant, in coding preview pane.
+2. Typed details render the right subtype view.
+3. User can approve once, approve scoped/session, or deny.
+4. App sends `approval/respond`.
+5. Response and lifecycle notifications update approval history.
+6. Duplicate/stale responses never leave a pending card behind.
+
+### 4. Diff And File Mutation Review
+
+Precondition: approval or progress event includes a diff preview id.
+
+Expected flow:
+
+1. App fetches `diff/preview/get`.
+2. Diff renders by file and hunk, with clear additions/removals.
+3. Large or unavailable diff content shows limitation state.
+4. User can inspect diff before approving a diff/file mutation.
+
+### 5. Task Output Drill-Down
+
+Precondition: task is selected in task dock.
+
+Expected flow:
+
+1. User opens task output.
+2. App sends `task/output/read` with last cursor and byte limit.
+3. Store updates rolling output buffer and cursor.
+4. Future `task/output/delta` appends without duplicates.
+5. Reconnect rehydrates visible task state and output cursor safely.
+
+### 6. Reconnect And Recovery
+
+Precondition: WebSocket drops or app resumes from sleep.
+
+Expected flow:
+
+1. App enters reconnecting state without discarding current visible state.
+2. App reconnects and sends last cursor in `session/open`.
+3. Valid replay applies in order.
+4. Cursor invalid or lossy replay triggers snapshot rehydrate and visible user
+   warning.
+5. Pending approvals/tasks are reconciled to server truth.
+
+## Required Test Coverage
+
+### Store Tests
+
+- Session open, cursor update, reconnect, replay lossy, and cursor reset.
+- Turn start, live delta, completed, error, and interrupt.
+- Approval requested, responded, decided, auto-resolved, cancelled, stale.
+- Task updated for pending, running, completed, failed, cancelled.
+- Task output read result, output delta, cursor preservation, duplicate
+  prevention, and buffer cap.
+- Unknown/future wire values.
+- Connection and auth state transitions.
+
+### Transport Tests
+
+- JSON-RPC request/response correlation.
+- WebSocket reconnect and replay.
+- Auth/profile headers.
+- Capability request and parsing.
+- `session/open` with workspace cwd.
+- `approval/respond`, `diff/preview/get`, `task/output/read`.
+- Future task-control methods once server API lands.
+- Fault injection for malformed frames, unknown methods, timeout, closed socket,
+  and typed AppUI errors.
+
+### UI/Render Tests
+
+- Chat stream with markdown, CJK, code, table, and long message.
+- Coding screen empty, active approval, typed diff, command approval, selected
+  task output, and failed task.
+- Task dock with many tasks and all states.
+- Connection status banner/dot across all global states.
+- Window-size snapshots for small, normal, and large desktop sizes.
+- Secret redaction in copied diagnostics and logs.
+
+### Live Tests
+
+- Connect to real `octos serve`.
+- Run a live coding turn with approval, diff preview, task output, and reconnect.
+- Compare core protocol behavior with `octos-tui` on the same fixture.
+- Verify app remains responsive through a long-running coding session.
+
+## Current Implementation Notes
+
+The current local `octos-app` workspace already contains implementation pieces
+for this contract:
+
+- `crates/octos-app-transport` handles AppUI transport/capabilities.
+- `crates/octos-app-store` folds protocol notifications into app state.
+- `app/src/backend/octos_ui.rs` owns WebSocket/backend integration.
+- `app/src/main.rs` wires backend state, task output handle, and app actions.
+- `app/src/app/coding.rs` provides the coding screen surface.
+- `crates/octos-app-store/src/approvals.rs` owns approval queue/history.
+- `crates/octos-app-store/src/state.rs` handles task state, approval lifecycle,
+  replay-lossy, and reducers.
+
+Known operational issue:
+
+- `/Users/yuechen/home/octos-app` is currently not a git repository in this
+  environment. Before release work, restore or reclone it as a real checkout so
+  diffs, branches, commits, and PRs are auditable.
+
+Known gaps relative to this requirements document:
+
+- AppUI task-control methods depend on the server task-control merge path.
+- Diff hunk rendering and large-diff behavior need full UI snapshot coverage.
+- Some coding screen implementation is still monolithic and should be split
+  only when doing so lowers test and maintenance risk.
+- True task stdout/stderr live-tail depends on the server feature; current app
+  support must respect the server's snapshot-projection limitation.
+- Cross-client parity with `octos-tui` should be added as shared fixtures, not
+  hand-checked only.
+
+## Release Gate
+
+No `octos-app` branch should be considered production-ready unless:
+
+- all P0 requirements have store, transport, UI, or live coverage
+- the app builds from a real git checkout
+- AppUI protocol changes compile against current `octos-core`
+- unknown/future protocol values do not crash decode/render paths
+- auth/profile/secret hygiene is verified
+- live coding session with approvals, diff, task output, and reconnect passes

--- a/api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md
@@ -1,0 +1,250 @@
+# Octos Server Feature Requirements
+
+Status: proposed test contract.
+Owner: octos server/runtime.
+Applies to: `octos serve`, AppUI/UI Protocol, harness runtime, task supervisor,
+approval gate, durable ledger, dashboard/API surfaces, and client integration.
+
+## Purpose
+
+This document defines the server-side feature requirements that Octos must
+satisfy before the server can be treated as a production AppUI/harness runtime.
+It is intended to be used as a merge gate for `octos` main and as a shared
+contract for `octos-tui`, `octos-app`, dashboard, API clients, and future app
+harnesses.
+
+The server is responsible for runtime truth. Clients may render, organize, and
+request state, but they must not need to guess the runtime lifecycle from raw
+logs, prompt text, or private implementation details.
+
+## Non-Negotiable Product Principles
+
+- AppUI is the stable client contract. Server behavior that clients depend on
+  must be represented in shared `octos-core` protocol types and protocol golden
+  tests.
+- Runtime truth lives on the server. The server owns session state, approval
+  state, task state, sandbox policy, workspace cwd, artifact truth, and replay
+  cursors.
+- Durable state must not be overwritten by stale replay. A disk snapshot or old
+  ledger segment must never regress a newer live session.
+- Terminal states must survive backpressure. Completed, failed, cancelled, and
+  approval-decided/cancelled events are not optional progress noise.
+- App harnesses are not prompt conventions. Artifact contracts, validators,
+  background tasks, and operator truth must be explicit runtime objects.
+- Additive protocol changes must preserve old clients where possible and must
+  advertise capabilities before clients rely on them.
+
+## Requirement Matrix
+
+| ID | Requirement | Priority | Acceptance Criteria | Verification |
+|---|---|---:|---|---|
+| SRV-001 | AppUI protocol source of truth | P0 | All client-visible methods, notifications, params, results, error codes, and feature flags are defined in `octos-core`; no server/client private wire extensions. | core golden tests and API grep gate |
+| SRV-002 | Capability advertisement | P0 | Server advertises only supported AppUI methods/features, including mode-specific limitations or typed `runtime_not_ready` behavior. | protocol e2e capability test |
+| SRV-003 | Session open and replay | P0 | `session/open` creates or rehydrates a session, returns active profile, workspace root, cursor, pane snapshots when supported, and typed errors on invalid cursor/session/cwd. | `m9-protocol-session-open` e2e |
+| SRV-004 | Workspace cwd enforcement | P0 | Requested cwd is canonicalized and accepted only under approved readable/writable roots. Tools execute relative to session cwd, not server launch cwd. | unit tests plus live cwd fixture |
+| SRV-005 | Turn lifecycle | P0 | `turn/start`, `turn/started`, streamed `message/delta`, `turn/completed`, and `turn/error` form a deterministic lifecycle with one active turn per session unless explicitly supported otherwise. | protocol e2e and race tests |
+| SRV-006 | Turn interruption | P0 | `turn/interrupt` is idempotent, scoped to session and turn id, drains pending approvals, cancels active work safely, and emits terminal state. | TOCTOU and approval-drain tests |
+| SRV-007 | Typed error taxonomy | P0 | AppUI errors use stable JSON-RPC/app code ranges and typed `error.data.kind`; no collisions with reserved JSON-RPC codes. | core taxonomy tests |
+| SRV-008 | Approval request shape | P0 | Approval requests include stable id, session, turn, tool name, title/body, risk, approval kind, typed details, render hints, and optional diff preview id. | approval protocol golden tests |
+| SRV-009 | Approval response semantics | P0 | `approval/respond` accepts approve/deny decisions, enforces scope, rejects stale decisions with typed errors, records manual and auto decisions, and resumes runtime only when appropriate. | approval unit and e2e tests |
+| SRV-010 | Approval lifecycle notifications | P0 | `approval/requested`, `approval/auto_resolved`, `approval/decided`, and `approval/cancelled` are durable enough for reconnecting clients to render the true state. | replay and interrupt tests |
+| SRV-011 | Approval backpressure safety | P0 | Approval send failures/backpressure cancel or drain pending runtime waits so the model cannot continue as if the user approved. | fault injection test |
+| SRV-012 | Manifest-declared risk | P0 | Tool risk shown to clients comes from trusted manifests or explicit `unspecified`; missing risk must not silently downgrade to low risk. | plugin manifest tests |
+| SRV-013 | Sandbox policy preservation | P0 | AppUI and tool execution preserve profile/session sandbox config, network policy, writable roots, and approval policy. Defaults are used only when no explicit policy exists. | sandbox parity tests |
+| SRV-014 | Diff preview API | P0 | File mutation progress and diff approvals produce stable preview ids; `diff/preview/get` resolves paths against session cwd, supports multi-file previews, and returns typed missing/expired errors. | diff preview e2e |
+| SRV-015 | Diff preview durability | P1 | Diff preview metadata survives reconnect while relevant, with clear expiry semantics. Stale previews return typed errors, not wrong content. | replay/expiry tests |
+| SRV-016 | Task lifecycle model | P0 | Task runtime state includes pending, running, completed, failed, and cancelled; mappings from internal supervisor states are deterministic. | core/server mapping tests |
+| SRV-017 | Task registry | P0 | Server maintains a scoped background task registry with stable task ids, title/tool, session lineage, state, runtime detail, output cursor, and timestamps. | task supervisor tests |
+| SRV-018 | Task updates | P0 | Task updates are emitted as AppUI notifications with task id, session id, title, state, runtime detail, and terminal states. Terminal updates survive backpressure. | backpressure tests |
+| SRV-019 | Task output read | P0 | `task/output/read` returns a bounded snapshot projection with cursor, output text, output files, source, and limitations. It must not pretend to be full live-tail unless live-tail is implemented. | task output protocol tests |
+| SRV-020 | Task output live-tail | P1 | Active task output deltas are streamed through `task/output/delta` with cursor monotonicity and duplicate prevention. | live-tail e2e |
+| SRV-021 | Task control API | P1 | AppUI supports task list, cancel, and restart-from-node when advertised. Requests are session/profile scoped and reject missing/invalid scope with typed errors. | task-control protocol e2e |
+| SRV-022 | Restart-from-node semantics | P1 | Restart creates a successor task only when runtime can either execute it or explicitly marks it as accepted/pending-runtime. Clients must not mistake placeholder registration for completed restart. | supervisor and protocol tests |
+| SRV-023 | Swarm task lifecycle | P0 | Swarm/subagent tasks expose creation, task id, pending/running/completed/failed/cancelled states, cancellation, progress, structured output, and registry visibility. | swarm/task supervisor tests |
+| SRV-024 | Swarm observability | P1 | Server exposes enough task and progress data for clients to implement `/ps`, status rows, expandable task cards, and agent labels without scraping logs. | AppUI contract tests |
+| SRV-025 | MCP/CLI/subagent parity | P1 | Swarm work launched as MCP server calls, CLI calls, or subagents maps into the same task lifecycle and observability model. | integration tests |
+| SRV-026 | Durable UI ledger | P0 | Durable AppUI notifications are appended to a ledger with monotonic cursors and schema versioning. Replay by cursor must be deterministic. | ledger unit and e2e tests |
+| SRV-027 | Ledger recovery safety | P0 | Disk replay, rotation, and snapshot recovery must never apply a stale snapshot over newer live state. | crash/replay regression test |
+| SRV-028 | Replay lossy signal | P0 | If durable notifications are dropped or cursor continuity is broken, server emits `protocol/replay_lossy` with dropped count and last durable cursor when known. | backpressure/fault tests |
+| SRV-029 | Backpressure policy | P0 | Non-terminal progress can coalesce or drop with accounting. Terminal state, approval lifecycle, and replay-lossy signals must use delivery paths that survive transient backpressure. | stress tests |
+| SRV-030 | Pane snapshots | P1 | `session/open` can include workspace, artifacts, and git snapshots when capability is advertised; missing panes degrade gracefully. | pane snapshot tests |
+| SRV-031 | Artifact truth | P0 | Final artifacts come from declared contract/runtime truth, not filename heuristics. Failed validators block success. | harness artifact tests |
+| SRV-032 | Validator enforcement | P0 | Harness validators run at declared lifecycle points and can prevent a task/session from being marked ready. | harness policy tests |
+| SRV-033 | Workspace policy | P0 | App/workspace policy declares roots, artifacts, validation, spawn rules, and sandbox limits; runtime enforces it before publish/delivery. | policy fixture tests |
+| SRV-034 | Session/task persistence | P0 | Release-critical session/task state survives chat compaction, process restart, host restart, actor crash, and reconnect where required by the contract. | restart/recovery tests |
+| SRV-035 | Client compatibility | P0 | Any AppUI enum or wire change is tested against known clients or made forward-compatible through fallback variants/wildcard-safe client guidance. | downstream compile checks |
+| SRV-036 | Protocol change governance | P0 | Every AppUI behavior change has a UPCR or protocol doc update, shared type changes, golden tests, server tests, and client migration notes. | PR checklist |
+| SRV-037 | Security and secret hygiene | P0 | API keys, auth tokens, bearer headers, and sensitive env values are never emitted through AppUI notifications, logs intended for clients, e2e captures, or task output summaries. | redaction tests |
+| SRV-038 | Auth and profile isolation | P0 | WebSocket/API requests are authenticated, profile scoped, and cannot read/control sessions or tasks outside the authorized profile/session. | auth tests |
+| SRV-039 | Metrics and audit | P1 | Server records counters for dropped sends, replay-lossy, approval decisions, task terminal states, tool failures, and task-control commands. | metrics tests |
+| SRV-040 | Live coding UX support | P1 | Server emits enough structured data for clients to show model working state, tool cards, approvals, diffs, plan/task progress, final recap, and background task status without parsing assistant prose. | long coding tmux harness |
+
+## Major Server Flows
+
+### 1. Session Open And Rehydrate
+
+Precondition: an authenticated AppUI client connects to the WebSocket endpoint.
+
+Expected flow:
+
+1. Client sends `session/open` with session id, profile id, optional cwd, and
+   optional cursor.
+2. Server validates auth, profile scope, cwd policy, and cursor.
+3. Server opens or rehydrates the session.
+4. Server sends a typed success result and durable replay notifications after
+   the requested cursor when applicable.
+5. If replay cannot be exact, server emits `protocol/replay_lossy` and gives
+   clients enough state to rehydrate.
+
+### 2. Coding Turn
+
+Precondition: session is open and no incompatible active turn exists.
+
+Expected flow:
+
+1. Client sends `turn/start`.
+2. Server records turn identity and emits `turn/started`.
+3. Server streams `message/delta`, tool lifecycle notifications, progress, task
+   updates, approval requests, diff preview ids, and task output deltas as
+   structured AppUI events.
+4. Server enforces sandbox, approval, workspace policy, and validator gates.
+5. Server emits exactly one terminal turn event: `turn/completed` or
+   `turn/error`.
+
+### 3. Approval-Gated Tool Execution
+
+Precondition: a tool requires user approval.
+
+Expected flow:
+
+1. Server creates a stable approval id and stores pending approval state.
+2. Server emits `approval/requested` with risk and typed details.
+3. Runtime waits for manual response or auto-resolution.
+4. `approval/respond` is scoped and validates decision, approval id, session,
+   turn, and policy.
+5. Server emits `approval/decided` or `approval/auto_resolved`.
+6. If turn is interrupted or send fails, server emits `approval/cancelled` and
+   unblocks runtime safely.
+
+### 4. Background Task And Swarm Execution
+
+Precondition: server spawns background work as CLI, MCP, or subagent work.
+
+Expected flow:
+
+1. Server allocates stable task id and records lineage/session scope.
+2. Server emits task state transitions and progress.
+3. Server captures structured output and bounded output previews.
+4. Terminal task state is durable and survives transient send backpressure.
+5. Task list/read/cancel/restart APIs operate only within authorized session
+   and profile scope.
+
+### 5. Diff Preview
+
+Precondition: a file mutation or diff approval has a previewable patch.
+
+Expected flow:
+
+1. Server stores preview metadata keyed by preview id.
+2. Server emits preview id through typed approval details or file mutation
+   progress.
+3. Client requests `diff/preview/get`.
+4. Server resolves file paths relative to session cwd and returns a bounded
+   multi-file diff preview.
+5. Stale or unknown preview ids return typed errors.
+
+### 6. Ledger Replay And Crash Recovery
+
+Precondition: server restarts or client reconnects with a cursor.
+
+Expected flow:
+
+1. Server loads durable ledger segments and current live state.
+2. Server refuses to apply stale snapshots over newer live session state.
+3. Server replays durable notifications in cursor order.
+4. Server surfaces gaps with `protocol/replay_lossy`.
+5. Client can call `session/open`, `task/list`, `task/output/read`, and pane
+   snapshot APIs to rehydrate current visible state.
+
+## Required Test Coverage
+
+### Rust Unit Tests
+
+- AppUI method/result mapping and golden JSON.
+- Error taxonomy code ranges and `error.data.kind` shapes.
+- Session key parsing, profile/cwd/scope validation.
+- Approval state transitions including stale respond, auto-resolution,
+  cancellation, and interruption.
+- Task state mapping including cancelled.
+- Task supervisor terminal delivery under backpressure.
+- Ledger append, cursor replay, rotation, snapshot recovery, and stale snapshot
+  prevention.
+- Diff preview path resolution and unknown/expired preview errors.
+- Sandbox config preservation across AppUI request handling.
+
+### Protocol E2E Tests
+
+- `session/open` with valid cwd, invalid cwd, cursor replay, cursor out of
+  range, and pane snapshots.
+- `turn/start` with streaming, tools, approval, diff preview, task output, and
+  terminal events.
+- `turn/interrupt` during model thinking, during approval wait, and during tool
+  execution.
+- `approval/respond` for approve once, approve session, deny, stale approval,
+  profile mismatch, and auto-resolved approval.
+- `task/output/read` with cursor, limit, unknown task, and projection
+  limitations.
+- Task list/cancel/restart when task-control is advertised.
+- Backpressure/fault injection for terminal task updates and approval sends.
+
+### Integration And Live Tests
+
+- Long-running coding session with real provider and many tool calls.
+- Multi-agent/swarm session where task registry shows all child work.
+- Server restart/reconnect during active or recently completed background work.
+- Dashboard/API/TUI compatibility smoke.
+- Downstream `octos-tui` and `octos-app` compile and protocol smoke after
+  AppUI changes.
+
+## Current Implementation Notes
+
+Current implementation already includes many server primitives that should be
+preserved and tested:
+
+- Shared AppUI/UI Protocol types in `crates/octos-core/src/ui_protocol.rs` and
+  `crates/octos-core/src/app_ui.rs`.
+- WebSocket AppUI handler in `crates/octos-cli/src/api/ui_protocol.rs`.
+- Approval helpers in `crates/octos-cli/src/api/ui_protocol_approvals.rs`.
+- Durable UI ledger in `crates/octos-cli/src/api/ui_protocol_ledger.rs`.
+- Diff preview helper in `crates/octos-cli/src/api/ui_protocol_diff.rs`.
+- Task output projection in `crates/octos-cli/src/api/ui_protocol_task_output.rs`.
+- Task supervisor in `crates/octos-agent/src/task_supervisor.rs`.
+- Harness event/error primitives in `crates/octos-agent/src/harness_events.rs`
+  and `crates/octos-agent/src/harness_errors.rs`.
+- Harness developer contract docs under `docs/OCTOS_HARNESS_*`.
+
+Known gaps to track against this document:
+
+- AppUI task-control support must be merged only with compatible `octos-tui`
+  and `octos-app` client handling.
+- `task/output/read` is currently a snapshot projection; true disk-routed
+  stdout/stderr live-tail is a separate feature.
+- Task-control capability advertisement must define whether support is binary
+  level or runtime-mode level.
+- Restart-from-node semantics must distinguish accepted placeholder from actual
+  re-execution when no relaunch callback is wired.
+- Some client UX needs, such as `/ps`, `/stop`, expandable task cards, and
+  Codex-style status rows, depend on this server exposing stable structured
+  task/progress data.
+
+## Release Gate
+
+No server branch should merge to main as AppUI/harness complete unless:
+
+- all P0 requirements touched by the branch have focused tests
+- AppUI protocol changes update shared types and golden tests
+- terminal states survive backpressure in tests
+- replay/ledger changes include stale snapshot regression coverage
+- approval and sandbox policy behavior is preserved
+- downstream `octos-tui` and `octos-app` compatibility is verified or the
+  branch is explicitly marked server-only with a migration plan

--- a/api/OCTOS_TUI_FEATURE_REQUIREMENTS.md
+++ b/api/OCTOS_TUI_FEATURE_REQUIREMENTS.md
@@ -1,0 +1,253 @@
+# Octos TUI Feature Requirements
+
+Status: proposed test contract.
+Owner: octos-tui.
+Applies to: mock mode, protocol mode, live coding UX parity runs.
+
+## Purpose
+
+This document defines the user-facing feature requirements that `octos-tui`
+must satisfy before it can be treated as a production coding client for the
+Octos AppUI protocol. It is intended to be used by unit tests, snapshot tests,
+tmux harnesses, and human review.
+
+The goal is not visual imitation for its own sake. The goal is a terminal UX
+where a coding user can always answer four questions:
+
+- What is the model doing now?
+- What is waiting on me?
+- What changed in the workspace?
+- What can I safely do next?
+
+## Non-Negotiable Product Principles
+
+- The TUI is an AppUI client. It must consume shared `octos-core` AppUI/UI
+  Protocol types and must not invent private wire extensions.
+- The first screen is the working coding interface, not a landing page or
+  diagnostic page.
+- The composer, system status, and blocking approvals must remain stable and
+  visible while chat content scrolls.
+- Chat output must be readable as a transcript. Raw protocol events, tracing
+  logs, API keys, timestamps, and internal debug noise must not appear in the
+  normal chat flow.
+- Terminal colors must respect the selected theme and terminal constraints.
+  Important states can use accent colors, but the UI must not force bright
+  green or high-saturation blocks when the terminal theme does not call for it.
+- Long-running coding sessions are the primary UX case. The TUI must remain
+  understandable after many turns, many tool calls, queued user messages, and
+  background tasks.
+
+## Requirement Matrix
+
+| ID | Requirement | Priority | Acceptance Criteria | Verification |
+|---|---|---:|---|---|
+| TUI-001 | Chat-first default layout | P0 | Default view shows transcript, composer, and status without requiring inspector mode. Composer never scrolls with transcript. | tmux screenshot at idle/running/done |
+| TUI-002 | Stable composer cursor | P0 | Exactly one visible input cursor exists and it is inside the composer input line, never above the input line. | tmux visual assertion and cursor-position test |
+| TUI-003 | Sticky status row | P0 | A status row is visually attached to the composer area and shows idle/working/blocked/error/done state. It is not rendered as chat text or composer input. | snapshot test and tmux capture |
+| TUI-004 | Non-animated idle state | P0 | When no turn, task, approval, or background job is active, the status row shows a static `Idle` state with no spinner. | unit state test and idle tmux capture |
+| TUI-005 | Live working state | P0 | During an active turn, the status row shows a changing working label, elapsed time, interrupt affordance, and background task count when available. | live tmux harness |
+| TUI-006 | User message transcript rendering | P0 | Every submitted user prompt is inserted into chat history before the assistant/tool output caused by that prompt. User messages use subtle shading or a distinct prefix. | store unit test and transcript ordering capture |
+| TUI-007 | Queued user messages | P0 | If the user submits while a turn is active, the message is shown as queued/staged near the composer, not as current composer text. The queued message must not be placed above older chat bubbles. | event-loop unit test and tmux capture |
+| TUI-008 | Approval blocks execution | P0 | When approval is required, the TUI shows a blocking approval card and the model/tool stream must not appear to continue until a decision is sent or auto-resolved. | protocol e2e approval fixture |
+| TUI-009 | Approval action clarity | P0 | Approval card shows one action per line: `y = approve this command once`, `s = approve this command/scope for the session`, `n = deny it`; diff approvals also show `d = view diff`. | render snapshot |
+| TUI-010 | Markdown rendering | P0 | Assistant output renders headings, bullets, numbered lists, checkboxes, fenced code, inline code, bold emphasis, and markdown tables without showing raw markdown artifacts such as table pipes as plain wrapped prose. | renderer unit tests with golden text |
+| TUI-011 | Paragraph-aware wrapping | P0 | A new markdown paragraph, table, code block, or section heading is treated as a separate render block. Collapse thresholds and spacing must not merge it into the previous paragraph. | renderer unit tests |
+| TUI-012 | Strict left alignment | P0 | Assistant text is left aligned within its transcript block. The renderer must not introduce unexplained leading spaces in normal prose. | render snapshot |
+| TUI-013 | Plan visibility | P0 | The live plan is sticky above or adjacent to the composer/status region, not only embedded in scrolling chat. | tmux screenshot |
+| TUI-014 | Plan completeness | P0 | The plan pane shows all current steps or a clear collapsed-count indicator. It must not silently show only the first few items. | model/render unit test |
+| TUI-015 | Plan status updates | P0 | Completed plan items are checked as `[x]` or equivalent as soon as protocol/model output indicates completion. Stale unchecked completed steps are a failure. | long-session harness |
+| TUI-016 | Tool cards | P0 | Tool activity renders as recognizable cards with action label, tool name, command or target, cwd when known, status, elapsed time, and output preview. | renderer golden tests |
+| TUI-017 | Tool action labels | P0 | Common actions use human-readable labels such as `Ran`, `Running`, `Waited`, `Watching`, `Coding`, `Reading`, `Edited`, `Searched`, `Built`, `Tested`, and `Installed` rather than raw protocol event names. | activity label unit tests |
+| TUI-018 | Expandable tool output | P0 | Long tool output and command output are collapsed by default with a one-line summary and expandable with `Ctrl+O`. Expanded state can be toggled back. | keyboard and render tests |
+| TUI-019 | Diff output collapse | P0 | Diff previews and file creation previews collapse aggressively enough that generated files do not flood the transcript. The preview must show file path, status, first relevant lines, and hidden-line count. | diff fixture render test |
+| TUI-020 | Inline diff preview | P0 | Diff approvals and file mutation progress open inline diff preview when `preview_id` is available. Hunks can be selected with `[` and `]`. | store unit test and tmux capture |
+| TUI-021 | Diff context staging | P0 | Pressing `c` on a selected diff hunk stages that hunk as next-turn context. If a turn is active, it queues context for the next turn. | existing context harness plus snapshot |
+| TUI-022 | Slash commands | P1 | If slash commands are shown in status/help, `/ps`, `/stop`, and other advertised commands must work. If unsupported, they must not be advertised. | event-loop tests |
+| TUI-023 | Background task registry | P1 | `/ps` or equivalent task view lists background tasks with id, title/tool, state, elapsed time, and cancel/stop affordance. | protocol task fixture |
+| TUI-024 | Task cancellation | P1 | `/stop` or equivalent can cancel a running background task through AppUI task control when the server advertises support. Cancelled state is rendered distinctly. | protocol e2e |
+| TUI-025 | Task output read | P1 | Selecting a task and requesting output reads from `task/output/read`, preserves cursor, appends deltas, and avoids duplicate output after reconnect. | reducer tests |
+| TUI-026 | Activity noise folding | P0 | Low-value progress events such as token/cost updates, raw thinking markers, stream-end events, and transport bookkeeping are folded into status rows or hidden unless inspector/debug mode is active. | fixture render test |
+| TUI-027 | Finished-turn recap | P1 | After a long turn completes, the TUI shows a subtle recap block in transcript or status history with elapsed time, background task count, files changed, validation, and next step when available. It must not appear inside the composer input. | long-session harness |
+| TUI-028 | Error and replay visibility | P0 | Protocol errors, turn errors, replay-lossy warnings, approval-cancelled, and cancelled task states are surfaced in status/activity with actionable language. | reducer tests |
+| TUI-029 | Theme discipline | P0 | Themes use subtle contrast and terminal-appropriate colors. `--theme terminal` must use terminal default foreground/background and avoid forcing green highlight. Existing themes must not use large saturated blocks for normal chat. | theme snapshot across themes |
+| TUI-030 | Read-only protocol mode | P1 | `--readonly` opens and renders sessions but prevents `turn/start`; attempts to submit show clear read-only status and clear the draft. | event-loop unit test |
+| TUI-031 | Workspace cwd display | P1 | Status or inspector shows effective cwd/workspace root from `session/open`, and wrong-cwd errors are visible as typed protocol errors. | protocol bootstrap test |
+| TUI-032 | Inspector mode | P1 | Tab cycles to inspector panes for sessions, tasks, artifacts, workspace, and git. Inspector must not break composer stability or transcript scroll. | keyboard snapshot test |
+| TUI-033 | Scrolling behavior | P0 | Transcript, workspace, git, task output, and diff views have deterministic scroll behavior. New output follows tail unless the user has intentionally scrolled up. | render/model tests |
+| TUI-034 | Interrupt behavior | P0 | `Ctrl+C` interrupts active turn. `Esc` with queued messages interrupts active turn and sends queued work after the turn stops. Status text must distinguish interrupt requested vs no active turn. | event-loop tests |
+| TUI-035 | Secret hygiene | P0 | Captures and normal UI must not show auth tokens, provider keys, raw bearer headers, or secret environment values. | redaction/harness checks |
+| TUI-036 | Long-session stability | P0 | A 30+ minute real coding session remains responsive, does not truncate all history to only visible rows, and keeps enough transcript history for review. | live mini host parity test |
+
+## Major Interaction Flows
+
+### 1. Normal Coding Turn
+
+Precondition: protocol session is open and idle.
+
+Expected flow:
+
+1. User types a prompt in the composer.
+2. Pressing Enter creates a user chat bubble immediately.
+3. Status changes from `Idle` to working with elapsed time.
+4. Assistant text streams into a live assistant block.
+5. Tool calls render as cards using action labels such as `Running` and `Ran`.
+6. Long output is collapsed with an expand hint.
+7. Turn completion commits live assistant text to history, clears active spinner, updates plan checks, and shows done/recap state.
+
+### 2. Approval-Gated Command
+
+Precondition: active turn requests command, sandbox, network, filesystem, or diff approval.
+
+Expected flow:
+
+1. Approval card appears inline near the latest context and composer.
+2. Composer remains focused but the approval key map takes precedence while visible.
+3. The card uses explicit action lines:
+   - `y = approve this command once`
+   - `s = approve this command/scope for the session`
+   - `n = deny it`
+4. The assistant/tool stream does not continue until a decision or auto-resolution is received.
+5. Approval decided, cancelled, and auto-resolved notifications clear the pending card and leave a visible activity record.
+
+### 3. Queued Follow-Up During Active Turn
+
+Precondition: a turn is running.
+
+Expected flow:
+
+1. User presses Enter with a new prompt.
+2. The prompt is staged near the composer and shown as queued for next turn.
+3. The composer input is cleared.
+4. The queued message is not inserted ahead of already-rendered chat content.
+5. `Ctrl+U` clears queued messages.
+6. `Esc` interrupts the active turn and preserves the queued message for submission when the turn stops.
+
+### 4. Diff Review and Context Staging
+
+Precondition: a task or approval exposes a `preview_id`.
+
+Expected flow:
+
+1. TUI requests diff preview through AppUI.
+2. Inline diff preview shows file status, path, hunks, and line-level additions/removals.
+3. Large diffs are collapsed by file/hunk with hidden-line counts.
+4. `[` and `]` move selected hunk.
+5. `c` stages selected hunk context into the composer or next-turn queue.
+
+### 5. Background Task and Swarm Management
+
+Precondition: server advertises AppUI task-control support.
+
+Expected flow:
+
+1. Task updates appear in activity and task views with stable task ids.
+2. `/ps` or the task inspector lists running and completed background tasks.
+3. Running tasks can be cancelled through `/stop` or an equivalent task command.
+4. Cancelled, failed, completed, and running states are rendered distinctly.
+5. Reconnect rehydrates visible task state through `task/list` or session snapshot rather than duplicating stale updates.
+
+### 6. Long Output Inspection
+
+Precondition: a tool produces output longer than the preview threshold.
+
+Expected flow:
+
+1. Transcript shows a collapsed tool card with first useful lines and hidden-line count.
+2. `Ctrl+O` expands the focused card.
+3. Expanded content is scrollable without moving the composer or status row.
+4. `Ctrl+O` collapses the card again.
+5. The current expansion state is stable across redraws.
+
+## Required Test Coverage
+
+### Unit and Reducer Tests
+
+- Markdown parser/rendering for headings, bullets, numbered lists, checkboxes,
+  tables, fenced code, inline code, and paragraph boundaries.
+- Store ordering for user prompt, active turn, queued prompt, completion, and
+  error.
+- Approval request, approval decided, auto-resolved, cancelled, and hidden-modal
+  flows.
+- Task update states including pending, running, completed, failed, and
+  cancelled.
+- Tool label classification for shell, file, search, build, test, install,
+  wait/watch, and unknown tools.
+- Collapse threshold behavior for command output, generated files, and diffs.
+- Status row state transitions: idle, working, blocked, error, done.
+
+### Snapshot and Render Tests
+
+- 80x24, 100x30, and 140x40 terminal sizes.
+- Codex, Claude, Slate, Solarized, and terminal themes.
+- Chat layout with and without inspector.
+- Sticky plan/status/composer during transcript overflow.
+- Long markdown table in assistant output.
+- Long diff preview.
+- Approval card with and without diff preview.
+- Collapsed and expanded tool cards.
+
+### Tmux Harness Tests
+
+The parent Octos tmux harness should keep the state matrix from
+`docs/M9_33_VISUAL_PARITY_HARNESS.md` and add checks for:
+
+- exactly one composer cursor inside the composer input line
+- no green forced cursor/theme artifact in terminal theme
+- sticky plan/status/composer while transcript scrolls
+- markdown table rendered as a table-like block
+- `/ps` and `/stop` behavior if advertised
+- `Ctrl+O` expandable tool cards
+- approval card action text in the explicit `key = meaning` format
+- no raw protocol progress spam in normal transcript
+- queued user message position after active output
+
+### Live Coding Parity Tests
+
+Run a real long coding task against the same fixture in Codex and `octos-tui`.
+The TUI passes when human review can confirm:
+
+- user intent and current model state are easier to locate than in raw logs
+- command cards preserve command, cwd, status, duration, and output preview
+- approvals are impossible to miss and cannot be confused with normal chat
+- plan progress visibly changes as work completes
+- long outputs do not bury the transcript
+- final recap gives enough information to decide whether to continue, stop, or
+  inspect files
+
+## Current Implementation Notes
+
+The current implementation already has building blocks for several
+requirements:
+
+- Chat-first layout with composer/status regions in `src/app.rs`.
+- Inline approval card and `y`/`s`/`n` handling in `src/app.rs` and
+  `src/event_loop.rs`.
+- Markdown basics for headings, bullets, numbered lists, checkboxes, and fenced
+  code in `src/app.rs`.
+- Tool activity cards and command labels in `src/app.rs`.
+- Diff preview, hunk selection, and context staging in `src/store.rs`.
+- Task output cursor handling in `src/store.rs`.
+- Visual parity harness scope in `docs/M9_33_VISUAL_PARITY_HARNESS.md`.
+
+Known gaps relative to this requirements document:
+
+- Plan is still inferred from chat and rendered inline or in inspector, not yet
+  guaranteed sticky above the composer/status region.
+- Markdown table rendering is not yet a full table renderer.
+- `Ctrl+O` expandable tool cards are not yet the documented primary interaction.
+- `/ps` and `/stop` must either be implemented or removed from visible help.
+- AppUI task-control client support depends on the server task-control API
+  merge path.
+- `--theme terminal` is not listed in the current README theme set and must be
+  implemented before tests require it.
+
+## Release Gate
+
+No TUI release should be considered UX-complete unless:
+
+- all P0 requirements have automated coverage or a documented manual harness
+  assertion
+- no advertised interaction is unsupported
+- current `octos-core` AppUI protocol changes compile in `octos-tui`
+- live coding parity harness produces retained artifacts and a human-readable
+  summary


### PR DESCRIPTION
## Summary

Adds 3 product+engineering spec docs covering Octos's three client/runtime contracts + allowlists \`api/*.md\` in \`.gitignore\`.

## Files added

- \`api/OCTOS_SERVER_FEATURE_REQUIREMENTS.md\` (17 KB) — server-side feature contract
- \`api/OCTOS_APP_FEATURE_REQUIREMENTS.md\` (15 KB) — octos-app/web client contract
- \`api/OCTOS_TUI_FEATURE_REQUIREMENTS.md\` (17 KB) — octos-tui terminal client contract

## .gitignore allowlist

The pre-existing \`*.md\` catchall was hiding all 3 of these. Adding \`!api/*.md\` mirrors the convention already used to track \`api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md\`.

## Why these docs are repo-canonical

- They've been the source of truth for today's codex audit reviews
- Issues #700–#721 cite them directly
- PR #699 (M6-M9 harness audit) explicitly references the M6-M9 requirements doc; these 3 are its sibling specs for server/app/tui

## Test plan

- [ ] CI green
- [ ] \`git ls-files api/*.md\` lists all 4 spec docs after merge (UI Protocol v1 + 3 new feature requirements)