### PR TITLE
test(appui): add ui protocol golden frame fixtures

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10606,8 +10606,9 @@ mod tests {
         ApprovalDecision, ApprovalId, ApprovalRespondParams, ApprovalRespondStatus, DiffPreview,
         DiffPreviewFile, DiffPreviewFileStatus, DiffPreviewGetParams, DiffPreviewGetStatus,
         DiffPreviewHunk, DiffPreviewLine, DiffPreviewLineKind, DiffPreviewSource, PreviewId,
-        approval_scopes, methods, rpc_error_codes,
+        TaskOutputReadParams, approval_scopes, methods, rpc_error_codes,
     };
+    use uuid::Uuid;
 
     fn local_profile_state(dir: &Path) -> AppState {
         AppState {
@@ -12085,6 +12086,636 @@ mod tests {
         match rx.recv().await.expect("rpc frame") {
             WsMessage::Text(text) => serde_json::from_str(text.as_str()).expect("json frame"),
             other => panic!("expected text frame, got {other:?}"),
+        }
+    }
+
+    async fn collect_ws_json_frames(
+        rx: &mut mpsc::Receiver<WsMessage>,
+        expected: usize,
+    ) -> Vec<Value> {
+        let mut frames = Vec::with_capacity(expected);
+        for _ in 0..expected {
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), recv_rpc_json(rx))
+                .await
+                .expect("timed out waiting for golden frame");
+            frames.push(frame);
+        }
+        let extra = tokio::time::timeout(std::time::Duration::from_millis(25), rx.recv()).await;
+        assert!(
+            !matches!(extra, Ok(Some(_))),
+            "golden scenario emitted more than {expected} frames"
+        );
+        frames
+    }
+
+    fn fixed_turn_id(seed: u128) -> TurnId {
+        TurnId(Uuid::from_u128(seed))
+    }
+
+    fn fixed_approval_id(seed: u128) -> ApprovalId {
+        ApprovalId(Uuid::from_u128(seed))
+    }
+
+    fn fixed_preview_id(seed: u128) -> PreviewId {
+        PreviewId(Uuid::from_u128(seed))
+    }
+
+    fn fixed_timestamp(offset_seconds: i64) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-05-09T00:00:00Z")
+            .expect("fixed timestamp")
+            .with_timezone(&Utc)
+            + chrono::Duration::seconds(offset_seconds)
+    }
+
+    fn normalize_ws_frames(frames: Vec<Value>) -> Value {
+        let mut uuid_placeholders: HashMap<String, String> = HashMap::new();
+        let mut next_uuid = 1usize;
+        Value::Array(
+            frames
+                .into_iter()
+                .map(|frame| normalize_json_value(frame, &mut uuid_placeholders, &mut next_uuid))
+                .collect(),
+        )
+    }
+
+    fn normalize_json_value(
+        value: Value,
+        uuid_placeholders: &mut HashMap<String, String>,
+        next_uuid: &mut usize,
+    ) -> Value {
+        match value {
+            Value::Array(values) => Value::Array(
+                values
+                    .into_iter()
+                    .map(|value| normalize_json_value(value, uuid_placeholders, next_uuid))
+                    .collect(),
+            ),
+            Value::Object(map) => Value::Object(
+                map.into_iter()
+                    .map(|(key, value)| {
+                        (
+                            key,
+                            normalize_json_value(value, uuid_placeholders, next_uuid),
+                        )
+                    })
+                    .collect(),
+            ),
+            Value::String(value) => {
+                Value::String(normalize_string_value(value, uuid_placeholders, next_uuid))
+            }
+            other => other,
+        }
+    }
+
+    fn normalize_string_value(
+        value: String,
+        uuid_placeholders: &mut HashMap<String, String>,
+        next_uuid: &mut usize,
+    ) -> String {
+        if Uuid::parse_str(&value).is_ok() {
+            return uuid_placeholder(value, uuid_placeholders, next_uuid);
+        }
+        if DateTime::parse_from_rfc3339(&value).is_ok() {
+            return "<timestamp>".to_owned();
+        }
+        normalize_embedded_uuids(value, uuid_placeholders, next_uuid)
+    }
+
+    fn uuid_placeholder(
+        uuid: String,
+        uuid_placeholders: &mut HashMap<String, String>,
+        next_uuid: &mut usize,
+    ) -> String {
+        uuid_placeholders
+            .entry(uuid)
+            .or_insert_with(|| {
+                let placeholder = format!("<uuid-{next_uuid}>");
+                *next_uuid += 1;
+                placeholder
+            })
+            .clone()
+    }
+
+    fn normalize_embedded_uuids(
+        value: String,
+        uuid_placeholders: &mut HashMap<String, String>,
+        next_uuid: &mut usize,
+    ) -> String {
+        const UUID_LEN: usize = 36;
+        if value.len() < UUID_LEN {
+            return value;
+        }
+        let mut output = String::with_capacity(value.len());
+        let mut index = 0;
+        let mut changed = false;
+        while index < value.len() {
+            if index + UUID_LEN <= value.len() {
+                if let Some(candidate) = value.get(index..index + UUID_LEN) {
+                    if Uuid::parse_str(candidate).is_ok() {
+                        output.push_str(&uuid_placeholder(
+                            candidate.to_owned(),
+                            uuid_placeholders,
+                            next_uuid,
+                        ));
+                        index += UUID_LEN;
+                        changed = true;
+                        continue;
+                    }
+                }
+            }
+            let ch = value[index..]
+                .chars()
+                .next()
+                .expect("index is within string");
+            output.push(ch);
+            index += ch.len_utf8();
+        }
+        if changed { output } else { value }
+    }
+
+    fn assert_ui_protocol_golden(name: &str, frames: Vec<Value>) {
+        let normalized = normalize_ws_frames(frames);
+        let actual = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&normalized).expect("serialize golden frames")
+        );
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("ui_protocol_golden")
+            .join(format!("{name}.json"));
+        if std::env::var("OCTOS_BLESS_UI_PROTOCOL_GOLDEN").as_deref() == Ok("1") {
+            std::fs::create_dir_all(path.parent().expect("fixture parent"))
+                .expect("create golden fixture directory");
+            std::fs::write(&path, actual).expect("write golden fixture");
+            return;
+        }
+        let expected = std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        assert_eq!(
+            actual,
+            expected,
+            "golden fixture drifted: {}",
+            path.display()
+        );
+    }
+
+    fn golden_diff_preview(session_id: &SessionKey, preview_id: PreviewId) -> DiffPreview {
+        DiffPreview {
+            session_id: session_id.clone(),
+            preview_id,
+            title: Some("Golden fixture diff".into()),
+            files: vec![DiffPreviewFile {
+                path: "src/lib.rs".into(),
+                old_path: None,
+                status: DiffPreviewFileStatus::Modified,
+                hunks: vec![DiffPreviewHunk {
+                    header: "@@ -1,2 +1,2 @@".into(),
+                    lines: vec![
+                        DiffPreviewLine {
+                            kind: DiffPreviewLineKind::Context,
+                            content: " pub fn run() {".into(),
+                            old_line: Some(1),
+                            new_line: Some(1),
+                        },
+                        DiffPreviewLine {
+                            kind: DiffPreviewLineKind::Removed,
+                            content: "-    old();".into(),
+                            old_line: Some(2),
+                            new_line: None,
+                        },
+                        DiffPreviewLine {
+                            kind: DiffPreviewLineKind::Added,
+                            content: "+    new();".into(),
+                            old_line: None,
+                            new_line: Some(2),
+                        },
+                    ],
+                }],
+            }],
+        }
+    }
+
+    async fn seed_hydrate_messages(state: &Arc<AppState>, session_id: &SessionKey) {
+        let sessions = state.sessions.as_ref().expect("sessions state");
+        let mut sessions = sessions.lock().await;
+        let session = sessions.get_or_create(session_id).await;
+        session.messages.push(Message {
+            role: MessageRole::User,
+            content: "golden hydrate prompt".into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: Some("client-message-1".into()),
+            thread_id: Some("client-message-1".into()),
+            timestamp: fixed_timestamp(0),
+        });
+        session.messages.push(Message {
+            role: MessageRole::Assistant,
+            content: "golden hydrate answer".into(),
+            media: vec!["artifacts/answer.md".into()],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("client-message-1".into()),
+            timestamp: fixed_timestamp(1),
+        });
+    }
+
+    async fn golden_session_open_success() -> Vec<Value> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let approvals = PendingApprovalStore::default();
+        let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        handle_session_open(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &forwarders,
+            None,
+            ConnectionUiFeatures::default(),
+            "session-open-1".into(),
+            SessionOpenParams {
+                session_id: SessionKey("local:golden-session-open".into()),
+                profile_id: Some("coding".into()),
+                cwd: None,
+                after: None,
+            },
+        )
+        .await;
+
+        let frames = collect_ws_json_frames(&mut rx, 2).await;
+        abort_live_forwarders(&forwarders).await;
+        frames
+    }
+
+    async fn golden_session_open_profile_mismatch() -> Vec<Value> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let state = state_with_sessions(temp.path());
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let approvals = PendingApprovalStore::default();
+        let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let (ws, mut rx) = ws_connection_for_test(4);
+
+        handle_session_open(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &forwarders,
+            Some("profile-a"),
+            ConnectionUiFeatures::default(),
+            "session-open-auth-fail".into(),
+            SessionOpenParams {
+                session_id: SessionKey::with_profile("profile-b", "web", "chat-1"),
+                profile_id: None,
+                cwd: None,
+                after: None,
+            },
+        )
+        .await;
+
+        collect_ws_json_frames(&mut rx, 1).await
+    }
+
+    async fn golden_turn_start_fast() -> Vec<Value> {
+        let session_id = SessionKey("local:golden-turn-start".into());
+        let turn_id = fixed_turn_id(0x10);
+        let request = UiCommand::TurnStart(TurnStartParams {
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            input: vec![InputItem::Text {
+                text: "golden fast turn".into(),
+            }],
+        })
+        .into_rpc_request("turn-start-1")
+        .expect("turn/start request");
+        assert!(matches!(
+            route_rpc_command(request, ConnectionUiFeatures::default()).expect("route"),
+            UiCommand::TurnStart(_)
+        ));
+
+        let ledger = UiProtocolLedger::new(16);
+        let (ws, mut rx) = ws_connection_for_test(8);
+        send_rpc_result(&ws, "turn-start-1".into(), json!({ "accepted": true }))
+            .expect("turn/start ack");
+        send_notification_lifecycle(
+            &ws,
+            &ledger,
+            UiNotification::TurnStarted(octos_core::ui_protocol::TurnStartedEvent {
+                session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
+                timestamp: fixed_timestamp(0),
+            }),
+        )
+        .expect("turn/started");
+        send_notification_ephemeral(
+            &ws,
+            &ledger,
+            UiNotification::MessageDelta(MessageDeltaEvent {
+                session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
+                text: "golden answer".into(),
+            }),
+        )
+        .expect("message/delta");
+        send_notification_lifecycle(
+            &ws,
+            &ledger,
+            UiNotification::TurnCompleted(TurnCompletedEvent {
+                session_id,
+                turn_id,
+                cursor: None,
+            }),
+        )
+        .expect("turn/completed");
+
+        collect_ws_json_frames(&mut rx, 4).await
+    }
+
+    async fn golden_turn_interrupt_terminal() -> Vec<Value> {
+        let session_id = SessionKey("local:golden-interrupt".into());
+        let turn_id = fixed_turn_id(0x20);
+        let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+        let (interrupt_tx, _interrupt_rx) = mpsc::channel::<()>(1);
+        let task = tokio::spawn(async { std::future::pending::<()>().await });
+        let abort = task.abort_handle();
+        task.abort();
+        active_turns.lock().await.insert(
+            session_id.clone(),
+            ActiveTurn {
+                turn_id: turn_id.clone(),
+                state: Arc::new(TokioMutex::new(TurnState::Terminal(
+                    TerminalReason::Completed,
+                ))),
+                interrupt_tx: Arc::new(TokioMutex::new(Some(interrupt_tx))),
+                abort,
+            },
+        );
+
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let contracts = Arc::new(UiProtocolContractStores::default());
+        let (ws, mut rx) = ws_connection_for_test(4);
+        handle_turn_interrupt(
+            &ws,
+            &ledger,
+            &active_turns,
+            &contracts,
+            "turn-interrupt-1".into(),
+            TurnInterruptParams {
+                session_id,
+                turn_id,
+            },
+        )
+        .await;
+
+        collect_ws_json_frames(&mut rx, 1).await
+    }
+
+    async fn golden_approval_respond_decided() -> Vec<Value> {
+        let session_id = SessionKey("local:golden-approval".into());
+        let turn_id = fixed_turn_id(0x30);
+        let approval_id = fixed_approval_id(0x31);
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let contracts = Arc::new(UiProtocolContractStores::default());
+        let state = Arc::new(AppState::empty_for_tests());
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        let request = ApprovalRequestedEvent::generic(
+            session_id.clone(),
+            approval_id.clone(),
+            turn_id,
+            "shell",
+            "Approve golden command",
+            "printf golden",
+        );
+        let _runtime_rx = contracts.approvals.request_runtime(request.clone());
+        send_notification_durable(&ws, &ledger, UiNotification::ApprovalRequested(request))
+            .expect("approval/requested");
+        handle_approval_respond(
+            &ws,
+            &state,
+            &ledger,
+            &contracts,
+            None,
+            "approval-respond-1".into(),
+            ApprovalRespondParams::new(session_id, approval_id, ApprovalDecision::Approve),
+        )
+        .await;
+
+        collect_ws_json_frames(&mut rx, 3).await
+    }
+
+    async fn golden_diff_preview_get_ready() -> Vec<Value> {
+        let session_id = SessionKey("local:golden-diff".into());
+        let preview_id = fixed_preview_id(0x40);
+        let store = PendingDiffPreviewStore::default();
+        store.insert(golden_diff_preview(&session_id, preview_id.clone()));
+        let (ws, mut rx) = ws_connection_for_test(4);
+
+        handle_diff_preview_get(
+            &ws,
+            &store,
+            None,
+            "diff-preview-1".into(),
+            DiffPreviewGetParams {
+                session_id,
+                preview_id,
+            },
+        )
+        .await;
+
+        collect_ws_json_frames(&mut rx, 1).await
+    }
+
+    async fn golden_task_list_running() -> Vec<Value> {
+        let session_id = SessionKey("local:golden-task-list".into());
+        let (state, _supervisor, _task_id) = appui_task_state_with_running_task(&session_id);
+        let (ws, mut rx) = ws_connection_for_test(4);
+
+        handle_task_list(
+            &ws,
+            &state,
+            None,
+            "task-list-1".into(),
+            TaskListParams {
+                session_id,
+                topic: None,
+            },
+        )
+        .await;
+
+        collect_ws_json_frames(&mut rx, 1).await
+    }
+
+    async fn golden_task_output_read_snapshot() -> Vec<Value> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:golden-task-output".into());
+        let state = state_with_sessions(temp.path());
+        {
+            let sessions = state.sessions.as_ref().expect("sessions");
+            let mut sessions = sessions.lock().await;
+            sessions
+                .add_message(&session_id, Message::user("materialize session"))
+                .await
+                .expect("persist session");
+        }
+        let supervisor = octos_agent::TaskSupervisor::new();
+        supervisor
+            .enable_persistence(ui_protocol_task_output::task_state_path(
+                temp.path(),
+                &session_id,
+            ))
+            .expect("task persistence");
+        let task_id = supervisor.register("shell", "golden-task-output", Some(&session_id.0));
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(
+            &task_id,
+            "golden stderr line one\ngolden stderr line two\n".into(),
+        );
+        let task_id = task_id.parse::<TaskId>().expect("task id");
+        let (ws, mut rx) = ws_connection_for_test(4);
+
+        handle_task_output_read(
+            &ws,
+            &state,
+            None,
+            "task-output-1".into(),
+            TaskOutputReadParams {
+                session_id,
+                task_id,
+                cursor: Some(OutputCursor { offset: 0 }),
+                limit_bytes: Some(64),
+            },
+        )
+        .await;
+
+        collect_ws_json_frames(&mut rx, 1).await
+    }
+
+    async fn golden_session_hydrate_full() -> Vec<Value> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = SessionKey("local:golden-hydrate".into());
+        let state = state_with_sessions(temp.path());
+        seed_hydrate_messages(&state, &session_id).await;
+        let ledger = event_ledger(&state).await;
+        let approvals = PendingApprovalStore::default();
+        let active_turns: SharedActiveTurns = Arc::new(TokioMutex::new(HashMap::new()));
+        let (ws, mut rx) = ws_connection_for_test(4);
+
+        handle_session_hydrate(
+            &ws,
+            &state,
+            &ledger,
+            &approvals,
+            &active_turns,
+            None,
+            ConnectionUiFeatures::default(),
+            "hydrate-1".into(),
+            SessionHydrateParams {
+                session_id,
+                after: None,
+                include: vec![],
+            },
+        )
+        .await;
+
+        collect_ws_json_frames(&mut rx, 1).await
+    }
+
+    async fn golden_durable_message_events() -> Vec<Value> {
+        let session_id = SessionKey("local:golden-durable-message".into());
+        let turn_id = fixed_turn_id(0x50);
+        let ledger = UiProtocolLedger::new(16);
+        let (ws, mut rx) = ws_connection_for_test(4);
+
+        send_notification_durable(
+            &ws,
+            &ledger,
+            UiNotification::MessagePersisted(MessagePersistedEvent {
+                session_id: session_id.clone(),
+                turn_id: Some(turn_id.clone()),
+                thread_id: Some("client-message-1".into()),
+                seq: 1,
+                role: "assistant".into(),
+                message_id: "assistant-message-1".into(),
+                client_message_id: None,
+                source: MessagePersistedSource::Assistant,
+                cursor: UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 0,
+                },
+                persisted_at: fixed_timestamp(0),
+                media: vec!["artifacts/assistant.md".into()],
+            }),
+        )
+        .expect("message/persisted");
+        send_notification_durable(
+            &ws,
+            &ledger,
+            UiNotification::TurnSpawnComplete(TurnSpawnCompleteEvent {
+                session_id: session_id.clone(),
+                turn_id: Some(turn_id),
+                thread_id: Some("client-message-1".into()),
+                task_id: "spawn-task-1".into(),
+                response_to_client_message_id: Some("client-message-1".into()),
+                seq: 2,
+                message_id: "spawn-message-1".into(),
+                source: "background".into(),
+                cursor: UiCursor {
+                    stream: session_id.0,
+                    seq: 0,
+                },
+                persisted_at: fixed_timestamp(1),
+                content: "background result ready".into(),
+                media: vec!["research/report.md".into()],
+            }),
+        )
+        .expect("turn/spawn_complete");
+
+        collect_ws_json_frames(&mut rx, 2).await
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn ui_protocol_golden_frame_order_matches_checked_in_fixtures() {
+        let scenarios = [
+            ("session_open_success", golden_session_open_success().await),
+            (
+                "session_open_profile_mismatch",
+                golden_session_open_profile_mismatch().await,
+            ),
+            ("turn_start_fast", golden_turn_start_fast().await),
+            (
+                "turn_interrupt_terminal",
+                golden_turn_interrupt_terminal().await,
+            ),
+            (
+                "approval_respond_decided",
+                golden_approval_respond_decided().await,
+            ),
+            (
+                "diff_preview_get_ready",
+                golden_diff_preview_get_ready().await,
+            ),
+            ("task_list_running", golden_task_list_running().await),
+            (
+                "task_output_read_snapshot",
+                golden_task_output_read_snapshot().await,
+            ),
+            ("session_hydrate_full", golden_session_hydrate_full().await),
+            (
+                "durable_message_events",
+                golden_durable_message_events().await,
+            ),
+        ];
+        for (name, frames) in scenarios {
+            assert_ui_protocol_golden(name, frames);
         }
     }
 

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/approval_respond_decided.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/approval_respond_decided.json
@@ -1,0 +1,37 @@
+[
+  {
+    "jsonrpc": "2.0",
+    "method": "approval/requested",
+    "params": {
+      "approval_id": "<uuid-1>",
+      "body": "printf golden",
+      "session_id": "local:golden-approval",
+      "title": "Approve golden command",
+      "tool_name": "shell",
+      "turn_id": "<uuid-2>"
+    }
+  },
+  {
+    "id": "approval-respond-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "accepted": true,
+      "approval_id": "<uuid-1>",
+      "runtime_resumed": true,
+      "status": "accepted"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "approval/decided",
+    "params": {
+      "approval_id": "<uuid-1>",
+      "auto_resolved": false,
+      "decided_at": "<timestamp>",
+      "decided_by": "",
+      "decision": "approve",
+      "session_id": "local:golden-approval",
+      "turn_id": "<uuid-2>"
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/diff_preview_get_ready.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/diff_preview_get_ready.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "diff-preview-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "preview": {
+        "files": [
+          {
+            "hunks": [
+              {
+                "header": "@@ -1,2 +1,2 @@",
+                "lines": [
+                  {
+                    "content": " pub fn run() {",
+                    "kind": "context",
+                    "new_line": 1,
+                    "old_line": 1
+                  },
+                  {
+                    "content": "-    old();",
+                    "kind": "removed",
+                    "old_line": 2
+                  },
+                  {
+                    "content": "+    new();",
+                    "kind": "added",
+                    "new_line": 2
+                  }
+                ]
+              }
+            ],
+            "path": "src/lib.rs",
+            "status": "modified"
+          }
+        ],
+        "preview_id": "<uuid-1>",
+        "session_id": "local:golden-diff",
+        "title": "Golden fixture diff"
+      },
+      "source": "pending_store",
+      "status": "ready"
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/durable_message_events.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/durable_message_events.json
@@ -1,0 +1,46 @@
+[
+  {
+    "jsonrpc": "2.0",
+    "method": "message/persisted",
+    "params": {
+      "cursor": {
+        "seq": 1,
+        "stream": "local:golden-durable-message"
+      },
+      "media": [
+        "artifacts/assistant.md"
+      ],
+      "message_id": "assistant-message-1",
+      "persisted_at": "<timestamp>",
+      "role": "assistant",
+      "seq": 1,
+      "session_id": "local:golden-durable-message",
+      "source": "assistant",
+      "thread_id": "client-message-1",
+      "turn_id": "<uuid-1>"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "turn/spawn_complete",
+    "params": {
+      "content": "background result ready",
+      "cursor": {
+        "seq": 2,
+        "stream": "local:golden-durable-message"
+      },
+      "media": [
+        "research/report.md"
+      ],
+      "message_id": "spawn-message-1",
+      "persisted_at": "<timestamp>",
+      "response_to_client_message_id": "client-message-1",
+      "seq": 2,
+      "session_id": "local:golden-durable-message",
+      "source": "background",
+      "task_id": "spawn-task-1",
+      "thread_id": "client-message-1",
+      "turn_id": "<uuid-1>"
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_hydrate_full.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_hydrate_full.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "hydrate-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "cursor": {
+        "seq": 0,
+        "stream": "local:golden-hydrate"
+      },
+      "messages": [
+        {
+          "client_message_id": "client-message-1",
+          "content": "golden hydrate prompt",
+          "persisted_at": "<timestamp>",
+          "role": "user",
+          "seq": 0,
+          "thread_id": "client-message-1"
+        },
+        {
+          "content": "golden hydrate answer",
+          "media": [
+            "artifacts/answer.md"
+          ],
+          "persisted_at": "<timestamp>",
+          "role": "assistant",
+          "seq": 1,
+          "thread_id": "client-message-1"
+        }
+      ],
+      "pending_approvals": [],
+      "session_id": "local:golden-hydrate",
+      "threads": [
+        {
+          "message_seqs": [
+            0,
+            1
+          ],
+          "root_client_message_id": "client-message-1",
+          "root_seq": 0,
+          "status": "unknown",
+          "thread_id": "client-message-1"
+        }
+      ],
+      "turns": []
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_open_profile_mismatch.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_open_profile_mismatch.json
@@ -1,0 +1,13 @@
+[
+  {
+    "error": {
+      "code": -32602,
+      "data": {
+        "expected_profile_id": "profile-a"
+      },
+      "message": "session_id must include the authenticated profile"
+    },
+    "id": "session-open-auth-fail",
+    "jsonrpc": "2.0"
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_open_success.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_open_success.json
@@ -1,0 +1,138 @@
+[
+  {
+    "id": "session-open-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "opened": {
+        "active_profile_id": "coding",
+        "capabilities": {
+          "capabilities_schema_version": 2,
+          "supported_features": [
+            "approval.typed.v1",
+            "pane.snapshots.v1",
+            "session.workspace_cwd.v1",
+            "harness.task_control.v1",
+            "state.session_hydrate.v1",
+            "state.thread_graph.v1",
+            "state.turn_state_get.v1",
+            "event.message_persisted.v1",
+            "event.spawn_complete.v1"
+          ],
+          "supported_methods": [
+            "session/open",
+            "turn/start",
+            "turn/interrupt",
+            "approval/respond",
+            "approval/scopes/list",
+            "diff/preview/get",
+            "task/list",
+            "task/cancel",
+            "task/restart_from_node",
+            "task/output/read",
+            "session/hydrate",
+            "thread/graph/get",
+            "turn/state/get"
+          ],
+          "supported_notifications": [
+            "session/open",
+            "turn/started",
+            "turn/completed",
+            "turn/error",
+            "message/delta",
+            "tool/started",
+            "tool/progress",
+            "tool/completed",
+            "approval/requested",
+            "approval/auto_resolved",
+            "approval/decided",
+            "approval/cancelled",
+            "task/updated",
+            "task/output/delta",
+            "progress/updated",
+            "warning",
+            "protocol/replay_lossy",
+            "message/persisted",
+            "turn/spawn_complete"
+          ],
+          "version": {
+            "jsonrpc": "2.0",
+            "protocol": "octos-ui/v1alpha1",
+            "schema_version": 1
+          }
+        },
+        "cursor": {
+          "seq": 1,
+          "stream": "local:golden-session-open"
+        },
+        "session_id": "local:golden-session-open"
+      }
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "session/open",
+    "params": {
+      "active_profile_id": "coding",
+      "capabilities": {
+        "capabilities_schema_version": 2,
+        "supported_features": [
+          "approval.typed.v1",
+          "pane.snapshots.v1",
+          "session.workspace_cwd.v1",
+          "harness.task_control.v1",
+          "state.session_hydrate.v1",
+          "state.thread_graph.v1",
+          "state.turn_state_get.v1",
+          "event.message_persisted.v1",
+          "event.spawn_complete.v1"
+        ],
+        "supported_methods": [
+          "session/open",
+          "turn/start",
+          "turn/interrupt",
+          "approval/respond",
+          "approval/scopes/list",
+          "diff/preview/get",
+          "task/list",
+          "task/cancel",
+          "task/restart_from_node",
+          "task/output/read",
+          "session/hydrate",
+          "thread/graph/get",
+          "turn/state/get"
+        ],
+        "supported_notifications": [
+          "session/open",
+          "turn/started",
+          "turn/completed",
+          "turn/error",
+          "message/delta",
+          "tool/started",
+          "tool/progress",
+          "tool/completed",
+          "approval/requested",
+          "approval/auto_resolved",
+          "approval/decided",
+          "approval/cancelled",
+          "task/updated",
+          "task/output/delta",
+          "progress/updated",
+          "warning",
+          "protocol/replay_lossy",
+          "message/persisted",
+          "turn/spawn_complete"
+        ],
+        "version": {
+          "jsonrpc": "2.0",
+          "protocol": "octos-ui/v1alpha1",
+          "schema_version": 1
+        }
+      },
+      "cursor": {
+        "seq": 1,
+        "stream": "local:golden-session-open"
+      },
+      "session_id": "local:golden-session-open"
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/task_list_running.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/task_list_running.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "task-list-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "session_id": "local:golden-task-list",
+      "tasks": [
+        {
+          "child_session_key": "local:golden-task-list#child-<uuid-1>",
+          "id": "<uuid-1>",
+          "lifecycle_state": "running",
+          "parent_session_key": "local:golden-task-list",
+          "runtime_state": "executing_tool",
+          "session_key": "local:golden-task-list",
+          "started_at": "<timestamp>",
+          "state": "running",
+          "status": "running",
+          "tool_call_id": "call-appui-task",
+          "tool_name": "run_pipeline",
+          "updated_at": "<timestamp>"
+        }
+      ]
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/task_output_read_snapshot.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/task_output_read_snapshot.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "task-output-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "bytes_read": 64,
+      "complete": false,
+      "cursor": {
+        "offset": 0
+      },
+      "is_snapshot_projection": true,
+      "lifecycle_state": "failed",
+      "limitations": [
+        {
+          "code": "disk_output_unavailable",
+          "message": "No M8.7 disk-routed task stdout/stderr stream is discoverable in this runtime"
+        },
+        {
+          "code": "live_tail_unavailable",
+          "message": "task/output/read is served from a snapshot projection; live tail is available only from task/output/delta notifications emitted during active turns"
+        }
+      ],
+      "live_tail_supported": false,
+      "next_cursor": {
+        "offset": 64
+      },
+      "runtime_state": "failed",
+      "session_id": "local:golden-task-output",
+      "source": "runtime_projection",
+      "task_id": "<uuid-1>",
+      "task_status": "failed",
+      "text": "task_id: <uuid-1>\ntool_name: shell\nt",
+      "total_bytes": 365,
+      "truncated": true
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/turn_interrupt_terminal.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/turn_interrupt_terminal.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "turn-interrupt-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "interrupted": false,
+      "terminal_state": "completed"
+    }
+  }
+]

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/turn_start_fast.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/turn_start_fast.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "turn-start-1",
+    "jsonrpc": "2.0",
+    "result": {
+      "accepted": true
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "turn/started",
+    "params": {
+      "session_id": "local:golden-turn-start",
+      "timestamp": "<timestamp>",
+      "turn_id": "<uuid-1>"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "message/delta",
+    "params": {
+      "session_id": "local:golden-turn-start",
+      "text": "golden answer",
+      "turn_id": "<uuid-1>"
+    }
+  },
+  {
+    "jsonrpc": "2.0",
+    "method": "turn/completed",
+    "params": {
+      "cursor": {
+        "seq": 2,
+        "stream": "local:golden-turn-start"
+      },
+      "session_id": "local:golden-turn-start",
+      "turn_id": "<uuid-1>"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add checked-in AppUI/UI protocol golden frame fixtures under `crates/octos-cli/tests/fixtures/ui_protocol_golden`
- cover 10 pre-stdio scenarios: session open success/profile mismatch, turn start, terminal interrupt, approval response, diff preview, task list, task output snapshot, session hydrate, and durable message/spawn events
- compare normalized JSON byte-for-byte after capturing frames from the internal WebSocket send path

## Verification
- `OCTOS_BLESS_UI_PROTOCOL_GOLDEN=1 CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-cli --features api ui_protocol_golden_frame_order_matches_checked_in_fixtures -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-cli --features api ui_protocol_golden_frame_order_matches_checked_in_fixtures -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-cli --features api api::ui_protocol::tests::`
- `CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-cli --features api` passed: 895 library tests plus integration and doctest slices; only pre-existing warnings were observed
- `git diff --check`

## M9 Task A note
mini5 TUI soak remains blocked on SSH authentication from the supervisor host. Local P0.1 and P0.2 verification is green; soak orchestration will continue once mini5 access is usable.
