### PR TITLE
feat(appui): add client hello capability handshake

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -561,6 +561,39 @@ impl ConnectionUiFeatures {
         }
     }
 
+    fn from_client_capabilities(capabilities: &[String]) -> Self {
+        Self {
+            typed_approvals: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1),
+            pane_snapshots: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1),
+            session_workspace_cwd: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1),
+            harness_task_control: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1),
+            session_hydrate: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1),
+            thread_graph: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1),
+            turn_state_get: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1),
+            message_persisted: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1),
+            spawn_complete: capabilities
+                .iter()
+                .any(|feature| feature == UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1),
+            header_present: true,
+        }
+    }
+
     /// Build the `UiProtocolCapabilities` payload to advertise on
     /// `SessionOpened` per UPCR-2026-007 § 4 capability negotiation. When
     /// the client sent no feature header at all, the server returns the
@@ -1464,7 +1497,8 @@ async fn ui_protocol_connection(
             }
         };
         let id = request.id.clone();
-        let command = match route_rpc_command(request, features) {
+        let route_features = driver.features().await;
+        let command = match route_rpc_command(request, route_features) {
             Ok(command) => command,
             Err(error) => {
                 let _ = send_rpc_error(&ws, Some(id), error);
@@ -5871,10 +5905,11 @@ mod tests {
     use super::*;
     use crate::user_store::UserRole;
     use octos_core::ui_protocol::{
-        ApprovalDecision, ApprovalId, ApprovalRespondParams, ApprovalRespondStatus, DiffPreview,
-        DiffPreviewFile, DiffPreviewFileStatus, DiffPreviewGetParams, DiffPreviewGetStatus,
-        DiffPreviewHunk, DiffPreviewLine, DiffPreviewLineKind, DiffPreviewSource, PreviewId,
-        TaskOutputReadParams, approval_scopes, methods, rpc_error_codes,
+        ApprovalDecision, ApprovalId, ApprovalRespondParams, ApprovalRespondStatus,
+        ClientHelloParams, DiffPreview, DiffPreviewFile, DiffPreviewFileStatus,
+        DiffPreviewGetParams, DiffPreviewGetStatus, DiffPreviewHunk, DiffPreviewLine,
+        DiffPreviewLineKind, DiffPreviewSource, PreviewId, TaskOutputReadParams, approval_scopes,
+        methods, rpc_error_codes,
     };
     use uuid::Uuid;
 
@@ -5954,6 +5989,123 @@ mod tests {
 
         assert!(features.typed_approvals);
         assert!(features.pane_snapshots);
+    }
+
+    #[test]
+    fn client_hello_negotiates_features_without_http_headers() {
+        let features = ConnectionUiFeatures::from_client_capabilities(&[
+            UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1.to_owned(),
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1.to_owned(),
+            "unknown.future.v1".to_owned(),
+        ]);
+
+        assert!(features.header_present);
+        assert!(features.pane_snapshots);
+        assert!(features.harness_task_control);
+        assert!(!features.typed_approvals);
+
+        let capabilities = features.negotiated_capabilities();
+        assert_eq!(
+            capabilities.supported_features,
+            vec![
+                UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1.to_owned(),
+                UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1.to_owned(),
+            ]
+        );
+        assert!(capabilities.supports_method(methods::TASK_LIST));
+        assert!(capabilities.supports_method(methods::TASK_CANCEL));
+    }
+
+    #[test]
+    fn client_hello_routes_before_feature_gates() {
+        let request = UiCommand::ClientHello(ClientHelloParams {
+            client_id: "octos-app".into(),
+            client_version: "0.1.0".into(),
+            capabilities: Vec::new(),
+        })
+        .into_rpc_request("hello-1")
+        .expect("request");
+
+        assert!(matches!(
+            route_rpc_command(request, ConnectionUiFeatures::from_client_capabilities(&[]))
+                .expect("client_hello routes"),
+            UiCommand::ClientHello(_)
+        ));
+    }
+
+    #[test]
+    fn client_hello_feature_set_gates_subsequent_methods() {
+        let task_list = RpcRequest::new(
+            "task-list-1",
+            methods::TASK_LIST,
+            json!({ "session_id": "local:test" }),
+        );
+        let error = route_rpc_command(
+            task_list,
+            ConnectionUiFeatures::from_client_capabilities(&[]),
+        )
+        .expect_err("task/list requires harness task control after client_hello");
+        assert_eq!(error.code, rpc_error_codes::METHOD_NOT_SUPPORTED);
+
+        let task_list = RpcRequest::new(
+            "task-list-2",
+            methods::TASK_LIST,
+            json!({ "session_id": "local:test" }),
+        );
+        assert!(matches!(
+            route_rpc_command(
+                task_list,
+                ConnectionUiFeatures::from_client_capabilities(&[
+                    UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1.to_owned(),
+                ])
+            )
+            .expect("task/list routes after capability handshake"),
+            UiCommand::TaskList(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn client_hello_driver_updates_connection_features_and_replies() {
+        let state = Arc::new(AppState::empty_for_tests());
+        let (ws, mut rx) = ws_connection_for_test(8);
+        let driver =
+            UiProtocolDriver::new(state, None, None, ConnectionUiFeatures::default()).await;
+
+        driver
+            .handle_command(
+                &ws,
+                "hello-1".into(),
+                UiCommand::ClientHello(ClientHelloParams {
+                    client_id: "octos-tui".into(),
+                    client_version: "0.1.0".into(),
+                    capabilities: vec![
+                        UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1.to_owned(),
+                        UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1.to_owned(),
+                    ],
+                }),
+            )
+            .await;
+
+        let frame = recv_rpc_json(&mut rx).await;
+        assert_eq!(frame["id"], "hello-1");
+        assert_eq!(
+            frame["result"]["accepted_capabilities"],
+            json!([
+                UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
+                UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+            ])
+        );
+        assert_eq!(
+            frame["result"]["server_capabilities"]["supported_features"],
+            json!([
+                UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
+                UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+            ])
+        );
+        let features = driver.features().await;
+        assert!(features.header_present);
+        assert!(features.message_persisted);
+        assert!(features.spawn_complete);
     }
 
     #[test]
@@ -6458,7 +6610,16 @@ mod tests {
         let preview_id = PreviewId::new();
         let task_id = octos_core::TaskId::new();
 
-        for request in [
+        let requests = [
+            RpcRequest::new(
+                "client-hello",
+                methods::CLIENT_HELLO,
+                json!({
+                    "client_id": "octos-app-test",
+                    "client_version": "0.1.0",
+                    "capabilities": [],
+                }),
+            ),
             RpcRequest::new(
                 "session-open",
                 methods::SESSION_OPEN,
@@ -6491,19 +6652,18 @@ mod tests {
                 }),
             ),
             RpcRequest::new(
+                "approval-scopes-list",
+                methods::APPROVAL_SCOPES_LIST,
+                json!({
+                    "session_id": session_id.clone(),
+                }),
+            ),
+            RpcRequest::new(
                 "diff-preview",
                 methods::DIFF_PREVIEW_GET,
                 json!({
                     "session_id": session_id.clone(),
                     "preview_id": preview_id.clone(),
-                }),
-            ),
-            RpcRequest::new(
-                "task-output",
-                methods::TASK_OUTPUT_READ,
-                json!({
-                    "session_id": session_id.clone(),
-                    "task_id": task_id.clone(),
                 }),
             ),
             RpcRequest::new(
@@ -6530,10 +6690,52 @@ mod tests {
                     "node_id": "design",
                 }),
             ),
-        ] {
+            RpcRequest::new(
+                "task-output",
+                methods::TASK_OUTPUT_READ,
+                json!({
+                    "session_id": session_id.clone(),
+                    "task_id": task_id.clone(),
+                }),
+            ),
+            RpcRequest::new(
+                "session-hydrate",
+                methods::SESSION_HYDRATE,
+                json!({
+                    "session_id": session_id.clone(),
+                    "include": [],
+                }),
+            ),
+            RpcRequest::new(
+                "thread-graph",
+                methods::THREAD_GRAPH_GET,
+                json!({
+                    "session_id": session_id.clone(),
+                }),
+            ),
+            RpcRequest::new(
+                "turn-state",
+                methods::TURN_STATE_GET,
+                json!({
+                    "session_id": session_id.clone(),
+                    "turn_id": turn_id.clone(),
+                }),
+            ),
+        ];
+        let advertised = ui_protocol_server_supported_methods();
+        let covered: Vec<&str> = requests
+            .iter()
+            .map(|request| request.method.as_str())
+            .collect();
+        assert_eq!(
+            covered, advertised,
+            "route-completeness test must cover every advertised server method in order"
+        );
+
+        for request in requests {
             let method = request.method.clone();
             assert!(
-                ui_protocol_server_supported_methods().contains(&method.as_str()),
+                advertised.contains(&method.as_str()),
                 "{method} should be advertised by the server slice"
             );
             let command = route_rpc_command(request, ConnectionUiFeatures::default())

--- a/crates/octos-cli/src/api/ui_protocol_driver.rs
+++ b/crates/octos-cli/src/api/ui_protocol_driver.rs
@@ -6,7 +6,8 @@
 
 use super::*;
 use octos_core::ui_protocol::{
-    ApprovalRespondParams, ApprovalScopesListParams, DiffPreviewGetParams, TaskOutputReadParams,
+    ApprovalRespondParams, ApprovalScopesListParams, ClientHelloParams, ClientHelloResult,
+    DiffPreviewGetParams, TaskOutputReadParams,
 };
 
 pub(super) struct UiProtocolDriver {
@@ -18,7 +19,7 @@ pub(super) struct UiProtocolDriver {
     ledger: Arc<UiProtocolLedger>,
     connection_profile_id: Option<String>,
     routed_profile_id: Option<String>,
-    features: ConnectionUiFeatures,
+    features: TokioMutex<ConnectionUiFeatures>,
 }
 
 impl UiProtocolDriver {
@@ -50,12 +51,17 @@ impl UiProtocolDriver {
             ledger,
             connection_profile_id,
             routed_profile_id,
-            features,
+            features: TokioMutex::new(features),
         }
+    }
+
+    pub(super) async fn features(&self) -> ConnectionUiFeatures {
+        *self.features.lock().await
     }
 
     pub(super) async fn handle_command(&self, ws: &WsConnection, id: String, command: UiCommand) {
         match command {
+            UiCommand::ClientHello(params) => self.handle_client_hello(ws, id, params).await,
             UiCommand::SessionOpen(params) => self.handle_session_open(ws, id, params).await,
             UiCommand::TurnStart(params) => self.handle_turn_start(ws, id, params).await,
             UiCommand::TurnInterrupt(params) => self.handle_turn_interrupt(ws, id, params).await,
@@ -92,7 +98,46 @@ impl UiProtocolDriver {
         abort_live_forwarders(&self.live_forwarders).await;
     }
 
+    async fn handle_client_hello(&self, ws: &WsConnection, id: String, params: ClientHelloParams) {
+        if params.client_id.trim().is_empty() {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params("client_id is required"),
+            );
+            return;
+        }
+        if params.client_version.trim().is_empty() {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params("client_version is required"),
+            );
+            return;
+        }
+
+        let negotiated = ConnectionUiFeatures::from_client_capabilities(&params.capabilities);
+        {
+            let mut features = self.features.lock().await;
+            *features = negotiated;
+        }
+
+        let server_capabilities = negotiated.negotiated_capabilities();
+        let accepted_capabilities = server_capabilities.supported_features.clone();
+        let result = ClientHelloResult::new(accepted_capabilities, server_capabilities);
+        let Ok(value) = serde_json::to_value(result) else {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::internal_error("failed to serialize client_hello result"),
+            );
+            return;
+        };
+        let _ = send_rpc_result(ws, id, value);
+    }
+
     async fn handle_session_open(&self, ws: &WsConnection, id: String, params: SessionOpenParams) {
+        let features = self.features().await;
         handle_session_open(
             ws,
             &self.state,
@@ -100,7 +145,7 @@ impl UiProtocolDriver {
             &self.contracts.approvals,
             &self.live_forwarders,
             self.connection_profile_id.as_deref(),
-            self.features,
+            features,
             id,
             params,
         )
@@ -108,6 +153,7 @@ impl UiProtocolDriver {
     }
 
     async fn handle_turn_start(&self, ws: &WsConnection, id: String, params: TurnStartParams) {
+        let features = self.features().await;
         handle_turn_start(
             ws,
             &self.state,
@@ -117,7 +163,7 @@ impl UiProtocolDriver {
             &self.connection_turns,
             self.connection_profile_id.as_deref(),
             self.routed_profile_id.as_deref(),
-            self.features,
+            features,
             id,
             params,
         )
@@ -252,6 +298,7 @@ impl UiProtocolDriver {
         id: String,
         params: SessionHydrateParams,
     ) {
+        let features = self.features().await;
         handle_session_hydrate(
             ws,
             &self.state,
@@ -259,7 +306,7 @@ impl UiProtocolDriver {
             &self.contracts.approvals,
             &self.active_turns,
             self.connection_profile_id.as_deref(),
-            self.features,
+            features,
             id,
             params,
         )

--- a/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_open_success.json
+++ b/crates/octos-cli/tests/fixtures/ui_protocol_golden/session_open_success.json
@@ -19,6 +19,7 @@
             "event.spawn_complete.v1"
           ],
           "supported_methods": [
+            "client_hello",
             "session/open",
             "turn/start",
             "turn/interrupt",
@@ -87,6 +88,7 @@
           "event.spawn_complete.v1"
         ],
         "supported_methods": [
+          "client_hello",
           "session/open",
           "turn/start",
           "turn/interrupt",

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -626,6 +626,7 @@ where
 }
 
 pub mod methods {
+    pub const CLIENT_HELLO: &str = "client_hello";
     pub const SESSION_OPEN: &str = "session/open";
     pub const TURN_START: &str = "turn/start";
     pub const TURN_INTERRUPT: &str = "turn/interrupt";
@@ -686,6 +687,7 @@ pub mod approval_cancelled_reasons {
 
 /// All command methods defined by the v1alpha1 protocol model.
 pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
+    methods::CLIENT_HELLO,
     methods::SESSION_OPEN,
     methods::TURN_START,
     methods::TURN_INTERRUPT,
@@ -726,6 +728,7 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
 
 /// Request methods currently handled by the first server/runtime slice.
 pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
+    methods::CLIENT_HELLO,
     methods::SESSION_OPEN,
     methods::TURN_START,
     methods::TURN_INTERRUPT,
@@ -981,6 +984,7 @@ impl RpcError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UiResultKind {
+    ClientHello,
     SessionOpen,
     TurnStart,
     TurnInterrupt,
@@ -999,6 +1003,7 @@ pub enum UiResultKind {
 
 pub fn first_server_result_kind_for_method(method: &str) -> Option<UiResultKind> {
     match method {
+        methods::CLIENT_HELLO => Some(UiResultKind::ClientHello),
         methods::SESSION_OPEN => Some(UiResultKind::SessionOpen),
         methods::TURN_START => Some(UiResultKind::TurnStart),
         methods::TURN_INTERRUPT => Some(UiResultKind::TurnInterrupt),
@@ -1855,6 +1860,7 @@ pub struct TurnSpawnCompleteEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum UiCommand {
+    ClientHello(ClientHelloParams),
     SessionOpen(SessionOpenParams),
     TurnStart(TurnStartParams),
     TurnInterrupt(TurnInterruptParams),
@@ -1873,6 +1879,7 @@ pub enum UiCommand {
 impl UiCommand {
     pub fn method(&self) -> &'static str {
         match self {
+            Self::ClientHello(_) => methods::CLIENT_HELLO,
             Self::SessionOpen(_) => methods::SESSION_OPEN,
             Self::TurnStart(_) => methods::TURN_START,
             Self::TurnInterrupt(_) => methods::TURN_INTERRUPT,
@@ -1895,6 +1902,7 @@ impl UiCommand {
     ) -> Result<RpcRequest<Value>, serde_json::Error> {
         let method = self.method();
         let params = match self {
+            Self::ClientHello(params) => serde_json::to_value(params),
             Self::SessionOpen(params) => serde_json::to_value(params),
             Self::TurnStart(params) => serde_json::to_value(params),
             Self::TurnInterrupt(params) => serde_json::to_value(params),
@@ -1927,6 +1935,7 @@ impl UiCommand {
 
     pub fn from_method_and_params(method: &str, params: Value) -> Result<Self, RpcError> {
         match method {
+            methods::CLIENT_HELLO => Ok(Self::ClientHello(decode_params(method, params)?)),
             methods::SESSION_OPEN => Ok(Self::SessionOpen(decode_params(method, params)?)),
             methods::TURN_START => Ok(Self::TurnStart(decode_params(method, params)?)),
             methods::TURN_INTERRUPT => Ok(Self::TurnInterrupt(decode_params(method, params)?)),
@@ -2095,6 +2104,34 @@ impl SessionOpenResult {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientHelloParams {
+    pub client_id: String,
+    pub client_version: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientHelloResult {
+    pub server_version: UiProtocolVersion,
+    pub accepted_capabilities: Vec<String>,
+    pub server_capabilities: UiProtocolCapabilities,
+}
+
+impl ClientHelloResult {
+    pub fn new(
+        accepted_capabilities: Vec<String>,
+        server_capabilities: UiProtocolCapabilities,
+    ) -> Self {
+        Self {
+            server_version: UiProtocolVersion::current(),
+            accepted_capabilities,
+            server_capabilities,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnStartResult {
     pub accepted: bool,
@@ -2206,6 +2243,7 @@ impl TurnInterruptResult {
 #[allow(clippy::large_enum_variant)]
 #[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
 pub enum UiRpcResult {
+    ClientHello(ClientHelloResult),
     SessionOpen(SessionOpenResult),
     TurnStart(TurnStartResult),
     TurnInterrupt(TurnInterruptResult),
@@ -2225,6 +2263,7 @@ pub enum UiRpcResult {
 impl UiRpcResult {
     pub fn kind(&self) -> UiResultKind {
         match self {
+            Self::ClientHello(_) => UiResultKind::ClientHello,
             Self::SessionOpen(_) => UiResultKind::SessionOpen,
             Self::TurnStart(_) => UiResultKind::TurnStart,
             Self::TurnInterrupt(_) => UiResultKind::TurnInterrupt,
@@ -2244,6 +2283,7 @@ impl UiRpcResult {
 
     pub fn method(&self) -> Option<&str> {
         match self {
+            Self::ClientHello(_) => Some(methods::CLIENT_HELLO),
             Self::SessionOpen(_) => Some(methods::SESSION_OPEN),
             Self::TurnStart(_) => Some(methods::TURN_START),
             Self::TurnInterrupt(_) => Some(methods::TURN_INTERRUPT),
@@ -2263,6 +2303,7 @@ impl UiRpcResult {
 
     pub fn into_result_value(self) -> Result<Value, serde_json::Error> {
         match self {
+            Self::ClientHello(result) => serde_json::to_value(result),
             Self::SessionOpen(result) => serde_json::to_value(result),
             Self::TurnStart(result) => serde_json::to_value(result),
             Self::TurnInterrupt(result) => serde_json::to_value(result),
@@ -2299,6 +2340,7 @@ impl UiRpcResult {
             return Ok(Self::UnsupportedCapability(parsed));
         }
         match method {
+            methods::CLIENT_HELLO => Ok(Self::ClientHello(decode_result(method, result)?)),
             methods::SESSION_OPEN => Ok(Self::SessionOpen(decode_result(method, result)?)),
             methods::TURN_START => Ok(Self::TurnStart(decode_result(method, result)?)),
             methods::TURN_INTERRUPT => Ok(Self::TurnInterrupt(decode_result(method, result)?)),
@@ -3136,6 +3178,7 @@ mod tests {
             capabilities.capabilities_schema_version,
             UI_PROTOCOL_CAPABILITIES_SCHEMA_VERSION
         );
+        assert!(capabilities.supports_method(methods::CLIENT_HELLO));
         assert!(capabilities.supports_method(methods::SESSION_OPEN));
         assert!(capabilities.supports_method(methods::TURN_START));
         assert!(capabilities.supports_method(methods::TURN_INTERRUPT));
@@ -3186,6 +3229,7 @@ mod tests {
     fn full_protocol_capabilities_advertise_harness_task_control() {
         let capabilities = UiProtocolCapabilities::full_protocol();
 
+        assert!(capabilities.supports_method(methods::CLIENT_HELLO));
         assert!(capabilities.supports_method(methods::TASK_LIST));
         assert!(capabilities.supports_method(methods::TASK_CANCEL));
         assert!(capabilities.supports_method(methods::TASK_RESTART_FROM_NODE));
@@ -3450,6 +3494,7 @@ mod tests {
         assert_eq!(
             UI_PROTOCOL_COMMAND_METHODS,
             &[
+                "client_hello",
                 "session/open",
                 "turn/start",
                 "turn/interrupt",
@@ -3492,6 +3537,7 @@ mod tests {
         assert_eq!(
             UI_PROTOCOL_FIRST_SERVER_METHODS,
             &[
+                "client_hello",
                 "session/open",
                 "turn/start",
                 "turn/interrupt",
@@ -3528,6 +3574,7 @@ mod tests {
                 },
                 "capabilities_schema_version": 2,
                 "supported_methods": [
+                    "client_hello",
                     "session/open",
                     "turn/start",
                     "turn/interrupt",


### PR DESCRIPTION
## Summary
- Add `client_hello` to the AppUI v1 protocol method/result surface.
- Add `ClientHelloParams` / `ClientHelloResult` and negotiated server capability payloads.
- Let the extracted UI protocol driver update per-connection negotiated features from `client_hello` while preserving legacy WebSocket clients that do not send it.
- Route subsequent RPC capability gates through the driver's current negotiated feature set.
- Update route-completeness and golden frame fixtures so `client_hello` stays covered.

## Verification
- `CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-core ui_protocol::tests`
- `CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-cli --features api client_hello`
- `CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-cli --features api api::ui_protocol::tests::`
- `CARGO_TARGET_DIR=/private/tmp/m9-work/target-octos cargo test -p octos-cli --features api`