### PR TITLE
feat(spec): M9-γ-1 — canonical envelope type union (closes #838) [retarget]

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -204,6 +204,15 @@ Current M9 sandbox-parity decision:
   fsync) is governed by accepted
   [UPCR-2026-012](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_012_MESSAGE_PERSISTED.md),
   gated behind `event.message_persisted.v1`. Strict-ordered per session.
+- The additive M9-γ projection `Envelope` shape (canonical
+  `(thread_id, seq, client_message_id?, payload)` tuple consumed by the
+  deterministic web client projection) is governed by accepted
+  [UPCR-2026-014](../docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_014_PROJECTION_ENVELOPE.md),
+  gated behind `projection.envelope.v1`. The shape is documented in § 14
+  "M9-γ Envelope" of this spec; legacy `message/delta`,
+  `message/persisted`, `tool/*`, and `turn/completed` notifications
+  continue to flow on connections that do not negotiate this feature
+  until `M9-γ-3` deletes them.
 
 ## 5. Identity Model
 
@@ -227,6 +236,25 @@ These ids need to be stable and client-visible:
   A resumable position in the ordered protocol event stream.
 
 Current draft Rust types for `turn_id`, `approval_id`, `preview_id`, `output_cursor`, and `event_cursor` live in [ui_protocol.rs](/Users/yuechen/home/octos/crates/octos-core/src/ui_protocol.rs:1).
+
+### 5.1 M9-γ projection identity (UPCR-2026-014)
+
+Under the M9-γ deterministic projection model (§ 14), envelope identity
+collapses to the per-thread `seq`. Specifically:
+
+- The canonical projection key is `(thread_id, seq)` — see `Envelope`
+  in § 14.
+- `client_message_id` rides on user-message-rooted envelopes ONLY for
+  the optimistic `<GhostBubble>` overlay's match-and-unmount logic;
+  the projection itself MUST NOT consult it.
+- The legacy per-row `message_id` (carried, for example, on
+  `MessagePersistedEvent.message_id`) is **deprecated for projection
+  identity** as of UPCR-2026-014. It survives in
+  `Envelope.payload` (e.g. `assistant_persisted.meta.message_id`) for
+  audit/render display, but the projection uses `seq` as the sole key.
+  The field is retained — not deleted — so legacy
+  `appendCompletionBubble` / `message/persisted` consumers continue to
+  work until `M9-γ-3` removes them.
 
 ## 6. Envelope Model
 
