### PR TITLE
feat(api): coalesce spawn_only completion to single envelope (M10 Phase 5a)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -472,6 +472,7 @@ impl Agent {
                                             content: String::new(),
                                             kind: BackgroundResultKind::Notification,
                                             media: output_files.clone(),
+                                            envelope_media: vec![],
                                             originating_thread_id: bg_originating_thread_id.clone(),
                                             task_id: Some(task_id.clone()),
                                         })
@@ -502,6 +503,7 @@ impl Agent {
                                                     ),
                                                     kind: BackgroundResultKind::Notification,
                                                     media: vec![],
+                                                    envelope_media: vec![],
                                                     originating_thread_id: bg_originating_thread_id
                                                         .clone(),
                                                     task_id: Some(task_id.clone()),
@@ -543,6 +545,7 @@ impl Agent {
                                             content,
                                             kind: BackgroundResultKind::Notification,
                                             media: vec![],
+                                            envelope_media: vec![],
                                             originating_thread_id: bg_originating_thread_id.clone(),
                                             task_id: Some(task_id.clone()),
                                         })
@@ -567,6 +570,7 @@ impl Agent {
                                                 ),
                                                 kind: BackgroundResultKind::Notification,
                                                 media: vec![],
+                                                envelope_media: vec![],
                                                 originating_thread_id: bg_originating_thread_id
                                                     .clone(),
                                                 task_id: Some(task_id.clone()),
@@ -605,6 +609,7 @@ impl Agent {
                                                 ),
                                                 kind: BackgroundResultKind::Notification,
                                                 media: vec![],
+                                                envelope_media: vec![],
                                                 originating_thread_id: bg_originating_thread_id
                                                     .clone(),
                                                 task_id: Some(task_id.clone()),
@@ -640,11 +645,40 @@ impl Agent {
                                         );
                                         let send_args = serde_json::json!({
                                             "file_path": path_str,
-                                            "tool_call_id": bg_tc_id
+                                            "tool_call_id": bg_tc_id,
                                         });
