### PR TITLE
test(e2e): M9-α-7 — replace chatSSE() with chatWS() helper (closes #836)

### DIFF
--- a/e2e/lib/m9-ws-client.ts
+++ b/e2e/lib/m9-ws-client.ts
@@ -416,3 +416,249 @@ export class RpcErrorImpl extends Error {
     this.name = "RpcErrorImpl";
   }
 }
+
+// ---------------------------------------------------------------------------
+// chatWS — drop-in replacement for the legacy chatSSE() helpers used across
+// the e2e suite. Issues #836 (M9-α-7), #845 (audit lock).
+//
+// Design contract:
+//
+// 1. Same return shape as chatSSE: `{ events, content, doneEvent }` so spec
+//    bodies can swap `chatSSE(...)` -> `chatWS(...)` without rewriting their
+//    assertions, except for SSE-only fields explicitly flagged in the
+//    α-3 deferred-set follow-up (token usage, has_bg_tasks, session_result,
+//    file events). Specs that need those still use test.fixme until the
+//    server publishes the corresponding WS notifications (γ-3 / β-1).
+//
+// 2. We do NOT keep an SSE socket open in parallel — that would defeat
+//    α-5/α-6 (atomic SSE delete). Every byte we observe is a JSON-RPC
+//    notification on the M9 WebSocket.
+//
+// 3. WS notification -> synthesized SSE-shaped event mapping:
+//
+//      message/delta              -> { type: 'token', text }
+//      tool/started               -> { type: 'tool_start', tool, tool_call_id, arguments }
+//      tool/progress              -> { type: 'tool_progress', tool, tool_call_id, message, progress_pct }
+//      tool/completed             -> { type: 'tool_completed', tool, tool_call_id, ... }
+//      task/updated               -> { type: 'task_updated', task_id, status, ... }
+//      task/output/delta          -> { type: 'task_output_delta', task_id, text }
+//      progress/updated (α-4)     -> { type: 'progress_updated', ... }
+//      warning                    -> { type: 'warning', message }
+//      turn/started               -> { type: 'turn_started', turn_id }
+//      turn/completed             -> { type: 'done', content, cursor }
+//      turn/error                 -> { type: 'error', message }
+//
+//    Cumulative `content` is the concatenation of every `message/delta.text`
+//    for the active turn, matching what SSE callers see in `done.content`.
+// ---------------------------------------------------------------------------
+
+import type { Server as HttpServer } from "node:http"; // eslint-disable-line @typescript-eslint/no-unused-vars
+
+export interface ChatWsEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface ChatWsResult {
+  events: ChatWsEvent[];
+  content: string;
+  doneEvent?: ChatWsEvent;
+}
+
+export interface ChatWsOptions {
+  /** http(s):// or ws(s):// base URL. Path is appended automatically. */
+  baseUrl: string;
+  token: string;
+  message: string;
+  sessionId: string;
+  /** Optional profile id forwarded as `session/open.profile_id`. */
+  profileId?: string;
+  /** Total wait budget in ms before forcing return without `turn/completed`. */
+  maxWait?: number;
+  /** Override the WS connect timeout (default 10s). */
+  connectTimeoutMs?: number;
+  /** Override the request timeout for individual JSON-RPC calls. */
+  requestTimeoutMs?: number;
+  /** Reuse an existing client. If provided, caller owns close(). */
+  client?: M9WsClient;
+  /** Override the freshly generated turn id (defaults to a random uuid). */
+  turnId?: string;
+}
+
+/**
+ * Drive a single chat turn over the M9 WebSocket UI Protocol and collect
+ * synthesized SSE-shaped events until `turn/completed` (or `turn/error`,
+ * or the `maxWait` budget is exhausted).
+ *
+ * The promise resolves on the first terminal event for the turn, OR when the
+ * deadline elapses, whichever comes first.
+ */
+export async function chatWS(opts: ChatWsOptions): Promise<ChatWsResult> {
+  const ownsClient = !opts.client;
+  const client =
+    opts.client ??
+    new M9WsClient({
+      url: opts.baseUrl,
+      token: opts.token,
+      profileId: opts.profileId,
+      connectTimeoutMs: opts.connectTimeoutMs,
+      requestTimeoutMs: opts.requestTimeoutMs,
+    });
+  const turnId = opts.turnId ?? freshTurnId();
+  const deadline = Date.now() + (opts.maxWait ?? 60_000);
+  const events: ChatWsEvent[] = [];
+  let content = "";
+  let doneEvent: ChatWsEvent | undefined;
+  let terminal = false;
+  let resolveTerminal!: () => void;
+  const terminalPromise = new Promise<void>((r) => {
+    resolveTerminal = r;
+  });
+
+  const handler = (n: UiNotification) => {
+    // Filter on turn_id when present; some notifications (warnings, status)
+    // arrive without a turn scope and we forward them so spec bodies can see
+    // them in `events` if they want.
+    const params = (n.params ?? {}) as Record<string, unknown>;
+    const noteTurnId = params.turn_id;
+    if (noteTurnId !== undefined && noteTurnId !== turnId) return;
+    switch (n.method) {
+      case "turn/started": {
+        events.push({ type: "turn_started", turn_id: noteTurnId, raw: params });
+        break;
+      }
+      case "message/delta": {
+        const text = String(params.text ?? "");
+        if (text) {
+          content += text;
+          events.push({ type: "token", text });
+        }
+        break;
+      }
+      case "tool/started": {
+        events.push({
+          type: "tool_start",
+          tool: params.tool_name,
+          tool_call_id: params.tool_call_id,
+          arguments: params.arguments,
+        });
+        break;
+      }
+      case "tool/progress": {
+        events.push({
+          type: "tool_progress",
+          tool: params.tool_name,
+          tool_call_id: params.tool_call_id,
+          message: params.message,
+          progress_pct: params.progress_pct,
+        });
+        break;
+      }
+      case "tool/completed": {
+        events.push({
+          type: "tool_completed",
+          tool: params.tool_name,
+          tool_call_id: params.tool_call_id,
+          ok: params.ok,
+          error: params.error,
+        });
+        break;
+      }
+      case "task/updated": {
+        events.push({
+          type: "task_updated",
+          task_id: params.task_id,
+          status: params.status,
+          tool_call_id: params.tool_call_id,
+          raw: params,
+        });
+        break;
+      }
+      case "task/output/delta": {
+        events.push({
+          type: "task_output_delta",
+          task_id: params.task_id,
+          text: params.text,
+        });
+        break;
+      }
+      case "progress/updated": {
+        events.push({ type: "progress_updated", raw: params });
+        break;
+      }
+      case "warning": {
+        events.push({ type: "warning", message: params.message });
+        break;
+      }
+      case "turn/completed": {
+        const ev: ChatWsEvent = {
+          type: "done",
+          content,
+          cursor: params.cursor,
+          turn_id: noteTurnId,
+        };
+        events.push(ev);
+        doneEvent = ev;
+        terminal = true;
+        resolveTerminal();
+        break;
+      }
+      case "turn/error": {
+        const ev: ChatWsEvent = {
+          type: "error",
+          message: params.message ?? params.code ?? "turn/error",
+          code: params.code,
+          turn_id: noteTurnId,
+        };
+        events.push(ev);
+        doneEvent = ev;
+        terminal = true;
+        resolveTerminal();
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  client.onNotification(handler);
+
+  try {
+    await client.openSession({
+      session_id: opts.sessionId,
+      profile_id: opts.profileId,
+    });
+    await client.startTurn({
+      session_id: opts.sessionId,
+      turn_id: turnId,
+      input: [{ kind: "text", text: opts.message }],
+    });
+
+    const remaining = Math.max(1_000, deadline - Date.now());
+    await Promise.race([
+      terminalPromise,
+      new Promise<void>((r) => setTimeout(r, remaining)),
+    ]);
+  } catch (err) {
+    // On RPC error during open/start, surface as `error` event so callers
+    // see an SSE-equivalent shape rather than a thrown promise.
+    const message = err instanceof Error ? err.message : String(err);
+    const ev: ChatWsEvent = { type: "error", message };
+    events.push(ev);
+    doneEvent ??= ev;
+  } finally {
+    if (ownsClient) {
+      try {
+        await client.close();
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+
+  // Best-effort post-condition: if no terminal arrived, do NOT inject a
+  // synthetic done — callers historically rely on `doneEvent === undefined`
+  // to detect timeouts.
+  void terminal;
+  return { events, content, doneEvent };
+}

--- a/e2e/tests/live-cost-tracking.spec.ts
+++ b/e2e/tests/live-cost-tracking.spec.ts
@@ -25,6 +25,7 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
 const BASE = process.env.OCTOS_TEST_URL || 'https://dspfac.bot.ominix.io';
 const TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
@@ -38,10 +39,7 @@ if (BASE.includes('dspfac.ocean.ominix.io')) {
 
 test.setTimeout(900_000);
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+type SseEvent = ChatWsEvent;
 
 interface BackgroundTaskRow {
   id?: string;
@@ -63,64 +61,24 @@ interface BackgroundTaskRow {
   completed_at?: string | null;
 }
 
-async function chatSSE(
+/**
+ * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ * Returns the same `{ events, content, doneEvent }` shape the SSE helper
+ * exposed so call sites stay unchanged.
+ */
+async function chatViaWs(
   message: string,
   sessionId: string,
   maxWait = 60_000,
 ): Promise<{ events: SseEvent[]; content: string; doneEvent?: SseEvent }> {
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({ message, session_id: sessionId, stream: true }),
+  return chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait,
   });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    if (resp.status === 502 || resp.status === 504) {
-      return { events: [], content: body || '(proxy timeout)' };
-    }
-    throw new Error(`Chat failed: ${resp.status} ${body.slice(0, 200)}`);
-  }
-  if (!resp.body) return { events: [], content: '' };
-  const events: SseEvent[] = [];
-  let content = '';
-  let doneEvent: SseEvent | undefined;
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const start = Date.now();
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop()!;
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-        try {
-          const event: SseEvent = JSON.parse(data);
-          events.push(event);
-          if (event.type === 'replace' && typeof event.text === 'string') content = event.text;
-          if (event.type === 'done') {
-            doneEvent = event;
-            if (typeof event.content === 'string' && event.content) content = event.content;
-            return { events, content, doneEvent };
-          }
-        } catch {
-          /* skip malformed */
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return { events, content, doneEvent };
 }
 
 async function getTasks(sessionId: string): Promise<BackgroundTaskRow[]> {
@@ -193,7 +151,7 @@ const PIPELINE_PROMPT_B =
 test.describe('M8 cost tracking', () => {
   test('a single pipeline run produces per-task cost rows', async () => {
     const sid = `m8-cost-single-${Date.now()}`;
-    const { doneEvent } = await chatSSE(PIPELINE_PROMPT_A, sid, 480_000);
+    const { doneEvent } = await chatViaWs(PIPELINE_PROMPT_A, sid, 480_000);
     expect(doneEvent, 'expected SSE done').toBeTruthy();
 
     const { taskCosts, totalUsd, totalTokensIn, totalTokensOut } = await getCostsForSession(sid);
@@ -226,8 +184,8 @@ test.describe('M8 cost tracking', () => {
     const sidB = `m8-cost-iso-b-${Date.now()}`;
 
     // Run them in series to keep the test budget tractable.
-    await chatSSE(PIPELINE_PROMPT_A, sidA, 480_000);
-    await chatSSE(PIPELINE_PROMPT_B, sidB, 480_000);
+    await chatViaWs(PIPELINE_PROMPT_A, sidA, 480_000);
+    await chatViaWs(PIPELINE_PROMPT_B, sidB, 480_000);
 
     const a = await getCostsForSession(sidA);
     const b = await getCostsForSession(sidB);
@@ -256,12 +214,12 @@ test.describe('M8 cost tracking', () => {
     const sid = `m8-cost-agg-${Date.now()}`;
 
     // First pipeline.
-    const { doneEvent: done1 } = await chatSSE(PIPELINE_PROMPT_A, sid, 480_000);
+    const { doneEvent: done1 } = await chatViaWs(PIPELINE_PROMPT_A, sid, 480_000);
     expect(done1).toBeTruthy();
     const after1 = await getCostsForSession(sid);
 
     // Second pipeline (in same session).
-    const { doneEvent: done2 } = await chatSSE(PIPELINE_PROMPT_B, sid, 480_000);
+    const { doneEvent: done2 } = await chatViaWs(PIPELINE_PROMPT_B, sid, 480_000);
     expect(done2).toBeTruthy();
     const after2 = await getCostsForSession(sid);
 
@@ -286,9 +244,12 @@ test.describe('M8 cost tracking', () => {
   // Spec 4 — done event includes session-level token totals
   // ══════════════════════════════════════════════════════════════════════════
 
-  test('SSE done event includes tokens_in / tokens_out for the turn', async () => {
+  // Deferred (γ-3): WS `turn/completed` does not yet carry tokens_in /
+  // tokens_out. The session-level token totals are still observable via the
+  // REST `/api/sessions/:id/tasks` snapshot covered by the specs above.
+  test.fixme('done event includes tokens_in / tokens_out for the turn', async () => {
     const sid = `m8-cost-done-${Date.now()}`;
-    const { doneEvent } = await chatSSE('what is the capital of france', sid, 30_000);
+    const { doneEvent } = await chatViaWs('what is the capital of france', sid, 30_000);
     expect(doneEvent).toBeTruthy();
     const evt = doneEvent as { tokens_in?: number; tokens_out?: number };
     expect(typeof evt.tokens_in).toBe('number');
@@ -303,7 +264,7 @@ test.describe('M8 cost tracking', () => {
 
   test('plugin v2 cost_attribution events surface on supervised tasks', async () => {
     const sid = `m8-cost-v2-${Date.now()}`;
-    const { doneEvent } = await chatSSE(PIPELINE_PROMPT_A, sid, 480_000);
+    const { doneEvent } = await chatViaWs(PIPELINE_PROMPT_A, sid, 480_000);
     expect(doneEvent).toBeTruthy();
 
     const { tasks } = await getCostsForSession(sid);

--- a/e2e/tests/live-overflow-stress.spec.ts
+++ b/e2e/tests/live-overflow-stress.spec.ts
@@ -325,6 +325,82 @@ const SCENARIOS: Scenario[] = [
     ],
     timeout_ms: 480_000,
   },
+  {
+    // Marathon stress: 30 rounds in one session with mixed pacing AND
+    // three long-running spawn_only background tasks (deep_research)
+    // dropped at turns 5, 15, 25 — i.e. each background task overlaps
+    // with ~10 fast follow-ups before it finalises. Catches:
+    //   - sticky-map / thread-binding drift across many rotations
+    //   - WebSocket envelope ordering when a foreground assistant
+    //     finalises while two-or-three background tasks are still
+    //     emitting `tool_progress` frames
+    //   - per-bubble auth/state drift if the OTP/admin token rotates
+    //     mid-session
+    //   - DOM bubble pairing across long bubble lists (>60 bubbles)
+    //   - context window pressure: 30 paired turns is enough rounds
+    //     that the server may compact mid-session (depending on the
+    //     model's window vs the running token total)
+    // Total wall time is dominated by the deep_research spawn_only's
+    // (each ~3-5 min). Fast turn gaps stay short (1-5s) so the 30
+    // user-sends complete in ~3 min — the trailing wait is the
+    // long-tail spawn_only finalisation.
+    name: 'marathon-thirty-messages',
+    messages: [
+      { gap_ms: 0, text: '1+1 = ?', expected_in_response: ['2', '两', '二'] },
+      { gap_ms: 1500, text: '2+2 = ?', expected_in_response: ['4', '四'] },
+      { gap_ms: 1500, text: '3+3 = ?', expected_in_response: ['6', '六'] },
+      { gap_ms: 1500, text: '今天日期是？', expected_in_response: ['2026', 'date', '日期', '月'] },
+      // Background #1 at turn 5 — deep_research runs while the next
+      // ~10 fast turns rotate the sticky-map underneath it.
+      {
+        gap_ms: 2000,
+        text: 'Use deep research to find latest Rust news. Run pipeline directly. One paragraph.',
+        expected_in_response: ['rust', 'language', 'news'],
+        is_spawn_only: true,
+      },
+      { gap_ms: 4000, text: '4+4 = ?', expected_in_response: ['8', '八'] },
+      { gap_ms: 1500, text: '5+5 = ?', expected_in_response: ['10', '十'] },
+      { gap_ms: 1500, text: '北京天气怎么样？', expected_in_response: ['beijing', '北京', 'weather', '天气', 'temperature'] },
+      { gap_ms: 2000, text: '6+6 = ?', expected_in_response: ['12', '十二'] },
+      { gap_ms: 1500, text: '7+7 = ?', expected_in_response: ['14', '十四'] },
+      { gap_ms: 1500, text: '你有哪些内置语音', expected_in_response: ['vivian', 'serena', 'voice', '语音', 'tts'] },
+      { gap_ms: 2000, text: '8+8 = ?', expected_in_response: ['16', '十六'] },
+      { gap_ms: 1500, text: '9+9 = ?', expected_in_response: ['18', '十八'] },
+      { gap_ms: 1500, text: '10+10 = ?', expected_in_response: ['20', '二十'] },
+      // Background #2 at turn 15 — second deep_research drop while
+      // background #1 is likely still in flight (timing-dependent).
+      {
+        gap_ms: 2000,
+        text: '深度搜索一下今天的天气情况 (deep search)',
+        expected_in_response: ['weather', '天气', 'temperature', '温度', 'forecast'],
+        is_spawn_only: true,
+      },
+      { gap_ms: 4000, text: '11+11 = ?', expected_in_response: ['22', '二十二'] },
+      { gap_ms: 1500, text: '12+12 = ?', expected_in_response: ['24', '二十四'] },
+      { gap_ms: 1500, text: '13+13 = ?', expected_in_response: ['26', '二十六'] },
+      { gap_ms: 1500, text: '14+14 = ?', expected_in_response: ['28', '二十八'] },
+      { gap_ms: 1500, text: '15+15 = ?', expected_in_response: ['30', '三十'] },
+      { gap_ms: 1500, text: '上海天气如何？', expected_in_response: ['shanghai', '上海', 'weather', '天气', 'temperature'] },
+      { gap_ms: 2000, text: '16+16 = ?', expected_in_response: ['32', '三十二'] },
+      { gap_ms: 1500, text: '17+17 = ?', expected_in_response: ['34', '三十四'] },
+      { gap_ms: 1500, text: '18+18 = ?', expected_in_response: ['36', '三十六'] },
+      // Background #3 at turn 25 — final deep_research drop. By now
+      // the sticky-map has rotated 20+ times and #1/#2 may or may not
+      // have finalised yet.
+      {
+        gap_ms: 2000,
+        text: 'Use deep research on AI assistant trends. Run pipeline directly. One paragraph.',
+        expected_in_response: ['ai', 'assistant', 'agent', 'llm'],
+        is_spawn_only: true,
+      },
+      { gap_ms: 4000, text: '19+19 = ?', expected_in_response: ['38', '三十八'] },
+      { gap_ms: 1500, text: '20+20 = ?', expected_in_response: ['40', '四十'] },
+      { gap_ms: 1500, text: '21+21 = ?', expected_in_response: ['42', '四十二'] },
+      { gap_ms: 1500, text: '22+22 = ?', expected_in_response: ['44', '四十四'] },
+      { gap_ms: 1500, text: '23+23 = ?', expected_in_response: ['46', '四十六'] },
+    ],
+    timeout_ms: 1_200_000,
+  },
 ];
 
 async function enableThreadStoreV2(page: Page) {
@@ -622,6 +698,26 @@ function assertPairing(
     const spawnAttestation =
       message.is_spawn_only === true && unionHrefs.length > 0;
     const matched = textMatched || hrefMatched || spawnAttestation;
+
+    // PHANTOM BUBBLE assertion (added 2026-05-09 after the
+    // `appendPersistedMessage` empty-late-event bug shipped under the
+    // old harness): if there are assistant bubbles in this turn region
+    // that contain NO text (after normalization) AND NO attachment
+    // hrefs, they are pure-orphan timestamp-only bubbles and constitute
+    // a real production UX defect — the user sees a phantom bubble
+    // appear after their question completes. The previous
+    // `bubbleHasRealContent` filter silently dropped these from the
+    // pairing logic, which let the bug ship for weeks. We surface them
+    // explicitly now so a regression here fails the gate.
+    const phantomBubbles = assistantsBetween.filter(
+      (b) =>
+        normalizeBubbleText(b.text).length === 0 && b.hrefs.length === 0,
+    );
+    if (phantomBubbles.length > 0) {
+      violations.push(
+        `User ${i} ("${userPrompt.slice(0, 30)}") [PHANTOM_BUBBLE]: ${phantomBubbles.length} empty assistant bubble(s) (timestamp-only, no text, no hrefs) appeared in this turn — UI ghost bubble bug`,
+      );
+    }
 
     if (!matched) {
       // Differentiate the failure modes for clearer triage:

--- a/e2e/tests/live-pipeline-cards.spec.ts
+++ b/e2e/tests/live-pipeline-cards.spec.ts
@@ -32,59 +32,25 @@ const PROFILE = process.env.OCTOS_PROFILE || 'dspfac';
 
 test.setTimeout(180_000);
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
-async function chatSSE(message: string, sessionId: string, maxWait = 150_000) {
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({ message, session_id: sessionId, stream: true }),
+type SseEvent = ChatWsEvent;
+
+/**
+ * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ * The whole describe block below is currently `.skip`'d (run_pipeline is
+ * spawn_only post-#688) but we still migrate the helper so the file does
+ * not depend on `/api/chat` once SSE is deleted in α-5/α-6.
+ */
+async function chatViaWs(message: string, sessionId: string, maxWait = 150_000): Promise<SseEvent[]> {
+  const { events } = await chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait,
   });
-  expect(resp.ok, `chat POST status: ${resp.status}`).toBeTruthy();
-  if (!resp.body) throw new Error('empty response body');
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const events: SseEvent[] = [];
-  const start = Date.now();
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      let idx = buffer.indexOf('\n\n');
-      while (idx >= 0) {
-        const block = buffer.slice(0, idx);
-        buffer = buffer.slice(idx + 2);
-        idx = buffer.indexOf('\n\n');
-        const dataLines = block
-          .split('\n')
-          .filter((l) => l.startsWith('data:'))
-          .map((l) => l.slice(5).trim())
-          .filter(Boolean);
-        for (const line of dataLines) {
-          try {
-            const evt = JSON.parse(line) as SseEvent;
-            events.push(evt);
-            if (evt.type === 'done' || evt.type === 'error') {
-              return events;
-            }
-          } catch {
-            // skip non-JSON keepalive lines
-          }
-        }
-      }
-    }
-  } finally {
-    try { reader.releaseLock(); } catch { /* ignore */ }
-  }
   return events;
 }
 
@@ -111,7 +77,7 @@ test.describe.skip('W1.G1 — pipeline node card SSE invariants', () => {
       'summary [handler="codergen", prompt="Summarise the topics in two sentences.", tools=""] ' +
       'plan -> summary }';
 
-    const events = await chatSSE(prompt, sessionId);
+    const events = await chatViaWs(prompt, sessionId);
 
     const progressEvents = events.filter(
       (e) => e.type === 'tool_progress' && e.tool === 'run_pipeline',

--- a/e2e/tests/live-pipeline-cost.spec.ts
+++ b/e2e/tests/live-pipeline-cost.spec.ts
@@ -30,59 +30,25 @@ const PROFILE = process.env.OCTOS_PROFILE || 'dspfac';
 
 test.setTimeout(180_000);
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
-async function chatSSE(message: string, sessionId: string, maxWait = 150_000) {
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({ message, session_id: sessionId, stream: true }),
+type SseEvent = ChatWsEvent;
+
+/**
+ * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ * The whole describe block below is currently `.skip`'d (run_pipeline is
+ * spawn_only post-#688) but we still migrate the helper so the file does
+ * not depend on `/api/chat` once SSE is deleted in α-5/α-6.
+ */
+async function chatViaWs(message: string, sessionId: string, maxWait = 150_000): Promise<SseEvent[]> {
+  const { events } = await chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait,
   });
-  expect(resp.ok, `chat POST status: ${resp.status}`).toBeTruthy();
-  if (!resp.body) throw new Error('empty response body');
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const events: SseEvent[] = [];
-  const start = Date.now();
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      let idx = buffer.indexOf('\n\n');
-      while (idx >= 0) {
-        const block = buffer.slice(0, idx);
-        buffer = buffer.slice(idx + 2);
-        idx = buffer.indexOf('\n\n');
-        const dataLines = block
-          .split('\n')
-          .filter((l) => l.startsWith('data:'))
-          .map((l) => l.slice(5).trim())
-          .filter(Boolean);
-        for (const line of dataLines) {
-          try {
-            const evt = JSON.parse(line) as SseEvent;
-            events.push(evt);
-            if (evt.type === 'done' || evt.type === 'error') {
-              return events;
-            }
-          } catch {
-            // ignore keepalive lines
-          }
-        }
-      }
-    }
-  } finally {
-    try { reader.releaseLock(); } catch { /* ignore */ }
-  }
   return events;
 }
 
@@ -133,7 +99,7 @@ test.describe.skip('W1.G4 — pipeline cost breakdown SSE invariants', () => {
       'refine [handler="codergen", prompt="Refine the haiku for rhythm.", tools=""] ' +
       'draft -> refine }';
 
-    const events = await chatSSE(prompt, sessionId);
+    const events = await chatViaWs(prompt, sessionId);
 
     const errorEvent = events.find((e) => e.type === 'error');
     expect(errorEvent, 'pipeline run must not surface an error event').toBeUndefined();
@@ -155,7 +121,7 @@ test.describe.skip('W1.G4 — pipeline cost breakdown SSE invariants', () => {
       (e) => Array.isArray((e as Record<string, unknown>).node_costs),
     );
     if (eventWithRows) {
-      const rows = (eventWithRows as { node_costs: Array<Record<string, unknown>> }).node_costs;
+      const rows = (eventWithRows as unknown as { node_costs: Array<Record<string, unknown>> }).node_costs;
       expect(
         rows.length,
         'node_costs payload must carry at least one node row',

--- a/e2e/tests/live-pipeline-end-to-end.spec.ts
+++ b/e2e/tests/live-pipeline-end-to-end.spec.ts
@@ -30,6 +30,7 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
 const BASE = process.env.OCTOS_TEST_URL || 'https://dspfac.bot.ominix.io';
 const TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
@@ -45,10 +46,7 @@ if (BASE.includes('dspfac.ocean.ominix.io')) {
 // Per-test timeout: a deep-research run can take several minutes.
 test.setTimeout(900_000);
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+type SseEvent = ChatWsEvent;
 
 interface ToolProgressEvent extends SseEvent {
   type: 'tool_progress';
@@ -82,67 +80,24 @@ interface BackgroundTaskRow {
   completed_at?: string | null;
 }
 
-async function chatSSE(
+/**
+ * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ * Returns the same `{ events, content, doneEvent }` shape the SSE helper
+ * exposed so call sites stay unchanged.
+ */
+async function chatViaWs(
   message: string,
   sessionId: string,
   maxWait = 60_000,
 ): Promise<{ events: SseEvent[]; content: string; doneEvent?: SseEvent }> {
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({ message, session_id: sessionId, stream: true }),
+  return chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait,
   });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    if (resp.status === 502 || resp.status === 504) {
-      return { events: [], content: body || '(proxy timeout)' };
-    }
-    throw new Error(`Chat failed: ${resp.status} ${body.slice(0, 200)}`);
-  }
-  if (!resp.body) return { events: [], content: '' };
-
-  const events: SseEvent[] = [];
-  let content = '';
-  let doneEvent: SseEvent | undefined;
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const start = Date.now();
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop()!;
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-        try {
-          const event: SseEvent = JSON.parse(data);
-          events.push(event);
-          if (event.type === 'replace' && typeof event.text === 'string') {
-            content = event.text;
-          }
-          if (event.type === 'done') {
-            doneEvent = event;
-            if (typeof event.content === 'string' && event.content) content = event.content;
-            return { events, content, doneEvent };
-          }
-        } catch {
-          /* skip malformed */
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return { events, content, doneEvent };
 }
 
 async function getTasks(sessionId: string): Promise<BackgroundTaskRow[]> {
@@ -203,7 +158,7 @@ test.describe('M8 pipeline end-to-end', () => {
   test('per-node tasks register under the run_pipeline parent task', async () => {
     const sid = `m8-pipe-tree-${Date.now()}`;
 
-    const { doneEvent, events } = await chatSSE(DEEP_RESEARCH_PROMPT, sid, 480_000);
+    const { doneEvent, events } = await chatViaWs(DEEP_RESEARCH_PROMPT, sid, 480_000);
     expect(doneEvent, 'expected SSE done').toBeTruthy();
 
     // Find the run_pipeline tool_call_id from the first ToolStarted event.
@@ -262,7 +217,7 @@ test.describe('M8 pipeline end-to-end', () => {
   test('tool_progress frames carry tool_call_id for every supervised event', async () => {
     const sid = `m8-pipe-tcid-${Date.now()}`;
 
-    const { events } = await chatSSE(DEEP_RESEARCH_PROMPT, sid, 480_000);
+    const { events } = await chatViaWs(DEEP_RESEARCH_PROMPT, sid, 480_000);
     const progressEvents = events.filter(
       (e): e is ToolProgressEvent => e.type === 'tool_progress',
     );
@@ -291,7 +246,7 @@ test.describe('M8 pipeline end-to-end', () => {
   test('plugin v2 progress events surface in runtime_detail', async () => {
     const sid = `m8-pipe-v2-${Date.now()}`;
 
-    const { doneEvent } = await chatSSE(DEEP_RESEARCH_PROMPT, sid, 480_000);
+    const { doneEvent } = await chatViaWs(DEEP_RESEARCH_PROMPT, sid, 480_000);
     expect(doneEvent, 'expected SSE done').toBeTruthy();
 
     const tasks = (await getTasks(sid)) ?? [];
@@ -348,7 +303,7 @@ test.describe('M8 pipeline end-to-end', () => {
       'investigation of the history of agentic AI from 2010 onward. Take ' +
       'your time, do many search passes, do not return early.';
     const start = Date.now();
-    const sseFinish = chatSSE(longPrompt, sid, 600_000);
+    const sseFinish = chatViaWs(longPrompt, sid, 600_000);
 
     // Wait until at least one supervised task is running.
     const runningTask = await pollUntil(
@@ -423,7 +378,7 @@ test.describe('M8 pipeline end-to-end', () => {
       'Use run_pipeline with deep_research to research a topic that does not ' +
       'exist: "the cohort of 0-source citations". Fail explicitly if you ' +
       'cannot find any sources. Do not invent.';
-    const { doneEvent } = await chatSSE(failPrompt, sid, 360_000);
+    const { doneEvent } = await chatViaWs(failPrompt, sid, 360_000);
     expect(doneEvent).toBeTruthy();
 
     const tasks = (await getTasks(sid)) ?? [];

--- a/e2e/tests/live-progress-gate.spec.ts
+++ b/e2e/tests/live-progress-gate.spec.ts
@@ -728,7 +728,13 @@ test.describe('M4.1A live progress gate', () => {
     ).toBe(true);
   });
 
-  test('task API and event SSE stream expose the same phase truth', async ({
+  // M9-α-7 (#836) deferred: `/api/sessions/:id/events/stream` is the
+  // session events SSE channel, separate from `/api/chat`. This test
+  // asserts on its raw frame shape, which has no M9 WebSocket equivalent
+  // yet (the M9 protocol notifications cover task/* and progress/* but
+  // the event-stream SSE is its own surface). Un-fixme once the events
+  // stream is migrated to WS notifications under the sole-transport effort.
+  test.fixme('task API and event SSE stream expose the same phase truth', async ({
     page,
   }) => {
     await submitPrompt(page, DEEP_RESEARCH_PROMPT);

--- a/e2e/tests/live-realtime-status.spec.ts
+++ b/e2e/tests/live-realtime-status.spec.ts
@@ -38,9 +38,11 @@
  *     current wire — pinning would gate the timeline test on a contract
  *     the daemon does not implement.
  *
- * Why this is tight enough to catch SSE-pipeline regressions:
- *   * If the SSE bridge silently dropped tool_progress frames, the
- *     timeline `<ul>` would never render (empty `tc.progress` array
+ * Why this is tight enough to catch streaming-pipeline regressions
+ * (post M9-α-7 the streaming layer is the WebSocket UI Protocol; pre-α-7
+ * it was SSE — same invariants):
+ *   * If the streaming bridge silently dropped tool_progress frames,
+ *     the timeline `<ul>` would never render (empty `tc.progress` array
  *     hides the `<ul>` — see chat-thread.tsx:162). Step 3 fails.
  *   * If progress frames arrived but with wrong/missing tool_call_id,
  *     they'd attach to a different bubble or float orphaned. The
@@ -353,7 +355,8 @@ test.describe(`Realtime status surface (${BASE})`, () => {
 
     // 7. tool_call_id is `runPipelineToolCallId` (already extracted in
     //    step 4 from `data-tool-call-id` on the run_pipeline bubble).
-    //    This is the same id the backend SSE channel used.
+    //    This is the same id the backend streaming channel uses (WS
+    //    `tool/started`/`tool/progress` notifications post M9-α-7).
     const renderedToolCallId = runPipelineToolCallId;
     expect(
       renderedToolCallId,
@@ -382,7 +385,7 @@ test.describe(`Realtime status surface (${BASE})`, () => {
     //    identity nor the literal 'run_pipeline' tool_name match is achievable
     //    against the current wire — the cross-check would gate the timeline
     //    test on a contract the daemon does not implement. Steps 3-6 already
-    //    proved the SSE pipeline + timeline rendering work; this step keeps
+    //    proved the streaming pipeline + timeline rendering work; this step keeps
     //    the freshness/anti-stale anchor and rejects unrelated bg tools.
     const sessionIdNow = await page.evaluate(() =>
       localStorage.getItem('octos_current_session'),

--- a/e2e/tests/live-spawn-end-to-end.spec.ts
+++ b/e2e/tests/live-spawn-end-to-end.spec.ts
@@ -29,6 +29,7 @@
 
 import { test, expect } from '@playwright/test';
 import { execSync } from 'node:child_process';
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
 const BASE = process.env.OCTOS_TEST_URL || 'https://dspfac.bot.ominix.io';
 const TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
@@ -61,10 +62,7 @@ const REMOTE_DATA_DIR = `~/.octos/profiles/${PROFILE}/data`;
 
 test.setTimeout(900_000);
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+type SseEvent = ChatWsEvent;
 
 interface BackgroundTaskRow {
   id?: string;
@@ -83,64 +81,24 @@ interface BackgroundTaskRow {
   updated_at?: string;
 }
 
-async function chatSSE(
+/**
+ * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ * Returns the same `{ events, content, doneEvent }` shape the SSE helper
+ * exposed so call sites stay unchanged.
+ */
+async function chatViaWs(
   message: string,
   sessionId: string,
   maxWait = 60_000,
 ): Promise<{ events: SseEvent[]; content: string; doneEvent?: SseEvent }> {
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({ message, session_id: sessionId, stream: true }),
+  return chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait,
   });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    if (resp.status === 502 || resp.status === 504) {
-      return { events: [], content: body || '(proxy timeout)' };
-    }
-    throw new Error(`Chat failed: ${resp.status} ${body.slice(0, 200)}`);
-  }
-  if (!resp.body) return { events: [], content: '' };
-  const events: SseEvent[] = [];
-  let content = '';
-  let doneEvent: SseEvent | undefined;
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const start = Date.now();
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop()!;
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-        try {
-          const event: SseEvent = JSON.parse(data);
-          events.push(event);
-          if (event.type === 'replace' && typeof event.text === 'string') content = event.text;
-          if (event.type === 'done') {
-            doneEvent = event;
-            if (typeof event.content === 'string' && event.content) content = event.content;
-            return { events, content, doneEvent };
-          }
-        } catch {
-          /* skip malformed */
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return { events, content, doneEvent };
 }
 
 async function getMessages(sessionId: string): Promise<unknown[]> {
@@ -221,12 +179,12 @@ test.describe('M8 spawn end-to-end (slides)', () => {
     const slug = `m8-spawn-slides-${Date.now().toString(36)}`;
     const sid = `m8-spawn-slides-sid-${Date.now()}`;
 
-    await chatSSE(`/new slides ${slug}`, sid, 90_000);
+    await chatViaWs(`/new slides ${slug}`, sid, 90_000);
     const designPrompt =
       'Design a 2-slide deck about M8 runtime parity. Slide 1 cover, slide 2 ' +
       'one-bullet summary. Use style nb-pro. Show outline only, do not generate yet.';
-    await chatSSE(designPrompt, sid, 120_000);
-    const { doneEvent, events } = await chatSSE('go', sid, 600_000);
+    await chatViaWs(designPrompt, sid, 120_000);
+    const { doneEvent, events } = await chatViaWs('go', sid, 600_000);
     expect(doneEvent).toBeTruthy();
 
     // Find the spawn-driven mofa_slides task from the events stream.
@@ -282,9 +240,9 @@ test.describe('M8 spawn end-to-end (slides)', () => {
     const slug = `m8-spawn-cancel-${Date.now().toString(36)}`;
     const sid = `m8-spawn-cancel-sid-${Date.now()}`;
 
-    await chatSSE(`/new slides ${slug}`, sid, 60_000);
+    await chatViaWs(`/new slides ${slug}`, sid, 60_000);
     // Kick off generation; do not wait for done.
-    const longGen = chatSSE(
+    const longGen = chatViaWs(
       'Design and generate a 12-slide deck about every public agentic-AI ' +
         'system from 2018 to 2026. Use nb-pro. Generate now.',
       sid,
@@ -372,7 +330,7 @@ test.describe('M8 spawn end-to-end (slides)', () => {
       `直接调用 fm_tts，把 voice 参数精确设为 ` +
       `definitely_not_a_real_voice_${Date.now().toString(36)}，` +
       `文本只说：m8 恢复测试。不要先检查声音，也不要解释。`;
-    const { doneEvent } = await chatSSE(prompt, sid, 120_000);
+    const { doneEvent } = await chatViaWs(prompt, sid, 120_000);
     expect(doneEvent).toBeTruthy();
 
     // Wait for the recovery prompt to land as a system-internal user message
@@ -428,7 +386,7 @@ test.describe('M8 spawn end-to-end (slides)', () => {
     const prompt =
       `直接调用 fm_tts，把 voice 参数精确设为 vivian，` +
       `文本只说：m8 路由测试。不要先检查声音，也不要解释。`;
-    const { doneEvent } = await chatSSE(prompt, sid, 90_000);
+    const { doneEvent } = await chatViaWs(prompt, sid, 90_000);
     expect(doneEvent, 'expected SSE done').toBeTruthy();
 
     let foundPath = '';

--- a/e2e/tests/live-thread-interleave.spec.ts
+++ b/e2e/tests/live-thread-interleave.spec.ts
@@ -105,7 +105,8 @@ async function getOrderedBubbles(page: Page) {
  *
  * Issue #731 hardening: PR #688 made `run_pipeline` `spawn_only`, so
  * deep_research now delivers as a media-attachment bubble (`.md`
- * link) ~1-3 min after the SSE `done` event for the foreground turn,
+ * link) ~1-3 min after the foreground turn's terminal event
+ * (`turn/completed` over WS post M9-α-7; previously SSE `done`),
  * NOT as inline markdown text. The bubble's `innerText` for an
  * attachment-only message can be a generic "✓ run_pipeline completed
  * (...)" or empty, neither of which contains `rust`. We extend the
@@ -273,7 +274,7 @@ test.describe('Live thread interleave (M8.10 PR #4)', () => {
     // 2. Wait briefly, then send the fast question. The slow Q may be
     //    in active foreground streaming OR may have already spawned to
     //    background — `deep_search` / `run_pipeline` are spawn_only, so
-    //    the foreground SSE turn ends with a "background started" ack
+    //    the foreground turn ends with a "background started" ack
     //    within ~2-3s and the cancel button disappears even though the
     //    real research is still running. We DO NOT gate on
     //    `cancelButton.isVisible()` here: gating on it caused a
@@ -374,10 +375,11 @@ test.describe('Live thread interleave (M8.10 PR #4)', () => {
     // attached to Q1's bubble (and not Q2's, which is the #649
     // misrouting symptom). Post-PR-#688, `run_pipeline` is `spawn_only`
     // and delivers the report as a media attachment ~1-3 min after
-    // SSE done; for those bubbles the inline text is just a generic
+    // turn/completed; for those bubbles the inline text is just a generic
     // success notification with no `rust` token, so the text-only
     // assertion would false-fail. Without either signal, the spec
-    // would false-pass on the spawn-ack alone.
+    // would false-pass on the spawn-ack alone. (Streaming transport
+    // post M9-α-7 is the WebSocket `turn/completed` notification.)
     // `waitForBothFinished` already polls for this evidence, so by the
     // time we reach here it should be present; if it's not, the late
     // result either timed out (raise SLOW_MAX_WAIT_MS) or got bound to

--- a/e2e/tests/m8-runtime-invariants-live.spec.ts
+++ b/e2e/tests/m8-runtime-invariants-live.spec.ts
@@ -24,6 +24,7 @@
 
 import { test, expect } from '@playwright/test';
 import { execSync } from 'node:child_process';
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
 const BASE = process.env.OCTOS_TEST_URL || 'https://dspfac.ocean.ominix.io';
 const TOKEN = process.env.OCTOS_AUTH_TOKEN || 'e2e-test-2026';
@@ -58,69 +59,26 @@ const SSH_HOST =
   })();
 const REMOTE_DATA_DIR = `~/.octos/profiles/${PROFILE}/data`;
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+type SseEvent = ChatWsEvent;
 
-/** Minimal SSE chat helper, mirrored from runtime-regression.spec.ts. */
-async function chatSSE(
+/**
+ * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ * Returns the same `{ events, content, doneEvent }` shape the SSE helper
+ * used so call sites stay unchanged.
+ */
+async function chatViaWs(
   message: string,
   sessionId: string,
   maxWait = 60_000,
 ): Promise<{ events: SseEvent[]; content: string; doneEvent?: SseEvent }> {
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({ message, session_id: sessionId, stream: true }),
+  return chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait,
   });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    if (resp.status === 502 || resp.status === 504) {
-      return { events: [], content: body || '(proxy timeout)' };
-    }
-    throw new Error(`Chat failed: ${resp.status} ${body.slice(0, 200)}`);
-  }
-  if (!resp.body) return { events: [], content: '' };
-
-  const events: SseEvent[] = [];
-  let content = '';
-  let doneEvent: SseEvent | undefined;
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const start = Date.now();
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop()!;
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-        try {
-          const event: SseEvent = JSON.parse(data);
-          events.push(event);
-          if (event.type === 'replace' && typeof event.text === 'string') content = event.text;
-          if (event.type === 'done') {
-            doneEvent = event;
-            if (typeof event.content === 'string' && event.content) content = event.content;
-            return { events, content, doneEvent };
-          }
-        } catch { /* skip malformed */ }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return { events, content, doneEvent };
 }
 
 async function getMessages(sessionId: string): Promise<any[]> {
@@ -170,7 +128,7 @@ test.describe('M8.4 FileStateCache short-circuit', () => {
     // (e.g. bot's ~40 active tools) the first turn pays for the entire LLM
     // tool-spec inventory, so the 45s cap previously misfired here despite
     // FileStateCache wiring being correct end-to-end.
-    const probe = await chatSSE(
+    const probe = await chatViaWs(
       'List up to 10 files in your current working directory using the list_dir tool. Return only the names.',
       sid,
       90_000,
@@ -210,7 +168,7 @@ test.describe('M8.4 FileStateCache short-circuit', () => {
     ].join(' ');
 
     const t0 = Date.now();
-    const { content, doneEvent } = await chatSSE(prompt, sid, 90_000);
+    const { content, doneEvent } = await chatViaWs(prompt, sid, 90_000);
     const elapsed = Date.now() - t0;
 
     expect(doneEvent, 'expected SSE done').toBeTruthy();
@@ -274,7 +232,7 @@ test.describe('M8.6 Resume sanitizer worktree-missing refusal', () => {
     // 1. Trigger something that materialises a workspace under the
     //    user-session dir. A shell write_file is the cheapest way.
     const sentinel = `m8-6-${Date.now().toString(36)}.txt`;
-    const create = await chatSSE(
+    const create = await chatViaWs(
       `Use the write_file tool to write the file ./${sentinel} with the contents "marker". Then describe what you did.`,
       sid,
       60_000,
@@ -358,7 +316,7 @@ test.describe('M8.6 Resume sanitizer worktree-missing refusal', () => {
       // denies `rm -rf`, so we use `find -delete` (allowed) and pin the
       // path to one that contains the session id (defensive).
       const evictSid = `m8-6-evict-${Date.now()}`;
-      await chatSSE(
+      await chatViaWs(
         `Use the shell tool to run exactly: find ${wsRel} -mindepth 1 -delete && rmdir ${wsRel} && echo CONFIRMED_GONE`,
         evictSid,
         45_000,
@@ -382,7 +340,7 @@ test.describe('M8.6 Resume sanitizer worktree-missing refusal', () => {
     }
 
     // 4. Send a follow-up that depends on the workspace.
-    const followup = await chatSSE(
+    const followup = await chatViaWs(
       `Use read_file to read ./${sentinel} and tell me its contents.`,
       sid,
       60_000,
@@ -444,9 +402,11 @@ test.describe('M8.7 SubAgentOutputRouter on-disk write', () => {
       `直接调用 fm_tts，把 voice 参数精确设为 yangmi（不要使用 clone:yangmi 或任何 clone: 前缀），` +
       `文本只说：m8七路由测试。不要先检查声音，也不要解释。`;
     const t0 = Date.now();
-    const { doneEvent } = await chatSSE(prompt, sid, 90_000);
-    expect(doneEvent, 'expected SSE done event').toBeTruthy();
-    expect((doneEvent as any).has_bg_tasks).toBe(true);
+    const { doneEvent } = await chatViaWs(prompt, sid, 90_000);
+    expect(doneEvent, 'expected WS turn/completed terminal').toBeTruthy();
+    // Deferred (γ-3): WS `turn/completed` does not yet carry `has_bg_tasks`.
+    // The disk-side router check below remains the authoritative invariant.
+    // expect((doneEvent as any).has_bg_tasks).toBe(true);
 
     // Wait for the spawn to actually fire. The router seeds a startup line
     // synchronously, so the file appears within a few seconds.
@@ -502,7 +462,7 @@ test.describe('M8.9 Runtime failure recovery', () => {
     const prompt =
       `直接调用 fm_tts，把 voice 参数精确设为 definitely_not_a_real_voice_2026，` +
       `文本只说：m8九恢复测试。不要先检查声音，也不要解释。`;
-    const { doneEvent } = await chatSSE(prompt, sid, 90_000);
+    const { doneEvent } = await chatViaWs(prompt, sid, 90_000);
     expect(doneEvent).toBeTruthy();
 
     // Wait up to ~90s for the spawn to terminate and the failure

--- a/e2e/tests/refactor-capabilities.spec.ts
+++ b/e2e/tests/refactor-capabilities.spec.ts
@@ -14,6 +14,7 @@
  *   npx playwright test tests/refactor-capabilities.spec.ts
  */
 import { expect, test } from '@playwright/test';
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
 const BASE = process.env.OCTOS_TEST_URL || 'https://dspfac.crew.ominix.io';
 const TOKEN = process.env.OCTOS_AUTH_TOKEN || 'octos-admin-2026';
@@ -21,80 +22,36 @@ const PROFILE = process.env.OCTOS_PROFILE || 'dspfac';
 
 test.setTimeout(240_000);
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+type SseEvent = ChatWsEvent;
 
-async function chatSSE(
+/**
+ * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ *
+ * NOTE: The legacy SSE helper accepted an optional `topic` field on the
+ * `/api/chat` body — used by `topic-scoped histories` to partition a single
+ * session_id into isolated conversation threads. The M9 `turn/start` request
+ * does NOT yet have a `topic` parameter (deferred follow-up). Tests that
+ * pass `topic` are marked `test.fixme` until the WS protocol grows the
+ * field.
+ */
+async function chatViaWs(
   message: string,
   sessionId: string,
   opts: { topic?: string; maxWait?: number } = {},
 ): Promise<{ events: SseEvent[]; content: string; doneEvent?: SseEvent }> {
-  const { topic, maxWait = 90_000 } = opts;
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({
-      message,
-      session_id: sessionId,
-      stream: true,
-      ...(topic ? { topic } : {}),
-    }),
+  if (opts.topic !== undefined) {
+    throw new Error(
+      'chatViaWs: `topic` is not yet supported on the M9 WebSocket; mark the test as test.fixme',
+    );
+  }
+  return chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait: opts.maxWait ?? 90_000,
   });
-
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    throw new Error(`Chat failed: ${resp.status} ${body.slice(0, 200)}`);
-  }
-  if (!resp.body) return { events: [], content: '' };
-
-  const events: SseEvent[] = [];
-  let content = '';
-  let doneEvent: SseEvent | undefined;
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const start = Date.now();
-
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || '';
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-        try {
-          const event: SseEvent = JSON.parse(data);
-          events.push(event);
-          if (event.type === 'replace' && typeof event.text === 'string') {
-            content = event.text;
-          }
-          if (event.type === 'done') {
-            doneEvent = event;
-            if (typeof event.content === 'string' && event.content) {
-              content = event.content;
-            }
-            return { events, content, doneEvent };
-          }
-        } catch {
-          // Ignore non-JSON SSE lines.
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  return { events, content, doneEvent };
 }
 
 async function getMessages(sessionId: string, topic?: string): Promise<any[]> {
@@ -134,14 +91,17 @@ function taskCurrentPhase(task: any): string | undefined {
 }
 
 test.describe('Refactor capability proofs', () => {
-  test('same session id can host separate topic-scoped histories', async () => {
+  // Deferred follow-up: the `topic` parameter on `/api/chat` is not yet
+  // mirrored on the M9 `turn/start` request — un-fixme once the WS protocol
+  // gains a `topic` field on `TurnStartParams`.
+  test.fixme('same session id can host separate topic-scoped histories', async () => {
     const sid = `cap-topic-${Date.now()}`;
     const baseMarker = `BASE-${Date.now()}`;
     const topicMarker = `TOPIC-${Date.now()}`;
     const topic = `slides capability-${Date.now().toString(36)}`;
 
-    await chatSSE(`Reply with exactly: ${baseMarker}`, sid);
-    await chatSSE(`Reply with exactly: ${topicMarker}`, sid, { topic });
+    await chatViaWs(`Reply with exactly: ${baseMarker}`, sid);
+    await chatViaWs(`Reply with exactly: ${topicMarker}`, sid, { topic });
 
     const baseMsgs = await getMessages(sid);
     const topicMsgs = await getMessages(sid, topic);
@@ -171,11 +131,13 @@ test.describe('Refactor capability proofs', () => {
     const prompt =
       '不要搜索，直接生成一个简短测试播客并把音频发回会话。脚本： [杨幂 - clone:yangmi, professional] 这里验证子会话契约。 [窦文涛 - clone:douwentao, professional] 任务应该暴露结构化终态。 [杨幂 - clone:yangmi, professional] 只需简短音频。';
 
-    const initial = await chatSSE(prompt, sid, {
+    const initial = await chatViaWs(prompt, sid, {
       maxWait: 90_000,
     });
     expect(initial.doneEvent).toBeTruthy();
-    expect(initial.doneEvent?.has_bg_tasks).toBe(true);
+    // Deferred (γ-3): WS `turn/completed` does not yet carry `has_bg_tasks`.
+    // The downstream task-API poll is the authoritative invariant.
+    // expect(initial.doneEvent?.has_bg_tasks).toBe(true);
 
     let task: any | undefined;
     const start = Date.now();
@@ -209,9 +171,11 @@ test.describe('Refactor capability proofs', () => {
     const prompt =
       '不要搜索，直接生成一个简短测试播客并把音频发回会话。脚本： [杨幂 - clone:yangmi, professional] 大家好。 [窦文涛 - clone:douwentao, professional] 这里是能力验证。 [杨幂 - clone:yangmi, professional] 我们只检查工作流元数据。 [窦文涛 - clone:douwentao, professional] 感谢收听。';
 
-    const initial = await chatSSE(prompt, sid, { maxWait: 90_000 });
+    const initial = await chatViaWs(prompt, sid, { maxWait: 90_000 });
     expect(initial.doneEvent).toBeTruthy();
-    expect(initial.doneEvent?.has_bg_tasks).toBe(true);
+    // Deferred (γ-3): WS `turn/completed` does not yet carry `has_bg_tasks`.
+    // The downstream task-API poll is the authoritative invariant.
+    // expect(initial.doneEvent?.has_bg_tasks).toBe(true);
 
     const seenPhases = new Set<string>();
     let workflowTask: any | undefined;

--- a/e2e/tests/runtime-regression.spec.ts
+++ b/e2e/tests/runtime-regression.spec.ts
@@ -22,6 +22,7 @@
  */
 
 import { test, expect } from '@playwright/test';
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
 const BASE = process.env.OCTOS_TEST_URL || 'https://dspfac.crew.ominix.io';
 const TOKEN = process.env.OCTOS_AUTH_TOKEN || 'e2e-test-2026';
@@ -29,75 +30,32 @@ const PROFILE = process.env.OCTOS_PROFILE || 'dspfac';
 
 test.setTimeout(120_000);
 
-interface SseEvent {
-  type: string;
-  [key: string]: unknown;
-}
+type SseEvent = ChatWsEvent;
 
 function customVoiceTtsPrompt(text: string): string {
   return `直接调用 fm_tts，把 voice 参数精确设为 yangmi（不要使用 clone:yangmi 或任何 clone: 前缀），文本只说：${text}。不要先检查声音，也不要解释。`;
 }
 
-/** Send a message and collect SSE events until done. */
-async function chatSSE(
+/**
+ * Drive a chat turn over the M9 WebSocket UI Protocol and return the same
+ * `{ events, content, doneEvent }` shape the legacy SSE helper used. M9-α-7
+ * (#836). The local function is preserved (renamed) so the call sites in
+ * this spec only need a one-line rename, but the wire transport is now the
+ * `/api/ui-protocol/ws` JSON-RPC endpoint.
+ */
+async function chatViaWs(
   message: string,
   sessionId: string,
   maxWait = 60_000,
 ): Promise<{ events: SseEvent[]; content: string; doneEvent?: SseEvent }> {
-  const resp = await fetch(`${BASE}/api/chat`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${TOKEN}`,
-      'X-Profile-Id': PROFILE,
-    },
-    body: JSON.stringify({ message, session_id: sessionId, stream: true }),
+  return chatWS({
+    baseUrl: BASE,
+    token: TOKEN,
+    profileId: PROFILE,
+    message,
+    sessionId,
+    maxWait,
   });
-
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    if (resp.status === 502 || resp.status === 504) {
-      return { events: [], content: body || '(proxy timeout)' };
-    }
-    throw new Error(`Chat failed: ${resp.status} ${body.slice(0, 200)}`);
-  }
-  if (!resp.body) return { events: [], content: '' };
-
-  const events: SseEvent[] = [];
-  let content = '';
-  let doneEvent: SseEvent | undefined;
-  const reader = resp.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const start = Date.now();
-
-  try {
-    while (Date.now() - start < maxWait) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop()!;
-      for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-        const data = line.slice(6).trim();
-        if (!data || data === '[DONE]') continue;
-        try {
-          const event: SseEvent = JSON.parse(data);
-          events.push(event);
-          if (event.type === 'replace' && typeof event.text === 'string') content = event.text;
-          if (event.type === 'done') {
-            doneEvent = event;
-            if (typeof event.content === 'string' && event.content) content = event.content;
-            return { events, content, doneEvent };
-          }
-        } catch { /* skip malformed */ }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  return { events, content, doneEvent };
 }
 
 /** Get session messages via REST. */
@@ -128,11 +86,11 @@ async function startBackgroundTts(
   doneEvent?: SseEvent;
 }> {
   let effectiveSessionId = sessionId;
-  let result = await chatSSE(customVoiceTtsPrompt(text), effectiveSessionId, 90_000);
+  let result = await chatViaWs(customVoiceTtsPrompt(text), effectiveSessionId, 90_000);
   if (!result.doneEvent) {
     await new Promise((resolve) => setTimeout(resolve, 2_000));
     effectiveSessionId = `${sessionId}-retry`;
-    result = await chatSSE(customVoiceTtsPrompt(text), effectiveSessionId, 90_000);
+    result = await chatViaWs(customVoiceTtsPrompt(text), effectiveSessionId, 90_000);
   }
   return { sessionId: effectiveSessionId, ...result };
 }
@@ -144,10 +102,10 @@ async function startBackgroundTts(
 test.describe('Session persistence', () => {
   test('messages persist across requests (#386)', async () => {
     const sid = `persist-${Date.now()}`;
-    await chatSSE('hello from persistence test', sid);
+    await chatViaWs('hello from persistence test', sid);
 
     // Second request to same session
-    await chatSSE('follow up message', sid);
+    await chatViaWs('follow up message', sid);
 
     // Verify both messages exist
     const msgs = await getMessages(sid);
@@ -159,7 +117,7 @@ test.describe('Session persistence', () => {
 
   test('user message always appears before assistant response', async () => {
     const sid = `order-${Date.now()}`;
-    await chatSSE('what is 2+2', sid);
+    await chatViaWs('what is 2+2', sid);
 
     const msgs = await getMessages(sid);
     const firstUser = msgs.findIndex((m: any) => m.role === 'user');
@@ -169,7 +127,7 @@ test.describe('Session persistence', () => {
 
   test('empty messages are not persisted (#386)', async () => {
     const sid = `noempty-${Date.now()}`;
-    await chatSSE('say hello', sid);
+    await chatViaWs('say hello', sid);
 
     const msgs = await getMessages(sid);
     const emptyAssistant = msgs.filter(
@@ -198,25 +156,27 @@ test.describe('Session persistence', () => {
 test.describe('SSE streaming', () => {
   test('SSE stream ends with done event (#251)', async () => {
     const sid = `sse-done-${Date.now()}`;
-    const { doneEvent } = await chatSSE('say hello briefly', sid);
+    const { doneEvent } = await chatViaWs('say hello briefly', sid);
     expect(doneEvent).toBeTruthy();
     expect(doneEvent!.type).toBe('done');
   });
 
   test('SSE preserves CJK characters', async () => {
     const sid = `cjk-${Date.now()}`;
-    const { content } = await chatSSE('用中文说"你好世界"', sid);
+    const { content } = await chatViaWs('用中文说"你好世界"', sid);
     // Response should contain Chinese characters, not garbled bytes
     expect(content).toMatch(/[\u4e00-\u9fff]/);
   });
 
-  test('done event includes token counts', async () => {
+  // Deferred (γ-3): the M9 `turn/completed` notification does not yet
+  // carry tokens_in / tokens_out. Tracked alongside the α-3 deferred set;
+  // un-fixme once the WS terminal frame surfaces token usage.
+  test.fixme('done event includes token counts', async () => {
     const sid = `tokens-${Date.now()}`;
-    const { doneEvent } = await chatSSE('what is 1+1', sid);
+    const { doneEvent } = await chatViaWs('what is 1+1', sid);
     expect(doneEvent).toBeTruthy();
-    // tokens_in and tokens_out should be present
-    expect(typeof doneEvent!.tokens_in).toBe('number');
-    expect(typeof doneEvent!.tokens_out).toBe('number');
+    expect(typeof (doneEvent as any).tokens_in).toBe('number');
+    expect(typeof (doneEvent as any).tokens_out).toBe('number');
   });
 });
 
@@ -248,13 +208,13 @@ test.describe('Coding shell repair', () => {
     ].join(' ');
 
     let sid = `shell-repair-${Date.now()}`;
-    let { content } = await chatSSE(basePrompt, sid, 180_000);
+    let { content } = await chatViaWs(basePrompt, sid, 180_000);
     if (
       !content.includes('diff --git') &&
       /don'?t have access to a shell tool|available tools|activate_tools/i.test(content)
     ) {
       sid = `${sid}-retry`;
-      ({ content } = await chatSSE(retryPrompt, sid, 180_000));
+      ({ content } = await chatViaWs(retryPrompt, sid, 180_000));
     }
 
     if (!content.includes('diff --git')) {
@@ -285,7 +245,11 @@ test.describe('Background task lifecycle', () => {
     const { doneEvent, sessionId } = await startBackgroundTts(sid, '测试消息');
 
     expect(doneEvent).toBeTruthy();
-    expect(doneEvent!.has_bg_tasks).toBe(true);
+    // Deferred (γ-3): WS `turn/completed` does not yet carry `has_bg_tasks`.
+    // Once the WS terminal frame surfaces it, restore the strict assertion.
+    // For now, the REST-derived `sawTtsTaskOrAudio` check below is the
+    // authoritative invariant.
+    // expect(doneEvent!.has_bg_tasks).toBe(true);
 
     let sawTtsTaskOrAudio = false;
     for (let i = 0; i < 10; i++) {
@@ -343,7 +307,7 @@ test.describe('Background task lifecycle', () => {
     const { sessionId } = await startBackgroundTts(sid, '后台测试');
 
     // Immediately send a regular question — should not be blocked
-    const { content, doneEvent } = await chatSSE('what is 3+3', sessionId, 30_000);
+    const { content, doneEvent } = await chatViaWs('what is 3+3', sessionId, 30_000);
     expect(content.length).toBeGreaterThan(0);
     expect(doneEvent).toBeTruthy();
   });
@@ -356,7 +320,7 @@ test.describe('Background task lifecycle', () => {
 test.describe('Slides workspace', () => {
   test('/new slides creates project with workspace policy', async () => {
     const sid = `slides-new-${Date.now()}`;
-    const { content } = await chatSSE(`/new slides regtest-${Date.now().toString(36)}`, sid);
+    const { content } = await chatViaWs(`/new slides regtest-${Date.now().toString(36)}`, sid);
 
     expect(
       content.includes('slides') ||
@@ -373,9 +337,9 @@ test.describe('Slides workspace', () => {
 
   test('design-first: agent writes script.js without generating', async () => {
     const sid = `slides-design-${Date.now()}`;
-    await chatSSE(`/new slides design-${Date.now().toString(36)}`, sid);
+    await chatViaWs(`/new slides design-${Date.now().toString(36)}`, sid);
 
-    const { content } = await chatSSE(
+    const { content } = await chatViaWs(
       'Make a 2-slide deck: 1) Cover "Test", 2) "Content". Style nb-pro. Write script.js ONLY, do NOT generate.',
       sid,
       60_000,
@@ -396,7 +360,7 @@ test.describe('Slides workspace', () => {
 
   test('/help returns commands, not LLM response', async () => {
     const sid = `slides-help-${Date.now()}`;
-    const { content } = await chatSSE('/help', sid, 15_000);
+    const { content } = await chatViaWs('/help', sid, 15_000);
 
     expect(
       content.includes('/new') ||
@@ -418,8 +382,8 @@ test.describe('Cross-session isolation', () => {
 
     // Send different messages to each session
     await Promise.all([
-      chatSSE('session A unique message alpha', sidA),
-      chatSSE('session B unique message beta', sidB),
+      chatViaWs('session A unique message alpha', sidA),
+      chatViaWs('session B unique message beta', sidB),
     ]);
 
     // Verify no cross-contamination
@@ -453,7 +417,7 @@ test.describe('Cross-session isolation', () => {
 test.describe('Session create & delete lifecycle', () => {
   test('new session appears in session list', async () => {
     const sid = `lifecycle-new-${Date.now()}`;
-    await chatSSE('hello from lifecycle test', sid);
+    await chatViaWs('hello from lifecycle test', sid);
 
     const resp = await fetch(`${BASE}/api/sessions`, {
       headers: { 'Authorization': `Bearer ${TOKEN}`, 'X-Profile-Id': PROFILE },
@@ -465,7 +429,7 @@ test.describe('Session create & delete lifecycle', () => {
 
   test('DELETE /api/sessions/:id removes session from list', async () => {
     const sid = `lifecycle-del-${Date.now()}`;
-    await chatSSE('message to delete', sid);
+    await chatViaWs('message to delete', sid);
 
     // Verify it exists
     let resp = await fetch(`${BASE}/api/sessions`, {
@@ -491,7 +455,7 @@ test.describe('Session create & delete lifecycle', () => {
 
   test('deleted session messages are not retrievable', async () => {
     const sid = `lifecycle-msgs-${Date.now()}`;
-    await chatSSE('secret message that should be deleted', sid);
+    await chatViaWs('secret message that should be deleted', sid);
 
     // Verify messages exist
     let msgs = await getMessages(sid);
@@ -513,10 +477,10 @@ test.describe('Session create & delete lifecycle', () => {
     const sid = `lifecycle-ws-${Date.now()}`;
 
     // Create a slides project (generates workspace files)
-    await chatSSE(`/new slides ${slug}`, sid);
+    await chatViaWs(`/new slides ${slug}`, sid);
 
     // Verify project was created by checking via a second message
-    const { content } = await chatSSE(
+    const { content } = await chatViaWs(
       `Use shell to run: ls slides/${slug}/.octos-workspace.toml 2>&1 && echo EXISTS || echo MISSING`,
       sid,
       30_000,
@@ -530,8 +494,8 @@ test.describe('Session create & delete lifecycle', () => {
 
     // Create a new session and check if workspace files still exist on disk
     const sid2 = `lifecycle-ws-check-${Date.now()}`;
-    await chatSSE(`/new slides ${slug}-check`, sid2);
-    const { content: checkContent } = await chatSSE(
+    await chatViaWs(`/new slides ${slug}-check`, sid2);
+    const { content: checkContent } = await chatViaWs(
       `Use shell to run: ls -la slides/ 2>&1 | grep "${slug}" && echo STILL_EXISTS || echo CLEANED_UP`,
       sid2,
       30_000,
@@ -546,7 +510,7 @@ test.describe('Session create & delete lifecycle', () => {
 
   test('cannot send messages to a deleted session', async () => {
     const sid = `lifecycle-nosend-${Date.now()}`;
-    await chatSSE('first message', sid);
+    await chatViaWs('first message', sid);
 
     // Delete
     await fetch(`${BASE}/api/sessions/${encodeURIComponent(sid)}`, {
@@ -556,7 +520,7 @@ test.describe('Session create & delete lifecycle', () => {
 
     // Send to deleted session — should either create a new empty session
     // or return the response without the old context
-    const { content } = await chatSSE('hello after delete', sid);
+    const { content } = await chatViaWs('hello after delete', sid);
 
     // Old messages should not be in context
     const msgs = await getMessages(sid);

--- a/e2e/tests/web-client.spec.ts
+++ b/e2e/tests/web-client.spec.ts
@@ -1,24 +1,26 @@
 /**
- * Web client tests for SSE streaming, UTF-8 handling, and file delivery.
+ * Web client tests for chat streaming, UTF-8 handling, and file delivery.
  *
- * Tests the gateway API channel (POST /chat → SSE response) which is
- * used by the octos-web chat client.
+ * M9-α-7 (#836): rewritten to drive the chat turn through the M9 WebSocket
+ * UI Protocol via `chatWS()` instead of the legacy `/api/chat` SSE endpoint.
+ * The original SSE assertions on UTF-8 byte integrity are preserved by
+ * inspecting the cumulative `content` produced from `message/delta`
+ * notifications — the JSON-RPC frame layer carries text losslessly so any
+ * encoding bug regressing in the LLM provider chain still surfaces.
  *
  * Run against a live octos-serve instance:
  *   OCTOS_TEST_URL=http://localhost:3000 npx playwright test web-client
- *
- * These tests target the dspfac profile's API channel, proxied through
- * the dashboard at /api/admin/profiles/{id}/proxy/chat.
  */
 import { test, expect } from '@playwright/test';
+import { chatWS, type ChatWsEvent } from '../lib/m9-ws-client';
 
 test.setTimeout(240_000);
 
-/**
- * Auth token (optional). If not set, tests use the profile subdomain
- * (e.g. dspfac.crew.ominix.io) where Caddy injects X-Profile-Id.
- */
-const AUTH_TOKEN = process.env.OCTOS_AUTH_TOKEN || '';
+const AUTH_TOKEN =
+  process.env.OCTOS_AUTH_TOKEN ||
+  process.env.OCTOS_LIVE_TOKEN ||
+  process.env.OCTOS_TEST_TOKEN ||
+  '';
 
 function headers() {
   const h: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -26,98 +28,22 @@ function headers() {
   return h;
 }
 
-/**
- * POST /chat and collect all SSE events until the stream closes.
- * Returns parsed JSON events.
- *
- * The /api/chat endpoint accepts a message and returns an SSE stream.
- * Profile is resolved from X-Profile-Id header or auth token.
- */
-async function chatSSE(
-  _request: any,
+async function chatViaWs(
   baseURL: string,
   message: string,
   sessionId?: string,
   timeoutMs = 120_000,
-): Promise<{ events: any[]; raw: string }> {
-  const sid = sessionId || `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-  // Use a real streaming reader for SSE. Playwright's request.post buffers the
-  // full body and can time out on longer streams before the server closes it.
-  for (let attempt = 0; attempt < 2; attempt++) {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    const res = await fetch(`${baseURL}/api/chat`, {
-      method: 'POST',
-      headers: headers(),
-      body: JSON.stringify({
-        message,
-        session_id: attempt === 0 ? sid : `${sid}-r`,
-        stream: true,
-      }),
-      signal: controller.signal,
-    });
-
-    if (!res.ok) {
-      clearTimeout(timeout);
-      const body = await res.text().catch(() => '');
-      throw new Error(`chat failed: ${res.status} ${body.slice(0, 200)}`);
-    }
-
-    if (!res.body) {
-      clearTimeout(timeout);
-      if (attempt === 1) {
-        return { events: [], raw: '' };
-      }
-      continue;
-    }
-
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let raw = '';
-    let buffer = '';
-    const events: any[] = [];
-    let sawDone = false;
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        const chunk = decoder.decode(value, { stream: true });
-        raw += chunk;
-        buffer += chunk;
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (!trimmed.startsWith('data:')) continue;
-          const json = trimmed.slice(5).trim();
-          if (!json || json === '[DONE]') continue;
-          try {
-            const event = JSON.parse(json);
-            events.push(event);
-            if (event?.type === 'done') {
-              sawDone = true;
-              return { events, raw };
-            }
-          } catch {
-            // skip non-JSON lines
-          }
-        }
-      }
-    } finally {
-      clearTimeout(timeout);
-      reader.releaseLock();
-    }
-
-    if (sawDone || events.length > 0 || attempt === 1) {
-      return { events, raw };
-    }
-    // Empty response — wait briefly and retry with fresh session
-    await new Promise((r) => setTimeout(r, 1000));
-  }
-
-  return { events: [], raw: '' };
+): Promise<{ events: ChatWsEvent[]; content: string; doneEvent?: ChatWsEvent }> {
+  const sid =
+    sessionId ||
+    `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return chatWS({
+    baseUrl: baseURL,
+    token: AUTH_TOKEN,
+    message,
+    sessionId: sid,
+    maxWait: timeoutMs,
+  });
 }
 
 async function getSessionMessages(
@@ -140,121 +66,113 @@ async function getSessionMessages(
 }
 
 // ---------------------------------------------------------------------------
-// Test 1: SSE stream returns valid UTF-8 for CJK characters
+// Test 1: WS chat preserves UTF-8 for CJK characters
 //
-// Bug: SSE parser used String::from_utf8_lossy on each HTTP chunk.
-// Multi-byte CJK characters split across chunks became U+FFFD (�).
-// Fix: f4b27b9 — byte-buffer SSE parser.
+// Historical bug (SSE-era): the SSE parser used String::from_utf8_lossy on
+// each HTTP chunk and multi-byte CJK split across chunks became U+FFFD.
+// Fix: f4b27b9 (byte-buffer SSE parser). The chat path now runs over
+// JSON-RPC frames on WebSocket, so this regression is structurally
+// impossible at the transport layer; we keep an equivalent assertion
+// against the cumulative `content` string so any *upstream* (LLM provider)
+// regression would still surface.
 // ---------------------------------------------------------------------------
-test('SSE response preserves CJK characters without corruption', async ({
-  request,
+test('WS chat preserves CJK characters without corruption', async ({
   baseURL,
 }) => {
 
-  const { events, raw } = await chatSSE(
-    request,
+  const { events, content } = await chatViaWs(
     baseURL!,
     '用中文回复：你好世界。只回复这四个字，不要多说。',
   );
 
-  // The raw SSE response should not contain U+FFFD replacement characters
-  expect(raw).not.toContain('\uFFFD');
-  expect(raw).not.toContain('�');
+  // The synthesized chat content should be free of replacement characters.
+  expect(content).not.toContain('�');
 
   // Should have received at least some events
   expect(events.length).toBeGreaterThan(0);
 
   // Check all text-bearing events for CJK content
   const allContent = events
-    .map((e) => e.text || e.content || '')
+    .map((e) =>
+      (typeof e.text === 'string' ? e.text : '') ||
+      (typeof e.content === 'string' ? e.content : ''),
+    )
     .join('');
-  expect(allContent).toMatch(/[\u4e00-\u9fff]/); // Contains CJK characters
+  expect(allContent).toMatch(/[一-鿿]/); // Contains CJK characters
 });
 
 // ---------------------------------------------------------------------------
-// Test 2: SSE stream handles multi-byte characters in longer responses
+// Test 2: WS chat handles multi-byte characters in longer responses
 //
-// Longer responses are more likely to trigger chunk-boundary splits.
+// Longer responses surface chunk-boundary handling bugs. Same protective
+// assertion as test 1, scaled up.
 // ---------------------------------------------------------------------------
-test('SSE handles long CJK response without garbling', async ({
-  request,
+test('WS chat handles long CJK response without garbling', async ({
   baseURL,
 }) => {
 
-  const { events, raw } = await chatSSE(
-    request,
+  const { content } = await chatViaWs(
     baseURL!,
     '列出5个中国城市的名字，每个城市一行，只要城市名不要其他内容。',
     undefined,
     120_000,
   );
 
-  // No replacement characters anywhere in the stream
-  expect(raw).not.toContain('\uFFFD');
+  // No replacement characters anywhere in the assistant content stream.
+  expect(content).not.toContain('�');
 
   // The final streamed content should still contain substantial CJK text.
-  const finalContent = events
-    .filter((e) => e.type === 'replace' || e.type === 'done')
-    .map((e) => e.text || e.content || '')
-    .filter((text) => typeof text === 'string' && text.length > 0)
-    .pop() || '';
-  const cjkChars = finalContent.match(/[\u4e00-\u9fff]/g) || [];
+  const cjkChars = content.match(/[一-鿿]/g) || [];
   expect(cjkChars.length).toBeGreaterThan(8);
 });
 
 // ---------------------------------------------------------------------------
-// Test 3: SSE stream completes with a done event
+// Test 3: WS chat completes with a turn/completed -> synthesized done
 //
-// Verifies the basic SSE lifecycle: events flow, stream terminates with
-// a "done" event containing token usage metadata.
+// Verifies the basic chat lifecycle terminates with a `done` event
+// synthesized from `turn/completed`.
+//
+// NOTE on token counts: The legacy SSE `done` event carried `tokens_in` /
+// `tokens_out`. The M9 `turn/completed` notification does NOT yet carry
+// them (deferred follow-up — α-3 punted token usage to γ-3). For now this
+// test asserts on the lifecycle terminal only; the cost-tracking spec
+// covers token math via the REST /api/sessions/:id/tasks snapshot.
 // ---------------------------------------------------------------------------
-test('SSE stream completes with done event and token counts', async ({
-  request,
+test('WS chat completes with terminal done event', async ({
   baseURL,
 }) => {
 
-  const { events } = await chatSSE(
-    request,
+  const { events, doneEvent } = await chatViaWs(
     baseURL!,
     'Say "hello" and nothing else.',
   );
 
   expect(events.length).toBeGreaterThan(0);
 
-  // Last meaningful event should be "done"
+  // Exactly one synthesized `done` event from `turn/completed`.
   const doneEvents = events.filter((e) => e.type === 'done');
   expect(doneEvents.length).toBe(1);
-
-  const done = doneEvents[0];
-  expect(done.tokens_in).toBeGreaterThan(0);
-  expect(done.tokens_out).toBeGreaterThan(0);
+  expect(doneEvent).toBeTruthy();
 });
 
 // ---------------------------------------------------------------------------
 // Test 4: Chat session persistence — messages survive across requests
 //
 // Verifies that sending two messages with the same session_id maintains
-// conversation context.
+// conversation context (the persistence guarantee is independent of the
+// streaming transport — REST `/api/sessions/:id/messages` is the source
+// of truth, the WS path just drives the live turn).
 // ---------------------------------------------------------------------------
 test('session persists across requests', async ({ request, baseURL }) => {
 
   const sid = `test-persist-${Date.now()}`;
 
-  // Send via the SSE chat API, then verify the same session is readable via
-  // the messages API. This proves persistence across requests without relying
-  // on a second live-model recall turn.
-  const { events } = await chatSSE(
-    request,
+  const { content } = await chatViaWs(
     baseURL!,
     'Say "OK" and nothing else.',
     sid,
     180_000,
   );
-
-  const content = events
-    .filter((e) => e.type === 'replace' || e.type === 'done')
-    .map((e) => e.text || e.content || '')
-    .join('');
 
   expect(content.toUpperCase()).toContain('OK');
 
@@ -271,49 +189,49 @@ test('session persists across requests', async ({ request, baseURL }) => {
 });
 
 // ---------------------------------------------------------------------------
-// Test 5: File event is delivered via SSE when tool produces a file
+// Test 5: File event is delivered when tool produces a file
 //
-// Verifies that tools returning files_to_send get delivered as SSE
-// "file" events with path and filename.
+// SSE-era this test asserted on `type === 'file'` events and on
+// `session_result.message.media`. The M9 WS protocol has NO equivalent
+// notification yet — `session_result` is on the α-3 deferred set
+// (UPCR-2026-012 / γ-3 follow-up) and per-turn file events have not been
+// promoted to a typed UI notification at all. We mark the test as fixme;
+// once the WS variant lands, the body can use the same REST fallback path
+// it already uses for has_bg_tasks turns.
 // ---------------------------------------------------------------------------
-test('file delivery is visible via SSE or committed session result', async ({ request, baseURL }) => {
+test.fixme('file delivery is visible via WS or committed session result', async ({ request, baseURL }) => {
   test.slow();
   const sid = `test-file-${Date.now()}`;
   const fileDir = `octos-web-file-${Date.now()}`;
   const filePath = `./${fileDir}/octos_e2e_test.txt`;
 
-  const { events } = await chatSSE(
-    request,
+  const { events, doneEvent } = await chatViaWs(
     baseURL!,
     `Use write_file to create ${filePath} with exactly this content: test123. Then use send_file to send ${filePath} to me. Do not use shell.`,
     sid,
     180_000,
   );
 
-  // Look for a file event in the SSE stream
+  // Look for a file event (deferred per α-3) or session_result media.
   const fileEvents = events.filter((e) => e.type === 'file');
   const sessionResultMediaEvents = events.filter(
-    (e) => e.type === 'session_result' && Array.isArray(e.message?.media) && e.message.media.length > 0,
+    (e) =>
+      e.type === 'session_result' &&
+      Array.isArray((e as any).message?.media) &&
+      (e as any).message.media.length > 0,
   );
-  const doneEvent = events.find((e) => e.type === 'done');
 
-  // If the agent successfully created and sent the file, we should see a file event
   if (fileEvents.length > 0 || sessionResultMediaEvents.length > 0) {
     if (fileEvents.length > 0) {
-      expect(fileEvents[0].filename).toBeTruthy();
-      expect(fileEvents[0].path).toBeTruthy();
+      expect((fileEvents[0] as any).filename).toBeTruthy();
+      expect((fileEvents[0] as any).path).toBeTruthy();
     } else {
-      expect(sessionResultMediaEvents[0].message.media[0]).toBeTruthy();
+      expect((sessionResultMediaEvents[0] as any).message.media[0]).toBeTruthy();
     }
     return;
   }
 
-  const content = events
-    .filter((e) => e.type === 'replace' || e.type === 'done')
-    .map((e) => e.text || e.content || '')
-    .join('');
-
-  if (doneEvent?.has_bg_tasks) {
+  if ((doneEvent as any)?.has_bg_tasks) {
     const deadline = Date.now() + 90_000;
     let latestMessages: any[] = [];
     while (Date.now() < deadline) {
@@ -344,39 +262,32 @@ test('file delivery is visible via SSE or committed session result', async ({ re
     return;
   }
 
-  // Agent might not have used send_file — check that the response at least
-  // mentions the file was created (acceptable fallback)
-  expect(content).toMatch(/test.*file|created|written/i);
+  // Acceptable fallback: the agent at least mentions creation.
+  const synthContent = events
+    .filter((e) => e.type === 'token' || e.type === 'done')
+    .map((e) => (typeof e.text === 'string' ? e.text : '') || (typeof e.content === 'string' ? e.content : ''))
+    .join('');
+  expect(synthContent).toMatch(/test.*file|created|written/i);
 });
 
 // ---------------------------------------------------------------------------
 // Test 6: Concurrent sessions don't cross-contaminate
 //
-// Two simultaneous requests with different session IDs should get
-// independent responses.
+// Two simultaneous chat turns with different session IDs should get
+// independent responses on independent WS connections.
 // ---------------------------------------------------------------------------
-test('concurrent sessions are isolated', async ({ request, baseURL }) => {
+test('concurrent sessions are isolated', async ({ baseURL }) => {
 
   const sidA = `test-iso-a-${Date.now()}`;
   const sidB = `test-iso-b-${Date.now()}`;
 
   const [resultA, resultB] = await Promise.all([
-    chatSSE(request, baseURL!, 'Reply with exactly: ALPHA', sidA),
-    chatSSE(request, baseURL!, 'Reply with exactly: BRAVO', sidB),
+    chatViaWs(baseURL!, 'Reply with exactly: ALPHA', sidA),
+    chatViaWs(baseURL!, 'Reply with exactly: BRAVO', sidB),
   ]);
 
-  const contentA = resultA.events
-    .filter((e) => e.type === 'replace' || e.type === 'done')
-    .map((e) => e.text || e.content || '')
-    .join('');
-
-  const contentB = resultB.events
-    .filter((e) => e.type === 'replace' || e.type === 'done')
-    .map((e) => e.text || e.content || '')
-    .join('');
-
-  expect(contentA.toUpperCase()).toContain('ALPHA');
-  expect(contentB.toUpperCase()).toContain('BRAVO');
+  expect(resultA.content.toUpperCase()).toContain('ALPHA');
+  expect(resultB.content.toUpperCase()).toContain('BRAVO');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Centralizes chat-turn streaming helpers across the e2e suite onto a single `chatWS()` (`e2e/lib/m9-ws-client.ts`) that drives the M9 WebSocket UI Protocol (`session/open` + `turn/start` over `/api/ui-protocol/ws`) and synthesizes SSE-shaped events so spec bodies can swap `chatSSE -> chatWS` without rewriting assertions.
- Migrates every spec listed in the #845 audit. After this lands no e2e spec talks to `/api/chat`, unblocking M9-α-5 / α-6 (atomic SSE delete from server + web bundle).
- ADR alignment: `docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md` (#830). Audit lock: #845.

## Scope

| Spec file | chatSSE → chatWS | Notes |
| --- | --- | --- |
| `web-client.spec.ts` | 5 | 1 `test.fixme` (file delivery — depends on `session_result` + per-turn `file` events, both on the α-3 deferred set). |
| `runtime-regression.spec.ts` | 27 | 1 `test.fixme` (token counts on `done`). |
| `m8-runtime-invariants-live.spec.ts` | 7 | `has_bg_tasks` assertion commented out, REST-based invariant remains authoritative. |
| `live-spawn-end-to-end.spec.ts` | 7 | — |
| `live-cost-tracking.spec.ts` | 7 | 1 `test.fixme` (`done.tokens_in/tokens_out`). |
| `live-pipeline-end-to-end.spec.ts` | 5 | — |
| `refactor-capabilities.spec.ts` | 4 | 1 `test.fixme` (`topic` parameter — `turn/start` does not carry it yet). |
| `live-pipeline-cards.spec.ts` | 1 | Whole describe is `.skip`'d; helper migrated for cleanliness. |
| `live-pipeline-cost.spec.ts` | 1 | Whole describe is `.skip`'d; helper migrated for cleanliness. |
| `live-progress-gate.spec.ts` | 0 | One test now `test.fixme` — its assertion is on `/api/sessions/:id/events/stream` (a separate SSE channel, no WS counterpart yet). |
| `live-realtime-status.spec.ts` | 0 | Comment prose only — SSE → streaming/WS phrasing. |
| `live-thread-interleave.spec.ts` | 0 | Comment prose only — `SSE done` → `turn/completed` phrasing. |

Per-spec local copies of `chatSSE()` are deleted; every migrated file imports the centralized helper.

## Helper contract

`chatWS({ baseUrl, token, profileId, message, sessionId, maxWait })` returns `{ events, content, doneEvent }`. WS → synthesized event mapping:

- `message/delta` → `{ type: 'token', text }` and accumulates into `content`
- `tool/started`/`progress`/`completed` → `{ type: 'tool_start'|'tool_progress'|'tool_completed', tool, tool_call_id, ... }`
- `task/updated`, `task/output/delta`, `progress/updated`, `warning` → forwarded
- `turn/completed` → `{ type: 'done', content, cursor }` (terminal)
- `turn/error` → `{ type: 'error', message, code }` (terminal)

## Smoke test verdict

Ran two migrated tests against `dspfac.crew.ominix.io` (canonical request fleet):

| Test | Result |
| --- | --- |
| `web-client.spec.ts:79 WS chat preserves CJK characters without corruption` | PASS (1.0s) |
| `web-client.spec.ts:141 WS chat completes with terminal done event` | PASS (4.7s) |
| `web-client.spec.ts:166 session persists across requests` | FAIL — pre-existing fleet-version skew: this test reads `/api/sessions/:id/messages` which only resolves WS-created session keys after the M10.5 fix (74ed37a5). Crew has not been redeployed to that revision yet. |

The third failure is **not** a migration bug; it surfaces an upstream infra gap. Filing a follow-up to redeploy crew once #836 + the M10.5 commit are both on the soak branch.

## Deferred follow-ups (γ-3 / β-1)

All flagged inline in the code with comments pointing back to this PR + the α-3 deferred set:

1. WS `turn/completed` does not yet carry `tokens_in` / `tokens_out` — `test.fixme` on the two tests that asserted those.
2. WS `turn/completed` does not yet carry `has_bg_tasks` — soft-commented in the runtime-regression / m8 tests where a REST-based check covers the same behaviour.
3. `session_result` + per-turn `file` events stay WS-exclusive deferred per α-3 — `test.fixme` on the file-delivery test in `web-client.spec.ts`.
4. `topic` parameter on `turn/start` is missing — `test.fixme` on the topic-scoped histories capability test in `refactor-capabilities.spec.ts`.
5. `/api/sessions/:id/events/stream` SSE (a separate surface from `/api/chat`) needs its own WS migration — `test.fixme` on the single test in `live-progress-gate.spec.ts` with a forward pointer.

## Test plan

- [x] TypeScript compiles for every migrated spec (`tsc --noEmit`)
- [x] `playwright test --list` enumerates all migrated cases without import errors
- [x] Smoke: two migrated tests pass against `dspfac.crew.ominix.io`
- [ ] Follow-up: rerun the full migrated set after crew picks up the M10.5 REST-fallback fix
- [ ] Follow-up issue (γ-3): WS `turn/completed` carries token usage and `has_bg_tasks`
- [ ] Follow-up issue (β-1): events-stream SSE → WS migration (`live-progress-gate.spec.ts:731`)