### PR TITLE
fix(serve): honor per-profile cfg.llm in web /chat agent

### DIFF
--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use clap::Args;
 use colored::Colorize;
 use eyre::{Result, WrapErr};
+use octos_agent::sandbox::BLOCKED_ENV_VARS;
 use octos_agent::{Agent, AgentConfig, HookExecutor, ToolRegistry};
 use octos_bus::SessionManager;
 use octos_core::AgentId;
@@ -241,9 +242,10 @@ fn select_serve_profile(
     if let Some(admin) = profiles
         .iter()
         .find(|p| p.id == crate::api::auth_handlers::ADMIN_PROFILE_ID)
-        && profile_has_active_primary_llm(admin)
     {
-        return Some(admin);
+        if profile_has_active_primary_llm(admin) {
+            return Some(admin);
+        }
     }
     profiles.iter().find(|p| profile_has_active_primary_llm(p))
 }
@@ -296,6 +298,93 @@ fn overlay_profile_llm(config: &mut Config, profiles: &[crate::profiles::UserPro
     config.fallback_models = profile_config.fallback_models;
     config.adaptive_routing = profile_config.adaptive_routing;
     config.content_routing = profile_config.content_routing;
+
+    // Inject the credentials the selected profile expects so
+    // `Config::get_api_key` can resolve them. The gateway path gets
+    // these via `ProcessManager` spawning a child with `cmd.env(...)`;
+    // the serve agent runs in-process and has no such hook, so without
+    // this step the overlay would still leave `/chat` with the wrong
+    // API key (e.g. profile says AUTODL_API_KEY but the serve parent
+    // process only has DEEPSEEK_API_KEY exported).
+    inject_profile_api_key_env(profile);
+}
+
+/// Set the API-key env vars referenced by the selected profile's primary
+/// + fallback routes from `profile.config.env_vars` into the current
+/// process environment, resolving any `keychain:` markers.
+///
+/// Only the env-var names actually referenced by `api_key_env` on the
+/// selected primary / fallbacks are injected — we don't shovel the
+/// entire `env_vars` map into the parent process. The set is bounded by
+/// the LLM contract and won't include unrelated channel/email/tool
+/// secrets.
+#[allow(unsafe_code)]
+fn inject_profile_api_key_env(profile: &crate::profiles::UserProfile) {
+    use std::collections::HashSet;
+
+    let llm = match profile.config.llm.as_ref() {
+        Some(llm) => llm,
+        None => return,
+    };
+
+    let mut wanted: HashSet<&str> = HashSet::new();
+    if let Some(primary) = llm.primary.as_ref() {
+        if let Some(env) = primary
+            .route
+            .as_ref()
+            .and_then(|r| r.api_key_env.as_deref())
+        {
+            wanted.insert(env);
+        }
+    }
+    for fb in &llm.fallbacks {
+        if let Some(env) = fb.route.as_ref().and_then(|r| r.api_key_env.as_deref()) {
+            wanted.insert(env);
+        }
+    }
+    if wanted.is_empty() {
+        return;
+    }
+
+    let resolved = crate::auth::keychain::resolve_env_vars(&profile.config.env_vars);
+    for env_name in wanted {
+        let Some(value) = resolved.get(env_name) else {
+            // Profile references this env var but didn't store it. Leave
+            // the parent process env as-is; `Config::get_api_key` will
+            // surface a clear error at first use.
+            tracing::debug!(
+                profile_id = %profile.id,
+                env_name,
+                "profile route references env var but no value in profile.env_vars"
+            );
+            continue;
+        };
+        if BLOCKED_ENV_VARS
+            .iter()
+            .any(|blocked| env_name.eq_ignore_ascii_case(blocked))
+        {
+            tracing::warn!(
+                profile_id = %profile.id,
+                env_name,
+                "skipping blocked env var injection from profile"
+            );
+            continue;
+        }
+        // SAFETY: serve runs this overlay during startup, before any
+        // tokio worker threads are spawned, so the process is still
+        // effectively single-threaded for env mutation purposes. We
+        // only inject env vars explicitly referenced by the profile's
+        // LLM routes (bounded set), and block the known-dangerous
+        // names via `BLOCKED_ENV_VARS`.
+        unsafe {
+            std::env::set_var(env_name, value);
+        }
+        tracing::info!(
+            profile_id = %profile.id,
+            env_name,
+            "injected profile-scoped API-key env var into serve process"
+        );
+    }
 }
 
 /// Start the REST API server.
@@ -2166,5 +2255,58 @@ mod tests {
             Some("moonshot"),
             "sub-account must be skipped in favor of top-level profile"
         );
+    }
+
+    /// Mutex serializing env-mutation tests in this module so concurrent
+    /// `cargo test` workers don't race the parent process env.
+    fn env_inject_lock() -> &'static std::sync::Mutex<()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn overlay_profile_llm_injects_profile_api_key_env_into_process() {
+        let _guard = env_inject_lock().lock().unwrap();
+        const ENV_NAME: &str = "OCTOS_TEST_PROFILE_LLM_INJECTION";
+        // SAFETY: serialized via `env_inject_lock`.
+        unsafe {
+            std::env::remove_var(ENV_NAME);
+        }
+
+        let mut config = Config::default();
+        let mut profile = make_profile_with_llm(
+            "dspfac",
+            true,
+            "moonshot",
+            "kimi-k2.5",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        );
+        // Point the primary route at our unique env name and store the
+        // literal value in profile.env_vars.
+        if let Some(llm) = profile.config.llm.as_mut() {
+            if let Some(primary) = llm.primary.as_mut() {
+                if let Some(route) = primary.route.as_mut() {
+                    route.api_key_env = Some(ENV_NAME.into());
+                }
+            }
+        }
+        profile
+            .config
+            .env_vars
+            .insert(ENV_NAME.into(), "sk-from-profile".into());
+
+        overlay_profile_llm(&mut config, &[profile]);
+
+        let injected = std::env::var(ENV_NAME)
+            .expect("overlay must inject the profile's api_key_env into the process env");
+        assert_eq!(injected, "sk-from-profile");
+
+        // SAFETY: serialized via `env_inject_lock`; cleanup.
+        unsafe {
+            std::env::remove_var(ENV_NAME);
+        }
     }
 }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -209,6 +209,72 @@ fn resolve_dashboard_auth_smtp_password(
     None
 }
 
