### PR TITLE
cleanup(api): retire POST /api/chat — migrate remaining callers to UI Protocol v1 WS

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -14,7 +14,9 @@ use octos_bus::file_handle::{
     encode_profile_file_handle, encode_tmp_upload_handle, resolve_legacy_file_request,
     resolve_scoped_file_handle,
 };
-use octos_core::{MAIN_PROFILE_ID, Message, SessionKey};
+#[cfg(test)]
+use octos_core::Message;
+use octos_core::{MAIN_PROFILE_ID, SessionKey};
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
@@ -22,43 +24,17 @@ use super::auth_handlers::ADMIN_PROFILE_ID;
 use super::router::AuthIdentity;
 use crate::project_templates::{SiteProjectMetadata, read_site_project_metadata};
 
-/// POST /api/chat -- send a message, get a response (sync JSON only).
+/// Legacy `POST /api/chat` retired.
 ///
-/// M9-α-5/α-6 (ADR PR #830): the SSE branch was deleted; `stream: true`
-/// now returns `410 Gone` and clients must use `/api/ui-protocol/ws`.
-/// `media` / `attach_only` / `client_message_id` are accepted for
-/// wire-compat with older clients but unused in the surviving sync
-/// path.
-#[derive(Deserialize)]
-pub struct ChatRequest {
-    pub message: String,
-    #[serde(default)]
-    pub session_id: Option<String>,
-    #[serde(default)]
-    pub topic: Option<String>,
-    #[serde(default)]
-    pub stream: bool,
-    /// File paths from prior `/api/upload` call.
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub media: Vec<String>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub attach_only: bool,
-    /// Web-generated correlation id. Used by the WS lifecycle handlers
-    /// downstream of `/api/ui-protocol/ws`. Pre-α-5/α-6 the streaming
-    /// HTTP path also threaded this through; that path is gone.
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub client_message_id: Option<String>,
-}
-
-#[derive(Serialize)]
-pub struct ChatResponse {
-    pub content: String,
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-}
+/// Transport history:
+/// - M9-α-5/α-6 (ADR PR #830): the SSE branch was deleted; `stream: true`
+///   returned `410 Gone` and clients had to use `/api/ui-protocol/ws`.
+/// - Cleanup follow-up to PR #908: the surviving sync JSON path was
+///   retired once the last callers (the `coding_multi_session`
+///   integration test, three e2e specs, and
+///   `scripts/validate-m4-1a-live.sh`) migrated to the WS path.
+///
+/// The sole chat transport is now `/api/ui-protocol/ws`.
 
 #[derive(Serialize)]
 pub(crate) struct ContentFileEntry {
@@ -86,9 +62,6 @@ fn resolve_scoped_download_path(
     resolve_scoped_file_handle(base_dir, request_path)
         .or_else(|| resolve_legacy_file_request(base_dir, request_path))
 }
-
-/// Maximum message length (1MB).
-const MAX_MESSAGE_LEN: usize = 1_048_576;
 
 fn request_host(headers: &HeaderMap) -> Option<String> {
     let raw = headers
@@ -307,196 +280,6 @@ fn encode_api_session_path_id(id: &str) -> String {
     octos_bus::session::encode_path_component(id)
 }
 
-pub async fn chat(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-    Json(req): Json<ChatRequest>,
-) -> Response {
-    // M9-α-5/α-6 (ADR PR #830 / audit issue #845): SSE chat is gone.
-    // `POST /api/chat` only supports the sync JSON path now — every
-    // streaming caller has migrated to `/api/ui-protocol/ws`. Fail
-    // closed when `stream=true` is requested so a stale client surfaces
-    // a clear error instead of a half-broken response.
-    if req.stream {
-        return (
-            StatusCode::GONE,
-            "POST /api/chat?stream=true was removed in M9-α-5/α-6 — \
-             use the WebSocket UI Protocol (/api/ui-protocol/ws) instead.",
-        )
-            .into_response();
-    }
-
-    match chat_sync(state, headers, req).await {
-        Ok(json) => json.into_response(),
-        Err((status, msg)) => (status, msg).into_response(),
-    }
-}
-
-/// Persist a `Message` to the canonical per-user `<topic>.jsonl` and
-/// invalidate the `SessionManager` LRU cache for the key.
-///
-/// This is the unified write path for the standalone `octos serve` /chat
-/// handlers. Mirrors `ApiChannel::persist_to_session` in the gateway path
-/// — both funnel through `octos_bus::persist_message_through_canonical_path`
-/// so the storage layer is the single ordering point.
-///
-/// Returns the committed per-session sequence number so callers (e.g. the
-/// streaming handler) can correlate it back to the optimistic bubble.
-async fn persist_chat_message_through_canonical(
-    sessions: &Arc<tokio::sync::Mutex<octos_bus::SessionManager>>,
-    key: &SessionKey,
-    message: Message,
-) -> eyre::Result<usize> {
-    let data_dir = {
-        let manager = sessions.lock().await;
-        manager.data_dir()
-    };
-
-    let result = octos_bus::persist_message_through_canonical_path(&data_dir, key, message).await;
-
-    // Drop any stale `SessionManager` cache entry so a follow-up read
-    // (duplicate-detection, `?source=full`) consults disk instead of
-    // returning a pre-write empty `Session`.
-    {
-        let mut manager = sessions.lock().await;
-        manager.invalidate_cache(key);
-    }
-
-    result
-}
-
-async fn chat_sync(
-    state: Arc<AppState>,
-    headers: HeaderMap,
-    req: ChatRequest,
-) -> Result<Json<ChatResponse>, (StatusCode, String)> {
-    if req.message.len() > MAX_MESSAGE_LEN {
-        tracing::warn!(len = req.message.len(), "chat: message exceeds size limit");
-        return Err((
-            StatusCode::PAYLOAD_TOO_LARGE,
-            format!("message exceeds {}KB limit", MAX_MESSAGE_LEN / 1024),
-        ));
-    }
-
-    let profile_id = api_profile_id_from_headers(&state, &headers);
-    let session_key = standalone_api_session_key_with_topic(
-        &state,
-        &headers,
-        req.session_id.as_deref().unwrap_or("default"),
-        req.topic.as_deref(),
-    );
-
-    tracing::info!(
-        profile_id = %profile_id,
-        session = req.session_id.as_deref().unwrap_or("default"),
-        msg_len = req.message.len(),
-        "chat: processing message"
-    );
-
-    // M11-F: every read path resolves through `state.profiles` +
-    // `state.session_cache`. An unregistered profile is a configuration
-    // bug, not a runtime fallback — `octos serve` bootstraps every
-    // profile in `ProfileStore::list()` at startup, so if a profile id
-    // arrives at `/api/chat` that the catalog doesn't know about, it
-    // means the request routed against a profile that failed (or never
-    // had) bootstrap. Fail closed with 503 rather than silently fall
-    // through to a server-wide agent (which M11-F removed).
-    let Some(profile_runtime) = state.profiles.get(&profile_id).cloned() else {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!(
-                "No LLM provider configured for profile '{profile_id}'. \
-                 Set up the profile with an API key in the dashboard.",
-            ),
-        ));
-    };
-    chat_sync_via_session_runtime(state, profile_runtime, session_key, req).await
-}
-
-/// `/api/chat` dispatcher: resolves the per-session
-/// [`crate::runtime::SessionRuntime`] from the cache (constructing it
-/// on first use), runs the agent against the session-bound workspace,
-/// and persists the response through the canonical per-user JSONL.
-///
-/// M11-F: the only `/api/chat` path. The legacy server-wide
-/// `state.agent` fallback was removed; unregistered profile → 503 in
-/// the caller.
-async fn chat_sync_via_session_runtime(
-    state: Arc<AppState>,
-    profile_runtime: Arc<crate::runtime::ProfileRuntime>,
-    session_key: SessionKey,
-    req: ChatRequest,
-) -> Result<Json<ChatResponse>, (StatusCode, String)> {
-    // Acquire (or build on first use) the per-session runtime.
-    //
-    // M11-F regression fix REG-6: when no client cwd is supplied,
-    // forward `state.appui_default_session_cwd` (mirrored from
-    // `config.appui.default_session_cwd`) as the workspace hint. The
-    // pre-M11-F serve path wired this into the server-wide agent via
-    // `agent.with_workspace_root(default_cwd)`; we now thread the
-    // same operator default through the per-session bootstrap. When
-    // the operator sets nothing, this is `None` and the bootstrap
-    // falls back to the canonical
-    // `<profile_data_dir>/users/<encoded session base>/workspace`
-    // layout — preserving the M11 fix for the
-    // `"workspace policy not found"` failure on yangmi voice clone.
-    let workspace_hint = state.appui_default_session_cwd.clone();
-    let session_runtime = state
-        .session_cache
-        .get_or_init(&profile_runtime, session_key.clone(), workspace_hint)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                error = %e,
-                profile_id = %profile_runtime.profile_id,
-                session = %session_key,
-                "chat: SessionRuntime::bootstrap failed",
-            );
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("failed to bootstrap session runtime: {e}"),
-            )
-        })?;
-
-    let history: Vec<Message> = {
-        let mut sess = session_runtime.sessions.lock().await;
-        let session = sess.get_or_create(&session_key).await;
-        session.get_history(50).to_vec()
-    };
-
-    let response = session_runtime
-        .agent
-        .process_message(&req.message, &history, vec![])
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "chat: LLM processing failed");
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-        })?;
-
-    tracing::info!(
-        input_tokens = response.token_usage.input_tokens,
-        output_tokens = response.token_usage.output_tokens,
-        profile_id = %profile_runtime.profile_id,
-        session = %session_key,
-        "chat: response generated via SessionRuntime",
-    );
-
-    for msg in &response.messages {
-        let _ = persist_chat_message_through_canonical(
-            &session_runtime.sessions,
-            &session_key,
-            msg.clone(),
-        )
-        .await;
-    }
-
-    Ok(Json(ChatResponse {
-        content: response.content,
-        input_tokens: response.token_usage.input_tokens,
-        output_tokens: response.token_usage.output_tokens,
-    }))
-}
-
 /// GET /api/sessions -- list sessions.
 #[derive(Serialize, Deserialize)]
 pub struct SessionInfo {
@@ -607,16 +390,6 @@ pub struct TopicQueryParams {
 
 fn default_page_limit() -> usize {
     100
-}
-
-fn standalone_api_session_key_with_topic(
-    state: &AppState,
-    headers: &HeaderMap,
-    session_id: &str,
-    topic: Option<&str>,
-) -> SessionKey {
-    let profile_id = api_profile_id_from_headers(state, headers);
-    SessionKey::with_profile_topic(&profile_id, "api", session_id, topic.unwrap_or_default())
 }
 
 fn append_topic_query(path: &mut String, topic: Option<&str>) {
@@ -1210,7 +983,7 @@ pub async fn delete_session(
     StatusCode::NO_CONTENT.into_response()
 }
 
-/// POST /api/upload -- upload files, returns paths for use in /api/chat media field.
+/// POST /api/upload -- upload files, returns paths for use as turn-input media handles.
 ///
 /// Accepts multipart/form-data with one or more `file` fields.
 /// Returns JSON array of server-side upload handles.
@@ -2644,62 +2417,12 @@ pub async fn health() -> Json<serde_json::Value> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn chat_request_deserialize() {
-        let json = r#"{"message": "hello"}"#;
-        let req: ChatRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.message, "hello");
-        assert!(req.session_id.is_none());
-        assert!(!req.stream);
-    }
-
-    #[test]
-    fn chat_request_with_session() {
-        let json = r#"{"message": "hi", "session_id": "s1"}"#;
-        let req: ChatRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.message, "hi");
-        assert_eq!(req.session_id.as_deref(), Some("s1"));
-    }
-
-    #[test]
-    fn chat_request_with_stream() {
-        let json = r#"{"message": "hi", "stream": true}"#;
-        let req: ChatRequest = serde_json::from_str(json).unwrap();
-        assert!(req.stream);
-    }
-
-    /// FA-12f follow-up: the outer `ChatRequest` (served at `/api/chat`) must
-    /// accept `client_message_id` so it survives proxy forwarding to the
-    /// gateway. The prior fix patched only the gateway-internal struct; the
-    /// outer struct silently dropped the field and overflow replies arrived
-    /// with `response_to_client_message_id: null`, breaking web-side
-    /// correlation under `/queue speculative`.
-    #[test]
-    fn chat_request_accepts_client_message_id() {
-        let json = r#"{"message": "hi", "client_message_id": "client-bravo-xyz"}"#;
-        let req: ChatRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.client_message_id.as_deref(), Some("client-bravo-xyz"));
-    }
-
-    #[test]
-    fn chat_request_client_message_id_defaults_to_none() {
-        let json = r#"{"message": "hi"}"#;
-        let req: ChatRequest = serde_json::from_str(json).unwrap();
-        assert!(req.client_message_id.is_none());
-    }
-
-    #[test]
-    fn chat_response_serialize() {
-        let resp = ChatResponse {
-            content: "world".into(),
-            input_tokens: 10,
-            output_tokens: 5,
-        };
-        let json = serde_json::to_value(&resp).unwrap();
-        assert_eq!(json["content"], "world");
-        assert_eq!(json["input_tokens"], 10);
-        assert_eq!(json["output_tokens"], 5);
-    }
+    // Legacy `POST /api/chat` REST tests (chat_request_*, chat_response_*)
+    // were retired with the handler in the cleanup follow-up to PR #908.
+    // Wire-level chat coverage now lives in
+    // `api::ui_protocol::tests` (turn/start, turn/completed, etc.) and
+    // the `coding_multi_session` integration test (per-session workspace
+    // isolation).
 
     #[test]
     fn session_info_serialize() {
@@ -3676,93 +3399,12 @@ mod tests {
         assert_eq!(default_page_limit(), 100);
     }
 
-    #[test]
-    fn max_message_len_is_1mb() {
-        assert_eq!(MAX_MESSAGE_LEN, 1_048_576);
-    }
-
-    #[tokio::test]
-    async fn chat_sync_writes_to_canonical_per_user_topic_jsonl() {
-        // Regression for the standalone `octos serve` /chat handlers writing
-        // to the legacy flat layout instead of the canonical per-user JSONL.
-        //
-        // Pre-fix, `chat_sync`/`chat_streaming`/the websocket handler all
-        // called `SessionManager::add_message_with_seq` directly. That writes
-        // to `<data_dir>/sessions/<encoded_full_key>.jsonl` (legacy flat),
-        // not the canonical per-user `<topic>.jsonl`. A standalone deployment
-        // without a gateway-side `ApiChannel` therefore split-brained — the
-        // actor wrote to one path, handlers wrote to another, replays missed
-        // half the history.
-        //
-        // Post-fix, every `/chat` write must funnel through
-        // `persist_chat_message_through_canonical` — a wrapper around
-        // `octos_bus::persist_message_through_canonical_path` that also
-        // invalidates the `SessionManager` LRU cache (mirroring what
-        // `ApiChannel::persist_to_session` does). The contract: messages
-        // committed via this helper land in the canonical per-user JSONL
-        // and never touch the legacy flat directory.
-        let data_dir = tempfile::tempdir().unwrap();
-        let sessions = Arc::new(tokio::sync::Mutex::new(
-            octos_bus::SessionManager::open(data_dir.path()).unwrap(),
-        ));
-        let session_id = "web-canonical-handlers";
-        let topic = "research";
-        let key = SessionKey::with_profile_topic(MAIN_PROFILE_ID, "api", session_id, topic);
-
-        // Drive a write through the helper the production handlers now use.
-        let seq = persist_chat_message_through_canonical(
-            &sessions,
-            &key,
-            Message::user("please summarise the q1 numbers"),
-        )
-        .await
-        .expect("canonical persist");
-        assert_eq!(seq, 0);
-
-        // Canonical per-user `<encoded_topic>.jsonl` must exist and carry
-        // the user message.
-        let encoded_base = octos_bus::session::encode_path_component(&format!(
-            "{MAIN_PROFILE_ID}:api:{session_id}"
-        ));
-        let encoded_topic = octos_bus::session::encode_path_component(topic);
-        let canonical = data_dir
-            .path()
-            .join("users")
-            .join(&encoded_base)
-            .join("sessions")
-            .join(format!("{encoded_topic}.jsonl"));
-        assert!(
-            canonical.exists(),
-            "/chat handler write must land in canonical per-user JSONL ({}) — \
-             this is the unified file the SessionActor and the bus-side \
-             ApiChannel also write",
-            canonical.display()
-        );
-        let body = std::fs::read_to_string(&canonical).unwrap();
-        assert!(
-            body.contains("please summarise the q1 numbers"),
-            "canonical JSONL must contain the user message text"
-        );
-
-        // Legacy flat `sessions/<encoded_full_key>.jsonl` must NOT exist —
-        // that's the old split-brain location standalone /chat used to
-        // write to.
-        let sessions_dir = data_dir.path().join("sessions");
-        if sessions_dir.exists() {
-            for entry in std::fs::read_dir(&sessions_dir).unwrap().flatten() {
-                let path = entry.path();
-                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                    panic!(
-                        "/chat handler must NOT write to the legacy flat \
-                         layout (sessions/{}.jsonl) — that is the split-brain \
-                         path the storage unification PR is closing",
-                        name
-                    );
-                }
-            }
-        }
-    }
+    // `max_message_len_is_1mb` + `chat_sync_writes_to_canonical_per_user_topic_jsonl`
+    // were retired with the legacy `POST /api/chat` handler in the
+    // cleanup follow-up to PR #908. The canonical-JSONL invariant is
+    // now covered end-to-end by the `coding_multi_session` integration
+    // test (which drives the same `octos_bus::persist_message_through_canonical_path`
+    // call site) and by the WS UI Protocol handler's own unit tests.
 
     // ────────── M7.9 / W2 cancel + restart-from-node API tests ──────────
 
