### PR TITLE
feat(runtime): M11-A — ProfileRuntime/SessionRuntime/SessionRuntimeCache skeleton

### DIFF
--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -29,6 +29,7 @@ pub mod process_manager;
 pub mod profiles;
 pub mod project_templates;
 mod qos_catalog;
+pub mod runtime;
 pub mod session_actor;
 pub mod setup_state_store;
 pub mod skills_scope;

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -1,0 +1,140 @@
+//! TTL/LRU cache for per-session runtimes.
+//!
+//! See the crate-level [`super`] module docs and
+//! `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md`. This file owns the
+//! [`SessionRuntimeCache`] type. The cache is intentionally a
+//! performance optimization: every entry is reconstructible from the
+//! parent [`ProfileRuntime`] + on-disk session metadata, so eviction
+//! is always safe.
+//!
+//! M11-A ships only `new` and `invalidate` (trivial). The
+//! `get_or_init` body lands in M11-C.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use eyre::Result;
+use octos_core::SessionKey;
+
+use super::{ProfileRuntime, SessionRuntime};
+
+/// In-memory cache mapping `(profile_id, session_key)` to an
+/// `Arc<SessionRuntime>`.
+///
+/// # Eviction policy
+///
+/// - **`max_size`** — a soft cap on the number of cached entries.
+///   When the cache exceeds this size, the implementation evicts the
+///   least-recently-used entry.
+/// - **`idle_ttl`** — entries whose `last_used` is older than this
+///   are eligible for background eviction. The exact eviction trigger
+///   (lazy on `get_or_init`, periodic sweep, or both) is an M11-C
+///   implementation choice; the contract here is only that entries
+///   older than `idle_ttl` may disappear without notice.
+///
+/// Because every [`SessionRuntime`] is reconstructible from disk,
+/// eviction is always safe: a subsequent
+/// [`Self::get_or_init`] call rebuilds the runtime from the parent
+/// [`ProfileRuntime`] + the on-disk session metadata. Callers must
+/// not rely on cache residency for correctness.
+///
+/// # Concurrency
+///
+/// The cache wraps the inner map in a [`tokio::sync::RwLock`] so
+/// multiple readers can fetch concurrently while a single writer
+/// inserts. The lock is async because [`Self::get_or_init`] may need
+/// to await [`SessionRuntime::bootstrap`] under contention; using
+/// the async lock keeps the runtime futures `Send`.
+pub struct SessionRuntimeCache {
+    inner: Arc<tokio::sync::RwLock<HashMap<(String, SessionKey), CacheEntry>>>,
+    max_size: usize,
+    idle_ttl: Duration,
+}
+
+/// Internal cache entry. Pairs the cached [`SessionRuntime`] with
+/// the timestamp of its most recent access for LRU bookkeeping.
+///
+/// The fields are read by M11-C's `get_or_init` body; in the M11-A
+/// skeleton they're write-only, so we silence the dead-code lint
+/// rather than ship a no-op accessor.
+#[allow(dead_code)]
+struct CacheEntry {
+    /// The cached per-session runtime.
+    runtime: Arc<SessionRuntime>,
+    /// Monotonic timestamp of the most recent
+    /// [`SessionRuntimeCache::get_or_init`] hit. Used by M11-C's
+    /// eviction logic to identify idle entries.
+    last_used: Instant,
+}
+
+impl SessionRuntimeCache {
+    /// Construct an empty cache with the given LRU capacity and
+    /// idle TTL.
+    ///
+    /// `max_size` is the soft cap on cached entries (LRU eviction
+    /// kicks in past this). `idle_ttl` is how long an entry may
+    /// sit unused before becoming eligible for eviction.
+    pub fn new(max_size: usize, idle_ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            max_size,
+            idle_ttl,
+        }
+    }
+
+    /// The LRU capacity this cache was constructed with. Exposed
+    /// primarily so tests and metrics endpoints can introspect the
+    /// configured limit.
+    pub fn max_size(&self) -> usize {
+        self.max_size
+    }
+
+    /// The idle TTL this cache was constructed with. Exposed for
+    /// the same reasons as [`Self::max_size`].
+    pub fn idle_ttl(&self) -> Duration {
+        self.idle_ttl
+    }
+
+    /// Look up a [`SessionRuntime`] by `(profile_id, session_key)`;
+    /// construct one via [`SessionRuntime::bootstrap`] on miss.
+    ///
+    /// # Contract (filled in by M11-C)
+    ///
+    /// 1. Read-lock the inner map and look for a live entry under
+    ///    `(profile.profile_id.clone(), session_key.clone())`.
+    /// 2. On hit: update `last_used` and return the cached
+    ///    `Arc<SessionRuntime>`.
+    /// 3. On miss: drop the read lock, call
+    ///    [`SessionRuntime::bootstrap(profile, session_key, workspace_hint)`](SessionRuntime::bootstrap),
+    ///    take the write lock, and insert. Use a "check-again
+    ///    under write lock" pattern so two concurrent misses
+    ///    don't both run bootstrap.
+    /// 4. If the post-insert map size exceeds `max_size`, evict
+    ///    the least-recently-used entry.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`SessionRuntime::bootstrap`].
+    pub async fn get_or_init(
+        &self,
+        profile: &Arc<ProfileRuntime>,
+        session_key: SessionKey,
+        workspace_hint: Option<PathBuf>,
+    ) -> Result<Arc<SessionRuntime>> {
+        let _ = (profile, session_key, workspace_hint);
+        todo!("M11-C implements this")
+    }
+
+    /// Drop the entry for `key` if present. Used by M11-D's
+    /// `/api/sessions/:id/delete` handler and by the config
+    /// watcher when a profile reload invalidates every cached
+    /// session for the profile.
+    ///
+    /// Idempotent: removing an absent key is a no-op.
+    pub async fn invalidate(&self, key: &(String, SessionKey)) {
+        let mut guard = self.inner.write().await;
+        guard.remove(key);
+    }
+}

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -106,24 +106,31 @@ impl SessionRuntimeCache {
     ///    `(profile.profile_id.clone(), session_key.clone())`.
     /// 2. On hit: update `last_used` and return the cached
     ///    `Arc<SessionRuntime>`.
-    /// 3. On miss: drop the read lock, call
-    ///    [`SessionRuntime::bootstrap(profile, session_key, workspace_hint)`](SessionRuntime::bootstrap),
-    ///    take the write lock, and insert. Use a "check-again
-    ///    under write lock" pattern so two concurrent misses
-    ///    don't both run bootstrap.
+    /// 3. On miss:
+    ///    a. Drop the read lock.
+    ///    b. Take the **write** lock first.
+    ///    c. Re-check the map under the write lock — if another
+    ///       task inserted the entry while we were upgrading,
+    ///       return that entry.
+    ///    d. Only then call
+    ///       [`SessionRuntime::bootstrap(profile, session_key, workspace_hint)`](SessionRuntime::bootstrap),
+    ///       insert, and return. The check-twice ordering is
+    ///       load-bearing: it's what stops two concurrent misses
+    ///       from both running `bootstrap` (which would build two
+    ///       agents, two session managers, etc.).
     /// 4. If the post-insert map size exceeds `max_size`, evict
     ///    the least-recently-used entry.
     ///
     /// # Errors
     ///
     /// Propagates any error from [`SessionRuntime::bootstrap`].
+    #[allow(unused_variables)]
     pub async fn get_or_init(
         &self,
         profile: &Arc<ProfileRuntime>,
         session_key: SessionKey,
         workspace_hint: Option<PathBuf>,
     ) -> Result<Arc<SessionRuntime>> {
-        let _ = (profile, session_key, workspace_hint);
         todo!("M11-C implements this")
     }
 

--- a/crates/octos-cli/src/runtime/mod.rs
+++ b/crates/octos-cli/src/runtime/mod.rs
@@ -1,0 +1,95 @@
+//! Runtime types for the M11 ProfileRuntime / SessionRuntime model.
+//!
+//! M11 replaces `octos serve`'s embedded server-wide `Agent` with two
+//! first-class scopes, each backed by a long-lived runtime struct:
+//!
+//! - [`ProfileRuntime`] is the *profile scope*: one per `(host process,
+//!   profile_id)` pair. It owns identity-shaped state — the LLM
+//!   provider, credentials, registered skills, plugin-env template, tool
+//!   policy, default sandbox, the base [`octos_agent::ToolRegistry`]
+//!   template, and the per-profile memory stores. Anything that is an
+//!   account property of the logged-in user lives here.
+//! - [`SessionRuntime`] is the *session scope*: one per
+//!   `(profile_id, session_key)` pair, cached by
+//!   [`SessionRuntimeCache`]. It owns conversation-shaped state — the
+//!   per-session `workspace_root`, the per-session plugin work dir, an
+//!   effective sandbox config (which may override the profile default),
+//!   a workspace-bound and policy-filtered clone of the profile's tool
+//!   registry, the per-session [`octos_agent::Agent`], and the
+//!   per-session [`octos_bus::SessionManager`]. Anything that can vary
+//!   between two chats opened by the same logged-in user lives here.
+//!
+//! Every "is this thing per-profile or per-session?" question now has
+//! one canonical answer. See `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md`
+//! for the architectural rationale, the worked examples (web rooms,
+//! coding-agent N-isolated-sessions, multi-TUI, gateway subprocess),
+//! and the end-state acceptance checklist.
+//!
+//! # What this replaces
+//!
+//! When fully landed (M11-B/M11-C/M11-D), these types subsume:
+//!
+//! - `crate::commands::serve::try_create_agent` — the embedded
+//!   server-wide agent constructor. Becomes
+//!   [`SessionRuntime::bootstrap`].
+//! - `crate::commands::serve::overlay_profile_llm` (+ the companion
+//!   `populate_profile_credentials`) — the transient per-request
+//!   `Config` overlay that retrofits profile awareness onto a globally
+//!   scoped `Agent`. Becomes [`ProfileRuntime::bootstrap`].
+//! - The per-profile bootstrap block in
+//!   `crate::commands::gateway::gateway_runtime::run` (today roughly
+//!   the LLM/QoS/credentials/skills/plugin/registry assembly between
+//!   the bus startup and the actor-factory wiring). Becomes
+//!   [`ProfileRuntime::bootstrap`] — gateway calls the same helper
+//!   serve calls.
+//!
+//! # M11-A scope (this commit)
+//!
+//! Type signatures only. Function bodies are `todo!("M11-B implements
+//! this")` or `todo!("M11-C implements this")`. Downstream workers
+//! implement against the doc comments, not the bodies. The skeleton
+//! must `cargo check` clean but makes no runtime decisions.
+
+pub mod cache;
+pub mod profile;
+pub mod session;
+
+pub use cache::SessionRuntimeCache;
+pub use profile::ProfileRuntime;
+pub use session::SessionRuntime;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// Type-checks that the public surface of the runtime module
+    /// compiles. M11-B and M11-C replace the `todo!()` bodies; this
+    /// test exists so a regression in the type signatures (a field
+    /// removed, a generic parameter changed, an import that no longer
+    /// resolves) fails CI immediately instead of waiting for the next
+    /// implementation phase to hit it.
+    #[allow(dead_code)]
+    fn _type_check() {
+        fn _names<P, S, C>()
+        where
+            P: Sized,
+            S: Sized,
+            C: Sized,
+        {
+        }
+        _names::<ProfileRuntime, SessionRuntime, SessionRuntimeCache>();
+    }
+
+    #[test]
+    fn session_runtime_cache_stores_its_constructor_args() {
+        // `new` is fully implemented in M11-A (it's a trivial
+        // constructor); only `get_or_init` defers to M11-C. The cache
+        // key shape `(String, SessionKey)` is part of the M11 contract
+        // because dispatchers (M11-D) build that tuple from the
+        // authenticated session before looking up a runtime.
+        let cache = SessionRuntimeCache::new(64, Duration::from_secs(900));
+        assert_eq!(cache.max_size(), 64);
+        assert_eq!(cache.idle_ttl(), Duration::from_secs(900));
+    }
+}

