### PR TITLE
fix(runtime): M11-F regression — propagate SKILL.md prompt fragments into per-session Agent (closes #891)

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -4502,6 +4502,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             plugin_prompt_fragments: Vec::new(),
             plugin_hooks: Vec::new(),
+            system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
             tool_config,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -11919,6 +11919,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             plugin_prompt_fragments: Vec::new(),
             plugin_hooks: Vec::new(),
+            system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
             tool_config,

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -551,6 +551,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             plugin_prompt_fragments: Vec::new(),
             plugin_hooks: Vec::new(),
+            system_prompt: "test-system-prompt".to_string(),
             memory,
             memory_store,
             tool_config,

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -21,10 +21,13 @@ use octos_memory::{EpisodeStore, MemoryStore};
 use tracing::{info, warn};
 
 use crate::commands::chat;
+use crate::commands::gateway::build_system_prompt;
 use crate::commands::gateway::profile_factory::{profile_plugin_env, profile_search_provider_keys};
 use crate::profiles::{UserProfile, config_from_profile};
 use crate::qos_catalog::{ExporterMode, build_adaptive_provider_chain};
-use crate::skills_scope::{discover_ominix_url, push_runtime_plugin_env};
+use crate::skills_scope::{
+    build_account_skills_loader, discover_ominix_url, push_runtime_plugin_env,
+};
 
 /// All long-lived state that belongs to a single profile within the
 /// current host process.
@@ -189,6 +192,25 @@ pub struct ProfileRuntime {
     /// gateway-built system prompt; serve appends them to the per-
     /// session agent.
     pub plugin_prompt_fragments: Vec<String>,
+
+    /// Fully pre-assembled system prompt for this profile. Built once
+    /// at bootstrap by calling [`build_system_prompt`] (the gateway's
+    /// canonical assembler) and then appending every fragment in
+    /// [`Self::plugin_prompt_fragments`]. Every [`super::SessionRuntime`]
+    /// bootstrapped from this profile copies the value onto its
+    /// per-session [`octos_agent::Agent`] via
+    /// [`octos_agent::Agent::with_system_prompt`]. This is the M11-F
+    /// regression fix (#891) — the previous serve-mode
+    /// `try_create_agent` helper called the same build + append loop
+    /// inline, but M11-F deleted that helper and routed everything
+    /// through [`super::SessionRuntime::bootstrap`], which never
+    /// re-derived the prompt. The result was that SKILL.md auto-
+    /// injected guidance (e.g. the mofa-fm "call fm_tts directly"
+    /// note) never reached the LLM on `/api/chat` or the UI Protocol
+    /// WebSocket path. Pre-assembling once on `ProfileRuntime` keeps
+    /// the heavy work (memory context, skills summary, bootstrap
+    /// files) off the per-request hot path.
+    pub system_prompt: String,
 
     /// Hook configurations contributed by loaded plugins (skill
     /// manifests can declare `before_tool_call` / `after_tool_call` /
@@ -492,12 +514,55 @@ impl ProfileRuntime {
             tools.apply_policy(policy);
         }
 
+        // Step 18: pre-assemble the profile-scope system prompt.
+        //
+        // This is the M11-F regression fix (#891). Before M11-F, serve
+        // mode's `try_create_agent` helper called `build_system_prompt`
+        // + the fragment-append loop inline, so every per-request agent
+        // observed the SKILL.md guidance. M11-F deleted that helper and
+        // routed everything through `SessionRuntime::bootstrap`, which
+        // never re-derived the prompt — meaning `/api/chat` and the UI
+        // Protocol WS path lost the mofa-fm "call fm_tts directly"
+        // teaching (and any future skill-injected guidance).
+        //
+        // We assemble once per profile and stash it on the runtime so
+        // every `SessionRuntime` bootstrapped from this profile inherits
+        // the same prompt onto its per-session `Agent`. The gateway path
+        // is unaffected — `profile_factory::build` continues to call
+        // `build_system_prompt` itself for child-bot sub-agents, and
+        // `plugin_prompt_fragments` is still populated for that path.
+        //
+        // `project_dir` is `data_dir` in serve mode. The bootstrap-files
+        // assembly (`load_bootstrap_files`) reads AGENTS.md / SOUL.md /
+        // USER.md from this dir — gateway uses its `--cwd` / project
+        // dir, but serve mode has no project_dir concept, and the
+        // per-profile data dir is the only profile-scoped directory we
+        // can hand to the helper. Operators who want per-profile
+        // bootstrap files drop them in `<data_dir>/`, which matches the
+        // pre-M11-F serve-mode behavior.
+        let skills_loader = build_account_skills_loader(data_dir);
+        let mut system_prompt = build_system_prompt(
+            profile.config.gateway.system_prompt.as_deref(),
+            data_dir,
+            data_dir,
+            &memory_store,
+            &skills_loader,
+            &tool_config,
+        )
+        .await;
+        for fragment in &plugin_result.prompt_fragments {
+            system_prompt.push_str("\n\n");
+            system_prompt.push_str(fragment);
+        }
+
         info!(
             profile_id = %profile.id,
             provider = %provider_name,
             model = %primary_model_id,
             plugin_count = plugin_result.tool_names.len(),
             tool_count = tools.specs().len(),
+            system_prompt_len = system_prompt.len(),
+            prompt_fragment_count = plugin_result.prompt_fragments.len(),
             "ProfileRuntime: bootstrapped"
         );
 
@@ -519,6 +584,7 @@ impl ProfileRuntime {
             plugin_dirs,
             plugin_prompt_fragments: plugin_result.prompt_fragments.clone(),
             plugin_hooks: plugin_result.hooks.clone(),
+            system_prompt,
             memory,
             memory_store,
             tool_config,
@@ -529,7 +595,9 @@ impl ProfileRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::profiles::{GatewaySettings, ProfileConfig};
+    use crate::profiles::{
+        GatewaySettings, LlmModelSelectionConfig, LlmProfileConfig, LlmRouteConfig, ProfileConfig,
+    };
     use chrono::Utc;
     use octos_agent::SandboxConfig;
     use std::collections::HashMap;
@@ -607,6 +675,121 @@ mod tests {
         assert!(
             err.to_string().contains("named-err"),
             "error should mention profile id: {err}",
+        );
+    }
+
+    /// M11 regression fix (#891): `ProfileRuntime::bootstrap` must
+    /// pre-assemble the full system prompt so every `SessionRuntime`
+    /// built from it observes the SKILL.md prompt fragments. Without
+    /// this, `/api/chat` and the UI Protocol WS path miss the
+    /// mofa-fm SKILL.md (and any future skill-injected guidance) and
+    /// the LLM falls back to its prior over the bare tool list.
+    ///
+    /// Fixture: a single skill (no executable required — the loader's
+    /// "extras-only" path handles manifests with empty tools) that
+    /// declares `prompts.include = ["SKILL.md"]` and ships a SKILL.md
+    /// with a recognizable token. We then bootstrap a profile pointing
+    /// at this skills dir and assert the token surfaces on
+    /// `ProfileRuntime::system_prompt`.
+    #[tokio::test]
+    #[allow(unsafe_code)]
+    async fn profile_runtime_bootstrap_includes_skill_prompt_fragments() {
+        // Uniquely-named env var to avoid contention with other tests.
+        const KEY_NAME: &str = "OCTOS_M11_891_TEST_API_KEY";
+        // SAFETY: this env var name is unique to this test; nothing
+        // else in the test suite reads or writes it. We also unset it
+        // on the way out via the guard below.
+        unsafe {
+            std::env::set_var(KEY_NAME, "test-key-sk-fake");
+        }
+        struct EnvGuard;
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: see set_var above.
+                unsafe {
+                    std::env::remove_var(KEY_NAME);
+                }
+            }
+        }
+        let _guard = EnvGuard;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profiles").join("test").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // Plant a fixture skill with a recognizable token in SKILL.md.
+        let skills_dir = data_dir.join("skills").join("test-fragment-skill");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+        std::fs::write(
+            skills_dir.join("manifest.json"),
+            r#"{
+                "name": "test-fragment-skill",
+                "version": "1.0.0",
+                "tools": [],
+                "prompts": { "include": ["SKILL.md"] }
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            skills_dir.join("SKILL.md"),
+            "## Test Fragment Skill\n\nMARKER-FRAGMENT-XYZ — call fm_tts directly.\n",
+        )
+        .unwrap();
+
+        let profile = UserProfile {
+            id: "with-skill".to_string(),
+            name: "With Skill".to_string(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                gateway: GatewaySettings::default(),
+                llm: Some(LlmProfileConfig {
+                    primary: Some(LlmModelSelectionConfig {
+                        family_id: Some("openai".to_string()),
+                        model_id: Some("gpt-4o-mini".to_string()),
+                        route: Some(LlmRouteConfig {
+                            route_id: None,
+                            label: None,
+                            base_url: None,
+                            api_key_env: Some(KEY_NAME.to_string()),
+                            api_type: None,
+                        }),
+                        ..Default::default()
+                    }),
+                    fallbacks: Vec::new(),
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let rt = ProfileRuntime::bootstrap(&profile, &data_dir, None)
+            .await
+            .expect("bootstrap should succeed with a valid provider config");
+
+        assert!(
+            rt.system_prompt.contains("MARKER-FRAGMENT-XYZ"),
+            "system_prompt should contain SKILL.md fragment; got: {}",
+            rt.system_prompt
+        );
+        // Sanity: it's not _only_ the fragment — base prompt content
+        // (e.g. the date marker injected by `build_system_prompt`)
+        // should also be present.
+        assert!(
+            rt.system_prompt.contains("Current date:"),
+            "system_prompt should also contain the base prompt body; got: {}",
+            rt.system_prompt
+        );
+        // The plugin_prompt_fragments field also still carries the
+        // raw fragment (gateway path consumers depend on it).
+        assert!(
+            rt.plugin_prompt_fragments
+                .iter()
+                .any(|f| f.contains("MARKER-FRAGMENT-XYZ")),
+            "plugin_prompt_fragments should still surface the fragment for gateway",
         );
     }
 }

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -272,6 +272,17 @@ impl SessionRuntime {
             save_episodes: true,
             ..Default::default()
         })
+        // M11-F regression fix (#891): propagate the pre-assembled
+        // profile-scope system prompt onto the per-session agent. The
+        // profile assembled it once during `ProfileRuntime::bootstrap`
+        // via `build_system_prompt` + the SKILL.md fragment-append
+        // loop, so every session for the profile inherits the same
+        // skill-aware guidance (the mofa-fm "call fm_tts directly"
+        // note, future skill-injected guidance, etc.). Without this
+        // line, the agent's prompt would fall back to the
+        // `Agent::new_shared` default and the LLM would lose its
+        // skill-aware routing.
+        .with_system_prompt(profile.system_prompt.clone())
         .with_file_state_cache(file_state_cache)
         .with_subagent_output_router(subagent_output_router)
         .with_subagent_summary_generator(subagent_summary_generator)
@@ -445,6 +456,13 @@ mod tests {
     }
 
     async fn make_profile(data_dir: PathBuf) -> Arc<ProfileRuntime> {
+        make_profile_with_prompt(data_dir, "test-system-prompt".to_string()).await
+    }
+
+    async fn make_profile_with_prompt(
+        data_dir: PathBuf,
+        system_prompt: String,
+    ) -> Arc<ProfileRuntime> {
         std::fs::create_dir_all(&data_dir).unwrap();
         let memory = Arc::new(EpisodeStore::open(&data_dir).await.unwrap());
         let memory_store = Arc::new(MemoryStore::open(&data_dir).await.unwrap());
@@ -470,6 +488,7 @@ mod tests {
             plugin_dirs: Vec::new(),
             plugin_prompt_fragments: Vec::new(),
             plugin_hooks: Vec::new(),
+            system_prompt,
             memory,
             memory_store,
             tool_config,
@@ -574,6 +593,34 @@ mod tests {
             "policy file was overwritten; expected sentinel preserved"
         );
         assert_eq!(after, edited);
+    }
+
+    /// M11 regression fix (#891): `SessionRuntime::bootstrap` must
+    /// propagate the parent profile's pre-assembled `system_prompt`
+    /// onto the per-session `Agent`. Without this, `/api/chat` and the
+    /// UI Protocol WS path miss SKILL.md prompt fragments and the
+    /// kimi-k2.5 LLM falls back to a "fm_voice_list precheck" pattern
+    /// instead of going straight to `fm_tts`.
+    #[tokio::test]
+    async fn session_runtime_agent_receives_system_prompt_from_profile() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile_with_prompt(
+            data_dir.clone(),
+            "DISTINCTIVE-PROFILE-PROMPT-789".to_string(),
+        )
+        .await;
+
+        let key = SessionKey::new("api", "system-prompt-probe");
+        let rt = SessionRuntime::bootstrap(&profile, key, None)
+            .await
+            .expect("bootstrap");
+
+        let snapshot = rt.agent.system_prompt_snapshot();
+        assert!(
+            snapshot.contains("DISTINCTIVE-PROFILE-PROMPT-789"),
+            "agent system prompt should inherit the profile-level prompt; got: {snapshot}",
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -207,6 +207,7 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
         plugin_dirs: Vec::new(),
         plugin_prompt_fragments: Vec::new(),
         plugin_hooks: Vec::new(),
+        system_prompt: "test-system-prompt".to_string(),
         memory,
         memory_store,
         tool_config,


### PR DESCRIPTION
## Symptom (verbatim from #891)

> User asks yangmi to speak; LLM (kimi-k2.5) calls `fm_voice_list` as precheck instead of going straight to `fm_tts`. SOAK-1 mini1 phase (#878 Phase 5) saw 2/5 turns hit `fm_tts`; mini3 phase (Phase 6) saw 5/5 — same binary, asymmetry is LLM nondeterminism amplifying the underlying gap.

Production regression on `https://dspfac.crew.ominix.io/chat` after M11-F (#888) deploy. fm_tts misfiring on mini1; kimi-k2.5 preferring `fm_voice_list` precheck instead of going straight to `fm_tts`.

## Root cause

`SessionRuntime::bootstrap` in `crates/octos-cli/src/runtime/session.rs:264-279` built per-session `Agent` instances WITHOUT `.with_system_prompt(...)`. Before M11-F, serve mode's deleted `try_create_agent` helper constructed the agent inline using the same pattern `gateway/profile_factory.rs:521-533` still uses (call `build_system_prompt(...)` + loop-append `plugin_prompt_fragments`). When M11-F (#888) deleted that helper and routed everything through `SessionRuntime::bootstrap`, the SKILL.md auto-injected guidance never reached the LLM on `/api/chat` or the UI Protocol v1 WebSocket path. The dispatcher comment in `session.rs:241-243` claimed the dispatcher would layer fragments on — it didn't.

`ProfileRuntime` correctly populated `plugin_prompt_fragments: Vec<String>` from skill SKILL.md files, but the only reader on the serve-side path was missing.

## Fix (Option B — pre-assemble on `ProfileRuntime`)

1. Add `pub system_prompt: String` field to `ProfileRuntime`.
2. In `ProfileRuntime::bootstrap` (step 18), call `build_system_prompt(profile.config.gateway.system_prompt.as_deref(), data_dir, data_dir, &memory_store, &skills_loader, &tool_config).await` and append every `plugin_result.prompt_fragments` entry with `\n\n`. `data_dir` is the right `project_dir` for serve mode (no project cwd concept; ADR-defined per-profile data dir is tenant-scoped + deterministic).
3. In `SessionRuntime::bootstrap`, add `.with_system_prompt(profile.system_prompt.clone())` to the `Agent::new_shared(...)` builder chain.
4. Update test stubs in `cache.rs`, `handlers.rs`, `ui_protocol.rs`, `coding_multi_session.rs`, `session.rs` to set `system_prompt: \"test-system-prompt\".to_string()`.

The gateway path (`profile_factory.rs:521-533`) is unchanged. `plugin_prompt_fragments` remains populated for the child-bot sub-agent consumers.

## Tests

- `runtime::profile::tests::profile_runtime_bootstrap_includes_skill_prompt_fragments` — plants a fixture skill with `MARKER-FRAGMENT-XYZ` in SKILL.md, bootstraps a profile, asserts the marker appears on `rt.system_prompt` and that base prompt content (date marker) is also present.
- `runtime::session::tests::session_runtime_agent_receives_system_prompt_from_profile` — builds a profile with `system_prompt = \"DISTINCTIVE-PROFILE-PROMPT-789\"`, bootstraps a session, asserts `rt.agent.system_prompt_snapshot()` contains the marker.

## Codex review (read-only, mandatory) — APPROVE on all 3 dimensions

> (a) **APPROVE** — `ProfileRuntime::bootstrap` builds the prompt with `build_system_prompt(...)`, appends `plugin_result.prompt_fragments`, stores it on `ProfileRuntime.system_prompt`, and `SessionRuntime::bootstrap` applies it via `.with_system_prompt(profile.system_prompt.clone())`. `/api/chat` uses `session_runtime.agent.process_message(...)`, and both WS paths clone the session agent prompt snapshot before creating request-scoped agents, so the SKILL.md fragments propagate.
>
> (b) **APPROVE** — Using `profile_data_dir` as `project_dir` is the right serve-mode choice. `build_system_prompt` only uses `project_dir` for bootstrap files like `AGENTS.md`/`SOUL.md`/`USER.md`; serve has no stable project cwd, while ADR-defined per-profile data dir is tenant-scoped and deterministic.
>
> (c) **APPROVE with caveat** — Direct `/api/chat` and UI Protocol WS paths are covered. Gateway profile actors are separately covered by `profile_factory.rs`/`gateway_runtime.rs`. Pipeline codegen workers and spawn subagents may still miss SKILL.md fragments — pre-existing/orthogonal, not a blocker for #891.
>
> Other notes: prompt assembly is done once per profile, so no hot-path cost concern. Logging only emits prompt length/count, not prompt content. No race introduced.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p octos-cli --features api` → 981 tests passing
- `cargo build --release -p octos-cli --features \"api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot\"` clean

## Deploy

Deploy to fleet is a separate operational step after merge.

## Test plan

- [ ] Merge to main
- [ ] Build release binary with canonical features
- [ ] Deploy to mini1 + verify 5/5 turns produce mp3 for "yangmi please say hello" (was 2/5 pre-fix)
- [ ] Manual via dspfac.crew.ominix.io/chat after fleet deploy
- [ ] SOAK-1 M11-H driver re-run on mini1 to confirm fix