### PR TITLE
fix(api): resolve plugin work_dir from host-routed profile id

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -132,7 +132,10 @@ fn resolve_profile_id_candidate(state: &AppState, candidate: &str) -> Option<Str
         .and_then(|store| store.resolve_routable_profile_id(candidate).ok().flatten())
 }
 
-fn routed_profile_id_from_headers(state: &AppState, headers: &HeaderMap) -> Option<String> {
+pub(crate) fn routed_profile_id_from_headers(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Option<String> {
     if let Some(host) = request_host(headers) {
         if !is_local_request_host(&host) {
             if let Some(candidate) = host.split('.').next() {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1295,9 +1295,23 @@ pub async fn ws_handler(
         .as_ref()
         .and_then(|Extension(identity)| authenticated_profile_id(identity))
         .map(ToOwned::to_owned);
+    // Hosted multi-tenant standalone serve routes by subdomain
+    // (`<profile>.<base>.example.com`). Admin tokens authenticate as
+    // `AuthIdentity::Admin` so `connection_profile_id` is `None`, but the
+    // `Host` header still carries the per-tenant profile. Stash it on the
+    // connection so per-session resolution (notably plugin work_dir →
+    // file-API root) can pick the right profile data dir even for admin
+    // sessions originated from a hosted subdomain.
+    let routed_profile_id = super::handlers::routed_profile_id_from_headers(&state, &headers);
     let features = ConnectionUiFeatures::from_headers_and_query(&headers, uri.query());
     ws.on_upgrade(move |socket| {
-        ui_protocol_connection(socket, state, connection_profile_id, features)
+        ui_protocol_connection(
+            socket,
+            state,
+            connection_profile_id,
+            routed_profile_id,
+            features,
+        )
     })
 }
 
@@ -1305,6 +1319,7 @@ async fn ui_protocol_connection(
     socket: WebSocket,
     state: Arc<AppState>,
     connection_profile_id: Option<String>,
+    routed_profile_id: Option<String>,
     features: ConnectionUiFeatures,
 ) {
     let (ws_sink, mut ws_rx) = socket.split();
@@ -1327,6 +1342,7 @@ async fn ui_protocol_connection(
     // installs the ephemeral RAM-only fallback.
     let _ = diff_preview_store(&state, contracts.as_ref()).await;
     let connection_profile_id = connection_profile_id.as_deref();
+    let routed_profile_id = routed_profile_id.as_deref();
 
     while let Some(Ok(msg)) = ws_rx.next().await {
         let text = match msg {
@@ -1382,6 +1398,7 @@ async fn ui_protocol_connection(
                     &active_turns,
                     &connection_turns,
                     connection_profile_id,
+                    routed_profile_id,
                     features,
                     id,
                     params,
@@ -2555,6 +2572,7 @@ async fn handle_turn_start(
     active_turns: &SharedActiveTurns,
     connection_turns: &SharedConnectionTurns,
     connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     id: String,
     params: TurnStartParams,
@@ -2592,6 +2610,9 @@ async fn handle_turn_start(
     let interrupt_tx = Arc::new(TokioMutex::new(Some(interrupt_tx)));
     let turn_state_for_task = turn_state.clone();
     let (start_tx, start_rx) = tokio::sync::oneshot::channel();
+    let resolved_profile_id = connection_profile_id
+        .or(routed_profile_id)
+        .map(ToOwned::to_owned);
     let handle = tokio::spawn(async move {
         if start_rx.await.is_err() {
             return;
@@ -2617,6 +2638,7 @@ async fn handle_turn_start(
                 features,
                 params,
                 prompt,
+                resolved_profile_id,
                 turn_state_for_task,
                 interrupt_rx,
             )
@@ -4352,6 +4374,7 @@ async fn run_standalone_turn(
     features: ConnectionUiFeatures,
     params: TurnStartParams,
     prompt: String,
+    routed_profile_id: Option<String>,
     turn_state: Arc<TokioMutex<TurnState>>,
     mut interrupt_rx: mpsc::Receiver<()>,
 ) {
@@ -4405,11 +4428,22 @@ async fn run_standalone_turn(
     // `/api/files/...` against the per-profile data dir (`<server_data>/
     // profiles/<profile>/data`), not the server-wide one. Plugin output
     // must land under the SAME root the file API will check, otherwise
-    // `resolve_legacy_file_request` rejects it. Resolve the profile data
-    // dir from the session_id's encoded profile (set by the SPA's hosted
-    // subdomain) and fall back to the runtime data dir for local sessions.
-    let plugin_root_dir = session_id
+    // `resolve_legacy_file_request` rejects it.
+    //
+    // The active profile id can come from three places, in order:
+    //   1. `session_id.profile_id()` — when the SPA encodes it via
+    //      `SessionKey::with_profile`. Bare-channel session ids
+    //      (`web-…`) skip this.
+    //   2. `routed_profile_id` — derived from the connection's `Host`
+    //      header during WS handshake. Hosted admin-token requests land
+    //      here; the SPA at `dspfac.crew.ominix.io` matches.
+    // Falls back to the server-wide data dir for local sessions / dev.
+    let active_profile_id = session_id
         .profile_id()
+        .map(ToOwned::to_owned)
+        .or(routed_profile_id);
+    let plugin_root_dir = active_profile_id
+        .as_deref()
         .and_then(|profile_id| {
             state
                 .profile_store
@@ -4551,9 +4585,18 @@ async fn run_standalone_turn(
         let send_file_base = workspace_root
             .clone()
             .unwrap_or_else(|| bg_data_dir.clone());
-        let send_file_tool = octos_agent::SendFileTool::new(out_tx)
+        let mut send_file_tool = octos_agent::SendFileTool::new(out_tx)
             .with_base_dir(send_file_base)
             .with_extra_allowed_dir(bg_data_dir.clone());
+        // Profiles with a custom `data_dir` outside `bg_data_dir` host
+        // their plugin output under a path the default extras above would
+        // reject. Add `plugin_root_dir` (resolved per-profile via
+        // `routed_profile_id` or `session_id.profile_id()`) as an extra
+        // allowed dir so spawn_only `send_file` deliveries from those
+        // profiles still pass the path-scoping check.
+        if plugin_root_dir != bg_data_dir {
+            send_file_tool = send_file_tool.with_extra_allowed_dir(plugin_root_dir.clone());
+        }
         send_file_tool.set_context("api", &bg_session_id.0);
         tool_registry.register(send_file_tool);
 


### PR DESCRIPTION
## Summary

Follow-up to #769 + #770. The SPA at `dspfac.crew.ominix.io` authenticates with the bootstrap admin token (`AuthIdentity::Admin`), which `authenticated_profile_id` returns `None` for, AND sends `session_id` as a bare `web-...` (no profile prefix). So #770's `session_id.profile_id()` path returned `None` and we fell back to the server-wide data dir → output at `~/.octos/skill-output/...`, still outside `~/.octos/profiles/dspfac/data`, still **403**.

The hosted multi-tenant flow already routes by subdomain in the file API path (`should_resolve_file_access_from_profile` → `routed_profile_id_from_headers`). Mirror that on the WebSocket path: extract the routed profile from the `Host` header at WS handshake, stash it on the connection, and thread it through `handle_turn_start` into `run_standalone_turn` so the plugin work_dir resolves to the correct per-profile data dir for admin-token-on-subdomain sessions.

Also extends `SendFileTool`'s extra_allowed_dirs to include the resolved `plugin_root_dir` when it differs from `bg_data_dir`, so profiles with a custom `data_dir` outside the serve data root still pass the file-scoping check.

## Resolution order

1. `session_id.profile_id()` — SPAs that encode profile via `SessionKey::with_profile`.
2. `routed_profile_id` — derived from `Host` header during WS handshake. Catches admin-token requests on hosted subdomains (the deployed mini1 case).

Falls back to the runtime data dir when both are absent (local / non-hosted sessions, dev).

## Empirical anchor

With #770 the SPA fetched:
```
/api/files/%2FUsers%2Fcloud%2F.octos%2Fskill-output%2F.../_report.md
→ HTTP 403
```
because the file landed at server data root rather than profile root. With this fix, output lands at `~/.octos/profiles/dspfac/data/skill-output/research/.../_report.md`, which `resolve_legacy_file_request` accepts via the profile-root `starts_with` check.

## Test plan

- [x] `cargo build -p octos-cli --features api` clean
- [x] All 875 octos-cli unit tests pass
- [x] `codex review --base origin/main` flagged a single P2 about `SendFileTool`'s allowed dirs for profiles with a custom `data_dir`; fix included in this PR by extending `extra_allowed_dirs` with `plugin_root_dir` when it differs from `bg_data_dir`.
- [ ] Soak verification on `dspfac.crew.ominix.io` after deploy.

Bumps `routed_profile_id_from_headers`'s visibility to `pub(crate)` so the WS handler can reuse the same resolution logic the file API already uses; no behavioural change to existing callers.