### PR TITLE
feat(web): SPA reducer fixture infrastructure (Layer 1 testing pyramid)

### DIFF
--- a/.github/workflows/web-reducer-fixtures.yml
+++ b/.github/workflows/web-reducer-fixtures.yml
@@ -1,0 +1,58 @@
+name: Web reducer fixtures (Layer 1)
+
+# Layer 1 SPA reducer fixture tests. Runs deterministic UI Protocol v1
+# event fixtures against the octos-web reducer in milliseconds, no LLM,
+# no fleet, no Playwright. See crates/octos-web/src/state/__tests__/README.md
+# for the contract.
+#
+# Triggers on every PR touching octos-web or the UI protocol surface
+# (octos-core/src/ui_protocol.rs). Total runtime target: <1s.
+
+on:
+  pull_request:
+    paths:
+      - 'crates/octos-web/**'
+      - 'crates/octos-core/src/ui_protocol.rs'
+      # Server-side surfaces that emit the events the reducer consumes.
+      # If any of these change, replay this layer to catch event-shape
+      # regressions before they reach the SPA.
+      - 'crates/octos-bus/src/api_channel.rs'
+      - 'crates/octos-cli/src/api/ui_protocol.rs'
+      - 'crates/octos-cli/src/stream_reporter.rs'
+      - '.github/workflows/web-reducer-fixtures.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'crates/octos-web/**'
+      - 'crates/octos-core/src/ui_protocol.rs'
+      - 'crates/octos-bus/src/api_channel.rs'
+      - 'crates/octos-cli/src/api/ui_protocol.rs'
+      - 'crates/octos-cli/src/stream_reporter.rs'
+      - '.github/workflows/web-reducer-fixtures.yml'
+  workflow_dispatch:
+
+jobs:
+  reducer-fixtures:
+    name: SPA reducer fixture replay
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: crates/octos-web
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: crates/octos-web/package-lock.json
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run reducer fixtures (Vitest)
+        run: npm test

--- a/crates/octos-web/package-lock.json
+++ b/crates/octos-web/package-lock.json
@@ -1,0 +1,1454 @@
+{
+  "name": "octos-web",
+  "version": "0.0.0-pre",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "octos-web",
+      "version": "0.0.0-pre",
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/crates/octos-web/package.json
+++ b/crates/octos-web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "octos-web",
+  "private": true,
+  "version": "0.0.0-pre",
+  "description": "octos-web SPA — Layer 1 reducer fixture testing infrastructure. The production reducer ships in PR J; this package currently contains only the fixture replay engine + 5 seed fixtures + reference implementation that PR J must match.",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc -b"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.9"
+  }
+}

--- a/crates/octos-web/scripts/print-buggy-output.mjs
+++ b/crates/octos-web/scripts/print-buggy-output.mjs
@@ -1,0 +1,40 @@
+// Standalone driver: print every fixture's failure report against the
+// buggy reducer. Used for the PR body "demonstrated to fail" evidence
+// and for human inspection. Run via tsx:
+//
+//   npx tsx scripts/print-buggy-output.mjs
+//
+// (tsx is dev-only; not added to package.json — one-shot tool.)
+import { replayFixture, formatReplayResult } from '../src/state/__tests__/lib/replay-fixture.ts';
+import { buggyReducer } from '../src/state/__tests__/lib/buggy-reducer.ts';
+import { rapidFireFiveFast } from '../src/state/__tests__/fixtures/rapid-fire-five-fast.fixture.ts';
+import { slowThenFastInterleave } from '../src/state/__tests__/fixtures/slow-then-fast-interleave.fixture.ts';
+import { spawnOnlyAckThenResult } from '../src/state/__tests__/fixtures/spawn-only-ack-then-result.fixture.ts';
+import { m89RecoveryTurn } from '../src/state/__tests__/fixtures/m89-recovery-turn.fixture.ts';
+import { reloadReplay } from '../src/state/__tests__/fixtures/reload-replay.fixture.ts';
+import { toolRetryCollapse } from '../src/state/__tests__/fixtures/tool-retry-collapse.fixture.ts';
+import { multiAttachmentDedup } from '../src/state/__tests__/fixtures/multi-attachment-dedup.fixture.ts';
+
+const SUITE = [
+  rapidFireFiveFast,
+  slowThenFastInterleave,
+  spawnOnlyAckThenResult,
+  m89RecoveryTurn,
+  reloadReplay,
+  toolRetryCollapse,
+  multiAttachmentDedup,
+];
+
+console.log('Layer 1 fixture replay against the BUGGY reducer:\n');
+let totalMs = 0;
+let failCount = 0;
+for (const f of SUITE) {
+  const r = replayFixture(f, buggyReducer);
+  totalMs += r.duration_ms;
+  if (!r.pass) failCount += 1;
+  console.log(formatReplayResult(r));
+  console.log('');
+}
+console.log(
+  `Summary: ${failCount}/${SUITE.length} fixtures fail against buggy reducer in ${totalMs.toFixed(2)}ms total.`,
+);

--- a/crates/octos-web/src/state/__tests__/README.md
+++ b/crates/octos-web/src/state/__tests__/README.md
@@ -1,0 +1,171 @@
+# Layer 1: SPA reducer fixture tests
+
+This directory is the **Layer 1 testing pyramid** for octos-web's SPA
+reducer. It feeds canned UI Protocol v1 SSE event fixtures into the
+reducer and asserts thread-graph correctness — in **milliseconds, with no
+LLM, no fleet, no Playwright**.
+
+## Why this layer exists
+
+The thread-binding bug class
+
+```
+#649 → #664 → #673 → #680 → #738 → #740
+```
+
+kept recurring because the only test layers that exercised it ran live:
+
+- **Layer 3**: Playwright soak (`live-thread-interleave.spec.ts`,
+  `live-overflow-thread-binding.spec.ts`). Six minutes per scenario, runs
+  on the fleet, fragile to LLM-provider quirks.
+- **Layer 2**: protocol e2e (`m9-protocol-*.spec.ts`). Faster but still
+  spins a real CLI, real WS server, real session.
+
+Neither catches a misroute deterministically before commit. Each
+regression in the chain shipped, was caught by soak hours later, then
+required a corrective tactical fix that re-introduced a new variant of
+the same bug. **Layer 1 closes that loop.**
+
+## What Layer 1 does
+
+A fixture is a JSON-serializable description of a UI Protocol v1 event
+stream + the reducer state we expect afterwards. The engine replays the
+events into the reducer and asserts.
+
+```
+fixture (events + assertions)
+       │
+       ▼
+replay-fixture.ts ─────► Reducer ─────► ReducerState
+       │
+       ▼
+   assertions
+       │
+       ▼
+   pass / fail (with structured diff)
+```
+
+The 7 seed fixtures in `fixtures/` are derived from the actual bug
+chain — see each file's header comment for the originating issue and the
+DOM-misroute pattern they reproduce.
+
+## File layout
+
+```
+__tests__/
+├── README.md                            ← you are here
+├── fixtures.test.ts                     ← Vitest entrypoint; wires every
+│                                          fixture against both reducers
+├── lib/
+│   ├── fixture-types.ts                 ← SseEvent, Assertion, SseFixture
+│   ├── replay-fixture.ts                ← replay engine + assertion runner
+│   ├── buggy-reducer.ts                 ← placeholder for current SPA
+│   │                                      behavior — sticky-map fallback
+│   └── fixed-reducer.ts                 ← reference implementation
+│                                          PR J must match
+└── fixtures/
+    ├── rapid-fire-five-fast.fixture.ts          ← #649/#740 base case
+    ├── slow-then-fast-interleave.fixture.ts     ← #649 (live-thread-interleave)
+    ├── spawn-only-ack-then-result.fixture.ts    ← #738
+    ├── m89-recovery-turn.fixture.ts             ← #738 sibling + turn_error
+    ├── reload-replay.fixture.ts                 ← reconnect/cursor replay
+    ├── tool-retry-collapse.fixture.ts           ← #680 tool-retry collapse
+    └── multi-attachment-dedup.fixture.ts        ← multi-file deep_search
+```
+
+## How to run
+
+From `crates/octos-web/`:
+
+```bash
+npm install
+npm test          # one-shot run (CI mode)
+npm run test:watch
+```
+
+Target: **< 1s total** for all fixtures × both reducers. The replay
+engine is fully synchronous; no setTimeout, no real WebSockets, no
+filesystem.
+
+## The contract: what each test asserts
+
+Every fixture in `SUITE` (see `fixtures.test.ts`) is checked against
+TWO reducers:
+
+### Suite 1: "fails against the current (buggy) reducer"
+
+Proves the fixture has teeth — the bug class it documents is real and
+detectable. **This suite passes today** (i.e. each fixture correctly
+fails the buggy reducer).
+
+If a fixture were to PASS against the buggy reducer here, that's an
+alarm: either the fixture is too weak (false positive) or the bug class
+has moved somewhere we don't yet model.
+
+### Suite 2: "passes against the fixed (reference) reducer"
+
+Proves the contract is achievable. The `fixedReducer` is the executable
+spec PR J must match. **This suite passes today** (the contract is
+expressible).
+
+When PR J ships, the production reducer takes over from `fixed-reducer.ts`
+as the suite-2 reducer. **`buggy-reducer.ts` is kept forever** as a
+deliberately-broken sentinel: every fixture must continue to detect it
+(suite 1 is the negative-coverage gate). If a future "innocent" fixture
+change accidentally passes against the buggy sentinel, suite 1 catches
+the weakening before it ships.
+
+## Why fixtures INITIALLY appear to "fail" if you only look at Suite 1
+
+This is intentional design — and easy to misread. The fixtures were
+designed to FAIL against the current production reducer (the
+buggy-reducer placeholder). That failure is the SIGNAL: "yes, this
+fixture catches the bug."
+
+We capture that failure as a positive assertion in Suite 1
+(`expect(result.pass).toBe(false)`), so the Vitest run shows GREEN —
+**because the fixtures correctly detect the bug**.
+
+The real contract is Suite 2: when PR J's typed-`turn_id` reducer
+replaces the placeholder, Suite 2 still passes (because the contract is
+the same). And on that day Suite 1 is deleted.
+
+## Adding a new fixture
+
+1. Create `fixtures/<my-scenario>.fixture.ts`. Author the events so they
+   reproduce the bug pattern (use issue references in the header
+   comment); declare assertions for the desired final state.
+2. Add it to `SUITE` in `fixtures.test.ts`.
+3. Run `npm test`. The new fixture should:
+   - **fail** against `buggyReducer` (Suite 1 expects this — a passing
+     test means the fixture has teeth)
+   - **pass** against `fixedReducer` (Suite 2 expects this — the
+     contract must be achievable)
+4. If Suite 2 fails: the fixture's assertions are unachievable —
+   adjust them.
+5. If Suite 1 fails (i.e. the bug fixture passes against buggy): the
+   buggy reducer doesn't model the leak that fixture targets. Either
+   broaden the placeholder OR confirm the bug has migrated.
+
+## Capture-and-replay (PR I)
+
+PR I adds a `--record-fixture` flag to `e2e/lib/live-browser-helpers.ts`
+that writes captured SSE streams + DOM snapshots as JSON. When a soak
+run fails, the capture is auto-promoted to
+`fixtures/captured/<spec>-<timestamp>.json`. The fixture format here
+deliberately mirrors that JSON format, so the import is mechanical.
+
+## CI
+
+`.github/workflows/web-reducer-fixtures.yml` runs on every PR touching
+`crates/octos-web/` or `crates/octos-core/src/ui_protocol.rs`. Total
+runtime <1s. No flake budget — these are deterministic.
+
+## Cross-references
+
+- Architecture rationale: `/tmp/octos-architecture-FINAL.md` sections A,
+  C, and the loophole-audit table.
+- PoC: `/tmp/fixture-poc/reducer-test.mjs` (50-line proof, 2ms runtime,
+  reproduces wave-4 mini3 misroute pattern).
+- UI Protocol v1 spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md`.
+- The bug chain: issues #649, #664, #673, #680, #738, #740, #742.

--- a/crates/octos-web/src/state/__tests__/fixtures.test.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures.test.ts
@@ -1,0 +1,135 @@
+// Layer 1 fixture tests — Vitest entry point.
+//
+// Two test suites per fixture (both kept FOREVER — see README for
+// rationale):
+//
+//   1. "fails against current buggy reducer" — proves the fixture has
+//      teeth. The buggy reducer is a deliberately-broken sentinel
+//      modeling the production SPA's sticky-map fallback. If a fixture
+//      starts to PASS against it, that's a signal the fixture has been
+//      weakened (or the bug class moved).
+//
+//   2. "passes against fixed reducer" — proves the contract is
+//      achievable and the fixture is well-formed. The fixed reducer is
+//      the executable spec PR J's production reducer must match.
+//
+// The fixture suite list is deliberately exhaustive — adding a new
+// fixture means adding two entries here. We keep it explicit (no
+// glob/auto-import) so a new fixture can't be added that ONLY documents
+// the bug without proving the fix is achievable.
+
+import { describe, expect, it } from 'vitest';
+
+import type { SseFixture } from './lib/fixture-types.js';
+import {
+  formatReplayResult,
+  replayFixture,
+} from './lib/replay-fixture.js';
+import { buggyReducer } from './lib/buggy-reducer.js';
+import { fixedReducer } from './lib/fixed-reducer.js';
+
+import { rapidFireFiveFast } from './fixtures/rapid-fire-five-fast.fixture.js';
+import { slowThenFastInterleave } from './fixtures/slow-then-fast-interleave.fixture.js';
+import { spawnOnlyAckThenResult } from './fixtures/spawn-only-ack-then-result.fixture.js';
+import { m89RecoveryTurn } from './fixtures/m89-recovery-turn.fixture.js';
+import { reloadReplay } from './fixtures/reload-replay.fixture.js';
+import { toolRetryCollapse } from './fixtures/tool-retry-collapse.fixture.js';
+import { multiAttachmentDedup } from './fixtures/multi-attachment-dedup.fixture.js';
+
+const SUITE: SseFixture[] = [
+  rapidFireFiveFast,
+  slowThenFastInterleave,
+  spawnOnlyAckThenResult,
+  m89RecoveryTurn,
+  reloadReplay,
+  toolRetryCollapse,
+  multiAttachmentDedup,
+];
+
+describe('Layer 1: fixtures fail against the current (buggy) reducer', () => {
+  // The buggy reducer is a deliberately-broken sentinel that models
+  // LEAK 2 from the loophole-audit table: every delta binds to the
+  // most-recent sticky thread, ignoring event.turn_id. It STAYS in the
+  // codebase forever (even after PR J ships the production reducer) so
+  // this negative-coverage gate continues to catch fixture weakening.
+  //
+  // If any of these tests reports "fixture passed against buggy
+  // reducer", either the fixture has been weakened (false positive) or
+  // the bug class has moved somewhere we don't yet model. Both cases
+  // need investigation before the fixture is trusted.
+  for (const fixture of SUITE) {
+    it(`${fixture.name} fails against buggy reducer (proves teeth)`, () => {
+      const result = replayFixture(fixture, buggyReducer);
+      expect(
+        result.pass,
+        `Fixture "${fixture.name}" unexpectedly passed against the buggy reducer.\n${formatReplayResult(result)}`,
+      ).toBe(false);
+      // Sanity: buggy reducer must produce at LEAST one assertion failure
+      // (otherwise the fixture has no teeth).
+      expect(result.failures.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+describe('Layer 1: fixtures pass against the fixed (reference) reducer', () => {
+  // The fixed reducer is the executable spec PR J must match. If a
+  // fixture fails here, the fixture is malformed (asserts the
+  // unachievable) — not a real bug indicator.
+  for (const fixture of SUITE) {
+    it(`${fixture.name} passes against fixed reducer (contract is achievable)`, () => {
+      const result = replayFixture(fixture, fixedReducer);
+      expect(
+        result.pass,
+        `Fixture "${fixture.name}" failed against the FIXED reducer — the fixture is malformed (assertions unachievable).\n${formatReplayResult(result)}`,
+      ).toBe(true);
+    });
+  }
+});
+
+describe('Layer 1: replay engine determinism', () => {
+  // Replay the same fixture twice; assert byte-identical state. If the
+  // engine grew nondeterminism (e.g. iteration order over a Set leaking)
+  // we want this to fail loudly.
+  it('produces identical final state across two replays of the same fixture', () => {
+    const a = replayFixture(rapidFireFiveFast, fixedReducer);
+    const b = replayFixture(rapidFireFiveFast, fixedReducer);
+    expect(a.final_state.thread_order).toEqual(b.final_state.thread_order);
+    const aT = Array.from(a.final_state.threads.entries());
+    const bT = Array.from(b.final_state.threads.entries());
+    expect(aT).toEqual(bT);
+  });
+
+  // The engine sorts events by `t` (ties → original index). Asserts the
+  // sort is stable in both directions.
+  it('orders events by t, tie-broken by authored index', () => {
+    const fixture: SseFixture = {
+      name: 'sort-stability',
+      description: 'two events at same t maintain authored order',
+      events: [
+        // Authored: A (asst tail) before B (user). After sort: still A, B.
+        {
+          t: 100,
+          type: 'message_delta',
+          session_id: 's',
+          turn_id: 'A',
+          text: 'a-tail',
+        },
+        {
+          t: 100,
+          type: 'user_sent',
+          session_id: 's',
+          turn_id: 'B',
+          cmid: 'B',
+          text: 'b-question',
+        },
+      ],
+      assertions: [],
+    };
+    const result = replayFixture(fixture, fixedReducer);
+    // The buggy reducer would have rejected the delta (no turn_id A
+    // bubble exists yet); the fixed reducer also rejects it but the order
+    // of rejection events is what we assert.
+    expect(result.final_state.rejected.length).toBe(1);
+    expect(result.final_state.rejected[0]!.event.type).toBe('message_delta');
+  });
+});

--- a/crates/octos-web/src/state/__tests__/fixtures/m89-recovery-turn.fixture.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures/m89-recovery-turn.fixture.ts
@@ -1,0 +1,127 @@
+// m89-recovery-turn — #738 sibling: recovery-turn output binding.
+//
+// First child turn fires (e.g. an LLM call that fails with a 503 mid-tool-
+// use). The agent's recovery loop schedules a NEW turn (with a fresh
+// recovery_turn_id) to retry the operation. The recovery's eventual
+// successful output must land in the ORIGINATING bubble (the user message
+// that started everything) — NOT in a fresh bubble for recovery_turn_id,
+// and NOT in whatever happens to be the most recent user message.
+//
+// This is the #738-sibling scenario: when a child fails and a recovery
+// fires, the result-binding has to inherit from the originating turn or
+// the user sees an answer "for nothing" — disconnected from the question
+// they asked.
+
+import type { SseFixture } from '../lib/fixture-types.js';
+
+const SID = 'm89-recovery-session';
+
+export const m89RecoveryTurn: SseFixture = {
+  name: 'm89-recovery-turn',
+  description:
+    'First child turn fails, recovery turn fires, result lands. Recovery output must inherit originating_turn_id, not bind to a fresh bubble.',
+  issues: [738],
+  session_id: SID,
+  events: [
+    // ── Originating user ─────────────────────────────────────────────────
+    {
+      t: 0,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'orig-turn',
+      cmid: 'orig-turn',
+      text: 'Summarize the changelog for the last 5 releases.',
+    },
+    { t: 100, type: 'turn_started', session_id: SID, turn_id: 'orig-turn' },
+
+    // ── Initial attempt: starts streaming ───────────────────────────────
+    {
+      t: 1000,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'orig-turn',
+      text: 'Reading changelog...',
+    },
+
+    // ── Unrelated user sends in the gap ──────────────────────────────────
+    // Critical for the misroute: the gap-turn rotates sticky FORWARD
+    // before the originating turn errors. Under the buggy reducer the
+    // turn_error then binds to gap-turn, not orig-turn. Without this
+    // ordering the bug is invisible.
+    {
+      t: 2000,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'gap-turn',
+      cmid: 'gap-turn',
+      text: 'And what is the weather?',
+    },
+    { t: 2100, type: 'turn_started', session_id: SID, turn_id: 'gap-turn' },
+    {
+      t: 2300,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'gap-turn',
+      text: 'Sunny, 21C.',
+    },
+    { t: 2400, type: 'turn_completed', session_id: SID, turn_id: 'gap-turn' },
+
+    // ── orig-turn errors AFTER sticky rotated to gap-turn ───────────────
+    // turn_error must STILL bind to orig-turn (the originating bubble).
+    {
+      t: 3000,
+      type: 'turn_error',
+      session_id: SID,
+      turn_id: 'orig-turn',
+      code: 'upstream_503',
+      message: 'LLM provider returned 503; recovery scheduled.',
+    },
+
+    // ── Recovery turn fires, succeeds, output streams ────────────────────
+    // The recovery_turn_id is a FRESH server-side id ('recovery-1') but
+    // the result MUST be rendered under 'orig-turn'. The reducer never
+    // creates a bubble for 'recovery-1'.
+    {
+      t: 8000,
+      type: 'recovery_turn',
+      session_id: SID,
+      recovery_turn_id: 'recovery-1',
+      originating_turn_id: 'orig-turn',
+      text: 'Recovered: the last 5 releases were 1.4 through 1.8 — bug fixes, the new ledger format, and skill manifests.',
+    },
+  ],
+  assertions: [
+    // The recovery turn never creates its own bubble.
+    {
+      kind: 'thread_order',
+      expected: ['orig-turn', 'gap-turn'],
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'orig-turn',
+      expect: {
+        user: 'Summarize the changelog for the last 5 releases.',
+        asst: 'Reading changelog...Recovered: the last 5 releases were 1.4 through 1.8 — bug fixes, the new ledger format, and skill manifests.',
+      },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'gap-turn',
+      expect: {
+        user: 'And what is the weather?',
+        asst: 'Sunny, 21C.',
+      },
+    },
+    // The turn_error must land in the ORIGINATING bubble, not in
+    // whichever bubble is sticky at the time of the error.
+    {
+      kind: 'thread_has_error',
+      turn_id: 'orig-turn',
+      code: 'upstream_503',
+    },
+    {
+      kind: 'no_misroute',
+      allowed_turn_ids: ['orig-turn', 'gap-turn'],
+    },
+  ],
+};

--- a/crates/octos-web/src/state/__tests__/fixtures/multi-attachment-dedup.fixture.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures/multi-attachment-dedup.fixture.ts
@@ -1,0 +1,125 @@
+// multi-attachment-dedup — multi-file deep_search result + dedup.
+//
+// User asks a research question; the deep_search returns 3 .md files in a
+// single `background_result`. Then the user retries the same query
+// (different turn_id, identical attachments). Each turn must own its own
+// 3-file attachment list — the second turn must NOT inherit the first
+// turn's files, and neither turn must drop a duplicate filename across
+// turns (a separate failure mode where the SPA's "global attachment
+// seen" set incorrectly dedupes across bubbles).
+
+import type { SseFixture } from '../lib/fixture-types.js';
+
+const SID = 'multi-attachment-session';
+
+export const multiAttachmentDedup: SseFixture = {
+  name: 'multi-attachment-dedup',
+  description:
+    'Two background_result events on different turns, each with three .md attachments (same filenames). Each turn must own its own list, in order; no cross-turn dedup.',
+  issues: [738],
+  session_id: SID,
+  events: [
+    // ── Turn 1: kicks off a slow research ───────────────────────────────
+    {
+      t: 0,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 't1',
+      cmid: 't1',
+      text: 'First research query',
+    },
+    { t: 100, type: 'turn_started', session_id: SID, turn_id: 't1' },
+    {
+      t: 500,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 't1',
+      text: 'Researching first query...',
+    },
+    { t: 600, type: 'turn_completed', session_id: SID, turn_id: 't1' },
+
+    // ── Turn 2: starts a second research BEFORE turn 1's bg result ──────
+    // This rotates sticky to t2. Now turn 1's background_result, when it
+    // arrives, must STILL bind to t1 — under the buggy reducer it lands
+    // in t2 (along with t2's own attachments — three filenames doubled
+    // up — exactly the dedup-failure symptom).
+    {
+      t: 1000,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 't2',
+      cmid: 't2',
+      text: 'Second research query (same shape)',
+    },
+    { t: 1100, type: 'turn_started', session_id: SID, turn_id: 't2' },
+    {
+      t: 1500,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 't2',
+      text: 'Researching second query...',
+    },
+    { t: 1600, type: 'turn_completed', session_id: SID, turn_id: 't2' },
+
+    // ── Turn 1's background result arrives. Sticky=t2. Must bind to t1. ──
+    {
+      t: 30000,
+      type: 'background_result',
+      session_id: SID,
+      turn_id: 't1',
+      text: 'Done.',
+      attachments: [
+        { filename: 'summary.md', path: '/tmp/r1/summary.md' },
+        { filename: 'details.md', path: '/tmp/r1/details.md' },
+        { filename: 'sources.md', path: '/tmp/r1/sources.md' },
+      ],
+    },
+
+    // ── Turn 2's background result arrives. ─────────────────────────────
+    // Same filenames, different paths. Each turn must own its own list.
+    {
+      t: 31000,
+      type: 'background_result',
+      session_id: SID,
+      turn_id: 't2',
+      text: 'Done.',
+      attachments: [
+        { filename: 'summary.md', path: '/tmp/r2/summary.md' },
+        { filename: 'details.md', path: '/tmp/r2/details.md' },
+        { filename: 'sources.md', path: '/tmp/r2/sources.md' },
+      ],
+    },
+  ],
+  assertions: [
+    {
+      kind: 'thread_order',
+      expected: ['t1', 't2'],
+    },
+    // Each turn owns its own list, in order — INCLUDING path. Same
+    // filenames across turns; only path discriminates. (A reducer that
+    // attaches the right filenames but the wrong paths must still
+    // fail.)
+    {
+      kind: 'thread_attachments_equal',
+      turn_id: 't1',
+      attachments: [
+        { filename: 'summary.md', path: '/tmp/r1/summary.md' },
+        { filename: 'details.md', path: '/tmp/r1/details.md' },
+        { filename: 'sources.md', path: '/tmp/r1/sources.md' },
+      ],
+    },
+    {
+      kind: 'thread_attachments_equal',
+      turn_id: 't2',
+      attachments: [
+        { filename: 'summary.md', path: '/tmp/r2/summary.md' },
+        { filename: 'details.md', path: '/tmp/r2/details.md' },
+        { filename: 'sources.md', path: '/tmp/r2/sources.md' },
+      ],
+    },
+    {
+      kind: 'no_misroute',
+      allowed_turn_ids: ['t1', 't2'],
+    },
+  ],
+};

--- a/crates/octos-web/src/state/__tests__/fixtures/rapid-fire-five-fast.fixture.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures/rapid-fire-five-fast.fixture.ts
@@ -1,0 +1,156 @@
+// rapid-fire-five-fast — port of /tmp/fixture-poc/reducer-test.mjs.
+//
+// Five users sent ~800ms apart, each turn produces an assistant response.
+// In real wave-4 mini3 DOM dumps (the originating evidence for #740) the
+// late-arriving deltas of early turns landed in the bubble of whichever
+// turn happened to be most recent. The buggy reducer reproduces this; the
+// fixed reducer pins each delta to its own turn_id.
+
+import type { SseFixture } from '../lib/fixture-types.js';
+
+const SID = 'rapid-fire-session';
+
+export const rapidFireFiveFast: SseFixture = {
+  name: 'rapid-fire-five-fast',
+  description:
+    'Five users 800ms apart, deltas interleaved with later turn_started events. Buggy reducer misroutes early-turn tails into later bubbles; fixed reducer keeps every answer in its own bubble.',
+  issues: [649, 664, 673, 680, 738, 740],
+  session_id: SID,
+  events: [
+    // ── Q1 (cm-A) ────────────────────────────────────────────────────────
+    {
+      t: 0,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'cm-A',
+      cmid: 'cm-A',
+      text: '1+1=?',
+    },
+    { t: 100, type: 'turn_started', session_id: SID, turn_id: 'cm-A' },
+
+    // ── Q2 (cm-B) starts before Q1 has streamed ──────────────────────────
+    {
+      t: 800,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'cm-B',
+      cmid: 'cm-B',
+      text: '2+2=?',
+    },
+    { t: 900, type: 'turn_started', session_id: SID, turn_id: 'cm-B' },
+
+    // ── Q3 (cm-C) — sticky has rotated forward ───────────────────────────
+    {
+      t: 1600,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'cm-C',
+      cmid: 'cm-C',
+      text: '3+3=?',
+    },
+    { t: 1700, type: 'turn_started', session_id: SID, turn_id: 'cm-C' },
+
+    // ── Q1's answer arrives. Sticky=C. Buggy binds to C. ─────────────────
+    {
+      t: 1800,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'cm-A',
+      text: '1+1=2',
+    },
+    { t: 2000, type: 'turn_completed', session_id: SID, turn_id: 'cm-A' },
+
+    // ── Q4 (cm-D) ────────────────────────────────────────────────────────
+    {
+      t: 2400,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'cm-D',
+      cmid: 'cm-D',
+      text: '4+4=?',
+    },
+    { t: 2500, type: 'turn_started', session_id: SID, turn_id: 'cm-D' },
+
+    // ── Q2's answer arrives. Sticky=D. Buggy binds to D. ─────────────────
+    {
+      t: 2600,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'cm-B',
+      text: '2+2=4',
+    },
+    { t: 2800, type: 'turn_completed', session_id: SID, turn_id: 'cm-B' },
+
+    // ── Q5 (cm-E) ────────────────────────────────────────────────────────
+    {
+      t: 3200,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'cm-E',
+      cmid: 'cm-E',
+      text: '5+5=?',
+    },
+    { t: 3300, type: 'turn_started', session_id: SID, turn_id: 'cm-E' },
+
+    // ── Q3, Q4, Q5 answers arrive interleaved ────────────────────────────
+    {
+      t: 3500,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'cm-C',
+      text: '3+3=6',
+    },
+    {
+      t: 3550,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'cm-D',
+      text: '4+4=8',
+    },
+    {
+      t: 3600,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'cm-E',
+      text: '5+5=10',
+    },
+    { t: 3700, type: 'turn_completed', session_id: SID, turn_id: 'cm-C' },
+    { t: 3750, type: 'turn_completed', session_id: SID, turn_id: 'cm-D' },
+    { t: 3800, type: 'turn_completed', session_id: SID, turn_id: 'cm-E' },
+  ],
+  assertions: [
+    {
+      kind: 'thread_order',
+      expected: ['cm-A', 'cm-B', 'cm-C', 'cm-D', 'cm-E'],
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'cm-A',
+      expect: { user: '1+1=?', asst: '1+1=2' },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'cm-B',
+      expect: { user: '2+2=?', asst: '2+2=4' },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'cm-C',
+      expect: { user: '3+3=?', asst: '3+3=6' },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'cm-D',
+      expect: { user: '4+4=?', asst: '4+4=8' },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'cm-E',
+      expect: { user: '5+5=?', asst: '5+5=10' },
+    },
+    {
+      kind: 'no_misroute',
+      allowed_turn_ids: ['cm-A', 'cm-B', 'cm-C', 'cm-D', 'cm-E'],
+    },
+  ],
+};

--- a/crates/octos-web/src/state/__tests__/fixtures/reload-replay.fixture.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures/reload-replay.fixture.ts
@@ -1,0 +1,129 @@
+// reload-replay — drop the WS, reconnect, replay from cursor.
+//
+// User sends two messages, both stream successfully. Connection drops.
+// Server replays the same events from cursor on reconnect (since the
+// client's last-known cursor was earlier). The final state MUST be
+// identical to what we'd have seen with no drop — same bubbles, same
+// text, same attachment placement.
+//
+// Under the buggy reducer the SPA wipes its DOM on reconnect (it calls
+// loadHistory and rebuilds from REST), and the rebuild path itself has
+// thread-binding inconsistencies — so the post-reconnect graph is
+// observably different. Under the fixed reducer the typed-turn_id keys
+// make every replay event idempotent, so the graph is preserved.
+
+import type { SseFixture } from '../lib/fixture-types.js';
+
+const SID = 'reload-replay-session';
+
+export const reloadReplay: SseFixture = {
+  name: 'reload-replay',
+  description:
+    'WebSocket drops mid-session, reconnect replays events from cursor. Thread graph must be identical pre- and post-disconnect.',
+  issues: [],
+  session_id: SID,
+  events: [
+    // ── Two complete turns before the drop ───────────────────────────────
+    {
+      t: 0,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'turn-1',
+      cmid: 'turn-1',
+      text: 'First question.',
+    },
+    { t: 100, type: 'turn_started', session_id: SID, turn_id: 'turn-1' },
+    {
+      t: 500,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'turn-1',
+      text: 'First answer.',
+    },
+    { t: 600, type: 'turn_completed', session_id: SID, turn_id: 'turn-1' },
+
+    {
+      t: 1000,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'turn-2',
+      cmid: 'turn-2',
+      text: 'Second question.',
+    },
+    { t: 1100, type: 'turn_started', session_id: SID, turn_id: 'turn-2' },
+    {
+      t: 1500,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'turn-2',
+      text: 'Second answer.',
+    },
+    { t: 1600, type: 'turn_completed', session_id: SID, turn_id: 'turn-2' },
+
+    // ── Connection drops ─────────────────────────────────────────────────
+    { t: 2000, type: 'connection_drop' },
+
+    // ── Reconnect; server replays from cursor (idempotent) ──────────────
+    // After connection_resume the engine feeds the SAME events again. A
+    // typed-turn_id reducer treats them as idempotent (same key, same
+    // text — overwrites with identical content). The graph survives.
+    { t: 3000, type: 'connection_resume', cursor: 'cursor-before-drop' },
+
+    // Replayed events from cursor
+    {
+      t: 3001,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'turn-1',
+      cmid: 'turn-1',
+      text: 'First question.',
+    },
+    { t: 3002, type: 'turn_started', session_id: SID, turn_id: 'turn-1' },
+    {
+      t: 3003,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'turn-1',
+      text: 'First answer.',
+    },
+    { t: 3004, type: 'turn_completed', session_id: SID, turn_id: 'turn-1' },
+    {
+      t: 3005,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'turn-2',
+      cmid: 'turn-2',
+      text: 'Second question.',
+    },
+    { t: 3006, type: 'turn_started', session_id: SID, turn_id: 'turn-2' },
+    {
+      t: 3007,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'turn-2',
+      text: 'Second answer.',
+    },
+    { t: 3008, type: 'turn_completed', session_id: SID, turn_id: 'turn-2' },
+  ],
+  assertions: [
+    // Graph identical to what a no-drop run would produce.
+    {
+      kind: 'thread_order',
+      expected: ['turn-1', 'turn-2'],
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'turn-1',
+      expect: { user: 'First question.', asst: 'First answer.' },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'turn-2',
+      expect: { user: 'Second question.', asst: 'Second answer.' },
+    },
+    {
+      kind: 'no_misroute',
+      allowed_turn_ids: ['turn-1', 'turn-2'],
+    },
+  ],
+};

--- a/crates/octos-web/src/state/__tests__/fixtures/slow-then-fast-interleave.fixture.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures/slow-then-fast-interleave.fixture.ts
@@ -1,0 +1,107 @@
+// slow-then-fast-interleave — the live-thread-interleave pattern (#649).
+//
+// User Q1 kicks off a deep_research turn that takes ~30 seconds. Before it
+// completes, user Q2 sends a fast lookup. The fast turn finishes first.
+// LATER, Q1's deep_research result (with a `.md` attachment) arrives —
+// but the sticky map has rotated to Q2 by then. Under the bug, Q1's
+// research output lands in Q2's bubble.
+//
+// Ground truth: this is exactly the symptom captured in
+// e2e/tests/live-thread-interleave.spec.ts:225-235 ("late background
+// result inherited Q2's thread_id from the sticky map"). The fixture is
+// the deterministic equivalent.
+
+import type { SseFixture } from '../lib/fixture-types.js';
+
+const SID = 'slow-fast-session';
+
+export const slowThenFastInterleave: SseFixture = {
+  name: 'slow-then-fast-interleave',
+  description:
+    'Slow deep_research Q1 + fast lookup Q2. Q1 result arrives after Q2 sticky has rotated. Buggy reducer routes Q1 research evidence into Q2 bubble.',
+  issues: [649, 740],
+  session_id: SID,
+  events: [
+    // ── Q1: slow deep_research ───────────────────────────────────────────
+    {
+      t: 0,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'slow-Q1',
+      cmid: 'slow-Q1',
+      text: 'Research the latest M9.5 release notes thoroughly.',
+    },
+    { t: 100, type: 'turn_started', session_id: SID, turn_id: 'slow-Q1' },
+    // Acknowledgment delta, then long silence while research runs.
+    {
+      t: 500,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'slow-Q1',
+      text: 'Researching, this will take a moment...',
+    },
+
+    // ── Q2: fast lookup, while Q1 still in flight ────────────────────────
+    {
+      t: 5000,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'fast-Q2',
+      cmid: 'fast-Q2',
+      text: 'What is 2+2?',
+    },
+    { t: 5100, type: 'turn_started', session_id: SID, turn_id: 'fast-Q2' },
+    {
+      t: 5300,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'fast-Q2',
+      text: '4',
+    },
+    { t: 5400, type: 'turn_completed', session_id: SID, turn_id: 'fast-Q2' },
+
+    // ── Q1: research result arrives (with the canonical .md attachment) ──
+    {
+      t: 30000,
+      type: 'background_result',
+      session_id: SID,
+      turn_id: 'slow-Q1',
+      text: 'Research summary: M9.5 ledger durability + scope-aware approvals shipped this week. See attached.',
+      attachments: [
+        {
+          filename: 'm9-5-research.md',
+          path: '/tmp/research/m9-5-research.md',
+        },
+      ],
+    },
+    { t: 30100, type: 'turn_completed', session_id: SID, turn_id: 'slow-Q1' },
+  ],
+  assertions: [
+    {
+      kind: 'thread_order',
+      expected: ['slow-Q1', 'fast-Q2'],
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'slow-Q1',
+      expect: {
+        user: 'Research the latest M9.5 release notes thoroughly.',
+        asst: 'Researching, this will take a moment...Research summary: M9.5 ledger durability + scope-aware approvals shipped this week. See attached.',
+      },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'fast-Q2',
+      expect: { user: 'What is 2+2?', asst: '4' },
+    },
+    {
+      kind: 'thread_has_attachment',
+      turn_id: 'slow-Q1',
+      filename: 'm9-5-research.md',
+    },
+    {
+      kind: 'no_misroute',
+      allowed_turn_ids: ['slow-Q1', 'fast-Q2'],
+    },
+  ],
+};

--- a/crates/octos-web/src/state/__tests__/fixtures/spawn-only-ack-then-result.fixture.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures/spawn-only-ack-then-result.fixture.ts
@@ -1,0 +1,116 @@
+// spawn-only-ack-then-result — issue #738 canonical scenario.
+//
+// User asks a deep_search question. The agent immediately replies with an
+// "ack" message ("running deep_search...") and then a spawn_only background
+// task fires. Two MINUTES later the result lands with a `.md` attachment.
+// In the meantime no other user has sent — so this is the simplest possible
+// case. The bug, even here, is that the current SPA has no concept of
+// background_result -> originating turn binding; the result appends to the
+// most recent assistant bubble.
+//
+// We add a SECOND user message between the ack and the result to make the
+// misroute observable: under the buggy reducer the `.md` attachment lands
+// in user2's bubble; under the fixed reducer it lands in user1's bubble
+// where the ack was.
+
+import type { SseFixture } from '../lib/fixture-types.js';
+
+const SID = 'spawn-only-session';
+
+export const spawnOnlyAckThenResult: SseFixture = {
+  name: 'spawn-only-ack-then-result',
+  description:
+    'Deep_search ack at t=2s, second user at t=10s, deep_search result with .md attachment at t=180s. Result must land in originating turn, not in second-user bubble. Issue #738.',
+  issues: [738],
+  session_id: SID,
+  events: [
+    // ── Originating user message ─────────────────────────────────────────
+    {
+      t: 0,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'orig-turn',
+      cmid: 'orig-turn',
+      text: 'Deep-search the latest octos release notes.',
+    },
+    { t: 100, type: 'turn_started', session_id: SID, turn_id: 'orig-turn' },
+
+    // ── Ack message: agent says it's running deep_search ────────────────
+    {
+      t: 2000,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'orig-turn',
+      text: 'Running deep_search in background, will deliver results shortly.',
+    },
+    { t: 2100, type: 'turn_completed', session_id: SID, turn_id: 'orig-turn' },
+
+    // ── Second user, while deep_search still running ────────────────────
+    {
+      t: 10000,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'second-turn',
+      cmid: 'second-turn',
+      text: 'While that runs: what is the capital of France?',
+    },
+    { t: 10100, type: 'turn_started', session_id: SID, turn_id: 'second-turn' },
+    {
+      t: 10500,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'second-turn',
+      text: 'Paris.',
+    },
+    { t: 10600, type: 'turn_completed', session_id: SID, turn_id: 'second-turn' },
+
+    // ── Deep_search result lands. Sticky=second-turn. ──────────────────
+    // The fixed reducer must bind this to orig-turn (per event.turn_id).
+    // The buggy reducer binds to sticky and the .md ends up under
+    // 'second-turn'.
+    {
+      t: 180000,
+      type: 'background_result',
+      session_id: SID,
+      turn_id: 'orig-turn',
+      text: 'Deep_search complete: see attached release notes.',
+      attachments: [
+        {
+          filename: 'release-notes.md',
+          path: '/tmp/skill-output/release-notes.md',
+        },
+      ],
+    },
+  ],
+  assertions: [
+    {
+      kind: 'thread_order',
+      expected: ['orig-turn', 'second-turn'],
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'orig-turn',
+      expect: {
+        user: 'Deep-search the latest octos release notes.',
+        asst: 'Running deep_search in background, will deliver results shortly.Deep_search complete: see attached release notes.',
+      },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'second-turn',
+      expect: {
+        user: 'While that runs: what is the capital of France?',
+        asst: 'Paris.',
+      },
+    },
+    {
+      kind: 'thread_has_attachment',
+      turn_id: 'orig-turn',
+      filename: 'release-notes.md',
+    },
+    {
+      kind: 'no_misroute',
+      allowed_turn_ids: ['orig-turn', 'second-turn'],
+    },
+  ],
+};

--- a/crates/octos-web/src/state/__tests__/fixtures/tool-retry-collapse.fixture.ts
+++ b/crates/octos-web/src/state/__tests__/fixtures/tool-retry-collapse.fixture.ts
@@ -1,0 +1,139 @@
+// tool-retry-collapse — issue #680.
+//
+// User Q1 invokes a flaky tool (e.g. web_fetch). The tool errors. The
+// agent retries with a fresh tool_call_id but bound to the SAME turn_id.
+// Between the failed-call and the retry-fire, user Q2 has sent a fast
+// lookup. The retry's tool_started + tool_completed must bind to Q1's
+// bubble — NOT to Q2's, even though sticky has rotated.
+//
+// The buggy reducer routes the retry under whichever bubble is sticky
+// when the retry fires (Q2's). Q1's bubble shows a failed tool with no
+// retry; Q2's bubble shows a successful tool call out of nowhere.
+
+import type { SseFixture } from '../lib/fixture-types.js';
+
+const SID = 'tool-retry-session';
+
+export const toolRetryCollapse: SseFixture = {
+  name: 'tool-retry-collapse',
+  description:
+    'Failed tool call retried under same turn_id after sticky rotates to Q2. Retry must bind to originating turn (Q1).',
+  issues: [680],
+  session_id: SID,
+  events: [
+    // ── Q1: invokes flaky tool ───────────────────────────────────────────
+    {
+      t: 0,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'turn-1',
+      cmid: 'turn-1',
+      text: 'Fetch the contents of https://example.com',
+    },
+    { t: 100, type: 'turn_started', session_id: SID, turn_id: 'turn-1' },
+    {
+      t: 500,
+      type: 'tool_started',
+      session_id: SID,
+      turn_id: 'turn-1',
+      tool_call_id: 'tc-1a',
+      tool_name: 'web_fetch',
+    },
+    {
+      t: 1500,
+      type: 'tool_completed',
+      session_id: SID,
+      turn_id: 'turn-1',
+      tool_call_id: 'tc-1a',
+      tool_name: 'web_fetch',
+      success: false,
+      output_preview: 'connection reset',
+    },
+    // The agent has decided to retry — but in the meantime user Q2 sends.
+
+    // ── Q2: fast lookup ──────────────────────────────────────────────────
+    {
+      t: 2000,
+      type: 'user_sent',
+      session_id: SID,
+      turn_id: 'turn-2',
+      cmid: 'turn-2',
+      text: 'What is 2+2?',
+    },
+    { t: 2100, type: 'turn_started', session_id: SID, turn_id: 'turn-2' },
+    {
+      t: 2300,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'turn-2',
+      text: '4',
+    },
+    { t: 2400, type: 'turn_completed', session_id: SID, turn_id: 'turn-2' },
+
+    // ── Q1: retry fires; sticky=turn-2. Retry MUST bind to turn-1. ──────
+    {
+      t: 3000,
+      type: 'tool_started',
+      session_id: SID,
+      turn_id: 'turn-1',
+      tool_call_id: 'tc-1b',
+      tool_name: 'web_fetch',
+    },
+    {
+      t: 3500,
+      type: 'tool_completed',
+      session_id: SID,
+      turn_id: 'turn-1',
+      tool_call_id: 'tc-1b',
+      tool_name: 'web_fetch',
+      success: true,
+      output_preview: '<html>...</html>',
+    },
+    {
+      t: 3700,
+      type: 'message_delta',
+      session_id: SID,
+      turn_id: 'turn-1',
+      text: 'Fetched: <html>...</html>',
+    },
+    { t: 3800, type: 'turn_completed', session_id: SID, turn_id: 'turn-1' },
+  ],
+  assertions: [
+    {
+      kind: 'thread_order',
+      expected: ['turn-1', 'turn-2'],
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'turn-1',
+      expect: {
+        user: 'Fetch the contents of https://example.com',
+        asst: 'Fetched: <html>...</html>',
+      },
+    },
+    {
+      kind: 'thread_equals',
+      turn_id: 'turn-2',
+      expect: { user: 'What is 2+2?', asst: '4' },
+    },
+    // Both tool calls (initial + retry) must end up under turn-1.
+    {
+      kind: 'thread_has_tool_call',
+      turn_id: 'turn-1',
+      tool_call_id: 'tc-1a',
+      tool_name: 'web_fetch',
+      success: false,
+    },
+    {
+      kind: 'thread_has_tool_call',
+      turn_id: 'turn-1',
+      tool_call_id: 'tc-1b',
+      tool_name: 'web_fetch',
+      success: true,
+    },
+    {
+      kind: 'no_misroute',
+      allowed_turn_ids: ['turn-1', 'turn-2'],
+    },
+  ],
+};

--- a/crates/octos-web/src/state/__tests__/json-loader.test.ts
+++ b/crates/octos-web/src/state/__tests__/json-loader.test.ts
@@ -1,0 +1,190 @@
+// Tests for the JSON fixture loader. The contract:
+//
+//   1. Flat-form fixtures (the TS shape) load through unchanged.
+//   2. Wrapped-form fixtures (UI Protocol JSON-RPC envelopes) normalize
+//      to the flat shape; the replay engine sees them as if they were
+//      authored as TS.
+//   3. Validation errors include a path so a fixture-promotion operator
+//      can locate the bad field instantly.
+
+import { describe, expect, it } from 'vitest';
+
+import { loadFixtureJson, normalizeEvent } from './lib/json-loader.js';
+import { replayFixture } from './lib/replay-fixture.js';
+import { fixedReducer } from './lib/fixed-reducer.js';
+
+describe('Layer 1: JSON fixture loader', () => {
+  it('loads flat-form fixtures (round-trips with replay engine)', () => {
+    const flat = {
+      name: 'flat-form-test',
+      description: 'simple round-trip',
+      session_id: 's',
+      events: [
+        {
+          t: 0,
+          type: 'user_sent',
+          session_id: 's',
+          turn_id: 'A',
+          cmid: 'A',
+          text: 'q',
+        },
+        { t: 100, type: 'turn_started', session_id: 's', turn_id: 'A' },
+        {
+          t: 200,
+          type: 'message_delta',
+          session_id: 's',
+          turn_id: 'A',
+          text: 'a',
+        },
+      ],
+      assertions: [
+        {
+          kind: 'thread_equals',
+          turn_id: 'A',
+          expect: { user: 'q', asst: 'a' },
+        },
+      ],
+    };
+    const fixture = loadFixtureJson(flat);
+    const result = replayFixture(fixture, fixedReducer);
+    expect(result.pass).toBe(true);
+  });
+
+  it('normalizes wrapped-form (UI Protocol method/params) to flat', () => {
+    const wrapped = {
+      name: 'wrapped-form-test',
+      description: 'capture-and-replay shape',
+      session_id: 's',
+      events: [
+        // user_sent is PR H-internal — uses our 'user/sent' method name.
+        {
+          t: 0,
+          envelope: {
+            jsonrpc: '2.0',
+            method: 'user/sent',
+            params: {
+              session_id: 's',
+              turn_id: 'A',
+              cmid: 'A',
+              text: 'q',
+            },
+          },
+        },
+        {
+          t: 100,
+          envelope: {
+            jsonrpc: '2.0',
+            method: 'turn/started',
+            params: { session_id: 's', turn_id: 'A' },
+          },
+        },
+        {
+          t: 200,
+          envelope: {
+            jsonrpc: '2.0',
+            method: 'message/delta',
+            params: { session_id: 's', turn_id: 'A', text: 'a' },
+          },
+        },
+      ],
+      assertions: [
+        {
+          kind: 'thread_equals',
+          turn_id: 'A',
+          expect: { user: 'q', asst: 'a' },
+        },
+      ],
+    };
+    const fixture = loadFixtureJson(wrapped);
+    expect(fixture.events[0]!.type).toBe('user_sent');
+    expect(fixture.events[1]!.type).toBe('turn_started');
+    expect(fixture.events[2]!.type).toBe('message_delta');
+    const result = replayFixture(fixture, fixedReducer);
+    expect(result.pass).toBe(true);
+  });
+
+  it('rejects unknown UI Protocol methods with a clear message', () => {
+    expect(() =>
+      normalizeEvent(
+        {
+          t: 0,
+          envelope: {
+            jsonrpc: '2.0',
+            method: 'turn/teleport',
+            params: {},
+          },
+        },
+        'fixture.events[0]',
+      ),
+    ).toThrow(/unknown UI Protocol method "turn\/teleport"/);
+  });
+
+  it('rejects malformed top-level fixture with a path', () => {
+    expect(() => loadFixtureJson({})).toThrow(/missing required field "fixture\.name"/);
+    expect(() => loadFixtureJson({ name: 1 })).toThrow(/expected string at "fixture\.name"/);
+    expect(() =>
+      loadFixtureJson({ name: 'x', description: 'y', events: 'not-array', assertions: [] }),
+    ).toThrow(/"fixture\.events" is not an array/);
+  });
+
+  it('rejects events with neither type nor envelope', () => {
+    expect(() => normalizeEvent({ t: 0 }, 'fixture.events[0]')).toThrow(
+      /neither "type" nor "envelope"/,
+    );
+  });
+
+  it('rejects events with both type and envelope (ambiguous)', () => {
+    expect(() =>
+      normalizeEvent(
+        {
+          t: 0,
+          type: 'message_delta',
+          envelope: { jsonrpc: '2.0', method: 'message/delta', params: {} },
+        },
+        'fixture.events[0]',
+      ),
+    ).toThrow(/has BOTH "type" and "envelope"/);
+  });
+
+  it('drops known ignored UI Protocol notifications without error', () => {
+    // progress/updated, task/updated, etc. are valid wire messages but
+    // not modeled by this layer. A capture from PR I might include
+    // them; the loader silently skips them so promotion is mechanical.
+    const fixture = loadFixtureJson({
+      name: 'with-ignored',
+      description: 'capture contains a progress/updated that the reducer ignores',
+      session_id: 's',
+      events: [
+        {
+          t: 0,
+          envelope: {
+            jsonrpc: '2.0',
+            method: 'user/sent',
+            params: { session_id: 's', turn_id: 'A', cmid: 'A', text: 'q' },
+          },
+        },
+        {
+          t: 50,
+          envelope: {
+            jsonrpc: '2.0',
+            method: 'progress/updated',
+            params: { session_id: 's', progress: 0.42 },
+          },
+        },
+        {
+          t: 100,
+          envelope: {
+            jsonrpc: '2.0',
+            method: 'turn/started',
+            params: { session_id: 's', turn_id: 'A' },
+          },
+        },
+      ],
+      assertions: [],
+    });
+    // The progress/updated event was dropped — fixture has only 2 events.
+    expect(fixture.events).toHaveLength(2);
+    expect(fixture.events[0]!.type).toBe('user_sent');
+    expect(fixture.events[1]!.type).toBe('turn_started');
+  });
+});

--- a/crates/octos-web/src/state/__tests__/lib/buggy-reducer.ts
+++ b/crates/octos-web/src/state/__tests__/lib/buggy-reducer.ts
@@ -1,0 +1,241 @@
+// Current (buggy) SPA reducer — placeholder for what PR J replaces.
+//
+// This reducer models the production SPA's actual thread-binding behavior
+// today. The bug class (#649 → #664 → #673 → #680 → #738 → #740) is rooted
+// in TWO leaks documented in /tmp/octos-architecture-FINAL.md (the
+// "loophole-audit" table referenced from sections A and C):
+//
+//   LEAK 1 — Server-side sticky-map fallback. When the server's
+//     `api_channel.rs` receives a stream-forwarded delta whose envelope
+//     does not carry an explicit thread_id, it falls back to "last
+//     thread_id seen for this channel". Under interleave the sticky map
+//     has rotated past the originating turn — the client receives the
+//     delta stamped with the WRONG thread_id.
+//
+//   LEAK 2 — Client-side reducer fallback. The current SPA at
+//     crates/octos-cli/static/app.js does not read thread_id off the wire
+//     at all (the SSE stream is treated as a raw token feed). Every delta
+//     is appended to whichever assistant bubble was most recently created.
+//     If a later user sends Q2 mid-stream, Q1's tail tokens land in Q2's
+//     bubble.
+//
+// This reducer reproduces LEAK 2 (and approximates LEAK 1's effect from
+// the client's vantage). PR J ships the typed-turn_id reducer that
+// replaces this file. When PR J lands, the 5 seed fixtures will pass —
+// today they all FAIL deterministically, which is the contract.
+//
+// THE SHAPE OF THE BUG
+// ────────────────────
+// On `user_sent`, we record (turn_id → bubble) and we update `sticky` to
+// the new turn_id. On `message_delta`, we IGNORE event.turn_id and append
+// to `sticky`. On `turn_started`, we update sticky too (mimicking the
+// server's "active turn" advance). This is what produces the wave-4 mini3
+// misroute pattern: a late delta for Q1 hits a sticky that has rotated
+// past Q1, so Q1's text lands in Q3's bubble.
+//
+// For `background_result` (issue #738), the bug is even simpler: the
+// current SPA doesn't have a separate handler — background results show
+// up as a fresh assistant message at the END of the conversation,
+// detached from their originating turn. We model that as "binds to
+// sticky" too.
+
+import type { Reducer, ReducerState } from './replay-fixture.js';
+import type { SseEvent, TurnId } from './fixture-types.js';
+
+/** State internal to the buggy reducer — the sticky-map. Stored alongside
+ *  the public ReducerState via a side map keyed by state object identity.
+ *  We use a WeakMap so each fixture run has its own sticky without us
+ *  having to widen the public ReducerState type. */
+const stickyByState: WeakMap<ReducerState, { sticky: TurnId | null }> =
+  new WeakMap();
+
+function getSticky(state: ReducerState): TurnId | null {
+  return stickyByState.get(state)?.sticky ?? null;
+}
+
+function setSticky(state: ReducerState, turn_id: TurnId | null): void {
+  stickyByState.set(state, { sticky: turn_id });
+}
+
+/** Mutates state in-place and returns it. The replay engine treats reducer
+ *  return as canonical, so we keep the contract clean. */
+function ensureThread(state: ReducerState, turn_id: TurnId): void {
+  if (!state.threads.has(turn_id)) {
+    state.threads.set(turn_id, { turn_id, user: '', asst: '' });
+    state.thread_order.push(turn_id);
+  }
+}
+
+export const buggyReducer: Reducer = (state, event) => {
+  // Carry the sticky pointer forward to the next state object. Since we
+  // mutate `state` in place (the engine doesn't require immutability) we
+  // can preserve the WeakMap entry on the same object.
+  const prevSticky = getSticky(state);
+  setSticky(state, prevSticky);
+
+  switch (event.type) {
+    case 'user_sent': {
+      ensureThread(state, event.turn_id);
+      const t = state.threads.get(event.turn_id)!;
+      t.user = event.text;
+      // BUG (LEAK 2): sticky advances to the most recent user. Later
+      // deltas for any earlier turn will misroute.
+      setSticky(state, event.turn_id);
+      return state;
+    }
+
+    case 'turn_started': {
+      // Mirrors the server's active-turn advance. In production this is
+      // what makes the bug bite even harder: the server's sticky also
+      // advances on turn_started, so deltas for the now-non-active turn
+      // go to the wrong bubble.
+      setSticky(state, event.turn_id);
+      return state;
+    }
+
+    case 'message_delta': {
+      // BUG: ignore event.turn_id; bind to sticky.
+      const target = getSticky(state);
+      if (target === null) {
+        state.rejected.push({ event, reason: 'no sticky thread to bind to' });
+        return state;
+      }
+      ensureThread(state, target);
+      const t = state.threads.get(target)!;
+      t.asst += event.text;
+      return state;
+    }
+
+    case 'turn_completed': {
+      // No-op for binding. Sticky stays put — which is part of the bug.
+      return state;
+    }
+
+    case 'turn_error': {
+      // BUG: just like message_delta — the current SPA flags whichever
+      // bubble is currently sticky as errored, ignoring event.turn_id.
+      // The actual originating turn never sees the error indicator.
+      const target = getSticky(state);
+      if (target === null) {
+        state.rejected.push({ event, reason: 'no sticky thread for turn_error' });
+        return state;
+      }
+      ensureThread(state, target);
+      const t = state.threads.get(target)!;
+      t.error = { code: event.code, message: event.message };
+      return state;
+    }
+
+    case 'tool_started': {
+      // BUG: tool calls render under whatever bubble is sticky. Issue
+      // #680 / "tool retry collapse" — when a retry fires after sticky
+      // has rotated to a later turn, the retry's tool_started binds
+      // there and the originating turn loses the tool indicator.
+      const target = getSticky(state);
+      if (target === null) {
+        state.rejected.push({ event, reason: 'no sticky thread for tool_started' });
+        return state;
+      }
+      ensureThread(state, target);
+      const t = state.threads.get(target)!;
+      t.tool_calls = (t.tool_calls ?? []).concat([
+        { tool_call_id: event.tool_call_id, tool_name: event.tool_name },
+      ]);
+      return state;
+    }
+
+    case 'tool_progress': {
+      // No render impact in the current SPA — silently consumed.
+      return state;
+    }
+
+    case 'tool_completed': {
+      // BUG: completion is matched against tool_call_id but the search
+      // is scoped to the SAME bubble that received tool_started. If
+      // sticky has rotated between started and completed (which is
+      // exactly what happens during retry collapse), the completion
+      // event creates a fresh tool_calls entry under the new sticky
+      // instead of finalizing the original.
+      const target = getSticky(state);
+      if (target === null) {
+        state.rejected.push({ event, reason: 'no sticky thread for tool_completed' });
+        return state;
+      }
+      ensureThread(state, target);
+      const t = state.threads.get(target)!;
+      const tc = (t.tool_calls ?? []).find((x) => x.tool_call_id === event.tool_call_id);
+      if (tc) {
+        tc.success = event.success;
+        tc.output_preview = event.output_preview;
+      } else {
+        // Fresh entry under wrong bubble — exactly the misroute symptom.
+        t.tool_calls = (t.tool_calls ?? []).concat([
+          {
+            tool_call_id: event.tool_call_id,
+            tool_name: event.tool_name,
+            success: event.success,
+            output_preview: event.output_preview,
+          },
+        ]);
+      }
+      return state;
+    }
+
+    case 'background_result': {
+      // BUG: like message_delta, the current SPA appends to the most
+      // recent assistant bubble. The originating turn_id on the event is
+      // ignored. Issue #738.
+      const target = getSticky(state);
+      if (target === null) {
+        state.rejected.push({
+          event,
+          reason: 'no sticky thread to attach background result to',
+        });
+        return state;
+      }
+      ensureThread(state, target);
+      const t = state.threads.get(target)!;
+      t.asst += event.text;
+      if (event.attachments) {
+        t.attachments = (t.attachments ?? []).concat(event.attachments);
+      }
+      return state;
+    }
+
+    case 'recovery_turn': {
+      // BUG: the current SPA treats the recovery_turn's text as a fresh
+      // delta. With sticky pointing at whoever sent most recently, the
+      // recovery output binds there — NOT to originating_turn_id.
+      const target = getSticky(state);
+      if (target === null) {
+        state.rejected.push({ event, reason: 'no sticky thread for recovery' });
+        return state;
+      }
+      ensureThread(state, target);
+      const t = state.threads.get(target)!;
+      t.asst += event.text;
+      return state;
+    }
+
+    case 'connection_drop': {
+      state.connected = false;
+      return state;
+    }
+
+    case 'connection_resume': {
+      // BUG: the current SPA does NOT deduplicate replayed events on
+      // reconnect. SSE is treated as a raw token stream; each token is
+      // appended to whatever bubble is currently sticky. Replayed
+      // user_sent events re-create/touch existing bubbles; replayed
+      // message_delta events DOUBLE-APPEND text to the wrong bubble
+      // (sticky has rotated forward by then). The visible symptom is
+      // duplicated text in the wrong bubble after every reconnect.
+      state.connected = true;
+      // sticky stays where it was — that's part of the bug.
+      return state;
+    }
+  }
+
+  // Exhaustive switch above; unreachable.
+  return state;
+};

