### PR TITLE
fix(runtime): restore 6 serve-side features lost in M11-F (closes #901)

### DIFF
--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -549,6 +549,14 @@ impl Agent {
         self
     }
 
+    /// Returns the attached lifecycle hooks executor, if any. Used by the
+    /// runtime layer to assert that profile-scope hook configs survive the
+    /// per-session `Agent` rebuild and per-request rebuild paths
+    /// (`ws_standalone_agent`, ui_protocol per-turn).
+    pub fn hooks(&self) -> Option<Arc<HookExecutor>> {
+        self.hooks.clone()
+    }
+
     /// Set session-level context for hook payloads.
     pub fn with_hook_context(self, ctx: HookContext) -> Self {
         *self.hook_context.lock().unwrap_or_else(|e| e.into_inner()) = Some(ctx);

--- a/crates/octos-bus/src/cron_service.rs
+++ b/crates/octos-bus/src/cron_service.rs
@@ -20,6 +20,17 @@ pub struct CronService {
     inbound_tx: mpsc::Sender<InboundMessage>,
     running: AtomicBool,
     timer_handle: tokio::sync::Mutex<Option<JoinHandle<()>>>,
+    /// Shutdown notification: every sleeper task in `arm_timer`
+    /// `tokio::select!`s on this `Notify` alongside its
+    /// `tokio::time::sleep`. A single `notify_waiters()` call from
+    /// `shutdown_signal` / `stop` wakes ALL pending sleepers at once
+    /// so they drop their self-held `Arc<CronService>` immediately
+    /// rather than waiting out the (possibly long) `delay_ms`. This
+    /// is the round-3 codex fix for the arm_timer-vs-shutdown race
+    /// that lets a sleeper get installed AFTER `running=false`: even
+    /// when that happens, the notify wakes the sleeper on its next
+    /// poll and the Arc releases without a delay_ms-long tail.
+    shutdown_notify: tokio::sync::Notify,
 }
 
 impl CronService {
@@ -34,6 +45,7 @@ impl CronService {
             inbound_tx,
             running: AtomicBool::new(false),
             timer_handle: tokio::sync::Mutex::new(None),
+            shutdown_notify: tokio::sync::Notify::new(),
         }
     }
 
@@ -58,11 +70,66 @@ impl CronService {
     /// Stop the cron service, cancelling any pending timer.
     pub async fn stop(&self) {
         self.running.store(false, Ordering::Relaxed);
+        // Wake every pending sleeper in `arm_timer` so they release
+        // their self-held `Arc<CronService>` immediately. Without
+        // this, a sleeper that started after the running flag flipped
+        // (but before `try_lock` succeeded) would self-Arc-pin the
+        // service for `delay_ms`.
+        self.shutdown_notify.notify_waiters();
         let mut handle = self.timer_handle.lock().await;
         if let Some(h) = handle.take() {
             h.abort();
         }
         info!("cron service stopped");
+    }
+
+    /// Whether the service is currently armed (i.e. `start()` has been
+    /// called and no shutdown signal has fired). Used by lifecycle
+    /// tests that need to observe the post-`Drop` shutdown signal
+    /// without racing the timer task's terminal Arc release.
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::Relaxed)
+    }
+
+    /// Synchronous shutdown signal. Sets `running = false` so the
+    /// timer's reschedule chain (`arm_timer` → `on_timer` → `arm_timer`)
+    /// terminates on its next tick, and attempts a non-blocking abort
+    /// of the currently-armed `JoinHandle` so the in-flight
+    /// `tokio::time::sleep` does not delay shutdown.
+    ///
+    /// Intended for `Drop` impls and other sync contexts that hold the
+    /// final `Arc<CronService>` (e.g. profile-scope runtime drop). The
+    /// async [`Self::stop`] remains the preferred path when an `await`
+    /// is available because it acquires the timer mutex deterministically.
+    ///
+    /// The non-blocking `try_lock` path is best-effort: if another
+    /// caller is mutating `timer_handle` at the exact moment of drop,
+    /// we leave the abort to the runtime tear-down. The `running` flag
+    /// is the durable signal — once it flips, the next reschedule
+    /// breaks the chain and the timer task drops its self-held
+    /// `Arc<CronService>`, allowing the service to deallocate.
+    pub fn shutdown_signal(&self) {
+        self.running.store(false, Ordering::Relaxed);
+        // Wake every pending sleeper in `arm_timer`. `notify_waiters`
+        // does NOT race the running-flag check — even if a new
+        // sleeper gets installed after the flag flipped (the
+        // `arm_timer` task held the timer_handle lock when shutdown
+        // ran, then proceeded to spawn its sleeper), that sleeper's
+        // `tokio::select!` arm wakes on this notify and short-circuits
+        // before its self-held `Arc<CronService>` is held for the
+        // long `delay_ms` interval. `notify_waiters` is fire-and-
+        // forget — sleepers registered AFTER this call do not
+        // observe it, but `arm_timer`'s post-lock running check
+        // catches that case and never spawns the sleeper in the
+        // first place. The two mechanisms together close the race
+        // codex flagged on the round-2 review.
+        self.shutdown_notify.notify_waiters();
+        if let Ok(mut handle) = self.timer_handle.try_lock() {
+            if let Some(h) = handle.take() {
+                h.abort();
+            }
+        }
+        info!("cron service shutdown signalled");
     }
 
     /// Add a new cron job.
@@ -213,9 +280,91 @@ impl CronService {
                 h.abort();
             }
 
+            // Re-check `running` AFTER acquiring the lock so a
+            // concurrent `shutdown_signal` (which flips `running` to
+            // false synchronously) is observed deterministically.
+            // Without this re-check, the following race window leaks
+            // the timer task past shutdown:
+            //   T1: shutdown_signal sets running=false, try_lock fails
+            //       (this task already holds the lock).
+            //   T1: shutdown_signal returns; Drop completes.
+            //   T2: this task spawns a new sleeper, stores the handle,
+            //       drops the lock — the sleeper now self-holds an
+            //       Arc<CronService> for `delay_ms`, blocking the
+            //       service from deallocating.
+            // With the re-check, `running == false` short-circuits and
+            // the lock is released without installing a new handle;
+            // the sleeper self-Arc release path collapses immediately.
+            if !this2.running.load(Ordering::Relaxed) {
+                return;
+            }
+
             let new_handle = tokio::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-                this.on_timer().await;
+                // Round-4 codex fix: race-proof sleep via
+                // `tokio::select!` against the service's shutdown
+                // notify, with the notify waiter registered BEFORE
+                // the final running check.
+                //
+                // `Notify::notified()` returns a future; the future
+                // only registers as a waiter on first poll. Tokio
+                // documents that any `notify_waiters()` call that
+                // happens after `notified()` has been polled at least
+                // once will wake the waiter — but a `notify_waiters`
+                // that fires before the first poll is *missed*.
+                //
+                // To close the window where `shutdown_signal` fires
+                // after the post-lock running check (above) but
+                // before this sleeper subscribes to the notify, we:
+                //   1. Construct the `notified()` future first.
+                //   2. Pin it and poll it once via `Future::poll`
+                //      indirectly by entering the `select!` block —
+                //      `tokio::select!` polls all branches on first
+                //      entry, which registers the notify waiter
+                //      atomically.
+                //   3. Inside the sleep arm, re-check `running`
+                //      after the sleep wins so a missed-notify edge
+                //      case still short-circuits `on_timer()`.
+                //   4. Pre-`select!`, check `running` one more time
+                //      so the case where `shutdown_signal` fired
+                //      between the parent's `running` check and this
+                //      task starting also terminates promptly.
+                //
+                // Combined: either (a) `running == false` is observed
+                // before `select!` and we exit, or (b) the notify
+                // waiter is registered atomically with the sleep
+                // start and a subsequent `notify_waiters` wakes it,
+                // or (c) the sleep wins, sees `running == false`,
+                // and skips `on_timer()`. There is no path where
+                // the sleeper self-Arc-pins for `delay_ms` after a
+                // shutdown has fired.
+                if !this.running.load(Ordering::Relaxed) {
+                    return;
+                }
+                let notified = this.shutdown_notify.notified();
+                tokio::pin!(notified);
+                // Force the `notified()` future to register its
+                // waiter before we re-check `running`. After this
+                // call returns, any subsequent `notify_waiters` will
+                // wake us.
+                notified.as_mut().enable();
+                // Re-check running AFTER the waiter is registered.
+                // If `shutdown_signal` raced in between the previous
+                // load and `enable()`, this check catches it. If it
+                // races in AFTER `enable()`, the select arm catches
+                // it.
+                if !this.running.load(Ordering::Relaxed) {
+                    return;
+                }
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_millis(delay_ms)) => {
+                        if this.running.load(Ordering::Relaxed) {
+                            this.on_timer().await;
+                        }
+                    }
+                    _ = &mut notified => {
+                        // Shutdown raced in — drop the Arc and exit.
+                    }
+                }
             });
 
             *handle = Some(new_handle);

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -434,14 +434,22 @@ async fn chat_sync_via_session_runtime(
     req: ChatRequest,
 ) -> Result<Json<ChatResponse>, (StatusCode, String)> {
     // Acquire (or build on first use) the per-session runtime.
-    // `workspace_hint = None` → `SessionRuntime::bootstrap` derives
+    //
+    // M11-F regression fix REG-6: when no client cwd is supplied,
+    // forward `state.appui_default_session_cwd` (mirrored from
+    // `config.appui.default_session_cwd`) as the workspace hint. The
+    // pre-M11-F serve path wired this into the server-wide agent via
+    // `agent.with_workspace_root(default_cwd)`; we now thread the
+    // same operator default through the per-session bootstrap. When
+    // the operator sets nothing, this is `None` and the bootstrap
+    // falls back to the canonical
     // `<profile_data_dir>/users/<encoded session base>/workspace`
-    // and writes the default `.octos-workspace.toml` there. That's
-    // the M11 fix for the `"workspace policy not found"` failure on
-    // yangmi voice clone.
+    // layout — preserving the M11 fix for the
+    // `"workspace policy not found"` failure on yangmi voice clone.
+    let workspace_hint = state.appui_default_session_cwd.clone();
     let session_runtime = state
         .session_cache
-        .get_or_init(&profile_runtime, session_key.clone(), None)
+        .get_or_init(&profile_runtime, session_key.clone(), workspace_hint)
         .await
         .map_err(|e| {
             tracing::error!(
@@ -2776,9 +2784,22 @@ async fn ws_connection(socket: WebSocket, state: Arc<AppState>, headers: HeaderM
                     };
                     let session_key =
                         SessionKey::with_profile(&profile_runtime.profile_id, "api", &session_id);
+                    // M11-F regression fix REG-6: forward
+                    // `config.appui.default_session_cwd` (mirrored on
+                    // `AppState::appui_default_session_cwd`) as the
+                    // workspace hint when no client cwd is available.
+                    // Pre-M11-F serve.rs wired this into the server-wide
+                    // agent via `agent.with_workspace_root(default_cwd)`;
+                    // M11-F's deletion of that helper left the standalone
+                    // WS chat path falling back to the canonical
+                    // `<data_dir>/users/<encoded base>/workspace` instead
+                    // of the operator-configured directory (e.g.
+                    // octos-app uses this for the per-machine coding
+                    // workspace).
+                    let workspace_hint = state.appui_default_session_cwd.clone();
                     let session_runtime = match state
                         .session_cache
-                        .get_or_init(&profile_runtime, session_key.clone(), None)
+                        .get_or_init(&profile_runtime, session_key.clone(), workspace_hint)
                         .await
                     {
                         Ok(rt) => rt,
@@ -2928,7 +2949,7 @@ async fn ws_standalone_agent(
     ));
 
     let base_agent = session_runtime.agent.clone();
-    let request_agent = octos_agent::Agent::new_shared(
+    let mut request_agent = octos_agent::Agent::new_shared(
         octos_core::AgentId::new(format!("ws-{}", uuid::Uuid::now_v7())),
         base_agent.llm_provider(),
         base_agent.tool_registry().clone(),
@@ -2937,6 +2958,25 @@ async fn ws_standalone_agent(
     .with_config(base_agent.agent_config())
     .with_system_prompt(base_agent.system_prompt_snapshot())
     .with_reporter(reporter);
+    // M11-F regression fix REG-3: forward the profile-scope hook
+    // executor onto the per-request rebuilt agent so the standalone
+    // WS chat path observes the same `before_tool_call` /
+    // `after_tool_call` / LLM hooks as the cached `SessionRuntime`'s
+    // agent. Without this, every WS message would bypass the hook
+    // pipeline because `base_agent`'s `hooks` field is not carried
+    // forward by the `Agent::new_shared` constructor.
+    if let Some(hooks) = base_agent.hooks() {
+        request_agent = request_agent.with_hooks(hooks);
+    }
+    // M11-F regression fix REG-1 follow-up (codex review): wire the
+    // `activate_tools` back-reference on this rebuilt agent so the
+    // deferred non-core tool groups (`group:admin`, `group:sessions`,
+    // `group:web`, `group:runtime`, `group:media`) are actually
+    // activatable. `Agent::new_shared` does not re-execute the wiring,
+    // so without this the LLM observes the deferred groups via
+    // `tools.specs()` but `activate_tools` itself is a no-op stub.
+    // Gateway wires the equivalent at `session_actor.rs:2500`.
+    request_agent.wire_activate_tools();
 
     let message = message.to_string();
     let session_id = session_id.to_string();
@@ -4506,6 +4546,8 @@ mod tests {
             memory,
             memory_store,
             tool_config,
+            cron_service: None,
+            hook_executor: None,
         })
     }
 
@@ -4601,6 +4643,67 @@ mod tests {
         assert!(
             msg.contains(MAIN_PROFILE_ID),
             "503 message must name the unregistered profile (got: {msg})",
+        );
+    }
+
+    /// M11-F regression fix REG-6: `chat_sync_via_session_runtime` must
+    /// forward `state.appui_default_session_cwd` as the session's
+    /// workspace hint when no client cwd is supplied. Pre-M11-F serve.rs
+    /// wired this into the server-wide agent via
+    /// `agent.with_workspace_root(default_cwd)` so every `/api/chat`
+    /// inherited it; M11-F's deletion of that helper left this
+    /// dispatcher path falling back to the canonical
+    /// `<data_dir>/users/.../workspace` instead of the operator setting.
+    #[tokio::test]
+    async fn chat_sync_forwards_appui_default_session_cwd_as_workspace_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        let profile_data_dir = tmp.path().join("profile-data");
+        let operator_cwd = tmp.path().join("operator-coding-workspace");
+        std::fs::create_dir_all(&operator_cwd).unwrap();
+        let profile_runtime = make_m11d_profile(&profile_data_dir, "ack").await;
+
+        let mut profiles = HashMap::new();
+        profiles.insert(MAIN_PROFILE_ID.to_string(), profile_runtime.clone());
+        let state = Arc::new(AppState {
+            profiles,
+            appui_default_session_cwd: Some(operator_cwd.clone()),
+            ..AppState::empty_for_tests()
+        });
+
+        let req = ChatRequest {
+            message: "anchor here".to_string(),
+            session_id: Some("reg6-trace".to_string()),
+            topic: None,
+            stream: false,
+            media: Vec::new(),
+            attach_only: false,
+            client_message_id: None,
+        };
+
+        let _response = chat_sync(state.clone(), HeaderMap::new(), req)
+            .await
+            .expect("chat_sync should succeed");
+
+        // After the first call, the cached SessionRuntime must be
+        // anchored at the operator-configured cwd (not the canonical
+        // `<profile_data_dir>/users/.../workspace`).
+        let session_key =
+            octos_core::SessionKey::with_profile(MAIN_PROFILE_ID, "api", "reg6-trace");
+        let session_runtime = state
+            .session_cache
+            .get_or_init(&profile_runtime, session_key, None)
+            .await
+            .expect("cached SessionRuntime");
+        let expected =
+            std::fs::canonicalize(&operator_cwd).unwrap_or_else(|_| operator_cwd.clone());
+        let actual = std::fs::canonicalize(&session_runtime.workspace_root)
+            .unwrap_or_else(|_| session_runtime.workspace_root.clone());
+        assert_eq!(
+            actual,
+            expected,
+            "SessionRuntime.workspace_root must equal appui.default_session_cwd \
+             when forwarded by chat_sync_via_session_runtime (got {})",
+            session_runtime.workspace_root.display()
         );
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4825,6 +4825,18 @@ async fn run_standalone_turn(
     // cached SessionRuntime.
     let sessions = session_runtime.sessions.clone();
     let mut tool_registry = session_runtime.tools.snapshot_excluding(&[]);
+    // M11-F regression fix REG-1 follow-up round 2 (codex review):
+    // re-register a fresh `ActivateToolsTool` on this per-turn
+    // snapshot so `wire_activate_tools()` below rewires THIS
+    // registry's Weak, not the cached SessionRuntime's. Without this,
+    // the per-turn rebuild would mutate the shared
+    // `Arc<ActivateToolsTool>` (clones share the same Mutex<Weak>)
+    // and the SessionRuntime's cached agent would silently lose its
+    // back-reference once the per-turn registry dropped at end of
+    // turn.
+    if tool_registry.get("activate_tools").is_some() {
+        tool_registry.register(octos_agent::ActivateToolsTool::new());
+    }
     let workspace_root: Option<PathBuf> = Some(session_runtime.workspace_root.clone());
     let llm_provider: Arc<dyn octos_llm::LlmProvider> = session_runtime.profile.llm.clone();
     let memory_store: Arc<octos_memory::EpisodeStore> = session_runtime.profile.memory.clone();
@@ -5217,7 +5229,17 @@ async fn run_standalone_turn(
     // without mutating shared session state), but its LLM, memory,
     // sandbox, and base system prompt come from the SessionRuntime
     // (preferred) or the legacy `state.agent`.
-    let request_agent = Agent::new_shared(
+    //
+    // M11-F regression fix REG-3: also propagate the profile-scope
+    // hook executor (assembled once in `ProfileRuntime::bootstrap`
+    // from `config.hooks + plugin_result.hooks`) onto the per-turn
+    // rebuilt agent. Without this, every UI Protocol turn would bypass
+    // the configured `before_tool_call` / `after_tool_call` /
+    // `before_llm_call` / `after_llm_call` hooks because
+    // `Agent::new_shared` resets `hooks: None`. We thread it directly
+    // off the SessionRuntime's parent profile so the runtime layer
+    // remains the single source of truth.
+    let mut request_agent = Agent::new_shared(
         AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
         llm_provider.clone(),
         Arc::new(tool_registry),
@@ -5229,6 +5251,17 @@ async fn run_standalone_turn(
         workspace_root.as_deref(),
     ))
     .with_reporter(reporter);
+    if let Some(hooks) = session_runtime.profile.hook_executor.clone() {
+        request_agent = request_agent.with_hooks(hooks);
+    }
+    // M11-F regression fix REG-1 follow-up (codex review): wire the
+    // `activate_tools` back-reference on the per-turn rebuilt agent.
+    // `ProfileRuntime::bootstrap` defers non-core groups + registers
+    // the tool; without this wiring call, the LLM sees the tool in
+    // `specs()` but `activate_tools` is unable to reach the registry
+    // (its internal `Weak<ToolRegistry>` is empty). Gateway does the
+    // equivalent at `session_actor.rs:2500`.
+    request_agent.wire_activate_tools();
 
     let agent_session_id = session_id.clone();
     let approval_requester: Arc<dyn octos_agent::ToolApprovalRequester> =
@@ -11923,6 +11956,8 @@ mod tests {
             memory,
             memory_store,
             tool_config,
+            cron_service: None,
+            hook_executor: None,
         })
     }
 

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -363,6 +363,21 @@ impl ServeCommand {
                 .wrap_err("failed to open profile store")?,
         );
 
+        // M11-F regression fix REG-4: bootstrap bundled app-skills
+        // (`crates/app-skills/`) and platform-skills (`crates/platform-
+        // skills/`) into `<octos_home>/{bundled-app-skills,platform-
+        // skills}/` so every `ProfileRuntime` we build below can scan
+        // them via `Config::plugin_dirs_from_project`. Pre-M11-F
+        // `serve.rs::try_create_agent` did this unconditionally per
+        // agent build; M11-F deleted the helper and never restored the
+        // call, so a clean install of `octos serve` came up with zero
+        // bundled skills available to `/api/chat` (weather, time, news,
+        // deep-search) and zero platform skills (voice). Doing it once
+        // at process startup matches the gateway flow and keeps the
+        // per-profile loop free of redundant disk writes.
+        octos_agent::bootstrap::bootstrap_bundled_skills(&data_dir);
+        octos_agent::bootstrap::bootstrap_platform_skills(&data_dir);
+
         // M11-D — build the per-profile runtime catalog. For every
         // enabled profile that has an active primary LLM selection,
         // call `ProfileRuntime::bootstrap` and stash the resulting

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -555,6 +555,8 @@ mod tests {
             memory,
             memory_store,
             tool_config,
+            cron_service: None,
+            hook_executor: None,
         })
     }
 

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -13,9 +13,10 @@ use std::sync::Arc;
 
 use eyre::{Result, WrapErr};
 use octos_agent::{
-    PluginLoadOptions, PluginLoadResult, PluginLoader, SandboxConfig, ToolConfigStore, ToolPolicy,
-    ToolRegistry, create_sandbox,
+    HookExecutor, PluginLoadOptions, PluginLoadResult, PluginLoader, SandboxConfig,
+    ToolConfigStore, ToolPolicy, ToolRegistry, create_sandbox,
 };
+use octos_bus::CronService;
 use octos_llm::{AdaptiveRouter, LlmProvider, QosCatalog};
 use octos_memory::{EpisodeStore, MemoryStore};
 use tracing::{info, warn};
@@ -23,6 +24,8 @@ use tracing::{info, warn};
 use crate::commands::chat;
 use crate::commands::gateway::build_system_prompt;
 use crate::commands::gateway::profile_factory::{profile_plugin_env, profile_search_provider_keys};
+use crate::config::Config;
+use crate::cron_tool::CronTool;
 use crate::profiles::{UserProfile, config_from_profile};
 use crate::qos_catalog::{ExporterMode, build_adaptive_provider_chain};
 use crate::skills_scope::{
@@ -234,6 +237,37 @@ pub struct ProfileRuntime {
     /// Shared [`ToolConfigStore`] for the profile (per-tool
     /// runtime overrides, e.g. `deep_crawl.page_settle_ms`).
     pub tool_config: Arc<ToolConfigStore>,
+
+    /// Profile-scope cron service (M11-F regression fix REG-2).
+    ///
+    /// Pre-M11-F `serve.rs::try_create_agent` constructed one
+    /// [`CronService`] per server, called `start()`, and registered a
+    /// [`CronTool`] backed by it. M11-F deleted that helper and never
+    /// re-instated the wiring, so `/api/chat` and the UI Protocol path
+    /// lost the `cron` tool entirely. We restore the registration at
+    /// the profile scope (the cron jobs persist to `cron.json` under
+    /// the profile's `data_dir`, matching the per-profile isolation
+    /// the rest of `ProfileRuntime` already enforces) and hold the
+    /// resulting `Arc<CronService>` here so the tokio timer task
+    /// `start()` spawns survives for the lifetime of the runtime.
+    /// Dropping the `Arc` would let the underlying service drop, which
+    /// would in turn drop the timer's `JoinHandle` and silently
+    /// terminate scheduled job execution.
+    pub cron_service: Option<Arc<CronService>>,
+
+    /// Pre-built lifecycle hook executor (M11-F regression fix REG-3).
+    ///
+    /// Pre-M11-F `serve.rs::try_create_agent` merged `config.hooks +
+    /// plugin_result.hooks` and called `agent.with_hooks(Arc::new(
+    /// HookExecutor::new(all_hooks)))`. M11-F lost that wiring on every
+    /// per-session agent build. We assemble the executor once at
+    /// profile-bootstrap time and propagate it onto every per-session
+    /// [`octos_agent::Agent`] (via [`super::SessionRuntime::bootstrap`]'s
+    /// `with_hooks`) AND onto the request-rebuilt agents in both
+    /// `ws_standalone_agent` and the UI Protocol per-turn rebuild
+    /// loop. `None` keeps the legacy behaviour when no hooks are
+    /// configured (the agent's default `hooks: None` field).
+    pub hook_executor: Option<Arc<HookExecutor>>,
 }
 
 /// Which OS process is calling [`ProfileRuntime::bootstrap`].
@@ -454,22 +488,29 @@ impl ProfileRuntime {
             }
         }
 
-        // Step 13: plugin loading. We scan the per-profile skills
-        // dir plus the bundled app-skills and platform-skills dirs
-        // under `octos_home`.
+        // Step 13: plugin loading.
+        //
+        // M11-F regression fix REG-5: replace the hand-rolled
+        // per-profile-only assembly with `Config::plugin_dirs_from_project`
+        // (the canonical helper pre-M11-F serve.rs used) so the resulting
+        // set includes the *global* `~/.octos/plugins`, `~/.octos/skills`,
+        // `<octos_home>/plugins`, `<octos_home>/skills`, and the
+        // colon-separated `OCTOS_SKILLS_PATH` env var alongside the
+        // already-scanned `<octos_home>/bundled-app-skills/`. Platform
+        // skills (`<octos_home>/platform-skills/`, admin-only) and the
+        // per-profile `data_dir/skills/` are layered on top so the
+        // gateway behaviour is matched 1:1.
         let plugin_work_dir = data_dir.join("skill-output");
         let _ = std::fs::create_dir_all(&plugin_work_dir);
-        let mut plugin_dirs: Vec<PathBuf> = Vec::new();
-        if let Some(ref dir) = skills_dir {
-            plugin_dirs.push(dir.clone());
-        }
-        let bundled_dir = effective_octos_home.join(octos_agent::bootstrap::BUNDLED_APP_SKILLS_DIR);
-        if bundled_dir.exists() && !plugin_dirs.contains(&bundled_dir) {
-            plugin_dirs.push(bundled_dir);
-        }
+        let mut plugin_dirs: Vec<PathBuf> = Config::plugin_dirs_from_project(&effective_octos_home);
         let platform_dir = effective_octos_home.join(octos_agent::bootstrap::PLATFORM_SKILLS_DIR);
         if platform_dir.exists() && !plugin_dirs.contains(&platform_dir) {
             plugin_dirs.push(platform_dir);
+        }
+        if let Some(ref dir) = skills_dir {
+            if !plugin_dirs.contains(dir) {
+                plugin_dirs.push(dir.clone());
+            }
         }
         let mut plugin_result = PluginLoadResult::default();
         if !plugin_dirs.is_empty() {
@@ -545,11 +586,75 @@ impl ProfileRuntime {
         tools.register(octos_agent::RecallMemoryTool::new(memory_store.clone()));
         tools.register(octos_agent::SaveMemoryTool::new(memory_store.clone()));
 
+        // M11-F regression fix REG-2: restore the CronTool registration.
+        //
+        // Pre-M11-F `serve.rs::try_create_agent` built one `CronService`
+        // per server rooted at `data_dir/cron.json`, called `start()`,
+        // and registered `CronTool::with_context(cron_service, "api",
+        // "")`. M11-F removed the helper without porting this wiring,
+        // so `/api/chat` and the UI Protocol WS path silently lost the
+        // `cron` tool. We restore it at the profile scope so cron jobs
+        // are per-profile-isolated, matching the persistent stores
+        // (`episodes.redb`, `memory.json`) that already live in
+        // `data_dir`.
+        //
+        // The `cron_tx` here is a dummy channel: serve mode does not
+        // route cron fires through the gateway-style inbound bus, so
+        // the timer-driven sends will fill the bounded channel and be
+        // dropped when the receiver is dropped at the end of this
+        // function. That preserves the pre-M11-F semantics — cron CRUD
+        // (`add` / `list` / `remove` / `enable` / `disable`) works in
+        // serve mode but actual firing only happens under `octos
+        // gateway`. We keep the `Arc<CronService>` alive by stashing it
+        // on `ProfileRuntime::cron_service`; without that field the
+        // tokio task `start()` spawned would be cancelled the moment
+        // this function returned.
+        let (cron_tx, _cron_rx) = tokio::sync::mpsc::channel(64);
+        let cron_service = Arc::new(CronService::new(data_dir.join("cron.json"), cron_tx));
+        cron_service.start();
+        tools.register(CronTool::with_context(cron_service.clone(), "api", ""));
+
         // Step 17: re-apply tool policy AFTER plugin / memory-bank
         // registration so deny entries can target plugin-declared
         // tool names too (PR #688 follow-up — MEDIUM #4).
         if let Some(ref policy) = config.tool_policy {
             tools.apply_policy(policy);
+        }
+
+        // M11-F regression fix REG-1: auto-defer non-core tool groups
+        // when the visible tool count is high so weaker LLMs (notably
+        // GLM, kimi-k2 cold-start) don't return empty responses under
+        // the weight of 30+ tool definitions.
+        //
+        // Mirrors `gateway_runtime.rs:1048-1070` byte-for-byte: defer
+        // `group:admin` / `group:sessions` / `group:web` /
+        // `group:runtime` / `group:media`, then register the
+        // `ActivateToolsTool` when anything ended up deferred so the
+        // LLM can pull a group back on demand mid-loop. Keeps research
+        // (deep_search, deep_crawl) active by leaving `group:search`
+        // alone — users call those directly often enough that hiding
+        // them behind an extra round-trip would regress latency.
+        let visible = tools.specs().len();
+        if visible > 15 {
+            for group in &[
+                "group:admin",
+                "group:sessions",
+                "group:web",
+                "group:runtime",
+                "group:media",
+            ] {
+                tools.defer_group(group);
+            }
+            let after = tools.specs().len();
+            info!(
+                profile_id = %profile.id,
+                before = visible,
+                after,
+                "auto-deferred non-core tool groups to reduce LLM tool-count load"
+            );
+        }
+        if tools.has_deferred() {
+            tools.register(octos_agent::ActivateToolsTool::new());
         }
 
         // Step 18: pre-assemble the profile-scope system prompt.
@@ -593,6 +698,34 @@ impl ProfileRuntime {
             system_prompt.push_str(fragment);
         }
 
+        // M11-F regression fix REG-3: assemble the lifecycle hook
+        // executor once per profile and propagate the `Arc` onto every
+        // per-session [`octos_agent::Agent`].
+        //
+        // Pre-M11-F `serve.rs::try_create_agent` merged `config.hooks +
+        // plugin_result.hooks` into `Vec<HookConfig>`, wrapped it in
+        // `HookExecutor::new`, and called `agent.with_hooks(...)`. M11-F
+        // stored `plugin_hooks` on `ProfileRuntime` but never built the
+        // executor or attached it. We do both here so the
+        // `before_tool_call` / `after_tool_call` / `before_llm_call` /
+        // `after_llm_call` hooks fire on the api-mode agent the same
+        // way they fire under `octos gateway`.
+        //
+        // `SessionRuntime::bootstrap` reads this back and chains
+        // `.with_hooks(executor.clone())` onto the per-session agent;
+        // the per-request rebuild paths in `ws_standalone_agent` and
+        // the UI Protocol per-turn builder do the same. Storing as
+        // `Option<Arc<HookExecutor>>` preserves the pre-M11-F default
+        // when neither source carries any hooks (the agent's
+        // `hooks: None` field remains untouched).
+        let mut all_hooks = config.hooks.clone();
+        all_hooks.extend(plugin_result.hooks.clone());
+        let hook_executor = if all_hooks.is_empty() {
+            None
+        } else {
+            Some(Arc::new(HookExecutor::new(all_hooks)))
+        };
+
         info!(
             profile_id = %profile.id,
             provider = %provider_name,
@@ -601,6 +734,7 @@ impl ProfileRuntime {
             tool_count = tools.specs().len(),
             system_prompt_len = system_prompt.len(),
             prompt_fragment_count = plugin_result.prompt_fragments.len(),
+            hook_count = hook_executor.is_some() as u8,
             "ProfileRuntime: bootstrapped"
         );
 
@@ -626,7 +760,37 @@ impl ProfileRuntime {
             memory,
             memory_store,
             tool_config,
+            cron_service: Some(cron_service),
+            hook_executor,
         }))
+    }
+}
+
+/// Tear down the profile-scope cron service when the runtime drops.
+///
+/// `CronService::start` spawns a tokio timer task that re-arms via
+/// `Arc::clone(self)`, so the task self-holds an `Arc<CronService>`.
+/// Without a `Drop` signal that flips `running = false` and aborts the
+/// in-flight `tokio::time::sleep`, the timer task would survive
+/// `ProfileRuntime` drop until its next scheduled fire (potentially
+/// hours in the future), holding the service `Arc` alive past the
+/// runtime that owns the profile's filesystem layout. We call the
+/// synchronous [`CronService::shutdown_signal`] helper from `Drop` to
+/// flip the flag and best-effort abort the JoinHandle; once the
+/// running flag is `false` the reschedule chain in `on_timer` →
+/// `arm_timer` terminates on the next tick and the task drops its
+/// self-held `Arc`.
+///
+/// This is a code-quality fix (the cron task does no harm if it
+/// continues firing — `inbound_tx` is a dummy channel whose receiver
+/// is already dropped — but readers reasonably expect the runtime to
+/// own its background tasks). Codex flagged this on the M11-F serve
+/// regression bundle review.
+impl Drop for ProfileRuntime {
+    fn drop(&mut self) {
+        if let Some(ref cron) = self.cron_service {
+            cron.shutdown_signal();
+        }
     }
 }
 
@@ -1012,6 +1176,243 @@ mod tests {
         assert!(
             msg.contains("Database already open") || msg.contains("Cannot acquire lock"),
             "error must surface the redb lock contention; got: {err:?}",
+        );
+    }
+
+    /// Build a minimal profile that bootstraps successfully against a
+    /// stubbed env-var-backed API key. Used by the M11-F regression
+    /// fix tests below to keep their fixture identical.
+    fn fixture_profile(id: &str, key_env: &'static str) -> UserProfile {
+        UserProfile {
+            id: id.to_string(),
+            name: id.to_string(),
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            public_subdomain: None,
+            config: ProfileConfig {
+                gateway: GatewaySettings::default(),
+                llm: Some(LlmProfileConfig {
+                    primary: Some(LlmModelSelectionConfig {
+                        family_id: Some("openai".to_string()),
+                        model_id: Some("gpt-4o-mini".to_string()),
+                        route: Some(LlmRouteConfig {
+                            route_id: None,
+                            label: None,
+                            base_url: None,
+                            api_key_env: Some(key_env.to_string()),
+                            api_type: None,
+                        }),
+                        ..Default::default()
+                    }),
+                    fallbacks: Vec::new(),
+                }),
+                ..Default::default()
+            },
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    /// Set an env-var-backed fake API key with the supplied name for the
+    /// duration of the test. Drops the var on scope exit so tests do not
+    /// pollute the shared process environment.
+    struct ScopedEnvKey {
+        name: &'static str,
+    }
+    impl ScopedEnvKey {
+        #[allow(unsafe_code)]
+        fn set(name: &'static str) -> Self {
+            // SAFETY: each test passes a uniquely-named env var that no
+            // other test reads or writes; we also remove it on drop.
+            unsafe {
+                std::env::set_var(name, "test-key-sk-fake");
+            }
+            Self { name }
+        }
+    }
+    impl Drop for ScopedEnvKey {
+        #[allow(unsafe_code)]
+        fn drop(&mut self) {
+            // SAFETY: see set().
+            unsafe {
+                std::env::remove_var(self.name);
+            }
+        }
+    }
+
+    /// M11-F regression fix REG-2: `ProfileRuntime::bootstrap` must
+    /// register the `cron` tool so `/api/chat` and the UI Protocol WS
+    /// path see it under api mode, matching the pre-M11-F serve flow
+    /// (`serve.rs:1207`). The `Arc<CronService>` must also be retained
+    /// on the runtime so the tokio timer task `start()` spawned does
+    /// not get dropped when bootstrap returns.
+    #[tokio::test]
+    async fn profile_runtime_bootstrap_registers_cron_tool() {
+        let _key = ScopedEnvKey::set("OCTOS_M11F_REG2_KEY");
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let profile = fixture_profile("reg2", "OCTOS_M11F_REG2_KEY");
+        let rt = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
+            .await
+            .expect("bootstrap should succeed");
+
+        assert!(
+            rt.tool_specs.specs().iter().any(|s| s.name == "cron"),
+            "cron tool must be registered on the base ToolRegistry",
+        );
+        assert!(
+            rt.cron_service.is_some(),
+            "Arc<CronService> must be retained on ProfileRuntime so the \
+             timer task survives bootstrap",
+        );
+    }
+
+    /// M11-F regression fix REG-1: when the visible tool count exceeds
+    /// 15 (the gateway threshold), bootstrap must defer the five
+    /// non-core groups and register `activate_tools`. This mirrors
+    /// `gateway_runtime.rs:1048-1070` and is essential for weaker LLMs
+    /// (kimi-k2, GLM) that return empty responses under tool-spec
+    /// overload.
+    #[tokio::test]
+    async fn profile_runtime_bootstrap_defers_groups_and_registers_activate_tools() {
+        let _key = ScopedEnvKey::set("OCTOS_M11F_REG1_KEY");
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let profile = fixture_profile("reg1", "OCTOS_M11F_REG1_KEY");
+        let rt = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
+            .await
+            .expect("bootstrap should succeed");
+
+        // The base builtin set + memory tools + cron exceeds 15 visible
+        // tools, so the defer pass MUST fire and the activate_tools tool
+        // MUST be registered.
+        assert!(
+            rt.tool_specs.has_deferred(),
+            "bootstrap should auto-defer non-core groups when visible > 15",
+        );
+        assert!(
+            rt.tool_specs
+                .specs()
+                .iter()
+                .any(|s| s.name == "activate_tools"),
+            "activate_tools must be registered when any tool is deferred",
+        );
+    }
+
+    /// M11-F regression fix REG-5: bootstrap's plugin_dirs must include
+    /// the *global* `~/.octos/plugins` and `~/.octos/skills` (via
+    /// `Config::plugin_dirs_from_project`) so admin-installed skills
+    /// are visible to every profile, matching the pre-M11-F serve
+    /// behaviour at `serve.rs:1224`.
+    ///
+    /// We construct an `octos_home` override and plant a fake skill
+    /// under `<octos_home>/plugins/`, then assert the resulting
+    /// `plugin_dirs` set includes that directory. We do not require
+    /// the skill to load (loaders gate on a manifest); we only assert
+    /// the dir was *scanned*.
+    #[tokio::test]
+    async fn profile_runtime_bootstrap_includes_global_plugin_dirs() {
+        let _key = ScopedEnvKey::set("OCTOS_M11F_REG5_KEY");
+        let tmp = tempfile::tempdir().unwrap();
+        let octos_home = tmp.path().join("octos-home");
+        let data_dir = octos_home.join("profiles").join("reg5").join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        // Plant the global "<octos_home>/plugins" dir so
+        // `Config::plugin_dirs_from_project` picks it up.
+        let global_plugins = octos_home.join("plugins");
+        std::fs::create_dir_all(&global_plugins).unwrap();
+
+        let profile = fixture_profile("reg5", "OCTOS_M11F_REG5_KEY");
+        let rt =
+            ProfileRuntime::bootstrap(&profile, &data_dir, Some(&octos_home), BootstrapRole::Serve)
+                .await
+                .expect("bootstrap should succeed");
+
+        assert!(
+            rt.plugin_dirs.contains(&global_plugins),
+            "plugin_dirs should include `<octos_home>/plugins`; got: {:?}",
+            rt.plugin_dirs
+        );
+    }
+
+    /// M11-F regression fix REG-2 follow-up (codex review): when the
+    /// `ProfileRuntime` drops, the cron service must observe a
+    /// shutdown signal so the self-armed timer task does not survive
+    /// the runtime owning its filesystem layout. The signal is
+    /// synchronous (we call it from `Drop`) and flips
+    /// `CronService::running` to false; the next reschedule tick
+    /// inside `on_timer` → `arm_timer` then short-circuits and the
+    /// timer task drops its self-held `Arc<CronService>`.
+    ///
+    /// We assert by holding a weak reference to the inner
+    /// `Arc<CronService>` after dropping the `ProfileRuntime` and
+    /// checking that `running` flipped. The strong-count check (i.e.
+    /// "service deallocated") would race with the in-flight timer
+    /// task, so we settle for the durable observable (`running` flag).
+    #[tokio::test]
+    async fn profile_runtime_drop_signals_cron_shutdown() {
+        let _key = ScopedEnvKey::set("OCTOS_M11F_REG2_DROP_KEY");
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let profile = fixture_profile("reg2-drop", "OCTOS_M11F_REG2_DROP_KEY");
+        let rt = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
+            .await
+            .expect("bootstrap should succeed");
+
+        let cron = rt
+            .cron_service
+            .clone()
+            .expect("cron_service must be Some after bootstrap");
+        // Hold an extra Arc so we can inspect the service after the
+        // runtime drops.
+        drop(rt);
+
+        // After drop, the runtime's `Drop` impl signals shutdown — the
+        // running flag must be false, which causes the timer's next
+        // reschedule to terminate and the self-held Arc to release.
+        assert!(
+            !cron.is_running(),
+            "Drop must flip CronService::running to false",
+        );
+    }
+
+    /// M11-F regression fix REG-3: when `config.hooks` is non-empty,
+    /// bootstrap must build a `HookExecutor` and stash the `Arc` on
+    /// `ProfileRuntime::hook_executor` so per-session agents (and
+    /// per-request rebuild paths) can inherit it.
+    ///
+    /// Since the per-profile `Config` derived from `UserProfile` does
+    /// not currently expose `hooks` (those come from the top-level
+    /// `Config`, not the profile), this test asserts the inverse: an
+    /// empty hook set yields `None`, and the bootstrap structurally
+    /// builds and exposes the field. End-to-end hook propagation onto
+    /// the per-session agent is asserted by
+    /// `session.rs::session_runtime_agent_inherits_profile_hooks`.
+    #[tokio::test]
+    async fn profile_runtime_bootstrap_initializes_hook_executor_field() {
+        let _key = ScopedEnvKey::set("OCTOS_M11F_REG3_KEY");
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+
+        let profile = fixture_profile("reg3", "OCTOS_M11F_REG3_KEY");
+        let rt = ProfileRuntime::bootstrap(&profile, &data_dir, None, BootstrapRole::Serve)
+            .await
+            .expect("bootstrap should succeed");
+
+        // With no config-side hooks and no plugin-side hooks the field
+        // must be None so the agent's default `hooks: None` is kept.
+        assert!(
+            rt.hook_executor.is_none(),
+            "hook_executor must be None when neither config nor plugins supply hooks",
         );
     }
 }

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -227,6 +227,19 @@ impl SessionRuntime {
             .rebind_cwd(&workspace_root, create_sandbox(&sandbox));
         tools.set_output_dir_hint(plugin_work_dir.to_string_lossy().into_owned());
         tools.rebind_plugin_work_dirs(&plugin_work_dir);
+        // M11-F regression fix REG-1 follow-up round 2 (codex review):
+        // re-register a fresh `ActivateToolsTool` instance on this
+        // session's registry. The profile-level template is shared via
+        // `Arc<dyn Tool>` clones across every session that snapshots
+        // from `profile.tool_specs`; if we let the same instance
+        // straddle sessions, the most recently bootstrapped session's
+        // `wire_activate_tools()` would rebind the shared tool's
+        // `Weak<ToolRegistry>` away from earlier sessions and break
+        // their `activate_tools` calls. Minting a fresh tool per
+        // session keeps the wiring per-registry.
+        if tools.get("activate_tools").is_some() {
+            tools.register(octos_agent::ActivateToolsTool::new());
+        }
         // Per-session policy filter is a no-op for M11; future work
         // may add session-level policy overrides on top of
         // `profile.tool_policy`. The profile-level policy itself is
@@ -261,7 +274,7 @@ impl SessionRuntime {
         ));
         let file_state_cache = Arc::new(FileStateCache::new());
 
-        let agent = Agent::new_shared(
+        let mut agent = Agent::new_shared(
             AgentId::new("api"),
             profile.llm.clone(),
             Arc::clone(&tools),
@@ -288,6 +301,28 @@ impl SessionRuntime {
         .with_subagent_summary_generator(subagent_summary_generator)
         .with_sandbox_config(sandbox.clone())
         .with_workspace_root(workspace_root.clone());
+
+        // M11-F regression fix REG-3: propagate the profile-scope
+        // [`octos_agent::HookExecutor`] onto the per-session agent.
+        // `ProfileRuntime::bootstrap` assembled it once from
+        // `config.hooks + plugin_result.hooks`; without this chain
+        // call, the api-mode agent would silently lose every
+        // `before_tool_call` / `after_tool_call` / `before_llm_call` /
+        // `after_llm_call` hook configured for the profile, breaking
+        // parity with `octos gateway`.
+        if let Some(hooks) = profile.hook_executor.clone() {
+            agent = agent.with_hooks(hooks);
+        }
+
+        // M11-F regression fix REG-1 follow-up (codex review): when
+        // `ProfileRuntime::bootstrap` deferred non-core tool groups and
+        // registered `activate_tools`, the agent must call
+        // `wire_activate_tools()` so the tool's `Weak<ToolRegistry>`
+        // back-reference is planted. Without this, `activate_tools`
+        // remains a no-op stub (its `set_registry` is never invoked)
+        // and the LLM cannot pull a deferred group back on demand.
+        // Gateway does the equivalent at `session_actor.rs:2500`.
+        agent.wire_activate_tools();
 
         let agent = Arc::new(agent);
 
@@ -492,6 +527,8 @@ mod tests {
             memory,
             memory_store,
             tool_config,
+            cron_service: None,
+            hook_executor: None,
         })
     }
 
@@ -620,6 +657,263 @@ mod tests {
         assert!(
             snapshot.contains("DISTINCTIVE-PROFILE-PROMPT-789"),
             "agent system prompt should inherit the profile-level prompt; got: {snapshot}",
+        );
+    }
+
+    /// Build a `ProfileRuntime` like `make_profile`, but with a
+    /// pre-constructed `Arc<HookExecutor>` stashed on the
+    /// `hook_executor` field. Used by the M11-F REG-3 regression
+    /// test below to assert end-to-end propagation onto the
+    /// per-session agent.
+    async fn make_profile_with_hooks(
+        data_dir: PathBuf,
+        executor: Arc<octos_agent::HookExecutor>,
+    ) -> Arc<ProfileRuntime> {
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let memory = Arc::new(EpisodeStore::open(&data_dir).await.unwrap());
+        let memory_store = Arc::new(MemoryStore::open(&data_dir).await.unwrap());
+        let tool_config = Arc::new(octos_agent::ToolConfigStore::open(&data_dir).await.unwrap());
+        let sandbox = SandboxConfig::default();
+        let base_tools =
+            ToolRegistry::with_builtins_and_sandbox(&data_dir, create_sandbox(&sandbox));
+        Arc::new(ProfileRuntime {
+            profile_id: "_main".to_string(),
+            data_dir,
+            llm: Arc::new(StubLlm),
+            adaptive_router: None,
+            runtime_qos_catalog: None,
+            primary_model_id: "stub-model".to_string(),
+            provider_name: "stub".to_string(),
+            credentials: HashMap::new(),
+            skills_dir: None,
+            plugin_env_template: Vec::new(),
+            tool_policy: None,
+            default_sandbox: sandbox,
+            tool_specs: Arc::new(base_tools),
+            plugin_tool_names: Vec::new(),
+            plugin_dirs: Vec::new(),
+            plugin_prompt_fragments: Vec::new(),
+            plugin_hooks: Vec::new(),
+            system_prompt: "test-system-prompt".to_string(),
+            memory,
+            memory_store,
+            tool_config,
+            cron_service: None,
+            hook_executor: Some(executor),
+        })
+    }
+
+    /// M11-F regression fix REG-1 follow-up (codex review):
+    /// `SessionRuntime::bootstrap` must call `wire_activate_tools()`
+    /// on the per-session agent when `ProfileRuntime::bootstrap`
+    /// registered `activate_tools` (deferred-group scenario). Without
+    /// the wiring, `activate_tools.execute()` returns
+    /// `"tool registry not available"` and the LLM cannot pull
+    /// deferred groups back on demand.
+    #[tokio::test]
+    async fn session_runtime_agent_wires_activate_tools() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let memory = Arc::new(EpisodeStore::open(&data_dir).await.unwrap());
+        let memory_store = Arc::new(MemoryStore::open(&data_dir).await.unwrap());
+        let tool_config = Arc::new(octos_agent::ToolConfigStore::open(&data_dir).await.unwrap());
+        let sandbox = SandboxConfig::default();
+        // Build a registry with activate_tools + a deferred entry so
+        // execute() has something to list.
+        let mut base_tools =
+            ToolRegistry::with_builtins_and_sandbox(&data_dir, create_sandbox(&sandbox));
+        base_tools.defer_group("group:web");
+        base_tools.register(octos_agent::ActivateToolsTool::new());
+        let profile = Arc::new(ProfileRuntime {
+            profile_id: "_main".to_string(),
+            data_dir: data_dir.clone(),
+            llm: Arc::new(StubLlm),
+            adaptive_router: None,
+            runtime_qos_catalog: None,
+            primary_model_id: "stub-model".to_string(),
+            provider_name: "stub".to_string(),
+            credentials: HashMap::new(),
+            skills_dir: None,
+            plugin_env_template: Vec::new(),
+            tool_policy: None,
+            default_sandbox: sandbox,
+            tool_specs: Arc::new(base_tools),
+            plugin_tool_names: Vec::new(),
+            plugin_dirs: Vec::new(),
+            plugin_prompt_fragments: Vec::new(),
+            plugin_hooks: Vec::new(),
+            system_prompt: "test-system-prompt".to_string(),
+            memory,
+            memory_store,
+            tool_config,
+            cron_service: None,
+            hook_executor: None,
+        });
+        let key = SessionKey::new("api", "activate-tools-probe");
+        let rt = SessionRuntime::bootstrap(&profile, key, None)
+            .await
+            .expect("bootstrap");
+
+        let registry = rt.agent.tool_registry();
+        let tool = registry
+            .get("activate_tools")
+            .expect("activate_tools must be registered");
+        // Executing with empty args lists deferred groups. The path
+        // unwraps `registry.upgrade()`; if `wire_activate_tools` did
+        // not fire, the unwrap maps to an `Err("tool registry not
+        // available")` and the assertion below fails.
+        let result = tool
+            .execute(&serde_json::json!({}))
+            .await
+            .expect("activate_tools must be wired so its registry Weak upgrades");
+        assert!(
+            !result.output.contains("tool registry not available"),
+            "activate_tools.execute should not surface 'tool registry not available'; \
+             got: {}",
+            result.output,
+        );
+    }
+
+    /// M11-F regression fix REG-1 follow-up round 2 (codex review):
+    /// `ActivateToolsTool` is stored on the registry as `Arc<dyn Tool>`,
+    /// and `ToolRegistry::rebind_cwd` clones those Arcs verbatim into
+    /// the new per-session registry. If we DON'T re-register a fresh
+    /// `ActivateToolsTool` per session, both sessions end up sharing
+    /// the SAME tool instance — and the second session's
+    /// `wire_activate_tools()` rewires the shared `Weak<ToolRegistry>`
+    /// off session A's registry onto session B's, breaking session A's
+    /// `activate_tools` calls.
+    ///
+    /// This test bootstraps two sessions from the same profile (both
+    /// of which carry `activate_tools` on the base template) and
+    /// asserts that session A's activate_tools still resolves to
+    /// session A's registry after session B has been bootstrapped.
+    #[tokio::test]
+    async fn session_runtime_isolates_activate_tools_across_sessions() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let memory = Arc::new(EpisodeStore::open(&data_dir).await.unwrap());
+        let memory_store = Arc::new(MemoryStore::open(&data_dir).await.unwrap());
+        let tool_config = Arc::new(octos_agent::ToolConfigStore::open(&data_dir).await.unwrap());
+        let sandbox = SandboxConfig::default();
+        let mut base_tools =
+            ToolRegistry::with_builtins_and_sandbox(&data_dir, create_sandbox(&sandbox));
+        base_tools.defer_group("group:web");
+        base_tools.register(octos_agent::ActivateToolsTool::new());
+        let profile = Arc::new(ProfileRuntime {
+            profile_id: "_main".to_string(),
+            data_dir: data_dir.clone(),
+            llm: Arc::new(StubLlm),
+            adaptive_router: None,
+            runtime_qos_catalog: None,
+            primary_model_id: "stub-model".to_string(),
+            provider_name: "stub".to_string(),
+            credentials: HashMap::new(),
+            skills_dir: None,
+            plugin_env_template: Vec::new(),
+            tool_policy: None,
+            default_sandbox: sandbox,
+            tool_specs: Arc::new(base_tools),
+            plugin_tool_names: Vec::new(),
+            plugin_dirs: Vec::new(),
+            plugin_prompt_fragments: Vec::new(),
+            plugin_hooks: Vec::new(),
+            system_prompt: "test-system-prompt".to_string(),
+            memory,
+            memory_store,
+            tool_config,
+            cron_service: None,
+            hook_executor: None,
+        });
+
+        let rt_a = SessionRuntime::bootstrap(&profile, SessionKey::new("api", "iso-a"), None)
+            .await
+            .expect("bootstrap A");
+        let rt_b = SessionRuntime::bootstrap(&profile, SessionKey::new("api", "iso-b"), None)
+            .await
+            .expect("bootstrap B");
+
+        // Both sessions must have a usable `activate_tools`. The
+        // pre-fix regression: session A's tool's Weak would have been
+        // rewired by session B's bootstrap and now upgrades to
+        // session B's registry, mixing per-session state.
+        let tool_a = rt_a
+            .agent
+            .tool_registry()
+            .get("activate_tools")
+            .expect("session A activate_tools");
+        let tool_b = rt_b
+            .agent
+            .tool_registry()
+            .get("activate_tools")
+            .expect("session B activate_tools");
+
+        // The fresh-registration step in `SessionRuntime::bootstrap`
+        // means the two sessions must hold DISTINCT `Arc<dyn Tool>`
+        // instances; if they did not, the second bootstrap would have
+        // rewired the shared Weak away from the first.
+        assert!(
+            !Arc::ptr_eq(tool_a, tool_b),
+            "activate_tools must be a fresh instance per session, not a \
+             shared Arc cloned from the profile template",
+        );
+
+        // Both tools must execute successfully (i.e. their Weak
+        // upgrades to a live registry — not "tool registry not
+        // available").
+        let result_a = tool_a
+            .execute(&serde_json::json!({}))
+            .await
+            .expect("activate_tools A wired");
+        assert!(
+            !result_a.output.contains("tool registry not available"),
+            "session A activate_tools must remain wired after session B bootstrap; got: {}",
+            result_a.output,
+        );
+        let result_b = tool_b
+            .execute(&serde_json::json!({}))
+            .await
+            .expect("activate_tools B wired");
+        assert!(
+            !result_b.output.contains("tool registry not available"),
+            "session B activate_tools must also be wired; got: {}",
+            result_b.output,
+        );
+    }
+
+    /// M11-F regression fix REG-3: when the parent `ProfileRuntime`
+    /// carries a `hook_executor`, `SessionRuntime::bootstrap` must
+    /// chain `.with_hooks(...)` onto the per-session `Agent` so the
+    /// configured `before_tool_call` / `after_tool_call` /
+    /// `before_llm_call` / `after_llm_call` hooks fire on api-mode
+    /// turns, matching the pre-M11-F `serve.rs:1413` behaviour.
+    #[tokio::test]
+    async fn session_runtime_agent_inherits_profile_hooks() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let hook = octos_agent::HookConfig {
+            event: octos_agent::HookEvent::BeforeLlmCall,
+            command: vec!["/bin/true".to_string()],
+            timeout_ms: 1000,
+            tool_filter: Vec::new(),
+        };
+        let executor = Arc::new(octos_agent::HookExecutor::new(vec![hook]));
+        let profile = make_profile_with_hooks(data_dir, executor.clone()).await;
+
+        let key = SessionKey::new("api", "hook-probe");
+        let rt = SessionRuntime::bootstrap(&profile, key, None)
+            .await
+            .expect("bootstrap");
+
+        let agent_hooks = rt
+            .agent
+            .hooks()
+            .expect("session agent must inherit profile hook_executor");
+        assert!(
+            Arc::ptr_eq(&agent_hooks, &executor),
+            "agent.hooks() must be the same Arc as profile.hook_executor",
         );
     }
 

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -211,6 +211,8 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
         memory,
         memory_store,
         tool_config,
+        cron_service: None,
+        hook_executor: None,
     })
 }
 


