### PR TITLE
docs(upcr): UPCRs 009-012 for state-control primitives (session/hydrate, thread/graph/get, turn/state/get, message/persisted)

### DIFF
--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_009_SESSION_HYDRATE.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_009_SESSION_HYDRATE.md
@@ -1,0 +1,351 @@
+# Octos UI Protocol Change Request: `session/hydrate` Command
+
+## Header
+
+- Request id: `UPCR-2026-009`
+- Title: Add `session/hydrate` RPC command for authoritative chat-state reload
+- Author: 5-day structural plan, Day 1 (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: proposed
+- Related issues: `#738`, `#740`, `#742` (thread-binding bug chain — persistence-side
+  reload misbinding observed in this week's web-client soak)
+- Related plan: `/tmp/octos-architecture-FINAL.md` § Day 1 (UPCR-2026-009)
+
+## Summary
+
+This change request adds one additive JSON-RPC command method, `session/hydrate`,
+to the AppUi protocol so clients can fetch the authoritative chat state of a
+session — messages, threads, turns, and pending approvals — in a single
+round-trip on reload. Today the only reload entry point is `session/open`,
+which advertises capabilities and replays the event ledger from a cursor but
+does **not** return the canonical message/thread/turn projection. Clients are
+forced to either reconstruct the chat state from a stream of `message/delta`
+notifications replayed from cursor 0 (slow, lossy if the ledger is compacted)
+or fall back to the legacy REST `GET /api/sessions/:id/messages` endpoint
+(out-of-band, unaware of UPCR-2026-007 capability negotiation). This UPCR
+closes that gap by giving clients a typed snapshot RPC gated behind the new
+`state.session_hydrate.v1` capability flag.
+
+The change is strictly additive: no existing method, notification, payload,
+enum variant, capability bit, or protocol identifier is modified.
+
+## Motivation
+
+The 5-day structural plan (`/tmp/octos-architecture-FINAL.md`) traces the
+thread-binding bug chain `#738 → #740 → #742` to a single root cause: clients
+have no authoritative way to ask the server "what is the canonical state of
+this session right now?". The web SPA's reload path infers chat state from a
+mix of REST snapshots, SSE replay, and locally cached optimistic bubbles. Each
+inference site is a place a real bug has shipped this quarter:
+
+- **#738**: a persisted assistant row with a stale `thread_id` was rendered
+  under the wrong question on reload because the SPA could not distinguish
+  "the row the server just wrote" from "the row I optimistically rendered".
+- **#740**: the same row was further misbound because the SPA could not see
+  the canonical `(turn_id, thread_id, seq)` tuple the server actually
+  committed — only the wire-side message it streamed.
+- **#742**: the tactical fix pre-stamps `thread_id` at persistence time, but
+  there is still no client-side way to verify the stamp landed.
+
+`session/open` itself does not solve this:
+
+- Its result type `SessionOpenResult { opened: SessionOpened { session_id,
+  active_profile_id, workspace_root, cursor, panes } }`
+  (`crates/octos-core/src/ui_protocol.rs:1342-1352`) carries **no** message,
+  thread, turn, or approval payload.
+- Its `cursor` field is a resume point for the event stream, not a snapshot
+  of state.
+- Its primary job is capability negotiation (see accepted `UPCR-2026-007`)
+  and lifecycle: it must stay fast and small so it can run on every WebSocket
+  reconnect.
+
+A separate `session/hydrate` command lets clients pay the snapshot cost only
+when they need it (initial load, full reload, debugger inspection) without
+bloating `session/open`.
+
+## Change Type
+
+Additive method.
+
+One new JSON-RPC command method on the existing AppUi v1alpha1 protocol. No
+new notifications. No existing method, notification, required field, enum
+variant, or capability flag is modified. One additive feature flag
+(`state.session_hydrate.v1`) is added so clients can negotiate availability.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Capability payload: `UiProtocolCapabilities` (new feature flag entry,
+  full-protocol method-set entry)
+- Capability feature registry: `state.session_hydrate.v1`
+- Command method: `session/hydrate` (new)
+- Command params: `SessionHydrateParams` (new)
+- Command result: `SessionHydrateResult` (new)
+
+No existing command method, notification, params, results, or enum variants
+are modified by this UPCR.
+
+### `session/hydrate`
+
+Purpose:
+
+- Return the authoritative chat-state projection for one session in one
+  round-trip: messages, thread graph, turn lifecycle states, and pending
+  approvals. Primary consumer: web SPA reload, TUI session-restore, harness
+  test fixtures.
+
+Params:
+
+```json
+{
+  "session_id": "local:demo",
+  "after": { "stream": "session", "seq": 0 },
+  "include": ["messages", "threads", "turns", "pending_approvals"]
+}
+```
+
+- `session_id` (required): canonical session identifier.
+- `after` (optional `UiCursor`): when present, hydrate returns only items with
+  cursor strictly greater than `after`. Useful for incremental rehydration
+  when the client retains a partial cache. Absent = full hydrate from the
+  beginning.
+- `include` (optional `string[]`): selection set restricting the response to
+  the requested projections. Empty or absent = include all four. Unknown
+  tokens are silently dropped (matches the `X-Octos-Ui-Features` precedent
+  from `UPCR-2026-007`). Recognised tokens:
+  - `messages` — populates `messages`.
+  - `threads` — populates `threads`.
+  - `turns` — populates `turns`.
+  - `pending_approvals` — populates `pending_approvals`.
+
+Result:
+
+```json
+{
+  "session_id": "local:demo",
+  "cursor": { "stream": "session", "seq": 142 },
+  "messages": [
+    {
+      "seq": 17,
+      "role": "user",
+      "client_message_id": "01900000-0000-7000-8000-000000000001",
+      "thread_id": "thread-1",
+      "turn_id": "01900000-0000-7000-8000-000000000010",
+      "content": "hello"
+    }
+  ],
+  "threads": [
+    {
+      "thread_id": "thread-1",
+      "root_seq": 17,
+      "root_client_message_id": "01900000-0000-7000-8000-000000000001",
+      "turn_id": "01900000-0000-7000-8000-000000000010",
+      "message_seqs": [17, 18, 19],
+      "status": "completed"
+    }
+  ],
+  "turns": [
+    {
+      "turn_id": "01900000-0000-7000-8000-000000000010",
+      "thread_id": "thread-1",
+      "state": "completed",
+      "started_at": "2026-04-30T12:00:00Z",
+      "completed_at": "2026-04-30T12:00:05Z"
+    }
+  ],
+  "pending_approvals": []
+}
+```
+
+- `cursor` (required `UiCursor`): the head cursor of the session at the
+  moment the snapshot was assembled. Clients should use this as the
+  baseline for any subsequent `after` request and as the resume point for
+  the live event stream — the snapshot is an atomic projection up to and
+  including this cursor.
+- `messages` (required `Message[]`, may be empty): the canonical chat rows.
+  Each entry carries `(seq, role, thread_id, turn_id, client_message_id?,
+  content)` matching the existing on-disk projection. Omitted from the
+  response only when `include` excludes `messages`; never `null` when
+  included.
+- `threads` (required `Thread[]`, may be empty): the thread graph (see
+  `UPCR-2026-010` for the same shape). Bundled here so a single hydrate
+  round-trip is sufficient for full SPA rehydration.
+- `turns` (required `TurnSummary[]`, may be empty): one entry per known
+  turn for the session. State enum values match `UPCR-2026-011`'s
+  `turn/state/get` registry.
+- `pending_approvals` (required `PendingApproval[]`, may be empty): the
+  set of approvals currently in `Awaiting` state, with the same payload
+  shape `approval/requested` carries (governed by `UPCR-2026-001`). This
+  lets clients re-render the approval UI on reload without replaying the
+  ledger.
+
+Sections that the client did not request via `include` are omitted from the
+response object entirely (not present as `null`). The `cursor` and
+`session_id` fields are always present.
+
+## Error Model
+
+The new command returns errors from the existing v1 taxonomy:
+
+- `unknown_session` — server has no session with the given `session_id`, or
+  the session is scoped to a different connection profile than the request.
+- `cursor_out_of_range` — the supplied `after` cursor addresses a position
+  beyond the current ledger head. Echoes ledger head per the existing
+  cursor-range error shape (`crates/octos-core/src/ui_protocol.rs:419-433`).
+- `cursor_invalid` — the supplied `after` cursor is malformed or wrong-stream.
+- `invalid_params` — params failed structural validation. Includes:
+  - `data.kind = "include_too_large"` when the `include` array exceeds 32
+    entries (defensive against pathological requests).
+- `runtime_unavailable` — server has no chat-state projection wired for this
+  deployment (e.g. lite/embedded build that never persisted messages).
+  Returned with `data.kind = "runtime_unavailable"`.
+
+A `session/hydrate` request for a known but empty session returns success
+with `messages: []`, `threads: []`, `turns: []`, `pending_approvals: []`,
+and the current head cursor. Empty is not an error.
+
+No new error categories are introduced.
+
+## Compatibility
+
+- Old clients that never request `state.session_hydrate.v1` and never send
+  `session/hydrate` are unaffected. They continue to use `session/open` for
+  capability negotiation and either replay from cursor or call the legacy
+  REST endpoint for chat state.
+- Old servers that have not implemented this method reject incoming
+  `session/hydrate` requests with the existing `method_not_supported` error
+  (`UI_PROTOCOL_FIRST_SERVER_METHODS` membership check). Clients should
+  detect this via capability negotiation rather than by trial-call.
+- Clients that exhaustively match on `UiCommand` or `UiResultKind` and have
+  not been recompiled against the new enum variants will fail to deserialize
+  a message carrying the new method. This is the standard
+  forward-compatibility behaviour for any added method, acknowledged by
+  spec § 4.1.
+- The legacy REST `GET /api/sessions/:id/messages` endpoint stays live for
+  the deprecation window; this UPCR does not delete it. The web SPA migration
+  in PR J of the structural plan switches from REST to `session/hydrate` only
+  when capability negotiation succeeds.
+- No new protocol identifier is required because the change is additive.
+
+## Capability Negotiation
+
+New feature flag:
+
+- `state.session_hydrate.v1`
+
+Servers advertise it through `UiProtocolCapabilities.supported_features`
+when the chat-state projection is available. The flag is included in
+`UiProtocolCapabilities::full_protocol()` and in the first server slice's
+supported method set. Clients that want to depend on `session/hydrate`
+should request the feature through the existing `X-Octos-Ui-Features`
+header or the `ui_feature` / `ui_features` query parameters, then read
+back the negotiated set from `SessionOpened.capabilities` (per
+`UPCR-2026-007`).
+
+If a client sends `session/hydrate` to a server that does not advertise
+the feature, the server returns the existing `method_not_supported` error.
+A client that observes `state.session_hydrate.v1` absent from
+`SessionOpened.capabilities.supported_features` should fall back to the
+legacy REST endpoint or to ledger replay from `session/open`'s cursor.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `session_hydrate_command_round_trips_through_json_rpc` — round-trips
+    `session/hydrate` request through the JSON-RPC envelope including the
+    optional `after` and `include` fields.
+  - `session_hydrate_result_omits_excluded_sections` — golden: an `include`
+    of `["messages"]` produces a result with `messages` populated and
+    `threads` / `turns` / `pending_approvals` absent (not `null`).
+  - `session_hydrate_result_round_trips_with_full_payload` — golden:
+    full-shape result round-trips through serde unchanged.
+  - `typed_rpc_results_map_from_methods_and_round_trip` — extended with
+    `SessionHydrateResult` golden coverage.
+  - `full_protocol_capabilities_advertise_state_session_hydrate` — asserts
+    the new feature flag and method are advertised in `full_protocol()`.
+  - Capability-set golden tests updated to include the new method and the
+    `state.session_hydrate.v1` feature literal.
+- `crates/octos-cli/src/api/ui_protocol.rs`:
+  - `appui_session_hydrate_returns_full_chat_state` — verifies the handler
+    returns messages, threads, turns, and pending approvals for a
+    populated session.
+  - `appui_session_hydrate_honours_after_cursor` — verifies items with
+    cursor ≤ `after` are excluded from the response.
+  - `appui_session_hydrate_honours_include_filter` — verifies an `include`
+    of `["threads"]` returns only the thread graph.
+  - `appui_session_hydrate_returns_empty_for_unknown_session` — verifies
+    the unknown-session path returns `unknown_session` rather than an
+    empty success.
+  - Routing tests extended with `session/hydrate` requests.
+- `e2e/tests/`:
+  - `m9-protocol-session-hydrate.spec.ts` — end-to-end: open a session,
+    drive a turn, disconnect WS, reconnect, call `session/hydrate`, assert
+    the projection matches the live state observed pre-disconnect.
+
+## Rollout Plan
+
+1. Land the protocol constants, params/result types, command/result enums,
+   capability flag, and golden tests in `octos-core`.
+2. Land the server handler `handle_session_hydrate` in `octos-cli`, including
+   the chat-state projection helper that reads from
+   `Session::messages()` / `Session::threads()` / the active-turns registry
+   / the approval store. Routing tests added.
+3. Update `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 4.1, § 6, and § 7
+   to reference `UPCR-2026-009`.
+4. Web SPA migration (Day 4 PR J) consumes `session/hydrate` for reload
+   instead of the REST endpoint.
+5. Deprecation window: keep `GET /api/sessions/:id/messages` live through
+   the next minor release. Removal is tracked separately and requires its
+   own UPCR if the wire surface changes.
+
+No client renegotiation is required for clients that do not consume the new
+method.
+
+## Risks
+
+- **Snapshot cost**: hydrating a long session may produce a large response.
+  Mitigation: the `after` cursor and `include` filter let clients page or
+  scope the request. Large-session pagination beyond `after` is out of
+  scope for this UPCR — if it proves necessary, a follow-up UPCR can add
+  `limit` semantics. The 32-entry `include` cap is defensive against
+  pathological requests, not a per-section size cap.
+- **Snapshot/stream divergence**: if a turn completes between the snapshot
+  assembly and the client's resume, the client must reconcile the snapshot
+  cursor with the live stream's cursor. This is the same reconciliation
+  rule the `session/open` cursor already implies; the UPCR does not change
+  it.
+- **Bundled projections**: bundling `threads` / `turns` / `pending_approvals`
+  into one RPC means a future schema change to any one of them affects the
+  hydrate result shape. Mitigation: each section is governed by its own
+  UPCR (`UPCR-2026-010` for threads, `UPCR-2026-011` for turns,
+  `UPCR-2026-001` for approvals), and `include` lets clients opt out of
+  sections they do not need. The bundled response is a convenience, not a
+  coupling — a client may always issue separate `thread/graph/get` and
+  `turn/state/get` requests instead.
+
+## Decision
+
+Proposed by: 5-day structural plan, Day 1.
+
+Decision notes: Pending review. Closes the persistence-side reload
+misbinding gap exposed by `#738` / `#740` / `#742` by giving clients a
+single typed RPC for authoritative chat state on reload. The new
+capability flag `state.session_hydrate.v1` lets clients depend on the
+method only when negotiated. Bundled with `UPCR-2026-010` /
+`UPCR-2026-011` / `UPCR-2026-012` as the four state-control primitives
+the structural plan identifies as missing from v1.
+
+### Out of scope
+
+- **Pagination beyond `after`**: large-session pagination (`limit` / page
+  tokens) is deferred. The `after` cursor is sufficient for incremental
+  rehydration; a separate UPCR can add `limit` if it proves necessary.
+- **Server-side caching of snapshots**: the handler may cache snapshots
+  internally (e.g. memoize per `session_id` until the next cursor advance),
+  but this is an implementation detail and not a wire contract. Clients
+  must not assume caching semantics.
+- **Pushed snapshots**: `session/hydrate` is request-driven only. A
+  notification variant ("server-initiated hydrate") is not part of this
+  UPCR; if needed, it requires a separate accepted UPCR.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_010_THREAD_GRAPH_GET.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_010_THREAD_GRAPH_GET.md
@@ -1,0 +1,337 @@
+# Octos UI Protocol Change Request: `thread/graph/get` Command
+
+## Header
+
+- Request id: `UPCR-2026-010`
+- Title: Add `thread/graph/get` RPC command exposing the inferred thread graph
+- Author: 5-day structural plan, Day 1 (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: proposed
+- Related issues: `#742` (thread-binding pre-stamp at persist time — exposed
+  the gap that the inferred grouping is invisible to clients)
+- Related plan: `/tmp/octos-architecture-FINAL.md` § Day 1 (UPCR-2026-010)
+
+## Summary
+
+This change request adds one additive JSON-RPC command method,
+`thread/graph/get`, to the AppUi protocol so clients can fetch the canonical
+thread graph for a session — the partition of messages into render-grouping
+threads, plus any orphan rows the grouping rule could not assign. Today the
+grouping is **inferred at runtime** by `Session::threads()` in
+`crates/octos-bus/src/session.rs` (target call site in the structural plan:
+`session.rs:469-514` after PR A's typed-identity refactor). The grouping
+function exists; it is just not on the wire. Clients must reconstruct it
+from message-ordering heuristics, which is exactly what produced the
+mis-binding bugs `#738` / `#740` / `#742`.
+
+The change is strictly additive: no existing method, notification, payload,
+enum variant, capability bit, or protocol identifier is modified.
+
+## Motivation
+
+In the v1 chat model:
+
+- `client_message_id` is the client's idempotency token (web SPA mints it).
+- `turn_id` is the server's per-turn protocol identity.
+- `thread_id` is the **render grouping** — which DOM bubble a row should
+  appear under.
+
+The structural plan identifies these as three distinct types with three
+distinct sources of truth (`/tmp/octos-architecture-FINAL.md` § Three IDs).
+The third — `thread_id` — has the weakest contract today: it is currently
+optional, derived, and only exists in-memory as the output of
+`Session::threads()`. When the grouping function decides a row belongs to
+thread X, that decision is invisible to the client. The client renders the
+row under whichever thread its own heuristic says — and when the two
+heuristics disagree, a bug ships.
+
+Codifying the grouping on the wire as `thread/graph/get` would have surfaced
+PR `#742`'s gap immediately. Specifically:
+
+- A persisted assistant row mis-routed under Q3 instead of Q1 would either
+  show up under the wrong `thread_id` in the response (visible in test
+  fixtures, easily asserted) or land in `orphans` (loud signal). Either way
+  the bug is observable, not silent.
+- The Layer 1 reducer fixtures from Day 3 of the structural plan (`PR H`)
+  can use the response shape directly as the assertion target — no
+  client-side reconstruction.
+
+`thread/graph/get` is split out from `session/hydrate` (`UPCR-2026-009`)
+because:
+
+1. The thread graph is a small, stable projection that clients may want to
+   refetch frequently (e.g. after every turn completes) without paying the
+   full hydrate cost.
+2. Test fixtures and debugger tools want to inspect the graph in isolation.
+3. The capability gate is independent: a client may want the thread graph
+   without committing to the bundled hydrate semantics.
+
+## Change Type
+
+Additive method.
+
+One new JSON-RPC command method on the existing AppUi v1alpha1 protocol. No
+new notifications. No existing method, notification, required field, enum
+variant, or capability flag is modified. One additive feature flag
+(`state.thread_graph.v1`) is added so clients can negotiate availability.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Capability payload: `UiProtocolCapabilities` (new feature flag entry,
+  full-protocol method-set entry)
+- Capability feature registry: `state.thread_graph.v1`
+- Command method: `thread/graph/get` (new)
+- Command params: `ThreadGraphGetParams` (new)
+- Command result: `ThreadGraphGetResult` (new)
+- Wire payload: `Thread` (new — also reused by `UPCR-2026-009`)
+
+No existing command method, notification, params, results, or enum variants
+are modified by this UPCR.
+
+### `thread/graph/get`
+
+Purpose:
+
+- Return the current thread graph for one session: the set of threads with
+  their member message seqs, plus any rows the grouping rule could not
+  assign. Primary consumers: web SPA reload reconciliation, TUI thread
+  navigation, debugger inspection, Layer 1 reducer fixtures.
+
+Params:
+
+```json
+{
+  "session_id": "local:demo",
+  "at": { "stream": "session", "seq": 142 }
+}
+```
+
+- `session_id` (required): canonical session identifier.
+- `at` (optional `UiCursor`): when present, return the thread graph as it
+  stood at the given cursor (point-in-time projection). Absent = current
+  head. Useful for fixtures that want a deterministic snapshot.
+
+Result:
+
+```json
+{
+  "session_id": "local:demo",
+  "cursor": { "stream": "session", "seq": 142 },
+  "threads": [
+    {
+      "thread_id": "thread-1",
+      "root_seq": 17,
+      "root_client_message_id": "01900000-0000-7000-8000-000000000001",
+      "turn_id": "01900000-0000-7000-8000-000000000010",
+      "message_seqs": [17, 18, 19],
+      "status": "completed"
+    },
+    {
+      "thread_id": "thread-2",
+      "root_seq": 22,
+      "root_client_message_id": "01900000-0000-7000-8000-000000000002",
+      "turn_id": "01900000-0000-7000-8000-000000000011",
+      "message_seqs": [22, 23],
+      "status": "active"
+    }
+  ],
+  "orphans": [42]
+}
+```
+
+Field descriptions:
+
+- `session_id` (required): echoes the request.
+- `cursor` (required `UiCursor`): the cursor at which the graph was assembled.
+  When the request specified `at`, this echoes that value; otherwise it is
+  the current ledger head for the session.
+- `threads` (required `Thread[]`, may be empty): the partition of message
+  seqs into threads. Each entry:
+  - `thread_id` (required `string`): canonical thread identifier — stable
+    across reloads, mints from the server's grouping rule.
+  - `root_seq` (required `u64`): the sequence number of the user message
+    that started the thread.
+  - `root_client_message_id` (optional `string`): the client-minted
+    idempotency token of the root user message. Absent for legacy rows that
+    pre-date `client_message_id` (loaded via `synthesize_thread_ids_for_legacy`,
+    see `/tmp/octos-architecture-FINAL.md` § What does NOT change).
+  - `turn_id` (optional `string`): the canonical turn id for this thread,
+    when the originating turn is known to the server. Absent for legacy
+    threads or for rows persisted before `turn_id` was on the type.
+  - `message_seqs` (required `u64[]`): the seqs of all messages bound to
+    this thread, in commit order. Always non-empty (at minimum carries the
+    root user seq).
+  - `status` (required `string`): the thread's lifecycle state. Initial
+    string registry:
+    - `active` — the originating turn is still running.
+    - `completed` — the originating turn reached a terminal `completed` state.
+    - `errored` — the originating turn reached a terminal `errored` state.
+    - `interrupted` — the originating turn was interrupted.
+    - `unknown` — the server has no live record of the originating turn
+      (e.g. legacy load, server restart).
+- `orphans` (required `u64[]`, may be empty): seqs of persisted messages
+  the grouping rule could not bind to any thread. Examples: a tool result
+  whose originating turn the server has lost track of (legacy data); a
+  recovery row from a crash whose turn never re-emitted. **Orphans should
+  be rare in healthy operation; a client observing non-empty `orphans` in
+  steady state should log a metric.**
+
+A `thread/graph/get` request for a known but empty session returns success
+with `threads: []`, `orphans: []`, and the current head cursor. Empty is
+not an error.
+
+### Why the result mirrors `Session::threads()`
+
+The result fields are a 1:1 lift of the existing internal `Thread` struct
+that `Session::threads()` constructs (target location after PR A's
+typed-identity refactor: `crates/octos-bus/src/session.rs:469-514`). The
+grouping logic does not change — only its visibility on the wire.
+
+PR A from the structural plan promotes `thread_id` from `Option<String>` to
+a typed `ThreadId` newtype. This UPCR's wire shape uses the JSON
+serialization of that newtype (a plain `string`), so the wire format is
+stable across the type-system upgrade.
+
+## Error Model
+
+The new command returns errors from the existing v1 taxonomy:
+
+- `unknown_session` — server has no session with the given `session_id`, or
+  the session is scoped to a different connection profile than the request.
+- `cursor_out_of_range` — the supplied `at` cursor addresses a position
+  beyond the current ledger head.
+- `cursor_invalid` — the supplied `at` cursor is malformed or wrong-stream.
+- `runtime_unavailable` — server has no chat-state projection wired for
+  this deployment. Returned with `data.kind = "runtime_unavailable"`.
+
+No new error categories are introduced.
+
+## Compatibility
+
+- Old clients that never request `state.thread_graph.v1` and never send
+  `thread/graph/get` are unaffected.
+- Old servers that have not implemented this method reject incoming
+  requests with the existing `method_not_supported` error.
+- Clients that exhaustively match on `UiCommand` or `UiResultKind` and have
+  not been recompiled against the new enum variants will fail to deserialize
+  a message carrying the new method. Standard forward-compatibility
+  behaviour for any added method (spec § 4.1).
+- The `Thread` payload shape is shared with `SessionHydrateResult.threads`
+  in `UPCR-2026-009`. Both UPCRs reference the same JSON shape; a future
+  schema change to `Thread` requires extending both UPCRs simultaneously,
+  or a strictly additive change governed by spec § 4 (additive optional
+  fields allowed within a version).
+- `thread_id` is currently optional in the wire model (`message/delta`,
+  persisted messages). This UPCR does **not** change that — it only adds
+  a separate, dedicated query for the graph. The `thread_id` evolution
+  on persisted messages is governed by PR A of the structural plan and is
+  out of scope here.
+- No new protocol identifier is required because the change is additive.
+
+## Capability Negotiation
+
+New feature flag:
+
+- `state.thread_graph.v1`
+
+Servers advertise it through `UiProtocolCapabilities.supported_features`
+when the thread-graph projection is available. The flag is included in
+`UiProtocolCapabilities::full_protocol()` and in the first server slice's
+supported method set. Clients that want to depend on `thread/graph/get`
+should request the feature through `X-Octos-Ui-Features` and read back
+the negotiated set from `SessionOpened.capabilities` (per `UPCR-2026-007`).
+
+If a client sends `thread/graph/get` to a server that does not advertise
+the feature, the server returns `method_not_supported`.
+
+## Tests
+
+- `crates/octos-core/src/ui_protocol.rs`:
+  - `thread_graph_get_command_round_trips_through_json_rpc` — round-trips
+    the request including the optional `at` cursor.
+  - `thread_graph_get_result_round_trips_with_orphans` — golden:
+    response with non-empty `orphans` round-trips through serde.
+  - `thread_graph_get_result_round_trips_with_legacy_thread` — golden:
+    a thread with `root_client_message_id: None` and `turn_id: None`
+    round-trips (legacy-load case).
+  - `thread_status_string_registry_is_stable` — golden: the five known
+    `status` literals (`active`, `completed`, `errored`, `interrupted`,
+    `unknown`) serialize as snake_case and round-trip.
+  - `typed_rpc_results_map_from_methods_and_round_trip` — extended with
+    `ThreadGraphGetResult` golden coverage.
+  - `full_protocol_capabilities_advertise_state_thread_graph` — asserts
+    the new feature flag and method are advertised in `full_protocol()`.
+- `crates/octos-cli/src/api/ui_protocol.rs`:
+  - `appui_thread_graph_get_returns_session_threads` — verifies the
+    handler returns the partition produced by `Session::threads()`.
+  - `appui_thread_graph_get_reports_orphans_for_unbound_messages` —
+    seeds a session with a row whose `turn_id` cannot be resolved;
+    verifies it lands in `orphans`.
+  - `appui_thread_graph_get_honours_at_cursor` — verifies a point-in-time
+    snapshot at an earlier cursor excludes later threads.
+  - Routing tests extended with `thread/graph/get` requests.
+- `e2e/tests/`:
+  - `m9-protocol-thread-graph.spec.ts` — end-to-end: drive three
+    interleaved turns, call `thread/graph/get`, assert the partition
+    matches the message stream observed via notifications.
+
+## Rollout Plan
+
+1. Land the protocol constants, params/result types, command/result enums,
+   `Thread` payload shape, capability flag, and golden tests in `octos-core`.
+2. Land the server handler `handle_thread_graph_get` in `octos-cli`,
+   delegating to `Session::threads()` for the underlying partition.
+   Routing tests added.
+3. Update `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 4.1, § 6, and § 7
+   to reference `UPCR-2026-010`.
+4. Layer 1 reducer fixtures (Day 3 PR H) consume `thread/graph/get`'s shape
+   as the assertion target.
+5. Web SPA migration (Day 4 PR J) calls `thread/graph/get` after every
+   `turn/completed` notification to reconcile its local thread state.
+
+No client renegotiation is required for clients that do not consume the new
+method.
+
+## Risks
+
+- **Cost on long sessions**: a session with thousands of messages produces
+  a large `message_seqs` payload. Mitigation: clients can filter to a
+  cursor range via `at`, or use `session/hydrate`'s `after` for incremental
+  fetches. Per-thread pagination is out of scope; if it proves necessary,
+  a follow-up UPCR can add it.
+- **Grouping algorithm churn**: any change to the `Session::threads()`
+  partition rule changes the wire output. Mitigation: the grouping rule
+  is governed by spec § 4 as a semantic surface; behavioural changes
+  require their own UPCR. The wire shape stays additive across rule
+  changes as long as the response fields don't change meaning.
+- **Orphan steady-state**: if `orphans` is consistently non-empty in
+  production, that signals an upstream binding bug (the very class
+  `#738` / `#740` / `#742` was about). This is the intent — observable,
+  alertable. Operators should add a metric on `orphans.len() > 0`.
+
+## Decision
+
+Proposed by: 5-day structural plan, Day 1.
+
+Decision notes: Pending review. Lifts the existing in-memory thread
+partition produced by `Session::threads()` onto the wire so clients no
+longer reconstruct grouping from message-ordering heuristics. Would have
+made `#742`'s mis-binding observable in test fixtures rather than only
+in soak. Bundled with `UPCR-2026-009` / `UPCR-2026-011` / `UPCR-2026-012`
+as the four state-control primitives the structural plan identifies as
+missing from v1.
+
+### Out of scope
+
+- **Per-thread pagination** (limit / offset semantics on `message_seqs`):
+  deferred. Snapshot via `at` is the only point-in-time control in this
+  UPCR.
+- **Push notifications on graph changes**: this UPCR is request-driven
+  only. A `thread/graph/changed` notification variant is not part of
+  this UPCR; clients should re-fetch after `turn/completed` until / unless
+  a separate UPCR adds push semantics.
+- **Thread mutation RPCs** (rename, merge, fork): out of scope. This
+  UPCR is read-only.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_011_TURN_STATE_GET.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_011_TURN_STATE_GET.md
@@ -1,0 +1,192 @@
+# Octos UI Protocol Change Request: `turn/state/get` Command
+
+## Header
+
+- Request id: `UPCR-2026-011`
+- Title: Add `turn/state/get` RPC command for deterministic turn lifecycle introspection
+- Author: 5-day structural plan, Day 1 (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: proposed
+- Related issues: `#738`, `#740` (thread-binding bug chain — wire-side misroute observed when clients fall back to "current sticky thread" instead of the originating turn)
+- Related plan: `/tmp/octos-architecture-FINAL.md` § Day 1 (UPCR-2026-011)
+- Sibling UPCRs: `UPCR-2026-009` (session/hydrate), `UPCR-2026-010` (thread/graph/get), `UPCR-2026-012` (message/persisted)
+
+## Summary
+
+This change request adds one additive JSON-RPC command method, `turn/state/get`, to the AppUi protocol. The command returns the authoritative lifecycle state of one turn: `active | interrupting | completed | errored | interrupted | unknown`, plus optional `started_at`, `completed_at`, `thread_id`, and the list of `committed_seqs` for the turn's persisted messages.
+
+The server already maintains this information in the active-turn registry at `crates/octos-cli/src/api/ui_protocol.rs:2030-2135` (the `ActiveConnectionTurns` map keyed by `(SessionKey, TurnId)`). Today the registry is internal — clients must INFER turn state from notification ordering (`turn/started → message/delta* → turn/completed | turn/error`). When a client misses or interleaves notifications during reconnect, this inference fails.
+
+The change is strictly additive: no existing method, notification, payload, enum variant, capability bit, or protocol identifier is modified.
+
+## Motivation
+
+The 5-day structural plan traces the live-wire side of the thread-binding bug chain (`#738`, `#740`, sticky-map drift in `crates/octos-bus/src/api_channel.rs:97-103`) to a single root cause: when a late-arriving server frame (e.g., `edit_message`, `send_raw_sse`) arrives without a typed thread_id, the channel falls back to "the most-recent sticky thread for this chat_id" — which has been rotated forward by intervening user messages.
+
+The fundamental question the channel cannot answer today is: **"is the originating turn for this frame still active, and what thread_id did it own?"**. A server can answer this trivially — the active-turn registry already exists. But the client cannot ask. Two consequences:
+
+- **#740**: the SPA cannot verify whether a streaming token belongs to the turn it remembered or the latest turn the server thinks is live. The reducer is forced to use ambient sticky state.
+- **PR #742**: the persistence-side fix pre-stamped `thread_id`, but the wire-side counterpart (PR-F in the structural plan) needs a typed-bound channel API where the originating turn's thread_id is known. Clients then need a way to verify, post-emission, that the stamp matches the server's record.
+
+A `turn/state/get` command lets:
+
+- Web SPA: confirm a turn is still alive before reading its bubble. Detect stale optimistic state on resume.
+- TUI: surface "interrupting" / "errored" turn state in the activity pane without waiting for the next notification.
+- Harness fixtures (PR H): assert turn lifecycle deterministically without relying on event-ordering heuristics.
+- Debug tooling: query state of a turn from a CLI or browser devtools.
+
+## Change Type
+
+Additive method. One new JSON-RPC command method on the existing AppUi v1alpha1 protocol. No new notifications. No existing method, notification, required field, enum variant, or capability flag is modified. One additive feature flag (`state.turn_state_get.v1`) is added so clients can negotiate availability.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Capability payload: `UiProtocolCapabilities` (new feature flag entry, full-protocol method-set entry)
+- Capability feature registry: `state.turn_state_get.v1`
+- Command method: `turn/state/get` (new)
+- Command params: `TurnStateGetParams` (new)
+- Command result: `TurnStateGetResult` (new)
+
+### `turn/state/get`
+
+Purpose:
+
+- Return the canonical lifecycle state of one turn as observed by the server's active-turn registry.
+
+Params:
+
+```json
+{
+  "session_id": "local:demo",
+  "turn_id": "01900000-0000-7000-8000-000000000010"
+}
+```
+
+- `session_id` (required): canonical session identifier.
+- `turn_id` (required): the turn whose state to query.
+
+Result:
+
+```json
+{
+  "session_id": "local:demo",
+  "turn_id": "01900000-0000-7000-8000-000000000010",
+  "state": "active",
+  "started_at": "2026-05-01T18:30:00Z",
+  "completed_at": null,
+  "thread_id": "thread-1",
+  "committed_seqs": [17, 18, 19]
+}
+```
+
+Required fields:
+
+- `session_id` (echoed)
+- `turn_id` (echoed)
+- `state`: open string registry, snake_case, with initial values:
+  - `active` — turn is in flight
+  - `interrupting` — interrupt requested, server stopping the turn
+  - `completed` — terminal: turn finished normally
+  - `errored` — terminal: turn finished with an error
+  - `interrupted` — terminal: turn was interrupted
+  - `unknown` — server has no record of this turn (already evicted, never existed, or wrong session)
+
+Optional fields:
+
+- `started_at` (RFC 3339): when the turn first transitioned to `active`. Absent for `unknown` and may be absent for legacy turns that pre-date the field.
+- `completed_at` (RFC 3339): when the turn reached a terminal state. Present iff `state` is one of `completed | errored | interrupted`.
+- `thread_id` (string): the thread the turn is bound to. Always present for non-`unknown` states once the typed-binding refactor (PR-F in the structural plan) lands. May be absent on legacy active turns from older daemon versions.
+- `committed_seqs` (`u64[]`): the persisted-message seqs owned by this turn (user, assistant, tool, recovery). Allows clients to cross-check `message/persisted` notifications against the canonical set. Empty for `unknown` and for turns that have started but not yet committed any messages.
+
+Future state values must be registered via UPCR.
+
+### Errors
+
+Follow the v1 error taxonomy (see § 10 of the spec):
+
+- `unknown_session` if the session identifier is unknown to the server.
+- `invalid_params` (with `data.kind = "invalid_turn_id"`) if `turn_id` is empty or malformed.
+- `runtime_unavailable` (with `data.kind = "runtime_unavailable"`) if the server has no active-turn registry wired (e.g., during early startup or in certain test harness configurations).
+
+A `turn/state/get` request for a known session but unknown turn returns `state: "unknown"` rather than an error, matching the precedent set by `task/list` (UPCR-2026-005) returning empty `tasks` for unknown sessions.
+
+## Capability Negotiation
+
+Capability feature: `state.turn_state_get.v1`
+
+- Advertised through optional `supported_features` in `UiProtocolCapabilities` (`crates/octos-core/src/ui_protocol.rs::UiProtocolCapabilities`).
+- Clients request it through `X-Octos-Ui-Features` using comma or space-separated feature tokens, matching the precedent from UPCR-2026-001 (typed approvals) and UPCR-2026-007 (session capabilities).
+- If the client did not request the feature, the server MUST NOT include `turn/state/get` in `supported_methods` and MUST return JSON-RPC `-32601 Method not found` if it is invoked.
+- The capability schema version is `1`.
+
+The feature MUST always be included in the server's known feature registry once shipped. A server that returns `supported_features` containing `state.turn_state_get.v1` MUST handle the method.
+
+## Compatibility
+
+- All existing clients (octos-tui, octos-app, web SPA) continue to function unchanged. The method is opt-in via `X-Octos-Ui-Features`.
+- Legacy daemon versions that do not implement `turn/state/get` will not advertise the feature in `supported_features`, and clients will not invoke it.
+- The active-turn registry already exists and is populated for every turn started after `turn/start`. No daemon-side state migration is required.
+- Telegram, Discord, Email, Matrix, and other linear channels: unaffected. They do not expose UI Protocol; their state is observable only via REST and channel-native message ids.
+
+## Testing Strategy
+
+### Server-side
+
+- Unit tests at `crates/octos-cli/src/api/ui_protocol.rs::tests`:
+  - `turn_state_get_returns_active_for_in_flight_turn`
+  - `turn_state_get_returns_completed_after_turn_completed_event`
+  - `turn_state_get_returns_errored_after_turn_error_event`
+  - `turn_state_get_returns_interrupted_after_turn_interrupt_command`
+  - `turn_state_get_returns_unknown_for_evicted_turn`
+  - `turn_state_get_rejects_unknown_session`
+  - `turn_state_get_rejects_empty_turn_id`
+  - `turn_state_get_negotiation_excluded_when_feature_not_requested`
+  - `turn_state_get_negotiation_included_when_feature_requested`
+- Integration test at `crates/octos-cli/tests/m9_protocol_turn_state_get.rs`:
+  - Drive a real session through `turn/start → message/delta → turn/completed`; assert `turn/state/get` returns each state at the expected boundary.
+
+### Client-side
+
+- TUI fixture at `octos-tui/tests/...`: render activity pane after invoking `turn/state/get` against a paused turn. Assert "interrupting" surfaces.
+- Layer 1 SPA fixture (PR H): the `slow-then-fast-interleave.fixture.ts` and `m89-recovery-turn.fixture.ts` fixtures should call `turn/state/get` between events and assert the returned state matches the expected lifecycle.
+
+### Wire contract
+
+- Golden test in `crates/octos-core/src/ui_protocol.rs` (the literal protocol contract gate):
+  - `golden_turn_state_get_params_serde`
+  - `golden_turn_state_get_result_serde`
+  - `golden_capabilities_includes_turn_state_get_v1_when_negotiated`
+
+## Rollout
+
+- **Day 1 (this UPCR)**: drafted, reviewed, accepted before any code lands.
+- **Day 2 (PR G in the structural plan)**: server handler implemented under capability gate. octos-tui adopts in the same PR. Web SPA does not adopt until PR J (Day 4).
+- **Pre-release validation**: golden tests pass; `cargo test -p octos-core --features api` covers the capability-negotiation behavior.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Active-turn registry is in-memory only and evicted on daemon restart | Low | The `unknown` state is the documented response. Clients should not depend on `turn/state/get` for terminal-state introspection of a turn older than the daemon's lifetime. |
+| `committed_seqs` could grow unboundedly for very long turns | Low | The registry only retains active turns; once terminal, the turn is evicted from the registry within seconds. The `committed_seqs` for a still-active turn is bounded by per-turn message count (typically <100). |
+| Future enum variants on `state` may break exhaustive-match clients | Low | The v1alpha1 contract already mandates clients treat unknown enum variants as forward-compatible (§4 of the spec). Capability flag scoping prevents unrequested variants from arriving. |
+| Race: client invokes `turn/state/get` between the actor emitting `turn/completed` and the registry transitioning to `completed` | Low | The registry transitions BEFORE the notification is emitted; the race is server-side only and resolved by the actor's strict-ordering invariant. Add a regression test. |
+| Method-set disagreement with `task/list` (which returns empty for unknown sessions) | Low | Documented in the Errors section. The two methods consistently return a "not found" sentinel rather than throwing, matching v1's idiom. |
+
+## Open Questions
+
+- Should `committed_seqs` be paginated? **Decision**: no for v1. Active turns rarely have >100 commits; if usage grows, add a follow-up UPCR with `cursor` semantics.
+- Should there be a sibling `turn/list` for enumerating all active turns in a session? **Decision**: deferred. The use case is debugger/operator workflows, not the bug class this UPCR closes. Track as a separate `UPCR-2026-XXX` candidate.
+- Should the result include the originating `client_message_id`? **Decision**: yes, but as a follow-up additive field. v1 of this UPCR returns `thread_id` only; v2 can extend with `client_message_id` once the typed-identity work in PR A lands and the canonical relationship `client_message_id == thread_id` is enforced server-side.
+
+## Acceptance Criteria
+
+- [ ] Reviewer sign-off on the wire contract.
+- [ ] Reviewer sign-off on the capability-flag name.
+- [ ] Reviewer sign-off on the `state` enum value list.
+- [ ] No conflicts with the existing AppUi v1alpha1 method set.
+- [ ] No conflicts with sibling UPCRs (-009, -010, -012).
+- [ ] Status flipped to `accepted` before implementation lands in `crates/octos-cli/src/api/ui_protocol.rs`.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_012_MESSAGE_PERSISTED.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_012_MESSAGE_PERSISTED.md
@@ -1,0 +1,190 @@
+# Octos UI Protocol Change Request: `message/persisted` Notification
+
+## Header
+
+- Request id: `UPCR-2026-012`
+- Title: Add `message/persisted` notification for durable message-row commit confirmation
+- Author: 5-day structural plan, Day 1 (coding-green)
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: proposed
+- Related issues: `#738`, `#740`, `#742` (thread-binding bug chain — ack/result divergence and reload misbinding under spawn_only flows)
+- Related plan: `/tmp/octos-architecture-FINAL.md` § Day 1 (UPCR-2026-012)
+- Sibling UPCRs: `UPCR-2026-009` (session/hydrate), `UPCR-2026-010` (thread/graph/get), `UPCR-2026-011` (turn/state/get)
+
+## Summary
+
+This change request adds one additive JSON-RPC notification method, `message/persisted`, to the AppUi protocol. The notification fires once per durable commit of a message row to the session ledger, carrying the canonical `(turn_id, thread_id, seq)` tuple plus the message's identity and durability cursor.
+
+Today the closest signal a client gets is `TurnCompletedEvent`, which carries an optional `cursor` but does NOT confirm which message rows committed under that turn (`crates/octos-core/src/ui_protocol.rs:2455-2461`). Spawn_only flows compound this gap: an ack message ("background work started…") is emitted on the wire, but the eventual result message — possibly arriving minutes later under a recovery path — has no synchronous notification confirming it landed in the ledger.
+
+The change is strictly additive: no existing method, notification, payload, enum variant, capability bit, or protocol identifier is modified.
+
+## Motivation
+
+The 5-day structural plan traces three failure modes to the absence of a durable-commit confirmation event:
+
+1. **Ack/result divergence** (`#738`): `run_pipeline` emits a spawn-ack via `message/delta` + `turn/completed` immediately. The actual result lands minutes later via `synthetic_recovery_inbound` at `crates/octos-cli/src/session_actor.rs:5806-5905`. Today the SPA has no event signaling the durable commit of the result row — only the optional refresh of `cursor` via the next `turn/started`.
+
+2. **Reload misbinding** (`#740`): under rapid-fire interleave, the SPA optimistically renders message bubbles before durable commit. When the WebSocket reconnects (or the user reloads), the reducer cannot reconcile its optimistic bubbles against the server's authoritative view because no event confirms which seq the server actually wrote.
+
+3. **Optimistic-bubble correction**: web SPA's `client_message_id` → `seq` correlation today depends on the `session_result` event payload, which only fires at turn completion. Tools running mid-turn (file delivery, sub-agent output) commit rows that the SPA cannot correlate without a backfill round-trip via REST `GET /api/sessions/:id/messages`.
+
+A `message/persisted` notification — fired once per durable commit, regardless of source path (user input, assistant turn, tool output, background spawn, recovery) — closes all three. It also gives PR H's Layer 1 fixture infrastructure a deterministic event to assert on, replacing the brittle "wait for turn/completed and then read messages" pattern.
+
+## Change Type
+
+Additive notification. One new JSON-RPC notification on the existing AppUi v1alpha1 protocol. No new commands. No existing notification, command, required field, enum variant, or capability flag is modified. One additive feature flag (`event.message_persisted.v1`) is added so clients can negotiate availability.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Capability payload: `UiProtocolCapabilities` (new feature flag entry, full-protocol notification-set entry)
+- Capability feature registry: `event.message_persisted.v1`
+- Notification method: `message/persisted` (new)
+- Notification params: `MessagePersistedEvent` (new)
+
+No existing notification, command, params, results, or enum variants are modified by this UPCR.
+
+### `message/persisted`
+
+Purpose:
+
+- Carry a single, durably-committed message row from the session ledger to subscribed clients. One notification per row, fired AFTER the row is fsynced to the JSONL ledger by `Session::add_message_with_seq` (`crates/octos-bus/src/session.rs:1850-1903`). Idempotent on cursor: the same seq is never emitted twice for the same session.
+
+Notification params:
+
+```json
+{
+  "session_id": "local:demo",
+  "turn_id": "01900000-0000-7000-8000-000000000010",
+  "thread_id": "thread-1",
+  "seq": 18,
+  "role": "assistant",
+  "message_id": "01900000-0000-7000-8000-000000000018",
+  "client_message_id": "01900000-0000-7000-8000-000000000001",
+  "source": "assistant",
+  "cursor": { "stream": "session", "seq": 18 },
+  "persisted_at": "2026-05-01T18:30:01Z"
+}
+```
+
+Required fields:
+
+- `session_id`: canonical session identifier.
+- `seq`: the authoritative committed sequence number assigned by `add_message_with_seq`. Strictly monotonic per session.
+- `role`: open snake_case enum, matching `crates/octos-core::MessageRole`. Initial values: `system | user | assistant | tool`.
+- `message_id`: server-assigned UUID for the row. Stable across replays.
+- `cursor`: durable cursor pointing at this commit. Clients can use this as their `after` value for subsequent `session/hydrate` and `session/open` calls.
+- `source`: open snake_case enum identifying the WRITE PATH that committed this row. Initial values:
+  - `user` — direct API ingress (web POST /api/chat, `turn/start`, telegram message, etc.)
+  - `assistant` — primary turn assistant output
+  - `tool` — tool invocation result (sync tool, attached to a turn)
+  - `background` — spawn_only result row (commits after the parent turn's `turn/completed`)
+  - `recovery` — synthetic recovery turn row (M8.9 path)
+- `persisted_at` (RFC 3339): wall-clock time the row was committed.
+
+Optional fields:
+
+- `turn_id`: the originating turn. Always present once the typed-binding refactor (PR-F in the structural plan) lands. Absent on legacy rows that pre-date the field.
+- `thread_id`: the thread grouping. Same enforcement story as `turn_id`.
+- `client_message_id`: present for `source = user` rows where the client supplied a cmid; present on `assistant`/`tool`/`background`/`recovery` rows ONCE the typed-identity work in PR A propagates the cmid into derived rows. Absent on legacy rows.
+
+Future `source` values must be registered via UPCR.
+
+### Ordering and Cursor Semantics
+
+`message/persisted` notifications are emitted in **strict commit order per session**. Two consequences:
+
+- A client that consumes `message/persisted` and tracks the latest seen `cursor` has an authoritative, replay-safe view of the session's message log. This is the cursor-based equivalent of the JSONL ledger.
+- A client that drops the WebSocket and reconnects with `session/open { after: <last cursor> }` MUST receive `message/persisted` for every seq strictly greater than `after`, in order, before any new live notifications. Implementations MAY batch notifications during replay to bound bandwidth; ordering must be preserved.
+
+Relationship with other notifications:
+
+- `message/delta` carries WIRE-LEVEL incremental tokens (ephemeral). Clients use it for live streaming UX. No durability guarantee.
+- `message/persisted` carries DURABLE row commits (post-fsync). Clients use it for state truth.
+- `turn/completed` continues to fire once per terminal turn; `message/persisted` fires once per row, possibly multiple times per turn (e.g., assistant + tool calls).
+
+These are NOT redundant: `message/delta` is the streaming UX; `message/persisted` is the durable-state UX. `turn/completed` is turn-lifecycle; `message/persisted` is row-lifecycle.
+
+### Errors
+
+Notifications cannot return errors per JSON-RPC. The server MUST NOT emit `message/persisted` for a row that did not commit. If a commit fails (disk full, fsync error), the server emits a `warning` notification (existing surface) and does NOT emit `message/persisted` for that row.
+
+## Capability Negotiation
+
+Capability feature: `event.message_persisted.v1`
+
+- Advertised through optional `supported_features` in `UiProtocolCapabilities`.
+- Clients request it through `X-Octos-Ui-Features` using comma or space-separated feature tokens.
+- Servers MUST NOT emit `message/persisted` to a connection that did not negotiate the feature. Pre-existing connections (TUI, octos-app) continue to receive only the events they negotiated.
+- The capability schema version is `1`.
+
+## Compatibility
+
+- All existing clients continue to function unchanged. The notification is opt-in via `X-Octos-Ui-Features`.
+- Legacy daemon versions that do not implement `message/persisted` will not advertise the feature, and clients will not expect it.
+- Server implementation requires emitting the notification from the `add_message_with_seq` post-commit hook. The hook point already exists for the durable-ledger write (`crates/octos-bus/src/session.rs:1872-1894`); this UPCR adds one notification dispatch alongside it.
+- Cross-channel: telegram/discord/etc. do not subscribe to UI Protocol notifications. They are unaffected.
+- The notification IS emitted for `source = user` rows, which means the SPA can use it to confirm its own POST /api/chat persisted before rendering the optimistic bubble as committed. (This is the missing piece in today's optimistic-bubble flow.)
+
+## Testing Strategy
+
+### Server-side
+
+- Unit tests at `crates/octos-bus/src/session.rs::tests`:
+  - `message_persisted_emitted_after_user_commit`
+  - `message_persisted_emitted_after_assistant_commit`
+  - `message_persisted_emitted_after_tool_commit`
+  - `message_persisted_emitted_for_background_spawn_result`
+  - `message_persisted_emitted_for_recovery_turn`
+  - `message_persisted_not_emitted_on_commit_failure`
+  - `message_persisted_strict_ordering_under_concurrent_writes`
+  - `message_persisted_idempotent_seq_never_repeated`
+- Integration test at `crates/octos-cli/tests/m9_protocol_message_persisted.rs`:
+  - Drive a session through user → assistant → tool → spawn_only → recovery; assert one notification per commit, in order, with correct `(turn_id, thread_id, seq, source)` for each.
+
+### Client-side
+
+- TUI fixture at `octos-tui/tests/...`: subscribe to `message/persisted`, assert the message-list view stays consistent with `session/hydrate` after disconnect/reconnect.
+- Layer 1 SPA fixture (PR H): every fixture asserts that `message/persisted` events arrive in the expected order with the expected `(turn_id, thread_id, seq)` tuples. The `rapid-fire-five-fast` fixture in particular asserts no row is mis-routed to a sibling thread.
+
+### Wire contract
+
+- Golden test in `crates/octos-core/src/ui_protocol.rs`:
+  - `golden_message_persisted_event_serde`
+  - `golden_message_persisted_strict_ordering`
+  - `golden_capabilities_includes_message_persisted_v1_when_negotiated`
+
+## Rollout
+
+- **Day 1 (this UPCR)**: drafted, reviewed, accepted before any code lands.
+- **Day 2 (PR G in the structural plan)**: server emitter implemented under capability gate. The hook lives in `crates/octos-bus/src/session.rs::add_message_with_seq` post-commit, so it fires for ALL write paths (user, assistant, tool, spawn-only, recovery) without per-call-site changes.
+- **Day 3 (PR H Layer 1 fixtures)**: fixtures consume the notification as the deterministic durability signal.
+- **Day 4 (PR J web SPA migration)**: SPA subscribes; uses `message/persisted` to correlate optimistic bubbles to durable seqs without backfill round-trip.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Notification volume on busy sessions | Medium | Each row triggers exactly one notification. For sessions with high tool-call density, this could approach 10/s for short windows. Wire compression (per-frame brotli over WS) handles this; payload is ~250 bytes per notification. Add a benchmark gate at 100/s sustained rate. |
+| Replay storm on reconnect after long offline window | Medium | The capability gate scopes replay to clients that opted in. Clients that need only live state can skip the feature. For clients that need replay, batching during replay (existing pattern, see UPCR-2026-002 panes replay) limits bandwidth. |
+| Backwards-compat with legacy `Message.thread_id: None` rows | Low | The notification's `thread_id` field is optional (matching `Message`). Legacy rows emit notifications with absent/synthesized thread_id, identical to today's reload behavior. |
+| Race: emit before client subscribed | Low | The capability flag is evaluated at session/open time. Notifications for rows committed before session/open arrive only via cursor-based replay through `session/hydrate` (UPCR-2026-009), which carries the same data. |
+| Cross-cancel semantics | Low | A cancelled turn's already-committed rows still emit `message/persisted`. The terminal `turn/error` or `turn/interrupted` notification carries the lifecycle truth; `message/persisted` carries the row truth. The two are independent. |
+
+## Open Questions
+
+- Should `message/persisted` carry the row's full content (`text`)? **Decision**: no for v1. Including the content makes the notification large (kilobytes for assistant messages) and duplicates `message/delta`. Clients that need content fetch via `session/hydrate` (UPCR-2026-009).
+- Should there be a separate `tool/persisted` notification for tool rows? **Decision**: no. The `source = tool` discriminator on the unified notification is sufficient.
+- Should the notification include the row's `client_message_id` for assistant/tool rows that inherit it? **Decision**: yes once PR A's typed-identity work lands; the field is defined as optional in v1 and becomes always-present in v2 once the inheritance is enforced server-side.
+
+## Acceptance Criteria
+
+- [ ] Reviewer sign-off on the wire contract (param shape, source enum values).
+- [ ] Reviewer sign-off on the capability-flag name and version.
+- [ ] Reviewer sign-off on ordering guarantees (strict per-session monotonic seq).
+- [ ] No conflicts with sibling UPCRs (-009 hydrate, -010 thread-graph, -011 turn-state).
+- [ ] No regression on the existing `turn/completed` cursor-update behavior — the new notification is supplementary, not a replacement.
+- [ ] Status flipped to `accepted` before implementation lands in `crates/octos-bus/src/session.rs::add_message_with_seq` post-commit hook.


### PR DESCRIPTION
## Summary

Drafts 4 UI Protocol v1 change requests that add the missing primitives for client-side state introspection. Each maps directly to a bug shipped this week and to a structural fix in the 5-day architectural plan at \`/tmp/octos-architecture-FINAL.md\`.

| UPCR | Bug it would have prevented | Capability |
|---|---|---|
| **009 session/hydrate** | persistence-side reload-misbinding (#738/#740/#742) — clients had no authoritative way to ask the server what the current state of a session is | \`state.session_hydrate.v1\` |
| **010 thread/graph/get** | live-wire thread mis-routing (#740) — clients couldn't observe the canonical thread graph; today it's INFERRED in \`Session::threads()\` at \`crates/octos-bus/src/session.rs:469-514\` | \`state.thread_graph.v1\` |
| **011 turn/state/get** | sticky-map drift in api_channel — server already maintains this at \`crates/octos-cli/src/api/ui_protocol.rs:2030-2135\`, this just exposes it | \`state.turn_state_get.v1\` |
| **012 message/persisted** | ack/result divergence in spawn_only flows (#738) and reload misbinding race — durable-commit confirmation closes the gap | \`event.message_persisted.v1\` |

## Why these 4 (and not more)

Each addition closes a specific bug we shipped this week. The 4 together close the entire #738/#740/#742 chain at the protocol level — clients cannot fall into "infer state from ambient signals" because the protocol provides authoritative answers.

## Status

All 4 marked \`proposed\`. Ready for review. To be flipped to \`accepted\` before implementation lands (in PR G of the 5-day plan).

## Compatibility

- All 4 are strictly additive. No existing method, notification, payload, enum, or capability flag is modified.
- All 4 are opt-in via \`X-Octos-Ui-Features\`.
- Legacy daemon versions: don't advertise the features, clients don't expect them.
- Cross-channel (telegram/discord/etc.): unaffected — they don't subscribe to UI Protocol notifications.

## Test strategy

Each UPCR specifies its server-side, client-side, and wire-contract test plans. Key acceptance criterion: golden tests in \`crates/octos-core/src/ui_protocol.rs\` lock the wire shape; integration tests in \`crates/octos-cli/tests/m9_protocol_*.rs\` cover the command/notification semantics.

## Related

- Architecture plan: \`/tmp/octos-architecture-FINAL.md\` (Day 1 work)
- Bug chain: #649 → #664 → #673 → #680 → #738 → #740
- Sibling PRs in this 5-day wave: PR A (typed identities), PR F (server thread-binding fix), PR G (these UPCR handlers), PR H (Layer 1 fixture infra), PR I (capture-and-replay), PR J (web SPA migration)

## Author note

UPCRs 009-010 drafted by background agent; agent timed out mid-stream. UPCRs 011-012 drafted by hand using 009-010 as template. All 4 reviewed for consistency before commit.