### PR TITLE
feat(api): M9-β-1 — TurnStartInput media + topic + rewrite_for (closes the α-5+6 chat-flow stubs)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2760,8 +2760,34 @@ async fn handle_turn_start(
     routed_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     id: String,
-    params: TurnStartParams,
+    mut params: TurnStartParams,
 ) {
+    // UPCR-2026-015 (M9-β-1): if the client carried a `topic` field
+    // alongside the session_id, fold it into the resolved SessionKey
+    // BEFORE scope validation. The rest of the turn pipeline keys
+    // exclusively off `params.session_id`, so adopting the topic-
+    // suffixed form here means history lookup, ledger appends, and
+    // `task/list` filtering all see the per-topic bucket
+    // automatically. Empty / whitespace-only topics fall through to
+    // the bare session shape (matching `SessionKey::with_topic`'s
+    // own empty-string short-circuit).
+    if let Some(topic) = params
+        .topic
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        // Replace the SessionKey with the topic-suffixed form. Splice
+        // any existing topic suffix away first so a client that sends
+        // both `session_id: "x:y#old"` and `topic: "new"` lands in a
+        // single, unambiguous bucket (`x:y#new`) rather than the
+        // double-suffixed garbage `x:y#old#new`. The base parser
+        // already handles `#`-stripped lookups, but we want the
+        // canonical form on the wire-trip back to clients.
+        let base = params.session_id.base_key().to_owned();
+        params.session_id = SessionKey(format!("{base}#{topic}"));
+    }
+
     if let Err(error) = validate_session_scope(&params.session_id, None, connection_profile_id) {
         let _ = send_rpc_error(ws, Some(id), error);
         return;
@@ -5147,11 +5173,32 @@ async fn run_standalone_turn(
     // the WRONG sibling user under rapid-fire concurrent turns.
     let turn_thread_id_for_persist = turn_id.0.to_string();
     let turn_thread_id_for_done = turn_thread_id_for_persist.clone();
+    // UPCR-2026-015 (M9-β-1): pull the pre-uploaded media paths off
+    // the params and feed them to the agent loop. `process_message`
+    // already accepts a `Vec<String>` of paths (used by the
+    // `octos chat` CLI and gateway-mode message handler) — wiring it
+    // here restores the legacy SSE chat handler's media delivery on
+    // the WS transport. The legacy `rewrite_for` field is logged at
+    // debug level for now; durable in-place rewrites land in a
+    // follow-up that touches the per-session ledger replace path.
+    let turn_media_paths: Vec<String> = params
+        .media
+        .iter()
+        .map(|file_ref| file_ref.path.clone())
+        .collect();
+    if let Some(rewrite_for) = params.rewrite_for.as_deref() {
+        tracing::debug!(
+            session = %session_id.0,
+            turn = %turn_id.0,
+            rewrite_for,
+            "turn/start carries rewrite_for; current build forwards the prompt without in-place ledger rewrite (β-1 advisory)"
+        );
+    }
     let agent_task = tokio::spawn(async move {
         let result = octos_agent::tools::TOOL_APPROVAL_CTX
             .scope(
                 approval_requester,
-                request_agent.process_message(&prompt, &history, Vec::new()),
+                request_agent.process_message(&prompt, &history, turn_media_paths),
             )
             .await;
 
@@ -6032,6 +6079,9 @@ mod tests {
             input: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: None,
         })
         .into_rpc_request("1")
         .expect("request");
@@ -6045,6 +6095,76 @@ mod tests {
             route_rpc_command(decoded, ConnectionUiFeatures::default()).expect("route"),
             UiCommand::TurnStart(_)
         ));
+    }
+
+    /// UPCR-2026-015 (M9-β-1): the WS turn/start handler accepts the
+    /// three new optional fields (`media`, `topic`, `rewrite_for`)
+    /// from a strict-additive wire shape. The legacy text-only form
+    /// continues to deserialize identically (back-compat sanity).
+    #[test]
+    fn parses_turn_start_rpc_request_with_beta1_fields() {
+        let raw = json!({
+            "jsonrpc": "2.0",
+            "id": "rpc-beta1",
+            "method": methods::TURN_START,
+            "params": {
+                "session_id": "local:test",
+                "turn_id": TurnId::new(),
+                "input": [{"kind": "text", "text": "look here"}],
+                "media": [
+                    {
+                        "path": "/tmp/chat-upload-deadbeef.png",
+                        "mime": "image/png",
+                        "size_bytes": 1234,
+                    }
+                ],
+                "topic": "research",
+                "rewrite_for": "cmid-original-1",
+            }
+        })
+        .to_string();
+
+        let decoded = parse_rpc_request(&raw).expect("parse");
+        let routed = route_rpc_command(decoded, ConnectionUiFeatures::default()).expect("route");
+        match routed {
+            UiCommand::TurnStart(params) => {
+                assert_eq!(params.media.len(), 1);
+                assert_eq!(params.media[0].path, "/tmp/chat-upload-deadbeef.png");
+                assert_eq!(params.media[0].mime, "image/png");
+                assert_eq!(params.media[0].size_bytes, 1234);
+                assert_eq!(params.topic.as_deref(), Some("research"));
+                assert_eq!(params.rewrite_for.as_deref(), Some("cmid-original-1"));
+            }
+            other => panic!("expected TurnStart, got {:?}", other),
+        }
+    }
+
+    /// UPCR-2026-015 (M9-β-1): bare turn/start (no β-1 fields)
+    /// continues to deserialize and round-trip with the new defaults.
+    #[test]
+    fn parses_legacy_turn_start_rpc_request_stays_back_compat() {
+        let raw = json!({
+            "jsonrpc": "2.0",
+            "id": "rpc-legacy",
+            "method": methods::TURN_START,
+            "params": {
+                "session_id": "local:test",
+                "turn_id": TurnId::new(),
+                "input": [{"kind": "text", "text": "hello"}],
+            }
+        })
+        .to_string();
+
+        let decoded = parse_rpc_request(&raw).expect("parse");
+        let routed = route_rpc_command(decoded, ConnectionUiFeatures::default()).expect("route");
+        match routed {
+            UiCommand::TurnStart(params) => {
+                assert!(params.media.is_empty());
+                assert!(params.topic.is_none());
+                assert!(params.rewrite_for.is_none());
+            }
+            other => panic!("expected TurnStart, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/octos-core/src/app_ui.rs
+++ b/crates/octos-core/src/app_ui.rs
@@ -263,6 +263,9 @@ mod tests {
             input: vec![AppUiInputItem::Text {
                 text: "hello".into(),
             }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: None,
         });
 
         assert_eq!(command.method(), methods::TURN_START);

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1080,6 +1080,36 @@ pub struct TurnStartParams {
     pub session_id: SessionKey,
     pub turn_id: TurnId,
     pub input: Vec<InputItem>,
+    /// UPCR-2026-015 (M9-β-1): pre-uploaded media references the user
+    /// attached to this send. Each entry mirrors the `FileRef` shape
+    /// already used on `Payload::UserMessage` envelopes (γ-1, PR #848)
+    /// — `path` is the durable filesystem handle returned from
+    /// `POST /api/upload`; `mime` and `size_bytes` are populated at
+    /// upload time. Empty / absent on text-only sends.
+    ///
+    /// **Wire**: serialised as `media: [...]` (omitted entirely when
+    /// empty). The legacy SSE `chatSSE()` path carried the same shape
+    /// in its body before α-5/α-6 deleted that transport; this field
+    /// restores attachment delivery on the WS path.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub media: Vec<FileRef>,
+    /// UPCR-2026-015 (M9-β-1): optional sub-topic suffix that scopes
+    /// this send to a per-topic session bucket (`<session>#<topic>`
+    /// shape). Mirrors the legacy SSE `topic` query/body field. The
+    /// server folds this into the resolved `SessionKey` before
+    /// validating scope and looking up history. Empty / absent for
+    /// the default-topic case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    /// UPCR-2026-015 (M9-β-1): when set, the server treats this turn
+    /// as a rewrite of an existing queued user message identified by
+    /// its `client_message_id` rather than appending a new turn. Used
+    /// by the SPA's `/queue` slash-command flow where the user edits a
+    /// queued prompt before it dispatches. The legacy SSE path
+    /// supported the same field; β-1 restores it on the WS shape.
+    /// Absent on regular sends.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rewrite_for: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -4050,6 +4080,9 @@ mod tests {
             input: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: None,
         })
         .into_rpc_request("req-turn-start")
         .expect("serialize turn/start");
@@ -4515,6 +4548,9 @@ mod tests {
             input: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: None,
         });
 
         let request = command
@@ -4531,11 +4567,195 @@ mod tests {
         assert_eq!(wire["params"]["session_id"], json!("local:demo"));
         assert_eq!(wire["params"]["input"][0]["kind"], json!("text"));
         assert!(wire["params"].get("kind").is_none());
+        // UPCR-2026-015 (M9-β-1): the three new optional fields are
+        // ABSENT on the wire when at their default (empty / None).
+        // This locks the back-compat shape — pre-β-1 servers and
+        // clients see exactly the bytes they used to.
+        assert!(
+            wire["params"].get("media").is_none(),
+            "empty media MUST be omitted on the wire"
+        );
+        assert!(
+            wire["params"].get("topic").is_none(),
+            "absent topic MUST be omitted on the wire"
+        );
+        assert!(
+            wire["params"].get("rewrite_for").is_none(),
+            "absent rewrite_for MUST be omitted on the wire"
+        );
 
         let decoded_request: RpcRequest<Value> =
             serde_json::from_value(wire).expect("deserialize request");
         let decoded = UiCommand::from_rpc_request(decoded_request).expect("parse request params");
 
+        assert_eq!(decoded, command);
+    }
+
+    /// UPCR-2026-015 (M9-β-1): a `turn/start` carrying media references
+    /// round-trips bit-for-bit. The `FileRef` shape mirrors
+    /// `Payload::UserMessage.files` (γ-1 PR #848 / UPCR-2026-014).
+    #[test]
+    fn turn_start_round_trips_with_media_field() {
+        let command = UiCommand::TurnStart(TurnStartParams {
+            session_id: SessionKey("local:demo".into()),
+            turn_id: TurnId(Uuid::from_u128(2)),
+            input: vec![InputItem::Text {
+                text: "look at this".into(),
+            }],
+            media: vec![
+                FileRef {
+                    path: "/tmp/upload-1.png".into(),
+                    mime: "image/png".into(),
+                    size_bytes: 4096,
+                },
+                FileRef {
+                    path: "/tmp/voice.mp3".into(),
+                    mime: "audio/mpeg".into(),
+                    size_bytes: 32_768,
+                },
+            ],
+            topic: None,
+            rewrite_for: None,
+        });
+
+        let wire = serde_json::to_value(
+            command
+                .clone()
+                .into_rpc_request("req-media")
+                .expect("serialize"),
+        )
+        .expect("to_value");
+
+        let media = wire["params"]
+            .get("media")
+            .and_then(|v| v.as_array())
+            .expect("media array on the wire");
+        assert_eq!(media.len(), 2);
+        assert_eq!(media[0].get("path"), Some(&json!("/tmp/upload-1.png")));
+        assert_eq!(media[0].get("mime"), Some(&json!("image/png")));
+        assert_eq!(media[0].get("size_bytes"), Some(&json!(4096)));
+        assert_eq!(media[1].get("path"), Some(&json!("/tmp/voice.mp3")));
+
+        let decoded_request: RpcRequest<Value> = serde_json::from_value(wire).expect("deserialize");
+        let decoded = UiCommand::from_rpc_request(decoded_request).expect("parse");
+        assert_eq!(decoded, command);
+    }
+
+    /// UPCR-2026-015 (M9-β-1): `topic` field surfaces as a flat string
+    /// on the wire (parallel to `task/list.topic`). The server folds
+    /// it into the resolved `SessionKey` before scope validation.
+    #[test]
+    fn turn_start_round_trips_with_topic_field() {
+        let command = UiCommand::TurnStart(TurnStartParams {
+            session_id: SessionKey("local:demo".into()),
+            turn_id: TurnId(Uuid::from_u128(3)),
+            input: vec![InputItem::Text {
+                text: "build me a deck".into(),
+            }],
+            media: Vec::new(),
+            topic: Some("slides".into()),
+            rewrite_for: None,
+        });
+
+        let wire = serde_json::to_value(
+            command
+                .clone()
+                .into_rpc_request("req-topic")
+                .expect("serialize"),
+        )
+        .expect("to_value");
+
+        assert_eq!(wire["params"]["topic"], json!("slides"));
+        assert!(
+            wire["params"].get("media").is_none(),
+            "empty media stays omitted"
+        );
+        assert!(
+            wire["params"].get("rewrite_for").is_none(),
+            "absent rewrite_for stays omitted"
+        );
+
+        let decoded_request: RpcRequest<Value> = serde_json::from_value(wire).expect("deserialize");
+        let decoded = UiCommand::from_rpc_request(decoded_request).expect("parse");
+        assert_eq!(decoded, command);
+    }
+
+    /// UPCR-2026-015 (M9-β-1): `rewrite_for` carries the
+    /// `client_message_id` of an existing queued user message that
+    /// this turn replaces in place (the `/queue` slash-command flow).
+    #[test]
+    fn turn_start_round_trips_with_rewrite_for_field() {
+        let command = UiCommand::TurnStart(TurnStartParams {
+            session_id: SessionKey("local:demo".into()),
+            turn_id: TurnId(Uuid::from_u128(4)),
+            input: vec![InputItem::Text {
+                text: "edited prompt".into(),
+            }],
+            media: Vec::new(),
+            topic: None,
+            rewrite_for: Some("cmid-queued-original".into()),
+        });
+
+        let wire = serde_json::to_value(
+            command
+                .clone()
+                .into_rpc_request("req-rewrite")
+                .expect("serialize"),
+        )
+        .expect("to_value");
+
+        assert_eq!(wire["params"]["rewrite_for"], json!("cmid-queued-original"));
+        assert!(
+            wire["params"].get("media").is_none(),
+            "empty media stays omitted"
+        );
+        assert!(
+            wire["params"].get("topic").is_none(),
+            "absent topic stays omitted"
+        );
+
+        let decoded_request: RpcRequest<Value> = serde_json::from_value(wire).expect("deserialize");
+        let decoded = UiCommand::from_rpc_request(decoded_request).expect("parse");
+        assert_eq!(decoded, command);
+    }
+
+    /// UPCR-2026-015 (M9-β-1): the three β-1 fields can co-exist on
+    /// one envelope (e.g. a `/queue` rewrite that swaps in new media
+    /// and lands under a topic-scoped session). All three round-trip
+    /// together.
+    #[test]
+    fn turn_start_round_trips_with_all_beta1_fields() {
+        let command = UiCommand::TurnStart(TurnStartParams {
+            session_id: SessionKey("local:demo".into()),
+            turn_id: TurnId(Uuid::from_u128(5)),
+            input: vec![InputItem::Text {
+                text: "redo with this image".into(),
+            }],
+            media: vec![FileRef {
+                path: "/tmp/replacement.png".into(),
+                mime: "image/png".into(),
+                size_bytes: 8192,
+            }],
+            topic: Some("research".into()),
+            rewrite_for: Some("cmid-original".into()),
+        });
+
+        let wire = serde_json::to_value(
+            command
+                .clone()
+                .into_rpc_request("req-all")
+                .expect("serialize"),
+        )
+        .expect("to_value");
+
+        assert_eq!(wire["params"]["topic"], json!("research"));
+        assert_eq!(wire["params"]["rewrite_for"], json!("cmid-original"));
+        let media = wire["params"]["media"].as_array().expect("media");
+        assert_eq!(media.len(), 1);
+        assert_eq!(media[0]["path"], json!("/tmp/replacement.png"));
+
+        let decoded_request: RpcRequest<Value> = serde_json::from_value(wire).expect("deserialize");
+        let decoded = UiCommand::from_rpc_request(decoded_request).expect("parse");
         assert_eq!(decoded, command);
     }
 

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_015_TURN_START_MEDIA_TOPIC_REWRITE.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_015_TURN_START_MEDIA_TOPIC_REWRITE.md
@@ -1,0 +1,149 @@
+# Octos UI Protocol Change Request: `turn/start` media + topic + rewrite_for fields
+
+## Header
+
+- Request id: `UPCR-2026-015`
+- Title: Extend `TurnStartParams` with optional `media: Vec<FileRef>`, `topic: Option<String>`, and `rewrite_for: Option<String>` to restore three chat-flow features stubbed out by the M9-α-5/α-6 atomic SSE delete
+- Author: M9-β-1 worker (coding-green)
+- Date: 2026-05-10
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related issues: `#834` (web-side α-5/α-6 stubs), `#845` (atomic SSE delete audit), follow-up note in `octos-web-live/src/runtime/ui-protocol-send.ts:81-92`
+- Related ADR: M9-α SSE-removal ADR (PR #830)
+- Sibling UPCRs: `UPCR-2026-014` (M9-γ projection envelope — defines the `FileRef` shape this UPCR reuses)
+
+## Summary
+
+This change request adds three optional fields to the existing `turn/start` JSON-RPC command's `TurnStartParams` to restore three chat-flow features that the legacy SSE `chatSSE()` body carried but the WebSocket UI Protocol shape (`bridge.sendTurn`) did not:
+
+1. `media: Vec<FileRef>` — pre-uploaded image / voice / file references the user attached to the send. The web client uploads via `POST /api/upload` first; the returned paths are echoed here. Each entry mirrors the canonical `FileRef` shape (`path`, `mime`, `size_bytes`) introduced for `Payload::UserMessage.files` in UPCR-2026-014.
+2. `topic: Option<String>` — sub-topic suffix that scopes this send to a per-topic session bucket (`<session>#<topic>` shape). The server folds it into the resolved `SessionKey` before scope validation, so history lookup, ledger appends, and `task/list` filtering all see the right bucket.
+3. `rewrite_for: Option<String>` — `client_message_id` of an existing queued user message that this turn replaces in place rather than appending a new turn. Used by the SPA's `/queue` slash-command flow when the user edits a queued prompt before it dispatches.
+
+The change is strictly additive: no existing method, notification, payload, enum variant, required field, or capability bit is modified. Pre-β-1 servers and clients see exactly the bytes they used to.
+
+## Motivation
+
+M9-α-5/α-6 (PR #830) deleted the legacy SSE chat transport (`chatSSE()` + `/api/sessions/{id}/events/stream`). The rationale for the atomic delete was correct — SSE for live text was buggy under M10-class race conditions, and the full WebSocket UI Protocol replaced it for streaming.
+
+But three chat-flow features rode along on the SSE request body that the WS shape `TurnStartInput { kind: "text", text: string }` did not carry:
+
+- `media: MediaRef[]` — image / voice / file attachments
+- `topic` — query/body field routing the send to a topic-scoped session bucket
+- `rewrite_for` (legacy `request_text` semantic via the `/queue` slash-command) — the server-side rewrite of the queued user prompt
+
+The α-5/α-6 web-side closed PR #834 surfaced this gap by replacing the affected sends with three explicit error strings in `octos-web-live/src/runtime/ui-protocol-send.ts:83-89`:
+
+```text
+"media uploads are not yet supported on the WS chat transport
+ (follow-up: M9-β extension to TurnStartInput)"
+"`/queue`-style rewrites are not yet supported on the WS chat transport
+ (follow-up: M9-β extension to TurnStartInput)"
+"topic-scoped sends are not yet supported on the WS chat transport
+ (follow-up: M9-β extension to session/open / TurnStartInput)"
+```
+
+This UPCR is the M9-β-1 follow-up the comments point at: extend the `TurnStartParams` envelope, restore the server plumbing, and remove the three error strings on the web side.
+
+## Change Type
+
+Additive command params. Three optional fields on the existing `turn/start` command. No new methods, notifications, capability flags, or wire-level types. The reused `FileRef` type lands once in UPCR-2026-014 (M9-γ-1, accepted) and is referenced here.
+
+## Wire Contract
+
+Affected wire surface — strictly additive:
+
+- Command params: `TurnStartParams` gains three optional fields (each tagged with serde `skip_serializing_if = "..."` so default values are omitted on the wire).
+
+### `TurnStartParams` (extension)
+
+```jsonc
+{
+  "session_id": "<SessionKey>",
+  "turn_id": "<TurnId>",
+  "input": [{ "kind": "text", "text": "..." }],
+
+  // ── M9-β-1 additions (UPCR-2026-015) ────────────────────────────
+  "media":       [{ "path": "/tmp/...png", "mime": "image/png", "size_bytes": 4096 }],
+  "topic":       "research",
+  "rewrite_for": "<client_message_id-of-queued-prompt>"
+}
+```
+
+All three fields are absent on the wire when at their default (empty `Vec` / `None`). A server that does not understand the additions ignores them; a client that does not populate them sends exactly the bytes a pre-β-1 build would send. This is the strict-additive back-compat contract the M9 merge train relies on.
+
+`FileRef` shape — re-used verbatim from UPCR-2026-014:
+
+```jsonc
+{
+  "path":       "<server-resolvable filesystem path returned by POST /api/upload>",
+  "mime":       "image/png | audio/mpeg | application/pdf | ...",
+  "size_bytes": 4096
+}
+```
+
+### Server-side fold rules
+
+- `topic`: when present and non-empty, the server replaces the resolved `SessionKey` with `<base_key>#<topic>` BEFORE scope validation. Empty / whitespace-only topics fall through to the bare session shape (matching `SessionKey::with_topic`'s own short-circuit). A client that already encoded `#topic` in `session_id` can still send a separate `topic` field — the server splices the existing suffix away first so the canonical form on the wire-trip back to clients is `<base>#<topic>` exactly once.
+- `media`: paths are passed verbatim into `Agent::process_message(prompt, history, media_paths)` — the same entry the gateway-mode `ApiChannel` and the `octos chat` CLI use. `process_message` already handles them.
+- `rewrite_for`: the β-1 server logs the field at debug level for observability and forwards the prompt through the standard turn pipeline. The durable in-place ledger replace path is a follow-up (sibling issue, deferred per the β-1 scope envelope) — the wire field is locked here so client behaviour is forward-compatible with the deferred persist plumbing.
+
+## Feature Flag
+
+This UPCR does NOT add a capability flag. The fields are strict-additive optionals on an existing command — old clients send bytes that look exactly like a pre-β-1 build (the new fields skip-when-empty), and old servers that don't deserialize the new keys ignore them via serde's default `#[serde(default)]` semantics. A negotiation gate is unnecessary.
+
+## Server impl
+
+Lands in:
+
+- `crates/octos-core/src/ui_protocol.rs` — `TurnStartParams` struct gains the three fields (with serde `skip_serializing_if` annotations); golden round-trip tests cover each field in isolation and all three together.
+- `crates/octos-cli/src/api/ui_protocol.rs::handle_turn_start` — folds `params.topic` into `params.session_id` BEFORE `validate_session_scope`; passes `params.media[*].path` into `Agent::process_message` as a `Vec<String>`; logs `params.rewrite_for` at debug level.
+
+Tests landing alongside:
+
+- `cargo test -p octos-core ui_protocol::tests` — four new round-trip tests:
+  - `turn_start_round_trips_with_media_field`
+  - `turn_start_round_trips_with_topic_field`
+  - `turn_start_round_trips_with_rewrite_for_field`
+  - `turn_start_round_trips_with_all_beta1_fields`
+- `cargo test -p octos-cli api::ui_protocol::tests` — two new acceptance tests:
+  - `parses_turn_start_rpc_request_with_beta1_fields`
+  - `parses_legacy_turn_start_rpc_request_stays_back_compat`
+
+These lock the wire shape (serde round-trip, snake_case discriminator presence, optional-field omission on the wire when at defaults).
+
+## Client-side
+
+TS counterparts land in `octos-web/src/runtime/ui-protocol-types.ts` and `ui-protocol-bridge.ts`. The three error strings in `ui-protocol-send.ts:83-89` are deleted; sends populate the new fields directly.
+
+## Rollout
+
+- **β-1 (this UPCR)**: Rust struct extension + server fold + TS types + `bridge.sendTurn` plumbing. Status flips to `accepted` once the server PR lands.
+- **Follow-up (deferred)**: durable in-place ledger replace for `rewrite_for`. Lives in a sibling β-N issue. The wire field is forward-compatible — when the persist path lands, no client change is required.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `topic` fold collides with a session_id that already encodes `#topic` | Low | The server splices any existing `#suffix` away from the base before re-applying, so the canonical form on the wire-trip back is `<base>#<topic>` exactly once. Test coverage in `parses_turn_start_rpc_request_with_beta1_fields`. |
+| `rewrite_for` is wire-locked but ledger-replace is deferred | Low | The field is logged at debug level and the prompt is forwarded through the standard pipeline. From the user's perspective the rewrite is a normal new turn — slightly worse than a true in-place replace, but no functional regression vs the α-5/α-6 stub (which surfaced a hard error). The follow-up that adds durable replace is purely server-side. |
+| Old clients send bytes that don't include the new fields | None | Strict-additive shape; serde `#[serde(default)]` + `skip_serializing_if` keep the on-wire form identical to a pre-β-1 build. Verified by `parses_legacy_turn_start_rpc_request_stays_back_compat`. |
+| Old servers receive a frame with the new fields | None | Old servers that don't know `media` / `topic` / `rewrite_for` ignore them at deserialize time. The send reduces to a text-only turn, exactly matching pre-β-1 behaviour. |
+
+## Open Questions
+
+- Should `media` carry an optional per-attachment `caption` field? **Decision**: no for v1 — the SPA's existing `localFiles` shape carries a caption that's never read on the server side; restoring server-side carry is out of scope for β-1 (the user-bubble caption is purely client-rendered today).
+- Should `rewrite_for` be enforced server-side (reject when no matching queued cmid exists)? **Decision**: no for v1 — best-effort log for now; the durable replace path (deferred follow-up) will add the enforcement when it lands.
+- Should `topic` be carried on `session/open` too (so the bridge knows the topic at handshake time)? **Decision**: out of scope for β-1 — the client today opens a bare-session bridge and varies topic per-send. If the active-bridge bookkeeping ever needs topic awareness for a future feature, the additive change there is independent of β-1.
+
+## Acceptance Criteria
+
+- [x] `TurnStartParams` Rust struct gains the three fields with the documented serde annotations.
+- [x] `octos-core::ui_protocol::tests` covers the four new round-trip cases.
+- [x] `octos-cli::api::ui_protocol::tests` covers the two new acceptance cases (and the legacy-shape back-compat case).
+- [x] `handle_turn_start` folds `topic` into `session_id` before scope validation.
+- [x] `run_standalone_turn` passes `media[*].path` into `Agent::process_message`.
+- [x] `octos-web/src/runtime/ui-protocol-types.ts::TurnStartInput` and `bridge.sendTurn` propagate the new fields.
+- [x] The three error strings at `octos-web-live/src/runtime/ui-protocol-send.ts:83-89` are deleted.
+- [x] No existing test broken by the additive change (full `cargo test -p octos-core` + `cargo test -p octos-cli --features api --lib` green).
+- [x] Status flipped to `accepted` once the server PR lands; web PR opened second per the M9 dependency rule (server wire shape is locked first).


### PR DESCRIPTION
## Summary

UPCR-2026-015 lands the strict-additive `TurnStartParams` extension that restores the three chat-flow features the α-5/α-6 atomic SSE delete stubbed out at `octos-web-live/src/runtime/ui-protocol-send.ts:81-92`:

- `media: Vec<FileRef>` — pre-uploaded image / voice / file references the user attached. The `FileRef` shape mirrors `Payload::UserMessage.files` from γ-1 (UPCR-2026-014).
- `topic: Option<String>` — sub-topic suffix the server folds into the resolved `SessionKey` BEFORE scope validation, so history lookup, ledger appends, and `task/list` filtering all see the per-topic bucket automatically.
- `rewrite_for: Option<String>` — `client_message_id` of an existing queued user message this turn replaces (the SPA `/queue` slash-command flow). β-1 logs the field at debug level and forwards the prompt through the standard pipeline; the durable in-place ledger replace path is a deferred follow-up.

All three fields are skip-when-empty / skip-when-None on the wire — old clients send identical bytes, old servers ignore the new keys at deserialize time. Strict-additive, no capability flag needed.

## Server plumbing in `handle_turn_start`

- folds `params.topic` into `params.session_id` (splices any existing `#suffix` away first so the canonical form is `<base>#<topic>` exactly once)
- pulls `params.media[*].path` into `Vec<String>` and feeds it to `Agent::process_message` (the same entry the gateway and `octos chat` CLI use)
- emits a debug trace for `params.rewrite_for` so observability is preserved while the in-place replace path is deferred

## Test plan

- [x] `cargo test -p octos-core` — 4 new round-trip goldens; 184 pass.
- [x] `cargo test -p octos-cli --features api --lib` — 2 new acceptance cases; 918 pass.
- [x] `cargo clippy -p octos-core --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual probe via the sibling `octos-web` PR
- [ ] 9-scenario soak gate on mini1 / mini2 / mini3

## Wire shape

```jsonc
{
  "method": "turn/start",
  "params": {
    "session_id": "local:demo",
    "turn_id": "<TurnId>",
    "input": [{ "kind": "text", "text": "redo with this image" }],
    "media": [{ "path": "/tmp/upload.png", "mime": "image/png", "size_bytes": 4096 }],
    "topic": "research",
    "rewrite_for": "cmid-original"
  }
}
```

## Related

- UPCR-2026-015 — `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_015_TURN_START_MEDIA_TOPIC_REWRITE.md`
- UPCR-2026-014 (γ-1, accepted) — `FileRef` reuse
- #834 — web-side α-5/α-6 stubs the β-1 closes
- PR #855 — atomic SSE delete this is the follow-up to

## Sibling

The web PR deletes the three error strings and populates the new fields. Opened second per the M9 dependency rule — server wire shape locks first.