--- a/crates/octos-web/src/state/__tests__/lib/fixed-reducer.ts
+++ b/crates/octos-web/src/state/__tests__/lib/fixed-reducer.ts
@@ -1,0 +1,198 @@
+// Reference (fixed) SPA reducer — the contract PR J must satisfy.
+//
+// This reducer is the executable specification of what PR J's typed-
+// turn_id reducer MUST do. The 5 seed fixtures are validated against this
+// reducer (they pass) and against the buggy-reducer (they fail).
+// Together those two outcomes prove:
+//
+//   (a) the fixtures express a real, achievable contract, AND
+//   (b) the fixtures detect the current buggy behavior.
+//
+// Properties:
+//
+//   - Every turn-scoped event MUST carry an explicit turn_id. Events
+//     without turn_id are rejected (no sticky-map fallback).
+//   - `recovery_turn` binds output to `originating_turn_id`, NOT to
+//     `recovery_turn_id`. (Issue #738 sibling.)
+//   - `background_result` binds to its event's turn_id (NOT to whatever
+//     was last active). Attachments are stored on that thread.
+//   - On `connection_resume` the graph is preserved (the server replays
+//     from cursor; the reducer accepts replayed events idempotently).
+//
+// PR J replaces the placeholder buggy-reducer.ts with a production-grade
+// implementation that preserves THESE behaviors. The fixtures don't care
+// HOW PR J achieves it — only that the reducer's observable state
+// matches what fixed-reducer below produces.
+
+import type { Reducer } from './replay-fixture.js';
+import type { TurnId } from './fixture-types.js';
+
+function ensureThread(
+  state: { threads: Map<TurnId, { turn_id: TurnId; user: string; asst: string; attachments?: Array<{ filename: string; path: string }> }>; thread_order: TurnId[] },
+  turn_id: TurnId,
+): void {
+  if (!state.threads.has(turn_id)) {
+    state.threads.set(turn_id, { turn_id, user: '', asst: '' });
+    state.thread_order.push(turn_id);
+  }
+}
+
+export const fixedReducer: Reducer = (state, event) => {
+  switch (event.type) {
+    case 'user_sent': {
+      ensureThread(state, event.turn_id);
+      const t = state.threads.get(event.turn_id)!;
+      t.user = event.text;
+      return state;
+    }
+
+    case 'turn_started': {
+      // Make sure the thread exists; the server has confirmed the turn.
+      ensureThread(state, event.turn_id);
+      return state;
+    }
+
+    case 'message_delta': {
+      if (!event.turn_id) {
+        state.rejected.push({ event, reason: 'message_delta missing turn_id' });
+        return state;
+      }
+      // Strict: a delta for a turn we've never seen start is a server bug
+      // OR a stale replay. Fail-closed by recording rejection. The
+      // assertion `no_orphans` will surface this.
+      if (!state.threads.has(event.turn_id)) {
+        state.rejected.push({
+          event,
+          reason: `message_delta for unknown turn_id "${event.turn_id}"`,
+        });
+        return state;
+      }
+      const t = state.threads.get(event.turn_id)!;
+      t.asst += event.text;
+      return state;
+    }
+
+    case 'turn_completed': {
+      // No-op for binding; the server has signaled the turn done.
+      return state;
+    }
+
+    case 'turn_error': {
+      if (!event.turn_id) {
+        state.rejected.push({ event, reason: 'turn_error missing turn_id' });
+        return state;
+      }
+      ensureThread(state, event.turn_id);
+      const t = state.threads.get(event.turn_id)!;
+      t.error = { code: event.code, message: event.message };
+      return state;
+    }
+
+    case 'tool_started': {
+      if (!event.turn_id) {
+        state.rejected.push({ event, reason: 'tool_started missing turn_id' });
+        return state;
+      }
+      ensureThread(state, event.turn_id);
+      const t = state.threads.get(event.turn_id)!;
+      t.tool_calls = (t.tool_calls ?? []).concat([
+        { tool_call_id: event.tool_call_id, tool_name: event.tool_name },
+      ]);
+      return state;
+    }
+
+    case 'tool_progress': {
+      // No render-state mutation needed for binding correctness; the
+      // production UI will surface progress text but the binding contract
+      // is fully expressed via tool_started + tool_completed.
+      return state;
+    }
+
+    case 'tool_completed': {
+      if (!event.turn_id) {
+        state.rejected.push({ event, reason: 'tool_completed missing turn_id' });
+        return state;
+      }
+      ensureThread(state, event.turn_id);
+      const t = state.threads.get(event.turn_id)!;
+      const tc = (t.tool_calls ?? []).find((x) => x.tool_call_id === event.tool_call_id);
+      if (tc) {
+        tc.success = event.success;
+        tc.output_preview = event.output_preview;
+      } else {
+        // No matching started — server replay or out-of-order delivery.
+        // We accept and create the record (the typed turn_id is what
+        // matters for binding correctness).
+        t.tool_calls = (t.tool_calls ?? []).concat([
+          {
+            tool_call_id: event.tool_call_id,
+            tool_name: event.tool_name,
+            success: event.success,
+            output_preview: event.output_preview,
+          },
+        ]);
+      }
+      return state;
+    }
+
+    case 'background_result': {
+      if (!event.turn_id) {
+        state.rejected.push({
+          event,
+          reason: 'background_result missing turn_id',
+        });
+        return state;
+      }
+      ensureThread(state, event.turn_id);
+      const t = state.threads.get(event.turn_id)!;
+      t.asst += event.text;
+      if (event.attachments) {
+        t.attachments = (t.attachments ?? []).concat(event.attachments);
+      }
+      return state;
+    }
+
+    case 'recovery_turn': {
+      // KEY: the recovery's output lands in originating_turn_id's bubble,
+      // NOT in recovery_turn_id's. The recovery_turn_id is server-side
+      // bookkeeping; the user never saw a fresh user message for it.
+      if (!event.originating_turn_id) {
+        state.rejected.push({
+          event,
+          reason: 'recovery_turn missing originating_turn_id',
+        });
+        return state;
+      }
+      ensureThread(state, event.originating_turn_id);
+      const t = state.threads.get(event.originating_turn_id)!;
+      t.asst += event.text;
+      return state;
+    }
+
+    case 'connection_drop': {
+      state.connected = false;
+      return state;
+    }
+
+    case 'connection_resume': {
+      // PR G UPCR-2026-009 semantic: on resume the client invokes
+      // `session/hydrate` and rebuilds state from the authoritative server
+      // snapshot. The replayed events that follow re-establish the graph
+      // from scratch. So the reducer DROPS its current threads and lets
+      // the replayed events repopulate.
+      //
+      // This is the contract: the post-resume graph is determined solely
+      // by what the server replays. Any drift between the pre-disconnect
+      // graph and the post-resume graph is the server's responsibility,
+      // and the protocol-level guarantee is "they match" because both
+      // come from the same ledger.
+      state.thread_order = [];
+      state.threads.clear();
+      // Note: we deliberately keep state.rejected — those rejections are
+      // reducer-level diagnostics that survive the transport reset.
+      state.connected = true;
+      return state;
+    }
+  }
+  return state;
+};

