### PR TITLE
feat(dora-mcp): add octos-dora-mcp crate + dora-bridge-config walkthrough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,6 +3736,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "octos-dora-mcp"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "eyre",
+ "octos-agent",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "octos-llm"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/app-skills/harness-starter-audio",
     "crates/app-skills/harness-starter-coding",
     "crates/platform-skills/voice",
+    "crates/octos-dora-mcp",
     "crates/octos-pipeline",
     "crates/octos-plugin",
     "crates/octos-sandbox",

--- a/crates/octos-dora-mcp/Cargo.toml
+++ b/crates/octos-dora-mcp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "octos-dora-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Dora-RS to MCP tool bridge for octos"
+
+[dependencies]
+octos-agent = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+eyre = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/octos-dora-mcp/src/config.rs
+++ b/crates/octos-dora-mcp/src/config.rs
@@ -1,0 +1,76 @@
+//! Configuration loader for dora tool mappings.
+
+use crate::DoraToolMapping;
+use serde::{Deserialize, Serialize};
+
+/// Top-level bridge configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeConfig {
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Tool mappings.
+    pub mappings: Vec<DoraToolMapping>,
+}
+
+impl BridgeConfig {
+    /// Load from a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the JSON is malformed or missing required fields.
+    pub fn from_json(json: &str) -> eyre::Result<Self> {
+        let config: Self = serde_json::from_str(json)?;
+        Ok(config)
+    }
+
+    /// Load from a JSON file path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or the JSON is invalid.
+    pub fn from_file(path: &str) -> eyre::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Self::from_json(&content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_config_from_json() {
+        let json = r#"{
+            "description": "UR5e inspection tools",
+            "mappings": [
+                {
+                    "tool_name": "scan_station",
+                    "description": "Scan station for objects",
+                    "dora_node_id": "moveit-skills",
+                    "dora_output_id": "skill_request",
+                    "parameters": {"station": "Station ID to scan"},
+                    "safety_tier": "full_actuation",
+                    "timeout_secs": 120
+                }
+            ]
+        }"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        assert_eq!(config.mappings.len(), 1);
+        assert_eq!(config.mappings[0].tool_name, "scan_station");
+        assert_eq!(config.mappings[0].safety_tier, "full_actuation");
+    }
+
+    #[test]
+    fn should_default_description_to_empty_string() {
+        let json = r#"{"mappings": []}"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        assert_eq!(config.description, "");
+    }
+
+    #[test]
+    fn should_fail_on_invalid_json() {
+        let result = BridgeConfig::from_json("{not valid json}");
+        assert!(result.is_err());
+    }
+}

