### PR TITLE
fix(e2e): update live-browser login helper to match current SPA auth surface

### DIFF
--- a/e2e/tests/live-browser-helpers.ts
+++ b/e2e/tests/live-browser-helpers.ts
@@ -15,90 +15,162 @@ const BASE_URL = process.env.OCTOS_TEST_URL || 'http://localhost:3000';
 const STRONG_ADMIN_TOKEN =
   process.env.OCTOS_TEST_ADMIN_TOKEN || 'Octos-E2E-Strong-Token-2026-XYZ-123!';
 
-let tokenRotationPromise: Promise<string> | null = null;
+// Cache of `host -> effective token`. The token rotation flow is per-host
+// because every mini in the fleet has its own `admin_token.json`. Memoising
+// across hosts (the previous module-scope `tokenRotationPromise`) caused
+// every spec in a single Playwright process to inherit the FIRST host's
+// answer — which broke as soon as different specs targeted different hosts
+// or the page's actual `baseURL` differed from the env-derived `BASE_URL`.
+const tokenCacheByHost: Map<string, Promise<string>> = new Map();
 
 /**
- * Rotate the bootstrap admin token to a known strong value if the daemon is
- * still in bootstrap mode. Returns the token that callers should use for all
- * subsequent auth — either the rotated strong token, or the original token
- * if rotation isn't needed (or isn't possible because it was already rotated
- * to a different value).
+ * Resolve a working admin Bearer token for the SPA auth surface (i.e. one
+ * that `/api/auth/me` accepts as `AuthIdentity::Admin`).
  *
- * The returned token is memoised at the module level so multiple specs in
- * the same Playwright process share the work.
+ * The dashboard SPA's `AuthGuard` runs `syncMe()` (calls `/api/auth/me`) on
+ * every page load that has a token in localStorage. If the token doesn't
+ * authenticate, AuthGuard CLEARS localStorage and redirects to `/login`.
+ * That redirect is what makes `[data-testid='chat-input']` never appear and
+ * the helper time out.
+ *
+ * Failure modes the previous helper missed:
+ *
+ *  1. **Already-rotated mini**: production minis have a hashed
+ *     `admin_token.json` whose hash does NOT match the bootstrap value
+ *     (`octos-admin-2026`). The bootstrap token returns 401 against
+ *     `/api/auth/me` — even though `/api/sessions` still serves traffic
+ *     because the Caddy proxy injects `X-Profile-Id` from the subdomain
+ *     and that bypasses the admin gate.
+ *
+ *  2. **Wrong base URL**: the previous probe used the env-derived
+ *     `BASE_URL` (default `http://localhost:3000`). When tests run against
+ *     a remote mini without `OCTOS_TEST_URL` set, the probe hit a
+ *     non-existent local daemon and silently returned the bootstrap token
+ *     unchanged — guaranteeing 401 against the actual target.
+ *
+ * The fix probes BOTH candidate tokens against `/api/auth/me` (the same
+ * endpoint the SPA uses) on the requested host. The strong token is tried
+ * first because it's the steady-state on every production mini. If both
+ * fail we fall back to the bootstrap-rotation flow used on freshly
+ * provisioned daemons.
  */
 export async function ensureAdminTokenRotated(
   baseUrl: string = BASE_URL,
   currentToken: string = AUTH_TOKEN,
 ): Promise<string> {
-  if (!tokenRotationPromise) {
-    tokenRotationPromise = (async () => {
-      const probe = async (token: string): Promise<{ rotated?: boolean } | null> => {
-        try {
-          const resp = await fetch(`${baseUrl}/api/admin/token/status`, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          if (!resp.ok) return null;
-          return (await resp.json().catch(() => null)) as
-            | { rotated?: boolean }
-            | null;
-        } catch {
-          return null;
-        }
-      };
+  const host = normaliseHost(baseUrl);
+  let cached = tokenCacheByHost.get(host);
+  if (cached) return cached;
 
-      // 1) Probe with the caller-provided token first.
-      const currentStatus = await probe(currentToken);
-
-      if (currentStatus) {
-        if (!currentStatus.rotated) {
-          // Bootstrap mode — rotate to the strong token now.
-          const rotateResp = await fetch(`${baseUrl}/api/admin/token/rotate`, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${currentToken}`,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ new_token: STRONG_ADMIN_TOKEN }),
-          });
-          if (!rotateResp.ok) {
-            // Cross-worker race: another Playwright worker process may have
-            // rotated first, which leaves us with a 401 (current bootstrap
-            // token now invalid) or a 409 (token store already populated).
-            // In both cases, probe with STRONG_ADMIN_TOKEN; if it works,
-            // the other worker rotated to the same target and we're done.
-            const fallbackStatus = await probe(STRONG_ADMIN_TOKEN);
-            if (fallbackStatus) return STRONG_ADMIN_TOKEN;
-            if (rotateResp.status !== 409) {
-              const text = await rotateResp.text().catch(() => '');
-              throw new Error(
-                `failed to rotate admin token: ${rotateResp.status} ${text}`,
-              );
-            }
-          }
-          return STRONG_ADMIN_TOKEN;
-        }
-        // Already rotated and the current token still works — caller passed
-        // the rotated token directly. Use it as-is.
-        return currentToken;
+  cached = (async () => {
+    // `/api/auth/me` is the authoritative gate the SPA uses. A token that
+    // returns 200 here will satisfy AuthGuard and let `/chat` render.
+    const meProbe = async (token: string): Promise<boolean> => {
+      try {
+        const resp = await fetch(`${host}/api/auth/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        return resp.ok;
+      } catch {
+        return false;
       }
+    };
 
-      // 2) currentToken didn't authenticate. Common case after the first
-      //    run on a host: the bootstrap token is gone but the caller is
-      //    still passing it. Fall back to the strong token we previously
-      //    rotated to (or that someone matching `OCTOS_TEST_ADMIN_TOKEN`
-      //    rotated to). If THAT works, use it.
-      const strongStatus = await probe(STRONG_ADMIN_TOKEN);
-      if (strongStatus) {
-        return STRONG_ADMIN_TOKEN;
+    // 0) Steady state on production minis: STRONG_ADMIN_TOKEN matches the
+    //    rotated `admin_token.json`. Try this first — both `currentToken`
+    //    and `STRONG_ADMIN_TOKEN` are equally likely to be the right one
+    //    depending on how the host was bootstrapped, but in practice any
+    //    long-lived deploy has already been rotated.
+    if (await meProbe(STRONG_ADMIN_TOKEN)) return STRONG_ADMIN_TOKEN;
+
+    // 1) Caller passed the right token directly (e.g. fresh local daemon
+    //    where `currentToken` IS the bootstrap token AND no rotation has
+    //    happened yet, OR the caller threaded a known-rotated token via
+    //    `OCTOS_AUTH_TOKEN`).
+    if (await meProbe(currentToken)) return currentToken;
+
+    // 2) Bootstrap mode — `/api/admin/token/status` says `rotated: false`,
+    //    so we own the rotation. This branch only runs against fresh local
+    //    daemons; on production minis step 0 already returned.
+    const statusProbe = async (token: string): Promise<{ rotated?: boolean } | null> => {
+      try {
+        const resp = await fetch(`${host}/api/admin/token/status`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) return null;
+        return (await resp.json().catch(() => null)) as
+          | { rotated?: boolean }
+          | null;
+      } catch {
+        return null;
       }
+    };
 
-      // 3) Neither token works. Return currentToken so the spec fails
-      //    with the original auth error rather than a silent fallback.
-      return currentToken;
-    })();
+    const currentStatus = await statusProbe(currentToken);
+    if (currentStatus && !currentStatus.rotated) {
+      const rotateResp = await fetch(`${host}/api/admin/token/rotate`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${currentToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ new_token: STRONG_ADMIN_TOKEN }),
+      });
+      if (rotateResp.ok || rotateResp.status === 409) {
+        // 409 = another worker rotated first; STRONG_ADMIN_TOKEN should
+        // now work either way.
+        if (await meProbe(STRONG_ADMIN_TOKEN)) return STRONG_ADMIN_TOKEN;
+      }
+    }
+
+    // 3) Neither known token authenticates and we couldn't rotate. Return
+    //    the strong token rather than the bootstrap value: the spec will
+    //    still fail at the chat-input wait, but the surfaced auth error
+    //    will hint at "rotated to a different secret" rather than the
+    //    misleading "bootstrap token expired".
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[live-browser-helpers] no admin Bearer authenticates against ${host}/api/auth/me ` +
+        `(tried STRONG_ADMIN_TOKEN and OCTOS_AUTH_TOKEN). Set OCTOS_TEST_ADMIN_TOKEN ` +
+        `to the rotated admin secret for this host.`,
+    );
+    return STRONG_ADMIN_TOKEN;
+  })();
+
+  tokenCacheByHost.set(host, cached);
+  return cached;
+}
+
+function normaliseHost(input: string): string {
+  try {
+    const u = new URL(input);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return input.replace(/\/+$/, '');
   }
-  return tokenRotationPromise;
+}
+
+/**
+ * Best-effort recovery of the page's effective base URL. Playwright stores
+ * it on `BrowserContext._options.baseURL` which is not on the public type,
+ * so we fall back to `page.url()` when the page has navigated, then to the
+ * env-derived `BASE_URL` constant.
+ */
+function pageBaseUrl(page: Page): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ctxBase = (page.context() as any)?._options?.baseURL as
+    | string
+    | undefined;
+  if (ctxBase) return ctxBase;
+  const current = page.url();
+  if (current && current !== 'about:blank') {
+    try {
+      return new URL(current).origin;
+    } catch {
+      // fall through
+    }
+  }
+  return BASE_URL;
 }
 
 /**
@@ -128,10 +200,13 @@ export const SEL = {
 } as const;
 
 export async function login(page: Page) {
-  // Bootstrap-mode daemons reject every `/admin/*` page until the admin
-  // token has been rotated. Do this once per Playwright process and use the
-  // rotated value everywhere below.
-  const effectiveToken = await ensureAdminTokenRotated();
+  // The dashboard SPA `AuthGuard` calls `/api/auth/me` on mount. If that
+  // returns 401 it CLEARS localStorage and redirects to `/login` — which is
+  // why merely stuffing a Bearer into localStorage isn't enough. The token
+  // we stuff has to authenticate as `AuthIdentity::Admin` against
+  // `/api/auth/me` on THIS host. Resolve the right token (per host)
+  // before we navigate.
+  const effectiveToken = await ensureAdminTokenRotated(pageBaseUrl(page));
 
   await page.addInitScript(
     ({ token, profile }) => {

--- a/e2e/tests/live-browser-helpers.ts
+++ b/e2e/tests/live-browser-helpers.ts
@@ -64,13 +64,22 @@ export async function ensureAdminTokenRotated(
 
   cached = (async () => {
     // `/api/auth/me` is the authoritative gate the SPA uses. A token that
-    // returns 200 here will satisfy AuthGuard and let `/chat` render.
+    // returns 200 here will satisfy AuthGuard and let `/chat` render. The
+    // server accepts both admin tokens and email-OTP user sessions on
+    // this endpoint, but we want admin specifically — non-admin sessions
+    // fail downstream when specs hit `/admin/*` SPA routes (e.g.
+    // live-mofa-skills, live-realtime-status). Require `role === 'admin'`
+    // so we don't silently degrade.
     const meProbe = async (token: string): Promise<boolean> => {
       try {
         const resp = await fetch(`${host}/api/auth/me`, {
           headers: { Authorization: `Bearer ${token}` },
         });
-        return resp.ok;
+        if (!resp.ok) return false;
+        const body = (await resp.json().catch(() => null)) as
+          | { user?: { role?: string } }
+          | null;
+        return body?.user?.role === 'admin';
       } catch {
         return false;
       }
@@ -178,9 +187,14 @@ function pageBaseUrl(page: Page): string {
  * `octos_session_token` / `octos_auth_token` localStorage entries. Resolves
  * to the rotated strong token when the helper had to bootstrap the daemon,
  * otherwise to whatever `OCTOS_AUTH_TOKEN` was passed in.
+ *
+ * Pass `baseUrl` when the caller targets a host that doesn't match
+ * `OCTOS_TEST_URL` (e.g. when a spec uses its own `BASE` constant or
+ * threads the page baseURL through). Defaults preserve the previous
+ * env-only behaviour so this call is backward compatible.
  */
-export async function getEffectiveAdminToken(): Promise<string> {
-  return ensureAdminTokenRotated();
+export async function getEffectiveAdminToken(baseUrl?: string): Promise<string> {
+  return ensureAdminTokenRotated(baseUrl);
 }
 
 export const SEL = {


### PR DESCRIPTION
## Summary

The e2e \`login()\` helper at \`e2e/tests/live-browser-helpers.ts\` was timing out on \`chat-input\` for ~15-17 of the 20 browser-driven \`live-*\` specs because none of its fallbacks land on a chat-rendered page when run against rotated production minis (mini1/mini3 build \`0.1.1+b8b2cb85\`).

This breaks specs that gate the wave-2 regression hunt — including \`live-thread-interleave\` (PR #730 target), \`live-overflow-stress\`, \`live-mofa-skills\`, and others.

## Root cause

The dashboard SPA's \`AuthGuard\` calls \`/api/auth/me\` on every page mount. When the token in \`localStorage\` returns 401 there, AuthGuard CLEARS the storage and redirects to \`/login\` — so \`chat-input\` never renders. Two failure modes had drifted past the old probe:

1. **Already-rotated mini** — production minis have a hashed \`admin_token.json\` whose hash does NOT match the bootstrap value \`octos-admin-2026\`. The bootstrap token returns 401 against \`/api/auth/me\` even though \`/api/sessions\` still serves traffic (Caddy injects \`X-Profile-Id\` from the subdomain and that bypasses the admin gate, masking the failure).

2. **Wrong base URL** — the previous \`ensureAdminTokenRotated()\` probe used the env-derived \`BASE_URL\` (default \`http://localhost:3000\`) and probed \`/api/admin/token/status\`, not \`/api/auth/me\`. When \`OCTOS_TEST_URL\` was unset, the probe hit a non-existent local daemon, silently returned the bootstrap token, and \`login()\` guaranteed a 401 against the real target.

## What changed

\`e2e/tests/live-browser-helpers.ts\` only:

- **Probe \`/api/auth/me\` directly** (the actual SPA gate), and require \`user.role === 'admin'\` so a stray user-session token can't sneak past. Bootstrap-rotation flow is preserved for fresh local daemons.
- **Try \`STRONG_ADMIN_TOKEN\` first**, then \`OCTOS_AUTH_TOKEN\`, then bootstrap rotation. Production minis are rotated by default; this resolves on the first probe.
- **Per-host token cache** (\`Map<host, Promise<token>>\`) instead of a single module-scope promise so different specs targeting different hosts in the same Playwright process don't poison each other's cache.
- **\`login(page)\` derives baseURL from the page itself** (\`page.context()._options.baseURL\` or \`page.url()\`), so the probe targets the actual host the page will navigate to regardless of \`OCTOS_TEST_URL\` state.
- **\`getEffectiveAdminToken(baseUrl?)\`** now accepts an optional baseUrl for direct callers (\`live-mofa-skills\`, \`live-realtime-status\`); no-arg call sites preserve the previous env-only behaviour.
- **Surfaces a console.warn** when no token authenticates, so the failure is self-explanatory rather than a silent 15s timeout.

## Verification

\`\`\`
cd /tmp/harness-login-fix/e2e
OCTOS_TEST_URL=https://dspfac.octos.ominix.io OCTOS_AUTH_TOKEN=octos-admin-2026 OCTOS_PROFILE=dspfac \\
  npx playwright test tests/live-thread-interleave.spec.ts --reporter=line --timeout=60000
\`\`\`

Result on mini3 (\`https://dspfac.octos.ominix.io\`):
- \`login()\` lands on \`/chat\` with \`chat-input\` visible
- Both slow + fast prompts send successfully
- 4 bubbles render with thread-IDs (\`user-message\` / \`assistant-message\`)
- The spec proceeds and runs to its real assertion (which fails on the wave-2 deep-research regression — the regression this harness fix unmasks)

Codex review (\`/tmp/codex-harness-login.log\`) confirmed \`/api/auth/me\` is the right SPA gate and flagged two refinements (admin-role check, baseURL parameter on \`getEffectiveAdminToken\`) — both folded in as a follow-up commit.

## Test plan

- [ ] Verified by running \`live-thread-interleave.spec.ts\` against mini3 — helper lands on \`/chat\` with \`chat-input\` visible
- [ ] No spec changes; existing flows of \`live-mofa-skills\` and \`live-realtime-status\` still work via backward-compatible defaults
- [ ] \`getEffectiveAdminToken()\` no-arg call sites unchanged

## Context

Surfaced by wave-2 redeploy soak Cluster A (\`/tmp/soak-wave2-comprehensive.md\`).