@@ -3944,245 +3586,23 @@ mod tests {
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 
-    // ────────── M11-D `/api/chat` routes through `SessionRuntime` ──────────
-
-    /// Minimal stub LLM that returns a fixed assistant reply. Used to drive
-    /// the M11-D `/api/chat` route through `SessionRuntime::bootstrap` +
-    /// `Agent::process_message` without hitting a real provider.
-    struct EchoLlm {
-        reply: String,
-    }
-
-    #[async_trait::async_trait]
-    impl octos_llm::LlmProvider for EchoLlm {
-        async fn chat(
-            &self,
-            _messages: &[Message],
-            _tools: &[octos_llm::ToolSpec],
-            _config: &octos_llm::ChatConfig,
-        ) -> eyre::Result<octos_llm::ChatResponse> {
-            Ok(octos_llm::ChatResponse {
-                content: Some(self.reply.clone()),
-                reasoning_content: None,
-                tool_calls: Vec::new(),
-                stop_reason: octos_llm::StopReason::EndTurn,
-                usage: octos_llm::TokenUsage {
-                    input_tokens: 7,
-                    output_tokens: 11,
-                    ..Default::default()
-                },
-                provider_index: None,
-            })
-        }
-
-        fn model_id(&self) -> &str {
-            "m11d-echo"
-        }
-
-        fn provider_name(&self) -> &str {
-            "stub"
-        }
-
-        fn context_window(&self) -> u32 {
-            64_000
-        }
-    }
-
-    async fn make_m11d_profile(
-        data_dir: &std::path::Path,
-        reply: &str,
-    ) -> Arc<crate::runtime::ProfileRuntime> {
-        std::fs::create_dir_all(data_dir).unwrap();
-        let memory = Arc::new(octos_memory::EpisodeStore::open(data_dir).await.unwrap());
-        let memory_store = Arc::new(octos_memory::MemoryStore::open(data_dir).await.unwrap());
-        let tool_config = Arc::new(octos_agent::ToolConfigStore::open(data_dir).await.unwrap());
-        let sandbox = octos_agent::SandboxConfig::default();
-        let base_tools = octos_agent::ToolRegistry::with_builtins_and_sandbox(
-            data_dir,
-            octos_agent::create_sandbox(&sandbox),
-        );
-        Arc::new(crate::runtime::ProfileRuntime {
-            profile_id: MAIN_PROFILE_ID.to_string(),
-            data_dir: data_dir.to_path_buf(),
-            llm: Arc::new(EchoLlm {
-                reply: reply.to_string(),
-            }),
-            adaptive_router: None,
-            runtime_qos_catalog: None,
-            primary_model_id: "m11d-echo".to_string(),
-            provider_name: "stub".to_string(),
-            credentials: HashMap::new(),
-            skills_dir: None,
-            plugin_env_template: Vec::new(),
-            tool_policy: None,
-            default_sandbox: sandbox,
-            tool_specs: Arc::new(base_tools),
-            plugin_tool_names: Vec::new(),
-            plugin_dirs: Vec::new(),
-            plugin_prompt_fragments: Vec::new(),
-            plugin_hooks: Vec::new(),
-            system_prompt: "test-system-prompt".to_string(),
-            memory,
-            memory_store,
-            tool_config,
-            cron_service: None,
-            hook_executor: None,
-        })
-    }
-
-    #[tokio::test]
-    async fn chat_routes_through_session_runtime_when_profile_registered() {
-        // Acceptance evidence (M11-D Part 3): a `/api/chat` request lands
-        // in `chat_sync_via_session_runtime` whenever the routed profile
-        // is registered in `state.profiles`. The route is the exact
-        // structural path the live yangmi flow takes — it implies
-        // `SessionRuntime::bootstrap` ran, which writes the per-session
-        // `.octos-workspace.toml` (closing the "workspace policy not
-        // found" failure mode without any hotfix file at the daemon
-        // cwd).
-        let data_dir = tempfile::tempdir().unwrap();
-        let profile_data_dir = data_dir.path().join("profile-data");
-        let profile_runtime = make_m11d_profile(&profile_data_dir, "yangmi reply ack").await;
-
-        let mut profiles = HashMap::new();
-        profiles.insert(MAIN_PROFILE_ID.to_string(), profile_runtime.clone());
-        let state = Arc::new(AppState {
-            profiles,
-            ..AppState::empty_for_tests()
-        });
-
-        let req = ChatRequest {
-            message: "用 yangmi 语音说北京今天天气晴朗".to_string(),
-            session_id: Some("yangmi-trace-001".to_string()),
-            topic: None,
-            stream: false,
-            media: Vec::new(),
-            attach_only: false,
-            client_message_id: None,
-        };
-
-        let response = chat_sync(state.clone(), HeaderMap::new(), req)
-            .await
-            .expect("chat_sync must succeed via SessionRuntime path");
-        assert_eq!(response.content, "yangmi reply ack");
-        assert_eq!(response.input_tokens, 7);
-        assert_eq!(response.output_tokens, 11);
-
-        // The session runtime was materialized into the cache — a second
-        // call for the same session reuses the same `Arc<SessionRuntime>`.
-        let cache_len = state.session_cache.len().await;
-        assert_eq!(cache_len, 1, "session cache must hold one entry");
-
-        // The per-session workspace policy bootstrap actually ran — i.e.
-        // the yangmi gap is closed at the structural level.
-        let encoded = octos_bus::session::encode_path_component(&format!(
-            "{MAIN_PROFILE_ID}:api:yangmi-trace-001"
-        ));
-        let policy_path = profile_data_dir
-            .join("users")
-            .join(&encoded)
-            .join("workspace")
-            .join(".octos-workspace.toml");
-        assert!(
-            policy_path.exists(),
-            "SessionRuntime::bootstrap must write the workspace policy at {} \
-             without any operator-side hotfix",
-            policy_path.display(),
-        );
-    }
-
-    #[tokio::test]
-    async fn chat_returns_503_when_routed_profile_not_registered() {
-        // M11-F: the legacy `state.agent` fallback was deleted; an
-        // unregistered profile is a configuration bug, not a runtime
-        // fallback. `octos serve` bootstraps every profile in
-        // `ProfileStore::list()` at startup, so a request that lands on
-        // a profile id missing from `state.profiles` must fail closed
-        // with 503 SERVICE UNAVAILABLE (and a body that names the
-        // offending profile so operators can investigate).
-        let state = Arc::new(AppState::empty_for_tests());
-        let req = ChatRequest {
-            message: "ping".to_string(),
-            session_id: Some("legacy".to_string()),
-            topic: None,
-            stream: false,
-            media: Vec::new(),
-            attach_only: false,
-            client_message_id: None,
-        };
-
-        let result = chat_sync(state, HeaderMap::new(), req).await;
-        let (status, msg) = result
-            .err()
-            .expect("expected 503 when profile not registered");
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-        // The error must name the missing profile so the operator log
-        // surfaces the misrouted-request shape (not an opaque "no
-        // provider" message that pre-M11-F's legacy path returned).
-        assert!(
-            msg.contains(MAIN_PROFILE_ID),
-            "503 message must name the unregistered profile (got: {msg})",
-        );
-    }
-
-    /// M11-F regression fix REG-6: `chat_sync_via_session_runtime` must
-    /// forward `state.appui_default_session_cwd` as the session's
-    /// workspace hint when no client cwd is supplied. Pre-M11-F serve.rs
-    /// wired this into the server-wide agent via
-    /// `agent.with_workspace_root(default_cwd)` so every `/api/chat`
-    /// inherited it; M11-F's deletion of that helper left this
-    /// dispatcher path falling back to the canonical
-    /// `<data_dir>/users/.../workspace` instead of the operator setting.
-    #[tokio::test]
-    async fn chat_sync_forwards_appui_default_session_cwd_as_workspace_hint() {
-        let tmp = tempfile::tempdir().unwrap();
-        let profile_data_dir = tmp.path().join("profile-data");
-        let operator_cwd = tmp.path().join("operator-coding-workspace");
-        std::fs::create_dir_all(&operator_cwd).unwrap();
-        let profile_runtime = make_m11d_profile(&profile_data_dir, "ack").await;
-
-        let mut profiles = HashMap::new();
-        profiles.insert(MAIN_PROFILE_ID.to_string(), profile_runtime.clone());
-        let state = Arc::new(AppState {
-            profiles,
-            appui_default_session_cwd: Some(operator_cwd.clone()),
-            ..AppState::empty_for_tests()
-        });
-
-        let req = ChatRequest {
-            message: "anchor here".to_string(),
-            session_id: Some("reg6-trace".to_string()),
-            topic: None,
-            stream: false,
-            media: Vec::new(),
-            attach_only: false,
-            client_message_id: None,
-        };
-
-        let _response = chat_sync(state.clone(), HeaderMap::new(), req)
-            .await
-            .expect("chat_sync should succeed");
-
-        // After the first call, the cached SessionRuntime must be
-        // anchored at the operator-configured cwd (not the canonical
-        // `<profile_data_dir>/users/.../workspace`).
-        let session_key =
-            octos_core::SessionKey::with_profile(MAIN_PROFILE_ID, "api", "reg6-trace");
-        let session_runtime = state
-            .session_cache
-            .get_or_init(&profile_runtime, session_key, None)
-            .await
-            .expect("cached SessionRuntime");
-        let expected =
-            std::fs::canonicalize(&operator_cwd).unwrap_or_else(|_| operator_cwd.clone());
-        let actual = std::fs::canonicalize(&session_runtime.workspace_root)
-            .unwrap_or_else(|_| session_runtime.workspace_root.clone());
-        assert_eq!(
-            actual,
-            expected,
-            "SessionRuntime.workspace_root must equal appui.default_session_cwd \
-             when forwarded by chat_sync_via_session_runtime (got {})",
-            session_runtime.workspace_root.display()
-        );
-    }
+    // ────────── Legacy `POST /api/chat` REST tests retired ──────────
+    //
+    // The original M11-D block exercised `chat_sync` /
+    // `chat_sync_via_session_runtime` end-to-end via the
+    // `ChatRequest` shape. With the legacy REST entrypoint retired
+    // (cleanup follow-up to PR #908), the equivalent acceptance
+    // evidence now lives in:
+    //
+    //   * `crates/octos-cli/tests/coding_multi_session.rs`
+    //     — per-session `SessionRuntime::bootstrap` writes
+    //       `.octos-workspace.toml` AND multi-tenant tool registries
+    //       stay isolated when distinct `workspace_hint`s are pinned.
+    //   * `api::ui_protocol::tests` (`turn/start` happy path +
+    //     503-on-missing-profile-runtime) — WS handler hits the same
+    //     `SessionRuntimeCache::get_or_init` call site.
+    //
+    // The `appui_default_session_cwd` workspace-hint forwarding the
+    // M11-F regression-fix test asserted is now exercised directly
+    // through the WS turn dispatcher (`ui_protocol::run_standalone_turn`).
 }

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -94,17 +94,22 @@ pub fn build_router(state: Arc<AppState>) -> Router {
 
     // Chat + status API (existing)
     //
-    // M9-α-5/α-6 (ADR PR #830 / audit issue #845): the chat SSE
-    // transport (`POST /api/chat?stream=true`, `GET /api/chat/stream`,
-    // `GET /api/sessions/:id/events/stream`) has been deleted. The
-    // sole chat transport is `/api/ui-protocol/ws`. The legacy
-    // text-frame `/api/ws` was retired as a follow-up cleanup (it
-    // never carried the UI Protocol v1 wire format and had no live
-    // clients on the modern web/TUI). The harness/admin
-    // `/api/events/harness` SSE endpoint is unrelated to chat and
-    // remains.
+    // Transport history:
+    // - M9-α-5/α-6 (ADR PR #830 / audit issue #845): the chat SSE
+    //   transport (`POST /api/chat?stream=true`, `GET /api/chat/stream`,
+    //   `GET /api/sessions/:id/events/stream`) was deleted.
+    // - Cleanup PR #908: the legacy text-frame `/api/ws` was retired
+    //   (no live clients and it never carried the UI Protocol v1 wire
+    //   format).
+    // - Cleanup follow-up to #908: the surviving sync REST endpoint
+    //   `POST /api/chat` was retired once the last callers
+    //   (coding_multi_session integration test, three e2e specs,
+    //   validate-m4-1a-live.sh) migrated to the canonical WS path.
+    //
+    // The sole chat transport is `/api/ui-protocol/ws`. The
+    // harness/admin `/api/events/harness` SSE endpoint is unrelated to
+    // chat and remains.
     let chat_api = Router::new()
-        .route("/api/chat", post(handlers::chat))
         .route("/api/events/harness", get(events_harness::events_harness))
         .route("/api/ui-protocol/ws", get(ui_protocol::ws_handler))
         .route(
@@ -727,8 +732,7 @@ async fn user_auth_middleware(
         // Allow proxy auth for chat- and session-scoped endpoints, not admin.
         // Task-control verbs (`/api/tasks/{id}/cancel`, `/restart-from-node`)
         // are session-scoped — same trust posture as `/api/sessions`.
-        if uri_str.starts_with("/api/chat")
-            || uri_str.starts_with("/api/ui-protocol")
+        if uri_str.starts_with("/api/ui-protocol")
             || uri_str.starts_with("/api/upload")
             || uri_str.starts_with("/api/sessions")
             || uri_str.starts_with("/api/files")

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -4,19 +4,35 @@
 //! End-to-end test proving the N-sessions-per-profile invariant: two
 //! AppUI sessions opened on the SAME profile with DIFFERENT
 //! `workspace_hint`s must each observe their own files and never see
-//! each other's. The test drives the public `POST /api/chat` route via
-//! `build_router` + `tower::ServiceExt::oneshot` so the assertions
-//! exercise the production handler chain
-//! (`chat` → `chat_sync` → `chat_sync_via_session_runtime` →
-//! `SessionRuntimeCache::get_or_init` → `Agent::process_message`).
+//! each other's.
+//!
+//! # Wire-level dispatcher (post `POST /api/chat` retirement)
+//!
+//! The originating draft of this test drove `POST /api/chat` via
+//! `tower::ServiceExt::oneshot` because that was the production sync
+//! entry point. With the cleanup that retired the legacy REST chat
+//! handler (predecessor PR #908; the canonical chat transport is now
+//! `/api/ui-protocol/ws`), there is no synchronous in-process HTTP
+//! surface to drive. We could spin up a real tungstenite WebSocket
+//! against the in-process router, but the WS handler is async and
+//! delivers the final assistant content via `turn/completed`
+//! notifications, not a JSON response body — replicating it in a unit
+//! test would re-implement most of the WS run loop.
+//!
+//! Instead this test drives the **exact same production code path**
+//! that `chat_sync_via_session_runtime` did (and the WS `turn/start`
+//! pipeline still does today): resolve the per-session
+//! [`SessionRuntime`] from the cache (constructing it on first use),
+//! run [`octos_agent::Agent::process_message`] against the session-
+//! bound workspace, and persist the response through the canonical
+//! per-user JSONL via
+//! [`octos_bus::persist_message_through_canonical_path`]. Every
+//! invariant the original test cared about — `workspace_hint`
+//! forwarding, `ToolRegistry` isolation, per-session JSONL writes,
+//! per-session `.octos-workspace.toml` policy files — still surfaces
+//! at the same call site.
 //!
 //! # Step-by-step → invariant map
-//!
-//! Every assertion below is paired with the production code path it
-//! catches. The mapping is deliberate: a single mutation experiment
-//! (e.g. deleting `workspace_hint` handling in
-//! `SessionRuntime::bootstrap`) must surface as a SPECIFIC assertion
-//! failure, not a generic smoke regression.
 //!
 //! 1. Pre-warm the session cache for session A with hint = `repo-A`
 //!    → exercises [`SessionRuntime::bootstrap`]'s `workspace_hint`
@@ -24,39 +40,29 @@
 //!    `<data_dir>/users/<encoded base>/workspace` and the
 //!    "session A reads its own a.txt" assertion fails because the
 //!    workspace_root does not contain `a.txt`.
-//! 2. Drive `POST /api/chat` for session A with `read_file:a.txt`
-//!    → exercises the M11-D dispatcher and the workspace-bound
-//!    [`ToolRegistry`] cloned by [`SessionRuntime::bootstrap`].
-//!    Assertion: response body contains `"hello-A"` (the per-session
-//!    cwd was actually honored by the tool call).
-//! 3. Drive `POST /api/chat` for session B with `read_file:a.txt`
-//!    → the cross-read MUST fail. Assertion: response body contains
-//!    a "not found" / "outside working directory" marker. If the two
-//!    sessions shared a workspace, B would see A's file and this
-//!    assertion would fail. This is the multi-tenant-leak gate
-//!    codex flagged on PR #868.
-//! 4. Drive `POST /api/chat` for session B with `read_file:b.txt`
-//!    → response body contains `"hello-B"`. Symmetric check that B's
-//!    own workspace is wired correctly.
+//! 2. Drive the agent loop for session A with `read_file:a.txt`
+//!    → exercises the workspace-bound [`ToolRegistry`] cloned by
+//!    [`SessionRuntime::bootstrap`]. Assertion: response content
+//!    contains `"hello-A"` (the per-session cwd was actually honored
+//!    by the tool call).
+//! 3. Drive the agent loop for session B with `read_file:a.txt`
+//!    → the cross-read MUST fail. Assertion: response content
+//!    contains a "not found" / "outside working directory" marker.
+//!    If the two sessions shared a workspace, B would see A's file
+//!    and this assertion would fail. This is the multi-tenant-leak
+//!    gate codex flagged on PR #868.
+//! 4. Drive the agent loop for session B with `read_file:b.txt`
+//!    → response content contains `"hello-B"`. Symmetric check that
+//!    B's own workspace is wired correctly.
 //! 5. Assert independent canonical JSONL chat history files exist
 //!    under each session's `user_key` directory.
-//!    → exercises `persist_chat_message_through_canonical` writing
-//!    per-session paths derived from `SessionKey`.
+//!    → exercises `octos_bus::persist_message_through_canonical_path`
+//!    writing per-session paths derived from `SessionKey`.
 //! 6. Assert per-session `.octos-workspace.toml` files exist at
 //!    `repo-A/.octos-workspace.toml` AND `repo-B/.octos-workspace.toml`.
 //!    → exercises [`SessionRuntime::bootstrap`]'s
 //!    `write_workspace_policy_if_absent` step. If the policy write is
 //!    skipped, the M11-D yangmi gap re-opens.
-//!
-//! The mutation experiment required by the issue: delete the
-//! `workspace_hint` path in
-//! `crates/octos-cli/src/runtime/session.rs::resolve_workspace_root`
-//! (so the function always returns the data-dir-relative default).
-//! Step 2's "hello-A" assertion fails first because session A's
-//! workspace becomes the data-dir-relative path (no `a.txt` present);
-//! step 6's policy-at-repo-A path also disappears because the bootstrap
-//! writes the policy under the default workspace, not `repo-A`. The
-//! failing transcript is pasted into the PR description.
 
 #![cfg(feature = "api")]
 
@@ -64,15 +70,12 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::body::Body;
-use axum::http::{Request, StatusCode};
-use octos_cli::api::{AppState, build_router};
+use octos_cli::api::AppState;
 use octos_cli::runtime::ProfileRuntime;
 use octos_core::{MAIN_PROFILE_ID, Message, MessageRole, SessionKey, ToolCall};
 use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
 use serde_json::json;
 use tempfile::TempDir;
-use tower::util::ServiceExt;
 
 /// Stub LLM that simulates a coding-agent turn.
 ///
@@ -91,7 +94,7 @@ use tower::util::ServiceExt;
 ///   result appended — that second pass takes the first branch above.
 ///
 /// This is the minimal shape needed to drive a `read_file` turn
-/// through the M11-D `/api/chat` dispatcher without any external API
+/// through the `SessionRuntime` dispatcher without any external API
 /// keys or real LLM provider, mirroring the
 /// `qos_catalog::StubProvider` and the M11-C/D `EchoLlm` pattern.
 struct ReadFileStubLlm;
@@ -216,56 +219,73 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
     })
 }
 
