### PR TITLE
fix(agent): deliver text output for spawn_only tools that produce no files

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -597,13 +597,63 @@ impl Agent {
                                     }
 
                                     if r.files_to_send.is_empty() {
+                                        // spawn_only tool finished without
+                                        // file outputs. Two sub-cases:
+                                        //
+                                        //   (a) Informational tool (e.g.
+                                        //       `fm_voice_list`) — produced
+                                        //       a textual result on stdout
+                                        //       but has nothing to attach.
+                                        //       Treat as success and deliver
+                                        //       the text as a Notification.
+                                        //   (b) Genuinely-failed tool — no
+                                        //       text either. Mark failed
+                                        //       with the legacy error.
+                                        //
+                                        // The strict "no output files
+                                        // produced" failure was too sharp
+                                        // for skills with mixed sync/async
+                                        // tool families (e.g. mofa-fm marks
+                                        // its list/delete tools spawn_only
+                                        // for uniformity with the
+                                        // file-producing fm_tts/fm_voice_save).
+                                        let trimmed_output = r.output.trim();
+                                        if !trimmed_output.is_empty() {
+                                            tracing::info!(
+                                                tool = %bg_name,
+                                                output_len = trimmed_output.len(),
+                                                "spawn_only tool produced text-only result"
+                                            );
+                                            bg_supervisor.mark_completed(&task_id, Vec::new());
+                                            if let Some(ref sender) = bg_sender {
+                                                let _ = sender(BackgroundResultPayload {
+                                                    task_label: bg_name.clone(),
+                                                    content: r.output.clone(),
+                                                    kind: BackgroundResultKind::Notification,
+                                                    media: vec![],
+                                                    envelope_media: vec![],
+                                                    originating_thread_id: bg_originating_thread_id
+                                                        .clone(),
+                                                    task_id: Some(task_id.clone()),
+                                                })
+                                                .await;
+                                            }
+                                            if let Some(ref router) = bg_output_router {
+                                                router.mark_terminal(&task_id);
+                                            }
+                                            if let Some(ref summary_gen) = bg_summary_generator {
+                                                summary_gen.stop_watcher(&task_id);
+                                            }
+                                            return;
+                                        }
+
                                         let err_msg = format!(
                                             "completed with no output (stdout: {})",
                                             r.output.chars().take(200).collect::<String>()
                                         );
                                         tracing::warn!(
                                             tool = %bg_name,
-                                            "spawn_only tool produced no files"
+                                            "spawn_only tool produced no files and no text"
                                         );
                                         bg_supervisor.mark_failed(&task_id, err_msg);
                                         if let Some(ref sender) = bg_sender {


### PR DESCRIPTION
## Summary

`mofa-fm`'s `fm_voice_list` is declared `spawn_only: true` in its manifest (same family as `fm_tts` for uniformity), but the binary only writes a textual voice listing to stdout — no file outputs. The runtime check at \`crates/octos-agent/src/agent/execution.rs:611\` was strict: spawn_only tools that produced an empty \`files_to_send\` got marked failed with **\`✗ <tool> failed: no output files produced\`**, regardless of whether `r.output` had a valid text result.

Live evidence on mini1 today: when the user asked the web /chat agent for a yangmi voice clone, the LLM correctly invoked \`fm_voice_list\` first to discover available voices. The runtime returned the failure message back to the LLM, which then decided the tool family was broken and fell back to \`voice_synthesize\` / vivian. Hotfix on mini1 (flipping \`fm_voice_list\` + \`fm_voice_delete\` to \`spawn_only: false\` in the on-disk manifest) confirmed the yangmi mp3 generates correctly end-to-end.

This PR removes the manifest workaround by relaxing the runtime contract:

- If \`files_to_send.is_empty()\` **but** \`r.output.trim()\` is non-empty → treat as a successful informational result. Mark the task completed (with empty \`output_files\`) and deliver \`r.output\` as a \`Notification\` payload. The LLM sees the listing it asked for.
- If **both** \`files_to_send\` and trimmed \`r.output\` are empty → keep the legacy "no output files produced" failure path. That's the genuinely-broken case (binary crashed silently, returned empty JSON, etc.).

Behavior change is on a sharp edge of the spawn_only contract, but it only affects tools that previously failed with that specific error — never tools that already produced files.

## Test plan

- [x] \`cargo check -p octos-agent\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p octos-agent --lib\` — 1286 passed, 0 failed
- [x] Hotfix verified end-to-end on mini1 (yangmi mp3 generated with correct text)
- [ ] After merge: rebuild + redeploy mini1, revert the manifest hotfix (set \`spawn_only: true\` back on \`fm_voice_list\` / \`fm_voice_delete\` since the runtime now handles it), retest yangmi turn.

Codex review next.