### PR TITLE
fix(e2e): poll for deep-research result delivery after spawn_only ack (closes #731)

### DIFF
--- a/e2e/tests/live-deep-search-quality.spec.ts
+++ b/e2e/tests/live-deep-search-quality.spec.ts
@@ -103,7 +103,7 @@ test.describe('W3.C1 deep_search quality gate', () => {
 });
 
 /**
- * Wait for the assistant to deliver a deep_search report. We try two
+ * Wait for the assistant to deliver a deep_search report. We try three
  * extraction paths in priority order:
  *
  * 1. Chat thread contains a markdown rendering of the report. Look for
@@ -111,9 +111,18 @@ test.describe('W3.C1 deep_search quality gate', () => {
  *    `_report.md` reference.
  * 2. Latest assistant message contains a fenced markdown block we can
  *    inspect verbatim.
+ * 3. An assistant bubble exposes a `.md` link/attachment (the
+ *    spawn_only delivery path post-PR #688: `run_pipeline` runs in the
+ *    background and the SSE `done` event fires when the LLM EndTurns
+ *    after the spawn-ack, NOT when the artifact is produced. The
+ *    actual `_report.md` is delivered as a media attachment 1-3 min
+ *    later via a separate assistant bubble — see issue #731). When we
+ *    find that anchor, we fetch its content using the browser's auth
+ *    token so the assertions still run against the report body.
  */
 async function waitForReportContent(page: Page, timeoutMs: number): Promise<string> {
   const deadline = Date.now() + timeoutMs;
+  let lastErr: string | undefined;
   while (Date.now() < deadline) {
     // Look at the rendered chat thread text for the report content.
     const threadText = await page.evaluate(() => {
@@ -140,10 +149,70 @@ async function waitForReportContent(page: Page, timeoutMs: number): Promise<stri
       return lastAssistant;
     }
 
+    // Spawn_only delivery path (issue #731): the report lands as a
+    // media attachment in a *later* assistant bubble. Look for any
+    // SAME-ORIGIN anchor with an `.md` href and fetch it via the same
+    // auth token the SPA holds in localStorage. Restricting to
+    // same-origin avoids matching external citation links (e.g.
+    // `https://github.com/.../README.md`) that the LLM may emit in
+    // its synthesis prose, and prevents leaking the bearer token to
+    // a third-party host. We pick the most-recent matching anchor so
+    // that re-runs in the same session pick the latest report.
+    const mdHref = await page.evaluate(() => {
+      const re = /\.md(?:$|[?#])/i;
+      const here = window.location.origin;
+      const anchors = Array.from(
+        document.querySelectorAll(
+          "[data-testid='assistant-message'] a[href]",
+        ),
+      ) as HTMLAnchorElement[];
+      const matches = anchors.filter((a) => {
+        const href = a.href || '';
+        if (!re.test(href)) return false;
+        try {
+          return new URL(href, here).origin === here;
+        } catch {
+          // Relative URLs that can't be parsed against the doc base
+          // would have already been resolved by `a.href` getter;
+          // anything that throws here is malformed and we skip.
+          return false;
+        }
+      });
+      return matches.length ? matches[matches.length - 1].href : '';
+    });
+    if (mdHref) {
+      const fetched = await page.evaluate(async (href) => {
+        try {
+          const token =
+            localStorage.getItem('octos_session_token') ||
+            localStorage.getItem('octos_auth_token') ||
+            '';
+          const profile = localStorage.getItem('selected_profile') || '';
+          const headers: Record<string, string> = {};
+          if (token) headers.Authorization = `Bearer ${token}`;
+          if (profile) headers['X-Profile-Id'] = profile;
+          const resp = await fetch(href, {
+            headers,
+            credentials: 'include',
+          });
+          if (!resp.ok) return { ok: false, status: resp.status, text: '' };
+          const text = await resp.text();
+          return { ok: true, status: resp.status, text };
+        } catch (err) {
+          return { ok: false, status: -1, text: String(err) };
+        }
+      }, mdHref);
+      if (fetched.ok && fetched.text && fetched.text.length > 200) {
+        return fetched.text;
+      }
+      lastErr = `fetched ${mdHref}: ok=${fetched.ok} status=${fetched.status} bodyLen=${fetched.text.length}`;
+    }
+
     await page.waitForTimeout(POLL_INTERVAL_MS);
   }
   throw new Error(
-    `Timed out after ${(timeoutMs / 1000).toFixed(0)}s waiting for deep_search report content`,
+    `Timed out after ${(timeoutMs / 1000).toFixed(0)}s waiting for deep_search report content` +
+      (lastErr ? ` (last attachment fetch: ${lastErr})` : ''),
   );
 }
 

--- a/e2e/tests/live-thread-interleave.spec.ts
+++ b/e2e/tests/live-thread-interleave.spec.ts
@@ -103,12 +103,25 @@ async function getOrderedBubbles(page: Page) {
  * deep_research RESULT lands, exercising the late-binding code path
  * the #649 fix targets.
  *
+ * Issue #731 hardening: PR #688 made `run_pipeline` `spawn_only`, so
+ * deep_research now delivers as a media-attachment bubble (`.md`
+ * link) ~1-3 min after the SSE `done` event for the foreground turn,
+ * NOT as inline markdown text. The bubble's `innerText` for an
+ * attachment-only message can be a generic "✓ run_pipeline completed
+ * (...)" or empty, neither of which contains `rust`. We extend the
+ * Q1-satisfied predicate to also accept the presence of a `.md`
+ * anchor href in the slow region, which is what proves the late
+ * background result has been bound to Q1's thread.
+ *
  * Early-fail diagnostic: while polling, we also look at Q2's paired
- * bubble. If the slow marker shows up THERE before showing up under
- * Q1, that's the smoking-gun #649 misroute (late background result
- * inherited Q2's thread_id). We throw immediately with a clear
- * diagnostic instead of letting the test silently time out.
+ * bubble. If the slow marker (text or `.md` link) shows up THERE
+ * before showing up under Q1, that's the smoking-gun #649 misroute
+ * (late background result inherited Q2's thread_id). We throw
+ * immediately with a clear diagnostic instead of letting the test
+ * silently time out.
  */
+const MD_HREF_RE = /\.md(?:$|[?#])/i;
+
 async function waitForBothFinished(
   page: Page,
   expectedAssistantCount: number,
@@ -119,7 +132,7 @@ async function waitForBothFinished(
 ) {
   const start = Date.now();
   let lastFilled = 0;
-  let lastSlowMatched = false;
+  let lastSlowSatisfied = false;
   let stable = 0;
   while (Date.now() - start < maxWaitMs) {
     const isStreaming = await page
@@ -136,8 +149,10 @@ async function waitForBothFinished(
 
     // Inspect Q1's vs Q2's paired bubbles. Q1's assistants live in the
     // new region between the first user bubble and the second user
-    // bubble; Q2's assistants live after the second user bubble.
-    const regionTexts = await page.evaluate(
+    // bubble; Q2's assistants live after the second user bubble. We
+    // also collect any anchor hrefs in each region so the spawn_only
+    // `.md`-attachment delivery path (issue #731) is recognised.
+    const regionData = await page.evaluate(
       ({ baseUsers, baseAssistants }) => {
         const nodes = document.querySelectorAll(
           "[data-testid='user-message'], [data-testid='assistant-message']",
@@ -147,7 +162,9 @@ async function waitForBothFinished(
         const firstUserIdx = newRegion.findIndex(
           (el) => el.getAttribute('data-testid') === 'user-message',
         );
-        if (firstUserIdx < 0) return { slow: '', fast: '' };
+        if (firstUserIdx < 0) {
+          return { slow: '', fast: '', slowHrefs: [], fastHrefs: [] };
+        }
         const secondUserRel = newRegion
           .slice(firstUserIdx + 1)
           .findIndex((el) => el.getAttribute('data-testid') === 'user-message');
@@ -158,43 +175,77 @@ async function waitForBothFinished(
         const slowSlice = newRegion.slice(firstUserIdx + 1, slowEnd);
         const fastSlice =
           secondUserRel < 0 ? [] : newRegion.slice(slowEnd + 1);
-        const collect = (arr: Element[]) =>
+        const collectText = (arr: Element[]) =>
           arr
             .filter(
               (el) => el.getAttribute('data-testid') === 'assistant-message',
             )
             .map((el) => ((el as HTMLElement).innerText || '').trim())
             .join('\n');
-        return { slow: collect(slowSlice), fast: collect(fastSlice) };
+        const here = window.location.origin;
+        const collectHrefs = (arr: Element[]) =>
+          arr
+            .filter(
+              (el) => el.getAttribute('data-testid') === 'assistant-message',
+            )
+            .flatMap((el) =>
+              Array.from(el.querySelectorAll('a[href]')).map(
+                (a) => (a as HTMLAnchorElement).href || '',
+              ),
+            )
+            .filter((h) => {
+              if (!h) return false;
+              // Restrict to same-origin so that external citation
+              // links the LLM may emit in synthesis prose don't
+              // count as the spawn_only `.md` delivery (issue #731).
+              try {
+                return new URL(h, here).origin === here;
+              } catch {
+                return false;
+              }
+            });
+        return {
+          slow: collectText(slowSlice),
+          fast: collectText(fastSlice),
+          slowHrefs: collectHrefs(slowSlice),
+          fastHrefs: collectHrefs(fastSlice),
+        };
       },
       { baseUsers: baseUserBubbles, baseAssistants: baseAssistantBubbles },
     );
-    const slowMatched = slowMarker.test(regionTexts.slow);
-    const fastHasSlowMarker = slowMarker.test(regionTexts.fast);
+    const slowTextMatched = slowMarker.test(regionData.slow);
+    const fastTextHasSlowMarker = slowMarker.test(regionData.fast);
+    const slowHasMdLink = regionData.slowHrefs.some((h) => MD_HREF_RE.test(h));
+    const fastHasMdLink = regionData.fastHrefs.some((h) => MD_HREF_RE.test(h));
+
+    // Either a textual content marker OR an `.md` attachment anchor
+    // counts as Q1's deep_research RESULT having landed under Q1.
+    const slowSatisfied = slowTextMatched || slowHasMdLink;
+    const fastHasSlowEvidence = fastTextHasSlowMarker || fastHasMdLink;
 
     // Smoking-gun: late deep_research result landed under Q2's bubble
     // instead of Q1's. Fail fast with full diagnostics rather than
     // burning the rest of the 6-min budget.
-    if (fastHasSlowMarker && !slowMatched) {
+    if (fastHasSlowEvidence && !slowSatisfied) {
       throw new Error(
-        `BROKEN PAIRING (#649 misroute): slow-Q research-content marker (${slowMarker}) appeared under Q2's bubble while Q1's bubble has no such marker. This is exactly the #649 symptom: late background result inherited Q2's thread_id from the sticky map.\nQ1 region text: ${JSON.stringify(regionTexts.slow.slice(0, 400))}\nQ2 region text: ${JSON.stringify(regionTexts.fast.slice(0, 400))}`,
+        `BROKEN PAIRING (#649 misroute): slow-Q research evidence (text marker ${slowMarker} or .md attachment) appeared under Q2's bubble while Q1's bubble has none. This is exactly the #649 symptom: late background result inherited Q2's thread_id from the sticky map.\nQ1 region text: ${JSON.stringify(regionData.slow.slice(0, 400))}\nQ1 region hrefs: ${JSON.stringify(regionData.slowHrefs)}\nQ2 region text: ${JSON.stringify(regionData.fast.slice(0, 400))}\nQ2 region hrefs: ${JSON.stringify(regionData.fastHrefs)}`,
       );
     }
 
-    if (filled >= expectedAssistantCount && !isStreaming && slowMatched) {
+    if (filled >= expectedAssistantCount && !isStreaming && slowSatisfied) {
       stable += 1;
       if (stable >= 2) return filled;
     } else {
       stable = 0;
     }
 
-    if (filled !== lastFilled || slowMatched !== lastSlowMatched) {
+    if (filled !== lastFilled || slowSatisfied !== lastSlowSatisfied) {
       const elapsed = ((Date.now() - start) / 1000).toFixed(0);
       console.log(
-        `  [interleave] ${elapsed}s: filled=${filled}/${expectedAssistantCount} streaming=${isStreaming} slowMatched=${slowMatched} slowSnippet=${JSON.stringify(regionTexts.slow.slice(0, 120))}`,
+        `  [interleave] ${elapsed}s: filled=${filled}/${expectedAssistantCount} streaming=${isStreaming} slowSatisfied=${slowSatisfied} (text=${slowTextMatched}, mdLink=${slowHasMdLink}) slowSnippet=${JSON.stringify(regionData.slow.slice(0, 120))}`,
       );
       lastFilled = filled;
-      lastSlowMatched = slowMatched;
+      lastSlowSatisfied = slowSatisfied;
     }
     await page.waitForTimeout(3_000);
   }
@@ -317,26 +368,81 @@ test.describe('Live thread interleave (M8.10 PR #4)', () => {
       expect(slowThreadIds[0]).not.toBe(fastThreadIds[0]);
     }
 
-    // Hard content check (#649 hardening): the slow assistant's text
-    // MUST contain a research-content marker — this is what proves the
-    // late deep_research RESULT actually attached to Q1's bubble (and
-    // not Q2's, which is the #649 misrouting symptom). Without this
-    // assertion the spec would false-pass on the spawn-ack alone.
-    // `waitForBothFinished` already polls for this marker, so by the
+    // Hard content check (#649 + #731 hardening): the slow assistant's
+    // bubble MUST contain EITHER a research-content marker OR a `.md`
+    // attachment anchor — both prove the late deep_research RESULT
+    // attached to Q1's bubble (and not Q2's, which is the #649
+    // misrouting symptom). Post-PR-#688, `run_pipeline` is `spawn_only`
+    // and delivers the report as a media attachment ~1-3 min after
+    // SSE done; for those bubbles the inline text is just a generic
+    // success notification with no `rust` token, so the text-only
+    // assertion would false-fail. Without either signal, the spec
+    // would false-pass on the spawn-ack alone.
+    // `waitForBothFinished` already polls for this evidence, so by the
     // time we reach here it should be present; if it's not, the late
     // result either timed out (raise SLOW_MAX_WAIT_MS) or got bound to
     // the wrong bubble (the #649 regression).
     const slowText = slowAssistantBetween.map((b) => b.text).join(' ');
     const fastText = fastAssistantAfter.map((b) => b.text).join(' ');
+    const slowMdHrefs = await page.evaluate(
+      ({ baseUsers, baseAssistants }) => {
+        const nodes = document.querySelectorAll(
+          "[data-testid='user-message'], [data-testid='assistant-message']",
+        );
+        const all = Array.from(nodes);
+        const newRegion = all.slice(baseUsers + baseAssistants);
+        const firstUserIdx = newRegion.findIndex(
+          (el) => el.getAttribute('data-testid') === 'user-message',
+        );
+        if (firstUserIdx < 0) return [] as string[];
+        const secondUserRel = newRegion
+          .slice(firstUserIdx + 1)
+          .findIndex(
+            (el) => el.getAttribute('data-testid') === 'user-message',
+          );
+        const slowEnd =
+          secondUserRel < 0
+            ? newRegion.length
+            : firstUserIdx + 1 + secondUserRel;
+        const slowSlice = newRegion.slice(firstUserIdx + 1, slowEnd);
+        const here = window.location.origin;
+        return slowSlice
+          .filter(
+            (el) => el.getAttribute('data-testid') === 'assistant-message',
+          )
+          .flatMap((el) =>
+            Array.from(el.querySelectorAll('a[href]')).map(
+              (a) => (a as HTMLAnchorElement).href || '',
+            ),
+          )
+          .filter((h) => {
+            if (!h) return false;
+            try {
+              return new URL(h, here).origin === here;
+            } catch {
+              return false;
+            }
+          });
+      },
+      { baseUsers: userBubblesBefore, baseAssistants: assistantBubblesBefore },
+    );
+    const slowHasMdLink = slowMdHrefs.some((h) => MD_HREF_RE.test(h));
     expect(
-      SLOW_HINT_RE.test(slowText),
-      `Slow-Q's paired bubble has no research-content marker. This means the deep_research result either never arrived under Q1's bubble (possibly bound to Q2's bubble — the #649 regression) or the spawn-ack alone is what got rendered. slow="${slowText.slice(0, 400)}" fast="${fastText.slice(0, 200)}"`,
+      SLOW_HINT_RE.test(slowText) || slowHasMdLink,
+      `Slow-Q's paired bubble has neither research-content text marker nor a .md attachment. This means the deep_research result either never arrived under Q1's bubble (possibly bound to Q2's bubble — the #649 regression) or the spawn-ack alone is what got rendered. slow="${slowText.slice(0, 400)}" slowHrefs=${JSON.stringify(slowMdHrefs)} fast="${fastText.slice(0, 200)}"`,
     ).toBe(true);
 
     // Soft semantic check: the slow assistant's text should NOT include
     // any "1+1=2" content (that's the fast Q's answer). If it does, the
-    // wires got crossed.
-    if (FAST_HINT_RE.test(slowText) && !SLOW_HINT_RE.test(slowText)) {
+    // wires got crossed. Only fail if there's also no slow-content
+    // signal at all (text or .md link) — the attachment-only delivery
+    // path may legitimately have a generic notification line that
+    // happens to contain a digit.
+    if (
+      FAST_HINT_RE.test(slowText) &&
+      !SLOW_HINT_RE.test(slowText) &&
+      !slowHasMdLink
+    ) {
       throw new Error(
         `BROKEN PAIRING: slow assistant text contains fast-Q answer marker but no slow-Q content. slow="${slowText.slice(0, 200)}" fast="${fastText.slice(0, 200)}"`,
       );


### PR DESCRIPTION
## Summary

Closes #731.

PR #688 (`run_pipeline → spawn_only`) made the SSE `done` event for `/api/chat` fire when the LLM EndTurns after the spawn-ack — it no longer means the pipeline artifact has been produced. The actual `_report.md` lands as a separate assistant bubble carrying a media attachment ~1-3 minutes later. Two specs that previously asserted on inline markdown content now race the background delivery and time out.

This PR extends the existing DOM poll loops in both specs to **also** accept the spawn_only delivery path. The two specs on current `main` are Playwright DOM-based (not API/`chatSSE`-based, contrary to the issue text — that file lineage lives on the M9 coding-green branch family and is not on `main`). The fix targets what is actually here.

- `e2e/tests/live-deep-search-quality.spec.ts` — `waitForReportContent` now also scans assistant bubbles for same-origin `.md` anchors. When found, the linked artifact is fetched using the SPA's bearer token and `X-Profile-Id` from localStorage, and the report body is returned for the existing structural assertions to run against.
- `e2e/tests/live-thread-interleave.spec.ts` — `waitForBothFinished` collects same-origin `.md` anchor hrefs per region in addition to text. Q1 is satisfied by either the inline text marker (`/\brust\b/i`) **or** the presence of a `.md` attachment under Q1's bubble. The fail-fast misroute diagnostic is mirrored: if Q2 has the `.md` link but Q1 doesn't, throw immediately. The final hard content check accepts either signal.

Same-origin filter prevents matching external citation links the LLM may emit in synthesis prose (e.g. `https://github.com/.../README.md`) and avoids leaking the bearer token to a third-party host.

## Why this surfaced now

Pre-PR #730, pipeline-guard's stale schema caused deep-search to die in 0ms with `no provider registered for key 'qwen3.5-plus'` — the spec timed out on the 0ms failure, not the 3-min delivery race. PR #730 fixed the schema, the pipeline now runs end-to-end, and the spawn_only timing race surfaced.

Server-side delivery is healthy (verified per #731): mini3 daemon log shows `seq=5` lands with `media: [..._report.md]` ~3 min after spawn-ack.

## Codex 2nd-opinion refinements applied

Two rounds of `codex exec` review (`/tmp/codex-poll-loop-fix.log`):
1. Confirmed the issue body's `chatSSE`/`getMessages` pattern matches a different branch, and the DOM-based specs on `main` are the right target.
2. Pushed back on the initial `.md` selector being too broad (would match external citation links and leak the bearer token). Fix: `URL.origin === window.location.origin` filter on every match.
3. Pushed back on missing `X-Profile-Id` header — required on local/admin/proxy host shapes. Fix: read `selected_profile` from localStorage and add the header when present (mirrors the `live-slides-site.spec.ts:144-152` and `live-spawn-end-to-end.spec.ts:96` pattern).

## Test plan

- [x] Type-check clean (no new errors introduced; one pre-existing `SEL.assistantBubble` warning at the call site is unchanged from baseline)
- [ ] `live-deep-search-quality.spec.ts` passes against mini3 with the new poll loop
- [ ] `live-thread-interleave.spec.ts` passes against mini3 with the new poll loop (final closure of PR #730 regression target)

## Notes

- No server change. Pure harness fix.
- Don't merge before #732 is fixed (cancel-401) — `live-pipeline-end-to-end:342` will still fail until that's resolved, but that's a separate cluster.