### PR TITLE
feat(ui-protocol): add turn.spawn_complete event for envelope-based spawn_only completion (M10 Phase 1)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -728,7 +728,7 @@ impl Agent {
                                                         .join(", ")
                                                 );
                                                 if let Some(ref sender) = bg_sender {
-                                                    // M10 Phase 1 (codex round 5):
+                                                    // M10 Phase 1 (codex rounds 5+6):
                                                     // carry `sent_files` into the
                                                     // payload so the
                                                     // `turn/spawn_complete` envelope
@@ -742,6 +742,31 @@ impl Agent {
                                                     // without the media here they'd
                                                     // see a "completed" bubble with
                                                     // no downloadable attachments.
+                                                    //
+                                                    // Round 6 P2-A: canonicalize
+                                                    // each path so a relative
+                                                    // `files_to_send` entry from
+                                                    // the tool resolves to an
+                                                    // absolute path matching what
+                                                    // `SendFileTool` writes into
+                                                    // its own per-file row. Falls
+                                                    // back to the original string
+                                                    // if canonicalization fails
+                                                    // (broken symlink, missing
+                                                    // file) — same posture as
+                                                    // `SendFileTool`'s own
+                                                    // resolver.
+                                                    let resolved_media: Vec<String> = sent_files
+                                                        .iter()
+                                                        .map(|p| {
+                                                            std::fs::canonicalize(p)
+                                                                .map(|cp| {
+                                                                    cp.to_string_lossy()
+                                                                        .into_owned()
+                                                                })
+                                                                .unwrap_or_else(|_| p.clone())
+                                                        })
+                                                        .collect();
                                                     let _ = sender(BackgroundResultPayload {
                                                         task_label: bg_name.clone(),
                                                         content: format!(
@@ -749,7 +774,7 @@ impl Agent {
                                                             bg_name, file_info
                                                         ),
                                                         kind: BackgroundResultKind::Notification,
-                                                        media: sent_files.clone(),
+                                                        media: resolved_media,
                                                         originating_thread_id:
                                                             bg_originating_thread_id.clone(),
                                                         task_id: Some(task_id.clone()),

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -728,45 +728,40 @@ impl Agent {
                                                         .join(", ")
                                                 );
                                                 if let Some(ref sender) = bg_sender {
-                                                    // M10 Phase 1 (codex rounds 5+6):
-                                                    // carry `sent_files` into the
-                                                    // payload so the
-                                                    // `turn/spawn_complete` envelope
-                                                    // surfaces the attachments
-                                                    // inline. Clients that negotiated
-                                                    // ONLY `event.spawn_complete.v1`
-                                                    // (not `event.message_persisted.v1`)
-                                                    // suppress the per-file
-                                                    // `message/persisted` rows the
-                                                    // `send_file` consumer emits, so
-                                                    // without the media here they'd
-                                                    // see a "completed" bubble with
-                                                    // no downloadable attachments.
+                                                    // M10 Phase 1 design choice
+                                                    // (codex rounds 5+7 traded
+                                                    // duplicate-attachments vs
+                                                    // missing-attachments): keep
+                                                    // `media: vec![]` for the
+                                                    // `NotConfigured`/`send_file`
+                                                    // fallback success path. Each
+                                                    // file already has its own
+                                                    // `message/persisted` row
+                                                    // emitted by the `send_file`
+                                                    // consumer (with `source:
+                                                    // assistant`, which passes
+                                                    // both legacy and
+                                                    // dual-negotiated client
+                                                    // filters). Adding the same
+                                                    // files here would duplicate
+                                                    // attachment bubbles for
+                                                    // clients that negotiated
+                                                    // both `event.message_persisted.v1`
+                                                    // AND `event.spawn_complete.v1`.
                                                     //
-                                                    // Round 6 P2-A: canonicalize
-                                                    // each path so a relative
-                                                    // `files_to_send` entry from
-                                                    // the tool resolves to an
-                                                    // absolute path matching what
-                                                    // `SendFileTool` writes into
-                                                    // its own per-file row. Falls
-                                                    // back to the original string
-                                                    // if canonicalization fails
-                                                    // (broken symlink, missing
-                                                    // file) — same posture as
-                                                    // `SendFileTool`'s own
-                                                    // resolver.
-                                                    let resolved_media: Vec<String> = sent_files
-                                                        .iter()
-                                                        .map(|p| {
-                                                            std::fs::canonicalize(p)
-                                                                .map(|cp| {
-                                                                    cp.to_string_lossy()
-                                                                        .into_owned()
-                                                                })
-                                                                .unwrap_or_else(|_| p.clone())
-                                                        })
-                                                        .collect();
+                                                    // Documented limitation:
+                                                    // `event.spawn_complete.v1`-only
+                                                    // negotiation in this fallback
+                                                    // sees the completion text
+                                                    // without inline attachments.
+                                                    // The web SPA (Phase 2)
+                                                    // negotiates both flags, so
+                                                    // production hits the
+                                                    // both-flags path. CLI/TUI
+                                                    // clients use the contract-
+                                                    // `Satisfied` branch above
+                                                    // (which carries `output_files`
+                                                    // directly).
                                                     let _ = sender(BackgroundResultPayload {
                                                         task_label: bg_name.clone(),
                                                         content: format!(
@@ -774,7 +769,7 @@ impl Agent {
                                                             bg_name, file_info
                                                         ),
                                                         kind: BackgroundResultKind::Notification,
-                                                        media: resolved_media,
+                                                        media: vec![],
                                                         originating_thread_id:
                                                             bg_originating_thread_id.clone(),
                                                         task_id: Some(task_id.clone()),

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -473,6 +473,7 @@ impl Agent {
                                             kind: BackgroundResultKind::Notification,
                                             media: output_files.clone(),
                                             originating_thread_id: bg_originating_thread_id.clone(),
+                                            task_id: Some(task_id.clone()),
                                         })
                                         .await
                                     } else {
@@ -503,6 +504,7 @@ impl Agent {
                                                     media: vec![],
                                                     originating_thread_id: bg_originating_thread_id
                                                         .clone(),
+                                                    task_id: Some(task_id.clone()),
                                                 })
                                                 .await;
                                             }
@@ -542,6 +544,7 @@ impl Agent {
                                             kind: BackgroundResultKind::Notification,
                                             media: vec![],
                                             originating_thread_id: bg_originating_thread_id.clone(),
+                                            task_id: Some(task_id.clone()),
                                         })
                                         .await;
                                     }
@@ -566,6 +569,7 @@ impl Agent {
                                                 media: vec![],
                                                 originating_thread_id: bg_originating_thread_id
                                                     .clone(),
+                                                task_id: Some(task_id.clone()),
                                             })
                                             .await;
                                         }
@@ -603,6 +607,7 @@ impl Agent {
                                                 media: vec![],
                                                 originating_thread_id: bg_originating_thread_id
                                                     .clone(),
+                                                task_id: Some(task_id.clone()),
                                             })
                                             .await;
                                         }
@@ -704,6 +709,7 @@ impl Agent {
                                                 media: vec![],
                                                 originating_thread_id: bg_originating_thread_id
                                                     .clone(),
+                                                task_id: Some(task_id.clone()),
                                             })
                                             .await;
                                         }
@@ -732,6 +738,7 @@ impl Agent {
                                                         media: vec![],
                                                         originating_thread_id:
                                                             bg_originating_thread_id.clone(),
+                                                        task_id: Some(task_id.clone()),
                                                     })
                                                     .await;
                                                 }
@@ -754,6 +761,7 @@ impl Agent {
                                                         media: vec![],
                                                         originating_thread_id:
                                                             bg_originating_thread_id.clone(),
+                                                        task_id: Some(task_id.clone()),
                                                     })
                                                     .await;
                                                 }
@@ -778,6 +786,7 @@ impl Agent {
                                     kind: BackgroundResultKind::Notification,
                                     media: vec![],
                                     originating_thread_id: bg_originating_thread_id.clone(),
+                                    task_id: Some(task_id.clone()),
                                 })
                                 .await;
                             }
@@ -796,6 +805,7 @@ impl Agent {
                                     kind: BackgroundResultKind::Notification,
                                     media: vec![],
                                     originating_thread_id: bg_originating_thread_id.clone(),
+                                    task_id: Some(task_id.clone()),
                                 })
                                 .await;
                             }

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -728,6 +728,20 @@ impl Agent {
                                                         .join(", ")
                                                 );
                                                 if let Some(ref sender) = bg_sender {
+                                                    // M10 Phase 1 (codex round 5):
+                                                    // carry `sent_files` into the
+                                                    // payload so the
+                                                    // `turn/spawn_complete` envelope
+                                                    // surfaces the attachments
+                                                    // inline. Clients that negotiated
+                                                    // ONLY `event.spawn_complete.v1`
+                                                    // (not `event.message_persisted.v1`)
+                                                    // suppress the per-file
+                                                    // `message/persisted` rows the
+                                                    // `send_file` consumer emits, so
+                                                    // without the media here they'd
+                                                    // see a "completed" bubble with
+                                                    // no downloadable attachments.
                                                     let _ = sender(BackgroundResultPayload {
                                                         task_label: bg_name.clone(),
                                                         content: format!(
@@ -735,7 +749,7 @@ impl Agent {
                                                             bg_name, file_info
                                                         ),
                                                         kind: BackgroundResultKind::Notification,
-                                                        media: vec![],
+                                                        media: sent_files.clone(),
                                                         originating_thread_id:
                                                             bg_originating_thread_id.clone(),
                                                         task_id: Some(task_id.clone()),

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -81,6 +81,13 @@ pub struct BackgroundResultPayload {
     /// map happens to hold when the background task finally finalises.
     /// `None` for legacy callers and tests that don't track origination.
     pub originating_thread_id: Option<String>,
+    /// M10 Phase 1: the task supervisor `TaskId` for the spawn_only task
+    /// that produced this completion. Surfaced on the wire as
+    /// `TurnSpawnCompleteEvent.task_id` so the client can attribute the
+    /// new bubble to a specific background task (and, in Phase 4, drive
+    /// `read_task_output` against it). `None` for legacy callers and
+    /// tests that do not register tasks with the supervisor.
+    pub task_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2936,6 +2943,7 @@ impl Tool for SpawnTool {
                         kind: result_kind,
                         media: result_media.clone(),
                         originating_thread_id: originating_thread_id.clone(),
+                        task_id: tracked_task_id.clone(),
                     },
                 )
                 .await
@@ -3940,6 +3948,7 @@ PY
             kind: BackgroundResultKind::Notification,
             media: vec!["/tmp/output.mp3".to_string()],
             originating_thread_id: None,
+            task_id: None,
         };
 
         assert!(deliver_background_result(Some(sender), payload.clone()).await);

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -32,16 +32,17 @@ use octos_core::ui_protocol::{
     TaskRestartFromNodeResult, TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent,
     ThreadGraphEntry, ThreadGraphGetParams, ThreadGraphGetResult, ToolCompletedEvent,
     ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId,
-    TurnInterruptParams, TurnInterruptResult, TurnLifecycleState, TurnStartParams,
-    TurnStateGetParams, TurnStateGetResult, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    TurnInterruptParams, TurnInterruptResult, TurnLifecycleState, TurnSpawnCompleteEvent,
+    TurnStartParams, TurnStateGetParams, TurnStateGetResult, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
     UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
     UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
-    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand,
-    UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem,
-    UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata,
-    UiProtocolCapabilities, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot,
-    approval_cancelled_reasons, approval_kinds, hydrate_sections, progress_kinds, thread_status,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+    UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1, UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UiArtifactPaneItem,
+    UiArtifactPaneSnapshot, UiCommand, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
+    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
+    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiWorkspacePaneEntry,
+    UiWorkspacePaneSnapshot, approval_cancelled_reasons, approval_kinds, hydrate_sections,
+    progress_kinds, thread_status,
 };
 use octos_core::{AgentId, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId};
 use serde::Serialize;
@@ -509,6 +510,14 @@ struct ConnectionUiFeatures {
     turn_state_get: bool,
     /// UPCR-2026-012 `event.message_persisted.v1` negotiated.
     message_persisted: bool,
+    /// M10 Phase 1 `event.spawn_complete.v1` negotiated. When set, the
+    /// connection receives `turn/spawn_complete` envelope events for
+    /// `spawn_only` background completions and the corresponding
+    /// `message/persisted` row (with `source: background`) is suppressed
+    /// at the per-connection wire-emit gate. When unset, the legacy
+    /// `message/persisted` shape is preserved and `turn/spawn_complete`
+    /// is suppressed.
+    spawn_complete: bool,
     /// `true` when the client sent at least one feature token via the
     /// `X-Octos-Ui-Features` header or the `ui_feature` / `ui_features`
     /// query parameter (UPCR-2026-007). Distinguishes "no header at all"
@@ -541,6 +550,7 @@ impl ConnectionUiFeatures {
                 query,
                 UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
             ),
+            spawn_complete: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1),
             header_present: has_any_ui_feature_token(headers, query),
         }
     }
@@ -582,6 +592,9 @@ impl ConnectionUiFeatures {
         }
         if self.message_persisted {
             requested.push(UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1);
+        }
+        if self.spawn_complete {
+            requested.push(UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1);
         }
         UiProtocolCapabilities::for_negotiated_features(requested)
     }
