### PR TITLE
docs(M11): ProfileRuntime/SessionRuntime ADR + workstreams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ scripts/deploy.sh
 !docs/M9-LEDGER-DURABILITY-ADR.md
 !docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md
 !docs/M9-GAMMA-SERVER-PROJECTION-ADR.md
+!docs/M11-PROFILE-SESSION-RUNTIME-ADR.md
+!workstreams/M11-runtime-unification.md
 # Canonical product/engineering spec docs under api/. The UI Protocol v1
 # spec (api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md) was tracked manually before
 # this rule existed; the server/app/tui feature-requirement specs added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1273,6 +1273,48 @@ Polls every 5 seconds. SHA-256 hash comparison of file contents.
 
 Triggered when message count > 40 (threshold). Keeps 10 recent messages. Summarizes older messages via LLM to <500 words. Rewrites JSONL session file.
 
+### Runtime Types: ProfileRuntime / SessionRuntime (M11)
+
+Status: **PROPOSED** as of 2026-05-10. See `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md` and `workstreams/M11-runtime-unification.md`. This subsection documents the target shape; the legacy `state.agent: Option<Arc<Agent>>` path is removed during M11-D / M11-F.
+
+Two first-class runtime types make profile scope and session scope explicit:
+
+| Type | Cardinality | Owns |
+|---|---|---|
+| `ProfileRuntime` | One per profile per host process | `llm`, `adaptive_router`, `credentials`, `skills_dir`, `plugin_env_template`, `tool_policy`, `default_sandbox`, `tool_specs` (base, no workspace), `memory`, `memory_store` |
+| `SessionRuntime` | One per `(profile_id, session_key)` | `profile: Arc<ProfileRuntime>`, `workspace_root`, `plugin_work_dir`, `sandbox` (override), `tools` (cloned + workspace-bound + policy-filtered), `agent`, `sessions: SessionManager` |
+| `SessionRuntimeCache` | One per host process | TTL/LRU `HashMap<(String, SessionKey), Arc<SessionRuntime>>` |
+
+**Scope contract.** Anything that varies between two chats opened by the same logged-in user is session-scope. Anything that's an account property is profile-scope.
+
+| Concern | Scope | Lives on |
+|---|---|---|
+| LLM provider + adaptive router | Profile | `ProfileRuntime.llm`, `ProfileRuntime.adaptive_router` |
+| API key credentials | Profile | `ProfileRuntime.credentials` |
+| Installed skills + plugin env template | Profile | `ProfileRuntime.skills_dir`, `ProfileRuntime.plugin_env_template`, `ProfileRuntime.tool_specs` |
+| Tool policy default | Profile | `ProfileRuntime.tool_policy` |
+| Workspace root + plugin work dir | Session | `SessionRuntime.workspace_root`, `SessionRuntime.plugin_work_dir` |
+| Tool registry view (workspace-bound, policy-filtered) | Session | `SessionRuntime.tools` (clone of `profile.tool_specs`) |
+| Sandbox config (with optional session override) | Session | `SessionRuntime.sandbox` |
+| Agent instance | Session | `SessionRuntime.agent` |
+| Conversation history | Session | `SessionRuntime.sessions` (per-session `SessionManager`) |
+
+**Bootstrap chain.** On first message in a session:
+1. `state.profiles[profile_id]` resolves the `Arc<ProfileRuntime>`.
+2. `state.sessions.get_or_init(profile, session_key, workspace_hint)`:
+   - Cache miss → `SessionRuntime::bootstrap`:
+     1. Resolve `workspace_root` from hint or auto-derive `<profile.data_dir>/users/<key>/workspace/`.
+     2. Write default `WorkspacePolicy::for_session()` to `<workspace_root>/.octos-workspace.toml` if missing (idempotent).
+     3. Compute `plugin_work_dir = <workspace_root>/skill-output`.
+     4. Clone `profile.tool_specs`; apply `set_workspace_root` + `set_output_dir_hint` + per-session policy filter.
+     5. Build `Agent` from `profile.llm` + cloned tools.
+     6. Open per-session `SessionManager` at `<profile.data_dir>/users/<key>/`.
+   - Cache hit → return existing `Arc<SessionRuntime>`.
+
+**Bootstrap path is shared between serve and gateway.** Both `commands/serve.rs::run_async` and each `ProcessManager`-spawned gateway subprocess call `ProfileRuntime::bootstrap`. The gateway's bus loop continues to use the returned `ProfileRuntime`'s fields for per-channel session actors.
+
+**Why this exists.** Before M11, `octos serve` ran a server-wide embedded `Agent` constructed by `commands/serve.rs::try_create_agent`. The agent had no notion of profile or session scope. A series of PRs (#866 / #867 / #868 / #869, all 2026-05-10) retrofitted profile awareness one transient `Config` field at a time. The pattern was clearly leaking architecture; M11 replaces the embedded agent with the two-scope model. See the ADR for the full incident trail.
+
 ---
 
 ## octos-plugin — Plugin SDK

--- a/docs/M11-PROFILE-SESSION-RUNTIME-ADR.md
+++ b/docs/M11-PROFILE-SESSION-RUNTIME-ADR.md
@@ -1,0 +1,238 @@
+# M11 — ProfileRuntime / SessionRuntime ADR
+
+Date: 2026-05-10
+Branch (target): `main` (no release branch; M11 is foundational and merges to main directly)
+Status: PROPOSED — accepted after the 2026-05-10 yangmi-voice incident
+chain.
+
+## Context
+
+Between 2026-05-10 06:00 and 2026-05-10 23:00 four PRs landed on the
+serve agent, each fixing one mis-scoped variable surfaced by the
+yangmi voice-clone failure on `dspfac.crew.ominix.io`:
+
+- **#866** — serve never read per-profile `cfg.llm`; web `/chat`
+  always used the seeded top-level deepseek provider. Fixed by
+  overlaying `cfg.llm` onto a transient `Config` and threading
+  per-profile credentials via a new `Config::credentials` map.
+- **#867** — QoE adaptive routing wiring was duplicated between
+  gateway and serve. Lifted into shared `qos_catalog::build_adaptive_provider_chain`.
+- **#868** — serve scanned only global skill dirs
+  (`~/.octos/{plugins,skills}/`), not the dashboard-installed
+  per-profile path (`~/.octos/profiles/<id>/data/skills/`). Fixed by
+  adding `Config::profile_skills_dir` and `Config::profile_plugin_env`
+  transient fields, and switching the loader to `load_into_with_options`.
+- **#869** — runtime contract for `spawn_only` tools required file
+  outputs; informational tools like `fm_voice_list` failed with "no
+  output files produced" despite returning valid text. Fixed by
+  delivering text-only output as a Notification when `files_to_send`
+  is empty.
+
+Despite all four, live re-test on mini1 surfaced a fifth gap:
+`✗ fm_tts failed: workspace policy not found`. The runtime calls
+`enforce_spawn_task_contract` which reads
+`tools.workspace_root() + .octos-workspace.toml`. Serve sets
+`workspace_root = cwd = /Users/cloud` (the daemon's working dir);
+no policy file lives there. Gateway dodges this because its per-session
+workspace bootstrap creates the policy under
+`profiles/<id>/data/users/<session_key>/workspace/`. Serve never had
+the equivalent setup.
+
+The pattern is unmistakable. Every fix this week patched a single
+mis-scoped variable on `serve::try_create_agent`'s output. Each fix
+surfaces the next gap. We have been retrofitting per-profile and
+per-session awareness onto an `Agent` instance that was originally
+built for the standalone `octos chat` CLI in a single-tenant
+checkout — and it does not match the multi-profile, multi-session
+shape the dashboard, web `/chat`, AppUI coding sessions, and TUI
+multi-window now demand.
+
+## Decision
+
+Eliminate the embedded server-wide `state.agent` and replace it with
+two first-class types, both built from the same code path gateway
+subprocesses already use:
+
+- **`ProfileRuntime`** — one per profile per host process. Owns the
+  LLM provider, credentials, registered skills, plugin-env template,
+  tool policy, default sandbox config, and the base `ToolRegistry`
+  template. Long-lived; hot-reloaded on profile-config change.
+- **`SessionRuntime`** — one per `(profile_id, session_key)`. Owns
+  the per-session `workspace_root`, `plugin_work_dir`, sandbox config
+  (with optional per-session override), the session's cloned
+  `ToolRegistry` (workspace-bound, policy-filtered), and the per-session
+  `Agent` instance. Cached with TTL/LRU; rebuildable from disk.
+
+These map 1:1 onto the two scopes a multi-session product has:
+
+- **Profile scope** — identity, billing, model, secrets, what skills
+  are installed. Shared by every session opened by the same logged-in
+  user.
+- **Session scope** — workspace, what's allowed in this conversation,
+  what's been said. Independent across two sessions opened by the
+  same user.
+
+Anything that can vary between two chats opened by the same logged-in
+user is session-scope. Anything that's an account property is
+profile-scope. Every "is this thing per-profile or per-session?"
+question now has one canonical answer instead of one PR per question.
+
+## Worked examples
+
+The same two types handle the four shapes we ship today.
+
+### Web — one logged-in user, multiple rooms
+
+```
+serve process
+└─ AppState
+   ├─ profiles: { "dspfac": ProfileRuntime(kimi-k2.5, AUTODL_API_KEY, mofa-fm + slides-skill) }
+   └─ sessions:
+        ("dspfac", "chat-room-1"):  SessionRuntime { cwd=<data_dir>/users/.../workspace,
+                                                     tools=clone(profile.tools), … }
+        ("dspfac", "slides-1"):     SessionRuntime { cwd=<data_dir>/users/slides-1/workspace,
+                                                     tools=clone(profile.tools).filter(slides),
+                                                     sandbox=no-network, … }
+        ("dspfac", "chat-room-2"):  SessionRuntime { distinct cwd, history, sandbox … }
+```
+
+All three rooms share the LLM and credentials (profile-scope). All
+three have independent cwd, tool registry view, sandbox, chat
+history (session-scope).
+
+### Coding-agent — N concurrent repos per user
+
+A coding-agent UI opens a session with `workspace_root` set to a
+specific repo path. `SessionRuntime::bootstrap` honors that hint
+(after `validate_session_workspace_allowed`). A second coding session
+in another repo is a separate `SessionRuntime` — separate `Agent`,
+separate tools view, separate sandbox state, zero interference.
+
+This is the Codex model. Sessions map to `SessionRuntime`; the LLM
+API account + global config maps to `ProfileRuntime`.
+
+### TUI — multiple terminals on one box
+
+Each `octos tui` is its own process. Two terminals get two isolated
+state spaces by virtue of OS process separation. Inside one TUI
+process you can also have multiple sessions (split panes) sharing the
+one `ProfileRuntime`. Different OS users get extra isolation via
+`~/.octos` being scoped to `$HOME` — separate auth stores, separate
+profile stores, separate processes.
+
+### Gateway — per-profile subprocess
+
+Each gateway subprocess constructs one `ProfileRuntime` and one or
+more `SessionRuntime`s (one per Telegram chat, Discord channel, etc.).
+The same code path serve uses, just in a child process started by
+`ProcessManager`.
+
+## What this dissolves
+
+| Symptom we patched in 2026-05 | Reason it was a symptom | How the new model removes it |
+|---|---|---|
+| `Config::credentials` transient field (#866) | API key plumbing was bolted onto a global Config | `ProfileRuntime.credentials` — it's profile state, not config state |
+| `Config::profile_skills_dir` transient field (#868) | Plugin loader scanned wrong dirs | `ProfileRuntime.skills_dir` populates the base `ToolRegistry` at bootstrap; every session inherits |
+| `Config::profile_plugin_env` transient field (#868) | Skill spawns missed per-profile env | `ProfileRuntime.plugin_env_template` injected into every `SessionRuntime` plugin spawn |
+| `overlay_profile_llm` in `serve.rs` (#866) | Serve had to retrofit profile awareness onto a globally-scoped Agent | `ProfileRuntime::bootstrap(profile)` builds it correctly from the start |
+| `"workspace policy not found"` (today) | Serve's `workspace_root = cwd`; no per-session policy bootstrap | `SessionRuntime::bootstrap` creates `<workspace_root>/.octos-workspace.toml` if missing |
+| Multi-tenant base-registry leak (codex's note on #868) | One global ToolRegistry shared by every session | `SessionRuntime.tools` is a per-session clone of `ProfileRuntime.tool_specs` |
+| Coding-agent N-sessions-per-profile (M10 deliverable) | One Agent per profile gateway subprocess | Each session has its own `SessionRuntime` with its own `Agent` |
+
+None of the four PRs from 2026-05-10 is wasted; each PR's body becomes
+the implementation of `ProfileRuntime::bootstrap` or
+`SessionRuntime::bootstrap`. The transient `Config` fields they
+introduced go away — they always wanted to live somewhere else.
+
+## What this is NOT
+
+- **Not a subprocess refactor.** Sessions run in-process within the
+  host (`serve` or `octos tui`). Sandbox isolation continues to live
+  at the shell-tool spawn boundary (`Bwrap`/`Macos sbpl`/`Docker`),
+  not at the session level. If we ever need stronger session
+  isolation (hostile multi-tenant compute), the abstraction supports a
+  "session = subprocess" mode without changing the type signatures.
+- **Not a config rewrite.** Profile JSON on disk stays the same. The
+  change is internal: how the runtime reads it into in-memory state.
+- **Not a wire-protocol change.** `/api/chat`, UI Protocol v1 WS, and
+  the bus message shape are unchanged. Only the server-side
+  dispatcher changes.
+- **Not per-session credentials.** If a session needs a different API
+  key, that's a different profile. Credentials are an identity
+  property. Codex draws the same line; we keep it.
+
+## Workstream plan
+
+See `workstreams/M11-runtime-unification.md` for the full breakdown.
+Eight workstreams (`M11-A` through `M11-H`) with explicit allowed
+file sets, deliverables, and acceptance gates. Designed for parallel
+agent execution under supervisor gating.
+
+Phase order, with explicit blockers:
+
+```
+M11-A (type skeleton)      ── blocks B, C, D
+   │
+   ├── M11-B (gateway bootstrap → ProfileRuntime)
+   ├── M11-C (serve agent → SessionRuntime + workspace bootstrap)
+   │
+   └── M11-D (AppState refactor, /api/chat dispatcher)  ── blocks E, F, G
+          │
+          ├── M11-E (UI Protocol per-session workspace wiring)
+          ├── M11-F (delete legacy Config transients + overlay)
+          │
+          └── M11-G (coding-agent multi-session e2e)  ── blocks H
+                 │
+                 └── M11-H (fleet redeploy + soak gate)
+```
+
+`M11-B` and `M11-C` can run in parallel after `M11-A`. `M11-E` and
+`M11-F` can run in parallel after `M11-D`. `M11-G` requires both `D`
+and `E`. `M11-H` ships only after `F` and `G` are clean on CI and on
+mini1/2/3 staging.
+
+## Acceptance: end-state checklist
+
+1. `state.agent: Option<Arc<Agent>>` is gone from `AppState`. Replaced
+   by `state.profiles` and `state.sessions`.
+2. `try_create_agent` in `commands/serve.rs` is gone. Replaced by
+   `SessionRuntime::bootstrap`.
+3. `overlay_profile_llm` and `populate_profile_credentials` in
+   `commands/serve.rs` are gone. The logic lives inside
+   `ProfileRuntime::bootstrap`.
+4. `Config::credentials`, `Config::profile_skills_dir`,
+   `Config::profile_plugin_env` are gone. The runtime state lives
+   on `ProfileRuntime`.
+5. Gateway subprocess startup calls the same `ProfileRuntime::bootstrap`
+   function serve calls.
+6. Web `/chat` and AppUI WS handlers resolve `SessionRuntime` per
+   request from `(profile_id, session_key)`.
+7. Multi-session test: open two AppUI coding sessions on the same
+   profile, point them at different `workspace_root`s, run a
+   `read_file` in one and assert the other sees its own workspace.
+   Existing unit test (`session_filesystem_profile_for_workspace`)
+   stays green.
+8. yangmi voice-clone end-to-end on mini1 with the `/Users/cloud/.octos-workspace.toml`
+   hotfix DELETED. The workspace policy is bootstrapped under
+   `<profile_data_dir>/users/<session_key>/workspace/` per-session.
+9. `cargo clippy --workspace --all-targets -- -D warnings` clean.
+10. M9-era soak harness (Telegram + web + AppUI) green on
+    mini1/mini2/mini3.
+
+## Risks
+
+- **Behavior drift in gateway during refactor.** Mitigated by
+  `M11-B` keeping gateway behavior byte-identical (just relocating
+  the bootstrap body to a callable function). Codex review required.
+- **SessionRuntime cache eviction edge cases.** Mitigated by making
+  the cache a perf optimization only — every `SessionRuntime` is
+  reconstructible from disk-persisted session metadata + chat
+  history.
+- **Tool registry clone cost.** Today's `ToolRegistry::snapshot_excluding`
+  is already paid by `with_workspace_root`. Per-session clone is one
+  more invocation; profile data on big skill graphs is bounded
+  (~30 tools max).
+- **Migration window.** The four 2026-05-10 PRs land before M11 and
+  remain in main. M11 deletes the transient `Config` fields they
+  introduced; that's a normal "extract → relocate → delete" cycle, not
+  a revert.

--- a/workstreams/M11-runtime-unification.md
+++ b/workstreams/M11-runtime-unification.md
@@ -1,0 +1,544 @@
+# M11 Runtime Unification — Workstreams
+
+Status: PROPOSED — accepts after `M11-PROFILE-SESSION-RUNTIME-ADR.md`
+is APPROVED.
+
+ADR: `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md`
+
+## Goal
+
+Replace the server-wide embedded `state.agent: Option<Arc<Agent>>` in
+`octos serve` with two first-class types — `ProfileRuntime` (per
+profile) and `SessionRuntime` (per `(profile_id, session_key)`) —
+unifying the path serve and gateway take to construct an agent.
+Surface coding-agent's N-isolated-sessions-per-profile model. Delete
+the four transient `Config::profile_*` fields introduced by PR #866
+and PR #868.
+
+## Non-Goals
+
+- **Not** rewriting profile JSON on disk. The schema stays the same.
+- **Not** changing any wire protocol (`/api/chat`, UI Protocol v1 WS,
+  bus message shape).
+- **Not** adding per-session credentials. Credentials are
+  profile-scope; sessions inherit.
+- **Not** moving sessions into subprocesses. Sandbox isolation
+  continues to live at the shell-tool spawn boundary.
+- **Not** changing gateway's external behavior. Gateway's startup is
+  refactored to call the new `ProfileRuntime::bootstrap`, but the
+  observable behavior (channels it serves, env it injects into
+  skills, sessions it manages) is byte-identical pre/post.
+
+## Current State (2026-05-10)
+
+`commands/serve.rs::try_create_agent` constructs ONE `Agent` from
+`Config` overlaid by `overlay_profile_llm`. It writes per-profile
+state onto four transient fields on `Config`:
+
+- `Config::credentials: HashMap<String, String>` (PR #866)
+- `Config::profile_skills_dir: Option<PathBuf>` (PR #868)
+- `Config::profile_plugin_env: Vec<(String, String)>` (PR #868)
+- `Config::content_routing` (already on Config, no extra transient)
+
+`AppState::agent` is `Some(this single Agent)`. Every `/api/chat` and
+UI Protocol WS session shares it. `workspace_root` is set once at
+startup to the daemon cwd. `plugin_work_dir` is set once to the
+top-level data dir's `skill-output`.
+
+`commands/gateway/gateway_runtime.rs` does the same construction
+inline (~500 LOC of setup before its bus loop starts), per-profile,
+inside each subprocess `ProcessManager` spawns. It correctly sets
+`workspace_root` per-session under `<data_dir>/users/<key>/workspace/`
+and writes `.octos-workspace.toml` there.
+
+The mismatch caused the yangmi-voice incident chain on 2026-05-10
+(four PRs landed; a fifth gap — workspace policy — surfaced after the
+fourth and still requires a hotfix on mini1).
+
+## Workstreams
+
+### M11-A: Runtime types skeleton
+
+Repository: `octos`
+
+Owns:
+
+- The type signatures of `ProfileRuntime`, `SessionRuntime`, and
+  `SessionRuntimeCache`. No behavior yet — types compile, doc
+  comments fully specify the contract.
+- A new module `crates/octos-cli/src/runtime/`.
+
+Allowed areas:
+
+- `crates/octos-cli/src/runtime/mod.rs` (new)
+- `crates/octos-cli/src/runtime/profile.rs` (new)
+- `crates/octos-cli/src/runtime/session.rs` (new)
+- `crates/octos-cli/src/runtime/cache.rs` (new)
+- `crates/octos-cli/src/lib.rs` (add `mod runtime;`)
+
+Deliverables:
+
+- `pub struct ProfileRuntime` with fields:
+  - `profile_id: String`
+  - `data_dir: PathBuf` — `~/.octos/profiles/<id>/data`
+  - `llm: Arc<dyn LlmProvider>`
+  - `adaptive_router: Option<Arc<AdaptiveRouter>>` — from `qos_catalog::AdaptiveProviderBundle`
+  - `credentials: HashMap<String, String>`
+  - `skills_dir: Option<PathBuf>`
+  - `plugin_env_template: Vec<(String, String)>` — `OCTOS_PROFILE_ID`, `OCTOS_VOICE_DIR`, etc.
+  - `tool_policy: Option<ToolPolicy>`
+  - `default_sandbox: SandboxConfig`
+  - `tool_specs: Arc<ToolRegistry>` — base registry, NO workspace bound
+  - `memory: Arc<EpisodeStore>`
+  - `memory_store: Arc<MemoryStore>`
+- `impl ProfileRuntime` signature only:
+  - `pub async fn bootstrap(profile: &UserProfile, store: &ProfileStore, data_dir: &Path) -> Result<Arc<Self>>` — body: `todo!()`
+- `pub struct SessionRuntime` with fields:
+  - `session_key: SessionKey`
+  - `profile: Arc<ProfileRuntime>`
+  - `workspace_root: PathBuf`
+  - `plugin_work_dir: PathBuf`
+  - `sandbox: SandboxConfig` — may override profile default
+  - `tools: Arc<ToolRegistry>` — cloned from profile, workspace-bound, policy-filtered
+  - `agent: Arc<Agent>`
+  - `sessions: Arc<tokio::sync::Mutex<SessionManager>>`
+- `impl SessionRuntime` signature only:
+  - `pub async fn bootstrap(profile: &Arc<ProfileRuntime>, session_key: SessionKey, workspace_hint: Option<PathBuf>) -> Result<Arc<Self>>` — body: `todo!()`
+- `pub struct SessionRuntimeCache` — wraps `tokio::sync::RwLock<HashMap<(String, SessionKey), Arc<SessionRuntime>>>`. TTL/LRU policy parameters.
+  - `pub fn new(max_size: usize, idle_ttl: Duration) -> Self`
+  - `pub async fn get_or_init(&self, profile: &Arc<ProfileRuntime>, session_key: SessionKey, workspace_hint: Option<PathBuf>) -> Result<Arc<SessionRuntime>>` — body: `todo!()`
+  - `pub async fn invalidate(&self, key: &(String, SessionKey))`
+- Module doc comments (`//!`) at the top of `runtime/mod.rs` explain
+  the two-scope model and reference the ADR.
+
+Acceptance:
+
+- `cargo check -p octos-cli --features api` clean with `todo!()` bodies.
+- `cargo doc -p octos-cli --no-deps` renders the module docs.
+- A unit test asserts the type signatures compile and the cache key
+  format is `(String, SessionKey)`.
+
+Blocks: M11-B, M11-C, M11-D.
+
+### M11-B: Extract gateway's profile bootstrap into ProfileRuntime
+
+Repository: `octos`
+
+Owns:
+
+- Moving the per-profile bootstrap body from
+  `gateway_runtime.rs::run` (~lines 286–520 today) into
+  `ProfileRuntime::bootstrap`.
+- Keeping gateway behavior byte-identical pre/post — gateway's
+  observable lifecycle (channels it serves, env injected to skills,
+  bus startup) does not change.
+
+Depends on: M11-A.
+
+Allowed areas:
+
+- `crates/octos-cli/src/runtime/profile.rs`
+- `crates/octos-cli/src/commands/gateway/gateway_runtime.rs`
+- `crates/octos-cli/src/skills_scope.rs` (already exports the helpers
+  we need; small re-export tweaks only)
+- tests under these crates
+
+Deliverables:
+
+- `ProfileRuntime::bootstrap` implementation that:
+  1. Calls `crate::profiles::config_from_profile(profile, None, None)` to derive a Config (preserves the existing per-profile-LLM contract).
+  2. Wraps the primary LLM via `qos_catalog::build_adaptive_provider_chain(..., ExporterMode::Spawn)` — the helper PR #867 introduced — and stores `(llm, adaptive_router)` on the struct.
+  3. Resolves `credentials` from `profile.config.env_vars` via `keychain::resolve_env_vars`.
+  4. Resolves `skills_dir = data_dir.join("skills")` (PR #868's logic).
+  5. Builds `plugin_env_template` via `skills_scope::push_runtime_plugin_env` (PR #868's helper).
+  6. Constructs the base `ToolRegistry` via `with_builtins_and_sandbox` + tool_config + the registration sequence gateway currently does (browser, web_search, MCP, etc.).
+  7. Loads plugins via `PluginLoader::load_into_with_options` with the per-profile env + work dir.
+  8. Pins plugin tool names as base tools (today's LRU defense from PR #764).
+  9. Opens `EpisodeStore` and `MemoryStore` against `data_dir`.
+  10. Returns `Arc<Self>`.
+- `gateway_runtime.rs::run` refactored to call `ProfileRuntime::bootstrap` once, then use its fields for the bus loop, session actors, etc. The bus / channel / cron / heartbeat setup downstream of the agent stays where it is.
+- New module `crates/octos-cli/src/runtime/profile.rs` exports the implementation.
+
+Acceptance:
+
+- `cargo test -p octos-cli --lib commands::gateway` passes unchanged.
+- Manual diff: before-PR and after-PR `gateway run` produces the same
+  startup log lines (provider list, adaptive routing, skills loaded,
+  plugin env keys, base-tool pin count).
+- A unit test in `runtime/profile.rs` builds a `ProfileRuntime` from
+  a synthetic profile + temp data_dir + stub LLM and asserts
+  `tool_specs` contains a known builtin (e.g. `read_file`) and
+  `credentials` is populated from `env_vars`.
+- Gateway live boot on a dev mini works end-to-end (Telegram echo,
+  fm_voice_list, fm_tts) — soak test under
+  `scripts/test-local-tenant-deploy.sh` or equivalent.
+
+Blocks: M11-D.
+
+### M11-C: SessionRuntime + per-session workspace bootstrap
+
+Repository: `octos`
+
+Owns:
+
+- The implementation of `SessionRuntime::bootstrap` — the per-session
+  agent constructor that fixes the yangmi/workspace gap.
+- Per-session workspace dir + `.octos-workspace.toml` creation step.
+
+Depends on: M11-A.
+
+Allowed areas:
+
+- `crates/octos-cli/src/runtime/session.rs`
+- `crates/octos-cli/src/runtime/cache.rs`
+- `crates/octos-agent/src/workspace_policy.rs` (helper to write a
+  default policy; existing `write_workspace_policy` is sufficient —
+  no semantic change)
+- tests under the above
+
+Deliverables:
+
+- `SessionRuntime::bootstrap(profile, session_key, workspace_hint) -> Result<Arc<Self>>` implementation:
+  1. Resolve `workspace_root`:
+     - If `workspace_hint` is `Some(path)` and
+       `validate_session_workspace_allowed(state, path)` accepts, use
+       it (coding-agent path).
+     - Else, derive `profile.data_dir.join("users").join(encode(session_key)).join("workspace")` and `create_dir_all`.
+  2. If `workspace_root/.octos-workspace.toml` does not exist, write
+     `WorkspacePolicy::for_session()` to it via `write_workspace_policy`.
+  3. Compute `plugin_work_dir = workspace_root.join("skill-output")` and `create_dir_all`.
+  4. Clone `profile.tool_specs` via `ToolRegistry::snapshot_excluding(&[])` and apply:
+     - `set_workspace_root(workspace_root.clone())`
+     - `set_output_dir_hint(plugin_work_dir.to_string_lossy().into_owned())`
+     - Per-session policy filter (no-op default).
+  5. Resolve `sandbox` — profile default unless an explicit override
+     is provided in the future; for M11 the default is fine.
+  6. Construct the `Agent` from `profile.llm` + the cloned tools.
+     Today's `Agent` builder pattern — `Agent::new(...)` plus the
+     `.with_*` chain — moves verbatim from `try_create_agent` into
+     this function.
+  7. Construct the per-session `SessionManager` against
+     `profile.data_dir.join("users").join(session_key.user_key())`.
+  8. Return `Arc<Self>`.
+- `SessionRuntimeCache::get_or_init`:
+  - Holds an `RwLock<HashMap<(String, SessionKey), Arc<SessionRuntime>>>`.
+  - On hit, return.
+  - On miss, drop read lock, take write lock, double-check, call
+    `SessionRuntime::bootstrap`, insert, return.
+  - Eviction is best-effort: a background task scans every 60 s and
+    drops entries idle > `idle_ttl`. M11 starts with `idle_ttl =
+    30 min`, `max_size = 64`. Eviction is a perf optimization, never
+    correctness — every entry is rebuildable.
+- Unit tests:
+  - Two sessions on the same profile with different `workspace_hint`
+    paths produce `SessionRuntime`s with distinct `workspace_root`,
+    distinct `plugin_work_dir`, and the same `profile` `Arc`.
+  - A session bootstrap with no `workspace_hint` creates the
+    auto-derived workspace dir and writes the default policy file.
+  - A second `get_or_init` for the same key returns the same `Arc`
+    (cache hit).
+
+Acceptance:
+
+- `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- All M11-C unit tests pass.
+- A focused integration test simulates a yangmi flow (stub LLM, stub
+  skill binary, real workspace bootstrap) and asserts
+  `enforce_spawn_task_contract` reaches `Satisfied` without any
+  hotfix policy file at the daemon cwd.
+
+Blocks: M11-D.
+
+### M11-D: AppState refactor — replace state.agent with profiles/sessions
+
+Repository: `octos`
+
+Owns:
+
+- Replacing `AppState::agent: Option<Arc<Agent>>` with
+  `state.profiles: HashMap<ProfileId, Arc<ProfileRuntime>>` and
+  `state.sessions: Arc<SessionRuntimeCache>`.
+- Wiring `/api/chat` (`api/handlers.rs::chat`) and the synchronous
+  `chat_sync` path to resolve the right `SessionRuntime` per request.
+- Updating `commands/serve.rs::run_async` to build the `profiles` map
+  from `ProfileStore::list()` instead of calling `try_create_agent`.
+
+Depends on: M11-A, M11-B, M11-C.
+
+Allowed areas:
+
+- `crates/octos-cli/src/api/mod.rs` (AppState struct)
+- `crates/octos-cli/src/api/handlers.rs`
+- `crates/octos-cli/src/commands/serve.rs`
+- tests under these crates
+
+Deliverables:
+
+- `AppState`:
+  - Replace `pub agent: Option<Arc<Agent>>` with
+    `pub profiles: HashMap<String, Arc<ProfileRuntime>>`.
+  - Add `pub sessions: Arc<SessionRuntimeCache>`.
+  - Keep `pub sessions_manager: Option<Arc<Mutex<SessionManager>>>`
+    if any handler still needs the global one for legacy paths; mark
+    it deprecated and route new code through `SessionRuntime.sessions`.
+- `commands/serve.rs::run_async`:
+  - On startup, iterate `ProfileStore::list()` and call
+    `ProfileRuntime::bootstrap` for every enabled profile with a
+    fully populated `llm.primary`. Log per-profile bootstrap success.
+  - If any profile fails bootstrap, log a warning and continue —
+    other profiles still serve.
+  - Wire the populated `state.profiles` + a fresh
+    `SessionRuntimeCache::new(64, Duration::from_secs(1800))` into
+    `AppState`.
+- `api/handlers.rs::chat`:
+  - Resolve `profile_id` from `validate_authenticated_session_scope`
+    (already extracted from the session_id format).
+  - `let profile = state.profiles.get(profile_id).cloned().ok_or(...)?;`
+  - `let session = state.sessions.get_or_init(&profile, session_key, /* workspace_hint */ None).await?;`
+  - Dispatch the user message to `session.agent`.
+  - Wire response through the same persistence helpers
+    (`persist_chat_message_through_canonical`) but against
+    `session.sessions` instead of the global one.
+
+Acceptance:
+
+- `cargo test -p octos-cli --lib api::handlers` passes.
+- `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- Live `curl -X POST /api/chat` against a dev serve completes a
+  one-turn echo against the routed profile's LLM.
+- yangmi voice-clone end-to-end on a dev mini WITHOUT the
+  `/Users/cloud/.octos-workspace.toml` hotfix — the workspace policy
+  is bootstrapped per-session by `SessionRuntime::bootstrap`.
+
+Blocks: M11-E, M11-F.
+
+### M11-E: UI Protocol per-session workspace wiring
+
+Repository: `octos`
+
+Owns:
+
+- Threading the `session_workspaces` map already present in
+  `ui_protocol.rs` (line 752 today) into `SessionRuntime::bootstrap`
+  as the `workspace_hint`.
+- Removing the legacy "global tool registry clone with per-session
+  cwd rebind" path codex flagged in PR #868's multi-tenant scope note.
+
+Depends on: M11-D.
+
+Allowed areas:
+
+- `crates/octos-cli/src/api/ui_protocol.rs`
+- `crates/octos-cli/src/api/ui_protocol_*.rs` bridges
+- tests under the same crates
+
+Deliverables:
+
+- `ui_protocol::handle_session_open` (or equivalent) honors the
+  client-supplied `cwd` (via the `session.workspace_cwd.v1`
+  capability), validates via the existing
+  `validate_session_workspace_allowed`, passes it as `workspace_hint`
+  into `SessionRuntimeCache::get_or_init`.
+- The legacy `clone_session_tools` path that built a per-session
+  tool registry from `base_agent.tool_registry()` is removed —
+  `SessionRuntime.tools` IS the per-session view.
+- `session_workspaces` in-memory map either goes away (preferred —
+  `SessionRuntime` is the single store) or becomes a thin
+  read-through to the cache.
+
+Acceptance:
+
+- An AppUI coding session opened with a custom `cwd` runs `read_file`
+  and observes the supplied workspace, not the daemon cwd.
+- Two AppUI sessions on the same profile with different `cwd`s do
+  not see each other's files (regression: the multi-tenant scope
+  note from PR #868 is now an enforced invariant).
+- The existing M10-A unit test
+  (`two AppUI sessions with different profiles use different
+  effective runtime descriptors`) stays green.
+
+Blocks: M11-G.
+
+### M11-F: Delete legacy Config transients + overlay machinery
+
+Repository: `octos`
+
+Owns:
+
+- Deleting `Config::credentials`, `Config::profile_skills_dir`,
+  `Config::profile_plugin_env`.
+- Deleting `commands/serve.rs::overlay_profile_llm`,
+  `select_serve_profile`, `profile_has_active_primary_llm`,
+  `populate_profile_credentials`, `inject_profile_api_key_env` (any
+  remnants), and `try_create_agent`.
+- Auditing every remaining reader of these fields and migrating to
+  `ProfileRuntime` / `SessionRuntime` access.
+
+Depends on: M11-D (the replacement must be live before deletion is
+safe).
+
+Allowed areas:
+
+- `crates/octos-cli/src/config.rs`
+- `crates/octos-cli/src/commands/serve.rs`
+- `crates/octos-cli/src/profiles.rs` (only to update
+  `config_from_profile` if it still touches the deleted fields)
+- `crates/octos-cli/src/api/handlers.rs` (consumer migration)
+- `crates/octos-cli/src/api/ui_protocol.rs` (consumer migration)
+- tests under these crates
+
+Deliverables:
+
+- The three transient Config fields are removed; nothing reads them.
+- Functions named above are removed; nothing calls them.
+- Documentation in `docs/ARCHITECTURE.md` updated to reference the
+  new module instead of `try_create_agent`.
+
+Acceptance:
+
+- `cargo build -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"` clean.
+- `cargo test -p octos-cli --lib` clean.
+- `git grep -nE 'profile_skills_dir|profile_plugin_env|overlay_profile_llm|populate_profile_credentials|try_create_agent|Config::credentials\b'` returns 0 hits in non-doc files.
+
+Blocks: M11-H.
+
+### M11-G: Coding-agent multi-session e2e
+
+Repository: `octos` + `octos-web` (if needed for client driver)
+
+Owns:
+
+- An end-to-end test that proves coding-agent's N-sessions-per-profile
+  isolation invariant.
+
+Depends on: M11-D, M11-E.
+
+Allowed areas:
+
+- `crates/octos-cli/tests/` (new integration test)
+- `e2e/` (Playwright spec) — optional
+- the M10 coding-runtime soak harness if reusable
+
+Deliverables:
+
+- An integration test in `crates/octos-cli/tests/coding_multi_session.rs`:
+  1. Boot a `serve` instance with two AppUI sessions for the same
+     profile.
+  2. Session A: `workspace_hint = /tmp/repo-A` (pre-seeded with file `a.txt`).
+  3. Session B: `workspace_hint = /tmp/repo-B` (pre-seeded with file `b.txt`).
+  4. Run a `read_file("a.txt")` turn on session A; expect 200 + content.
+  5. Run a `read_file("a.txt")` turn on session B; expect failure (file not visible from B's workspace).
+  6. Run a `read_file("b.txt")` turn on session B; expect 200 + content.
+  7. Assert session A and session B accumulate independent chat
+     history JSONLs under their respective `user_key`s.
+- The test must be `#[tokio::test]` and runnable via `cargo test -p octos-cli --test coding_multi_session`. No external API keys
+  required — use the `Stub LLM` already used in `qos_catalog.rs`
+  tests.
+
+Acceptance:
+
+- Test passes locally and on CI.
+- Removing the workspace_root resolution from `SessionRuntime::bootstrap`
+  (mutation experiment) makes the test fail.
+
+Blocks: M11-H.
+
+### M11-H: Fleet redeploy + soak gate
+
+Repository: `octos` (deploy + verify; no code change)
+
+Owns:
+
+- Building the M11 binary, deploying to mini1/2/3, removing the
+  hotfix `.octos-workspace.toml` at `/Users/cloud/.octos-workspace.toml`,
+  and running a soak that exercises yangmi + a coding-agent-style
+  multi-session flow.
+
+Depends on: M11-F, M11-G.
+
+Allowed areas:
+
+- `scripts/` (if a new soak driver is needed)
+- deploy automation only — no source changes
+
+Deliverables:
+
+- mini1, mini2, mini3 running an M11 binary, with the hotfix file
+  deleted, and the per-session workspace policy created automatically
+  on first turn for every new session.
+- Smoke results captured for:
+  - yangmi voice clone via web `/api/chat` and via Telegram on each
+    mini.
+  - Two AppUI coding sessions running concurrently against the
+    `dspfac` profile, each in a different cwd, completing one
+    `read_file` turn each.
+- Marathon-30 stress test (mini1+2+3, 30 minutes of mixed chat +
+  spawn_only traffic) — no `workspace policy not found` failures, no
+  `no output files produced` failures, no cross-session content
+  bleed.
+
+Acceptance:
+
+- Soak results posted to the M11 tracking issue (see below).
+- Zero "workspace policy not found" entries in `serve.log` across
+  the soak window.
+- Audio attachments delivered for at least 5 yangmi turns per mini.
+
+## Cross-Workstream Invariants
+
+These hold across every workstream. Any PR that violates them must
+be rebased before merge.
+
+1. **No subprocess introduction.** Sessions stay in-process. Sandbox
+   isolation continues at the shell-tool boundary.
+2. **No wire-protocol change.** `/api/chat`, UI Protocol v1, bus
+   message shape stay identical.
+3. **`ProfileRuntime` and `SessionRuntime` bodies never read
+   `Config::credentials`, `Config::profile_skills_dir`,
+   `Config::profile_plugin_env`.** Those fields are slated for
+   deletion in M11-F. New code reads from `profile.*` fields
+   directly.
+4. **Gateway behavior is preserved.** Any gateway PR must keep the
+   gateway boot output byte-identical (provider list, adaptive
+   routing log, skills loaded count, plugin env keys, base-tool pin
+   count).
+5. **Workspace policy bootstrap is idempotent.** If a file exists at
+   `<workspace_root>/.octos-workspace.toml`, do not overwrite it.
+
+## Swarm Assignment Template
+
+Each worker receives:
+
+- the workstream id (M11-A through M11-H)
+- the linked GitHub issue
+- the allowed file set verbatim (above)
+- the deliverables list
+- the acceptance gate
+- explicit instruction not to modify other workstreams' files
+- explicit instruction to escalate to the supervisor (this thread)
+  if a needed API shape change falls outside the allowed file set
+- explicit instruction to run codex review on every PR before
+  requesting merge
+
+Workers may add focused docs / tests inside their allowed area. Any
+needed API shape change outside the allowlist must be escalated
+before editing.
+
+## Tracking
+
+Top-level tracker issue: `#TBD-M11` (to be created with this
+document). All workstream issues link back to it.
+
+Each workstream issue title format: `M11-<letter>: <one-line>`.
+
+Each workstream issue body includes:
+
+1. Link to ADR.
+2. Link to this workstreams doc.
+3. Allowed files (copy-paste from above).
+4. Deliverables (copy-paste from above).
+5. Acceptance gate (copy-paste from above).
+6. Blockers / depends-on (which other M11-? issues must close first).
+
+Workers update the tracker by closing their issue with a comment
+linking to the merged PR + the codex-approve thread.


### PR DESCRIPTION
## Summary

Captures the architectural decision behind the M11 milestone — replace \`octos serve\`'s embedded server-wide \`Agent\` with two first-class runtime types (\`ProfileRuntime\`, \`SessionRuntime\`) driven by the 2026-05-10 yangmi-voice incident chain.

Three deliverables:

1. **\`docs/M11-PROFILE-SESSION-RUNTIME-ADR.md\`** — the why. Walks through the four sequential 2026-05-10 PRs that patched the same underlying scope mismatch, defines profile-scope vs session-scope, gives worked examples for web multi-room, coding-agent N-isolated-sessions-per-profile, multi-TUI on one box, and gateway subprocesses, and lists the 10-item end-state acceptance checklist.

2. **\`workstreams/M11-runtime-unification.md\`** — the how. Eight workstreams (M11-A through M11-H) with allowed file sets, deliverables, acceptance gates, and the dependency graph. Designed for parallel agent execution under supervisor gating.

3. **\`docs/ARCHITECTURE.md\`** — gets a new \"Runtime Types: ProfileRuntime / SessionRuntime (M11)\" subsection under octos-cli documenting the target shape and the bootstrap chain.

## Tracking

- Tracker: #870
- Children: #871–#878

## Test plan

- [x] Docs render correctly (\`mdbook\`-style preview)
- [x] All eight GitHub issues created and linked from tracker
- [ ] Workers can pick up M11-A in parallel after this PR merges

No code changes. Pure docs.