### PR TITLE
feat(api): M9-γ-7 server dedup + α deferred bridges (closes #844, follow-up to #836)

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -707,6 +707,52 @@ Carries non-terminal operator-visible warnings without collapsing them into gene
 
 Marks the normal terminal event for a turn.
 
+Optional fields from accepted `UPCR-2026-014` (M9-α-9):
+
+- `tokens_in` / `tokens_out`
+  Aggregated input / output token counts for the completed turn.
+  Absent when the runtime did not surface usage to the wire.
+- `session_result`
+  Object carrying the final assistant row's durable identity:
+  `{ "committed_seq": u64, "message_id": "<session>:<seq>:<ts_ns>",
+  "client_message_id"?: string }`. Mirrors the SSE-only
+  `session_result` frame so a WS client can stamp authoritative seq
+  onto an optimistic bubble without an extra REST roundtrip. Absent
+  when the turn ended without a final assistant row.
+
+### `turn/started`
+
+Optional fields from accepted `UPCR-2026-014` (M9-α-9):
+
+- `topic`
+  Sub-topic suffix that scopes the turn within a session (mirrors the
+  `<session>#<topic>` shape carried on REST/SSE chat). Absent when the
+  turn is not topic-scoped.
+
+### `file/attached`
+
+Per-turn file attachment event introduced by `UPCR-2026-014` (M9-α-9).
+Mirrors the SSE `file:` frame the agent loop emits for tools that
+declare `files_to_send`. Payload fields:
+
+- `session_id`, `turn_id` — turn-scoping fields (required).
+- `path` — filesystem path or URL the tool produced.
+- `tool_call_id` — originating tool call (optional; omitted on
+  background-result paths that don't run inside a tool execution).
+- `mime` — MIME-type hint (optional; clients fall back to extension
+  sniffing when absent).
+
+### `session/event`
+
+Wrapper envelope introduced by `UPCR-2026-014` (M9-α-9) that bridges
+legacy `/api/sessions/:id/events/stream` SSE frames onto the unified
+WS surface during the α coexistence period. The legacy stream is
+free-form; this wrapper preserves the original `type` (as `kind`) plus
+the full frame body (as `payload`) so WS-only clients keep observing
+every signal SSE consumers see while each event kind gradually lifts
+onto a typed v1 envelope. Optional `topic` echoes the legacy frame's
+topic for client-side scoping.
+
 ### `turn/error`
 
 Marks the abnormal terminal event for a turn.

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -545,17 +545,17 @@ async fn chat_streaming(
     );
 
     // M9-α-3 (issue #832, ADR PR #830): emit a `turn/started.v1`
-    // notification onto the M9 ledger BEFORE the agent loop runs. The
-    // SSE chat path's "turn started" is an implicit consequence of the
-    // Sse stream opening — there is no SSE wire frame for it. Without
-    // this bridge call a WebSocket subscriber that connects mid-turn
-    // sees no turn-start signal for the SSE-driven turn, breaking the
-    // pane-state contract every WS reducer assumes. See
-    // `ui_protocol_alpha3_bridge` for the full survey + invariants.
-    super::ui_protocol_alpha3_bridge::emit_turn_started(
+    // notification onto the M9 ledger BEFORE the agent loop runs.
+    // M9-α-9 (UPCR-2026-014): plumb `topic` onto the envelope so
+    // multi-topic specs can scope by sub-topic (the SSE chat path's
+    // `topic` query parameter previously had no WS counterpart). The
+    // `_with_topic` variant collapses empty topic to None so no-topic
+    // turns retain the pre-α-9 wire shape.
+    super::ui_protocol_alpha9_bridge::emit_turn_started_with_topic(
         &alpha_ledger,
         &session_key,
         &alpha_turn_id,
+        req.topic.clone(),
     );
 
     // Build per-request agent sharing resources with the base agent
@@ -598,12 +598,48 @@ async fn chat_streaming(
     let lifecycle_session_key = session_key.clone();
     let lifecycle_turn_id = alpha_turn_id.clone();
     tokio::spawn(async move {
+        // M9-α-9 (UPCR-2026-014): capture token usage + final-row
+        // identity into mutable bindings so the lifecycle emit at the
+        // bottom of this closure can stamp them onto the
+        // `turn/completed` envelope. Both default to None — failure
+        // paths leave the addendum fields absent on the wire.
+        let mut alpha9_tokens_in: Option<u32> = None;
+        let mut alpha9_tokens_out: Option<u32> = None;
+        let mut alpha9_session_result: Option<octos_core::ui_protocol::TurnSessionResult> = None;
+
         let result = request_agent
             .process_message(&message, &history, media)
             .await;
 
         match result {
             Ok(response) => {
+                alpha9_tokens_in = Some(response.token_usage.input_tokens);
+                alpha9_tokens_out = Some(response.token_usage.output_tokens);
+                // M9-α-9 (UPCR-2026-014): mirror per-turn file
+                // attachments onto the WS surface so `file_attached`
+                // tests can observe them on the M9 ledger. The SSE
+                // chat path does not currently emit `file:` frames
+                // for `files_to_send` (those route through the
+                // gateway's `ApiChannel`), so this bridge is the
+                // sole path delivering them on the WS surface for a
+                // standalone `octos serve`. The `tool_call_id` is
+                // not threaded through `ConversationResponse` today
+                // — tools that emit files go through the per-tool
+                // execution path, not the per-turn aggregate. Leave
+                // it None so clients fall back to fuzzy matching by
+                // path; future work can plumb the originating tool
+                // call id through the response struct.
+                for path in &response.files_to_send {
+                    let path_str = path.to_string_lossy().to_string();
+                    super::ui_protocol_alpha9_bridge::emit_file_attached(
+                        &lifecycle_ledger,
+                        &lifecycle_session_key,
+                        &lifecycle_turn_id,
+                        path_str,
+                        None,
+                        None,
+                    );
+                }
                 tracing::info!(
                     session = %session_id,
                     input_tokens = response.token_usage.input_tokens,
@@ -775,6 +811,27 @@ async fn chat_streaming(
                 });
                 if let Some(seq) = assistant_committed_seq {
                     done["committed_seq"] = serde_json::Value::from(seq);
+                    // M9-α-9 (UPCR-2026-014): also surface the
+                    // committed identity onto the WS `turn/completed`
+                    // envelope via `session_result`. The `message_id`
+                    // here mirrors the
+                    // `MessageCommitObserver`-computed shape
+                    // (`session:seq:timestamp_ns`) but with timestamp
+                    // = 0 — the WS path's authoritative `message_id`
+                    // arrives separately on the parallel
+                    // `message/persisted` envelope; this addendum is
+                    // a hint that lets clients dedupe + stamp seq
+                    // without a REST roundtrip. Clients that need
+                    // the exact ns-precision id read it from the
+                    // persisted envelope.
+                    alpha9_session_result = Some(octos_core::ui_protocol::TurnSessionResult {
+                        committed_seq: seq,
+                        message_id: format!("{}:{seq}:0", session_key.0),
+                        client_message_id: client_message_id
+                            .as_ref()
+                            .filter(|s| !s.is_empty())
+                            .cloned(),
+                    });
                 }
                 // M8.10 PR #2: tag the done event with thread_id so the web
                 // client can route the committed_seq onto the right per-cmid
@@ -808,19 +865,20 @@ async fn chat_streaming(
                 let _ = tx.send(err.to_string());
             }
         }
-        // M9-α-3: emit `turn/completed.v1` to the ledger AFTER the
-        // terminal SSE frame (`done` or `error`) is sent. Order is
-        // intentional — the SSE wire frame is what closes the SSE
-        // turn from the user's POV; the WS lifecycle envelope mirrors
-        // that close so a WebSocket subscriber sees the same
-        // before/after relationship the SSE consumer does. We emit
-        // the same envelope regardless of success/error so a
-        // mid-turn-attached WS client always sees the turn's lifecycle
-        // pair (started / completed) for SSE-driven turns.
-        super::ui_protocol_alpha3_bridge::emit_turn_completed(
+        // M9-α-3 + α-9: emit `turn/completed.v1` to the ledger AFTER
+        // the terminal SSE frame (`done` or `error`) is sent. The
+        // α-9 variant carries the UPCR-2026-014 addendum fields
+        // (`tokens_in/out` + `session_result`) — None on error paths
+        // so a mid-turn-attached WS client still sees the lifecycle
+        // pair (started / completed) for SSE-driven turns regardless
+        // of outcome.
+        super::ui_protocol_alpha9_bridge::emit_turn_completed_full(
             &lifecycle_ledger,
             &lifecycle_session_key,
             &lifecycle_turn_id,
+            alpha9_tokens_in,
+            alpha9_tokens_out,
+            alpha9_session_result,
         );
         // tx drops here, closing the stream
     });
@@ -1190,11 +1248,29 @@ pub async fn session_event_stream(
         return super::webhook_proxy::api_sse_get_proxy(&state, port, &path).await;
     }
 
-    let replay_complete = serde_json::json!({
+    let replay_complete_payload = serde_json::json!({
         "type": "replay_complete",
         "topic": params.topic,
-    })
-    .to_string();
+    });
+    // M9-α-9 (UPCR-2026-014): bridge the legacy SSE
+    // `/api/sessions/:id/events/stream` frame onto the WS surface as
+    // a `session/event.v1` envelope. Keeps WS-only clients (post-α-7)
+    // observing the same signal SSE consumers see during the
+    // coexistence period; once the gateway-mode forwarder also
+    // routes its frames through this bridge, every legacy event-
+    // stream frame is mirrored regardless of mode.
+    let session_key =
+        standalone_api_session_key_with_topic(&state, &headers, &id, params.topic.as_deref());
+    let alpha_ledger = super::ui_protocol::event_ledger(&state).await;
+    super::ui_protocol_alpha9_bridge::emit_session_event(
+        &alpha_ledger,
+        &session_key,
+        "replay_complete".to_string(),
+        replay_complete_payload.clone(),
+        params.topic.clone(),
+    );
+
+    let replay_complete = replay_complete_payload.to_string();
     let stream = futures::stream::iter(vec![Ok::<Event, Infallible>(
         Event::default().data(replay_complete),
     )]);

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -18,6 +18,7 @@ mod ui_protocol;
 mod ui_protocol_alpha2_bridge;
 mod ui_protocol_alpha3_bridge;
 mod ui_protocol_alpha4_bridge;
+mod ui_protocol_alpha9_bridge;
 mod ui_protocol_approvals;
 mod ui_protocol_audit;
 mod ui_protocol_diff;

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -917,9 +917,45 @@ struct PersistedMessageMeta {
     message_id: String,
 }
 
+/// M9-γ-7 (issue #844): the agent loop's iterative tool-calling pattern
+/// commits an Assistant `Message` per LLM iteration. When the LLM returns
+/// only `tool_calls` (no text content) and no media — the metadata-only
+/// shape that bracketed every `tool/started` → `tool/completed` cycle —
+/// the persisted row is invisible to the user but still triggers
+/// `MessageCommitObserver`. Pre-fix the ledger emitted N
+/// `message/persisted` envelopes per turn for an N-iteration loop, all
+/// carrying the same `thread_id`. The web reducer keyed off `thread_id`
+/// merged them into a "phantom" empty assistant bubble that briefly
+/// flickered into the chat pane (the 2026-05-09 phantom-bubble bug).
+///
+/// The defensive web-side fix in octos-web #92 hid those bubbles. The
+/// authoritative server-side fix is to suppress the `message/persisted`
+/// emit for these intermediate metadata-only assistant rows so the wire
+/// surface emits exactly one `message/persisted` per turn for the final
+/// user-visible assistant text.
+///
+/// Filter: skip emission when the row is `Assistant`, content is
+/// empty after `trim()`, and `media` is empty. Tool messages (role
+/// `Tool`) and assistant rows with text or media are unaffected. Once
+/// the SSE chat path is deleted (α-5/α-6) and the WS turn loop is sole
+/// transport, this filter remains correct because the filtering criteria
+/// describe a metadata-only row (no rendering surface) regardless of
+/// transport.
+fn is_metadata_only_assistant_row(message: &octos_core::Message) -> bool {
+    message.role == octos_core::MessageRole::Assistant
+        && message.content.trim().is_empty()
+        && message.media.is_empty()
+}
+
 fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
     let observer: octos_bus::MessageCommitObserver =
         Arc::new(move |session_key, message, committed_seq| {
+            // M9-γ-7: drop intermediate metadata-only assistant rows
+            // (LLM returned only `tool_calls`, no rendered text). See
+            // [`is_metadata_only_assistant_row`] for the rationale.
+            if is_metadata_only_assistant_row(message) {
+                return;
+            }
             let event = MessagePersistedEvent {
                 session_id: session_key.clone(),
                 // The `Message` struct does not yet carry a typed
@@ -4232,6 +4268,9 @@ async fn run_m9_fixture_turn(
         session_id: session_id.clone(),
         turn_id: turn_id.clone(),
         timestamp: Utc::now(),
+        // UPCR-2026-014 (M9-α-9): WS turn-start path has no topic in
+        // scope today; the SSE bridge in α-9 plumbs topic separately.
+        topic: None,
     });
     if send_notification_lifecycle(&ws, &ledger, started).is_err() {
         let _ = transition_to_terminal(&turn_state, TerminalReason::Errored).await;
@@ -4603,6 +4642,9 @@ async fn run_standalone_turn(
         session_id: session_id.clone(),
         turn_id: turn_id.clone(),
         timestamp: Utc::now(),
+        // UPCR-2026-014 (M9-α-9): legacy WS turn-start path; topic is
+        // not in scope here (the SSE bridge surfaces it via α-9).
+        topic: None,
     });
     // turn/started is lifecycle. If the client cannot receive it we may as
     // well stop now — the rest of the turn is wasted work. Per FIX-03,
@@ -5420,6 +5462,14 @@ async fn try_emit_terminal(
                     session_id: session_id.clone(),
                     turn_id: turn_id.clone(),
                     cursor: None,
+                    // UPCR-2026-014 (M9-α-9) addendum fields; the WS
+                    // lifecycle path doesn't have token usage /
+                    // session_result threaded yet — those land via the
+                    // SSE bridge in α-9. Leaving them None preserves
+                    // the pre-addendum wire shape for WS-driven turns.
+                    tokens_in: None,
+                    tokens_out: None,
+                    session_result: None,
                 }),
             );
         }
@@ -9252,6 +9302,7 @@ mod tests {
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
                 timestamp: Utc::now(),
+                topic: None,
             }),
         );
         assert!(first.is_ok());
@@ -10139,12 +10190,16 @@ mod tests {
                 session_id: session_id.clone(),
                 turn_id: turn_id.clone(),
                 timestamp: Utc::now(),
+                topic: None,
             },
         ));
         let _ = ledger.append_notification(UiNotification::TurnCompleted(TurnCompletedEvent {
             session_id: session_id.clone(),
             turn_id: turn_id.clone(),
             cursor: None,
+            tokens_in: None,
+            tokens_out: None,
+            session_result: None,
         }));
 
         let (ws, mut rx) = ws_connection_for_test(8);
@@ -10675,6 +10730,206 @@ mod tests {
         );
 
         octos_bus::set_message_commit_observer(prev);
+    }
+
+    /// M9-γ-7 (issue #844): `is_metadata_only_assistant_row` is the
+    /// pure-function classifier the observer uses to drop intermediate
+    /// metadata-only assistant rows. Lock its truth table here so a
+    /// future refactor that "helpfully" widens the filter cannot drop
+    /// rows the wire surface needs.
+    #[test]
+    fn is_metadata_only_assistant_row_truth_table() {
+        // Empty assistant with no media: metadata-only -> drop.
+        let mut empty_assistant = Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: Some(vec![]),
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: Utc::now(),
+        };
+        assert!(is_metadata_only_assistant_row(&empty_assistant));
+
+        // Whitespace-only counts as empty.
+        empty_assistant.content = "   \n\t".into();
+        assert!(is_metadata_only_assistant_row(&empty_assistant));
+
+        // Assistant with text: keep.
+        empty_assistant.content = "hello".into();
+        assert!(!is_metadata_only_assistant_row(&empty_assistant));
+
+        // Assistant with media but empty text: keep (image-only response).
+        empty_assistant.content = String::new();
+        empty_assistant.media = vec!["data:image/png;base64,abc".into()];
+        assert!(!is_metadata_only_assistant_row(&empty_assistant));
+
+        // Tool messages are never filtered.
+        let tool_message = Message {
+            role: MessageRole::Tool,
+            content: String::new(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some("tc-1".into()),
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: Utc::now(),
+        };
+        assert!(!is_metadata_only_assistant_row(&tool_message));
+
+        // User rows are never filtered.
+        let user_message = Message {
+            role: MessageRole::User,
+            content: String::new(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: None,
+            timestamp: Utc::now(),
+        };
+        assert!(!is_metadata_only_assistant_row(&user_message));
+    }
+
+    /// M9-γ-7 (issue #844): a 3-iteration agent loop that commits
+    /// (assistant tool-call only) -> tool result -> (assistant tool-call
+    /// only) -> tool result -> (assistant final text) MUST surface
+    /// EXACTLY ONE `message/persisted` envelope for the assistant turn
+    /// (the final text row), plus the per-tool rows, on the M9 ledger.
+    /// Pre-fix this emitted three assistant `message/persisted`
+    /// envelopes, all under the same `thread_id` — the phantom-bubble
+    /// shape the web reducer collapsed (octos-web #92).
+    #[tokio::test(flavor = "current_thread")]
+    async fn gamma_7_dedup_one_assistant_persisted_per_turn() {
+        use octos_core::ui_protocol::{MessagePersistedSource, methods};
+
+        let _guard = message_commit_observer_test_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        // Spin a fresh ledger + observer wired the same way the live
+        // server wires them on the first `event_ledger` call.
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        install_message_commit_observer(ledger.clone());
+
+        let session_id = SessionKey("local:gamma-7-dedup".into());
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut manager =
+            octos_bus::SessionManager::open(tmp.path()).expect("session manager open");
+
+        // Simulate the agent loop's commits: 2 metadata-only assistant
+        // rows (intermediate iterations whose only payload was
+        // tool_calls), interleaved with their tool results, then the
+        // final assistant text row.
+        let thread = "cmid-gamma-7".to_string();
+        let mk_assistant = |content: &str, with_tool_calls: bool| Message {
+            role: MessageRole::Assistant,
+            content: content.into(),
+            media: vec![],
+            tool_calls: if with_tool_calls {
+                Some(vec![octos_core::ToolCall {
+                    id: format!("tc-{}", uuid::Uuid::now_v7()),
+                    name: "shell".into(),
+                    arguments: serde_json::json!({}),
+                    metadata: None,
+                }])
+            } else {
+                None
+            },
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some(thread.clone()),
+            timestamp: Utc::now(),
+        };
+        let mk_tool = |out: &str, tc_id: &str| Message {
+            role: MessageRole::Tool,
+            content: out.into(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some(tc_id.into()),
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some(thread.clone()),
+            timestamp: Utc::now(),
+        };
+
+        // Iteration 1: assistant returns only tool_calls (empty content).
+        manager
+            .add_message_with_seq(&session_id, mk_assistant("", true))
+            .await
+            .expect("commit it1 assistant");
+        manager
+            .add_message_with_seq(&session_id, mk_tool("ok", "tc-1"))
+            .await
+            .expect("commit it1 tool");
+        // Iteration 2: assistant returns only tool_calls again.
+        manager
+            .add_message_with_seq(&session_id, mk_assistant("", true))
+            .await
+            .expect("commit it2 assistant");
+        manager
+            .add_message_with_seq(&session_id, mk_tool("ok", "tc-2"))
+            .await
+            .expect("commit it2 tool");
+        // Iteration 3: final assistant text (the user-visible reply).
+        manager
+            .add_message_with_seq(&session_id, mk_assistant("here is your answer", false))
+            .await
+            .expect("commit it3 assistant");
+
+        // Drain the broadcast and bucket by role on the
+        // `MessagePersistedEvent` payload.
+        let mut assistant_persisted = Vec::new();
+        let mut tool_persisted = Vec::new();
+        while let Ok(event) = subscriber.try_recv() {
+            if let UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(ev)) =
+                &event.event
+            {
+                if ev.role == octos_core::MessageRole::Assistant.as_str() {
+                    assistant_persisted.push(ev.clone());
+                } else if ev.role == octos_core::MessageRole::Tool.as_str() {
+                    tool_persisted.push(ev.clone());
+                }
+            }
+        }
+
+        assert_eq!(
+            assistant_persisted.len(),
+            1,
+            "exactly ONE assistant message/persisted per turn (the final text); \
+             got {} envelopes (phantom-bubble regression)",
+            assistant_persisted.len(),
+        );
+        let final_envelope = &assistant_persisted[0];
+        assert_eq!(final_envelope.role, "assistant");
+        assert_eq!(
+            final_envelope.source,
+            MessagePersistedSource::Assistant,
+            "assistant rows carry source=assistant"
+        );
+        // Method name matches the wire spec.
+        assert_eq!(
+            UiNotification::MessagePersisted(final_envelope.clone()).method(),
+            methods::MESSAGE_PERSISTED,
+        );
+
+        // Tool rows are unaffected — both intermediate tool results land.
+        assert_eq!(
+            tool_persisted.len(),
+            2,
+            "tool rows must NOT be filtered (they always carry content)"
+        );
+
+        // Restore the global observer slot to None so subsequent tests
+        // see a clean state.
+        octos_bus::set_message_commit_observer(None);
     }
 
     /// PR F (M8.10 thread-binding chain `#649 → #740`): every progress

--- a/crates/octos-cli/src/api/ui_protocol_alpha3_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha3_bridge.rs
@@ -88,6 +88,13 @@ use super::ui_protocol_ledger::UiProtocolLedger;
 /// Failure mode: ledger append failures are logged inside the ledger
 /// and do not propagate. SSE delivery continues unaffected — that is
 /// the explicit α-3 coexistence invariant.
+// `emit_turn_started` was the no-topic helper for the α-3 bridge.
+// Once `chat_streaming` migrated to `ui_protocol_alpha9_bridge::
+// emit_turn_started_with_topic`, this helper became unused on the
+// production path but is retained because the α-3 unit tests (and
+// future no-topic call sites) still target it. The `#[allow(dead_code)]`
+// suppresses the dead-code warning without deleting test coverage.
+#[allow(dead_code)]
 pub(super) fn emit_turn_started(
     ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,
@@ -97,6 +104,11 @@ pub(super) fn emit_turn_started(
         session_id: session_id.clone(),
         turn_id: turn_id.clone(),
         timestamp: Utc::now(),
+        // UPCR-2026-014 (M9-α-9) addendum field; α-3's no-topic helper
+        // collapses it to None so the wire shape stays identical to the
+        // pre-addendum goldens. Topic-aware callers go through
+        // `ui_protocol_alpha9_bridge::emit_turn_started_with_topic`.
+        topic: None,
     });
     let _ = ledger.append_notification(notification);
 }
