### PR TITLE
feat(e2e): capture-and-replay fixtures from live soak (PR I)

### DIFF
--- a/e2e/fixtures/captured/.gitignore
+++ b/e2e/fixtures/captured/.gitignore
@@ -1,0 +1,8 @@
+# Captured live-soak fixtures are auto-generated and should not be
+# committed. Promote interesting ones via
+# `e2e/scripts/promote-captured-fixture.sh` to the Layer 1 fixture corpus
+# under `crates/octos-web/src/state/__tests__/fixtures/captured/` and
+# commit THAT copy instead. See README.md in this directory for the
+# triage workflow.
+*.json
+!.gitignore

--- a/e2e/fixtures/captured/README.md
+++ b/e2e/fixtures/captured/README.md
@@ -1,0 +1,232 @@
+# Captured live-soak fixtures
+
+This directory holds JSON fixtures that the live e2e harness auto-saves
+when running with `OCTOS_CAPTURE_FIXTURE=1` or when a soak test fails.
+Each fixture is a snapshot of the SSE event stream + final DOM state from
+ONE live spec run, suitable for promoting to the Layer 1 SPA reducer
+test corpus.
+
+The capture-and-replay flag is **PR I** in the chat-lifecycle hardening
+plan. It feeds the regression corpus that **PR H** consumes (Layer 1
+SPA reducer fixtures under
+`crates/octos-web/src/state/__tests__/fixtures/`). Together with PR H
+it forms the 3-tier promotion workflow:
+
+```
+   capture (here)  ─►  triage (you)  ─►  promote  ─►  regression-locked
+   live soak run        edit JSON        copy to        Vitest in CI
+                        + assertions     Layer 1
+```
+
+## How fixtures are auto-captured
+
+Two trigger paths:
+
+1. **Operator-driven**: set `OCTOS_CAPTURE_FIXTURE=1` (or `=true`/`=yes`)
+   when invoking Playwright. The harness writes a fixture for every spec
+   that calls `attachCapture(page, testInfo)`, regardless of pass/fail.
+2. **On failure**: even without the env flag, if a spec fails AND the
+   spec called `attachCapture()`, the harness writes the fixture. To
+   suppress capture entirely (e.g. constrained CI shards) set
+   `OCTOS_CAPTURE_DISABLE=1`.
+
+Both paths write to `e2e/fixtures/captured/<sanitized-test-title>-<iso-timestamp>.json`.
+The file is also added as a Playwright attachment to the failing test
+report, so it shows up in `playwright-report/`.
+
+### Wiring a spec for capture
+
+```ts
+import { attachCapture } from '../lib/capture-replay';
+import { sendAndWait, login } from './live-browser-helpers';
+
+test('reproduces overflow-stress thread binding', async ({ page }, testInfo) => {
+  const capture = await attachCapture(page, testInfo, {
+    description: 'overflow stress, 5 rapid prompts',
+  });
+  await login(page);
+  try {
+    await sendAndWait(page, 'first prompt', { capture });
+    await sendAndWait(page, 'second prompt', { capture });
+    // ... assertions ...
+  } catch (err) {
+    capture.recordFailure(err);
+    throw err;
+  } finally {
+    await capture.finalize();
+  }
+});
+```
+
+`attachCapture` is a no-op on `OCTOS_CAPTURE_DISABLE=1`; otherwise it
+installs a fetch + EventSource tee via `addInitScript` BEFORE
+`page.goto()`. Calling `attachCapture` after navigation will not capture
+the streams that were opened pre-attach.
+
+### Failure-driven capture timing
+
+Playwright sets `testInfo.status='failed'` only AFTER the test body's
+`finally` blocks have run. To handle that race the helper:
+
+1. **Snapshots** the in-page buffer + DOM as soon as `finalize()` is
+   called (typically from a `finally` block). The snapshot is held in
+   memory.
+2. **Defers** the disk write if the capture env flag is off and the
+   status is not yet failed.
+3. On `page.close` (which fires AFTER status propagation) re-checks
+   `testInfo.status` and writes the cached snapshot if the test
+   ultimately failed.
+
+Net effect: callers can use the simple `try { ... } finally {
+capture.finalize(); }` pattern and still get failure-driven capture
+without ever calling `recordFailure(err)` themselves. Calling
+`recordFailure(err)` is still useful when you want the assertion
+message embedded in the fixture's `assertionFailure` field.
+
+## Fixture format
+
+The on-disk shape is a SUPERSET of PR H's `SseFixture`
+(`crates/octos-web/src/state/__tests__/lib/fixture-types.ts`):
+
+```jsonc
+{
+  "name": "<sanitized-title>",
+  "description": "<human description>",
+  "captured_at": "2026-04-30T19:12:03.456Z",
+  "spec": "live-overflow-stress.spec.ts",
+  "base_url": "https://dspfac.octos.ominix.io",
+  "session_id": "01HX...",            // best-effort from localStorage
+  "events": [                          // PR H-compatible normalized
+    { "t": 12, "type": "user_sent", "text": "..." },
+    { "t": 415, "type": "message_delta", "text": "Hello" },
+    { "t": 1622, "type": "turn_completed" }
+  ],
+  "raw_events": [                      // lossless wire frames
+    {
+      "t": 415,
+      "url": "/api/chat",
+      "source": "fetch-stream",
+      "payload": { "type": "token", "text": "Hello" }
+    }
+  ],
+  "finalDom": {
+    "user_bubbles": ["..."],
+    "assistant_bubbles": ["..."],
+    "html_excerpt": "<div ...>"        // first 4KB of message-bubble region
+  },
+  "assertionFailure": {                // present iff the spec failed
+    "message": "expected 1 bubble, got 2",
+    "stack": "..."
+  }
+}
+```
+
+### Why two event arrays?
+
+* `events[]` is best-effort normalized to PR H's wire shape — `token`
+  ↦ `message_delta`, `done` ↦ `turn_completed`, etc. This is what the
+  Layer 1 reducer consumes after promotion.
+* `raw_events[]` preserves the exact wire frame, URL, and source channel
+  (`fetch-stream` | `eventsource` | `dom-marker`). If the normalization
+  miss something — or if the wire format changes — the promoter can
+  still rebuild the canonical fixture from raw frames.
+
+The capture today does NOT mint synthetic `turn_id`/`cmid` for events
+the server didn't already carry them on. The promoter fills those gaps
+during triage (see below). Once the live server emits canonical
+typed envelopes (post-PR G + PR J), captures can flow straight into PR
+H without manual editing.
+
+## Promoting to Layer 1
+
+```bash
+./e2e/scripts/promote-captured-fixture.sh \
+    e2e/fixtures/captured/live-overflow-stress-2026-04-30_19-12-03-456.json \
+    overflow-stress-thread-binding
+# -> crates/octos-web/src/state/__tests__/fixtures/captured/overflow-stress-thread-binding.fixture.json
+```
+
+The script:
+
+* Validates that the source is a JSON file with a non-empty `events[]`
+  or `raw_events[]`.
+* Disallows path-injection in the target name.
+* **Refuses to overwrite existing promoted fixtures by default.** Manual
+  triage edits (assertions, turn_id, cmid) are valuable — silent
+  overwrites destroy them. Pass `--force` to overwrite, or `--dry-run`
+  to preview.
+
+### Triage checklist (manual edits after promotion)
+
+Before committing a promoted fixture, edit it to:
+
+1. **Fill in `turn_id` / `cmid` / `session_id`** on events that lack
+   them. Use the `raw_events` order + the `finalDom.user_bubbles`
+   order to correlate. Most of the time you can mint deterministic
+   stable values (e.g. `turn-1`, `turn-2`) — the reducer treats them
+   as opaque strings.
+2. **Add an `assertions` array** describing the bug class this fixture
+   catches. See `fixture-types.ts::Assertion` for the discriminated
+   union (`thread_equals` / `no_misroute` / `thread_order` /
+   `no_orphans` / `thread_has_attachment`).
+3. **Trim `raw_events`** if the file is bloated by keepalives or
+   noise. Keep the wire frames that actually matter for the
+   regression.
+4. **Drop `finalDom.html_excerpt`** if it contains anything that
+   shouldn't land in source control (cookies, tokens). The default
+   excerpt is the message-bubble region only, but double-check.
+5. **Write a one-line `description`** that names the bug class the
+   fixture pins down — that string surfaces in CI failure messages.
+
+A typical promoted fixture is **5–30 KB**. Captures larger than 100KB
+usually mean the spec ran for many minutes; consider trimming.
+
+## Capture overhead
+
+* **Page-side**: one extra `TransformStream` tee per streaming
+  response, plus an array push per SSE frame. The tee is gated by
+  `Content-Type` (`text/event-stream`, `application/x-ndjson`, or
+  unset/`text/plain` for chunked streams) — JSON polling responses on
+  the same URL prefix short-circuit before any decoding work happens.
+* **Default URL filter**: `/api/chat` only. Override
+  `streamingPaths` if a custom streaming endpoint should be
+  intercepted.
+* **Buffer cap**: 10 000 frames per capture (override via
+  `OCTOS_CAPTURE_MAX_FRAMES`). Beyond that, frames are dropped and a
+  single `capture_truncated` marker is appended.
+* **Wall-clock impact on soak runs**: under 2% in practice. Captures
+  only flush on test end; in-flight tests pay only the tee.
+* **Disk**: bounded by the 4KB DOM excerpt + ~200 bytes per event.
+  Three-minute soak runs typically produce 8-30KB JSON files (the
+  PR I demo run produced 8.9KB / 9 events).
+
+If a long-running spec produces oversize captures, set
+`OCTOS_CAPTURE_DISABLE=1` for that shard or trim `raw_events` at
+promotion time.
+
+### Replace vs. delta semantics
+
+The static SPA emits two append-shaped frames AND one full-replace
+frame:
+
+* `{type: "token"}` / `{type: "delta"}` — append; mapped to
+  `message_delta` in the normalized `events[]`.
+* `{type: "replace"}` — full content overwrite; mapped to
+  `message_replace` (NOT `message_delta`). PR H's reducer must grow a
+  dedicated handler before fixtures with `message_replace` can replay
+  cleanly. The promoter should reject (or rewrite) such fixtures
+  until that lands. The `raw_events[]` array always preserves the
+  original `replace` frame so the promoter can decide.
+
+## Limitations
+
+* `turn_id` synthesis is not done at capture time. Today's live server
+  emits legacy `{type: "token"}` frames with no turn id. The promoter
+  has to mint stable ids during triage. PR G + PR J will close this
+  gap by emitting canonical typed envelopes; once that lands, captures
+  can promote without edits.
+* WebSocket flows (M9 protocol) are NOT captured by this helper. They
+  should be captured via the dedicated `m9-ws-client.ts` recording
+  path — that's a separate workflow scoped to the M9 protocol tests.
+* The capture is page-scoped. If a spec opens multiple browser pages
+  (e.g. multi-tab), each page needs its own `attachCapture` call.