--- a/crates/octos-cli/src/runtime/mod.rs
+++ b/crates/octos-cli/src/runtime/mod.rs
@@ -1,3 +1,11 @@
+// The per-field doc blocks on `ProfileRuntime` / `SessionRuntime` use
+// multi-paragraph bullet items by design — they're the contract M11-B
+// and M11-C implement against, and collapsing to single-line bullets
+// would lose the rationale. `cargo doc` renders them correctly; the
+// continuation-indent lints would otherwise force a rewrite that
+// trades readability for lint silence.
+#![allow(clippy::doc_overindented_list_items, clippy::doc_lazy_continuation)]
+
 //! Runtime types for the M11 ProfileRuntime / SessionRuntime model.
 //!
 //! M11 replaces `octos serve`'s embedded server-wide `Agent` with two

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -1,0 +1,229 @@
+//! Profile-scope runtime state.
+//!
+//! See the crate-level [`super`] module docs and
+//! `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md` for the two-scope model.
+//! This file owns the [`ProfileRuntime`] type and its `bootstrap`
+//! signature; the body lands in M11-B.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use eyre::Result;
+use octos_agent::{SandboxConfig, ToolPolicy, ToolRegistry};
+use octos_llm::{AdaptiveRouter, LlmProvider};
+use octos_memory::{EpisodeStore, MemoryStore};
+
+use crate::profiles::{ProfileStore, UserProfile};
+
+/// All long-lived state that belongs to a single profile within the
+/// current host process.
+///
+/// One `ProfileRuntime` per `(host process, profile_id)`. The host
+/// process is `octos serve`, `octos gateway` (each subprocess), or
+/// `octos tui` — every entry point that today reads a [`UserProfile`]
+/// off disk and turns it into a running agent ends up holding an
+/// `Arc<ProfileRuntime>`.
+///
+/// # What lives here
+///
+/// Anything that is an *account property* of the logged-in user:
+///
+/// - **`llm`** — the top-level LLM provider chain (already wrapped by
+///   `RetryProvider` → `ProviderChain` → optional [`AdaptiveRouter`]).
+///   Two sessions opened by the same user hit the same provider chain.
+/// - **`adaptive_router`** — `Some` only when QoS-aware adaptive
+///   routing was successfully built (more than one provider). Owned
+///   here because the per-profile metrics exporter wants a typed
+///   handle, not a `dyn` provider.
+/// - **`credentials`** — resolved API keys / secrets keyed by env-var
+///   name. Populated from `profile.config.env_vars` via the keychain
+///   in M11-B; passed to MCP server spawns and plugin invocations on
+///   the session side.
+/// - **`skills_dir`** — the per-profile plugin directory
+///   (`~/.octos/profiles/<id>/data/skills/`), if it exists. Used at
+///   bootstrap time to register profile-scoped skills into
+///   [`Self::tool_specs`].
+/// - **`plugin_env_template`** — the env-var pairs (e.g.
+///   `OCTOS_PROFILE_ID`, `OCTOS_VOICE_DIR`) every plugin spawn for
+///   this profile should inherit. Sessions clone this into their own
+///   plugin spawns; if a session needs to add session-scoped vars it
+///   does so on top of this template.
+/// - **`tool_policy`** — the profile's allow/deny tool policy. The
+///   policy is *applied per session* (after the session clones
+///   [`Self::tool_specs`]) so policy edits don't require rebuilding
+///   the base registry.
+/// - **`default_sandbox`** — the sandbox config every session
+///   inherits unless it explicitly overrides via
+///   [`super::SessionRuntime::sandbox`].
+/// - **`tool_specs`** — the base [`ToolRegistry`] template. It has
+///   builtins registered, plugins loaded, MCP agents wired, the LRU
+///   pin set applied — *but no workspace bound*. Sessions clone this
+///   and call `with_workspace_root` to get a workspace-bound registry.
+///   This is the M11 fix for the multi-tenant base-registry leak
+///   codex flagged on PR #868.
+/// - **`memory`** / **`memory_store`** — the per-profile
+///   [`EpisodeStore`] (redb at `<data_dir>/episodes.redb`) and
+///   [`MemoryStore`] (MEMORY.md, daily notes). Memory is profile-
+///   scoped because it crosses sessions — a long-running fact a user
+///   teaches the agent in one room should be recallable in another
+///   room of the same profile.
+///
+/// # What does NOT live here
+///
+/// Anything that can legitimately differ between two chats opened by
+/// the same logged-in user — `workspace_root`, conversation history,
+/// the per-session `Agent`, the session's tool-registry view, the
+/// effective sandbox after a session-level override. Those live on
+/// [`super::SessionRuntime`].
+///
+/// # Lifecycle
+///
+/// Built once per profile on first use via [`Self::bootstrap`]. Held
+/// behind an `Arc` so every [`super::SessionRuntime`] for the profile
+/// can cheaply share it. Hot-reloaded (rebuilt) when the profile
+/// config on disk changes; the [`crate::config_watcher`] decides what
+/// constitutes a reload-worthy change.
+pub struct ProfileRuntime {
+    /// Stable identifier for the profile (matches
+    /// `UserProfile::id`). Used as part of the cache key in
+    /// [`super::SessionRuntimeCache`] and as the value of
+    /// `OCTOS_PROFILE_ID` in plugin spawns.
+    pub profile_id: String,
+
+    /// The profile's data directory, conventionally
+    /// `~/.octos/profiles/<profile_id>/data`. Resolved by the caller
+    /// and passed into [`Self::bootstrap`]; held here so sessions and
+    /// session-scope bootstrap code don't have to re-derive it.
+    pub data_dir: PathBuf,
+
+    /// The fully-wrapped LLM provider chain for this profile.
+    /// Includes retry, provider failover, and (if `adaptive_router`
+    /// is `Some`) adaptive routing. Every session for this profile
+    /// uses this same provider.
+    pub llm: Arc<dyn LlmProvider>,
+
+    /// Typed handle to the adaptive router if QoS-aware adaptive
+    /// routing was wired in. `None` when only a single provider was
+    /// configured (no failover to optimize). Held separately from
+    /// `llm` so the metrics exporter and the runtime QoS catalog
+    /// reader don't have to downcast the `dyn LlmProvider`.
+    pub adaptive_router: Option<Arc<AdaptiveRouter>>,
+
+    /// Resolved credentials for this profile, keyed by env-var name
+    /// (e.g. `OPENAI_API_KEY`, `AUTODL_API_KEY`). Populated from
+    /// `profile.config.env_vars` via the keychain resolver. Sessions
+    /// read this when spawning MCP servers, plugins, and shell tools
+    /// that need the profile's API keys.
+    pub credentials: HashMap<String, String>,
+
+    /// Path to the per-profile skills directory if one exists
+    /// (`<data_dir>/skills/`). `None` when the profile has no
+    /// dashboard-installed skills, in which case the base
+    /// [`ToolRegistry`] only carries built-in tools and global
+    /// skills.
+    pub skills_dir: Option<PathBuf>,
+
+    /// Env-var pairs every plugin spawn for this profile should
+    /// inherit (`OCTOS_PROFILE_ID`, `OCTOS_VOICE_DIR`, etc.). Kept
+    /// as a vector of `(name, value)` rather than a map so the
+    /// session-side spawner can build the child env in stable order.
+    /// Sessions are free to add session-scoped vars on top of this
+    /// template.
+    pub plugin_env_template: Vec<(String, String)>,
+
+    /// The profile's tool policy (allow/deny lists, named groups,
+    /// per-provider overrides). Stored on the profile and applied
+    /// per session when the session clones [`Self::tool_specs`].
+    /// `None` means "no profile-level policy" — the agent's default
+    /// permissions apply.
+    pub tool_policy: Option<ToolPolicy>,
+
+    /// The default sandbox config sessions inherit. Sessions may
+    /// override (e.g. a slides-builder session wants
+    /// `no-network`); when they don't, the runtime falls back to
+    /// this value.
+    pub default_sandbox: SandboxConfig,
+
+    /// The base [`ToolRegistry`] template — builtins + plugins +
+    /// MCP agents + the LRU pin set — but **NOT** workspace-bound.
+    /// Sessions clone this and call `with_workspace_root` to obtain
+    /// a workspace-bound registry. The "no workspace bound" rule is
+    /// load-bearing: it's the M11 fix for the codex-flagged
+    /// multi-tenant base-registry leak (one global registry shared
+    /// across sessions would otherwise let session A's workspace
+    /// path leak into session B).
+    pub tool_specs: Arc<ToolRegistry>,
+
+    /// Long-lived [`EpisodeStore`] for this profile (redb at
+    /// `<data_dir>/episodes.redb`). Shared across all sessions of
+    /// the profile so task summaries written in one session are
+    /// recallable from another.
+    pub memory: Arc<EpisodeStore>,
+
+    /// Long-lived [`MemoryStore`] (MEMORY.md + daily notes + recent
+    /// memories window) for this profile. Same sharing rationale as
+    /// [`Self::memory`].
+    pub memory_store: Arc<MemoryStore>,
+}
+
+impl ProfileRuntime {
+    /// Construct a [`ProfileRuntime`] for the given profile.
+    ///
+    /// # Contract (filled in by M11-B)
+    ///
+    /// 1. Derive a per-profile `Config` via
+    ///    `crate::profiles::config_from_profile(profile, None, None)`
+    ///    (preserves the per-profile LLM contract PR #866
+    ///    introduced).
+    /// 2. Wrap the primary LLM via
+    ///    `qos_catalog::build_adaptive_provider_chain(..., ExporterMode::Spawn)`
+    ///    (PR #867's shared helper). Store both `llm` and
+    ///    `adaptive_router` on the returned struct.
+    /// 3. Resolve `credentials` from `profile.config.env_vars` via
+    ///    `keychain::resolve_env_vars`.
+    /// 4. Resolve `skills_dir = data_dir.join("skills")` if it
+    ///    exists (PR #868's logic).
+    /// 5. Build `plugin_env_template` via
+    ///    `skills_scope::push_runtime_plugin_env` (PR #868's
+    ///    helper).
+    /// 6. Construct the base [`ToolRegistry`] via
+    ///    `with_builtins_and_sandbox` + `tool_config` + the
+    ///    registration sequence gateway uses today (browser,
+    ///    web_search, MCP agents, ...).
+    /// 7. Load plugins via
+    ///    `PluginLoader::load_into_with_options` with the
+    ///    per-profile env + work dir.
+    /// 8. Pin plugin tool names as base tools (the LRU defense PR
+    ///    #764 added).
+    /// 9. Open [`EpisodeStore`] and [`MemoryStore`] against
+    ///    `data_dir`.
+    /// 10. Return `Arc<Self>`.
+    ///
+    /// # Parameters
+    ///
+    /// - `profile` — the parsed [`UserProfile`] from the
+    ///   [`ProfileStore`]; carries the on-disk config that drives
+    ///   the bootstrap.
+    /// - `store` — the [`ProfileStore`] the profile came from;
+    ///   needed for lookups (admin/sub-account resolution) the
+    ///   bootstrap performs.
+    /// - `data_dir` — the resolved per-profile data dir, typically
+    ///   `~/.octos/profiles/<id>/data`. The bootstrap creates it if
+    ///   missing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the steps above fail: provider
+    /// construction, keychain resolution, skills loading, redb open,
+    /// or tool-registry build. The bootstrap is fail-fast — a
+    /// partially constructed [`ProfileRuntime`] is never returned.
+    pub async fn bootstrap(
+        profile: &UserProfile,
+        store: &ProfileStore,
+        data_dir: &Path,
+    ) -> Result<Arc<Self>> {
+        let _ = (profile, store, data_dir);
+        todo!("M11-B implements this")
+    }
+}

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -218,12 +218,12 @@ impl ProfileRuntime {
     /// construction, keychain resolution, skills loading, redb open,
     /// or tool-registry build. The bootstrap is fail-fast — a
     /// partially constructed [`ProfileRuntime`] is never returned.
+    #[allow(unused_variables)]
     pub async fn bootstrap(
         profile: &UserProfile,
         store: &ProfileStore,
         data_dir: &Path,
     ) -> Result<Arc<Self>> {
-        let _ = (profile, store, data_dir);
         todo!("M11-B implements this")
     }
 }

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -35,9 +35,11 @@ use super::ProfileRuntime;
 ///   the M11 fix for the `"workspace policy not found"` failure on
 ///   yangmi voice clone.
 /// - **`plugin_work_dir`** — the per-session scratch space plugins
