### PR TITLE
fix(pipeline-guard): read models from config.llm.primary/fallbacks schema (closes thread-interleave deep_research delivery)

### DIFF
--- a/crates/app-skills/pipeline-guard/src/main.rs
+++ b/crates/app-skills/pipeline-guard/src/main.rs
@@ -92,6 +92,23 @@ impl ModelPicks {
 }
 
 // ── Profile config (to know which models are configured) ─────
+//
+// Schema mirrors the live `~/.octos/profiles/<id>.json` files:
+//
+//   {
+//     "config": {
+//       "llm": {
+//         "primary":   { "family_id": "...", "model_id": "...", "route": {...} },
+//         "fallbacks": [
+//           { "family_id": "...", "model_id": "...", "route": {...} },
+//           ...
+//         ]
+//       },
+//       ...
+//     }
+//   }
+//
+// All fields outside `family_id`/`model_id` are tolerated and ignored.
 
 #[derive(Deserialize)]
 struct ProfileConfig {
@@ -101,27 +118,39 @@ struct ProfileConfig {
 #[derive(Deserialize)]
 struct ProfileInner {
     #[serde(default)]
-    provider: Option<String>,
-    #[serde(default)]
-    model: Option<String>,
-    #[serde(default)]
-    fallback_models: Vec<FallbackModel>,
+    llm: Option<LlmConfig>,
 }
 
 #[derive(Deserialize)]
-struct FallbackModel {
+struct LlmConfig {
     #[serde(default)]
-    provider: String,
-    model: String,
+    primary: Option<ModelEntry>,
+    #[serde(default)]
+    fallbacks: Vec<ModelEntry>,
 }
 
-/// Load the profile's configured models from the profile JSON.
-/// Returns provider/model keys like "dashscope/qwen3.5-plus", "nvidia/minimaxai/minimax-m2.5".
-fn load_profile_models() -> HashSet<String> {
-    let mut models = HashSet::new();
+#[derive(Deserialize)]
+struct ModelEntry {
+    // Both fields are Option<> to mirror the canonical
+    // `LlmModelSelectionConfig` in `octos-cli/src/profiles.rs` — a primary or
+    // fallback entry may legitimately omit family_id while keeping model_id
+    // (or vice versa) without rejecting the whole profile.
+    #[serde(default)]
+    family_id: Option<String>,
+    #[serde(default)]
+    model_id: Option<String>,
+    // Other fields like `route`, `strong`, `label`, `cost_per_m`, `model_hints`
+    // are tolerated by serde unless `#[serde(deny_unknown_fields)]` is added —
+    // keep it permissive so future schema additions don't break the guard.
+}
 
-    // Try OCTOS_PROFILE env (set by managed gateway — full path to profile JSON)
-    // Also try standard profile dirs
+/// Discover candidate profile JSON paths.
+///
+/// Order:
+///   1. `$OCTOS_PROFILE` (full path to a profile JSON, set by the managed gateway)
+///   2. `*.json` under `~/.octos/profiles/`
+///   3. `*.json` under `~/.crew/profiles/`
+fn discover_profile_paths() -> Vec<String> {
     let home = std::env::var("HOME").unwrap_or_default();
     let mut paths = Vec::new();
 
@@ -129,7 +158,6 @@ fn load_profile_models() -> HashSet<String> {
         paths.push(profile_path);
     }
 
-    // Scan profile dirs for .json files
     for base in &[
         format!("{home}/.octos/profiles"),
         format!("{home}/.crew/profiles"),
@@ -144,32 +172,69 @@ fn load_profile_models() -> HashSet<String> {
         }
     }
 
-    for path in &paths {
-        if let Ok(content) = std::fs::read_to_string(path) {
-            if let Ok(profile) = serde_json::from_str::<ProfileConfig>(&content) {
-                // Add primary model
-                if let (Some(provider), Some(model)) =
-                    (&profile.config.provider, &profile.config.model)
-                {
-                    models.insert(format!("{provider}/{model}"));
-                    models.insert(model.clone());
-                }
-                // Add all fallback models
-                for fb in &profile.config.fallback_models {
-                    models.insert(format!("{}/{}", fb.provider, fb.model));
-                    models.insert(fb.model.clone());
-                }
-                if !models.is_empty() {
-                    eprintln!(
-                        "[pipeline-guard] loaded {} models from profile {path}",
-                        models.len()
-                    );
-                    return models;
-                }
+    paths
+}
+
+/// Resolve `family_id`/`model_id` pairs from a parsed profile into a flat
+/// HashSet that includes BOTH:
+///   - `format!("{family_id}/{model_id}")` — fully-qualified key
+///   - `model_id`                          — bare model name
+///
+/// Both forms are inserted because pipeline-guard's STRONG/FAST advertisement
+/// uses bare ids while the ProviderRouter sometimes registers under the
+/// qualified key. Inserting both ensures whatever pipeline-guard injects
+/// matches what the ProviderRouter has registered.
+fn collect_models_from_profile(profile: &ProfileConfig, out: &mut HashSet<String>) {
+    let Some(llm) = profile.config.llm.as_ref() else {
+        return;
+    };
+    let mut insert_entry = |entry: &ModelEntry| {
+        // Only meaningful when there's a model_id — bare family_id is not a
+        // routing key the ProviderRouter understands.
+        if let Some(model_id) = entry.model_id.as_deref() {
+            if let Some(family_id) = entry.family_id.as_deref() {
+                out.insert(format!("{family_id}/{model_id}"));
             }
+            out.insert(model_id.to_string());
+        }
+    };
+    if let Some(primary) = llm.primary.as_ref() {
+        insert_entry(primary);
+    }
+    for fb in &llm.fallbacks {
+        insert_entry(fb);
+    }
+}
+
+/// Read the given profile JSON paths, parse, and collect every configured
+/// model into a flat HashSet. Returns the first non-empty set found.
+fn load_profile_models_from_paths(paths: &[String]) -> HashSet<String> {
+    let mut models = HashSet::new();
+
+    for path in paths {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let Ok(profile) = serde_json::from_str::<ProfileConfig>(&content) else {
+            continue;
+        };
+        collect_models_from_profile(&profile, &mut models);
+        if !models.is_empty() {
+            eprintln!(
+                "[pipeline-guard] loaded {} models from profile {path}",
+                models.len()
+            );
+            return models;
         }
     }
     models
+}
+
+/// Load the profile's configured models from disk.
+/// Returns family/model keys like "moonshot/kimi-k2.5", plus bare ids
+/// like "kimi-k2.5".
+fn load_profile_models() -> HashSet<String> {
+    load_profile_models_from_paths(&discover_profile_paths())
 }
 
 /// Load the system-wide model_catalog.json, filter to profile's available models,
@@ -195,11 +260,25 @@ fn load_catalog() -> Option<ModelCatalog> {
     // 2. Load system-wide catalog
     let system_catalog = load_system_catalog(&home)?;
 
-    // 3. Filter by profile's available models
+    // 3. Filter by profile's available models.
+    //
+    // FAIL CLOSED: when no profile models are discoverable, or when no
+    // catalog entries match the profile, we must NOT fall back to the
+    // full catalog. The full-catalog fallback was the root cause of the
+    // pipeline-guard injection bug (live-thread-interleave:207): it
+    // advertised models like `qwen3.5-plus` that the profile-scoped
+    // ProviderRouter never registered, causing pipelines to die in 0 ms
+    // with `no provider registered for key '…'`. Returning None here
+    // makes main() pass through (exit 0) — the LLM's original DOT runs
+    // unmodified, which is the safest behavior when guard cannot reason
+    // about the profile.
     let profile_models = load_profile_models();
     if profile_models.is_empty() {
-        eprintln!("[pipeline-guard] no profile models found, using full catalog");
-        return Some(system_catalog);
+        eprintln!(
+            "[pipeline-guard] no profile models found — passing through \
+             (full-catalog fallback removed; see fix/pipeline-guard-profile-schema)"
+        );
+        return None;
     }
 
     let filtered_models: Vec<CatalogEntry> = system_catalog
@@ -225,10 +304,14 @@ fn load_catalog() -> Option<ModelCatalog> {
     );
 
     if filtered_models.is_empty() {
-        eprintln!("[pipeline-guard] no catalog models match profile, using full catalog");
-        return Some(ModelCatalog {
-            models: load_system_catalog(&home)?.models,
-        });
+        // Same fail-closed reasoning as above: profile is known but no
+        // catalog entry matches → don't risk advertising unregistered
+        // models. Pass through.
+        eprintln!(
+            "[pipeline-guard] no catalog models match profile — passing through \
+             (full-catalog fallback removed)"
+        );
+        return None;
     }
 
     let filtered_catalog = ModelCatalog {
@@ -611,10 +694,20 @@ fn main() {
     }
 
     // ── Step 2: Load model catalog and pick models ──────────────
+    // load_catalog() returns None for any of:
+    //   - no system-wide model_catalog.json on disk
+    //   - no profile models discoverable (would have caused the
+    //     historical "no profile models found, using full catalog" bug)
+    //   - profile models discoverable but no catalog entries match
+    // In every "None" case we pass through unchanged — the LLM's DOT
+    // runs as-written, which is safer than injecting models the
+    // ProviderRouter cannot resolve.
     let catalog = match load_catalog() {
         Some(c) => c,
         None => {
-            eprintln!("[pipeline-guard] no model_catalog.json found, passing through");
+            eprintln!(
+                "[pipeline-guard] catalog/profile not resolvable — passing through unchanged"
+            );
             std::process::exit(0);
         }
     };
@@ -748,4 +841,144 @@ fn main() {
     eprintln!("[pipeline-guard] DOT modified with resolved models");
     println!("{}", serde_json::to_string(&new_args).unwrap());
     std::process::exit(2);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+    fn load_fixture(name: &str) -> HashSet<String> {
+        let path = format!("{FIXTURE_DIR}/{name}");
+        load_profile_models_from_paths(&[path])
+    }
+
+    /// Real-shape `dspfac.json` profile (sanitized). Verifies pipeline-guard
+    /// reads `config.llm.primary` + `config.llm.fallbacks` correctly and
+    /// returns BOTH fully-qualified keys (family_id/model_id) AND bare
+    /// model_ids — both forms are needed so whatever pipeline-guard injects
+    /// matches whatever the ProviderRouter has registered.
+    #[test]
+    fn pipeline_guard_loads_models_from_real_profile_schema() {
+        let models = load_fixture("dspfac.json");
+
+        // Bare model_ids — what pipeline-guard's STRONG/FAST advertisement uses
+        assert!(
+            models.contains("kimi-k2.5"),
+            "expected bare primary model_id in {models:?}"
+        );
+        assert!(
+            models.contains("MiniMax-M2.5-highspeed"),
+            "expected bare fallback model_id in {models:?}"
+        );
+        assert!(
+            models.contains("DeepSeek-V3.2"),
+            "expected bare fallback model_id in {models:?}"
+        );
+
+        // Fully-qualified family_id/model_id — what the ProviderRouter
+        // registers in some configurations.
+        assert!(
+            models.contains("moonshot/kimi-k2.5"),
+            "expected qualified primary key in {models:?}"
+        );
+        assert!(
+            models.contains("minimax/MiniMax-M2.5-highspeed"),
+            "expected qualified fallback key in {models:?}"
+        );
+        assert!(
+            models.contains("deepseek/DeepSeek-V3.2"),
+            "expected qualified fallback key in {models:?}"
+        );
+
+        // Exactly 6 entries: 3 bare + 3 qualified
+        assert_eq!(models.len(), 6, "unexpected model set: {models:?}");
+    }
+
+    /// Old-style profile without an `llm` section returns empty set.
+    /// Ensures pipeline-guard degrades to "no profile models found" rather
+    /// than panicking on legacy/incomplete profile JSON.
+    #[test]
+    fn pipeline_guard_handles_missing_llm_section_gracefully() {
+        let models = load_fixture("legacy_no_llm.json");
+        assert!(
+            models.is_empty(),
+            "expected empty set for profile without llm section, got {models:?}"
+        );
+    }
+
+    /// Profile with `llm.primary` but no `llm.fallbacks` returns just the
+    /// primary's family/bare pair.
+    #[test]
+    fn pipeline_guard_handles_missing_fallbacks_array() {
+        let models = load_fixture("primary_only.json");
+        assert!(models.contains("kimi-k2.5"));
+        assert!(models.contains("moonshot/kimi-k2.5"));
+        assert_eq!(models.len(), 2, "expected only primary entries: {models:?}");
+    }
+
+    /// Sanity check that an unknown route field on a fallback (e.g. `strong: true`)
+    /// does not break parsing — serde tolerance is intentional.
+    #[test]
+    fn pipeline_guard_tolerates_unknown_fields_on_model_entries() {
+        let models = load_fixture("dspfac.json");
+        // The DeepSeek fallback in the fixture carries a `strong: true` field;
+        // if we accidentally added `deny_unknown_fields`, parsing would fail
+        // and DeepSeek would be missing from the set.
+        assert!(
+            models.contains("DeepSeek-V3.2"),
+            "deny_unknown_fields likely re-introduced — fixture has unknown 'strong' field"
+        );
+    }
+
+    /// Mirrors the canonical `LlmModelSelectionConfig` schema where
+    /// `family_id` and `model_id` are both `Option<String>`. A profile with
+    /// only `model_id` should still yield a usable bare key — the qualified
+    /// key is simply omitted.
+    #[test]
+    fn pipeline_guard_handles_optional_family_id() {
+        let models = load_fixture("missing_family_id.json");
+        assert!(
+            models.contains("kimi-k2.5"),
+            "expected bare model_id even without family_id in {models:?}"
+        );
+        // Without family_id, the qualified key should not appear.
+        assert!(
+            !models.iter().any(|m| m.ends_with("/kimi-k2.5")),
+            "qualified key should be skipped when family_id absent: {models:?}"
+        );
+        assert_eq!(models.len(), 1);
+    }
+
+    /// A profile written in the OLD pre-fix struct shape (flat
+    /// `config.provider`/`config.model`/`config.fallback_models`) must
+    /// return EMPTY under the new schema-aware reader. Combined with the
+    /// fail-closed `load_catalog()` change (which now returns None when
+    /// `load_profile_models()` is empty), this guarantees pipeline-guard
+    /// passes through unchanged for legacy profiles rather than silently
+    /// advertising the full system catalog — the bug that broke
+    /// live-thread-interleave:207.
+    #[test]
+    fn pipeline_guard_returns_empty_for_legacy_pre_fix_shape() {
+        let models = load_fixture("legacy_pre_fix_shape.json");
+        assert!(
+            models.is_empty(),
+            "legacy pre-fix shape must not be silently parsed; got {models:?}"
+        );
+    }
+
+    /// Multiple paths: first non-empty wins. Confirms the iteration order
+    /// in `load_profile_models_from_paths` keeps a parsed dspfac profile
+    /// even if a legacy/empty profile precedes it.
+    #[test]
+    fn pipeline_guard_skips_empty_profile_and_keeps_searching() {
+        let legacy = format!("{FIXTURE_DIR}/legacy_no_llm.json");
+        let real = format!("{FIXTURE_DIR}/dspfac.json");
+        let models = load_profile_models_from_paths(&[legacy, real]);
+        assert!(
+            models.contains("kimi-k2.5"),
+            "expected to fall through legacy profile to dspfac fixture: {models:?}"
+        );
+    }
 }

--- a/crates/app-skills/pipeline-guard/tests/fixtures/dspfac.json
+++ b/crates/app-skills/pipeline-guard/tests/fixtures/dspfac.json
@@ -1,0 +1,122 @@
+{
+  "id": "dspfac",
+  "name": "dspfac",
+  "enabled": true,
+  "data_dir": null,
+  "config": {
+    "llm": {
+      "primary": {
+        "family_id": "moonshot",
+        "model_id": "kimi-k2.5",
+        "route": {
+          "base_url": "https://example.invalid/api/v1",
+          "api_key_env": "AUTODL_API_KEY"
+        }
+      },
+      "fallbacks": [
+        {
+          "family_id": "minimax",
+          "model_id": "MiniMax-M2.5-highspeed",
+          "route": {
+            "route_id": "wisemodel",
+            "label": "WiseModel",
+            "base_url": "https://example.invalid/v1",
+            "api_key_env": "WISEMODEL_API_KEY"
+          }
+        },
+        {
+          "family_id": "deepseek",
+          "model_id": "DeepSeek-V3.2",
+          "route": {
+            "base_url": "https://example.invalid/api/v1",
+            "api_key_env": "AUTODL_API_KEY"
+          },
+          "strong": true
+        }
+      ]
+    },
+    "search": {
+      "providers": {
+        "perplexity": {
+          "api_key_env": "PERPLEXITY_API_KEY"
+        },
+        "tavily": {
+          "api_key_env": "TAVILY_API_KEY"
+        }
+      }
+    },
+    "channels": [
+      {
+        "type": "telegram",
+        "token_env": "TELEGRAM_BOT_TOKEN",
+        "allowed_senders": "0000000000"
+      }
+    ],
+    "gateway": {
+      "max_history": 500,
+      "max_iterations": 80,
+      "system_prompt": null,
+      "max_concurrent_sessions": 100,
+      "browser_timeout_secs": null,
+      "max_output_tokens": null
+    },
+    "email": {
+      "provider": "smtp",
+      "smtp_host": "smtp.example.invalid",
+      "smtp_port": 587,
+      "username": "dspfac@example.invalid",
+      "password_env": "SMTP_PASSWORD",
+      "password": "REDACTED",
+      "from_address": "dspfac@example.invalid",
+      "feishu_app_id": null,
+      "feishu_app_secret_env": null,
+      "feishu_app_secret": null,
+      "feishu_from_address": null,
+      "feishu_region": null
+    },
+    "api_type": null,
+    "env_vars": {
+      "MINIMAX_API_KEY": "REDACTED",
+      "DEEPSEEK_API_KEY": "REDACTED",
+      "PERPLEXITY_API_KEY": "REDACTED",
+      "SERPER_API_KEY": "REDACTED",
+      "TAVILY_API_KEY": "REDACTED",
+      "TELEGRAM_BOT_TOKEN": "REDACTED",
+      "SMTP_PORT": "587",
+      "SMTP_HOST": "smtp.example.invalid",
+      "ZAI_API_KEY": "REDACTED",
+      "SMTP_USERNAME": "dspfac@example.invalid",
+      "MOONSHOT_API_KEY": "REDACTED",
+      "SMTP_FROM": "dspfac@example.invalid",
+      "KIMI_API_KEY": "REDACTED",
+      "GEMINI_API_KEY": "REDACTED",
+      "WISEMODEL_API_KEY": "REDACTED",
+      "NVIDIA_API_KEY": "REDACTED",
+      "SMTP_PASSWORD": "REDACTED",
+      "DASHSCOPE_API_KEY": "REDACTED",
+      "AUTODL_API_KEY": "REDACTED",
+      "OMINIX_API_URL": "http://127.0.0.1:8080",
+      "OPENAI_API_KEY": "REDACTED"
+    },
+    "hooks": [],
+    "admin_mode": false,
+    "sandbox": {
+      "enabled": true,
+      "mode": "auto",
+      "allow_network": true,
+      "docker": {
+        "image": "ubuntu:24.04",
+        "cpu_limit": null,
+        "memory_limit": null,
+        "pids_limit": null,
+        "mount_mode": "rw",
+        "extra_binds": []
+      },
+      "read_allow_paths": [],
+      "profile_name": null
+    },
+    "adaptive_routing": null
+  },
+  "created_at": "2026-03-23T21:26:05.549973Z",
+  "updated_at": "2026-04-21T06:33:23.393986Z"
+}

--- a/crates/app-skills/pipeline-guard/tests/fixtures/legacy_no_llm.json
+++ b/crates/app-skills/pipeline-guard/tests/fixtures/legacy_no_llm.json
@@ -1,0 +1,24 @@
+{
+  "id": "legacy",
+  "name": "legacy",
+  "enabled": true,
+  "data_dir": null,
+  "config": {
+    "search": {
+      "providers": {}
+    },
+    "channels": [],
+    "gateway": {
+      "max_history": 500,
+      "max_iterations": 80,
+      "system_prompt": null,
+      "max_concurrent_sessions": 100,
+      "browser_timeout_secs": null,
+      "max_output_tokens": null
+    },
+    "env_vars": {},
+    "hooks": [],
+    "admin_mode": false,
+    "adaptive_routing": null
+  }
+}

--- a/crates/app-skills/pipeline-guard/tests/fixtures/legacy_pre_fix_shape.json
+++ b/crates/app-skills/pipeline-guard/tests/fixtures/legacy_pre_fix_shape.json
@@ -1,0 +1,25 @@
+{
+  "id": "legacy_pre_fix",
+  "name": "legacy_pre_fix",
+  "enabled": true,
+  "config": {
+    "provider": "moonshot",
+    "model": "kimi-k2.5",
+    "fallback_models": [
+      { "provider": "minimax", "model": "MiniMax-M2.5-highspeed" }
+    ],
+    "channels": [],
+    "gateway": {
+      "max_history": 500,
+      "max_iterations": 80,
+      "system_prompt": null,
+      "max_concurrent_sessions": 100,
+      "browser_timeout_secs": null,
+      "max_output_tokens": null
+    },
+    "env_vars": {},
+    "hooks": [],
+    "admin_mode": false,
+    "adaptive_routing": null
+  }
+}

--- a/crates/app-skills/pipeline-guard/tests/fixtures/missing_family_id.json
+++ b/crates/app-skills/pipeline-guard/tests/fixtures/missing_family_id.json
@@ -1,0 +1,30 @@
+{
+  "id": "missing_family",
+  "name": "missing_family",
+  "enabled": true,
+  "config": {
+    "llm": {
+      "primary": {
+        "model_id": "kimi-k2.5",
+        "route": {
+          "base_url": "https://example.invalid/api/v1",
+          "api_key_env": "AUTODL_API_KEY"
+        }
+      },
+      "fallbacks": []
+    },
+    "channels": [],
+    "gateway": {
+      "max_history": 500,
+      "max_iterations": 80,
+      "system_prompt": null,
+      "max_concurrent_sessions": 100,
+      "browser_timeout_secs": null,
+      "max_output_tokens": null
+    },
+    "env_vars": {},
+    "hooks": [],
+    "admin_mode": false,
+    "adaptive_routing": null
+  }
+}

--- a/crates/app-skills/pipeline-guard/tests/fixtures/primary_only.json
+++ b/crates/app-skills/pipeline-guard/tests/fixtures/primary_only.json
@@ -1,0 +1,31 @@
+{
+  "id": "primary_only",
+  "name": "primary_only",
+  "enabled": true,
+  "data_dir": null,
+  "config": {
+    "llm": {
+      "primary": {
+        "family_id": "moonshot",
+        "model_id": "kimi-k2.5",
+        "route": {
+          "base_url": "https://example.invalid/api/v1",
+          "api_key_env": "AUTODL_API_KEY"
+        }
+      }
+    },
+    "channels": [],
+    "gateway": {
+      "max_history": 500,
+      "max_iterations": 80,
+      "system_prompt": null,
+      "max_concurrent_sessions": 100,
+      "browser_timeout_secs": null,
+      "max_output_tokens": null
+    },
+    "env_vars": {},
+    "hooks": [],
+    "admin_mode": false,
+    "adaptive_routing": null
+  }
+}


### PR DESCRIPTION
## Summary

Pipeline-guard's `ProfileInner` was schema-stale: it expected top-level `provider` / `model` / `fallback_models`, but the live `~/.octos/profiles/<id>.json` nests models under `config.llm.primary.{family_id, model_id}` and `config.llm.fallbacks[].{family_id, model_id}`. Every field had `#[serde(default)]`, so deserialization succeeded silently and yielded an empty model set, triggering the fatal "no profile models found, using full catalog" code path.

The full-catalog fallback then advertised models the profile-scoped `ProviderRouter` had never registered (e.g. `qwen3.5-plus`, `glm-5`, `gemini-2.5-flash`) — pipelines died in 0 ms with `no provider registered for key '…'`.

This is the actual fix for `live-thread-interleave:207` deep_research failure on mini1. PR #691 was correct but irrelevant for this code path: it patched a Gemini call site the pipeline never reached, since pipeline-guard aborted upstream of any LLM HTTP call. With #691 in flight, this bug became the dominant failure mode.

Investigation report: `/tmp/mini1-thread-interleave-23-08-investigation.md`.

## Smoking-gun (mini1 daemon log, 2026-05-01 06:08 UTC)

```
06:08:25.351Z  [pipeline-guard] loaded system catalog from /Users/cloud/.octos/model_catalog.json
06:08:25.351Z  [pipeline-guard] no profile models found, using full catalog            <- BUG
06:08:25.351Z  [pipeline-guard] resolved STRONG=[..., qwen3.5-plus, ...], FAST=[gemini-2.5-flash, ...]
06:08:25.351Z  [pipeline-guard] node 'search': injected planner_model='qwen3.5-plus'   <- unregistered
06:08:25.354Z  ERROR pipeline failed duration_ms=0
                  error=no provider registered for key 'qwen3.5-plus'
                  (available: ["MiniMax-M2.5-highspeed", "DeepSeek-V3.2", "kimi-k2.5"])
```

Predates today's wave: mini1 saw 503 of these errors on Apr 30 alone (per investigation), masked all morning by the louder Gemini schema spiral that #691 silenced.

## Why this PR

Two structural changes:

1. **Schema fix.** `ProfileInner` now points at `Option<LlmConfig>` and `LlmConfig` carries `primary: Option<ModelEntry>` + `fallbacks: Vec<ModelEntry>`, mirroring the canonical `LlmProfileConfig` in `crates/octos-cli/src/profiles.rs:433`. `ModelEntry.family_id` / `ModelEntry.model_id` are `Option<String>` to match the canonical `LlmModelSelectionConfig`. Both fully-qualified `family_id/model_id` AND bare `model_id` keys are inserted, matching `ProviderRouter::resolve`'s exact + suffix lookup (`crates/octos-llm/src/router.rs:121,143`).

2. **Remove the full-catalog fallback.** When no profile models are discoverable, OR no catalog entries match, `load_catalog()` returns `None` and `main()` passes through unchanged (exit 0). The LLM's original DOT runs as written. Keeping the fallback was the source of the bug for at least 5 days. Codex 2nd-opinion review concurred (high-priority finding).

Splits `load_profile_models` into `discover_profile_paths` + `load_profile_models_from_paths` for testability.

## Test plan

- [x] `cargo test -p pipeline-guard` — 7 tests passing (real profile schema, missing llm section, missing fallbacks, optional family_id, unknown-field tolerance, legacy pre-fix shape returns empty, multi-path skip-and-search)
- [x] `cargo build --release -p pipeline-guard` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] codex 2nd-opinion review (`/tmp/codex-pg-fix.log`) — three findings addressed (full-catalog removal, legacy back-compat fixture, Option<> on family_id/model_id)
- [ ] Fleet redeploy must rebuild and ship the pipeline-guard binary at `~/.octos/bundled-app-skills/pipeline-guard/main` — not just `octos serve`
- [ ] Post-deploy: rerun `live-thread-interleave:207` on mini1 and verify the deep_research bubble produces a `report.md` with `\brust\b/i` content

## Test fixtures

`crates/app-skills/pipeline-guard/tests/fixtures/dspfac.json` is a sanitized copy of the live profile from mini1 — all API keys, tokens, and addresses replaced with `REDACTED` / `example.invalid` / `0000000000`. Other fixtures (`legacy_no_llm.json`, `primary_only.json`, `missing_family_id.json`, `legacy_pre_fix_shape.json`) are synthetic and contain no real data.

## Deployment note

Pipeline-guard ships as a binary skill at `~/.octos/bundled-app-skills/pipeline-guard/main`. **Fleet redeploy MUST include the rebuilt skill binary**, not just `octos serve` — the daemon hot-reload doesn't touch external skill processes.

## Severity

High but not sev-1. Predates today's wave; chat still works for non-pipeline workflows. **Do not auto-merge** — verify on mini1 first.

## Defense-in-depth (deferred)

Codex also flagged a router-level skip-and-fallback at `crates/octos-pipeline/src/executor.rs:1711,1781` and `crates/octos-llm/src/router.rs:151` so an unknown model key gets logged and skipped to a known fallback rather than aborting the whole pipeline. Deferred to a follow-up PR — pipeline-guard struct fix is the load-bearing one, and adding both in one PR risks hiding regressions during fleet rollout.