### PR TITLE
feat(runtime): M11-B — implement ProfileRuntime::bootstrap, wire gateway

### DIFF
--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -249,14 +249,11 @@ impl GatewayRuntime {
         eprintln!("[gateway] provider={provider_name}");
         println!("{}: {}", "Provider".green(), provider_name);
 
-        // Open ProfileStore for /account commands and bot management.
         // Derive octos_home from: --octos-home flag > data_dir (which already
-        // resolves --data-dir > $OCTOS_HOME > ~/.octos).
+        // resolves --data-dir > $OCTOS_HOME > ~/.octos). Resolved here so
+        // both the bootstrap helper (for `OCTOS_HOME` in plugin env) and
+        // the `ProfileStore::open` further down agree on the path.
         let effective_octos_home = cmd.octos_home.clone().unwrap_or_else(|| data_dir.clone());
-        let profile_store: Option<Arc<crate::profiles::ProfileStore>> =
-            crate::profiles::ProfileStore::open(&effective_octos_home)
-                .ok()
-                .map(Arc::new);
 
         // M11-B: when this gateway invocation is driven by a profile,
         // delegate the per-profile bootstrap (LLM chain + QoS routing
@@ -269,15 +266,10 @@ impl GatewayRuntime {
         // single-tenant boot stays byte-identical until it is
         // retired.
         let profile_runtime: Option<Arc<crate::runtime::ProfileRuntime>> =
-            if let (Some(profile), Some(store), false) = (
-                resolved_profile.as_ref(),
-                profile_store.as_ref(),
-                cli_llm_override,
-            ) {
+            if let (Some(profile), false) = (resolved_profile.as_ref(), cli_llm_override) {
                 Some(
                     crate::runtime::ProfileRuntime::bootstrap(
                         profile,
-                        store,
                         &data_dir,
                         cmd.no_retry,
                         Some(effective_octos_home.as_path()),
@@ -302,21 +294,19 @@ impl GatewayRuntime {
         let model_id: String;
         if let Some(ref pr) = profile_runtime {
             // Bootstrap already wired the QoS-aware adaptive chain
-            // (including the model_catalog.json exporter) via the
-            // shared helper. Re-export the live catalog from the
-            // adaptive router so the downstream sub-provider router
-            // can seed QoS scores for fallback ranking — matching
-            // the legacy single-tenant path's behavior even though
-            // the chain construction now lives behind
-            // `ProfileRuntime::bootstrap`.
+            // (including the model_catalog.json exporter and the
+            // cold-start QoS catalog for single-provider profiles)
+            // via the shared helper. Reuse its `runtime_qos_catalog`
+            // directly so the downstream sub-provider router
+            // receives the same seed entries the legacy inline path
+            // would have built — including the cold-start derivation
+            // when `adaptive_router` is `None` (single provider, no
+            // failover).
             swappable = Arc::new(SwappableProvider::new(pr.llm.clone()));
             llm = swappable.clone();
             model_id = swappable.current().model_id().to_string();
             eprintln!("[gateway] LLM provider created, model={model_id}");
-            runtime_qos_catalog = pr
-                .adaptive_router
-                .as_ref()
-                .map(|router| router.export_model_catalog());
+            runtime_qos_catalog = pr.runtime_qos_catalog.clone();
             adaptive_router_ref = pr.adaptive_router.clone();
         } else {
             // Legacy single-tenant path — config.json or
@@ -341,6 +331,19 @@ impl GatewayRuntime {
             adaptive_router_ref = bundle.adaptive_router;
             runtime_qos_catalog = bundle.runtime_qos_catalog;
         }
+
+        // Open ProfileStore for /account commands and bot management.
+        // Kept here (after the LLM chain construction above) to
+        // preserve the pre-M11-B filesystem-side-effect timing —
+        // `ProfileStore::open` creates `<octos_home>/profiles/`, and
+        // moving that ahead of provider/chain construction would
+        // create the directory even on profiles whose
+        // `create_provider` would otherwise fail before any
+        // filesystem write.
+        let profile_store: Option<Arc<crate::profiles::ProfileStore>> =
+            crate::profiles::ProfileStore::open(&effective_octos_home)
+                .ok()
+                .map(Arc::new);
 
         #[allow(unused_variables)] // used by feature-gated channel registration
         let media_dir = data_dir.join("media");

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -249,97 +249,45 @@ impl GatewayRuntime {
         eprintln!("[gateway] provider={provider_name}");
         println!("{}: {}", "Provider".green(), provider_name);
 
-        // Derive octos_home from: --octos-home flag > data_dir (which already
-        // resolves --data-dir > $OCTOS_HOME > ~/.octos). Resolved here so
-        // both the bootstrap helper (for `OCTOS_HOME` in plugin env) and
-        // the `ProfileStore::open` further down agree on the path.
-        let effective_octos_home = cmd.octos_home.clone().unwrap_or_else(|| data_dir.clone());
+        // Create LLM provider (reuses the shared create_provider from chat.rs)
+        let base_provider = chat::create_provider(&provider_name, &config, model, base_url)?;
+        eprintln!(
+            "[gateway] LLM provider created, model={}",
+            base_provider.model_id()
+        );
 
-        // M11-B: when this gateway invocation is driven by a profile,
-        // delegate the per-profile bootstrap (LLM chain + QoS routing
-        // + memory stores + credentials + plugin env template) to the
-        // shared helper. The helper is what `octos serve` and
-        // `octos tui` will adopt in M11-D so every host process
-        // builds the per-profile state through the same path. The
-        // legacy non-profile path (running with a flat `config.json`
-        // and no `UserProfile`) keeps the inline code so the
-        // single-tenant boot stays byte-identical until it is
-        // retired.
-        let profile_runtime: Option<Arc<crate::runtime::ProfileRuntime>> =
-            if let (Some(profile), false) = (resolved_profile.as_ref(), cli_llm_override) {
-                Some(
-                    crate::runtime::ProfileRuntime::bootstrap(
-                        profile,
-                        &data_dir,
-                        cmd.no_retry,
-                        Some(effective_octos_home.as_path()),
-                    )
-                    .await
-                    .wrap_err("failed to bootstrap profile runtime")?,
-                )
-            } else {
-                None
-            };
+        // Capture the base provider's model_id *before* the adaptive
+        // / retry / swappable wrapping below. Gateway uses this for
+        // `resolve_provider_policy(..., model_id)` and as the
+        // primary key in the sub-provider router. The wrapped
+        // chain's `model_id()` can dispatch through
+        // `AdaptiveRouter::model_id()`, which performs lane selection
+        // and may return a fallback model's id — so we stash the
+        // primary's id here before wrapping.
+        let model_id = base_provider.model_id().to_string();
 
-        // LLM chain + QoS adaptive wiring. When the profile-driven
-        // bootstrap above ran, reuse its outputs; otherwise fall back
-        // to the inline construction used by the legacy
-        // single-tenant gateway path. Either way the downstream code
-        // sees the same `(adaptive_router_ref, runtime_qos_catalog,
-        // swappable, llm)` quadruple.
-        let adaptive_router_ref: Option<Arc<AdaptiveRouter>>;
-        let runtime_qos_catalog: Option<octos_llm::QosCatalog>;
-        let swappable: Arc<SwappableProvider>;
-        let llm: Arc<dyn LlmProvider>;
-        let model_id: String;
-        if let Some(ref pr) = profile_runtime {
-            // Bootstrap already wired the QoS-aware adaptive chain
-            // (including the model_catalog.json exporter and the
-            // cold-start QoS catalog for single-provider profiles)
-            // via the shared helper. Reuse its `runtime_qos_catalog`
-            // directly so the downstream sub-provider router
-            // receives the same seed entries the legacy inline path
-            // would have built — including the cold-start derivation
-            // when `adaptive_router` is `None` (single provider, no
-            // failover).
-            swappable = Arc::new(SwappableProvider::new(pr.llm.clone()));
-            llm = swappable.clone();
-            model_id = swappable.current().model_id().to_string();
-            eprintln!("[gateway] LLM provider created, model={model_id}");
-            runtime_qos_catalog = pr.runtime_qos_catalog.clone();
-            adaptive_router_ref = pr.adaptive_router.clone();
-        } else {
-            // Legacy single-tenant path — config.json or
-            // Config::load, no UserProfile, no ProfileRuntime. Keep
-            // the inline assembly byte-identical with pre-M11-B
-            // behavior.
-            let base_provider = chat::create_provider(&provider_name, &config, model, base_url)?;
-            eprintln!(
-                "[gateway] LLM provider created, model={}",
-                base_provider.model_id()
-            );
-            model_id = base_provider.model_id().to_string();
-            let bundle = build_adaptive_provider_chain(
-                base_provider,
-                &config,
-                &data_dir,
-                cmd.no_retry,
-                ExporterMode::Spawn,
-            );
-            swappable = Arc::new(SwappableProvider::new(bundle.llm));
-            llm = swappable.clone();
-            adaptive_router_ref = bundle.adaptive_router;
-            runtime_qos_catalog = bundle.runtime_qos_catalog;
-        }
+        // Build the full LLM provider chain + QoS adaptive wiring via
+        // the shared helper. Keep `adaptive_router_ref` typed so we can
+        // hand it to `ActorFactory` further below (and so the helper
+        // can spawn its 30s metrics exporter against it).
+        let bundle = build_adaptive_provider_chain(
+            base_provider,
+            &config,
+            &data_dir,
+            cmd.no_retry,
+            ExporterMode::Spawn,
+        );
+        let adaptive_router_ref: Option<Arc<AdaptiveRouter>> = bundle.adaptive_router;
+        let runtime_qos_catalog = bundle.runtime_qos_catalog;
+
+        // Wrap LLM in SwappableProvider for runtime model switching
+        let swappable = Arc::new(SwappableProvider::new(bundle.llm));
+        let llm: Arc<dyn LlmProvider> = swappable.clone();
 
         // Open ProfileStore for /account commands and bot management.
-        // Kept here (after the LLM chain construction above) to
-        // preserve the pre-M11-B filesystem-side-effect timing —
-        // `ProfileStore::open` creates `<octos_home>/profiles/`, and
-        // moving that ahead of provider/chain construction would
-        // create the directory even on profiles whose
-        // `create_provider` would otherwise fail before any
-        // filesystem write.
+        // Derive octos_home from: --octos-home flag > data_dir (which already
+        // resolves --data-dir > $OCTOS_HOME > ~/.octos).
+        let effective_octos_home = cmd.octos_home.clone().unwrap_or_else(|| data_dir.clone());
         let profile_store: Option<Arc<crate::profiles::ProfileStore>> =
             crate::profiles::ProfileStore::open(&effective_octos_home)
                 .ok()
@@ -350,36 +298,77 @@ impl GatewayRuntime {
 
         let voice_config = config.voice.clone();
 
-        // Episode + memory stores: opened by the profile bootstrap
-        // when one ran; otherwise fall back to the inline opens used
-        // by the legacy single-tenant path. The eprintln pairs
-        // surround the actual open so downstream readers see the
-        // same `opening / opened` stderr framing the gateway has
-        // always emitted.
         eprintln!("[gateway] opening episode store at {}", data_dir.display());
-        let memory = if let Some(ref pr) = profile_runtime {
-            pr.memory.clone()
-        } else {
-            Arc::new(
-                EpisodeStore::open(&data_dir)
-                    .await
-                    .wrap_err("failed to open episode store")?,
-            )
-        };
+        let memory = Arc::new(
+            EpisodeStore::open(&data_dir)
+                .await
+                .wrap_err("failed to open episode store")?,
+        );
         eprintln!("[gateway] episode store opened");
 
         // Initialize memory store
         eprintln!("[gateway] opening memory store");
-        let memory_store = if let Some(ref pr) = profile_runtime {
-            pr.memory_store.clone()
-        } else {
-            Arc::new(
-                MemoryStore::open(&data_dir)
-                    .await
-                    .wrap_err("failed to open memory store")?,
-            )
-        };
+        let memory_store = Arc::new(
+            MemoryStore::open(&data_dir)
+                .await
+                .wrap_err("failed to open memory store")?,
+        );
         eprintln!("[gateway] memory store opened");
+
+        // M11-B: assemble a `ProfileRuntime` from the pieces gateway
+        // already built (LLM chain, memory stores) plus the
+        // per-profile derivations (plugin env template, skills_dir,
+        // credentials, tool_specs floor). The runtime is held here
+        // so `octos serve` and `octos tui` (M11-D) can adopt the
+        // same helper instead of re-implementing the per-profile
+        // assembly. Today's gateway does not yet consume the
+        // returned struct downstream — the inline tool registry +
+        // ActorFactory wiring below is unchanged — so this PR is a
+        // pure additive wire-up. The legacy non-profile path (no
+        // `UserProfile`) and the CLI-override path
+        // (`--model` / `--provider` / `--base-url`) skip the
+        // bootstrap; the resulting `Option<Arc<ProfileRuntime>>`
+        // tracks whether the assembler was invoked.
+        let _profile_runtime: Option<Arc<crate::runtime::ProfileRuntime>> =
+            if let (Some(profile), false) = (resolved_profile.as_ref(), cli_llm_override) {
+                // Gateway's own tool registry is built later in the
+                // `let mut tools; …` block below (with the full
+                // gateway-extras: WebSearchTool with provider keys,
+                // BrowserTool with timeout, MCP, plugins, admin
+                // tools, …). The `ProfileRuntime`'s
+                // `tool_specs` is the per-profile *builtin floor*
+                // that future callers (`octos serve` / TUI) will
+                // share via the M11-A multi-tenant fix; gateway
+                // does not consume it in M11-B (the inline tool
+                // registry stays in place to preserve byte-identical
+                // boot). We hand `ToolRegistry::new()` so bootstrap
+                // does not need to call `create_sandbox` itself —
+                // doing so a second time here would emit a duplicate
+                // `"sandbox disabled, …"` info log on profiles that
+                // disable sandboxing.
+                let inputs = crate::runtime::profile::ProfileRuntimeInputs {
+                    llm: llm.clone(),
+                    adaptive_router: adaptive_router_ref.clone(),
+                    runtime_qos_catalog: runtime_qos_catalog.clone(),
+                    primary_model_id: model_id.clone(),
+                    memory: memory.clone(),
+                    memory_store: memory_store.clone(),
+                    default_sandbox: config.sandbox.clone(),
+                    tool_specs: ToolRegistry::new(),
+                };
+                Some(
+                    crate::runtime::ProfileRuntime::bootstrap(
+                        profile,
+                        &data_dir,
+                        Some(effective_octos_home.as_path()),
+                        inputs,
+                    )
+                    .await
+                    .wrap_err("failed to bootstrap profile runtime")?,
+                )
+            } else {
+                None
+            };
 
         // Derive project_dir from octos_home (when launched by process_manager)
         // or fall back to cwd/.octos (standalone octos gateway / octos chat mode).

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -216,6 +216,15 @@ impl GatewayRuntime {
             Config::load(&cwd, &data_dir)?
         };
 
+        // Track whether any CLI override (`--model`, `--provider`,
+        // `--base-url`) was supplied; `ProfileRuntime::bootstrap` is
+        // profile-driven and resolves these from `profile.config`
+        // alone, so when an override is present we must fall back to
+        // the inline assembly to preserve byte-identical behavior.
+        // This gate goes away in M11-D when bootstrap takes the
+        // overrides directly.
+        let cli_llm_override =
+            cmd.model.is_some() || cmd.provider.is_some() || cmd.base_url.is_some();
         let model = cmd.model.or(config.model.clone());
         let base_url = cmd.base_url.or(config.base_url.clone());
         let provider_name = cmd
@@ -240,33 +249,6 @@ impl GatewayRuntime {
         eprintln!("[gateway] provider={provider_name}");
         println!("{}: {}", "Provider".green(), provider_name);
 
-        // Create LLM provider (reuses the shared create_provider from chat.rs)
-        let base_provider = chat::create_provider(&provider_name, &config, model, base_url)?;
-        eprintln!(
-            "[gateway] LLM provider created, model={}",
-            base_provider.model_id()
-        );
-
-        let model_id = base_provider.model_id().to_string();
-
-        // Build the full LLM provider chain + QoS adaptive wiring via
-        // the shared helper. Keep `adaptive_router_ref` typed so we can
-        // hand it to `ActorFactory` further below (and so the helper
-        // can spawn its 30s metrics exporter against it).
-        let bundle = build_adaptive_provider_chain(
-            base_provider,
-            &config,
-            &data_dir,
-            cmd.no_retry,
-            ExporterMode::Spawn,
-        );
-        let adaptive_router_ref: Option<Arc<AdaptiveRouter>> = bundle.adaptive_router;
-        let runtime_qos_catalog = bundle.runtime_qos_catalog;
-
-        // Wrap LLM in SwappableProvider for runtime model switching
-        let swappable = Arc::new(SwappableProvider::new(bundle.llm));
-        let llm: Arc<dyn LlmProvider> = swappable.clone();
-
         // Open ProfileStore for /account commands and bot management.
         // Derive octos_home from: --octos-home flag > data_dir (which already
         // resolves --data-dir > $OCTOS_HOME > ~/.octos).
@@ -276,26 +258,124 @@ impl GatewayRuntime {
                 .ok()
                 .map(Arc::new);
 
+        // M11-B: when this gateway invocation is driven by a profile,
+        // delegate the per-profile bootstrap (LLM chain + QoS routing
+        // + memory stores + credentials + plugin env template) to the
+        // shared helper. The helper is what `octos serve` and
+        // `octos tui` will adopt in M11-D so every host process
+        // builds the per-profile state through the same path. The
+        // legacy non-profile path (running with a flat `config.json`
+        // and no `UserProfile`) keeps the inline code so the
+        // single-tenant boot stays byte-identical until it is
+        // retired.
+        let profile_runtime: Option<Arc<crate::runtime::ProfileRuntime>> =
+            if let (Some(profile), Some(store), false) = (
+                resolved_profile.as_ref(),
+                profile_store.as_ref(),
+                cli_llm_override,
+            ) {
+                Some(
+                    crate::runtime::ProfileRuntime::bootstrap(
+                        profile,
+                        store,
+                        &data_dir,
+                        cmd.no_retry,
+                        Some(effective_octos_home.as_path()),
+                    )
+                    .await
+                    .wrap_err("failed to bootstrap profile runtime")?,
+                )
+            } else {
+                None
+            };
+
+        // LLM chain + QoS adaptive wiring. When the profile-driven
+        // bootstrap above ran, reuse its outputs; otherwise fall back
+        // to the inline construction used by the legacy
+        // single-tenant gateway path. Either way the downstream code
+        // sees the same `(adaptive_router_ref, runtime_qos_catalog,
+        // swappable, llm)` quadruple.
+        let adaptive_router_ref: Option<Arc<AdaptiveRouter>>;
+        let runtime_qos_catalog: Option<octos_llm::QosCatalog>;
+        let swappable: Arc<SwappableProvider>;
+        let llm: Arc<dyn LlmProvider>;
+        let model_id: String;
+        if let Some(ref pr) = profile_runtime {
+            // Bootstrap already wired the QoS-aware adaptive chain
+            // (including the model_catalog.json exporter) via the
+            // shared helper. Re-export the live catalog from the
+            // adaptive router so the downstream sub-provider router
+            // can seed QoS scores for fallback ranking — matching
+            // the legacy single-tenant path's behavior even though
+            // the chain construction now lives behind
+            // `ProfileRuntime::bootstrap`.
+            swappable = Arc::new(SwappableProvider::new(pr.llm.clone()));
+            llm = swappable.clone();
+            model_id = swappable.current().model_id().to_string();
+            eprintln!("[gateway] LLM provider created, model={model_id}");
+            runtime_qos_catalog = pr
+                .adaptive_router
+                .as_ref()
+                .map(|router| router.export_model_catalog());
+            adaptive_router_ref = pr.adaptive_router.clone();
+        } else {
+            // Legacy single-tenant path — config.json or
+            // Config::load, no UserProfile, no ProfileRuntime. Keep
+            // the inline assembly byte-identical with pre-M11-B
+            // behavior.
+            let base_provider = chat::create_provider(&provider_name, &config, model, base_url)?;
+            eprintln!(
+                "[gateway] LLM provider created, model={}",
+                base_provider.model_id()
+            );
+            model_id = base_provider.model_id().to_string();
+            let bundle = build_adaptive_provider_chain(
+                base_provider,
+                &config,
+                &data_dir,
+                cmd.no_retry,
+                ExporterMode::Spawn,
+            );
+            swappable = Arc::new(SwappableProvider::new(bundle.llm));
+            llm = swappable.clone();
+            adaptive_router_ref = bundle.adaptive_router;
+            runtime_qos_catalog = bundle.runtime_qos_catalog;
+        }
+
         #[allow(unused_variables)] // used by feature-gated channel registration
         let media_dir = data_dir.join("media");
 
         let voice_config = config.voice.clone();
 
+        // Episode + memory stores: opened by the profile bootstrap
+        // when one ran; otherwise fall back to the inline opens used
+        // by the legacy single-tenant path. The eprintln pairs
+        // surround the actual open so downstream readers see the
+        // same `opening / opened` stderr framing the gateway has
+        // always emitted.
         eprintln!("[gateway] opening episode store at {}", data_dir.display());
-        let memory = Arc::new(
-            EpisodeStore::open(&data_dir)
-                .await
-                .wrap_err("failed to open episode store")?,
-        );
+        let memory = if let Some(ref pr) = profile_runtime {
+            pr.memory.clone()
+        } else {
+            Arc::new(
+                EpisodeStore::open(&data_dir)
+                    .await
+                    .wrap_err("failed to open episode store")?,
+            )
+        };
         eprintln!("[gateway] episode store opened");
 
         // Initialize memory store
         eprintln!("[gateway] opening memory store");
-        let memory_store = Arc::new(
-            MemoryStore::open(&data_dir)
-                .await
-                .wrap_err("failed to open memory store")?,
-        );
+        let memory_store = if let Some(ref pr) = profile_runtime {
+            pr.memory_store.clone()
+        } else {
+            Arc::new(
+                MemoryStore::open(&data_dir)
+                    .await
+                    .wrap_err("failed to open memory store")?,
+            )
+        };
         eprintln!("[gateway] memory store opened");
 
         // Derive project_dir from octos_home (when launched by process_manager)

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -315,61 +315,6 @@ impl GatewayRuntime {
         );
         eprintln!("[gateway] memory store opened");
 
-        // M11-B: assemble a `ProfileRuntime` from the pieces gateway
-        // already built (LLM chain, memory stores) plus the
-        // per-profile derivations (plugin env template, skills_dir,
-        // credentials, tool_specs floor). The runtime is held here
-        // so `octos serve` and `octos tui` (M11-D) can adopt the
-        // same helper instead of re-implementing the per-profile
-        // assembly. Today's gateway does not yet consume the
-        // returned struct downstream — the inline tool registry +
-        // ActorFactory wiring below is unchanged — so this PR is a
-        // pure additive wire-up. The legacy non-profile path (no
-        // `UserProfile`) and the CLI-override path
-        // (`--model` / `--provider` / `--base-url`) skip the
-        // bootstrap; the resulting `Option<Arc<ProfileRuntime>>`
-        // tracks whether the assembler was invoked.
-        let _profile_runtime: Option<Arc<crate::runtime::ProfileRuntime>> =
-            if let (Some(profile), false) = (resolved_profile.as_ref(), cli_llm_override) {
-                // Gateway's own tool registry is built later in the
-                // `let mut tools; …` block below (with the full
-                // gateway-extras: WebSearchTool with provider keys,
-                // BrowserTool with timeout, MCP, plugins, admin
-                // tools, …). The `ProfileRuntime`'s
-                // `tool_specs` is the per-profile *builtin floor*
-                // that future callers (`octos serve` / TUI) will
-                // share via the M11-A multi-tenant fix; gateway
-                // does not consume it in M11-B (the inline tool
-                // registry stays in place to preserve byte-identical
-                // boot). We hand `ToolRegistry::new()` so bootstrap
-                // does not need to call `create_sandbox` itself —
-                // doing so a second time here would emit a duplicate
-                // `"sandbox disabled, …"` info log on profiles that
-                // disable sandboxing.
-                let inputs = crate::runtime::profile::ProfileRuntimeInputs {
-                    llm: llm.clone(),
-                    adaptive_router: adaptive_router_ref.clone(),
-                    runtime_qos_catalog: runtime_qos_catalog.clone(),
-                    primary_model_id: model_id.clone(),
-                    memory: memory.clone(),
-                    memory_store: memory_store.clone(),
-                    default_sandbox: config.sandbox.clone(),
-                    tool_specs: ToolRegistry::new(),
-                };
-                Some(
-                    crate::runtime::ProfileRuntime::bootstrap(
-                        profile,
-                        &data_dir,
-                        Some(effective_octos_home.as_path()),
-                        inputs,
-                    )
-                    .await
-                    .wrap_err("failed to bootstrap profile runtime")?,
-                )
-            } else {
-                None
-            };
-
         // Derive project_dir from octos_home (when launched by process_manager)
         // or fall back to cwd/.octos (standalone octos gateway / octos chat mode).
         // This is decoupled from cwd so that narrowing cwd to data_dir for
@@ -405,6 +350,68 @@ impl GatewayRuntime {
                 None
             };
         let asr_language = voice_config.as_ref().and_then(|vc| vc.asr_language.clone());
+
+        // M11-B: assemble a `ProfileRuntime` from the pieces gateway
+        // already built (LLM chain, memory stores, Ominix URL) plus
+        // the per-profile derivations (plugin env template, tool
+        // policy, credentials). The runtime is held here so
+        // `octos serve` and `octos tui` (M11-D) can adopt the same
+        // helper instead of re-implementing the per-profile
+        // assembly. Today's gateway does not yet consume the
+        // returned struct downstream — the inline tool registry +
+        // ActorFactory wiring below is unchanged — so this PR is a
+        // pure additive wire-up. The legacy non-profile path (no
+        // `UserProfile`) and the CLI-override path
+        // (`--model` / `--provider` / `--base-url`) skip the
+        // bootstrap; the resulting `Option<Arc<ProfileRuntime>>`
+        // tracks whether the assembler was invoked. The call lives
+        // here (after `discover_ominix_url` and before
+        // `build_account_skills_loader` / `build_account_plugin_dirs`)
+        // so bootstrap can reuse the gateway's already-resolved
+        // Ominix URL and skills-dir candidate without doing a
+        // duplicate filesystem read.
+        let _profile_runtime: Option<Arc<crate::runtime::ProfileRuntime>> =
+            if let (Some(profile), false) = (resolved_profile.as_ref(), cli_llm_override) {
+                // Gateway's own tool registry is built later in the
+                // `let mut tools; …` block below (with the full
+                // gateway-extras: WebSearchTool with provider keys,
+                // BrowserTool with timeout, MCP, plugins, admin
+                // tools, …). The `ProfileRuntime`'s `tool_specs` is
+                // the per-profile *builtin floor* that future
+                // callers (`octos serve` / TUI) will share via the
+                // M11-A multi-tenant fix; gateway does not consume
+                // it in M11-B (the inline tool registry stays in
+                // place to preserve byte-identical boot). We hand
+                // `ToolRegistry::new()` so bootstrap does not need
+                // to call `create_sandbox` itself — doing so a
+                // second time here would emit a duplicate
+                // `"sandbox disabled, …"` info log on profiles
+                // that disable sandboxing.
+                let inputs = crate::runtime::profile::ProfileRuntimeInputs {
+                    llm: llm.clone(),
+                    adaptive_router: adaptive_router_ref.clone(),
+                    runtime_qos_catalog: runtime_qos_catalog.clone(),
+                    primary_model_id: model_id.clone(),
+                    memory: memory.clone(),
+                    memory_store: memory_store.clone(),
+                    default_sandbox: config.sandbox.clone(),
+                    tool_specs: ToolRegistry::new(),
+                    skills_dir: Some(data_dir.join("skills")),
+                    ominix_url: ominix_url.clone(),
+                };
+                Some(
+                    crate::runtime::ProfileRuntime::bootstrap(
+                        profile,
+                        &data_dir,
+                        Some(effective_octos_home.as_path()),
+                        inputs,
+                    )
+                    .await
+                    .wrap_err("failed to bootstrap profile runtime")?,
+                )
+            } else {
+                None
+            };
 
         // Customer-installed skills are strictly account-scoped.
         let skills_loader = crate::skills_scope::build_account_skills_loader(&data_dir);

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -11,13 +11,12 @@ use std::sync::Arc;
 
 use eyre::{Result, WrapErr};
 use octos_agent::{SandboxConfig, ToolPolicy, ToolRegistry};
-use octos_llm::{AdaptiveRouter, LlmProvider};
+use octos_llm::{AdaptiveRouter, LlmProvider, QosCatalog};
 use octos_memory::{EpisodeStore, MemoryStore};
 
-use crate::auth::keychain;
 use crate::commands::chat;
 use crate::config::detect_provider;
-use crate::profiles::{ProfileStore, UserProfile, config_from_profile};
+use crate::profiles::{UserProfile, config_from_profile};
 use crate::qos_catalog::{ExporterMode, build_adaptive_provider_chain};
 use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
 
@@ -115,6 +114,16 @@ pub struct ProfileRuntime {
     /// reader don't have to downcast the `dyn LlmProvider`.
     pub adaptive_router: Option<Arc<AdaptiveRouter>>,
 
+    /// Materialized runtime QoS catalog produced alongside the
+    /// adaptive chain. Populated even when [`Self::adaptive_router`]
+    /// is `None` — `build_adaptive_provider_chain` derives a
+    /// cold-start catalog from `model_catalog.json` for single-
+    /// provider profiles too, and the downstream sub-provider
+    /// router needs that seed for fallback ranking. Held here so
+    /// gateway's `provider_router.seed_qos_scores` path stays
+    /// byte-identical with the pre-M11-B inline assembly.
+    pub runtime_qos_catalog: Option<QosCatalog>,
+
     /// Resolved credentials for this profile, keyed by env-var name
     /// (e.g. `OPENAI_API_KEY`, `AUTODL_API_KEY`). Populated from
     /// `profile.config.env_vars` via the keychain resolver. Sessions
@@ -182,28 +191,33 @@ impl ProfileRuntime {
     /// # Steps (per workstreams/M11-runtime-unification.md § M11-B)
     ///
     /// 1. Derive a per-profile `Config` via
-    ///    [`crate::profiles::config_from_profile`] with `None, None`
+    ///    `crate::profiles::config_from_profile` with `None, None`
     ///    (preserves the per-profile LLM contract PR #866
     ///    introduced).
     /// 2. Wrap the primary LLM via
-    ///    [`build_adaptive_provider_chain`] with
-    ///    [`ExporterMode::Spawn`] (PR #867's shared helper). Stores
+    ///    `crate::qos_catalog::build_adaptive_provider_chain` with
+    ///    `ExporterMode::Spawn` (PR #867's shared helper). Stores
     ///    both `llm` and `adaptive_router` on the returned struct.
-    /// 3. Resolve `credentials` from `profile.config.env_vars` via
-    ///    [`keychain::resolve_env_vars`].
+    /// 3. Surface `profile.config.env_vars` as a pass-through copy
+    ///    under `credentials`. Keychain resolution stays at the
+    ///    downstream call sites (`profile_plugin_env`,
+    ///    `profile_search_provider_keys`) for M11-B so warnings are
+    ///    not duplicated; M11-D will unify both onto a single
+    ///    resolution.
     /// 4. Resolve `skills_dir = data_dir.join("skills")` when the
     ///    directory exists (PR #868's logic).
     /// 5. Build `plugin_env_template` via
-    ///    [`push_runtime_plugin_env`] (PR #868's helper).
+    ///    `crate::skills_scope::push_runtime_plugin_env` (PR #868's
+    ///    helper).
     /// 6. Construct the base [`ToolRegistry`] via
-    ///    [`ToolRegistry::with_builtins_and_sandbox`] — gateway's
+    ///    `ToolRegistry::with_builtins_and_sandbox` — gateway's
     ///    full registration sequence (browser, web_search, MCP,
     ///    plugins, ...) is layered on top of this base by the caller
     ///    so cmd-flag-dependent tools (`SwitchModelTool`,
     ///    `SwappableProvider`, admin tools, etc.) can still be
     ///    wired without leaking into the profile-scope abstraction.
     /// 7. Plugin loading + LRU pinning happen on the caller's copy of
-    ///    the registry (see [`ToolRegistry::snapshot_excluding`]) so
+    ///    the registry (see `ToolRegistry::snapshot_excluding`) so
     ///    `ProfileRuntime::bootstrap` stays signature-stable across
     ///    callers — gateway today and `octos serve` / TUI tomorrow.
     /// 8. Open [`EpisodeStore`] and [`MemoryStore`] against
@@ -212,17 +226,14 @@ impl ProfileRuntime {
     ///
     /// # Parameters
     ///
-    /// - `profile` — the parsed [`UserProfile`] from the
-    ///   [`ProfileStore`]; carries the on-disk config that drives
-    ///   the bootstrap.
-    /// - `store` — the [`ProfileStore`] the profile came from;
-    ///   needed for lookups (admin/sub-account resolution) the
-    ///   bootstrap performs.
+    /// - `profile` — the parsed [`UserProfile`] from the profile
+    ///   store; carries the on-disk config that drives the
+    ///   bootstrap.
     /// - `data_dir` — the resolved per-profile data dir, typically
     ///   `~/.octos/profiles/<id>/data`. The bootstrap creates it if
     ///   missing.
     /// - `no_retry` — when `true`, skip the `RetryProvider` wrapping.
-    ///   Plumbed through to [`build_adaptive_provider_chain`] so the
+    ///   Plumbed through to `build_adaptive_provider_chain` so the
     ///   gateway `--no-retry` flag still inhibits retries when the
     ///   gateway delegates here.
     /// - `octos_home` — the host's `~/.octos` (or `--octos-home`
@@ -231,15 +242,24 @@ impl ProfileRuntime {
     ///   so call sites without the flag stay in lockstep with
     ///   gateway's current `effective_octos_home` fallback.
     ///
+    /// **Note on the missing `store` parameter:** the M11-A skeleton
+    /// listed `store: &ProfileStore` for "admin/sub-account
+    /// resolution" but M11-B's body has no such lookup — gateway's
+    /// admin/sub-account logic lives downstream of bootstrap and
+    /// stays there. Dropping the parameter lets the gateway keep
+    /// its `ProfileStore::open` at its original position in the
+    /// init sequence (preserving filesystem-side-effect timing).
+    /// Re-introducing the parameter when M11-C/D actually needs it
+    /// is a one-line API change.
+    ///
     /// # Errors
     ///
     /// Returns an error if any of the steps above fail: provider
-    /// construction, keychain resolution, redb open, or tool-registry
-    /// build. The bootstrap is fail-fast — a partially constructed
+    /// construction, redb open, or tool-registry build. The
+    /// bootstrap is fail-fast — a partially constructed
     /// [`ProfileRuntime`] is never returned.
     pub async fn bootstrap(
         profile: &UserProfile,
-        _store: &ProfileStore,
         data_dir: &Path,
         no_retry: bool,
         octos_home: Option<&Path>,
@@ -274,10 +294,20 @@ impl ProfileRuntime {
         );
         let llm = bundle.llm;
         let adaptive_router = bundle.adaptive_router;
+        let runtime_qos_catalog = bundle.runtime_qos_catalog;
 
-        // Step 3: resolve secrets from the profile's env_vars map
-        // (handles `"keychain:"` markers transparently).
-        let credentials = keychain::resolve_env_vars(&profile.config.env_vars);
+        // Step 3: surface the profile's declared env vars under
+        // `credentials` as a pass-through copy. Keychain resolution
+        // is deferred to the gateway / serve helpers that already
+        // call `keychain::resolve_env_vars` downstream (today via
+        // `profile_plugin_env` and `profile_search_provider_keys`).
+        // Doing the resolution here too would duplicate any
+        // failure-path keychain warnings the downstream helpers
+        // already emit, which violates the byte-identical gateway
+        // boot invariant. M11-D will move both call sites onto a
+        // single shared resolution and lift the resolved map into
+        // this field.
+        let credentials: HashMap<String, String> = profile.config.env_vars.clone();
 
         // Step 4: derive skills_dir as Some(...) only when the
         // directory exists (mirrors `build_account_plugin_dirs`).
@@ -349,6 +379,7 @@ impl ProfileRuntime {
             data_dir: data_dir.to_path_buf(),
             llm,
             adaptive_router,
+            runtime_qos_catalog,
             credentials,
             skills_dir,
             plugin_env_template,
@@ -380,18 +411,34 @@ mod tests {
         format!("M11B_BOOTSTRAP_TEST_{}_{}", std::process::id(), suffix)
     }
 
+    /// Process-wide mutex that serializes env-var mutation across
+    /// every test in this module. Mirrors the pattern in
+    /// `commands/gateway/profile_factory.rs::tests::synthesis_env_lock`
+    /// — `std::env::set_var` / `remove_var` are not thread-safe even
+    /// with unique key names because they mutate the process-wide
+    /// environment, so all env-mutating tests in the binary need to
+    /// share a single lock to be sound.
+    fn bootstrap_env_lock() -> &'static std::sync::Mutex<()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
     #[tokio::test]
     async fn bootstrap_populates_tool_specs_and_credentials() {
+        let _env_guard = bootstrap_env_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+
         // The provider chain needs a resolvable API key to construct
         // the base LLM. We point `api_key_env` at a process-local env
         // var we set ourselves so the test doesn't touch the OS
         // keychain or require a real provider key.
         let env_key = unique_env_key("API_KEY");
-        // SAFETY: writing a process-unique env var inside a `#[test]`
-        // is the established pattern in this crate (see
-        // `commands/gateway/profile_factory.rs::tests`). The key is
-        // unique per process+test so no concurrent reader observes
-        // a partially mutated state.
+        // SAFETY: serialized by `bootstrap_env_lock`; the env-var
+        // mutation happens under the module-wide mutex so no other
+        // env-mutating test in this binary reads or writes the
+        // process environment concurrently with this block.
         #[allow(unsafe_code)]
         unsafe {
             std::env::set_var(&env_key, "synthetic-key");
@@ -400,9 +447,6 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path().join("profiles").join("test").join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
-        let store_dir = tmp.path().join("octos_home");
-        std::fs::create_dir_all(&store_dir).unwrap();
-        let store = ProfileStore::open(&store_dir).unwrap();
 
         let mut env_vars = HashMap::new();
         env_vars.insert("CREDENTIAL_PROBE".to_string(), "probe-value".to_string());
@@ -435,7 +479,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let runtime = ProfileRuntime::bootstrap(&profile, &store, &data_dir, false, None)
+        let runtime = ProfileRuntime::bootstrap(&profile, &data_dir, false, None)
             .await
             .expect("bootstrap should succeed with a synthetic profile");
 
@@ -475,7 +519,23 @@ mod tests {
         assert!(env_map.contains_key("OCTOS_DATA_DIR"));
         assert!(env_map.contains_key("OCTOS_VOICE_DIR"));
 
+        // M11-B codex review fix: the QoS runtime catalog is
+        // materialized for single-provider profiles too (cold-start
+        // derivation from the seed catalog), so it must survive
+        // bootstrap and remain available for the gateway's
+        // sub-provider router seeding. We don't assert the exact
+        // shape (it depends on the seed catalog on disk) but the
+        // field is observably exposed as `Option<QosCatalog>` — the
+        // sub-provider-router seeding path skips when `None`, which
+        // is the correct behavior when no catalog is reachable.
+        // The struct-shape check below is enough to wedge a
+        // regression test against any future refactor that drops
+        // the field again.
+        let _: &Option<octos_llm::QosCatalog> = &runtime.runtime_qos_catalog;
+
         // Cleanup — leave the process env clean for other tests.
+        // SAFETY: still under the `_env_guard` lock acquired at the
+        // top of the test.
         #[allow(unsafe_code)]
         unsafe {
             std::env::remove_var(&env_key);

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -9,15 +9,12 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use eyre::{Result, WrapErr};
+use eyre::Result;
 use octos_agent::{SandboxConfig, ToolPolicy, ToolRegistry};
 use octos_llm::{AdaptiveRouter, LlmProvider, QosCatalog};
 use octos_memory::{EpisodeStore, MemoryStore};
 
-use crate::commands::chat;
-use crate::config::detect_provider;
 use crate::profiles::{UserProfile, config_from_profile};
-use crate::qos_catalog::{ExporterMode, build_adaptive_provider_chain};
 use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
 
 /// All long-lived state that belongs to a single profile within the
@@ -124,6 +121,19 @@ pub struct ProfileRuntime {
     /// byte-identical with the pre-M11-B inline assembly.
     pub runtime_qos_catalog: Option<QosCatalog>,
 
+    /// The primary (base) provider's `model_id()` *before* the
+    /// adaptive router / retry / swappable wrapping is applied.
+    /// Gateway uses this for `resolve_provider_policy(..., model_id)`
+    /// and as the `primary_key` of the sub-provider router's
+    /// fallback ranking. We capture it here at bootstrap time
+    /// because `Arc<dyn LlmProvider>::model_id()` on the wrapped
+    /// chain can dispatch through `AdaptiveRouter::model_id()`,
+    /// which performs lane selection and may return a fallback
+    /// model's id rather than the primary's — that would silently
+    /// change the per-provider tool policy and the auto router
+    /// keys across the M11-B refactor.
+    pub primary_model_id: String,
+
     /// Resolved credentials for this profile, keyed by env-var name
     /// (e.g. `OPENAI_API_KEY`, `AUTODL_API_KEY`). Populated from
     /// `profile.config.env_vars` via the keychain resolver. Sessions
@@ -181,122 +191,137 @@ pub struct ProfileRuntime {
     pub memory_store: Arc<MemoryStore>,
 }
 
+/// Pre-built inputs the caller hands to [`ProfileRuntime::bootstrap`].
+///
+/// Bundles the LLM chain pieces and the memory stores the caller has
+/// already constructed so `bootstrap` does not duplicate the
+/// side-effects (no second `create_provider` print, no second
+/// `model_catalog.json` exporter spawn, no double `EpisodeStore::open`
+/// against the same redb file). The caller is responsible for
+/// emitting whatever log lines that gateway emits today around the
+/// LLM and memory-store construction (`Model:`, `[gateway] LLM
+/// provider created`, `[gateway] opening episode store`, ...); this
+/// is what lets gateway preserve byte-identical startup logs across
+/// the M11-B refactor.
+///
+/// M11-D will fold these back into the helper once the gateway /
+/// serve split is gone and the caller-agnostic helper can own the
+/// log emissions.
+pub struct ProfileRuntimeInputs {
+    /// The fully-wrapped LLM provider chain (RetryProvider /
+    /// ProviderChain / AdaptiveRouter). Gateway and serve build
+    /// this via `qos_catalog::build_adaptive_provider_chain` and
+    /// hand the result to `bootstrap`.
+    pub llm: Arc<dyn LlmProvider>,
+
+    /// Typed handle to the adaptive router when QoS adaptive
+    /// routing is wired. `None` for single-provider profiles.
+    pub adaptive_router: Option<Arc<AdaptiveRouter>>,
+
+    /// Materialized runtime QoS catalog (cold-start derived from
+    /// `model_catalog.json` even when `adaptive_router` is `None`).
+    pub runtime_qos_catalog: Option<QosCatalog>,
+
+    /// The base provider's `model_id()` captured *before* the
+    /// adaptive / retry / swappable wrapping.
+    pub primary_model_id: String,
+
+    /// Profile-scope episode store opened against
+    /// `<data_dir>/episodes.redb`.
+    pub memory: Arc<EpisodeStore>,
+
+    /// Profile-scope memory store opened against `<data_dir>`.
+    pub memory_store: Arc<MemoryStore>,
+
+    /// The effective sandbox config gateway / serve derived from
+    /// the profile's config (potentially with
+    /// `read_allow_paths` augmented for `project_dir`). Sessions
+    /// inherit this by default.
+    pub default_sandbox: SandboxConfig,
+
+    /// The base tool registry the caller has already built (e.g.
+    /// via `ToolRegistry::with_builtins_and_sandbox`). Bootstrap
+    /// takes it by value and stores it as `Arc<ToolRegistry>` so
+    /// it does NOT call `create_sandbox` itself — that call
+    /// already happened on the caller's side (gateway already runs
+    /// it inside its tool registry construction block). Doing it
+    /// here too would emit a duplicate
+    /// `"sandbox disabled, shell commands run without isolation"`
+    /// info-level log line when the profile disables sandboxing.
+    /// M11-D will fold this responsibility back in once the
+    /// gateway's tool-registry construction is fully unified with
+    /// serve's.
+    pub tool_specs: ToolRegistry,
+}
+
 impl ProfileRuntime {
-    /// Construct a [`ProfileRuntime`] for the given profile.
+    /// Assemble a [`ProfileRuntime`] from already-constructed LLM /
+    /// memory inputs plus the profile + paths.
     ///
-    /// Lifts the per-profile bootstrap sequence currently inlined in
-    /// `gateway_runtime.rs::init` so that the gateway, serve, and TUI
-    /// entry points can share one helper.
+    /// In M11-B this is a pure assembler: the caller hands in
+    /// pre-built LLM chain, memory stores, and sandbox config (so
+    /// gateway can keep the pre-PR ordering of its `create_provider`
+    /// prints, `[gateway] …` markers, and `ProfileStore::open` /
+    /// `EpisodeStore::open` filesystem side effects). The helper
+    /// then derives:
     ///
-    /// # Steps (per workstreams/M11-runtime-unification.md § M11-B)
+    /// 1. `credentials` — pass-through clone of
+    ///    `profile.config.env_vars`. Keychain resolution stays at
+    ///    the downstream call sites (`profile_plugin_env`,
+    ///    `profile_search_provider_keys`) so warnings are not
+    ///    duplicated; M11-D will unify the call sites and lift the
+    ///    resolved map into this field.
+    /// 2. `skills_dir` — `Some(<data_dir>/skills)` when the
+    ///    directory exists, else `None`. Mirrors
+    ///    `build_account_plugin_dirs`.
+    /// 3. `plugin_env_template` — built via
+    ///    `crate::skills_scope::push_runtime_plugin_env`. Carries
+    ///    `OCTOS_DATA_DIR`, `OCTOS_HOME`, `OCTOS_PROFILE_ID`,
+    ///    `OCTOS_VOICE_DIR`, `OMINIX_API_URL` (when discoverable).
+    /// 4. `tool_specs` — the builtin floor via
+    ///    `ToolRegistry::with_builtins_and_sandbox`. Gateway
+    ///    snapshots this and layers its full registration sequence
+    ///    on top so cmd-flag-dependent tools
+    ///    (`SwitchModelTool`, admin tools, ...) stay on the
+    ///    caller side. The "no workspace bound" rule is preserved.
     ///
-    /// 1. Derive a per-profile `Config` via
-    ///    `crate::profiles::config_from_profile` with `None, None`
-    ///    (preserves the per-profile LLM contract PR #866
-    ///    introduced).
-    /// 2. Wrap the primary LLM via
-    ///    `crate::qos_catalog::build_adaptive_provider_chain` with
-    ///    `ExporterMode::Spawn` (PR #867's shared helper). Stores
-    ///    both `llm` and `adaptive_router` on the returned struct.
-    /// 3. Surface `profile.config.env_vars` as a pass-through copy
-    ///    under `credentials`. Keychain resolution stays at the
-    ///    downstream call sites (`profile_plugin_env`,
-    ///    `profile_search_provider_keys`) for M11-B so warnings are
-    ///    not duplicated; M11-D will unify both onto a single
-    ///    resolution.
-    /// 4. Resolve `skills_dir = data_dir.join("skills")` when the
-    ///    directory exists (PR #868's logic).
-    /// 5. Build `plugin_env_template` via
-    ///    `crate::skills_scope::push_runtime_plugin_env` (PR #868's
-    ///    helper).
-    /// 6. Construct the base [`ToolRegistry`] via
-    ///    `ToolRegistry::with_builtins_and_sandbox` — gateway's
-    ///    full registration sequence (browser, web_search, MCP,
-    ///    plugins, ...) is layered on top of this base by the caller
-    ///    so cmd-flag-dependent tools (`SwitchModelTool`,
-    ///    `SwappableProvider`, admin tools, etc.) can still be
-    ///    wired without leaking into the profile-scope abstraction.
-    /// 7. Plugin loading + LRU pinning happen on the caller's copy of
-    ///    the registry (see `ToolRegistry::snapshot_excluding`) so
-    ///    `ProfileRuntime::bootstrap` stays signature-stable across
-    ///    callers — gateway today and `octos serve` / TUI tomorrow.
-    /// 8. Open [`EpisodeStore`] and [`MemoryStore`] against
-    ///    `data_dir`.
-    /// 9. Return `Arc<Self>`.
+    /// M11-D will fold steps 1-3 of the M11-A docstring (Config
+    /// derivation, LLM chain, memory store opens) back into this
+    /// helper once `octos serve` / TUI adopt it and the gateway
+    /// path is the last caller still doing them inline. Until then
+    /// the assembler shape is what lets gateway preserve
+    /// byte-identical boot behavior.
     ///
     /// # Parameters
     ///
     /// - `profile` — the parsed [`UserProfile`] from the profile
-    ///   store; carries the on-disk config that drives the
-    ///   bootstrap.
+    ///   store; drives the per-profile derivations.
     /// - `data_dir` — the resolved per-profile data dir, typically
-    ///   `~/.octos/profiles/<id>/data`. The bootstrap creates it if
-    ///   missing.
-    /// - `no_retry` — when `true`, skip the `RetryProvider` wrapping.
-    ///   Plumbed through to `build_adaptive_provider_chain` so the
-    ///   gateway `--no-retry` flag still inhibits retries when the
-    ///   gateway delegates here.
+    ///   `~/.octos/profiles/<id>/data`.
     /// - `octos_home` — the host's `~/.octos` (or `--octos-home`
     ///   override). Used to seed `OCTOS_HOME` in
     ///   `plugin_env_template`; defaults to `data_dir` when `None`
     ///   so call sites without the flag stay in lockstep with
     ///   gateway's current `effective_octos_home` fallback.
-    ///
-    /// **Note on the missing `store` parameter:** the M11-A skeleton
-    /// listed `store: &ProfileStore` for "admin/sub-account
-    /// resolution" but M11-B's body has no such lookup — gateway's
-    /// admin/sub-account logic lives downstream of bootstrap and
-    /// stays there. Dropping the parameter lets the gateway keep
-    /// its `ProfileStore::open` at its original position in the
-    /// init sequence (preserving filesystem-side-effect timing).
-    /// Re-introducing the parameter when M11-C/D actually needs it
-    /// is a one-line API change.
+    /// - `inputs` — pre-built LLM / memory / sandbox pieces the
+    ///   caller has already constructed. See
+    ///   [`ProfileRuntimeInputs`] for the contract.
     ///
     /// # Errors
     ///
-    /// Returns an error if any of the steps above fail: provider
-    /// construction, redb open, or tool-registry build. The
-    /// bootstrap is fail-fast — a partially constructed
-    /// [`ProfileRuntime`] is never returned.
+    /// Returns an error only if the synchronous derivations fail.
+    /// In M11-B's assembler shape that means *no* error path
+    /// remains — all I/O has already been performed by the caller
+    /// before this function is called. The `Result` return is kept
+    /// so the M11-D version (which folds the I/O back in) doesn't
+    /// need a signature change.
     pub async fn bootstrap(
         profile: &UserProfile,
         data_dir: &Path,
-        no_retry: bool,
         octos_home: Option<&Path>,
+        inputs: ProfileRuntimeInputs,
     ) -> Result<Arc<Self>> {
-        // Step 1: derive the per-profile Config. We deliberately pass
-        // `None, None` for bridge_url / feishu_port — those overrides
-        // are channel-level concerns and `ProfileRuntime` only owns
-        // LLM/tools/memory state. Gateway derives its own `Config`
-        // (with the overrides) for channel wiring; the LLM/tools
-        // pieces derived here are byte-identical regardless.
-        let config = config_from_profile(profile, None, None);
-
-        // Step 2a: resolve provider_name + model + base_url the same
-        // way gateway does today (see `gateway_runtime.rs::init`).
-        let model = config.model.clone();
-        let base_url = config.base_url.clone();
-        let provider_name = config
-            .provider
-            .clone()
-            .or_else(|| model.as_deref().and_then(detect_provider).map(String::from))
-            .ok_or_else(|| eyre::eyre!("no LLM provider configured for this profile"))?;
-
-        // Step 2b: build the base provider, then the QoS-aware
-        // adaptive chain via the shared helper PR #867 introduced.
-        let base_provider = chat::create_provider(&provider_name, &config, model, base_url)?;
-        let bundle = build_adaptive_provider_chain(
-            base_provider,
-            &config,
-            data_dir,
-            no_retry,
-            ExporterMode::Spawn,
-        );
-        let llm = bundle.llm;
-        let adaptive_router = bundle.adaptive_router;
-        let runtime_qos_catalog = bundle.runtime_qos_catalog;
-
-        // Step 3: surface the profile's declared env vars under
+        // Step 1: surface the profile's declared env vars under
         // `credentials` as a pass-through copy. Keychain resolution
         // is deferred to the gateway / serve helpers that already
         // call `keychain::resolve_env_vars` downstream (today via
@@ -309,7 +334,7 @@ impl ProfileRuntime {
         // this field.
         let credentials: HashMap<String, String> = profile.config.env_vars.clone();
 
-        // Step 4: derive skills_dir as Some(...) only when the
+        // Step 2: derive skills_dir as Some(...) only when the
         // directory exists (mirrors `build_account_plugin_dirs`).
         let candidate_skills_dir = data_dir.join("skills");
         let skills_dir = if candidate_skills_dir.exists() {
@@ -318,14 +343,12 @@ impl ProfileRuntime {
             None
         };
 
-        // Step 5: build the per-profile plugin env template. Only the
-        // runtime envs (`OCTOS_DATA_DIR`, `OCTOS_HOME`,
+        // Step 3: build the per-profile plugin env template. Only
+        // the runtime envs (`OCTOS_DATA_DIR`, `OCTOS_HOME`,
         // `OCTOS_PROFILE_ID`, `OCTOS_VOICE_DIR`, `OMINIX_API_URL`)
-        // belong here — `ProfileRuntime` is provider-agnostic, so
-        // provider-API-key envs (`build_plugin_env`,
-        // `profile_plugin_env`) stay on the caller until gateway's
-        // legacy non-profile path is retired and we can lift them
-        // safely.
+        // belong here — provider-API-key envs (`build_plugin_env`,
+        // `profile_plugin_env`) stay on the caller until M11-D
+        // unifies the call sites.
         let mut plugin_env_template: Vec<(String, String)> = Vec::new();
         let ominix_url = discover_ominix_url();
         let effective_octos_home = octos_home
@@ -339,55 +362,36 @@ impl ProfileRuntime {
             ominix_url.as_deref(),
         );
 
-        // Step 8: open the per-profile memory stores. Gateway logs
-        // these with `eprintln!("[gateway] …")`; that logging stays
-        // on the caller so this helper is caller-agnostic (serve and
-        // TUI will use the same helper without inheriting gateway's
-        // log prefixes).
-        let memory = Arc::new(
-            EpisodeStore::open(data_dir)
-                .await
-                .wrap_err("failed to open episode store")?,
-        );
-        let memory_store = Arc::new(
-            MemoryStore::open(data_dir)
-                .await
-                .wrap_err("failed to open memory store")?,
-        );
+        // Step 4: wrap the caller-built tool registry in `Arc` so
+        // sessions can share it cheaply. We deliberately do NOT
+        // call `octos_agent::create_sandbox` here — the caller
+        // (gateway today, serve / TUI tomorrow) has already built a
+        // registry against its own `Sandbox` instance, and calling
+        // `create_sandbox` here too would emit a duplicate
+        // `"sandbox disabled, ..."` info-level log line when the
+        // profile disables sandboxing.
+        let tool_specs = Arc::new(inputs.tool_specs);
 
-        // Step 6: build the base ToolRegistry. We register only the
-        // sandbox-bound builtins here; gateway layers its full
-        // registration sequence (WebSearchTool with provider keys,
-        // BrowserTool with timeout override, MCP, plugin loading,
-        // ProviderRouter-aware tools, SwitchModelTool, admin tools)
-        // on top by snapshotting `tool_specs` into a mutable copy
-        // and extending it. Keeping the layering on the caller is
-        // what lets gateway preserve byte-identical startup logs +
-        // ordering across the M11-B refactor — the spec's
-        // "construct base registry" is taken to mean "the builtin
-        // floor every caller shares" and the caller-specific
-        // additions stay where they are.
-        let sandbox_config = config.sandbox.clone();
-        let sandbox = octos_agent::create_sandbox(&sandbox_config);
-        let cwd = data_dir; // workspace_root is bound per-session; the base registry
-        // anchors to the data dir as a stable default before sessions rebind.
-        let tools = ToolRegistry::with_builtins_and_sandbox(cwd, sandbox);
-        let tool_specs = Arc::new(tools);
+        // Step 5: derive the tool_policy from the profile's Config.
+        // Same derivation gateway used pre-PR — read the policy off
+        // the per-profile `Config`.
+        let config = config_from_profile(profile, None, None);
 
         Ok(Arc::new(Self {
             profile_id: profile.id.clone(),
             data_dir: data_dir.to_path_buf(),
-            llm,
-            adaptive_router,
-            runtime_qos_catalog,
+            llm: inputs.llm,
+            adaptive_router: inputs.adaptive_router,
+            runtime_qos_catalog: inputs.runtime_qos_catalog,
+            primary_model_id: inputs.primary_model_id,
             credentials,
             skills_dir,
             plugin_env_template,
             tool_policy: config.tool_policy.clone(),
-            default_sandbox: sandbox_config,
+            default_sandbox: inputs.default_sandbox,
             tool_specs,
-            memory,
-            memory_store,
+            memory: inputs.memory,
+            memory_store: inputs.memory_store,
         }))
     }
 }
@@ -396,54 +400,70 @@ impl ProfileRuntime {
 mod tests {
     use super::*;
     use crate::profiles::{GatewaySettings, ProfileConfig};
+    use async_trait::async_trait;
     use chrono::Utc;
+    use octos_core::Message;
+    use octos_llm::{ChatConfig, ChatResponse, ChatStream, ToolSpec};
 
-    /// Smoke-test the bootstrap path on a synthetic profile with a
-    /// stub keychain-free env_vars map. The assertion targets the
-    /// two contractual outputs M11-B promises:
-    ///
-    /// - `tool_specs` carries the builtin floor (probe: `read_file`).
-    /// - `credentials` is populated from `profile.config.env_vars`.
-    /// Build a per-process-unique env-var name so this test doesn't
-    /// collide with other tests in the same process when run under
-    /// `cargo test`'s default parallel scheduler.
-    fn unique_env_key(suffix: &str) -> String {
-        format!("M11B_BOOTSTRAP_TEST_{}_{}", std::process::id(), suffix)
+    /// Minimal stub LLM that satisfies the [`LlmProvider`] trait so
+    /// `ProfileRuntime::bootstrap` can be exercised end-to-end
+    /// without hitting the OS keychain, the network, or
+    /// `chat::create_provider` (which would require a registered
+    /// provider entry with a resolvable API key). The stub returns
+    /// an error on `chat` / `chat_stream` — those paths are not
+    /// exercised by bootstrap, which only reads `model_id()` /
+    /// `provider_name()`.
+    struct StubLlm {
+        model_id: String,
     }
 
-    /// Process-wide mutex that serializes env-var mutation across
-    /// every test in this module. Mirrors the pattern in
-    /// `commands/gateway/profile_factory.rs::tests::synthesis_env_lock`
-    /// — `std::env::set_var` / `remove_var` are not thread-safe even
-    /// with unique key names because they mutate the process-wide
-    /// environment, so all env-mutating tests in the binary need to
-    /// share a single lock to be sound.
-    fn bootstrap_env_lock() -> &'static std::sync::Mutex<()> {
-        use std::sync::{Mutex, OnceLock};
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    #[tokio::test]
-    async fn bootstrap_populates_tool_specs_and_credentials() {
-        let _env_guard = bootstrap_env_lock()
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-
-        // The provider chain needs a resolvable API key to construct
-        // the base LLM. We point `api_key_env` at a process-local env
-        // var we set ourselves so the test doesn't touch the OS
-        // keychain or require a real provider key.
-        let env_key = unique_env_key("API_KEY");
-        // SAFETY: serialized by `bootstrap_env_lock`; the env-var
-        // mutation happens under the module-wide mutex so no other
-        // env-mutating test in this binary reads or writes the
-        // process environment concurrently with this block.
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::set_var(&env_key, "synthetic-key");
+    #[async_trait]
+    impl LlmProvider for StubLlm {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            Err(eyre::eyre!(
+                "StubLlm::chat not used by ProfileRuntime::bootstrap"
+            ))
         }
 
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatStream> {
+            Err(eyre::eyre!(
+                "StubLlm::chat_stream not used by ProfileRuntime::bootstrap"
+            ))
+        }
+
+        fn context_window(&self) -> u32 {
+            0
+        }
+
+        fn model_id(&self) -> &str {
+            &self.model_id
+        }
+
+        fn provider_name(&self) -> &str {
+            "stub"
+        }
+    }
+
+    /// Smoke-test the bootstrap assembler on a synthetic profile +
+    /// temp data_dir + stub LLM. The assertion targets every
+    /// contractual output M11-B promises: `tool_specs` carries the
+    /// builtin floor, `credentials` is populated from `env_vars`,
+    /// `plugin_env_template` carries the M11 contract env vars,
+    /// `primary_model_id` round-trips, and `runtime_qos_catalog` is
+    /// exposed as `Option<QosCatalog>` so a future refactor that
+    /// drops the field again fails CI immediately.
+    #[tokio::test]
+    async fn bootstrap_populates_tool_specs_and_credentials() {
         let tmp = tempfile::tempdir().unwrap();
         let data_dir = tmp.path().join("profiles").join("test").join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
@@ -461,27 +481,55 @@ mod tests {
             config: ProfileConfig {
                 gateway: GatewaySettings::default(),
                 env_vars,
-                llm: Some(crate::profiles::LlmProfileConfig {
-                    primary: Some(crate::profiles::LlmModelSelectionConfig {
-                        family_id: Some("gemini".to_string()),
-                        model_id: Some("gemini-2.0-flash".to_string()),
-                        route: Some(crate::profiles::LlmRouteConfig {
-                            api_key_env: Some(env_key.clone()),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                }),
                 ..Default::default()
             },
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
 
-        let runtime = ProfileRuntime::bootstrap(&profile, &data_dir, false, None)
+        let memory = Arc::new(
+            EpisodeStore::open(&data_dir)
+                .await
+                .expect("EpisodeStore::open"),
+        );
+        let memory_store = Arc::new(
+            MemoryStore::open(&data_dir)
+                .await
+                .expect("MemoryStore::open"),
+        );
+
+        let stub_llm: Arc<dyn LlmProvider> = Arc::new(StubLlm {
+            model_id: "stub-model-id".to_string(),
+        });
+
+        // The test builds the same builtin-floor registry M11-D's
+        // bootstrap will eventually own — pre-built here so
+        // bootstrap stays sandbox-call-free for byte-identical
+        // gateway boot.
+        let sandbox_config = SandboxConfig {
+            // Disable so `create_sandbox` returns NoSandbox without
+            // touching the host's bwrap / sandbox-exec binaries
+            // (the test runs cross-platform).
+            enabled: false,
+            ..SandboxConfig::default()
+        };
+        let sandbox = octos_agent::create_sandbox(&sandbox_config);
+        let tools = ToolRegistry::with_builtins_and_sandbox(&data_dir, sandbox);
+
+        let inputs = ProfileRuntimeInputs {
+            llm: stub_llm.clone(),
+            adaptive_router: None,
+            runtime_qos_catalog: None,
+            primary_model_id: "stub-model-id".to_string(),
+            memory,
+            memory_store,
+            default_sandbox: sandbox_config,
+            tool_specs: tools,
+        };
+
+        let runtime = ProfileRuntime::bootstrap(&profile, &data_dir, None, inputs)
             .await
-            .expect("bootstrap should succeed with a synthetic profile");
+            .expect("bootstrap should succeed with a synthetic profile + stub LLM");
 
         // Acceptance #6 — `tool_specs` carries the builtin floor.
         let specs = runtime.tool_specs.specs();
@@ -519,26 +567,21 @@ mod tests {
         assert!(env_map.contains_key("OCTOS_DATA_DIR"));
         assert!(env_map.contains_key("OCTOS_VOICE_DIR"));
 
-        // M11-B codex review fix: the QoS runtime catalog is
-        // materialized for single-provider profiles too (cold-start
-        // derivation from the seed catalog), so it must survive
-        // bootstrap and remain available for the gateway's
-        // sub-provider router seeding. We don't assert the exact
-        // shape (it depends on the seed catalog on disk) but the
-        // field is observably exposed as `Option<QosCatalog>` — the
-        // sub-provider-router seeding path skips when `None`, which
-        // is the correct behavior when no catalog is reachable.
-        // The struct-shape check below is enough to wedge a
-        // regression test against any future refactor that drops
-        // the field again.
-        let _: &Option<octos_llm::QosCatalog> = &runtime.runtime_qos_catalog;
+        // M11-B codex review fix #1: `primary_model_id` round-trips
+        // through the assembler so gateway can use it for
+        // `resolve_provider_policy(..., model_id)` + sub-provider
+        // router primary key without dispatching through
+        // `AdaptiveRouter::model_id()` (which performs lane
+        // selection and would return a fallback model's id).
+        assert_eq!(runtime.primary_model_id, "stub-model-id");
 
-        // Cleanup — leave the process env clean for other tests.
-        // SAFETY: still under the `_env_guard` lock acquired at the
-        // top of the test.
-        #[allow(unsafe_code)]
-        unsafe {
-            std::env::remove_var(&env_key);
-        }
+        // M11-B codex review fix #2: `runtime_qos_catalog` is
+        // exposed as `Option<QosCatalog>` — gateway needs this
+        // (populated by `build_adaptive_provider_chain` for single-
+        // provider profiles too) for the sub-provider router's QoS
+        // seeding. The struct-shape check below is enough to wedge
+        // a regression test against any future refactor that drops
+        // the field again.
+        let _: &Option<QosCatalog> = &runtime.runtime_qos_catalog;
     }
 }

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -3,18 +3,23 @@
 //! See the crate-level [`super`] module docs and
 //! `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md` for the two-scope model.
 //! This file owns the [`ProfileRuntime`] type and its `bootstrap`
-//! signature; the body lands in M11-B.
+//! signature; M11-B fills in the body.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use octos_agent::{SandboxConfig, ToolPolicy, ToolRegistry};
 use octos_llm::{AdaptiveRouter, LlmProvider};
 use octos_memory::{EpisodeStore, MemoryStore};
 
-use crate::profiles::{ProfileStore, UserProfile};
+use crate::auth::keychain;
+use crate::commands::chat;
+use crate::config::detect_provider;
+use crate::profiles::{ProfileStore, UserProfile, config_from_profile};
+use crate::qos_catalog::{ExporterMode, build_adaptive_provider_chain};
+use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
 
 /// All long-lived state that belongs to a single profile within the
 /// current host process.
@@ -170,35 +175,40 @@ pub struct ProfileRuntime {
 impl ProfileRuntime {
     /// Construct a [`ProfileRuntime`] for the given profile.
     ///
-    /// # Contract (filled in by M11-B)
+    /// Lifts the per-profile bootstrap sequence currently inlined in
+    /// `gateway_runtime.rs::init` so that the gateway, serve, and TUI
+    /// entry points can share one helper.
+    ///
+    /// # Steps (per workstreams/M11-runtime-unification.md § M11-B)
     ///
     /// 1. Derive a per-profile `Config` via
-    ///    `crate::profiles::config_from_profile(profile, None, None)`
+    ///    [`crate::profiles::config_from_profile`] with `None, None`
     ///    (preserves the per-profile LLM contract PR #866
     ///    introduced).
     /// 2. Wrap the primary LLM via
-    ///    `qos_catalog::build_adaptive_provider_chain(..., ExporterMode::Spawn)`
-    ///    (PR #867's shared helper). Store both `llm` and
-    ///    `adaptive_router` on the returned struct.
+    ///    [`build_adaptive_provider_chain`] with
+    ///    [`ExporterMode::Spawn`] (PR #867's shared helper). Stores
+    ///    both `llm` and `adaptive_router` on the returned struct.
     /// 3. Resolve `credentials` from `profile.config.env_vars` via
-    ///    `keychain::resolve_env_vars`.
-    /// 4. Resolve `skills_dir = data_dir.join("skills")` if it
-    ///    exists (PR #868's logic).
+    ///    [`keychain::resolve_env_vars`].
+    /// 4. Resolve `skills_dir = data_dir.join("skills")` when the
+    ///    directory exists (PR #868's logic).
     /// 5. Build `plugin_env_template` via
-    ///    `skills_scope::push_runtime_plugin_env` (PR #868's
-    ///    helper).
+    ///    [`push_runtime_plugin_env`] (PR #868's helper).
     /// 6. Construct the base [`ToolRegistry`] via
-    ///    `with_builtins_and_sandbox` + `tool_config` + the
-    ///    registration sequence gateway uses today (browser,
-    ///    web_search, MCP agents, ...).
-    /// 7. Load plugins via
-    ///    `PluginLoader::load_into_with_options` with the
-    ///    per-profile env + work dir.
-    /// 8. Pin plugin tool names as base tools (the LRU defense PR
-    ///    #764 added).
-    /// 9. Open [`EpisodeStore`] and [`MemoryStore`] against
+    ///    [`ToolRegistry::with_builtins_and_sandbox`] — gateway's
+    ///    full registration sequence (browser, web_search, MCP,
+    ///    plugins, ...) is layered on top of this base by the caller
+    ///    so cmd-flag-dependent tools (`SwitchModelTool`,
+    ///    `SwappableProvider`, admin tools, etc.) can still be
+    ///    wired without leaking into the profile-scope abstraction.
+    /// 7. Plugin loading + LRU pinning happen on the caller's copy of
+    ///    the registry (see [`ToolRegistry::snapshot_excluding`]) so
+    ///    `ProfileRuntime::bootstrap` stays signature-stable across
+    ///    callers — gateway today and `octos serve` / TUI tomorrow.
+    /// 8. Open [`EpisodeStore`] and [`MemoryStore`] against
     ///    `data_dir`.
-    /// 10. Return `Arc<Self>`.
+    /// 9. Return `Arc<Self>`.
     ///
     /// # Parameters
     ///
@@ -211,19 +221,264 @@ impl ProfileRuntime {
     /// - `data_dir` — the resolved per-profile data dir, typically
     ///   `~/.octos/profiles/<id>/data`. The bootstrap creates it if
     ///   missing.
+    /// - `no_retry` — when `true`, skip the `RetryProvider` wrapping.
+    ///   Plumbed through to [`build_adaptive_provider_chain`] so the
+    ///   gateway `--no-retry` flag still inhibits retries when the
+    ///   gateway delegates here.
+    /// - `octos_home` — the host's `~/.octos` (or `--octos-home`
+    ///   override). Used to seed `OCTOS_HOME` in
+    ///   `plugin_env_template`; defaults to `data_dir` when `None`
+    ///   so call sites without the flag stay in lockstep with
+    ///   gateway's current `effective_octos_home` fallback.
     ///
     /// # Errors
     ///
     /// Returns an error if any of the steps above fail: provider
-    /// construction, keychain resolution, skills loading, redb open,
-    /// or tool-registry build. The bootstrap is fail-fast — a
-    /// partially constructed [`ProfileRuntime`] is never returned.
-    #[allow(unused_variables)]
+    /// construction, keychain resolution, redb open, or tool-registry
+    /// build. The bootstrap is fail-fast — a partially constructed
+    /// [`ProfileRuntime`] is never returned.
     pub async fn bootstrap(
         profile: &UserProfile,
-        store: &ProfileStore,
+        _store: &ProfileStore,
         data_dir: &Path,
+        no_retry: bool,
+        octos_home: Option<&Path>,
     ) -> Result<Arc<Self>> {
-        todo!("M11-B implements this")
+        // Step 1: derive the per-profile Config. We deliberately pass
+        // `None, None` for bridge_url / feishu_port — those overrides
+        // are channel-level concerns and `ProfileRuntime` only owns
+        // LLM/tools/memory state. Gateway derives its own `Config`
+        // (with the overrides) for channel wiring; the LLM/tools
+        // pieces derived here are byte-identical regardless.
+        let config = config_from_profile(profile, None, None);
+
+        // Step 2a: resolve provider_name + model + base_url the same
+        // way gateway does today (see `gateway_runtime.rs::init`).
+        let model = config.model.clone();
+        let base_url = config.base_url.clone();
+        let provider_name = config
+            .provider
+            .clone()
+            .or_else(|| model.as_deref().and_then(detect_provider).map(String::from))
+            .ok_or_else(|| eyre::eyre!("no LLM provider configured for this profile"))?;
+
+        // Step 2b: build the base provider, then the QoS-aware
+        // adaptive chain via the shared helper PR #867 introduced.
+        let base_provider = chat::create_provider(&provider_name, &config, model, base_url)?;
+        let bundle = build_adaptive_provider_chain(
+            base_provider,
+            &config,
+            data_dir,
+            no_retry,
+            ExporterMode::Spawn,
+        );
+        let llm = bundle.llm;
+        let adaptive_router = bundle.adaptive_router;
+
+        // Step 3: resolve secrets from the profile's env_vars map
+        // (handles `"keychain:"` markers transparently).
+        let credentials = keychain::resolve_env_vars(&profile.config.env_vars);
+
+        // Step 4: derive skills_dir as Some(...) only when the
+        // directory exists (mirrors `build_account_plugin_dirs`).
+        let candidate_skills_dir = data_dir.join("skills");
+        let skills_dir = if candidate_skills_dir.exists() {
+            Some(candidate_skills_dir)
+        } else {
+            None
+        };
+
+        // Step 5: build the per-profile plugin env template. Only the
+        // runtime envs (`OCTOS_DATA_DIR`, `OCTOS_HOME`,
+        // `OCTOS_PROFILE_ID`, `OCTOS_VOICE_DIR`, `OMINIX_API_URL`)
+        // belong here — `ProfileRuntime` is provider-agnostic, so
+        // provider-API-key envs (`build_plugin_env`,
+        // `profile_plugin_env`) stay on the caller until gateway's
+        // legacy non-profile path is retired and we can lift them
+        // safely.
+        let mut plugin_env_template: Vec<(String, String)> = Vec::new();
+        let ominix_url = discover_ominix_url();
+        let effective_octos_home = octos_home
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| data_dir.to_path_buf());
+        push_runtime_plugin_env(
+            &mut plugin_env_template,
+            data_dir,
+            &effective_octos_home,
+            Some(profile.id.as_str()),
+            ominix_url.as_deref(),
+        );
+
+        // Step 8: open the per-profile memory stores. Gateway logs
+        // these with `eprintln!("[gateway] …")`; that logging stays
+        // on the caller so this helper is caller-agnostic (serve and
+        // TUI will use the same helper without inheriting gateway's
+        // log prefixes).
+        let memory = Arc::new(
+            EpisodeStore::open(data_dir)
+                .await
+                .wrap_err("failed to open episode store")?,
+        );
+        let memory_store = Arc::new(
+            MemoryStore::open(data_dir)
+                .await
+                .wrap_err("failed to open memory store")?,
+        );
+
+        // Step 6: build the base ToolRegistry. We register only the
+        // sandbox-bound builtins here; gateway layers its full
+        // registration sequence (WebSearchTool with provider keys,
+        // BrowserTool with timeout override, MCP, plugin loading,
+        // ProviderRouter-aware tools, SwitchModelTool, admin tools)
+        // on top by snapshotting `tool_specs` into a mutable copy
+        // and extending it. Keeping the layering on the caller is
+        // what lets gateway preserve byte-identical startup logs +
+        // ordering across the M11-B refactor — the spec's
+        // "construct base registry" is taken to mean "the builtin
+        // floor every caller shares" and the caller-specific
+        // additions stay where they are.
+        let sandbox_config = config.sandbox.clone();
+        let sandbox = octos_agent::create_sandbox(&sandbox_config);
+        let cwd = data_dir; // workspace_root is bound per-session; the base registry
+        // anchors to the data dir as a stable default before sessions rebind.
+        let tools = ToolRegistry::with_builtins_and_sandbox(cwd, sandbox);
+        let tool_specs = Arc::new(tools);
+
+        Ok(Arc::new(Self {
+            profile_id: profile.id.clone(),
+            data_dir: data_dir.to_path_buf(),
+            llm,
+            adaptive_router,
+            credentials,
+            skills_dir,
+            plugin_env_template,
+            tool_policy: config.tool_policy.clone(),
+            default_sandbox: sandbox_config,
+            tool_specs,
+            memory,
+            memory_store,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profiles::{GatewaySettings, ProfileConfig};
+    use chrono::Utc;
+
+    /// Smoke-test the bootstrap path on a synthetic profile with a
+    /// stub keychain-free env_vars map. The assertion targets the
+    /// two contractual outputs M11-B promises:
+    ///
+    /// - `tool_specs` carries the builtin floor (probe: `read_file`).
+    /// - `credentials` is populated from `profile.config.env_vars`.
+    /// Build a per-process-unique env-var name so this test doesn't
+    /// collide with other tests in the same process when run under
+    /// `cargo test`'s default parallel scheduler.
+    fn unique_env_key(suffix: &str) -> String {
+        format!("M11B_BOOTSTRAP_TEST_{}_{}", std::process::id(), suffix)
+    }
+
+    #[tokio::test]
+    async fn bootstrap_populates_tool_specs_and_credentials() {
+        // The provider chain needs a resolvable API key to construct
+        // the base LLM. We point `api_key_env` at a process-local env
+        // var we set ourselves so the test doesn't touch the OS
+        // keychain or require a real provider key.
+        let env_key = unique_env_key("API_KEY");
+        // SAFETY: writing a process-unique env var inside a `#[test]`
+        // is the established pattern in this crate (see
+        // `commands/gateway/profile_factory.rs::tests`). The key is
+        // unique per process+test so no concurrent reader observes
+        // a partially mutated state.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var(&env_key, "synthetic-key");
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profiles").join("test").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let store_dir = tmp.path().join("octos_home");
+        std::fs::create_dir_all(&store_dir).unwrap();
+        let store = ProfileStore::open(&store_dir).unwrap();
+
+        let mut env_vars = HashMap::new();
+        env_vars.insert("CREDENTIAL_PROBE".to_string(), "probe-value".to_string());
+
+        let profile = UserProfile {
+            id: "m11b-test".to_string(),
+            name: "M11-B Test".to_string(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                gateway: GatewaySettings::default(),
+                env_vars,
+                llm: Some(crate::profiles::LlmProfileConfig {
+                    primary: Some(crate::profiles::LlmModelSelectionConfig {
+                        family_id: Some("gemini".to_string()),
+                        model_id: Some("gemini-2.0-flash".to_string()),
+                        route: Some(crate::profiles::LlmRouteConfig {
+                            api_key_env: Some(env_key.clone()),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let runtime = ProfileRuntime::bootstrap(&profile, &store, &data_dir, false, None)
+            .await
+            .expect("bootstrap should succeed with a synthetic profile");
+
+        // Acceptance #6 — `tool_specs` carries the builtin floor.
+        let specs = runtime.tool_specs.specs();
+        let names: std::collections::HashSet<&str> =
+            specs.iter().map(|spec| spec.name.as_str()).collect();
+        assert!(
+            names.contains("read_file"),
+            "tool_specs must include read_file (got: {names:?})",
+        );
+
+        // Acceptance #6 — `credentials` populated from env_vars.
+        assert_eq!(
+            runtime
+                .credentials
+                .get("CREDENTIAL_PROBE")
+                .map(String::as_str),
+            Some("probe-value"),
+            "credentials must carry the profile's env_vars entries",
+        );
+
+        // Profile id + data_dir are stamped onto the runtime so
+        // session bootstrap (M11-C) can derive workspace paths
+        // without re-resolving from the store.
+        assert_eq!(runtime.profile_id, "m11b-test");
+        assert_eq!(runtime.data_dir, data_dir);
+
+        // plugin_env_template carries the M11 contract env vars that
+        // dashboard-installed skills depend on.
+        let env_map: HashMap<&str, &str> = runtime
+            .plugin_env_template
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        assert_eq!(env_map.get("OCTOS_PROFILE_ID"), Some(&"m11b-test"));
+        assert!(env_map.contains_key("OCTOS_DATA_DIR"));
+        assert!(env_map.contains_key("OCTOS_VOICE_DIR"));
+
+        // Cleanup — leave the process env clean for other tests.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var(&env_key);
+        }
     }
 }

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -15,7 +15,7 @@ use octos_llm::{AdaptiveRouter, LlmProvider, QosCatalog};
 use octos_memory::{EpisodeStore, MemoryStore};
 
 use crate::profiles::{UserProfile, config_from_profile};
-use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
+use crate::skills_scope::push_runtime_plugin_env;
 
 /// All long-lived state that belongs to a single profile within the
 /// current host process.
@@ -252,6 +252,24 @@ pub struct ProfileRuntimeInputs {
     /// gateway's tool-registry construction is fully unified with
     /// serve's.
     pub tool_specs: ToolRegistry,
+
+    /// The per-profile skills dir candidate path, or `None` when
+    /// the caller knows the profile has no installed skills. The
+    /// caller decides whether to do the existence check; bootstrap
+    /// does NOT stat the filesystem here so the helper does not
+    /// add an observable filesystem read outside the pre-PR
+    /// sequence. Gateway hands in
+    /// `Some(data_dir.join("skills"))` when the caller would
+    /// otherwise check existence — the read happens later inside
+    /// `build_account_plugin_dirs` exactly as pre-PR.
+    pub skills_dir: Option<PathBuf>,
+
+    /// Pre-computed Ominix discovery URL. Caller resolves it once
+    /// via `crate::skills_scope::discover_ominix_url` (gateway
+    /// already does this for its voice / ASR plumbing) and hands
+    /// the result to bootstrap so we do not read
+    /// `~/.ominix/api_url` a second time on profile boot.
+    pub ominix_url: Option<String>,
 }
 
 impl ProfileRuntime {
@@ -334,23 +352,20 @@ impl ProfileRuntime {
         // this field.
         let credentials: HashMap<String, String> = profile.config.env_vars.clone();
 
-        // Step 2: derive skills_dir as Some(...) only when the
-        // directory exists (mirrors `build_account_plugin_dirs`).
-        let candidate_skills_dir = data_dir.join("skills");
-        let skills_dir = if candidate_skills_dir.exists() {
-            Some(candidate_skills_dir)
-        } else {
-            None
-        };
+        // Step 2: take the pre-computed `skills_dir` from the
+        // caller. We deliberately do not stat
+        // `data_dir.join("skills")` here — gateway already performs
+        // the same check via `build_account_plugin_dirs` further
+        // down, and doing it twice would add an observable
+        // filesystem read outside the pre-PR sequence.
+        let skills_dir = inputs.skills_dir;
 
-        // Step 3: build the per-profile plugin env template. Only
-        // the runtime envs (`OCTOS_DATA_DIR`, `OCTOS_HOME`,
-        // `OCTOS_PROFILE_ID`, `OCTOS_VOICE_DIR`, `OMINIX_API_URL`)
-        // belong here — provider-API-key envs (`build_plugin_env`,
-        // `profile_plugin_env`) stay on the caller until M11-D
-        // unifies the call sites.
+        // Step 3: build the per-profile plugin env template using
+        // the caller's pre-resolved Ominix URL. Gateway already
+        // calls `discover_ominix_url()` once for its voice / ASR
+        // plumbing and hands the result to bootstrap so we do not
+        // read `~/.ominix/api_url` a second time on profile boot.
         let mut plugin_env_template: Vec<(String, String)> = Vec::new();
-        let ominix_url = discover_ominix_url();
         let effective_octos_home = octos_home
             .map(Path::to_path_buf)
             .unwrap_or_else(|| data_dir.to_path_buf());
@@ -359,7 +374,7 @@ impl ProfileRuntime {
             data_dir,
             &effective_octos_home,
             Some(profile.id.as_str()),
-            ominix_url.as_deref(),
+            inputs.ominix_url.as_deref(),
         );
 
         // Step 4: wrap the caller-built tool registry in `Arc` so
@@ -525,6 +540,11 @@ mod tests {
             memory_store,
             default_sandbox: sandbox_config,
             tool_specs: tools,
+            // The test does not care whether the synthetic
+            // `<data_dir>/skills` path exists on disk — bootstrap
+            // does not stat it, by contract.
+            skills_dir: Some(data_dir.join("skills")),
+            ominix_url: None,
         };
 
         let runtime = ProfileRuntime::bootstrap(&profile, &data_dir, None, inputs)


### PR DESCRIPTION
## Summary

Implements `ProfileRuntime::bootstrap` (M11-B) as a pure in-memory assembler that takes pre-built LLM / memory / sandbox / tool-registry pieces via `ProfileRuntimeInputs` and returns the assembled `Arc<ProfileRuntime>`. Gateway calls it once per profile boot. The runtime is held but not yet consumed downstream — that consumption lands in M11-D's `AppState` refactor.

The shape (assembler vs spec's "verbatim function-extract") evolved through three rounds of codex review to land on a byte-identical gateway boot. See "Scope vs spec" below.

## Files touched

- `crates/octos-cli/src/runtime/profile.rs` — full body for `ProfileRuntime::bootstrap` + new `ProfileRuntimeInputs` struct + stub-LLM unit test.
- `crates/octos-cli/src/commands/gateway/gateway_runtime.rs` — additive bootstrap call site after `discover_ominix_url`, plus `cli_llm_override` gate and the `primary_model_id` comment.

## Scope vs spec

The spec asked for a verbatim function-extract of gateway's per-profile bootstrap into `ProfileRuntime::bootstrap`. Codex's three review rounds surfaced concrete byte-identical regressions every time bootstrap pulled responsibilities away from the gateway (each one a BLOCK):

- Round 1: extra `keychain::resolve_env_vars` call → duplicate warnings; `ProfileStore::open` moved earlier → filesystem timing shift; single-provider QoS catalog lost → routing regression.
- Round 2: `model_id` taken from the wrapped chain → lane-selection through `AdaptiveRouter::model_id` returning a fallback's id; `ProfileStore::open` now ordered after memory store opens → filesystem timing shift.
- Round 3: bootstrap's `data_dir.join("skills").exists()` stat and `discover_ominix_url` read → duplicate filesystem reads outside the pre-PR sequence.

Each round converged on the same conclusion: the *responsibilities the spec lists for bootstrap* (LLM chain construction, memory store opens, QoS catalog materialization, plugin env env-var resolution) are tightly entangled with gateway's existing log-emit ordering and filesystem-side-effect ordering, so lifting them into bootstrap without changing those orders is not mechanical.

The final shape moves all of that *outward* into the caller and makes bootstrap a pure assembler:

- Inputs (`ProfileRuntimeInputs`): `llm`, `adaptive_router`, `runtime_qos_catalog`, `primary_model_id`, `memory`, `memory_store`, `default_sandbox`, `tool_specs`, `skills_dir`, `ominix_url`.
- Body: `credentials = profile.config.env_vars.clone()`, `push_runtime_plugin_env(...)`, `Arc::new(inputs.tool_specs)`, `config_from_profile(profile, None, None)` for the `tool_policy` field, then struct assembly.
- No `fs::*`, no `tokio::fs::*`, no `exists()`, no `read_to_string`, no `discover_ominix_url`, no `chat::create_provider`, no `build_adaptive_provider_chain`, no `create_sandbox`, no `keychain::resolve_env_vars`. Every call site that could write to disk or emit a log line is on the caller's side.

M11-D will fold those responsibilities back into bootstrap once gateway and serve have been unified onto the helper and the caller-agnostic version can own the log emissions.

## Byte-identical gateway boot

Gateway-side diff is purely additive:

1. Compute `cli_llm_override` boolean (in-memory only).
2. Add an explanatory comment above the existing `model_id` line.
3. Insert the `ProfileRuntime::bootstrap` call after `discover_ominix_url`, before `build_account_skills_loader`. The result is held as `_profile_runtime` (underscore-prefixed because M11-D consumes it; M11-B does not).

Nothing else in `gateway_runtime.rs` changes. The pre-PR code flow — stdout colored prints, stderr `[gateway] …` markers, tracing info/warn lines, tool registration list/order, ActorFactory inputs, ProviderRouter QoS seeding, channel/bus/cron/heartbeat lifecycle, filesystem side-effect timing — is preserved verbatim.

## Acceptance checklist

- [x] `cargo check -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"` clean.
- [x] `cargo test -p octos-cli --lib --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"` — 931/931 pass (M11-B test included).
- [x] `cargo test -p octos-cli --lib commands::gateway` — 9/9 unchanged.
- [x] `cargo clippy -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot" --lib` — zero new warnings in `runtime/profile.rs` or `gateway_runtime.rs`.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo doc -p octos-cli --no-deps` — zero new warnings in `runtime/profile.rs`.
- [x] New unit test in `runtime/profile.rs` builds a `ProfileRuntime` from a synthetic profile + temp data_dir + stub LLM (no OS keychain, no env mutation, no network), asserts `tool_specs` contains `read_file`, `credentials` populated from `env_vars`, `plugin_env_template` carries the M11 contract env vars, `primary_model_id` round-trips, `runtime_qos_catalog` exposed as `Option<QosCatalog>`.
- [ ] Manual gateway-boot diff (before-PR vs after-PR `octos gateway`): **deferred to live verify after merge** — no dev profile in this worktree to capture the side-by-side. The static-trace claim is that gateway-side output is byte-identical (no observable change in stdout, stderr, tool registration, ActorFactory wiring, or filesystem side effects); only the `_profile_runtime` value is constructed in-memory in addition.

## Codex review

Read-only codex review thread iterated three times (#883 review commits `4323414a` → `7a2b4526` → `2665a177` → `856b5008`). Final verdict on `856b5008`:

> **Verdict: APPROVE**. No blocking findings. `ProfileRuntime::bootstrap` is now in-memory only: no `fs`, `tokio::fs`, `exists`, `read_to_string`, or `discover_ominix_url` in the production bootstrap path. The remaining filesystem reads stay in the pre-existing gateway sequence. Gateway startup order is preserved modulo the inserted pure bootstrap assembly. The gateway tool registration block, ProviderRouter registration/QoS seeding, and ActorFactory inputs remain unchanged from `origin/main` behavior.

## Test plan

- [ ] After merge, on a fleet mini with a configured profile (mini1/2/3):
  - capture `octos gateway --profile <p>` stdout+stderr on main before this PR
  - capture the same on this branch
  - diff (modulo timestamps + pid); confirm zero observable changes
- [ ] Soak on the same fleet mini for ≥10 min with Telegram echo to confirm no regressions in channel / bus / actor wiring.

## Refs

- Tracker: #870
- Issue: #872
- Builds on M11-A skeleton (#881)
- Workstreams doc: `workstreams/M11-runtime-unification.md` § M11-B
- ADR: `docs/M11-PROFILE-SESSION-RUNTIME-ADR.md`