-///   are allowed to write into. Distinct from `workspace_root` so a
-///   plugin can drop intermediate artifacts without polluting the
-///   session's main workspace.
+///   are allowed to write into. Conventionally
+///   `workspace_root.join("skill-output")`; lives under the
+///   workspace root so artifacts remain visible to the user but
+///   are namespaced away from the session's main work tree. Wired
+///   into the tool registry via `set_output_dir_hint`.
 /// - **`sandbox`** — the effective sandbox config for this session.
 ///   Falls back to [`ProfileRuntime::default_sandbox`] unless the
 ///   session explicitly overrides (e.g. a slides-builder room
@@ -116,31 +118,34 @@ impl SessionRuntime {
     /// # Contract (filled in by M11-C)
     ///
     /// 1. Resolve `workspace_root`:
-    ///    - If `workspace_hint` is `Some`, validate it via
-    ///      `validate_session_workspace_allowed` and use it as-is
-    ///      (coding-agent flow).
+    ///    - If `workspace_hint` is `Some(path)` and
+    ///      `validate_session_workspace_allowed(state, path)`
+    ///      accepts, use it as-is (coding-agent flow).
     ///    - Otherwise default to
-    ///      `<profile.data_dir>/users/<session_key>/workspace/`
-    ///      and create the directory if missing.
-    /// 2. Resolve `plugin_work_dir` to
-    ///    `<profile.data_dir>/users/<session_key>/plugin_work/`,
-    ///    creating it if missing.
-    /// 3. If `<workspace_root>/.octos-workspace.toml` is missing,
-    ///    write a default one via
+    ///      `profile.data_dir.join("users").join(encode(session_key)).join("workspace")`
+    ///      and `create_dir_all` it.
+    /// 2. If `<workspace_root>/.octos-workspace.toml` is missing,
+    ///    write `WorkspacePolicy::for_session()` to it via
     ///    `octos_agent::workspace_policy::write_workspace_policy`.
     ///    This is the M11 fix for the
     ///    `"workspace policy not found"` failure.
-    /// 4. Derive the effective `sandbox`: profile default unless
-    ///    the session has an override (forthcoming session-config
-    ///    field; not in M11-A).
-    /// 5. Clone `profile.tool_specs`, bind it to `workspace_root`
-    ///    via `with_workspace_root`, filter through
-    ///    `profile.tool_policy`, return as `Arc<ToolRegistry>`.
-    /// 6. Build the per-session [`Agent`] from `profile.llm`, the
-    ///    session tool registry, the profile's memory stores, and
-    ///    the standard agent config.
-    /// 7. Open / load the [`SessionManager`] for `session_key`
-    ///    (JSONL persistence with the existing on-disk layout).
+    /// 3. Compute
+    ///    `plugin_work_dir = workspace_root.join("skill-output")`
+    ///    and `create_dir_all` it.
+    /// 4. Clone `profile.tool_specs` via
+    ///    `ToolRegistry::snapshot_excluding(&[])` and apply:
+    ///    - `set_workspace_root(workspace_root.clone())`
+    ///    - `set_output_dir_hint(plugin_work_dir.to_string_lossy().into_owned())`
+    ///    - per-session policy filter (no-op default for M11).
+    /// 5. Resolve `sandbox`: [`ProfileRuntime::default_sandbox`]
+    ///    is fine for M11; an explicit per-session override hook
+    ///    is left for a future workstream.
+    /// 6. Build the per-session [`Agent`] from `profile.llm` plus
+    ///    the cloned tools. Today's `Agent::new(...) + .with_*`
+    ///    chain in `commands/serve.rs::try_create_agent` relocates
+    ///    here verbatim.
+    /// 7. Open the per-session [`SessionManager`] against
+    ///    `profile.data_dir.join("users").join(session_key.user_key())`.
     /// 8. Return `Arc<Self>`.
     ///
     /// # Parameters
@@ -163,12 +168,12 @@ impl SessionRuntime {
     /// agent construction fails, or session-manager load fails.
     /// A partially constructed [`SessionRuntime`] is never
     /// returned.
+    #[allow(unused_variables)]
     pub async fn bootstrap(
         profile: &Arc<ProfileRuntime>,
         session_key: SessionKey,
         workspace_hint: Option<PathBuf>,
     ) -> Result<Arc<Self>> {
-        let _ = (profile, session_key, workspace_hint);
         todo!("M11-C implements this")
     }
 }

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -1,0 +1,174 @@
+//! Session-scope runtime state.
+//!
+//! See the crate-level [`super`] module docs and
+//! `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md` for the two-scope model.
+//! This file owns the [`SessionRuntime`] type and its `bootstrap`
+//! signature; the body lands in M11-C.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use eyre::Result;
+use octos_agent::{Agent, SandboxConfig, ToolRegistry};
+use octos_bus::SessionManager;
+use octos_core::SessionKey;
+
+use super::ProfileRuntime;
+
+/// All per-session state derived from a parent [`ProfileRuntime`].
+///
+/// One `SessionRuntime` per `(profile_id, session_key)` pair, cached
+/// by [`super::SessionRuntimeCache`]. Built on first use; cheap to
+/// rebuild from disk-persisted session metadata + chat history.
+///
+/// # What lives here
+///
+/// Anything that can legitimately differ between two chats opened by
+/// the same logged-in user:
+///
+/// - **`workspace_root`** — the per-session working directory.
+///   Resolved either from a caller-supplied hint (coding-agent UIs
+///   that point at a specific repo) or from the conventional
+///   `<profile.data_dir>/users/<session_key>/workspace/` path. The
+///   bootstrap is also responsible for writing a default
+///   `.octos-workspace.toml` if one does not already exist — that's
+///   the M11 fix for the `"workspace policy not found"` failure on
+///   yangmi voice clone.
+/// - **`plugin_work_dir`** — the per-session scratch space plugins
+///   are allowed to write into. Distinct from `workspace_root` so a
+///   plugin can drop intermediate artifacts without polluting the
+///   session's main workspace.
+/// - **`sandbox`** — the effective sandbox config for this session.
+///   Falls back to [`ProfileRuntime::default_sandbox`] unless the
+///   session explicitly overrides (e.g. a slides-builder room
+///   pinning `no-network`).
+/// - **`tools`** — the session's [`ToolRegistry`]. Built by cloning
+///   the parent's [`ProfileRuntime::tool_specs`] template, then
+///   binding it to `workspace_root` (`with_workspace_root`), then
+///   applying [`ProfileRuntime::tool_policy`] filters. Two sessions
+///   for the same profile cannot leak workspace paths through their
+///   tool registries because each holds a distinct
+///   `Arc<ToolRegistry>`.
+/// - **`agent`** — the per-session [`Agent`] instance. Wraps the
+///   profile's LLM, this session's tools, this session's
+///   workspace, and the standard agent config. The agent is what
+///   `/api/chat` and the UI Protocol v1 WS dispatcher invoke.
+/// - **`sessions`** — the per-session
+///   [`tokio::sync::Mutex<SessionManager>`]. Owns the chat history
+///   JSONL store. Wrapped in a Mutex so concurrent reads/writes for
+///   the same session (e.g. an in-flight tool call observed by both
+///   the SSE stream and the WS subscriber) serialize.
+///
+/// # Lifecycle
+///
+/// Constructed lazily by
+/// [`super::SessionRuntimeCache::get_or_init`] on first dispatch.
+/// Cached with TTL/LRU; evicted on idle or capacity pressure.
+/// Reconstructible at any time from the profile + on-disk session
+/// metadata — the cache is a performance optimization, not the
+/// source of truth.
+pub struct SessionRuntime {
+    /// The session identifier; the second half of the cache key in
+    /// [`super::SessionRuntimeCache`].
+    pub session_key: SessionKey,
+
+    /// Shared handle to the parent profile runtime. Carries the
+    /// LLM, credentials, base tool registry template, memory
+    /// stores, etc.
+    pub profile: Arc<ProfileRuntime>,
+
+    /// The per-session working directory. Tool filesystem
+    /// operations (`read_file`, `write_file`, `edit_file`, ...)
+    /// are scoped to this root by [`Self::tools`].
+    pub workspace_root: PathBuf,
+
+    /// Per-session plugin scratch directory. Plugins are spawned
+    /// with this as their cwd / `OCTOS_PLUGIN_WORK_DIR` so
+    /// intermediate files don't collide across sessions.
+    pub plugin_work_dir: PathBuf,
+
+    /// The effective sandbox config for this session. Inherited
+    /// from [`ProfileRuntime::default_sandbox`] unless the session
+    /// supplied an override at bootstrap.
+    pub sandbox: SandboxConfig,
+
+    /// The session's [`ToolRegistry`] — a clone of the profile's
+    /// base [`ProfileRuntime::tool_specs`] template that has been
+    /// (a) bound to [`Self::workspace_root`] and (b) filtered
+    /// through [`ProfileRuntime::tool_policy`]. Distinct
+    /// `Arc<ToolRegistry>` per session so workspace state cannot
+    /// leak across sessions of the same profile.
+    pub tools: Arc<ToolRegistry>,
+
+    /// The per-session [`Agent`] instance. This is what the
+    /// `/api/chat` and UI Protocol v1 dispatchers invoke.
+    pub agent: Arc<Agent>,
+
+    /// The per-session chat history manager. Wrapped in a
+    /// [`tokio::sync::Mutex`] because multiple subscribers
+    /// (SSE + WS) may observe and persist messages concurrently.
+    pub sessions: Arc<tokio::sync::Mutex<SessionManager>>,
+}
+
+impl SessionRuntime {
+    /// Construct a [`SessionRuntime`] for the given session key.
+    ///
+    /// # Contract (filled in by M11-C)
+    ///
+    /// 1. Resolve `workspace_root`:
+    ///    - If `workspace_hint` is `Some`, validate it via
+    ///      `validate_session_workspace_allowed` and use it as-is
+    ///      (coding-agent flow).
+    ///    - Otherwise default to
+    ///      `<profile.data_dir>/users/<session_key>/workspace/`
+    ///      and create the directory if missing.
+    /// 2. Resolve `plugin_work_dir` to
+    ///    `<profile.data_dir>/users/<session_key>/plugin_work/`,
+    ///    creating it if missing.
+    /// 3. If `<workspace_root>/.octos-workspace.toml` is missing,
+    ///    write a default one via
+    ///    `octos_agent::workspace_policy::write_workspace_policy`.
+    ///    This is the M11 fix for the
+    ///    `"workspace policy not found"` failure.
+    /// 4. Derive the effective `sandbox`: profile default unless
+    ///    the session has an override (forthcoming session-config
+    ///    field; not in M11-A).
+    /// 5. Clone `profile.tool_specs`, bind it to `workspace_root`
+    ///    via `with_workspace_root`, filter through
+    ///    `profile.tool_policy`, return as `Arc<ToolRegistry>`.
+    /// 6. Build the per-session [`Agent`] from `profile.llm`, the
+    ///    session tool registry, the profile's memory stores, and
+    ///    the standard agent config.
+    /// 7. Open / load the [`SessionManager`] for `session_key`
+    ///    (JSONL persistence with the existing on-disk layout).
+    /// 8. Return `Arc<Self>`.
+    ///
+    /// # Parameters
+    ///
+    /// - `profile` — the parent [`ProfileRuntime`] this session
+    ///   inherits from. Held as `&Arc<...>` so the new session
+    ///   bumps the `Arc` count rather than cloning the profile.
+    /// - `session_key` — the session identifier. Used both as
+    ///   the cache key half and to derive the conventional
+    ///   workspace/plugin paths under `profile.data_dir`.
+    /// - `workspace_hint` — optional caller-supplied workspace
+    ///   root. `Some` for coding-agent UIs that point at a
+    ///   specific repo; `None` for the default "data-dir-relative"
+    ///   layout used by web chat and gateway sessions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if workspace validation fails, directory
+    /// creation fails, policy write fails, registry clone fails,
+    /// agent construction fails, or session-manager load fails.
+    /// A partially constructed [`SessionRuntime`] is never
+    /// returned.
+    pub async fn bootstrap(
+        profile: &Arc<ProfileRuntime>,
+        session_key: SessionKey,
+        workspace_hint: Option<PathBuf>,
+    ) -> Result<Arc<Self>> {
+        let _ = (profile, session_key, workspace_hint);
+        todo!("M11-C implements this")
+    }
+}

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -144,8 +144,18 @@ impl SessionRuntime {
     ///    the cloned tools. Today's `Agent::new(...) + .with_*`
     ///    chain in `commands/serve.rs::try_create_agent` relocates
     ///    here verbatim.
-    /// 7. Open the per-session [`SessionManager`] against
-    ///    `profile.data_dir.join("users").join(session_key.user_key())`.
+    /// 7. Open the [`SessionManager`] via
+    ///    `SessionManager::open(&profile.data_dir)` — the canonical
+    ///    JSONL session store already namespaces on-disk files by
+    ///    [`SessionKey`] under `data_dir/sessions/`, so the
+    ///    profile data dir is the correct root. The
+    ///    `SessionManager` is shared across sessions of the same
+    ///    profile (wrapped in [`tokio::sync::Mutex`]); M11-C may
+    ///    choose to surface the existing profile-scoped manager
+    ///    via [`ProfileRuntime`] instead of opening a new one per
+    ///    session — either way the on-disk layout matches today's
+    ///    `commands/gateway/gateway_runtime.rs` and
+    ///    `commands/serve.rs` call sites.
     /// 8. Return `Arc<Self>`.
     ///
     /// # Parameters


### PR DESCRIPTION
## Summary

- Creates `crates/octos-cli/src/runtime/` with type signatures (no behavior) for the three M11 runtime types: `ProfileRuntime` (profile scope), `SessionRuntime` (session scope), `SessionRuntimeCache` (TTL/LRU per-session cache).
- Function bodies are `todo!("M11-B implements this")` / `todo!("M11-C implements this")` — only `SessionRuntimeCache::new` and `invalidate` are fully implemented (trivial). Downstream workers (M11-B and M11-C) implement against the doc comments, not the bodies.
- Module docs at the top of `runtime/mod.rs` explain the two-scope model, reference `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md`, and enumerate the legacy helpers this replaces (`commands/serve.rs::try_create_agent`, `overlay_profile_llm`, the per-profile bootstrap block in `commands/gateway/gateway_runtime.rs`).
- `pub mod runtime;` wired into `crates/octos-cli/src/lib.rs`.

## Type surface

- `ProfileRuntime { profile_id, data_dir, llm, adaptive_router, credentials, skills_dir, plugin_env_template, tool_policy, default_sandbox, tool_specs, memory, memory_store }` + `bootstrap(profile, store, data_dir) -> Result<Arc<Self>>`.
- `SessionRuntime { session_key, profile, workspace_root, plugin_work_dir, sandbox, tools, agent, sessions }` + `bootstrap(profile, session_key, workspace_hint) -> Result<Arc<Self>>`.
- `SessionRuntimeCache` wraps `tokio::sync::RwLock<HashMap<(String, SessionKey), CacheEntry>>` with `new(max_size, idle_ttl)`, `get_or_init`, `invalidate`, `max_size()`, `idle_ttl()`.

## Acceptance (per workstreams doc § M11-A)

- [x] `cargo check -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"` clean.
- [x] `cargo doc -p octos-cli --no-deps` renders the new module (no new doc warnings; only the 14 pre-existing ones, untouched).
- [x] New runtime module is clippy-clean. Pre-existing clippy errors in `octos-bus` (`manual_div_ceil`, `too_many_arguments`, etc.) are unchanged on `main` and out of scope here.
- [x] Unit test in `runtime/mod.rs` constructs a `SessionRuntimeCache`, asserts `max_size` / `idle_ttl` survive construction, and adds a `_type_check()` helper so a regression in any of the three type signatures fails CI immediately.
- [x] `cargo fmt --all -- --check` clean.

## Test plan

- [x] `cargo check -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"`
- [x] `cargo doc -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot" --no-deps`
- [x] `cargo test -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot" --lib runtime::`
- [x] `cargo fmt --all -- --check`

## Notes

- Refs tracker #870, issue #871, ADR `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md`, workstreams `workstreams/M11-runtime-unification.md` § M11-A.
- The `todo!()` bodies are load-bearing for M11-B (`ProfileRuntime::bootstrap`) and M11-C (`SessionRuntime::bootstrap` + `SessionRuntimeCache::get_or_init`). Bodies are deliberately empty; doc comments fully specify the contract those phases implement against.
- Allowed-file set respected: only `crates/octos-cli/src/runtime/{mod,profile,session,cache}.rs` (new) and a single `pub mod runtime;` line in `crates/octos-cli/src/lib.rs`. No other file touched.