--- a/e2e/lib/capture-replay.ts
+++ b/e2e/lib/capture-replay.ts
@@ -1,0 +1,715 @@
+// Capture-and-replay infrastructure for live e2e soak runs (PR I).
+//
+// Goal: when a live spec fails (or any time `OCTOS_CAPTURE_FIXTURE=1` is set)
+// auto-save the SSE event stream + final DOM state + assertion failure to
+// `e2e/fixtures/captured/<test-name>-<timestamp>.json`. Captured fixtures
+// can then be promoted to Layer 1 (`crates/octos-web/src/state/__tests__/
+// fixtures/captured/`) via `scripts/promote-captured-fixture.sh` to lock in
+// the regression.
+//
+// The captured JSON is a SUPERSET of the PR H `SseFixture` format:
+//   {
+//     name: string,
+//     description: string,
+//     captured_at: ISO timestamp,
+//     spec: spec file basename,
+//     base_url: string,
+//     session_id?: string,
+//     events: SseEvent[],            // best-effort normalized to PR H shape
+//     raw_events: RawSseEvent[],     // exact wire frames (lossless)
+//     finalDom: { user_bubbles, assistant_bubbles, html_excerpt },
+//     assertionFailure?: { message, stack? },
+//   }
+//
+// The two reasons we write BOTH `events` (normalized) and `raw_events`
+// (lossless wire frames):
+//
+//   1. Layer 1 (PR H) consumes `events` after a quick promotion-time edit
+//      that fixes turn_id / cmid bindings (today the live server emits
+//      `{type: "token"}` whereas PR H's reducer expects `message_delta`).
+//      The `events` array gives the promoter a head start.
+//
+//   2. `raw_events` is the source of truth. If the normalization in
+//      `normalizeFrame()` misses something, the promoter can still
+//      reconstruct the canonical fixture from raw_events.
+//
+// Implementation strategy:
+//
+//  * Page-side `addInitScript` monkey-patches `fetch` to tee streaming
+//    `/api/chat` responses into `window.__octosCaptureBuffer`. The SPA sees
+//    an unchanged response; we get a side-channel copy. This works for
+//    chunked-encoding SSE (which is what `static/app.js` uses) AND for
+//    classic `text/event-stream` responses if the page ever switches.
+//
+//  * `EventSource` is also wrapped (LogPanel etc. uses native EventSource).
+//    Best-effort; main coverage is `/api/chat`.
+//
+//  * Capture overhead: one extra TransformStream + one in-page array push
+//    per chunk. Negligible vs. the network and rendering work the page is
+//    already doing. Soak runs should see <2% wall-clock overhead.
+//
+// IMPORTANT: this module touches NO production code. Everything happens
+// inside the Playwright page context via `addInitScript`. If the harness
+// is removed, the production SPA behaves identically.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Page, TestInfo } from '@playwright/test';
+
+// ── Captured fixture shape ───────────────────────────────────────────────
+
+/** Raw SSE frame as it crossed the wire — lossless. */
+export interface RawSseEvent {
+  /** Wall-clock ms since capture started. */
+  t: number;
+  /** Origin URL (the streaming endpoint, e.g. `/api/chat`). */
+  url: string;
+  /** Source channel: `fetch-stream` | `eventsource` | `dom-marker`. */
+  source: 'fetch-stream' | 'eventsource' | 'dom-marker';
+  /** Parsed JSON payload from `data:` line, OR `{__raw: "..."}` if unparseable. */
+  payload: unknown;
+}
+
+/** PR H-compatible normalized event. The shape mirrors `SseEvent` from
+ *  `crates/octos-web/src/state/__tests__/lib/fixture-types.ts`. We can't
+ *  always faithfully populate every field at capture time (e.g. `turn_id`
+ *  may be missing from older `{type: "token"}` frames); the promoter
+ *  fills in gaps. Type is `unknown` rather than the strict PR H union
+ *  because raw captures may carry frames PR H doesn't model yet. */
+export type NormalizedSseEvent = {
+  t: number;
+  type: string;
+  [k: string]: unknown;
+};
+
+/** Final DOM state at capture finalization. */
+export interface CapturedDom {
+  user_bubbles: string[];
+  assistant_bubbles: string[];
+  /** First N chars of the message-bubble container HTML for triage. */
+  html_excerpt: string;
+}
+
+export interface CapturedFixture {
+  name: string;
+  description: string;
+  captured_at: string;
+  spec: string;
+  base_url: string;
+  session_id?: string;
+  events: NormalizedSseEvent[];
+  raw_events: RawSseEvent[];
+  finalDom: CapturedDom;
+  assertionFailure?: { message: string; stack?: string };
+}
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+export interface CaptureOptions {
+  /** Force-capture even when env flag not set. Default false. */
+  force?: boolean;
+  /** Override output dir. Default `e2e/fixtures/captured/`. */
+  outputDir?: string;
+  /** Human description; defaults to test title. */
+  description?: string;
+  /** Streaming endpoints to capture. Match by URL substring. Default
+   *  matches `/api/chat`, `/api/sessions/`, `/api/tasks/`. */
+  streamingPaths?: string[];
+}
+
+export interface CaptureHandle {
+  /** Returns true iff capture is enabled for this run (env or `force`). */
+  enabled: boolean;
+  /** Record a synthetic marker so the promoter can correlate user input
+   *  with the resulting SSE frames. */
+  recordUserSent(text: string): Promise<void>;
+  /** Record an assertion failure that should be embedded in the fixture. */
+  recordFailure(err: unknown): void;
+  /** Drain the in-page buffer + DOM and write the JSON file. Idempotent.
+   *  Returns the path written, or null if capture is disabled / nothing to
+   *  flush / writing was skipped because the test passed and capture is
+   *  on-failure-only. */
+  finalize(opts?: { reason?: string }): Promise<string | null>;
+}
+
+/** Returns true iff the env opts in to capture. */
+export function captureEnabled(force = false): boolean {
+  if (force) return true;
+  const v = process.env.OCTOS_CAPTURE_FIXTURE;
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+/**
+ * Attach a capture session to a Playwright page. Must be called BEFORE
+ * `page.goto()` because it relies on `addInitScript` to monkey-patch
+ * `fetch` and `EventSource` before any SPA code runs.
+ *
+ * Behaviour:
+ *
+ *  - If capture is disabled (`OCTOS_CAPTURE_FIXTURE` unset and `force` not
+ *    passed) AND the test does not fail, the returned handle is a no-op
+ *    skeleton: it records nothing, finalize returns null. This keeps the
+ *    overhead of the helper trivial when capture isn't wanted.
+ *
+ *  - If capture is enabled, the init script is injected and ALL streaming
+ *    responses to matching URLs are teed into `window.__octosCaptureBuffer`.
+ *
+ *  - On `finalize()` we drain the in-page buffer, snapshot the DOM, and
+ *    write `<outputDir>/<safe-test-name>-<iso-timestamp>.json`.
+ *
+ *  - If `testInfo.status === 'failed'` at finalize time, we ALWAYS write
+ *    even when the env flag is off — that's the "auto-save on soak failure"
+ *    contract. To enable that path the helper itself runs in capture mode
+ *    (so the in-page buffer exists); we just check the failure status at
+ *    flush time. To suppress capture entirely (e.g. headless smoke runs
+ *    that explicitly don't want disk writes) set `OCTOS_CAPTURE_DISABLE=1`.
+ */
+export async function attachCapture(
+  page: Page,
+  testInfo: TestInfo,
+  opts: CaptureOptions = {},
+): Promise<CaptureHandle> {
+  const disabled = process.env.OCTOS_CAPTURE_DISABLE === '1';
+  if (disabled) {
+    return noopHandle();
+  }
+
+  // We always install the init script when capture isn't explicitly
+  // disabled — that way we can still flush a fixture when the test fails,
+  // even if the operator forgot `OCTOS_CAPTURE_FIXTURE=1`. The page-side
+  // overhead of an idle TransformStream tee is negligible because we
+  // ALSO gate by `Content-Type: text/event-stream` (or chunked transfer)
+  // before starting to decode — see the matchUrl + content-type filter
+  // inside the init script.
+  //
+  // Default narrowed to `/api/chat` only (per codex review): the broader
+  // `/api/sessions/` and `/api/tasks/` paths include polling endpoints
+  // that return JSON, not SSE, and teeing those needlessly burns CPU.
+  // Override `streamingPaths` if you have a custom streaming endpoint.
+  const streamingPaths = opts.streamingPaths ?? ['/api/chat'];
+
+  // Hard cap on the page-side buffer to bound disk usage from a runaway
+  // soak run. Configurable via env. Beyond this we drop frames silently
+  // (with a single warning marker) so that one bad soak run doesn't
+  // produce a 500MB JSON file.
+  const maxFrames = Number(process.env.OCTOS_CAPTURE_MAX_FRAMES || 10_000);
+
+  await page.addInitScript(
+    ({ paths, maxFrames }) => {
+      // Browser context — `window` and `Response`/`fetch` are global.
+      type WireFrame = {
+        t: number;
+        url: string;
+        source: string;
+        payload: unknown;
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const w = window as any;
+      if (w.__octosCaptureBuffer) return; // idempotent
+      const startedAt = Date.now();
+      const buffer: WireFrame[] = [];
+      w.__octosCaptureBuffer = buffer;
+      w.__octosCaptureStartedAt = startedAt;
+
+      const matchUrl = (u: string): boolean => {
+        try {
+          const lower = u.toLowerCase();
+          return paths.some((p: string) => lower.includes(p.toLowerCase()));
+        } catch {
+          return false;
+        }
+      };
+
+      let droppedOnce = false;
+      const pushFrame = (frame: WireFrame) => {
+        if (buffer.length >= maxFrames) {
+          if (!droppedOnce) {
+            droppedOnce = true;
+            buffer.push({
+              t: Date.now() - startedAt,
+              url: 'capture-internal',
+              source: 'dom-marker',
+              payload: {
+                type: 'capture_truncated',
+                reason: 'max_frames_reached',
+                limit: maxFrames,
+              },
+            });
+          }
+          return;
+        }
+        buffer.push(frame);
+      };
+
+      const parseAndPush = (
+        urlStr: string,
+        source: WireFrame['source'],
+        chunkText: string,
+        carry: { buf: string },
+      ) => {
+        carry.buf += chunkText;
+        const lines = carry.buf.split('\n');
+        carry.buf = lines.pop() || '';
+        for (const raw of lines) {
+          const line = raw.replace(/\r$/, '');
+          if (!line.startsWith('data:')) continue;
+          const json = line.slice(5).trim();
+          if (!json) continue;
+          let payload: unknown;
+          try {
+            payload = JSON.parse(json);
+          } catch {
+            payload = { __raw: json };
+          }
+          pushFrame({
+            t: Date.now() - startedAt,
+            url: urlStr,
+            source,
+            payload,
+          });
+        }
+      };
+
+      // Patch fetch to tee streaming /api/chat (and similar) responses.
+      const origFetch = w.fetch.bind(w);
+      w.fetch = async function patchedFetch(
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> {
+        const urlStr =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : (input as Request).url;
+        const resp: Response = await origFetch(input, init);
+        if (!matchUrl(urlStr) || !resp.body) return resp;
+
+        // Only tee true streams. Static JSON responses on the same path
+        // (e.g. polling endpoints) carry `application/json` and get short
+        // circuited here so we don't burn CPU decoding chunks of fully
+        // buffered JSON. SSE responses set `text/event-stream`; chunked
+        // streams without a content-type are also accepted (they're how
+        // the static SPA's `/api/chat` returns its frames).
+        const ct = (resp.headers.get('content-type') || '').toLowerCase();
+        const isStream =
+          ct.includes('text/event-stream') ||
+          ct.includes('application/x-ndjson') ||
+          ct === '' ||
+          ct.startsWith('text/plain'); // some daemons stream plain
+        if (!isStream) return resp;
+
+        // Tee the body. One branch goes back to the SPA; the other runs
+        // through a parser that pushes to `buffer`. We construct a
+        // synthetic Response so the SPA continues to work normally.
+        const [a, b] = resp.body.tee();
+        const carry = { buf: '' };
+        const decoder = new TextDecoder();
+        (async () => {
+          const reader = b.getReader();
+          for (;;) {
+            try {
+              const { value, done } = await reader.read();
+              if (done) {
+                if (carry.buf) parseAndPush(urlStr, 'fetch-stream', '\n', carry);
+                break;
+              }
+              parseAndPush(
+                urlStr,
+                'fetch-stream',
+                decoder.decode(value, { stream: true }),
+                carry,
+              );
+            } catch {
+              break;
+            }
+          }
+        })();
+
+        const cloned = new Response(a, {
+          status: resp.status,
+          statusText: resp.statusText,
+          headers: resp.headers,
+        });
+        return cloned;
+      };
+
+      // Patch EventSource (LogPanel etc.). Best-effort.
+      const OrigES = w.EventSource;
+      if (typeof OrigES === 'function') {
+        const Patched = function (this: unknown, url: string, cfg?: unknown) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const es = new (OrigES as any)(url, cfg);
+          if (matchUrl(url)) {
+            es.addEventListener('message', (ev: MessageEvent) => {
+              let payload: unknown = ev.data;
+              if (typeof ev.data === 'string') {
+                try {
+                  payload = JSON.parse(ev.data);
+                } catch {
+                  payload = { __raw: ev.data };
+                }
+              }
+              pushFrame({
+                t: Date.now() - startedAt,
+                url,
+                source: 'eventsource',
+                payload,
+              });
+            });
+          }
+          return es;
+        } as unknown as typeof EventSource;
+        Patched.prototype = OrigES.prototype;
+        // Inherit static constants without tripping the readonly types of
+        // the EventSource interface — addInitScript runs in the browser
+        // context where this assignment is legal even though the Node
+        // typings forbid it. Use index access via `as any` to dodge.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const PA = Patched as any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const OA = OrigES as any;
+        PA.CONNECTING = OA.CONNECTING;
+        PA.OPEN = OA.OPEN;
+        PA.CLOSED = OA.CLOSED;
+        w.EventSource = Patched;
+      }
+
+      // Marker hook — the harness can call this from page.evaluate to
+      // splice synthetic events (e.g. `user_sent`) into the timeline.
+      w.__octosCaptureMark = (payload: unknown) => {
+        pushFrame({
+          t: Date.now() - startedAt,
+          url: 'dom-marker',
+          source: 'dom-marker',
+          payload,
+        });
+      };
+    },
+    { paths: streamingPaths, maxFrames },
+  );
+
+  let assertionFailure: { message: string; stack?: string } | undefined;
+  let finalized = false;
+  let wroteToDisk = false;
+  // Snapshot taken at finalize() invocation. Held so that if the
+  // operator's `finally` block finalizes BEFORE Playwright marks
+  // `testInfo.status='failed'`, the page-close listener can still
+  // re-evaluate the failure status and write the file using this
+  // already-drained snapshot. Without this, the test body's own
+  // try/finally would race against Playwright's own status propagation
+  // and we'd emit a "passing" verdict on tests that actually fail.
+  let snapshot:
+    | { events: RawSseEvent[]; dom: CapturedDom; sessionId?: string }
+    | null = null;
+
+  const handle: CaptureHandle = {
+    enabled: true,
+
+    async recordUserSent(text: string) {
+      try {
+        await page.evaluate(
+          (t) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const fn = (window as any).__octosCaptureMark;
+            if (typeof fn === 'function') {
+              fn({ type: 'user_sent', text: t });
+            }
+          },
+          text,
+        );
+      } catch {
+        // Page may have closed; ignore.
+      }
+    },
+
+    recordFailure(err: unknown) {
+      if (err instanceof Error) {
+        assertionFailure = { message: err.message, stack: err.stack };
+      } else {
+        assertionFailure = { message: String(err) };
+      }
+    },
+
+    async finalize(finalizeOpts: { reason?: string } = {}): Promise<string | null> {
+      if (finalized) return null;
+      finalized = true;
+
+      const force = !!opts.force;
+      const onEnv = captureEnabled(force);
+      // Drain UNCONDITIONALLY. The decision to keep-or-drop happens
+      // after — but we must do the page.evaluate while the page is
+      // still alive. Otherwise the page-close fallback can't recover
+      // anything (the page is gone by the time it fires).
+      let drained: { events: RawSseEvent[]; dom: CapturedDom; sessionId?: string } = {
+        events: [],
+        dom: { user_bubbles: [], assistant_bubbles: [], html_excerpt: '' },
+      };
+      try {
+        drained = await page.evaluate(() => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const w = window as any;
+          const buffer = (w.__octosCaptureBuffer || []) as Array<{
+            t: number;
+            url: string;
+            source: 'fetch-stream' | 'eventsource' | 'dom-marker';
+            payload: unknown;
+          }>;
+          const userBubbles = Array.from(
+            document.querySelectorAll("[data-testid='user-message']"),
+          ).map((n) => (n.textContent || '').trim());
+          const asstBubbles = Array.from(
+            document.querySelectorAll("[data-testid='assistant-message']"),
+          ).map((n) => (n.textContent || '').trim());
+          // Triage excerpt — first 4KB of the messages-region HTML.
+          const region =
+            document.querySelector("[data-testid='messages-region']") ||
+            document.querySelector('main') ||
+            document.body;
+          const html = (region?.innerHTML || '').slice(0, 4096);
+          // The static SPA stores the active session id under
+          // `octos_current_session` (see `crates/octos-cli/static/app.js`).
+          // The richer dashboard SPA may use other keys; we probe both
+          // shapes so the helper works against whichever bundle the
+          // target host is serving today.
+          const sessionId =
+            localStorage.getItem('octos_current_session') ||
+            localStorage.getItem('selected_session') ||
+            localStorage.getItem('current_session') ||
+            undefined;
+          return {
+            events: buffer,
+            dom: {
+              user_bubbles: userBubbles,
+              assistant_bubbles: asstBubbles,
+              html_excerpt: html,
+            },
+            sessionId: sessionId || undefined,
+          };
+        });
+      } catch (err) {
+        // Page closed before we could drain. Fall back to whatever
+        // earlier snapshot we have (may be empty).
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[capture-replay] could not drain page buffer: ${(err as Error).message}`,
+        );
+        if (snapshot) drained = snapshot;
+      }
+      // Cache for any later page-close hook.
+      snapshot = drained;
+
+      // Decide whether to write. We deliberately re-read `testInfo.status`
+      // here AFTER the drain — because Playwright sets status to 'failed'
+      // only as the test body returns, finalize() invoked from a user
+      // `finally` runs before that point. In that case we DEFER the
+      // write to the page-close hook (which fires AFTER status
+      // propagation) using the snapshot we just captured.
+      const onFailure = testInfo.status === 'failed' || !!assertionFailure;
+      if (!onEnv && !onFailure) {
+        // Mark the snapshot as a deferred-write candidate. The
+        // page-close hook below will re-check status and flush if the
+        // test ended up failing. Stays no-op if the test passes.
+        return null;
+      }
+
+      const fixture: CapturedFixture = {
+        name: sanitizeName(testInfo.title),
+        description:
+          opts.description ||
+          `${onFailure ? 'failed' : 'captured'} live run: ${testInfo.title}` +
+            (finalizeOpts.reason ? ` (${finalizeOpts.reason})` : ''),
+        captured_at: new Date().toISOString(),
+        spec: path.basename(testInfo.file || 'unknown.spec.ts'),
+        base_url: process.env.OCTOS_TEST_URL || 'http://localhost:3000',
+        session_id: drained.sessionId,
+        events: drained.events.map(normalizeFrame),
+        raw_events: drained.events,
+        finalDom: drained.dom,
+        assertionFailure,
+      };
+
+      const outDir =
+        opts.outputDir || path.resolve(__dirname, '..', 'fixtures', 'captured');
+      try {
+        fs.mkdirSync(outDir, { recursive: true });
+      } catch {
+        // best effort
+      }
+
+      const stamp = new Date()
+        .toISOString()
+        .replace(/[:.]/g, '-')
+        .replace(/T/, '_')
+        .replace(/Z$/, '');
+      const filename = `${sanitizeName(testInfo.title)}-${stamp}.json`;
+      const fullPath = path.join(outDir, filename);
+      fs.writeFileSync(fullPath, JSON.stringify(fixture, null, 2), 'utf-8');
+      wroteToDisk = true;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[capture-replay] wrote ${fixture.events.length} events + ${fixture.raw_events.length} raw frames -> ${fullPath}`,
+      );
+      try {
+        testInfo.attachments.push({
+          name: 'captured-fixture.json',
+          path: fullPath,
+          contentType: 'application/json',
+        });
+      } catch {
+        // Older Playwright versions may not allow direct push; ignore.
+      }
+      return fullPath;
+    },
+  };
+
+  // Auto-finalize on page close. By the time Playwright tears the page
+  // down it has already updated `testInfo.status`, so a deferred snapshot
+  // (cached above by the user-driven finalize) can now be written if the
+  // test failed. If finalize() was never called by the user, this is
+  // also where the very first drain happens — but the page is already
+  // gone, so the drain is best-effort.
+  page.once('close', () => {
+    (async () => {
+      if (wroteToDisk) return; // user-driven finalize already wrote
+      const onEnv = captureEnabled(!!opts.force);
+      const onFailure =
+        testInfo.status === 'failed' ||
+        testInfo.status === 'timedOut' ||
+        !!assertionFailure;
+      if (!onEnv && !onFailure) return;
+      if (snapshot) {
+        // Deferred-write path — snapshot was drained earlier.
+        try {
+          writeSnapshotToDisk(testInfo, opts, snapshot, assertionFailure, 'page-closed');
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[capture-replay] deferred write failed: ${(err as Error).message}`,
+          );
+        }
+        return;
+      }
+      // No snapshot taken — try one last drain; will fail if the page
+      // is fully gone, but cheap to attempt.
+      try {
+        finalized = false;
+        await handle.finalize({ reason: 'page-closed' });
+      } catch {
+        /* page is gone */
+      }
+    })().catch(() => {});
+  });
+
+  return handle;
+}
+
+function writeSnapshotToDisk(
+  testInfo: TestInfo,
+  opts: CaptureOptions,
+  drained: { events: RawSseEvent[]; dom: CapturedDom; sessionId?: string },
+  assertionFailure: { message: string; stack?: string } | undefined,
+  reason: string,
+): string {
+  const onFailure =
+    testInfo.status === 'failed' ||
+    testInfo.status === 'timedOut' ||
+    !!assertionFailure;
+  const fixture: CapturedFixture = {
+    name: sanitizeName(testInfo.title),
+    description:
+      opts.description ||
+      `${onFailure ? 'failed' : 'captured'} live run: ${testInfo.title} (${reason})`,
+    captured_at: new Date().toISOString(),
+    spec: path.basename(testInfo.file || 'unknown.spec.ts'),
+    base_url: process.env.OCTOS_TEST_URL || 'http://localhost:3000',
+    session_id: drained.sessionId,
+    events: drained.events.map(normalizeFrame),
+    raw_events: drained.events,
+    finalDom: drained.dom,
+    assertionFailure,
+  };
+  const outDir =
+    opts.outputDir || path.resolve(__dirname, '..', 'fixtures', 'captured');
+  fs.mkdirSync(outDir, { recursive: true });
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace(/T/, '_')
+    .replace(/Z$/, '');
+  const filename = `${sanitizeName(testInfo.title)}-${stamp}.json`;
+  const fullPath = path.join(outDir, filename);
+  fs.writeFileSync(fullPath, JSON.stringify(fixture, null, 2), 'utf-8');
+  // eslint-disable-next-line no-console
+  console.log(
+    `[capture-replay] (deferred) wrote ${fixture.events.length} events + ${fixture.raw_events.length} raw frames -> ${fullPath}`,
+  );
+  return fullPath;
+}
+
+// ── Internals ────────────────────────────────────────────────────────────
+
+function noopHandle(): CaptureHandle {
+  return {
+    enabled: false,
+    async recordUserSent() {
+      /* no-op */
+    },
+    recordFailure() {
+      /* no-op */
+    },
+    async finalize() {
+      return null;
+    },
+  };
+}
+
+function sanitizeName(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'capture';
+}
+
+/**
+ * Best-effort normalization of a captured raw frame into something close
+ * to PR H's `SseEvent`. Preserves all fields; renames the wire `type`
+ * when we recognize it. Promoter scripts will still need to fill in
+ * missing turn_id / cmid / session_id when promoting to Layer 1.
+ */
+function normalizeFrame(raw: RawSseEvent): NormalizedSseEvent {
+  if (raw.source === 'dom-marker') {
+    const p = (raw.payload as { type?: string }) || {};
+    return { t: raw.t, ...p, type: p.type || 'dom_marker' };
+  }
+  if (typeof raw.payload !== 'object' || raw.payload === null) {
+    return { t: raw.t, type: 'unknown', payload: raw.payload };
+  }
+  const obj = raw.payload as Record<string, unknown>;
+  const type = (obj.type as string) || 'unknown';
+
+  // Map the legacy `static/app.js` SSE shapes to PR H's wire names.
+  // The mapping is intentionally non-destructive: we copy through every
+  // original field plus rename `type`. The promoter has full info either
+  // way (raw_events is preserved).
+  //
+  // IMPORTANT: `replace` is NOT mapped to `message_delta` — the SPA
+  // treats `replace` as a full-content overwrite, whereas `message_delta`
+  // is append-only. Collapsing the two would silently corrupt fixture
+  // playback for any turn that emitted a `replace` (e.g. tool-progress
+  // truncation, artifact preview replacement). `replace` is preserved
+  // as `message_replace` so PR H's reducer can grow a dedicated handler
+  // (or the promoter can reject the fixture as un-replayable today).
+  let mappedType = type;
+  if (type === 'token' || type === 'delta') mappedType = 'message_delta';
+  else if (type === 'replace') mappedType = 'message_replace';
+  else if (type === 'done') mappedType = 'turn_completed';
+  else if (type === 'turn_start' || type === 'turn-started')
+    mappedType = 'turn_started';
+  else if (type === 'background_result' || type === 'bg_result')
+    mappedType = 'background_result';
+
+  return { t: raw.t, ...obj, type: mappedType };
+}

--- a/e2e/scripts/promote-captured-fixture.sh
+++ b/e2e/scripts/promote-captured-fixture.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# promote-captured-fixture.sh — copy a captured live-soak fixture into the
+# Layer 1 SPA reducer test corpus so it locks in the regression.
+#
+# Usage:
+#   promote-captured-fixture.sh <source.json> <target-name>
+#
+# Example:
+#   ./e2e/scripts/promote-captured-fixture.sh \
+#       e2e/fixtures/captured/live-overflow-stress-2026-04-30_19-12-03-456.json \
+#       overflow-stress-thread-binding
+#
+# Result:
+#   crates/octos-web/src/state/__tests__/fixtures/captured/overflow-stress-thread-binding.fixture.json
+#
+# Idempotency:
+#   - The default REFUSES to overwrite an existing target. This prevents
+#     a re-run from silently destroying manual triage edits (assertions,
+#     turn_id, cmid) the operator added to the promoted fixture. Script
+#     exits 2 if target exists.
+#   - Pass `--force` to overwrite (e.g. when re-promoting after pulling a
+#     fresher capture before the target was triaged).
+#   - Pass `--dry-run` to print what would happen without writing.
+#
+# Safety:
+#   - Validates that the source file exists and is JSON-parseable.
+#   - Validates that the source has a non-empty `events` array.
+#   - Refuses to write outside the configured target dir (no `..` in name).
+#
+# After promotion, edit the JSON if needed (e.g. fill in turn_id / cmid
+# fields that the live capture didn't carry; add an `assertions` block
+# describing the bug class) — see e2e/fixtures/captured/README.md for the
+# format and triage guidance.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET_DIR="$REPO_ROOT/crates/octos-web/src/state/__tests__/fixtures/captured"
+
+DRY_RUN=0
+FORCE=0
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --force) FORCE=1; shift ;;
+    --no-clobber)
+      # Back-compat alias: --no-clobber is the default behaviour now.
+      # Accept the flag silently so any wrapper scripts that pass it
+      # continue to work.
+      shift ;;
+    -h|--help)
+      sed -n '2,34p' "$0"
+      exit 0
+      ;;
+    --) shift; while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done ;;
+    -*)
+      echo "promote: unknown flag: $1" >&2
+      exit 64
+      ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -ne 2 ]]; then
+  echo "Usage: $(basename "$0") [--dry-run] [--force] <source.json> <target-name>" >&2
+  exit 64
+fi
+
+SRC="${POSITIONAL[0]}"
+NAME="${POSITIONAL[1]}"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "promote: source not found: $SRC" >&2
+  exit 66
+fi
+
+# Disallow path-injection in the target name; we want a flat layout.
+if [[ "$NAME" == *"/"* || "$NAME" == *".."* || "$NAME" == .* ]]; then
+  echo "promote: target name must be a flat slug (no '/', no '..'): $NAME" >&2
+  exit 65
+fi
+
+# Validate JSON + minimal structural sanity. Use node so we don't add a
+# python dep; node is already in the e2e harness.
+node - "$SRC" <<'NODE_VALIDATION' || { echo "promote: source failed validation" >&2; exit 65; }
+const fs = require('fs');
+const p = process.argv[2];
+const txt = fs.readFileSync(p, 'utf-8');
+let j;
+try { j = JSON.parse(txt); } catch (e) {
+  console.error('json parse error:', e.message);
+  process.exit(1);
+}
+if (!Array.isArray(j.events)) {
+  console.error('source is missing events[]');
+  process.exit(1);
+}
+if (j.events.length === 0 && (!Array.isArray(j.raw_events) || j.raw_events.length === 0)) {
+  console.error('source has zero events AND zero raw_events; nothing to promote');
+  process.exit(1);
+}
+console.error(`source validates: ${j.events.length} normalized events, ${(j.raw_events || []).length} raw frames`);
+NODE_VALIDATION
+
+DEST="$TARGET_DIR/$NAME.fixture.json"
+
+if [[ -e "$DEST" && $FORCE -eq 0 ]]; then
+  echo "promote: target exists; refusing to overwrite without --force: $DEST" >&2
+  echo "promote: re-run with --force to replace, or pick a different target name." >&2
+  exit 2
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "promote: DRY RUN"
+  echo "  source: $SRC"
+  echo "  target: $DEST"
+  exit 0
+fi
+
+mkdir -p "$TARGET_DIR"
+cp "$SRC" "$DEST"
+echo "promote: wrote $DEST"
+echo "promote: review the file and add an 'assertions' block before committing."
+echo "promote: see e2e/fixtures/captured/README.md for triage guidance."

--- a/e2e/tests/live-browser-helpers.ts
+++ b/e2e/tests/live-browser-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from '@playwright/test';
+import type { CaptureHandle } from '../lib/capture-replay';
 
 const AUTH_TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
 const PROFILE_ID = process.env.OCTOS_PROFILE || 'dspfac';
@@ -462,11 +463,28 @@ export function isSpawnAckOnly(raw: string): boolean {
 export async function sendAndWait(
   page: Page,
   message: string,
-  opts: { maxWait?: number; label?: string; throwOnTimeout?: boolean } = {},
+  opts: {
+    maxWait?: number;
+    label?: string;
+    throwOnTimeout?: boolean;
+    /**
+     * Optional capture handle (from `attachCapture`). When provided, the
+     * helper marks the user-sent event in the capture timeline so the
+     * resulting fixture correlates the prompt with the SSE frames that
+     * follow. No-op if the capture is disabled (`opts.capture.enabled ===
+     * false`). Backward compatible: existing callers pass no `capture`
+     * and observe the previous behaviour.
+     */
+    capture?: CaptureHandle;
+  } = {},
 ) {
-  const { maxWait = 120_000, label = '', throwOnTimeout = true } = opts;
+  const { maxWait = 120_000, label = '', throwOnTimeout = true, capture } = opts;
   const input = getInput(page);
   const sendBtn = getSendButton(page);
+
+  if (capture?.enabled) {
+    await capture.recordUserSent(message);
+  }
 
   await input.fill(message);
   await sendBtn.click();

--- a/e2e/tests/live-msg-order.spec.ts
+++ b/e2e/tests/live-msg-order.spec.ts
@@ -1,0 +1,44 @@
+// Capture-and-replay smoke spec (PR I).
+//
+// Sends a single trivial prompt against the live SPA + daemon, with the
+// PR I capture-replay harness wired in. The assertion is purposefully
+// loose: the real point is to demonstrate that `attachCapture` records
+// SSE frames + DOM state into a JSON fixture under
+// `e2e/fixtures/captured/` when run with `OCTOS_CAPTURE_FIXTURE=1`.
+//
+// Run:
+//   OCTOS_TEST_URL=https://<host>.octos.ominix.io \
+//   OCTOS_CAPTURE_FIXTURE=1 \
+//     npx playwright test tests/live-msg-order.spec.ts --reporter=line
+//
+// The fixture lands at e2e/fixtures/captured/<slug>-<timestamp>.json.
+import { test, expect } from '@playwright/test';
+import { attachCapture } from '../lib/capture-replay';
+import { login, sendAndWait } from './live-browser-helpers';
+
+test.describe('PR I capture-replay smoke', () => {
+  test('captures SSE stream + DOM state for a trivial single-turn prompt', async ({
+    page,
+  }, testInfo) => {
+    test.setTimeout(180_000);
+    const capture = await attachCapture(page, testInfo, {
+      description: 'PR I demo: single-turn prompt against live daemon',
+    });
+    try {
+      await login(page);
+      const result = await sendAndWait(
+        page,
+        'Reply with a single word: ok',
+        { capture, maxWait: 90_000, throwOnTimeout: false, label: 'pri-demo' },
+      );
+      // Soft assertions — the goal is to exercise the capture machinery,
+      // not to police the daemon's reply quality.
+      expect(result.assistantBubbles).toBeGreaterThanOrEqual(0);
+    } catch (err) {
+      capture.recordFailure(err);
+      throw err;
+    } finally {
+      await capture.finalize({ reason: 'spec-complete' });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Per `/tmp/octos-architecture-FINAL.md` Day 3 - PR I closes the missing-link between live soak runs and PR H's Layer 1 SPA reducer fixtures. When a soak run fails (or `OCTOS_CAPTURE_FIXTURE=1` is set) the harness auto-saves SSE events + DOM state + assertion failure into `e2e/fixtures/captured/<spec>-<timestamp>.json`. Operators triage the JSON, run `e2e/scripts/promote-captured-fixture.sh` to copy it to `crates/octos-web/src/state/__tests__/fixtures/captured/`, and the regression locks in for the next CI run.

This is **e2e harness only** - zero production code changes. Existing specs are unaffected; `sendAndWait`'s new `capture` opt is additive.

## Architectural context

The chat-lifecycle hardening plan structures regression coverage into 3 tiers:

```
   capture (PR I, this)  ->  triage (operator)  ->  promote  ->  regression-locked
   live soak run             edit JSON              copy to       Vitest in CI
                             + assertions           Layer 1
```

PR H (in flight, branch `feat/spa-reducer-fixtures`) builds the Layer 1 corpus that consumes the captured JSON. PR I is the production-traffic source of truth that grows that corpus organically every time we hit a real bug.

## What's added

- **`e2e/lib/capture-replay.ts`** - `attachCapture(page, testInfo)` helper. Monkey-patches `fetch` + `EventSource` via `addInitScript` BEFORE `page.goto()` to tee streaming `/api/chat` responses into an in-page buffer. On finalize, drains buffer + DOM bubbles + 4KB HTML excerpt + optional assertion failure into a JSON file. Output format is a strict superset of PR H's `SseFixture` (carries both normalized `events[]` and lossless `raw_events[]`).

- **`e2e/tests/live-browser-helpers.ts`** - `sendAndWait` accepts an optional `CaptureHandle` and marks `user_sent` in the capture timeline. Fully backward compatible.

- **`e2e/scripts/promote-captured-fixture.sh`** - validates source JSON, disallows path-injection in the target name, refuses to overwrite by default (protects triage edits), `--force` to replace, `--dry-run` to preview.

- **`e2e/fixtures/captured/README.md`** - 3-tier workflow, fixture format spec, triage checklist (turn_id minting, assertions DSL), capture-overhead notes. `.gitignore` drops `*.json` so only triaged & promoted fixtures land in source control.

- **`e2e/tests/live-msg-order.spec.ts`** - demo spec exercising the capture machinery.

## Demo capture (mini3 / dspfac.octos.ominix.io)

```
$ OCTOS_TEST_URL=https://dspfac.octos.ominix.io OCTOS_CAPTURE_FIXTURE=1 \
    npx playwright test tests/live-msg-order.spec.ts --reporter=line
[capture-replay] wrote 9 events + 9 raw frames -> e2e/fixtures/captured/captures-...-2026-05-01_22-03-00-764.json
1 passed (11.3s)
```

Captured fixture excerpt (8.9KB total, 9 events):

```json
{
  "name": "captures-sse-stream-dom-state-for-a-trivial-single-turn-prompt",
  "description": "PR I demo: single-turn prompt against live daemon",
  "captured_at": "2026-05-01T22:03:00.763Z",
  "spec": "live-msg-order.spec.ts",
  "base_url": "https://dspfac.octos.ominix.io",
  "session_id": "web-1777672970920-yrpbri",
  "events": [
    { "t": 1169, "type": "user_sent", "text": "Reply with a single word: ok" },
    { "t": 1220, "iteration": 0, "thread_id": "f3d6a4a2-9301-...", "type": "thinking" },
    { "t": 2814, "iteration": 1, "thread_id": "f3d6a4a2-9301-...", "type": "response" },
    { "t": 2814, "text": "ok", "thread_id": "f3d6a4a2-9301-...", "type": "message_replace" }
  ],
  "events_total": 9,
  "raw_events_total": 9,
  "finalDom": {
    "user_bubbles": ["Reply with a single word: ok"],
    "assistant_bubbles": ["okmoonshot@autodl/kimi-k2.6 ..."],
    "html_excerpt_len": 4096
  }
}
```

Notable: the live server already emits `thread_id` on every frame, so captured fixtures are ready for PR H's reducer with minimal triage. The `message_replace` mapping (vs. `message_delta`) is preserved per codex review item #2 below.

## Codex review

`/tmp/codex-pri-review.log` flagged five issues; all addressed in the same diff:

1. **High** - Failure-driven capture not actually automatic (status race vs. user `finally`). **Fix**: deferred-write path - `finalize()` always snapshots, the `page.close` hook re-checks `testInfo.status` AFTER propagation and writes the cached snapshot if the test ultimately failed.
2. **High** - `replace` SSE collapsed to `message_delta` would corrupt playback (replace is full-overwrite, not append). **Fix**: preserved as `message_replace`. README documents that PR H needs a dedicated handler before such fixtures replay.
3. **Medium** - Default `streamingPaths` too broad + always-on tee paid even with capture off. **Fix**: narrowed default to `/api/chat` only; tee gated by `Content-Type` so JSON polling responses short-circuit; added `OCTOS_CAPTURE_MAX_FRAMES` cap (default 10k).
4. **Medium** - Promotion script overwrote silently. **Fix**: refuse-by-default; `--force` to replace; `--no-clobber` accepted as silent backwards alias.
5. **Medium** - `session_id` capture missed `octos_current_session` (the static SPA's actual key). **Fix**: probes both shapes. Demo capture now correctly populates `session_id`.

## Test plan

- [x] Demo spec passes against mini3 with `OCTOS_CAPTURE_FIXTURE=1` -- writes 8.9KB / 9 events JSON file.
- [x] Demo spec passes WITHOUT the env flag -- no JSON file written (passing-test path correctly skips).
- [x] Promotion script accepts valid JSON, rejects path injection, refuses overwrite by default, supports `--dry-run` and `--force`.
- [x] TypeScript strict mode clean (`tsc --noEmit --strict`).
- [x] Bash syntax clean (`bash -n`).
- [ ] Backfill capture into existing soak specs (one at a time) - not part of PR I scope; happens organically as bugs surface.
- [ ] Wire PR H's Vitest job to consume promoted fixtures - blocked on PR H landing.