@@ -793,18 +806,12 @@ async fn persist_assistant_with_media(
     thread_id: String,
     label: &str,
 ) -> bool {
-    let mut message = Message::assistant_with_thread(
-        content,
-        octos_core::ThreadId::new(thread_id),
-    );
+    let mut message = Message::assistant_with_thread(content, octos_core::ThreadId::new(thread_id));
     message.media = media;
 
-    if let Err(error) = octos_bus::session::persist_message_through_canonical_path(
-        data_dir,
-        session_id,
-        message,
-    )
-    .await
+    if let Err(error) =
+        octos_bus::session::persist_message_through_canonical_path(data_dir, session_id, message)
+            .await
     {
         tracing::warn!(
             session = %session_id.0,
@@ -1331,8 +1338,7 @@ async fn ui_protocol_connection(
     let ws = WsConnection::new(writer_tx);
     let active_turns = active_turns_registry();
     let connection_turns: SharedConnectionTurns = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let live_forwarders: SharedLiveForwarders =
-        Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let live_forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let contracts = contract_stores();
     let ledger = event_ledger(&state).await;
     // Force lazy init of the diff-preview store on this connection so
@@ -1718,13 +1724,16 @@ async fn handle_session_open(
     // We silently skip filtered events rather than emitting
     // `protocol/replay_lossy`. The client never asked for these events,
     // so dropping them is not lossy from their perspective.
+    //
+    // M10 Phase 1: the same dual filter that `live_event_passes_capability_filter`
+    // applies for the live broadcast must apply during replay so a
+    // reconnecting client sees exactly one shape per `spawn_only`
+    // completion (either the legacy `message/persisted` OR the new
+    // `turn/spawn_complete`, never both). Reusing the helper keeps replay
+    // and live in lockstep.
     for event in outcome.replay {
-        if !features.message_persisted {
-            if let UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(_)) =
-                &event.event
-            {
-                continue;
-            }
+        if !live_event_passes_capability_filter(&event.event, features) {
+            continue;
         }
         let _ = send_ledger_event_durable(ws, ledger, event.event);
     }
@@ -1842,6 +1851,19 @@ async fn spawn_live_forwarder(
 /// `event.message_persisted.v1` must not receive `message/persisted`
 /// notifications via the live broadcast either. Other notifications pass
 /// unchanged today; future capability-gated kinds get added here.
+///
+/// M10 Phase 1 extends this with two intertwined gates for the
+/// `event.spawn_complete.v1` capability:
+///
+/// 1. Clients that did NOT negotiate `event.spawn_complete.v1` must not
+///    receive `turn/spawn_complete` notifications. They continue to see
+///    the legacy `message/persisted` row for the same `spawn_only`
+///    completion, preserving the wire shape they shipped with.
+/// 2. Clients that DID negotiate `event.spawn_complete.v1` see
+///    `turn/spawn_complete` instead — and the corresponding
+///    `message/persisted` row (carrying `source: background`) is
+///    suppressed at this gate so the same logical event is not
+///    delivered twice in two different shapes.
 fn live_event_passes_capability_filter(
     event: &UiProtocolLedgerEvent,
     features: ConnectionUiFeatures,
@@ -1849,6 +1871,23 @@ fn live_event_passes_capability_filter(
     if !features.message_persisted {
         if let UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(_)) = event {
             return false;
+        }
+    }
+    if !features.spawn_complete {
+        // Old client: never deliver the new envelope.
+        if let UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(_)) = event {
+            return false;
+        }
+    } else {
+        // New client: suppress the `message/persisted` row that
+        // duplicates a `turn/spawn_complete` envelope. The row is
+        // identified by `source: background` — the only path through
+        // `MessageCommitObserver` that fires from `BackgroundResultSender`.
+        if let UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(event)) = event
+        {
+            if matches!(event.source, MessagePersistedSource::Background) {
+                return false;
+            }
         }
     }
     true
@@ -2142,15 +2181,13 @@ fn session_tool_registry(
     //    which under launchd is `~` outside the profile root): fall back
     //    to `<data_dir>/skill-output` so spawn_only artefacts resolve
     //    through the file API instead of 403'ing.
-    let plugin_target =
-        if session_workspaces().get(session_id).is_some() || matches_operator_default(
-            operator_default_cwd,
-            &workspace_root,
-        ) {
-            &workspace_root
-        } else {
-            &plugin_default_dir
-        };
+    let plugin_target = if session_workspaces().get(session_id).is_some()
+        || matches_operator_default(operator_default_cwd, &workspace_root)
+    {
+        &workspace_root
+    } else {
+        &plugin_default_dir
+    };
     rebound.rebind_plugin_work_dirs(plugin_target);
 
     Ok((rebound, Some(workspace_root)))
@@ -2164,7 +2201,8 @@ fn matches_operator_default(operator_default: Option<&Path>, workspace_root: &Pa
     let Some(default) = operator_default else {
         return false;
     };
-    let canonical_default = std::fs::canonicalize(default).unwrap_or_else(|_| default.to_path_buf());
+    let canonical_default =
+        std::fs::canonicalize(default).unwrap_or_else(|_| default.to_path_buf());
     let canonical_root =
         std::fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
     canonical_default == canonical_root
@@ -4459,30 +4497,29 @@ async fn run_standalone_turn(
         })
         .unwrap_or_else(|| runtime_data_dir.clone());
 
-    let (mut tool_registry, workspace_root) =
-        match session_tool_registry(
-            base_agent.as_ref(),
-            &session_id,
-            &plugin_root_dir,
-            state.appui_default_session_cwd.as_deref(),
-        ) {
-            Ok(registry) => registry,
-            Err(error) => {
-                // FIX-03 pattern: terminal emission + state transition is atomic.
-                try_emit_terminal(
-                    &turn_state,
-                    TerminalReason::Errored,
-                    &ws,
-                    &ledger,
-                    &session_id,
-                    &turn_id,
-                    Some(("cwd_binding_failed", error.as_str())),
-                )
-                .await;
-                contracts.scopes.evict_turn(&session_id, &turn_id);
-                return;
-            }
-        };
+    let (mut tool_registry, workspace_root) = match session_tool_registry(
+        base_agent.as_ref(),
+        &session_id,
+        &plugin_root_dir,
+        state.appui_default_session_cwd.as_deref(),
+    ) {
+        Ok(registry) => registry,
+        Err(error) => {
+            // FIX-03 pattern: terminal emission + state transition is atomic.
+            try_emit_terminal(
+                &turn_state,
+                TerminalReason::Errored,
+                &ws,
+                &ledger,
+                &session_id,
+                &turn_id,
+                Some(("cwd_binding_failed", error.as_str())),
+            )
+            .await;
+            contracts.scopes.evict_turn(&session_id, &turn_id);
+            return;
+        }
+    };
 
     // β: wire `BackgroundResultSender` + `SendFileTool` so spawn_only tool
     // completions and explicit `send_file` calls persist as assistant
@@ -4501,31 +4538,50 @@ async fn run_standalone_turn(
     // `/api/sessions/:id/messages` reads pick up the new row instead of
     // the pre-persist snapshot (matches `ApiChannel::persist_to_session`'s
     // post-write invalidate at `api_channel.rs:1503`).
+    //
+    // M10 Phase 1: in addition to persisting (which still fires
+    // `message/persisted` via `MessageCommitObserver` for ledger
+    // durability + `event.message_persisted.v1` clients), the closure
+    // now appends a `turn/spawn_complete` envelope event to the ledger
+    // for clients that negotiated `event.spawn_complete.v1`. The
+    // per-connection capability filter (`live_event_passes_capability_filter`)
+    // routes each connection to exactly one wire shape — old clients
+    // see `message/persisted` as before, new clients see
+    // `turn/spawn_complete` and the duplicate `message/persisted`
+    // (with `source: background`) is suppressed.
     {
         let bg_data_dir = sessions.lock().await.data_dir().to_path_buf();
         let bg_sessions = sessions.clone();
         let bg_session_id = session_id.clone();
         let bg_thread_id = turn_id.0.to_string();
+        let bg_turn_id = turn_id.clone();
 
         // Wire spawn_only contract-satisfied path.
         let payload_sessions = bg_sessions.clone();
         let payload_data_dir = bg_data_dir.clone();
         let payload_session_id = bg_session_id.clone();
         let payload_thread_id = bg_thread_id.clone();
+        let payload_turn_id = bg_turn_id.clone();
+        let payload_ledger = ledger.clone();
         tool_registry.set_background_result_sender(std::sync::Arc::new(
             move |payload: BackgroundResultPayload| {
                 let sessions = payload_sessions.clone();
                 let data_dir = payload_data_dir.clone();
                 let session_id = payload_session_id.clone();
-                let thread_id = payload
+                let originating_thread_id = payload
                     .originating_thread_id
                     .clone()
-                    .filter(|tid| !tid.is_empty())
+                    .filter(|tid| !tid.is_empty());
+                let thread_id = originating_thread_id
+                    .clone()
                     .unwrap_or_else(|| payload_thread_id.clone());
                 let task_label = payload.task_label.clone();
                 let media = payload.media.clone();
                 let kind = payload.kind;
                 let raw_content = payload.content.clone();
+                let task_id = payload.task_id.clone();
+                let turn_id = payload_turn_id.clone();
+                let ledger = payload_ledger.clone();
                 Box::pin(async move {
                     let content_text = match kind {
                         BackgroundResultKind::Notification => {
@@ -4539,30 +4595,87 @@ async fn run_standalone_turn(
                             if raw_content.is_empty() && !media.is_empty() {
                                 format!("✅ {} completed.", task_label)
                             } else if raw_content.len() > 1000 {
-                                let preview: String =
-                                    raw_content.chars().take(300).collect();
-                                format!(
-                                    "✅ **{}** completed.\n\n{}…",
-                                    task_label, preview,
-                                )
+                                let preview: String = raw_content.chars().take(300).collect();
+                                format!("✅ **{}** completed.\n\n{}…", task_label, preview,)
                             } else {
-                                format!(
-                                    "✅ **{}** completed.\n\n{}",
-                                    task_label, raw_content,
-                                )
+                                format!("✅ **{}** completed.\n\n{}", task_label, raw_content,)
                             }
                         }
                     };
-                    persist_assistant_with_media(
+                    let persisted = persist_assistant_with_media(
                         &sessions,
                         &data_dir,
                         &session_id,
-                        content_text,
-                        media,
-                        thread_id,
+                        content_text.clone(),
+                        media.clone(),
+                        thread_id.clone(),
                         &task_label,
                     )
-                    .await
+                    .await;
+                    // M10 Phase 1: even if persistence failed (rare —
+                    // canonical path returned an error), still emit
+                    // `turn/spawn_complete` so connected new-shape
+                    // clients see the completion. Persistence is the
+                    // ledger durability + `message/persisted`
+                    // confirmation path; the envelope event is the
+                    // authoritative wire shape for the new client and
+                    // is independently durable through the UI protocol
+                    // ledger. If we suppressed it on persist failure
+                    // we'd silently drop a completion the user is
+                    // waiting for. Only the legacy `message/persisted`
+                    // path is gated on persisted=true (that's
+                    // `MessageCommitObserver`'s contract).
+                    if let Some(task_id_value) = task_id.clone() {
+                        let event = TurnSpawnCompleteEvent {
+                            session_id: session_id.clone(),
+                            turn_id: Some(turn_id.clone()),
+                            thread_id: Some(thread_id.clone()),
+                            task_id: task_id_value,
+                            response_to_client_message_id: originating_thread_id.clone(),
+                            // Cursor + seq are stamped by
+                            // `LedgeredUiProtocolEvent::with_cursor`
+                            // when the ledger appends. We seed `0` so
+                            // the field is well-formed if a future
+                            // change observes the event pre-stamp.
+                            seq: 0,
+                            // Stable id mirroring `MessageCommitObserver`'s
+                            // convention. The seq isn't yet known here;
+                            // the ledger fills cursor authoritatively.
+                            // Format keeps it human-debuggable (session
+                            // + task) — the spec does not constrain
+                            // collision properties beyond "stable
+                            // string per row."
+                            message_id: format!(
+                                "{}:spawn:{}:{}",
+                                session_id.0,
+                                task_id.as_deref().unwrap_or(""),
+                                Utc::now().timestamp_nanos_opt().unwrap_or(0),
+                            ),
+                            source: "background".to_owned(),
+                            cursor: UiCursor {
+                                stream: session_id.0.clone(),
+                                seq: 0,
+                            },
+                            persisted_at: Utc::now(),
+                            content: content_text,
+                            media,
+                        };
+                        ledger.append_notification(UiNotification::TurnSpawnComplete(event));
+                    } else {
+                        // Best-effort: a payload without `task_id`
+                        // arrives only from legacy callers (cf.
+                        // `BackgroundResultPayload.task_id` doc). Old
+                        // clients see `message/persisted` as before;
+                        // new clients miss this single completion.
+                        // Logging surfaces the gap so we can fix
+                        // upstream callers.
+                        tracing::debug!(
+                            session_id = %session_id.0,
+                            task_label,
+                            "background result missing task_id; turn/spawn_complete suppressed"
+                        );
+                    }
+                    persisted
                 })
             },
         ));
@@ -5694,6 +5807,7 @@ mod tests {
                 thread_graph: false,
                 turn_state_get: false,
                 message_persisted: false,
+                spawn_complete: false,
                 header_present: true,
             },
         );
@@ -5743,6 +5857,7 @@ mod tests {
                 thread_graph: false,
                 turn_state_get: false,
                 message_persisted: false,
+                spawn_complete: false,
                 header_present: true,
             },
         );
@@ -5837,6 +5952,7 @@ mod tests {
                 thread_graph: false,
                 turn_state_get: false,
                 message_persisted: false,
+                spawn_complete: false,
                 header_present: true,
             },
         );
@@ -5886,6 +6002,7 @@ mod tests {
                 thread_graph: false,
                 turn_state_get: false,
                 message_persisted: false,
+                spawn_complete: false,
                 header_present: true,
             },
         );
@@ -5928,6 +6045,7 @@ mod tests {
                 thread_graph: false,
                 turn_state_get: false,
                 message_persisted: false,
+                spawn_complete: false,
                 header_present: true,
             },
         );
@@ -6013,6 +6131,7 @@ mod tests {
                 thread_graph: false,
                 turn_state_get: false,
                 message_persisted: false,
+                spawn_complete: false,
                 header_present: true,
             },
         );
@@ -7303,6 +7422,7 @@ mod tests {
                 thread_graph: false,
                 turn_state_get: false,
                 message_persisted: false,
+                spawn_complete: false,
                 header_present: true,
             },
             SessionOpenParams {
@@ -9957,6 +10077,68 @@ mod tests {
         }
     }
 
+    /// Build a `ConnectionUiFeatures` with the M10 Phase 1 dual gating
+    /// flags set as requested. `message_persisted` is independent so the
+    /// test can simulate clients that negotiated only one or both.
+    fn features_for_spawn_complete_test(
+        message_persisted: bool,
+        spawn_complete: bool,
+    ) -> ConnectionUiFeatures {
+        ConnectionUiFeatures {
+            message_persisted,
+            spawn_complete,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        }
+    }
+
+    /// Builds a minimal `MessagePersistedEvent` with `source: background`,
+    /// matching what `BackgroundResultSender`'s persist path produces
+    /// via `MessageCommitObserver`. M10 Phase 1's per-connection filter
+    /// suppresses this exact shape for new clients (which receive
+    /// `turn/spawn_complete` instead).
+    fn background_message_persisted_for(session: &SessionKey) -> UiNotification {
+        UiNotification::MessagePersisted(MessagePersistedEvent {
+            session_id: session.clone(),
+            turn_id: Some(TurnId::new()),
+            thread_id: Some("thread-1".into()),
+            seq: 0,
+            role: "assistant".into(),
+            message_id: "msg-bg".into(),
+            client_message_id: None,
+            source: MessagePersistedSource::Background,
+            cursor: UiCursor {
+                stream: session.0.clone(),
+                seq: 0,
+            },
+            persisted_at: Utc::now(),
+            media: vec!["research/_report.md".into()],
+        })
+    }
+
+    /// Build a representative `TurnSpawnCompleteEvent` that mirrors what
+    /// `BackgroundResultSender` emits when a `spawn_only` task contracts
+    /// and the originating `client_message_id` was tracked.
+    fn turn_spawn_complete_for(session: &SessionKey) -> UiNotification {
+        UiNotification::TurnSpawnComplete(TurnSpawnCompleteEvent {
+            session_id: session.clone(),
+            turn_id: Some(TurnId::new()),
+            thread_id: Some("thread-1".into()),
+            task_id: "task_abc123".into(),
+            response_to_client_message_id: Some("cmid-user-1".into()),
+            seq: 0,
+            message_id: "msg-spawn".into(),
+            source: "background".into(),
+            cursor: UiCursor {
+                stream: session.0.clone(),
+                seq: 0,
+            },
+            persisted_at: Utc::now(),
+            content: "Background research complete.".into(),
+            media: vec!["research/_report.md".into()],
+        })
+    }
+
     /// Decodes a queued WS frame back to its JSON-RPC method name (or
     /// returns `None` for non-text / non-JSON frames). Lets tests assert
     /// the live broadcast forwarder routed a notification, without
@@ -10084,6 +10266,184 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "client without event.message_persisted.v1 must not receive message/persisted"
+        );
+
+        abort_live_forwarders(&forwarders).await;
+    }
+
+    // ========================================================================
+    // M10 Phase 1: `event.spawn_complete.v1` capability gating
+    // ========================================================================
+
+    /// Pure unit-level coverage of the dual filter — no WS / forwarder
+    /// machinery. Documents the four corners of the negotiation matrix
+    /// against the two relevant event shapes.
+    #[test]
+    fn capability_filter_routes_spawn_complete_dual_gating() {
+        let session = SessionKey("local:filter".into());
+        let bg_persisted =
+            UiProtocolLedgerEvent::Notification(background_message_persisted_for(&session));
+        let spawn_complete = UiProtocolLedgerEvent::Notification(turn_spawn_complete_for(&session));
+
+        // Old client (no spawn_complete capability, has message_persisted):
+        // sees `message/persisted` (Background source preserved); does NOT
+        // see `turn/spawn_complete`.
+        let old = features_for_spawn_complete_test(true, false);
+        assert!(
+            live_event_passes_capability_filter(&bg_persisted, old),
+            "old client must keep receiving the legacy message/persisted shape",
+        );
+        assert!(
+            !live_event_passes_capability_filter(&spawn_complete, old),
+            "old client must not receive the new turn/spawn_complete shape",
+        );
+
+        // New client (has both capabilities): sees `turn/spawn_complete`;
+        // the duplicate `message/persisted` (source: background) is
+        // suppressed so the same logical event is delivered exactly once.
+        let new = features_for_spawn_complete_test(true, true);
+        assert!(
+            !live_event_passes_capability_filter(&bg_persisted, new),
+            "new client must NOT receive the duplicate message/persisted background row",
+        );
+        assert!(
+            live_event_passes_capability_filter(&spawn_complete, new),
+            "new client must receive the turn/spawn_complete envelope",
+        );
+
+        // New client without message_persisted negotiation: still gets
+        // turn/spawn_complete. (The two capabilities are independent —
+        // a forward-only client can opt into the new shape without ever
+        // having shipped the older one.)
+        let new_only = features_for_spawn_complete_test(false, true);
+        assert!(
+            !live_event_passes_capability_filter(&bg_persisted, new_only),
+            "client without message_persisted does not see message/persisted regardless",
+        );
+        assert!(
+            live_event_passes_capability_filter(&spawn_complete, new_only),
+            "spawn_complete-only client receives turn/spawn_complete",
+        );
+
+        // Legacy client with NO negotiated features at all: sees neither
+        // (the old gate already blocks message/persisted; the new gate
+        // blocks turn/spawn_complete).
+        let neither = features_for_spawn_complete_test(false, false);
+        assert!(!live_event_passes_capability_filter(&bg_persisted, neither));
+        assert!(!live_event_passes_capability_filter(
+            &spawn_complete,
+            neither
+        ));
+
+        // Sanity: a non-spawn `message/persisted` (source != background,
+        // e.g. a regular assistant row) is unaffected by the spawn_complete
+        // gate. Only the duplicate-suppression branch keys on
+        // `MessagePersistedSource::Background`.
+        let regular = UiProtocolLedgerEvent::Notification(message_persisted_for(&session));
+        assert!(
+            live_event_passes_capability_filter(&regular, new),
+            "non-background message/persisted must still flow to new clients",
+        );
+    }
+
+    /// End-to-end through the live forwarder for a NEW client (negotiated
+    /// `event.spawn_complete.v1`): asserts they receive `turn/spawn_complete`
+    /// AND the duplicate `message/persisted` (source: background) is
+    /// suppressed. The combination is what kills the splice-merge
+    /// double-render.
+    #[tokio::test]
+    async fn live_forwarder_routes_spawn_complete_to_new_client() {
+        let (ws, mut rx) = ws_connection_for_test(16);
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let session_id = SessionKey("local:newfeat".into());
+        let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+        let live_rx = ledger.subscribe(&session_id);
+        spawn_live_forwarder(
+            ws.clone(),
+            ledger.clone(),
+            session_id.clone(),
+            0,
+            ws.connection_id(),
+            features_for_spawn_complete_test(true, true),
+            live_rx,
+            forwarders.clone(),
+        )
+        .await;
+
+        // Producer side fires both — the persistence-driven
+        // `message/persisted` (via `MessageCommitObserver`) AND the new
+        // envelope (direct ledger append from `BackgroundResultSender`).
+        ledger.append_notification(background_message_persisted_for(&session_id));
+        ledger.append_notification(turn_spawn_complete_for(&session_id));
+
+        // The new client must observe exactly one frame: the spawn_complete
+        // envelope. The duplicate background message/persisted is filtered.
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("expected the spawn_complete envelope within 1s")
+            .expect("ws still open");
+        assert_eq!(
+            frame_method(&frame).as_deref(),
+            Some(octos_core::ui_protocol::methods::TURN_SPAWN_COMPLETE),
+            "first frame must be turn/spawn_complete (background message/persisted suppressed)",
+        );
+
+        // No further frames should arrive — the background message/persisted
+        // was filtered.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "no second frame: background message/persisted is suppressed for new clients",
+        );
+
+        abort_live_forwarders(&forwarders).await;
+    }
+
+    /// End-to-end through the live forwarder for an OLD client (did NOT
+    /// negotiate `event.spawn_complete.v1`): they see `message/persisted`
+    /// (Background source preserved) and do NOT see `turn/spawn_complete`.
+    /// This is the back-compat path that keeps existing TUI/CLI consumers
+    /// working unchanged.
+    #[tokio::test]
+    async fn live_forwarder_falls_back_to_message_persisted_for_old_client() {
+        let (ws, mut rx) = ws_connection_for_test(16);
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let session_id = SessionKey("local:oldfeat".into());
+        let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+        let live_rx = ledger.subscribe(&session_id);
+        spawn_live_forwarder(
+            ws.clone(),
+            ledger.clone(),
+            session_id.clone(),
+            0,
+            ws.connection_id(),
+            // Old client: has message_persisted but NOT spawn_complete.
+            features_for_spawn_complete_test(true, false),
+            live_rx,
+            forwarders.clone(),
+        )
+        .await;
+
+        ledger.append_notification(background_message_persisted_for(&session_id));
+        ledger.append_notification(turn_spawn_complete_for(&session_id));
+
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("expected the legacy message/persisted within 1s")
+            .expect("ws still open");
+        assert_eq!(
+            frame_method(&frame).as_deref(),
+            Some(octos_core::ui_protocol::methods::MESSAGE_PERSISTED),
+            "first frame must be the legacy message/persisted shape for old clients",
+        );
+
+        // The new envelope must NOT be delivered to an un-negotiated client.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "no second frame: turn/spawn_complete is suppressed for old clients",
         );
 
         abort_live_forwarders(&forwarders).await;

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -828,6 +828,11 @@ fn current_message_persisted_source(role: octos_core::MessageRole) -> MessagePer
 /// new row instead of the pre-persist snapshot. Mirrors the gateway's
 /// `session_actor.rs::deliver_background_notification` post-write
 /// invalidate at `api_channel.rs:1503`.
+///
+/// Returns `Some(committed_seq)` on success — the row's index in the
+/// session's message log, matching `MessagePersistedEvent.seq` and the
+/// authoritative `seq` for any wire-protocol confirmation event. `None`
+/// signals a persist failure (already logged).
 async fn persist_assistant_with_media(
     sessions: &Arc<TokioMutex<octos_bus::SessionManager>>,
     data_dir: &Path,
@@ -836,25 +841,29 @@ async fn persist_assistant_with_media(
     media: Vec<String>,
     thread_id: String,
     label: &str,
-) -> bool {
+) -> Option<usize> {
     let mut message = Message::assistant_with_thread(content, octos_core::ThreadId::new(thread_id));
     message.media = media;
 
-    if let Err(error) =
-        octos_bus::session::persist_message_through_canonical_path(data_dir, session_id, message)
-            .await
+    let committed_seq = match octos_bus::session::persist_message_through_canonical_path(
+        data_dir, session_id, message,
+    )
+    .await
     {
-        tracing::warn!(
-            session = %session_id.0,
-            label,
-            error = %error,
-            "api/serve: failed to persist background-delivered message"
-        );
-        return false;
-    }
+        Ok(seq) => seq,
+        Err(error) => {
+            tracing::warn!(
+                session = %session_id.0,
+                label,
+                error = %error,
+                "api/serve: failed to persist background-delivered message"
+            );
+            return None;
+        }
+    };
 
     sessions.lock().await.invalidate_cache(session_id);
-    true
+    Some(committed_seq)
 }
 
 fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
@@ -4648,7 +4657,7 @@ async fn run_standalone_turn(
                     // duplicate-suppression filter would never fire,
                     // delivering both `message/persisted` AND
                     // `turn/spawn_complete` to upgraded clients.
-                    let persisted = MESSAGE_PERSISTED_SOURCE_OVERRIDE
+                    let committed_seq = MESSAGE_PERSISTED_SOURCE_OVERRIDE
                         .scope(
                             Some(MessagePersistedSource::Background),
                             persist_assistant_with_media(
@@ -4662,44 +4671,43 @@ async fn run_standalone_turn(
                             ),
                         )
                         .await;
-                    // M10 Phase 1: even if persistence failed (rare —
-                    // canonical path returned an error), still emit
-                    // `turn/spawn_complete` so connected new-shape
-                    // clients see the completion. Persistence is the
-                    // ledger durability + `message/persisted`
-                    // confirmation path; the envelope event is the
-                    // authoritative wire shape for the new client and
-                    // is independently durable through the UI protocol
-                    // ledger. If we suppressed it on persist failure
-                    // we'd silently drop a completion the user is
-                    // waiting for. Only the legacy `message/persisted`
-                    // path is gated on persisted=true (that's
-                    // `MessageCommitObserver`'s contract).
-                    if let Some(task_id_value) = task_id.clone() {
+                    // M10 Phase 1: emit `turn/spawn_complete` only when
+                    // persistence succeeded (codex P2 follow-up). The
+                    // wire `seq` field carries the COMMITTED-ROW seq
+                    // (the index in the session message log that
+                    // `MessagePersistedEvent.seq` carries today) — NOT
+                    // the UI-ledger cursor seq. Upgraded clients route
+                    // `turn/spawn_complete` through the same persisted
+                    // -message reducer they use for `message/persisted`,
+                    // so the two events MUST agree on this seq or the
+                    // reducer dedupes/anchors against a non-existent
+                    // row. The cursor is stamped separately by the
+                    // ledger so cursor-driven replay still works.
+                    //
+                    // `response_to_client_message_id` is intentionally
+                    // left `None` here: the UI-protocol turn-start path
+                    // doesn't propagate the user's `client_message_id`
+                    // through to this layer (the reporter's `thread_id`
+                    // is the `TurnId`, not the user cmid). Phase 2's
+                    // SPA reducer keys off `thread_id` to anchor the
+                    // bubble; once the user cmid is plumbed through
+                    // `BackgroundResultPayload`, this field will carry
+                    // the real value.
+                    if let (Some(task_id_value), Some(seq)) = (task_id.clone(), committed_seq) {
                         let event = TurnSpawnCompleteEvent {
                             session_id: session_id.clone(),
                             turn_id: Some(turn_id.clone()),
                             thread_id: Some(thread_id.clone()),
                             task_id: task_id_value,
-                            response_to_client_message_id: originating_thread_id.clone(),
-                            // Cursor + seq are stamped by
-                            // `LedgeredUiProtocolEvent::with_cursor`
-                            // when the ledger appends. We seed `0` so
-                            // the field is well-formed if a future
-                            // change observes the event pre-stamp.
-                            seq: 0,
+                            response_to_client_message_id: None,
+                            seq: seq as u64,
                             // Stable id mirroring `MessageCommitObserver`'s
-                            // convention. The seq isn't yet known here;
-                            // the ledger fills cursor authoritatively.
-                            // Format keeps it human-debuggable (session
-                            // + task) — the spec does not constrain
-                            // collision properties beyond "stable
-                            // string per row."
+                            // convention so the wire-id is consistent
+                            // across the two shapes for the same row.
                             message_id: format!(
-                                "{}:spawn:{}:{}",
+                                "{}:{seq}:spawn:{}",
                                 session_id.0,
                                 task_id.as_deref().unwrap_or(""),
-                                Utc::now().timestamp_nanos_opt().unwrap_or(0),
                             ),
                             source: "background".to_owned(),
                             cursor: UiCursor {
@@ -4711,21 +4719,32 @@ async fn run_standalone_turn(
                             media,
                         };
                         ledger.append_notification(UiNotification::TurnSpawnComplete(event));
-                    } else {
+                    } else if task_id.is_none() {
                         // Best-effort: a payload without `task_id`
                         // arrives only from legacy callers (cf.
                         // `BackgroundResultPayload.task_id` doc). Old
                         // clients see `message/persisted` as before;
                         // new clients miss this single completion.
-                        // Logging surfaces the gap so we can fix
-                        // upstream callers.
                         tracing::debug!(
                             session_id = %session_id.0,
                             task_label,
                             "background result missing task_id; turn/spawn_complete suppressed"
                         );
+                    } else {
+                        // Persist failed — the row never landed in the
+                        // session ledger, so emitting a `turn/spawn_complete`
+                        // would advertise a row that doesn't exist on
+                        // hydrate. Log; old clients also see nothing
+                        // (the observer never fired). The agent's
+                        // task_supervisor still records the failure for
+                        // operator visibility.
+                        tracing::warn!(
+                            session_id = %session_id.0,
+                            task_label,
+                            "background result persist failed; both wire shapes suppressed"
+                        );
                     }
-                    persisted
+                    committed_seq.is_some()
                 })
             },
         ));
@@ -10482,52 +10501,58 @@ mod tests {
         assert_eq!(after, MessagePersistedSource::Assistant);
     }
 
-    /// Codex P2: every `turn/spawn_complete` event must carry the same
-    /// monotonically-assigned ledger seq as its envelope, NOT 0. Producers
-    /// seed `seq: 0` at construction (they don't know the assigned cursor
-    /// yet); `LedgeredUiProtocolEvent::with_cursor` stamps it during
-    /// `append_notification`. Without this, replay/dedup reduces every
-    /// spawn_complete to the same logical row.
+    /// Codex P2 follow-up: the `turn/spawn_complete` envelope's flat
+    /// `seq` field carries the COMMITTED-ROW seq (the index in the
+    /// session message log, identical to `MessagePersistedEvent.seq`)
+    /// — NOT the UI-ledger cursor seq. The two scales differ in any
+    /// turn that has prior ledger notifications, so upgraded clients
+    /// reusing their `MessagePersisted` reducer for spawn completions
+    /// MUST observe the persisted-row seq the producer wrote, not the
+    /// ledger-assigned cursor seq.
     #[tokio::test]
-    async fn ledger_stamps_turn_spawn_complete_seq_in_lockstep_with_cursor() {
+    async fn ledger_preserves_producer_seq_and_stamps_only_cursor() {
         let ledger = UiProtocolLedger::new(8);
         let session_id = SessionKey("local:seq".into());
 
-        // Append twice — each event must observe a distinct, monotonically
-        // increasing seq stamped onto BOTH the cursor and the flat
-        // `seq` field.
-        let first = ledger.append_notification(turn_spawn_complete_for(&session_id));
-        let second = ledger.append_notification(turn_spawn_complete_for(&session_id));
-
-        let extract_seq = |event: &UiProtocolLedgerEvent| -> Option<(u64, u64)> {
-            match event {
-                UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(ev)) => {
-                    Some((ev.seq, ev.cursor.seq))
-                }
-                _ => None,
-            }
+        // Producer sets `seq = 7` (the committed-row index from the
+        // persist path). Ledger appends and stamps cursor.seq, but
+        // must leave `seq` untouched.
+        let mut event = match turn_spawn_complete_for(&session_id) {
+            UiNotification::TurnSpawnComplete(ev) => ev,
+            _ => unreachable!("test fixture is turn/spawn_complete"),
         };
-        let (first_seq, first_cursor_seq) =
-            extract_seq(&first.event).expect("first event is turn/spawn_complete");
-        let (second_seq, second_cursor_seq) =
-            extract_seq(&second.event).expect("second event is turn/spawn_complete");
+        event.seq = 7;
+        event.cursor.seq = 0; // producer seeds 0; ledger stamps the real cursor.
+        let appended = ledger.append_notification(UiNotification::TurnSpawnComplete(event));
 
-        assert!(
-            first_seq > 0,
-            "ledger must stamp non-zero seq onto first event"
-        );
+        let stamped = match &appended.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(ev)) => ev,
+            _ => panic!("expected turn/spawn_complete back from the ledger"),
+        };
         assert_eq!(
-            first_seq, first_cursor_seq,
-            "flat seq must equal cursor seq for the same event",
+            stamped.seq, 7,
+            "ledger must NOT overwrite the producer's committed-row seq",
         );
         assert!(
-            second_seq > first_seq,
-            "seq is strictly monotonic per session"
+            stamped.cursor.seq > 0,
+            "cursor.seq must be the ledger-assigned non-zero cursor",
         );
-        assert_eq!(
-            second_seq, second_cursor_seq,
-            "flat seq remains in lockstep with cursor seq across appends",
-        );
+
+        // Cursor is strictly monotonic across appends (same contract
+        // as the existing MessagePersisted path); flat `seq` is
+        // independent and tracked by the producer.
+        let mut event2 = match turn_spawn_complete_for(&session_id) {
+            UiNotification::TurnSpawnComplete(ev) => ev,
+            _ => unreachable!(),
+        };
+        event2.seq = 8;
+        let appended2 = ledger.append_notification(UiNotification::TurnSpawnComplete(event2));
+        let stamped2 = match &appended2.event {
+            UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(ev)) => ev,
+            _ => panic!("turn/spawn_complete"),
+        };
+        assert!(stamped2.cursor.seq > stamped.cursor.seq);
+        assert_eq!(stamped2.seq, 8);
     }
 
     /// End-to-end through the live forwarder for an OLD client (did NOT

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4737,21 +4737,21 @@ async fn run_standalone_turn(
                             turn_id: Some(turn_id.clone()),
                             thread_id: Some(thread_id.clone()),
                             task_id: task_id_value,
-                            // The bound thread_id IS the originating
-                            // thread anchor — in the gateway path it's
-                            // the user's `client_message_id`; in this
-                            // standalone-turn path it's the `TurnId`
-                            // (the reporter is wired with `turn_id`).
-                            // Either way, surfacing the same
-                            // identifier the user-prompt row carries
-                            // as `thread_id` is what lets the SPA
-                            // reducer anchor the new bubble under the
-                            // right prompt without falling back to
-                            // sticky-map heuristics. Phase 4 plumbing
-                            // will replace `originating_thread_id` with
-                            // a typed `originating_client_message_id`
-                            // for unambiguous semantics.
-                            response_to_client_message_id: originating_thread_id.clone(),
+                            // Codex rounds 2/6: leave this `None`. In
+                            // the standalone-turn path the reporter
+                            // binds `thread_id = turn_id.0.to_string()`
+                            // (a TurnId UUID), so `originating_thread_id`
+                            // here is NOT the user's `client_message_id`
+                            // the field is documented to carry. Phase 4
+                            // plumbing will add a typed
+                            // `originating_client_message_id` to
+                            // `BackgroundResultPayload` and populate
+                            // this from there. Today the SPA reducer
+                            // already anchors via `thread_id` (which
+                            // matches the user-prompt row's thread_id
+                            // through the M8.10 root-on-cmid
+                            // invariant), so this `None` is safe.
+                            response_to_client_message_id: None,
                             seq: meta.committed_seq as u64,
                             // Reuse the `MessageCommitObserver`-style
                             // wire id for the same durable row — see

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4679,34 +4679,56 @@ async fn run_standalone_turn(
                     // duplicate-suppression filter would never fire,
                     // delivering both `message/persisted` AND
                     // `turn/spawn_complete` to upgraded clients.
-                    let persisted_meta = MESSAGE_PERSISTED_SOURCE_OVERRIDE
-                        .scope(
-                            Some(MessagePersistedSource::Background),
-                            persist_assistant_with_media(
-                                &sessions,
-                                &data_dir,
-                                &session_id,
-                                content_text.clone(),
-                                media.clone(),
-                                thread_id.clone(),
-                                &task_label,
-                            ),
-                        )
-                        .await;
-                    // M10 Phase 1: emit `turn/spawn_complete` only when
-                    // persistence succeeded AND the supervisor returned
-                    // a real (non-empty) `task_id`. The wire `seq` and
-                    // `message_id` mirror `MessagePersistedEvent` for
-                    // the same durable row so a client that replays
-                    // with a different negotiated capability set sees
-                    // ONE logical row across both shapes (codex round 3
-                    // P2). Empty `Some("")` — the legacy register sentinel
+                    // M10 Phase 1 (codex round 4): only mark this row as
+                    // `source: background` if we will emit a replacement
+                    // `turn/spawn_complete` envelope for it. Otherwise
+                    // upgraded clients filter the legacy
+                    // `message/persisted` row AND see no envelope —
+                    // they receive nothing for the completion. The
+                    // marker has to stay coupled to the envelope emit
+                    // for the dual-gate invariant to hold.
+                    //
+                    // Empty `Some("")` — the legacy register sentinel
                     // returned when the supervisor's fan-out cap refuses
                     // a task — is treated like `None` (codex round 3 P3).
                     let task_id_clean = task_id
                         .as_deref()
                         .filter(|s| !s.is_empty())
                         .map(str::to_string);
+                    let will_emit_envelope = task_id_clean.is_some();
+                    let persisted_meta = if will_emit_envelope {
+                        MESSAGE_PERSISTED_SOURCE_OVERRIDE
+                            .scope(
+                                Some(MessagePersistedSource::Background),
+                                persist_assistant_with_media(
+                                    &sessions,
+                                    &data_dir,
+                                    &session_id,
+                                    content_text.clone(),
+                                    media.clone(),
+                                    thread_id.clone(),
+                                    &task_label,
+                                ),
+                            )
+                            .await
+                    } else {
+                        // No envelope incoming → leave the source as
+                        // role-derived (Assistant) so upgraded clients
+                        // still receive the `message/persisted` row.
+                        // This degrades to legacy behaviour for the
+                        // edge cases (no tracked task, empty sentinel)
+                        // rather than silently dropping the completion.
+                        persist_assistant_with_media(
+                            &sessions,
+                            &data_dir,
+                            &session_id,
+                            content_text.clone(),
+                            media.clone(),
+                            thread_id.clone(),
+                            &task_label,
+                        )
+                        .await
+                    };
                     if let (Some(task_id_value), Some(meta)) =
                         (task_id_clean.clone(), persisted_meta.as_ref())
                     {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -829,10 +829,14 @@ fn current_message_persisted_source(role: octos_core::MessageRole) -> MessagePer
 /// `session_actor.rs::deliver_background_notification` post-write
 /// invalidate at `api_channel.rs:1503`.
 ///
-/// Returns `Some(committed_seq)` on success — the row's index in the
-/// session's message log, matching `MessagePersistedEvent.seq` and the
-/// authoritative `seq` for any wire-protocol confirmation event. `None`
-/// signals a persist failure (already logged).
+/// Returns `Some(PersistedMessageMeta)` on success — the row's committed
+/// seq plus the wire `message_id` derived the same way `MessageCommitObserver`
+/// computes it (`session:seq:timestamp_ns`). The shared id lets the
+/// `BackgroundResultSender` callback emit a `turn/spawn_complete`
+/// envelope whose `message_id` matches the parallel `message/persisted`
+/// event — clients that key dedup or confirmation off `message_id`
+/// then see one logical row, regardless of which wire shape they
+/// negotiated. `None` signals a persist failure (already logged).
 async fn persist_assistant_with_media(
     sessions: &Arc<TokioMutex<octos_bus::SessionManager>>,
     data_dir: &Path,
@@ -841,9 +845,15 @@ async fn persist_assistant_with_media(
     media: Vec<String>,
     thread_id: String,
     label: &str,
-) -> Option<usize> {
+) -> Option<PersistedMessageMeta> {
     let mut message = Message::assistant_with_thread(content, octos_core::ThreadId::new(thread_id));
     message.media = media;
+    // Capture the stamped timestamp BEFORE the canonical persist
+    // consumes the message — `MessageCommitObserver` derives the wire
+    // `message_id` from `(session_id, committed_seq, message.timestamp)`,
+    // and we need that same value here so the spawn_complete envelope
+    // can advertise the identical id.
+    let timestamp_ns = message.timestamp.timestamp_nanos_opt().unwrap_or(0);
 
     let committed_seq = match octos_bus::session::persist_message_through_canonical_path(
         data_dir, session_id, message,
@@ -863,7 +873,19 @@ async fn persist_assistant_with_media(
     };
 
     sessions.lock().await.invalidate_cache(session_id);
-    Some(committed_seq)
+    Some(PersistedMessageMeta {
+        committed_seq,
+        message_id: format!("{}:{committed_seq}:{timestamp_ns}", session_id.0),
+    })
+}
+
+/// Metadata returned by [`persist_assistant_with_media`] so callers can
+/// emit wire events whose identity matches the durable row written by
+/// `MessageCommitObserver`. See the helper's doc comment for rationale.
+#[derive(Debug, Clone)]
+struct PersistedMessageMeta {
+    committed_seq: usize,
+    message_id: String,
 }
 
 fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
@@ -4657,7 +4679,7 @@ async fn run_standalone_turn(
                     // duplicate-suppression filter would never fire,
                     // delivering both `message/persisted` AND
                     // `turn/spawn_complete` to upgraded clients.
-                    let committed_seq = MESSAGE_PERSISTED_SOURCE_OVERRIDE
+                    let persisted_meta = MESSAGE_PERSISTED_SOURCE_OVERRIDE
                         .scope(
                             Some(MessagePersistedSource::Background),
                             persist_assistant_with_media(
@@ -4672,43 +4694,47 @@ async fn run_standalone_turn(
                         )
                         .await;
                     // M10 Phase 1: emit `turn/spawn_complete` only when
-                    // persistence succeeded (codex P2 follow-up). The
-                    // wire `seq` field carries the COMMITTED-ROW seq
-                    // (the index in the session message log that
-                    // `MessagePersistedEvent.seq` carries today) — NOT
-                    // the UI-ledger cursor seq. Upgraded clients route
-                    // `turn/spawn_complete` through the same persisted
-                    // -message reducer they use for `message/persisted`,
-                    // so the two events MUST agree on this seq or the
-                    // reducer dedupes/anchors against a non-existent
-                    // row. The cursor is stamped separately by the
-                    // ledger so cursor-driven replay still works.
-                    //
-                    // `response_to_client_message_id` is intentionally
-                    // left `None` here: the UI-protocol turn-start path
-                    // doesn't propagate the user's `client_message_id`
-                    // through to this layer (the reporter's `thread_id`
-                    // is the `TurnId`, not the user cmid). Phase 2's
-                    // SPA reducer keys off `thread_id` to anchor the
-                    // bubble; once the user cmid is plumbed through
-                    // `BackgroundResultPayload`, this field will carry
-                    // the real value.
-                    if let (Some(task_id_value), Some(seq)) = (task_id.clone(), committed_seq) {
+                    // persistence succeeded AND the supervisor returned
+                    // a real (non-empty) `task_id`. The wire `seq` and
+                    // `message_id` mirror `MessagePersistedEvent` for
+                    // the same durable row so a client that replays
+                    // with a different negotiated capability set sees
+                    // ONE logical row across both shapes (codex round 3
+                    // P2). Empty `Some("")` — the legacy register sentinel
+                    // returned when the supervisor's fan-out cap refuses
+                    // a task — is treated like `None` (codex round 3 P3).
+                    let task_id_clean = task_id
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string);
+                    if let (Some(task_id_value), Some(meta)) =
+                        (task_id_clean.clone(), persisted_meta.as_ref())
+                    {
                         let event = TurnSpawnCompleteEvent {
                             session_id: session_id.clone(),
                             turn_id: Some(turn_id.clone()),
                             thread_id: Some(thread_id.clone()),
                             task_id: task_id_value,
-                            response_to_client_message_id: None,
-                            seq: seq as u64,
-                            // Stable id mirroring `MessageCommitObserver`'s
-                            // convention so the wire-id is consistent
-                            // across the two shapes for the same row.
-                            message_id: format!(
-                                "{}:{seq}:spawn:{}",
-                                session_id.0,
-                                task_id.as_deref().unwrap_or(""),
-                            ),
+                            // The bound thread_id IS the originating
+                            // thread anchor — in the gateway path it's
+                            // the user's `client_message_id`; in this
+                            // standalone-turn path it's the `TurnId`
+                            // (the reporter is wired with `turn_id`).
+                            // Either way, surfacing the same
+                            // identifier the user-prompt row carries
+                            // as `thread_id` is what lets the SPA
+                            // reducer anchor the new bubble under the
+                            // right prompt without falling back to
+                            // sticky-map heuristics. Phase 4 plumbing
+                            // will replace `originating_thread_id` with
+                            // a typed `originating_client_message_id`
+                            // for unambiguous semantics.
+                            response_to_client_message_id: originating_thread_id.clone(),
+                            seq: meta.committed_seq as u64,
+                            // Reuse the `MessageCommitObserver`-style
+                            // wire id for the same durable row — see
+                            // `PersistedMessageMeta` doc.
+                            message_id: meta.message_id.clone(),
                             source: "background".to_owned(),
                             cursor: UiCursor {
                                 stream: session_id.0.clone(),
@@ -4719,15 +4745,19 @@ async fn run_standalone_turn(
                             media,
                         };
                         ledger.append_notification(UiNotification::TurnSpawnComplete(event));
-                    } else if task_id.is_none() {
-                        // Best-effort: a payload without `task_id`
-                        // arrives only from legacy callers (cf.
-                        // `BackgroundResultPayload.task_id` doc). Old
-                        // clients see `message/persisted` as before;
-                        // new clients miss this single completion.
+                    } else if task_id_clean.is_none() {
+                        // Best-effort: a payload without `task_id` (or
+                        // with the empty-string sentinel returned by
+                        // the legacy register-task path under fan-out
+                        // pressure) arrives only from edge-case
+                        // callers. Old clients see `message/persisted`
+                        // as before; new clients miss this single
+                        // completion. Logging surfaces the gap so we
+                        // can fix upstream callers.
                         tracing::debug!(
                             session_id = %session_id.0,
                             task_label,
+                            had_empty_task_id = task_id.as_deref() == Some(""),
                             "background result missing task_id; turn/spawn_complete suppressed"
                         );
                     } else {
@@ -4744,7 +4774,7 @@ async fn run_standalone_turn(
                             "background result persist failed; both wire shapes suppressed"
                         );
                     }
-                    committed_seq.is_some()
+                    persisted_meta.is_some()
                 })
             },
         ));

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -787,6 +787,37 @@ async fn event_ledger(state: &AppState) -> Arc<UiProtocolLedger> {
 /// rather backpressure the agent loop than balloon memory.
 const SEND_FILE_CHANNEL_CAPACITY: usize = 64;
 
+tokio::task_local! {
+    /// M10 Phase 1: task-local override for `MessagePersistedSource` read
+    /// by `install_message_commit_observer`. The
+    /// [`BackgroundResultSender`] callback enters this scope before
+    /// invoking [`persist_assistant_with_media`] so the resulting
+    /// `MessagePersistedEvent` carries `source: background` instead of
+    /// the role-derived `assistant` default. The per-connection
+    /// capability filter then identifies "this is a duplicate of a
+    /// `turn/spawn_complete`" and suppresses it for clients that
+    /// negotiated the new wire shape.
+    ///
+    /// Without this override the `Message` role is `Assistant`, the
+    /// observer maps it to `MessagePersistedSource::Assistant`, and
+    /// the duplicate-suppression branch at
+    /// `live_event_passes_capability_filter` never fires — which
+    /// codex flagged as a P1 against the Phase 1 wire contract.
+    static MESSAGE_PERSISTED_SOURCE_OVERRIDE: Option<MessagePersistedSource>;
+}
+
+/// Resolve the source for an upcoming `MessagePersistedEvent`. Returns the
+/// task-local override when one is set (e.g. inside the `BackgroundResultSender`
+/// scope), otherwise falls back to the role-derived default — preserving
+/// the pre-M10 behaviour for every other persist path.
+fn current_message_persisted_source(role: octos_core::MessageRole) -> MessagePersistedSource {
+    MESSAGE_PERSISTED_SOURCE_OVERRIDE
+        .try_with(|override_value| *override_value)
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| MessagePersistedSource::from_role(role))
+}
+
 /// Shared persist helper used by the api/serve background-result sender
 /// (spawn_only completions) and the `send_file` sink. Builds an assistant
 /// `Message` with the given content + media + thread_id, writes it through
@@ -849,7 +880,13 @@ fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
                     message.timestamp.timestamp_nanos_opt().unwrap_or(0)
                 ),
                 client_message_id: message.client_message_id.clone(),
-                source: MessagePersistedSource::from_role(message.role),
+                // M10 Phase 1: read the task-local source override
+                // first so a `BackgroundResultSender` persist (which
+                // duplicates a `turn/spawn_complete` envelope) emits
+                // `source: background`. The per-connection wire
+                // filter keys off this to suppress the duplicate for
+                // clients that negotiated `event.spawn_complete.v1`.
+                source: current_message_persisted_source(message.role),
                 // Placeholder; the ledger's `with_cursor` hook
                 // overwrites this with the assigned seq.
                 cursor: UiCursor {
@@ -4602,16 +4639,29 @@ async fn run_standalone_turn(
                             }
                         }
                     };
-                    let persisted = persist_assistant_with_media(
-                        &sessions,
-                        &data_dir,
-                        &session_id,
-                        content_text.clone(),
-                        media.clone(),
-                        thread_id.clone(),
-                        &task_label,
-                    )
-                    .await;
+                    // M10 Phase 1 (codex P1): scope the persist call in
+                    // the `MESSAGE_PERSISTED_SOURCE_OVERRIDE` task-local
+                    // so `install_message_commit_observer` emits
+                    // `source: background` for this row. Without this,
+                    // `MessagePersistedSource::from_role(Assistant)`
+                    // would return `Assistant` and the per-connection
+                    // duplicate-suppression filter would never fire,
+                    // delivering both `message/persisted` AND
+                    // `turn/spawn_complete` to upgraded clients.
+                    let persisted = MESSAGE_PERSISTED_SOURCE_OVERRIDE
+                        .scope(
+                            Some(MessagePersistedSource::Background),
+                            persist_assistant_with_media(
+                                &sessions,
+                                &data_dir,
+                                &session_id,
+                                content_text.clone(),
+                                media.clone(),
+                                thread_id.clone(),
+                                &task_label,
+                            ),
+                        )
+                        .await;
                     // M10 Phase 1: even if persistence failed (rare —
                     // canonical path returned an error), still emit
                     // `turn/spawn_complete` so connected new-shape
@@ -10398,6 +10448,86 @@ mod tests {
         );
 
         abort_live_forwarders(&forwarders).await;
+    }
+
+    /// Codex P1: when the BackgroundResultSender persist scope is
+    /// active, `current_message_persisted_source` must report
+    /// `Background` regardless of the `Message` role. Outside the scope
+    /// it falls back to the role-derived default — the pre-M10
+    /// behaviour stays intact for every other persist path.
+    #[tokio::test]
+    async fn message_persisted_source_override_routes_through_task_local() {
+        // Outside any scope: role-derived default.
+        let default_for_assistant = current_message_persisted_source(MessageRole::Assistant);
+        assert_eq!(default_for_assistant, MessagePersistedSource::Assistant);
+        let default_for_tool = current_message_persisted_source(MessageRole::Tool);
+        assert_eq!(default_for_tool, MessagePersistedSource::Tool);
+
+        // Inside the override scope (mirrors what the
+        // `BackgroundResultSender` closure does): every role maps to
+        // `Background`.
+        let bg = MESSAGE_PERSISTED_SOURCE_OVERRIDE
+            .scope(Some(MessagePersistedSource::Background), async {
+                (
+                    current_message_persisted_source(MessageRole::Assistant),
+                    current_message_persisted_source(MessageRole::Tool),
+                )
+            })
+            .await;
+        assert_eq!(bg.0, MessagePersistedSource::Background);
+        assert_eq!(bg.1, MessagePersistedSource::Background);
+
+        // After the scope ends, the default behaviour is restored.
+        let after = current_message_persisted_source(MessageRole::Assistant);
+        assert_eq!(after, MessagePersistedSource::Assistant);
+    }
+
+    /// Codex P2: every `turn/spawn_complete` event must carry the same
+    /// monotonically-assigned ledger seq as its envelope, NOT 0. Producers
+    /// seed `seq: 0` at construction (they don't know the assigned cursor
+    /// yet); `LedgeredUiProtocolEvent::with_cursor` stamps it during
+    /// `append_notification`. Without this, replay/dedup reduces every
+    /// spawn_complete to the same logical row.
+    #[tokio::test]
+    async fn ledger_stamps_turn_spawn_complete_seq_in_lockstep_with_cursor() {
+        let ledger = UiProtocolLedger::new(8);
+        let session_id = SessionKey("local:seq".into());
+
+        // Append twice — each event must observe a distinct, monotonically
+        // increasing seq stamped onto BOTH the cursor and the flat
+        // `seq` field.
+        let first = ledger.append_notification(turn_spawn_complete_for(&session_id));
+        let second = ledger.append_notification(turn_spawn_complete_for(&session_id));
+
+        let extract_seq = |event: &UiProtocolLedgerEvent| -> Option<(u64, u64)> {
+            match event {
+                UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(ev)) => {
+                    Some((ev.seq, ev.cursor.seq))
+                }
+                _ => None,
+            }
+        };
+        let (first_seq, first_cursor_seq) =
+            extract_seq(&first.event).expect("first event is turn/spawn_complete");
+        let (second_seq, second_cursor_seq) =
+            extract_seq(&second.event).expect("second event is turn/spawn_complete");
+
+        assert!(
+            first_seq > 0,
+            "ledger must stamp non-zero seq onto first event"
+        );
+        assert_eq!(
+            first_seq, first_cursor_seq,
+            "flat seq must equal cursor seq for the same event",
+        );
+        assert!(
+            second_seq > first_seq,
+            "seq is strictly monotonic per session"
+        );
+        assert_eq!(
+            second_seq, second_cursor_seq,
+            "flat seq remains in lockstep with cursor seq across appends",
+        );
     }
 
     /// End-to-end through the live forwarder for an OLD client (did NOT

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -166,6 +166,13 @@ impl UiProtocolLedgerEvent {
                 UiNotification::MessagePersisted(persisted) => {
                     persisted.cursor = cursor;
                 }
+                // M10 Phase 1: same convention for the `turn/spawn_complete`
+                // envelope — the wire `cursor` field tracks the ledger
+                // seq so cursor-driven clients can resume cleanly across
+                // both event shapes.
+                UiNotification::TurnSpawnComplete(spawn_complete) => {
+                    spawn_complete.cursor = cursor;
+                }
                 _ => {}
             }
         }