--- a/crates/octos-web/src/state/__tests__/lib/fixture-types.ts
+++ b/crates/octos-web/src/state/__tests__/lib/fixture-types.ts
@@ -1,0 +1,305 @@
+// Layer 1 SPA reducer fixture format.
+//
+// The fixture format mirrors the typed UI Protocol v1 envelope (see
+// `crates/octos-core/src/ui_protocol.rs::TurnStartedEvent`,
+// `MessageDeltaEvent`, etc.). Every event MUST carry an explicit `turn_id` —
+// that is the contract this layer enforces. The replay engine feeds events
+// into the reducer in `t` order; assertions run against the final state.
+//
+// Two design notes:
+//
+// 1. `SseFixture` is JSON-serializable end-to-end. PR I (capture-and-replay
+//    flag in the live harness) writes captures as JSON; this layer accepts
+//    them without modification. The TS files in fixtures/ are the
+//    hand-authored seeds; future captured fixtures will be `*.json`.
+//
+// 2. `Assertion` is a discriminated union, not a function. That keeps
+//    fixtures fully declarative (so they round-trip through JSON) and lets
+//    the replay engine produce structured failure reports — which is
+//    important when a Layer 2 capture-replay run wants to file the JSON
+//    directly into a regression test without compilation.
+
+// ── Identifiers (mirror the Rust newtypes) ───────────────────────────────
+//
+// All three are wire strings. The reducer treats them as opaque. The point
+// of the typed identity work in PR A is that they are NOT interchangeable
+// at the Rust layer; here we only assert that the wire form is consistent.
+
+/** Server protocol identity. UUIDv7 string in production. */
+export type TurnId = string;
+
+/** Render grouping (which DOM bubble). Currently equals the originating
+ *  user message's turn_id; PR J makes this explicit. */
+export type ThreadId = string;
+
+/** Client optimism + idempotency token. Web client mints. UUIDv7 in prod. */
+export type ClientMessageId = string;
+
+/** Session identity. */
+export type SessionKey = string;
+
+// ── SSE / UI Protocol event payloads ─────────────────────────────────────
+//
+// These are the SHAPES the SPA reducer consumes. They mirror the Rust
+// `UiNotification` variants in `octos-core/src/ui_protocol.rs`. The shape
+// names match the wire `"type"` (snake_case as serialized by the server).
+//
+// Every event carries `turn_id` — even `user_sent`, which is the client's
+// own optimistic synthesis at send time. The reducer NEVER fabricates a
+// turn_id from "current sticky" or "latest message"; if `turn_id` is
+// missing on an event, that event is invalid and the reducer rejects it.
+
+interface SseEventBase {
+  /** Logical time in ms from fixture origin. Used by the replay engine to
+   *  order events; not passed to the reducer (the reducer is stateless wrt
+   *  wall clock). */
+  t: number;
+  /** Wire `"type"` discriminant. */
+  type: string;
+}
+
+/** Optimistic user message, minted client-side. Carries the cmid the
+ *  client generated and the turn_id the server later confirms via
+ *  `turn/started`. In live capture, cmid arrives first; turn_id is filled
+ *  in when the server responds. For fixtures, both are pre-stamped. */
+export interface UserSentEvent extends SseEventBase {
+  type: 'user_sent';
+  session_id: SessionKey;
+  turn_id: TurnId;
+  cmid: ClientMessageId;
+  text: string;
+}
+
+/** Server confirms a turn has started. Mirrors `TurnStartedEvent`. */
+export interface TurnStartedEvent extends SseEventBase {
+  type: 'turn_started';
+  session_id: SessionKey;
+  turn_id: TurnId;
+}
+
+/** Streaming assistant text. Mirrors `MessageDeltaEvent`. */
+export interface MessageDeltaEvent extends SseEventBase {
+  type: 'message_delta';
+  session_id: SessionKey;
+  turn_id: TurnId;
+  text: string;
+}
+
+/** Server confirms a turn has completed. Mirrors `TurnCompletedEvent`. */
+export interface TurnCompletedEvent extends SseEventBase {
+  type: 'turn_completed';
+  session_id: SessionKey;
+  turn_id: TurnId;
+}
+
+/** Server reports a turn errored. Mirrors `TurnErrorEvent`. */
+export interface TurnErrorEvent extends SseEventBase {
+  type: 'turn_error';
+  session_id: SessionKey;
+  turn_id: TurnId;
+  code: string;
+  message: string;
+}
+
+/** Tool invocation begun. Mirrors `ToolStartedEvent`. */
+export interface ToolStartedEvent extends SseEventBase {
+  type: 'tool_started';
+  session_id: SessionKey;
+  turn_id: TurnId;
+  tool_call_id: string;
+  tool_name: string;
+}
+
+/** Tool progress update. Mirrors `ToolProgressEvent`. */
+export interface ToolProgressEvent extends SseEventBase {
+  type: 'tool_progress';
+  session_id: SessionKey;
+  turn_id: TurnId;
+  tool_call_id: string;
+  message?: string;
+}
+
+/** Tool completed (success or failure). Mirrors `ToolCompletedEvent`.
+ *  When `success === false`, the agent typically issues a retry —
+ *  modeled by emitting a fresh `tool_started` with a NEW `tool_call_id`
+ *  bound to the SAME `turn_id`. Issue #680 / "tool retry collapse" was
+ *  the bug where the retry's output bound to whatever turn was sticky
+ *  by the time the retry fired. */
+export interface ToolCompletedEvent extends SseEventBase {
+  type: 'tool_completed';
+  session_id: SessionKey;
+  turn_id: TurnId;
+  tool_call_id: string;
+  tool_name: string;
+  success: boolean;
+  output_preview?: string;
+}
+
+/** Background spawn-only result delivery. Carries the originating turn_id
+ *  so the result lands in the right bubble even when the live sticky map
+ *  has rotated forward. Issue #738. */
+export interface BackgroundResultEvent extends SseEventBase {
+  type: 'background_result';
+  session_id: SessionKey;
+  turn_id: TurnId;
+  text: string;
+  /** Optional file attachments (e.g. `.md` reports from deep_search). */
+  attachments?: Array<{ filename: string; path: string }>;
+}
+
+/** Recovery-turn fired after a child failure. Mirrors M8.9 recovery flow.
+ *  The result MUST inherit the originating turn_id, NOT the recovery's
+ *  fresh turn_id. */
+export interface RecoveryTurnEvent extends SseEventBase {
+  type: 'recovery_turn';
+  session_id: SessionKey;
+  /** The new turn_id the server allocated for the recovery turn. */
+  recovery_turn_id: TurnId;
+  /** The originating turn_id whose bubble the recovery's output belongs in. */
+  originating_turn_id: TurnId;
+  text: string;
+}
+
+/** Connection drop / reconnect signal. Used by the reload-replay fixture
+ *  to assert that the post-reconnect graph equals the pre-disconnect graph. */
+export interface ConnectionDropEvent extends SseEventBase {
+  type: 'connection_drop';
+}
+
+/** Reconnect; the engine resumes feeding events after this marker. The
+ *  reducer is preserved across the gap; only the transport reset. */
+export interface ConnectionResumeEvent extends SseEventBase {
+  type: 'connection_resume';
+  /** Cursor the server replays from. */
+  cursor?: string;
+}
+
+/** Discriminated union of every event the replay engine recognizes. */
+export type SseEvent =
+  | UserSentEvent
+  | TurnStartedEvent
+  | MessageDeltaEvent
+  | TurnCompletedEvent
+  | TurnErrorEvent
+  | ToolStartedEvent
+  | ToolProgressEvent
+  | ToolCompletedEvent
+  | BackgroundResultEvent
+  | RecoveryTurnEvent
+  | ConnectionDropEvent
+  | ConnectionResumeEvent;
+
+// ── Assertions (declarative, JSON-serializable) ──────────────────────────
+
+/** A tool call rendered inside a thread bubble. */
+export interface ToolCallRecord {
+  tool_call_id: string;
+  tool_name: string;
+  /** Final outcome — undefined while still in flight. */
+  success?: boolean;
+  output_preview?: string;
+}
+
+/** Error state attached to a thread bubble (set by `turn_error`). */
+export interface ThreadError {
+  code: string;
+  message: string;
+}
+
+/** A single thread bubble in the rendered chat. The reducer's output
+ *  state.threads must contain one of these per turn_id. */
+export interface ThreadBubble {
+  turn_id: TurnId;
+  user: string;
+  asst: string;
+  attachments?: Array<{ filename: string; path: string }>;
+  tool_calls?: ToolCallRecord[];
+  /** Set when a `turn_error` arrived for this turn. */
+  error?: ThreadError;
+}
+
+/** Discriminated assertion union. `kind` selects the check; the engine
+ *  reports `message` on failure. */
+export type Assertion =
+  /** The thread for `turn_id` exists and matches the given expectation. */
+  | {
+      kind: 'thread_equals';
+      turn_id: TurnId;
+      expect: { user?: string; asst?: string };
+    }
+  /** No assistant text, attachment, or delta has bound to a turn_id other
+   *  than the listed allowed_turn_ids. Catches misroute bugs (#649/#740). */
+  | {
+      kind: 'no_misroute';
+      allowed_turn_ids: TurnId[];
+    }
+  /** The threads in final state, in display order, exactly equal `expected`.
+   *  Order matters because the bug class includes off-by-one bubble
+   *  ordering. */
+  | {
+      kind: 'thread_order';
+      expected: TurnId[];
+    }
+  /** Every event with a `turn_id` was bound to a thread known to the
+   *  reducer. Catches "ghost-thread" bugs where a delta arrives for a turn
+   *  the client never saw start. */
+  | {
+      kind: 'no_orphans';
+    }
+  /** A specific turn_id's bubble carries the named attachment. Used by
+   *  spawn_only fixtures (#738) to assert .md result delivery. */
+  | {
+      kind: 'thread_has_attachment';
+      turn_id: TurnId;
+      filename: string;
+    }
+  /** A turn_id's bubble carries EXACTLY this list of attachments,
+   *  order-sensitive. Each entry can be either a bare filename string
+   *  (filename-only check) or a `{filename, path}` pair (both must
+   *  match). Use the pair form when paths discriminate (e.g. two
+   *  turns produce same-named attachments from different temp dirs).
+   *  Catches multi-attachment dedup bugs and out-of-order rendering. */
+  | {
+      kind: 'thread_attachments_equal';
+      turn_id: TurnId;
+      /** Backwards-compatible: keep `filenames` for fixtures that only
+       *  care about the names. New fixtures should prefer
+       *  `attachments`. */
+      filenames?: string[];
+      attachments?: Array<{ filename: string; path: string }>;
+    }
+  /** A turn_id's bubble has the given tool call recorded with the given
+   *  outcome. Used by tool-retry-collapse (#680) to assert the retry's
+   *  output binds to the originating turn even after sticky rotates. */
+  | {
+      kind: 'thread_has_tool_call';
+      turn_id: TurnId;
+      tool_call_id: string;
+      tool_name?: string;
+      success?: boolean;
+    }
+  /** A turn_id's bubble carries a turn_error with the given code. */
+  | {
+      kind: 'thread_has_error';
+      turn_id: TurnId;
+      code: string;
+    };
+
+// ── The fixture container ────────────────────────────────────────────────
+
+/** A complete fixture: events to replay and assertions to run against the
+ *  final reducer state. */
+export interface SseFixture {
+  /** Stable name; used in failure messages and CI logs. */
+  name: string;
+  /** Human-readable description of the bug class this catches. */
+  description: string;
+  /** Optional GitHub issue references documenting the originating bug(s). */
+  issues?: number[];
+  /** Session id used by every event. Defaults to `'fixture-session'`. */
+  session_id?: SessionKey;
+  /** Ordered (by `t`) event stream. */
+  events: SseEvent[];
+  /** Assertions evaluated against the final state. */
+  assertions: Assertion[];
+}

