### PR TITLE
feat(dora-mcp): add octos-dora-mcp + strict tier + registry wiring (supersedes #818)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,6 +3736,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "octos-dora-mcp"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "eyre",
+ "octos-agent",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "octos-llm"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/app-skills/harness-starter-audio",
     "crates/app-skills/harness-starter-coding",
     "crates/platform-skills/voice",
+    "crates/octos-dora-mcp",
     "crates/octos-pipeline",
     "crates/octos-plugin",
     "crates/octos-sandbox",

--- a/crates/octos-dora-mcp/Cargo.toml
+++ b/crates/octos-dora-mcp/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "octos-dora-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "Dora-RS to MCP tool bridge for octos"
+
+[dependencies]
+octos-agent = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+eyre = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/octos-dora-mcp/src/config.rs
+++ b/crates/octos-dora-mcp/src/config.rs
@@ -1,0 +1,76 @@
+//! Configuration loader for dora tool mappings.
+
+use crate::DoraToolMapping;
+use serde::{Deserialize, Serialize};
+
+/// Top-level bridge configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeConfig {
+    /// Human-readable description.
+    #[serde(default)]
+    pub description: String,
+    /// Tool mappings.
+    pub mappings: Vec<DoraToolMapping>,
+}
+
+impl BridgeConfig {
+    /// Load from a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the JSON is malformed or missing required fields.
+    pub fn from_json(json: &str) -> eyre::Result<Self> {
+        let config: Self = serde_json::from_str(json)?;
+        Ok(config)
+    }
+
+    /// Load from a JSON file path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or the JSON is invalid.
+    pub fn from_file(path: &str) -> eyre::Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Self::from_json(&content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_config_from_json() {
+        let json = r#"{
+            "description": "UR5e inspection tools",
+            "mappings": [
+                {
+                    "tool_name": "scan_station",
+                    "description": "Scan station for objects",
+                    "dora_node_id": "moveit-skills",
+                    "dora_output_id": "skill_request",
+                    "parameters": {"station": "Station ID to scan"},
+                    "safety_tier": "full_actuation",
+                    "timeout_secs": 120
+                }
+            ]
+        }"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        assert_eq!(config.mappings.len(), 1);
+        assert_eq!(config.mappings[0].tool_name, "scan_station");
+        assert_eq!(config.mappings[0].safety_tier, "full_actuation");
+    }
+
+    #[test]
+    fn should_default_description_to_empty_string() {
+        let json = r#"{"mappings": []}"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        assert_eq!(config.description, "");
+    }
+
+    #[test]
+    fn should_fail_on_invalid_json() {
+        let result = BridgeConfig::from_json("{not valid json}");
+        assert!(result.is_err());
+    }
+}

--- a/crates/octos-dora-mcp/src/config.rs
+++ b/crates/octos-dora-mcp/src/config.rs
@@ -38,6 +38,7 @@ impl BridgeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use octos_agent::SafetyTier;
 
     #[test]
     fn should_parse_config_from_json() {
@@ -58,7 +59,7 @@ mod tests {
         let config = BridgeConfig::from_json(json).unwrap();
         assert_eq!(config.mappings.len(), 1);
         assert_eq!(config.mappings[0].tool_name, "scan_station");
-        assert_eq!(config.mappings[0].safety_tier, "full_actuation");
+        assert_eq!(config.mappings[0].safety_tier, SafetyTier::FullActuation);
     }
 
     #[test]
@@ -72,5 +73,43 @@ mod tests {
     fn should_fail_on_invalid_json() {
         let result = BridgeConfig::from_json("{not valid json}");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_reject_unknown_safety_tier_string() {
+        // Strict parser: typos / forward-looking tier names must fail loading
+        // rather than silently downgrade to Observe (codex round-1 P1).
+        let json = r#"{
+            "mappings": [{
+                "tool_name": "x",
+                "description": "x",
+                "dora_node_id": "n",
+                "dora_output_id": "o",
+                "parameters": {},
+                "safety_tier": "kind_of_dangerous",
+                "timeout_secs": 1
+            }]
+        }"#;
+        let result = BridgeConfig::from_json(json);
+        assert!(result.is_err(), "expected unknown-tier rejection");
+    }
+
+    #[test]
+    fn should_default_safety_tier_when_field_omitted() {
+        // Omitting `safety_tier` falls back to `Observe` (the safest default
+        // for an explicitly-not-declared tool); only an explicit unknown
+        // string fails. Mirrors `default_tier()` in lib.rs.
+        let json = r#"{
+            "mappings": [{
+                "tool_name": "x",
+                "description": "x",
+                "dora_node_id": "n",
+                "dora_output_id": "o",
+                "parameters": {},
+                "timeout_secs": 1
+            }]
+        }"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        assert_eq!(config.mappings[0].safety_tier, SafetyTier::Observe);
     }
 }

--- a/crates/octos-dora-mcp/src/lib.rs
+++ b/crates/octos-dora-mcp/src/lib.rs
@@ -1,0 +1,381 @@
+//! Dora-RS to MCP tool bridge.
+//!
+//! Maps dora-rs dataflow nodes to MCP-compatible tools that can be
+//! registered in the octos agent's [`ToolRegistry`].
+//!
+//! # Overview
+//!
+//! Each [`DoraToolMapping`] declares a tool name, description, the dora node
+//! and output IDs that handle requests, and an optional safety tier string.
+//! [`DoraToolBridge`] wraps a mapping and implements the [`Tool`] trait so it
+//! can be registered directly in the agent.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use octos_dora_mcp::{BridgeConfig, load_bridges};
+//!
+//! let config = BridgeConfig::from_file("config/dora_tool_map.json").unwrap();
+//! let bridges = load_bridges(&config);
+//! // bridges can be registered in a ToolRegistry:
+//! // for bridge in bridges { registry.register(bridge); }
+//! ```
+
+mod config;
+
+use async_trait::async_trait;
+use octos_agent::tools::{Tool, ToolResult};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+pub use config::BridgeConfig;
+
+/// Safety tiers for dora tool operations.
+///
+/// Stored as plain strings in config for forward compatibility.
+/// Use [`SafetyTier`] variants for structured comparisons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SafetyTier {
+    /// Read-only observation, no physical effect.
+    Observe,
+    /// Controlled motion within pre-validated bounds.
+    SafeMotion,
+    /// Unrestricted actuation of joints and end-effectors.
+    FullActuation,
+    /// Emergency stop and override commands.
+    EmergencyOverride,
+}
+
+impl SafetyTier {
+    /// Parse from the string representation used in config files.
+    pub fn from_config_str(s: &str) -> Self {
+        match s {
+            "observe" => SafetyTier::Observe,
+            "safe_motion" => SafetyTier::SafeMotion,
+            "full_actuation" => SafetyTier::FullActuation,
+            "emergency_override" => SafetyTier::EmergencyOverride,
+            _ => SafetyTier::Observe,
+        }
+    }
+
+    /// Return the canonical string form.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SafetyTier::Observe => "observe",
+            SafetyTier::SafeMotion => "safe_motion",
+            SafetyTier::FullActuation => "full_actuation",
+            SafetyTier::EmergencyOverride => "emergency_override",
+        }
+    }
+}
+
+/// Mapping from a dora-rs node output to an MCP tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DoraToolMapping {
+    /// MCP tool name exposed to the agent.
+    pub tool_name: String,
+    /// Description for the LLM.
+    pub description: String,
+    /// Dora node ID that handles this tool.
+    pub dora_node_id: String,
+    /// Dora output ID to send the request to.
+    pub dora_output_id: String,
+    /// Expected input parameters (name -> description).
+    pub parameters: HashMap<String, String>,
+    /// Required safety tier for this tool.
+    #[serde(default = "default_tier")]
+    pub safety_tier: String,
+    /// Timeout in seconds for the tool call.
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_tier() -> String {
+    "observe".to_string()
+}
+
+fn default_timeout() -> u64 {
+    30
+}
+
+/// A bridge that wraps a [`DoraToolMapping`] as an MCP-compatible [`Tool`].
+///
+/// In production the `execute` method would forward the request to the dora
+/// dataflow via an IPC channel and await the response.  The current
+/// implementation returns a placeholder describing the would-be forwarded
+/// payload so the bridge can be tested without a running dora runtime.
+pub struct DoraToolBridge {
+    mapping: DoraToolMapping,
+}
+
+impl DoraToolBridge {
+    /// Create a new bridge from the given mapping.
+    pub fn new(mapping: DoraToolMapping) -> Self {
+        Self { mapping }
+    }
+
+    /// Return a reference to the underlying mapping.
+    pub fn mapping(&self) -> &DoraToolMapping {
+        &self.mapping
+    }
+
+    /// Parse the safety tier string into the typed enum.
+    pub fn required_safety_tier(&self) -> SafetyTier {
+        SafetyTier::from_config_str(&self.mapping.safety_tier)
+    }
+
+    /// Build the JSON Schema object describing the tool's input parameters.
+    fn build_input_schema(&self) -> serde_json::Value {
+        let properties: serde_json::Map<String, serde_json::Value> = self
+            .mapping
+            .parameters
+            .iter()
+            .map(|(name, desc)| {
+                (
+                    name.clone(),
+                    serde_json::json!({
+                        "type": "string",
+                        "description": desc
+                    }),
+                )
+            })
+            .collect();
+
+        let required: Vec<serde_json::Value> = self
+            .mapping
+            .parameters
+            .keys()
+            .map(|k| serde_json::Value::String(k.clone()))
+            .collect();
+
+        serde_json::json!({
+            "type": "object",
+            "properties": properties,
+            "required": required
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for DoraToolBridge {
+    fn name(&self) -> &str {
+        &self.mapping.tool_name
+    }
+
+    fn description(&self) -> &str {
+        &self.mapping.description
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        self.build_input_schema()
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["dora", "mcp-bridge"]
+    }
+
+    async fn execute(&self, args: &serde_json::Value) -> eyre::Result<ToolResult> {
+        // In a real implementation this would send args to the dora node
+        // via the dora dataflow and await the response.  We return a
+        // placeholder indicating the bridge would forward to dora.
+        let request = serde_json::json!({
+            "tool": self.mapping.tool_name,
+            "node_id": self.mapping.dora_node_id,
+            "output_id": self.mapping.dora_output_id,
+            "args": args,
+            "timeout_secs": self.mapping.timeout_secs,
+        });
+
+        Ok(ToolResult {
+            success: true,
+            output: format!(
+                "DoraToolBridge: would forward to node '{}' output '{}': {}",
+                self.mapping.dora_node_id,
+                self.mapping.dora_output_id,
+                serde_json::to_string_pretty(&request).unwrap_or_default()
+            ),
+            ..Default::default()
+        })
+    }
+}
+
+/// Load tool mappings from a [`BridgeConfig`] and create bridge tools.
+pub fn load_bridges(config: &BridgeConfig) -> Vec<DoraToolBridge> {
+    config
+        .mappings
+        .iter()
+        .map(|m| DoraToolBridge::new(m.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_mapping() -> DoraToolMapping {
+        let mut params = HashMap::new();
+        params.insert("waypoint".to_string(), "Target waypoint ID".to_string());
+
+        DoraToolMapping {
+            tool_name: "navigate_to".to_string(),
+            description: "Navigate robot to a waypoint".to_string(),
+            dora_node_id: "moveit-skills".to_string(),
+            dora_output_id: "skill_request".to_string(),
+            parameters: params,
+            safety_tier: "safe_motion".to_string(),
+            timeout_secs: 60,
+        }
+    }
+
+    #[test]
+    fn should_expose_correct_tool_name() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        assert_eq!(bridge.name(), "navigate_to");
+    }
+
+    #[test]
+    fn should_expose_correct_description() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        assert_eq!(bridge.description(), "Navigate robot to a waypoint");
+    }
+
+    #[test]
+    fn should_build_input_schema_with_parameters() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let schema = bridge.input_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["waypoint"].is_object());
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "waypoint"));
+    }
+
+    #[test]
+    fn should_build_empty_schema_when_no_parameters() {
+        let mut mapping = sample_mapping();
+        mapping.parameters.clear();
+        let bridge = DoraToolBridge::new(mapping);
+        let schema = bridge.input_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].as_object().unwrap().is_empty());
+    }
+
+    #[test]
+    fn should_include_dora_tags() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let tags = bridge.tags();
+        assert!(tags.contains(&"dora"));
+        assert!(tags.contains(&"mcp-bridge"));
+    }
+
+    #[test]
+    fn should_parse_safety_tier_safe_motion() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        assert_eq!(bridge.required_safety_tier(), SafetyTier::SafeMotion);
+    }
+
+    #[test]
+    fn should_default_to_observe_tier_for_unknown_string() {
+        let mut mapping = sample_mapping();
+        mapping.safety_tier = "unknown_tier".to_string();
+        let bridge = DoraToolBridge::new(mapping);
+        assert_eq!(bridge.required_safety_tier(), SafetyTier::Observe);
+    }
+
+    #[test]
+    fn should_parse_all_safety_tier_variants() {
+        for (s, expected) in [
+            ("observe", SafetyTier::Observe),
+            ("safe_motion", SafetyTier::SafeMotion),
+            ("full_actuation", SafetyTier::FullActuation),
+            ("emergency_override", SafetyTier::EmergencyOverride),
+        ] {
+            assert_eq!(SafetyTier::from_config_str(s), expected, "failed for '{s}'");
+        }
+    }
+
+    #[test]
+    fn should_round_trip_safety_tier_as_str() {
+        for tier in [
+            SafetyTier::Observe,
+            SafetyTier::SafeMotion,
+            SafetyTier::FullActuation,
+            SafetyTier::EmergencyOverride,
+        ] {
+            assert_eq!(SafetyTier::from_config_str(tier.as_str()), tier);
+        }
+    }
+
+    #[tokio::test]
+    async fn should_execute_bridge_tool_with_args() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let result = bridge
+            .execute(&serde_json::json!({"waypoint": "A"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("moveit-skills"));
+        assert!(result.output.contains("skill_request"));
+        assert!(result.output.contains("navigate_to"));
+    }
+
+    #[tokio::test]
+    async fn should_execute_bridge_tool_with_empty_args() {
+        let bridge = DoraToolBridge::new(sample_mapping());
+        let result = bridge.execute(&serde_json::json!({})).await.unwrap();
+        assert!(result.success);
+        assert!(result.file_modified.is_none());
+        assert!(result.files_to_send.is_empty());
+    }
+
+    #[test]
+    fn should_load_bridges_from_config() {
+        let json = r#"{
+            "description": "Test config",
+            "mappings": [
+                {
+                    "tool_name": "tool_a",
+                    "description": "First tool",
+                    "dora_node_id": "node-1",
+                    "dora_output_id": "out-1",
+                    "parameters": {},
+                    "safety_tier": "observe",
+                    "timeout_secs": 10
+                },
+                {
+                    "tool_name": "tool_b",
+                    "description": "Second tool",
+                    "dora_node_id": "node-2",
+                    "dora_output_id": "out-2",
+                    "parameters": {"param": "A parameter"},
+                    "safety_tier": "full_actuation",
+                    "timeout_secs": 30
+                }
+            ]
+        }"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        let bridges = load_bridges(&config);
+        assert_eq!(bridges.len(), 2);
+        assert_eq!(bridges[0].name(), "tool_a");
+        assert_eq!(bridges[1].name(), "tool_b");
+        assert_eq!(bridges[1].required_safety_tier(), SafetyTier::FullActuation);
+    }
+
+    #[test]
+    fn should_apply_default_safety_tier_when_omitted() {
+        let json = r#"{
+            "mappings": [
+                {
+                    "tool_name": "minimal_tool",
+                    "description": "A minimal tool",
+                    "dora_node_id": "node-x",
+                    "dora_output_id": "out-x",
+                    "parameters": {}
+                }
+            ]
+        }"#;
+        let config = BridgeConfig::from_json(json).unwrap();
+        let bridges = load_bridges(&config);
+        assert_eq!(bridges[0].required_safety_tier(), SafetyTier::Observe);
+        assert_eq!(bridges[0].mapping().timeout_secs, 30);
+    }
+}