@@ -578,7 +585,10 @@ impl UiProtocolLedger {
         event: UiProgressEvent,
         from_connection: ConnectionId,
     ) -> LedgeredUiProtocolEvent {
-        self.append(UiProtocolLedgerEvent::Progress(event), Some(from_connection))
+        self.append(
+            UiProtocolLedgerEvent::Progress(event),
+            Some(from_connection),
+        )
     }
 
     fn append(
@@ -1478,6 +1488,7 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::TurnError(event) => &event.session_id,
         UiNotification::ReplayLossy(event) => &event.session_id,
         UiNotification::MessagePersisted(event) => &event.session_id,
+        UiNotification::TurnSpawnComplete(event) => &event.session_id,
     }
 }
 

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -166,17 +166,18 @@ impl UiProtocolLedgerEvent {
                 UiNotification::MessagePersisted(persisted) => {
                     persisted.cursor = cursor;
                 }
-                // M10 Phase 1: same convention for the `turn/spawn_complete`
-                // envelope — the wire `cursor` field tracks the ledger
-                // seq so cursor-driven clients can resume cleanly across
-                // both event shapes. The flat `seq` field mirrors
-                // `MessagePersistedEvent.seq` (codex P2: producers seed
-                // 0 at construction; the assigned seq is only known
-                // here, so stamp both fields in lockstep — otherwise
-                // every spawn_complete arrives at the client as
-                // sequence 0 and reorder/dedup logic breaks).
+                // M10 Phase 1: stamp the ledger cursor onto the
+                // `turn/spawn_complete` envelope so cursor-driven
+                // clients can resume cleanly. The flat `seq` field is
+                // intentionally NOT overwritten here — it carries the
+                // committed-row index from the persistence path
+                // (matching `MessagePersistedEvent.seq`), which the
+                // producer set before append (codex P2 follow-up).
+                // The persisted-row seq and the UI-ledger cursor seq
+                // are different scales — conflating them would make
+                // upgraded clients dedupe / anchor against a
+                // non-existent message row on hydrate.
                 UiNotification::TurnSpawnComplete(spawn_complete) => {
-                    spawn_complete.seq = cursor.seq;
                     spawn_complete.cursor = cursor;
                 }
                 _ => {}

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -169,8 +169,14 @@ impl UiProtocolLedgerEvent {
                 // M10 Phase 1: same convention for the `turn/spawn_complete`
                 // envelope — the wire `cursor` field tracks the ledger
                 // seq so cursor-driven clients can resume cleanly across
-                // both event shapes.
+                // both event shapes. The flat `seq` field mirrors
+                // `MessagePersistedEvent.seq` (codex P2: producers seed
+                // 0 at construction; the assigned seq is only known
+                // here, so stamp both fields in lockstep — otherwise
+                // every spawn_complete arrives at the client as
+                // sequence 0 and reorder/dedup logic breaks).
                 UiNotification::TurnSpawnComplete(spawn_complete) => {
+                    spawn_complete.seq = cursor.seq;
                     spawn_complete.cursor = cursor;
                 }
                 _ => {}

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -54,6 +54,19 @@ pub const UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1: &str = "state.turn_state_get.v1
 /// notification.
 pub const UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1: &str = "event.message_persisted.v1";
 
+/// Feature flag for M10 Phase 1 `turn/spawn_complete` envelope event.
+///
+/// Negotiated by clients that understand the new "completion-as-new-envelope"
+/// wire shape for `spawn_only` background tool results. Clients that
+/// negotiate this capability receive `turn/spawn_complete` notifications in
+/// place of the `message/persisted` row that carries the late assistant
+/// content (the legacy splice-merge target). Clients that do NOT negotiate
+/// it continue to see `message/persisted` for the same row.
+///
+/// The persistence path is unchanged — the durability ledger still records
+/// the message — only the wire event the connected client observes flips.
+pub const UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1: &str = "event.spawn_complete.v1";
+
 /// Server-known feature registry. Used by
 /// [`UiProtocolCapabilities::for_negotiated_features`] (UPCR-2026-007) to
 /// intersect a client's `X-Octos-Ui-Features` request with the names the
@@ -68,6 +81,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
     UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
     UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
+    UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
 ];
 
 /// Returns the feature flag that gates `method` per spec § 7 capability
@@ -652,6 +666,15 @@ pub mod methods {
     pub const REPLAY_LOSSY: &str = "protocol/replay_lossy";
     /// UPCR-2026-012 `message/persisted` — durable-commit confirmation.
     pub const MESSAGE_PERSISTED: &str = "message/persisted";
+    /// M10 Phase 1 `turn/spawn_complete` — completion-as-new-envelope event
+    /// for `spawn_only` background tool results. Carries the late assistant
+    /// `content` + `media` plus the originating user prompt's
+    /// `client_message_id` (`response_to_client_message_id`) so the client
+    /// can render the result as a NEW assistant bubble under the correct
+    /// user prompt — without splice-merging into the existing
+    /// spawn-acknowledgement bubble. Gated by
+    /// [`UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1`].
+    pub const TURN_SPAWN_COMPLETE: &str = "turn/spawn_complete";
 }
 
 /// Reason codes for `approval/cancelled` notifications. The registry is
@@ -698,6 +721,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::WARNING,
     methods::REPLAY_LOSSY,
     methods::MESSAGE_PERSISTED,
+    methods::TURN_SPAWN_COMPLETE,
 ];
 
 /// Request methods currently handled by the first server/runtime slice.
