### PR TITLE
fix(api): carry message media on the wire (closes P1.3)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -850,6 +850,12 @@ fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
                     seq: 0,
                 },
                 persisted_at: Utc::now(),
+                // P1.3 fix: surface the persisted message's `media`
+                // attachments on the wire so spawn_only / send_file
+                // deliveries reach the chat bubble. Empty Vec
+                // serialises to omitted (back-compat for clients
+                // that don't yet understand the field).
+                media: message.media.clone(),
             };
             // Append to the ledger; the ledger stamps the cursor onto
             // both the envelope AND the `MessagePersistedEvent.cursor`
@@ -3205,6 +3211,13 @@ async fn handle_session_hydrate(
                         thread_id: msg.thread_id.clone(),
                         client_message_id: msg.client_message_id.clone(),
                         persisted_at: msg.timestamp,
+                        // P1.3 fix: surface canonical-ledger media so a
+                        // client reconnecting after a disconnect can
+                        // re-render the same `.md` / `.mp3` / `.pptx`
+                        // attachment it would have seen via the live
+                        // `message/persisted` push (`media` field on
+                        // MessagePersistedEvent).
+                        media: msg.media.clone(),
                     })
                     .collect::<Vec<_>>(),
             )
@@ -9785,6 +9798,7 @@ mod tests {
                 seq: 0,
             },
             persisted_at: Utc::now(),
+            media: vec![],
         })
     }
 

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2141,6 +2141,7 @@ mod tests {
             message_id: "msg-1".into(),
             client_message_id: None,
             source: MessagePersistedSource::Tool,
+            media: vec![],
             cursor: UiCursor {
                 stream: session.0.clone(),
                 seq: 0,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1464,6 +1464,16 @@ pub struct HydratedMessage {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_message_id: Option<String>,
     pub persisted_at: DateTime<Utc>,
+    /// File attachments stored with this row in the canonical session
+    /// JSONL — surfaced so clients reconstructing history after a
+    /// disconnect can render the same attachment they would have rendered
+    /// on the original `message/persisted` push (cf. the `media` field
+    /// on `MessagePersistedEvent`).
+    ///
+    /// Backwards-compatible: omitted from the wire when empty so clients
+    /// running older protocol versions see the same shape they used to.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub media: Vec<String>,
 }
 
 /// Lifecycle state strings for a thread in `ThreadGraphEntry.status` and the
@@ -1661,6 +1671,18 @@ pub struct MessagePersistedEvent {
     pub source: MessagePersistedSource,
     pub cursor: UiCursor,
     pub persisted_at: DateTime<Utc>,
+    /// File attachments persisted with this message — typically a single
+    /// `.md` / `.mp3` / `.pptx` artefact path emitted by `spawn_only`
+    /// background tools (`deep_search`, `mofa_*`, `fm_tts`) or an explicit
+    /// `send_file` call. Clients that advertise `event.message_persisted.v1`
+    /// AND understand a non-empty `media` field should render the attachment
+    /// inline (e.g. an `<a href>` to the file URL); legacy clients that only
+    /// know about `content` continue to render the text.
+    ///
+    /// Backwards-compatible: serialized as omitted when empty so clients
+    /// running older protocol versions see the same wire shape they used to.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub media: Vec<String>,
 }
 
 /// Draft command payloads for UI protocol v1.
@@ -5091,6 +5113,7 @@ mod tests {
                 thread_id: Some("thread-1".into()),
                 client_message_id: Some("cmid-1".into()),
                 persisted_at: sample_persisted_at(),
+                media: vec![],
             }]),
             threads: Some(vec![ThreadGraphEntry {
                 thread_id: "thread-1".into(),
@@ -5237,6 +5260,7 @@ mod tests {
                 seq: 18,
             },
             persisted_at: sample_persisted_at(),
+            media: vec!["report.md".into()],
         };
         let value = serde_json::to_value(&event).expect("serialize");
         assert_eq!(value.get("source"), Some(&json!("assistant")));
@@ -5265,6 +5289,7 @@ mod tests {
                     seq: 1,
                 },
                 persisted_at: sample_persisted_at(),
+                media: vec![],
             };
             let v = serde_json::to_value(&e).expect("serialize source");
             let p: MessagePersistedEvent = serde_json::from_value(v).expect("deserialize source");


### PR DESCRIPTION
## Summary

Wave-6e proved server-side spawn_only file delivery now works end to end:
the api/serve agent invokes \`deep_search\` / \`mofa_*\` / \`fm_tts\`, the
runtime auto-backgrounds, the BackgroundResultSender persists with media
via the canonical path, and the ledger publish-subscribe broadcasts
\`message/persisted\`. But the SPA bubble still rendered nothing because
the wire shape carried metadata only — clients had no way to learn the
persisted message had a \`.md\` / \`.mp3\` / \`.pptx\` attachment without
doing a follow-up history fetch that doesn't exist.

This PR closes the **codex P1.3 wire-format gap** identified during the
β review and confirmed empirically by wave-6e (5/5 specs failing with
\`slowHrefs=[]\`):

* \`MessagePersistedEvent\` — the live notification fired by
  \`MessageCommitObserver\` and broadcast via #761's publish-subscribe.
  Producer in \`install_message_commit_observer\` now copies
  \`message.media\` onto the event.
* \`HydratedMessage\` — the row shape returned by \`session/hydrate\` for
  clients reconstructing history after a disconnect. Producer in
  \`handle_session_hydrate\` now copies \`msg.media\`.

Both fields use \`#[serde(default, skip_serializing_if = \"Vec::is_empty\")]\`
so the wire shape is back-compat: empty serialises to omitted, clients
that don't yet understand \`media\` deserialise it as \`Vec::default()\`.

## Diagnosis

mini1 \`serve.2026-05-03.log\` during wave-6e showed:

\`\`\`
19:03:48 running spawn_only tool in background tool=deep_search
19:04:10 spawn_only background tool completed tool=deep_search success=true
19:04:10 background auto-sending file tool=deep_search file=…/_report.md
19:04:10 background file sent tool=deep_search file=…/_report.md
\`\`\`

6× \`background file sent\` events fired during the soak. ledger.sessions.active
peaked at 21, bytes.in_memory at 1.44 MB. Server-side α (#764) + β (#765)
fired correctly. But \`slowHrefs=[]\` empty in every spec — the SPA had no
\`.md\` href to render because \`MessagePersistedEvent.media\` didn't exist.

## Test plan

- [x] \`cargo build --workspace --features 'telegram,whatsapp,feishu,twilio,wecom,api'\`
- [x] \`cargo test -p octos-core --lib\` (167 passed)
- [x] \`cargo test -p octos-cli --features '...' --lib\` (875 passed)
- [x] golden_message_persisted_event_serde updated to exercise populated + empty media
- [x] golden_session_hydrate_result_serde updated to include media field
- [ ] Codex review before merge
- [ ] Pairs with octos-web bridge PR that renders \`<a href>\` for media — wave-6f confirms end to end

## Out of scope

- octos-web bridge handler — separate cross-repo PR coming next.
- Pin \`send_file\` against LRU eviction (#764 covers plugins; built-in send_file is still evictable). Easy follow-up.
- Narrow mofa-fm \`fm_voice_save/list/delete\` flags (over-patched as spawn_only). Easy follow-up.