### PR TITLE
fix(supervisor): preserve originating_client_message_id through M8.9 recovery (closes #738)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -273,10 +273,6 @@ impl Agent {
                 let bg_args = effective_args.clone();
                 let bg_sender = tools.background_result_sender();
                 let bg_tc_id = tc_id.clone();
-                let task_id =
-                    tools.register_task_with_input(&tc_name, &tc_id, Some(effective_args.clone()));
-                tools.mark_spawn_only_invoked();
-                let bg_supervisor = tools.supervisor();
                 let bg_reporter = reporter.clone();
                 // M8.10 follow-up (#649): snapshot the originating turn's
                 // thread_id NOW, before any other turn can swap reporters
@@ -286,6 +282,20 @@ impl Agent {
                 // correct turn even after subsequent unrelated user turns
                 // have advanced the per-chat sticky thread_id.
                 let bg_originating_thread_id = bg_reporter.thread_id().map(str::to_string);
+                // Issue #738 fix: thread the originating cmid into task
+                // registration so any SpawnOnlyFailureSignal emitted for
+                // this task carries it to the M8.9 synthetic recovery
+                // turn. Without this, the recovery turn mints a fresh
+                // UUIDv7 and the eventual successful retry's deliverables
+                // land under an orphan thread_id with no DOM bubble.
+                let task_id = tools.register_task_with_input_and_cmid(
+                    &tc_name,
+                    &tc_id,
+                    Some(effective_args.clone()),
+                    bg_originating_thread_id.clone(),
+                );
+                tools.mark_spawn_only_invoked();
+                let bg_supervisor = tools.supervisor();
                 // F004 B2: bridge supervised runtime-state transitions onto
                 // the per-request reporter so spawn_only tasks emit
                 // ToolProgress events keyed by `tool_call_id`. This is what

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -226,6 +226,16 @@ pub struct BackgroundTask {
     /// surface the exact input the LLM passed when offering alternatives.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_input: Option<Value>,
+    /// Issue #738 fix: the `client_message_id` of the user turn that
+    /// originated this background task. Captured at register time so the
+    /// M8.9 failure-recovery synthetic turn can inherit the same cmid
+    /// (instead of the recovery turn minting a fresh server UUIDv7 that
+    /// the SPA has no DOM bubble for, leaving the eventual successful
+    /// retry's deliverables stranded under an orphan thread_id).
+    /// `#[serde(default)]` so tasks persisted before this field was added
+    /// still deserialize as `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub originating_client_message_id: Option<String>,
 }
 
 impl BackgroundTask {
@@ -275,6 +285,16 @@ pub struct SpawnOnlyFailureSignal {
     pub suggested_alternatives: Vec<String>,
     /// Owning session, when the failed task is bound to one.
     pub parent_session_key: Option<String>,
+    /// Issue #738 fix: the `client_message_id` of the user turn that
+    /// originated this spawn_only task. Threaded end-to-end so the
+    /// synthetic recovery `InboundMessage` built by the session actor
+    /// inherits the original turn's cmid — without it, `process_inbound`
+    /// mints a fresh server UUIDv7 and the eventual successful retry's
+    /// deliverables (e.g. `_report.md`) land under an orphan thread_id
+    /// with no DOM bubble in the SPA. `None` for legacy callers that
+    /// pre-date the field; receivers must tolerate that.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub originating_client_message_id: Option<String>,
 }
 
 /// Callback invoked when a `spawn_only` task fails. Receives the structured
@@ -1169,11 +1189,15 @@ impl TaskSupervisor {
 
         // Pre-allocate a successor task id and seed it on the supervisor
         // so dashboards see the relaunch as a peer of the original task.
-        let new_task_id = self.register_with_input(
+        // Issue #738: carry the originating cmid forward so a relaunched
+        // task that itself fails again still has the right thread anchor
+        // for any synthetic recovery turn.
+        let new_task_id = self.register_with_input_and_cmid(
             &original.tool_name,
             &original.tool_call_id,
             original.session_key.as_deref(),
             original.tool_input.clone(),
+            original.originating_client_message_id.clone(),
         );
 
         // Stamp the lineage on the new task: callers can use
@@ -1258,7 +1282,14 @@ impl TaskSupervisor {
         session_key: Option<&str>,
         task_ledger_path: Option<&str>,
     ) -> String {
-        match self.register_full(tool_name, tool_call_id, session_key, task_ledger_path, None) {
+        match self.register_full(
+            tool_name,
+            tool_call_id,
+            session_key,
+            task_ledger_path,
+            None,
+            None,
+        ) {
             Ok(id) => id,
             Err(error) => {
                 tracing::error!(
@@ -1285,7 +1316,7 @@ impl TaskSupervisor {
         session_key: Option<&str>,
         tool_input: Option<Value>,
     ) -> String {
-        match self.register_full(tool_name, tool_call_id, session_key, None, tool_input) {
+        match self.register_full(tool_name, tool_call_id, session_key, None, tool_input, None) {
             Ok(id) => id,
             Err(error) => {
                 tracing::error!(
@@ -1294,6 +1325,41 @@ impl TaskSupervisor {
                     session_key = ?session_key,
                     error = %error,
                     "task supervisor register_with_input refused (legacy entry point); returning empty id"
+                );
+                String::new()
+            }
+        }
+    }
+
+    /// Issue #738 fix: register a task and capture the originating user
+    /// turn's `client_message_id`. The cmid is later threaded into any
+    /// `SpawnOnlyFailureSignal` emitted for this task so the M8.9
+    /// recovery `InboundMessage` keeps the original thread_id rather
+    /// than minting an orphan UUIDv7.
+    pub fn register_with_input_and_cmid(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        session_key: Option<&str>,
+        tool_input: Option<Value>,
+        originating_client_message_id: Option<String>,
+    ) -> String {
+        match self.register_full(
+            tool_name,
+            tool_call_id,
+            session_key,
+            None,
+            tool_input,
+            originating_client_message_id,
+        ) {
+            Ok(id) => id,
+            Err(error) => {
+                tracing::error!(
+                    tool = tool_name,
+                    tool_call_id = tool_call_id,
+                    session_key = ?session_key,
+                    error = %error,
+                    "task supervisor register_with_input_and_cmid refused (legacy entry point); returning empty id"
                 );
                 String::new()
             }
@@ -1311,7 +1377,7 @@ impl TaskSupervisor {
         session_key: Option<&str>,
         tool_input: Option<Value>,
     ) -> Result<String, RegisterTaskError> {
-        self.register_full(tool_name, tool_call_id, session_key, None, tool_input)
+        self.register_full(tool_name, tool_call_id, session_key, None, tool_input, None)
     }
 
     fn register_full(
@@ -1321,6 +1387,7 @@ impl TaskSupervisor {
         session_key: Option<&str>,
         task_ledger_path: Option<&str>,
         tool_input: Option<Value>,
+        originating_client_message_id: Option<String>,
     ) -> Result<String, RegisterTaskError> {
         // Per-parent fan-out cap. Detached registrations (`session_key ==
         // None`) skip the gate because they do not have a parent to
@@ -1446,6 +1513,7 @@ impl TaskSupervisor {
             error: None,
             session_key: session_key.map(|s| s.to_string()),
             tool_input,
+            originating_client_message_id,
         };
         let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
         tasks.insert(id.clone(), task);
@@ -1700,6 +1768,7 @@ impl TaskSupervisor {
             error_message,
             suggested_alternatives,
             parent_session_key: task.parent_session_key.clone(),
+            originating_client_message_id: task.originating_client_message_id.clone(),
         };
         cb(&signal);
     }

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -225,6 +225,27 @@ impl ToolRegistry {
         )
     }
 
+    /// Issue #738 fix: register a background task while also threading
+    /// the originating user turn's `client_message_id`. Used by the
+    /// spawn_only execution path so the synthetic recovery turn (M8.9)
+    /// can stamp the original cmid into its `InboundMessage` metadata
+    /// instead of minting an orphan UUIDv7.
+    pub fn register_task_with_input_and_cmid(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        tool_input: Option<serde_json::Value>,
+        originating_client_message_id: Option<String>,
+    ) -> String {
+        self.supervisor.register_with_input_and_cmid(
+            tool_name,
+            tool_call_id,
+            self.session_key.as_deref(),
+            tool_input,
+            originating_client_message_id,
+        )
+    }
+
     /// Return the number of currently active background tasks.
     pub fn bg_task_count(&self) -> u32 {
         self.supervisor.task_count() as u32

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7818,6 +7818,7 @@ mod tests {
             error: None,
             session_key: Some("local:test".into()),
             tool_input: None,
+            originating_client_message_id: None,
         }
     }
 

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -938,6 +938,7 @@ mod tests {
             error: None,
             session_key: Some("local:demo".into()),
             tool_input: None,
+            originating_client_message_id: None,
         };
 
         let event = background_task_to_progress_json(&task);

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1383,6 +1383,13 @@ pub enum ActorMessage {
         /// Best-effort prompt body. Already framed as `[system-internal]` so
         /// the LLM treats it as runtime guidance, not a user turn.
         prompt: String,
+        /// Issue #738 fix: the originating user turn's `client_message_id`,
+        /// captured when the spawn_only task was registered. Stamped onto
+        /// the synthetic recovery `InboundMessage`'s metadata so
+        /// `process_inbound` reuses it as the cmid for the recovery turn
+        /// instead of minting a fresh server UUIDv7. `None` for legacy
+        /// callers / tests that pre-date the fix.
+        originating_client_message_id: Option<String>,
     },
     /// Cancel the current operation.
     Cancel,
@@ -2162,6 +2169,12 @@ impl ActorFactory {
                 task_id: signal.task_id.clone(),
                 tool_name: signal.tool_name.clone(),
                 prompt,
+                // Issue #738 fix: forward the originating user turn's
+                // cmid into the recovery hint so the synthetic
+                // InboundMessage stamps `client_message_id` into its
+                // metadata and `process_inbound` reuses it instead of
+                // minting an orphan UUIDv7.
+                originating_client_message_id: signal.originating_client_message_id.clone(),
             });
         });
 
@@ -2714,7 +2727,29 @@ impl SessionActor {
     /// Build a synthetic `InboundMessage` carrying the recovery prompt so
     /// the existing inbound pipeline (history persistence, agent loop)
     /// runs unchanged.
-    fn synthetic_recovery_inbound(&self, prompt: String) -> InboundMessage {
+    ///
+    /// Issue #738 fix: when `originating_client_message_id` is supplied,
+    /// stamp it into `metadata.client_message_id` so `process_inbound`'s
+    /// `inbound_client_message_id` helper reads it back and the recovery
+    /// turn inherits the originating user turn's thread_id instead of
+    /// `process_inbound` minting a fresh server UUIDv7. The eventual
+    /// successful retry's deliverables (e.g. `_report.md`) then land
+    /// under the original SPA bubble rather than an orphan thread_id.
+    fn synthetic_recovery_inbound(
+        &self,
+        prompt: String,
+        originating_client_message_id: Option<String>,
+    ) -> InboundMessage {
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("_recovery_turn".to_string(), serde_json::json!(true));
+        if let Some(cmid) = originating_client_message_id {
+            if !cmid.is_empty() {
+                metadata.insert(
+                    "client_message_id".to_string(),
+                    serde_json::Value::String(cmid),
+                );
+            }
+        }
         InboundMessage {
             channel: self.channel.clone(),
             sender_id: "octos-runtime".to_string(),
@@ -2722,7 +2757,7 @@ impl SessionActor {
             content: prompt,
             timestamp: chrono::Utc::now(),
             media: vec![],
-            metadata: serde_json::json!({ "_recovery_turn": true }),
+            metadata: serde_json::Value::Object(metadata),
             message_id: None,
         }
     }
@@ -2868,6 +2903,7 @@ impl SessionActor {
                             task_id,
                             tool_name,
                             prompt,
+                            originating_client_message_id,
                         }) => {
                             // Cap recovery at one attempt per task to avoid
                             // runaway loops if the recovery turn itself
@@ -2886,9 +2922,14 @@ impl SessionActor {
                                 session = %self.session_key,
                                 task_id,
                                 tool_name,
+                                originating_client_message_id =
+                                    originating_client_message_id.as_deref().unwrap_or("<none>"),
                                 "enqueueing synthetic recovery turn"
                             );
-                            let synthetic = self.synthetic_recovery_inbound(prompt);
+                            let synthetic = self.synthetic_recovery_inbound(
+                                prompt,
+                                originating_client_message_id,
+                            );
                             let final_attachment_media = self
                                 .copy_media_to_workspace(Vec::new());
                             self.process_inbound(
@@ -5749,6 +5790,20 @@ impl SessionActor {
                                 persisted_user_message = true;
                                 let mut sanitized = msg.clone();
                                 sanitized.content = persisted_user_content.clone();
+                                // Issue #738 fix: stamp the inbound's
+                                // `client_message_id` onto the persisted user
+                                // Message. The agent's `process_message`
+                                // builds the user Message with
+                                // `client_message_id: None` so without this
+                                // override, recovery turns (whose synthetic
+                                // InboundMessage carries the originating cmid
+                                // in metadata) lose the cmid before reaching
+                                // the SessionHandle — leaving the eventual
+                                // successful retry's deliverables stranded
+                                // under an orphan thread_id with no DOM bubble.
+                                if sanitized.client_message_id.is_none() {
+                                    sanitized.client_message_id = client_message_id.clone();
+                                }
                                 sanitized
                             } else {
                                 msg.clone()
@@ -10705,6 +10760,7 @@ mod tests {
             error_message: "voice 'yangmi' not registered".into(),
             suggested_alternatives: vec![],
             parent_session_key: Some("api:test".into()),
+            originating_client_message_id: None,
         };
         let prompt = build_recovery_prompt(&signal);
         assert!(prompt.starts_with("[system-internal]"));
@@ -10722,6 +10778,7 @@ mod tests {
             error_message: "voice missing".into(),
             suggested_alternatives: vec!["vivian".into(), "serena".into(), "longxiang".into()],
             parent_session_key: None,
+            originating_client_message_id: None,
         };
         let prompt = build_recovery_prompt(&signal);
         assert!(prompt.contains("Detected alternatives"));
@@ -10739,6 +10796,7 @@ mod tests {
             error_message: "internal error".into(),
             suggested_alternatives: vec![],
             parent_session_key: None,
+            originating_client_message_id: None,
         };
         let prompt = build_recovery_prompt(&signal);
         assert!(!prompt.contains("Detected alternatives"));
@@ -10753,6 +10811,7 @@ mod tests {
             error_message: "voice missing".into(),
             suggested_alternatives: vec![],
             parent_session_key: None,
+            originating_client_message_id: None,
         };
         let prompt = build_recovery_prompt(&signal);
         assert!(prompt.contains("Original input"));
@@ -10782,11 +10841,13 @@ mod tests {
             error_message: "voice 'yangmi' not registered. available: vivian, serena.".into(),
             suggested_alternatives: vec!["vivian".into(), "serena".into()],
             parent_session_key: Some("cli:test".into()),
+            originating_client_message_id: None,
         });
         tx.send(ActorMessage::RecoveryHint {
             task_id: "task-rh-1".into(),
             tool_name: "fm_tts".into(),
             prompt,
+            originating_client_message_id: None,
         })
         .await
         .unwrap();
@@ -10858,6 +10919,7 @@ mod tests {
             task_id: "task-dup".into(),
             tool_name: "fm_tts".into(),
             prompt: prompt1,
+            originating_client_message_id: None,
         })
         .await
         .unwrap();
@@ -10866,6 +10928,7 @@ mod tests {
             task_id: "task-dup".into(),
             tool_name: "fm_tts".into(),
             prompt: prompt2,
+            originating_client_message_id: None,
         })
         .await
         .unwrap();
@@ -10920,6 +10983,7 @@ mod tests {
                 task_id: signal.task_id.clone(),
                 tool_name: signal.tool_name.clone(),
                 prompt,
+                originating_client_message_id: signal.originating_client_message_id.clone(),
             });
         });
         let task_id = supervisor.register_with_input(
@@ -10961,6 +11025,102 @@ mod tests {
             prompt_present,
             "synthetic recovery prompt should be in session history: {:?}",
             session.messages
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    #[tokio::test]
+    async fn recovery_turn_preserves_originating_client_message_id_from_failure_signal() {
+        // Issue #738 RED test: when the supervisor emits a
+        // `SpawnOnlyFailureSignal` with `originating_client_message_id`,
+        // the synthetic recovery turn the actor enqueues MUST persist a
+        // user message whose `client_message_id` matches the originating
+        // turn's cmid. Pre-fix, `synthetic_recovery_inbound` stamped only
+        // `_recovery_turn = true` into the InboundMessage metadata, so
+        // `inbound_client_message_id` returned None and `process_inbound`
+        // minted a fresh server UUIDv7 — leaving the eventual successful
+        // retry's deliverables stranded under an orphan thread_id with no
+        // DOM bubble in the SPA.
+        use octos_agent::TaskSupervisor;
+        const ORIGINATING_CMID: &str = "45756a8f-1234-4abc-8def-cafebabe0001";
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(
+                Duration::from_millis(50),
+                make_response("recovery-handled-738"),
+            )],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        // Mirror the production wiring: the failure-signal callback
+        // forwards `signal.originating_client_message_id` onto
+        // `ActorMessage::RecoveryHint` so the actor's
+        // `synthetic_recovery_inbound` builder can stamp it into metadata.
+        let supervisor = TaskSupervisor::new();
+        let recovery_tx = tx.clone();
+        supervisor.set_on_failure_signal(move |signal| {
+            let prompt = build_recovery_prompt(signal);
+            let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
+                task_id: signal.task_id.clone(),
+                tool_name: signal.tool_name.clone(),
+                prompt,
+                originating_client_message_id: signal.originating_client_message_id.clone(),
+            });
+        });
+
+        // Register the failed task with the originating user turn's
+        // cmid. The supervisor must thread it through to the failure
+        // signal so the recovery turn inherits it.
+        let task_id = supervisor.register_with_input_and_cmid(
+            "deep_research",
+            "call-738",
+            Some("cli:test"),
+            Some(serde_json::json!({"query": "rust news"})),
+            Some(ORIGINATING_CMID.to_string()),
+        );
+        supervisor.mark_failed(&task_id, "MiniMax 429 rate limited".into());
+
+        let mut responses = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+            if responses.iter().any(|r| r.contains("recovery-handled-738")) {
+                break;
+            }
+        }
+        assert!(
+            responses.iter().any(|c| c.contains("recovery-handled-738")),
+            "expected recovery turn to drive an LLM response, got: {responses:?}",
+        );
+
+        // The decisive assertion: the persisted user message for the
+        // recovery turn must carry the originating cmid, NOT a freshly
+        // minted server UUIDv7. Pre-fix this was None or a fresh UUID
+        // because synthetic_recovery_inbound only stamped
+        // `_recovery_turn` and `process_inbound` had nothing to read.
+        let session_handle = SessionHandle::open(dir.path(), &SessionKey::new("cli", "test"));
+        let session = session_handle.session();
+        let recovery_msg = session
+            .messages
+            .iter()
+            .find(|m| {
+                m.role == MessageRole::User
+                    && m.content.contains("[system-internal]")
+                    && m.content.contains("deep_research")
+            })
+            .expect("synthetic recovery user message must be persisted");
+        assert_eq!(
+            recovery_msg.client_message_id.as_deref(),
+            Some(ORIGINATING_CMID),
+            "recovery user message must inherit the originating cmid; got {:?}",
+            recovery_msg.client_message_id,
         );
 
         drop(tx);
@@ -11091,6 +11251,7 @@ mod tests {
             error: None,
             session_key: Some("local:test".into()),
             tool_input: None,
+            originating_client_message_id: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #738. Fixes the orphan-thread_id bug in the M8.9 spawn-only failure-recovery path that has been masking deep_research deliveries since at least PR #649's chain.

## Root cause

Per the diagnosis on #738 and codex 2nd-opinion transcript at `/tmp/codex-orphan-thread-fix.log`:

1. Slow-Q user message arrives with `client_message_id = 45756a8f-...` (the SPA's stable bubble id).
2. Spawn-only run_pipeline starts; first child fails (e.g., MiniMax 429).
3. M8.9 `synthetic_recovery_inbound` (`crates/octos-cli/src/session_actor.rs:2717`) builds a recovery `InboundMessage` with `metadata = {"_recovery_turn": true}` — **no `client_message_id`**.
4. `process_inbound` mints a fresh server UUIDv7 (`019de472-7b6d-...`).
5. The successful retry's `_report.md` is delivered under that orphan thread_id.
6. SPA has no DOM bubble for the orphan → result invisible.

## Fix

Thread `originating_client_message_id` end-to-end:

- **`BackgroundTask`** — new field `originating_client_message_id: Option<String>` captured at register time
- **`SpawnOnlyFailureSignal`** — new field populated by `notify_failure` from the task's stored cmid
- **`TaskSupervisor`** — new `register_with_input_and_cmid()` entry point; `relaunch()` propagates cmid forward
- **`agent/execution.rs` spawn_only branch** — passes `bg_originating_thread_id` (snapshot of `reporter.thread_id()`) into the new register entry point
- **`ActorMessage::RecoveryHint`** — new `originating_client_message_id` field; `set_on_failure_signal` forwards it
- **`synthetic_recovery_inbound`** — stamps `client_message_id` into `InboundMessage` metadata when set
- **`process_inbound` user-message persist** — backstop fix: stamps inbound's cmid onto the persisted user Message because `Agent::process_message_inner` builds it with `client_message_id=None` and would otherwise drop the cmid before `add_message_with_seq`

## Test plan

- [x] New unit test `recovery_turn_preserves_originating_client_message_id_from_failure_signal` — RED-GREEN cycle confirmed (removing the metadata-stamp in `synthetic_recovery_inbound` makes the test fail with `cmid=None`)
- [x] `cargo build --release --bin octos -p octos-cli --features telegram,whatsapp,feishu,twilio,wecom,api` clean
- [x] `cargo test -p octos-agent` — all pass
- [x] `cargo test -p octos-cli --features api` — 849 + 70 session_actor tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Codex 2nd-opinion attempted (`/tmp/codex-orphan-thread-fix.log`) — output was unusable (skill-router meta-instructions only); self-review covered the same questions inline
- [ ] After merge + redeploy: rerun `live-thread-interleave` against mini1 + mini3 and verify the deep_research result lands in the slow-Q's bubble

## Why this finally closes #649's chain

Earlier wave fixes (#649 thread-binding, #142/#143 tasks for thread_id persistence + frontend routing) covered the **happy path** — when the first attempt succeeds. M8.9's recovery path was added later (`aeb9c702`) and was a blind spot: the recovery turn dropped the cmid because `synthetic_recovery_inbound` was modeled on user-initiated turns, not on continuation of a previous user turn. This PR closes that loop.

The backstop fix in `process_inbound` is also load-bearing: the agent loop builds the per-turn user Message with `client_message_id=None`, so even with the recovery `InboundMessage` carrying the cmid in metadata, it would have been dropped before persistence without the explicit override.

## Severity

P1 — only fires when M8.9 recovery actually triggers (i.e., when at least one spawn_only child fails). With healthy provider routes this path may rarely fire; under load (MiniMax 429s, etc.) it fires frequently and silently breaks delivery.

## Related

- #738 — original investigation
- #649 — initial thread-binding bug (PR landed earlier)
- PR #730 — pipeline-guard schema (made M8.9 recovery actually trigger by un-blocking deep_research)
- PR #736 — spawn_only `.md` poll loop (spec now correctly waits for the result; this PR fixes the bug the wait exposes)