### PR TITLE
test(e2e): swap networkidle for domcontentloaded in login helper

### DIFF
--- a/e2e/tests/live-browser-helpers.ts
+++ b/e2e/tests/live-browser-helpers.ts
@@ -232,7 +232,7 @@ export async function login(page: Page) {
     { token: effectiveToken, profile: PROFILE_ID },
   );
 
-  await page.goto('/chat', { waitUntil: 'networkidle' });
+  await page.goto('/chat', { waitUntil: 'domcontentloaded' });
 
   const onChat = await page
     .locator(SEL.chatInput)
@@ -240,7 +240,7 @@ export async function login(page: Page) {
     .catch(() => false);
   if (onChat) return;
 
-  await page.goto('/chat', { waitUntil: 'networkidle' });
+  await page.goto('/chat', { waitUntil: 'domcontentloaded' });
   const chatVisible = await page
     .locator(SEL.chatInput)
     .isVisible({ timeout: 5_000 })
@@ -284,14 +284,14 @@ export async function login(page: Page) {
     );
 
     if (apiLoginResult) {
-      await page.reload({ waitUntil: 'networkidle' });
+      await page.reload({ waitUntil: 'domcontentloaded' });
       const apiLoginVisible = await page
         .locator(SEL.chatInput)
         .isVisible({ timeout: 10_000 })
         .catch(() => false);
       if (apiLoginVisible) return;
 
-      await page.goto('/chat', { waitUntil: 'networkidle' });
+      await page.goto('/chat', { waitUntil: 'domcontentloaded' });
       const chatAfterLogin = await page
         .locator(SEL.chatInput)
         .isVisible({ timeout: 10_000 })


### PR DESCRIPTION
## Summary

The M10 WS bridge reconnects continuously on every host other than mini1, which prevents the network from ever going idle. The four `waitUntil: 'networkidle'` calls in `e2e/tests/live-browser-helpers.ts` therefore block `page.goto`/`page.reload` until the per-test 60s timeout, and the `waitForSelector` 15s that follows fails before the SPA actually finishes hydrating.

`domcontentloaded` is the right primitive: the `chat-input` selector wait that the helper already issues immediately afterwards is the real readiness gate. Cuts no functionality, removes the WS-reconnect interaction.

## Verification

On .249 with the bundled chat SPA (octos-web `Dz5cASfH`) served via Caddy in front of the daemon at 50080, `tests/live-thread-interleave.spec.ts` gets past the login layer and runs the full 6-minute deep-research scenario where it previously failed at the 15s `chat-input` wait. Harness-only — no production code touched.

## Test plan

- [x] `npx playwright test tests/live-thread-interleave.spec.ts` reaches the assistant-bubble assertions instead of dying at chat-input wait
- [ ] full `live-overflow-stress.spec.ts` 7-scenario run (deferred; the harness change only affects the login helper, all other waits remain unchanged)