-/// Drive a single `POST /api/chat` request through the assembled
-/// router. Returns the response body parsed into the same shape the
-/// production [`octos_cli::api::handlers::chat`] handler emits.
-async fn post_chat(
-    app: &axum::Router,
+/// In-process equivalent of a single chat turn against the canonical
+/// transport.
+///
+/// Mirrors the inner loop shared by `chat_sync_via_session_runtime`
+/// (deleted with the legacy REST chat route) and the WS UI Protocol's
+/// `turn/start` pipeline. Both: resolve the per-session
+/// `SessionRuntime` from the cache (constructing it on first use),
+/// load history, run `Agent::process_message`, and persist every
+/// produced `Message` through the canonical per-user JSONL.
+///
+/// Returns the assistant content as the agent loop produced it — the
+/// same string the legacy `ChatResponse.content` carried and the WS
+/// `turn/completed` notification streams. Per-session tool failures
+/// surface inside this `String` (matching what
+/// `ToolRegistry::execute` writes back when `read_file` cannot find
+/// the requested path), so the test can assert against it directly.
+async fn drive_turn(
+    state: &Arc<AppState>,
+    profile: &Arc<ProfileRuntime>,
     session_id: &str,
     message: &str,
-) -> (StatusCode, serde_json::Value) {
-    let body = serde_json::to_string(&json!({
-        "message": message,
-        "session_id": session_id,
-        "stream": false,
-    }))
-    .expect("serialize chat request");
-
-    let resp = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/chat")
-                .header("content-type", "application/json")
-                .body(Body::from(body))
-                .unwrap(),
-        )
+) -> String {
+    let session_key = SessionKey::with_profile_topic(MAIN_PROFILE_ID, "api", session_id, "");
+    let session_runtime = state
+        .session_cache
+        .get_or_init(profile, session_key.clone(), None)
         .await
-        .expect("router serves chat request");
+        .expect("bootstrap session runtime");
 
-    let status = resp.status();
-    let bytes = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
-        .await
-        .expect("read response body");
-    let parsed = if bytes.is_empty() {
-        serde_json::Value::Null
-    } else {
-        serde_json::from_slice(&bytes).unwrap_or_else(|err| {
-            panic!(
-                "expected JSON body, got {err}; raw={}",
-                String::from_utf8_lossy(&bytes)
-            )
-        })
+    let history: Vec<Message> = {
+        let mut sess = session_runtime.sessions.lock().await;
+        let session = sess.get_or_create(&session_key).await;
+        session.get_history(50).to_vec()
     };
-    (status, parsed)
+
+    let response = session_runtime
+        .agent
+        .process_message(message, &history, vec![])
+        .await
+        .expect("agent must produce a turn");
+
+    let data_dir = {
+        let manager = session_runtime.sessions.lock().await;
+        manager.data_dir()
+    };
+    for msg in &response.messages {
+        let _ =
+            octos_bus::persist_message_through_canonical_path(&data_dir, &session_key, msg.clone())
+                .await;
+    }
+    // Drop any stale `SessionManager` cache entry so a follow-up read
+    // (duplicate-detection, history reload) consults disk instead of
+    // returning a pre-write empty `Session`. Mirrors what the deleted
+    // `persist_chat_message_through_canonical` helper did.
+    {
+        let mut manager = session_runtime.sessions.lock().await;
+        manager.invalidate_cache(&session_key);
+    }
+
+    response.content
 }
 
 #[tokio::test]
 async fn coding_agent_two_sessions_isolated_workspaces() {
-    // 1. Boot a `serve` instance with one profile + a stub LLM. We use
-    //    `MAIN_PROFILE_ID` because `POST /api/chat` without any routing
-    //    header falls back to it (see `api_profile_id_from_headers`).
+    // 1. Boot a `serve`-equivalent process state with one profile + a
+    //    stub LLM. We use `MAIN_PROFILE_ID` for parity with the legacy
+    //    `POST /api/chat` no-routing-header default.
     let temp = TempDir::new().expect("tempdir");
     let profile_data_dir = temp.path().join("profile-data");
     let profile_runtime = make_m11g_profile(MAIN_PROFILE_ID, &profile_data_dir).await;
@@ -276,7 +296,6 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
         profiles,
         ..AppState::empty_for_tests()
     });