--- a/crates/octos-dora-mcp/src/lib.rs
+++ b/crates/octos-dora-mcp/src/lib.rs
@@ -1,0 +1,381 @@
+//! Dora-RS to MCP tool bridge.
+//!
+//! Maps dora-rs dataflow nodes to MCP-compatible tools that can be
+//! registered in the octos agent's [`ToolRegistry`].
+//!
+//! # Overview
+//!
+//! Each [`DoraToolMapping`] declares a tool name, description, the dora node
+//! and output IDs that handle requests, and an optional safety tier string.
+//! [`DoraToolBridge`] wraps a mapping and implements the [`Tool`] trait so it
+//! can be registered directly in the agent.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use octos_dora_mcp::{BridgeConfig, load_bridges};
+//!
+//! let config = BridgeConfig::from_file("config/dora_tool_map.json").unwrap();
+//! let bridges = load_bridges(&config);
+//! // bridges can be registered in a ToolRegistry:
+//! // for bridge in bridges { registry.register(bridge); }
+//! ```
+
+mod config;
+
+use async_trait::async_trait;
+use octos_agent::tools::{Tool, ToolResult};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub use config::BridgeConfig;
+
+/// Safety tiers for dora tool operations.
+///
+/// Stored as plain strings in config for forward compatibility.
+/// Use [`SafetyTier`] variants for structured comparisons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SafetyTier {
+    /// Read-only observation, no physical effect.
+    Observe,
+    /// Controlled motion within pre-validated bounds.
+    SafeMotion,
+    /// Unrestricted actuation of joints and end-effectors.
+    FullActuation,
+    /// Emergency stop and override commands.
+    EmergencyOverride,
+}
+
+impl SafetyTier {
+    /// Parse from the string representation used in config files.
+    pub fn from_config_str(s: &str) -> Self {
+        match s {
+            "observe" => SafetyTier::Observe,
+            "safe_motion" => SafetyTier::SafeMotion,
+            "full_actuation" => SafetyTier::FullActuation,
+            "emergency_override" => SafetyTier::EmergencyOverride,
+            _ => SafetyTier::Observe,
+        }
+    }
+
+    /// Return the canonical string form.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SafetyTier::Observe => "observe",
+            SafetyTier::SafeMotion => "safe_motion",
+            SafetyTier::FullActuation => "full_actuation",
+            SafetyTier::EmergencyOverride => "emergency_override",
+        }
+    }
+}
+
+/// Mapping from a dora-rs node output to an MCP tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DoraToolMapping {
+    /// MCP tool name exposed to the agent.
+    pub tool_name: String,
+    /// Description for the LLM.
+    pub description: String,
+    /// Dora node ID that handles this tool.
+    pub dora_node_id: String,
+    /// Dora output ID to send the request to.
+    pub dora_output_id: String,
+    /// Expected input parameters (name -> description).
+    pub parameters: HashMap<String, String>,
+    /// Required safety tier for this tool.
+    #[serde(default = "default_tier")]
+    pub safety_tier: String,
+    /// Timeout in seconds for the tool call.
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_tier() -> String {
+    "observe".to_string()
+}
+
+fn default_timeout() -> u64 {
+    30
+}
+
+/// A bridge that wraps a [`DoraToolMapping`] as an MCP-compatible [`Tool`].
+///
+/// In production the `execute` method would forward the request to the dora
+/// dataflow via an IPC channel and await the response.  The current
+/// implementation returns a placeholder describing the would-be forwarded
+/// payload so the bridge can be tested without a running dora runtime.
+pub struct DoraToolBridge {
+    mapping: DoraToolMapping,
+}
+
+impl DoraToolBridge {
+    /// Create a new bridge from the given mapping.
+    pub fn new(mapping: DoraToolMapping) -> Self {
+        Self { mapping }
+    }
+
+    /// Return a reference to the underlying mapping.
+    pub fn mapping(&self) -> &DoraToolMapping {
+        &self.mapping
+    }
+
+    /// Parse the safety tier string into the typed enum.
+    pub fn required_safety_tier(&self) -> SafetyTier {
+        SafetyTier::from_config_str(&self.mapping.safety_tier)
+    }
+
+    /// Build the JSON Schema object describing the tool's input parameters.
+    fn build_input_schema(&self) -> serde_json::Value {
+        let properties: serde_json::Map<String, serde_json::Value> = self
+            .mapping
+            .parameters
+            .iter()
+            .map(|(name, desc)| {
+                (
+                    name.clone(),
+                    serde_json::json!({
+                        "type": "string",
+                        "description": desc
+                    }),
+                )
+            })
+            .collect();
+
+        let required: Vec<serde_json::Value> = self
+            .mapping
+            .parameters
+            .keys()
+            .map(|k| serde_json::Value::String(k.clone()))
+            .collect();
+
+        serde_json::json!({
+            "type": "object",
+            "properties": properties,
+            "required": required
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for DoraToolBridge {
+    fn name(&self) -> &str {
+        &self.mapping.tool_name
+    }
+
+    fn description(&self) -> &str {
+        &self.mapping.description
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        self.build_input_schema()
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["dora", "mcp-bridge"]
+    }
+
+    async fn execute(&self, args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        // In a real implementation this would send args to the dora node
+        // via the dora dataflow and await the response.  We return a
+        // placeholder indicating the bridge would forward to dora.
+        let request = serde_json::json!({
+            "tool": self.mapping.tool_name,
+            "node_id": self.mapping.dora_node_id,
+            "output_id": self.mapping.dora_output_id,
+            "args": args,
+            "timeout_secs": self.mapping.timeout_secs,
+        });
+
+        Ok(ToolResult {
+            success: true,
+            output: format!(
+                "DoraToolBridge: would forward to node '{}' output '{}': {}",
+                self.mapping.dora_node_id,
+                self.mapping.dora_output_id,
+                serde_json::to_string_pretty(&request).unwrap_or_default()
+            ),
+            ..Default::default()
+        })
+    }
+}
+
+/// Load tool mappings from a [`BridgeConfig`] and create bridge tools.
+pub fn load_bridges(config: &BridgeConfig) -> Vec<DoraToolBridge> {
+    config
+        .mappings
+        .iter()
+        .map(|m| DoraToolBridge::new(m.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_mapping() -> DoraToolMapping {
+        let mut params = HashMap::new();
+        params.insert("waypoint".to_string(), "Target waypoint ID".to_string());
+
+        DoraToolMapping {
+            tool_name: "navigate_to".to_string(),
+            description: "Navigate robot to a waypoint".to_string(),
+            dora_node_id: "moveit-skills".to_string(),
+            dora_output_id: "skill_request".to_string(),
+            parameters: params,
+            safety_tier: "safe_motion".to_string(),
+            timeout_secs: 60,
+        }
+    }
+
+    #[test]
+    fn should_expose_correct_tool_name() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        assert_eq!(bridge.name(), "navigate_to");
+    }
+
+    #[test]
+    fn should_expose_correct_description() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        assert_eq!(bridge.description(), "Navigate robot to a waypoint");
+    }
+
+    #[test]
+    fn should_build_input_schema_with_parameters() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let schema = bridge.input_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["waypoint"].is_object());
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "waypoint"));
+    }
+
+    #[test]
+    fn should_build_empty_schema_when_no_parameters() {
+        let mut mapping = sample_mapping();
+        mapping.parameters.clear();
+        let bridge = DoraToolBridge::new(mapping);
+        let schema = bridge.input_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn should_include_dora_tags() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let tags = bridge.tags();
+        assert!(tags.contains(&"dora"));
+        assert!(tags.contains(&"mcp-bridge"));
+    }
+
+    #[test]
+    fn should_parse_safety_tier_safe_motion() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        assert_eq!(bridge.required_safety_tier(), SafetyTier::SafeMotion);
+    }
+
+    #[test]
+    fn should_default_to_observe_tier_for_unknown_string() {
+        let mut mapping = sample_mapping();
+        mapping.safety_tier = "unknown_tier".to_string();
+        let bridge = DoraToolBridge::new(mapping);
+        assert_eq!(bridge.required_safety_tier(), SafetyTier::Observe);
+    }
+
+    #[test]
+    fn should_parse_all_safety_tier_variants() {
+        for (s, expected) in [
+            ("observe", SafetyTier::Observe),
+            ("safe_motion", SafetyTier::SafeMotion),
+            ("full_actuation", SafetyTier::FullActuation),
+            ("emergency_override", SafetyTier::EmergencyOverride),
+        ] {
+            assert_eq!(SafetyTier::from_config_str(s), expected, "failed for '{s}'");
+        }
+    }
+
+    #[test]
+    fn should_round_trip_safety_tier_as_str() {
+        for tier in [
+            SafetyTier::Observe,
+            SafetyTier::SafeMotion,
+            SafetyTier::FullActuation,
+            SafetyTier::EmergencyOverride,
+        ] {
+            assert_eq!(SafetyTier::from_config_str(tier.as_str()), tier);
+        }
+    }
+
+    #[tokio::test]
+    async fn should_execute_bridge_tool_with_args() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let result = bridge
+            .execute(&serde_json::json!({"waypoint": "A"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("moveit-skills"));
+        assert!(result.output.contains("skill_request"));
+        assert!(result.output.contains("navigate_to"));
+    }
+
+    #[tokio::test]
+    async fn should_execute_bridge_tool_with_empty_args() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let result = bridge.execute(&serde_json::json!({})).await.unwrap();
+        assert!(result.success);
+        assert!(result.file_modified.is_none());
+        assert!(result.files_to_send.is_empty());
+    }
+
+    #[test]
+    fn should_load_bridges_from_config() {
+        let json = r#"{
+            "description": "Test config",
+            "mappings": [
+                {
+                    "tool_name": "tool_a",
+                    "description": "First tool",
+                    "dora_node_id": "node-1",
+                    "dora_output_id": "out-1",
+                    "parameters": {},
+                    "safety_tier": "observe",
+                    "timeout_secs": 10
+                },
+                {
+                    "tool_name": "tool_b",
+                    "description": "Second tool",
+                    "dora_node_id": "node-2",
+                    "dora_output_id": "out-2",
+                    "parameters": {"param": "A parameter"},
+                    "safety_tier": "full_actuation",
+                    "timeout_secs": 30
+                }
+            ]
+        }"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        let bridges = load_bridges(&config);
+        assert_eq!(bridges.len(), 2);
+        assert_eq!(bridges[0].name(), "tool_a");
+        assert_eq!(bridges[1].name(), "tool_b");
+        assert_eq!(bridges[1].required_safety_tier(), SafetyTier::FullActuation);
+    }
+
+    #[test]
+    fn should_apply_default_safety_tier_when_omitted() {
+        let json = r#"{
+            "mappings": [
+                {
+                    "tool_name": "minimal_tool",
+                    "description": "A minimal tool",
+                    "dora_node_id": "node-x",
+                    "dora_output_id": "out-x",
+                    "parameters": {}
+                }
+            ]
+        }"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        let bridges = load_bridges(&config);
+        assert_eq!(bridges[0].required_safety_tier(), SafetyTier::Observe);
+        assert_eq!(bridges[0].mapping().timeout_secs, 30);
+    }
+}