@@ -783,6 +807,7 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
             UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
             UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
+            UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
         ])
     }
 
@@ -1681,6 +1706,68 @@ pub struct MessagePersistedEvent {
     ///
     /// Backwards-compatible: serialized as omitted when empty so clients
     /// running older protocol versions see the same wire shape they used to.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub media: Vec<String>,
+}
+
+// ----- M10 Phase 1 `turn/spawn_complete` -----
+
+/// Notification params for `turn/spawn_complete` (M10 Phase 1). Emitted once
+/// per `spawn_only` background tool completion AFTER the late assistant row
+/// is durably persisted, in addition to (and as the wire-level replacement
+/// of) the corresponding `message/persisted` event for clients that
+/// negotiated [`UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1`].
+///
+/// The wire shape mirrors [`MessagePersistedEvent`] (durable cursor, seq,
+/// `message_id`, `persisted_at`) so a client that already has a
+/// `MessagePersisted` reducer can route this through the same persistence
+/// confirmation path. It adds two distinguishing fields:
+///
+/// - `task_id` — which `spawn_only` task the completion came from.
+/// - `response_to_client_message_id` — the originating user message's
+///   `client_message_id`, telling the client which user prompt's thread
+///   the new assistant bubble belongs under (analogous to the existing
+///   `MessagePersistedEvent.thread_id`, but specifically the *user-prompt*
+///   anchor; the splice-merge logic in legacy clients was the bug surface
+///   the new envelope replaces).
+///
+/// Unlike `message/persisted` (which is metadata-only and works alongside
+/// streaming `message/delta` deltas to reconstruct content), this event
+/// carries the full `content` and `media` for the late completion in one
+/// frame — by design, the client never needs to splice-merge or wait for
+/// further deltas. `media` mirrors the convention in `MessagePersistedEvent`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnSpawnCompleteEvent {
+    pub session_id: SessionKey,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<TurnId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    /// The `spawn_only` task that produced this completion. Always
+    /// populated — a `turn/spawn_complete` without a task_id is a server
+    /// bug.
+    pub task_id: String,
+    /// The originating user message's `client_message_id`, i.e. the
+    /// user-prompt anchor under which the new assistant bubble should be
+    /// rendered. `None` only for legacy callers that did not propagate
+    /// origination through the spawn pipeline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_to_client_message_id: Option<String>,
+    pub seq: u64,
+    pub message_id: String,
+    /// Source of the completion. Always `background` today; reserved as
+    /// `String` so future variants (e.g. `recovery_background`) can extend
+    /// without a wire-breaking enum change.
+    pub source: String,
+    pub cursor: UiCursor,
+    pub persisted_at: DateTime<Utc>,
+    /// REQUIRED. The full assistant text for the completion bubble. Unlike
+    /// [`MessagePersistedEvent`] (where `content` lives only in the
+    /// session ledger), this event carries the text inline so the client
+    /// can render the new bubble atomically without a follow-up fetch.
+    pub content: String,
+    /// File attachments for this completion (e.g. `_report.md`,
+    /// `output.mp3`). Same convention as `MessagePersistedEvent.media`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub media: Vec<String>,
 }
