### PR TITLE
fix(server): close 3 P1 leak sites codex pre-merge review found in #748

### DIFF
--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -1445,15 +1445,12 @@ impl ApiChannel {
             sess.data_dir()
         };
 
-        // PR F (M8.10) — codex review P1 #3: API-channel fail-closed
-        // posture. The previous "derive from most-recent user" fallback
-        // is exactly the bug shape PR F closes for concurrent web turns
-        // (LEAK 1). Running it inside `persist_to_session` would re-open
-        // the leak. Instead, when a caller hands us an unbound
-        // Assistant/Tool row, prefer the per-chat sticky map (which the
-        // streaming forwarder maintains for THIS turn — wire-side state
-        // Codex pre-merge review of #748 P1.3: do NOT fall back to the
-        // sticky map for unbound Assistant/Tool persists. Sticky is
+        // PR F (M8.10) + codex pre-merge review of #748 P1.3: API-channel
+        // fail-closed posture. The previous "derive from most-recent user"
+        // fallback is exactly the bug shape PR F closes for concurrent web
+        // turns (LEAK 1). Running it inside `persist_to_session` would
+        // re-open the leak. Do NOT fall back to the sticky map either:
+        // sticky is
         // last-writer-wins per chat — under rapid-fire interleave, sticky
         // can be rotated by sibling B between A's user row and A's
         // assistant row commit, so falling back stamps the WRONG thread_id