--- a/crates/octos-dora-mcp/src/lib.rs
+++ b/crates/octos-dora-mcp/src/lib.rs
@@ -1,73 +1,22 @@
-//! Dora-RS to MCP tool bridge.
+//! Dora-RS to MCP tool bridge for octos.
 //!
-//! Maps dora-rs dataflow nodes to MCP-compatible tools that can be
-//! registered in the octos agent's [`ToolRegistry`].
-//!
-//! # Overview
-//!
-//! Each [`DoraToolMapping`] declares a tool name, description, the dora node
-//! and output IDs that handle requests, and an optional safety tier string.
-//! [`DoraToolBridge`] wraps a mapping and implements the [`Tool`] trait so it
-//! can be registered directly in the agent.
-//!
-//! # Example
-//!
-//! ```no_run
-//! use octos_dora_mcp::{BridgeConfig, load_bridges};
-//!
-//! let config = BridgeConfig::from_file("config/dora_tool_map.json").unwrap();
-//! let bridges = load_bridges(&config);
-//! // bridges can be registered in a ToolRegistry:
-//! // for bridge in bridges { registry.register(bridge); }
-//! ```
+//! Wraps a [`DoraToolMapping`] (a config-defined link from a Dora node output
+//! to an MCP tool name) so the agent's [`Tool`] machinery can dispatch the
+//! request like any other tool. The bridge also registers the tool's
+//! required safety tier in the global [`RobotToolRegistry`] so the existing
+//! `group:robot:<tier>` `ToolPolicy` machinery actually applies — without
+//! that registration the tier metadata would be decorative.
 
-mod config;
-
-use async_trait::async_trait;
-use octos_agent::tools::{Tool, ToolResult};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use async_trait::async_trait;
+use octos_agent::tools::robot_groups::{self, RobotToolRegistry};
+use octos_agent::tools::ConcurrencyClass;
+use octos_agent::{SafetyTier, Tool, ToolResult};
+use serde::{Deserialize, Serialize};
+
+pub mod config;
 pub use config::BridgeConfig;
-
-/// Safety tiers for dora tool operations.
-///
-/// Stored as plain strings in config for forward compatibility.
-/// Use [`SafetyTier`] variants for structured comparisons.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SafetyTier {
-    /// Read-only observation, no physical effect.
-    Observe,
-    /// Controlled motion within pre-validated bounds.
-    SafeMotion,
-    /// Unrestricted actuation of joints and end-effectors.
-    FullActuation,
-    /// Emergency stop and override commands.
-    EmergencyOverride,
-}
-
-impl SafetyTier {
-    /// Parse from the string representation used in config files.
-    pub fn from_config_str(s: &str) -> Self {
-        match s {
-            "observe" => SafetyTier::Observe,
-            "safe_motion" => SafetyTier::SafeMotion,
-            "full_actuation" => SafetyTier::FullActuation,
-            "emergency_override" => SafetyTier::EmergencyOverride,
-            _ => SafetyTier::Observe,
-        }
-    }
-
-    /// Return the canonical string form.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            SafetyTier::Observe => "observe",
-            SafetyTier::SafeMotion => "safe_motion",
-            SafetyTier::FullActuation => "full_actuation",
-            SafetyTier::EmergencyOverride => "emergency_override",
-        }
-    }
-}
 
 /// Mapping from a dora-rs node output to an MCP tool.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,16 +31,20 @@ pub struct DoraToolMapping {
     pub dora_output_id: String,
     /// Expected input parameters (name -> description).
     pub parameters: HashMap<String, String>,
-    /// Required safety tier for this tool.
+    /// Required safety tier for this tool. Strict: unknown tiers fail
+    /// `BridgeConfig::from_json` rather than silently defaulting to
+    /// `Observe`. Serialised as snake_case (matches existing config files
+    /// — `"observe"`, `"safe_motion"`, `"full_actuation"`,
+    /// `"emergency_override"`).
     #[serde(default = "default_tier")]
-    pub safety_tier: String,
+    pub safety_tier: SafetyTier,
     /// Timeout in seconds for the tool call.
     #[serde(default = "default_timeout")]
     pub timeout_secs: u64,
 }
 
-fn default_tier() -> String {
-    "observe".to_string()
+fn default_tier() -> SafetyTier {
+    SafetyTier::Observe
 }
 
 fn default_timeout() -> u64 {
@@ -119,9 +72,9 @@ impl DoraToolBridge {
         &self.mapping
     }
 
-    /// Parse the safety tier string into the typed enum.
+    /// Required safety tier for this tool, drawn directly from the mapping.
     pub fn required_safety_tier(&self) -> SafetyTier {
-        SafetyTier::from_config_str(&self.mapping.safety_tier)
+        self.mapping.safety_tier
     }
 
     /// Build the JSON Schema object describing the tool's input parameters.
@@ -140,18 +93,12 @@ impl DoraToolBridge {
                 )
             })
             .collect();
-
-        let required: Vec<serde_json::Value> = self
-            .mapping
-            .parameters
-            .keys()
-            .map(|k| serde_json::Value::String(k.clone()))
-            .collect();
-
+        let required: Vec<String> = self.mapping.parameters.keys().cloned().collect();
         serde_json::json!({
             "type": "object",
             "properties": properties,
-            "required": required
+            "required": required,
+            "additionalProperties": false,
         })
     }
 }
@@ -171,41 +118,70 @@ impl Tool for DoraToolBridge {
     }
 
     fn tags(&self) -> &[&str] {
-        &["dora", "mcp-bridge"]
+        &["dora", "mcp-bridge", "robot"]
+    }
+
+    /// Codex round-2 P2: anything that can actuate the robot must NOT run in
+    /// the same parallel batch as another bridge call against the same Dora
+    /// runtime — overlapping motion commands are a real safety hazard. Only
+    /// `Observe`-tier tools (sensors, status queries) keep the default
+    /// parallel-friendly `Safe` class; every higher tier is `Exclusive` so
+    /// the agent's batch dispatcher serialises them.
+    fn concurrency_class(&self) -> ConcurrencyClass {
+        match self.mapping.safety_tier {
+            SafetyTier::Observe => ConcurrencyClass::Safe,
+            SafetyTier::SafeMotion
+            | SafetyTier::FullActuation
+            | SafetyTier::EmergencyOverride => ConcurrencyClass::Exclusive,
+        }
     }
 
     async fn execute(&self, args: &serde_json::Value) -> eyre::Result<ToolResult> {
-        // In a real implementation this would send args to the dora node
-        // via the dora dataflow and await the response.  We return a
-        // placeholder indicating the bridge would forward to dora.
         let request = serde_json::json!({
-            "tool": self.mapping.tool_name,
-            "node_id": self.mapping.dora_node_id,
-            "output_id": self.mapping.dora_output_id,
+            "dora_node_id": self.mapping.dora_node_id,
+            "dora_output_id": self.mapping.dora_output_id,
+            "tool_name": self.mapping.tool_name,
             "args": args,
             "timeout_secs": self.mapping.timeout_secs,
+            "safety_tier": self.mapping.safety_tier.label(),
         });
 
         Ok(ToolResult {
-            success: true,
             output: format!(
-                "DoraToolBridge: would forward to node '{}' output '{}': {}",
+                "[dora-bridge] would forward to {}::{} with payload:\n{}",
                 self.mapping.dora_node_id,
                 self.mapping.dora_output_id,
                 serde_json::to_string_pretty(&request).unwrap_or_default()
             ),
+            success: true,
             ..Default::default()
         })
     }
 }
 
-/// Load tool mappings from a [`BridgeConfig`] and create bridge tools.
+/// Load tool mappings from a [`BridgeConfig`], create bridge tools, AND
+/// register each tool with the global [`RobotToolRegistry`] at its declared
+/// tier so the existing `group:robot:<tier>` `ToolPolicy` machinery sees
+/// the bridge tools. Without this registration the `safety_tier` field is
+/// decorative — group-based allow/deny silently misses every dora tool.
+///
+/// Idempotent: re-loading the same config replaces prior tier mappings for
+/// the same tool name (see [`RobotToolRegistry::insert`]).
 pub fn load_bridges(config: &BridgeConfig) -> Vec<DoraToolBridge> {
-    config
+    let bridges: Vec<DoraToolBridge> = config
         .mappings
         .iter()
         .map(|m| DoraToolBridge::new(m.clone()))
-        .collect()
+        .collect();
+    robot_groups::with_registry_mut(|reg: &mut RobotToolRegistry| {
+        for bridge in &bridges {
+            reg.insert(
+                bridge.mapping.tool_name.clone(),
+                bridge.mapping.safety_tier,
+            );
+        }
+    });
+    bridges
 }
 
 #[cfg(test)]
@@ -222,7 +198,7 @@ mod tests {
             dora_node_id: "moveit-skills".to_string(),
             dora_output_id: "skill_request".to_string(),
             parameters: params,
-            safety_tier: "safe_motion".to_string(),
+            safety_tier: SafetyTier::SafeMotion,
             timeout_secs: 60,
         }
     }
@@ -265,44 +241,66 @@ mod tests {
         let tags = bridge.tags();
         assert!(tags.contains(&"dora"));
         assert!(tags.contains(&"mcp-bridge"));
+        assert!(tags.contains(&"robot"));
     }
 
     #[test]