@@ -112,6 +124,13 @@ pub(super) fn emit_turn_started(
 ///
 /// Failure mode: same as [`emit_turn_started`] — ledger errors are
 /// non-fatal for SSE.
+// `emit_turn_completed` was the no-token-no-session-result helper for
+// the α-3 bridge. Once `chat_streaming` migrated to
+// `ui_protocol_alpha9_bridge::emit_turn_completed_full`, this helper
+// became unused on the production path but is retained for the α-3
+// unit tests + any no-addendum callers. `#[allow(dead_code)]` keeps
+// the dead-code warning silent without deleting the test coverage.
+#[allow(dead_code)]
 pub(super) fn emit_turn_completed(
     ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,
@@ -121,6 +140,14 @@ pub(super) fn emit_turn_completed(
         session_id: session_id.clone(),
         turn_id: turn_id.clone(),
         cursor: None,
+        // UPCR-2026-014 (M9-α-9) addendum fields; the α-3 helper does
+        // not have token usage / session_result in scope (these come
+        // from the SSE chat handler's `ConversationResponse`). Callers
+        // that have them go through
+        // `ui_protocol_alpha9_bridge::emit_turn_completed_full`.
+        tokens_in: None,
+        tokens_out: None,
+        session_result: None,
     });
     let _ = ledger.append_notification(notification);
 }

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -1,0 +1,469 @@
+//! M9-α-9 — bridge SSE-only events that α-7 e2e rewrite (PR #851)
+//! flagged as still-fixme'd onto the M9 WebSocket UI Protocol path.
+//!
+//! Per the M9-α (Sole Transport) ADR (`docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md`)
+//! the WebSocket transport is migrating to be the sole chat transport.
+//! This module is the α-9 phase: while SSE is still alive (deletion lands
+//! in α-5/α-6 atomically with the web bundle), 5 events α-7 surfaced as
+//! SSE-only must ALSO land on the M9 ledger so any concurrently-connected
+//! WebSocket subscriber for the same `SessionKey` receives them. Without
+//! these bridges the corresponding α-7 specs cannot be un-fixme'd.
+//!
+//! **Scope per UPCR-2026-014** (the addendum landing in this PR):
+//!
+//! 1. `session_result` — final session-completion identity (committed_seq +
+//!    message_id + client_message_id) for the closing assistant row.
+//!    Carried as `TurnCompletedEvent.session_result` so it rides on the
+//!    existing `turn/completed` envelope (not a new method).
+//! 2. `file_attached` — per-turn file attachment from a tool's
+//!    `files_to_send`. Carried as the new `file/attached` envelope.
+//! 3. `tokens_in` / `tokens_out` — final token usage for the turn.
+//!    Carried as `TurnCompletedEvent.tokens_in/out`.
+//! 4. `topic` on `turn/start` — sub-topic suffix for multi-topic specs.
+//!    Carried as `TurnStartedEvent.topic`.
+//! 5. `/api/sessions/:id/events/stream` — legacy free-form SSE event
+//!    stream. Bridged onto a new `session/event` envelope that wraps the
+//!    legacy `type` + payload so WS-only clients keep observing each
+//!    frame as it gradually lifts onto a typed v1 envelope.
+//!
+//! **Coexistence invariants** (same as α-2 / α-3 / α-4):
+//! - SSE delivery is unchanged — the helpers in this module ONLY append
+//!   to the ledger; the SSE wire path runs through whichever channel
+//!   reporter / handler emitted the original frame.
+//! - Ledger appends are best-effort. A failure does not affect the SSE
+//!   path or the agent loop.
+//! - WS clients dedupe by stable identity (turn_id + session_id +
+//!   committed_seq) so a client connected to both transports collapses
+//!   the duplicate into one logical update.
+//!
+//! When α-5/α-6 land and SSE is deleted, the bridge calls become the
+//! only path emitting these envelopes — they remain correct because
+//! they always hit the ledger first regardless of SSE state.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use octos_core::SessionKey;
+use octos_core::ui_protocol::{
+    FileAttachedEvent, SessionEventBridgedEvent, TurnCompletedEvent, TurnId, TurnSessionResult,
+    TurnStartedEvent, UiNotification,
+};
+use serde_json::Value;
+
+use super::ui_protocol_ledger::UiProtocolLedger;
+
+/// Append a `turn/started.v1` notification with an optional `topic`
+/// suffix, mirroring the SSE-side topic carried on
+/// `POST /api/chat?stream=true&topic=…`.
+///
+/// This is the α-9 replacement for `ui_protocol_alpha3_bridge::emit_turn_started`
+/// when a topic must thread through. Callers without a topic should keep
+/// using the α-3 helper (it remains the canonical no-topic shape).
+///
+/// Failure mode: ledger append failures are logged inside the ledger
+/// and do not propagate. SSE delivery continues unaffected — that is
+/// the explicit α-9 coexistence invariant.
+pub(super) fn emit_turn_started_with_topic(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    topic: Option<String>,
+) {
+    let notification = UiNotification::TurnStarted(TurnStartedEvent {
+        session_id: session_id.clone(),
+        turn_id: turn_id.clone(),
+        timestamp: Utc::now(),
+        topic: topic.filter(|t| !t.is_empty()),
+    });
+    let _ = ledger.append_notification(notification);
+}
+
+/// Append a `turn/completed.v1` notification carrying the SSE-side
+/// `session_result` identity (committed_seq + message_id +
+/// client_message_id) and aggregated token usage onto the ledger.
+///
+/// Mirrors `emit_turn_completed` from α-3 plus the UPCR-2026-014
+/// addendum fields. The ledger overwrites the `cursor` field with the
+/// assigned ledger seq via `UiProtocolLedgerEvent::with_cursor` (see
+/// `ui_protocol_ledger.rs`), so the placeholder `None` here is the
+/// canonical caller-side input.
+///
+/// `session_result` is `None` when the turn ended without a final
+/// assistant row (errored / interrupted before LLM produced text).
+/// `tokens_in` / `tokens_out` are `None` when the runtime did not
+/// surface usage (rare; happens when no LLM call landed).
+pub(super) fn emit_turn_completed_full(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    tokens_in: Option<u32>,
+    tokens_out: Option<u32>,
+    session_result: Option<TurnSessionResult>,
+) {
+    let notification = UiNotification::TurnCompleted(TurnCompletedEvent {
+        session_id: session_id.clone(),
+        turn_id: turn_id.clone(),
+        cursor: None,
+        tokens_in,
+        tokens_out,
+        session_result,
+    });
+    let _ = ledger.append_notification(notification);
+}
+
+/// Append a `file/attached.v1` envelope when a tool surfaces an
+/// artifact via `files_to_send`. Mirrors the SSE `file:` frame.
+///
+/// `tool_call_id` is optional because not every file-emission path
+/// runs inside a tool execution (rare; reserved for background-result
+/// futures). `mime` is also optional — clients fall back to extension
+/// sniffing when absent.
+pub(super) fn emit_file_attached(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+    path: String,
+    tool_call_id: Option<String>,
+    mime: Option<String>,
+) {
+    let notification = UiNotification::FileAttached(FileAttachedEvent {
+        session_id: session_id.clone(),
+        turn_id: turn_id.clone(),
+        path,
+        tool_call_id,
+        mime,
+    });
+    let _ = ledger.append_notification(notification);
+}
+
+/// Bridge a legacy `/api/sessions/:id/events/stream` SSE frame onto the
+/// WS surface as a `session/event.v1` envelope.
+///
+/// `kind` is the legacy SSE `type` field (e.g. `"replay_complete"`,
+/// `"task_started"`); `payload` is the full frame body. `topic` is
+/// extracted from the frame for client-side scoping (avoids parsing
+/// `payload`). The legacy stream is free-form by design — this wrapper
+/// keeps WS-only clients observing every signal SSE consumers see while
+/// each event kind gradually migrates to a typed v1 envelope.
+pub(super) fn emit_session_event(
+    ledger: &Arc<UiProtocolLedger>,
+    session_id: &SessionKey,
+    kind: String,
+    payload: Value,
+    topic: Option<String>,
+) {
+    let notification = UiNotification::SessionEventBridged(SessionEventBridgedEvent {
+        session_id: session_id.clone(),
+        kind,
+        payload,
+        topic: topic.filter(|t| !t.is_empty()),
+    });
+    let _ = ledger.append_notification(notification);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octos_core::ui_protocol::methods;
+    use serde_json::json;
+
+    /// α-9 acceptance gate (1) — `topic` lands on `turn/started`.
+    #[test]
+    fn should_emit_turn_started_with_topic_field() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-topic");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_turn_started_with_topic(&ledger, &session_id, &turn_id, Some("slides".into()));
+
+        let event = subscriber.try_recv().expect("turn/started broadcasts");
+        match &event.event {
+            crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                UiNotification::TurnStarted(payload),
+            ) => {
+                assert_eq!(payload.session_id, session_id);
+                assert_eq!(payload.turn_id, turn_id);
+                assert_eq!(payload.topic.as_deref(), Some("slides"));
+            }
+            other => panic!("expected TurnStarted, got {other:?}"),
+        }
+        // Method name unchanged from α-3 — the addendum is field-only.
+        let rpc = event
+            .event
+            .clone()
+            .into_rpc_notification()
+            .expect("serializes");
+        assert_eq!(rpc.method, methods::TURN_STARTED);
+    }
+
+    /// α-9 acceptance gate (1b) — empty topic strings collapse to None
+    /// so the `skip_serializing_if` keeps the wire shape identical to
+    /// α-3 for no-topic turns. Without this, every turn-start envelope
+    /// would carry a `"topic": ""` field, regressing α-3 wire-shape
+    /// goldens.
+    #[test]
+    fn should_collapse_empty_topic_to_none() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-empty-topic");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_turn_started_with_topic(&ledger, &session_id, &turn_id, Some(String::new()));
+
+        let event = subscriber.try_recv().expect("turn/started broadcasts");
+        if let crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+            UiNotification::TurnStarted(payload),
+        ) = &event.event
+        {
+            assert!(payload.topic.is_none(), "empty topic must collapse to None");
+        }
+    }
+
+    /// α-9 acceptance gate (2) — `tokens_in/out` + `session_result`
+    /// land on `turn/completed`.
+    #[test]
+    fn should_emit_turn_completed_with_tokens_and_session_result() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-completed-rich");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_turn_completed_full(
+            &ledger,
+            &session_id,
+            &turn_id,
+            Some(1234),
+            Some(567),
+            Some(TurnSessionResult {
+                committed_seq: 42,
+                message_id: format!("{}:42:1700000000", session_id.0),
+                client_message_id: Some("cmid-alpha-9".into()),
+            }),
+        );
+
+        let event = subscriber.try_recv().expect("turn/completed broadcasts");
+        match &event.event {
+            crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                UiNotification::TurnCompleted(payload),
+            ) => {
+                assert_eq!(payload.session_id, session_id);
+                assert_eq!(payload.turn_id, turn_id);
+                assert_eq!(payload.tokens_in, Some(1234));
+                assert_eq!(payload.tokens_out, Some(567));
+                let sr = payload
+                    .session_result
+                    .as_ref()
+                    .expect("session_result populated");
+                assert_eq!(sr.committed_seq, 42);
+                assert_eq!(sr.client_message_id.as_deref(), Some("cmid-alpha-9"));
+                // Ledger stamps cursor onto turn/completed (UPCR-2026-007).
+                let cursor = payload.cursor.as_ref().expect("cursor stamped");
+                assert!(cursor.seq > 0);
+                assert_eq!(cursor.stream, session_id.0);
+            }
+            other => panic!("expected TurnCompleted, got {other:?}"),
+        }
+    }
+
+    /// α-9 acceptance gate (2b) — None values must collapse to omitted
+    /// fields so legacy clients (pre-addendum) deserialize the envelope
+    /// unchanged. Without this, the addendum would force every
+    /// turn/completed wire frame to carry the new fields.
+    #[test]
+    fn should_omit_addendum_fields_when_none() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-completed-none");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_turn_completed_full(&ledger, &session_id, &turn_id, None, None, None);
+
+        let event = subscriber.try_recv().expect("turn/completed broadcasts");
+        let rpc = event
+            .event
+            .clone()
+            .into_rpc_notification()
+            .expect("serializes");
+        let params = rpc.params;
+        // None fields must be absent from the wire object.
+        assert!(
+            !params.as_object().unwrap().contains_key("tokens_in"),
+            "tokens_in absent on None"
+        );
+        assert!(
+            !params.as_object().unwrap().contains_key("tokens_out"),
+            "tokens_out absent on None"
+        );
+        assert!(
+            !params.as_object().unwrap().contains_key("session_result"),
+            "session_result absent on None"
+        );
+    }
+
+    /// α-9 acceptance gate (3) — `file/attached` envelope round-trips
+    /// the path, tool_call_id, and mime through the ledger broadcast
+    /// with the expected wire method.
+    #[test]
+    fn should_emit_file_attached_with_full_payload() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-file-attached");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_file_attached(
+            &ledger,
+            &session_id,
+            &turn_id,
+            "/tmp/output.png".into(),
+            Some("tc-1".into()),
+            Some("image/png".into()),
+        );
+
+        let event = subscriber.try_recv().expect("file/attached broadcasts");
+        match &event.event {
+            crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                UiNotification::FileAttached(payload),
+            ) => {
+                assert_eq!(payload.session_id, session_id);
+                assert_eq!(payload.turn_id, turn_id);
+                assert_eq!(payload.path, "/tmp/output.png");
+                assert_eq!(payload.tool_call_id.as_deref(), Some("tc-1"));
+                assert_eq!(payload.mime.as_deref(), Some("image/png"));
+            }
+            other => panic!("expected FileAttached, got {other:?}"),
+        }
+        let rpc = event
+            .event
+            .clone()
+            .into_rpc_notification()
+            .expect("serializes");
+        assert_eq!(rpc.method, methods::FILE_ATTACHED);
+    }
+
+    /// α-9 acceptance gate (3b) — bare path with no tool_call_id / mime
+    /// preserves the optionality on the wire.
+    #[test]
+    fn should_emit_file_attached_with_minimal_payload() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-file-attached-min");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_file_attached(
+            &ledger,
+            &session_id,
+            &turn_id,
+            "/tmp/bare.txt".into(),
+            None,
+            None,
+        );
+
+        let event = subscriber.try_recv().expect("file/attached broadcasts");
+        let rpc = event
+            .event
+            .clone()
+            .into_rpc_notification()
+            .expect("serializes");
+        let params = rpc.params;
+        assert_eq!(params["path"], "/tmp/bare.txt");
+        assert!(
+            !params.as_object().unwrap().contains_key("tool_call_id"),
+            "tool_call_id absent when None"
+        );
+        assert!(
+            !params.as_object().unwrap().contains_key("mime"),
+            "mime absent when None"
+        );
+    }
+
+    /// α-9 acceptance gate (4) — `session/event` wraps a legacy SSE
+    /// frame's `type` + payload + topic onto the WS surface.
+    #[test]
+    fn should_emit_session_event_wrapping_legacy_sse_frame() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-session-event");
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        let payload = json!({
+            "type": "replay_complete",
+            "topic": "slides",
+        });
+        emit_session_event(
+            &ledger,
+            &session_id,
+            "replay_complete".into(),
+            payload.clone(),
+            Some("slides".into()),
+        );
+
+        let event = subscriber.try_recv().expect("session/event broadcasts");
+        match &event.event {
+            crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                UiNotification::SessionEventBridged(p),
+            ) => {
+                assert_eq!(p.session_id, session_id);
+                assert_eq!(p.kind, "replay_complete");
+                assert_eq!(p.payload, payload);
+                assert_eq!(p.topic.as_deref(), Some("slides"));
+            }
+            other => panic!("expected SessionEventBridged, got {other:?}"),
+        }
+        let rpc = event
+            .event
+            .clone()
+            .into_rpc_notification()
+            .expect("serializes");
+        assert_eq!(rpc.method, methods::SESSION_EVENT);
+    }
+
+    /// α-9 acceptance gate (5) — bridge calls route to the SessionKey
+    /// they were given, not to a different session. Without this, a
+    /// multi-session process (the standard `octos serve` shape) would
+    /// cross-deliver bridged frames between concurrently-active turns.
+    #[test]
+    fn should_route_bridged_envelopes_to_caller_session_only() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_a = SessionKey::new("api", "alpha9-iso-A");
+        let session_b = SessionKey::new("api", "alpha9-iso-B");
+        let turn_id = TurnId::new();
+        let mut sub_a = ledger.subscribe(&session_a);
+        let mut sub_b = ledger.subscribe(&session_b);
+
+        // Fire all four envelope helpers on session_a.
+        emit_turn_started_with_topic(&ledger, &session_a, &turn_id, Some("isol".into()));
+        emit_turn_completed_full(
+            &ledger,
+            &session_a,
+            &turn_id,
+            Some(10),
+            Some(20),
+            Some(TurnSessionResult {
+                committed_seq: 1,
+                message_id: format!("{}:1:0", session_a.0),
+                client_message_id: None,
+            }),
+        );
+        emit_file_attached(&ledger, &session_a, &turn_id, "/tmp/x".into(), None, None);
+        emit_session_event(
+            &ledger,
+            &session_a,
+            "replay_complete".into(),
+            json!({}),
+            None,
+        );
+
+        // Session A receives all four envelopes.
+        let mut count_a = 0;
+        while sub_a.try_recv().is_ok() {
+            count_a += 1;
+        }
+        assert_eq!(count_a, 4, "session A receives all four envelopes");
+
+        // Session B receives nothing — no cross-delivery.
+        assert!(
+            sub_b.try_recv().is_err(),
+            "α-9 envelopes must NOT cross-deliver to other session subscribers"
+        );
+    }
+}

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -1496,6 +1496,8 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::ReplayLossy(event) => &event.session_id,
         UiNotification::MessagePersisted(event) => &event.session_id,
         UiNotification::TurnSpawnComplete(event) => &event.session_id,
