### PR TITLE
fix(api): add missing fields to ConnectionUiFeatures test fixtures

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4447,6 +4447,8 @@ mod tests {
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                harness_task_control: false,
+                header_present: true,
             },
         );
 
@@ -4490,6 +4492,8 @@ mod tests {
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                harness_task_control: false,
+                header_present: true,
             },
         );
 
@@ -4526,6 +4530,8 @@ mod tests {
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                harness_task_control: false,
+                header_present: true,
             },
         );
 


### PR DESCRIPTION
## Summary

Pre-existing compile error blocking `cargo test -p octos-cli --features api` (any path in the lib-test target) on every PR's CI:

```
error[E0063]: missing fields `harness_task_control` and `header_present` in initializer of `api::ui_protocol::ConnectionUiFeatures`
  --> crates/octos-cli/src/api/ui_protocol.rs:4446:13
  --> crates/octos-cli/src/api/ui_protocol.rs:4489:13
  --> crates/octos-cli/src/api/ui_protocol.rs:4525:13
```

Three test-fixture sites (4446 / 4489 / 4525) construct `ConnectionUiFeatures` literally without the two fields added in PR #720 (`feat(ui_protocol): emit UiProtocolCapabilities in SessionOpened`, commit `0922ca82`). Production code populates both via `ConnectionUiFeatures::from_headers_and_query` and the neighboring fixtures at lines 4311 / 4356 / 4604 / 5882 were updated correctly; these three were missed.

The user-reported symptom mentioned only 4446 and 4489, but the compiler surfaces 4525 in the same compile unit (`shell_approval_still_emits_risk_field`).

## Affected tests

- `plugin_high_risk_approval_emits_risk_field_on_wire` (line 4423)
- `plugin_critical_risk_approval_emits_risk_critical` (line 4468)
- `shell_approval_still_emits_risk_field` (line 4504)

## Fix

Add `harness_task_control: false, header_present: true` to all three fixture sites. All three exercise the typed-approval path (`typed_approvals: true`), which in production is reachable only when the client sent a feature header — so `header_present: true` matches the intent. None of the three touch task-control flow, so `harness_task_control: false`. This matches the prevailing pattern at lines 4311, 4356, 4604.

Style: explicit literal (matches the prevailing pattern for negotiated-client fixtures). `..Default::default()` is reserved in this file for legacy-untyped-client tests like the one at line 4569.

## Verification

- `cargo test -p octos-cli --features api api::auth_handlers` — 28/28 pass (was: failed to compile)
- `cargo fmt --all -- --check` — clean
- `cargo test -p octos-cli --features api` (full lib-test compile) — three E0063 errors removed; no new errors introduced
- Codex 2nd-opinion review (`/tmp/codex-uifeatures-fix.log`) — confirmed field values, style choice, and that `ConnectionUiFeatures` is only used in `ui_protocol.rs` (no other cfg-gated sites missed)

## Why now

Today's wave-2 redeploy soak surfaced this as a CI noise source on every PR. Fixing it now so future PRs have clean signal.

## Notes

- `cargo clippy -p octos-cli --features api -- -D warnings` reports 33 errors — all pre-existing on `main`, unrelated to this change, none in the test fixtures touched by this PR.