### PR TITLE
fix(agent + deep-search): propagate spawn_only file paths + topic-named research reports (closes #896, #897)

### DIFF
--- a/crates/app-skills/deep-search/SKILL.md
+++ b/crates/app-skills/deep-search/SKILL.md
@@ -56,7 +56,7 @@ Use `read_file` on specific source files for full content when you need detailed
 
 Results are saved to `./research/<query-slug>/`:
 
-- `<query-slug>.md` -- structured research report (topic-named; see issue #897)
+- `_<query-slug>.md` -- structured research report (topic-named; leading `_` keeps it out of `read_sources`' source-ingestion path on subsequent synthesis runs; see issue #897)
 - `_search_results.md` -- combined raw search results from all rounds
 - `01_<domain>.md` -- full page content from first source
 - `02_<domain>.md` -- full page content from second source

--- a/crates/app-skills/deep-search/SKILL.md
+++ b/crates/app-skills/deep-search/SKILL.md
@@ -56,7 +56,7 @@ Use `read_file` on specific source files for full content when you need detailed
 
 Results are saved to `./research/<query-slug>/`:
 
-- `_report.md` -- structured research report
+- `<query-slug>.md` -- structured research report (topic-named; see issue #897)
 - `_search_results.md` -- combined raw search results from all rounds
 - `01_<domain>.md` -- full page content from first source
 - `02_<domain>.md` -- full page content from second source

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -81,8 +81,9 @@ struct Output {
     #[serde(skip_serializing_if = "Option::is_none")]
     cost: Option<ResultCost>,
     /// Files the host should auto-deliver to chat. Mirrors v1
-    /// behavior; we name the synthesized `_report.md` here so the
-    /// chat UI shows the report file, not the search-engine dump.
+    /// behavior; we name the synthesized topic-named report (`<slug>.md`,
+    /// see `report_filename`) here so the chat UI shows the canonical
+    /// report file, not the search-engine dump.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     files_to_send: Vec<String>,
 }
@@ -592,7 +593,14 @@ async fn run_deep_search(
         Some(0.95),
     );
 
-    let report_path = dir.join("_report.md");
+    // Issue #897: canonical report filename derives from the topic slug
+    // (`<slug>.md`) instead of the hardcoded `_report.md`. The wrapper
+    // directory is unchanged; intermediate sidecars (`_search_results.md`,
+    // `01_*.md`, …) keep their existing shapes. The topic-named filename
+    // gives the chat UI a self-describing attachment and gives the LLM a
+    // stable name to reference on follow-up turns (sister issue #896).
+    let report_filename_str = report_filename(&slug);
+    let report_path = dir.join(&report_filename_str);
     let report = build_report(
         query,
         synthesis.as_ref(),
@@ -604,7 +612,7 @@ async fn run_deep_search(
     );
 
     // Save report
-    let _ = fs::write(dir.join("_report.md"), &report);
+    let _ = fs::write(&report_path, &report);
 
     progress_simple_with_fraction(ProgressPhase::Completion, "Deep search complete", Some(1.0));
     emit_v2_progress("complete", "Deep search complete", Some(1.0));
@@ -2210,6 +2218,24 @@ fn research_dir(slug: &str) -> PathBuf {
     base.join("research").join(slug)
 }
 
+/// Issue #897: derive the canonical report filename from the topic slug
+/// so each research run produces a topic-named markdown file rather than
+/// the legacy hardcoded `_report.md`. The wrapper directory still keeps
+/// the slug, and intermediate sidecars (`_search_results.md`,
+/// `01_*.md`, …) keep their leading-`_`/index prefix shapes so a
+/// directory listing groups by run.
+///
+/// Falls back to `_report.md` only if the slug is empty (degenerate
+/// query). Keeps the file extension uniformly `.md`.
+fn report_filename(slug: &str) -> String {
+    let trimmed = slug.trim_matches('-');
+    if trimmed.is_empty() {
+        "_report.md".to_string()
+    } else {
+        format!("{trimmed}.md")
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Report assembly (W3.C1)
 // ---------------------------------------------------------------------------
@@ -2917,6 +2943,36 @@ mod tests {
     }
 
     #[test]
+    fn should_save_report_with_topic_named_filename() {
+        // Issue #897: deep_search no longer hardcodes `_report.md`. The
+        // canonical report file inside `research/<slug>/` is named after
+        // the topic slug so it is self-describing when downloaded or
+        // attached, and so the LLM has a stable name to read back on the
+        // next turn (sister issue #896).
+        assert_eq!(
+            report_filename("rust-async-runtimes-2026"),
+            "rust-async-runtimes-2026.md"
+        );
+        assert_eq!(
+            report_filename("top-AI-startups-2025"),
+            "top-AI-startups-2025.md"
+        );
+        // CJK preserved (slugify keeps unicode > U+007F).
+        assert_eq!(report_filename("中美关系-的影响"), "中美关系-的影响.md");
+        // The legacy literal must never reappear for a real slug.
+        assert!(!report_filename("foo-bar").starts_with('_'));
+    }
+
+    #[test]
+    fn report_filename_falls_back_when_slug_is_empty() {
+        // Defensive: a degenerate empty slug (after `slugify` strips
+        // everything) keeps the historical filename so we never produce
+        // a zero-name `.md` file.
+        assert_eq!(report_filename(""), "_report.md");
+        assert_eq!(report_filename("---"), "_report.md");
+    }
+
+    #[test]
     fn test_host_slug() {
         assert_eq!(host_slug("https://www.example.com/page"), "example-com");
         assert_eq!(host_slug("https://api.you.com/search"), "api-you-com");
@@ -3481,7 +3537,9 @@ A second paragraph elaborates on alternatives [2]."
             usd: Some(0.0009),
         };
         let dir = std::path::PathBuf::from("/tmp/research/topic");
-        let report_path = dir.join("_report.md");
+        // Issue #897: canonical report filename now derives from the
+        // topic slug, not the literal `_report.md`.
+        let report_path = dir.join(report_filename("topic"));
         let report = build_report(
             "topic",
             Some(&syn),
@@ -3514,8 +3572,17 @@ A second paragraph elaborates on alternatives [2]."
             !report.contains("LLM synthesis unavailable"),
             "synthesis fallback leaked into successful path"
         );
-        // Trailer with report path stays for v1 host compatibility.
-        assert!(report.contains("Report saved to: /tmp/research/topic/_report.md"));
+        // Trailer with report path stays for v1 host compatibility,
+        // but now references the topic-named filename (issue #897).
+        assert!(
+            report.contains("Report saved to: /tmp/research/topic/topic.md"),
+            "expected topic-named report path in trailer: {report}"
+        );
+        // Belt-and-suspenders: the legacy literal must NOT leak back in.
+        assert!(
+            !report.contains("/topic/_report.md"),
+            "legacy `_report.md` must not appear once slug is set: {report}"
+        );
         // Multi-paragraph structure is preserved (we have a blank line in
         // the synthesis input → there should be at least 4 newlines around
         // the synthesis body).
@@ -3535,7 +3602,8 @@ A second paragraph elaborates on alternatives [2]."
         )];
         let queries = vec!["topic".to_string()];
         let dir = std::path::PathBuf::from("/tmp/research/topic");
-        let report_path = dir.join("_report.md");
+        // Issue #897: topic-named filename, no longer `_report.md`.
+        let report_path = dir.join(report_filename("topic"));
         let report = build_report(
             "topic",
             None,
@@ -3550,6 +3618,11 @@ A second paragraph elaborates on alternatives [2]."
         assert!(report.contains("Initial Bing dump"));
         assert!(report.contains("### Source [1]"));
         assert!(!report.contains("## Synthesis"));
+        // Trailer must reference the topic-named file.
+        assert!(
+            report.contains("Report saved to: /tmp/research/topic/topic.md"),
+            "expected topic-named trailer: {report}"
+        );
     }
 
     #[test]
@@ -3567,6 +3640,9 @@ A second paragraph elaborates on alternatives [2]."
             tokens_out: 0,
             usd: None,
         };
+        // Issue #897: even in the degenerate-synthesis fallback the
+        // file is named after the topic slug.
+        let topic_report = format!("/tmp/{}", report_filename("topic"));
         let report = build_report(
             "topic",
             Some(&syn),
@@ -3574,11 +3650,16 @@ A second paragraph elaborates on alternatives [2]."
             &[],
             &["topic".to_string()],
             std::path::Path::new("/tmp"),
-            std::path::Path::new("/tmp/_report.md"),
+            std::path::Path::new(&topic_report),
         );
         assert!(!report.contains("## Synthesis"));
         assert!(report.contains("LLM synthesis unavailable"));
         assert!(report.contains("raw initial"));
+        // Trailer references the topic-named filename.
+        assert!(
+            report.contains("Report saved to: /tmp/topic.md"),
+            "expected topic-named trailer in fallback path: {report}"
+        );
     }
 
     #[test]

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -2225,6 +2225,13 @@ fn research_dir(slug: &str) -> PathBuf {
 /// `01_*.md`, …) keep their leading-`_`/index prefix shapes so a
 /// directory listing groups by run.
 ///
+/// **The leading `_` prefix is load-bearing** —
+/// `octos_agent::tools::research_utils::read_sources` excludes
+/// `_`-prefixed files when collecting "source" inputs for the
+/// `synthesize_research` map-reduce. Without the prefix, the new
+/// topic-named report would be re-ingested as a source on the next
+/// synthesis run (codex review on PR #898).
+///
 /// Falls back to `_report.md` only if the slug is empty (degenerate
 /// query). Keeps the file extension uniformly `.md`.
 fn report_filename(slug: &str) -> String {
@@ -2232,7 +2239,7 @@ fn report_filename(slug: &str) -> String {
     if trimmed.is_empty() {
         "_report.md".to_string()
     } else {
-        format!("{trimmed}.md")
+        format!("_{trimmed}.md")
     }
 }
 
@@ -2949,18 +2956,27 @@ mod tests {
         // the topic slug so it is self-describing when downloaded or
         // attached, and so the LLM has a stable name to read back on the
         // next turn (sister issue #896).
+        //
+        // The leading `_` prefix is preserved (load-bearing — keeps the
+        // file out of `read_sources`' source-ingestion path; see the
+        // doc comment on `report_filename` for the full rationale).
         assert_eq!(
             report_filename("rust-async-runtimes-2026"),
-            "rust-async-runtimes-2026.md"
+            "_rust-async-runtimes-2026.md"
         );
         assert_eq!(
             report_filename("top-AI-startups-2025"),
-            "top-AI-startups-2025.md"
+            "_top-AI-startups-2025.md"
         );
         // CJK preserved (slugify keeps unicode > U+007F).
-        assert_eq!(report_filename("中美关系-的影响"), "中美关系-的影响.md");
-        // The legacy literal must never reappear for a real slug.
-        assert!(!report_filename("foo-bar").starts_with('_'));
+        assert_eq!(report_filename("中美关系-的影响"), "_中美关系-的影响.md");
+        // The `_`-prefix invariant: every real slug yields a filename
+        // that `research_utils::read_sources` will skip. This guard
+        // catches the regression codex flagged on PR #898 — without
+        // the prefix, the report would be re-ingested as a source on
+        // the next `synthesize_research` run.
+        assert!(report_filename("foo-bar").starts_with('_'));
+        assert!(report_filename("中美关系").starts_with('_'));
     }
 
     #[test]
@@ -3575,7 +3591,7 @@ A second paragraph elaborates on alternatives [2]."
         // Trailer with report path stays for v1 host compatibility,
         // but now references the topic-named filename (issue #897).
         assert!(
-            report.contains("Report saved to: /tmp/research/topic/topic.md"),
+            report.contains("Report saved to: /tmp/research/topic/_topic.md"),
             "expected topic-named report path in trailer: {report}"
         );
         // Belt-and-suspenders: the legacy literal must NOT leak back in.
@@ -3620,7 +3636,7 @@ A second paragraph elaborates on alternatives [2]."
         assert!(!report.contains("## Synthesis"));
         // Trailer must reference the topic-named file.
         assert!(
-            report.contains("Report saved to: /tmp/research/topic/topic.md"),
+            report.contains("Report saved to: /tmp/research/topic/_topic.md"),
             "expected topic-named trailer: {report}"
         );
     }
@@ -3657,7 +3673,7 @@ A second paragraph elaborates on alternatives [2]."
         assert!(report.contains("raw initial"));
         // Trailer references the topic-named filename.
         assert!(
-            report.contains("Report saved to: /tmp/topic.md"),
+            report.contains("Report saved to: /tmp/_topic.md"),
             "expected topic-named trailer in fallback path: {report}"
         );
     }

--- a/crates/app-skills/deep-search/src/main.rs
+++ b/crates/app-skills/deep-search/src/main.rs
@@ -81,7 +81,7 @@ struct Output {
     #[serde(skip_serializing_if = "Option::is_none")]
     cost: Option<ResultCost>,
     /// Files the host should auto-deliver to chat. Mirrors v1
-    /// behavior; we name the synthesized topic-named report (`<slug>.md`,
+    /// behavior; we name the synthesized topic-named report (`_<slug>.md`,
     /// see `report_filename`) here so the chat UI shows the canonical
     /// report file, not the search-engine dump.
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -593,8 +593,8 @@ async fn run_deep_search(
         Some(0.95),
     );
 
-    // Issue #897: canonical report filename derives from the topic slug
-    // (`<slug>.md`) instead of the hardcoded `_report.md`. The wrapper
+    // Issue #897: canonical report filename derives from the topic slug with `_` prefix
+    // (`_<slug>.md`) instead of the hardcoded `_report.md`. The wrapper
     // directory is unchanged; intermediate sidecars (`_search_results.md`,
     // `01_*.md`, …) keep their existing shapes. The topic-named filename
     // gives the chat UI a self-describing attachment and gives the LLM a

--- a/crates/app-skills/deep-search/tests/fixtures/sample_synthesized_report.md
+++ b/crates/app-skills/deep-search/tests/fixtures/sample_synthesized_report.md
@@ -87,4 +87,4 @@ a runtime at the binary level...
 
 ---
 5 pages crawled across 4 search rounds.
-Report saved to: research/rust-async-runtimes-2026/rust-async-runtimes-2026.md
+Report saved to: research/rust-async-runtimes-2026/_rust-async-runtimes-2026.md

--- a/crates/app-skills/deep-search/tests/fixtures/sample_synthesized_report.md
+++ b/crates/app-skills/deep-search/tests/fixtures/sample_synthesized_report.md
@@ -87,4 +87,4 @@ a runtime at the binary level...
 
 ---
 5 pages crawled across 4 search rounds.
-Report saved to: research/rust-async-runtimes-2026/_report.md
+Report saved to: research/rust-async-runtimes-2026/rust-async-runtimes-2026.md

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -541,64 +541,70 @@ impl Agent {
                                         false
                                     };
 
-                                    // Issue #896: append a produced-files
-                                    // notification on the workspace-contract
-                                    // success path too. Same rationale as the
-                                    // legacy `NotConfigured` path below — the
-                                    // LLM needs workspace-relative paths to
-                                    // reference the outputs on its next turn.
                                     if result_persisted {
-                                        if let Some(ref sender) = bg_sender {
-                                            if let Some(produced_msg) =
-                                                build_spawn_only_produced_files_message(
-                                                    &bg_name,
-                                                    &output_files,
-                                                    bg_tools.workspace_root(),
-                                                )
-                                            {
-                                                let _ = sender(BackgroundResultPayload {
-                                                    task_label: bg_name.clone(),
-                                                    content: produced_msg,
-                                                    kind: BackgroundResultKind::Notification,
-                                                    media: vec![],
-                                                    envelope_media: vec![],
-                                                    originating_thread_id: bg_originating_thread_id
-                                                        .clone(),
-                                                    task_id: Some(task_id.clone()),
-                                                })
-                                                .await;
+                                        // Issue #896: emit the produced-files
+                                        // notification ONLY after the supervisor
+                                        // validation passes. Codex review on
+                                        // PR #898 flagged the original ordering
+                                        // (notification before validation) as
+                                        // user-confusing — a success-looking
+                                        // paths block could land in chat right
+                                        // before a `✗ failed` notification if
+                                        // `mark_completed_with_validation`
+                                        // rejected the outputs. Matches the
+                                        // safer ordering used on the
+                                        // `NotConfigured` path below.
+                                        match bg_supervisor.mark_completed_with_validation(
+                                            &task_id,
+                                            output_files.clone(),
+                                        ) {
+                                            Ok(()) => {
+                                                if let Some(ref sender) = bg_sender {
+                                                    if let Some(produced_msg) =
+                                                        build_spawn_only_produced_files_message(
+                                                            &bg_name,
+                                                            &output_files,
+                                                            bg_tools.workspace_root(),
+                                                        )
+                                                    {
+                                                        let _ = sender(BackgroundResultPayload {
+                                                            task_label: bg_name.clone(),
+                                                            content: produced_msg,
+                                                            kind:
+                                                                BackgroundResultKind::Notification,
+                                                            media: vec![],
+                                                            envelope_media: vec![],
+                                                            originating_thread_id:
+                                                                bg_originating_thread_id.clone(),
+                                                            task_id: Some(task_id.clone()),
+                                                        })
+                                                        .await;
+                                                    }
+                                                }
                                             }
-                                        }
-                                    }
-
-                                    if result_persisted {
-                                        if let Err(validation_error) = bg_supervisor
-                                            .mark_completed_with_validation(
-                                                &task_id,
-                                                output_files.clone(),
-                                            )
-                                        {
-                                            tracing::warn!(
-                                                tool = %bg_name,
-                                                files = ?output_files,
-                                                error = %validation_error,
-                                                "workspace contract satisfied but supervisor artifact validation rejected outputs"
-                                            );
-                                            if let Some(ref sender) = bg_sender {
-                                                let _ = sender(BackgroundResultPayload {
-                                                    task_label: bg_name.clone(),
-                                                    content: format!(
-                                                        "✗ {} failed: {}",
-                                                        bg_name, validation_error
-                                                    ),
-                                                    kind: BackgroundResultKind::Notification,
-                                                    media: vec![],
-                                                    envelope_media: vec![],
-                                                    originating_thread_id: bg_originating_thread_id
-                                                        .clone(),
-                                                    task_id: Some(task_id.clone()),
-                                                })
-                                                .await;
+                                            Err(validation_error) => {
+                                                tracing::warn!(
+                                                    tool = %bg_name,
+                                                    files = ?output_files,
+                                                    error = %validation_error,
+                                                    "workspace contract satisfied but supervisor artifact validation rejected outputs"
+                                                );
+                                                if let Some(ref sender) = bg_sender {
+                                                    let _ = sender(BackgroundResultPayload {
+                                                        task_label: bg_name.clone(),
+                                                        content: format!(
+                                                            "✗ {} failed: {}",
+                                                            bg_name, validation_error
+                                                        ),
+                                                        kind: BackgroundResultKind::Notification,
+                                                        media: vec![],
+                                                        envelope_media: vec![],
+                                                        originating_thread_id:
+                                                            bg_originating_thread_id.clone(),
+                                                        task_id: Some(task_id.clone()),
+                                                    })
+                                                    .await;
+                                                }
                                             }
                                         }
                                     } else {

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -67,6 +67,60 @@ fn should_auto_send_tool_files(
     !(suppress_auto_send_files || explicit_send_file_requested && tool_name != "send_file")
 }
 
+/// Issue #896 — spawn_only filename propagation (Layer 1).
+///
+/// Build a short follow-up notification that lists the workspace-relative
+/// paths a spawn_only tool produced, so the LLM has stable filenames to
+/// reference on its next turn. Without this, the LLM only sees the
+/// `task_handle` envelope from `spawn_only_handle_message` (which carries
+/// `output_dir` but not the actual filename), and tends to hallucinate
+/// slugs (see live dspfac trace 2026-05-11).
+///
+/// Returns `None` when `files` is empty — the caller MUST suppress the
+/// follow-up notification in that case so we never persist an empty
+/// "produced files:" stub. Token-budget invariant (M10 Phase 4): paths
+/// only, never file contents.
+///
+/// `workspace_root`, when supplied, is used to convert absolute paths
+/// under the workspace into workspace-relative form (e.g.
+/// `/Users/foo/.octos/profiles/p1/workspace/research/x/x.md` →
+/// `research/x/x.md`) so the LLM can pass the path straight to
+/// `read_file({path: "research/x/x.md"})`. Paths outside the workspace
+/// (or when `workspace_root` is `None`) are kept verbatim.
+fn build_spawn_only_produced_files_message(
+    tool_name: &str,
+    files: &[String],
+    workspace_root: Option<&std::path::Path>,
+) -> Option<String> {
+    if files.is_empty() {
+        return None;
+    }
+    let mut out = format!("`{tool_name}` produced files:");
+    for path in files {
+        out.push_str("\n- ");
+        out.push_str(&relativize_workspace_path(path, workspace_root));
+    }
+    Some(out)
+}
+
+/// Strip the workspace prefix from an absolute path, returning a
+/// workspace-relative path string. Falls back to the original path if it
+/// cannot be relativised (already-relative input, different root, or no
+/// `workspace_root` configured).
+///
+/// Pure helper so we can unit-test the relativisation logic without
+/// standing up an Agent.
+fn relativize_workspace_path(path: &str, workspace_root: Option<&std::path::Path>) -> String {
+    let Some(root) = workspace_root else {
+        return path.to_string();
+    };
+    let abs = std::path::Path::new(path);
+    match abs.strip_prefix(root) {
+        Ok(rel) => rel.to_string_lossy().into_owned(),
+        Err(_) => path.to_string(),
+    }
+}
+
 /// Produce the composite system-prompt text (worker prompt + realtime sensor
 /// summary) used at the top of every agent turn. Centralizing this in
 /// `execution.rs` keeps the message-building policy in a single location so
@@ -487,6 +541,36 @@ impl Agent {
                                         false
                                     };
 
+                                    // Issue #896: append a produced-files
+                                    // notification on the workspace-contract
+                                    // success path too. Same rationale as the
+                                    // legacy `NotConfigured` path below — the
+                                    // LLM needs workspace-relative paths to
+                                    // reference the outputs on its next turn.
+                                    if result_persisted {
+                                        if let Some(ref sender) = bg_sender {
+                                            if let Some(produced_msg) =
+                                                build_spawn_only_produced_files_message(
+                                                    &bg_name,
+                                                    &output_files,
+                                                    bg_tools.workspace_root(),
+                                                )
+                                            {
+                                                let _ = sender(BackgroundResultPayload {
+                                                    task_label: bg_name.clone(),
+                                                    content: produced_msg,
+                                                    kind: BackgroundResultKind::Notification,
+                                                    media: vec![],
+                                                    envelope_media: vec![],
+                                                    originating_thread_id: bg_originating_thread_id
+                                                        .clone(),
+                                                    task_id: Some(task_id.clone()),
+                                                })
+                                                .await;
+                                            }
+                                        }
+                                    }
+
                                     if result_persisted {
                                         if let Err(validation_error) = bg_supervisor
                                             .mark_completed_with_validation(
@@ -875,6 +959,52 @@ impl Agent {
                                                         task_id: Some(task_id.clone()),
                                                     })
                                                     .await;
+
+                                                    // Issue #896: append an
+                                                    // additional notification
+                                                    // listing the produced file
+                                                    // paths (workspace-relative
+                                                    // when possible) so the
+                                                    // LLM has stable filenames
+                                                    // to reference on its next
+                                                    // turn. The legacy "✓
+                                                    // completed (basenames)"
+                                                    // bubble above only shows
+                                                    // basenames in parentheses
+                                                    // — enough to display in
+                                                    // the chat UI, but not
+                                                    // enough for the LLM to
+                                                    // pass to `read_file({path:
+                                                    // ...})` on the next turn.
+                                                    // Token-budget invariant
+                                                    // (M10 Phase 4): paths
+                                                    // only, never file
+                                                    // contents. Emitted only
+                                                    // on success and only when
+                                                    // `sent_files` is
+                                                    // non-empty (the helper
+                                                    // returns None and we
+                                                    // skip otherwise).
+                                                    if let Some(produced_msg) =
+                                                        build_spawn_only_produced_files_message(
+                                                            &bg_name,
+                                                            &sent_files,
+                                                            bg_tools.workspace_root(),
+                                                        )
+                                                    {
+                                                        let _ = sender(BackgroundResultPayload {
+                                                            task_label: bg_name.clone(),
+                                                            content: produced_msg,
+                                                            kind:
+                                                                BackgroundResultKind::Notification,
+                                                            media: vec![],
+                                                            envelope_media: vec![],
+                                                            originating_thread_id:
+                                                                bg_originating_thread_id.clone(),
+                                                            task_id: Some(task_id.clone()),
+                                                        })
+                                                        .await;
+                                                    }
                                                 }
                                             }
                                             Err(validation_error) => {
@@ -1550,7 +1680,10 @@ fn panic_result(tool_call: &octos_core::ToolCall, reason: &str) -> ToolCallResul
 
 #[cfg(test)]
 mod tests {
-    use super::should_auto_send_tool_files;
+    use super::{
+        build_spawn_only_produced_files_message, relativize_workspace_path,
+        should_auto_send_tool_files,
+    };
 
     #[test]
     fn explicit_send_file_turn_suppresses_plugin_auto_send_for_other_tools() {
@@ -1561,5 +1694,106 @@ mod tests {
     #[test]
     fn auto_send_respects_global_suppression_flag() {
         assert!(!should_auto_send_tool_files(true, false, "mofa_slides"));
+    }
+
+    #[test]
+    fn should_emit_produced_files_block_when_files_present() {
+        // Issue #896: spawn_only completion appends an additional message
+        // listing produced file paths so the LLM has a stable
+        // workspace-relative reference for its next turn.
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let files = vec![
+            "/tmp/ws/research/x/x.md".to_string(),
+            "/tmp/ws/research/x/_search_results.md".to_string(),
+        ];
+        let msg = build_spawn_only_produced_files_message("deep_search", &files, Some(&root))
+            .expect("non-empty file list must yield Some(message)");
+
+        // Format pinning: header + bulleted workspace-relative paths.
+        assert!(
+            msg.starts_with("`deep_search` produced files:"),
+            "expected header line, got: {msg}"
+        );
+        assert!(
+            msg.contains("\n- research/x/x.md"),
+            "expected workspace-relative bullet, got: {msg}"
+        );
+        assert!(
+            msg.contains("\n- research/x/_search_results.md"),
+            "expected second workspace-relative bullet, got: {msg}"
+        );
+        // No absolute paths leak through.
+        assert!(
+            !msg.contains("/tmp/ws/"),
+            "absolute workspace prefix must be stripped: {msg}"
+        );
+    }
+
+    #[test]
+    fn should_suppress_produced_files_block_when_no_files() {
+        // Token-budget invariant: never persist a stub message when the
+        // tool produced no files (e.g. failed run, text-only result).
+        assert!(
+            build_spawn_only_produced_files_message("deep_search", &[], None).is_none(),
+            "empty files must return None so caller suppresses follow-up"
+        );
+    }
+
+    #[test]
+    fn should_keep_absolute_path_when_outside_workspace() {
+        // Defensive: if a spawn_only tool produces a file outside the
+        // workspace root (e.g. /tmp/foo.mp3), keep it verbatim rather
+        // than producing a misleading relative path.
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let files = vec!["/var/tmp/external.bin".to_string()];
+        let msg =
+            build_spawn_only_produced_files_message("foo", &files, Some(&root)).expect("non-empty");
+        assert!(msg.contains("- /var/tmp/external.bin"), "got: {msg}");
+    }
+
+    #[test]
+    fn produced_files_block_never_contains_file_contents() {
+        // Token-budget invariant (M10 Phase 4): the produced-files block
+        // is a list of PATHS only — file contents are NEVER inlined,
+        // regardless of how many files were produced.
+        let root = std::path::PathBuf::from("/tmp/ws");
+        let files: Vec<String> = (1..=10)
+            .map(|i| format!("/tmp/ws/research/topic/{i:02}_source.md"))
+            .collect();
+        let msg = build_spawn_only_produced_files_message("deep_search", &files, Some(&root))
+            .expect("non-empty");
+        // Stays small: 10 paths × ~40 chars + header ≈ ~500 bytes.
+        assert!(
+            msg.len() < 2048,
+            "produced-files block grew unexpectedly: {} bytes",
+            msg.len()
+        );
+        // No file content sentinels.
+        assert!(!msg.contains("LLM synthesis"));
+        assert!(!msg.contains("# Deep Research:"));
+    }
+
+    #[test]
+    fn relativize_strips_workspace_prefix() {
+        let root = std::path::PathBuf::from("/u/me/ws");
+        assert_eq!(
+            relativize_workspace_path("/u/me/ws/skill-output/a.md", Some(&root)),
+            "skill-output/a.md"
+        );
+        // Path not under workspace stays verbatim.
+        assert_eq!(
+            relativize_workspace_path("/other/a.md", Some(&root)),
+            "/other/a.md"
+        );
+        // Already-relative input stays verbatim.
+        assert_eq!(
+            relativize_workspace_path("skill-output/a.md", Some(&root)),
+            "skill-output/a.md"
+        );
+        // None workspace → verbatim.
+        assert_eq!(
+            relativize_workspace_path("/u/me/ws/a.md", None),
+            "/u/me/ws/a.md"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two paired fixes from the 2026-05-11 dspfac trace where kimi-k2.5 hallucinated `zhong-mei-...-de-ying-xiang/_report.md` because (a) the spawn_only completion message only carried `output_dir` not `filename`, and (b) `deep_search` hardcoded `_report.md`.

### #896 spawn_only filename propagation (Layer 1)

`crates/octos-agent/src/agent/execution.rs` — on every spawn_only success path that yields produced files, emit an additional `BackgroundResultKind::Notification` of the form:

```
`<tool_name>` produced files:
- <workspace-relative-path-1>
- <workspace-relative-path-2>
```

Paths only — never contents. Token-budget invariant from M10 Phase 4 preserved. When the file is under the session's `workspace_root`, the message uses the workspace-relative form so the LLM can pass it directly into `read_file({path: "research/x/x.md"})`.

Tests: `should_emit_produced_files_block_when_files_present` + workspace-relativisation helper coverage.

### #897 deep_search topic-named report

`crates/app-skills/deep-search/src/main.rs:595, :607` (+ fixture + tests) — replace hardcoded `dir.join("_report.md")` with `dir.join(report_filename(&slug))`, deriving `<slug>.md` from the topic slug. Falls back to `_report.md` only on degenerate empty-slug case.

Wrapper dir + sidecars (`_search_results.md`, `01_*.md`, ...) unchanged. Test `should_save_report_with_topic_named_filename` pins the new shape.

## Acceptance

- cargo clippy --workspace --all-targets -- -D warnings clean
- cargo test -p octos-agent --lib: 1293/1293 pass
- cargo test -p deep-search --bins: 40/40 pass; new test green
- cargo fmt --all --check clean

## Provenance

Salvaged from a stalled background agent that completed implementation + tests but stalled at the codex gate step (subagent stream watchdog timeout, 600s no progress). The diff is the agent's work verbatim; supervisor verified clippy + tests locally before committing/pushing. Codex review to be run on this PR after CI.