### PR TITLE
test(e2e): teach isSpawnAckOnly to match M10-era spawn-ack chrome

### DIFF
--- a/e2e/tests/live-browser-helpers.ts
+++ b/e2e/tests/live-browser-helpers.ts
@@ -412,6 +412,14 @@ const SPAWN_ACK_PATTERNS: RegExp[] = [
   /^.{0,30}已在後台運行/,
   /^.{0,80}\b(?:has\s+)?started\s+in\s+(?:the\s+)?background\b/i,
   /^.{0,80}\b(?:is\s+now\s+)?running\s+in\s+(?:the\s+)?background\b/i,
+  // M10 spawn_only intercept (octos-cli/src/agent/loop_runner.rs):
+  // "Background work started for <tool>. The final result will be
+  // delivered automatically when it is ready." — phrase doesn't match
+  // the older "started in (the) background" anchor, so without this
+  // pattern bubbleHasRealContent false-positives on M10 spawn-ack
+  // chrome and assertPairing fails before the real envelope lands
+  // (two-fast-then-one-slow soak regression discovered 2026-05-07).
+  /^Background\s+work\s+started\s+for\b/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary

Fixes the only consistently-failing wave-6n soak scenario by recognizing the M10-era spawn-ack phrase.

The bare-substring \`Background work started for <tool>. The final result will be delivered automatically when it is ready.\` (emitted by the spawn_only intercept in \`crates/octos-agent/src/agent/loop_runner.rs\`) doesn't include the \"in (the) background\" phrase that the older \`SPAWN_ACK_PATTERNS\` regexes anchored on. Tests treated spawn-ack bubbles as real content, exited their content-wait loops the moment a spawn-ack landed, and then failed \`assertPairing\` on missing markers.

This surfaced as a phantom \"bug class #2\" (parallel/late spawn delivery) for weeks. **The bug never existed** — the deep_search delivery path always worked; the test-helper just couldn't tell ack from result.

## Verification

\`two-fast-then-one-slow\` (only failing wave-6n scenario at workers=1):

\`\`\`
0s: realContent=1/3 streaming=true        # date answered
6s: realContent=2/3 streaming=true        # weather answered
9s: realContent=2/3 streaming=false       # spawn-ack now correctly NOT counted
27s: realContent=3/3 streaming=false      # deep_search RESULT envelope arrived → bubble upgraded
1 passed (39.5s)
\`\`\`

Pre-fix the test exited at 9s with realContent=3/3 (counting the spawn-ack chrome) and false-failed at \`assertPairing\`.

## Test plan

- [x] Targeted re-run of \`live-overflow-stress.spec.ts -g two-fast-then-one-slow\` against mini1: PASS
- [ ] Full wave-6n soak (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)