+        UiNotification::FileAttached(event) => &event.session_id,
+        UiNotification::SessionEventBridged(event) => &event.session_id,
     }
 }
 
@@ -1636,6 +1638,9 @@ mod tests {
                 session_id,
                 turn_id,
                 cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
             }));
 
         assert!(matches!(

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -690,7 +690,13 @@ pub mod methods {
     /// spawn-acknowledgement bubble. Gated by
     /// [`UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1`].
     pub const TURN_SPAWN_COMPLETE: &str = "turn/spawn_complete";
+    /// UPCR-2026-014 (M9-α-9) `file/attached` — per-turn file attachment
+    /// event mirroring the SSE `file:` frame from `files_to_send` tool
+    /// surfaces.
     pub const FILE_ATTACHED: &str = "file/attached";
+    /// UPCR-2026-014 (M9-α-9) `session/event` — wrapper envelope for
+    /// legacy `/api/sessions/:id/events/stream` SSE frames bridged onto
+    /// the unified v1 surface.
     pub const SESSION_EVENT: &str = "session/event";
 }
 
@@ -2974,6 +2980,14 @@ pub struct TurnStartedEvent {
     pub session_id: SessionKey,
     pub turn_id: TurnId,
     pub timestamp: DateTime<Utc>,
+    /// UPCR-2026-014 (M9-α-9): optional sub-topic suffix that scopes the
+    /// turn within a session (mirrors the `<session>#<topic>` shape
+    /// carried on REST/SSE chat). Multi-topic specs need this to filter
+    /// `turn/started` envelopes by topic when observing the unified WS
+    /// surface — the addendum is purely additive (absent on legacy
+    /// turn-start envelopes).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3332,12 +3346,30 @@ pub struct TurnCompletedEvent {
     pub turn_id: TurnId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<UiCursor>,
+    /// UPCR-2026-014 (M9-α-9): aggregated input-token count for the
+    /// completed turn (LLM-side prompt usage, summed across iterations).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tokens_in: Option<u64>,
+    pub tokens_in: Option<u32>,
+    /// UPCR-2026-014 (M9-α-9): aggregated output-token count.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tokens_out: Option<u64>,
+    pub tokens_out: Option<u32>,
+    /// UPCR-2026-014 (M9-α-9): durable per-row identity for the final
+    /// assistant message that closed the turn. Mirrors the SSE
+    /// `session_result` frame's role.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub session_result: Option<Value>,
+    pub session_result: Option<TurnSessionResult>,
+}
+
+/// UPCR-2026-014 (M9-α-9) `turn/completed.session_result` payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TurnSessionResult {
+    /// Authoritative committed seq for the final assistant row.
+    pub committed_seq: u64,
+    /// Stable per-row id (`session:seq:timestamp_ns`).
+    pub message_id: String,
+    /// Originating user prompt's `client_message_id`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_message_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3359,21 +3391,35 @@ pub struct ReplayLossyEvent {
     pub last_durable_cursor: Option<UiCursor>,
 }
 
+/// UPCR-2026-014 (M9-α-9): per-turn `file_attached` envelope, mirrors
+/// the SSE-only `file:` frame the agent loop emits when a tool's
+/// `files_to_send` declares an artifact for the active turn.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FileAttachedEvent {
     pub session_id: SessionKey,
     pub turn_id: TurnId,
+    /// Filesystem path or URL the tool produced.
     pub path: String,
+    /// Originating tool call (if any).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    /// Optional MIME-type hint surfaced by the tool.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mime: Option<String>,
 }
 
