### PR TITLE
fix(session_actor): pre-stamp thread_id on assistant/tool persists (closes #740)

### DIFF
--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -4706,7 +4706,32 @@ impl SessionActor {
                         &conv_response.messages
                     };
                     for msg in messages_to_save {
-                        if let Err(e) = handle.add_message(msg.clone()).await {
+                        // Issue #740 fix: pre-stamp `thread_id` on Assistant /
+                        // Tool messages produced inside the agent loop. The
+                        // agent builds these with `thread_id: None` and on
+                        // persist `add_message_with_seq` derives thread_id
+                        // from the most-recent USER message in history. Under
+                        // rapid-fire fast-burst (live-overflow-stress.spec
+                        // `rapid-fire-five-fast`), Q2/Q3 user rows have already
+                        // been persisted to the same JSONL by the speculative-
+                        // overflow tasks before THIS primary turn finalises,
+                        // so derivation picks Qn's cmid instead of Q1's —
+                        // mis-binding Q1's reply under Q3's bubble on reload.
+                        // Pre-stamping the originating turn's cmid here pins
+                        // the persisted JSONL row to the correct thread, the
+                        // same fix shape PR #739 applied to the M8.9 spawn_only
+                        // recovery path.
+                        let mut to_save = msg.clone();
+                        if to_save.thread_id.is_none()
+                            && matches!(to_save.role, MessageRole::Assistant | MessageRole::Tool)
+                        {
+                            if let Some(ref tid) = client_message_id {
+                                if !tid.is_empty() {
+                                    to_save.thread_id = Some(tid.clone());
+                                }
+                            }
+                        }
+                        if let Err(e) = handle.add_message(to_save).await {
                             warn!(session = %self.session_key, role = ?msg.role, error = %e, "failed to persist message");
                         }
                     }
@@ -4724,7 +4749,19 @@ impl SessionActor {
                             tool_call_id: None,
                             reasoning_content: conv_response.reasoning_content.clone(),
                             client_message_id: None,
-                            thread_id: None,
+                            // Issue #740 fix: pre-stamp `thread_id` from the
+                            // originating turn's cmid so the persisted JSONL
+                            // row is pinned to the correct thread. Without
+                            // this, `add_message_with_seq`'s "most recent
+                            // user in history" derivation picks the LATEST
+                            // user message — which under rapid-fire is a
+                            // sibling overflow user, not THIS turn — and
+                            // reload mis-pairs the assistant under the
+                            // wrong bubble (live-overflow-stress mini3
+                            // `rapid-fire-five-fast` evidence: 1+1=2 rendered
+                            // under the 3+3 bubble). Mirrors PR #739's M8.9
+                            // recovery-path fix for the foreground SSE path.
+                            thread_id: client_message_id.clone(),
                             timestamp: chrono::Utc::now(),
                         };
                         // M8.10-A: capture the committed seq so the SSE `done`
@@ -5338,7 +5375,19 @@ impl SessionActor {
                         tool_call_id: None,
                         reasoning_content: conv_response.reasoning_content.clone(),
                         client_message_id: None,
-                        thread_id: None,
+                        // Issue #740 fix: pre-stamp `thread_id` with the
+                        // overflow user's own cmid. Without this, when
+                        // multiple rapid-fire overflow tasks finalise in
+                        // an out-of-order sequence (e.g. Q2's reply lands
+                        // after Q5's user message has been persisted),
+                        // `add_message_with_seq`'s derivation fallback
+                        // picks the latest user (Q5) instead of THIS
+                        // overflow's originating user (Q2), and the
+                        // persisted JSONL row mis-binds the reply under
+                        // Q5's bubble on reload. Mirrors PR #739's
+                        // BackgroundResult fix for the speculative-
+                        // overflow code path.
+                        thread_id: overflow_client_message_id.clone(),
                         timestamp: final_reply_timestamp,
                     };
                     let committed_seq = {
@@ -5806,7 +5855,28 @@ impl SessionActor {
                                 }
                                 sanitized
                             } else {
-                                msg.clone()
+                                let mut to_save = msg.clone();
+                                // Issue #740 fix: pre-stamp `thread_id` on
+                                // Assistant / Tool messages so the persisted
+                                // JSONL row is pinned to THIS turn's cmid
+                                // rather than letting `add_message_with_seq`
+                                // derive it from the most-recent user in
+                                // history (which can be a sibling rapid-fire
+                                // turn that landed in the JSONL between this
+                                // turn's user persist and assistant persist).
+                                if to_save.thread_id.is_none()
+                                    && matches!(
+                                        to_save.role,
+                                        MessageRole::Assistant | MessageRole::Tool
+                                    )
+                                {
+                                    if let Some(ref tid) = client_message_id {
+                                        if !tid.is_empty() {
+                                            to_save.thread_id = Some(tid.clone());
+                                        }
+                                    }
+                                }
+                                to_save
                             };
                         if let Err(e) = handle.add_message(message_to_save).await {
                             warn!(session = %self.session_key, role = ?msg.role, error = %e, "failed to persist message");
@@ -5826,7 +5896,11 @@ impl SessionActor {
                             tool_call_id: None,
                             reasoning_content: conv_response.reasoning_content.clone(),
                             client_message_id: None,
-                            thread_id: None,
+                            // Issue #740 fix: pre-stamp `thread_id` from the
+                            // originating turn's cmid so reload pairs the
+                            // assistant under the correct user bubble.
+                            // Sibling fix to PR #739's M8.9 recovery path.
+                            thread_id: client_message_id.clone(),
                             timestamp: chrono::Utc::now(),
                         };
                         if let Err(e) = handle.add_message(assistant_msg).await {


### PR DESCRIPTION
## Summary

Closes #740. Sibling fix to PR #739.

PR #739 fixed the M8.9 spawn_only-recovery side of the orphan-thread_id problem. This PR fixes the foreground SSE side — same pattern, different code path. Together they close the M8.10 / #649 / #664 / #673 / #680 / #738 / #740 thread-binding regression chain end-to-end.

## Root cause (from #740)

The agent loop in \`session_actor.rs\` builds Assistant / Tool messages with \`thread_id: None\` and relies on \`add_message_with_seq\`'s \"derive from the most-recent USER message in history\" fallback. Under rapid-fire fast-burst, sibling overflow user rows get persisted to the same JSONL **between** this turn's user-row write and its assistant-row write, so the fallback picks the WRONG user — and the persisted JSONL row mis-binds the reply under a sibling bubble on reload.

## Hard evidence

Wave-4 mini3 \`rapid-fire-five-fast\` DOM dump (`/tmp/wave4-soak-mini3.log`):
- \`1+1=?\` user → ONLY a "Thinking..." placeholder (Q1's answer never lands here)
- \`3+3=?\` user → \`1 + 1 = 2\` (Q1's answer mis-bound to Q3's bubble)
- \`5+5=?\` user → \`3+3=6\`, \`2+2=4\`, \`5+5=10\` (Q3 + Q2 + Q5 all clustered under Q5)
- \`4+4=?\` answer never arrived under any bubble

## Fix (4 sites in session_actor.rs)

Pre-stamp \`thread_id\` on Assistant / Tool messages from the originating turn's \`client_message_id\` at:
1. main process_inbound primary turn (~4706-4740) — pre-stamp on persist of conv_response messages
2. main process_inbound final assistant emit (~4724-4775) — pre-stamp on the final assistant Message construction
3. speculative-overflow final reply (~5338-5395) — pre-stamp from \`overflow_client_message_id\`
4. recovery / synthetic_recovery_inbound branches (~5806-5905) — pre-stamp on both Assistant and Tool persists

All four use the originating turn's cmid (or the overflow user's own cmid for the speculative path) instead of relying on the persist-time fallback.

## Test plan

- [x] \`cargo check -p octos-cli --features api\` clean
- [x] \`cargo fmt --check\` clean (after \`cargo fmt\`)
- [x] \`cargo clippy -p octos-cli --features api -- -D warnings\` clean (0 errors, 0 warnings introduced)
- [x] Existing \`session_actor\` tests pass (3 filtered, 0 fails)
- [ ] After merge + redeploy: rerun \`live-overflow-stress\` rapid-fire-five-fast / two-fast-then-one-slow / seven-messages-mixed-pacing — should pass and unblock the 3 \`test.fixme()\` markers added by PR #741
- [ ] After merge + redeploy: rerun \`live-thread-interleave\` — slow-Q's bubble should now contain the deep_research \`.md\` attachment + content marker

## Why two PRs

PR #739 covered the M8.9 spawn_only failure-recovery code path. The fast-burst foreground SSE path is structurally distinct (no failure → no recovery turn, just rapid user → assistant emission). The agent loop's \`thread_id: None\` + persist-time-derivation fallback is the actual bug; PR #739's fix addressed the recovery flavor of it; this PR closes the foreground flavor.

A potential follow-up: a single \"turn-context\" struct with cmid + thread_id baked in, used by both paths, to make this kind of bug structurally impossible. Worth a M9 epic — see #674 for the broader sticky-map retirement.

## Severity

P1 — closes the M8.10 chain end-to-end. UX-visible: every rapid-fire chat session with 3+ quick prompts currently mis-routes answers under wrong bubbles.

## Related

- #740 — original investigation
- #739 — M8.9 spawn_only recovery sibling fix
- #738 — the deep_research-result-not-surfaced precursor (closed by #739 partially)
- #649 / #664 / #673 / #680 — earlier regressions in the same chain
- #674 — long-term sticky-map retirement (M9 epic)
- PR #741 — harness fixme'd 3 stress scenarios pending this fix
- \`/tmp/wave4-closeout.md\` — full wave-4 close-out narrative