+/// Overlay per-profile `cfg.llm` selection onto the top-level [`Config`].
+///
+/// The serve agent historically only read `~/.octos/config.json`'s flat
+/// `provider`/`model` fields, ignoring the structured `llm.primary` +
+/// `llm.fallbacks` that the dashboard writes into per-profile JSON. The
+/// `gateway` command goes through [`crate::profiles::config_from_profile`]
+/// to honor those — `serve` did not, so the web `/chat` endpoint always
+/// used the bare top-level provider even when the dashboard had moonshot
+/// or minimax configured.
+///
+/// This helper picks the first profile that is `enabled` and has a fully
+/// populated `llm.primary` (family + model), reuses `config_from_profile`
+/// to produce a profile-derived [`Config`], and overlays the LLM-shaped
+/// fields onto the loaded top-level config. Non-LLM fields (auth, hosts,
+/// dashboard auth, hooks) are left untouched.
+fn overlay_profile_llm(config: &mut Config, profiles: &[crate::profiles::UserProfile]) {
+    let active = profiles.iter().find(|p| {
+        p.enabled
+            && p.config
+                .llm
+                .as_ref()
+                .and_then(|llm| llm.primary.as_ref())
+                .is_some_and(|sel| sel.family_id.is_some() && sel.model_id.is_some())
+    });
+    let Some(profile) = active else {
+        tracing::debug!("no enabled profile with primary LLM selection — keeping top-level config");
+        return;
+    };
+
+    let profile_config = crate::profiles::config_from_profile(profile, None, None);
+    tracing::info!(
+        profile_id = %profile.id,
+        provider = ?profile_config.provider,
+        model = ?profile_config.model,
+        base_url = ?profile_config.base_url,
+        api_key_env = ?profile_config.api_key_env,
+        fallback_models = profile_config.fallback_models.len(),
+        "overlaying per-profile LLM config onto top-level config for serve agent"
+    );
+
+    if let Some(p) = profile_config.provider {
+        config.provider = Some(p);
+    }
+    if let Some(m) = profile_config.model {
+        config.model = Some(m);
+    }
+    if let Some(b) = profile_config.base_url {
+        config.base_url = Some(b);
+    }
+    if let Some(k) = profile_config.api_key_env {
+        config.api_key_env = Some(k);
+    }
+    if let Some(t) = profile_config.api_type {
+        config.api_type = Some(t);
+    }
+    if profile_config.model_hints.is_some() {
+        config.model_hints = profile_config.model_hints;
+    }
+    if !profile_config.fallback_models.is_empty() {
+        config.fallback_models = profile_config.fallback_models;
+    }
+    if profile_config.adaptive_routing.is_some() {
+        config.adaptive_routing = profile_config.adaptive_routing;
+    }
+}
+
 /// Start the REST API server.
 #[derive(Debug, Args)]
 pub struct ServeCommand {
@@ -292,13 +358,30 @@ impl ServeCommand {
         // runtime state and config unless an explicit --config path is given.
         let data_dir = super::resolve_data_dir(self.data_dir.clone())?;
 
-        let (config, resolved_config_path) = if let Some(config_path) = &self.config {
+        let (mut config, resolved_config_path) = if let Some(config_path) = &self.config {
             tracing::info!(path = %config_path.display(), "loading config (--config)");
             (Config::from_file(config_path)?, Some(config_path.clone()))
         } else {
             Config::load_with_path(&cwd, &data_dir)?
         };
         tracing::info!(data_dir = %data_dir.display(), "data directory resolved");
+
+        // Overlay per-profile LLM config onto the top-level Config so the
+        // serve agent uses the dashboard-configured providers, not the bare
+        // `provider`/`model` fallback in `~/.octos/config.json`.
+        // See `overlay_profile_llm` for the rationale and contract.
+        match crate::profiles::ProfileStore::open(&data_dir) {
+            Ok(store) => {
+                let profiles = store.list().unwrap_or_default();
+                overlay_profile_llm(&mut config, &profiles);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "failed to open profile store for LLM overlay — falling back to top-level config"
+                );
+            }
+        }
 
         let broadcaster = Arc::new(EventBroadcaster::new(256));
 
@@ -1713,5 +1796,149 @@ mod tests {
              outcome was: {:?}",
             outcome.per_task_outcomes[0]
         );
+    }
+
+    fn make_profile_with_llm(
+        id: &str,
+        enabled: bool,
+        primary_family: &str,
+        primary_model: &str,
+        fallback_family: &str,
+        fallback_model: &str,
+    ) -> crate::profiles::UserProfile {
+        crate::profiles::UserProfile {
+            id: id.into(),
+            name: id.into(),
+            public_subdomain: None,
+            enabled,
+            data_dir: None,
+            parent_id: None,
+            config: crate::profiles::ProfileConfig {
+                llm: Some(crate::profiles::LlmProfileConfig {
+                    primary: Some(crate::profiles::LlmModelSelectionConfig {
+                        family_id: Some(primary_family.into()),
+                        model_id: Some(primary_model.into()),
+                        route: Some(crate::profiles::LlmRouteConfig {
+                            route_id: None,
+                            label: None,
+                            base_url: Some("https://primary.example.com/v1".into()),
+                            api_key_env: Some("PRIMARY_KEY".into()),
+                            api_type: None,
+                        }),
+                        model_hints: None,
+                        cost_per_m: None,
+                        strong: None,
+                    }),
+                    fallbacks: vec![crate::profiles::LlmModelSelectionConfig {
+                        family_id: Some(fallback_family.into()),
+                        model_id: Some(fallback_model.into()),
+                        route: Some(crate::profiles::LlmRouteConfig {
+                            route_id: None,
+                            label: None,
+                            base_url: Some("https://fallback.example.com/v1".into()),
+                            api_key_env: Some("FALLBACK_KEY".into()),
+                            api_type: None,
+                        }),
+                        model_hints: None,
+                        cost_per_m: None,
+                        strong: Some(true),
+                    }],
+                }),
+                ..Default::default()
+            },
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn overlay_profile_llm_applies_enabled_profile_primary_and_fallbacks() {
+        let mut config = Config {
+            provider: Some("deepseek".into()),
+            model: Some("deepseek-chat".into()),
+            ..Default::default()
+        };
+        let profiles = vec![make_profile_with_llm(
+            "dspfac",
+            true,
+            "moonshot",
+            "kimi-k2.5",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        )];
+
+        overlay_profile_llm(&mut config, &profiles);
+
+        assert_eq!(config.provider.as_deref(), Some("moonshot"));
+        assert_eq!(config.model.as_deref(), Some("kimi-k2.5"));
+        assert_eq!(
+            config.base_url.as_deref(),
+            Some("https://primary.example.com/v1")
+        );
+        assert_eq!(config.api_key_env.as_deref(), Some("PRIMARY_KEY"));
+        assert_eq!(config.fallback_models.len(), 1);
+        assert_eq!(config.fallback_models[0].provider, "minimax");
+        assert_eq!(
+            config.fallback_models[0].model.as_deref(),
+            Some("MiniMax-M2.5-highspeed")
+        );
+    }
+
+    #[test]
+    fn overlay_profile_llm_keeps_top_level_when_no_enabled_profile() {
+        let mut config = Config {
+            provider: Some("deepseek".into()),
+            model: Some("deepseek-chat".into()),
+            ..Default::default()
+        };
+        let profiles = vec![make_profile_with_llm(
+            "dspfac",
+            false, // disabled
+            "moonshot",
+            "kimi-k2.5",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        )];
+
+        overlay_profile_llm(&mut config, &profiles);
+
+        assert_eq!(config.provider.as_deref(), Some("deepseek"));
+        assert_eq!(config.model.as_deref(), Some("deepseek-chat"));
+        assert!(config.fallback_models.is_empty());
+    }
+
+    #[test]
+    fn overlay_profile_llm_skips_profiles_missing_primary_model() {
+        let mut config = Config {
+            provider: Some("deepseek".into()),
+            model: Some("deepseek-chat".into()),
+            ..Default::default()
+        };
+        let incomplete = crate::profiles::UserProfile {
+            id: "partial".into(),
+            name: "partial".into(),
+            public_subdomain: None,
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            config: crate::profiles::ProfileConfig {
+                llm: Some(crate::profiles::LlmProfileConfig {
+                    primary: Some(crate::profiles::LlmModelSelectionConfig {
+                        family_id: Some("moonshot".into()),
+                        model_id: None, // missing
+                        ..Default::default()
+                    }),
+                    fallbacks: vec![],
+                }),
+                ..Default::default()
+            },
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        overlay_profile_llm(&mut config, &[incomplete]);
+
+        assert_eq!(config.provider.as_deref(), Some("deepseek"));
+        assert_eq!(config.model.as_deref(), Some("deepseek-chat"));
     }
 }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use clap::Args;
 use colored::Colorize;
 use eyre::{Result, WrapErr};
-use octos_agent::sandbox::BLOCKED_ENV_VARS;
 use octos_agent::{Agent, AgentConfig, HookExecutor, ToolRegistry};
 use octos_bus::SessionManager;
 use octos_core::AgentId;
@@ -299,47 +298,44 @@ fn overlay_profile_llm(config: &mut Config, profiles: &[crate::profiles::UserPro
     config.adaptive_routing = profile_config.adaptive_routing;
     config.content_routing = profile_config.content_routing;
 
-    // Inject the credentials the selected profile expects so
-    // `Config::get_api_key` can resolve them. The gateway path gets
-    // these via `ProcessManager` spawning a child with `cmd.env(...)`;
-    // the serve agent runs in-process and has no such hook, so without
-    // this step the overlay would still leave `/chat` with the wrong
-    // API key (e.g. profile says AUTODL_API_KEY but the serve parent
-    // process only has DEEPSEEK_API_KEY exported).
-    inject_profile_api_key_env(profile);
+    // Pre-resolve the credentials the selected profile expects and
+    // stash them on `Config::credentials`. The gateway path gets these
+    // via `ProcessManager` spawning a child with `cmd.env(...)`; the
+    // serve agent runs in-process. Rather than mutate the shared
+    // parent-process environment (racy under the multi-threaded tokio
+    // runtime, and a privilege-escalation surface if a profile field
+    // names PATH/OCTOS_AUTH_TOKEN/etc.), we keep the secrets local to
+    // the agent's `Config` and let `Config::get_api_key` consult them
+    // before falling back to `std::env::var`.
+    populate_profile_credentials(profile, config);
 }
 
-/// Set the API-key env vars referenced by the selected profile's primary
-/// + fallback routes from `profile.config.env_vars` into the current
-/// process environment, resolving any `keychain:` markers.
-///
-/// Only the env-var names actually referenced by `api_key_env` on the
-/// selected primary / fallbacks are injected — we don't shovel the
-/// entire `env_vars` map into the parent process. The set is bounded by
-/// the LLM contract and won't include unrelated channel/email/tool
-/// secrets.
-#[allow(unsafe_code)]
-fn inject_profile_api_key_env(profile: &crate::profiles::UserProfile) {
+/// Resolve the API-key env-var values the selected profile expects (via
+/// `keychain::resolve_env_vars` to expand `keychain:` markers) and
+/// stash them on `Config::credentials`. Only env-var names explicitly
+/// listed on the profile's `llm.primary.route.api_key_env` or any
+/// `llm.fallbacks[].route.api_key_env` are pulled across — we never
+/// flood `Config::credentials` with the entire `profile.env_vars` map.
+fn populate_profile_credentials(profile: &crate::profiles::UserProfile, config: &mut Config) {
     use std::collections::HashSet;
 
-    let llm = match profile.config.llm.as_ref() {
-        Some(llm) => llm,
-        None => return,
+    let Some(llm) = profile.config.llm.as_ref() else {
+        return;
     };
 
-    let mut wanted: HashSet<&str> = HashSet::new();
+    let mut wanted: HashSet<String> = HashSet::new();
     if let Some(primary) = llm.primary.as_ref() {
         if let Some(env) = primary
             .route
             .as_ref()
             .and_then(|r| r.api_key_env.as_deref())
         {
-            wanted.insert(env);
+            wanted.insert(env.to_string());
         }
     }
     for fb in &llm.fallbacks {
         if let Some(env) = fb.route.as_ref().and_then(|r| r.api_key_env.as_deref()) {
-            wanted.insert(env);
+            wanted.insert(env.to_string());
         }
     }
     if wanted.is_empty() {
@@ -348,10 +344,7 @@ fn inject_profile_api_key_env(profile: &crate::profiles::UserProfile) {
 
     let resolved = crate::auth::keychain::resolve_env_vars(&profile.config.env_vars);
     for env_name in wanted {
-        let Some(value) = resolved.get(env_name) else {
-            // Profile references this env var but didn't store it. Leave
-            // the parent process env as-is; `Config::get_api_key` will
-            // surface a clear error at first use.
+        let Some(value) = resolved.get(&env_name) else {
             tracing::debug!(
                 profile_id = %profile.id,
                 env_name,
@@ -359,30 +352,11 @@ fn inject_profile_api_key_env(profile: &crate::profiles::UserProfile) {
             );
             continue;
         };
-        if BLOCKED_ENV_VARS
-            .iter()
-            .any(|blocked| env_name.eq_ignore_ascii_case(blocked))
-        {
-            tracing::warn!(
-                profile_id = %profile.id,
-                env_name,
-                "skipping blocked env var injection from profile"
-            );
-            continue;
-        }
-        // SAFETY: serve runs this overlay during startup, before any
-        // tokio worker threads are spawned, so the process is still
-        // effectively single-threaded for env mutation purposes. We
-        // only inject env vars explicitly referenced by the profile's
-        // LLM routes (bounded set), and block the known-dangerous
-        // names via `BLOCKED_ENV_VARS`.
-        unsafe {
-            std::env::set_var(env_name, value);
-        }
+        config.credentials.insert(env_name.clone(), value.clone());
         tracing::info!(
             profile_id = %profile.id,
-            env_name,
-            "injected profile-scoped API-key env var into serve process"
+            env_name = %env_name,
+            "stashed profile-scoped credential on Config::credentials"
         );
     }
 }
@@ -1062,13 +1036,14 @@ impl ServeCommand {
             let mut providers: Vec<Arc<dyn LlmProvider>> =
                 vec![Arc::new(RetryProvider::new(base_provider))];
             for fb in &config.fallback_models {
-                let fb_config = if fb.api_key_env.is_some() {
-                    let mut c = config.clone();
-                    c.api_key_env = fb.api_key_env.clone();
-                    c
-                } else {
-                    config.clone()
-                };
+                // Clone the config but always swap in this fallback's
+                // own `api_key_env`. When the fallback omits it, we
+                // clear the primary's `api_key_env` so the registry
+                // default kicks in — otherwise a cross-provider
+                // fallback (e.g. deepseek behind moonshot) would try
+                // to use the primary's AUTODL_API_KEY for DeepSeek.
+                let mut fb_config = config.clone();
+                fb_config.api_key_env = fb.api_key_env.clone();
                 match create_provider_with_api_type(
                     &fb.provider,
                     &fb_config,
@@ -2257,24 +2232,8 @@ mod tests {
         );
     }
 
-    /// Mutex serializing env-mutation tests in this module so concurrent
-    /// `cargo test` workers don't race the parent process env.
-    fn env_inject_lock() -> &'static std::sync::Mutex<()> {
-        use std::sync::{Mutex, OnceLock};
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
     #[test]
-    #[allow(unsafe_code)]
-    fn overlay_profile_llm_injects_profile_api_key_env_into_process() {
-        let _guard = env_inject_lock().lock().unwrap();
-        const ENV_NAME: &str = "OCTOS_TEST_PROFILE_LLM_INJECTION";
-        // SAFETY: serialized via `env_inject_lock`.
-        unsafe {
-            std::env::remove_var(ENV_NAME);
-        }
-
+    fn overlay_profile_llm_stashes_profile_api_key_into_config_credentials() {
         let mut config = Config::default();
         let mut profile = make_profile_with_llm(
             "dspfac",
@@ -2284,29 +2243,68 @@ mod tests {
             "minimax",
             "MiniMax-M2.5-highspeed",
         );
-        // Point the primary route at our unique env name and store the
-        // literal value in profile.env_vars.
         if let Some(llm) = profile.config.llm.as_mut() {
             if let Some(primary) = llm.primary.as_mut() {
                 if let Some(route) = primary.route.as_mut() {
-                    route.api_key_env = Some(ENV_NAME.into());
+                    route.api_key_env = Some("PRIMARY_KEY".into());
+                }
+            }
+            if let Some(fb) = llm.fallbacks.first_mut() {
+                if let Some(route) = fb.route.as_mut() {
+                    route.api_key_env = Some("FALLBACK_KEY".into());
                 }
             }
         }
         profile
             .config
             .env_vars
-            .insert(ENV_NAME.into(), "sk-from-profile".into());
+            .insert("PRIMARY_KEY".into(), "sk-from-profile-primary".into());
+        profile
+            .config
+            .env_vars
+            .insert("FALLBACK_KEY".into(), "sk-from-profile-fallback".into());
+        // An unrelated env var that the LLM contract does NOT
+        // reference — must not be copied into Config::credentials.
+        profile
+            .config
+            .env_vars
+            .insert("TELEGRAM_BOT_TOKEN".into(), "should-not-leak".into());
 
         overlay_profile_llm(&mut config, &[profile]);
 
-        let injected = std::env::var(ENV_NAME)
-            .expect("overlay must inject the profile's api_key_env into the process env");
-        assert_eq!(injected, "sk-from-profile");
+        assert_eq!(
+            config.credentials.get("PRIMARY_KEY").map(String::as_str),
+            Some("sk-from-profile-primary"),
+            "primary route credential must be stashed on Config::credentials"
+        );
+        assert_eq!(
+            config.credentials.get("FALLBACK_KEY").map(String::as_str),
+            Some("sk-from-profile-fallback"),
+            "fallback route credential must be stashed on Config::credentials"
+        );
+        assert!(
+            !config.credentials.contains_key("TELEGRAM_BOT_TOKEN"),
+            "unrelated profile env vars must NOT bleed into credentials, \
+             got keys: {:?}",
+            config.credentials.keys().collect::<Vec<_>>()
+        );
+    }
 
-        // SAFETY: serialized via `env_inject_lock`; cleanup.
-        unsafe {
-            std::env::remove_var(ENV_NAME);
-        }
+    #[test]
+    fn get_api_key_prefers_credentials_map_over_env() {
+        let mut config = Config {
+            provider: Some("moonshot".into()),
+            api_key_env: Some("OCTOS_TEST_API_KEY_PRIORITY".into()),
+            ..Default::default()
+        };
+        config.credentials.insert(
+            "OCTOS_TEST_API_KEY_PRIORITY".into(),
+            "from-credentials-map".into(),
+        );
+
+        let resolved = config
+            .get_api_key("moonshot")
+            .expect("credentials map must satisfy the lookup without the env var being set");
+        assert_eq!(resolved, "from-credentials-map");
     }
 }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -2291,7 +2291,15 @@ mod tests {
     }
 
     #[test]
-    fn get_api_key_prefers_credentials_map_over_env() {
+    fn get_api_key_returns_value_from_credentials_map() {
+        // Verifies that `Config::get_api_key` short-circuits on the
+        // `credentials` map before consulting the process env. This
+        // test deliberately uses a unique env-var name that no
+        // ambient shell exports, so the lookup would otherwise fail.
+        // The priority of credentials-map over env is also locked in
+        // structurally: `get_api_key` returns from
+        // `if let Some(value) = self.credentials.get(&env_var)` before
+        // reaching the `std::env::var` branch.
         let mut config = Config {
             provider: Some("moonshot".into()),
             api_key_env: Some("OCTOS_TEST_API_KEY_PRIORITY".into()),

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -9,11 +9,11 @@ use eyre::{Result, WrapErr};
 use octos_agent::{Agent, AgentConfig, HookExecutor, ToolRegistry};
 use octos_bus::SessionManager;
 use octos_core::AgentId;
-use octos_llm::{LlmProvider, RetryProvider};
+use octos_llm::{AdaptiveConfig, AdaptiveRouter, LlmProvider, ProviderChain, RetryProvider};
 use octos_memory::{EpisodeStore, MemoryStore};
 
 use super::Executable;
-use super::chat::create_provider;
+use super::chat::{create_provider, create_provider_with_api_type};
 use crate::api::metrics::MetricsReporter;
 use crate::api::{AppState, EventBroadcaster, build_router, init_metrics};
 use crate::config::Config;
@@ -209,6 +209,45 @@ fn resolve_dashboard_auth_smtp_password(
     None
 }
 
+/// Returns true when the profile is a viable server-wide LLM source: it's
+/// enabled, is not a sub-account (sub-accounts inherit their parent's LLM
+/// contract), and has both `family_id` and `model_id` set on `llm.primary`.
+fn profile_has_active_primary_llm(profile: &crate::profiles::UserProfile) -> bool {
+    if !profile.enabled || profile.parent_id.is_some() {
+        return false;
+    }
+    profile
+        .config
+        .llm
+        .as_ref()
+        .and_then(|llm| llm.primary.as_ref())
+        .is_some_and(|sel| sel.family_id.is_some() && sel.model_id.is_some())
+}
+
+/// Picks the server-wide LLM profile from a sorted profile list.
+///
+/// Selection precedence:
+///   1. The canonical admin profile (`ADMIN_PROFILE_ID`), if it has an active
+///      primary — keeps the host's "main" tenant deterministic.
+///   2. Otherwise the first non-sub-account enabled profile with an active
+///      primary, in `ProfileStore::list()` order (which sorts by name).
+///
+/// Sub-accounts (`parent_id.is_some()`) are excluded by design: per
+/// `UserProfile::parent_id` docs they inherit the parent's LLM contract,
+/// so they should never drive the server-wide agent on their own.
+fn select_serve_profile(
+    profiles: &[crate::profiles::UserProfile],
+) -> Option<&crate::profiles::UserProfile> {
+    if let Some(admin) = profiles
+        .iter()
+        .find(|p| p.id == crate::api::auth_handlers::ADMIN_PROFILE_ID)
+        && profile_has_active_primary_llm(admin)
+    {
+        return Some(admin);
+    }
+    profiles.iter().find(|p| profile_has_active_primary_llm(p))
+}
+
 /// Overlay per-profile `cfg.llm` selection onto the top-level [`Config`].
 ///
 /// The serve agent historically only read `~/.octos/config.json`'s flat
@@ -219,21 +258,15 @@ fn resolve_dashboard_auth_smtp_password(
 /// used the bare top-level provider even when the dashboard had moonshot
 /// or minimax configured.
 ///
-/// This helper picks the first profile that is `enabled` and has a fully
-/// populated `llm.primary` (family + model), reuses `config_from_profile`
-/// to produce a profile-derived [`Config`], and overlays the LLM-shaped
-/// fields onto the loaded top-level config. Non-LLM fields (auth, hosts,
-/// dashboard auth, hooks) are left untouched.
+/// When a viable profile is selected (see [`select_serve_profile`]),
+/// every LLM-scoped field is replaced **as a unit** from the
+/// profile-derived [`Config`] — even when the profile leaves a sub-field
+/// blank. This prevents stale top-level values (e.g. a `deepseek`
+/// `base_url` or `OPENAI_API_KEY`) from contaminating a freshly-selected
+/// `moonshot` model. Non-LLM fields (auth tokens, hosts, dashboard auth,
+/// hooks, mode, swarm budgets) are left untouched.
 fn overlay_profile_llm(config: &mut Config, profiles: &[crate::profiles::UserProfile]) {
-    let active = profiles.iter().find(|p| {
-        p.enabled
-            && p.config
-                .llm
-                .as_ref()
-                .and_then(|llm| llm.primary.as_ref())
-                .is_some_and(|sel| sel.family_id.is_some() && sel.model_id.is_some())
-    });
-    let Some(profile) = active else {
+    let Some(profile) = select_serve_profile(profiles) else {
         tracing::debug!("no enabled profile with primary LLM selection — keeping top-level config");
         return;
     };
@@ -246,33 +279,23 @@ fn overlay_profile_llm(config: &mut Config, profiles: &[crate::profiles::UserPro
         base_url = ?profile_config.base_url,
         api_key_env = ?profile_config.api_key_env,
         fallback_models = profile_config.fallback_models.len(),
+        content_routing = profile_config.content_routing.is_some(),
         "overlaying per-profile LLM config onto top-level config for serve agent"
     );
 
-    if let Some(p) = profile_config.provider {
-        config.provider = Some(p);
-    }
-    if let Some(m) = profile_config.model {
-        config.model = Some(m);
-    }
-    if let Some(b) = profile_config.base_url {
-        config.base_url = Some(b);
-    }
-    if let Some(k) = profile_config.api_key_env {
-        config.api_key_env = Some(k);
-    }
-    if let Some(t) = profile_config.api_type {
-        config.api_type = Some(t);
-    }
-    if profile_config.model_hints.is_some() {
-        config.model_hints = profile_config.model_hints;
-    }
-    if !profile_config.fallback_models.is_empty() {
-        config.fallback_models = profile_config.fallback_models;
-    }
-    if profile_config.adaptive_routing.is_some() {
-        config.adaptive_routing = profile_config.adaptive_routing;
-    }
+    // Replace the LLM-scoped fields atomically — including clearing stale
+    // values when the profile leaves a sub-field unset. Mixing a profile
+    // model with a leftover top-level base_url / api_key_env is worse
+    // than missing the field outright.
+    config.provider = profile_config.provider;
+    config.model = profile_config.model;
+    config.base_url = profile_config.base_url;
+    config.api_key_env = profile_config.api_key_env;
+    config.api_type = profile_config.api_type;
+    config.model_hints = profile_config.model_hints;
+    config.fallback_models = profile_config.fallback_models;
+    config.adaptive_routing = profile_config.adaptive_routing;
+    config.content_routing = profile_config.content_routing;
 }
 
 /// Start the REST API server.
@@ -936,10 +959,58 @@ impl ServeCommand {
         let base_provider: Arc<dyn LlmProvider> =
             create_provider(&provider_name, config, model, base_url)?;
 
+        // Build the provider chain. Match the `chat` command's behavior:
+        // wrap the primary in `RetryProvider`, then layer in any
+        // `config.fallback_models` so per-profile fallbacks configured
+        // through the dashboard (e.g. minimax + deepseek behind
+        // moonshot/kimi) actually take effect on `/chat`. Without this
+        // the overlaid `fallback_models` would be inert here.
         let llm: Arc<dyn LlmProvider> = if self.no_retry {
             base_provider
-        } else {
+        } else if config.fallback_models.is_empty() {
             Arc::new(RetryProvider::new(base_provider))
+        } else {
+            let mut providers: Vec<Arc<dyn LlmProvider>> =
+                vec![Arc::new(RetryProvider::new(base_provider))];
+            for fb in &config.fallback_models {
+                let fb_config = if fb.api_key_env.is_some() {
+                    let mut c = config.clone();
+                    c.api_key_env = fb.api_key_env.clone();
+                    c
+                } else {
+                    config.clone()
+                };
+                match create_provider_with_api_type(
+                    &fb.provider,
+                    &fb_config,
+                    fb.model.clone(),
+                    fb.base_url.clone(),
+                    fb.api_type.as_deref(),
+                ) {
+                    Ok(p) => providers.push(Arc::new(RetryProvider::new(p))),
+                    Err(e) => {
+                        tracing::warn!(
+                            provider = %fb.provider,
+                            error = %e,
+                            "skipping fallback provider in serve agent"
+                        );
+                    }
+                }
+            }
+            if providers.len() > 1 {
+                let adaptive_config = config
+                    .adaptive_routing
+                    .as_ref()
+                    .map(AdaptiveConfig::from)
+                    .unwrap_or_default();
+                tracing::info!(
+                    "serve adaptive routing enabled ({} providers)",
+                    providers.len()
+                );
+                Arc::new(AdaptiveRouter::new(providers, &[], adaptive_config))
+            } else {
+                Arc::new(ProviderChain::new(providers))
+            }
         };
 
         let memory = Arc::new(
@@ -1940,5 +2011,160 @@ mod tests {
 
         assert_eq!(config.provider.as_deref(), Some("deepseek"));
         assert_eq!(config.model.as_deref(), Some("deepseek-chat"));
+    }
+
+    #[test]
+    fn overlay_profile_llm_clears_stale_top_level_llm_fields() {
+        // Top-level config has a deepseek stack with leftover base_url
+        // and api_key_env. The selected profile has a `moonshot` primary
+        // without a `base_url` set on its route. The overlay must NOT
+        // leave the stale deepseek base_url in place — otherwise we'd
+        // call moonshot against a deepseek endpoint.
+        let mut config = Config {
+            provider: Some("deepseek".into()),
+            model: Some("deepseek-chat".into()),
+            base_url: Some("https://api.deepseek.com/v1".into()),
+            api_key_env: Some("DEEPSEEK_API_KEY".into()),
+            api_type: Some("openai".into()),
+            fallback_models: vec![crate::config::FallbackModel {
+                provider: "leftover".into(),
+                model: Some("leftover-model".into()),
+                base_url: None,
+                api_key_env: None,
+                model_hints: None,
+                api_type: None,
+                cost_per_m: None,
+                strong: true,
+            }],
+            ..Default::default()
+        };
+
+        let profile = crate::profiles::UserProfile {
+            id: "dspfac".into(),
+            name: "dspfac".into(),
+            public_subdomain: None,
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            config: crate::profiles::ProfileConfig {
+                llm: Some(crate::profiles::LlmProfileConfig {
+                    primary: Some(crate::profiles::LlmModelSelectionConfig {
+                        family_id: Some("moonshot".into()),
+                        model_id: Some("kimi-k2.5".into()),
+                        // route omitted — no base_url / api_key_env
+                        route: None,
+                        model_hints: None,
+                        cost_per_m: None,
+                        strong: None,
+                    }),
+                    fallbacks: vec![],
+                }),
+                ..Default::default()
+            },
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+
+        overlay_profile_llm(&mut config, &[profile]);
+
+        assert_eq!(config.provider.as_deref(), Some("moonshot"));
+        assert_eq!(config.model.as_deref(), Some("kimi-k2.5"));
+        assert!(
+            config.base_url.is_none(),
+            "stale deepseek base_url must be cleared, got {:?}",
+            config.base_url
+        );
+        assert!(
+            config.api_key_env.is_none(),
+            "stale deepseek api_key_env must be cleared, got {:?}",
+            config.api_key_env
+        );
+        assert!(
+            config.api_type.is_none(),
+            "stale api_type must be cleared, got {:?}",
+            config.api_type
+        );
+        assert!(
+            config.fallback_models.is_empty(),
+            "stale top-level fallbacks must be cleared, got {} entries",
+            config.fallback_models.len()
+        );
+    }
+
+    #[test]
+    fn overlay_profile_llm_prefers_admin_profile_when_present() {
+        // When both the admin profile and a tenant profile have viable
+        // primaries, admin wins regardless of alphabetical order.
+        let mut config = Config::default();
+        let admin = make_profile_with_llm(
+            crate::api::auth_handlers::ADMIN_PROFILE_ID,
+            true,
+            "openai",
+            "gpt-5.2",
+            "anthropic",
+            "claude-opus-4-7",
+        );
+        let tenant = make_profile_with_llm(
+            "alpha-tenant",
+            true,
+            "moonshot",
+            "kimi-k2.5",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        );
+        // List() sorts by name, so tenant ("alpha-tenant") sorts before
+        // admin ("admin")? No — "admin" < "alpha-tenant" alphabetically.
+        // Use a name that would sort first to make the test meaningful.
+        let tenant2 = make_profile_with_llm(
+            "a-first-tenant",
+            true,
+            "deepseek",
+            "deepseek-chat",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        );
+
+        overlay_profile_llm(&mut config, &[tenant2, admin, tenant]);
+
+        assert_eq!(
+            config.provider.as_deref(),
+            Some("openai"),
+            "admin profile must win over alphabetically-earlier tenant"
+        );
+        assert_eq!(config.model.as_deref(), Some("gpt-5.2"));
+    }
+
+    #[test]
+    fn overlay_profile_llm_skips_sub_accounts() {
+        // Sub-accounts (parent_id.is_some()) inherit their parent's LLM
+        // contract — they must not drive the server-wide agent on their
+        // own. The fallback should still find the top-level profile.
+        let mut config = Config::default();
+        let mut sub_account = make_profile_with_llm(
+            "sub-1",
+            true,
+            "rogue-provider",
+            "rogue-model",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        );
+        sub_account.parent_id = Some("parent-tenant".into());
+
+        let top_level = make_profile_with_llm(
+            "main-tenant",
+            true,
+            "moonshot",
+            "kimi-k2.5",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        );
+
+        overlay_profile_llm(&mut config, &[sub_account, top_level]);
+
+        assert_eq!(
+            config.provider.as_deref(),
+            Some("moonshot"),
+            "sub-account must be skipped in favor of top-level profile"
+        );
     }
 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -190,6 +190,19 @@ pub struct Config {
     /// cwds (Tier-1 of `session_tool_registry`) still take precedence.
     #[serde(default)]
     pub appui: AppUiConfig,
+
+    /// Resolved credentials keyed by env-var name. Populated at runtime
+    /// from per-profile `env_vars` (e.g. by `octos serve`'s LLM
+    /// overlay) so providers can resolve API keys without depending on
+    /// the process environment. `Config::get_api_key` checks this map
+    /// before falling back to `std::env`.
+    ///
+    /// Not serialized — this is a runtime-only map, never persisted to
+    /// `config.json`. Lives on `Config` instead of being passed
+    /// alongside it so the existing `create_provider` /
+    /// `Config::get_api_key` call sites need no signature changes.
+    #[serde(default, skip)]
+    pub credentials: std::collections::HashMap<String, String>,
 }
 
 /// AppUi session defaults applied by `octos serve`'s API agent.
@@ -952,7 +965,7 @@ impl Config {
             }
         }
 
-        // Fall back to environment variable.
+        // Resolve the env var name we expect to hold this provider's key.
         let env_var = self.api_key_env.clone().unwrap_or_else(|| {
             octos_llm::registry::lookup(provider)
                 .and_then(|e| e.api_key_env)
@@ -960,6 +973,14 @@ impl Config {
                 .unwrap_or_else(|| format!("{}_API_KEY", provider.to_uppercase()))
         });
 
+        // Check the runtime credentials map first — used by `octos serve`
+        // to surface per-profile API keys without mutating the parent
+        // process environment.
+        if let Some(value) = self.credentials.get(&env_var) {
+            return Ok(value.clone());
+        }
+
+        // Fall back to environment variable.
         std::env::var(&env_var).wrap_err_with(|| {
             format!("{env_var} not set. Run `octos auth login -p {provider}` or set the env var")
         })

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1475,6 +1475,7 @@ pub(crate) fn config_from_profile(
         credential_pool: None,
         content_routing: profile.config.content_routing.clone(),
         appui: Default::default(),
+        credentials: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

The serve agent (web `/chat` endpoint) has only ever read flat `provider`/`model` from `~/.octos/config.json`. The structured `cfg.llm.primary` + `cfg.llm.fallbacks` written by the admin dashboard per-profile were silently ignored, so `/chat` always used the seeded top-level provider (typically `deepseek/deepseek-chat`) even after the operator configured moonshot/kimi-k2.5 + minimax + deepseek fallbacks. The `gateway` command path already honored the structured contract via `config_from_profile`.

This PR closes the gap end-to-end after **4 rounds of codex review**.

### Mechanism

- New `overlay_profile_llm` in `commands/serve.rs` runs once during `ServeCommand::run_async` after `Config::load_with_path`.
- New `select_serve_profile` picks the canonical admin profile (`ADMIN_PROFILE_ID`) first if it has an active primary, otherwise the first non-sub-account enabled profile with primary set. Sub-accounts are excluded — they inherit their parent's LLM contract.
- Calls `crate::profiles::config_from_profile` (the same helper the gateway uses) to derive a Config, then **atomically replaces** every LLM-scoped field (provider, model, base_url, api_key_env, api_type, model_hints, fallback_models, adaptive_routing, content_routing) — including clearing to `None`/empty when the profile leaves a sub-field unset. Prevents mixing a profile model with stale top-level credentials.
- New `try_create_agent` builds a real provider chain from `config.fallback_models` (RetryProvider wrap + ProviderChain or AdaptiveRouter), mirroring `chat.rs`. Each fallback gets its own `api_key_env` set unconditionally so cross-provider fallbacks (deepseek behind moonshot) don't reuse the primary's key.

### Credential plumbing

The hard part. `Config::get_api_key` only resolved keys through `AuthStore` and `std::env`, never the per-profile `env_vars` map. Gateway gets these via `ProcessManager` spawning a child with `cmd.env(...)`; serve runs in-process and had no equivalent — so the LLM-selection overlay alone would have left `/chat` requesting AUTODL_API_KEY against a parent env that only had DEEPSEEK_API_KEY.

- New `credentials: HashMap<String, String>` field on `Config` with `#[serde(default, skip)]` — runtime-only, never persisted.
- `Config::get_api_key` now consults the map BEFORE `std::env::var` (AuthStore still first stop).
- `populate_profile_credentials` resolves only the env-var names referenced by the selected profile's primary + fallback `route.api_key_env` values (bounded set) through `keychain::resolve_env_vars` and stashes them on `config.credentials`. Unrelated profile env_vars (Telegram tokens, etc.) stay out.

No process-env mutation, no `unsafe`, no race under the multi-threaded tokio runtime.

### Tests

8 new unit tests (21 serve tests total, full 925-test octos-cli lib suite green):
- `overlay_profile_llm_applies_enabled_profile_primary_and_fallbacks`
- `overlay_profile_llm_keeps_top_level_when_no_enabled_profile`
- `overlay_profile_llm_skips_profiles_missing_primary_model`
- `overlay_profile_llm_clears_stale_top_level_llm_fields`
- `overlay_profile_llm_prefers_admin_profile_when_present`
- `overlay_profile_llm_skips_sub_accounts`
- `overlay_profile_llm_stashes_profile_api_key_into_config_credentials`
- `get_api_key_returns_value_from_credentials_map`

### Codex review history

- Round 1: BLOCK — stale field leak, fallback chain inert, multi-profile selection unsafe, content_routing dropped.
- Round 2: BLOCK — profile env vars not consulted by `Config::get_api_key`; let-chain MSRV violation.
- Round 3: BLOCK — `set_var` safety claim false under multi-thread runtime; BLOCKED_ENV_VARS insufficient for process-env safety; fallback inherited primary's `api_key_env`.
- Round 4: APPROVE.

## Test plan
- [x] `cargo check -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"` clean
- [x] `cargo test -p octos-cli --lib` — 925 passed, 0 failed
- [x] `cargo fmt --all` applied
- [x] 4 codex rounds: BLOCK → BLOCK → BLOCK → APPROVE
- [ ] Live verify on mini1 (`dspfac.crew.ominix.io`) after deploy: send a chat turn and confirm logs show `provider=moonshot model=kimi-k2.5` instead of `provider=deepseek`