-    fn should_parse_safety_tier_safe_motion() {
+    fn should_expose_declared_safety_tier() {
         let bridge = DoraToolBridge::new(sample_mapping());
         assert_eq!(bridge.required_safety_tier(), SafetyTier::SafeMotion);
     }
 
     #[test]
-    fn should_default_to_observe_tier_for_unknown_string() {
-        let mut mapping = sample_mapping();
-        mapping.safety_tier = "unknown_tier".to_string();
-        let bridge = DoraToolBridge::new(mapping);
-        assert_eq!(bridge.required_safety_tier(), SafetyTier::Observe);
+    fn should_fail_to_parse_unknown_safety_tier_string() {
+        // Codex round-1 P1: previously an unknown / misspelled tier silently
+        // collapsed to `Observe` (the LEAST restrictive), so a typo on a
+        // high-risk tool would slip past observe-only allow lists. Strict
+        // parsing now rejects the config.
+        let json = r#"{
+            "mappings": [{
+                "tool_name": "rogue",
+                "description": "should not load",
+                "dora_node_id": "n",
+                "dora_output_id": "o",
+                "parameters": {},
+                "safety_tier": "FullActuation",
+                "timeout_secs": 1
+            }]
+        }"#;
+        let result = BridgeConfig::from_json(json);
+        assert!(result.is_err(), "expected unknown-tier rejection, got Ok");
     }
 
     #[test]
-    fn should_parse_all_safety_tier_variants() {
-        for (s, expected) in [
-            ("observe", SafetyTier::Observe),
-            ("safe_motion", SafetyTier::SafeMotion),
-            ("full_actuation", SafetyTier::FullActuation),
-            ("emergency_override", SafetyTier::EmergencyOverride),
-        ] {
-            assert_eq!(SafetyTier::from_config_str(s), expected, "failed for '{s}'");
-        }
-    }
+    fn should_register_bridges_in_robot_tool_registry_at_declared_tier() {
+        // Codex round-1 P2: the bridge previously carried `safety_tier` but
+        // never enrolled the tool in `RobotToolRegistry`, so the existing
+        // `group:robot:<tier>` ToolPolicy machinery had nothing to evaluate
+        // against. `load_bridges` now wires both halves.
+        let mut high = sample_mapping();
+        high.tool_name = "dora_register_high_actuation".to_string();
+        high.safety_tier = SafetyTier::FullActuation;
 
-    #[test]
-    fn should_round_trip_safety_tier_as_str() {
-        for tier in [
-            SafetyTier::Observe,
-            SafetyTier::SafeMotion,
-            SafetyTier::FullActuation,
-            SafetyTier::EmergencyOverride,
-        ] {
-            assert_eq!(SafetyTier::from_config_str(tier.as_str()), tier);
-        }
+        let mut low = sample_mapping();
+        low.tool_name = "dora_register_observe".to_string();
+        low.safety_tier = SafetyTier::Observe;
+
+        let config = BridgeConfig {
+            description: String::new(),
+            mappings: vec![high, low],
+        };
+        let bridges = load_bridges(&config);
+        assert_eq!(bridges.len(), 2);
+
+        let snap = robot_groups::snapshot();
+        assert_eq!(
+            snap.tier_of("dora_register_high_actuation"),
+            Some(SafetyTier::FullActuation),
+        );
+        assert_eq!(
+            snap.tier_of("dora_register_observe"),
+            Some(SafetyTier::Observe),
+        );
     }
 
     #[tokio::test]
@@ -312,70 +310,9 @@ mod tests {
             .execute(&serde_json::json!({"waypoint": "A"}))
             .await
             .unwrap();
-        assert!(result.success);
+        assert!(result.output.contains("dora-bridge"));
         assert!(result.output.contains("moveit-skills"));
-        assert!(result.output.contains("skill_request"));
-        assert!(result.output.contains("navigate_to"));
-    }
-
-    #[tokio::test]
-    async fn should_execute_bridge_tool_with_empty_args() {
-        let bridge = DoraToolBridge::new(sample_mapping());
-        let result = bridge.execute(&serde_json::json!({})).await.unwrap();
+        assert!(result.output.contains("safe_motion"));
         assert!(result.success);
-        assert!(result.file_modified.is_none());
-        assert!(result.files_to_send.is_empty());
-    }
-
-    #[test]
-    fn should_load_bridges_from_config() {
-        let json = r#"{
-            "description": "Test config",
-            "mappings": [
-                {
-                    "tool_name": "tool_a",
-                    "description": "First tool",
-                    "dora_node_id": "node-1",
-                    "dora_output_id": "out-1",
-                    "parameters": {},
-                    "safety_tier": "observe",
-                    "timeout_secs": 10
-                },
-                {
-                    "tool_name": "tool_b",
-                    "description": "Second tool",
-                    "dora_node_id": "node-2",
-                    "dora_output_id": "out-2",
-                    "parameters": {"param": "A parameter"},
-                    "safety_tier": "full_actuation",
-                    "timeout_secs": 30
-                }
-            ]
-        }"#;
-        let config = BridgeConfig::from_json(json).unwrap();
-        let bridges = load_bridges(&config);
-        assert_eq!(bridges.len(), 2);
-        assert_eq!(bridges[0].name(), "tool_a");
-        assert_eq!(bridges[1].name(), "tool_b");
-        assert_eq!(bridges[1].required_safety_tier(), SafetyTier::FullActuation);
-    }
-
-    #[test]
-    fn should_apply_default_safety_tier_when_omitted() {
-        let json = r#"{
-            "mappings": [
-                {
-                    "tool_name": "minimal_tool",
-                    "description": "A minimal tool",
-                    "dora_node_id": "node-x",
-                    "dora_output_id": "out-x",
-                    "parameters": {}
-                }
-            ]
-        }"#;
-        let config = BridgeConfig::from_json(json).unwrap();
-        let bridges = load_bridges(&config);
-        assert_eq!(bridges[0].required_safety_tier(), SafetyTier::Observe);
-        assert_eq!(bridges[0].mapping().timeout_secs, 30);
     }
 }

--- a/crates/octos-dora-mcp/src/lib.rs
+++ b/crates/octos-dora-mcp/src/lib.rs
@@ -10,8 +10,8 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use octos_agent::tools::robot_groups::{self, RobotToolRegistry};
 use octos_agent::tools::ConcurrencyClass;
+use octos_agent::tools::robot_groups::{self, RobotToolRegistry};
 use octos_agent::{SafetyTier, Tool, ToolResult};
 use serde::{Deserialize, Serialize};
 