@@ -2840,6 +2927,11 @@ pub enum UiNotification {
     ReplayLossy(ReplayLossyEvent),
     /// UPCR-2026-012: durable-commit confirmation per session row.
     MessagePersisted(MessagePersistedEvent),
+    /// M10 Phase 1: completion-as-new-envelope event for `spawn_only`
+    /// background results. Emitted in addition to `MessagePersisted` for
+    /// the same row; per-connection capability filtering (the
+    /// `event.spawn_complete.v1` flag) decides which one the client sees.
+    TurnSpawnComplete(TurnSpawnCompleteEvent),
 }
 
 impl UiNotification {
@@ -2863,6 +2955,7 @@ impl UiNotification {
             Self::TurnError(_) => methods::TURN_ERROR,
             Self::ReplayLossy(_) => methods::REPLAY_LOSSY,
             Self::MessagePersisted(_) => methods::MESSAGE_PERSISTED,
+            Self::TurnSpawnComplete(_) => methods::TURN_SPAWN_COMPLETE,
         }
     }
 
@@ -2887,6 +2980,7 @@ impl UiNotification {
             Self::TurnError(params) => serde_json::to_value(params),
             Self::ReplayLossy(params) => serde_json::to_value(params),
             Self::MessagePersisted(params) => serde_json::to_value(params),
+            Self::TurnSpawnComplete(params) => serde_json::to_value(params),
         }?;
 
         Ok(RpcNotification::new(method, params))