--- a/examples/dora-bridge-config/README.md
+++ b/examples/dora-bridge-config/README.md
@@ -1,0 +1,147 @@
+# Dora MCP Bridge + Mission Pipeline — Config Example
+
+**Covers:** Dora MCP Bridge (Area 2) + Mission Pipeline (Area 5)
+
+## The Problem
+
+Robot hardware runs on Dora-RS dataflow graphs — camera nodes, motion planners,
+gripper controllers. The LLM agent runs on octos with MCP tools. These are two
+separate worlds with no connection. Without a bridge:
+
+- **Developers write glue code for every robot tool.** Each Dora node needs a
+  custom MCP adapter — parsing JSON, handling timeouts, mapping safety tiers.
+  For 10 nodes, that's 10 adapters with 10 sets of bugs.
+- **Multi-step missions are ad-hoc prompts.** "Go to valve V-101, inspect it,
+  fix if needed, come back" is a single LLM prompt. If it fails at step 3, you
+  start over. No checkpoints, no deadlines, no safety gates between steps.
+- **No safety tier enforcement across the bridge.** The LLM can call any Dora
+  node at any time — including full-speed actuation nodes during an observe-only
+  session.
+
+## The Solution
+
+### Dora MCP Bridge (`dora_tool_map.json`)
+
+A JSON config file that maps Dora-RS nodes to MCP tools **without writing code**.
+Each mapping declares:
+- Which Dora node/output handles the tool
+- What parameters the LLM should provide
+- What `safety_tier` is required (enforced by `RobotPermissionPolicy`)
+- Timeout for the tool call
+
+**Before:** Write a custom Rust adapter for each Dora node.
+**After:** Add 10 lines of JSON per tool. `BridgeConfig::from_file()` loads them all.
+
+### Mission Pipeline (`inspection_mission.dot`)
+
+A DOT graph that defines multi-step robot missions as a DAG with safety
+guarantees at each step. Each node has a `HandlerKind` that determines behavior:
+
+| Handler | Purpose | Example |
+|---------|---------|---------|
+| `SensorCheck` | Read sensor, evaluate condition | "Is battery > 20%?" |
+| `Motion` | Execute robot motion | "Navigate to valve P1" |
+| `SafetyGate` | Require safety condition | "Force < 50N before manipulation" |
+| `Codergen` | LLM-driven reasoning | "Inspect valve, decide action" |
+| `Gate` | Conditional branch | "Was anomaly detected?" |
+
+**Before:** One big LLM prompt. No checkpoints, no deadlines, no safety gates.
+**After:** Each step has deadlines, invariants, and checkpoints. If the LLM
+hangs on step 3, the deadline fires after 60s and skips to the next step. If
+force exceeds 50N at the safety gate, the mission triggers emergency stop.
+
+## Files
+
+| File | What It Shows |
+|------|---------------|
+| `dora_tool_map.json` | 4 tool mappings with safety tiers and timeouts |
+| `inspection_mission.dot` | 8-node pipeline DAG with all handler types |
+
+## dora_tool_map.json — Tool Mappings
+
+```
+capture_valve_image  ->  camera_node:capture_request     [observe]
+move_to_valve        ->  motion_planner:move_command      [safe_motion]
+turn_valve           ->  gripper_node:rotate_command      [full_actuation]
+read_pressure_gauge  ->  vision_node:gauge_read_request   [observe]
+```
+
+Each tool has a `safety_tier` field. When the agent is running in a `SafeMotion`
+session, it can use `capture_valve_image` and `move_to_valve`, but `turn_valve`
+(which requires `full_actuation`) is blocked — even though the LLM can see it
+in the tool list.
+
+### Loading the config
+
+```rust
+use octos_dora_mcp::{BridgeConfig, DoraToolBridge};
+
+// Load all tool mappings from the JSON config
+let config = BridgeConfig::from_file("examples/dora-bridge-config/dora_tool_map.json")?;
+
+// Each mapping becomes an MCP-compatible tool
+let tools: Vec<DoraToolBridge> = config
+    .mappings
+    .into_iter()
+    .map(DoraToolBridge::new)
+    .collect();
+
+// Register with the agent — safety tier is enforced automatically
+for tool in &tools {
+    let mapping = tool.mapping();
+    println!(
+        "{} -> {}:{} (tier: {:?})",
+        mapping.tool_name,
+        mapping.dora_node_id,
+        mapping.dora_output_id,
+        tool.required_safety_tier(),
+    );
+}
+```
+
+## inspection_mission.dot — Pipeline DAG
+
+```
+preflight --> navigate --> arrival_check --> safety_gate --> inspect --> result_gate
+                                                                           |
+                                                                      yes / \ no
+                                                                         /   \
+                                                                 corrective  return_home
+                                                                         \   /
+                                                                      return_home
+```
+
+### Key attributes demonstrated
+
+**Deadlines** — prevent the mission from hanging forever:
+```dot
+navigate [handler="Motion", deadline_secs="120", deadline_action="Abort"];
+// If navigation takes > 120s, abort the mission (robot might be stuck)
+
+inspect [handler="Codergen", deadline_secs="60", deadline_action="Skip"];
+// If LLM inspection takes > 60s, skip to the next step (non-critical)
+```
+
+**Invariants** — safety conditions checked before proceeding:
+```dot
+preflight [handler="SensorCheck", invariant="battery_soc > 20", on_violation="Abort"];
+// Don't start the mission if battery is too low to complete it
+
+safety_gate [handler="SafetyGate", invariant="max_force_n < 50.0", on_violation="EmergencyStop"];
+// If force exceeds 50N, something is wrong — trigger e-stop immediately
+```
+
+**Checkpoints** — resume a failed mission from where it left off:
+```dot
+navigate [checkpoint="true"];
+// After arriving at the valve, save state. If the mission fails later,
+// restart from here instead of navigating again.
+```
+
+### DeadlineAction options
+
+| Action | When to use |
+|--------|-------------|
+| `Abort` | Critical step — mission cannot continue without it |
+| `Skip` | Non-critical step — log the timeout and move to next node |
+| `EmergencyStop` | Safety violation — halt all motion immediately |