@@ -130,9 +130,9 @@ impl Tool for DoraToolBridge {
     fn concurrency_class(&self) -> ConcurrencyClass {
         match self.mapping.safety_tier {
             SafetyTier::Observe => ConcurrencyClass::Safe,
-            SafetyTier::SafeMotion
-            | SafetyTier::FullActuation
-            | SafetyTier::EmergencyOverride => ConcurrencyClass::Exclusive,
+            SafetyTier::SafeMotion | SafetyTier::FullActuation | SafetyTier::EmergencyOverride => {
+                ConcurrencyClass::Exclusive
+            }
         }
     }
 
@@ -175,10 +175,7 @@ pub fn load_bridges(config: &BridgeConfig) -> Vec<DoraToolBridge> {
         .collect();
     robot_groups::with_registry_mut(|reg: &mut RobotToolRegistry| {
         for bridge in &bridges {
-            reg.insert(
-                bridge.mapping.tool_name.clone(),
-                bridge.mapping.safety_tier,
-            );
+            reg.insert(bridge.mapping.tool_name.clone(), bridge.mapping.safety_tier);
         }
     });
     bridges

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -1559,9 +1559,19 @@ impl PipelineExecutor {
                         fanout_reservations.push(handle);
                     }
 
+                    // Parallel children inherit the fan-out node's
+                    // predecessor outcomes (same source the fan_input
+                    // string was concatenated from). Keeps GateHandler's
+                    // `predecessor_outcomes` view consistent with `input`.
+                    let par_predecessor_outcomes: Vec<NodeOutcome> = predecessors
+                        .iter()
+                        .filter_map(|p| completed.get(*p).cloned())
+                        .collect();
+
                     let ctx = HandlerContext {
                         input: fan_input.clone(),
                         completed: completed.clone(),
+                        predecessor_outcomes: par_predecessor_outcomes,
                         working_dir: self.config.working_dir.clone(),
                     };
 
@@ -1913,9 +1923,19 @@ impl PipelineExecutor {
                         dp_reservations.push(handle);
                     }
 
+                    // Same logic as the static-fan-out site: dynamic
+                    // workers inherit the dynamic_parallel node's
+                    // predecessors so GateHandler sees the same
+                    // upstream outcomes that built `dp_input`.
+                    let dp_predecessor_outcomes: Vec<NodeOutcome> = predecessors
+                        .iter()
+                        .filter_map(|p| completed.get(*p).cloned())
+                        .collect();
+
                     let ctx = HandlerContext {
                         input: dp_input.clone(),
                         completed: completed.clone(),
+                        predecessor_outcomes: dp_predecessor_outcomes,
                         working_dir: self.config.working_dir.clone(),
                     };
 
@@ -2078,9 +2098,20 @@ impl PipelineExecutor {
                 bridge.set_words(vec![seq_label.to_string()]);
             }
 
+            // Direct-predecessor outcomes in graph edge order — preserves
+            // each predecessor's `OutcomeStatus` (Pass/Fail/Error) for
+            // GateHandler. `Vec` ordering matches edge iteration so the
+            // single-predecessor branching case is fully deterministic
+            // (codex round-5 + round-6).
+            let predecessor_outcomes: Vec<NodeOutcome> = predecessors
+                .iter()
+                .filter_map(|p| completed.get(*p).cloned())
+                .collect();
+
             let ctx = HandlerContext {
                 input: input_text,
                 completed: completed.clone(),
+                predecessor_outcomes,
                 working_dir: self.config.working_dir.clone(),
             };
 

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -194,6 +194,15 @@ pub struct HandlerContext {
     pub input: String,
     /// All completed node outcomes so far.
     pub completed: HashMap<String, NodeOutcome>,
+    /// Outcomes of the current node's *direct* predecessors, in graph
+    /// edge order. Empty when the current node is a root (no incoming
+    /// edges). Critical for `GateHandler`: a gate must evaluate against
+    /// its real predecessor's status — the predecessor may have completed
+    /// with `OutcomeStatus::Fail`, which the executor permits to flow
+    /// through conditional edges. Without this field a gate predicate
+    /// like `outcome.status == "fail"` could never detect predecessor
+    /// failure (codex round-6 P2).
+    pub predecessor_outcomes: Vec<NodeOutcome>,
     /// Working directory for tools.
     pub working_dir: PathBuf,
 }
@@ -825,32 +834,69 @@ impl Handler for ShellHandler {
 }
 
 /// Evaluate a condition without any LLM call.
-/// The node prompt is treated as a condition expression evaluated against
-/// the gate's predecessor outcome — sourced from `ctx.input`, the
-/// executor's deterministic concatenation of the node's direct
-/// predecessor contents (see `executor.rs` predecessor-input
-/// construction). Earlier revisions read `ctx.completed.values().last()`
-/// from a `HashMap`, which is unordered and produced nondeterministic
-/// branching once more than one node had completed (codex round-5 P2).
+///
+/// The node prompt is treated as a condition expression. The outcome it
+/// evaluates against comes from `HandlerContext::predecessor_outcomes`:
+///
+///   * Exactly one direct predecessor (the common branching case) →
+///     use that predecessor's outcome verbatim, preserving its status.
+///     Round-6 fix: a `Fail` predecessor must remain `Fail` so a gate
+///     prompt of `outcome.status == "fail"` can detect it. Round-5
+///     fix: a `HashMap` last-value read was nondeterministic.
+///   * Fan-in (≥ 2 direct predecessors) → aggregate: status is `Error`
+///     if any predecessor errored, `Fail` if any predecessor failed,
+///     otherwise `Pass`. Content is `ctx.input` (executor's
+///     concatenation).
+///   * No direct predecessors (root gate) → synthesize a `Pass` outcome
+///     from `ctx.input`. Tests that don't populate
+///     `predecessor_outcomes` also fall through this branch and see
+///     content-only semantics, which matches their original intent.
 pub struct GateHandler;
+
+impl GateHandler {
+    fn synthesize_predecessor_outcome(gate_id: &str, ctx: &HandlerContext) -> NodeOutcome {
+        match ctx.predecessor_outcomes.len() {
+            0 => NodeOutcome {
+                node_id: format!("{gate_id}__no_predecessor"),
+                status: OutcomeStatus::Pass,
+                content: ctx.input.clone(),
+                token_usage: TokenUsage::default(),
+                files_modified: vec![],
+            },
+            1 => ctx.predecessor_outcomes[0].clone(),
+            _ => {
+                let aggregate_status = if ctx
+                    .predecessor_outcomes
+                    .iter()
+                    .any(|o| o.status == OutcomeStatus::Error)
+                {
+                    OutcomeStatus::Error
+                } else if ctx
+                    .predecessor_outcomes
+                    .iter()
+                    .any(|o| o.status == OutcomeStatus::Fail)
+                {
+                    OutcomeStatus::Fail
+                } else {
+                    OutcomeStatus::Pass
+                };
+                NodeOutcome {
+                    node_id: format!("{gate_id}__fan_in"),
+                    status: aggregate_status,
+                    content: ctx.input.clone(),
+                    token_usage: TokenUsage::default(),
+                    files_modified: vec![],
+                }
+            }
+        }
+    }
+}
 
 #[async_trait]
 impl Handler for GateHandler {
     async fn execute(&self, node: &PipelineNode, ctx: &HandlerContext) -> Result<NodeOutcome> {
         let cond_str = node.prompt.as_deref().unwrap_or("true");
-
-        // The executor only schedules a node after its direct predecessors
-        // have completed without aborting the run; the predecessor content
-        // therefore comes from `ctx.input` and the gate's "incoming status"
-        // is `Pass` by construction. (A skipped predecessor produces a
-        // skipped/unreachable path that never reaches us.)
-        let predecessor_outcome = NodeOutcome {
-            node_id: format!("{}__predecessor", node.id),
-            status: OutcomeStatus::Pass,
-            content: ctx.input.clone(),
-            token_usage: TokenUsage::default(),
-            files_modified: vec![],
-        };
+        let predecessor_outcome = Self::synthesize_predecessor_outcome(&node.id, ctx);
 
         if cond_str == "true" {
             return Ok(NodeOutcome {
@@ -1012,6 +1058,7 @@ mod tests {
             // Direct-predecessor content has no sentinel — gate must Fail.
             input: "fresh inspection: anomaly_clear".to_string(),
             completed,
+            predecessor_outcomes: Vec::new(),
             working_dir: std::env::temp_dir(),
         };
 
@@ -1079,6 +1126,7 @@ mod tests {
         let ctx = HandlerContext {
             input: "fresh inspection: anomaly_detected reading".to_string(),
             completed,
+            predecessor_outcomes: Vec::new(),
             working_dir: std::env::temp_dir(),
         };
 
@@ -1106,6 +1154,124 @@ mod tests {
 
         let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
         assert_eq!(outcome.status, OutcomeStatus::Pass);
+    }
+
+    /// Codex round-6 P2: a gate predicate of `outcome.status == "fail"`
+    /// must actually detect a `Fail` predecessor. Round-5's fix
+    /// hard-coded the synthesized predecessor status to `Pass`, which
+    /// silently broke status-based predicates. This test pins both the
+    /// status-preservation and the single-predecessor-source rule:
+    /// `predecessor_outcomes[0].status` propagates verbatim into the
+    /// outcome the gate evaluates.
+    #[tokio::test]
+    async fn gate_handler_preserves_predecessor_fail_status_for_status_predicates() {
+        use crate::graph::{HandlerKind, PipelineNode};
+
+        let predecessor = NodeOutcome {
+            node_id: "inspect".to_string(),
+            status: OutcomeStatus::Fail,
+            content: "no anomaly here".to_string(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
+
+        let ctx = HandlerContext {
+            input: predecessor.content.clone(),
+            completed: HashMap::new(),
+            predecessor_outcomes: vec![predecessor.clone()],
+            working_dir: std::env::temp_dir(),
+        };
+
+        let gate = PipelineNode {
+            id: "fail_gate".to_string(),
+            handler: HandlerKind::Gate,
+            prompt: Some("outcome.status == \"fail\"".to_string()),
+            label: None,
+            model: None,
+            context_window: None,
+            max_output_tokens: None,
+            tools: vec![],
+            goal_gate: false,
+            max_retries: 0,
+            timeout_secs: None,
+            suggested_next: None,
+            converge: None,
+            worker_prompt: None,
+            planner_model: None,
+            max_tasks: None,
+            deadline_secs: None,
+            deadline_action: None,
+            checkpoints: vec![],
+        };
+
+        let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
+        assert_eq!(
+            outcome.status,
+            OutcomeStatus::Pass,
+            "predicate `outcome.status == \"fail\"` must Pass when the predecessor outcome has status Fail; the gate must not lose the predecessor status",
+        );
+    }
+
+    /// Codex round-6 P2: fan-in aggregation. With multiple direct
+    /// predecessors the gate should evaluate against an aggregate whose
+    /// status is `Fail` if ANY predecessor failed, and content is the
+    /// executor's `ctx.input` concatenation. Without this rule a
+    /// fan-in safety gate after a partially-failed merge would never
+    /// detect the failure.
+    #[tokio::test]
+    async fn gate_handler_aggregates_fan_in_predecessor_status_as_fail_if_any_fail() {
+        use crate::graph::{HandlerKind, PipelineNode};
+
+        let pass = NodeOutcome {
+            node_id: "branch_a".to_string(),
+            status: OutcomeStatus::Pass,
+            content: "branch a ok".to_string(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
+        let fail = NodeOutcome {
+            node_id: "branch_b".to_string(),
+            status: OutcomeStatus::Fail,
+            content: "branch b broke".to_string(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
+
+        let ctx = HandlerContext {
+            input: format!("{}\n\n---\n\n{}", pass.content, fail.content),
+            completed: HashMap::new(),
+            predecessor_outcomes: vec![pass, fail],
+            working_dir: std::env::temp_dir(),
+        };
+
+        let gate = PipelineNode {
+            id: "merge_gate".to_string(),
+            handler: HandlerKind::Gate,
+            prompt: Some("outcome.status == \"fail\"".to_string()),
+            label: None,
+            model: None,
+            context_window: None,
+            max_output_tokens: None,
+            tools: vec![],
+            goal_gate: false,
+            max_retries: 0,
+            timeout_secs: None,
+            suggested_next: None,
+            converge: None,
+            worker_prompt: None,
+            planner_model: None,
+            max_tasks: None,
+            deadline_secs: None,
+            deadline_action: None,
+            checkpoints: vec![],
+        };
+
+        let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
+        assert_eq!(
+            outcome.status,
+            OutcomeStatus::Pass,
+            "fan-in gate must aggregate predecessor statuses to Fail if any branch failed, so that `outcome.status == \"fail\"` Passes",
+        );
     }
 
     /// Sanity check — the existing event arms still forward as before so

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -865,6 +865,12 @@ impl GateHandler {
             },
             1 => ctx.predecessor_outcomes[0].clone(),
             _ => {
+                // Severity ladder: Error > Fail > Skipped > Pass.
+                // The ladder is exhaustive over `OutcomeStatus`; adding
+                // a new variant is a compile-error if this match isn't
+                // updated, so we keep the ladder explicit rather than
+                // collapsing to "any non-pass" (codex round-7 P2:
+                // skipped predecessors were silently treated as pass).
                 let aggregate_status = if ctx
                     .predecessor_outcomes
                     .iter()
@@ -877,6 +883,12 @@ impl GateHandler {
                     .any(|o| o.status == OutcomeStatus::Fail)
                 {
                     OutcomeStatus::Fail
+                } else if ctx
+                    .predecessor_outcomes
+                    .iter()
+                    .any(|o| o.status == OutcomeStatus::Skipped)
+                {
+                    OutcomeStatus::Skipped
                 } else {
                     OutcomeStatus::Pass
                 };
@@ -1271,6 +1283,128 @@ mod tests {
             outcome.status,
             OutcomeStatus::Pass,
             "fan-in gate must aggregate predecessor statuses to Fail if any branch failed, so that `outcome.status == \"fail\"` Passes",
+        );
+    }
+
+    /// Codex round-7 P2: fan-in aggregation must surface `Skipped`
+    /// predecessors. The previous round-6 implementation collapsed
+    /// any non-`Error`/non-`Fail` set to `Pass`, so a gate predicate
+    /// of `outcome.status == "skipped"` after a fan-in that included
+    /// a deadline-skipped branch could never detect it. Severity
+    /// ladder is now `Error > Fail > Skipped > Pass`.
+    #[tokio::test]
+    async fn gate_handler_aggregates_fan_in_predecessor_status_as_skipped() {
+        use crate::graph::{HandlerKind, PipelineNode};
+
+        let pass = NodeOutcome {
+            node_id: "branch_a".to_string(),
+            status: OutcomeStatus::Pass,
+            content: "branch a ok".to_string(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
+        let skipped = NodeOutcome {
+            node_id: "branch_b".to_string(),
+            status: OutcomeStatus::Skipped,
+            content: "branch b skipped".to_string(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
+
+        let ctx = HandlerContext {
+            input: format!("{}\n\n---\n\n{}", pass.content, skipped.content),
+            completed: HashMap::new(),
+            predecessor_outcomes: vec![pass, skipped],
+            working_dir: std::env::temp_dir(),
+        };
+
+        let gate = PipelineNode {
+            id: "skip_gate".to_string(),
+            handler: HandlerKind::Gate,
+            prompt: Some("outcome.status == \"skipped\"".to_string()),
+            label: None,
+            model: None,
+            context_window: None,
+            max_output_tokens: None,
+            tools: vec![],
+            goal_gate: false,
+            max_retries: 0,
+            timeout_secs: None,
+            suggested_next: None,
+            converge: None,
+            worker_prompt: None,
+            planner_model: None,
+            max_tasks: None,
+            deadline_secs: None,
+            deadline_action: None,
+            checkpoints: vec![],
+        };
+
+        let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
+        assert_eq!(
+            outcome.status,
+            OutcomeStatus::Pass,
+            "fan-in with a skipped predecessor must aggregate to Skipped, so `outcome.status == \"skipped\"` Passes",
+        );
+    }
+
+    /// Codex round-7 P2 mirror: the `Skipped` tier must lose to `Fail`
+    /// in the severity ladder. A fan-in containing both a `Skipped`
+    /// and a `Fail` should aggregate to `Fail`, not `Skipped`.
+    #[tokio::test]
+    async fn gate_handler_fail_dominates_skipped_in_fan_in_aggregation() {
+        use crate::graph::{HandlerKind, PipelineNode};
+
+        let skipped = NodeOutcome {
+            node_id: "skipped".to_string(),
+            status: OutcomeStatus::Skipped,
+            content: "skipped".to_string(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
+        let fail = NodeOutcome {
+            node_id: "fail".to_string(),
+            status: OutcomeStatus::Fail,
+            content: "fail".to_string(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
+
+        let ctx = HandlerContext {
+            input: format!("{}\n\n---\n\n{}", skipped.content, fail.content),
+            completed: HashMap::new(),
+            predecessor_outcomes: vec![skipped, fail],
+            working_dir: std::env::temp_dir(),
+        };
+
+        let gate = PipelineNode {
+            id: "merge_gate".to_string(),
+            handler: HandlerKind::Gate,
+            // Skipped-only branch would Pass; Fail aggregation is required.
+            prompt: Some("outcome.status == \"fail\"".to_string()),
+            label: None,
+            model: None,
+            context_window: None,
+            max_output_tokens: None,
+            tools: vec![],
+            goal_gate: false,
+            max_retries: 0,
+            timeout_secs: None,
+            suggested_next: None,
+            converge: None,
+            worker_prompt: None,
+            planner_model: None,
+            max_tasks: None,
+            deadline_secs: None,
+            deadline_action: None,
+            checkpoints: vec![],
+        };
+
+        let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
+        assert_eq!(
+            outcome.status,
+            OutcomeStatus::Pass,
+            "Fail must dominate Skipped in fan-in aggregation",
         );
     }
 

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -826,7 +826,12 @@ impl Handler for ShellHandler {
 
 /// Evaluate a condition without any LLM call.
 /// The node prompt is treated as a condition expression evaluated against
-/// the last completed node's outcome.
+/// the gate's predecessor outcome — sourced from `ctx.input`, the
+/// executor's deterministic concatenation of the node's direct
+/// predecessor contents (see `executor.rs` predecessor-input
+/// construction). Earlier revisions read `ctx.completed.values().last()`
+/// from a `HashMap`, which is unordered and produced nondeterministic
+/// branching once more than one node had completed (codex round-5 P2).
 pub struct GateHandler;
 
 #[async_trait]
@@ -834,32 +839,31 @@ impl Handler for GateHandler {
     async fn execute(&self, node: &PipelineNode, ctx: &HandlerContext) -> Result<NodeOutcome> {
         let cond_str = node.prompt.as_deref().unwrap_or("true");
 
-        // Find the last completed outcome to evaluate against
-        let last_outcome = ctx
-            .completed
-            .values()
-            .last()
-            .cloned()
-            .unwrap_or_else(|| NodeOutcome {
-                node_id: "none".into(),
-                status: OutcomeStatus::Pass,
-                content: ctx.input.clone(),
-                token_usage: TokenUsage::default(),
-                files_modified: vec![],
-            });
+        // The executor only schedules a node after its direct predecessors
+        // have completed without aborting the run; the predecessor content
+        // therefore comes from `ctx.input` and the gate's "incoming status"
+        // is `Pass` by construction. (A skipped predecessor produces a
+        // skipped/unreachable path that never reaches us.)
+        let predecessor_outcome = NodeOutcome {
+            node_id: format!("{}__predecessor", node.id),
+            status: OutcomeStatus::Pass,
+            content: ctx.input.clone(),
+            token_usage: TokenUsage::default(),
+            files_modified: vec![],
+        };
 
         if cond_str == "true" {
             return Ok(NodeOutcome {
                 node_id: node.id.clone(),
                 status: OutcomeStatus::Pass,
-                content: last_outcome.content,
+                content: predecessor_outcome.content,
                 token_usage: TokenUsage::default(),
                 files_modified: vec![],
             });
         }
 
         let expr = condition::parse_condition(cond_str)?;
-        let passed = condition::evaluate(&expr, &last_outcome);
+        let passed = condition::evaluate(&expr, &predecessor_outcome);
 
         Ok(NodeOutcome {
             node_id: node.id.clone(),
@@ -868,7 +872,7 @@ impl Handler for GateHandler {
             } else {
                 OutcomeStatus::Fail
             },
-            content: last_outcome.content,
+            content: predecessor_outcome.content,
             token_usage: TokenUsage::default(),
             files_modified: vec![],
         })
@@ -964,6 +968,144 @@ mod tests {
             forwarded.contains("320") && forwarded.contains("110"),
             "forwarded message should carry the per-node token totals; got {forwarded:?}"
         );
+    }
+
+    /// Codex round-5 P2: GateHandler must evaluate its predicate against
+    /// the executor-supplied `ctx.input` (the deterministic concatenation
+    /// of direct-predecessor outputs), NOT against
+    /// `ctx.completed.values().last()` whose order depends on `HashMap`
+    /// iteration. This test seeds `completed` with two unrelated outcomes
+    /// whose content would *match* the gate's `outcome.contains(...)`
+    /// predicate — and sets `ctx.input` to content that does NOT match —
+    /// then asserts the gate fails. Under the old implementation the gate
+    /// would match one of the unrelated entries (HashMap order) and pass
+    /// nondeterministically; the new implementation must read input only.
+    #[tokio::test]
+    async fn gate_handler_evaluates_against_ctx_input_not_completed_map() {
+        use crate::graph::{HandlerKind, PipelineNode};
+
+        let mut completed = HashMap::new();
+        // Both completed entries contain the sentinel — these are
+        // distractors. The gate must NOT see them.
+        completed.insert(
+            "earlier_a".to_string(),
+            NodeOutcome {
+                node_id: "earlier_a".to_string(),
+                status: OutcomeStatus::Pass,
+                content: "leftover anomaly_detected reading".to_string(),
+                token_usage: TokenUsage::default(),
+                files_modified: vec![],
+            },
+        );
+        completed.insert(
+            "earlier_b".to_string(),
+            NodeOutcome {
+                node_id: "earlier_b".to_string(),
+                status: OutcomeStatus::Pass,
+                content: "another anomaly_detected note".to_string(),
+                token_usage: TokenUsage::default(),
+                files_modified: vec![],
+            },
+        );
+
+        let ctx = HandlerContext {
+            // Direct-predecessor content has no sentinel — gate must Fail.
+            input: "fresh inspection: anomaly_clear".to_string(),
+            completed,
+            working_dir: std::env::temp_dir(),
+        };
+
+        let gate = PipelineNode {
+            id: "result_gate".to_string(),
+            handler: HandlerKind::Gate,
+            prompt: Some("outcome.contains(\"anomaly_detected\")".to_string()),
+            label: None,
+            model: None,
+            context_window: None,
+            max_output_tokens: None,
+            tools: vec![],
+            goal_gate: false,
+            max_retries: 0,
+            timeout_secs: None,
+            suggested_next: None,
+            converge: None,
+            worker_prompt: None,
+            planner_model: None,
+            max_tasks: None,
+            deadline_secs: None,
+            deadline_action: None,
+            checkpoints: vec![],
+        };
+
+        let outcome = GateHandler
+            .execute(&gate, &ctx)
+            .await
+            .expect("gate execution must succeed");
+
+        assert_eq!(
+            outcome.status,
+            OutcomeStatus::Fail,
+            "gate must read predecessor content from ctx.input only; it must not pick up the `anomaly_detected` sentinel that lives in unrelated completed outcomes",
+        );
+        assert!(
+            outcome.content.contains("anomaly_clear"),
+            "gate outcome content must be the predecessor input, not a leftover completed outcome (got {:?})",
+            outcome.content,
+        );
+    }
+
+    /// Mirror of the above for the pass branch — the gate must also
+    /// recognise a sentinel that *is* present in `ctx.input` even when no
+    /// completed outcome contains it. Together with the fail-branch test
+    /// this pins both directions of the input-vs-completed-map fix.
+    #[tokio::test]
+    async fn gate_handler_passes_when_ctx_input_matches_predicate() {
+        use crate::graph::{HandlerKind, PipelineNode};
+
+        let mut completed = HashMap::new();
+        completed.insert(
+            "earlier".to_string(),
+            NodeOutcome {
+                node_id: "earlier".to_string(),
+                status: OutcomeStatus::Pass,
+                // Sentinel-free; would have made the gate Fail under the
+                // old `completed.last()` behaviour.
+                content: "boring earlier outcome".to_string(),
+                token_usage: TokenUsage::default(),
+                files_modified: vec![],
+            },
+        );
+
+        let ctx = HandlerContext {
+            input: "fresh inspection: anomaly_detected reading".to_string(),
+            completed,
+            working_dir: std::env::temp_dir(),
+        };
+
+        let gate = PipelineNode {
+            id: "result_gate".to_string(),
+            handler: HandlerKind::Gate,
+            prompt: Some("outcome.contains(\"anomaly_detected\")".to_string()),
+            label: None,
+            model: None,
+            context_window: None,
+            max_output_tokens: None,
+            tools: vec![],
+            goal_gate: false,
+            max_retries: 0,
+            timeout_secs: None,
+            suggested_next: None,
+            converge: None,
+            worker_prompt: None,
+            planner_model: None,
+            max_tasks: None,
+            deadline_secs: None,
+            deadline_action: None,
+            checkpoints: vec![],
+        };
+
+        let outcome = GateHandler.execute(&gate, &ctx).await.unwrap();
+        assert_eq!(outcome.status, OutcomeStatus::Pass);
     }
 
     /// Sanity check — the existing event arms still forward as before so

--- a/crates/octos-pipeline/src/recovery.rs
+++ b/crates/octos-pipeline/src/recovery.rs
@@ -279,6 +279,7 @@ mod tests {
         HandlerContext {
             input: "input".into(),
             completed: Default::default(),
+            predecessor_outcomes: Vec::new(),
             working_dir: std::env::temp_dir(),
         }
     }

--- a/crates/octos-pipeline/tests/dora_inspection_dot_smoke.rs
+++ b/crates/octos-pipeline/tests/dora_inspection_dot_smoke.rs
@@ -1,14 +1,19 @@
 //! The `examples/dora-bridge-config/inspection_mission.dot` file in the repo
 //! root is a documentation artifact that ships next to the dora-mcp bridge.
-//! It must use only parser-recognised handlers + deadline-action keywords;
-//! otherwise the example silently degrades to default `Codergen` behaviour
-//! and the README's claims diverge from runtime semantics.
+//! It must use only parser-recognised handlers + deadline-action keywords,
+//! and any `gate` node must carry an executable predicate so the example
+//! demonstrates real branching rather than degenerating into an
+//! always-pass / unconditional-edge no-op (codex round-3 P2 + round-4 P2s).
 //!
-//! Codex round-3 P2: an earlier revision used CamelCase / unsupported names
-//! (`SensorCheck`, `Motion`, `SafetyGate`, `Abort`, `Skip`, `EmergencyStop`)
-//! which all parsed as `Codergen` / `None`.
+//! Specifically:
+//!   * Round-3: handlers/actions had to live in the parser's set
+//!     (`codergen|gate|noop|...`, `abort|skip|escalate|retry:N`).
+//!   * Round-4: every `gate` node also needs `prompt=...` (the
+//!     `GateHandler` defaults to `"true"` when the prompt is absent), and
+//!     every gate-outgoing edge needs an explicit `condition=` so routing
+//!     does not fall through to the executor's label-substring fallback.
 
-use octos_pipeline::{parse_dot, DeadlineAction, HandlerKind};
+use octos_pipeline::{condition, parse_dot, DeadlineAction, HandlerKind};
 
 const DOT_PATH: &str = "../../examples/dora-bridge-config/inspection_mission.dot";
 
@@ -22,7 +27,7 @@ fn should_parse_inspection_mission_dot_with_supported_handlers() {
         assert!(
             matches!(
                 node.handler,
-                HandlerKind::Codergen | HandlerKind::Gate
+                HandlerKind::Codergen | HandlerKind::Gate | HandlerKind::Noop
             ),
             "node {} uses unsupported handler {:?}",
             node.id,
@@ -33,12 +38,141 @@ fn should_parse_inspection_mission_dot_with_supported_handlers() {
             assert!(
                 matches!(
                     action,
-                    DeadlineAction::Abort | DeadlineAction::Skip | DeadlineAction::Escalate | DeadlineAction::Retry { .. }
+                    DeadlineAction::Abort
+                        | DeadlineAction::Skip
+                        | DeadlineAction::Escalate
+                        | DeadlineAction::Retry { .. }
                 ),
                 "node {} has unsupported deadline_action {:?}",
                 node.id,
                 action,
             );
         }
+    }
+}
+
+#[test]
+fn should_wire_every_gate_node_with_an_executable_predicate() {
+    // GateHandler treats a missing/`"true"` prompt as unconditional pass, so
+    // a `gate` node without a real prompt is a documentation lie. Codex
+    // round-4 caught both `safety_gate` and `result_gate` in this state.
+
+    let src = std::fs::read_to_string(DOT_PATH)
+        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let graph = parse_dot(&src).expect("parse_dot must accept the example");
+
+    let gate_nodes: Vec<_> = graph
+        .nodes
+        .values()
+        .filter(|n| matches!(n.handler, HandlerKind::Gate))
+        .collect();
+
+    assert!(
+        !gate_nodes.is_empty(),
+        "the example is supposed to demonstrate gates; none found",
+    );
+
+    for node in gate_nodes {
+        let prompt = node
+            .prompt
+            .as_deref()
+            .unwrap_or_else(|| panic!("gate node {} has no prompt", node.id));
+        assert_ne!(
+            prompt.trim(),
+            "true",
+            "gate node {} has a no-op `true` predicate",
+            node.id,
+        );
+        assert!(
+            !prompt.trim().is_empty(),
+            "gate node {} has an empty predicate",
+            node.id,
+        );
+    }
+}
+
+#[test]
+fn should_route_every_gate_outgoing_edge_via_explicit_condition() {
+    // The executor's edge-selection step (executor.rs::next_edge) prefers
+    // `condition=`-matched edges; falling back to label substring or the
+    // first unconditional edge erases the gate's branching intent. Every
+    // gate-outgoing edge must therefore carry a real `condition=`.
+
+    let src = std::fs::read_to_string(DOT_PATH)
+        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let graph = parse_dot(&src).expect("parse_dot must accept the example");
+
+    let gate_ids: Vec<&str> = graph
+        .nodes
+        .values()
+        .filter(|n| matches!(n.handler, HandlerKind::Gate))
+        .map(|n| n.id.as_str())
+        .collect();
+
+    for gate_id in gate_ids {
+        let outgoing: Vec<_> = graph
+            .edges
+            .iter()
+            .filter(|e| e.source == gate_id)
+            .collect();
+        assert!(
+            outgoing.len() >= 2,
+            "gate {} should have at least two outgoing edges (pass/fail), found {}",
+            gate_id,
+            outgoing.len(),
+        );
+        for edge in outgoing {
+            let cond = edge.condition.as_deref().unwrap_or_else(|| {
+                panic!(
+                    "gate-outgoing edge {} -> {} has no condition= attribute",
+                    edge.source, edge.target,
+                )
+            });
+            assert!(
+                !cond.trim().is_empty(),
+                "edge {} -> {} has an empty condition",
+                edge.source,
+                edge.target,
+            );
+        }
+    }
+}
+
+#[test]
+fn should_compile_every_gate_predicate_and_edge_condition_via_the_dsl() {
+    // A `gate` prompt or edge condition that looks plausible but does not
+    // actually parse (e.g. plain English, missing quotes) silently degrades:
+    // GateHandler returns an Err for a bad prompt, and `next_edge` bubbles
+    // the parse error up, so a doc artifact that ships unparseable
+    // predicates is a runtime time-bomb. This test compiles every predicate
+    // through the real DSL.
+
+    let src = std::fs::read_to_string(DOT_PATH)
+        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let graph = parse_dot(&src).expect("parse_dot must accept the example");
+
+    for node in graph.nodes.values() {
+        if !matches!(node.handler, HandlerKind::Gate) {
+            continue;
+        }
+        let prompt = node.prompt.as_deref().expect("gate prompt asserted above");
+        condition::parse_condition(prompt).unwrap_or_else(|e| {
+            panic!(
+                "gate {} prompt did not compile via parse_condition: {} (source: {})",
+                node.id, e, prompt,
+            )
+        });
+    }
+
+    for edge in &graph.edges {
+        let Some(cond) = edge.condition.as_deref() else {
+            continue;
+        };
+        condition::parse_condition(cond).unwrap_or_else(|e| {
+            panic!(
+                "edge {} -> {} condition did not compile: {} (source: {})",
+                edge.source, edge.target, e, cond,
+            )
+        });
     }
 }

--- a/crates/octos-pipeline/tests/dora_inspection_dot_smoke.rs
+++ b/crates/octos-pipeline/tests/dora_inspection_dot_smoke.rs
@@ -1,0 +1,44 @@
+//! The `examples/dora-bridge-config/inspection_mission.dot` file in the repo
+//! root is a documentation artifact that ships next to the dora-mcp bridge.
+//! It must use only parser-recognised handlers + deadline-action keywords;
+//! otherwise the example silently degrades to default `Codergen` behaviour
+//! and the README's claims diverge from runtime semantics.
+//!
+//! Codex round-3 P2: an earlier revision used CamelCase / unsupported names
+//! (`SensorCheck`, `Motion`, `SafetyGate`, `Abort`, `Skip`, `EmergencyStop`)
+//! which all parsed as `Codergen` / `None`.
+
+use octos_pipeline::{parse_dot, DeadlineAction, HandlerKind};
+
+const DOT_PATH: &str = "../../examples/dora-bridge-config/inspection_mission.dot";
+
+#[test]
+fn should_parse_inspection_mission_dot_with_supported_handlers() {
+    let src = std::fs::read_to_string(DOT_PATH)
+        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let graph = parse_dot(&src).expect("parse_dot must accept the example");
+
+    for node in graph.nodes.values() {
+        assert!(
+            matches!(
+                node.handler,
+                HandlerKind::Codergen | HandlerKind::Gate
+            ),
+            "node {} uses unsupported handler {:?}",
+            node.id,
+            node.handler,
+        );
+
+        if let Some(action) = node.deadline_action {
+            assert!(
+                matches!(
+                    action,
+                    DeadlineAction::Abort | DeadlineAction::Skip | DeadlineAction::Escalate | DeadlineAction::Retry { .. }
+                ),
+                "node {} has unsupported deadline_action {:?}",
+                node.id,
+                action,
+            );
+        }
+    }
+}

--- a/crates/octos-pipeline/tests/dora_inspection_dot_smoke.rs
+++ b/crates/octos-pipeline/tests/dora_inspection_dot_smoke.rs
@@ -13,14 +13,13 @@
 //!     every gate-outgoing edge needs an explicit `condition=` so routing
 //!     does not fall through to the executor's label-substring fallback.
 
-use octos_pipeline::{condition, parse_dot, DeadlineAction, HandlerKind};
+use octos_pipeline::{DeadlineAction, HandlerKind, condition, parse_dot};
 
 const DOT_PATH: &str = "../../examples/dora-bridge-config/inspection_mission.dot";
 
 #[test]
 fn should_parse_inspection_mission_dot_with_supported_handlers() {
-    let src = std::fs::read_to_string(DOT_PATH)
-        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let src = std::fs::read_to_string(DOT_PATH).unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
     let graph = parse_dot(&src).expect("parse_dot must accept the example");
 
     for node in graph.nodes.values() {
@@ -57,8 +56,7 @@ fn should_wire_every_gate_node_with_an_executable_predicate() {
     // a `gate` node without a real prompt is a documentation lie. Codex
     // round-4 caught both `safety_gate` and `result_gate` in this state.
 
-    let src = std::fs::read_to_string(DOT_PATH)
-        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let src = std::fs::read_to_string(DOT_PATH).unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
     let graph = parse_dot(&src).expect("parse_dot must accept the example");
 
     let gate_nodes: Vec<_> = graph
@@ -98,8 +96,7 @@ fn should_route_every_gate_outgoing_edge_via_explicit_condition() {
     // first unconditional edge erases the gate's branching intent. Every
     // gate-outgoing edge must therefore carry a real `condition=`.
 
-    let src = std::fs::read_to_string(DOT_PATH)
-        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let src = std::fs::read_to_string(DOT_PATH).unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
     let graph = parse_dot(&src).expect("parse_dot must accept the example");
 
     let gate_ids: Vec<&str> = graph
@@ -110,11 +107,7 @@ fn should_route_every_gate_outgoing_edge_via_explicit_condition() {
         .collect();
 
     for gate_id in gate_ids {
-        let outgoing: Vec<_> = graph
-            .edges
-            .iter()
-            .filter(|e| e.source == gate_id)
-            .collect();
+        let outgoing: Vec<_> = graph.edges.iter().filter(|e| e.source == gate_id).collect();
         assert!(
             outgoing.len() >= 2,
             "gate {} should have at least two outgoing edges (pass/fail), found {}",
@@ -147,8 +140,7 @@ fn should_compile_every_gate_predicate_and_edge_condition_via_the_dsl() {
     // predicates is a runtime time-bomb. This test compiles every predicate
     // through the real DSL.
 
-    let src = std::fs::read_to_string(DOT_PATH)
-        .unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
+    let src = std::fs::read_to_string(DOT_PATH).unwrap_or_else(|e| panic!("read {DOT_PATH}: {e}"));
     let graph = parse_dot(&src).expect("parse_dot must accept the example");
 
     for node in graph.nodes.values() {

--- a/examples/dora-bridge-config/README.md
+++ b/examples/dora-bridge-config/README.md
@@ -1,0 +1,147 @@
+# Dora MCP Bridge + Mission Pipeline — Config Example
+
+**Covers:** Dora MCP Bridge (Area 2) + Mission Pipeline (Area 5)
+
+## The Problem
+
+Robot hardware runs on Dora-RS dataflow graphs — camera nodes, motion planners,
+gripper controllers. The LLM agent runs on octos with MCP tools. These are two
+separate worlds with no connection. Without a bridge:
+
+- **Developers write glue code for every robot tool.** Each Dora node needs a
+  custom MCP adapter — parsing JSON, handling timeouts, mapping safety tiers.
+  For 10 nodes, that's 10 adapters with 10 sets of bugs.
+- **Multi-step missions are ad-hoc prompts.** "Go to valve V-101, inspect it,
+  fix if needed, come back" is a single LLM prompt. If it fails at step 3, you
+  start over. No checkpoints, no deadlines, no safety gates between steps.
+- **No safety tier enforcement across the bridge.** The LLM can call any Dora
+  node at any time — including full-speed actuation nodes during an observe-only
+  session.
+
+## The Solution
+
+### Dora MCP Bridge (`dora_tool_map.json`)
+
+A JSON config file that maps Dora-RS nodes to MCP tools **without writing code**.
+Each mapping declares:
+- Which Dora node/output handles the tool
+- What parameters the LLM should provide
+- What `safety_tier` is required (enforced by `RobotPermissionPolicy`)
+- Timeout for the tool call
+
+**Before:** Write a custom Rust adapter for each Dora node.
+**After:** Add 10 lines of JSON per tool. `BridgeConfig::from_file()` loads them all.
+
+### Mission Pipeline (`inspection_mission.dot`)
+
+A DOT graph that defines multi-step robot missions as a DAG with safety
+guarantees at each step. Each node has a `HandlerKind` that determines behavior:
+
+| Handler | Purpose | Example |
+|---------|---------|---------|
+| `SensorCheck` | Read sensor, evaluate condition | "Is battery > 20%?" |
+| `Motion` | Execute robot motion | "Navigate to valve P1" |
+| `SafetyGate` | Require safety condition | "Force < 50N before manipulation" |
+| `Codergen` | LLM-driven reasoning | "Inspect valve, decide action" |
+| `Gate` | Conditional branch | "Was anomaly detected?" |
+
+**Before:** One big LLM prompt. No checkpoints, no deadlines, no safety gates.
+**After:** Each step has deadlines, invariants, and checkpoints. If the LLM
+hangs on step 3, the deadline fires after 60s and skips to the next step. If
+force exceeds 50N at the safety gate, the mission triggers emergency stop.
+
+## Files
+
+| File | What It Shows |
+|------|---------------|
+| `dora_tool_map.json` | 4 tool mappings with safety tiers and timeouts |
+| `inspection_mission.dot` | 8-node pipeline DAG with all handler types |
+
+## dora_tool_map.json — Tool Mappings
+
+```
+capture_valve_image  ->  camera_node:capture_request     [observe]
+move_to_valve        ->  motion_planner:move_command      [safe_motion]
+turn_valve           ->  gripper_node:rotate_command      [full_actuation]
+read_pressure_gauge  ->  vision_node:gauge_read_request   [observe]
+```
+
+Each tool has a `safety_tier` field. When the agent is running in a `SafeMotion`
+session, it can use `capture_valve_image` and `move_to_valve`, but `turn_valve`
+(which requires `full_actuation`) is blocked — even though the LLM can see it
+in the tool list.
+
+### Loading the config
+
+```rust
+use octos_dora_mcp::{BridgeConfig, DoraToolBridge};
+
+// Load all tool mappings from the JSON config
+let config = BridgeConfig::from_file("examples/dora-bridge-config/dora_tool_map.json")?;
+
+// Each mapping becomes an MCP-compatible tool
+let tools: Vec<DoraToolBridge> = config
+    .mappings
+    .into_iter()
+    .map(DoraToolBridge::new)
+    .collect();
+
+// Register with the agent — safety tier is enforced automatically
+for tool in &tools {
+    let mapping = tool.mapping();
+    println!(
+        "{} -> {}:{} (tier: {:?})",
+        mapping.tool_name,
+        mapping.dora_node_id,
+        mapping.dora_output_id,
+        tool.required_safety_tier(),
+    );
+}
+```
+
+## inspection_mission.dot — Pipeline DAG
+
+```
+preflight --> navigate --> arrival_check --> safety_gate --> inspect --> result_gate
+                                                                           |
+                                                                      yes / \ no
+                                                                         /   \
+                                                                 corrective  return_home
+                                                                         \   /
+                                                                      return_home
+```
+
+### Key attributes demonstrated
+
+**Deadlines** — prevent the mission from hanging forever:
+```dot
+navigate [handler="Motion", deadline_secs="120", deadline_action="Abort"];
+// If navigation takes > 120s, abort the mission (robot might be stuck)
+
+inspect [handler="Codergen", deadline_secs="60", deadline_action="Skip"];
+// If LLM inspection takes > 60s, skip to the next step (non-critical)
+```
+
+**Invariants** — safety conditions checked before proceeding:
+```dot
+preflight [handler="SensorCheck", invariant="battery_soc > 20", on_violation="Abort"];
+// Don't start the mission if battery is too low to complete it
+
+safety_gate [handler="SafetyGate", invariant="max_force_n < 50.0", on_violation="EmergencyStop"];
+// If force exceeds 50N, something is wrong — trigger e-stop immediately
+```
+
+**Checkpoints** — resume a failed mission from where it left off:
+```dot
+navigate [checkpoint="true"];
+// After arriving at the valve, save state. If the mission fails later,
+// restart from here instead of navigating again.
+```
+
+### DeadlineAction options
+
+| Action | When to use |
+|--------|-------------|
+| `Abort` | Critical step — mission cannot continue without it |
+| `Skip` | Non-critical step — log the timeout and move to next node |
+| `EmergencyStop` | Safety violation — halt all motion immediately |

--- a/examples/dora-bridge-config/README.md
+++ b/examples/dora-bridge-config/README.md
@@ -74,19 +74,21 @@ in the tool list.
 ### Loading the config
 
 ```rust
-use octos_dora_mcp::{BridgeConfig, DoraToolBridge};
+use octos_dora_mcp::{load_bridges, BridgeConfig};
 
-// Load all tool mappings from the JSON config
+// Load all tool mappings from the JSON config.
 let config = BridgeConfig::from_file("examples/dora-bridge-config/dora_tool_map.json")?;
 
-// Each mapping becomes an MCP-compatible tool
-let tools: Vec<DoraToolBridge> = config
-    .mappings
-    .into_iter()
-    .map(DoraToolBridge::new)
-    .collect();
+// `load_bridges` does TWO things:
+//   1. Constructs a `DoraToolBridge` per mapping (each impls `Tool`).
+//   2. Inserts each tool's name into the global `RobotToolRegistry` at its
+//      declared `safety_tier`. This is what wires `group:robot:<tier>`
+//      `ToolPolicy` allow/deny against these bridges. Constructing
+//      `DoraToolBridge::new` directly skips the registry registration and
+//      tier-based access control silently no-ops — always go through
+//      `load_bridges`.
+let tools = load_bridges(&config);
 
-// Register with the agent — safety tier is enforced automatically
 for tool in &tools {
     let mapping = tool.mapping();
     println!(

--- a/examples/dora-bridge-config/README.md
+++ b/examples/dora-bridge-config/README.md
@@ -35,20 +35,32 @@ Each mapping declares:
 ### Mission Pipeline (`inspection_mission.dot`)
 
 A DOT graph that defines multi-step robot missions as a DAG with safety
-guarantees at each step. Each node has a `HandlerKind` that determines behavior:
+guarantees at each step. Each node has a `HandlerKind` that determines behavior.
 
-| Handler | Purpose | Example |
-|---------|---------|---------|
-| `SensorCheck` | Read sensor, evaluate condition | "Is battery > 20%?" |
-| `Motion` | Execute robot motion | "Navigate to valve P1" |
-| `SafetyGate` | Require safety condition | "Force < 50N before manipulation" |
-| `Codergen` | LLM-driven reasoning | "Inspect valve, decide action" |
-| `Gate` | Conditional branch | "Was anomaly detected?" |
+The current `octos-pipeline` DOT parser recognises this set of handlers:
 
-**Before:** One big LLM prompt. No checkpoints, no deadlines, no safety gates.
-**After:** Each step has deadlines, invariants, and checkpoints. If the LLM
-hangs on step 3, the deadline fires after 60s and skips to the next step. If
-force exceeds 50N at the safety gate, the mission triggers emergency stop.
+| Handler (parser keyword) | Purpose | Example use in this graph |
+|---|---|---|
+| `codergen` | LLM-driven reasoning over allowed tools | Inspect valve, plan corrective action |
+| `gate` | Conditional branch on a runtime condition | "Was anomaly detected?" |
+| `shell` | Run a shell command | (not used here) |
+| `noop` | Pass-through marker node | (not used here) |
+| `parallel` / `dynamic_parallel` | Fan-out across workers | (not used here) |
+
+Higher-level robotics handlers — `SensorCheck`, `Motion`, `SafetyGate` —
+appear in design discussions but are **not yet implemented in the parser /
+executor**. The example uses `codergen` as the stand-in: the LLM is given the
+appropriate observe-tier or safe-motion bridge tool and prompted to perform
+the check or motion. When the dedicated handlers land, swap the
+`handler="codergen"` attributes for `handler="sensor_check"` /
+`handler="motion"` / `handler="safety_gate"` (and add the parser keywords +
+handler implementations in the same change).
+
+**Before:** One big LLM prompt. No checkpoints, no deadlines, no separation
+of concerns.
+**After:** Each step is its own node with its own deadline + checkpoint, and
+restricted to a tier-appropriate subset of bridge tools. If the LLM hangs on
+inspection, the deadline fires after 60s and skips to the next step.
 
 ## Files
 
@@ -115,35 +127,44 @@ preflight --> navigate --> arrival_check --> safety_gate --> inspect --> result_
 
 ### Key attributes demonstrated
 
-**Deadlines** — prevent the mission from hanging forever:
+**Deadlines** — prevent the mission from hanging forever (parser-supported
+attributes + lowercase action keywords):
 ```dot
-navigate [handler="Motion", deadline_secs="120", deadline_action="Abort"];
-// If navigation takes > 120s, abort the mission (robot might be stuck)
+navigate [handler="codergen", deadline_secs="120", deadline_action="abort"];
+// If navigation takes > 120s, abort the mission (robot might be stuck).
 
-inspect [handler="Codergen", deadline_secs="60", deadline_action="Skip"];
-// If LLM inspection takes > 60s, skip to the next step (non-critical)
+inspect [handler="codergen", deadline_secs="60", deadline_action="skip"];
+// If LLM inspection takes > 60s, skip to the next step (non-critical).
 ```
 
-**Invariants** — safety conditions checked before proceeding:
+**Invariants / safety gates** — modelled here with the `gate` handler. The
+parser does not yet recognise `invariant=...` / `on_violation=...` as
+attributes, so safety conditions live in the gate's runtime condition
+rather than node attributes:
 ```dot
-preflight [handler="SensorCheck", invariant="battery_soc > 20", on_violation="Abort"];
-// Don't start the mission if battery is too low to complete it
-
-safety_gate [handler="SafetyGate", invariant="max_force_n < 50.0", on_violation="EmergencyStop"];
-// If force exceeds 50N, something is wrong — trigger e-stop immediately
+safety_gate [handler="gate"];
+// Branch on whether force/torque is within limits before manipulation.
 ```
 
 **Checkpoints** — resume a failed mission from where it left off:
 ```dot
-navigate [checkpoint="true"];
+navigate [handler="codergen", checkpoint="true"];
 // After arriving at the valve, save state. If the mission fails later,
 // restart from here instead of navigating again.
 ```
 
-### DeadlineAction options
+### deadline_action keywords
 
-| Action | When to use |
-|--------|-------------|
-| `Abort` | Critical step — mission cannot continue without it |
-| `Skip` | Non-critical step — log the timeout and move to next node |
-| `EmergencyStop` | Safety violation — halt all motion immediately |
+The parser accepts these lowercase values for `deadline_action`:
+
+| Keyword | When to use |
+|---|---|
+| `abort` | Critical step — mission cannot continue without it. |
+| `skip` | Non-critical step — log the timeout and move on. |
+| `escalate` | Hand the timeout to the parent / supervisor handler. |
+| `retry:<N>` | Retry the node up to N attempts (e.g. `retry:3`). |
+
+There is no `EmergencyStop` action keyword today; trigger e-stop semantics by
+routing through a `gate` handler whose `false` branch fires the appropriate
+emergency-tier bridge tool, or extend the parser with a new keyword in the
+same change that adds the executor support.

--- a/examples/dora-bridge-config/README.md
+++ b/examples/dora-bridge-config/README.md
@@ -67,7 +67,7 @@ inspection, the deadline fires after 60s and skips to the next step.
 | File | What It Shows |
 |------|---------------|
 | `dora_tool_map.json` | 4 tool mappings with safety tiers and timeouts |
-| `inspection_mission.dot` | 8-node pipeline DAG with all handler types |
+| `inspection_mission.dot` | 9-node pipeline DAG using `codergen` / `gate` / `noop` |
 
 ## dora_tool_map.json — Tool Mappings
 
@@ -139,12 +139,21 @@ inspect [handler="codergen", deadline_secs="60", deadline_action="skip"];
 
 **Invariants / safety gates** — modelled here with the `gate` handler. The
 parser does not yet recognise `invariant=...` / `on_violation=...` as
-attributes, so safety conditions live in the gate's runtime condition
-rather than node attributes:
+attributes, so safety conditions are encoded in the gate's `prompt` (a
+predicate against the upstream outcome) and routing is encoded on the
+outgoing edges' `condition=` attribute:
 ```dot
-safety_gate [handler="gate"];
-// Branch on whether force/torque is within limits before manipulation.
+safety_gate [handler="gate", prompt="outcome.contains(\"force_ok\")"];
+
+safety_gate -> inspect        [condition="outcome.status == \"pass\""];
+safety_gate -> emergency_stop [condition="outcome.status == \"fail\""];
 ```
+The supported predicate language is `outcome.status == "pass"|"fail"`,
+`outcome.contains("...")`, plus `&& || !` combinators (see
+`crates/octos-pipeline/src/condition.rs`). Without a `prompt`, `gate` nodes
+default to `"true"` (always Pass), and without `condition=` on the
+outgoing edges the executor falls back to label substring matching against
+outcome content — so both halves are required for real branching.
 
 **Checkpoints** — resume a failed mission from where it left off:
 ```dot

--- a/examples/dora-bridge-config/dora_tool_map.json
+++ b/examples/dora-bridge-config/dora_tool_map.json
@@ -1,0 +1,53 @@
+{
+  "description": "Dora-RS to MCP tool bridge for a valve inspection pipeline",
+  "mappings": [
+    {
+      "tool_name": "capture_valve_image",
+      "description": "Capture a high-resolution image of the target valve using the inspection camera",
+      "dora_node_id": "camera_node",
+      "dora_output_id": "capture_request",
+      "parameters": {
+        "valve_id": "Identifier of the valve to photograph",
+        "resolution": "Image resolution (e.g., '1920x1080')"
+      },
+      "safety_tier": "observe",
+      "timeout_secs": 10
+    },
+    {
+      "tool_name": "move_to_valve",
+      "description": "Move the robot arm to a pre-taught valve inspection pose",
+      "dora_node_id": "motion_planner",
+      "dora_output_id": "move_command",
+      "parameters": {
+        "valve_id": "Target valve identifier",
+        "approach": "Approach strategy: 'direct' or 'via_home'"
+      },
+      "safety_tier": "safe_motion",
+      "timeout_secs": 30
+    },
+    {
+      "tool_name": "turn_valve",
+      "description": "Actuate a valve by rotating the gripper to the target angle",
+      "dora_node_id": "gripper_node",
+      "dora_output_id": "rotate_command",
+      "parameters": {
+        "valve_id": "Target valve identifier",
+        "angle_deg": "Target rotation angle in degrees",
+        "torque_limit_nm": "Maximum torque limit in Newton-meters"
+      },
+      "safety_tier": "full_actuation",
+      "timeout_secs": 45
+    },
+    {
+      "tool_name": "read_pressure_gauge",
+      "description": "Read the current pressure gauge value via computer vision",
+      "dora_node_id": "vision_node",
+      "dora_output_id": "gauge_read_request",
+      "parameters": {
+        "gauge_id": "Identifier of the pressure gauge"
+      },
+      "safety_tier": "observe",
+      "timeout_secs": 15
+    }
+  ]
+}

--- a/examples/dora-bridge-config/inspection_mission.dot
+++ b/examples/dora-bridge-config/inspection_mission.dot
@@ -1,0 +1,48 @@
+// Valve inspection mission pipeline
+// Demonstrates HandlerKind variants, DeadlineAction, Invariant, and MissionCheckpoint
+digraph inspection_mission {
+    rankdir=LR;
+
+    // SensorCheck: verify robot is operational before starting
+    preflight [shape=octagon, label="Preflight\nSensorCheck", handler="SensorCheck",
+               invariant="battery_soc > 20", on_violation="Abort"];
+
+    // Motion: navigate to the valve location
+    navigate [shape=pentagon, label="Navigate\nto Valve P1", handler="Motion",
+              deadline_secs="120", deadline_action="Abort",
+              checkpoint="true"];
+
+    // SensorCheck: confirm arrival at target position
+    arrival_check [shape=octagon, label="Arrival\nSensorCheck", handler="SensorCheck",
+                   invariant="position_error_m < 0.01", on_violation="Abort"];
+
+    // SafetyGate: require force/torque within limits before manipulation
+    safety_gate [shape=doubleoctagon, label="Force/Torque\nSafetyGate", handler="SafetyGate",
+                 invariant="max_force_n < 50.0", on_violation="EmergencyStop"];
+
+    // Codergen: LLM-driven valve inspection with camera tool
+    inspect [shape=box, label="Inspect Valve\nCodergen", handler="Codergen",
+             deadline_secs="60", deadline_action="Skip",
+             checkpoint="true"];
+
+    // Gate: evaluate inspection result
+    result_gate [shape=diamond, label="Anomaly\nDetected?", handler="Gate"];
+
+    // Codergen: LLM plans corrective action if anomaly found
+    corrective [shape=box, label="Corrective\nAction", handler="Codergen",
+                deadline_secs="90", deadline_action="Abort"];
+
+    // Motion: return to home position
+    return_home [shape=pentagon, label="Return\nHome", handler="Motion",
+                 deadline_secs="120", deadline_action="Skip"];
+
+    // Edges
+    preflight -> navigate;
+    navigate -> arrival_check;
+    arrival_check -> safety_gate;
+    safety_gate -> inspect;
+    inspect -> result_gate;
+    result_gate -> corrective [label="yes"];
+    result_gate -> return_home [label="no"];
+    corrective -> return_home;
+}

--- a/examples/dora-bridge-config/inspection_mission.dot
+++ b/examples/dora-bridge-config/inspection_mission.dot
@@ -7,9 +7,17 @@
 //     Higher-level robotics handlers (SensorCheck, Motion, SafetyGate) are
 //     described conceptually in the README but are not yet implemented; this
 //     graph stands them in with `codergen` (LLM-driven reasoning over the
-//     bridge tool list) and `gate` (boolean branch on a condition).
+//     bridge tool list), `gate` (boolean predicate over the last outcome),
+//     and `noop` (terminal sink).
+//   * `gate` nodes evaluate `prompt` as a condition against the previous
+//     outcome — the supported predicate language is
+//     `outcome.status == "pass"|"fail"`, `outcome.contains("...")`, plus
+//     `&& || !` combinators (see crates/octos-pipeline/src/condition.rs).
+//   * Edges that need to branch must use `condition="..."`. Plain `label=`
+//     is only a substring fallback against outcome content; this graph uses
+//     real conditions on every gate-outgoing edge.
 //   * `deadline_action` accepts lowercase `abort`, `skip`, `escalate`, and
-//     `retry:<n>`. Anything else is silently dropped.
+//     `retry:<n>`.
 //   * `invariant=...` / `on_violation=...` are not currently parsed; the
 //     `checkpoint="true"` attribute is.
 //
@@ -22,7 +30,7 @@ digraph inspection_mission {
     // Stand-in for SensorCheck: LLM is asked to confirm preflight via the
     // bridge's read_pressure_gauge / observe-tier sensor tools.
     preflight [shape=octagon, label="Preflight\nSensor Check", handler="codergen",
-               prompt="Confirm battery_soc > 20 via the observe-tier sensor tools before continuing.",
+               prompt="Confirm battery_soc > 20 via the observe-tier sensor tools. If healthy, end your reply with the literal token preflight_ok.",
                tools="read_pressure_gauge"];
 
     // Stand-in for Motion: LLM drives the safe-motion bridge tool. Deadline
@@ -33,25 +41,34 @@ digraph inspection_mission {
               deadline_secs="120", deadline_action="abort",
               checkpoint="true"];
 
-    // Stand-in for arrival SensorCheck.
+    // Stand-in for arrival SensorCheck. Ends its reply with `force_ok` only
+    // when force/torque is within spec — the safety_gate predicate below
+    // depends on this sentinel.
     arrival_check [shape=octagon, label="Arrival\nSensor Check", handler="codergen",
-                   prompt="Confirm position_error_m < 0.01 using the observe-tier sensors.",
+                   prompt="Confirm position_error_m < 0.01 and max_force_n < 50 via the observe-tier sensors. End with force_ok if both hold, otherwise force_fail.",
                    tools="capture_valve_image"];
 
-    // Stand-in for SafetyGate: a boolean gate on whether force is within
-    // limits. The decision logic lives in `condition` (evaluated by the gate
-    // handler at runtime).
-    safety_gate [shape=doubleoctagon, label="Force/Torque\nSafety Gate", handler="gate"];
+    // SafetyGate: pass iff the upstream outcome contains `force_ok`. On Fail
+    // the executor selects the conditional edge to emergency_stop.
+    safety_gate [shape=doubleoctagon, label="Force/Torque\nSafety Gate", handler="gate",
+                 prompt="outcome.contains(\"force_ok\")"];
 
-    // LLM-driven valve inspection.
+    // Terminal sink for the safety-gate failure branch. Distinct from the
+    // happy-path return_home node so an operator can grep the outcome graph
+    // for emergency stops.
+    emergency_stop [shape=Msquare, label="Emergency\nStop", handler="noop"];
+
+    // LLM-driven valve inspection. Ends with `anomaly_detected` when it
+    // believes the valve needs corrective action.
     inspect [shape=box, label="Inspect Valve\nCodergen", handler="codergen",
-             prompt="Inspect the valve using capture_valve_image and read_pressure_gauge; decide if it is anomalous.",
+             prompt="Inspect the valve using capture_valve_image and read_pressure_gauge. End with anomaly_detected if the valve looks anomalous, otherwise anomaly_clear.",
              tools="capture_valve_image,read_pressure_gauge",
              deadline_secs="60", deadline_action="skip",
              checkpoint="true"];
 
-    // Gate: was an anomaly detected?
-    result_gate [shape=diamond, label="Anomaly\nDetected?", handler="gate"];
+    // Branch on whether inspection flagged an anomaly. Pass = anomaly seen.
+    result_gate [shape=diamond, label="Anomaly\nDetected?", handler="gate",
+                 prompt="outcome.contains(\"anomaly_detected\")"];
 
     // Corrective action: LLM plans the response, may use the full-actuation
     // turn_valve tool (gated upstream by RobotPermissionPolicy).
@@ -66,13 +83,16 @@ digraph inspection_mission {
                  tools="move_to_valve",
                  deadline_secs="120", deadline_action="skip"];
 
-    // Edges
+    // Edges. Gate-outgoing edges carry real predicates over the gate's
+    // outcome (Pass/Fail) so the executor's condition step routes
+    // deterministically rather than falling back to label substring match.
     preflight -> navigate;
     navigate -> arrival_check;
     arrival_check -> safety_gate;
-    safety_gate -> inspect;
+    safety_gate -> inspect        [condition="outcome.status == \"pass\"", label="ok"];
+    safety_gate -> emergency_stop [condition="outcome.status == \"fail\"", label="halt"];
     inspect -> result_gate;
-    result_gate -> corrective [label="yes"];
-    result_gate -> return_home [label="no"];
+    result_gate -> corrective     [condition="outcome.status == \"pass\"", label="anomaly"];
+    result_gate -> return_home    [condition="outcome.status == \"fail\"", label="clear"];
     corrective -> return_home;
 }

--- a/examples/dora-bridge-config/inspection_mission.dot
+++ b/examples/dora-bridge-config/inspection_mission.dot
@@ -1,40 +1,70 @@
-// Valve inspection mission pipeline
-// Demonstrates HandlerKind variants, DeadlineAction, Invariant, and MissionCheckpoint
+// Valve inspection mission pipeline.
+//
+// IMPORTANT — what this example actually exercises today:
+//
+//   * The octos-pipeline DOT parser recognises a fixed set of handler kinds:
+//       codergen, shell, gate, noop, parallel, dynamic_parallel
+//     Higher-level robotics handlers (SensorCheck, Motion, SafetyGate) are
+//     described conceptually in the README but are not yet implemented; this
+//     graph stands them in with `codergen` (LLM-driven reasoning over the
+//     bridge tool list) and `gate` (boolean branch on a condition).
+//   * `deadline_action` accepts lowercase `abort`, `skip`, `escalate`, and
+//     `retry:<n>`. Anything else is silently dropped.
+//   * `invariant=...` / `on_violation=...` are not currently parsed; the
+//     `checkpoint="true"` attribute is.
+//
+// When dedicated robotics handler kinds land, swap each `codergen` node below
+// for the appropriate handler (e.g. `sensor_check`, `motion`, `safety_gate`)
+// and add the parser-side support in the same change.
 digraph inspection_mission {
     rankdir=LR;
 
-    // SensorCheck: verify robot is operational before starting
-    preflight [shape=octagon, label="Preflight\nSensorCheck", handler="SensorCheck",
-               invariant="battery_soc > 20", on_violation="Abort"];
+    // Stand-in for SensorCheck: LLM is asked to confirm preflight via the
+    // bridge's read_pressure_gauge / observe-tier sensor tools.
+    preflight [shape=octagon, label="Preflight\nSensor Check", handler="codergen",
+               prompt="Confirm battery_soc > 20 via the observe-tier sensor tools before continuing.",
+               tools="read_pressure_gauge"];
 
-    // Motion: navigate to the valve location
-    navigate [shape=pentagon, label="Navigate\nto Valve P1", handler="Motion",
-              deadline_secs="120", deadline_action="Abort",
+    // Stand-in for Motion: LLM drives the safe-motion bridge tool. Deadline
+    // fires `abort` if navigation hangs.
+    navigate [shape=pentagon, label="Navigate\nto Valve P1", handler="codergen",
+              prompt="Drive the robot to valve P1 using move_to_valve.",
+              tools="move_to_valve",
+              deadline_secs="120", deadline_action="abort",
               checkpoint="true"];
 
-    // SensorCheck: confirm arrival at target position
-    arrival_check [shape=octagon, label="Arrival\nSensorCheck", handler="SensorCheck",
-                   invariant="position_error_m < 0.01", on_violation="Abort"];
+    // Stand-in for arrival SensorCheck.
+    arrival_check [shape=octagon, label="Arrival\nSensor Check", handler="codergen",
+                   prompt="Confirm position_error_m < 0.01 using the observe-tier sensors.",
+                   tools="capture_valve_image"];
 
-    // SafetyGate: require force/torque within limits before manipulation
-    safety_gate [shape=doubleoctagon, label="Force/Torque\nSafetyGate", handler="SafetyGate",
-                 invariant="max_force_n < 50.0", on_violation="EmergencyStop"];
+    // Stand-in for SafetyGate: a boolean gate on whether force is within
+    // limits. The decision logic lives in `condition` (evaluated by the gate
+    // handler at runtime).
+    safety_gate [shape=doubleoctagon, label="Force/Torque\nSafety Gate", handler="gate"];
 
-    // Codergen: LLM-driven valve inspection with camera tool
-    inspect [shape=box, label="Inspect Valve\nCodergen", handler="Codergen",
-             deadline_secs="60", deadline_action="Skip",
+    // LLM-driven valve inspection.
+    inspect [shape=box, label="Inspect Valve\nCodergen", handler="codergen",
+             prompt="Inspect the valve using capture_valve_image and read_pressure_gauge; decide if it is anomalous.",
+             tools="capture_valve_image,read_pressure_gauge",
+             deadline_secs="60", deadline_action="skip",
              checkpoint="true"];
 
-    // Gate: evaluate inspection result
-    result_gate [shape=diamond, label="Anomaly\nDetected?", handler="Gate"];
+    // Gate: was an anomaly detected?
+    result_gate [shape=diamond, label="Anomaly\nDetected?", handler="gate"];
 
-    // Codergen: LLM plans corrective action if anomaly found
-    corrective [shape=box, label="Corrective\nAction", handler="Codergen",
-                deadline_secs="90", deadline_action="Abort"];
+    // Corrective action: LLM plans the response, may use the full-actuation
+    // turn_valve tool (gated upstream by RobotPermissionPolicy).
+    corrective [shape=box, label="Corrective\nAction", handler="codergen",
+                prompt="Plan and execute a corrective action using turn_valve if appropriate.",
+                tools="turn_valve",
+                deadline_secs="90", deadline_action="abort"];
 
-    // Motion: return to home position
-    return_home [shape=pentagon, label="Return\nHome", handler="Motion",
-                 deadline_secs="120", deadline_action="Skip"];
+    // Return to home: safe-motion tool again.
+    return_home [shape=pentagon, label="Return\nHome", handler="codergen",
+                 prompt="Drive back to the home pose using move_to_valve with the home waypoint.",
+                 tools="move_to_valve",
+                 deadline_secs="120", deadline_action="skip"];
 
     // Edges
     preflight -> navigate;


### PR DESCRIPTION
## Summary

Supersedes #818. Carries the full original change from `dorarobotics` (orphaned crate from closed #270 — `octos-dora-mcp` + `examples/dora-bridge-config/` walkthrough) PLUS fixes for both codex findings on #818, then closes #818.

## Codex findings on #818 + their fixes

**P1 — silent safety-tier downgrade**: previously unknown `safety_tier` strings (`FullActuation`, `Safe_Motion`, typos) silently fell back to `Observe`, the LEAST restrictive tier. Real safety regression for a robotics bridge.
**Fix**: `DoraToolMapping::safety_tier` is now typed `octos_agent::SafetyTier` (snake_case-serialised) instead of `String`. Unknown variants fail `BridgeConfig::from_json` with a clear deserialize error.

**P2 — tier metadata not enforced**: bridges carried `safety_tier` but never registered with `RobotToolRegistry`, so the existing `group:robot:<tier>` `ToolPolicy` machinery had nothing to evaluate.
**Fix**: `load_bridges` calls `with_registry_mut` to insert each bridge's tool name at its tier. Test verifies `tier_of(...)` returns the declared variant after load.

## Plus, two API-drift fixes vs current octos-agent main

- `ToolResult.content` was renamed `output`
- `Tool::tags(&self)` now returns `&[&str]` (was `Vec<&'static str>`)

#818's claimed clean-build-against-95cac6fe was correct at PR-open time; the trait/struct have drifted on main since.

## Verification

- [x] cargo build -p octos-dora-mcp clean
- [x] cargo test  -p octos-dora-mcp clean (14/14 unit tests + 0 doctests)
- [x] cargo clippy -p octos-dora-mcp -- -D warnings clean
- [x] cargo build --workspace clean (no impact on other crates)

## Closes

- Closes #818
- Closes #270 (orphaned crate now landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)