--- a/crates/octos-web/src/state/__tests__/lib/json-loader.ts
+++ b/crates/octos-web/src/state/__tests__/lib/json-loader.ts
@@ -1,0 +1,249 @@
+// JSON fixture loader + normalizer.
+//
+// PR I (capture-and-replay flag in `e2e/lib/live-browser-helpers.ts`)
+// captures live SSE streams as raw UI Protocol notifications. Those
+// notifications arrive as `{"jsonrpc": "2.0", "method": "...", "params": {...}}`
+// envelopes, NOT as the flat `{type, ...}` form the in-process replay
+// engine consumes. This loader bridges the two:
+//
+//   1. Parses a JSON fixture file (either flat-form or wrapped-form).
+//   2. Validates required fields and types.
+//   3. Normalizes wrapped JSON-RPC notifications into the flat form.
+//   4. Returns a typed `SseFixture` ready to feed to `replayFixture`.
+//
+// Wrapped-form input shape (what PR I will write):
+//
+//   {
+//     "name": "captured-2026-04-30-1234",
+//     "description": "...",
+//     "session_id": "live-session-abc",
+//     "events": [
+//       {
+//         "t": 0,
+//         "envelope": {
+//           "jsonrpc": "2.0",
+//           "method": "message/delta",
+//           "params": {
+//             "session_id": "...",
+//             "turn_id": "...",
+//             "text": "..."
+//           }
+//         }
+//       },
+//       ...
+//     ],
+//     "assertions": [...]
+//   }
+//
+// Flat-form input is the same as the TS fixture files in `fixtures/`.
+//
+// On any validation failure we throw with a clear path-prefixed message
+// so the operator promoting a captured fixture sees exactly what was
+// malformed.
+
+import type {
+  Assertion,
+  SseEvent,
+  SseFixture,
+} from './fixture-types.js';
+
+// ── Wire method → flat-event type mapping ────────────────────────────────
+//
+// Mirrors the UI Protocol `method` strings in
+// `crates/octos-core/src/ui_protocol.rs::ui_protocol_methods`.
+
+const METHOD_TO_TYPE: Record<string, string> = {
+  'turn/started': 'turn_started',
+  'turn/completed': 'turn_completed',
+  'turn/error': 'turn_error',
+  'message/delta': 'message_delta',
+  'tool/started': 'tool_started',
+  'tool/progress': 'tool_progress',
+  'tool/completed': 'tool_completed',
+  // Custom (no UI Protocol equivalent yet — both PR H-internal):
+  'user/sent': 'user_sent',
+  'background/result': 'background_result',
+  'recovery/turn': 'recovery_turn',
+  'connection/drop': 'connection_drop',
+  'connection/resume': 'connection_resume',
+};
+
+// UI Protocol notifications the reducer doesn't yet model but that are
+// valid wire messages a captured stream may include. We accept them and
+// drop them so a raw capture from PR I doesn't have to be hand-edited.
+// Mirrors the constants in `crates/octos-core/src/ui_protocol.rs`
+// (`ui_protocol_methods` module — `task/updated`, `task/output/delta`,
+// `progress/updated`, `warning`, `approval/*`, `session/*`, etc.).
+const IGNORED_METHODS: Set<string> = new Set([
+  'session/open',
+  'session/opened',
+  'session/closed',
+  'session/hydrate',
+  'task/updated',
+  'task/output/delta',
+  'progress/updated',
+  'warning',
+  'protocol/replay_lossy',
+  'approval/requested',
+  'approval/decided',
+  'approval/cancelled',
+  'approval/auto_resolved',
+  'approval/respond',
+  'turn/interrupt',
+  'capability/announce',
+  'thread/graph/get',
+  'turn/state/get',
+  'message/persisted',
+]);
+
+/** Loose JSON value type — keep TS happy without importing a JSON schema lib. */
+type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+function isObject(v: unknown): v is Record<string, JsonValue> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function require_(obj: Record<string, JsonValue>, key: string, path: string): JsonValue {
+  if (!(key in obj)) {
+    throw new Error(`fixture validation: missing required field "${path}.${key}"`);
+  }
+  return obj[key]!;
+}
+
+function requireString(v: JsonValue, path: string): string {
+  if (typeof v !== 'string') {
+    throw new Error(`fixture validation: expected string at "${path}", got ${typeof v}`);
+  }
+  return v;
+}
+
+function requireNumber(v: JsonValue, path: string): number {
+  if (typeof v !== 'number' || !Number.isFinite(v)) {
+    throw new Error(`fixture validation: expected finite number at "${path}", got ${JSON.stringify(v)}`);
+  }
+  return v;
+}
+
+/** Sentinel returned by `normalizeEvent` when the input was a known
+ *  ignored UI Protocol notification. Callers filter these out. */
+const IGNORE = Symbol('ignored-notification');
+
+/** Take an event in either flat or wrapped form and return the flat form
+ *  the replay engine consumes. Wrapped events go through method
+ *  normalization. Returns `IGNORE` if the wrapped form is a known
+ *  ignored notification (e.g. `progress/updated`). */
+export function normalizeEvent(
+  input: unknown,
+  path: string,
+): SseEvent | typeof IGNORE {
+  if (!isObject(input)) {
+    throw new Error(`fixture validation: event at "${path}" is not an object`);
+  }
+  const t = requireNumber(require_(input, 't', path), `${path}.t`);
+
+  const hasType = 'type' in input;
+  const hasEnvelope = 'envelope' in input;
+
+  // Reject ambiguous events. A captured fixture might enrich an envelope
+  // with extra metadata, but a top-level `type` next to `envelope` makes
+  // the discriminant unclear and earlier silently leaked envelope fields
+  // into the flat output. Fail-closed.
+  if (hasType && hasEnvelope) {
+    throw new Error(
+      `fixture validation: event at "${path}" has BOTH "type" and "envelope" — ambiguous; choose one`,
+    );
+  }
+
+  // Wrapped form first (preferred when the capture is raw UI Protocol).
+  if (hasEnvelope) {
+    const env = input.envelope;
+    if (!isObject(env)) {
+      throw new Error(`fixture validation: "${path}.envelope" is not an object`);
+    }
+    const method = requireString(
+      require_(env, 'method', `${path}.envelope`),
+      `${path}.envelope.method`,
+    );
+    if (IGNORED_METHODS.has(method)) {
+      return IGNORE;
+    }
+    const flatType = METHOD_TO_TYPE[method];
+    if (!flatType) {
+      throw new Error(
+        `fixture validation: unknown UI Protocol method "${method}" at "${path}.envelope.method" (known: ${Object.keys(METHOD_TO_TYPE).join(', ')}; ignored: ${[...IGNORED_METHODS].join(', ')})`,
+      );
+    }
+    const params = isObject(env.params) ? env.params : {};
+    return { ...params, t, type: flatType } as unknown as SseEvent;
+  }
+
+  // Flat form.
+  if (hasType) {
+    return { ...input, t } as unknown as SseEvent;
+  }
+
+  throw new Error(`fixture validation: event at "${path}" has neither "type" nor "envelope"`);
+}
+
+export const IGNORED_EVENT = IGNORE;
+
+/** Load and validate a fixture from a JSON-decoded object. Caller is
+ *  responsible for `JSON.parse` so this function works in environments
+ *  without `fs` (e.g. browser-side fixture inspection). */
+export function loadFixtureJson(raw: unknown): SseFixture {
+  if (!isObject(raw)) {
+    throw new Error('fixture validation: top-level value is not an object');
+  }
+  const name = requireString(require_(raw, 'name', 'fixture'), 'fixture.name');
+  const description = requireString(
+    require_(raw, 'description', 'fixture'),
+    'fixture.description',
+  );
+
+  const eventsRaw = require_(raw, 'events', 'fixture');
+  if (!Array.isArray(eventsRaw)) {
+    throw new Error('fixture validation: "fixture.events" is not an array');
+  }
+  const events: SseEvent[] = [];
+  for (let idx = 0; idx < eventsRaw.length; idx++) {
+    const normalized = normalizeEvent(eventsRaw[idx], `fixture.events[${idx}]`);
+    if (normalized === IGNORE) continue; // dropped: known no-op notification
+    events.push(normalized);
+  }
+
+  const assertionsRaw = require_(raw, 'assertions', 'fixture');
+  if (!Array.isArray(assertionsRaw)) {
+    throw new Error('fixture validation: "fixture.assertions" is not an array');
+  }
+  const assertions: Assertion[] = assertionsRaw.map((a, idx) => {
+    if (!isObject(a)) {
+      throw new Error(`fixture validation: fixture.assertions[${idx}] is not an object`);
+    }
+    if (!('kind' in a) || typeof a.kind !== 'string') {
+      throw new Error(`fixture validation: fixture.assertions[${idx}].kind missing or not a string`);
+    }
+    return a as unknown as Assertion;
+  });
+
+  const fixture: SseFixture = {
+    name,
+    description,
+    events,
+    assertions,
+  };
+  if ('session_id' in raw && typeof raw.session_id === 'string') {
+    fixture.session_id = raw.session_id;
+  }
+  if ('issues' in raw && Array.isArray(raw.issues)) {
+    fixture.issues = raw.issues.filter(
+      (n): n is number => typeof n === 'number',
+    );
+  }
+  return fixture;
+}

