### PR TITLE
fix(server): close M8.10 thread-binding chain end-to-end (PR F-interim)

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -612,6 +612,19 @@ fn inject_thread_id(value: &mut serde_json::Value, thread_id: Option<&str>) {
     }
 }
 
+/// PR F (M8.10 thread-binding): record a `last_thread_id_fallback_total`
+/// counter increment when wire-side `thread_id` resolution fell back to the
+/// per-chat sticky map instead of using a caller-supplied bound id. Pure
+/// observability — gives the deploy soak something to alert on if a new
+/// caller forgets to wire `_bound` variants.
+fn record_thread_id_fallback(site: &'static str) {
+    counter!(
+        "octos_last_thread_id_fallback_total",
+        "site" => site.to_string()
+    )
+    .increment(1);
+}
+
 /// Read the `thread_id` (if any) from outbound metadata. Empty strings are
 /// treated as absent.
 fn outbound_thread_id(metadata: &serde_json::Value) -> Option<String> {
@@ -1173,6 +1186,22 @@ impl Channel for ApiChannel {
     }
 
     async fn edit_message(&self, chat_id: &str, message_id: &str, new_content: &str) -> Result<()> {
+        // PR F (M8.10): forward to the bound implementation with no
+        // explicit override. Legacy callers that haven't migrated to
+        // `edit_message_bound` continue to fall back to the sticky map.
+        // This keeps non-API channels (Telegram/Discord/etc.) bug-for-bug
+        // compatible and gives deprecated callers a single place to land.
+        self.edit_message_bound(chat_id, message_id, new_content, None)
+            .await
+    }
+
+    async fn edit_message_bound(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        new_content: &str,
+        bound: Option<&str>,
+    ) -> Result<()> {
         if new_content.is_empty() {
             return Ok(());
         }
@@ -1181,20 +1210,27 @@ impl Channel for ApiChannel {
         // demultiplexed by web clients running multiple in-flight threads
         // against the same chat_id.
         let (_, decoded_thread_id) = decode_sse_message_id(message_id);
-        // M8.10 follow-up (#632): the synthetic message_id is bound by
-        // `send_with_id`, but the FIRST `edit_message` of a turn can fire
-        // BEFORE that bind happens (the placeholder bubble's first text
-        // streams in via `flush_to_channel`'s `send_with_id` call, but
-        // `do_flush` builds outbound metadata that lacks `thread_id`). Fall
-        // back to the sticky map populated by earlier `send`/`send_with_id`
-        // events on the same chat_id so the streaming `token`/`replace`
-        // payload still carries the right thread.
-        let sticky_thread_id = if decoded_thread_id.is_none() {
+        // PR F (M8.10): resolution priority is `bound > decoded > sticky`.
+        // Bound wins so the originating turn's thread_id beats any stale
+        // value that may have been encoded into `message_id` (rare but
+        // possible if the encode/decode pair races a sticky rotation).
+        // Sticky is consulted ONLY when both bound and decoded are absent
+        // — that's the legacy `edit_message` callers' compat surface.
+        let bound_thread_id = bound.filter(|s| !s.is_empty());
+        let resolved_thread_id = bound_thread_id.or(decoded_thread_id);
+        let sticky_thread_id = if resolved_thread_id.is_none() {
             self.sticky_thread_id(chat_id).await
         } else {
             None
         };
-        let thread_id = decoded_thread_id.or(sticky_thread_id.as_deref());
+        let thread_id = resolved_thread_id.or(sticky_thread_id.as_deref());
+        // Increment the fallback metric ONLY when the sticky branch was
+        // the actual source — codex's structural critique
+        // (`/tmp/codex-arch-final-review.log:12137+`) flags this as the
+        // observability hook that catches new callers forgetting to bind.
+        if bound_thread_id.is_none() && decoded_thread_id.is_none() && sticky_thread_id.is_some() {
+            record_thread_id_fallback("edit_message");
+        }
         // Update the sticky map whenever we resolved a thread_id, so a
         // subsequent edit on a different (legacy single-segment) message_id
         // still recovers it.
@@ -1249,33 +1285,69 @@ impl Channel for ApiChannel {
     }
 
     async fn send_raw_sse(&self, chat_id: &str, json: &str) -> Result<()> {
+        // PR F (M8.10): forward to the bound implementation with no
+        // explicit override. Legacy callers fall back to sticky/decoded
+        // payload. Non-API channels' default trait impl makes this a no-op.
+        self.send_raw_sse_bound(chat_id, json, None).await
+    }
+
+    async fn send_raw_sse_bound(
+        &self,
+        chat_id: &str,
+        json: &str,
+        bound: Option<&str>,
+    ) -> Result<()> {
         // M8.10 follow-up (#632): the stream reporter forwards discrete
         // events (thinking, response, tool_start, ...) here as pre-rendered
         // JSON. When the reporter constructed its payload before
         // `with_thread_id` had been bound, the JSON arrives without a
-        // `thread_id` field. Inject from the sticky map so wire events are
-        // still tagged with the right thread.
+        // `thread_id` field.
+        //
+        // PR F: resolution priority is `bound > payload > sticky`.
+        // - `bound`: caller-supplied via `send_raw_sse_bound` (the stream
+        //   forwarder's captured `thread_id`). When present, it OVERWRITES
+        //   any `thread_id` field on the JSON payload — this closes the
+        //   wire-side leak where a forwarder built its payload before its
+        //   reporter bound the thread, leaving an empty/wrong `thread_id`
+        //   in the rendered JSON.
+        // - `payload`: pre-rendered `thread_id` field on the JSON. Trusted
+        //   when no bound id was supplied (legacy callers).
+        // - `sticky`: per-chat sticky map (rotates under rapid-fire — the
+        //   reason `_bound` exists in the first place). Increments
+        //   `last_thread_id_fallback_total` so soak alerts on new callers
+        //   that forget to wire `_bound`.
+        let bound_thread_id = bound.filter(|s| !s.is_empty());
         let payload = match serde_json::from_str::<serde_json::Value>(json) {
             Ok(mut value) => {
-                let already_has = value
-                    .get("thread_id")
-                    .and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                    .is_some();
-                if already_has {
-                    if let Some(tid) = value
-                        .get("thread_id")
-                        .and_then(|v| v.as_str())
-                        .map(str::to_string)
-                    {
-                        self.remember_thread_id(chat_id, Some(tid.as_str())).await;
-                    }
-                    json.to_string()
-                } else if let Some(sticky) = self.sticky_thread_id(chat_id).await {
-                    inject_thread_id(&mut value, Some(sticky.as_str()));
+                if let Some(tid) = bound_thread_id {
+                    // Bound wins: overwrite any payload thread_id (or insert
+                    // when absent). Update sticky so subsequent untagged
+                    // legacy events on the same chat_id can recover.
+                    inject_thread_id(&mut value, Some(tid));
+                    self.remember_thread_id(chat_id, Some(tid)).await;
                     value.to_string()
                 } else {
-                    json.to_string()
+                    let already_has = value
+                        .get("thread_id")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .is_some();
+                    if already_has {
+                        if let Some(tid) = value
+                            .get("thread_id")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string)
+                        {
+                            self.remember_thread_id(chat_id, Some(tid.as_str())).await;
+                        }
+                        json.to_string()
+                    } else if let Some(sticky) = self.sticky_thread_id(chat_id).await {
+                        record_thread_id_fallback("send_raw_sse");
+                        inject_thread_id(&mut value, Some(sticky.as_str()));
+                        value.to_string()
+                    } else {
+                        json.to_string()
+                    }
                 }
             }
             Err(_) => json.to_string(),
@@ -1364,7 +1436,7 @@ impl ApiChannel {
         &self,
         chat_id: &str,
         topic: Option<&str>,
-        message: Message,
+        mut message: Message,
     ) -> Option<MessageInfo> {
         let key =
             current_profile_api_session_key_with_topic(self.profile_id.as_deref(), chat_id, topic);
@@ -1372,6 +1444,31 @@ impl ApiChannel {
             let sess = self.sessions.lock().await;
             sess.data_dir()
         };
+
+        // PR F (M8.10) — codex review P1 #3: API-channel fail-closed
+        // posture. The previous "derive from most-recent user" fallback
+        // is exactly the bug shape PR F closes for concurrent web turns
+        // (LEAK 1). Running it inside `persist_to_session` would re-open
+        // the leak. Instead, when a caller hands us an unbound
+        // Assistant/Tool row, prefer the per-chat sticky map (which the
+        // streaming forwarder maintains for THIS turn — wire-side state
+        // for the live request). If sticky is empty too, synthesize a
+        // UUIDv7 so the persist still succeeds — those rare orphan rows
+        // would be unrouted on the wire anyway, and at least the disk
+        // write is intact for legacy replay. Increments
+        // `octos_last_thread_id_fallback_total{site="persist_to_session"}`
+        // so soak alerts on new API call sites that forgot to bind.
+        if message.thread_id.is_none()
+            && matches!(
+                message.role,
+                octos_core::MessageRole::Assistant | octos_core::MessageRole::Tool
+            )
+        {
+            let sticky = self.sticky_thread_id(chat_id).await;
+            let resolved = sticky.unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
+            record_thread_id_fallback("persist_to_session");
+            message.thread_id = Some(resolved);
+        }
 
         let result = crate::session::persist_message_through_canonical_path(
             &data_dir,
@@ -2662,7 +2759,10 @@ mod tests {
             tool_call_id: None,
             reasoning_content: None,
             client_message_id: None,
-            thread_id: None,
+            // PR F (M8.10): pre-stamp thread_id for the test helper so the
+            // new-write fail-closed split accepts it. Production code uses
+            // `Message::assistant_with_thread`.
+            thread_id: Some("test-thread".to_string()),
             timestamp: Utc::now(),
         }
     }
@@ -3765,12 +3865,35 @@ mod tests {
     /// Mirrors `SessionActor::deliver_background_notification` for spawn_only
     /// file deliveries — the actor stamps `_history_persisted=true` on the
     /// outbound, so ApiChannel never writes for these.
+    ///
+    /// PR F (M8.10): pre-stamp `thread_id` on Assistant/Tool rows before
+    /// the canonical persist's new-write fail-closed split runs. Mirrors
+    /// the production `fallback_thread_id_for_assistant` helper.
     async fn actor_persist_to_per_user(
         data_dir: &Path,
         session_key: &SessionKey,
-        message: Message,
+        mut message: Message,
     ) {
         let mut handle = crate::session::SessionHandle::open(data_dir, session_key);
+        if message.thread_id.is_none()
+            && matches!(
+                message.role,
+                octos_core::MessageRole::Assistant | octos_core::MessageRole::Tool
+            )
+        {
+            message.thread_id = handle
+                .session()
+                .messages
+                .iter()
+                .rev()
+                .find(|m| matches!(m.role, octos_core::MessageRole::User))
+                .and_then(|user| {
+                    user.thread_id
+                        .clone()
+                        .or_else(|| user.client_message_id.clone())
+                })
+                .or_else(|| Some(uuid::Uuid::now_v7().to_string()));
+        }
         handle.add_message_with_seq(message).await.unwrap();
     }
 
@@ -4345,13 +4468,22 @@ mod tests {
                 .await
                 .unwrap();
             manager
-                .add_message_with_seq(&key, Message::assistant("first result"))
+                .add_message_with_seq(
+                    &key,
+                    Message::assistant_with_thread(
+                        "first result",
+                        octos_core::ThreadId::new("test-thread"),
+                    ),
+                )
                 .await
                 .unwrap();
             manager
                 .add_message_with_seq(
                     &key,
-                    Message::assistant("✓ report completed — file delivered"),
+                    Message::assistant_with_thread(
+                        "✓ report completed — file delivered",
+                        octos_core::ThreadId::new("test-thread"),
+                    ),
                 )
                 .await
                 .unwrap();
@@ -4405,7 +4537,13 @@ mod tests {
                 .await
                 .unwrap();
             manager
-                .add_message_with_seq(&key, Message::assistant("first result"))
+                .add_message_with_seq(
+                    &key,
+                    Message::assistant_with_thread(
+                        "first result",
+                        octos_core::ThreadId::new("test-thread"),
+                    ),
+                )
                 .await
                 .unwrap();
             manager
@@ -4419,7 +4557,8 @@ mod tests {
                         tool_call_id: None,
                         reasoning_content: None,
                         client_message_id: None,
-                        thread_id: None,
+                        // PR F: pre-stamp for the new-write fail-closed split.
+                        thread_id: Some("test-thread".to_string()),
                         timestamp: chrono::Utc::now(),
                     },
                 )
@@ -4578,7 +4717,10 @@ mod tests {
             manager
                 .add_message_with_seq(
                     &key,
-                    Message::assistant("John Ternus is Apple's SVP of hardware engineering."),
+                    Message::assistant_with_thread(
+                        "John Ternus is Apple's SVP of hardware engineering.",
+                        octos_core::ThreadId::new("test-thread"),
+                    ),
                 )
                 .await
                 .unwrap();
@@ -4634,7 +4776,10 @@ mod tests {
             manager
                 .add_message_with_seq(
                     &key,
-                    Message::assistant("好的，已记住你的时区为 PDT（America/Los_Angeles）。"),
+                    Message::assistant_with_thread(
+                        "好的，已记住你的时区为 PDT（America/Los_Angeles）。",
+                        octos_core::ThreadId::new("test-thread"),
+                    ),
                 )
                 .await
                 .unwrap();
@@ -6157,7 +6302,10 @@ mod tests {
             let mut sess = sessions.lock().await;
             sess.add_message(
                 &key,
-                Message::assistant("✓ fm_tts completed — file delivered"),
+                Message::assistant_with_thread(
+                    "✓ fm_tts completed — file delivered",
+                    octos_core::ThreadId::new("test-thread"),
+                ),
             )
             .await
             .unwrap();
@@ -6346,11 +6494,23 @@ mod tests {
                 .await
                 .unwrap();
             manager
-                .add_message_with_seq(&key, Message::assistant("first result"))
+                .add_message_with_seq(
+                    &key,
+                    Message::assistant_with_thread(
+                        "first result",
+                        octos_core::ThreadId::new("test-thread"),
+                    ),
+                )
                 .await
                 .unwrap();
             manager
-                .add_message_with_seq(&key, Message::assistant("second result"))
+                .add_message_with_seq(
+                    &key,
+                    Message::assistant_with_thread(
+                        "second result",
+                        octos_core::ThreadId::new("test-thread"),
+                    ),
+                )
                 .await
                 .unwrap();
         }
@@ -6406,7 +6566,13 @@ mod tests {
                 .await
                 .unwrap();
             manager
-                .add_message_with_seq(&key, Message::assistant("two"))
+                .add_message_with_seq(
+                    &key,
+                    Message::assistant_with_thread(
+                        "two",
+                        octos_core::ThreadId::new("test-thread-1"),
+                    ),
+                )
                 .await
                 .unwrap();
             manager
@@ -6414,7 +6580,13 @@ mod tests {
                 .await
                 .unwrap();
             manager
-                .add_message_with_seq(&key, Message::assistant("four"))
+                .add_message_with_seq(
+                    &key,
+                    Message::assistant_with_thread(
+                        "four",
+                        octos_core::ThreadId::new("test-thread-2"),
+                    ),
+                )
                 .await
                 .unwrap();
         }
@@ -6589,5 +6761,253 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // PR F (M8.10 thread-binding chain `#649 → #740`) — `_bound` variants
+    // ------------------------------------------------------------------
+    //
+    // The `_bound` methods (`edit_message_bound`, `send_raw_sse_bound`)
+    // implement codex's structural critique: when the originating turn's
+    // `thread_id` is in the caller's hand, the wire-side resolution must
+    // be `bound > decoded > sticky`, not the legacy `decoded > sticky`.
+    // The sticky fallback rotates per-chat under rapid-fire, so the
+    // legacy path mis-routed late deltas of an earlier turn into a later
+    // turn's bubble. These tests pin that invariant.
+
+    /// PR F: the bound-turn-override invariant — when the caller supplies
+    /// a `thread_id` via `_bound`, BOTH `edit_message_bound` AND
+    /// `send_raw_sse_bound` must emit that thread_id even if the sticky
+    /// map has rotated past the originating turn. Drives the same
+    /// rapid-fire setup the live soak hit on mini3:
+    ///   - chat `c`, sticky map rotated A → B → C
+    ///   - the user persist for cmid A is the typed `assistant_with_thread`
+    ///     constructor (no derive-from-history fallback)
+    ///   - edit_message_bound + send_raw_sse_bound for turn A's stream
+    ///     forwarder
+    /// The invariant: every wire payload tagged with `thread_id="A"`,
+    /// even though the sticky map points to `"C"`.
+    #[tokio::test]
+    async fn rapid_fire_bound_turn_overrides_sticky_for_persist_edit_and_raw_sse() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("chat-rapid-bound".into(), tx);
+        }
+
+        // Sticky rotated A → B → C — by the time any of A's late deltas
+        // reach the channel, sticky has moved on to C. This is the
+        // production race window the bug class kept tripping over.
+        for cmid in ["A", "B", "C"] {
+            ch.remember_thread_id("chat-rapid-bound", Some(cmid)).await;
+        }
+
+        // Persist Assistant for turn A using the typed
+        // `assistant_with_thread` constructor — codex's PR-A type-system
+        // enforcement. The persist must produce a row pinned to A
+        // regardless of sticky's "most recent user is C" answer.
+        let mut sessions = ch.sessions.lock().await;
+        let session_key = octos_core::SessionKey::new("api", "chat-rapid-bound");
+        // Seed the session with three siblings so the legacy
+        // "derive from most-recent user" walk would find C — the bug
+        // shape the bound path beats.
+        for cmid in ["A", "B", "C"] {
+            let user = octos_core::Message::user_with_cmid(
+                format!("question-{cmid}"),
+                octos_core::ClientMessageId::new(cmid),
+            );
+            sessions
+                .add_message(&session_key, user)
+                .await
+                .expect("user persist");
+        }
+        let assistant_for_a = octos_core::Message::assistant_with_thread(
+            "answer for A",
+            octos_core::ThreadId::new("A"),
+        );
+        sessions
+            .add_message(&session_key, assistant_for_a)
+            .await
+            .expect("assistant persist");
+        // Reload the in-memory session and assert the assistant row
+        // lands under thread A, NOT C (the most-recent user). This is
+        // the LEAK 1 closing assertion.
+        let session = sessions.get_or_create(&session_key).await;
+        let assistant_row = session
+            .messages
+            .iter()
+            .rev()
+            .find(|m| matches!(m.role, octos_core::MessageRole::Assistant))
+            .expect("assistant present");
+        assert_eq!(
+            assistant_row.thread_id.as_deref(),
+            Some("A"),
+            "PR F LEAK 1: typed `assistant_with_thread` must persist with the bound \
+             thread_id (`A`), NOT derive `C` from sticky/most-recent-user. \
+             Got: {:?}",
+            assistant_row.thread_id,
+        );
+        drop(sessions);
+
+        // LEAK 2 wire path: every emitted SSE event for turn A must carry
+        // `thread_id=A`, even though sticky points to C. We exercise both
+        // the `send_raw_sse_bound` path (used by the stream forwarder for
+        // discrete events: thinking, tool_start, ...) and the
+        // `edit_message_bound` path (used for streaming `token`/`replace`
+        // deltas).
+
+        // Step 1: send_raw_sse_bound with bound=A. Even though the JSON
+        // payload has NO thread_id and sticky points to C, the bound
+        // wins.
+        let raw = serde_json::json!({"type": "thinking", "iteration": 0});
+        ch.send_raw_sse_bound("chat-rapid-bound", &raw.to_string(), Some("A"))
+            .await
+            .unwrap();
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(
+            parsed["thread_id"], "A",
+            "send_raw_sse_bound must emit bound=A, NOT sticky=C. event: {parsed}"
+        );
+
+        // Step 2: send_raw_sse_bound with bound=A AND a stale thread_id
+        // already on the payload. Bound MUST overwrite — codex's spec at
+        // /tmp/codex-arch-final-review.log: bound > decoded > sticky.
+        let raw_with_stale = serde_json::json!({
+            "type": "thinking",
+            "iteration": 1,
+            "thread_id": "C-stale"
+        });
+        ch.send_raw_sse_bound("chat-rapid-bound", &raw_with_stale.to_string(), Some("A"))
+            .await
+            .unwrap();
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(
+            parsed["thread_id"], "A",
+            "send_raw_sse_bound must OVERWRITE stale payload thread_id (C-stale) with bound (A). event: {parsed}"
+        );
+
+        // Step 3: send_with_id seeds an encoded message_id (production
+        // path captures cmid in the synthetic id). Then edit_message_bound
+        // with bound=A must emit thread_id=A even when bound matches the
+        // encoded id (no sticky consulted).
+        let initial = OutboundMessage {
+            channel: "api".into(),
+            chat_id: "chat-rapid-bound".into(),
+            content: "Hi".into(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({"streaming": true, "thread_id": "A"}),
+        };
+        let msg_id = ch.send_with_id(&initial).await.unwrap().unwrap();
+        // Drain the initial replace event from send_with_id.
+        let _ = rx.recv().await.unwrap();
+
+        ch.edit_message_bound("chat-rapid-bound", &msg_id, "Hi there", Some("A"))
+            .await
+            .unwrap();
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(
+            parsed["thread_id"], "A",
+            "edit_message_bound must emit bound=A, NOT sticky=C. event: {parsed}"
+        );
+    }
+
+    /// PR F: when `edit_message_bound` is called with an explicit `bound`
+    /// id, the sticky map MUST NOT be consulted (and the
+    /// `last_thread_id_fallback_total` metric MUST NOT increment from
+    /// this call). Mirrors the codex-spec resolution priority.
+    #[tokio::test]
+    async fn edit_message_bound_does_not_consult_sticky_when_explicit_id_supplied() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("chat-bound-only".into(), tx);
+        }
+
+        // Sticky points to Z — should be ignored.
+        ch.remember_thread_id("chat-bound-only", Some("Z")).await;
+
+        // Encoded message_id decodes to X — should be overridden by bound A.
+        let encoded = encode_sse_message_id("chat-bound-only", Some("X"));
+
+        // Seed last_content for chat-bound-only/A so the edit emits a
+        // `token` delta.
+        ch.last_content.lock().await.insert(
+            last_content_key("chat-bound-only", Some("A")),
+            "Hi".to_string(),
+        );
+
+        ch.edit_message_bound("chat-bound-only", &encoded, "Hi there", Some("A"))
+            .await
+            .unwrap();
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        // Bound wins: not X (decoded), not Z (sticky).
+        assert_eq!(
+            parsed["thread_id"], "A",
+            "edit_message_bound must use bound=A, ignoring decoded=X and sticky=Z. event: {parsed}"
+        );
+    }
+
+    /// PR F: when `send_raw_sse_bound` is called with a bound id and the
+    /// JSON payload carries a STALE thread_id, bound MUST overwrite.
+    /// Without the overwrite, a forwarder that pre-rendered its payload
+    /// before its reporter rebound would leak the stale id on the wire —
+    /// the exact issue codex flagged at
+    /// `/tmp/codex-arch-final-review.log:12137+`.
+    #[tokio::test]
+    async fn send_raw_sse_bound_overwrites_stale_thread_id_in_payload() {
+        let ch = ApiChannel::new(
+            8091,
+            None,
+            Arc::new(AtomicBool::new(false)),
+            test_sessions(),
+            Some(TEST_PROFILE_ID.to_string()),
+        );
+        let (tx, mut rx) = new_sse_channel();
+        {
+            let mut pending = ch.pending.lock().await;
+            pending.insert("chat-overwrite".into(), tx);
+        }
+
+        let payload = serde_json::json!({
+            "type": "thinking",
+            "iteration": 0,
+            "thread_id": "stale-Z",
+        });
+        ch.send_raw_sse_bound("chat-overwrite", &payload.to_string(), Some("fresh-A"))
+            .await
+            .unwrap();
+        let event = rx.recv().await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&event).unwrap();
+        assert_eq!(
+            parsed["thread_id"], "fresh-A",
+            "send_raw_sse_bound must overwrite stale payload thread_id with bound id. event: {parsed}"
+        );
+
+        // Sticky map should now reflect the bound id (so a subsequent
+        // legacy untagged event recovers it correctly).
+        assert_eq!(
+            ch.sticky_thread_id("chat-overwrite").await.as_deref(),
+            Some("fresh-A"),
+            "send_raw_sse_bound must update the sticky map to the bound id"
+        );
     }
 }

--- a/crates/octos-bus/src/channel.rs
+++ b/crates/octos-bus/src/channel.rs
@@ -92,6 +92,28 @@ pub trait Channel: Send + Sync {
         Ok(())
     }
 
+    /// Edit an existing message with an explicit `thread_id` binding.
+    ///
+    /// PR F (M8.10 thread-binding chain `#649 → #740`): the originating
+    /// turn's `thread_id` is captured at the stream forwarder's task spawn
+    /// and threaded through every flush. Forwarding it explicitly here
+    /// closes the wire-side leak where the legacy `edit_message` path
+    /// recovered `thread_id` via `decode_sse_message_id` and then a
+    /// per-chat sticky map — under rapid-fire concurrent turns the sticky
+    /// has rotated, so late deltas of an earlier turn mis-routed to a
+    /// later turn's bubble. Channels that don't track threads ignore this
+    /// argument; the default impl forwards to legacy `edit_message`,
+    /// preserving Telegram/Discord/etc. behavior bug-for-bug.
+    async fn edit_message_bound(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        new_content: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<()> {
+        self.edit_message(chat_id, message_id, new_content).await
+    }
+
     /// Finalize a streamed message.
     ///
     /// Called once after the last streaming chunk. Channels that need special
@@ -104,6 +126,23 @@ pub trait Channel: Send + Sync {
         final_content: &str,
     ) -> Result<()> {
         self.edit_message(chat_id, message_id, final_content).await
+    }
+
+    /// Finalize a streamed message with an explicit `thread_id` binding.
+    ///
+    /// PR F sibling of [`edit_message_bound`]. Default: forwards to
+    /// [`edit_message_bound`] so the bound argument propagates through
+    /// the same `bound > decoded > sticky` resolution shape the API
+    /// channel implements.
+    async fn finish_stream_bound(
+        &self,
+        chat_id: &str,
+        message_id: &str,
+        final_content: &str,
+        thread_id: Option<&str>,
+    ) -> Result<()> {
+        self.edit_message_bound(chat_id, message_id, final_content, thread_id)
+            .await
     }
 
     /// Delete a message by platform message ID.
@@ -140,6 +179,24 @@ pub trait Channel: Send + Sync {
     /// (Telegram, Matrix, etc.) ignore this.
     async fn send_raw_sse(&self, _chat_id: &str, _json: &str) -> Result<()> {
         Ok(())
+    }
+
+    /// Send a raw SSE JSON event with an explicit `thread_id` binding.
+    ///
+    /// PR F (M8.10): the API channel implements this to override any
+    /// `thread_id` on the JSON payload (or absence thereof) with the
+    /// caller-supplied `bound` value before broadcasting. This closes the
+    /// LEAK 2 wire path — the legacy `send_raw_sse` falls back to a
+    /// per-chat sticky map that rotates under rapid-fire concurrent turns.
+    /// Default impl forwards to [`send_raw_sse`] so non-SSE channels
+    /// remain a strict no-op.
+    async fn send_raw_sse_bound(
+        &self,
+        chat_id: &str,
+        json: &str,
+        _thread_id: Option<&str>,
+    ) -> Result<()> {
+        self.send_raw_sse(chat_id, json).await
     }
 
     /// Add an emoji reaction to a message. Default: no-op.

--- a/crates/octos-bus/src/session.rs
+++ b/crates/octos-bus/src/session.rs
@@ -179,10 +179,23 @@ fn derive_title_from_message(content: &str) -> String {
         .to_string()
 }
 
-/// Derive `thread_id` for a freshly-arrived message about to be persisted
-/// (M8.10 PR #1). Strictly additive: callers that don't care about threads
-/// can ignore the field, and old clients that didn't set it on inbound
-/// messages still produce sensible groupings (see [`synthesize_thread_ids`]).
+/// Derive `thread_id` for a legacy JSONL load — gap-fill only.
+///
+/// PR F (M8.10): preserves the historical `derive_thread_id_for_new_message`
+/// semantics verbatim, but is reachable ONLY via the load-time
+/// [`synthesize_thread_ids`] call site. The new write path uses
+/// [`derive_thread_id_for_new_write`] instead, which fail-closes for
+/// Assistant/Tool roles when the caller didn't pre-stamp.
+///
+/// Why split? Under concurrent web turns (rapid-fire-five-fast,
+/// speculative-overflow) the in-memory `history` has been mutated by
+/// sibling user persists between *this* turn's user write and *this*
+/// turn's assistant write. Walking history backwards looking for the
+/// "most recent user" picks the WRONG cmid for Assistant rows. The fix
+/// is structural: the persist hot path now refuses to derive — every
+/// caller MUST pre-stamp the originating turn's `thread_id`. Legacy
+/// JSONL replay (which has no concurrent siblings to confuse it) keeps
+/// the old derivation.
 ///
 /// Rules (matches the spec in the M8.10 tracking issue):
 /// - `User`: thread_id = the message's `client_message_id`. If absent the
@@ -196,7 +209,12 @@ fn derive_title_from_message(content: &str) -> String {
 ///   thread_id when present, otherwise falls back to the most recent user
 ///   message's thread_id.
 /// - `System`: `None` — system messages are session-scoped, not thread-scoped.
-pub(crate) fn derive_thread_id_for_new_message(
+///
+/// Currently exercised only by the unit tests (and reserved for any future
+/// per-message legacy-load callers that arrive). [`synthesize_thread_ids`]
+/// inlines the same algorithm in batch form for full-transcript gap-fill.
+#[allow(dead_code)]
+pub(crate) fn derive_thread_id_for_legacy_load(
     message: &Message,
     history: &[Message],
 ) -> Option<String> {
@@ -244,10 +262,49 @@ pub(crate) fn derive_thread_id_for_new_message(
     }
 }
 
+/// Derive `thread_id` for a brand-new write about to be persisted.
+///
+/// PR F (M8.10 thread-binding chain `#649 → #740`): fail-closed for
+/// Assistant/Tool roles. Returns:
+/// - `Ok(Some(tid))` — User message: from `client_message_id`, or a
+///   freshly-synthesized UUIDv7 if no cmid was supplied.
+/// - `Ok(None)` — System message (system rows aren't thread-scoped).
+/// - `Err(_)` — Assistant/Tool message arrived unbound. The previous
+///   "walk history for the most recent user" derivation was structurally
+///   wrong under concurrent web turns: sibling users could rotate the
+///   in-memory history between the originating turn's user-write and its
+///   assistant-write, picking the WRONG cmid. The fix forces every
+///   caller on the new write path to pre-stamp `thread_id`. The metric
+///   `octos_session_persist_total{outcome="rejected_unbound_assistant"}`
+///   alerts on regressions.
+pub(crate) fn derive_thread_id_for_new_write(
+    message: &Message,
+    _history: &[Message],
+) -> Result<Option<String>> {
+    use octos_core::MessageRole;
+
+    match message.role {
+        MessageRole::System => Ok(None),
+        MessageRole::User => Ok(Some(
+            message
+                .client_message_id
+                .clone()
+                .unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
+        )),
+        MessageRole::Assistant | MessageRole::Tool => Err(eyre::eyre!(
+            "PR F (M8.10 thread-binding): Assistant/Tool persist on new write \
+             path requires caller-supplied `thread_id`. Pre-stamp the \
+             originating turn's `thread_id` before calling \
+             `add_message_with_seq` — see `persist_assistant_message` in \
+             `octos-cli/src/session_actor.rs` for the canonical helper."
+        )),
+    }
+}
+
 /// Synthesize `thread_id` for legacy JSONL records that pre-date the field
 /// (M8.10 PR #1). Runs on session load — the synthesized values are
 /// in-memory only; nothing is persisted at load time. On the next write,
-/// [`derive_thread_id_for_new_message`] produces the same logical structure
+/// [`derive_thread_id_for_new_write`] produces the same logical structure
 /// going forward, so transcripts converge naturally.
 ///
 /// Algorithm walks the messages in JSONL order and threads them via the
@@ -996,9 +1053,22 @@ impl SessionManager {
         // the persisted JSONL line and the in-memory mirror agree (M8.10
         // PR #1). Caller-supplied `thread_id` wins — covers replay paths
         // and tests that pre-fill the field deliberately.
+        //
+        // PR F (M8.10): the new-write derivation is fail-closed for
+        // Assistant/Tool roles. Callers MUST pre-stamp before calling this;
+        // the previous "derive from history" fallback picked the wrong
+        // sibling user under concurrent rapid-fire turns. Failure here
+        // surfaces a structural caller bug rather than silently shipping
+        // a mis-routed thread.
         if message.thread_id.is_none() {
             let session = self.get_or_create(key).await;
-            message.thread_id = derive_thread_id_for_new_message(&message, &session.messages);
+            match derive_thread_id_for_new_write(&message, &session.messages) {
+                Ok(tid) => message.thread_id = tid,
+                Err(error) => {
+                    record_session_persist("rejected_unbound_assistant");
+                    return Err(error);
+                }
+            }
         }
 
         let _ = self.get_or_create(key).await;
@@ -1998,8 +2068,17 @@ impl SessionHandle {
         // values are preserved; `None` triggers derivation against the
         // current in-memory log so the persisted line carries the field
         // and the in-memory copy matches without a reload.
+        //
+        // PR F (M8.10): fail-closed for Assistant/Tool. See the matching
+        // comment in [`SessionManager::add_message_with_seq`].
         if message.thread_id.is_none() {
-            message.thread_id = derive_thread_id_for_new_message(&message, &self.session.messages);
+            match derive_thread_id_for_new_write(&message, &self.session.messages) {
+                Ok(tid) => message.thread_id = tid,
+                Err(error) => {
+                    record_session_persist("rejected_unbound_assistant");
+                    return Err(error);
+                }
+            }
         }
 
         // UPCR-2026-012: write to disk BEFORE the in-memory push so a
@@ -2605,6 +2684,17 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_message(role: MessageRole, content: &str) -> Message {
+        // PR F (M8.10): pre-stamp Assistant/Tool messages with a synthetic
+        // thread_id so they pass the new-write fail-closed check. Tests
+        // that exercise the legacy untagged path use bare struct literals
+        // or the dedicated helpers directly. Production code uses the
+        // typed `Message::assistant_with_thread`/`tool_with_thread`
+        // constructors and the canonical `persist_assistant_message`
+        // helper, both of which already supply thread_id.
+        let thread_id = match role {
+            MessageRole::Assistant | MessageRole::Tool => Some("test-thread-default".to_string()),
+            _ => None,
+        };
         Message {
             role,
             content: content.into(),
@@ -2613,7 +2703,7 @@ mod tests {
             tool_call_id: None,
             reasoning_content: None,
             client_message_id: None,
-            thread_id: None,
+            thread_id,
             timestamp: Utc::now(),
         }
     }
@@ -4415,10 +4505,13 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-            handle
-                .add_message(make_message(MessageRole::Assistant, "answer"))
-                .await
-                .unwrap();
+            // PR F (M8.10): caller pre-stamps Assistant with the
+            // originating turn's `thread_id`. In production this is the
+            // canonical helper `persist_assistant_message` (see
+            // `octos-cli/src/session_actor.rs`); the test mirrors that.
+            let mut assistant = make_message(MessageRole::Assistant, "answer");
+            assistant.thread_id = Some("cmid-alpha".into());
+            handle.add_message(assistant).await.unwrap();
         }
 
         let reload = SessionHandle::open(tmp.path(), &key);
@@ -4604,14 +4697,14 @@ mod tests {
     #[test]
     fn derive_thread_id_user_uses_client_message_id() {
         let user_msg = make_message_with_cmid(MessageRole::User, "hi", Some("cmid-x"));
-        let id = derive_thread_id_for_new_message(&user_msg, &[]);
+        let id = derive_thread_id_for_legacy_load(&user_msg, &[]);
         assert_eq!(id.as_deref(), Some("cmid-x"));
     }
 
     #[test]
     fn derive_thread_id_user_without_cmid_synthesizes_uuid() {
         let user_msg = make_message(MessageRole::User, "hi");
-        let id = derive_thread_id_for_new_message(&user_msg, &[]);
+        let id = derive_thread_id_for_legacy_load(&user_msg, &[]);
         assert!(
             id.is_some(),
             "user without cmid still gets a synthesized id"
@@ -4626,7 +4719,7 @@ mod tests {
         user_msg.thread_id = Some("cmid-q".into());
         let history = vec![user_msg];
         let asst = make_message(MessageRole::Assistant, "answer");
-        let id = derive_thread_id_for_new_message(&asst, &history);
+        let id = derive_thread_id_for_legacy_load(&asst, &history);
         assert_eq!(id.as_deref(), Some("cmid-q"));
     }
 
@@ -4638,21 +4731,134 @@ mod tests {
         asst.thread_id = Some("cmid-q".into());
         let history = vec![user_msg, asst];
         let tool = make_message(MessageRole::Tool, "tool result");
-        let id = derive_thread_id_for_new_message(&tool, &history);
+        let id = derive_thread_id_for_legacy_load(&tool, &history);
         assert_eq!(id.as_deref(), Some("cmid-q"));
     }
 
     #[test]
     fn derive_thread_id_system_returns_none() {
         let sys = make_message(MessageRole::System, "system primer");
-        let id = derive_thread_id_for_new_message(&sys, &[]);
+        let id = derive_thread_id_for_legacy_load(&sys, &[]);
         assert!(id.is_none(), "system messages aren't thread-scoped");
+    }
+
+    /// PR F (M8.10): the new-write derivation MUST refuse Assistant rows
+    /// that arrived without a caller-supplied `thread_id`. Pre-fix, this
+    /// silently walked history backwards and picked the most-recent user
+    /// — under concurrent rapid-fire writes that's the WRONG turn (a
+    /// sibling user has rotated the in-memory history between the
+    /// originating turn's user-write and its assistant-write). The
+    /// metric `octos_session_persist_total{outcome="rejected_unbound_assistant"}`
+    /// is the alerting hook for soak.
+    #[test]
+    fn derive_thread_id_for_new_write_rejects_unbound_assistant() {
+        let mut user_msg = make_message_with_cmid(MessageRole::User, "ask", Some("cmid-q"));
+        user_msg.thread_id = Some("cmid-q".into());
+        let history = vec![user_msg];
+        let asst = make_message(MessageRole::Assistant, "answer");
+        let result = derive_thread_id_for_new_write(&asst, &history);
+        assert!(
+            result.is_err(),
+            "new-write path must fail-closed for unbound Assistant; got {result:?}"
+        );
+    }
+
+    /// PR F: the new-write derivation MUST refuse Tool rows that arrived
+    /// without a caller-supplied `thread_id`, for the same structural
+    /// reason as Assistant. Tools must inherit from the originating turn
+    /// (carried via `originating_thread_id` in BackgroundResultPayload),
+    /// not from history walking.
+    #[test]
+    fn derive_thread_id_for_new_write_rejects_unbound_tool() {
+        let mut user_msg = make_message_with_cmid(MessageRole::User, "ask", Some("cmid-q"));
+        user_msg.thread_id = Some("cmid-q".into());
+        let history = vec![user_msg];
+        let tool = make_message(MessageRole::Tool, "tool result");
+        let result = derive_thread_id_for_new_write(&tool, &history);
+        assert!(
+            result.is_err(),
+            "new-write path must fail-closed for unbound Tool; got {result:?}"
+        );
+    }
+
+    /// PR F: User rows always synthesize/derive cleanly (cmid → thread_id).
+    /// System rows return `Ok(None)`. These remain non-fail-closed
+    /// because the rule is structurally well-defined for them.
+    #[test]
+    fn derive_thread_id_for_new_write_accepts_user_and_system() {
+        let user_msg = make_message_with_cmid(MessageRole::User, "ask", Some("cmid-q"));
+        let id = derive_thread_id_for_new_write(&user_msg, &[]).expect("user must succeed");
+        assert_eq!(id.as_deref(), Some("cmid-q"));
+
+        let sys = make_message(MessageRole::System, "primer");
+        let id = derive_thread_id_for_new_write(&sys, &[]).expect("system must succeed");
+        assert!(id.is_none());
+    }
+
+    /// PR F: legacy JSONL replay must continue to gap-fill via
+    /// `derive_thread_id_for_legacy_load` — a transcript that pre-dates
+    /// the PR #1 typed write path has Assistant rows without thread_id
+    /// and must reconstruct via history walking. The new-write
+    /// fail-closed split MUST NOT regress this.
+    #[tokio::test]
+    async fn add_message_with_seq_accepts_legacy_replay_via_legacy_load() {
+        let tmp = TempDir::new().unwrap();
+        let key = SessionKey::new("api", "legacy-replay");
+
+        // Build a session in memory with legacy rows (no thread_id) using
+        // bare struct literals so the test exercises the actual legacy
+        // wire shape (Assistant/Tool rows lacking thread_id).
+        fn legacy_msg(role: MessageRole, content: &str, cmid: Option<&str>) -> Message {
+            Message {
+                role,
+                content: content.into(),
+                media: vec![],
+                tool_calls: None,
+                tool_call_id: None,
+                reasoning_content: None,
+                client_message_id: cmid.map(String::from),
+                thread_id: None,
+                timestamp: Utc::now(),
+            }
+        }
+        let mut messages = vec![
+            legacy_msg(MessageRole::User, "first", Some("cmid-old-1")),
+            legacy_msg(MessageRole::Assistant, "first reply", None),
+            legacy_msg(MessageRole::User, "second", Some("cmid-old-2")),
+            legacy_msg(MessageRole::Assistant, "second reply", None),
+        ];
+        for m in &mut messages {
+            assert!(m.thread_id.is_none(), "legacy fixture must lack thread_id");
+        }
+        synthesize_thread_ids(&mut messages);
+        // Synthesis populates every row.
+        assert_eq!(messages[0].thread_id.as_deref(), Some("cmid-old-1"));
+        assert_eq!(messages[1].thread_id.as_deref(), Some("cmid-old-1"));
+        assert_eq!(messages[2].thread_id.as_deref(), Some("cmid-old-2"));
+        assert_eq!(messages[3].thread_id.as_deref(), Some("cmid-old-2"));
+
+        // After legacy gap-fill, the rows can be re-persisted via the
+        // new-write path because the gap-fill stamped thread_id.
+        let mut handle = SessionHandle::open(tmp.path(), &key);
+        for m in messages {
+            handle
+                .add_message(m)
+                .await
+                .expect("legacy-gap-filled rows must persist via new write path");
+        }
     }
 
     #[tokio::test]
     async fn add_message_with_seq_stamps_thread_id_on_inbound_messages() {
         // The new write path must populate thread_id on the persisted line so
         // a later reload doesn't have to fall back to synthesis.
+        //
+        // PR F (M8.10): the persist path is fail-closed for unbound
+        // Assistant — the caller must pre-stamp `thread_id`. The test
+        // mirrors production: the User row derives its thread_id from
+        // its `client_message_id`; the Assistant row arrives pre-stamped
+        // with the originating turn's `thread_id` (in production via
+        // `Message::assistant_with_thread`).
         let tmp = TempDir::new().unwrap();
         let key = SessionKey::new("api", "stamp-on-write");
 
@@ -4665,10 +4871,9 @@ mod tests {
             ))
             .await
             .unwrap();
-        handle
-            .add_message(make_message(MessageRole::Assistant, "first reply"))
-            .await
-            .unwrap();
+        let mut assistant = make_message(MessageRole::Assistant, "first reply");
+        assistant.thread_id = Some("cmid-write-1".into());
+        handle.add_message(assistant).await.unwrap();
 
         // In-memory copy carries thread_id.
         assert_eq!(

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -490,6 +490,31 @@ async fn chat_streaming(
                             }
                         } else {
                             let is_assistant = msg.role == MessageRole::Assistant;
+                            // PR F (M8.10): pre-stamp `thread_id` on
+                            // Assistant/Tool rows so the canonical
+                            // persist's new-write fail-closed split
+                            // accepts them. Bind to the originating
+                            // `client_message_id` (the REST `chat`
+                            // endpoint requires it for proper threading).
+                            // When the request didn't supply one (legacy
+                            // clients), fall back to a UUIDv7 so the
+                            // persist still succeeds — these rows would
+                            // be invisible to per-thread routing
+                            // anyway, but at least they survive reload.
+                            if to_save.thread_id.is_none()
+                                && matches!(
+                                    to_save.role,
+                                    MessageRole::Assistant | MessageRole::Tool
+                                )
+                            {
+                                to_save.thread_id = Some(
+                                    client_message_id
+                                        .as_deref()
+                                        .filter(|s| !s.is_empty())
+                                        .map(str::to_string)
+                                        .unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
+                                );
+                            }
                             match persist_chat_message_through_canonical(
                                 &sessions,
                                 &session_key,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -827,6 +827,12 @@ struct BoundedChannelReporter {
     /// the cursor would lie. Surfaced opportunistically as `protocol/replay_lossy`
     /// from the consuming task.
     progress_dropped: Arc<AtomicU64>,
+    /// PR F (M8.10 thread-binding): bound `thread_id` for every progress
+    /// event this reporter emits. Set once at turn-start to the originating
+    /// `TurnId`; from then on every JSON payload carries `thread_id` so the
+    /// SPA reducer can demultiplex without a sticky-map fallback. `None`
+    /// preserves the legacy untagged path for callers that haven't migrated.
+    thread_id: Option<String>,
 }
 
 impl BoundedChannelReporter {
@@ -834,13 +840,26 @@ impl BoundedChannelReporter {
         Self {
             tx,
             progress_dropped,
+            thread_id: None,
         }
+    }
+
+    /// PR F: bind a `thread_id` to this reporter. Typically the originating
+    /// `TurnId` (the `params.turn_id` passed into `run_standalone_turn`),
+    /// stamped into every emitted SSE payload so wire events are routed
+    /// to the right per-turn bubble on the client.
+    fn with_thread_id(mut self, thread_id: Option<String>) -> Self {
+        self.thread_id = thread_id.filter(|s| !s.is_empty());
+        self
     }
 }
 
 impl octos_agent::ProgressReporter for BoundedChannelReporter {
     fn report(&self, event: octos_agent::ProgressEvent) {
-        let json = match serde_json::to_string(&super::sse::event_to_json(&event, None)) {
+        let json = match serde_json::to_string(&super::sse::event_to_json(
+            &event,
+            self.thread_id.as_deref(),
+        )) {
             Ok(json) => json,
             Err(_) => return,
         };
@@ -4093,11 +4112,16 @@ async fn run_standalone_turn(
     let (progress_tx, mut progress_rx) =
         tokio::sync::mpsc::channel::<String>(PROGRESS_CHANNEL_CAPACITY);
     let progress_dropped = Arc::new(AtomicU64::new(0));
+    // PR F (M8.10 thread-binding chain `#649 → #740`): bind the originating
+    // `TurnId` into the reporter so every progress event the agent emits
+    // carries `thread_id`. Closes the wire-side leak where standalone-turn
+    // SSE events landed unbound and the SPA reducer had to fall back to
+    // sticky-map heuristics.
     let reporter: Arc<dyn octos_agent::ProgressReporter> =
-        Arc::new(MetricsReporter::new(Arc::new(BoundedChannelReporter::new(
-            progress_tx.clone(),
-            progress_dropped.clone(),
-        ))));
+        Arc::new(MetricsReporter::new(Arc::new(
+            BoundedChannelReporter::new(progress_tx.clone(), progress_dropped.clone())
+                .with_thread_id(Some(turn_id.0.to_string())),
+        )));
     let progress_tx_for_result = progress_tx.clone();
     let progress_tx_for_tasks = progress_tx.clone();
     let task_progress_dropped = progress_dropped.clone();
@@ -4133,6 +4157,14 @@ async fn run_standalone_turn(
             turn_id: turn_id.clone(),
             features,
         });
+    // PR F (M8.10): capture the originating `TurnId` as a string so the
+    // tokio::spawn closure (which moves everything it touches) can pre-stamp
+    // each persisted Assistant/Tool message with the correct thread_id.
+    // Required because Patch 8 fails the persist closed if Assistant/Tool
+    // arrives unbound — the previous derive-from-history fallback picked
+    // the WRONG sibling user under rapid-fire concurrent turns.
+    let turn_thread_id_for_persist = turn_id.0.to_string();
+    let turn_thread_id_for_done = turn_thread_id_for_persist.clone();
     let agent_task = tokio::spawn(async move {
         let result = octos_agent::tools::TOOL_APPROVAL_CTX
             .scope(
@@ -4152,8 +4184,21 @@ async fn run_standalone_turn(
                         response.reasoning_content.clone(),
                     );
                     for message in response.messages.iter().cloned().chain(final_assistant) {
+                        let mut to_save = message;
+                        // PR F (M8.10): pre-stamp `thread_id` on the
+                        // persist path so Patch 8's fail-closed
+                        // `derive_thread_id_for_new_write` accepts the
+                        // write. The bound id is the originating `TurnId`,
+                        // the same value the reporter is broadcasting on
+                        // every wire event — keeps persist and wire in
+                        // lockstep so reload renders match the live UI.
+                        if to_save.thread_id.is_none()
+                            && matches!(to_save.role, MessageRole::Assistant | MessageRole::Tool)
+                        {
+                            to_save.thread_id = Some(turn_thread_id_for_persist.clone());
+                        }
                         if let Ok(seq) = sessions
-                            .add_message_with_seq(&agent_session_id, message)
+                            .add_message_with_seq(&agent_session_id, to_save)
                             .await
                         {
                             cursor = Some(UiCursor {
@@ -4169,6 +4214,7 @@ async fn run_standalone_turn(
                     "tokens_in": response.token_usage.input_tokens,
                     "tokens_out": response.token_usage.output_tokens,
                     "cursor": cursor,
+                    "thread_id": turn_thread_id_for_done,
                 });
                 let _ = progress_tx_for_result.send(done.to_string()).await;
             }
@@ -9286,5 +9332,40 @@ mod tests {
         );
 
         octos_bus::set_message_commit_observer(prev);
+    }
+
+    /// PR F (M8.10 thread-binding chain `#649 → #740`): every progress
+    /// event the BoundedChannelReporter emits MUST carry the bound
+    /// `thread_id`. Without this, the SPA reducer for the standalone
+    /// `octos serve` UI Protocol path falls back to sticky-map
+    /// heuristics — the exact wire-side leak PR F closes.
+    #[tokio::test]
+    async fn bounded_channel_reporter_emits_typed_thread_id_on_progress_events() {
+        use octos_agent::ProgressReporter;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(8);
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        let reporter = BoundedChannelReporter::new(tx, dropped.clone())
+            .with_thread_id(Some("turn-pr-f-A".to_string()));
+        reporter.report(octos_agent::ProgressEvent::Thinking { iteration: 0 });
+
+        let event = rx.try_recv().expect("event must be available");
+        let parsed: serde_json::Value = serde_json::from_str(&event).expect("valid json");
+        assert_eq!(
+            parsed["thread_id"], "turn-pr-f-A",
+            "BoundedChannelReporter must stamp every progress event with the bound thread_id. event: {parsed}"
+        );
+
+        // Without binding, `thread_id` must be absent (legacy compat).
+        let (tx2, mut rx2) = tokio::sync::mpsc::channel::<String>(8);
+        let unbound = BoundedChannelReporter::new(tx2, dropped);
+        unbound.report(octos_agent::ProgressEvent::Thinking { iteration: 1 });
+        let event = rx2.try_recv().expect("event must be available");
+        let parsed: serde_json::Value = serde_json::from_str(&event).expect("valid json");
+        assert!(
+            parsed.get("thread_id").is_none(),
+            "unbound reporter must not stamp thread_id (legacy compat): {parsed}"
+        );
     }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -205,6 +205,29 @@ fn save_retry_state(path: &std::path::Path, state: &LoopRetryState) {
     }
 }
 
+/// PR F (M8.10): pick a `thread_id` for an Assistant row when the caller
+/// didn't supply one and we want to honor the new-write fail-closed split.
+/// Walks `history` backwards for the most-recent User; falls back to a
+/// freshly-synthesized UUIDv7 (mirrors the legacy synthesizer's
+/// `synth_{seq}` shape but with temporal ordering).
+///
+/// Use ONLY for foreground turns on linear single-channel transcripts
+/// (CLI / telegram / discord) — these never have the concurrent-sibling
+/// problem #649 documented (one user at a time on the wire).
+fn fallback_thread_id_for_assistant(history: &[Message]) -> String {
+    history
+        .iter()
+        .rev()
+        .find(|m| matches!(m.role, MessageRole::User))
+        .and_then(|user| {
+            user.thread_id
+                .clone()
+                .or_else(|| user.client_message_id.clone())
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| uuid::Uuid::now_v7().to_string())
+}
+
 async fn persist_assistant_message(
     session_handle: &Arc<Mutex<SessionHandle>>,
     session_key: &SessionKey,
@@ -227,13 +250,49 @@ async fn persist_assistant_message(
     // originating turn (background results carry `originating_thread_id`
     // through `BackgroundResultPayload`), passing it here pins the
     // persisted JSONL row to the correct thread so reload pairs the
-    // assistant under the originating user bubble. Foreground turns pass
-    // `None` and continue to use the derivation fallback (correct).
-    let mut assistant_msg = match thread_id {
+    // assistant under the originating user bubble.
+    //
+    // PR F (M8.10): the fail-closed split in
+    // `derive_thread_id_for_new_write` means callers MUST supply
+    // `thread_id` for Assistant rows. Foreground turns on linear
+    // single-channel transcripts (CLI / telegram / discord) where the
+    // session_actor has no `client_message_id` to forward fall back to
+    // the load-style derivation here — those channels never have the
+    // concurrent-sibling problem #649 documented (one user at a time on
+    // the wire), so deriving from the most-recent user is safe.
+    let resolved_thread_id = match thread_id {
+        Some(tid) if !tid.is_empty() => Some(tid),
+        _ => {
+            // Linear-channel fallback: derive from history. Holding the
+            // lock briefly to read messages is fine — we're about to
+            // re-acquire below for the persist itself.
+            let handle = session_handle.lock().await;
+            handle
+                .session()
+                .messages
+                .iter()
+                .rev()
+                .find(|m| matches!(m.role, MessageRole::User))
+                .and_then(|user| {
+                    user.thread_id
+                        .clone()
+                        .or_else(|| user.client_message_id.clone())
+                })
+        }
+    };
+    let mut assistant_msg = match resolved_thread_id {
         Some(tid) if !tid.is_empty() => {
             Message::assistant_with_thread(content, octos_core::ThreadId::new(tid))
         }
-        _ => Message::assistant(content),
+        _ => {
+            // Orphan assistant (no user in history). Synthesize a stable
+            // UUIDv7 thread_id so the persist still succeeds — this
+            // mirrors the legacy synthesizer's `synth_{seq}` shape but
+            // uses UUIDv7 for temporal ordering. Rare: only fires for
+            // System-primer transcripts.
+            let synth = uuid::Uuid::now_v7().to_string();
+            Message::assistant_with_thread(content, octos_core::ThreadId::new(synth))
+        }
     };
     assistant_msg.media = media;
     let timestamp = assistant_msg.timestamp;
@@ -704,7 +763,14 @@ async fn persist_child_session_lifecycle(
                     message.role == MessageRole::Assistant && message.content == note
                 });
             if !exists {
-                child.add_message(Message::assistant(note)).await?;
+                // PR F (M8.10): the child session terminal note is a
+                // synthetic Assistant row injected by the lifecycle
+                // helper. Use the linear-channel fallback to derive a
+                // thread_id from the child's history (or synthesize
+                // a UUIDv7 if the child is brand new).
+                let tid = fallback_thread_id_for_assistant(&child.session().messages);
+                let note_msg = Message::assistant_with_thread(note, octos_core::ThreadId::new(tid));
+                child.add_message(note_msg).await?;
             }
             let contract = ChildSessionContract {
                 task_id: payload.task_id.clone(),
@@ -4242,13 +4308,19 @@ impl SessionActor {
                 .get("voice_transcript")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
-            si.start(
+            // PR F (M8.10) — codex review P1 #1: bind the originating
+            // turn's `client_message_id` to the status composer so its
+            // `edit_message_bound` calls and initial `send_with_id`
+            // metadata route to THIS turn's bubble, even when sticky
+            // has rotated under rapid-fire concurrent writes.
+            si.start_with_thread(
                 self.chat_id.clone(),
                 &inbound.content,
                 Arc::clone(&token_tracker),
                 voice_transcript,
                 &self.user_status_config,
                 self.sender_user_id.clone(),
+                client_message_id.clone(),
             )
         });
 
@@ -4713,6 +4785,25 @@ impl SessionActor {
                     } else {
                         &conv_response.messages
                     };
+                    // PR F (M8.10): cache the linear-channel fallback once
+                    // up front so all intermediate Assistant/Tool rows of
+                    // this turn share the same thread_id. Codex's PR-F
+                    // review (P1 #2) flagged that the per-message
+                    // pre-stamp dropped intermediate rows on linear
+                    // channels (CLI/telegram/discord) where
+                    // `client_message_id` is None — those rows now
+                    // hit the new-write fail-closed split and get
+                    // dropped silently. Computing the fallback once
+                    // here keeps the whole turn pinned to one thread.
+                    let linear_fallback_for_turn: Option<String> = if client_message_id
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .is_none()
+                    {
+                        Some(fallback_thread_id_for_assistant(&handle.session().messages))
+                    } else {
+                        None
+                    };
                     for msg in messages_to_save {
                         // Issue #740 fix: pre-stamp `thread_id` on Assistant /
                         // Tool messages produced inside the agent loop. The
@@ -4729,6 +4820,11 @@ impl SessionActor {
                         // the persisted JSONL row to the correct thread, the
                         // same fix shape PR #739 applied to the M8.9 spawn_only
                         // recovery path.
+                        //
+                        // PR F (M8.10): when `client_message_id` is absent
+                        // (linear channels), use the cached
+                        // `linear_fallback_for_turn` so intermediate
+                        // Assistant/Tool rows pass the fail-closed split.
                         let mut to_save = msg.clone();
                         if to_save.thread_id.is_none()
                             && matches!(to_save.role, MessageRole::Assistant | MessageRole::Tool)
@@ -4737,6 +4833,8 @@ impl SessionActor {
                                 if !tid.is_empty() {
                                     to_save.thread_id = Some(tid.clone());
                                 }
+                            } else if let Some(ref tid) = linear_fallback_for_turn {
+                                to_save.thread_id = Some(tid.clone());
                             }
                         }
                         if let Err(e) = handle.add_message(to_save).await {
@@ -4764,12 +4862,28 @@ impl SessionActor {
                         // `rapid-fire-five-fast` evidence: 1+1=2 rendered
                         // under the 3+3 bubble). Mirrors PR #739's M8.9
                         // recovery-path fix for the foreground SSE path.
+                        //
+                        // PR F (M8.10): non-API channels (CLI/telegram/etc.)
+                        // arrive with `client_message_id == None`. The
+                        // session.rs new-write split fail-closes for
+                        // unbound Assistant rows; on those linear
+                        // single-channel transcripts (one user at a time
+                        // on the wire) deriving from the most-recent
+                        // user is structurally safe. Use the helper to
+                        // keep the fallback in one place.
                         let mut assistant_msg = match client_message_id.as_deref() {
                             Some(tid) if !tid.is_empty() => Message::assistant_with_thread(
                                 final_content.clone(),
                                 octos_core::ThreadId::new(tid),
                             ),
-                            _ => Message::assistant(final_content.clone()),
+                            _ => {
+                                let tid =
+                                    fallback_thread_id_for_assistant(&handle.session().messages);
+                                Message::assistant_with_thread(
+                                    final_content.clone(),
+                                    octos_core::ThreadId::new(tid),
+                                )
+                            }
                         };
                         assistant_msg.reasoning_content = conv_response.reasoning_content.clone();
                         // M8.10-A: capture the committed seq so the SSE `done`
@@ -5246,14 +5360,20 @@ impl SessionActor {
             let tracker = Arc::new(TokenTracker::new());
 
             // ── Per-overflow status indicator (own "✦ Thinking..." message) ──
+            //
+            // PR F (M8.10): bind the overflow turn's cmid to the status
+            // composer so its wire events route to the OVERFLOW
+            // bubble, not whatever sticky/primary turn the chat is
+            // currently on.
             let status_handle = status_indicator.as_ref().map(|si| {
-                si.start(
+                si.start_with_thread(
                     chat_id.clone(),
                     &content,
                     Arc::clone(&tracker),
                     None,
                     &user_status_config,
                     sender_user_id.clone(),
+                    overflow_client_message_id.clone(),
                 )
             });
 
@@ -5392,7 +5512,20 @@ impl SessionActor {
                             final_content.clone(),
                             octos_core::ThreadId::new(tid),
                         ),
-                        _ => Message::assistant(final_content.clone()),
+                        _ => {
+                            // PR F (M8.10): non-API channels arrive
+                            // without cmid. Derive from history under
+                            // the session_handle lock so the persist
+                            // succeeds with the new-write fail-closed
+                            // split. See `fallback_thread_id_for_assistant`.
+                            let handle = session_handle.lock().await;
+                            let tid = fallback_thread_id_for_assistant(&handle.session().messages);
+                            drop(handle);
+                            Message::assistant_with_thread(
+                                final_content.clone(),
+                                octos_core::ThreadId::new(tid),
+                            )
+                        }
                     };
                     final_reply.reasoning_content = conv_response.reasoning_content.clone();
                     final_reply.timestamp = final_reply_timestamp;
@@ -5641,6 +5774,10 @@ impl SessionActor {
         let token_tracker = Arc::new(TokenTracker::new());
 
         // Start status indicator
+        //
+        // PR F (M8.10) — codex review P1 #1: bind the inbound's cmid
+        // to the status composer so its wire events route to the
+        // correct turn under rapid-fire concurrent writes.
         let status_handle = self.status_indicator.as_ref().map(|si| {
             let voice_transcript = inbound
                 .metadata
@@ -5648,13 +5785,14 @@ impl SessionActor {
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
-            si.start(
+            si.start_with_thread(
                 self.chat_id.clone(),
                 &inbound.content,
                 Arc::clone(&token_tracker),
                 voice_transcript,
                 &self.user_status_config,
                 self.sender_user_id.clone(),
+                client_message_id.clone(),
             )
         });
 
@@ -5838,6 +5976,19 @@ impl SessionActor {
                         }
                     }
 
+                    // PR F (M8.10): cache the linear-channel fallback
+                    // once per turn so intermediate Assistant/Tool rows
+                    // share a stable thread_id when no `client_message_id`
+                    // is supplied. See codex's PR-F review P1 #2.
+                    let recovery_linear_fallback: Option<String> = if client_message_id
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .is_none()
+                    {
+                        Some(fallback_thread_id_for_assistant(&handle.session().messages))
+                    } else {
+                        None
+                    };
                     let mut persisted_user_message = false;
                     for msg in &conv_response.messages {
                         let message_to_save =
@@ -5870,6 +6021,11 @@ impl SessionActor {
                                 // history (which can be a sibling rapid-fire
                                 // turn that landed in the JSONL between this
                                 // turn's user persist and assistant persist).
+                                //
+                                // PR F (M8.10): when client_message_id is
+                                // absent (linear channels), use the cached
+                                // recovery_linear_fallback so intermediate
+                                // rows pass the fail-closed split.
                                 if to_save.thread_id.is_none()
                                     && matches!(
                                         to_save.role,
@@ -5880,6 +6036,8 @@ impl SessionActor {
                                         if !tid.is_empty() {
                                             to_save.thread_id = Some(tid.clone());
                                         }
+                                    } else if let Some(ref tid) = recovery_linear_fallback {
+                                        to_save.thread_id = Some(tid.clone());
                                     }
                                 }
                                 to_save
@@ -5902,12 +6060,22 @@ impl SessionActor {
                         // from the originating turn's cmid so reload pairs
                         // the assistant under the correct user bubble.
                         // Sibling fix to PR #739's M8.9 recovery path.
+                        //
+                        // PR F (M8.10): linear-channel fallback when no
+                        // cmid is present. See site 1 above.
                         let mut assistant_msg = match client_message_id.as_deref() {
                             Some(tid) if !tid.is_empty() => Message::assistant_with_thread(
                                 final_content.clone(),
                                 octos_core::ThreadId::new(tid),
                             ),
-                            _ => Message::assistant(final_content.clone()),
+                            _ => {
+                                let tid =
+                                    fallback_thread_id_for_assistant(&handle.session().messages);
+                                Message::assistant_with_thread(
+                                    final_content.clone(),
+                                    octos_core::ThreadId::new(tid),
+                                )
+                            }
                         };
                         assistant_msg.reasoning_content = conv_response.reasoning_content.clone();
                         if let Err(e) = handle.add_message(assistant_msg).await {
@@ -10441,7 +10609,10 @@ mod tests {
             .await
             .unwrap();
         parent_handle
-            .add_message(Message::assistant("Starting research"))
+            .add_message(Message::assistant_with_thread(
+                "Starting research",
+                octos_core::ThreadId::new("test-thread"),
+            ))
             .await
             .unwrap();
 
@@ -10684,7 +10855,10 @@ mod tests {
                 .await
                 .expect("seed user");
             handle
-                .add_message(Message::assistant("hello, where to?"))
+                .add_message(Message::assistant_with_thread(
+                    "hello, where to?",
+                    octos_core::ThreadId::new("test-thread"),
+                ))
                 .await
                 .expect("seed assistant");
         }
@@ -10708,7 +10882,10 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(200)).await;
             let mut handle = writer_handle.lock().await;
             let _ = handle
-                .add_message(Message::assistant("Saratoga: 72°F sunny"))
+                .add_message(Message::assistant_with_thread(
+                    "Saratoga: 72°F sunny",
+                    octos_core::ThreadId::new("test-thread"),
+                ))
                 .await;
         });
 
@@ -10753,7 +10930,10 @@ mod tests {
                 .await
                 .expect("seed user");
             handle
-                .add_message(Message::assistant("hello, where to?"))
+                .add_message(Message::assistant_with_thread(
+                    "hello, where to?",
+                    octos_core::ThreadId::new("test-thread"),
+                ))
                 .await
                 .expect("seed assistant");
         }
@@ -10806,7 +10986,10 @@ mod tests {
             let mut handle = session_handle.lock().await;
             handle.add_message(Message::user("q")).await.expect("seed");
             handle
-                .add_message(Message::assistant("a"))
+                .add_message(Message::assistant_with_thread(
+                    "a",
+                    octos_core::ThreadId::new("test-thread"),
+                ))
                 .await
                 .expect("seed");
         }
@@ -11263,7 +11446,16 @@ mod tests {
                 } else {
                     // "Channel" path — the canonical helper directly (this is
                     // the same code `ApiChannel::persist_to_session` calls).
-                    let assistant = Message::assistant(format!("channel-{i}"));
+                    //
+                    // PR F (M8.10): the canonical helper now fails closed
+                    // for unbound Assistant rows. Production callers
+                    // (`ApiChannel::persist_to_session`) pre-stamp via the
+                    // typed `Message::assistant_with_thread`. The test
+                    // mirrors that.
+                    let assistant = Message::assistant_with_thread(
+                        format!("channel-{i}"),
+                        octos_core::ThreadId::new(format!("test-thread-{i}")),
+                    );
                     octos_bus::session::persist_message_through_canonical_path(
                         &data_dir, &key, assistant,
                     )

--- a/crates/octos-cli/src/status_layers.rs
+++ b/crates/octos-cli/src/status_layers.rs
@@ -304,6 +304,37 @@ impl StatusComposer {
         user_config: &UserStatusConfig,
         sender_user_id: Option<String>,
     ) -> ComposerHandle {
+        self.start_with_thread(
+            chat_id,
+            message_text,
+            tracker,
+            voice_transcript,
+            user_config,
+            sender_user_id,
+            None,
+        )
+    }
+
+    /// PR F (M8.10): start variant that binds an originating `thread_id`
+    /// to every status edit. Codex's PR-F review (P1 #1) flagged that
+    /// the API status composer was the last unbound wire path — under
+    /// slow rapid-fire turns, a late bound-A event could rotate sticky
+    /// back to A and B's unbound status send would emit under A.
+    /// Threading the bound id through to `edit_message_bound` /
+    /// `send_with_id` metadata closes that gap. Non-API channels'
+    /// default `_bound` impls forward to the legacy method, so this is
+    /// additive and zero-risk for them.
+    #[allow(clippy::too_many_arguments)]
+    pub fn start_with_thread(
+        &self,
+        chat_id: String,
+        message_text: &str,
+        tracker: Arc<TokenTracker>,
+        voice_transcript: Option<String>,
+        user_config: &UserStatusConfig,
+        sender_user_id: Option<String>,
+        thread_id: Option<String>,
+    ) -> ComposerHandle {
         let cancelled = Arc::new(AtomicBool::new(false));
         let status_msg_id = Arc::new(Mutex::new(None::<String>));
         let notify = Arc::new(Notify::new());
@@ -353,6 +384,7 @@ impl StatusComposer {
         let metrics_visible = user_config.metrics_visible;
         let provider_visible = user_config.provider_visible;
         let sender_user_id_for_loop = sender_user_id.clone();
+        let thread_id_for_loop = thread_id.clone().filter(|s| !s.is_empty());
 
         tokio::spawn(async move {
             run_compose_loop(
@@ -367,6 +399,7 @@ impl StatusComposer {
                 metrics_visible,
                 provider_visible,
                 sender_user_id_for_loop,
+                thread_id_for_loop,
             )
             .await;
         });
@@ -579,6 +612,10 @@ fn find_layer<'a>(layers: &'a [StatusLayer], id: &str) -> Option<&'a StatusLayer
 // Compose loop
 // ---------------------------------------------------------------------------
 
+// PR F (M8.10): `thread_id` is the originating turn's id, threaded through
+// to `edit_message_bound` and stamped into the initial `send_with_id`
+// metadata so the API channel binds the status bubble to the correct turn
+// under rapid-fire concurrent writes.
 #[allow(clippy::too_many_arguments)]
 async fn run_compose_loop(
     channel: Arc<dyn Channel>,
@@ -592,6 +629,7 @@ async fn run_compose_loop(
     metrics_visible: bool,
     provider_visible: bool,
     sender_user_id: Option<String>,
+    thread_id: Option<String>,
 ) {
     let start = Instant::now();
     let mut last_edit = Instant::now() - EDIT_THROTTLE;
@@ -683,19 +721,41 @@ async fn run_compose_loop(
         if composed != last_composed && last_edit.elapsed() >= EDIT_THROTTLE {
             let mid = status_msg_id.lock().await.clone();
             if let Some(ref mid) = mid {
-                let _ = channel.edit_message(&chat_id, mid, &composed).await;
+                // PR F (M8.10): forward the turn's bound thread_id so
+                // the API channel routes the wire event under THIS
+                // turn's bubble, not whatever sticky has rotated to.
+                let _ = channel
+                    .edit_message_bound(&chat_id, mid, &composed, thread_id.as_deref())
+                    .await;
             } else {
                 // Send initial status message
+                //
+                // PR F (M8.10): stamp `thread_id` into the metadata so
+                // the API channel's `send_with_id` encoder captures
+                // the bound id (and seeds the sticky map with it),
+                // pinning subsequent edit_message_bound calls to the
+                // same bubble.
+                let mut metadata = sender_user_id
+                    .as_ref()
+                    .map(|uid| serde_json::json!({ METADATA_SENDER_USER_ID: uid }))
+                    .unwrap_or_else(|| serde_json::json!({}));
+                if let Some(ref tid) = thread_id {
+                    if !tid.is_empty() {
+                        if let Some(map) = metadata.as_object_mut() {
+                            map.insert(
+                                "thread_id".to_string(),
+                                serde_json::Value::String(tid.clone()),
+                            );
+                        }
+                    }
+                }
                 let msg = OutboundMessage {
                     channel: channel.name().to_string(),
                     chat_id: chat_id.clone(),
                     content: composed.clone(),
                     reply_to: None,
                     media: vec![],
-                    metadata: sender_user_id
-                        .as_ref()
-                        .map(|uid| serde_json::json!({ METADATA_SENDER_USER_ID: uid }))
-                        .unwrap_or_else(|| serde_json::json!({})),
+                    metadata,
                 };
                 match channel.send_with_id(&msg).await {
                     Ok(Some(mid)) => {

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -579,7 +579,15 @@ pub async fn run_stream_forwarder(
             StreamProgressEvent::RawSse { json } => {
                 // Forward raw SSE JSON directly to the channel.
                 // Only ApiChannel implements this; other channels ignore it.
-                let _ = channel.send_raw_sse(&chat_id, &json).await;
+                //
+                // PR F (M8.10 thread-binding chain): use the `_bound`
+                // variant so the originating turn's `thread_id`
+                // (captured at this forwarder's task spawn) overrides
+                // any stale `thread_id` field embedded in `json` and
+                // short-circuits the api_channel's sticky-map fallback.
+                let _ = channel
+                    .send_raw_sse_bound(&chat_id, &json, thread_id.as_deref())
+                    .await;
             }
         }
     }
@@ -681,10 +689,23 @@ async fn do_flush(
     thread_id: Option<&str>,
 ) {
     if let Some(mid) = message_id.as_ref() {
+        // PR F (M8.10 thread-binding chain `#649 → #740`): use the
+        // `_bound` variants so the originating turn's `thread_id`
+        // (captured at this forwarder's task spawn and threaded through
+        // `flush_to_channel`/`finish_flush_to_channel`) is the ONLY
+        // input to the api_channel's wire-side `thread_id` resolution
+        // when the bound id is present. Falling back to the legacy
+        // (non-bound) trait methods here re-opens LEAK 2 — the sticky
+        // map rotates under rapid-fire so late deltas of an earlier
+        // turn would mis-route to a later turn's bubble.
         let result = if finish {
-            channel.finish_stream(chat_id, mid, text).await
+            channel
+                .finish_stream_bound(chat_id, mid, text, thread_id)
+                .await
         } else {
-            channel.edit_message(chat_id, mid, text).await
+            channel
+                .edit_message_bound(chat_id, mid, text, thread_id)
+                .await
         };
         if let Err(e) = result {
             warn!("stream edit failed: {e}");
@@ -752,9 +773,15 @@ mod tests {
     use octos_core::{InboundMessage, METADATA_SENDER_USER_ID};
     use tokio::sync::{Mutex, mpsc};
 
+    /// PR F (M8.10): record every `_bound` call's `thread_id`
+    /// argument so the test can assert the forwarder threads it
+    /// through the trait correctly.
+    type BoundCall = (&'static str, Option<String>);
+
     #[derive(Default)]
     struct MockChannel {
         sent: Arc<Mutex<Vec<OutboundMessage>>>,
+        bound_thread_ids: Arc<Mutex<Vec<BoundCall>>>,
     }
 
     #[async_trait]
@@ -779,6 +806,47 @@ mod tests {
 
         fn supports_edit(&self) -> bool {
             true
+        }
+
+        async fn edit_message_bound(
+            &self,
+            _chat_id: &str,
+            _message_id: &str,
+            _new_content: &str,
+            thread_id: Option<&str>,
+        ) -> eyre::Result<()> {
+            self.bound_thread_ids
+                .lock()
+                .await
+                .push(("edit_message_bound", thread_id.map(str::to_string)));
+            Ok(())
+        }
+
+        async fn finish_stream_bound(
+            &self,
+            _chat_id: &str,
+            _message_id: &str,
+            _final_content: &str,
+            thread_id: Option<&str>,
+        ) -> eyre::Result<()> {
+            self.bound_thread_ids
+                .lock()
+                .await
+                .push(("finish_stream_bound", thread_id.map(str::to_string)));
+            Ok(())
+        }
+
+        async fn send_raw_sse_bound(
+            &self,
+            _chat_id: &str,
+            _json: &str,
+            thread_id: Option<&str>,
+        ) -> eyre::Result<()> {
+            self.bound_thread_ids
+                .lock()
+                .await
+                .push(("send_raw_sse_bound", thread_id.map(str::to_string)));
+            Ok(())
         }
     }
 
@@ -1109,6 +1177,62 @@ mod tests {
             first2.metadata.get("thread_id").is_none(),
             "empty-string thread_id must be treated as absent, got {}",
             first2.metadata
+        );
+    }
+
+    /// PR F (M8.10 thread-binding chain `#649 → #740`): when
+    /// `do_flush` (via `flush_to_channel`/`finish_flush_to_channel`)
+    /// receives a non-`None` `thread_id`, it must thread that through
+    /// the `_bound` Channel trait methods rather than the legacy
+    /// `edit_message`/`finish_stream` (which fall back to the
+    /// api_channel's per-chat sticky map). The mock asserts the actual
+    /// argument observed.
+    #[tokio::test]
+    async fn do_flush_passes_thread_id_to_bound_methods() {
+        let mock = Arc::new(MockChannel::default());
+        let bound_calls = Arc::clone(&mock.bound_thread_ids);
+        let channel: Arc<dyn Channel> = mock.clone();
+
+        // edit path: message_id is set so do_flush dispatches to
+        // `edit_message_bound`. The forwarder's captured `thread_id` is
+        // forwarded as Some("cmid-A").
+        let mut message_id = Some("$stream-1".to_string());
+        let mut no_edit_support = false;
+        flush_to_channel(
+            &channel,
+            "chat-A",
+            "hello",
+            &mut message_id,
+            &mut no_edit_support,
+            None,
+            Some("cmid-A"),
+        )
+        .await;
+        // finish path: dispatches to `finish_stream_bound`.
+        finish_flush_to_channel(
+            &channel,
+            "chat-A",
+            "hello (final)",
+            &mut message_id,
+            &mut no_edit_support,
+            None,
+            Some("cmid-A"),
+        )
+        .await;
+
+        let calls = bound_calls.lock().await.clone();
+        assert!(
+            calls.iter().any(
+                |(name, tid)| *name == "edit_message_bound" && tid.as_deref() == Some("cmid-A")
+            ),
+            "expected edit_message_bound call with thread_id=cmid-A, got: {calls:?}"
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|(name, tid)| *name == "finish_stream_bound"
+                    && tid.as_deref() == Some("cmid-A")),
+            "expected finish_stream_bound call with thread_id=cmid-A, got: {calls:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes the bug class **#649 → #664 → #673 → #680 → #738 → #740** at the server level. PR F-interim ships patches 1-4 + 7 + 8 from `/tmp/pr-f-design.md`; patches 5+6 (the PR #742 ad-hoc pre-stamp rip-out) are deferred to the F-with-A follow-up.

Both **LEAK 1** (persist path: `derive_thread_id_for_new_message` walks history → wrong sibling user under rapid-fire) and **LEAK 2** (wire path: `api_channel`'s sticky-map fallback rotates per-chat) are closed.

## Patch ladder

| # | What | Where |
|---|---|---|
| 1 | `Channel` trait `_bound` variants (additive defaults) | `octos-bus/src/channel.rs` |
| 2 | Stream forwarder switches to `_bound` | `octos-cli/src/stream_reporter.rs` |
| 3 | `api_channel` `bound > decoded > sticky` resolution + `last_thread_id_fallback_total` metric | `octos-bus/src/api_channel.rs` |
| 4 | `session.rs` derive split: `_legacy_load` vs `_new_write` (fail-closed for Assistant/Tool) | `octos-bus/src/session.rs` |
| 7 | UI Protocol `BoundedChannelReporter::with_thread_id`, persist pre-stamp, `done` event carries `thread_id` | `octos-cli/src/api/ui_protocol.rs` |
| 8 | REST `handlers.rs` Assistant/Tool persist pre-stamp | `octos-cli/src/api/handlers.rs` |
| 8.5 | `StatusComposer::start_with_thread` (codex review P1 #1) | `octos-cli/src/status_layers.rs` |
| 8.6 | Linear-channel `fallback_thread_id_for_assistant` for non-API turns + intermediate Tool/Assistant rows (codex review P1 #2) | `octos-cli/src/session_actor.rs` |
| 8.7 | `persist_to_session` API channel sticky-or-synth (NOT history-derive — codex review P1 #3) | `octos-bus/src/api_channel.rs` |

PR #742's tactical pre-stamps remain in place as defense-in-depth for the foreground turn loop. They become structurally redundant once PR A's typed `Message::assistant_with_thread` constructor is required at every construction site (the F-with-A follow-up).

## Codex 2nd-opinion review

Run at `/tmp/codex-prf-review.log`. Findings P1 #1, P1 #2, P1 #3 incorporated:

1. **P1 #1**: API status composer was the last unbound wire path → added `start_with_thread`, threading the bound id through to `edit_message_bound` and the initial `send_with_id` metadata.
2. **P1 #2**: Intermediate Assistant/Tool rows for linear channels (`client_message_id == None`) would have been rejected by fail-closed → cached `linear_fallback_for_turn` once per turn so all intermediate rows share a stable thread_id.
3. **P1 #3**: `persist_to_session`'s history fallback would have re-opened LEAK 1 for the API channel → replaced with sticky-or-UUIDv7 + observability metric.

## Tests

* `rapid_fire_bound_turn_overrides_sticky_for_persist_edit_and_raw_sse`
* `edit_message_bound_does_not_consult_sticky_when_explicit_id_supplied`
* `send_raw_sse_bound_overwrites_stale_thread_id_in_payload`
* `do_flush_passes_thread_id_to_bound_methods`
* `bounded_channel_reporter_emits_typed_thread_id_on_progress_events`
* `derive_thread_id_for_new_write_rejects_unbound_assistant`
* `derive_thread_id_for_new_write_rejects_unbound_tool`
* `derive_thread_id_for_new_write_accepts_user_and_system`
* `add_message_with_seq_accepts_legacy_replay_via_legacy_load`

## Test plan

- [x] `cargo build --workspace --features api` clean
- [x] `cargo test --workspace --features api --no-fail-fast` all green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (CI runs without `--features api`)
- [x] Layer 1 fixture suite (PR #746) — 23/23 passing
- [ ] Deploy to mini5 (per memory `project_mini5_coding_green` it's reserved for coding-green); soak `live-overflow-stress.spec rapid-fire-five-fast`
- [ ] Watch metrics: `octos_last_thread_id_fallback_total{site=...}` should be 0 from new test invocations; `octos_session_persist_total{outcome="rejected_unbound_assistant"}` should be 0

## References

* Design doc: `/tmp/pr-f-design.md` (7 leak sites + 8 patches)
* Codex review: `/tmp/codex-prf-review.log`
* Bug chain: #649 → #664 → #673 → #680 → #738 → #740
* PR #742 ack-and-result fix carried forward (NOT yet ripped out — F-with-A follow-up)
* PR #745 typed identities consumed via `Message::assistant_with_thread`
* PR #746 Layer 1 fixtures kept passing as the wire-output contract