### PR TITLE
fix(api): add /api/tasks to X-Profile-Id bypass allowlist (closes #732)

### DIFF
--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -717,7 +717,9 @@ async fn user_auth_middleware(
         }
 
         let uri_str = uri.path();
-        // Only allow proxy auth for chat-related endpoints, not admin
+        // Allow proxy auth for chat- and session-scoped endpoints, not admin.
+        // Task-control verbs (`/api/tasks/{id}/cancel`, `/restart-from-node`)
+        // are session-scoped — same trust posture as `/api/sessions`.
         if uri_str.starts_with("/api/chat")
             || uri_str.starts_with("/api/ws")
             || uri_str.starts_with("/api/ui-protocol")
@@ -725,6 +727,7 @@ async fn user_auth_middleware(
             || uri_str.starts_with("/api/sessions")
             || uri_str.starts_with("/api/files")
             || uri_str.starts_with("/api/status")
+            || uri_str.starts_with("/api/tasks")
         {
             req.extensions_mut().insert(AuthIdentity::User {
                 id: profile_id,


### PR DESCRIPTION
## Summary

Closes #732. One-line fix to the `user_auth_middleware` `X-Profile-Id` proxy-auth bypass allowlist in `crates/octos-cli/src/api/router.rs`. Adds `/api/tasks` to the prefix list so task-control verbs registered at `router.rs:147` (`POST /api/tasks/{id}/cancel`, `POST /api/tasks/{id}/restart-from-node`) get the same Caddy/loopback proxy-auth treatment as the sibling `/api/sessions` and friends.

## Root cause (from #732)

`user_auth_middleware` at `router.rs:678` has two gates:

1. Token-based auth (`resolve_identity`) — admin token, `OCTOS_TEST_TOKEN`, user session.
2. Loopback-only `X-Profile-Id` bypass for the Caddy reverse-proxy case.

When the bearer token didn't match (e.g., on minis where `admin_token.json` had been rotated, making the env `OCTOS_AUTH_TOKEN` bootstrap inert), the request fell through to gate 2. But gate 2 had a hardcoded URI prefix allowlist of `/api/{chat,ws,ui-protocol,upload,sessions,files,status}` — `/api/tasks/*` was missing, so the cancel route returned `StatusCode::UNAUTHORIZED`.

## Why this is the right fix

The cancel route is session-scoped task control (M7.9). It's registered alongside `/api/sessions/{id}` ops at `router.rs:147`. Same trust posture as `/api/sessions/*` — which IS in the allowlist. The original allowlist was an oversight when the M7.9 task-control verbs landed.

## What changes

- `router.rs:728` — add `|| uri_str.starts_with(\"/api/tasks\")`
- `router.rs:720-722` — broaden comment to reflect that the allowlist covers chat- AND session-scoped routes, while still excluding admin

Behavior preserved: still gated on `is_loopback`, still validates `profile_id`, still warns + 401s when `X-Profile-Id` appears off-loopback.

## Test plan

- [x] `cargo check -p octos-cli --features api` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] After merge + redeploy: rerun `live-pipeline-end-to-end:342` against mini3 and verify `cancel.status` is one of `[200, 202, 409]` instead of 401

## Related

- #732 — original bug report
- #121 — sibling \"bearer auth env mismatch\" issue on mini1 + mini2 (same proximate cause)
- \`/tmp/mini1-121-spread-diagnosis.md\` — Caddy config drift narrative
- \`/tmp/soak-wave2-comprehensive.md\` — Cluster B in the wave-2 soak

## Severity

P0 for releases that assert task cancellation works via REST. UI Protocol task-cancel uses a different code path (not yet traced in this issue) and may be unaffected.