### PR TITLE
fix(api): plug session plugin work_dir under per-profile data root

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4401,11 +4401,35 @@ async fn run_standalone_turn(
         (history, data_dir)
     };
 
+    // For hosted multi-tenant standalone serve, the file API resolves
+    // `/api/files/...` against the per-profile data dir (`<server_data>/
+    // profiles/<profile>/data`), not the server-wide one. Plugin output
+    // must land under the SAME root the file API will check, otherwise
+    // `resolve_legacy_file_request` rejects it. Resolve the profile data
+    // dir from the session_id's encoded profile (set by the SPA's hosted
+    // subdomain) and fall back to the runtime data dir for local sessions.
+    let plugin_root_dir = session_id
+        .profile_id()
+        .and_then(|profile_id| {
+            state
+                .profile_store
+                .as_ref()
+                .and_then(|store| store.get(profile_id).ok().flatten())
+                .map(|profile| {
+                    state
+                        .profile_store
+                        .as_ref()
+                        .map(|store| store.resolve_data_dir(&profile))
+                        .unwrap_or_else(|| runtime_data_dir.clone())
+                })
+        })
+        .unwrap_or_else(|| runtime_data_dir.clone());
+
     let (mut tool_registry, workspace_root) =
         match session_tool_registry(
             base_agent.as_ref(),
             &session_id,
-            &runtime_data_dir,
+            &plugin_root_dir,
             state.appui_default_session_cwd.as_deref(),
         ) {
             Ok(registry) => registry,


### PR DESCRIPTION
## Summary

Follow-up to #769. The previous fix routed plugin output to `<runtime_data_dir>/skill-output`, where `runtime_data_dir = sessions.data_dir()`. For the hosted standalone-serve path that's the *server-wide* data dir (`~/.octos`), but `/api/files` resolves against the *per-profile* data dir (`~/.octos/profiles/<profile>/data`) for hosted requests routed by subdomain (`should_resolve_file_access_from_profile`).

So even after #769 the file landed at `~/.octos/skill-output/...`, which does NOT start with `~/.octos/profiles/<profile>/data`, and `resolve_legacy_file_request` still rejected it with 403.

Empirical verification on `dspfac.crew.ominix.io` after the #769 deploy:

```
GET /api/files/%2FUsers%2Fcloud%2F.octos%2Fskill-output%2Fresearch%2F.../_report.md
→ HTTP 403
```

## Fix

Resolve the per-profile data dir from `session_id.profile_id()` (populated by `SessionKey::with_profile` when the SPA's hosted subdomain routes the connection through `validate_session_scope`) plus `state.profile_store.resolve_data_dir(profile)`. Fall back to the runtime data dir when the session_id has no encoded profile (local sessions, the legacy non-hosted path) so behaviour stays unchanged there.

This matches the gateway convention where each per-profile factory uses its own `<profile_data_dir>/skill-output` (`profile_factory.rs:581`), just resolved on a per-request basis since standalone serve has a single shared agent across profiles.

## Test plan

- [x] `cargo build -p octos-cli --features api` clean
- [x] All 875 octos-cli unit tests pass; no test changes (the existing `session_tool_registry` tests use `SessionKey("local:...")` which has no profile dimension, exercising the fallback path)
- [x] `codex review --base origin/main` returned a single P2 about `SendFileTool`'s allowed dirs that doesn't actually apply: `bg_data_dir = ~/.octos` (server-wide) and the new plugin output at `~/.octos/profiles/<profile>/data/skill-output/...` is a starts_with descendant, so SendFileTool accepts it.
- [ ] Soak verification on `dspfac.crew.ominix.io`.