### PR TITLE
fix(voice): accept `voice` as alias for `speaker` in voice_synthesize

### DIFF
--- a/crates/platform-skills/voice/src/main.rs
+++ b/crates/platform-skills/voice/src/main.rs
@@ -30,7 +30,18 @@ struct SynthesizeInput {
     output_path: Option<String>,
     #[serde(default)]
     language: Option<String>,
-    #[serde(default)]
+    /// LLMs (especially deepseek-chat) naturally call this with `voice`
+    /// as the parameter name — it matches user phrasing like
+    /// "用 vivian 的声音说…" and the `fm_tts` tool's `voice` field.
+    /// Without the alias the call silently drops the LLM's `voice`
+    /// argument and `speaker` defaults to `vivian`, silently
+    /// substituting any non-preset voice (e.g. `yangmi`) without error.
+    /// Observed live on mini1 2026-05-10: users repeatedly asked for
+    /// `yangmi`, got `vivian` back with no warning. The Qwen3-TTS
+    /// rejection path (which emits the "use fm_tts" hint) only fires
+    /// when the non-preset name actually reaches ominix-api, which the
+    /// silent default prevented.
+    #[serde(default, alias = "voice")]
     speaker: Option<String>,
     /// Style/emotion prompt (e.g. "用兴奋激动的语气说话，充满热情和活力")
     #[serde(default)]


### PR DESCRIPTION
## Summary

`voice_synthesize`'s input struct uses `speaker` as the voice-name field; LLMs naturally call it with `voice` (matching user phrasing and the symmetric `fm_tts` field). The mismatched key was silently dropped, `speaker` fell back to default `vivian`, and any non-preset voice request (yangmi, douwentao, etc.) was substituted with vivian — `success: true`, no warning to the LLM, user gets the wrong voice.

Add `#[serde(alias = "voice")]` so the binary accepts both keys. Already-correct callers using `speaker` keep working unchanged.

## Live evidence (mini1, 2026-05-10)

Before the fix, direct probe:
```
echo '{"text":"测试","voice":"yangmi"}' | voice main voice_synthesize
→ {"output":"Generated audio: tts_xxx.mp3 (0.4s, 19244 bytes)…","success":true}
  stderr: "Synthesizing with preset voice 'vivian'..."   ← silent swap
```

After the fix:
```
echo '{"text":"测试","voice":"yangmi"}' | voice main voice_synthesize
→ {"output":"TTS failed: Qwen3-TTS rejected request for voice 'yangmi':
              TTS returned empty response. Preset voices only include 
              vivian, serena, ryan, aiden, eric, dylan, uncle_fu, ono_anna,
              sohee. For custom / cloned voices use `fm_tts` from the
              mofa-fm skill.","success":false}
```

LLM now sees the routing hint and re-dispatches to `fm_tts`.

## Test plan

- [x] Build: `cargo build --release -p voice` succeeds.
- [x] Live probe on mini1/2/3 with both `{voice: "yangmi"}` and `{voice: "vivian"}` paths — non-preset fails-loud with the fm_tts hint; preset succeeds normally.
- [ ] Browser chat probe: ask "用 yangmi 朗读 …" — agent should now pick fm_tts.