@@ -775,3 +803,299 @@ See [OCTOS_M8_FIX_FIRST_CHECKLIST_2026-04-24.md](../docs/OCTOS_M8_FIX_FIRST_CHEC
 1. Keep the shared Rust types in `octos-core` aligned with this doc.
 2. Build the mock `octos-tui` scaffold against these draft types.
 3. When M8 fixes land, start server-side `M9.1` transport wiring against the same shapes.
+
+## 14. M9-γ Envelope
+
+Status: **additive**, governed by accepted `UPCR-2026-014`. Capability-gated
+behind `projection.envelope.v1`. Legacy `message/delta`, `message/persisted`,
+`tool/*`, and `turn/completed` notifications continue to flow on connections
+that do not negotiate this feature, until `M9-γ-3` deletes them.
+
+ADR: [`docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`](../docs/M9-GAMMA-SERVER-PROJECTION-ADR.md).
+
+This section defines the canonical envelope shape that the M9-γ
+deterministic projection consumes. The web client maintains an
+append-only `Vec<Envelope>` indexed by `(thread_id, seq)` and the
+projection function `(committed_log) → ChatViewModel` is pure,
+deterministic, and side-effect free. Identity collapses to `seq`;
+`client_message_id` lives ONLY on `user_message` envelopes (see
+§ 14.2) for the optimistic `<GhostBubble>` overlay's match-and-unmount
+path (the projection MUST NOT consult it).
+
+**Turn shape** (locked by § 14.2): every chat turn begins with exactly
+one `user_message` envelope (server-mirrored from the client's send),
+followed by zero or more `assistant_delta` / `tool_*` / `file_attached`
+/ `assistant_persisted` envelopes, terminated by exactly one
+`turn_completed` envelope. A refresh-only projection reconstructs the
+`UserView` for the chat exclusively from `user_message` envelopes —
+`assistant_delta` and `assistant_persisted` alone are insufficient.
+
+### 14.1 Envelope
+
+Wire shape (JSON):
+
+```json
+{
+  "thread_id": "thread-1",
+  "seq": 18,
+  "client_message_id": "01900000-0000-7000-8000-000000000001",
+  "payload": { "type": "...", "data": { ... } }
+}
+```
+
+Field contract:
+
+- `thread_id` (`string`, required) — Multi-turn cluster identity. All
+  envelopes for one logical conversation share a `thread_id`.
+- `seq` (`u64`, required) — Server-assigned strict total order WITHIN
+  this `thread_id`. Strictly monotonic; gaps are an error and trigger
+  rehydration. Identity for the projection.
+- `client_message_id` (`string`, optional) — Populated ONLY on
+  `user_message` envelopes (the optimistic `<GhostBubble>` overlay
+  matches its server reflection here). Absent on every other variant
+  (`assistant_delta`, `assistant_persisted`, `tool_*`, `file_attached`,
+  `turn_completed`). The projection MUST NOT consult this field. A
+  server emitting `client_message_id` on a non-`user_message` envelope
+  is a wire contract violation.
+- `payload` (object, required) — Sealed tagged union; see § 14.2.
+
+Rust source: [`Envelope`](/Users/yuechen/home/octos/crates/octos-core/src/ui_protocol.rs:1)
+in `octos-core::ui_protocol`. TS source: `Envelope` in
+[`crates/octos-web/src/runtime/ui-protocol-types.ts`](/Users/yuechen/home/octos/crates/octos-web/src/runtime/ui-protocol-types.ts:1).
+
+### 14.2 Payload (sealed tagged union)
+
+Wire form: JSON with `"type"` discriminator and content under `"data"`
+(matches Rust `serde(tag = "type", content = "data", rename_all = "snake_case")`).
+Variants:
+
+#### `user_message`
+User-message turn root — server-mirrored from the client's send. Every
+chat turn begins with exactly one `user_message` envelope. The
+projection's `UserView` is reconstructed from these envelopes alone —
+a refresh-only projection cannot recover user bubbles from
+`assistant_delta` / `assistant_persisted`. The carrying envelope's
+`client_message_id` is populated here (and ONLY here) so the
+optimistic `<GhostBubble>` overlay can match its server reflection.
+
+```json
+{ "type": "user_message",
+  "data": {
+    "text": "<user prompt>",
+    "files": [
+      { "path": "/tmp/upload.png", "mime": "image/png", "size_bytes": 2048 }
+    ]
+  } }
+```
+
+`files` is an array of [`FileRef`](#145-fileref) entries; omitted on
+the wire when empty.
+
+#### `assistant_delta`
+One streamed assistant text fragment. Multiple `assistant_delta`
+envelopes for the same `thread_id` accumulate (concatenate by `seq`
+order) into the live assistant bubble.
+
+**Reconciliation rule** — `assistant_delta.text` events APPEND
+(concatenate by ascending `seq`). When an `assistant_persisted`
+envelope arrives for the same `thread_id`, its `text` field REPLACES
+the accumulated streamed text (the persisted form is canonical). This
+avoids double-rendering the final body when both delta and persisted
+events project into the same view.
+
+```json
+{ "type": "assistant_delta", "data": { "text": "<fragment>" } }
+```
+
+#### `assistant_persisted`
+Final assistant text persisted to the ledger after streaming completes.
+Carries durable [`MessageMeta`](#143-messagemeta) so the projection can
+finalize the bubble's identity and surface attachments. Per the
+`assistant_delta` reconciliation rule above, `text` REPLACES the
+concatenated streamed deltas for the same thread (canonical final
+form).
+
+```json
+{ "type": "assistant_persisted",
+  "data": {
+    "text": "<full text>",
+    "meta": {
+      "message_id": "01900000-0000-7000-8000-000000000018",
+      "persisted_at": "2026-05-09T18:30:01Z",
+      "media": ["report.md"]
+    }
+  } }
+```
+
+#### `tool_start`
+Tool invocation begun. The projection opens a tool-call card keyed on
+`tool_call_id`.
+
+```json
+{ "type": "tool_start",
+  "data": { "tool_call_id": "tc-1", "name": "shell" } }
+```
+
+#### `tool_progress`
+Tool emitted a progress message. Idempotent per `(tool_call_id, seq)`;
+the projection appends in `seq` order.
+
+```json
+{ "type": "tool_progress",
+  "data": { "tool_call_id": "tc-1", "message": "running…" } }
+```
+
+#### `tool_end`
+Tool invocation finished. `error` is set iff `status === "error"`;
+omitted on the wire when null. `reason` is an optional human-readable
+detail field, primarily populated for `skipped` and `aborted` outcomes
+(see below); omitted on the wire when null.
+
+```json
+{ "type": "tool_end",
+  "data": { "tool_call_id": "tc-1", "status": "complete" } }
+```
+
+```json
+{ "type": "tool_end",
+  "data": { "tool_call_id": "tc-2", "status": "error", "error": "…" } }
+```
+
+```json
+{ "type": "tool_end",
+  "data": { "tool_call_id": "tc-3", "status": "skipped",
+            "reason": "deadline elapsed before tool started" } }
+```
+
+```json
+{ "type": "tool_end",
+  "data": { "tool_call_id": "tc-4", "status": "aborted",
+            "reason": "user issued turn/interrupt" } }
+```
+
+`status` is a closed snake_case enum:
+
+- `complete` — tool ran to natural completion.
+- `error` — tool surfaced a failure (`error` carries the message).
+- `skipped` — tool was intentionally not run (deadline-skip,
+  pre-condition unmet). `reason` explains why.
+- `aborted` — tool execution was interrupted by an external signal
+  (user `turn/interrupt`, system cancellation). `reason` carries
+  detail.
+
+Future values require a follow-up UPCR.
+
+#### `file_attached`
+File attached to the current thread (e.g. `.md` report from
+`deep_search` or `.mp3` from `fm_tts`). The projection adds the
+attachment to the most-recent assistant bubble in `thread_id`.
+
+```json
+{ "type": "file_attached",
+  "data": { "path": "/tmp/report.md",
+            "mime": "text/markdown",
+            "size_bytes": 4096 } }
+```
+
+#### `turn_completed`
+**Hard barrier** — terminal payload for a turn within `thread_id`. Per
+the M9-γ ADR and § 14.6 below, any envelope arriving on the same
+`thread_id` AFTER this one is DROPPED by the projection (and counted
+in `octos_projection_post_completion_drop_total`). Threads are NOT
+reused — a new turn must use a NEW `thread_id`. Carries
+[`EnvelopeTokenUsage`](#144-envelopetokenusage); zero-valued fields are
+omitted on the wire.
+
+```json
+{ "type": "turn_completed",
+  "data": { "token_usage": { "input_tokens": 100, "output_tokens": 250 } } }
+```
+
+### 14.3 `MessageMeta`
+
+```json
+{
+  "message_id": "01900000-0000-7000-8000-000000000018",
+  "persisted_at": "2026-05-09T18:30:01Z",
+  "media": ["report.md"]
+}
+```
+
+- `message_id` (`string`, required) — Server-assigned UUID of the
+  durable row. Stable across replays. Mirrors
+  `MessagePersistedEvent.message_id`. **Note**: `message_id` is retained
+  here for audit/render display only; the projection uses `seq` as the
+  sole identity key (see § 5.1).
+- `persisted_at` (RFC 3339, required) — Wall-clock commit time.
+- `media` (`string[]`, optional) — File attachments persisted with the
+  message. Empty for assistant rows that carry only text. Omitted on
+  the wire when empty.
+
+### 14.4 `EnvelopeTokenUsage`
+
+```json
+{ "input_tokens": 100, "output_tokens": 250 }
+```
+
+Open object — all five fields default to zero and are omitted on the
+wire when zero (Rust `serde(skip_serializing_if = "is_zero_u64")`):
+
+- `input_tokens` (`u64`)
+- `output_tokens` (`u64`)
+- `reasoning_tokens` (`u64`)
+- `cache_read_tokens` (`u64`)
+- `cache_write_tokens` (`u64`)
+
+Future fields require a follow-up UPCR.
+
+### 14.5 `FileRef`
+
+```json
+{ "path": "/tmp/upload.png", "mime": "image/png", "size_bytes": 2048 }
+```
+
+Wire-form file reference carried on `user_message` envelopes (and
+reused as the canonical attachment shape elsewhere — `file_attached`
+embeds the same triple inline). All three fields are required:
+
+- `path` (`string`) — Absolute path the server resolved for the file.
+- `mime` (`string`) — IANA media type (e.g. `image/png`,
+  `text/markdown`).
+- `size_bytes` (`u64`) — Byte size at upload/persist time.
+
+### 14.6 Hard barrier semantics
+
+Per the M9-γ ADR and the `Envelope` Rust doc-comment, the server MUST
+emit at most one `turn_completed` envelope per `(thread_id, turn)`.
+After that envelope, the projection enforces the barrier with a single
+deterministic rule:
+
+> After `turn_completed` for `thread_id` T, any subsequent envelope
+> with the same `thread_id` is **DROPPED** by the projection. The
+> projection records the drop in the
+> `octos_projection_post_completion_drop_total` metric. Threads are
+> **NOT reused** — a new turn MUST use a NEW `thread_id`.
+
+This is the canonical wire-level enforcement of the "phantom bubble"
+elimination that motivated M9-γ. The drop is silent at the projection
+layer (the metric is the operational signal); clients do NOT
+rehydrate, restart, or treat the situation as a desync. The same
+behaviour is implemented by the M9-γ-2 projection
+([`octos-web` PR #93](https://github.com/octos-org/octos-web/pull/93)).
+
+A server that needs to emit a follow-up assistant or tool event
+belonging to a logically separate turn MUST mint a new `thread_id` for
+that turn — the projection treats the new `thread_id` as a brand-new
+chat thread and projects it independently.
+
+### 14.7 Capability negotiation
+
+Clients request `projection.envelope.v1` via the `X-Octos-Ui-Features`
+header at `session/open` time. Servers advertise it through
+`UiProtocolCapabilities.supported_features` (UPCR-2026-007) when they
+emit canonical envelopes; pre-existing connections (TUI, octos-app
+legacy) continue to receive only the legacy notification surface they
+negotiated.
+
+The capability schema version remains `2`; this is an additive feature
+flag and does not bump the schema version.

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -28,6 +28,9 @@ pub const UI_PROTOCOL_CAPABILITIES_SCHEMA_VERSION: u32 = 2;
 /// JSON-RPC version used by UI protocol v1 wire envelopes.
 pub const JSON_RPC_VERSION: &str = "2.0";
 
+/// Maximum accepted JSON-RPC text frame size for UI transports.
+pub const MAX_TEXT_FRAME_BYTES: usize = 1024 * 1024;
+
 /// Feature flag for UPCR-2026-001 typed approval payloads.
 pub const UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1: &str = "approval.typed.v1";
 
@@ -67,6 +70,15 @@ pub const UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1: &str = "event.message_persis
 /// the message — only the wire event the connected client observes flips.
 pub const UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1: &str = "event.spawn_complete.v1";
 
+/// Feature flag for UPCR-2026-014 M9-γ canonical projection envelope.
+///
+/// Capability-gated — servers advertise it only when they emit the
+/// canonical [`Envelope`] shape (see § 14 of the spec). Legacy
+/// `message/delta`, `message/persisted`, `tool/*`, and `turn/completed`
+/// notifications continue to flow on connections that do not negotiate
+/// this feature, until M9-γ-3 deletes them.
+pub const UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1: &str = "projection.envelope.v1";
+
 /// Server-known feature registry. Used by
 /// [`UiProtocolCapabilities::for_negotiated_features`] (UPCR-2026-007) to
 /// intersect a client's `X-Octos-Ui-Features` request with the names the
@@ -82,6 +94,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
     UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
     UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+    UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
 ];
 
 /// Returns the feature flag that gates `method` per spec § 7 capability
@@ -631,6 +644,8 @@ pub mod methods {
     pub const TURN_INTERRUPT: &str = "turn/interrupt";
     pub const APPROVAL_RESPOND: &str = "approval/respond";
     pub const APPROVAL_SCOPES_LIST: &str = "approval/scopes/list";
+    pub const PERMISSION_PROFILE_LIST: &str = "permission/profile/list";
+    pub const PERMISSION_PROFILE_SET: &str = "permission/profile/set";
     pub const DIFF_PREVIEW_GET: &str = "diff/preview/get";
     pub const TASK_LIST: &str = "task/list";
     pub const TASK_CANCEL: &str = "task/cancel";
@@ -675,6 +690,8 @@ pub mod methods {
     /// spawn-acknowledgement bubble. Gated by
     /// [`UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1`].
     pub const TURN_SPAWN_COMPLETE: &str = "turn/spawn_complete";
+    pub const FILE_ATTACHED: &str = "file/attached";
+    pub const SESSION_EVENT: &str = "session/event";
 }
 
 /// Reason codes for `approval/cancelled` notifications. The registry is
@@ -691,6 +708,8 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::TURN_INTERRUPT,
     methods::APPROVAL_RESPOND,
     methods::APPROVAL_SCOPES_LIST,
+    methods::PERMISSION_PROFILE_LIST,
+    methods::PERMISSION_PROFILE_SET,
     methods::DIFF_PREVIEW_GET,
     methods::TASK_LIST,
     methods::TASK_CANCEL,
@@ -722,6 +741,8 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::REPLAY_LOSSY,
     methods::MESSAGE_PERSISTED,
     methods::TURN_SPAWN_COMPLETE,
+    methods::FILE_ATTACHED,
+    methods::SESSION_EVENT,
 ];
 
 /// Request methods currently handled by the first server/runtime slice.
@@ -731,6 +752,8 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::TURN_INTERRUPT,
     methods::APPROVAL_RESPOND,
     methods::APPROVAL_SCOPES_LIST,
+    methods::PERMISSION_PROFILE_LIST,
+    methods::PERMISSION_PROFILE_SET,
     methods::DIFF_PREVIEW_GET,
     methods::TASK_LIST,
     methods::TASK_CANCEL,
@@ -986,6 +1009,8 @@ pub enum UiResultKind {
     TurnInterrupt,
     ApprovalRespond,
     ApprovalScopesList,
+    PermissionProfileList,
+    PermissionProfileSet,
     DiffPreviewGet,
     TaskList,
     TaskCancel,
@@ -1004,6 +1029,8 @@ pub fn first_server_result_kind_for_method(method: &str) -> Option<UiResultKind>
         methods::TURN_INTERRUPT => Some(UiResultKind::TurnInterrupt),
         methods::APPROVAL_RESPOND => Some(UiResultKind::ApprovalRespond),
         methods::APPROVAL_SCOPES_LIST => Some(UiResultKind::ApprovalScopesList),
+        methods::PERMISSION_PROFILE_LIST => Some(UiResultKind::PermissionProfileList),
+        methods::PERMISSION_PROFILE_SET => Some(UiResultKind::PermissionProfileSet),
         methods::DIFF_PREVIEW_GET => Some(UiResultKind::DiffPreviewGet),
         methods::TASK_LIST => Some(UiResultKind::TaskList),
         methods::TASK_CANCEL => Some(UiResultKind::TaskCancel),
@@ -1193,6 +1220,109 @@ pub struct ApprovalScopeEntry {
     /// Bound `turn_id` for `turn`-scoped entries; `None` otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<TurnId>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermissionProfileMode {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+impl PermissionProfileMode {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "Read Only",
+            Self::WorkspaceWrite => "Workspace Write",
+            Self::DangerFullAccess => "Full Access",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermissionNetworkPolicy {
+    Allow,
+    Deny,
+}
+
+impl PermissionNetworkPolicy {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Allow => "network allowed",
+            Self::Deny => "network blocked",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionProfileSelection {
+    pub mode: PermissionProfileMode,
+    pub network: PermissionNetworkPolicy,
+}
+
+impl Default for PermissionProfileSelection {
+    fn default() -> Self {
+        Self {
+            mode: PermissionProfileMode::WorkspaceWrite,
+            network: PermissionNetworkPolicy::Deny,
+        }
+    }
+}
+
+impl PermissionProfileSelection {
+    pub fn normalized(self) -> Self {
+        self
+    }
+
+    pub fn summary(self) -> String {
+        format!("{}, {}", self.mode.label(), self.network.label())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PermissionProfileUpdate {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<PermissionProfileMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network: Option<PermissionNetworkPolicy>,
+}
+
+impl PermissionProfileUpdate {
+    pub fn apply_to(self, previous: PermissionProfileSelection) -> PermissionProfileSelection {
+        PermissionProfileSelection {
+            mode: self.mode.unwrap_or(previous.mode),
+            network: self.network.unwrap_or(previous.network),
+        }
+        .normalized()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PermissionProfileListParams {
+    pub session_id: SessionKey,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PermissionProfileSetParams {
+    pub session_id: SessionKey,
+    pub update: PermissionProfileUpdate,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PermissionProfileListResult {
+    pub session_id: SessionKey,
+    pub current: PermissionProfileSelection,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub profiles: Vec<PermissionProfileSelection>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PermissionProfileSetResult {
+    pub session_id: SessionKey,
+    pub current: PermissionProfileSelection,
+    pub applied: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1851,6 +1981,221 @@ pub struct TurnSpawnCompleteEvent {
     pub media: Vec<String>,
 }
 
+// ----- UPCR-2026-014 M9-γ projection envelope -----
+
+/// Token usage carried on `turn_completed` projection envelopes.
+///
+/// Mirrors [`crate::TokenUsage`] but is wire-stable for the M9-γ
+/// projection: all fields default to zero, and the field set is frozen
+/// for the v1 envelope. Future fields require a follow-up UPCR.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvelopeTokenUsage {
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub input_tokens: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub output_tokens: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub reasoning_tokens: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub cache_read_tokens: u64,
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub cache_write_tokens: u64,
+}
+
+#[inline]
+fn is_zero_u64(value: &u64) -> bool {
+    *value == 0
+}
+
+/// Metadata carried on `assistant_persisted` projection envelopes.
+///
+/// The projection only needs the durable identity fields here — the
+/// committed `seq` already lives on the [`Envelope`] itself, so this
+/// struct carries the *row-level* identity (`message_id`) plus the
+/// wall-clock commit timestamp clients use for ordering displays.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageMeta {
+    /// Server-assigned UUID of the durable row (mirrors
+    /// [`MessagePersistedEvent::message_id`]). Stable across replays.
+    pub message_id: String,
+    /// RFC 3339 wall-clock time the row committed.
+    pub persisted_at: DateTime<Utc>,
+    /// File attachments persisted with the message — typically a single
+    /// `.md` / `.mp3` / `.pptx` artefact emitted by `spawn_only` background
+    /// tools (`deep_search`, `mofa_*`, `fm_tts`) or an explicit `send_file`.
+    /// Empty for assistant rows that carry only text.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub media: Vec<String>,
+}
+
+/// Status carried on `tool_end` projection envelopes.
+///
+/// Closed snake_case enum. The four variants distinguish the UX states
+/// the projection needs to render distinctly:
+///
+/// - `complete` — tool ran to natural completion, no error.
+/// - `error` — tool surfaced a failure (`error` field carries the
+///   message).
+/// - `skipped` — tool was intentionally not run (e.g. deadline-skip,
+///   pre-condition not met). The optional `reason` on the `tool_end`
+///   payload explains why.
+/// - `aborted` — tool execution was interrupted by an external signal
+///   (user `turn/interrupt`, system cancellation). The optional
+///   `reason` carries detail.
+///
+/// Future variants require a follow-up UPCR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeToolEndStatus {
+    Complete,
+    Error,
+    Skipped,
+    Aborted,
+}
+
+/// Wire-form file reference carried on `user_message` envelopes (and
+/// reused as the canonical attachment shape elsewhere in the protocol).
+///
+/// Mirrors the `file_attached` payload's identity triple so a client
+/// rendering a user upload and a server-attached file uses the same
+/// fields. All three are required on the wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileRef {
+    pub path: String,
+    pub mime: String,
+    pub size_bytes: u64,
+}
+
+/// Sealed tagged union of payloads carried by the M9-γ projection
+/// envelope. Each variant carries everything the projection needs;
+/// the projection function is `(committed_log) → ChatViewModel` and
+/// MUST NOT consult any other source of truth.
+///
+/// Wire form: JSON with `"type"` discriminator and content under `"data"`.
+/// Variant names are snake_case to match the spec § 14 / TS shape.
+///
+/// **Turn shape**: every chat turn begins with exactly one
+/// [`Payload::UserMessage`] envelope (server-mirrored from the client's
+/// send), followed by zero or more `assistant_delta` / `tool_*` /
+/// `file_attached` / `assistant_persisted` envelopes, terminated by
+/// exactly one [`Payload::TurnCompleted`]. A refresh-only projection
+/// reconstructs the `UserView` for the chat exclusively from
+/// `user_message` envelopes — `assistant_delta` and `assistant_persisted`
+/// alone are insufficient.
+///
+/// **Streaming reconciliation rule** (locked by spec § 14.2):
+/// `assistant_delta.text` fragments APPEND to the live bubble in
+/// strict `seq` order (concatenate). When an `assistant_persisted`
+/// arrives for the same thread, its `text` field REPLACES the
+/// accumulated streamed text — the persisted form is canonical and
+/// avoids double-rendering the final body.
+///
+/// **Hard barrier**: per the M9-γ ADR and spec § 14.6,
+/// [`Payload::TurnCompleted`] is the terminal payload for a `thread_id`.
+/// Any envelope arriving on the same `thread_id` AFTER `turn_completed`
+/// is DROPPED by the projection and counted in the
+/// `octos_projection_post_completion_drop_total` metric. Threads are
+/// NOT reused — a new turn must use a NEW `thread_id`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum Payload {
+    /// User-message turn root — server-mirrored from the client's send.
+    /// Every chat turn begins with exactly one `user_message` envelope,
+    /// and the projection's `UserView` is reconstructed from these
+    /// envelopes alone (a refresh-only projection cannot recover user
+    /// bubbles from `assistant_delta` / `assistant_persisted`).
+    ///
+    /// The carrying [`Envelope`] populates `client_message_id` here —
+    /// and ONLY here — so the optimistic `<GhostBubble>` overlay can
+    /// match its server reflection and unmount.
+    UserMessage {
+        text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        files: Vec<FileRef>,
+    },
+    /// One streamed assistant text fragment. Multiple `assistant_delta`
+    /// envelopes for the same `thread_id` accumulate (concatenate by
+    /// `seq` order) into the live assistant bubble. An
+    /// `assistant_persisted` for the same thread REPLACES the
+    /// accumulated text.
+    AssistantDelta { text: String },
+    /// Final assistant text persisted to the ledger after streaming
+    /// completes. Carries the durable [`MessageMeta`] so the projection
+    /// can finalize the bubble's identity and surface attachments. Its
+    /// `text` field REPLACES the concatenated streamed deltas for the
+    /// same thread (canonical final form; avoids double-rendering).
+    AssistantPersisted { text: String, meta: MessageMeta },
+    /// Tool invocation begun. The projection opens a tool-call card
+    /// keyed on `tool_call_id`.
+    ToolStart { tool_call_id: String, name: String },
+    /// Tool emitted a progress message. Idempotent per `(tool_call_id,
+    /// seq)`; the projection appends in `seq` order.
+    ToolProgress {
+        tool_call_id: String,
+        message: String,
+    },
+    /// Tool invocation finished. `error` is set iff `status == "error"`.
+    /// `reason` carries optional human-readable detail for `skipped`
+    /// (deadline-skip, pre-condition unmet) and `aborted`
+    /// (user `turn/interrupt`, system cancellation) outcomes.
+    ToolEnd {
+        tool_call_id: String,
+        status: EnvelopeToolEndStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    /// File attached to the current thread (e.g. `.md` report from
+    /// `deep_search` or `.mp3` from `fm_tts`). The projection adds the
+    /// attachment to the most-recent assistant bubble in `thread_id`.
+    FileAttached {
+        path: String,
+        mime: String,
+        size_bytes: u64,
+    },
+    /// Hard barrier — terminal payload for a turn within `thread_id`.
+    /// Per the M9-γ ADR, any envelope arriving with the same
+    /// `thread_id` AFTER this one is DROPPED by the projection (and
+    /// counted in `octos_projection_post_completion_drop_total`).
+    /// Threads are not reused — a new turn must use a new `thread_id`.
+    TurnCompleted { token_usage: EnvelopeTokenUsage },
+}
+
+/// Canonical M9-γ projection envelope.
+///
+/// Per UPCR-2026-014 and the M9-γ ADR, this is the single shape the
+/// web client's deterministic projection consumes. The committed
+/// envelope log is `Vec<Envelope>` indexed by `(thread_id, seq)`; the
+/// projection is a pure function from that log to `ChatViewModel`.
+///
+/// Identity collapses to `seq` — the only key the projection cares
+/// about. `client_message_id` is populated ONLY on
+/// [`Payload::UserMessage`] envelopes so the optimistic
+/// `<GhostBubble>` overlay can match its server reflection and unmount;
+/// the projection itself NEVER consults it. All other variants leave
+/// `client_message_id` at `None` (omitted on the wire).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Envelope {
+    /// Multi-turn cluster identity — the chat thread this envelope
+    /// projects into. All envelopes for one logical conversation share
+    /// a `thread_id`.
+    pub thread_id: String,
+    /// Server-assigned strict total order WITHIN this `thread_id`.
+    /// Strictly monotonic; gaps are an error and trigger
+    /// rehydration. Identity for the projection.
+    pub seq: u64,
+    /// Populated ONLY on [`Payload::UserMessage`] envelopes (the
+    /// optimistic `<GhostBubble>` overlay matches its server reflection
+    /// here). Absent on every other variant (assistant deltas /
+    /// persisted, tool events, file attached, turn_completed). The
+    /// projection MUST NOT consult this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_message_id: Option<String>,
+    /// Tagged-union payload — see [`Payload`].
+    pub payload: Payload,
+}
+
 /// Draft command payloads for UI protocol v1.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -1860,6 +2205,8 @@ pub enum UiCommand {
     TurnInterrupt(TurnInterruptParams),
     ApprovalRespond(ApprovalRespondParams),
     ApprovalScopesList(ApprovalScopesListParams),
+    PermissionProfileList(PermissionProfileListParams),
+    PermissionProfileSet(PermissionProfileSetParams),
     DiffPreviewGet(DiffPreviewGetParams),
     TaskList(TaskListParams),
     TaskCancel(TaskCancelParams),
@@ -1878,6 +2225,8 @@ impl UiCommand {
             Self::TurnInterrupt(_) => methods::TURN_INTERRUPT,
             Self::ApprovalRespond(_) => methods::APPROVAL_RESPOND,
             Self::ApprovalScopesList(_) => methods::APPROVAL_SCOPES_LIST,
+            Self::PermissionProfileList(_) => methods::PERMISSION_PROFILE_LIST,
+            Self::PermissionProfileSet(_) => methods::PERMISSION_PROFILE_SET,
             Self::DiffPreviewGet(_) => methods::DIFF_PREVIEW_GET,
             Self::TaskList(_) => methods::TASK_LIST,
             Self::TaskCancel(_) => methods::TASK_CANCEL,
@@ -1900,6 +2249,8 @@ impl UiCommand {
             Self::TurnInterrupt(params) => serde_json::to_value(params),
             Self::ApprovalRespond(params) => serde_json::to_value(params),
             Self::ApprovalScopesList(params) => serde_json::to_value(params),
+            Self::PermissionProfileList(params) => serde_json::to_value(params),
+            Self::PermissionProfileSet(params) => serde_json::to_value(params),
             Self::DiffPreviewGet(params) => serde_json::to_value(params),
             Self::TaskList(params) => serde_json::to_value(params),
             Self::TaskCancel(params) => serde_json::to_value(params),
@@ -1933,6 +2284,12 @@ impl UiCommand {
             methods::APPROVAL_RESPOND => Ok(Self::ApprovalRespond(decode_params(method, params)?)),
             methods::APPROVAL_SCOPES_LIST => {
                 Ok(Self::ApprovalScopesList(decode_params(method, params)?))
+            }
+            methods::PERMISSION_PROFILE_LIST => {
+                Ok(Self::PermissionProfileList(decode_params(method, params)?))
+            }
+            methods::PERMISSION_PROFILE_SET => {
+                Ok(Self::PermissionProfileSet(decode_params(method, params)?))
             }
             methods::DIFF_PREVIEW_GET => Ok(Self::DiffPreviewGet(decode_params(method, params)?)),
             methods::TASK_LIST => Ok(Self::TaskList(decode_params(method, params)?)),
@@ -2211,6 +2568,8 @@ pub enum UiRpcResult {
     TurnInterrupt(TurnInterruptResult),
     ApprovalRespond(ApprovalRespondResult),
     ApprovalScopesList(ApprovalScopesListResult),
+    PermissionProfileList(PermissionProfileListResult),
+    PermissionProfileSet(PermissionProfileSetResult),
     DiffPreviewGet(DiffPreviewGetResult),
     TaskList(TaskListResult),
     TaskCancel(TaskCancelResult),
@@ -2230,6 +2589,8 @@ impl UiRpcResult {
             Self::TurnInterrupt(_) => UiResultKind::TurnInterrupt,
             Self::ApprovalRespond(_) => UiResultKind::ApprovalRespond,
             Self::ApprovalScopesList(_) => UiResultKind::ApprovalScopesList,
+            Self::PermissionProfileList(_) => UiResultKind::PermissionProfileList,
+            Self::PermissionProfileSet(_) => UiResultKind::PermissionProfileSet,
             Self::DiffPreviewGet(_) => UiResultKind::DiffPreviewGet,
             Self::TaskList(_) => UiResultKind::TaskList,
             Self::TaskCancel(_) => UiResultKind::TaskCancel,
@@ -2249,6 +2610,8 @@ impl UiRpcResult {
             Self::TurnInterrupt(_) => Some(methods::TURN_INTERRUPT),
             Self::ApprovalRespond(_) => Some(methods::APPROVAL_RESPOND),
             Self::ApprovalScopesList(_) => Some(methods::APPROVAL_SCOPES_LIST),
+            Self::PermissionProfileList(_) => Some(methods::PERMISSION_PROFILE_LIST),
+            Self::PermissionProfileSet(_) => Some(methods::PERMISSION_PROFILE_SET),
             Self::DiffPreviewGet(_) => Some(methods::DIFF_PREVIEW_GET),
             Self::TaskList(_) => Some(methods::TASK_LIST),
             Self::TaskCancel(_) => Some(methods::TASK_CANCEL),
@@ -2268,6 +2631,8 @@ impl UiRpcResult {
             Self::TurnInterrupt(result) => serde_json::to_value(result),
             Self::ApprovalRespond(result) => serde_json::to_value(result),
             Self::ApprovalScopesList(result) => serde_json::to_value(result),
+            Self::PermissionProfileList(result) => serde_json::to_value(result),
+            Self::PermissionProfileSet(result) => serde_json::to_value(result),
             Self::DiffPreviewGet(result) => serde_json::to_value(result),
             Self::TaskList(result) => serde_json::to_value(result),
             Self::TaskCancel(result) => serde_json::to_value(result),
@@ -2305,6 +2670,12 @@ impl UiRpcResult {
             methods::APPROVAL_RESPOND => Ok(Self::ApprovalRespond(decode_result(method, result)?)),
             methods::APPROVAL_SCOPES_LIST => {
                 Ok(Self::ApprovalScopesList(decode_result(method, result)?))
+            }
+            methods::PERMISSION_PROFILE_LIST => {
+                Ok(Self::PermissionProfileList(decode_result(method, result)?))
+            }
+            methods::PERMISSION_PROFILE_SET => {
+                Ok(Self::PermissionProfileSet(decode_result(method, result)?))
             }
             methods::DIFF_PREVIEW_GET => Ok(Self::DiffPreviewGet(decode_result(method, result)?)),
             methods::TASK_LIST => Ok(Self::TaskList(decode_result(method, result)?)),
@@ -2961,6 +3332,12 @@ pub struct TurnCompletedEvent {
     pub turn_id: TurnId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<UiCursor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_in: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_out: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_result: Option<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2980,6 +3357,23 @@ pub struct ReplayLossyEvent {
     pub dropped_count: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_durable_cursor: Option<UiCursor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FileAttachedEvent {
+    pub session_id: SessionKey,
+    pub turn_id: TurnId,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionEventBridgedEvent {
+    pub session_id: SessionKey,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<Value>,
 }
 
 /// Draft notification payloads for UI protocol v1.
@@ -3011,6 +3405,8 @@ pub enum UiNotification {
     /// the same row; per-connection capability filtering (the
     /// `event.spawn_complete.v1` flag) decides which one the client sees.
     TurnSpawnComplete(TurnSpawnCompleteEvent),
+    FileAttached(FileAttachedEvent),
+    SessionEventBridged(SessionEventBridgedEvent),
 }
 
 impl UiNotification {
@@ -3035,6 +3431,8 @@ impl UiNotification {
             Self::ReplayLossy(_) => methods::REPLAY_LOSSY,
             Self::MessagePersisted(_) => methods::MESSAGE_PERSISTED,
             Self::TurnSpawnComplete(_) => methods::TURN_SPAWN_COMPLETE,
+            Self::FileAttached(_) => methods::FILE_ATTACHED,
+            Self::SessionEventBridged(_) => methods::SESSION_EVENT,
         }
     }
 
@@ -3060,6 +3458,8 @@ impl UiNotification {
             Self::ReplayLossy(params) => serde_json::to_value(params),
             Self::MessagePersisted(params) => serde_json::to_value(params),
             Self::TurnSpawnComplete(params) => serde_json::to_value(params),
+            Self::FileAttached(params) => serde_json::to_value(params),
+            Self::SessionEventBridged(params) => serde_json::to_value(params),
         }?;
 
         Ok(RpcNotification::new(method, params))
@@ -3106,6 +3506,10 @@ impl UiNotification {
             }
             methods::TURN_SPAWN_COMPLETE => {
                 Ok(Self::TurnSpawnComplete(decode_params(method, params)?))
+            }
+            methods::FILE_ATTACHED => Ok(Self::FileAttached(decode_params(method, params)?)),
+            methods::SESSION_EVENT => {
+                Ok(Self::SessionEventBridged(decode_params(method, params)?))
             }
             _ => Err(RpcError::method_not_found(method)),
         }
@@ -3446,6 +3850,10 @@ mod tests {
             UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
             "event.message_persisted.v1"
         );
+        assert_eq!(
+            UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
+            "projection.envelope.v1"
+        );
 
         assert_eq!(
             UI_PROTOCOL_COMMAND_METHODS,
@@ -3572,7 +3980,8 @@ mod tests {
                     "state.thread_graph.v1",
                     "state.turn_state_get.v1",
                     "event.message_persisted.v1",
-                    "event.spawn_complete.v1"
+                    "event.spawn_complete.v1",
+                    "projection.envelope.v1"
                 ]
             })
         );
@@ -4693,6 +5102,9 @@ mod tests {
             session_id,
             turn_id: TurnId(Uuid::from_u128(9)),
             cursor: Some(completed_cursor),
+            tokens_in: None,
+            tokens_out: None,
+            session_result: None,
         });
         let completed_wire = completed
             .clone()
@@ -5685,5 +6097,335 @@ mod tests {
         assert_eq!(rpc.method, methods::TURN_STATE_GET);
         let decoded = UiCommand::from_rpc_request(rpc).expect("decode state");
         assert_eq!(decoded, state);
+    }
+
+    // ===== UPCR-2026-014 M9-γ projection envelope golden tests =====
+
+    fn envelope(seq: u64, payload: Payload) -> Envelope {
+        Envelope {
+            thread_id: "thread-1".into(),
+            seq,
+            client_message_id: None,
+            payload,
+        }
+    }
+
+    #[test]
+    fn golden_envelope_assistant_delta_round_trips() {
+        let env = envelope(
+            1,
+            Payload::AssistantDelta {
+                text: "hello".into(),
+            },
+        );
+        let value = serde_json::to_value(&env).expect("serialize");
+        assert_eq!(value.get("thread_id"), Some(&json!("thread-1")));
+        assert_eq!(value.get("seq"), Some(&json!(1)));
+        assert!(
+            value.get("client_message_id").is_none(),
+            "client_message_id is absent on internal events"
+        );
+        let payload = value.get("payload").expect("payload");
+        assert_eq!(payload.get("type"), Some(&json!("assistant_delta")));
+        assert_eq!(
+            payload.get("data").and_then(|d| d.get("text")),
+            Some(&json!("hello"))
+        );
+        let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn golden_envelope_user_message_round_trips() {
+        // user_message envelopes are the turn root — server-mirrored
+        // from the client send. They carry `client_message_id` (and
+        // ONLY they do, per UPCR-2026-014 § 14.1) so the optimistic
+        // <GhostBubble> overlay can match its server reflection. The
+        // projection itself MUST NOT consult the field.
+        let env = Envelope {
+            thread_id: "thread-1".into(),
+            seq: 1,
+            client_message_id: Some("cmid-abc".into()),
+            payload: Payload::UserMessage {
+                text: "Q1 — what's 2+2?".into(),
+                files: vec![FileRef {
+                    path: "/tmp/upload.png".into(),
+                    mime: "image/png".into(),
+                    size_bytes: 2048,
+                }],
+            },
+        };
+        let value = serde_json::to_value(&env).expect("serialize");
+        assert_eq!(value.get("client_message_id"), Some(&json!("cmid-abc")));
+        let payload = value.get("payload").expect("payload");
+        assert_eq!(payload.get("type"), Some(&json!("user_message")));
+        let data = payload.get("data").expect("data");
+        assert_eq!(data.get("text"), Some(&json!("Q1 — what's 2+2?")));
+        let files = data.get("files").and_then(|f| f.as_array()).expect("files");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].get("path"), Some(&json!("/tmp/upload.png")));
+        assert_eq!(files[0].get("mime"), Some(&json!("image/png")));
+        assert_eq!(files[0].get("size_bytes"), Some(&json!(2048)));
+        let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn golden_envelope_user_message_omits_empty_files() {
+        // `files` is omitted on the wire when empty (matches the rest
+        // of the protocol's `Vec<_>` skip-empty convention).
+        let env = Envelope {
+            thread_id: "thread-1".into(),
+            seq: 1,
+            client_message_id: Some("cmid-1".into()),
+            payload: Payload::UserMessage {
+                text: "hi".into(),
+                files: vec![],
+            },
+        };
+        let value = serde_json::to_value(&env).expect("serialize");
+        let data = value
+            .get("payload")
+            .and_then(|p| p.get("data"))
+            .expect("data");
+        assert!(
+            data.get("files").is_none(),
+            "empty files array MUST be omitted on the wire"
+        );
+        let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn golden_envelope_assistant_delta_omits_client_message_id_on_wire() {
+        // Per spec § 14.1 + Envelope doc: client_message_id is ONLY
+        // populated on user_message envelopes. Internal events
+        // (assistant_delta and friends) leave it None and the wire
+        // shape MUST omit the field entirely.
+        let env = envelope(
+            2,
+            Payload::AssistantDelta {
+                text: "Q1 answer…".into(),
+            },
+        );
+        let value = serde_json::to_value(&env).expect("serialize");
+        assert!(
+            value.get("client_message_id").is_none(),
+            "client_message_id is absent on non-user_message envelopes"
+        );
+    }
+
+    #[test]
+    fn golden_envelope_assistant_persisted_round_trips() {
+        let env = envelope(
+            3,
+            Payload::AssistantPersisted {
+                text: "final answer".into(),
+                meta: MessageMeta {
+                    message_id: "msg-7".into(),
+                    persisted_at: sample_persisted_at(),
+                    media: vec!["report.md".into()],
+                },
+            },
+        );
+        let value = serde_json::to_value(&env).expect("serialize");
+        let payload = value.get("payload").expect("payload");
+        assert_eq!(payload.get("type"), Some(&json!("assistant_persisted")));
+        let data = payload.get("data").expect("data");
+        assert_eq!(data.get("text"), Some(&json!("final answer")));
+        assert_eq!(
+            data.get("meta").and_then(|m| m.get("message_id")),
+            Some(&json!("msg-7"))
+        );
+        let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn golden_envelope_tool_start_progress_end_round_trip() {
+        let start = envelope(
+            4,
+            Payload::ToolStart {
+                tool_call_id: "tc-1".into(),
+                name: "shell".into(),
+            },
+        );
+        let progress = envelope(
+            5,
+            Payload::ToolProgress {
+                tool_call_id: "tc-1".into(),
+                message: "running…".into(),
+            },
+        );
+        let end_ok = envelope(
+            6,
+            Payload::ToolEnd {
+                tool_call_id: "tc-1".into(),
+                status: EnvelopeToolEndStatus::Complete,
+                error: None,
+                reason: None,
+            },
+        );
+        let end_err = envelope(
+            7,
+            Payload::ToolEnd {
+                tool_call_id: "tc-2".into(),
+                status: EnvelopeToolEndStatus::Error,
+                error: Some("boom".into()),
+                reason: None,
+            },
+        );
+
+        for env in [&start, &progress, &end_ok, &end_err] {
+            let value = serde_json::to_value(env).expect("serialize");
+            let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(&parsed, env);
+        }
+
+        // Wire-form discriminator check.
+        let start_val = serde_json::to_value(&start).expect("serialize");
+        assert_eq!(
+            start_val.get("payload").and_then(|p| p.get("type")),
+            Some(&json!("tool_start"))
+        );
+        let end_err_val = serde_json::to_value(&end_err).expect("serialize");
+        assert_eq!(
+            end_err_val
+                .get("payload")
+                .and_then(|p| p.get("data"))
+                .and_then(|d| d.get("status")),
+            Some(&json!("error"))
+        );
+        // ToolEnd `error` and `reason` fields omitted when None.
+        let end_ok_val = serde_json::to_value(&end_ok).expect("serialize");
+        let end_ok_data = end_ok_val
+            .get("payload")
+            .and_then(|p| p.get("data"))
+            .expect("tool_end data");
+        assert!(end_ok_data.get("error").is_none());
+        assert!(end_ok_data.get("reason").is_none());
+    }
+
+    #[test]
+    fn golden_envelope_tool_end_skipped_and_aborted_round_trip() {
+        // Codex M9-γ-1 BLOCK 3: `complete | error` was too lossy. The
+        // sealed v1 union now also covers deadline-skip (`skipped`) and
+        // user/system-driven cancellation (`aborted`). Optional
+        // `reason` carries the human-readable detail.
+        let skipped = envelope(
+            10,
+            Payload::ToolEnd {
+                tool_call_id: "tc-3".into(),
+                status: EnvelopeToolEndStatus::Skipped,
+                error: None,
+                reason: Some("deadline elapsed before tool started".into()),
+            },
+        );
+        let aborted = envelope(
+            11,
+            Payload::ToolEnd {
+                tool_call_id: "tc-4".into(),
+                status: EnvelopeToolEndStatus::Aborted,
+                error: None,
+                reason: Some("user issued turn/interrupt".into()),
+            },
+        );
+        for (env, expected_status) in [(&skipped, "skipped"), (&aborted, "aborted")] {
+            let value = serde_json::to_value(env).expect("serialize");
+            let data = value
+                .get("payload")
+                .and_then(|p| p.get("data"))
+                .expect("tool_end data");
+            assert_eq!(data.get("status"), Some(&json!(expected_status)));
+            assert!(
+                data.get("reason").is_some(),
+                "reason populated for skipped/aborted"
+            );
+            assert!(data.get("error").is_none(), "error omitted when None");
+            let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+            assert_eq!(&parsed, env);
+        }
+    }
+
+    #[test]
+    fn golden_envelope_file_attached_round_trips() {
+        let env = envelope(
+            8,
+            Payload::FileAttached {
+                path: "/tmp/report.md".into(),
+                mime: "text/markdown".into(),
+                size_bytes: 4096,
+            },
+        );
+        let value = serde_json::to_value(&env).expect("serialize");
+        assert_eq!(
+            value.get("payload").and_then(|p| p.get("type")),
+            Some(&json!("file_attached"))
+        );
+        let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn golden_envelope_turn_completed_round_trips() {
+        let env = envelope(
+            9,
+            Payload::TurnCompleted {
+                token_usage: EnvelopeTokenUsage {
+                    input_tokens: 100,
+                    output_tokens: 250,
+                    reasoning_tokens: 0,
+                    cache_read_tokens: 80,
+                    cache_write_tokens: 0,
+                },
+            },
+        );
+        let value = serde_json::to_value(&env).expect("serialize");
+        assert_eq!(
+            value.get("payload").and_then(|p| p.get("type")),
+            Some(&json!("turn_completed"))
+        );
+        let usage = value
+            .get("payload")
+            .and_then(|p| p.get("data"))
+            .and_then(|d| d.get("token_usage"))
+            .expect("token_usage");
+        assert_eq!(usage.get("input_tokens"), Some(&json!(100)));
+        assert_eq!(usage.get("output_tokens"), Some(&json!(250)));
+        // Zero fields are omitted on the wire.
+        assert!(usage.get("reasoning_tokens").is_none());
+        assert!(usage.get("cache_write_tokens").is_none());
+        let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn golden_envelope_token_usage_zero_default_round_trips() {
+        // turn_completed with all-zero usage emits an empty `token_usage: {}`.
+        let env = envelope(
+            10,
+            Payload::TurnCompleted {
+                token_usage: EnvelopeTokenUsage::default(),
+            },
+        );
+        let value = serde_json::to_value(&env).expect("serialize");
+        let usage = value
+            .get("payload")
+            .and_then(|p| p.get("data"))
+            .and_then(|d| d.get("token_usage"))
+            .expect("token_usage");
+        assert!(usage.as_object().expect("object").is_empty());
+        let parsed: Envelope = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(parsed, env);
+    }
+
+    #[test]
+    fn golden_envelope_capability_feature_flag_registered() {
+        // The projection feature flag must be in the known-features
+        // registry so capability negotiation honours it.
+        assert!(
+            UI_PROTOCOL_KNOWN_FEATURES.contains(&UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1),
+            "projection.envelope.v1 must be registered for capability negotiation"
+        );
     }
 }

--- a/crates/octos-web/src/runtime/ui-protocol-types.ts
+++ b/crates/octos-web/src/runtime/ui-protocol-types.ts
@@ -1,0 +1,276 @@
+// UI Protocol v1 — M9-γ canonical projection envelope (UPCR-2026-014).
+//
+// This file is the TypeScript counterpart of
+// `crates/octos-core/src/ui_protocol.rs` for the M9-γ projection
+// envelope. The two MUST stay byte-aligned: the Rust enum uses
+// `serde(tag = "type", content = "data", rename_all = "snake_case")`,
+// so every wire JSON value here round-trips through `serde_json` on
+// the server side and through this discriminated union on the client.
+//
+// Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14
+// "M9-γ Envelope".
+// ADR: `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`.
+//
+// **Hard barrier**: per the ADR, `turn_completed` is the terminal
+// payload for a `thread_id`. No further `assistant_*`/`tool_*`
+// payloads on the same thread are valid after it.
+//
+// This module is type-only — it has zero runtime cost. The M9-γ-2
+// projection function will import these types and the M9-γ-3 cutover
+// will route the `ThreadStore` ingest path through them.
+
+// ── Identifier aliases ───────────────────────────────────────────────────
+//
+// All wire strings; the projection treats them as opaque. They mirror
+// the Rust newtypes in `octos-core` but are NOT the same as the legacy
+// fixture-types in `crates/octos-web/src/state/__tests__/lib/fixture-types.ts`,
+// which carry `turn_id`. Identity in M9-γ collapses to `seq` — there
+// is no `turn_id` on the envelope.
+
+/** Multi-turn cluster identity — the chat thread this envelope projects
+ *  into. All envelopes for one logical conversation share a `thread_id`. */
+export type ThreadId = string;
+
+/** Server-assigned UUID of a durable message row. Stable across replays.
+ *  Mirrors `MessageMeta.message_id` in the Rust types. */
+export type MessageId = string;
+
+/** Client optimism + idempotency token. Web client mints; UUIDv7 in prod.
+ *  ONLY the optimistic <GhostBubble> overlay consults this — the
+ *  projection itself never does. */
+export type ClientMessageId = string;
+
+/** RFC 3339 timestamp string (e.g. "2026-05-09T18:30:01Z"). */
+export type IsoTimestamp = string;
+
+/** Sub-typed numeric for the strict per-thread server ordering. */
+export type Seq = number;
+
+// ── Token usage ──────────────────────────────────────────────────────────
+
+/** Token usage carried on `turn_completed` envelopes. Mirrors
+ *  `EnvelopeTokenUsage` in the Rust types. All fields default to zero
+ *  and are omitted on the wire when zero (serde
+ *  `skip_serializing_if = "is_zero_u64"`). */
+export interface EnvelopeTokenUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+}
+
+// ── Message metadata ─────────────────────────────────────────────────────
+
+/** Metadata carried on `assistant_persisted` envelopes. Mirrors
+ *  `MessageMeta` in the Rust types. */
+export interface MessageMeta {
+  /** Server-assigned UUID of the durable row. */
+  message_id: MessageId;
+  /** Wall-clock RFC 3339 commit time. */
+  persisted_at: IsoTimestamp;
+  /** File attachments persisted with the message — typically a single
+   *  `.md` / `.mp3` / `.pptx` artefact. Empty for assistant rows that
+   *  carry only text. Omitted on the wire when empty. */
+  media?: string[];
+}
+
+// ── Tool end status ──────────────────────────────────────────────────────
+
+/** Status carried on `tool_end` payloads. Mirrors `EnvelopeToolEndStatus`
+ *  (snake_case wire form) in the Rust types. Closed v1 union; future
+ *  variants require a follow-up UPCR.
+ *
+ *  - `complete` — tool ran to natural completion.
+ *  - `error` — tool surfaced a failure (`error` field carries the message).
+ *  - `skipped` — tool was intentionally not run (deadline-skip,
+ *    pre-condition unmet). The optional `reason` field on the payload
+ *    explains why.
+ *  - `aborted` — tool execution was interrupted by an external signal
+ *    (user `turn/interrupt`, system cancellation). Optional `reason`
+ *    carries detail. */
+export type EnvelopeToolEndStatus = 'complete' | 'error' | 'skipped' | 'aborted';
+
+// ── File reference ───────────────────────────────────────────────────────
+
+/** Wire-form file reference carried on `user_message` envelopes (and
+ *  reused as the canonical attachment shape elsewhere). Mirrors
+ *  `FileRef` in the Rust types. All three fields are required. */
+export interface FileRef {
+  path: string;
+  mime: string;
+  size_bytes: number;
+}
+
+// ── Payload variants (sealed tagged union) ───────────────────────────────
+//
+// The Rust enum uses `serde(tag = "type", content = "data", rename_all =
+// "snake_case")`, so each variant on the wire looks like:
+//
+//   { "type": "assistant_delta", "data": { "text": "…" } }
+//
+// The TS shape mirrors this exactly. Adding a new variant is a wire
+// contract change and requires a follow-up UPCR.
+
+/** User-message turn root — server-mirrored from the client's send.
+ *  Every chat turn begins with exactly one `user_message` envelope, and
+ *  the projection's `UserView` is reconstructed from these envelopes
+ *  alone (a refresh-only projection cannot recover user bubbles from
+ *  `assistant_delta` / `assistant_persisted`).
+ *
+ *  The carrying envelope populates `client_message_id` here — and ONLY
+ *  here — so the optimistic <GhostBubble> overlay can match its server
+ *  reflection and unmount. */
+interface UserMessagePayload {
+  type: 'user_message';
+  data: {
+    text: string;
+    /** Omitted on the wire when empty (matches Rust serde
+     *  `skip_serializing_if = "Vec::is_empty"`). */
+    files?: FileRef[];
+  };
+}
+
+interface AssistantDeltaPayload {
+  type: 'assistant_delta';
+  data: { text: string };
+}
+
+interface AssistantPersistedPayload {
+  type: 'assistant_persisted';
+  data: { text: string; meta: MessageMeta };
+}
+
+interface ToolStartPayload {
+  type: 'tool_start';
+  data: { tool_call_id: string; name: string };
+}
+
+interface ToolProgressPayload {
+  type: 'tool_progress';
+  data: { tool_call_id: string; message: string };
+}
+
+interface ToolEndPayload {
+  type: 'tool_end';
+  data: {
+    tool_call_id: string;
+    status: EnvelopeToolEndStatus;
+    /** Set iff `status === 'error'`. Omitted on the wire when null. */
+    error?: string;
+    /** Optional human-readable detail. Populated for `skipped`
+     *  (deadline-skip, pre-condition unmet) and `aborted`
+     *  (user `turn/interrupt`, system cancellation) outcomes. Omitted
+     *  on the wire when null. */
+    reason?: string;
+  };
+}
+
+interface FileAttachedPayload {
+  type: 'file_attached';
+  data: { path: string; mime: string; size_bytes: number };
+}
+
+interface TurnCompletedPayload {
+  type: 'turn_completed';
+  data: { token_usage: EnvelopeTokenUsage };
+}
+
+/** Sealed tagged union of payloads carried by the M9-γ projection
+ *  envelope. The discriminator is `type`; payload data lives under
+ *  `data`. Variant names are snake_case to match the wire / Rust shape. */
+export type Payload =
+  | UserMessagePayload
+  | AssistantDeltaPayload
+  | AssistantPersistedPayload
+  | ToolStartPayload
+  | ToolProgressPayload
+  | ToolEndPayload
+  | FileAttachedPayload
+  | TurnCompletedPayload;
+
+// ── Envelope ─────────────────────────────────────────────────────────────
+
+/** Canonical M9-γ projection envelope.
+ *
+ *  Per UPCR-2026-014 and the M9-γ ADR, this is the single shape the
+ *  web client's deterministic projection consumes. The committed
+ *  envelope log is `Envelope[]` indexed by `(thread_id, seq)`; the
+ *  projection is a pure function from that log to `ChatViewModel`.
+ *
+ *  Identity collapses to `seq` — the only key the projection cares
+ *  about. `client_message_id` is populated ONLY on `user_message`
+ *  envelopes so the optimistic `<GhostBubble>` overlay can match its
+ *  server reflection and unmount; the projection itself NEVER consults
+ *  it. All other variants leave `client_message_id` undefined.
+ *
+ *  **Streaming reconciliation rule** (locked by spec § 14.2):
+ *  `assistant_delta.text` fragments APPEND to the live bubble in
+ *  strict `seq` order (concatenate). When an `assistant_persisted`
+ *  arrives for the same thread, its `text` field REPLACES the
+ *  accumulated streamed text — the persisted form is canonical and
+ *  avoids double-rendering the final body.
+ *
+ *  **Hard barrier** (spec § 14.6): after a `turn_completed` envelope
+ *  for `thread_id` T, any subsequent envelope with the same `thread_id`
+ *  is DROPPED by the projection (and counted in the
+ *  `octos_projection_post_completion_drop_total` metric). Threads are
+ *  NOT reused — a new turn must use a NEW `thread_id`. */
+export interface Envelope {
+  thread_id: ThreadId;
+  seq: Seq;
+  /** Populated ONLY on `user_message` envelopes (the optimistic
+   *  `<GhostBubble>` overlay matches its server reflection here).
+   *  Absent on every other variant (assistant deltas / persisted, tool
+   *  events, file attached, turn_completed). The projection MUST NOT
+   *  consult this field. */
+  client_message_id?: ClientMessageId;
+  payload: Payload;
+}
+
+// ── Capability feature flag ──────────────────────────────────────────────
+
+/** Wire-form capability flag for UPCR-2026-014. Servers advertise it via
+ *  `UiProtocolCapabilities.supported_features`; clients request it via
+ *  the `X-Octos-Ui-Features` header. Mirrors
+ *  `UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1` in the Rust types. */
+export const UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1 = 'projection.envelope.v1';
+
+// ── Type guards (optional ergonomic helpers) ─────────────────────────────
+//
+// The projection function will switch on `envelope.payload.type` and
+// rely on TS's discriminated-union narrowing. These helpers exist for
+// callers that need a runtime check (e.g. a debug overlay rendering a
+// raw envelope).
+
+export function isUserMessage(p: Payload): p is UserMessagePayload {
+  return p.type === 'user_message';
+}
+
+export function isAssistantDelta(p: Payload): p is AssistantDeltaPayload {
+  return p.type === 'assistant_delta';
+}
+
+export function isAssistantPersisted(p: Payload): p is AssistantPersistedPayload {
+  return p.type === 'assistant_persisted';
+}
+
+export function isToolStart(p: Payload): p is ToolStartPayload {
+  return p.type === 'tool_start';
+}
+
+export function isToolProgress(p: Payload): p is ToolProgressPayload {
+  return p.type === 'tool_progress';
+}
+
+export function isToolEnd(p: Payload): p is ToolEndPayload {
+  return p.type === 'tool_end';
+}
+
+export function isFileAttached(p: Payload): p is FileAttachedPayload {
+  return p.type === 'file_attached';
+}
+
+export function isTurnCompleted(p: Payload): p is TurnCompletedPayload {
+  return p.type === 'turn_completed';
+}

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_014_PROJECTION_ENVELOPE.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_014_PROJECTION_ENVELOPE.md
@@ -1,0 +1,320 @@
+# Octos UI Protocol Change Request: M9-γ Projection Envelope
+
+## Header
+
+- Request id: `UPCR-2026-014`
+- Title: Add canonical M9-γ `Envelope` shape (`thread_id`, `seq`,
+  `client_message_id?`, `payload`) for deterministic web client projection
+- Author: M9-γ-1 worker (coding-green)
+- Date: 2026-05-09
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related issues: `#838` (M9-γ-1 envelope spec)
+- Related ADR: [`docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`](./M9-GAMMA-SERVER-PROJECTION-ADR.md)
+- Sibling UPCRs: `UPCR-2026-009` (session/hydrate), `UPCR-2026-010`
+  (thread/graph/get), `UPCR-2026-011` (turn/state/get), `UPCR-2026-012`
+  (message/persisted)
+
+## Summary
+
+This change request adds the canonical M9-γ projection envelope shape to
+the AppUi protocol. The web client's deterministic projection consumes
+an append-only `Vec<Envelope>` indexed by `(thread_id, seq)` and a pure
+projection function `(committed_log) → ChatViewModel` produces the
+rendered chat. Identity collapses to `seq` — the only key the projection
+cares about. `client_message_id` lives ONLY on `user_message` envelopes
+so the optimistic `<GhostBubble>` overlay can match its server
+reflection and unmount; the projection itself never consults it.
+
+The eight payload variants are: `user_message` (turn root,
+server-mirrored from the client's send), `assistant_delta` (streamed
+fragment — APPENDS in `seq` order), `assistant_persisted` (final text
+with durable `MessageMeta` — REPLACES the streamed deltas),
+`tool_start` / `tool_progress` / `tool_end` (with `complete | error |
+skipped | aborted` status and an optional `reason`), `file_attached`,
+and `turn_completed` (hard barrier — any later envelope on the same
+`thread_id` is DROPPED by the projection and counted in the
+`octos_projection_post_completion_drop_total` metric; threads are not
+reused).
+
+The change is strictly additive: no existing notification, command,
+payload, enum variant, or capability flag is modified. The legacy
+`message/delta`, `message/persisted`, `tool/*`, and `turn/completed`
+notifications continue to flow on connections that do not negotiate
+this feature, until `M9-γ-3` deletes them.
+
+## Motivation
+
+The M9-γ ADR traces the entire "Q1 works, Q2 disappears" /
+"phantom-bubble" / "ack-result-divergence" / "reload-misbinding" bug
+class to a single root cause: the web client's `ThreadStore` is a
+*parallel mutable copy* of server state, with ten reducer entry points
+each doing partial reconciliation against a different identity field
+(`clientMessageId`, `messageId`, `historySeq`, `intra_thread_seq`,
+`threadId`, `responseToClientMessageId`). Under race conditions they
+contradict each other and produce phantom rows.
+
+The fix is structural, not transport: collapse identity to `(thread_id,
+seq)`, make the projection a pure function, and move optimistic UI to a
+visual-only `<GhostBubble>` overlay that never enters the projection.
+
+This UPCR defines the canonical wire envelope the projection consumes.
+Server emit support and client projection consumption land in
+follow-up M9-γ-N issues; `γ-1` is the spec lock.
+
+## Change Type
+
+Additive notification shape. One new wire-level type union (`Envelope`,
+`Payload`) is defined. One additive feature flag
+(`projection.envelope.v1`) is added so clients can negotiate
+availability. No existing notification, command, params, results, or
+enum variants are modified by this UPCR.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Capability payload: `UiProtocolCapabilities.supported_features` (new
+  feature flag entry)
+- Capability feature registry: `projection.envelope.v1`
+- Wire envelope shape: `Envelope` (new, see § 14 of the spec)
+- Wire payload tagged union: `Payload` (new, see § 14.2 of the spec)
+- Supporting types: `MessageMeta`, `EnvelopeTokenUsage`,
+  `EnvelopeToolEndStatus`, `FileRef`
+
+Spec section: § 14 "M9-γ Envelope" of
+`api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md`.
+
+### `Envelope`
+
+```json
+{
+  "thread_id": "thread-1",
+  "seq": 18,
+  "client_message_id": "01900000-0000-7000-8000-000000000001",
+  "payload": { "type": "...", "data": { ... } }
+}
+```
+
+Required fields:
+
+- `thread_id` (`string`) — Multi-turn cluster identity.
+- `seq` (`u64`) — Server-assigned strict total order WITHIN the
+  `thread_id`. Strictly monotonic; gaps are an error.
+- `payload` (object) — Sealed tagged union (see below).
+
+Optional fields:
+
+- `client_message_id` (`string`) — Populated ONLY on `user_message`
+  envelopes. Absent on every other variant. The projection MUST NOT
+  consult this field; it exists for the optimistic overlay's
+  match-and-unmount.
+
+### `Payload` variants
+
+Wire form: `{ "type": <snake_case>, "data": <variant-specific> }`.
+Mirrors Rust `serde(tag = "type", content = "data", rename_all =
+"snake_case")`.
+
+- `user_message { text: string, files: FileRef[] }` — Turn root,
+  server-mirrored from the client's send. The carrying envelope's
+  `client_message_id` is populated here (and ONLY here). `files` is
+  omitted on the wire when empty.
+- `assistant_delta { text: string }` — One streamed text fragment.
+  APPENDS to the live bubble in `seq` order.
+- `assistant_persisted { text: string, meta: MessageMeta }` — Final
+  text + durable identity. **REPLACES** the accumulated streamed
+  deltas for the same `thread_id` (canonical final form). See § 14.3.
+- `tool_start { tool_call_id: string, name: string }` — Tool invocation
+  begun.
+- `tool_progress { tool_call_id: string, message: string }` — Tool
+  progress update.
+- `tool_end { tool_call_id: string, status: "complete" | "error" |
+  "skipped" | "aborted", error?: string, reason?: string }` — Tool
+  finished. `error` set iff `status === "error"`. `reason` is
+  optional human-readable detail (primary use: `skipped` /
+  `aborted`).
+- `file_attached { path: string, mime: string, size_bytes: u64 }` —
+  File attached to current thread. Embeds the same triple as `FileRef`.
+- `turn_completed { token_usage: EnvelopeTokenUsage }` — **Hard
+  barrier**; see § 14.6 of spec.
+
+Future variants must be registered via UPCR.
+
+### Turn shape and reconciliation rule
+
+- Every chat turn begins with exactly one `user_message` envelope, and
+  the projection's `UserView` is reconstructed from `user_message`
+  envelopes alone. `assistant_delta` / `assistant_persisted` cannot
+  rebuild the user side of the chat on a refresh-only projection.
+- `assistant_delta.text` events APPEND to the live bubble in strict
+  `seq` order. When an `assistant_persisted` envelope arrives for the
+  same `thread_id`, its `text` field REPLACES the accumulated
+  streamed text — the persisted form is canonical and avoids
+  double-rendering the final body.
+
+### Hard barrier semantics (drop-with-metric)
+
+Per the M9-γ ADR and § 14.6 of the spec, the server MUST emit at most
+one `turn_completed` envelope per `(thread_id, turn)`. After it:
+
+> Any envelope arriving on the same `thread_id` is DROPPED by the
+> projection (and counted in
+> `octos_projection_post_completion_drop_total`). Threads are NOT
+> reused — a new turn must use a NEW `thread_id`.
+
+The drop is silent at the projection layer. Clients do NOT rehydrate
+or treat the situation as a desync. The M9-γ-2 projection
+([`octos-web` PR #93](https://github.com/octos-org/octos-web/pull/93))
+implements the same behaviour and is the canonical reference.
+
+### Identity model
+
+Per § 5.1 of the spec:
+
+- The projection key is `(thread_id, seq)`.
+- `client_message_id` is OPTIONAL and ONLY for the optimistic overlay.
+- The legacy per-row `message_id` (carried on
+  `MessagePersistedEvent.message_id` and on
+  `assistant_persisted.meta.message_id`) is **deprecated for
+  projection identity**. It is retained for audit/render display so
+  legacy `appendCompletionBubble` / `message/persisted` consumers
+  continue to work until `M9-γ-3` deletes them.
+
+## Capability Negotiation
+
+Capability feature: `projection.envelope.v1`
+
+- Advertised through optional `supported_features` in
+  `UiProtocolCapabilities`.
+- Clients request it through `X-Octos-Ui-Features` (comma- or
+  space-separated tokens).
+- Servers MUST NOT emit canonical `Envelope` notifications to a
+  connection that did not negotiate the feature. Pre-existing
+  connections (TUI, octos-app legacy) continue to receive only the
+  legacy notification surface they negotiated.
+- The capability schema version remains `2` — this is additive.
+
+## Compatibility
+
+- All existing clients continue to function unchanged. The envelope is
+  opt-in via `X-Octos-Ui-Features`.
+- Legacy daemon versions that do not implement canonical envelopes
+  will not advertise the feature, and clients will not expect them.
+- The deprecation note in § 5.1 of the spec is informational; legacy
+  identity fields stay on the wire until `M9-γ-3` retires them
+  behind a separate flag flip (see ADR phase plan).
+- Cross-channel: telegram/discord/etc. do not subscribe to UI Protocol
+  notifications; unaffected.
+
+## Testing Strategy
+
+### Server-side / wire contract
+
+- Golden tests in `crates/octos-core/src/ui_protocol.rs::tests`:
+  - `golden_envelope_assistant_delta_round_trips`
+  - `golden_envelope_user_message_round_trips`
+  - `golden_envelope_user_message_omits_empty_files`
+  - `golden_envelope_assistant_delta_omits_client_message_id_on_wire`
+  - `golden_envelope_assistant_persisted_round_trips`
+  - `golden_envelope_tool_start_progress_end_round_trip`
+  - `golden_envelope_tool_end_skipped_and_aborted_round_trip`
+  - `golden_envelope_file_attached_round_trips`
+  - `golden_envelope_turn_completed_round_trips`
+  - `golden_envelope_token_usage_zero_default_round_trips`
+  - `golden_envelope_capability_feature_flag_registered`
+
+  These lock the wire shape: `serde_json` round-trip, snake_case
+  discriminator presence, optional-field omission on the wire
+  (`client_message_id` on non-`user_message` envelopes, `files` when
+  empty, `error`, `reason`, zero `token_usage` fields), and the
+  closed-union extension of `EnvelopeToolEndStatus` to four variants.
+
+### Client-side
+
+- TS types in `crates/octos-web/src/runtime/ui-protocol-types.ts`
+  mirror the Rust enum bit-for-bit. `tsc --noEmit` keeps them honest.
+- M9-γ-2 will land property tests for the projection function
+  (replay determinism: any `seq`-ordered prefix of a turn's envelopes
+  → byte-identical `ChatViewModel`).
+- M9-γ-3 fixtures will assert that ingesting an envelope after a
+  same-turn `turn_completed` triggers the rehydrate code path (the
+  hard-barrier enforcement).
+
+## Rollout
+
+- **γ-1 (this UPCR)**: spec lands; types regenerated for Rust + TS;
+  capability flag wired into the known-features registry.
+- **γ-2**: pure-function `projection(envelopes) → ChatViewModel` lands
+  in `octos-web/src/runtime/projection.ts` behind the
+  `chat_projection_v1` flag.
+- **γ-3**: `ThreadStore` cutover — the ten reducer entry points
+  collapse to one `ingest(envelope)` dispatcher.
+- **γ-4**: `<GhostBubble>` overlay component lands; optimistic UI moves
+  out of `ThreadStore`.
+- **γ-5**: identity collapse — `clientMessageId` /
+  `responseToClientMessageId` / `intra_thread_seq` removed from
+  projection code.
+- **γ-6**: `MessageStore` deletion.
+- **γ-7**: server-side cleanup — server emits exactly N+1 envelopes
+  per turn (N tool/assistant cycles + 1 `turn_completed`).
+
+Each step is gated behind 7-day soak green per ADR.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Wire size: each envelope is bigger than today's `message/delta` because of the `payload` wrapper | Low | The `payload` wrapper adds ~30 bytes/event vs the legacy flat shape. WS per-frame compression already in place; payload size is negligible at chat bandwidth scales. |
+| `client_message_id` leak into projection code | Medium | Spec § 14.1 + ADR explicitly forbid it. The projection's TS type narrows on `payload.type` exclusively; tests in γ-2 will assert via `grep` that the projection module never reads `client_message_id`. |
+| Hard-barrier violation on the server side | Medium | Server emitter (γ-7) emits exactly N+1 envelopes per turn; the existing turn-lifecycle plumbing already serializes terminal events. A unit test on the emitter will assert the invariant. The projection itself drops post-`turn_completed` envelopes silently and counts the drop in `octos_projection_post_completion_drop_total` (see § 14.6 of the spec); operators alert on the metric rather than rehydrating clients. |
+| Forward-compat of `Payload` enum | Low | `Payload` is closed in v1 (sealed). Adding a variant is a wire contract change requiring a follow-up UPCR. Clients MUST treat unknown `type` discriminators as a desync signal and rehydrate. |
+| Cross-cancel: a cancelled turn's `turn_completed` still fires | Low | The `turn_completed` envelope IS emitted for cancelled turns (spec § 14.6). The lifecycle truth (cancelled vs completed) lives in legacy `turn/error` / `turn/interrupted` notifications until M10 unifies them. |
+
+## Open Questions
+
+- Should `Envelope` carry a top-level `cursor` field for replay
+  alignment with `session/open { after: <cursor> }`? **Decision**:
+  no for v1 — `(thread_id, seq)` is the projection key and the
+  existing `event_cursor` (already documented in § 5) handles
+  reconnect replay. Adding a per-envelope cursor would duplicate state
+  the cursor index already covers.
+- Should `tool_end.status` be an open snake_case enum (matching
+  `MessagePersistedSource`) or closed (matching `DiffPreviewLineKind`)?
+  **Decision**: closed for v1, and codex M9-γ-1 review extended the
+  set from `complete | error` to `complete | error | skipped | aborted`
+  (with optional `reason` carrying detail) so deadline-skip and
+  user/system-driven cancellation are first-class wire states. Future
+  variants still require a follow-up UPCR.
+- Should `assistant_persisted` ALSO carry the `cursor` from the
+  underlying `MessagePersistedEvent`? **Decision**: no for v1 — the
+  `cursor` is for resumable replay over the existing notification
+  stream; the projection consumes envelopes from the committed log
+  and uses `seq` for ordering. The two cursor namespaces stay
+  independent.
+
+## Acceptance Criteria
+
+- [x] Spec § 14 "M9-γ Envelope" lands in
+      `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md`.
+- [x] § 4.1 governance entry references this UPCR.
+- [x] § 5.1 documents the identity-model collapse and the legacy
+      `message_id` deprecation note.
+- [x] Rust `Envelope`, `Payload` (with `UserMessage` variant),
+      `MessageMeta`, `EnvelopeTokenUsage`, `EnvelopeToolEndStatus`
+      (`complete | error | skipped | aborted`), and `FileRef` land in
+      `crates/octos-core/src/ui_protocol.rs` with serde
+      `tag = "type", content = "data", rename_all = "snake_case"`.
+- [x] TS counterparts land in
+      `crates/octos-web/src/runtime/ui-protocol-types.ts` and pass
+      `tsc --noEmit`.
+- [x] Golden round-trip tests in `octos-core::ui_protocol::tests`
+      pass (`cargo test -p octos-core`), including coverage for
+      `user_message` (with and without files), `assistant_delta`
+      omitting `client_message_id`, and `tool_end` with `skipped` /
+      `aborted` status.
+- [x] Capability flag `projection.envelope.v1` registered in
+      `UI_PROTOCOL_KNOWN_FEATURES`.
+- [x] No existing tests broken by the additive change (full
+      `cargo test -p octos-core` green).
+- [x] Status flipped to `accepted` before any γ-2 implementation lands.


### PR DESCRIPTION
Re-target of #848 (which merged into the closed docs/m9-alpha-gamma-adr branch) directly onto main.