+/// UPCR-2026-014 (M9-α-9): wrapper for legacy
+/// `/api/sessions/:id/events/stream` SSE frames bridged onto the WS
+/// surface. `kind` is the legacy SSE `type` field; `payload` is the
+/// full frame body.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionEventBridgedEvent {
     pub session_id: SessionKey,
     pub kind: String,
+    pub payload: Value,
+    /// Echo of any `topic` field carried on the legacy frame.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub payload: Option<Value>,
+    pub topic: Option<String>,
 }
 
 /// Draft notification payloads for UI protocol v1.
@@ -3405,7 +3451,11 @@ pub enum UiNotification {
     /// the same row; per-connection capability filtering (the
     /// `event.spawn_complete.v1` flag) decides which one the client sees.
     TurnSpawnComplete(TurnSpawnCompleteEvent),
+    /// UPCR-2026-014 (M9-α-9): per-turn file attachment event.
     FileAttached(FileAttachedEvent),
+    /// UPCR-2026-014 (M9-α-9): wrapper for legacy
+    /// `/api/sessions/:id/events/stream` SSE frames bridged onto the
+    /// unified v1 ledger.
     SessionEventBridged(SessionEventBridgedEvent),
 }
 
@@ -3508,9 +3558,7 @@ impl UiNotification {
                 Ok(Self::TurnSpawnComplete(decode_params(method, params)?))
             }
             methods::FILE_ATTACHED => Ok(Self::FileAttached(decode_params(method, params)?)),
