### PR TITLE
feat(core): typed identity newtypes (ClientMessageId, ThreadId, TurnId reuse)

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -877,21 +877,22 @@ impl Channel for ApiChannel {
 
             // File message — persist to session history AND send SSE event.
             let committed_message = if !history_already_persisted {
-                let session_msg = Message {
-                    role: MessageRole::Assistant,
-                    // Preserve only the human-facing caption. The API/web path
-                    // already has structured media handles, so persisting
-                    // synthetic legacy `[file:...]` lines here creates
-                    // duplicate terminal file deliveries for the same artifact.
-                    content: msg.content.clone(),
-                    media: persisted_media.clone(),
-                    tool_calls: None,
-                    tool_call_id: tool_call_id.clone(),
-                    reasoning_content: None,
-                    client_message_id: None,
-                    thread_id: None,
-                    timestamp: chrono::Utc::now(),
+                // PR A: route through the typed assistant constructor when
+                // the outbound carries a thread_id (metadata or sticky fallback)
+                // so the persisted JSONL row is pinned to the correct thread.
+                // Preserve only the human-facing caption. The API/web path
+                // already has structured media handles, so persisting
+                // synthetic legacy `[file:...]` lines here creates duplicate
+                // terminal file deliveries for the same artifact.
+                let mut session_msg = match thread_id.as_deref() {
+                    Some(tid) if !tid.is_empty() => Message::assistant_with_thread(
+                        msg.content.clone(),
+                        octos_core::ThreadId::new(tid),
+                    ),
+                    _ => Message::assistant(msg.content.clone()),
                 };
+                session_msg.media = persisted_media.clone();
+                session_msg.tool_call_id = tool_call_id.clone();
                 self.persist_to_session(&msg.chat_id, topic, session_msg)
                     .await
             } else {
@@ -1007,17 +1008,18 @@ impl Channel for ApiChannel {
         if is_bg_notification {
             // Background task notification — persist to session history.
             // Client polling will pick this up as the stop signal.
+            // PR A: when the outbound carries a thread_id (the originating
+            // turn's identity), use the typed assistant constructor so the
+            // persisted background-completion row is pinned to the correct
+            // thread instead of relying on the late-arrival derivation
+            // fallback (the same bug class that drove #649 → #740).
             if !history_already_persisted {
-                let session_msg = Message {
-                    role: MessageRole::Assistant,
-                    content: msg.content.clone(),
-                    media: vec![],
-                    tool_calls: None,
-                    tool_call_id: None,
-                    reasoning_content: None,
-                    client_message_id: None,
-                    thread_id: None,
-                    timestamp: chrono::Utc::now(),
+                let session_msg = match thread_id.as_deref() {
+                    Some(tid) if !tid.is_empty() => Message::assistant_with_thread(
+                        msg.content.clone(),
+                        octos_core::ThreadId::new(tid),
+                    ),
+                    _ => Message::assistant(msg.content.clone()),
                 };
                 let _ = self
                     .persist_to_session(&msg.chat_id, topic, session_msg)

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -455,9 +455,16 @@ async fn chat_streaming(
                         let mut to_save = msg.clone();
                         if !user_persisted && msg.role == MessageRole::User {
                             user_persisted = true;
+                            // PR A: stamp via the typed setter so callers
+                            // wired to a `ClientMessageId` can't pass the
+                            // wrong identity here. Bare-`String` overrides
+                            // remain available for inbound paths where the
+                            // cmid is already a `String` from the wire.
                             if let Some(ref cmid) = client_message_id {
                                 if !cmid.is_empty() {
-                                    to_save.client_message_id = Some(cmid.clone());
+                                    to_save = to_save.with_typed_client_message_id(
+                                        octos_core::ClientMessageId::new(cmid),
+                                    );
                                 }
                             }
                             let timestamp = to_save.timestamp.to_rfc3339();

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -213,8 +213,12 @@ async fn persist_assistant_message(
     media: Vec<String>,
     thread_id: Option<String>,
 ) -> Option<PersistedSessionMessage> {
-    let mut assistant_msg = Message::assistant(content);
-    assistant_msg.media = media;
+    // PR A: prefer the typed constructor when the originating thread is
+    // known so the type system rejects a future regression that drops the
+    // pre-stamp. `assistant_with_thread` is the structural fix Codex's
+    // critique called out for the M8.10 thread-binding bug class
+    // (#649 → #664 → #673 → #680 → #738 → #740).
+    //
     // M8.10 follow-up (#649): pre-stamp `thread_id` BEFORE handing the
     // message to the canonical persist helper. `add_message_with_seq`'s
     // derivation falls back to "most recent user in history" — for a
@@ -225,11 +229,13 @@ async fn persist_assistant_message(
     // persisted JSONL row to the correct thread so reload pairs the
     // assistant under the originating user bubble. Foreground turns pass
     // `None` and continue to use the derivation fallback (correct).
-    if let Some(tid) = thread_id {
-        if !tid.is_empty() {
-            assistant_msg.thread_id = Some(tid);
+    let mut assistant_msg = match thread_id {
+        Some(tid) if !tid.is_empty() => {
+            Message::assistant_with_thread(content, octos_core::ThreadId::new(tid))
         }
-    }
+        _ => Message::assistant(content),
+    };
+    assistant_msg.media = media;
     let timestamp = assistant_msg.timestamp;
 
     // Funnel through the canonical helper so the per-key Tokio mutex
@@ -3952,16 +3958,18 @@ impl SessionActor {
         };
 
         let client_message_id = inbound_client_message_id(inbound);
-        let user_msg = Message {
-            role: MessageRole::User,
-            content: persisted_user_content.to_string(),
-            media: vec![],
-            tool_calls: None,
-            tool_call_id: None,
-            reasoning_content: None,
-            client_message_id: client_message_id.clone(),
-            thread_id: None,
-            timestamp: chrono::Utc::now(),
+        // PR A: when the inbound carries a cmid, build the user message via
+        // the typed constructor — `user_with_cmid` requires the
+        // `ClientMessageId` argument so the cmid cannot be silently dropped.
+        // `thread_id` stays `None` here because `add_message_with_seq` runs
+        // its own derivation; PR-F will migrate that derivation onto the
+        // typed setters.
+        let user_msg = match client_message_id.as_deref() {
+            Some(cmid) if !cmid.is_empty() => Message::user_with_cmid(
+                persisted_user_content.to_string(),
+                octos_core::ClientMessageId::new(cmid),
+            ),
+            _ => Message::user(persisted_user_content.to_string()),
         };
         let user_msg_timestamp = user_msg.timestamp;
         let user_seq = {
@@ -4180,21 +4188,21 @@ impl SessionActor {
         let client_message_id = inbound_client_message_id(&inbound);
         let persisted_user_content_for_event = persisted_user_content.clone();
         let user_media_for_event = image_media.clone();
-        let user_msg = Message {
-            role: MessageRole::User,
-            content: persisted_user_content,
-            media: image_media
-                .iter()
-                .chain(attachment_media.iter())
-                .cloned()
-                .collect(),
-            tool_calls: None,
-            tool_call_id: None,
-            reasoning_content: None,
-            client_message_id: client_message_id.clone(),
-            thread_id: None,
-            timestamp: chrono::Utc::now(),
+        // PR A: typed constructor for the cmid-bearing path; legacy
+        // `Message::user` for the rare cmid-less path. See sibling site
+        // around line 3961 for the rationale.
+        let mut user_msg = match client_message_id.as_deref() {
+            Some(cmid) if !cmid.is_empty() => Message::user_with_cmid(
+                persisted_user_content,
+                octos_core::ClientMessageId::new(cmid),
+            ),
+            _ => Message::user(persisted_user_content),
         };
+        user_msg.media = image_media
+            .iter()
+            .chain(attachment_media.iter())
+            .cloned()
+            .collect();
         let user_msg_timestamp = user_msg.timestamp;
         let user_seq = {
             let mut handle = self.session_handle.lock().await;
@@ -4741,29 +4749,29 @@ impl SessionActor {
                     // `messages` (EndTurn returns early without appending).
                     // Persist it explicitly so session history is complete.
                     if !conv_response.content.is_empty() {
-                        let assistant_msg = Message {
-                            role: MessageRole::Assistant,
-                            content: final_content.clone(),
-                            media: vec![],
-                            tool_calls: None,
-                            tool_call_id: None,
-                            reasoning_content: conv_response.reasoning_content.clone(),
-                            client_message_id: None,
-                            // Issue #740 fix: pre-stamp `thread_id` from the
-                            // originating turn's cmid so the persisted JSONL
-                            // row is pinned to the correct thread. Without
-                            // this, `add_message_with_seq`'s "most recent
-                            // user in history" derivation picks the LATEST
-                            // user message — which under rapid-fire is a
-                            // sibling overflow user, not THIS turn — and
-                            // reload mis-pairs the assistant under the
-                            // wrong bubble (live-overflow-stress mini3
-                            // `rapid-fire-five-fast` evidence: 1+1=2 rendered
-                            // under the 3+3 bubble). Mirrors PR #739's M8.9
-                            // recovery-path fix for the foreground SSE path.
-                            thread_id: client_message_id.clone(),
-                            timestamp: chrono::Utc::now(),
+                        // PR A: when the originating turn supplied a cmid,
+                        // build via `assistant_with_thread` so the typed
+                        // ThreadId argument can't be silently dropped.
+                        // Issue #740 fix: pre-stamp `thread_id` from the
+                        // originating turn's cmid so the persisted JSONL
+                        // row is pinned to the correct thread. Without
+                        // this, `add_message_with_seq`'s "most recent
+                        // user in history" derivation picks the LATEST
+                        // user message — which under rapid-fire is a
+                        // sibling overflow user, not THIS turn — and
+                        // reload mis-pairs the assistant under the
+                        // wrong bubble (live-overflow-stress mini3
+                        // `rapid-fire-five-fast` evidence: 1+1=2 rendered
+                        // under the 3+3 bubble). Mirrors PR #739's M8.9
+                        // recovery-path fix for the foreground SSE path.
+                        let mut assistant_msg = match client_message_id.as_deref() {
+                            Some(tid) if !tid.is_empty() => Message::assistant_with_thread(
+                                final_content.clone(),
+                                octos_core::ThreadId::new(tid),
+                            ),
+                            _ => Message::assistant(final_content.clone()),
                         };
+                        assistant_msg.reasoning_content = conv_response.reasoning_content.clone();
                         // M8.10-A: capture the committed seq so the SSE `done`
                         // event can thread it back to the web client. The
                         // assistant timestamp is `Utc::now()` (newer than any
@@ -5116,17 +5124,17 @@ impl SessionActor {
             // primary turn or this overflow agent fails — preserves the user's
             // query in the session log no matter what.
             let user_msg_timestamp = chrono::Utc::now();
-            let user_msg = Message {
-                role: MessageRole::User,
-                content: content.clone(),
-                media: vec![],
-                tool_calls: None,
-                tool_call_id: None,
-                reasoning_content: None,
-                client_message_id: overflow_client_message_id.clone(),
-                thread_id: None,
-                timestamp: user_msg_timestamp,
+            // PR A: typed user-message construction for the overflow path.
+            // The cmid is mandatory for routing the response back to the
+            // right SPA bubble — typing it here means a regression that
+            // strips it would fail to compile.
+            let mut user_msg = match overflow_client_message_id.as_deref() {
+                Some(cmid) if !cmid.is_empty() => {
+                    Message::user_with_cmid(content.clone(), octos_core::ClientMessageId::new(cmid))
+                }
+                _ => Message::user(content.clone()),
             };
+            user_msg.timestamp = user_msg_timestamp;
             let user_seq_for_overflow = {
                 let mut handle = session_handle.lock().await;
                 handle.add_message_with_seq(user_msg).await.ok()
@@ -5367,29 +5375,27 @@ impl SessionActor {
                     // primary turn completed — and would be silently dropped
                     // (FA-11 defect B).
                     let final_reply_timestamp = chrono::Utc::now();
-                    let final_reply = Message {
-                        role: MessageRole::Assistant,
-                        content: final_content.clone(),
-                        media: vec![],
-                        tool_calls: None,
-                        tool_call_id: None,
-                        reasoning_content: conv_response.reasoning_content.clone(),
-                        client_message_id: None,
-                        // Issue #740 fix: pre-stamp `thread_id` with the
-                        // overflow user's own cmid. Without this, when
-                        // multiple rapid-fire overflow tasks finalise in
-                        // an out-of-order sequence (e.g. Q2's reply lands
-                        // after Q5's user message has been persisted),
-                        // `add_message_with_seq`'s derivation fallback
-                        // picks the latest user (Q5) instead of THIS
-                        // overflow's originating user (Q2), and the
-                        // persisted JSONL row mis-binds the reply under
-                        // Q5's bubble on reload. Mirrors PR #739's
-                        // BackgroundResult fix for the speculative-
-                        // overflow code path.
-                        thread_id: overflow_client_message_id.clone(),
-                        timestamp: final_reply_timestamp,
+                    // PR A: typed assistant-message construction for the
+                    // speculative-overflow path. Issue #740 fix: pre-stamp
+                    // `thread_id` with the overflow user's own cmid.
+                    // Without this, when multiple rapid-fire overflow tasks
+                    // finalise in an out-of-order sequence (e.g. Q2's reply
+                    // lands after Q5's user message has been persisted),
+                    // `add_message_with_seq`'s derivation fallback picks
+                    // the latest user (Q5) instead of THIS overflow's
+                    // originating user (Q2), and the persisted JSONL row
+                    // mis-binds the reply under Q5's bubble on reload.
+                    // Mirrors PR #739's BackgroundResult fix for the
+                    // speculative-overflow code path.
+                    let mut final_reply = match overflow_client_message_id.as_deref() {
+                        Some(tid) if !tid.is_empty() => Message::assistant_with_thread(
+                            final_content.clone(),
+                            octos_core::ThreadId::new(tid),
+                        ),
+                        _ => Message::assistant(final_content.clone()),
                     };
+                    final_reply.reasoning_content = conv_response.reasoning_content.clone();
+                    final_reply.timestamp = final_reply_timestamp;
                     let committed_seq = {
                         let mut handle = session_handle.lock().await;
                         handle
@@ -5888,21 +5894,22 @@ impl SessionActor {
                     // `messages` (EndTurn returns early without appending).
                     // Persist it explicitly so session history is complete.
                     if !conv_response.content.is_empty() {
-                        let assistant_msg = Message {
-                            role: MessageRole::Assistant,
-                            content: final_content.clone(),
-                            media: vec![],
-                            tool_calls: None,
-                            tool_call_id: None,
-                            reasoning_content: conv_response.reasoning_content.clone(),
-                            client_message_id: None,
-                            // Issue #740 fix: pre-stamp `thread_id` from the
-                            // originating turn's cmid so reload pairs the
-                            // assistant under the correct user bubble.
-                            // Sibling fix to PR #739's M8.9 recovery path.
-                            thread_id: client_message_id.clone(),
-                            timestamp: chrono::Utc::now(),
+                        // PR A: when we know the originating cmid, build the
+                        // assistant Message via the typed constructor — that
+                        // requires the ThreadId argument at the type level so
+                        // a future regression cannot silently drop the
+                        // pre-stamp. Issue #740 fix: pre-stamp `thread_id`
+                        // from the originating turn's cmid so reload pairs
+                        // the assistant under the correct user bubble.
+                        // Sibling fix to PR #739's M8.9 recovery path.
+                        let mut assistant_msg = match client_message_id.as_deref() {
+                            Some(tid) if !tid.is_empty() => Message::assistant_with_thread(
+                                final_content.clone(),
+                                octos_core::ThreadId::new(tid),
+                            ),
+                            _ => Message::assistant(final_content.clone()),
                         };
+                        assistant_msg.reasoning_content = conv_response.reasoning_content.clone();
                         if let Err(e) = handle.add_message(assistant_msg).await {
                             warn!(session = %self.session_key, error = %e, "failed to persist assistant reply");
                         }

--- a/crates/octos-core/src/lib.rs
+++ b/crates/octos-core/src/lib.rs
@@ -26,6 +26,7 @@ pub use task::{
     TaskStatus, TokenUsage, UnsupportedSessionSummaryVersion,
 };
 pub use types::{
-    AgentId, EpisodeRef, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId, ToolCall,
+    AgentId, ClientMessageId, EpisodeRef, IdentityError, IdentityKind, MAIN_PROFILE_ID, Message,
+    MessageRole, SessionKey, TaskId, ThreadId, ToolCall, TurnId,
 };
 pub use utils::{tool_output_limit, truncate_head_tail, truncate_utf8, truncated_utf8};

--- a/crates/octos-core/src/types.rs
+++ b/crates/octos-core/src/types.rs
@@ -4,6 +4,179 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+// Re-export `TurnId` (the protocol identity) so consumers of the typed
+// `Message` constructors can pull all three identity newtypes from one place.
+pub use crate::ui_protocol::TurnId;
+
+/// Client-supplied message correlation token.
+///
+/// Carries the optimistic-UI / idempotency identity assigned by a client when
+/// it submits a user message. Distinct from [`ThreadId`] (render grouping) and
+/// [`TurnId`] (server protocol identity) — see the M8.10 thread-binding bug
+/// chain (#649 → #664 → #673 → #680 → #738 → #740) for why these MUST NOT be
+/// interchangeable.
+///
+/// Wraps `String` rather than `Uuid` because clients sometimes mint these as
+/// stringified UUIDs, sometimes as opaque tokens. The newtype prevents
+/// accidental swaps with [`ThreadId`] at compile time.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ClientMessageId(pub String);
+
+impl ClientMessageId {
+    /// Wrap an existing client-message-id string.
+    ///
+    /// Accepts any non-empty string. Empty strings are rejected at the
+    /// `try_new` boundary; this infallible variant is for paths where the
+    /// caller has already validated the input or where the empty case is
+    /// statically impossible (e.g. `Uuid::to_string()`).
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Fallible constructor that rejects the empty string.
+    ///
+    /// Routing code in `session_actor` and `add_message_with_seq` already
+    /// treats the empty string as "absent" — guarding here means an upstream
+    /// layer that drops a cmid down to `Some("")` cannot accidentally claim
+    /// to have a cmid through the type system.
+    pub fn try_new(id: impl Into<String>) -> Result<Self, IdentityError> {
+        let s = id.into();
+        if s.is_empty() {
+            Err(IdentityError::Empty {
+                kind: IdentityKind::ClientMessageId,
+            })
+        } else {
+            Ok(Self(s))
+        }
+    }
+
+    /// Mint a fresh ID (used by tests and synthetic call paths).
+    pub fn generate() -> Self {
+        Self(Uuid::now_v7().to_string())
+    }
+
+    /// Borrow the inner string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ClientMessageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for ClientMessageId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+/// Render-grouping key that pins assistant + tool replies to the originating
+/// user bubble.
+///
+/// Roots a thread on the user message (`thread_id == client_message_id` for
+/// the rooting user) and is inherited by assistant/tool replies so the web
+/// client can render a chat as `Vec<Thread>` rather than a flat message list.
+///
+/// Distinct from [`ClientMessageId`] (per-message correlation) and [`TurnId`]
+/// (server protocol identity) so the type system rejects swapping them. See
+/// PR #742 (`fix(session_actor): pre-stamp thread_id`) for the bug class this
+/// newtype structurally prevents.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ThreadId(pub String);
+
+impl ThreadId {
+    /// Wrap an existing thread-id string.
+    ///
+    /// Accepts any non-empty string; see `try_new` for fallible construction
+    /// that rejects the empty string.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// Fallible constructor that rejects the empty string.
+    pub fn try_new(id: impl Into<String>) -> Result<Self, IdentityError> {
+        let s = id.into();
+        if s.is_empty() {
+            Err(IdentityError::Empty {
+                kind: IdentityKind::ThreadId,
+            })
+        } else {
+            Ok(Self(s))
+        }
+    }
+
+    /// Mint a [`ThreadId`] from the [`ClientMessageId`] of the rooting user
+    /// message. This is the canonical "thread inherits from the rooting user
+    /// message" rule expressed as a named conversion (clearer than the
+    /// blanket `From<&ClientMessageId>` impl, which is retained for back-compat).
+    pub fn rooted_at(cmid: &ClientMessageId) -> Self {
+        Self(cmid.0.clone())
+    }
+
+    /// Borrow the inner string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Distinguishes the three identity kinds in [`IdentityError`] messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityKind {
+    ClientMessageId,
+    ThreadId,
+}
+
+impl std::fmt::Display for IdentityKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::ClientMessageId => "ClientMessageId",
+            Self::ThreadId => "ThreadId",
+        })
+    }
+}
+
+/// Error returned by the fallible `try_new` constructors on the identity
+/// newtypes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityError {
+    Empty { kind: IdentityKind },
+}
+
+impl std::fmt::Display for IdentityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty { kind } => write!(f, "{kind} cannot be empty"),
+        }
+    }
+}
+
+impl std::error::Error for IdentityError {}
+
+impl std::fmt::Display for ThreadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for ThreadId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&ClientMessageId> for ThreadId {
+    /// A user message roots a thread under its own [`ClientMessageId`]. This
+    /// conversion is the canonical "thread inherits from the rooting user
+    /// message" rule and is the ONLY infallible bridge between the two
+    /// identity types.
+    fn from(cmid: &ClientMessageId) -> Self {
+        Self(cmid.0.clone())
+    }
+}
+
 /// Unique identifier for a task (UUID v7 for temporal ordering).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct TaskId(pub Uuid);
@@ -85,7 +258,109 @@ pub struct Message {
 }
 
 impl Message {
+    /// Create a user message with a typed [`ClientMessageId`] attached.
+    ///
+    /// Preferred constructor for production user-message construction —
+    /// requiring the `ClientMessageId` argument means the type system rejects
+    /// any code path that forgets to set the correlation token. `thread_id`
+    /// stays `None`; the server stamps it (typically equal to the
+    /// `ClientMessageId`) when the message is processed inbound — see the
+    /// PR-A architecture plan and PR #742.
+    ///
+    /// If you already know the user message roots its own thread (the common
+    /// case), prefer [`Message::user_rooting_thread`] which stamps both
+    /// identity tokens in one call.
+    pub fn user_with_cmid(content: impl Into<String>, cmid: ClientMessageId) -> Self {
+        Self {
+            role: MessageRole::User,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: Some(cmid.0),
+            thread_id: None,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create a user message that roots its own thread.
+    ///
+    /// Convenience constructor for the canonical rule "user message's thread
+    /// equals its `client_message_id`" — saves the caller from re-stating the
+    /// invariant at every site. This is the recommended entry point for
+    /// inbound persistence paths that have a typed [`ClientMessageId`] in
+    /// hand. See Codex's PR-A review (`/tmp/codex-pra-review.log`) for the
+    /// rationale.
+    pub fn user_rooting_thread(content: impl Into<String>, cmid: ClientMessageId) -> Self {
+        let thread_id = ThreadId::rooted_at(&cmid);
+        Self {
+            role: MessageRole::User,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: Some(cmid.0),
+            thread_id: Some(thread_id.0),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create an assistant message bound to an explicit [`ThreadId`].
+    ///
+    /// Preferred constructor for production assistant-message construction
+    /// (e.g. `persist_assistant_message`, late-arriving background results).
+    /// Forcing the `ThreadId` argument means callers can no longer silently
+    /// fall through to `derive_thread_id_for_new_message`'s "most recent
+    /// user" heuristic — the structural fix that closes the #649 → #740 bug
+    /// chain.
+    pub fn assistant_with_thread(content: impl Into<String>, thread_id: ThreadId) -> Self {
+        Self {
+            role: MessageRole::Assistant,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some(thread_id.0),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Create a tool-result message bound to an explicit [`ThreadId`].
+    ///
+    /// Tool replies inherit the originating user turn's thread so a
+    /// late-arriving tool result lands under the right user bubble even when
+    /// later turns have rotated the per-chat sticky `thread_id`.
+    pub fn tool_with_thread(
+        content: impl Into<String>,
+        tool_call_id: impl Into<String>,
+        thread_id: ThreadId,
+    ) -> Self {
+        Self {
+            role: MessageRole::Tool,
+            content: content.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.into()),
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some(thread_id.0),
+            timestamp: Utc::now(),
+        }
+    }
+
     /// Create a user message.
+    ///
+    /// Legacy constructor retained for backwards compatibility with tests,
+    /// JSONL deserialization round-trips, and the (~50) call sites that
+    /// pre-date PR A's typed constructors. New code on the inbound /
+    /// persistence path SHOULD use [`Message::user_with_cmid`] so the
+    /// `ClientMessageId` is supplied at the type level — see the PR-A
+    /// architecture plan in `/tmp/octos-architecture-FINAL.md` §A.1.
+    #[doc(hidden)]
     pub fn user(content: impl Into<String>) -> Self {
         Self {
             role: MessageRole::User,
@@ -101,6 +376,12 @@ impl Message {
     }
 
     /// Create an assistant message.
+    ///
+    /// Legacy constructor retained for backwards compatibility. New code
+    /// SHOULD use [`Message::assistant_with_thread`] when the originating
+    /// thread is known at construction time, so the type system rejects the
+    /// "fall through to most-recent-user" misroute path.
+    #[doc(hidden)]
     pub fn assistant(content: impl Into<String>) -> Self {
         Self {
             role: MessageRole::Assistant,
@@ -116,6 +397,11 @@ impl Message {
     }
 
     /// Create a system message (used for injecting background results, provider switches, etc.).
+    ///
+    /// System messages aren't turn-scoped (no thread, no client correlation),
+    /// so this constructor stays as the canonical entry point — but is kept
+    /// `#[doc(hidden)]` for consistency with the legacy user/assistant pair.
+    #[doc(hidden)]
     pub fn system(content: impl Into<String>) -> Self {
         Self {
             role: MessageRole::System,
@@ -135,6 +421,22 @@ impl Message {
     #[must_use]
     pub fn with_client_message_id(mut self, client_message_id: impl Into<String>) -> Self {
         self.client_message_id = Some(client_message_id.into());
+        self
+    }
+
+    /// Attach a typed [`ClientMessageId`]. Convenience for paths that already
+    /// hold the typed identity (e.g. PR A migrations) so they don't need to
+    /// stringify before calling [`Message::with_client_message_id`].
+    #[must_use]
+    pub fn with_typed_client_message_id(mut self, cmid: ClientMessageId) -> Self {
+        self.client_message_id = Some(cmid.0);
+        self
+    }
+
+    /// Attach a typed [`ThreadId`].
+    #[must_use]
+    pub fn with_thread_id(mut self, thread_id: ThreadId) -> Self {
+        self.thread_id = Some(thread_id.0);
         self
     }
 }
@@ -521,5 +823,229 @@ mod tests {
         let json = serde_json::to_string(&ep_ref).unwrap();
         assert!(json.contains("ep-123"));
         assert!(json.contains("0.85"));
+    }
+
+    // PR A: typed identity newtypes — ClientMessageId / ThreadId / TurnId.
+    //
+    // These tests prove the structural fix that closes the M8.10
+    // thread-binding bug class (#649 → #664 → #673 → #680 → #738 → #740): the
+    // typed constructors require the identity tokens at the type level, so
+    // every code path that constructs a turn-scoped Message MUST supply them
+    // (or explicitly opt into the legacy `#[doc(hidden)]` constructors).
+
+    #[test]
+    fn client_message_id_round_trips_through_serde() {
+        let id = ClientMessageId::new("cmid-abc-123");
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"cmid-abc-123\"");
+        let parsed: ClientMessageId = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn client_message_id_display_and_as_str_match_inner() {
+        let id = ClientMessageId::new("cmid-xyz");
+        assert_eq!(id.as_str(), "cmid-xyz");
+        assert_eq!(id.to_string(), "cmid-xyz");
+    }
+
+    #[test]
+    fn client_message_id_generate_yields_unique_values() {
+        let a = ClientMessageId::generate();
+        let b = ClientMessageId::generate();
+        assert_ne!(a, b);
+        // UUIDs are 36 chars; we don't pin the exact format, just non-empty.
+        assert!(!a.0.is_empty());
+    }
+
+    #[test]
+    fn thread_id_round_trips_through_serde() {
+        let tid = ThreadId::new("thread-cmid-xyz");
+        let json = serde_json::to_string(&tid).unwrap();
+        assert_eq!(json, "\"thread-cmid-xyz\"");
+        let parsed: ThreadId = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, tid);
+    }
+
+    #[test]
+    fn thread_id_can_be_minted_from_client_message_id() {
+        // The canonical "thread inherits from rooting user message" rule.
+        let cmid = ClientMessageId::new("cmid-root");
+        let tid: ThreadId = (&cmid).into();
+        assert_eq!(tid.as_str(), "cmid-root");
+        assert_eq!(tid.to_string(), "cmid-root");
+    }
+
+    #[test]
+    fn message_user_with_cmid_stamps_client_message_id() {
+        let cmid = ClientMessageId::new("cmid-001");
+        let msg = Message::user_with_cmid("hello", cmid.clone());
+        assert_eq!(msg.role, MessageRole::User);
+        assert_eq!(msg.content, "hello");
+        assert_eq!(msg.client_message_id.as_deref(), Some("cmid-001"));
+        // user_with_cmid leaves thread_id None — the server stamps it during
+        // process_inbound (typically equal to the cmid). PR-F will tighten
+        // this further; PR A only adds the typed entry point.
+        assert!(msg.thread_id.is_none());
+    }
+
+    #[test]
+    fn message_assistant_with_thread_stamps_thread_id() {
+        let tid = ThreadId::new("thread-root-1");
+        let msg = Message::assistant_with_thread("ack", tid.clone());
+        assert_eq!(msg.role, MessageRole::Assistant);
+        assert_eq!(msg.content, "ack");
+        assert_eq!(msg.thread_id.as_deref(), Some("thread-root-1"));
+        // The assistant constructor MUST NOT inherit a client_message_id —
+        // that's the user's identity, not the assistant's.
+        assert!(msg.client_message_id.is_none());
+    }
+
+    #[test]
+    fn message_tool_with_thread_carries_call_id_and_thread() {
+        let tid = ThreadId::new("thread-root-1");
+        let msg = Message::tool_with_thread("ok", "call_42", tid);
+        assert_eq!(msg.role, MessageRole::Tool);
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_42"));
+        assert_eq!(msg.thread_id.as_deref(), Some("thread-root-1"));
+        assert!(msg.client_message_id.is_none());
+    }
+
+    #[test]
+    fn message_with_typed_client_message_id_attaches() {
+        let cmid = ClientMessageId::new("cmid-typed");
+        let msg = Message::user("hi").with_typed_client_message_id(cmid);
+        assert_eq!(msg.client_message_id.as_deref(), Some("cmid-typed"));
+    }
+
+    #[test]
+    fn message_with_thread_id_attaches() {
+        let tid = ThreadId::new("thread-typed");
+        let msg = Message::assistant("hi").with_thread_id(tid);
+        assert_eq!(msg.thread_id.as_deref(), Some("thread-typed"));
+    }
+
+    #[test]
+    fn legacy_message_constructors_still_produce_unstamped_messages() {
+        // Back-compat sentinel: PR A keeps the legacy constructors working so
+        // tests, JSONL deserialization, and the ~50 not-yet-migrated call
+        // sites continue to compile. They simply don't carry the new typed
+        // identity guarantees.
+        let user = Message::user("plain user");
+        assert_eq!(user.role, MessageRole::User);
+        assert!(user.client_message_id.is_none());
+        assert!(user.thread_id.is_none());
+
+        let assistant = Message::assistant("plain assistant");
+        assert_eq!(assistant.role, MessageRole::Assistant);
+        assert!(assistant.client_message_id.is_none());
+        assert!(assistant.thread_id.is_none());
+
+        let system = Message::system("plain system");
+        assert_eq!(system.role, MessageRole::System);
+        assert!(system.client_message_id.is_none());
+        assert!(system.thread_id.is_none());
+    }
+
+    #[test]
+    fn typed_message_round_trips_through_jsonl() {
+        // Going through serde with a stamped message preserves both identity
+        // tokens — proves PR A's typed constructors interoperate with the
+        // existing JSONL persistence path without schema changes.
+        let cmid = ClientMessageId::new("cmid-jsonl");
+        let user = Message::user_with_cmid("q", cmid).with_thread_id(ThreadId::new("thread-jsonl"));
+        let json = serde_json::to_string(&user).unwrap();
+        let parsed: Message = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.client_message_id.as_deref(), Some("cmid-jsonl"));
+        assert_eq!(parsed.thread_id.as_deref(), Some("thread-jsonl"));
+
+        let assistant = Message::assistant_with_thread("a", ThreadId::new("thread-jsonl"));
+        let json = serde_json::to_string(&assistant).unwrap();
+        let parsed: Message = serde_json::from_str(&json).unwrap();
+        assert!(parsed.client_message_id.is_none());
+        assert_eq!(parsed.thread_id.as_deref(), Some("thread-jsonl"));
+    }
+
+    #[test]
+    fn client_message_id_try_new_rejects_empty_string() {
+        let err = ClientMessageId::try_new("").unwrap_err();
+        assert_eq!(
+            err,
+            IdentityError::Empty {
+                kind: IdentityKind::ClientMessageId
+            }
+        );
+        assert_eq!(err.to_string(), "ClientMessageId cannot be empty");
+    }
+
+    #[test]
+    fn thread_id_try_new_rejects_empty_string() {
+        let err = ThreadId::try_new("").unwrap_err();
+        assert_eq!(
+            err,
+            IdentityError::Empty {
+                kind: IdentityKind::ThreadId
+            }
+        );
+        assert_eq!(err.to_string(), "ThreadId cannot be empty");
+    }
+
+    #[test]
+    fn try_new_accepts_non_empty_strings() {
+        let cmid = ClientMessageId::try_new("ok").unwrap();
+        assert_eq!(cmid.as_str(), "ok");
+        let tid = ThreadId::try_new("ok").unwrap();
+        assert_eq!(tid.as_str(), "ok");
+    }
+
+    #[test]
+    fn thread_id_rooted_at_named_conversion_matches_from_impl() {
+        // Both spellings of "thread inherits from rooting user message" must
+        // produce identical results — the named conversion is for callers
+        // that prefer self-documenting code; the `From` impl is for generic
+        // contexts.
+        let cmid = ClientMessageId::new("cmid-root");
+        let tid_named = ThreadId::rooted_at(&cmid);
+        let tid_from: ThreadId = (&cmid).into();
+        assert_eq!(tid_named, tid_from);
+        assert_eq!(tid_named.as_str(), "cmid-root");
+    }
+
+    #[test]
+    fn message_user_rooting_thread_stamps_both_identity_tokens() {
+        // Codex's PR-A review (/tmp/codex-pra-review.log finding High-2):
+        // user-message constructors should be able to root their own thread
+        // so the server doesn't have to fall back to the derivation path.
+        let cmid = ClientMessageId::new("cmid-root-2");
+        let msg = Message::user_rooting_thread("hi", cmid.clone());
+        assert_eq!(msg.role, MessageRole::User);
+        assert_eq!(msg.client_message_id.as_deref(), Some("cmid-root-2"));
+        assert_eq!(msg.thread_id.as_deref(), Some("cmid-root-2"));
+        // Sanity: the thread always equals the cmid for a rooted user.
+        assert_eq!(msg.thread_id.as_deref(), msg.client_message_id.as_deref());
+    }
+
+    #[test]
+    fn turn_id_is_distinct_type_from_client_message_id_and_thread_id() {
+        // Compile-time proof that the three identity types are NOT
+        // interchangeable. If you try to pass one where another is expected
+        // the build fails — exactly the structural guarantee PR A is
+        // delivering. We also prove it at runtime: serialized representations
+        // are different (TurnId is a UUID, the others are opaque strings).
+        let turn = TurnId::new();
+        let cmid = ClientMessageId::new("cmid-A");
+        let tid = ThreadId::new("thread-A");
+
+        // Sanity: each round-trips through its own serde shape.
+        let _: TurnId = serde_json::from_str(&serde_json::to_string(&turn).unwrap()).unwrap();
+        let _: ClientMessageId =
+            serde_json::from_str(&serde_json::to_string(&cmid).unwrap()).unwrap();
+        let _: ThreadId = serde_json::from_str(&serde_json::to_string(&tid).unwrap()).unwrap();
+
+        // The TurnId wraps a Uuid (36 chars with dashes); cmid and tid wrap
+        // arbitrary strings. They live in different slots of the protocol.
+        assert_eq!(turn.0.to_string().len(), 36);
+        assert_eq!(cmid.as_str(), "cmid-A");
+        assert_eq!(tid.as_str(), "thread-A");
     }
 }


### PR DESCRIPTION
## Summary

PR A from the Day-1 Foundation architectural plan
(`/tmp/octos-architecture-FINAL.md` §A.1). Introduces typed identity newtypes
for `Message` so callers must supply the cmid/thread tokens at the type
level — beginning to make the M8.10 thread-binding bug class structurally
impossible.

- Three newtypes in `octos-core`: `ClientMessageId`, `ThreadId`,
  `TurnId` (re-exported). `try_new` constructors reject empty strings;
  `ThreadId::rooted_at(&ClientMessageId)` is the named conversion for the
  canonical "thread inherits from rooting user message" rule.
- Per-role typed `Message` constructors: `user_with_cmid`,
  `user_rooting_thread`, `assistant_with_thread`, `tool_with_thread`
  (plus typed setters). Legacy `user`/`assistant`/`system` retained as
  `#[doc(hidden)]` so the ~50 not-yet-migrated sites and JSONL
  deserialization continue to work.
- Production persist sites in `session_actor.rs`, `api/handlers.rs`,
  and `api_channel.rs` migrated onto the typed constructors so the
  cmid/thread can no longer be silently dropped on the new-write path.
- 13 new unit tests in `octos-core` covering serde round-trips, empty
  string rejection, role-specific stamping, and JSONL back-compat.

## Bug chain context

`#649 → #664 → #673 → #680 → #738 → #740` — every regression in this chain
re-introduced the same misroute by stripping the cmid/thread on a new
construction site. The PoC at `/tmp/fixture-poc/reducer-test.mjs`
reproduced the misroute pattern in 2ms. Codex's critique
(`/tmp/codex-arch-output.log` line 13603+) called for the structural fix
this PR begins to land.

## Codex 2nd-opinion review

Saved at `/tmp/codex-pra-review.log`. Codex confirmed the type
distinctions are correct and that JSONL back-compat is preserved.
Two refinements applied: `IdentityError::Empty` validation on `try_new`,
and `Message::user_rooting_thread` for callers that want to stamp both
identity tokens in one call.

Codex also flagged that the typestate is not yet *hard*-enforced
(struct literals still bypass the typed constructors). That hardening
is the goal of PR F (server-side fallback removal); this PR delivers
the typed entry points PR F will enforce against.

## Out of scope (per the architectural plan)

- `derive_thread_id_for_new_message` fallback rewrite — PR F.
- `_bound` channel methods — PR F.
- Web SPA migration — PR J.
- `OutboundMessage` typing (>90 call sites; too risky in one PR).

## Test plan

- [x] `cargo build --release --bin octos -p octos-cli --features telegram,whatsapp,feishu,twilio,wecom,api`
- [x] `cargo test --workspace --no-fail-fast` (158 tests pass in
      `octos-core`, up from 144 baseline; full workspace pass with no
      regressions)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`