@@ -2930,6 +3024,9 @@ impl UiNotification {
             methods::REPLAY_LOSSY => Ok(Self::ReplayLossy(decode_params(method, params)?)),
             methods::MESSAGE_PERSISTED => {
                 Ok(Self::MessagePersisted(decode_params(method, params)?))
+            }
+            methods::TURN_SPAWN_COMPLETE => {
+                Ok(Self::TurnSpawnComplete(decode_params(method, params)?))
             }
             _ => Err(RpcError::method_not_found(method)),
         }
@@ -3310,6 +3407,7 @@ mod tests {
                 "warning",
                 "protocol/replay_lossy",
                 "message/persisted",
+                "turn/spawn_complete",
             ]
         );
         assert_eq!(
@@ -3383,7 +3481,8 @@ mod tests {
                     "progress/updated",
                     "warning",
                     "protocol/replay_lossy",
-                    "message/persisted"
+                    "message/persisted",
+                    "turn/spawn_complete"
                 ],
                 "supported_features": [
                     "approval.typed.v1",
@@ -3393,7 +3492,8 @@ mod tests {
                     "state.session_hydrate.v1",
                     "state.thread_graph.v1",
                     "state.turn_state_get.v1",
-                    "event.message_persisted.v1"
+                    "event.message_persisted.v1",
+                    "event.spawn_complete.v1"
                 ]
             })
         );