-    let app = build_router(state.clone());
 
     // 2. Pre-seed two distinct "repo" workspaces. Using `tempfile`
     //    instead of literal `/tmp/repo-A` so parallel `cargo test` runs
@@ -288,15 +307,12 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
     std::fs::write(repo_a.join("a.txt"), "hello-A\n").expect("seed a.txt");
     std::fs::write(repo_b.join("b.txt"), "hello-B\n").expect("seed b.txt");
 
-    // 3. The session keys POST /api/chat will resolve to (handlers.rs
-    //    builds these via `standalone_api_session_key_with_topic` →
-    //    `SessionKey::with_profile_topic`). We use them to pre-warm
-    //    the session cache with the desired `workspace_hint` per
-    //    session — the cache is single-flight per key, so the
-    //    subsequent `chat_sync_via_session_runtime` call that passes
-    //    `None` for the hint reuses the cached runtime built against
-    //    the supplied repo. This mirrors how `session/open` (M11-E)
-    //    threads the hint into the cache ahead of any turn.
+    // 3. The session keys we drive turns against. We pre-warm the
+    //    cache with the desired `workspace_hint` per session — the
+    //    cache is single-flight per key, so subsequent `drive_turn`
+    //    calls reuse the cached runtime built against the supplied
+    //    repo. This mirrors how `session/open` (M11-E) threads the
+    //    hint into the cache ahead of any turn.
     let session_a_id = "coding-multi-session-A";
     let session_b_id = "coding-multi-session-B";
     let key_a = SessionKey::with_profile_topic(MAIN_PROFILE_ID, "api", session_a_id, "");