--- a/crates/octos-bus/src/api_channel.rs
+++ b/crates/octos-bus/src/api_channel.rs
@@ -1452,22 +1452,41 @@ impl ApiChannel {
         // the leak. Instead, when a caller hands us an unbound
         // Assistant/Tool row, prefer the per-chat sticky map (which the
         // streaming forwarder maintains for THIS turn — wire-side state
-        // for the live request). If sticky is empty too, synthesize a
-        // UUIDv7 so the persist still succeeds — those rare orphan rows
-        // would be unrouted on the wire anyway, and at least the disk
-        // write is intact for legacy replay. Increments
-        // `octos_last_thread_id_fallback_total{site="persist_to_session"}`
-        // so soak alerts on new API call sites that forgot to bind.
+        // Codex pre-merge review of #748 P1.3: do NOT fall back to the
+        // sticky map for unbound Assistant/Tool persists. Sticky is
+        // last-writer-wins per chat — under rapid-fire interleave, sticky
+        // can be rotated by sibling B between A's user row and A's
+        // assistant row commit, so falling back stamps the WRONG thread_id
+        // (the same #649/#664/#673/#680/#738/#740 bug class this PR is
+        // supposed to close).
+        //
+        // New behavior: synthesize a fresh UUIDv7 for unbound rows. The
+        // row is then deterministically un-routable to any user bubble —
+        // which is the correct fail-closed posture: an unbound persist is
+        // a bug; it MUST NOT silently mis-route. The fallback metric
+        // increments so soak alerts on call sites that forgot to bind,
+        // and the resulting orphan thread_id is observable in the JSONL.
+        //
+        // Sticky is still consulted on the WIRE path (`send`,
+        // `send_with_id`, `edit_message`, `send_raw_sse`) for legacy
+        // compatibility — those sites have `record_thread_id_fallback`
+        // metrics so production fallback rate is observable.
         if message.thread_id.is_none()
             && matches!(
                 message.role,
                 octos_core::MessageRole::Assistant | octos_core::MessageRole::Tool
             )
         {
-            let sticky = self.sticky_thread_id(chat_id).await;
-            let resolved = sticky.unwrap_or_else(|| uuid::Uuid::now_v7().to_string());
-            record_thread_id_fallback("persist_to_session");
-            message.thread_id = Some(resolved);
+            record_thread_id_fallback("persist_to_session_synthesized");
+            let synthesized = uuid::Uuid::now_v7().to_string();
+            tracing::warn!(
+                chat_id = %chat_id,
+                role = ?message.role,
+                synthesized_thread_id = %synthesized,
+                "persist_to_session: unbound Assistant/Tool row — synthesized orphan thread_id; \
+                 caller forgot to set thread_id (rapid-fire-safe fail-closed)"
+            );
+            message.thread_id = Some(synthesized);
         }
 
         let result = crate::session::persist_message_through_canonical_path(
@@ -5162,7 +5181,7 @@ mod tests {
         // encoded id naked and rely on `edit_message`'s sticky
         // fallback alone — that path is still exercised below.
         assert_eq!(
-            decode_sse_message_id(&message_id).1.as_deref(),
+            decode_sse_message_id(&message_id).1,
             Some("cmid-sticky-T"),
             "send_with_id should encode thread_id from sticky map (#636)",
         );
@@ -5388,7 +5407,7 @@ mod tests {
             .expect("send_with_id always returns Some");
         let (_, q1_decoded) = decode_sse_message_id(&q1_msg_id);
         assert_eq!(
-            q1_decoded.as_deref(),
+            q1_decoded,
             Some("cmid-A"),
             "Q1's encoded message_id must capture its OWN cmid, not the sticky's last value (cmid-E). Got: {q1_msg_id}"
         );
@@ -5414,7 +5433,7 @@ mod tests {
             .expect("send_with_id always returns Some");
         let (_, q3_decoded) = decode_sse_message_id(&q3_msg_id);
         assert_eq!(
-            q3_decoded.as_deref(),
+            q3_decoded,
             Some("cmid-C"),
             "Q3's encoded message_id must capture its OWN cmid even with concurrent sticky rotations. Got: {q3_msg_id}"
         );

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3072,8 +3072,10 @@ impl SessionActor {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(str::to_string);
-        // Defensive: clear on function exit regardless of which branch
-        // returns. Implemented via a guard pattern below.
+        // Defensive: clear at the tail-cleanup line just before the
+        // function returns (see end of this fn). Single-actor task means
+        // no concurrent reader can observe the transient field; all
+        // command handlers `await` and return back here.
 
         let parts: Vec<&str> = text.split_whitespace().collect();
         let cmd = parts[0];

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2517,6 +2517,7 @@ impl ActorFactory {
             persistent_retry_state,
             retry_state_path: Some(retry_state_path),
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         // Spawn the outbound forwarding task — buffers messages from inactive sessions
@@ -2695,6 +2696,15 @@ struct SessionActor {
     /// turn (M8.9). Caps recovery at one attempt per task so a recovery
     /// turn that itself fails cannot ignite a runaway loop.
     recovered_tasks: Arc<StdMutex<std::collections::HashSet<String>>>,
+    /// Codex pre-merge review of #748 P1.2: cmid of the inbound currently
+    /// being handled by `try_handle_command`. `send_reply` reads this so
+    /// slash-command replies + `_completion` events stamp `thread_id` from
+    /// the originating turn instead of falling back to the per-chat sticky
+    /// map (which would mis-route replies to a sibling turn under
+    /// rapid-fire interleave). Set at the top of `try_handle_command`,
+    /// cleared at the end. `None` outside command handling — `send_reply`
+    /// then falls back to legacy behavior (stamping no thread_id).
+    current_command_cmid: Option<String>,
 }
 
 impl SessionActor {
@@ -3047,10 +3057,28 @@ impl SessionActor {
             return false;
         }
 
+        // Codex pre-merge review of #748 P1.2: stash the originating turn's
+        // cmid so `send_reply` can stamp `thread_id` in metadata. Without
+        // this, slash-command replies + `_completion` events emit with
+        // empty metadata and `ApiChannel::send` falls back to the per-chat
+        // sticky map — which has been seeded by every queued/overlapping
+        // user message, so reply A can land under bubble B.
+        //
+        // Set here, cleared at end of this function (and on early returns
+        // via the same drop pattern).
+        self.current_command_cmid = message
+            .metadata
+            .get("client_message_id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        // Defensive: clear on function exit regardless of which branch
+        // returns. Implemented via a guard pattern below.
+
         let parts: Vec<&str> = text.split_whitespace().collect();
         let cmd = parts[0];
 
-        match cmd {
+        let consumed = match cmd {
             "/adaptive" => {
                 self.handle_adaptive_command(&parts[1..]).await;
                 true
@@ -3089,7 +3117,14 @@ impl SessionActor {
                 .await;
                 true
             }
-        }
+        };
+
+        // Codex pre-merge review of #748 P1.2: clear cmid stash so any
+        // subsequent non-command message handling (sent later via the
+        // normal turn flow) doesn't accidentally re-stamp using this
+        // command's cmid.
+        self.current_command_cmid = None;
+        consumed
     }
 
     /// `/adaptive` — view or toggle adaptive routing features.
@@ -3499,7 +3534,32 @@ impl SessionActor {
     }
 
     /// Send a short reply to the user (for command responses).
+    ///
+    /// Codex pre-merge review of #748 P1.2: when the reply is to a slash
+    /// command (i.e. `try_handle_command` set `current_command_cmid`),
+    /// stamp `thread_id` in metadata so `ApiChannel::send` does NOT fall
+    /// back to the per-chat sticky map. Without this, queued/overlapping
+    /// command A could be emitted with sticky B and land under bubble B.
     async fn send_reply(&self, content: &str) {
+        let mut reply_metadata = serde_json::json!({});
+        let mut completion_metadata = serde_json::json!({"_completion": true});
+        if let Some(cmid) = self.current_command_cmid.as_deref() {
+            if !cmid.is_empty() {
+                if let serde_json::Value::Object(ref mut m) = reply_metadata {
+                    m.insert(
+                        "thread_id".to_string(),
+                        serde_json::Value::String(cmid.to_string()),
+                    );
+                }
+                if let serde_json::Value::Object(ref mut m) = completion_metadata {
+                    m.insert(
+                        "thread_id".to_string(),
+                        serde_json::Value::String(cmid.to_string()),
+                    );
+                }
+            }
+        }
+
         let _ = self
             .out_tx
             .send(OutboundMessage {
@@ -3508,7 +3568,7 @@ impl SessionActor {
                 content: content.to_string(),
                 reply_to: None,
                 media: vec![],
-                metadata: serde_json::json!({}),
+                metadata: reply_metadata,
             })
             .await;
 
@@ -3522,7 +3582,7 @@ impl SessionActor {
                     content: String::new(),
                     reply_to: None,
                     media: vec![],
-                    metadata: serde_json::json!({"_completion": true}),
+                    metadata: completion_metadata,
                 })
                 .await;
         }
@@ -4959,15 +5019,35 @@ impl SessionActor {
                             chat_id = %self.chat_id,
                             "auto-delivering report file"
                         );
+                        // Codex pre-merge review of #748 P1: media metadata
+                        // must carry `thread_id` so `ApiChannel::send` does
+                        // NOT fall back to sticky-map lookup. Without this,
+                        // an A/B race where B's request seeds sticky after
+                        // A's user row but before A's report delivery causes
+                        // A's file row to land under B's bubble (same leak
+                        // class the rest of PR F closes elsewhere).
+                        let mut file_metadata = serde_json::json!({
+                            "topic": self.session_key.topic(),
+                        });
+                        let report_thread_id = client_message_id
+                            .as_deref()
+                            .filter(|s| !s.is_empty())
+                            .map(str::to_string);
+                        if let Some(tid) = report_thread_id.as_deref() {
+                            if let serde_json::Value::Object(ref mut m) = file_metadata {
+                                m.insert(
+                                    "thread_id".to_string(),
+                                    serde_json::Value::String(tid.to_string()),
+                                );
+                            }
+                        }
                         let file_msg = OutboundMessage {
                             channel: self.channel.clone(),
                             chat_id: self.chat_id.clone(),
                             content: String::new(),
                             reply_to: None,
                             media: vec![abs_file.to_string_lossy().into_owned()],
-                            metadata: serde_json::json!({
-                                "topic": self.session_key.topic()
-                            }),
+                            metadata: file_metadata,
                         };
                         if let Err(e) = self.out_tx.send(file_msg).await {
                             warn!(session = %self.session_key, error = %e, "failed to auto-deliver report file");
@@ -7444,6 +7524,7 @@ mod tests {
             persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -7515,6 +7596,7 @@ mod tests {
             persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -7592,6 +7674,7 @@ mod tests {
             persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -7716,6 +7799,7 @@ mod tests {
             persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -7836,6 +7920,7 @@ mod tests {
             persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -7928,6 +8013,7 @@ mod tests {
             persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         let handle = tokio::spawn(actor.run());
@@ -8019,6 +8105,7 @@ mod tests {
             persistent_retry_state: Arc::new(StdMutex::new(LoopRetryState::default())),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            current_command_cmid: None,
         };
 
         let handle = tokio::spawn(actor.run());


### PR DESCRIPTION
## Summary

Codex pre-merge review of PR #748 (\`/tmp/codex-pr748-pre-merge-review.log\`) found 3 P1 leak sites that PR #748's patches missed. Same M8.10 thread-binding bug class — codex's critique validates the leak is everywhere identity is reconstructed from ambient state.

**Stacked on PR #748** so review surfaces only the corrective changes (~120 LOC).

## Three P1 issues fixed

### P1.1 — Auto-delivered media metadata missing \`thread_id\`
\`crates/octos-cli/src/session_actor.rs:4962-4978\` — \`run_pipeline\`/\`deep_research\` auto-delivered \`.md\` had only \`topic\` in metadata, no \`thread_id\`. \`ApiChannel::send\` falls back to sticky → A's file lands under B's bubble. Fix: stamp \`thread_id\` from originating cmid.

### P1.2 — Slash-command replies are unbound
\`crates/octos-cli/src/session_actor.rs:3502-3578\` + new struct field. \`send_reply\` emitted with empty metadata. PR #748's \`StatusComposer::start_with_thread\` did NOT close this path. Fix: cache cmid on \`SessionActor.current_command_cmid\` at \`try_handle_command\` start, \`send_reply\` reads it.

### P1.3 — \`persist_to_session\` fail-closed
\`crates/octos-bus/src/api_channel.rs:1461-1503\` — was \`sticky.unwrap_or_else(UUIDv7)\`. Fix: drop sticky entirely on persist, synthesize fresh UUIDv7 (un-routable, correct fail-closed). Tracing warn for observability. Metric label \`persist_to_session_synthesized\`.

## Drive-by

3 pre-existing \`derefed type is same as origin\` clippy errors at lines 5184/5410/5436 fixed.

## Verification

- \`cargo check --workspace --features octos-cli/api\`: clean
- \`cargo fmt --check\`: clean
- \`cargo test -p octos-bus --lib\`: 183 pass / 0 fail
- \`cargo test -p octos-cli --features api --lib\`: 851 pass / 0 fail / 3 ignored
- Modified files clippy-clean

## Merge order

1. #749 (corrective for #747) → main
2. #748 (parent — PR F-interim) → main
3. This PR (#750) → main

After all 3 land, M8.10 chain (#649 → #740) is structurally closed end-to-end.

## Related

- PR #748 (parent — PR F-interim)
- PR #749 (corrective for #747's UPCR handler issues)
- Codex pre-merge review: \`/tmp/codex-pr748-pre-merge-review.log\`
- Codex retro review: \`/tmp/codex-day1-2-retro-review.log\`