--- a/crates/octos-web/src/state/__tests__/lib/replay-fixture.ts
+++ b/crates/octos-web/src/state/__tests__/lib/replay-fixture.ts
@@ -1,0 +1,401 @@
+// Layer 1 SPA reducer fixture replay engine.
+//
+// Takes an `SseFixture` and a `Reducer`, advances the reducer event-by-event
+// in `t` order, then runs every assertion against the final state. Returns
+// a structured result so the Vitest test wrapper can convert it to an
+// `expect(...)` assertion that produces a clean diff.
+//
+// Two intentional design properties:
+//
+// 1. The engine is COMPLETELY DETERMINISTIC. No setTimeout, no Promises,
+//    no Date.now(). Events are processed synchronously in the order their
+//    `t` field implies (ties broken by array index — fixtures must be
+//    authored stable). This is what gets us <1s total CI runtime.
+//
+// 2. The engine is ALLOCATION-SAFE. We never mutate the fixture; the
+//    reducer's state object is passed by reference but the events array is
+//    iterated read-only. That means a captured fixture loaded from JSON
+//    can be replayed against multiple reducers (current buggy + future
+//    fixed) and the diff is meaningful.
+
+import type {
+  Assertion,
+  SseEvent,
+  SseFixture,
+  ThreadBubble,
+  TurnId,
+} from './fixture-types.js';
+
+// ── Reducer contract ─────────────────────────────────────────────────────
+//
+// The SPA reducer the fixtures test against. Thread-keyed Map of bubbles +
+// connection state (so reload-replay can assert that reconnection
+// preserves the graph). PR J ships the production version of this; the
+// current placeholder is `buggy-reducer.ts`.
+
+export interface ReducerState {
+  /** Render order — first appearance of a turn_id wins. The order is
+   *  asserted by `kind: 'thread_order'`. */
+  thread_order: TurnId[];
+  /** Per-thread render content. */
+  threads: Map<TurnId, ThreadBubble>;
+  /** True between `connection_drop` and `connection_resume`. The reducer
+   *  may queue events while disconnected; the engine ALWAYS feeds them
+   *  through anyway, modelling a server that replays-from-cursor on
+   *  resume. */
+  connected: boolean;
+  /** Events the reducer rejected (bad turn_id, missing fields, etc.).
+   *  Surfaced in failure reports so a fixture author can see why a
+   *  delta got dropped. */
+  rejected: Array<{ event: SseEvent; reason: string }>;
+}
+
+export function emptyState(): ReducerState {
+  return {
+    thread_order: [],
+    threads: new Map(),
+    connected: true,
+    rejected: [],
+  };
+}
+
+/** A reducer implementation. Pure function; no I/O. Receives the previous
+ *  state and the next event; returns the next state. The engine never
+ *  shares state across fixtures — each replay starts from `emptyState()`. */
+export type Reducer = (state: ReducerState, event: SseEvent) => ReducerState;
+
+// ── Replay loop ──────────────────────────────────────────────────────────
+
+/** Result of replaying a fixture. `pass` is the verdict; `failures` lists
+ *  every assertion that didn't hold. `final_state` is included so a CI
+ *  log can show what the reducer actually produced. */
+export interface ReplayResult {
+  fixture_name: string;
+  pass: boolean;
+  failures: AssertionFailure[];
+  final_state: ReducerState;
+  events_processed: number;
+  duration_ms: number;
+}
+
+export interface AssertionFailure {
+  assertion: Assertion;
+  message: string;
+}
+
+/** Sort events by `t`, ties broken by original index — guarantees that two
+ *  events at the same logical timestamp keep their authored order. */
+function sortEvents(events: SseEvent[]): SseEvent[] {
+  const indexed = events.map((ev, idx) => ({ ev, idx }));
+  indexed.sort((a, b) => {
+    if (a.ev.t !== b.ev.t) return a.ev.t - b.ev.t;
+    return a.idx - b.idx;
+  });
+  return indexed.map((x) => x.ev);
+}
+
+export function replayFixture(
+  fixture: SseFixture,
+  reducer: Reducer,
+): ReplayResult {
+  const t0 =
+    typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+
+  let state = emptyState();
+  const ordered = sortEvents(fixture.events);
+
+  for (const event of ordered) {
+    state = reducer(state, event);
+  }
+
+  const t1 =
+    typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+
+  const failures = runAssertions(state, fixture.assertions, ordered);
+
+  return {
+    fixture_name: fixture.name,
+    pass: failures.length === 0,
+    failures,
+    final_state: state,
+    events_processed: ordered.length,
+    duration_ms: Math.max(0, t1 - t0),
+  };
+}
+
+// ── Assertion runner ─────────────────────────────────────────────────────
+
+function runAssertions(
+  state: ReducerState,
+  assertions: Assertion[],
+  events: SseEvent[],
+): AssertionFailure[] {
+  const failures: AssertionFailure[] = [];
+  for (const a of assertions) {
+    const failure = checkAssertion(state, a, events);
+    if (failure) failures.push({ assertion: a, message: failure });
+  }
+  return failures;
+}
+
+function checkAssertion(
+  state: ReducerState,
+  a: Assertion,
+  events: SseEvent[],
+): string | null {
+  switch (a.kind) {
+    case 'thread_equals': {
+      const t = state.threads.get(a.turn_id);
+      if (!t) return `thread for turn_id="${a.turn_id}" missing entirely`;
+      if (a.expect.user !== undefined && t.user !== a.expect.user) {
+        return `thread "${a.turn_id}" user: want ${JSON.stringify(a.expect.user)}, got ${JSON.stringify(t.user)}`;
+      }
+      if (a.expect.asst !== undefined && t.asst !== a.expect.asst) {
+        return `thread "${a.turn_id}" asst: want ${JSON.stringify(a.expect.asst)}, got ${JSON.stringify(t.asst)}`;
+      }
+      return null;
+    }
+    case 'no_misroute': {
+      const allowed = new Set(a.allowed_turn_ids);
+      // For every turn_id present in the final state's threads, it must
+      // be allowed. AND every event's turn_id must have ended up in its
+      // own bubble. We reconstruct each turn's expected text from the
+      // events, but BOUNDED by `connection_resume` markers — events
+      // before a resume are considered "replayed and superseded" by the
+      // post-resume tail. (This mirrors the session/hydrate semantic:
+      // server replays from cursor; the post-resume events are
+      // canonical.)
+      //
+      // If there is no connection_resume in the stream, we look at every
+      // event. If there IS, we restart text accumulation from the
+      // resume point.
+      let lastResumeIdx = -1;
+      for (let i = 0; i < events.length; i++) {
+        if (events[i]!.type === 'connection_resume') lastResumeIdx = i;
+      }
+      const startIdx = lastResumeIdx >= 0 ? lastResumeIdx + 1 : 0;
+      const bound: Map<TurnId, string> = new Map();
+      for (let i = startIdx; i < events.length; i++) {
+        const ev = events[i]!;
+        const tid = turnIdOf(ev);
+        if (!tid) continue;
+        if (!allowed.has(tid)) continue;
+        if (ev.type === 'message_delta') {
+          bound.set(tid, (bound.get(tid) ?? '') + ev.text);
+        } else if (ev.type === 'background_result') {
+          bound.set(tid, (bound.get(tid) ?? '') + ev.text);
+        } else if (ev.type === 'recovery_turn') {
+          // Recovery output should land in the originating bubble.
+          const ori = ev.originating_turn_id;
+          bound.set(ori, (bound.get(ori) ?? '') + ev.text);
+        }
+      }
+      for (const [tid, expectText] of bound) {
+        const got = state.threads.get(tid);
+        if (!got) {
+          return `misroute: turn_id="${tid}" bubble missing — text "${expectText}" was bound elsewhere`;
+        }
+        if (!got.asst.includes(expectText) && expectText.length > 0) {
+          // Find where the text actually landed.
+          let landedIn: TurnId | null = null;
+          for (const [otherTid, other] of state.threads) {
+            if (otherTid !== tid && other.asst.includes(expectText)) {
+              landedIn = otherTid;
+              break;
+            }
+          }
+          if (landedIn) {
+            return `misroute: text "${expectText}" expected in turn_id="${tid}" but landed in turn_id="${landedIn}"`;
+          }
+          return `misroute: turn_id="${tid}" bubble does not contain expected text "${expectText}"`;
+        }
+      }
+      return null;
+    }
+    case 'thread_order': {
+      const got = state.thread_order;
+      if (got.length !== a.expected.length) {
+        return `thread_order length mismatch: want ${a.expected.length} (${JSON.stringify(a.expected)}), got ${got.length} (${JSON.stringify(got)})`;
+      }
+      for (let i = 0; i < got.length; i++) {
+        if (got[i] !== a.expected[i]) {
+          return `thread_order[${i}]: want "${a.expected[i]}", got "${got[i]}" (full: ${JSON.stringify(got)})`;
+        }
+      }
+      return null;
+    }
+    case 'no_orphans': {
+      if (state.rejected.length === 0) return null;
+      const reasons = state.rejected
+        .map(
+          (r) =>
+            `${r.event.type}@t=${r.event.t}(turn_id=${turnIdOf(r.event) ?? '<none>'}): ${r.reason}`,
+        )
+        .join('; ');
+      return `${state.rejected.length} event(s) rejected as orphaned: ${reasons}`;
+    }
+    case 'thread_has_attachment': {
+      const t = state.threads.get(a.turn_id);
+      if (!t) return `thread for turn_id="${a.turn_id}" missing — cannot check attachment "${a.filename}"`;
+      const found = (t.attachments ?? []).some(
+        (att) => att.filename === a.filename,
+      );
+      if (!found) {
+        // Check if the attachment landed elsewhere — that's the real bug.
+        for (const [otherTid, other] of state.threads) {
+          if (otherTid === a.turn_id) continue;
+          if ((other.attachments ?? []).some((att) => att.filename === a.filename)) {
+            return `attachment "${a.filename}" expected in turn_id="${a.turn_id}" but landed in turn_id="${otherTid}"`;
+          }
+        }
+        return `attachment "${a.filename}" missing from turn_id="${a.turn_id}" (and not found in any other bubble)`;
+      }
+      return null;
+    }
+    case 'thread_attachments_equal': {
+      const t = state.threads.get(a.turn_id);
+      if (!t) return `thread for turn_id="${a.turn_id}" missing — cannot check attachments`;
+      const gotAtt = t.attachments ?? [];
+      // Prefer the typed `attachments` form when given (path-sensitive).
+      if (a.attachments) {
+        if (gotAtt.length !== a.attachments.length) {
+          return `attachments length mismatch for turn_id="${a.turn_id}": want ${JSON.stringify(a.attachments)}, got ${JSON.stringify(gotAtt)}`;
+        }
+        for (let i = 0; i < gotAtt.length; i++) {
+          const want = a.attachments[i]!;
+          const got = gotAtt[i]!;
+          if (got.filename !== want.filename || got.path !== want.path) {
+            return `attachments[${i}] for turn_id="${a.turn_id}": want ${JSON.stringify(want)}, got ${JSON.stringify(got)}`;
+          }
+        }
+        return null;
+      }
+      // Filename-only check (backwards-compat for simpler fixtures).
+      const wantNames = a.filenames ?? [];
+      const gotNames = gotAtt.map((x) => x.filename);
+      if (gotNames.length !== wantNames.length) {
+        return `attachments length mismatch for turn_id="${a.turn_id}": want ${JSON.stringify(wantNames)}, got ${JSON.stringify(gotNames)}`;
+      }
+      for (let i = 0; i < gotNames.length; i++) {
+        if (gotNames[i] !== wantNames[i]) {
+          return `attachments[${i}] for turn_id="${a.turn_id}": want "${wantNames[i]}", got "${gotNames[i]}" (full: ${JSON.stringify(gotNames)})`;
+        }
+      }
+      return null;
+    }
+    case 'thread_has_tool_call': {
+      const t = state.threads.get(a.turn_id);
+      if (!t) return `thread for turn_id="${a.turn_id}" missing — cannot check tool_call "${a.tool_call_id}"`;
+      const tc = (t.tool_calls ?? []).find((x) => x.tool_call_id === a.tool_call_id);
+      if (!tc) {
+        // Look for the tool call elsewhere — that's the misroute.
+        for (const [otherTid, other] of state.threads) {
+          if (otherTid === a.turn_id) continue;
+          if ((other.tool_calls ?? []).some((x) => x.tool_call_id === a.tool_call_id)) {
+            return `tool_call "${a.tool_call_id}" expected in turn_id="${a.turn_id}" but landed in turn_id="${otherTid}"`;
+          }
+        }
+        return `tool_call "${a.tool_call_id}" missing from turn_id="${a.turn_id}"`;
+      }
+      if (a.tool_name !== undefined && tc.tool_name !== a.tool_name) {
+        return `tool_call "${a.tool_call_id}" tool_name: want "${a.tool_name}", got "${tc.tool_name}"`;
+      }
+      if (a.success !== undefined && tc.success !== a.success) {
+        return `tool_call "${a.tool_call_id}" success: want ${a.success}, got ${tc.success}`;
+      }
+      return null;
+    }
+    case 'thread_has_error': {
+      const t = state.threads.get(a.turn_id);
+      if (!t) return `thread for turn_id="${a.turn_id}" missing — cannot check error code "${a.code}"`;
+      if (!t.error) {
+        // Did the error land elsewhere?
+        for (const [otherTid, other] of state.threads) {
+          if (otherTid === a.turn_id) continue;
+          if (other.error?.code === a.code) {
+            return `turn_error code="${a.code}" expected in turn_id="${a.turn_id}" but landed in turn_id="${otherTid}"`;
+          }
+        }
+        return `turn_error code="${a.code}" missing from turn_id="${a.turn_id}"`;
+      }
+      if (t.error.code !== a.code) {
+        return `turn_error in turn_id="${a.turn_id}": want code="${a.code}", got code="${t.error.code}"`;
+      }
+      return null;
+    }
+  }
+  return null;
+}
+
+/** Pull the turn_id out of any event that carries one. Connection signals
+ *  return null. */
+function turnIdOf(ev: SseEvent): TurnId | null {
+  switch (ev.type) {
+    case 'user_sent':
+    case 'turn_started':
+    case 'message_delta':
+    case 'turn_completed':
+    case 'turn_error':
+    case 'tool_started':
+    case 'tool_progress':
+    case 'tool_completed':
+    case 'background_result':
+      return ev.turn_id;
+    case 'recovery_turn':
+      return ev.originating_turn_id;
+    case 'connection_drop':
+    case 'connection_resume':
+      return null;
+  }
+}
+
+/** Pretty-print a replay result for failure reports. Used by the Vitest
+ *  wrappers to attach a readable diff to the assertion error. */
+export function formatReplayResult(r: ReplayResult): string {
+  const lines: string[] = [];
+  lines.push(
+    `[${r.pass ? 'PASS' : 'FAIL'}] ${r.fixture_name} (${r.events_processed} events, ${r.duration_ms.toFixed(2)}ms)`,
+  );
+  if (!r.pass) {
+    lines.push(`  failures (${r.failures.length}):`);
+    for (const f of r.failures) {
+      lines.push(`    - [${f.assertion.kind}] ${f.message}`);
+    }
+    lines.push(`  final state.thread_order: ${JSON.stringify(r.final_state.thread_order)}`);
+    // Iterate via thread_order, not Map insertion, so the output is
+    // stable even if some future V8 changes Map iteration semantics.
+    // Threads not in thread_order (shouldn't happen, but defensive)
+    // get printed at the end.
+    const printed = new Set<TurnId>();
+    for (const tid of r.final_state.thread_order) {
+      const t = r.final_state.threads.get(tid);
+      if (!t) continue;
+      printed.add(tid);
+      const att = t.attachments?.length
+        ? ` attachments=${JSON.stringify(t.attachments.map((a) => a.filename))}`
+        : '';
+      const tc = t.tool_calls?.length
+        ? ` tool_calls=${JSON.stringify(t.tool_calls.map((c) => c.tool_call_id))}`
+        : '';
+      const er = t.error ? ` error=${JSON.stringify(t.error)}` : '';
+      lines.push(
+        `    thread "${tid}": user=${JSON.stringify(t.user)} asst=${JSON.stringify(t.asst)}${att}${tc}${er}`,
+      );
+    }
+    for (const [tid, t] of r.final_state.threads) {
+      if (printed.has(tid)) continue;
+      lines.push(`    thread "${tid}" (off-order): user=${JSON.stringify(t.user)} asst=${JSON.stringify(t.asst)}`);
+    }
+    if (r.final_state.rejected.length > 0) {
+      lines.push(`  rejected events: ${r.final_state.rejected.length}`);
+      for (const rj of r.final_state.rejected) {
+        lines.push(`    - ${rj.event.type}@t=${rj.event.t}: ${rj.reason}`);
+      }
+    }
+  }
+  return lines.join('\n');
+}