--- a/examples/dora-bridge-config/dora_tool_map.json
+++ b/examples/dora-bridge-config/dora_tool_map.json
@@ -1,0 +1,53 @@
+{
+  "description": "Dora-RS to MCP tool bridge for a valve inspection pipeline",
+  "mappings": [
+    {
+      "tool_name": "capture_valve_image",
+      "description": "Capture a high-resolution image of the target valve using the inspection camera",
+      "dora_node_id": "camera_node",
+      "dora_output_id": "capture_request",
+      "parameters": {
+        "valve_id": "Identifier of the valve to photograph",
+        "resolution": "Image resolution (e.g., '1920x1080')"
+      },
+      "safety_tier": "observe",
+      "timeout_secs": 10
+    },
+    {
+      "tool_name": "move_to_valve",
+      "description": "Move the robot arm to a pre-taught valve inspection pose",
+      "dora_node_id": "motion_planner",
+      "dora_output_id": "move_command",
+      "parameters": {
+        "valve_id": "Target valve identifier",
+        "approach": "Approach strategy: 'direct' or 'via_home'"
+      },
+      "safety_tier": "safe_motion",
+      "timeout_secs": 30
+    },
+    {
+      "tool_name": "turn_valve",
+      "description": "Actuate a valve by rotating the gripper to the target angle",
+      "dora_node_id": "gripper_node",
+      "dora_output_id": "rotate_command",
+      "parameters": {
+        "valve_id": "Target valve identifier",
+        "angle_deg": "Target rotation angle in degrees",
+        "torque_limit_nm": "Maximum torque limit in Newton-meters"
+      },
+      "safety_tier": "full_actuation",
+      "timeout_secs": 45
+    },
+    {
+      "tool_name": "read_pressure_gauge",
+      "description": "Read the current pressure gauge value via computer vision",
+      "dora_node_id": "vision_node",
+      "dora_output_id": "gauge_read_request",
+      "parameters": {
+        "gauge_id": "Identifier of the pressure gauge"
+      },
+      "safety_tier": "observe",
+      "timeout_secs": 15
+    }
+  ]
+}