@@ -338,15 +354,7 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
     );
 
     // 4. Session A reads its own a.txt → response carries "hello-A".
-    let (status_a, body_a) = post_chat(&app, session_a_id, "read_file:a.txt").await;
-    assert_eq!(
-        status_a,
-        StatusCode::OK,
-        "session A read_file(a.txt) must return 200; body={body_a}",
-    );
-    let content_a = body_a["content"]
-        .as_str()
-        .unwrap_or_else(|| panic!("session A response missing content field: {body_a}"));
+    let content_a = drive_turn(&state, &profile_runtime, session_a_id, "read_file:a.txt").await;
     assert!(
         content_a.contains("hello-A"),
         "session A's read_file(a.txt) must observe its own workspace; \
@@ -357,16 +365,8 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
     //    marker. Session B's workspace is `repo-B`; `a.txt` only
     //    exists under `repo-A`. If the workspace-bound `ToolRegistry`
     //    leaked across sessions, B would observe A's file here.
-    let (status_b_cross, body_b_cross) = post_chat(&app, session_b_id, "read_file:a.txt").await;
-    assert_eq!(
-        status_b_cross,
-        StatusCode::OK,
-        "request must return 200 — the FAILURE is at the tool layer, \
-         carried in the response body; got body={body_b_cross}",
-    );
-    let content_b_cross = body_b_cross["content"]
-        .as_str()
-        .unwrap_or_else(|| panic!("session B response missing content field: {body_b_cross}"));
+    let content_b_cross =
+        drive_turn(&state, &profile_runtime, session_b_id, "read_file:a.txt").await;
     let content_b_cross_lower = content_b_cross.to_lowercase();
     assert!(
         !content_b_cross.contains("hello-A"),
@@ -382,15 +382,7 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
     );
 
     // 6. Session B reads its own b.txt → response carries "hello-B".
-    let (status_b, body_b) = post_chat(&app, session_b_id, "read_file:b.txt").await;
-    assert_eq!(
-        status_b,
-        StatusCode::OK,
-        "session B read_file(b.txt) must return 200; body={body_b}",
-    );
-    let content_b = body_b["content"]
-        .as_str()
-        .unwrap_or_else(|| panic!("session B response missing content field: {body_b}"));
+    let content_b = drive_turn(&state, &profile_runtime, session_b_id, "read_file:b.txt").await;
     assert!(
         content_b.contains("hello-B"),
         "session B's read_file(b.txt) must observe its own workspace; \
@@ -399,7 +391,6 @@ async fn coding_agent_two_sessions_isolated_workspaces() {
 
     // 7. Independent canonical chat history JSONLs under each
     //    session's user_key directory. Layout follows
-    //    `persist_chat_message_through_canonical` →
     //    `octos_bus::persist_message_through_canonical_path` →
     //    `<data_dir>/users/<encoded base_key>/sessions/<encoded topic>.jsonl`.
     //    Both files must exist AND contain their respective session's

--- a/e2e/lib/capture-replay.ts
+++ b/e2e/lib/capture-replay.ts
@@ -1,11 +1,21 @@
 // Capture-and-replay infrastructure for live e2e soak runs (PR I).
 //
 // Goal: when a live spec fails (or any time `OCTOS_CAPTURE_FIXTURE=1` is set)
-// auto-save the SSE event stream + final DOM state + assertion failure to
+// auto-save the streamed event log + final DOM state + assertion failure to
 // `e2e/fixtures/captured/<test-name>-<timestamp>.json`. Captured fixtures
 // can then be promoted to Layer 1 (`crates/octos-web/src/state/__tests__/
 // fixtures/captured/`) via `scripts/promote-captured-fixture.sh` to lock in
 // the regression.
+//
+// Transport note: the original PR I shipped while chat turns rode the
+// `POST /api/chat` SSE stream. That route was retired post-PR #908; the
+// canonical chat transport is now `/api/ui-protocol/ws`, which frames its
+// JSON-RPC notifications through a WebSocket rather than `fetch`. The
+// fetch / EventSource monkey-patches below still capture any fetch-based
+// stream the SPA opens, but they no longer see chat frames by default —
+// callers that need WS-frame capture should run M9WsClient-driven specs
+// directly (which already maintain their own notification log) instead
+// of relying on this page-side tee.
 //
 // The captured JSON is a SUPERSET of the PR H `SseFixture` format:
 //   {
@@ -36,13 +46,16 @@
 // Implementation strategy:
 //
 //  * Page-side `addInitScript` monkey-patches `fetch` to tee streaming
-//    `/api/chat` responses into `window.__octosCaptureBuffer`. The SPA sees
-//    an unchanged response; we get a side-channel copy. This works for
-//    chunked-encoding SSE (which is what `static/app.js` uses) AND for
-//    classic `text/event-stream` responses if the page ever switches.
+//    responses into `window.__octosCaptureBuffer`. The SPA sees an
+//    unchanged response; we get a side-channel copy. This works for
+//    classic `text/event-stream` responses and chunked-encoding streams
+//    on any fetch-based endpoint the caller lists in `streamingPaths`.
+//    Chat traffic now rides `/api/ui-protocol/ws` (post-#908) and does
+//    NOT come through fetch — capturing chat frames requires a parallel
+//    `M9WsClient` instance, not this helper.
 //
-//  * `EventSource` is also wrapped (LogPanel etc. uses native EventSource).
-//    Best-effort; main coverage is `/api/chat`.
+//  * `EventSource` is also wrapped (LogPanel etc. uses native
+//    EventSource). Best-effort; chat is no longer in scope here.
 //
 //  * Capture overhead: one extra TransformStream + one in-page array push
 //    per chunk. Negligible vs. the network and rendering work the page is
@@ -62,7 +75,7 @@ import type { Page, TestInfo } from '@playwright/test';
 export interface RawSseEvent {
   /** Wall-clock ms since capture started. */
   t: number;
-  /** Origin URL (the streaming endpoint, e.g. `/api/chat`). */
+  /** Origin URL (the fetch-streaming endpoint). */
   url: string;
   /** Source channel: `fetch-stream` | `eventsource` | `dom-marker`. */
   source: 'fetch-stream' | 'eventsource' | 'dom-marker';
@@ -112,8 +125,10 @@ export interface CaptureOptions {
   outputDir?: string;
   /** Human description; defaults to test title. */
   description?: string;
-  /** Streaming endpoints to capture. Match by URL substring. Default
-   *  matches `/api/chat`, `/api/sessions/`, `/api/tasks/`. */
+  /** Streaming fetch endpoints to capture. Match by URL substring.
+   *  Default: empty — chat traffic moved off `fetch` post-#908. Callers
+   *  should pass the specific path(s) of any remaining fetch/SSE
+   *  endpoint they want teed. */
   streamingPaths?: string[];
 }
 
@@ -182,11 +197,13 @@ export async function attachCapture(
   // before starting to decode — see the matchUrl + content-type filter
   // inside the init script.
   //
-  // Default narrowed to `/api/chat` only (per codex review): the broader
-  // `/api/sessions/` and `/api/tasks/` paths include polling endpoints
-  // that return JSON, not SSE, and teeing those needlessly burns CPU.
-  // Override `streamingPaths` if you have a custom streaming endpoint.
-  const streamingPaths = opts.streamingPaths ?? ['/api/chat'];
+  // Default narrowed to nothing: chat traffic moved to `/api/ui-protocol/ws`
+  // post-#908, so there is no built-in fetch-streaming endpoint left to
+  // tee. Callers can still capture their own SSE/NDJSON endpoints by
+  // passing `streamingPaths`. With an empty list the page-side init
+  // script installs the patches but never matches a URL, so the SPA
+  // runs unmodified.
+  const streamingPaths = opts.streamingPaths ?? [];
 
   // Hard cap on the page-side buffer to bound disk usage from a runaway
   // soak run. Configurable via env. Beyond this we drop frames silently
@@ -270,7 +287,9 @@ export async function attachCapture(
         }
       };
 
-      // Patch fetch to tee streaming /api/chat (and similar) responses.
+      // Patch fetch to tee any streaming response whose URL matches one
+      // of the configured `streamingPaths`. With an empty list (the
+      // post-#908 default) this is a no-op.
       const origFetch = w.fetch.bind(w);
       w.fetch = async function patchedFetch(
         input: RequestInfo | URL,
@@ -289,8 +308,7 @@ export async function attachCapture(
         // (e.g. polling endpoints) carry `application/json` and get short
         // circuited here so we don't burn CPU decoding chunks of fully
         // buffered JSON. SSE responses set `text/event-stream`; chunked
-        // streams without a content-type are also accepted (they're how
-        // the static SPA's `/api/chat` returns its frames).
+        // streams without a content-type are also accepted.
         const ct = (resp.headers.get('content-type') || '').toLowerCase();
         const isStream =
           ct.includes('text/event-stream') ||

--- a/e2e/scripts/ws-chat.mjs
+++ b/e2e/scripts/ws-chat.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Tiny standalone driver for a single chat turn over the M9 UI Protocol
+ * WebSocket. Used by validate-m4-1a-live.sh and other bash-based release
+ * gates that previously POSTed `POST /api/chat` (retired post-#908).
+ *
+ * Wire contract:
+ *   session/open + turn/start with one text input item, then collect
+ *   notifications until `turn/completed`, `turn/error`, or the deadline
+ *   elapses. Mirrors the inner loop in e2e/lib/m9-ws-client.ts::chatWS
+ *   but with zero TypeScript / Playwright deps so it can run from a
+ *   plain shell harness.
+ *
+ * Usage:
+ *   node ws-chat.mjs \
+ *     --url http://127.0.0.1:56831 \
+ *     --token octos-admin-2026 \
+ *     --session m4-1a-live-… \
+ *     --message "deep research prompt" \
+ *     [--profile dspfac] \
+ *     [--max-wait-ms 90000]
+ *
+ * Exit code:
+ *   0  turn/completed received
+ *   2  bad usage
+ *   3  WS connection or RPC error
+ *   4  deadline elapsed without turn/completed
+ *
+ * Output (stdout, single line):
+ *   {"status":"completed","content":"…","events":[…]}  (on success)
+ *   {"status":"error","message":"…"}                   (on failure)
+ */
+
+import WebSocket from 'ws';
+import { randomBytes, randomUUID } from 'node:crypto';
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (!k.startsWith('--')) continue;
+    const key = k.slice(2);
+    const v = argv[i + 1];
+    if (v && !v.startsWith('--')) {
+      out[key] = v;
+      i++;
+    } else {
+      out[key] = true;
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const url = args.url;
+const token = args.token;
+const sessionId = args.session;
+const message = args.message;
+const profileId = args.profile;
+const maxWaitMs = Number(args['max-wait-ms'] || 60_000);
+
+if (!url || !token || !sessionId || !message) {
+  console.error('usage: ws-chat.mjs --url <url> --token <t> --session <id> --message <msg> [--profile <p>] [--max-wait-ms <n>]');
+  process.exit(2);
+}
+
+const wsUrl = url
+  .replace(/^http:/, 'ws:')
+  .replace(/^https:/, 'wss:')
+  .replace(/\/$/, '')
+  .concat(url.includes('/api/ui-protocol/ws') ? '' : '/api/ui-protocol/ws');
+
+const ws = new WebSocket(wsUrl, { headers: { Authorization: `Bearer ${token}` } });
+
+const pending = new Map();
+let content = '';
+const events = [];
+let turnId;
+let done = false;
+let timer;
+
+function send(method, params) {
+  const id = `req-${Date.now()}-${randomBytes(2).toString('hex')}`;
+  ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }));
+  return new Promise((resolve, reject) => {
+    const to = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`rpc timeout: ${method}`));
+    }, 30_000);
+    pending.set(id, {
+      resolve: (v) => { clearTimeout(to); resolve(v); },
+      reject: (e) => { clearTimeout(to); reject(e); },
+    });
+  });
+}
+
+function finish(payload, exitCode) {
+  if (done) return;
+  done = true;
+  clearTimeout(timer);
+  console.log(JSON.stringify(payload));
+  try { ws.close(); } catch { /* ignore */ }
+  setTimeout(() => process.exit(exitCode), 50);
+}
+
+ws.on('open', async () => {
+  try {
+    await send('session/open', { session_id: sessionId, profile_id: profileId });
+    turnId = randomUUID();
+    await send('turn/start', {
+      session_id: sessionId,
+      turn_id: turnId,
+      input: [{ kind: 'text', text: message }],
+    });
+    timer = setTimeout(() => {
+      finish({ status: 'timeout', content, events }, 4);
+    }, maxWaitMs);
+  } catch (err) {
+    finish({ status: 'error', message: String(err?.message ?? err) }, 3);
+  }
+});
+
+ws.on('message', (data) => {
+  let frame;
+  try { frame = JSON.parse(data.toString()); } catch { return; }
+  if (frame && 'id' in frame && frame.id != null) {
+    const p = pending.get(String(frame.id));
+    if (p) {
+      pending.delete(String(frame.id));
+      if (frame.error) p.reject(new Error(`rpc-error[${frame.error.code}] ${frame.error.message}`));
+      else p.resolve(frame.result);
+    }
+    return;
+  }
+  if (frame && frame.method) {
+    const params = frame.params || {};
+    if (params.turn_id !== undefined && params.turn_id !== turnId) return;
+    events.push({ method: frame.method, params });
+    switch (frame.method) {
+      case 'message/delta':
+        if (typeof params.text === 'string') content += params.text;
+        break;
+      case 'turn/completed':
+        finish({ status: 'completed', content, events }, 0);
+        break;
+      case 'turn/error':
+        finish({ status: 'error', message: params.message || params.code || 'turn/error', events }, 3);
+        break;
+    }
+  }
+});
+
+ws.on('error', (err) => {
+  finish({ status: 'error', message: `ws-error: ${err.message}` }, 3);
+});
+
+ws.on('close', () => {
+  if (!done) finish({ status: 'error', message: 'ws-closed-before-turn-completed' }, 3);
+});