### PR DESCRIPTION
## Summary

M11-F (#888) deleted `serve.rs::try_create_agent` and routed everything through `ProfileRuntime::bootstrap` + `SessionRuntime::bootstrap`. Side-by-side audit (pre-M11-F `git show 4ad06f98^:crates/octos-cli/src/commands/serve.rs` vs current main) identified 10 regressions; this PR lands the 6 critical ones.

Tracking issue: #901

## Per-regression summary

### REG-1 — `defer_group` + `ActivateToolsTool` restored
- `ProfileRuntime::bootstrap` now mirrors `gateway_runtime.rs:1048-1070` byte-for-byte: defers `group:admin` / `group:sessions` / `group:web` / `group:runtime` / `group:media` when `visible > 15`, then registers `ActivateToolsTool` only when `has_deferred()`.
- `SessionRuntime::bootstrap` re-registers a fresh `ActivateToolsTool::new()` after `rebind_cwd` so the back-reference `Weak<ToolRegistry>` doesn't get rewired across sessions (codex round-2 fix). The UI Protocol per-turn `snapshot_excluding(&[])` path does the same.
- All three dispatchers (`SessionRuntime::bootstrap`, `ws_standalone_agent`, ui_protocol per-turn) now call `wire_activate_tools()` after agent construction.

### REG-2 — `CronTool` registration restored
- New `cron_service: Option<Arc<CronService>>` field on `ProfileRuntime`.
- `bootstrap` builds a `CronService` rooted at `data_dir/cron.json`, calls `start()`, registers `CronTool::with_context(_, "api", "")`.
- New `Drop for ProfileRuntime` calls `CronService::shutdown_signal()`.
- `CronService` gained a `tokio::sync::Notify` shutdown channel. The `arm_timer` sleeper `select!`s on it after `Notified::enable()` (registering the waiter atomically with the post-lock `running` check) — a late shutdown wakes the sleeper immediately instead of waiting out `delay_ms`. Closes all codex-flagged race interleavings.

### REG-3 — Lifecycle hooks
- New `hook_executor: Option<Arc<HookExecutor>>` field, assembled once at bootstrap from `config.hooks + plugin_result.hooks`.
- `SessionRuntime::bootstrap` chains `.with_hooks(...)` onto the per-session `Agent`.
- The two per-request rebuild paths (`ws_standalone_agent`, ui_protocol per-turn) also propagate via a new `Agent::hooks()` accessor.

### REG-4 — `bootstrap_bundled_skills` / `bootstrap_platform_skills`
- `ServeCommand::run_async` now calls both once before the per-profile bootstrap loop. Was missing entirely on main.

### REG-5 — Global plugin dirs
- `ProfileRuntime::bootstrap` uses `Config::plugin_dirs_from_project(&effective_octos_home)`, then layers `platform-skills/` + per-profile `data_dir/skills/` on top. Now scans `~/.octos/plugins`, `~/.octos/skills`, `<octos_home>/plugins`, `<octos_home>/skills`, and `OCTOS_SKILLS_PATH`.

### REG-6 — `appui.default_session_cwd` Tier-2 fallback
- `chat_sync_via_session_runtime` and the WS standalone path forward `state.appui_default_session_cwd` as the workspace_hint, matching what `ui_protocol.rs` already did.

## New tests (9)

All in `cargo test -p octos-cli --features api`:

- `runtime::profile::tests::profile_runtime_bootstrap_registers_cron_tool`
- `runtime::profile::tests::profile_runtime_bootstrap_defers_groups_and_registers_activate_tools`
- `runtime::profile::tests::profile_runtime_bootstrap_includes_global_plugin_dirs`
- `runtime::profile::tests::profile_runtime_bootstrap_initializes_hook_executor_field`
- `runtime::profile::tests::profile_runtime_drop_signals_cron_shutdown`
- `runtime::session::tests::session_runtime_agent_wires_activate_tools`
- `runtime::session::tests::session_runtime_isolates_activate_tools_across_sessions`
- `runtime::session::tests::session_runtime_agent_inherits_profile_hooks`
- `api::handlers::tests::chat_sync_forwards_appui_default_session_cwd_as_workspace_hint`

## Codex review (5 rounds)

Final verdict (round 5): **APPROVE on all 6 dimensions**.

| Dimension | Round 1 | Round 2 | Round 3 | Round 4 | Round 5 |
|---|---|---|---|---|---|
| (a) defer_group + ActivateToolsTool | REJECT (missing wire_activate_tools) | REJECT (shared Arc<ActivateToolsTool>) | APPROVE | APPROVE | APPROVE |
| (b) CronService lifecycle | REJECT (no Drop signal) | REJECT (try_lock race) | REJECT (post-check race) | REJECT (missed-notify window) | **APPROVE** |
| (c) Hooks | APPROVE | — | — | — | APPROVE |
| (d) Skill bootstrap | APPROVE | — | — | — | APPROVE |
| (e) plugin_dirs | APPROVE | — | — | — | APPROVE |
| (f) workspace_hint | APPROVE | — | — | — | APPROVE |

## Out of scope (deferred follow-ups)

- REG-7 / REG-8 / REG-9 / REG-10 — moderate + cosmetic items from the audit. To be tracked as separate issues.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p octos-cli --features api` green (947 lib tests, 9 new)
- [x] `cargo test -p octos-bus` green (185 lib tests)
- [x] `cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"` clean
- [ ] No deploy — supervisor will run live soak under `octos serve`