### PR TITLE
fix(gateway): don't crash gateway subprocess on redb lock contention (closes #899)

### DIFF
--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -289,7 +289,14 @@ impl GatewayRuntime {
         let profile_runtime: Option<Arc<ProfileRuntime>> = if let Some(profile) =
             resolved_profile.as_ref().filter(|_| !cli_llm_override)
         {
-            match ProfileRuntime::bootstrap(profile, &data_dir, Some(&effective_octos_home)).await {
+            match ProfileRuntime::bootstrap(
+                profile,
+                &data_dir,
+                Some(&effective_octos_home),
+                crate::runtime::BootstrapRole::Gateway,
+            )
+            .await
+            {
                 Ok(rt) => {
                     info!(
                         profile_id = %profile.id,

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -387,13 +387,22 @@ impl GatewayRuntime {
         let memory: Arc<EpisodeStore> = if let Some(rt) = profile_runtime.as_ref() {
             rt.memory.clone()
         } else {
+            // Non-profile / CLI-override inline path. This is still
+            // an `octos gateway` host process, so it shares the same
+            // role expectation as the profile-mode branch above: if a
+            // sibling `octos serve` daemon already owns the redb
+            // lock on this `data_dir`, fall back to a degraded store
+            // instead of crashlooping. (Issue #899.)
             eprintln!("[gateway] opening episode store at {}", data_dir.display());
             let store = Arc::new(
-                EpisodeStore::open(&data_dir)
+                EpisodeStore::open_or_degraded(&data_dir)
                     .await
                     .wrap_err("failed to open episode store")?,
             );
-            eprintln!("[gateway] episode store opened");
+            eprintln!(
+                "[gateway] episode store opened (degraded={})",
+                store.is_degraded(),
+            );
             store
         };
 

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -395,6 +395,7 @@ impl ServeCommand {
                 profile,
                 &profile_data_dir,
                 Some(&data_dir),
+                crate::runtime::BootstrapRole::Serve,
             )
             .await
             {

--- a/crates/octos-cli/src/runtime/mod.rs
+++ b/crates/octos-cli/src/runtime/mod.rs
@@ -58,7 +58,7 @@ pub mod profile;
 pub mod session;
 
 pub use cache::SessionRuntimeCache;
-pub use profile::ProfileRuntime;
+pub use profile::{BootstrapRole, ProfileRuntime};
 pub use session::SessionRuntime;
 
 #[cfg(test)]

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -792,4 +792,104 @@ mod tests {
             "plugin_prompt_fragments should still surface the fragment for gateway",
         );
     }
+
+    /// Regression test for the M11-F production crashloop tracked in
+    /// `octos-org/octos#899`:
+    ///
+    /// `octos serve` and `octos gateway` are separate OS processes,
+    /// both calling `ProfileRuntime::bootstrap` against the same
+    /// per-profile data dir. Before this fix the second bootstrap
+    /// crashed inside `EpisodeStore::open` with
+    /// `redb::DatabaseError::DatabaseAlreadyOpen`, gateway exited,
+    /// launchd auto-restarted it, and every profile crashlooped every
+    /// ~2 seconds. Now the second bootstrap must succeed with the
+    /// EpisodeStore in degraded mode.
+    ///
+    /// We simulate the cross-process race by bootstrapping the same
+    /// profile twice in a row in the same test — the first handle on
+    /// `rt_owner.memory` keeps the redb lock held while the second
+    /// `ProfileRuntime::bootstrap` call runs, exercising the same
+    /// `DatabaseAlreadyOpen` path the gateway subprocess hits in
+    /// production.
+    #[tokio::test]
+    #[allow(unsafe_code)]
+    async fn bootstrap_succeeds_when_redb_already_owned_by_sibling_process() {
+        const KEY_NAME: &str = "OCTOS_GH899_TEST_API_KEY";
+        // SAFETY: env var name is unique to this test.
+        unsafe {
+            std::env::set_var(KEY_NAME, "test-key-sk-fake");
+        }
+        struct EnvGuard;
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: see set_var above.
+                unsafe {
+                    std::env::remove_var(KEY_NAME);
+                }
+            }
+        }
+        let _guard = EnvGuard;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profiles").join("gh899").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let profile = UserProfile {
+            id: "gh899".to_string(),
+            name: "GH899".to_string(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                gateway: GatewaySettings::default(),
+                llm: Some(LlmProfileConfig {
+                    primary: Some(LlmModelSelectionConfig {
+                        family_id: Some("openai".to_string()),
+                        model_id: Some("gpt-4o-mini".to_string()),
+                        route: Some(LlmRouteConfig {
+                            route_id: None,
+                            label: None,
+                            base_url: None,
+                            api_key_env: Some(KEY_NAME.to_string()),
+                            api_type: None,
+                        }),
+                        ..Default::default()
+                    }),
+                    fallbacks: Vec::new(),
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        // Simulates `octos serve`: bootstraps first, takes the redb
+        // lock. `rt_owner` stays live for the whole test so the lock
+        // remains held.
+        let rt_owner = ProfileRuntime::bootstrap(&profile, &data_dir, None)
+            .await
+            .expect("first bootstrap (owner) should succeed");
+        assert!(
+            !rt_owner.memory.is_degraded(),
+            "first bootstrap should hold the canonical redb",
+        );
+
+        // Simulates `octos gateway` running as a subprocess of serve:
+        // hits the lock contention. Before #899 this returned
+        // `Err(failed to open episode store ... Database already open)`.
+        // Now it must succeed; the resulting handle's EpisodeStore
+        // operates in degraded mode.
+        let rt_sibling = ProfileRuntime::bootstrap(&profile, &data_dir, None)
+            .await
+            .expect(
+                "second bootstrap (sibling process) should succeed even \
+                 when redb is already locked — this is the crashloop \
+                 fix from issue #899",
+            );
+        assert!(
+            rt_sibling.memory.is_degraded(),
+            "second bootstrap's episode store must be degraded",
+        );
+    }
 }

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -236,6 +236,33 @@ pub struct ProfileRuntime {
     pub tool_config: Arc<ToolConfigStore>,
 }
 
+/// Which OS process is calling [`ProfileRuntime::bootstrap`].
+///
+/// Used to decide whether [`EpisodeStore::open`] should fail loudly
+/// on redb lock contention (the canonical owner — `Serve`) or degrade
+/// gracefully (the companion process — `Gateway`).
+///
+/// See the type-level docs on
+/// [`octos_memory::EpisodeStore`](EpisodeStore) for why the role
+/// split exists: redb is single-writer-single-process, and `octos
+/// serve` + `octos gateway` are separate OS processes that both
+/// bootstrap the same profile. Serve owns the canonical store;
+/// gateway is allowed to degrade so channel polling stays alive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootstrapRole {
+    /// Caller owns the canonical EpisodeStore. `EpisodeStore::open`
+    /// runs in strict mode and fails if the redb file lock is already
+    /// held. Use this from `octos serve` and other entry points whose
+    /// correctness depends on persistence being intact.
+    Serve,
+    /// Caller is a companion process that should keep running even
+    /// when the canonical EpisodeStore is owned elsewhere.
+    /// `EpisodeStore::open_or_degraded` runs and silently installs a
+    /// no-op store on lock contention. Use this from
+    /// `octos gateway` subprocesses.
+    Gateway,
+}
+
 impl ProfileRuntime {
     /// Build a fully populated [`ProfileRuntime`] from a parsed
     /// [`UserProfile`] + the per-profile `data_dir`.
@@ -279,6 +306,7 @@ impl ProfileRuntime {
         profile: &UserProfile,
         data_dir: &Path,
         octos_home: Option<&Path>,
+        role: BootstrapRole,
     ) -> Result<Arc<Self>> {
         // Step 1: derive the per-profile Config.
         let config = config_from_profile(profile, None, None);
@@ -319,7 +347,17 @@ impl ProfileRuntime {
         let runtime_qos_catalog = bundle.runtime_qos_catalog.clone();
 
         // Step 4: open the memory stores.
-        let memory = Arc::new(EpisodeStore::open(data_dir).await.wrap_err_with(|| {
+        //
+        // The opener variant depends on the caller's role (see
+        // [`BootstrapRole`] docs). Serve must hold the canonical
+        // EpisodeStore; gateway falls back to a degraded handle when
+        // serve already owns the redb lock so it doesn't crashloop on
+        // every startup. Tracked by issue #899.
+        let memory_open_result = match role {
+            BootstrapRole::Serve => EpisodeStore::open(data_dir).await,
+            BootstrapRole::Gateway => EpisodeStore::open_or_degraded(data_dir).await,
+        };
+        let memory = Arc::new(memory_open_result.wrap_err_with(|| {
             format!("failed to open episode store for profile '{}'", profile.id)
         })?);
         let memory_store = Arc::new(MemoryStore::open(data_dir).await.wrap_err_with(|| {
@@ -625,7 +663,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let err = ProfileRuntime::bootstrap(&profile, &data_dir, None)
+        let err = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
             .await
             .err()
             .expect("bootstrap must fail without a provider");
@@ -668,7 +706,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let err = ProfileRuntime::bootstrap(&profile, &data_dir, None)
+        let err = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
             .await
             .err()
             .expect("bootstrap must fail without a provider");
@@ -766,7 +804,7 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        let rt = ProfileRuntime::bootstrap(&profile, &data_dir, None)
+        let rt = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
             .await
             .expect("bootstrap should succeed with a valid provider config");
 
@@ -864,10 +902,10 @@ mod tests {
             updated_at: Utc::now(),
         };
 
-        // Simulates `octos serve`: bootstraps first, takes the redb
-        // lock. `rt_owner` stays live for the whole test so the lock
-        // remains held.
-        let rt_owner = ProfileRuntime::bootstrap(&profile, &data_dir, None)
+        // Simulates `octos serve`: bootstraps first as `Serve`,
+        // takes the redb lock. `rt_owner` stays live for the whole
+        // test so the lock remains held.
+        let rt_owner = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
             .await
             .expect("first bootstrap (owner) should succeed");
         assert!(
@@ -878,18 +916,102 @@ mod tests {
         // Simulates `octos gateway` running as a subprocess of serve:
         // hits the lock contention. Before #899 this returned
         // `Err(failed to open episode store ... Database already open)`.
-        // Now it must succeed; the resulting handle's EpisodeStore
+        // Now it must succeed because the `Gateway` role opts into
+        // the degraded fallback; the resulting handle's EpisodeStore
         // operates in degraded mode.
-        let rt_sibling = ProfileRuntime::bootstrap(&profile, &data_dir, None)
-            .await
-            .expect(
-                "second bootstrap (sibling process) should succeed even \
-                 when redb is already locked — this is the crashloop \
-                 fix from issue #899",
-            );
+        let rt_sibling =
+            ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Gateway)
+                .await
+                .expect(
+                    "second bootstrap (Gateway role) should succeed even \
+                     when redb is already locked — this is the crashloop \
+                     fix from issue #899",
+                );
         assert!(
             rt_sibling.memory.is_degraded(),
-            "second bootstrap's episode store must be degraded",
+            "Gateway-role bootstrap's episode store must be degraded",
+        );
+    }
+
+    /// Companion to the crashloop test: a *second* `Serve`-role
+    /// bootstrap must NOT silently degrade. This prevents a
+    /// gateway-first/dev-workflow misordering from flipping canonical
+    /// ownership to the gateway and quietly degrading serve's
+    /// persistence — a concern codex raised on the round-1 review of
+    /// #899. Serve must fail loudly so the operator sees the
+    /// deployment misconfiguration.
+    #[tokio::test]
+    #[allow(unsafe_code)]
+    async fn second_serve_role_bootstrap_fails_loudly_when_redb_already_owned() {
+        const KEY_NAME: &str = "OCTOS_GH899_SERVE_STRICT_TEST_API_KEY";
+        // SAFETY: env var name is unique to this test.
+        unsafe {
+            std::env::set_var(KEY_NAME, "test-key-sk-fake");
+        }
+        struct EnvGuard;
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: see set_var above.
+                unsafe {
+                    std::env::remove_var(KEY_NAME);
+                }
+            }
+        }
+        let _guard = EnvGuard;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profiles").join("gh899s").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let profile = UserProfile {
+            id: "gh899s".to_string(),
+            name: "GH899S".to_string(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                gateway: GatewaySettings::default(),
+                llm: Some(LlmProfileConfig {
+                    primary: Some(LlmModelSelectionConfig {
+                        family_id: Some("openai".to_string()),
+                        model_id: Some("gpt-4o-mini".to_string()),
+                        route: Some(LlmRouteConfig {
+                            route_id: None,
+                            label: None,
+                            base_url: None,
+                            api_key_env: Some(KEY_NAME.to_string()),
+                            api_type: None,
+                        }),
+                        ..Default::default()
+                    }),
+                    fallbacks: Vec::new(),
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        let _rt_owner = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
+            .await
+            .expect("first Serve bootstrap should succeed");
+
+        // Second Serve-role bootstrap must error — never silently
+        // degrade. This is the property codex's round-1 review asked
+        // us to lock down.
+        let err = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
+            .await
+            .err()
+            .expect(
+                "second Serve-role bootstrap must fail loudly on redb \
+                 lock contention — silent degradation would risk \
+                 flipping canonical ownership",
+            );
+        let msg = err.to_string() + " " + &format!("{err:?}");
+        assert!(
+            msg.contains("Database already open") || msg.contains("Cannot acquire lock"),
+            "error must surface the redb lock contention; got: {err:?}",
         );
     }
 }

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -39,15 +39,27 @@ const DEFAULT_DIMENSION: usize = 1536;
 /// repeated every ~2 seconds.
 ///
 /// To prevent that crashloop without sacrificing serve-mode
-/// persistence, [`EpisodeStore::open`] now falls back to a
+/// persistence, [`EpisodeStore::open_or_degraded`] falls back to a
 /// **degraded** in-memory store when the redb file is already locked:
 /// `db` is `None`, all mutating operations silently no-op, and all
-/// read operations return empty. Callers that need to observe the
-/// degradation (logging, metrics) can read [`Self::is_degraded`].
+/// public read operations return empty. Callers that need to observe
+/// the degradation (logging, metrics) can read [`Self::is_degraded`].
 ///
-/// This is the correct degradation for the gateway: the gateway
-/// subprocess does not own the canonical EpisodeStore — `octos serve`
-/// does. Episode reads on the gateway path are best-effort already
+/// Two opener entry points formalize the role split:
+/// - [`Self::open`] (strict) — fails when the lock is already held.
+///   The right choice for the process that *must* own the canonical
+///   store (`octos serve`, `octos chat`, the test suite). Surfaces
+///   deployment misconfigurations as errors instead of silently
+///   degrading the canonical writer.
+/// - [`Self::open_or_degraded`] — falls back to the degraded handle
+///   on lock contention. The right choice for `octos gateway`
+///   subprocesses (and other companion processes) that should keep
+///   going when the canonical store is owned elsewhere.
+///
+/// This split prevents the gateway-starts-first dev workflow from
+/// flipping canonical ownership to gateway and degrading serve.
+///
+/// Episode reads on the gateway path are best-effort already
 /// (memory-bank recall happens through the in-process `MemoryStore`,
 /// not `EpisodeStore`), and episode writes from a sub-agent are
 /// completion-summary persistence that serve will redo on
@@ -65,11 +77,43 @@ pub struct EpisodeStore {
 impl EpisodeStore {
     /// Open or create an episode store at the given path.
     ///
-    /// Falls back to a degraded in-memory store when the redb file
-    /// lock is already held by another process (see the type-level
-    /// docs on [`EpisodeStore`]). All other errors propagate.
+    /// **Strict mode** — fails if the redb file lock is already held
+    /// by another process. This is the right entry point for the
+    /// process that *must* own the canonical store (`octos serve`,
+    /// `octos chat`, the agent test suite). If the lock is held, the
+    /// caller likely has a deployment misconfiguration and should
+    /// surface the error rather than silently degrading.
+    ///
+    /// For the `octos gateway` subprocess (and anywhere else that
+    /// runs alongside an existing serve daemon and should keep going
+    /// when the canonical store is owned elsewhere), use
+    /// [`Self::open_or_degraded`].
     pub async fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
-        let data_dir = data_dir.as_ref().to_path_buf();
+        Self::open_inner(data_dir.as_ref(), false).await
+    }
+
+    /// Open or create an episode store at the given path, falling
+    /// back to a degraded in-memory store when the redb file lock is
+    /// already held by another process.
+    ///
+    /// This is the right entry point for the `octos gateway`
+    /// subprocess: `octos serve` always wins the lock in production
+    /// (process_manager spawns gateway after `ProfileRuntime` has
+    /// already bootstrapped every profile), so gateway always gets a
+    /// degraded handle when serve is the parent daemon. Writes on a
+    /// degraded handle silently no-op; reads return empty. See the
+    /// type-level docs on [`EpisodeStore`].
+    ///
+    /// **Other failure modes still bubble up.** Only the typed
+    /// `redb::DatabaseError::DatabaseAlreadyOpen` triggers the
+    /// degraded fallback; corruption / I/O / permission errors are
+    /// returned as `Err`.
+    pub async fn open_or_degraded(data_dir: impl AsRef<Path>) -> Result<Self> {
+        Self::open_inner(data_dir.as_ref(), true).await
+    }
+
+    async fn open_inner(data_dir: &Path, allow_degraded: bool) -> Result<Self> {
+        let data_dir = data_dir.to_path_buf();
         tokio::fs::create_dir_all(&data_dir)
             .await
             .wrap_err("failed to create data directory")?;
@@ -79,9 +123,10 @@ impl EpisodeStore {
 
         // redb is sync, so we spawn_blocking for the initial open + table init + index rebuild.
         //
-        // Return `Ok(None)` for the typed `DatabaseAlreadyOpen` case so the
-        // outer task can install a degraded store without crashing the
-        // process; bubble up every other error verbatim.
+        // We surface the `DatabaseAlreadyOpen` case as a typed sentinel
+        // (`Ok(None)`) so the outer task can decide whether to install
+        // the degraded fallback (gateway) or propagate the error
+        // (serve). Every other error bubbles up verbatim.
         let result: Result<Option<(Database, HybridIndex)>> =
             tokio::task::spawn_blocking(move || {
                 let db = match Database::create(&db_path) {
@@ -132,7 +177,7 @@ impl EpisodeStore {
                 db: Some(Arc::new(db)),
                 index: RwLock::new(index),
             }),
-            None => {
+            None if allow_degraded => {
                 warn!(
                     path = %db_path_for_log.display(),
                     "redb episode store already held by another process; \
@@ -146,14 +191,22 @@ impl EpisodeStore {
                     index: RwLock::new(HybridIndex::new(DEFAULT_DIMENSION)),
                 })
             }
+            None => Err(eyre::eyre!(
+                "failed to open redb database at {}: \
+                 Database already open. Cannot acquire lock. \
+                 (Strict `EpisodeStore::open` was used — if this is the \
+                 `octos gateway` subprocess, call `open_or_degraded` \
+                 instead.)",
+                db_path_for_log.display(),
+            )),
         }
     }
 
     /// `true` when this store is operating in the degraded in-memory
     /// fallback mode described on the type-level docs (the redb file
-    /// lock was already held when [`Self::open`] ran). Callers can
-    /// use this for diagnostics, metrics, or to skip persistence-
-    /// dependent codepaths.
+    /// lock was already held when [`Self::open_or_degraded`] ran).
+    /// Callers can use this for diagnostics, metrics, or to skip
+    /// persistence-dependent codepaths.
     pub fn is_degraded(&self) -> bool {
         self.db.is_none()
     }
@@ -161,9 +214,14 @@ impl EpisodeStore {
     /// Store an episode.
     ///
     /// In degraded mode ([`Self::is_degraded`]) the disk write is
-    /// skipped; the in-memory hybrid index is still updated so
-    /// callers that store-then-recall within the same process see
-    /// the entry. Returns `Ok(())` either way.
+    /// skipped and the call returns `Ok(())`. The in-memory hybrid
+    /// index is updated with the summary so [`Self::find_relevant_hybrid`]
+    /// (which is index-only when populated) can match it for ranking,
+    /// but full episode bodies come from disk — so the public read
+    /// methods ([`Self::find_relevant`], [`Self::find_relevant_hybrid`])
+    /// still return empty on a degraded handle because there is no
+    /// DB to fetch bodies from. The intent is "writes accepted, reads
+    /// empty," not in-memory persistence.
     pub async fn store(&self, episode: Episode) -> Result<()> {
         let episode_id = episode.id.clone();
         let episode_id_for_index = episode_id.clone();
@@ -767,16 +825,17 @@ mod tests {
     /// (PR #888 / M11-F gateway consolidation).
     ///
     /// `octos serve` and `octos gateway` run as separate processes;
-    /// both call `EpisodeStore::open` against the same per-profile
+    /// both call `EpisodeStore::open*` against the same per-profile
     /// data dir. The second open used to crash with
     /// `redb::DatabaseError::DatabaseAlreadyOpen` because redb is a
     /// single-writer-single-process embedded database. This test
-    /// pins the new contract: the second opener gets a degraded
+    /// pins the new contract: `open_or_degraded` returns a degraded
     /// in-memory fallback handle instead of an error.
     #[tokio::test]
     async fn should_return_degraded_store_when_redb_already_held_by_another_handle() {
         let dir = tempfile::tempdir().unwrap();
-        // Owner: behaves like `octos serve` holding the lock.
+        // Owner: behaves like `octos serve` holding the lock. Strict
+        // `open` is used so misconfigurations would still surface.
         let owner = EpisodeStore::open(dir.path()).await.unwrap();
         assert!(
             !owner.is_degraded(),
@@ -784,12 +843,13 @@ mod tests {
         );
 
         // Second opener: behaves like an `octos gateway` subprocess.
+        // It opts into the degraded fallback via `open_or_degraded`.
         // Before the fix this returned `Err(... DatabaseAlreadyOpen ...)`;
         // now it must succeed with a degraded fallback.
-        let degraded = EpisodeStore::open(dir.path()).await.unwrap();
+        let degraded = EpisodeStore::open_or_degraded(dir.path()).await.unwrap();
         assert!(
             degraded.is_degraded(),
-            "second opener must return a degraded in-memory fallback",
+            "open_or_degraded must return a degraded in-memory fallback",
         );
 
         // The degraded handle accepts writes (silent no-op on disk)
@@ -815,6 +875,43 @@ mod tests {
         assert!(
             owner_view.is_empty(),
             "degraded writes must not surface to the owner; got {owner_view:?}",
+        );
+
+        // The degraded handle's own reads also return empty: the
+        // hybrid index can match the summary for ranking, but
+        // `find_relevant` / `find_relevant_hybrid` fetch full episode
+        // bodies from disk, and the degraded handle has no disk
+        // backing. This is the "writes accepted, reads empty"
+        // contract — anything stricter would be incorrect because
+        // the canonical store is owned elsewhere.
+        let degraded_view = degraded
+            .find_relevant(Path::new("/proj"), "recorded", 10)
+            .await
+            .unwrap();
+        assert!(
+            degraded_view.is_empty(),
+            "degraded reads must return empty; got {degraded_view:?}",
+        );
+    }
+
+    /// Strict `open` must fail (not silently degrade) when the redb
+    /// file lock is already held. This locks down the contract that
+    /// codex's round-1 review of #899 called out: a second
+    /// `Serve`-role bootstrap should never quietly flip canonical
+    /// ownership.
+    #[tokio::test]
+    async fn should_error_on_strict_open_when_redb_already_held() {
+        let dir = tempfile::tempdir().unwrap();
+        let _owner = EpisodeStore::open(dir.path()).await.unwrap();
+
+        let err = EpisodeStore::open(dir.path())
+            .await
+            .err()
+            .expect("strict open must error when lock is held");
+        let msg = err.to_string() + " " + &format!("{err:?}");
+        assert!(
+            msg.contains("Database already open") || msg.contains("Cannot acquire lock"),
+            "strict open error must surface the lock contention; got: {err:?}",
         );
     }
 }

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -422,9 +422,12 @@ impl EpisodeStore {
 
     /// Store an embedding for an episode.
     ///
-    /// In degraded mode the disk write is skipped; the in-memory
-    /// hybrid index is still updated so within-process embedding
-    /// search keeps working for this handle's lifetime.
+    /// In degraded mode the disk write is skipped and the call
+    /// returns `Ok(())`. The in-memory hybrid index is updated with
+    /// the embedding, but the public read methods still return
+    /// empty for the same reason as [`Self::store`] — they need
+    /// disk-backed bodies. Follows the same "writes accepted, reads
+    /// empty" contract.
     pub async fn store_embedding(&self, episode_id: &str, embedding: Vec<f32>) -> Result<()> {
         // Degraded fallback: skip the disk write, update the in-memory
         // embedding entry only, return success.

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -23,13 +23,51 @@ const EMBEDDINGS_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("emb
 const DEFAULT_DIMENSION: usize = 1536;
 
 /// Store for episodes using redb (pure Rust embedded database).
+///
+/// # Degraded mode
+///
+/// `redb` is a single-writer-single-process embedded database — only
+/// one process at a time may hold the OS file lock on
+/// `episodes.redb`. In the production fleet `octos serve` and
+/// `octos gateway` run as separate processes that bootstrap
+/// `ProfileRuntime` independently per profile, and both call
+/// `EpisodeStore::open` against the same path. The first opener (the
+/// long-lived `octos serve` daemon) wins; the second opener (`octos
+/// gateway` subprocesses) previously crashed with
+/// `redb::DatabaseError::DatabaseAlreadyOpen` ("Database already
+/// open. Cannot acquire lock."), launchd restarted it, and the cycle
+/// repeated every ~2 seconds.
+///
+/// To prevent that crashloop without sacrificing serve-mode
+/// persistence, [`EpisodeStore::open`] now falls back to a
+/// **degraded** in-memory store when the redb file is already locked:
+/// `db` is `None`, all mutating operations silently no-op, and all
+/// read operations return empty. Callers that need to observe the
+/// degradation (logging, metrics) can read [`Self::is_degraded`].
+///
+/// This is the correct degradation for the gateway: the gateway
+/// subprocess does not own the canonical EpisodeStore — `octos serve`
+/// does. Episode reads on the gateway path are best-effort already
+/// (memory-bank recall happens through the in-process `MemoryStore`,
+/// not `EpisodeStore`), and episode writes from a sub-agent are
+/// completion-summary persistence that serve will redo on
+/// `/api/chat` if it cares. The fleet still benefits from gateway
+/// channel polling staying alive.
 pub struct EpisodeStore {
-    db: Arc<Database>,
+    /// `Some(db)` when the redb file was successfully opened (the
+    /// owning process). `None` when this is a degraded in-memory
+    /// fallback because the redb file lock was already held by
+    /// another process (see the type-level docs).
+    db: Option<Arc<Database>>,
     index: RwLock<HybridIndex>,
 }
 
 impl EpisodeStore {
     /// Open or create an episode store at the given path.
+    ///
+    /// Falls back to a degraded in-memory store when the redb file
+    /// lock is already held by another process (see the type-level
+    /// docs on [`EpisodeStore`]). All other errors propagate.
     pub async fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
         let data_dir = data_dir.as_ref().to_path_buf();
         tokio::fs::create_dir_all(&data_dir)
@@ -37,58 +75,110 @@ impl EpisodeStore {
             .wrap_err("failed to create data directory")?;
 
         let db_path = data_dir.join("episodes.redb");
+        let db_path_for_log = db_path.clone();
 
-        // redb is sync, so we spawn_blocking for the initial open + table init + index rebuild
-        let (db, index) = tokio::task::spawn_blocking(move || {
-            let db = Database::create(&db_path).wrap_err("failed to open redb database")?;
+        // redb is sync, so we spawn_blocking for the initial open + table init + index rebuild.
+        //
+        // Return `Ok(None)` for the typed `DatabaseAlreadyOpen` case so the
+        // outer task can install a degraded store without crashing the
+        // process; bubble up every other error verbatim.
+        let result: Result<Option<(Database, HybridIndex)>> =
+            tokio::task::spawn_blocking(move || {
+                let db = match Database::create(&db_path) {
+                    Ok(db) => db,
+                    Err(redb::DatabaseError::DatabaseAlreadyOpen) => return Ok(None),
+                    Err(e) => {
+                        return Err(eyre::Report::new(e).wrap_err("failed to open redb database"));
+                    }
+                };
 
-            // Initialize tables
-            let write_txn = db.begin_write()?;
-            {
-                let _ = write_txn.open_table(EPISODES_TABLE)?;
-                let _ = write_txn.open_table(CWD_INDEX_TABLE)?;
-                let _ = write_txn.open_table(EMBEDDINGS_TABLE)?;
-            }
-            write_txn.commit()?;
+                // Initialize tables
+                let write_txn = db.begin_write()?;
+                {
+                    let _ = write_txn.open_table(EPISODES_TABLE)?;
+                    let _ = write_txn.open_table(CWD_INDEX_TABLE)?;
+                    let _ = write_txn.open_table(EMBEDDINGS_TABLE)?;
+                }
+                write_txn.commit()?;
 
-            // Rebuild in-memory hybrid index from stored data
-            let mut index = HybridIndex::new(DEFAULT_DIMENSION);
-            {
-                let read_txn = db.begin_read()?;
-                let episodes_table = read_txn.open_table(EPISODES_TABLE)?;
-                let embeddings_table = read_txn.open_table(EMBEDDINGS_TABLE)?;
+                // Rebuild in-memory hybrid index from stored data
+                let mut index = HybridIndex::new(DEFAULT_DIMENSION);
+                {
+                    let read_txn = db.begin_read()?;
+                    let episodes_table = read_txn.open_table(EPISODES_TABLE)?;
+                    let embeddings_table = read_txn.open_table(EMBEDDINGS_TABLE)?;
 
-                for entry in episodes_table.iter()? {
-                    let (key, value) = entry?;
-                    let ep_id = key.value().to_string();
-                    if let Ok(episode) = serde_json::from_str::<Episode>(value.value()) {
-                        let embedding: Option<Vec<f32>> = embeddings_table
-                            .get(ep_id.as_str())
-                            .ok()
-                            .flatten()
-                            .and_then(|v| bincode::deserialize(v.value()).ok());
-                        index.insert(&ep_id, &episode.summary, embedding.as_deref());
+                    for entry in episodes_table.iter()? {
+                        let (key, value) = entry?;
+                        let ep_id = key.value().to_string();
+                        if let Ok(episode) = serde_json::from_str::<Episode>(value.value()) {
+                            let embedding: Option<Vec<f32>> = embeddings_table
+                                .get(ep_id.as_str())
+                                .ok()
+                                .flatten()
+                                .and_then(|v| bincode::deserialize(v.value()).ok());
+                            index.insert(&ep_id, &episode.summary, embedding.as_deref());
+                        }
                     }
                 }
+
+                debug!(path = %data_dir.display(), "opened episode store");
+                Ok(Some((db, index)))
+            })
+            .await?;
+
+        match result? {
+            Some((db, index)) => Ok(Self {
+                db: Some(Arc::new(db)),
+                index: RwLock::new(index),
+            }),
+            None => {
+                warn!(
+                    path = %db_path_for_log.display(),
+                    "redb episode store already held by another process; \
+                     installing degraded in-memory fallback. Writes will \
+                     no-op and reads will return empty for this handle. \
+                     This is expected for `octos gateway` subprocesses \
+                     when `octos serve` already owns the lock."
+                );
+                Ok(Self {
+                    db: None,
+                    index: RwLock::new(HybridIndex::new(DEFAULT_DIMENSION)),
+                })
             }
+        }
+    }
 
-            debug!(path = %data_dir.display(), "opened episode store");
-            Ok::<_, eyre::Report>((db, index))
-        })
-        .await??;
-
-        Ok(Self {
-            db: Arc::new(db),
-            index: RwLock::new(index),
-        })
+    /// `true` when this store is operating in the degraded in-memory
+    /// fallback mode described on the type-level docs (the redb file
+    /// lock was already held when [`Self::open`] ran). Callers can
+    /// use this for diagnostics, metrics, or to skip persistence-
+    /// dependent codepaths.
+    pub fn is_degraded(&self) -> bool {
+        self.db.is_none()
     }
 
     /// Store an episode.
+    ///
+    /// In degraded mode ([`Self::is_degraded`]) the disk write is
+    /// skipped; the in-memory hybrid index is still updated so
+    /// callers that store-then-recall within the same process see
+    /// the entry. Returns `Ok(())` either way.
     pub async fn store(&self, episode: Episode) -> Result<()> {
-        let db = self.db.clone();
         let episode_id = episode.id.clone();
         let episode_id_for_index = episode_id.clone();
         let summary = episode.summary.clone();
+
+        // Degraded fallback: skip the disk write, update the in-memory
+        // index, return success. See type-level docs on `EpisodeStore`.
+        let Some(db) = self.db.clone() else {
+            match self.index.write() {
+                Ok(mut idx) => idx.insert(&episode_id_for_index, &summary, None),
+                Err(e) => warn!("index write lock poisoned, skipping update: {e}"),
+            }
+            return Ok(());
+        };
+
         let cwd = episode.working_dir.to_string_lossy().to_string();
         let episode_json =
             serde_json::to_string(&episode).wrap_err("failed to serialize episode")?;
@@ -194,7 +284,10 @@ impl EpisodeStore {
         query: &str,
         limit: usize,
     ) -> Result<Vec<Episode>> {
-        let db = self.db.clone();
+        // Degraded fallback: no DB to scan; return empty.
+        let Some(db) = self.db.clone() else {
+            return Ok(Vec::new());
+        };
         let cwd_str = cwd.to_string_lossy().to_string();
         let query = query.to_lowercase();
 
@@ -270,8 +363,22 @@ impl EpisodeStore {
     }
 
     /// Store an embedding for an episode.
+    ///
+    /// In degraded mode the disk write is skipped; the in-memory
+    /// hybrid index is still updated so within-process embedding
+    /// search keeps working for this handle's lifetime.
     pub async fn store_embedding(&self, episode_id: &str, embedding: Vec<f32>) -> Result<()> {
-        let db = self.db.clone();
+        // Degraded fallback: skip the disk write, update the in-memory
+        // embedding entry only, return success.
+        let Some(db) = self.db.clone() else {
+            match self.index.write() {
+                Ok(mut idx) => {
+                    let _ = idx.add_embedding(episode_id, &embedding);
+                }
+                Err(e) => warn!("index write lock poisoned, skipping embedding update: {e}"),
+            }
+            return Ok(());
+        };
         let ep_id = episode_id.to_string();
         let emb_bytes = bincode::serialize(&embedding).wrap_err("failed to serialize embedding")?;
 
@@ -300,8 +407,23 @@ impl EpisodeStore {
     /// Delete an episode by its ID. Removes from all DB tables and the in-memory index.
     ///
     /// Returns `true` if the episode existed and was deleted.
+    ///
+    /// In degraded mode the disk delete is skipped; this attempts to
+    /// remove the entry from the in-memory index only and returns
+    /// `false` (there is nothing the degraded handle can authoritatively
+    /// claim was persisted).
     pub async fn delete_by_id(&self, episode_id: &str) -> Result<bool> {
-        let db = self.db.clone();
+        // Degraded fallback: no DB to delete from; clear the in-memory
+        // entry (if any) and report `false`.
+        let Some(db) = self.db.clone() else {
+            match self.index.write() {
+                Ok(mut idx) => {
+                    let _ = idx.remove(episode_id);
+                }
+                Err(e) => warn!("index write lock poisoned, skipping removal: {e}"),
+            }
+            return Ok(false);
+        };
         let ep_id = episode_id.to_string();
 
         let found = tokio::task::spawn_blocking(move || {
@@ -387,8 +509,14 @@ impl EpisodeStore {
         };
 
         // Fetch full episodes from DB
-        let db = self.db.clone();
         let ids: Vec<String> = matches.into_iter().map(|(id, _)| id).collect();
+        // Degraded fallback: there is no on-disk store to read from.
+        // The hybrid index only knows about episodes inserted in this
+        // process's lifetime (which is empty at open for a degraded
+        // handle) so returning an empty Vec is correct.
+        let Some(db) = self.db.clone() else {
+            return Ok(Vec::new());
+        };
 
         tokio::task::spawn_blocking(move || {
             let read_txn = db.begin_read()?;
@@ -633,5 +761,60 @@ mod tests {
             .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].summary, "persistent data");
+    }
+
+    /// RED-first repro for the production crashloop tracked in #899
+    /// (PR #888 / M11-F gateway consolidation).
+    ///
+    /// `octos serve` and `octos gateway` run as separate processes;
+    /// both call `EpisodeStore::open` against the same per-profile
+    /// data dir. The second open used to crash with
+    /// `redb::DatabaseError::DatabaseAlreadyOpen` because redb is a
+    /// single-writer-single-process embedded database. This test
+    /// pins the new contract: the second opener gets a degraded
+    /// in-memory fallback handle instead of an error.
+    #[tokio::test]
+    async fn should_return_degraded_store_when_redb_already_held_by_another_handle() {
+        let dir = tempfile::tempdir().unwrap();
+        // Owner: behaves like `octos serve` holding the lock.
+        let owner = EpisodeStore::open(dir.path()).await.unwrap();
+        assert!(
+            !owner.is_degraded(),
+            "first opener should hold the canonical DB",
+        );
+
+        // Second opener: behaves like an `octos gateway` subprocess.
+        // Before the fix this returned `Err(... DatabaseAlreadyOpen ...)`;
+        // now it must succeed with a degraded fallback.
+        let degraded = EpisodeStore::open(dir.path()).await.unwrap();
+        assert!(
+            degraded.is_degraded(),
+            "second opener must return a degraded in-memory fallback",
+        );
+
+        // The degraded handle accepts writes (silent no-op on disk)
+        // and reports them as successful — gateway sub-agents that
+        // record completion episodes don't crash.
+        let ep = make_episode("recorded on degraded handle", "/proj");
+        let ep_id = ep.id.clone();
+        degraded
+            .store(ep)
+            .await
+            .expect("store on degraded handle must succeed");
+        degraded
+            .store_embedding(&ep_id, vec![0.0_f32; 1536])
+            .await
+            .expect("store_embedding on degraded handle must succeed");
+
+        // The owner still sees zero episodes — degraded writes are
+        // not persisted to disk, so the owner's view is unchanged.
+        let owner_view = owner
+            .find_relevant(Path::new("/proj"), "recorded", 10)
+            .await
+            .unwrap();
+        assert!(
+            owner_view.is_empty(),
+            "degraded writes must not surface to the owner; got {owner_view:?}",
+        );
     }
 }


### PR DESCRIPTION
Closes #899.

## Symptom

Every ~2 seconds, per profile, on every mini in the production fleet (mini1/2/3/5) since PR #888 (M11-F gateway consolidation) deployed:

```
WARN ProfileRuntime::bootstrap failed; gateway falling back to inline assembly profile_id=<X> error=failed to open episode store for profile '<X>'
[gateway] opening episode store at /Users/cloud/.octos/profiles/<X>/data
Error:
   0: failed to open episode store
   1: failed to open redb database
   2: Database already open. Cannot acquire lock.
ERROR gateway failed to start
INFO auto-restarting crashed gateway profile=<X>
```

Telegram / Discord / WeChat / WhatsApp / etc. polling completely broken across the fleet for ~12 hours; logs flooded.

## Architecture: why this happens

```
octos serve  (main daemon, holds redb lock per profile)
   |
   |   spawn `octos gateway --profile <X>` via process_manager
   v
octos gateway  (subprocess; ProfileRuntime::bootstrap calls
                EpisodeStore::open → DatabaseAlreadyOpen → crash)
   |
   v
launchd auto-restarts → loop forever every ~2s
```

`octos serve` opens `~/.octos/profiles/<X>/data/episodes.redb` per profile (`crates/octos-cli/src/commands/serve.rs:394` → `ProfileRuntime::bootstrap` → `EpisodeStore::open`). Then it spawns `octos gateway` as a separate OS process (`crates/octos-cli/src/process_manager.rs:246`). The gateway subprocess **also** calls `ProfileRuntime::bootstrap`, which **also** calls `EpisodeStore::open` for the same redb path. `redb` is single-writer-single-process — the second open fails with `redb::DatabaseError::DatabaseAlreadyOpen`. Gateway exits. launchd restarts. Repeat.

PR #888's reviewer comment said "no redb double-open" — that was true at the time *inside a single process*, but production runs serve + gateway as separate processes, where the lock contention is unavoidable.

## Chosen option: Option B (graceful degradation), with role-aware split

Three options were considered in the issue triage:

- **A — Gateway runs without its own EpisodeStore**: thread `Option<Arc<EpisodeStore>>` through `Agent`, `RunPipelineTool`, `DelegateTool`, `SpawnTool`, `ActorFactory`, `SessionRuntime`, `ProfileActorFactoryBuilder`. 11+ files, breaks public trait signatures across `octos-agent` and `octos-pipeline`. Far over the local-fix budget.
- **B — Catch the lock error, install a degraded in-memory no-op store**: small, localized, ships today.
- **C — Separate redb file for gateway**: fragments persistence; worst option.

Picked **B**.

### Initial implementation (commit `4a91133e`)

Single `EpisodeStore::open` that detected the typed `redb::DatabaseError::DatabaseAlreadyOpen` and silently installed a degraded handle (`db: None`). Writes silently no-op; reads return empty.

### Codex round-1 (REJECT on dimension c) → role-aware split (commit `213f0c73`)

Codex round-1 raised a real concern: a single role-agnostic `open()` would let a gateway-first dev workflow flip canonical ownership to gateway, then quietly degrade serve when it later bootstrapped. The fix:

- `EpisodeStore::open` is now **strict** — fails on `DatabaseAlreadyOpen`. Signature unchanged; all serve / chat / test paths keep their existing semantics. A second `Serve`-role bootstrap surfaces "Database already open. Cannot acquire lock." instead of silently degrading.
- `EpisodeStore::open_or_degraded` is the new gentle entry point: falls back to the no-op store on lock contention. Only `BootstrapRole::Gateway` calls it.
- `ProfileRuntime::bootstrap` takes a new `BootstrapRole` parameter:
  - `Serve` → calls strict `EpisodeStore::open`.
  - `Gateway` → calls `EpisodeStore::open_or_degraded`.
- `commands/serve.rs` passes `Serve`; `commands/gateway/gateway_runtime.rs` passes `Gateway` (both profile-mode and the inline CLI-override branch).

Result: gateway subprocess always survives, channel polling stays alive, **and** serve can never accidentally end up degraded. A misordered dev workflow fails loudly on serve startup — which is the correct behaviour.

### Codex round-2 (APPROVE all three) + minor doc cleanups (commit `3ef2afb5`)

Codex round-2 APPROVED on (a), (b), (c). Two non-blocking notes addressed: the `store_embedding` doc had the same "within-process search keeps working" phrasing the round-1 review caught on `store()` (corrected to "writes accepted, reads empty"); and the non-profile / CLI-override inline path in `gateway_runtime.rs` was still using strict `open` (switched to `open_or_degraded` for consistency with the gateway role).

## What features degrade

Episode-store-dependent gateway features all degrade benignly:

- `Agent::run` → `episode_store.store()` on completion: silently no-ops on a degraded handle, returns `Ok(())`. Agent loop continues.
- `RunPipelineTool` → reads episode history: returns empty Vec on a degraded handle. Pipelines that don't depend on history are unaffected.
- `DelegateTool` / `SpawnTool` sub-agent runs: same Agent code path — completion summaries no-op locally; they would only persist when delegated *through serve*, which serve does normally because it owns the canonical store.
- Memory bank tools (`RecallMemoryTool`, `SaveMemoryTool`): unaffected — they use `MemoryStore` (filesystem MEMORY.md), not `EpisodeStore`.

Episodes that *must* persist for a profile flow through `/api/chat` (serve owns the canonical store, persists normally) per the M11-F architecture. The gateway is the channel-polling / message-forwarding layer; episode persistence on the gateway side is best-effort and the degraded handle preserves that.

## Codex review (3-dimension gate per issue #899)

**Round 1 (REJECT on c)**: "if standalone gateway starts first, serve later bootstraps successfully with a degraded `EpisodeStore` at profile.rs:322. That prevents a crash, but serve-mode episode persistence is no longer intact until processes are restarted in the right order." Also flagged a misleading doc claiming in-memory store-then-recall works (it doesn't because reads need disk-backed bodies).

**Round 2 (APPROVE on (a), (b), (c))**: "The round-1 blocker is addressed: `EpisodeStore::open` is strict again, `open_or_degraded` is explicit, and `ProfileRuntime::bootstrap` now makes the serve/gateway ownership choice via `BootstrapRole`. Serve passes `Serve`; gateway profile bootstrap passes `Gateway`." Two non-blocking notes addressed in commit `3ef2afb5`.

## Tests

RED-first repro + GREEN contract:

- `octos-memory/src/store.rs`:
  - `should_return_degraded_store_when_redb_already_held_by_another_handle` — pins the new `open_or_degraded` contract; second opener succeeds with `is_degraded() == true`, writes don't surface to the owner, degraded reads return empty.
  - `should_error_on_strict_open_when_redb_already_held` — strict `open` errors with the redb lock message when the lock is already held.
- `octos-cli/src/runtime/profile.rs`:
  - `bootstrap_succeeds_when_redb_already_owned_by_sibling_process` — end-to-end at the `ProfileRuntime::bootstrap` level with `BootstrapRole::Gateway`: before the fix this failed at "failed to open episode store"; now it succeeds and the sibling's `memory.is_degraded()` is true.
  - `second_serve_role_bootstrap_fails_loudly_when_redb_already_owned` — locks down the property codex's round-1 review asked us to lock down: a second `Serve`-role bootstrap must error, never silently degrade.

All 43 store tests + 5 profile tests pass.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — all tests pass, including 4 new ones (2 in store.rs, 2 in profile.rs)
- [x] `cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"` clean
- [x] Codex 3-dimension review APPROVE on (a) (b) (c) after round-1 → round-2 fix
- [ ] Fleet deploy + soak (separate operational step after merge — issue says "Don't touch mini hosts during this task")