--- a/examples/dora-bridge-config/inspection_mission.dot
+++ b/examples/dora-bridge-config/inspection_mission.dot
@@ -1,0 +1,48 @@
+// Valve inspection mission pipeline
+// Demonstrates HandlerKind variants, DeadlineAction, Invariant, and MissionCheckpoint
+digraph inspection_mission {
+    rankdir=LR;
+
+    // SensorCheck: verify robot is operational before starting
+    preflight [shape=octagon, label="Preflight\nSensorCheck", handler="SensorCheck",
+               invariant="battery_soc > 20", on_violation="Abort"];
+
+    // Motion: navigate to the valve location
+    navigate [shape=pentagon, label="Navigate\nto Valve P1", handler="Motion",
+              deadline_secs="120", deadline_action="Abort",
+              checkpoint="true"];
+
+    // SensorCheck: confirm arrival at target position
+    arrival_check [shape=octagon, label="Arrival\nSensorCheck", handler="SensorCheck",
+                   invariant="position_error_m < 0.01", on_violation="Abort"];
+
+    // SafetyGate: require force/torque within limits before manipulation
+    safety_gate [shape=doubleoctagon, label="Force/Torque\nSafetyGate", handler="SafetyGate",
+                 invariant="max_force_n < 50.0", on_violation="EmergencyStop"];
+
+    // Codergen: LLM-driven valve inspection with camera tool
+    inspect [shape=box, label="Inspect Valve\nCodergen", handler="Codergen",
+             deadline_secs="60", deadline_action="Skip",
+             checkpoint="true"];
+
+    // Gate: evaluate inspection result
+    result_gate [shape=diamond, label="Anomaly\nDetected?", handler="Gate"];
+
+    // Codergen: LLM plans corrective action if anomaly found
+    corrective [shape=box, label="Corrective\nAction", handler="Codergen",
+                deadline_secs="90", deadline_action="Abort"];
+
+    // Motion: return to home position
+    return_home [shape=pentagon, label="Return\nHome", handler="Motion",
+                 deadline_secs="120", deadline_action="Skip"];
+
+    // Edges
+    preflight -> navigate;
+    navigate -> arrival_check;
+    arrival_check -> safety_gate;
+    safety_gate -> inspect;
+    inspect -> result_gate;
+    result_gate -> corrective [label="yes"];
+    result_gate -> return_home [label="no"];
+    corrective -> return_home;
+}