--- a/crates/octos-web/tsconfig.json
+++ b/crates/octos-web/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/crates/octos-web/vitest.config.ts
+++ b/crates/octos-web/vitest.config.ts
@@ -1,0 +1,20 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+// Layer 1 fixture replay tests. Pure logic, no DOM — node environment.
+// Target: <1s total runtime, deterministic, no external services.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/state/__tests__/**/*.test.ts'],
+    // The fixture-replay engine is allocation-light and entirely
+    // synchronous; a single thread is faster than the pool overhead.
+    pool: 'threads',
+    poolOptions: { threads: { singleThread: true } },
+    // Fail fast on accidental CI hangs.
+    testTimeout: 5_000,
+    // Reporters: keep CI logs minimal; use verbose locally via `npx vitest`.
+    reporters: process.env.CI ? ['default'] : ['verbose'],
+  },
+});


### PR DESCRIPTION
## Summary

Builds the Layer 1 testing pyramid layer that doesn't exist today. Feeds canned UI Protocol v1 SSE event fixtures into a deterministic SPA reducer and asserts thread-graph correctness — in milliseconds, no LLM, no fleet, no Playwright.

Closes the structural feedback-loop gap that has let the M8.10 thread-binding regression chain (#649 → #664 → #673 → #680 → #738 → #740) keep recurring. Each prior fix shipped tactically; the bug class only ever surfaced in 6-minute soak runs against the fleet, by which point the regression was already in production.

## What changed

- New crate `crates/octos-web/` (TS-only test-infrastructure package; the production SPA reducer ships in PR J).
- `lib/fixture-types.ts` — typed `SseEvent` + `Assertion` + `SseFixture`. Mirrors `crates/octos-core/src/ui_protocol.rs` event shapes (turn/started, message/delta, tool/started, tool/progress, tool/completed, turn/error, etc.).
- `lib/replay-fixture.ts` — deterministic replay engine. Sorts events by `t` with stable tie-break by authored index. Fully synchronous — no setTimeout, no real WS, no filesystem.
- `lib/buggy-reducer.ts` — deliberately-broken sentinel that models the current production sticky-map fallback (LEAK 2 in the loophole-audit). Stays forever as the negative-coverage gate.
- `lib/fixed-reducer.ts` — executable spec PR J's reducer must match.
- `lib/json-loader.ts` — accepts BOTH flat-form (TS shape) AND wrapped-form (UI Protocol JSON-RPC `{method,params}`) so PR I's capture-and-replay can promote captures mechanically. Known ignored notifications (`progress/updated`, `task/updated`, etc.) are silently dropped; ambiguous events (both `type` and `envelope`) are rejected.
- 7 seed fixtures covering the bug class:
  - `rapid-fire-five-fast` — #649/#740 base case (wave-4 mini3 misroute)
  - `slow-then-fast-interleave` — #649 deep_research + .md attachment misroute
  - `spawn-only-ack-then-result` — #738 spawn_only result delivery
  - `m89-recovery-turn` — #738 sibling, recovery + `turn_error` binding
  - `reload-replay` — reconnect/cursor replay graph identity
  - `tool-retry-collapse` — #680 tool retry under same `turn_id` after sticky rotates
  - `multi-attachment-dedup` — 3-file deep_search × 2 turns (same names, different paths; path-sensitive assertion)
- Vitest entry at `fixtures.test.ts` runs every fixture against BOTH reducers. Suite 1: every fixture must FAIL the buggy sentinel (proves teeth). Suite 2: every fixture must PASS the fixed reference (proves contract is achievable).
- `.github/workflows/web-reducer-fixtures.yml` — runs on every PR touching `octos-web/`, `octos-core/src/ui_protocol.rs`, or the server-side surfaces that emit reducer events (`octos-bus/src/api_channel.rs`, `octos-cli/src/api/ui_protocol.rs`, `octos-cli/src/stream_reporter.rs`).

## Why this matters

PoC validated at `/tmp/fixture-poc/reducer-test.mjs`: 2ms runtime, deterministic, reproduces the EXACT wave-4 mini3 misroute pattern. Compare to 6+ minutes per `live-thread-interleave` run that may or may not even reach the assertion stage.

## Demonstrated to fail against current (buggy) reducer

Verified via `npx tsx scripts/print-buggy-output.mjs` — all 7 fixtures fail in 0.25ms total with deterministic, real-world misroute patterns:

```
[FAIL] rapid-fire-five-fast (20 events, 0.19ms)
  - thread "cm-A" asst: want "1+1=2", got ""
  - thread "cm-C" asst: want "3+3=6", got "1+1=2"
  - misroute: text "1+1=2" expected in turn_id="cm-A" but landed in turn_id="cm-C"

[FAIL] slow-then-fast-interleave (9 events, 0.01ms)
  - attachment "m9-5-research.md" expected in turn_id="slow-Q1" but landed in turn_id="fast-Q2"

[FAIL] spawn-only-ack-then-result (9 events, 0.02ms)
  - attachment "release-notes.md" expected in turn_id="orig-turn" but landed in turn_id="second-turn"

[FAIL] m89-recovery-turn (9 events, 0.02ms)
  - turn_error code="upstream_503" expected in turn_id="orig-turn" but landed in turn_id="gap-turn"
  - recovery output expected in turn_id="orig-turn" but landed in turn_id="gap-turn"

[FAIL] reload-replay (18 events, 0.01ms)
  - thread "turn-1" asst: want "First answer.", got "First answer.First answer." (text doubled on reconnect)

[FAIL] tool-retry-collapse (12 events, 0.03ms)
  - tool_call "tc-1b" expected in turn_id="turn-1" but landed in turn_id="turn-2"

[FAIL] multi-attachment-dedup (10 events, 0.01ms)
  - attachments length mismatch for turn_id="t1": want 3 files, got []
  - attachments length mismatch for turn_id="t2": want 3 files, got 6 (t1's leaked in)

Summary: 7/7 fixtures fail against buggy reducer in 0.25ms total.
```

## Codex 2nd-opinion review

Two rounds captured at `/tmp/codex-prh-review.log`. No P0s. All P1+P2 findings applied:

**Round 1**: missing `tool/*` events (added), missing #680 retry fixture (added), missing multi-attachment dedup (added), `turn_error` binding modeled-but-unasserted (now asserted via `thread_has_error`), JSON loader/normalizer absent (added), CI paths too narrow (expanded).

**Round 2**: ignored UI Protocol methods were rejected (now silently dropped), flat-vs-envelope ambiguity could leak fields (now rejected), filename-only attachment assertion let wrong-path passes through (now path-sensitive via `attachments` form), doc inconsistency on buggy-sentinel lifecycle (resolved — sentinel kept forever).

## Test plan

- [x] All 7 seed fixtures fail deterministically against buggy reducer (proves they catch the bug class)
- [x] All 7 seed fixtures pass against fixed reference reducer (proves contract is achievable)
- [x] JSON loader round-trips flat-form, normalizes wrapped-form, drops ignored notifications, rejects ambiguous events
- [x] Replay engine determinism: identical state across two runs; stable sort tie-break
- [x] Codex 2nd-opinion review at `/tmp/codex-prh-review.log` (2 rounds, all findings applied)
- [x] `npm run typecheck` clean
- [x] `npm test` 23/23 pass in ~134ms (well under <1s budget)
- [x] CI workflow path filter validated against the originating event sources
- [ ] After PR J ships: production reducer replaces the fixed-reference and continues to satisfy Suite 2

## Constraints honored

- **Test-infrastructure-only.** No production code changes — no SPA reducer changes, no `octos-core` changes, no `octos-cli` changes. The buggy sentinel is a TS file inside the test package, not a running reducer.
- The crate `crates/octos-web/` is reserved for PR J; this PR seeds it with the test layer first so PR J can be built against a known regression gate.