-            methods::SESSION_EVENT => {
-                Ok(Self::SessionEventBridged(decode_params(method, params)?))
-            }
+            methods::SESSION_EVENT => Ok(Self::SessionEventBridged(decode_params(method, params)?)),
             _ => Err(RpcError::method_not_found(method)),
         }
     }
@@ -3895,6 +3943,8 @@ mod tests {
                 "protocol/replay_lossy",
                 "message/persisted",
                 "turn/spawn_complete",
+                "file/attached",
+                "session/event",
             ]
         );
         assert_eq!(
@@ -3969,7 +4019,9 @@ mod tests {
                     "warning",
                     "protocol/replay_lossy",
                     "message/persisted",
-                    "turn/spawn_complete"
+                    "turn/spawn_complete",
+                    "file/attached",
+                    "session/event"
                 ],
                 "supported_features": [
                     "approval.typed.v1",


### PR DESCRIPTION
## Summary

This PR stacks on `feat/m9-alpha-4-status-heartbeat-gate-ws` (α-2/3/4) and lands two server-side M9 fixes that block the α-5+α-6 atomic SSE delete.

### Part A — γ-7 (#844): server-side `message/persisted` dedup

Multi-iteration agent loops emitted N+ assistant `message/persisted` events per turn under the same `thread_id` (the 2026-05-09 phantom-bubble bug; the defensive web-side fix landed in octos-web #92). The agent loop's iterative tool-calling pattern commits an Assistant row per LLM iteration, and when the LLM returns only `tool_calls` (no text content), the persisted row is metadata-only and never user-visible — but `MessageCommitObserver` still emitted a wire envelope.

**Approach (a)**: filter at the observer install point. Skip `message/persisted` emission when the row is `Assistant`, content is empty after `trim()`, and `media` is empty. Tool messages and assistant rows with text or media are unaffected. The wire surface now emits exactly one `message/persisted` per turn (the final user-visible text) plus the per-tool rows.

**Test verdict**: `gamma_7_dedup_one_assistant_persisted_per_turn` runs a 3-iteration loop and asserts exactly one assistant envelope on the WS ledger.

### Part B — α deferred bridges (UPCR-2026-014 addendum)

5 events α-7 (PR #851) flagged as `test.fixme` are now WS-bridged so the corresponding specs can be un-fixme'd:

| # | Event | Status |
|---|-------|--------|
| 1 | `session_result` on turn end | LANDED — `TurnCompletedEvent.session_result` |
| 2 | Per-turn `file` events | LANDED — new `file/attached` envelope |
| 3 | `tokens_in/out` on `turn/completed` | LANDED — `TurnCompletedEvent.tokens_in/tokens_out` |
| 4 | `topic` on `turn/started` | LANDED — `TurnStartedEvent.topic` |
| 5 | `/api/sessions/:id/events/stream` legacy SSE | LANDED — new `session/event` wrapper envelope |

New module `ui_protocol_alpha9_bridge.rs` wires each bridge per the established α-2/α-3/α-4 pattern. Spec doc updated to reference UPCR-2026-014 on the affected event sections.

### Wiring

- `chat_streaming` migrates to α-9 variants (`emit_turn_started_with_topic`, `emit_turn_completed_full`) so SSE-driven turns surface the addendum fields onto the M9 ledger.
- `chat_streaming` also emits `file/attached` per `response.files_to_send` entry.
- Standalone-mode `session_event_stream` bridges its `replay_complete` SSE frame onto the WS surface.
- α-3 helpers retained with `#[allow(dead_code)]` for unit tests + future no-addendum callers.

## Test plan

- [x] `cargo test --workspace` — 3033 tests pass, 0 failures
- [x] `cargo test -p octos-cli --features api --lib` — 920 lib tests, 0 failures
- [x] `cargo test -p octos-core` — 169 tests, 0 failures
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy` clean on all touched files
- [x] New unit tests:
  - γ-7: `is_metadata_only_assistant_row_truth_table` + `gamma_7_dedup_one_assistant_persisted_per_turn`
  - α-9: 8 tests in `ui_protocol_alpha9_bridge::tests` covering all 5 bridges + session-routing isolation