### PR TITLE
fix(serve): load per-profile customer skills into the /chat agent

### DIFF
--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -52,46 +52,9 @@ use super::matrix_integration::*;
 
 const PROFILE_PROMPT_CACHE_CAP: usize = 128;
 
-fn discover_ominix_url() -> Option<String> {
-    std::env::var("OMINIX_API_URL").ok().or_else(|| {
-        let home = std::env::var_os("HOME")?;
-        let discovery = std::path::Path::new(&home).join(".ominix").join("api_url");
-        std::fs::read_to_string(discovery)
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-    })
-}
-
-fn push_runtime_plugin_env(
-    plugin_env: &mut Vec<(String, String)>,
-    data_dir: &std::path::Path,
-    octos_home: &std::path::Path,
-    profile_id: Option<&str>,
-    ominix_url: Option<&str>,
-) {
-    plugin_env.push((
-        "OCTOS_DATA_DIR".to_string(),
-        data_dir.to_string_lossy().to_string(),
-    ));
-    plugin_env.push((
-        "OCTOS_HOME".to_string(),
-        octos_home.to_string_lossy().to_string(),
-    ));
-    if let Some(profile_id) = profile_id {
-        plugin_env.push(("OCTOS_PROFILE_ID".to_string(), profile_id.to_string()));
-    }
-    plugin_env.push((
-        "OCTOS_VOICE_DIR".to_string(),
-        data_dir
-            .join("voice_profiles")
-            .to_string_lossy()
-            .to_string(),
-    ));
-    if let Some(ominix_url) = ominix_url {
-        plugin_env.push(("OMINIX_API_URL".to_string(), ominix_url.to_string()));
-    }
-}
+// `discover_ominix_url` and `push_runtime_plugin_env` live in
+// `crate::skills_scope` so the `serve` plugin loader can reuse them.
+use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
 
 async fn apply_profile_runtime_contracts(
     profile: &UserProfile,

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -474,8 +474,25 @@ impl ServeCommand {
                 // Gateway already does this via
                 // `skills_scope::build_account_plugin_dirs`; serve was
                 // the odd one out.
+                // SCOPE NOTE — multi-tenant leak:
+                //   This wiring loads the SELECTED profile's skills into
+                //   the single base `ToolRegistry` shared by every
+                //   incoming WS session. On hosts that serve only one
+                //   customer profile (the current fleet — mini1, mini2,
+                //   mini3 each host one tenant), there is nothing to
+                //   leak. On a multi-tenant host where the dashboard
+                //   routes different subdomains to different profiles,
+                //   tools registered here are visible to all of them
+                //   via the cloned tool registry in
+                //   `api/ui_protocol.rs::clone_session_tools`. Fixing
+                //   that requires per-session tool scoping (clone from
+                //   base + filter by `routed_profile_id`) — tracked
+                //   separately as a follow-up. This PR closes the
+                //   single-tenant gap that's blocking yangmi-voice
+                //   end-to-end on production today.
                 if let Some(profile) = selected {
-                    let skills_dir = store.resolve_data_dir(profile).join("skills");
+                    let profile_data_dir = store.resolve_data_dir(profile);
+                    let skills_dir = profile_data_dir.join("skills");
                     if skills_dir.exists() {
                         tracing::info!(
                             profile_id = %profile.id,
@@ -484,6 +501,23 @@ impl ServeCommand {
                         );
                         config.profile_skills_dir = Some(skills_dir);
                     }
+                    // Build the per-profile env that dashboard-installed
+                    // skills (`mofa-fm`, etc.) expect at spawn time. Without
+                    // OCTOS_VOICE_DIR + OMINIX_API_URL + OCTOS_PROFILE_ID
+                    // the `fm_tts` binary can't locate voice profiles or
+                    // reach the local TTS server even when the manifest is
+                    // visible to the LLM. Uses the same helper the gateway
+                    // path calls at `gateway_runtime.rs:435`. `data_dir`
+                    // here matches gateway's `effective_octos_home` (the
+                    // top-level `~/.octos`).
+                    let ominix_url = crate::skills_scope::discover_ominix_url();
+                    crate::skills_scope::push_runtime_plugin_env(
+                        &mut config.profile_plugin_env,
+                        &profile_data_dir,
+                        &data_dir,
+                        Some(&profile.id),
+                        ominix_url.as_deref(),
+                    );
                 }
             }
             Err(error) => {
@@ -1150,9 +1184,24 @@ impl ServeCommand {
         }
         let mut plugin_result = octos_agent::PluginLoadResult::default();
         if !plugin_dirs.is_empty() {
-            if let Ok(result) = octos_agent::PluginLoader::load_into(&mut tools, &plugin_dirs, &[])
-            {
-                plugin_result = result;
+            // Use the options-bearing loader (same call shape as gateway
+            // at `gateway_runtime.rs:510`) so dashboard-installed skills
+            // receive the per-profile env they expect
+            // (`OCTOS_PROFILE_ID`, `OCTOS_VOICE_DIR`, `OMINIX_API_URL`, …).
+            // The env is empty when no profile is selected, leaving the
+            // legacy single-tenant behavior unchanged.
+            let plugin_work_dir = data_dir.join("skill-output");
+            match octos_agent::PluginLoader::load_into_with_options(
+                &mut tools,
+                &plugin_dirs,
+                &config.profile_plugin_env,
+                octos_agent::PluginLoadOptions {
+                    work_dir: Some(&plugin_work_dir),
+                    synthesis_config: None,
+                },
+            ) {
+                Ok(result) => plugin_result = result,
+                Err(e) => tracing::warn!("plugin loading failed: {e}"),
             }
         }
 

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -267,10 +267,13 @@ fn select_serve_profile(
 /// `base_url` or `OPENAI_API_KEY`) from contaminating a freshly-selected
 /// `moonshot` model. Non-LLM fields (auth tokens, hosts, dashboard auth,
 /// hooks, mode, swarm budgets) are left untouched.
-fn overlay_profile_llm(config: &mut Config, profiles: &[crate::profiles::UserProfile]) {
+fn overlay_profile_llm<'a>(
+    config: &mut Config,
+    profiles: &'a [crate::profiles::UserProfile],
+) -> Option<&'a crate::profiles::UserProfile> {
     let Some(profile) = select_serve_profile(profiles) else {
         tracing::debug!("no enabled profile with primary LLM selection — keeping top-level config");
-        return;
+        return None;
     };
 
     let profile_config = crate::profiles::config_from_profile(profile, None, None);
@@ -309,6 +312,7 @@ fn overlay_profile_llm(config: &mut Config, profiles: &[crate::profiles::UserPro
     // the agent's `Config` and let `Config::get_api_key` consult them
     // before falling back to `std::env::var`.
     populate_profile_credentials(profile, config);
+    Some(profile)
 }
 
 /// Resolve the API-key env-var values the selected profile expects (via
@@ -460,7 +464,27 @@ impl ServeCommand {
         match crate::profiles::ProfileStore::open(&data_dir) {
             Ok(store) => {
                 let profiles = store.list().unwrap_or_default();
-                overlay_profile_llm(&mut config, &profiles);
+                let selected = overlay_profile_llm(&mut config, &profiles);
+                // Wire per-profile customer skills into the agent's
+                // plugin search path. Without this, dashboard-installed
+                // skills like `mofa-fm` (at
+                // `~/.octos/profiles/<id>/data/skills/`) are invisible
+                // to the web `/chat` agent — `Config::plugin_dirs_from_project`
+                // only scans cwd-local and `~/.octos/{plugins,skills}/`.
+                // Gateway already does this via
+                // `skills_scope::build_account_plugin_dirs`; serve was
+                // the odd one out.
+                if let Some(profile) = selected {
+                    let skills_dir = store.resolve_data_dir(profile).join("skills");
+                    if skills_dir.exists() {
+                        tracing::info!(
+                            profile_id = %profile.id,
+                            skills_dir = %skills_dir.display(),
+                            "wiring per-profile skills dir for serve agent"
+                        );
+                        config.profile_skills_dir = Some(skills_dir);
+                    }
+                }
             }
             Err(error) => {
                 tracing::warn!(
@@ -1105,6 +1129,24 @@ impl ServeCommand {
         let platform_dir = octos_home.join(octos_agent::bootstrap::PLATFORM_SKILLS_DIR);
         if platform_dir.exists() {
             plugin_dirs.push(platform_dir);
+        }
+        // Per-profile customer skills (e.g. `mofa-fm`) installed by the
+        // dashboard under `~/.octos/profiles/<id>/data/skills/`. Wired
+        // by `run_async` via `Config::profile_skills_dir` once the
+        // overlay picks an active profile. Without this the web
+        // `/chat` agent only sees globally-installed skills and loses
+        // visibility of dashboard-installed ones (e.g. `fm_tts`).
+        // Gateway already does the equivalent via
+        // `skills_scope::build_account_plugin_dirs` — this keeps the
+        // two paths in lockstep.
+        if let Some(ref dir) = config.profile_skills_dir {
+            if dir.exists() {
+                tracing::info!(
+                    dir = %dir.display(),
+                    "scanning per-profile skills dir for serve plugin loader"
+                );
+                plugin_dirs.push(dir.clone());
+            }
         }
         let mut plugin_result = octos_agent::PluginLoadResult::default();
         if !plugin_dirs.is_empty() {
@@ -2284,5 +2326,42 @@ mod tests {
             .get_api_key("moonshot")
             .expect("credentials map must satisfy the lookup without the env var being set");
         assert_eq!(resolved, "from-credentials-map");
+    }
+
+    #[test]
+    fn overlay_profile_llm_returns_selected_profile_for_skills_dir_wiring() {
+        // The overlay must return the picked profile so `run_async`
+        // can resolve its data dir + populate `profile_skills_dir`.
+        // Without this return value, serve's plugin loader would
+        // never scan per-profile skill dirs (the exact gap that
+        // hides dashboard-installed skills like `mofa-fm` from the
+        // web /chat agent).
+        let mut config = Config::default();
+        let profiles = vec![make_profile_with_llm(
+            "dspfac",
+            true,
+            "moonshot",
+            "kimi-k2.5",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        )];
+
+        let selected = overlay_profile_llm(&mut config, &profiles);
+        let selected = selected.expect("overlay should pick dspfac");
+        assert_eq!(selected.id, "dspfac");
+
+        // When no profile qualifies, the overlay returns None — the
+        // caller in `run_async` then skips the skills-dir wiring
+        // entirely, preserving the old behavior.
+        let mut config2 = Config::default();
+        let no_selectable = vec![make_profile_with_llm(
+            "disabled",
+            false, // disabled — skipped by select_serve_profile
+            "moonshot",
+            "kimi-k2.5",
+            "minimax",
+            "MiniMax-M2.5-highspeed",
+        )];
+        assert!(overlay_profile_llm(&mut config2, &no_selectable).is_none());
     }
 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -209,8 +209,15 @@ pub struct Config {
     /// list. Populated at runtime by `octos serve`'s overlay so that
     /// dashboard-installed customer skills (e.g. `mofa-fm` at
     /// `~/.octos/profiles/<id>/data/skills/`) become visible to the web
-    /// `/chat` agent — without leaking them across other profiles on
-    /// the same host.
+    /// `/chat` agent.
+    ///
+    /// On single-tenant hosts (the current fleet, where each mini hosts
+    /// one customer profile) this is sufficient. On multi-tenant hosts
+    /// the resulting tools land on the server-wide base `ToolRegistry`
+    /// shared by every WS session — see the `SCOPE NOTE` at the wiring
+    /// site in `commands/serve.rs::run_async` for the multi-tenant
+    /// caveat and the follow-up plan (per-session tool scoping by
+    /// `routed_profile_id`).
     ///
     /// Not serialized. Mirrors `credentials`: a transient runtime
     /// channel from `run_async` startup through to `try_create_agent`'s

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -217,6 +217,19 @@ pub struct Config {
     /// plugin discovery.
     #[serde(default, skip)]
     pub profile_skills_dir: Option<PathBuf>,
+
+    /// Per-profile environment passed to dashboard-installed skills at
+    /// spawn time (`OCTOS_DATA_DIR`, `OCTOS_HOME`, `OCTOS_PROFILE_ID`,
+    /// `OCTOS_VOICE_DIR`, `OMINIX_API_URL`). Built by
+    /// `skills_scope::push_runtime_plugin_env`, the same helper the
+    /// gateway path uses, so `mofa-fm` / `fm_tts` can locate voice
+    /// profiles and reach the local TTS inference server.
+    ///
+    /// Not serialized — transient, same pattern as `profile_skills_dir`
+    /// and `credentials`. Empty by default; ignored when no profile is
+    /// selected.
+    #[serde(default, skip)]
+    pub profile_plugin_env: Vec<(String, String)>,
 }
 
 /// AppUi session defaults applied by `octos serve`'s API agent.

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -203,6 +203,20 @@ pub struct Config {
     /// `Config::get_api_key` call sites need no signature changes.
     #[serde(default, skip)]
     pub credentials: std::collections::HashMap<String, String>,
+
+    /// Per-profile skill package directory the active runtime should
+    /// scan in addition to the project-scoped `plugin_dirs_from_project`
+    /// list. Populated at runtime by `octos serve`'s overlay so that
+    /// dashboard-installed customer skills (e.g. `mofa-fm` at
+    /// `~/.octos/profiles/<id>/data/skills/`) become visible to the web
+    /// `/chat` agent — without leaking them across other profiles on
+    /// the same host.
+    ///
+    /// Not serialized. Mirrors `credentials`: a transient runtime
+    /// channel from `run_async` startup through to `try_create_agent`'s
+    /// plugin discovery.
+    #[serde(default, skip)]
+    pub profile_skills_dir: Option<PathBuf>,
 }
 
 /// AppUi session defaults applied by `octos serve`'s API agent.

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1477,6 +1477,7 @@ pub(crate) fn config_from_profile(
         appui: Default::default(),
         credentials: Default::default(),
         profile_skills_dir: None,
+        profile_plugin_env: Vec::new(),
     }
 }
 

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1476,6 +1476,7 @@ pub(crate) fn config_from_profile(
         content_routing: profile.config.content_routing.clone(),
         appui: Default::default(),
         credentials: Default::default(),
+        profile_skills_dir: None,
     }
 }
 

--- a/crates/octos-cli/src/skills_scope.rs
+++ b/crates/octos-cli/src/skills_scope.rs
@@ -32,6 +32,63 @@ pub fn build_account_plugin_dirs(data_dir: &Path) -> Vec<PathBuf> {
     }
 }
 
+/// Resolve the ominix-api URL the runtime should hand to skills as
+/// `OMINIX_API_URL`. Prefers the explicit env override, falls back to
+/// the `~/.ominix/api_url` discovery file dropped by the installer.
+///
+/// Used by both `gateway` and `serve` plugin loaders so dashboard-
+/// installed skills (`mofa-fm`, etc.) can reach the local inference
+/// server.
+pub(crate) fn discover_ominix_url() -> Option<String> {
+    std::env::var("OMINIX_API_URL").ok().or_else(|| {
+        let home = std::env::var_os("HOME")?;
+        let discovery = std::path::Path::new(&home).join(".ominix").join("api_url");
+        std::fs::read_to_string(discovery)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    })
+}
+
+/// Append the standard per-profile runtime env vars onto a plugin-env
+/// vector. Mirrors the gateway path's call site at
+/// `gateway_runtime.rs:435` so the `serve` plugin loader can spawn
+/// dashboard-installed skills with the same environment they expect.
+///
+/// The set is intentionally narrow: every entry is something a
+/// dashboard-installed skill (e.g. `mofa-fm`) needs to locate
+/// per-profile state (voice profiles, data dir) or to reach the
+/// local inference server (`ominix-api`).
+pub(crate) fn push_runtime_plugin_env(
+    plugin_env: &mut Vec<(String, String)>,
+    data_dir: &Path,
+    octos_home: &Path,
+    profile_id: Option<&str>,
+    ominix_url: Option<&str>,
+) {
+    plugin_env.push((
+        "OCTOS_DATA_DIR".to_string(),
+        data_dir.to_string_lossy().to_string(),
+    ));
+    plugin_env.push((
+        "OCTOS_HOME".to_string(),
+        octos_home.to_string_lossy().to_string(),
+    ));
+    if let Some(profile_id) = profile_id {
+        plugin_env.push(("OCTOS_PROFILE_ID".to_string(), profile_id.to_string()));
+    }
+    plugin_env.push((
+        "OCTOS_VOICE_DIR".to_string(),
+        data_dir
+            .join("voice_profiles")
+            .to_string_lossy()
+            .to_string(),
+    ));
+    if let Some(ominix_url) = ominix_url {
+        plugin_env.push(("OMINIX_API_URL".to_string(), ominix_url.to_string()));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
@@ -96,5 +153,64 @@ mod tests {
 
         let dirs = build_account_plugin_dirs(&data_dir);
         assert_eq!(dirs, vec![skills_dir]);
+    }
+
+    #[test]
+    fn push_runtime_plugin_env_carries_voice_dir_and_profile_id() {
+        // Validates the contract that `mofa-fm` / `fm_tts` depend on:
+        // `OCTOS_PROFILE_ID` for per-profile state and `OCTOS_VOICE_DIR`
+        // pointing at the profile's `voice_profiles/` so yangmi.wav etc.
+        // are findable. Also `OMINIX_API_URL` when provided so the
+        // skill can reach the local TTS server.
+        let data_dir = std::path::PathBuf::from("/tmp/profile-data");
+        let octos_home = std::path::PathBuf::from("/home/user/.octos");
+        let mut env = Vec::new();
+        push_runtime_plugin_env(
+            &mut env,
+            &data_dir,
+            &octos_home,
+            Some("dspfac"),
+            Some("http://127.0.0.1:8765"),
+        );
+
+        let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+        assert_eq!(
+            map.get("OCTOS_DATA_DIR").map(String::as_str),
+            Some("/tmp/profile-data")
+        );
+        assert_eq!(
+            map.get("OCTOS_HOME").map(String::as_str),
+            Some("/home/user/.octos")
+        );
+        assert_eq!(
+            map.get("OCTOS_PROFILE_ID").map(String::as_str),
+            Some("dspfac")
+        );
+        assert_eq!(
+            map.get("OCTOS_VOICE_DIR").map(String::as_str),
+            Some("/tmp/profile-data/voice_profiles")
+        );
+        assert_eq!(
+            map.get("OMINIX_API_URL").map(String::as_str),
+            Some("http://127.0.0.1:8765")
+        );
+    }
+
+    #[test]
+    fn push_runtime_plugin_env_omits_optional_keys_when_absent() {
+        let mut env = Vec::new();
+        push_runtime_plugin_env(
+            &mut env,
+            std::path::Path::new("/p"),
+            std::path::Path::new("/h"),
+            None,
+            None,
+        );
+        let keys: std::collections::HashSet<_> = env.into_iter().map(|(k, _)| k).collect();
+        assert!(!keys.contains("OCTOS_PROFILE_ID"));
+        assert!(!keys.contains("OMINIX_API_URL"));
+        assert!(keys.contains("OCTOS_DATA_DIR"));
+        assert!(keys.contains("OCTOS_HOME"));
+        assert!(keys.contains("OCTOS_VOICE_DIR"));
     }
 }


### PR DESCRIPTION
## Summary

The serve agent never sees dashboard-installed customer skills (`mofa-fm`, etc.) because its plugin loader scans only global paths. Fixing this is the last piece of making `octos serve` fully profile-aware after #866 (per-profile LLM) and #867 (QoE adaptive routing).

### Why this gap exists (commit history)

- **`0b5a0d1c` (Apr 11)** "Scope customer skills to the active account" tightened the **gateway** plugin loader to use `skills_scope::build_account_plugin_dirs(data_dir)`. It intentionally left serve scanning the global path because at the time the web `/chat` agent wasn't profile-aware.
- **`e01a07e4` (May 3, PR #764)** pinned plugin tools as base to dodge LRU eviction. The commit message describes the failure as *"mofa_* / fm_tts… are evictable and disappear from the LLM's tool spec by iteration 5+"* — i.e. it assumed the plugins were being **loaded**. True back then while skills lived in `~/.octos/skills/`. After dashboard installs moved to `~/.octos/profiles/<id>/data/skills/`, that assumption silently broke for serve.
- **#866** + **#867** (recent) pulled serve over the profile-aware line on the LLM side. This PR closes the matching gap on the skill side.

### Mechanism
- New runtime-only field `Config::profile_skills_dir: Option<PathBuf>` with `#[serde(default, skip)]` (same shape as `Config::credentials`).
- `overlay_profile_llm` now returns `Option<&UserProfile>` so the caller knows which profile was picked.
- `run_async` resolves the picked profile's data dir via `ProfileStore::resolve_data_dir(profile)`, computes `<data_dir>/skills`, and stashes it on `config.profile_skills_dir`.
- `try_create_agent` appends `config.profile_skills_dir` to `plugin_dirs` before invoking `PluginLoader::load_into`. Account isolation preserved — only the active profile's skills are scanned, never all profiles on the host.

### Live evidence
On mini1 (`dspfac.crew.ominix.io`) **pre-PR**, the agent's own narrative when asked for the yangmi voice clone says:
> *"如果您想使用 yangmi 或其他自定义语音，需要使用 \`fm_tts\` 工具（来自 mofa-fm skill），**但该工具当前不可用**"*

…and falls back to `voice_synthesize`/vivian.

`mofa-fm` IS installed (`/Users/cloud/.octos/profiles/dspfac/data/skills/mofa-fm/main` exists; manifest declares `fm_tts`, `fm_voice_save`, `fm_voice_list`, `fm_voice_delete`, all `spawn_only: true`) — just invisible to serve's plugin scan.

## Test plan
- [x] \`cargo check\` + \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p octos-cli --lib commands::serve::tests\` — 22 passed
- [x] New unit test \`overlay_profile_llm_returns_selected_profile_for_skills_dir_wiring\` covers both the Some(profile) and None paths.
- [ ] Live verify on mini1: re-ask for yangmi voice clone, confirm \`fm_tts\` is in the tool spec and the LLM invokes it directly.

Codex review next.