### PR TITLE
docs: remove redundant browser feature from zh installation guide

### DIFF
--- a/book-zh/src/installation.md
+++ b/book-zh/src/installation.md
@@ -33,9 +33,6 @@ cargo install --path crates/octos-cli
 # 启用消息渠道
 cargo install --path crates/octos-cli --features telegram,discord,slack,whatsapp,feishu,email,wecom
 
-# 启用浏览器自动化（需要 Chrome/Chromium）
-cargo install --path crates/octos-cli --features browser
-
 # 启用 Web 界面和 REST API
 cargo install --path crates/octos-cli --features api
 


### PR DESCRIPTION
This pull request removes the redundant installation instructions for the `browser` feature in the Chinese documentation (`book-zh/src/installation.md`). 

The `browser` feature is now included by default in `octos-cli` (via `octos-agent`), making the explicit `--features browser` flag unnecessary. This change aligns the Chinese documentation with the current codebase and the English version of the docs.