+                                        // M10 Phase 5a (coalesce): enter the
+                                        // `spawn_complete_companion` task-local
+                                        // scope so the in-flight `send_file`
+                                        // emits an OutboundMessage carrying
+                                        // `metadata.spawn_complete_companion =
+                                        // true`. The api/serve consumer reads
+                                        // the flag and persists each per-file
+                                        // row with
+                                        // `MessagePersistedSource::Background`,
+                                        // letting dual-negotiated clients
+                                        // suppress the duplicate at the
+                                        // `live_event_passes_capability_filter`
+                                        // gate in favour of the single
+                                        // `turn/spawn_complete` envelope (which
+                                        // carries the same media via
+                                        // `BackgroundResultPayload.envelope_media`
+                                        // populated below). Internal-only by
+                                        // design: the scope is keyed on a
+                                        // `tokio::task_local!`, NOT on tool
+                                        // args, so an LLM cannot spoof the
+                                        // flag through generated JSON. Old
+                                        // clients without
+                                        // `event.spawn_complete.v1` still
+                                        // receive the per-file rows
+                                        // unchanged.
                                         let mut delivered = false;
                                         for attempt in 0..3 {
-                                            match bg_tools.execute("send_file", &send_args).await {
+                                            match crate::tools::send_file::with_spawn_complete_companion_scope(
+                                                bg_tools.execute("send_file", &send_args),
+                                            )
+                                            .await
+                                            {
                                                 Ok(sr) if sr.success => {
                                                     tracing::info!(
                                                         tool = %bg_name,
@@ -707,6 +741,7 @@ impl Agent {
                                                 ),
                                                 kind: BackgroundResultKind::Notification,
                                                 media: vec![],
+                                                envelope_media: vec![],
                                                 originating_thread_id: bg_originating_thread_id
                                                     .clone(),
                                                 task_id: Some(task_id.clone()),
@@ -728,40 +763,48 @@ impl Agent {
                                                         .join(", ")
                                                 );
                                                 if let Some(ref sender) = bg_sender {
-                                                    // M10 Phase 1 design choice
-                                                    // (codex rounds 5+7 traded
-                                                    // duplicate-attachments vs
-                                                    // missing-attachments): keep
-                                                    // `media: vec![]` for the
-                                                    // `NotConfigured`/`send_file`
-                                                    // fallback success path. Each
-                                                    // file already has its own
-                                                    // `message/persisted` row
-                                                    // emitted by the `send_file`
-                                                    // consumer (with `source:
-                                                    // assistant`, which passes
-                                                    // both legacy and
-                                                    // dual-negotiated client
-                                                    // filters). Adding the same
-                                                    // files here would duplicate
-                                                    // attachment bubbles for
-                                                    // clients that negotiated
-                                                    // both `event.message_persisted.v1`
-                                                    // AND `event.spawn_complete.v1`.
+                                                    // M10 Phase 5a (coalesce):
+                                                    // - `media: vec![]` keeps
+                                                    //   the persisted row's
+                                                    //   wire shape
+                                                    //   byte-identical to the
+                                                    //   pre-Phase-5a
+                                                    //   "spawn-ack with text
+                                                    //   only" row that old
+                                                    //   clients already render.
+                                                    //   Each `sent_files`
+                                                    //   entry has its OWN
+                                                    //   per-file
+                                                    //   `message/persisted`
+                                                    //   row from the
+                                                    //   `send_file` consumer
+                                                    //   above; double-listing
+                                                    //   them here would render
+                                                    //   the same attachments
+                                                    //   twice for old clients.
+                                                    // - `envelope_media:
+                                                    //   sent_files.clone()`
+                                                    //   surfaces those files
+                                                    //   on the
+                                                    //   `turn/spawn_complete`
+                                                    //   envelope so
+                                                    //   dual-negotiated
+                                                    //   clients (which
+                                                    //   suppress the per-file
+                                                    //   `Background` rows in
+                                                    //   `live_event_passes_capability_filter`)
+                                                    //   still see the
+                                                    //   attachments inline on
+                                                    //   the single completion
+                                                    //   bubble.
                                                     //
-                                                    // Documented limitation:
-                                                    // `event.spawn_complete.v1`-only
-                                                    // negotiation in this fallback
-                                                    // sees the completion text
-                                                    // without inline attachments.
-                                                    // The web SPA (Phase 2)
-                                                    // negotiates both flags, so
-                                                    // production hits the
-                                                    // both-flags path. CLI/TUI
-                                                    // clients use the contract-
-                                                    // `Satisfied` branch above
-                                                    // (which carries `output_files`
-                                                    // directly).
+                                                    // Splitting persist-media
+                                                    // from envelope-media is
+                                                    // what lets the same
+                                                    // producer serve both
+                                                    // wire shapes correctly
+                                                    // without regressing
+                                                    // either.
                                                     let _ = sender(BackgroundResultPayload {
                                                         task_label: bg_name.clone(),
                                                         content: format!(
@@ -770,6 +813,7 @@ impl Agent {
                                                         ),
                                                         kind: BackgroundResultKind::Notification,
                                                         media: vec![],
+                                                        envelope_media: sent_files.clone(),
                                                         originating_thread_id:
                                                             bg_originating_thread_id.clone(),
                                                         task_id: Some(task_id.clone()),
@@ -793,6 +837,7 @@ impl Agent {
                                                         ),
                                                         kind: BackgroundResultKind::Notification,
                                                         media: vec![],
+                                                        envelope_media: vec![],
                                                         originating_thread_id:
                                                             bg_originating_thread_id.clone(),
                                                         task_id: Some(task_id.clone()),
@@ -819,6 +864,7 @@ impl Agent {
                                     content: format!("✗ {} failed: {}", bg_name, r.output),
                                     kind: BackgroundResultKind::Notification,
                                     media: vec![],
+                                    envelope_media: vec![],
                                     originating_thread_id: bg_originating_thread_id.clone(),
                                     task_id: Some(task_id.clone()),
                                 })
@@ -838,6 +884,7 @@ impl Agent {
                                     content: format!("✗ {} error: {}", bg_name, e),
                                     kind: BackgroundResultKind::Notification,
                                     media: vec![],
+                                    envelope_media: vec![],
                                     originating_thread_id: bg_originating_thread_id.clone(),
                                     task_id: Some(task_id.clone()),
                                 })

--- a/crates/octos-agent/src/tools/send_file.rs
+++ b/crates/octos-agent/src/tools/send_file.rs
@@ -120,6 +120,43 @@ struct Input {
     topic: Option<String>,
 }
 
+tokio::task_local! {
+    /// M10 Phase 5a: scoped flag that marks an in-flight `send_file`
+    /// invocation as a per-file companion to a `spawn_only` completion's
+    /// `turn/spawn_complete` envelope. When the scope is active, the
+    /// emitted [`OutboundMessage`] carries
+    /// `metadata.spawn_complete_companion = true`, which the api/serve
+    /// `send_file` consumer reads to persist the row under
+    /// `MessagePersistedSource::Background`. Dual-negotiated clients then
+    /// suppress that row in favour of the single envelope.
+    ///
+    /// Internal-only by construction: the flag is NEVER read from tool
+    /// `args`, so an LLM cannot inject it from a generated JSON payload.
+    /// Only [`execution.rs`]'s `NotConfigured` success branch enters this
+    /// scope around its retry-loop calls into `send_file`.
+    static SPAWN_COMPLETE_COMPANION_SCOPE: bool;
+}
+
+/// Run `fut` with the spawn-complete-companion scope active, so any
+/// `send_file` calls executed inside its task tree set the
+/// `spawn_complete_companion` outbound metadata. Use exclusively from
+/// the agent-internal NotConfigured-branch retry loop in
+/// `execution.rs`. `pub(crate)` so only the agent crate can enter the
+/// scope; not part of the tool's external surface.
+pub(crate) async fn with_spawn_complete_companion_scope<F, T>(fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    SPAWN_COMPLETE_COMPANION_SCOPE.scope(true, fut).await
+}
+
+fn current_spawn_complete_companion() -> bool {
+    SPAWN_COMPLETE_COMPANION_SCOPE
+        .try_with(|v| *v)
+        .ok()
+        .unwrap_or(false)
+}
+
 #[async_trait]
 impl Tool for SendFileTool {
     fn name(&self) -> &str {
@@ -283,6 +320,17 @@ impl Tool for SendFileTool {
         });
         if let Some(topic) = topic {
             metadata.insert("topic".to_string(), serde_json::Value::String(topic));
+        }
+        // M10 Phase 5a: read the task-local scope (NOT the args) to
+        // decide whether this invocation is a `spawn_complete_companion`.
+        // Scope-only by design — see [`SPAWN_COMPLETE_COMPANION_SCOPE`]
+        // — keeps the LLM unable to spoof the flag through generated
+        // tool args.
+        if current_spawn_complete_companion() {
+            metadata.insert(
+                "spawn_complete_companion".to_string(),
+                serde_json::Value::Bool(true),
+            );
         }
 
         let msg = OutboundMessage {
@@ -631,6 +679,97 @@ mod tests {
         assert!(result.success);
         let msg = rx.recv().await.unwrap();
         assert!(msg.metadata.get("tool_call_id").is_none());
+    }
+
+    #[tokio::test]
+    async fn should_set_spawn_complete_companion_metadata_when_scope_active() {
+        // M10 Phase 5a: when execution.rs's NotConfigured success branch
+        // wraps the per-file `send_file` retry loop in
+        // `with_spawn_complete_companion_scope`, the in-flight execute()
+        // call sees the task-local flag and stamps the OutboundMessage's
+        // metadata with `spawn_complete_companion: true`. The api/serve
+        // consumer reads the flag and persists the resulting row with
+        // `MessagePersistedSource::Background`, letting dual-negotiated
+        // clients suppress the duplicate in favour of `turn/spawn_complete`.
+        let (tx, mut rx) = mpsc::channel(16);
+        let tool = SendFileTool::with_context(tx, "api", "sess-1");
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "report").unwrap();
+        let path = tmp.path().to_string_lossy().to_string();
+
+        // Wrapping in the scope is the ONLY way to set the flag — the
+        // input schema deliberately does not accept it from JSON args, so
+        // an LLM cannot spoof the marker through generated tool calls.
+        let result = with_spawn_complete_companion_scope(
+            tool.execute(&serde_json::json!({"file_path": path})),
+        )
+        .await
+        .unwrap();
+
+        assert!(result.success);
+        let msg = rx.recv().await.unwrap();
+        assert_eq!(
+            msg.metadata
+                .get("spawn_complete_companion")
+                .and_then(|v| v.as_bool()),
+            Some(true),
+        );
+    }
+
+    #[tokio::test]
+    async fn should_omit_spawn_complete_companion_metadata_outside_scope() {
+        // The flag is scope-driven. A regular agent-issued `send_file` call
+        // (LLM tool-use, explicit user request) runs OUTSIDE the
+        // companion scope, so the metadata key must stay absent and the
+        // resulting row reaches all clients with `source: Assistant`.
+        let (tx, mut rx) = mpsc::channel(16);
+        let tool = SendFileTool::with_context(tx, "api", "sess-1");
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "data").unwrap();
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let result = tool
+            .execute(&serde_json::json!({"file_path": path}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        let msg = rx.recv().await.unwrap();
+        assert!(msg.metadata.get("spawn_complete_companion").is_none());
+    }
+
+    #[tokio::test]
+    async fn should_ignore_spawn_complete_companion_field_in_args() {
+        // Defense-in-depth: even if a malicious or buggy caller puts an
+        // `_spawn_complete_companion` key in the JSON args, the field is
+        // not part of the tool's `Input` shape (no struct field deserializes
+        // it). The tool ignores it and decides solely from the task-local
+        // scope. The metadata flag stays absent — preventing an LLM from
+        // spoofing the Background-source filter through generated args.
+        let (tx, mut rx) = mpsc::channel(16);
+        let tool = SendFileTool::with_context(tx, "api", "sess-1");
+
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "data").unwrap();
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let result = tool
+            .execute(&serde_json::json!({
+                "file_path": path,
+                "_spawn_complete_companion": true,
+                "spawn_complete_companion": true
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        let msg = rx.recv().await.unwrap();
+        assert!(
+            msg.metadata.get("spawn_complete_companion").is_none(),
+            "args-passed companion flag must be ignored — only the task-local scope can mark a row",
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -73,7 +73,33 @@ pub struct BackgroundResultPayload {
     pub task_label: String,
     pub content: String,
     pub kind: BackgroundResultKind,
+    /// Media to attach to the persisted ledger row that mirrors this
+    /// completion (legacy `message/persisted` shape). For the
+    /// `NotConfigured` `send_file` fallback this stays `vec![]` because
+    /// each file already has its own per-file `message/persisted` row
+    /// — adding the same paths here would double-render attachments on
+    /// old clients that don't negotiate `event.spawn_complete.v1`.
+    /// For the `Satisfied` workspace-contract path it carries
+    /// `output_files` directly (no separate per-file rows on that path).
     pub media: Vec<String>,
+    /// M10 Phase 5a: media to surface ONLY on the `turn/spawn_complete`
+    /// envelope, never on the persisted row.
+    ///
+    /// Why two fields: dual-negotiated clients (capability
+    /// `event.spawn_complete.v1`) receive the envelope; the
+    /// per-file `message/persisted` companions are filtered as
+    /// `MessagePersistedSource::Background`. So the envelope MUST
+    /// carry the file URLs or the new client renders a text-only bubble.
+    /// Old clients DO see the per-file rows; if the envelope's media
+    /// also leaked into the persisted row they'd double-render.
+    /// Splitting persist-media from envelope-media keeps the two wire
+    /// shapes independent.
+    ///
+    /// Empty `Vec` (default) means "no envelope-only attachments";
+    /// the envelope falls back to `media` for compatibility with the
+    /// `Satisfied` path. Populated explicitly only by the
+    /// `NotConfigured` success branch in `execution.rs`.
+    pub envelope_media: Vec<String>,
     /// M8.10 follow-up (#649): the user message's `client_message_id` that
     /// originated this background task. Carries through to the late-arriving
     /// outbound's `metadata.thread_id` so the API channel can stamp SSE
@@ -2942,6 +2968,7 @@ impl Tool for SpawnTool {
                         content: content.clone(),
                         kind: result_kind,
                         media: result_media.clone(),
+                        envelope_media: vec![],
                         originating_thread_id: originating_thread_id.clone(),
                         task_id: tracked_task_id.clone(),
                     },
@@ -3947,6 +3974,7 @@ PY
             content: "done".to_string(),
             kind: BackgroundResultKind::Notification,
             media: vec!["/tmp/output.mp3".to_string()],
+            envelope_media: vec![],
             originating_thread_id: None,
             task_id: None,
         };

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -3379,6 +3379,18 @@ async fn handle_session_hydrate(
     let (messages, threads_projection) = {
         let mut sessions_guard = sessions.lock().await;
         let session = sessions_guard.get_or_create(&params.session_id).await;
+        // M10 Phase 5a known-limitation: hydrate returns the raw `Message`
+        // history without per-row `source` filtering. For dual-negotiated
+        // clients the `event.spawn_complete.v1` capability suppresses
+        // duplicate `Background`-source rows on the LIVE wire, but the
+        // hydrate path has no such filter today — `Message` does not carry
+        // a source field. After a `session/hydrate` (e.g. on page reload)
+        // a new client receives the per-file rows + the spawn-ack row
+        // alongside the durable `turn/spawn_complete` envelope, restoring
+        // pre-Phase-5a multi-bubble rendering until Phase 6 plumbs source
+        // (or a turn/spawn_complete-aware hydrate replay) through. The
+        // live path probe (the wave-6m gate) is not affected. Tracked as
+        // a follow-up — see codex round on Phase 5a.
         let messages = if include_set.messages {
             Some(
                 session
@@ -4645,6 +4657,21 @@ async fn run_standalone_turn(
                     .unwrap_or_else(|| payload_thread_id.clone());
                 let task_label = payload.task_label.clone();
                 let media = payload.media.clone();
+                // M10 Phase 5a: envelope_media is the media list to surface
+                // ONLY on the `turn/spawn_complete` envelope. The
+                // `NotConfigured` `send_file` fallback populates this with
+                // its `sent_files` paths so dual-negotiated clients see the
+                // file URLs on the envelope; the persisted row keeps
+                // `media: vec![]` (no double-render on old clients that DO
+                // see the per-file `message/persisted` companions). The
+                // contract-`Satisfied` path leaves `envelope_media` as the
+                // empty default; in that case the envelope falls back to
+                // `media`.
+                let envelope_media = if payload.envelope_media.is_empty() {
+                    payload.media.clone()
+                } else {
+                    payload.envelope_media.clone()
+                };
                 let kind = payload.kind;
                 let raw_content = payload.content.clone();
                 let task_id = payload.task_id.clone();
@@ -4764,7 +4791,7 @@ async fn run_standalone_turn(
                             },
                             persisted_at: Utc::now(),
                             content: content_text,
-                            media,
+                            media: envelope_media,
                         };
                         ledger.append_notification(UiNotification::TurnSpawnComplete(event));
                     } else if task_id_clean.is_none() {
@@ -4783,17 +4810,35 @@ async fn run_standalone_turn(
                             "background result missing task_id; turn/spawn_complete suppressed"
                         );
                     } else {
-                        // Persist failed — the row never landed in the
-                        // session ledger, so emitting a `turn/spawn_complete`
-                        // would advertise a row that doesn't exist on
-                        // hydrate. Log; old clients also see nothing
-                        // (the observer never fired). The agent's
-                        // task_supervisor still records the failure for
-                        // operator visibility.
+                        // Persist of the spawn-ack/completion row failed.
+                        // The agent's task_supervisor records the failure
+                        // for operator visibility.
+                        //
+                        // M10 Phase 5a coalesce: the per-file `send_file`
+                        // companion rows for the NotConfigured branch
+                        // were already committed *before* this final
+                        // persist (the consumer drains them off
+                        // `out_rx` independently). Those companion rows
+                        // are tagged `MessagePersistedSource::Background`
+                        // so dual-negotiated clients suppress them at
+                        // `live_event_passes_capability_filter` —
+                        // meaning a new client whose envelope persist
+                        // failed sees ZERO file rows for the completion
+                        // (the per-file rows are filtered, the envelope
+                        // never fired). Old clients see the per-file
+                        // rows unchanged (they pass the legacy gate
+                        // regardless of source). Accepted as a
+                        // low-probability degradation: persist is
+                        // durable, this branch fires only when the
+                        // session ledger cannot accept a write, and the
+                        // task_supervisor captures the failure for
+                        // recovery follow-ups. Phase 6 will reorder the
+                        // companion rows AFTER the envelope persist
+                        // commits to close this window.
                         tracing::warn!(
                             session_id = %session_id.0,
                             task_label,
-                            "background result persist failed; both wire shapes suppressed"
+                            "background result persist failed; new clients miss this completion (per-file companion rows already committed under source: background and are suppressed)"
                         );
                     }
                     persisted_meta.is_some()
@@ -4839,6 +4884,16 @@ async fn run_standalone_turn(
         // path used by the spawn_only sender. Drops out when the turn ends
         // (the `out_tx` half is dropped along with the registry / agent
         // when the turn-scoped state is freed).
+        //
+        // M10 Phase 5a coalesce: when the outbound carries
+        // `metadata.spawn_complete_companion = true`, persist the row with
+        // `MessagePersistedSource::Background` (via the
+        // `MESSAGE_PERSISTED_SOURCE_OVERRIDE` task-local). This marks each
+        // per-file row from a spawn_only completion as a duplicate of the
+        // forthcoming `turn/spawn_complete` envelope so dual-negotiated
+        // clients suppress it at `live_event_passes_capability_filter`.
+        // Without the capability the override has no wire-visible effect —
+        // the row still reaches old clients as `message/persisted`.
         let consumer_sessions = bg_sessions.clone();
         let consumer_data_dir = bg_data_dir.clone();
         let consumer_session_id = bg_session_id.clone();
@@ -4852,7 +4907,12 @@ async fn run_standalone_turn(
                     .filter(|s| !s.is_empty())
                     .map(str::to_string)
                     .unwrap_or_else(|| consumer_thread_id.clone());
-                let _ = persist_assistant_with_media(
+                let is_spawn_complete_companion = msg
+                    .metadata
+                    .get("spawn_complete_companion")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let persist = persist_assistant_with_media(
                     &consumer_sessions,
                     &consumer_data_dir,
                     &consumer_session_id,
@@ -4860,8 +4920,14 @@ async fn run_standalone_turn(
                     msg.media,
                     thread_id,
                     "send_file",
-                )
-                .await;
+                );
+                if is_spawn_complete_companion {
+                    let _ = MESSAGE_PERSISTED_SOURCE_OVERRIDE
+                        .scope(Some(MessagePersistedSource::Background), persist)
+                        .await;
+                } else {
+                    let _ = persist.await;
+                }
             }
         });
     }

--- a/typos.toml
+++ b/typos.toml
@@ -9,6 +9,11 @@ extend-ignore-identifiers-re = [
 AttributeIDSupressMenu = "AttributeIDSupressMenu"
 
 [default.extend-words]
+# Intentional typo fixture in mcp.rs / m8_integration_concurrency.rs:
+# both tests assert that the parser correctly REJECTS "exlusive" as
+# an invalid concurrency_class value. Allowlist the misspelling so
+# the typos lint doesn't flag the negative-test JSON literal.
+exlusive = "exlusive"
 # Don't correct the surname "Teh"
 teh = "teh"
 Hashi = "Hashi"


### PR DESCRIPTION
## Summary

For dual-negotiated clients (`event.spawn_complete.v1`), the `NotConfigured` `spawn_only` workspace-contract path used to emit N per-file `message/persisted` rows alongside the `turn/spawn_complete` envelope, producing 3+ assistant bubbles per completion. This PR coalesces the live wire shape to a single envelope:

- Per-file `send_file` rows for the `NotConfigured` branch persist with `MessagePersistedSource::Background` (via a `tokio::task_local!` scope entered only by `execution.rs`).
- The existing capability filter (`live_event_passes_capability_filter`) suppresses these rows for clients that negotiated `event.spawn_complete.v1`.
- `BackgroundResultPayload` gains `envelope_media: Vec<String>` so the `NotConfigured` branch can populate the envelope's `media` field without double-listing files on the persisted spawn-ack row (which would regress old clients).
- Old clients (no capability) continue to receive the per-file `message/persisted` rows unchanged.

## Defense-in-depth

- The companion marker is set via a `tokio::task_local!` scope (`SPAWN_COMPLETE_COMPANION_SCOPE`) entered only by `execution.rs`'s `NotConfigured` retry loop. The flag is NEVER read from JSON args, so an LLM cannot spoof the marker through generated `send_file` tool calls.
- `with_spawn_complete_companion_scope` is `pub(crate)`.

## Known limitations (deferred to Phase 6)

- **Hydrate not coalesced**: `session/hydrate` returns raw `Message` history; new clients on reload still see per-file rows + spawn-ack. `Message` lacks a `source` field today.
- **Persist failure ordering**: per-file companion rows commit before envelope persist. Documented at the warn site.

## Test plan

- [x] `cargo test -p octos-agent --lib spawn_complete_companion` — 3 new tests pass
- [x] `cargo test -p octos-cli --features "api,..." --lib api::ui_protocol` — 204/204 green
- [x] `cargo test -p octos-agent` — full suite green
- [x] `cargo fmt --all -- --check`
- [ ] Live probe at `tests/probe-m10-spawn-complete.spec.ts` — runs after Phase 5a + 5b deploy on mini1