@@ -5305,6 +5405,116 @@ mod tests {
         assert_eq!(rpc.method, methods::MESSAGE_PERSISTED);
         let decoded = UiNotification::from_rpc_notification(rpc).expect("notification deserialize");
         assert_eq!(decoded, notif);
+    }
+
+    #[test]
+    fn golden_turn_spawn_complete_event_serde() {
+        let event = TurnSpawnCompleteEvent {
+            session_id: sample_session_id(),
+            turn_id: Some(sample_turn_id()),
+            thread_id: Some("thread-1".into()),
+            task_id: "task_abc123".into(),
+            response_to_client_message_id: Some("cmid-user-1".into()),
+            seq: 42,
+            message_id: "msg-spawn-1".into(),
+            source: "background".into(),
+            cursor: UiCursor {
+                stream: "local:demo".into(),
+                seq: 42,
+            },
+            persisted_at: sample_persisted_at(),
+            content: "Research complete: 3 sources reviewed.".into(),
+            media: vec!["research/_report.md".into()],
+        };
+        let value = serde_json::to_value(&event).expect("serialize");
+        // Wire shape matches the spec: required fields land on the
+        // top-level object with snake_case keys; absent optional fields
+        // omit cleanly.
+        assert_eq!(value.get("task_id"), Some(&json!("task_abc123")));
+        assert_eq!(
+            value.get("response_to_client_message_id"),
+            Some(&json!("cmid-user-1")),
+        );
+        assert_eq!(
+            value.get("content"),
+            Some(&json!("Research complete: 3 sources reviewed.")),
+        );
+        assert_eq!(value.get("source"), Some(&json!("background")));
+        let parsed: TurnSpawnCompleteEvent = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, event);
+
+        // Empty media + absent optionals omit on the wire (legacy
+        // clients see the same shape as `MessagePersistedEvent`'s
+        // optional-fields convention).
+        let bare = TurnSpawnCompleteEvent {
+            session_id: sample_session_id(),
+            turn_id: None,
+            thread_id: None,
+            task_id: "task_zzz".into(),
+            response_to_client_message_id: None,
+            seq: 1,
+            message_id: "msg-bare".into(),
+            source: "background".into(),
+            cursor: UiCursor {
+                stream: "local:demo".into(),
+                seq: 1,
+            },
+            persisted_at: sample_persisted_at(),
+            content: String::new(),
+            media: vec![],
+        };
+        let bare_v = serde_json::to_value(&bare).expect("serialize bare");
+        assert!(bare_v.get("turn_id").is_none(), "absent turn_id omits");
+        assert!(bare_v.get("thread_id").is_none(), "absent thread_id omits");
+        assert!(
+            bare_v.get("response_to_client_message_id").is_none(),
+            "absent response_to_client_message_id omits",
+        );
+        assert!(bare_v.get("media").is_none(), "empty media omits");
+        let bare_p: TurnSpawnCompleteEvent =
+            serde_json::from_value(bare_v).expect("deserialize bare");
+        assert_eq!(bare_p, bare);
+
+        // Wire-level: round-trip via the JSON-RPC notification envelope.
+        let notif = UiNotification::TurnSpawnComplete(event.clone());
+        let rpc = notif
+            .clone()
+            .into_rpc_notification()
+            .expect("notification serialize");
+        assert_eq!(rpc.method, methods::TURN_SPAWN_COMPLETE);
+        let decoded = UiNotification::from_rpc_notification(rpc).expect("notification deserialize");
+        assert_eq!(decoded, notif);
+    }
+
+    #[test]
+    fn golden_capabilities_advertise_spawn_complete_v1() {
+        // No header at all -> server falls back to `first_server_slice` and
+        // advertises every known feature including `event.spawn_complete.v1`.
+        let full = UiProtocolCapabilities::first_server_slice();
+        assert!(full.supports_feature(UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1));
+
+        // `full_protocol()` advertises the same.
+        let full_proto = UiProtocolCapabilities::full_protocol();
+        assert!(full_proto.supports_feature(UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1));
+
+        // Negotiated subset: only `event.spawn_complete.v1` requested.
+        let only_spawn = UiProtocolCapabilities::for_negotiated_features([
+            UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+        ]);
+        assert!(only_spawn.supports_feature(UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1));
+        assert!(
+            !only_spawn.supports_feature(UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1),
+            "non-requested feature must NOT be advertised",
+        );
+
+        // The notification method is advertised regardless of negotiated
+        // gating today (mirrors how `message/persisted` is unconditionally
+        // listed in `UI_PROTOCOL_NOTIFICATION_METHODS`); per-connection
+        // emit-time filtering is what enforces the capability.
+        assert!(
+            UI_PROTOCOL_NOTIFICATION_METHODS.contains(&methods::TURN_SPAWN_COMPLETE),
+            "turn/spawn_complete is in the notification method registry",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 1 of the M10 envelope migration plan. Adds the wire event the SPA will use in lieu of splice-merging late `spawn_only` results into an existing assistant bubble — each background completion lands as a NEW assistant envelope under the originating user prompt, killing 8 of 12 historical UX bug classes that orbit the splice-merge surface.

- New `turn/spawn_complete` event in `octos-core` (`TurnSpawnCompleteEvent`) gated by the new `event.spawn_complete.v1` capability.
- Wire-mirror of `MessagePersistedEvent` for the same durable row (matching `seq` + `message_id`) plus `task_id` and inline `content` + `media` so the SPA renders an atomic completion bubble.
- Per-connection capability filter at `live_event_passes_capability_filter` routes each client to exactly one shape:
  - Old client (no `event.spawn_complete.v1`): legacy `message/persisted` (unchanged back-compat for TUI/CLI/SSE).
  - New client (with `event.spawn_complete.v1`): receives `turn/spawn_complete`; the duplicate `message/persisted` (source: background) is suppressed.
- `task_id` plumbed through `BackgroundResultPayload` so the envelope carries the supervisor task handle Phase 4's `read_task_output` will key off.

## Test plan

- [x] Core golden serde for `TurnSpawnCompleteEvent` + capability advertisement
- [x] CLI unit test for the four-corner capability matrix (`capability_filter_routes_spawn_complete_dual_gating`)
- [x] CLI live-forwarder e2e for new client (`live_forwarder_routes_spawn_complete_to_new_client`)
- [x] CLI live-forwarder e2e for old client (`live_forwarder_falls_back_to_message_persisted_for_old_client`)
- [x] Ledger preserves producer's persisted-row seq, stamps cursor only (`ledger_preserves_producer_seq_and_stamps_only_cursor`)
- [x] Task-local source override scopes correctly (`message_persisted_source_override_routes_through_task_local`)
- [x] Existing wire-contract goldens updated (notification methods + capabilities)
- [x] `cargo build --release -p octos-core -p octos-cli` clean
- [x] `cargo test -p octos-core` 169 pass
- [x] `cargo test -p octos-cli --features api` 880 lib + integration tests pass
- [x] `cargo test -p octos-agent` 1245 pass

## Risks

- **Capability gating discipline**: Both `live_event_passes_capability_filter` and the `session/open` replay path must apply the same dual filter (they share the helper now). A future code path that fans events out by-passing this helper could leak the duplicate-suppression invariant. Mitigated by routing the replay loop through the same helper.
- **Persisted-row identity**: `turn/spawn_complete.message_id` and `seq` reuse `MessageCommitObserver`'s convention so a client that flips capabilities mid-session sees one logical row. Captured via `PersistedMessageMeta` returned from `persist_assistant_with_media`.
- **Field semantics — `response_to_client_message_id`**: Set to `None` in this server path. The standalone-turn reporter binds to `turn_id` rather than the user's `client_message_id`; surfacing a TurnId in this field would lie about the contract. The SPA's reducer (Phase 2) already anchors via the existing `thread_id` field. Phase 4 plumbing will introduce a typed `originating_client_message_id` on `BackgroundResultPayload` and populate this from the real user cmid.
- **Documented limitation — `spawn_complete-only` negotiation**: For `NotConfigured`/`send_file` fallback completions, clients that negotiate only `event.spawn_complete.v1` (NOT `event.message_persisted.v1`) see the completion text without inline attachments. The web SPA negotiates both flags, so production is unaffected. Contract-`Satisfied` completions carry `output_files` on the spawn_complete payload directly.

## Codex review

Iterated through 7 codex rounds with each blocking finding addressed in a separate fix commit. Final state stops on a structurally-stable trade-off: the design questions around (a) `response_to_client_message_id` source and (b) media duplication for the send_file fallback are deferred to Phase 4 plumbing per the plan.