### PR DESCRIPTION
## Summary

Re-introduces the `octos-dora-mcp` crate and `examples/dora-bridge-config/` walkthrough that were part of closed PR #270 ("feat: add developer examples for 7 robot safety features"). The yellow-tree migration that landed the other 3 example files (`inspection_safety.rs`, `realtime_heartbeat.rs`, `pick_and_place_lifecycle.rs`) did not include this crate, leaving the walkthrough orphaned without an implementation to back it.

This PR is intentionally minimal and scoped — the crate is 3 files, no extra binaries or runtime dependencies beyond what `octos-agent` already pulls in.

## What's added

**Crate** (`crates/octos-dora-mcp/`):
- `Cargo.toml` — workspace member, all deps inherited from workspace
- `src/lib.rs` — `DoraToolMapping`, `DoraToolBridge` (`impl Tool`), `SafetyTier` enum, `load_bridges()` helper
- `src/config.rs` — `BridgeConfig` JSON loader

**Workspace `Cargo.toml`** — adds `crates/octos-dora-mcp` to `members`.

**Example walkthrough** (`examples/dora-bridge-config/`):
- `README.md` — problem/solution explainer with before/after
- `dora_tool_map.json` — 4 sample tool mappings with safety tiers
- `inspection_mission.dot` — 8-node mission DAG demonstrating deadlines, invariants, checkpoints

## Verification

Built and tested against current \`upstream/main\` (\`95cac6fe\`):

- [x] \`cargo build  -p octos-dora-mcp\` — clean
- [x] \`cargo test   -p octos-dora-mcp\` — 16 unit tests + 1 doctest pass
- [x] \`cargo clippy -p octos-dora-mcp -- -D warnings\` — clean
- [x] \`cargo fmt    -p octos-dora-mcp -- --check\` — clean

## Background

- PR #270 was closed as superseded on 2026-04-26 — most files had landed via the yellow-tree migration, but this crate had not.
- PR #269 was closed earlier as the head ref was the fork's \`main\` and the base was stale.
- This PR is cut fresh from current \`upstream/main\`, scoped to only the missing piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)