--- a/e2e/tests/refactor-capabilities.spec.ts
+++ b/e2e/tests/refactor-capabilities.spec.ts
@@ -25,14 +25,16 @@ test.setTimeout(240_000);
 type SseEvent = ChatWsEvent;
 
 /**
- * M9-α-7 (#836): chat helper now drives the M9 WebSocket UI Protocol.
+ * M9-α-7 (#836): chat helper drives the M9 WebSocket UI Protocol —
+ * `/api/ui-protocol/ws`. The legacy `POST /api/chat` route was retired
+ * as a follow-up to PR #908.
  *
  * NOTE: The legacy SSE helper accepted an optional `topic` field on the
- * `/api/chat` body — used by `topic-scoped histories` to partition a single
- * session_id into isolated conversation threads. The M9 `turn/start` request
- * does NOT yet have a `topic` parameter (deferred follow-up). Tests that
- * pass `topic` are marked `test.fixme` until the WS protocol grows the
- * field.
+ * request body — used by `topic-scoped histories` to partition a single
+ * session_id into isolated conversation threads. The M9 `turn/start`
+ * request does NOT yet have a `topic` parameter (deferred follow-up).
+ * Tests that pass `topic` are marked `test.fixme` until the WS protocol
+ * grows the field.
  */
 async function chatViaWs(
   message: string,
@@ -91,9 +93,10 @@ function taskCurrentPhase(task: any): string | undefined {
 }
 
 test.describe('Refactor capability proofs', () => {
-  // Deferred follow-up: the `topic` parameter on `/api/chat` is not yet
-  // mirrored on the M9 `turn/start` request — un-fixme once the WS protocol
-  // gains a `topic` field on `TurnStartParams`.
+  // Deferred follow-up: the legacy SSE chat body carried an optional
+  // `topic` parameter that has not yet been mirrored on the M9
+  // `turn/start` request — un-fixme once the WS protocol gains a
+  // `topic` field on `TurnStartParams`.
   test.fixme('same session id can host separate topic-scoped histories', async () => {
     const sid = `cap-topic-${Date.now()}`;
     const baseMarker = `BASE-${Date.now()}`;

--- a/e2e/tests/session-list-regression.spec.ts
+++ b/e2e/tests/session-list-regression.spec.ts
@@ -100,12 +100,13 @@ test.describe('session list regressions', () => {
     await login(page);
     await createNewSession(page);
 
-    let chatPosts = 0;
-    page.on('request', (request) => {
-      if (request.method() === 'POST' && new URL(request.url()).pathname === '/api/chat') {
-        chatPosts += 1;
-      }
-    });
+    // The pre-WS version asserted exactly one `POST /api/chat` was made,
+    // proving deep-research did not fan out into multiple user-visible
+    // turns. The modern SPA streams turns over `/api/ui-protocol/ws` and
+    // does not POST `/api/chat` (retired post-#908), so this counter is
+    // no longer the right invariant — the child_session_key task count
+    // poll below is the authoritative check that exactly one deep
+    // research child fanned out.
 
     await getInput(page).fill('深度搜索一下美国伊朗第二轮谈判可能的后果');
     await getSendButton(page).click();
@@ -120,8 +121,6 @@ test.describe('session list regressions', () => {
         { timeout: 90_000, intervals: [2_000, 3_000, 5_000] },
       )
       .toBe(1);
-
-    expect(chatPosts).toBe(1);
 
     await expect
       .poll(

--- a/e2e/tests/tool-use-regression.spec.ts
+++ b/e2e/tests/tool-use-regression.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Regression tests for tool-use bugs via the web API.
+ * Regression tests for tool-use bugs via the canonical chat transport.
  *
  * These tests exercise the exact tool-use sequences that triggered:
  *   1. activate_tools "tool registry not available" (OnceLock stale Weak bug)
@@ -8,16 +8,43 @@
  * Run against a live octos-serve instance:
  *   OCTOS_TEST_URL=http://localhost:3000 OCTOS_AUTH_TOKEN=<token> npx playwright test
  *
- * The tests use the /api/chat (sync) and /api/admin/shell endpoints.
+ * Transport: chat turns ride the M9 WebSocket UI Protocol via `chatWS()`
+ * (`/api/ui-protocol/ws`). The legacy `POST /api/chat` route was retired
+ * in the cleanup that followed PR #908; this spec was migrated as part
+ * of that cutover.
  */
 import { test, expect } from '@playwright/test';
+import { chatWS, type ChatWsResult } from '../lib/m9-ws-client';
 
 const AUTH_TOKEN = process.env.OCTOS_AUTH_TOKEN || '';
+const PROFILE_ID = process.env.OCTOS_PROFILE || undefined;
 
 function headers() {
   const h: Record<string, string> = { 'Content-Type': 'application/json' };
   if (AUTH_TOKEN) h['Authorization'] = `Bearer ${AUTH_TOKEN}`;
   return h;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: drive a single chat turn over the WS UI Protocol. Returns
+// `{ events, content, doneEvent }` shape preserved from `chatWS()` so
+// callers can introspect tool calls / progress in addition to the
+// final assistant content.
+// ---------------------------------------------------------------------------
+async function chatTurn(
+  baseURL: string,
+  message: string,
+  sessionId: string,
+  opts: { maxWait?: number } = {},
+): Promise<ChatWsResult> {
+  return chatWS({
+    baseUrl: baseURL,
+    token: AUTH_TOKEN,
+    profileId: PROFILE_ID,
+    message,
+    sessionId,
+    maxWait: opts.maxWait ?? 90_000,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -96,44 +123,36 @@ test('ffmpeg concat works in sandbox workdir', async ({ request, baseURL }) => {
 // then sending another message in a NEW session (different session_id) which
 // also triggers activate_tools. Both should succeed.
 // ---------------------------------------------------------------------------
-test('activate_tools works across different sessions', async ({ request, baseURL }) => {
+test('activate_tools works across different sessions', async ({ baseURL }) => {
   test.setTimeout(300_000);
   test.skip(!AUTH_TOKEN, 'OCTOS_AUTH_TOKEN required');
 
   // Session A: trigger activate_tools without also asking for shell execution.
   // This keeps the proof focused on the registry rewire bug: stale OnceLock
   // references used to fail with "tool registry not available" in session B.
-  const resA = await request.post(`${baseURL}/api/chat`, {
-    headers: headers(),
-    data: {
-      message: 'Call activate_tools with exactly ["shell"] once, then reply "session_a_ok".',
-      session_id: `test-session-a-${Date.now()}`,
-      stream: false,
-    },
-    timeout: 180_000,
-  });
+  const resA = await chatTurn(
+    baseURL!,
+    'Call activate_tools with exactly ["shell"] once, then reply "session_a_ok".',
+    `test-session-a-${Date.now()}`,
+    { maxWait: 180_000 },
+  );
 
   // We may get an error if no agent is configured (standalone mode),
-  // but the key test is that it doesn't fail with "tool registry not available"
-  if (resA.ok()) {
-    const bodyA = await resA.json();
-    expect(bodyA.content).not.toContain('tool registry not available');
+  // but the key test is that it doesn't fail with "tool registry not available".
+  if (resA.doneEvent?.type === 'done') {
+    expect(resA.content).not.toContain('tool registry not available');
   }
 
   // Session B: different session → may trigger a new SessionActor
-  const resB = await request.post(`${baseURL}/api/chat`, {
-    headers: headers(),
-    data: {
-      message: 'Call activate_tools with exactly ["shell"] once, then reply "session_b_ok".',
-      session_id: `test-session-b-${Date.now()}`,
-      stream: false,
-    },
-    timeout: 180_000,
-  });
+  const resB = await chatTurn(
+    baseURL!,
+    'Call activate_tools with exactly ["shell"] once, then reply "session_b_ok".',
+    `test-session-b-${Date.now()}`,
+    { maxWait: 180_000 },
+  );
 
-  if (resB.ok()) {
-    const bodyB = await resB.json();
-    expect(bodyB.content).not.toContain('tool registry not available');
+  if (resB.doneEvent?.type === 'done') {
+    expect(resB.content).not.toContain('tool registry not available');
   }
 });
 
@@ -145,7 +164,6 @@ test('activate_tools works across different sessions', async ({ request, baseURL
 // If any link in the chain is broken, this test fails.
 // ---------------------------------------------------------------------------
 test('full tool chain: chat triggers activate_tools → shell → ffmpeg', async ({
-  request,
   baseURL,
 }) => {
   test.setTimeout(180_000);
@@ -155,38 +173,26 @@ test('full tool chain: chat triggers activate_tools → shell → ffmpeg', async
   const prompt =
     'If shell is not already active, call activate_tools with exactly ["shell"] once and only once. Then call shell exactly once with this command: ffmpeg -version 2>&1 | head -1. Do not inspect available tools, do not call activate_tools repeatedly, and return only the ffmpeg version line.';
 
-  const sendPrompt = async (message: string, sessionId: string) =>
-    request.post(`${baseURL}/api/chat`, {
-      headers: headers(),
-      data: {
-        message,
-        session_id: sessionId,
-        stream: false,
-      },
-      timeout: 90_000,
-    });
+  let res = await chatTurn(baseURL!, prompt, baseSessionId);
 
-  let res = await sendPrompt(prompt, baseSessionId);
-
-  if (res.ok()) {
-    let body = await res.json();
-    if (typeof body.content === 'string' && body.content.includes('[LOOP DETECTED]')) {
-      res = await sendPrompt(
+  if (res.doneEvent?.type === 'done') {
+    if (res.content.includes('[LOOP DETECTED]')) {
+      res = await chatTurn(
+        baseURL!,
         'Call activate_tools(["shell"]) at most once, then call shell("ffmpeg -version 2>&1 | head -1") exactly once, then stop. Return only the ffmpeg version line.',
         `${baseSessionId}-retry`,
       );
-      if (!res.ok()) {
+      if (res.doneEvent?.type !== 'done') {
         return;
       }
-      body = await res.json();
     }
     // Should contain ffmpeg version string, NOT "tool registry not available"
     // or "ffmpeg: not found"
-    expect(body.content).not.toContain('tool registry not available');
-    expect(body.content).not.toContain('not found');
-    expect(body.content).not.toContain('not installed');
+    expect(res.content).not.toContain('tool registry not available');
+    expect(res.content).not.toContain('not found');
+    expect(res.content).not.toContain('not installed');
     // Positive check: should mention ffmpeg version somewhere
-    expect(body.content.toLowerCase()).toContain('ffmpeg');
+    expect(res.content.toLowerCase()).toContain('ffmpeg');
   }
 });
 

--- a/scripts/validate-m4-1a-live.sh
+++ b/scripts/validate-m4-1a-live.sh
@@ -5,7 +5,16 @@
 # that the full structured progress pipeline works end-to-end on a real
 # canary: deep-research emits octos.harness.event.v1 events, the runtime sink
 # folds them into durable task_status, the UI replays them through chat, and
-# /api/sessions/:id/tasks + the SSE event stream both expose the same truth.
+# /api/sessions/:id/tasks reflects the same truth as the WS UI Protocol
+# notification stream.
+#
+# Transport: chat traffic and per-session event projection both ride
+# `/api/ui-protocol/ws` (canonical M9 UI Protocol v1). The earlier draft of
+# this script POSTed to the legacy REST endpoint `/api/chat` and tailed the
+# `/api/sessions/:id/events/stream` SSE; both were retired post-PR #908.
+# A single chat turn is now driven by `e2e/scripts/ws-chat.mjs`, and the
+# WS notification log captured by that script doubles as the "snapshot"
+# equivalent the script used to fetch over SSE.
 #
 # The script is idempotent — two back-to-back runs produce identical
 # decisions. It exits 0 when all assertions pass, or a non-zero code with a
@@ -188,51 +197,58 @@ probe_health() {
 }
 
 start_deep_research() {
-  # The backend expects a simple chat POST with the profile+auth headers.
-  # We intentionally submit a fresh session label so the script is idempotent:
-  # two back-to-back runs create sibling sessions and do not reuse state.
+  # Drive a single chat turn over `/api/ui-protocol/ws` via the
+  # standalone `e2e/scripts/ws-chat.mjs` helper. We intentionally submit
+  # a fresh session label so the script is idempotent: two back-to-back
+  # runs create sibling sessions and do not reuse state. The helper
+  # writes a single JSON line to stdout (`{status, content, events}`) —
+  # we tee it into ${OUTPUT_DIR}/submit.body so it doubles as the
+  # captured-snapshot artifact below.
   local session_id="m4-1a-live-$(date -u +%Y%m%dT%H%M%SZ)-$$"
-  log "submitting deep research prompt to session $session_id"
-  local body
-  body="$(jq -n \
-    --arg id "$session_id" \
-    --arg msg "$DEEP_RESEARCH_PROMPT" \
-    '{session_id: $id, message: $msg, stream: false}')"
+  log "submitting deep research prompt to session $session_id (over UI Protocol v1 WS)"
 
-  # Two possible endpoints exist across canary versions; prefer /api/chat.
-  local http_code
-  http_code="$(curl --silent --show-error --output "${OUTPUT_DIR}/submit.out" \
-    -o "${OUTPUT_DIR}/submit.body" \
-    -w '%{http_code}' \
-    -H 'Content-Type: application/json' \
-    -H "Authorization: Bearer ${AUTH_TOKEN}" \
-    -H "X-Profile-Id: ${PROFILE_ID}" \
-    -X POST \
-    --data "$body" \
-    "${BASE_URL}/api/chat" || echo 000)"
-
-  if [[ "$http_code" != "200" && "$http_code" != "202" ]]; then
-    # Fall back to /api/sessions/:id/messages.
-    http_code="$(curl --silent --show-error --output "${OUTPUT_DIR}/submit.out" \
-      -o "${OUTPUT_DIR}/submit.body" \
-      -w '%{http_code}' \
-      -H 'Content-Type: application/json' \
-      -H "Authorization: Bearer ${AUTH_TOKEN}" \
-      -H "X-Profile-Id: ${PROFILE_ID}" \
-      -X POST \
-      --data "$(jq -n --arg msg "$DEEP_RESEARCH_PROMPT" '{content: $msg}')" \
-      "${BASE_URL}/api/sessions/${session_id}/messages" || echo 000)"
+  if ! command -v node >/dev/null 2>&1; then
+    emit_diagnostic \
+      "node_missing" \
+      "node is required to drive the canonical WS chat transport but was not found in PATH." \
+      "install Node.js >= 18 and ensure 'node' is on PATH"
+    exit 2
   fi
 
-  if [[ "$http_code" != "200" && "$http_code" != "202" ]]; then
+  local helper="${ROOT}/e2e/scripts/ws-chat.mjs"
+  if [[ ! -x "$helper" ]]; then
+    emit_diagnostic \
+      "ws_helper_missing" \
+      "WS chat helper missing or not executable at ${helper}." \
+      "chmod +x ${helper}"
+    exit 2
+  fi
+
+  # The helper exits with rc=0 on `turn/completed`, 3 on RPC/WS errors,
+  # 4 on deadline. We tolerate non-zero rc here because the downstream
+  # poll-until-terminal loop is the authoritative completion check —
+  # all this stage needs is for the turn to be ACCEPTED by the daemon.
+  local rc=0
+  ( cd "$ROOT/e2e" && node "$helper" \
+      --url "$BASE_URL" \
+      --token "$AUTH_TOKEN" \
+      --profile "$PROFILE_ID" \
+      --session "$session_id" \
+      --message "$DEEP_RESEARCH_PROMPT" \
+      --max-wait-ms "$((TIMEOUT_SECONDS * 1000))" \
+      > "${OUTPUT_DIR}/submit.body" 2> "${OUTPUT_DIR}/submit.out" ) || rc=$?
+
+  if (( rc == 2 || rc == 3 )); then
+    local helper_status
+    helper_status="$(jq -r '.status // .message // empty' "${OUTPUT_DIR}/submit.body" 2>/dev/null || true)"
     emit_diagnostic \
       "deep_research_submit_failed" \
-      "POST to /api/chat and /api/sessions/${session_id}/messages both returned ${http_code}." \
-      "curl -H 'Authorization: Bearer ${AUTH_TOKEN}' -H 'X-Profile-Id: ${PROFILE_ID}' -H 'Content-Type: application/json' -X POST --data '$(jq -rc . <<<"$body")' ${BASE_URL}/api/chat"
+      "ws-chat helper exited rc=${rc} (status=${helper_status:-unknown}). Inspect ${OUTPUT_DIR}/submit.body and ${OUTPUT_DIR}/submit.out." \
+      "node ${helper} --url ${BASE_URL} --token *** --profile ${PROFILE_ID} --session ${session_id} --message '<prompt>'"
     exit 3
   fi
 
-  pass "deep research submitted, session=${session_id}"
+  pass "deep research submitted, session=${session_id} (ws-chat rc=${rc})"
   printf "%s" "$session_id"
 }
 
@@ -393,18 +409,24 @@ observe_until_terminal() {
 
 capture_sse_snapshot() {
   local session_id="$1"
-  local stream_url="${BASE_URL}/api/sessions/${session_id}/events/stream"
-  log "capturing SSE snapshot from $stream_url"
+  # `/api/sessions/:id/events/stream` (legacy free-form SSE) was retired
+  # post-PR #908; per-session event projection now flows over the
+  # `session/open` notification replay on `/api/ui-protocol/ws`. The
+  # ws-chat helper that already ran for this session captured every
+  # notification it observed during the turn into ${OUTPUT_DIR}/submit.body
+  # (one JSON line of `{status, content, events: [...]}`). That log is
+  # the WS equivalent of what the script used to fetch from the SSE
+  # endpoint — point $LAST_SSE_SNAPSHOT at it so the existing emptiness
+  # check in `main()` continues to do something useful.
+  log "promoting ws-chat notification log as WS event snapshot (session=$session_id)"
   : > "$LAST_SSE_SNAPSHOT"
-  # --max-time bounds the curl window; we intentionally error-tolerant because
-  # the stream may legitimately be empty between task transitions.
-  curl --silent --show-error \
-    -H "Authorization: Bearer ${AUTH_TOKEN}" \
-    -H "X-Profile-Id: ${PROFILE_ID}" \
-    -H 'Accept: text/event-stream' \
-    --max-time 20 \
-    "$stream_url" > "$LAST_SSE_SNAPSHOT" 2>/dev/null || true
-  pass "SSE snapshot written to $LAST_SSE_SNAPSHOT"
+  if [[ -s "${OUTPUT_DIR}/submit.body" ]]; then
+    # Project the WS notification list out of the helper's single-line
+    # JSON envelope into a stream of one-notification-per-line records
+    # so the downstream byte-count check is meaningful.
+    jq -c '.events[]?' "${OUTPUT_DIR}/submit.body" > "$LAST_SSE_SNAPSHOT" 2>/dev/null || true
+  fi
+  pass "WS notification snapshot written to $LAST_SSE_SNAPSHOT"
 }
 
 validate_observation() {
@@ -597,16 +619,16 @@ main() {
 
     capture_sse_snapshot "$session_id"
     if [[ -s "$LAST_SSE_SNAPSHOT" ]]; then
-      pass "SSE stream produced data ($(wc -c < "$LAST_SSE_SNAPSHOT" | tr -d ' ') bytes)"
+      pass "WS event stream produced data ($(wc -c < "$LAST_SSE_SNAPSHOT" | tr -d ' ') bytes)"
     else
-      warn "SSE snapshot empty; retrying once"
+      warn "WS event snapshot empty; retrying once"
       sleep "$POLL_INTERVAL"
       capture_sse_snapshot "$session_id"
       if [[ ! -s "$LAST_SSE_SNAPSHOT" ]]; then
         emit_diagnostic \
-          "sse_stream_empty" \
-          "SSE endpoint produced no data within 20s twice in a row." \
-          "curl -N -H 'Authorization: Bearer ${AUTH_TOKEN}' -H 'X-Profile-Id: ${PROFILE_ID}' ${BASE_URL}/api/sessions/${session_id}/events/stream"
+          "ws_event_stream_empty" \
+          "WS UI Protocol produced no notifications during the deep-research turn (ws-chat helper exited cleanly but captured no events)." \
+          "node ${ROOT}/e2e/scripts/ws-chat.mjs --url ${BASE_URL} --token *** --profile ${PROFILE_ID} --session ${session_id} --message '<prompt>'"
         exit 3
       fi
     fi


### PR DESCRIPTION
## Summary

Follow-up to PR #908 (`cleanup/legacy-sse-rest-chat`). With the SSE chat transport (M9-α-5/α-6, PR #855) and the legacy `/api/ws` text-frame endpoint (PR #908) already gone, the only chat surface left to retire was the synchronous `POST /api/chat` JSON endpoint that PR #908 kept around because six callers still drove it. This PR migrates each caller and then deletes the handler, types, route, and the proxy-auth allowlist arm.

Motivation: PRs #855 (M9-α-5 atomic SSE delete) + #851 (M9-α-7 `chatSSE` → `chatWS`) + the Phase C octos-web migration established `/api/ui-protocol/ws` as the canonical chat transport. PR #908 cleared the SSE/REST scaffolding around it; this PR finishes the cutover.

## Migrated callers

| File | Old transport | New transport |
| --- | --- | --- |
| `crates/octos-cli/tests/coding_multi_session.rs:222-261` | `tower::ServiceExt::oneshot` against `POST /api/chat` | New `drive_turn` helper that hits the same in-process call path the WS `turn/start` pipeline takes (`session_cache.get_or_init` + `agent.process_message` + `octos_bus::persist_message_through_canonical_path`). Every workspace-isolation, multi-tenant-leak, JSONL, and policy-file assertion preserved. |
| `e2e/tests/tool-use-regression.spec.ts:106-167` | `request.post('${baseURL}/api/chat')` × 4 | `chatWS()` from `e2e/lib/m9-ws-client.ts`. All five tests preserved. |
| `e2e/tests/session-list-regression.spec.ts:104-124` | Browser `request` event listener counting `POST /api/chat` (`chatPosts === 1`) | Removed. The modern SPA streams turns over `/api/ui-protocol/ws`, so the counter was structurally moot. The `child_session_key` task-count poll on the line below it remains the authoritative "exactly one deep-research turn" invariant. |
| `e2e/tests/refactor-capabilities.spec.ts` | Comments only — spec already used `chatWS()`. | Docstrings updated. |
| `e2e/lib/capture-replay.ts` | Page-side `addInitScript` fetch tee defaulted `streamingPaths = ['/api/chat']` | Default now `[]`. Module docs note that chat moved off `fetch`. The DOM-capture half + caller-supplied path matching still work. |
| `scripts/validate-m4-1a-live.sh` | `curl POST /api/chat` + `curl /api/sessions/:id/events/stream` (the latter also already deleted) | New `e2e/scripts/ws-chat.mjs` helper that drives `session/open` + `turn/start` over `/api/ui-protocol/ws` and writes the notification log to the same `$LAST_SSE_SNAPSHOT` path the script already reads. |

## Server-side cleanup

- `crates/octos-cli/src/api/handlers.rs` — removed `ChatRequest`, `ChatResponse`, `chat`, `chat_sync`, `chat_sync_via_session_runtime`, `persist_chat_message_through_canonical`, `standalone_api_session_key_with_topic`, `MAX_MESSAGE_LEN`, and the ten tests that exclusively exercised those (`chat_request_*`, `chat_response_serialize`, `max_message_len_is_1mb`, `chat_sync_writes_to_canonical_per_user_topic_jsonl`, `chat_routes_through_session_runtime_when_profile_registered`, `chat_returns_503_when_routed_profile_not_registered`, `chat_sync_forwards_appui_default_session_cwd_as_workspace_hint`). The canonical-JSONL invariant + workspace-hint forwarding remain end-to-end covered by `coding_multi_session.rs` and the WS handler's own unit tests.
- `crates/octos-cli/src/api/router.rs` — dropped the `.route("/api/chat", post(handlers::chat))` registration and the `"/api/chat"` arm of the loopback proxy-auth allowlist.

## Notes / out-of-scope

- `swarm-app/src/api/swarm.ts` and `swarm-app/src/components/swarm/LiveView.tsx` still reference `/api/chat/stream` SSE. That endpoint was deleted in M9-α-5/α-6 (PR #855) — well before this PR. The swarm-app is a separate frontend bundle and is broken irrespective of this cleanup; it needs its own follow-up.
- Pre-existing flakes documented on PR #908 (`api::ui_protocol::tests::message_persisted_*`, the gateway test-only compile glitch) are unrelated and not addressed here.

## Test plan

- [x] `cargo test -p octos-cli --features api --test coding_multi_session` — 1 passed (in-process WS-equivalent path).
- [x] `cargo test -p octos-cli --features api --lib 'api::'` — 485 passed (was 496 on PR #908's tip; the 11-test delta matches the deleted REST chat tests).
- [x] `cargo check --workspace` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p octos-cli --features api --no-deps` — 33 warnings (identical count to PR #908; no new warnings introduced).
- [x] `npx playwright test --list tests/tool-use-regression.spec.ts tests/session-list-regression.spec.ts tests/refactor-capabilities.spec.ts` — all 11 specs discoverable.
- [x] `npx tsc --noEmit` on the three migrated spec files + `capture-replay.ts` — clean.
- [ ] CI green on the PR.
- [ ] Live exercise on a mini: `scripts/validate-m4-1a-live.sh --base-url … --auth-token …` once a canary with this branch is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)