### PR TITLE
feat(api): M12 Phase D-1 — add auxiliary.rest_to_ws.v1 WS UI Protocol frames

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -524,7 +524,7 @@ struct ConnectionUiFeatures {
     /// is suppressed.
     spawn_complete: bool,
     /// M12 Phase D-1 `auxiliary.rest_to_ws.v1` negotiated. Unlocks the
-    /// twelve auxiliary JSON-RPC methods (`session/list`,
+    /// thirteen auxiliary JSON-RPC methods (`session/list`,
     /// `session/snapshot`, `session/messages_page`, `session/status.get`,
     /// `session/files.list`, `session/tasks.list`,
     /// `session/workspace.get`, `session/title.set`, `session/delete`,
@@ -533,6 +533,12 @@ struct ConnectionUiFeatures {
     /// Capability-gated per ADR
     /// `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`. REST endpoints
     /// remain available for clients that do not negotiate this feature.
+    /// **Strict opt-in (codex review):** the gate fires for these methods
+    /// regardless of whether `header_present` is true, so a client that
+    /// sends no feature header at all still receives
+    /// `method_not_supported` and falls back to REST. This is what makes
+    /// Phase D-1 truly additive — pre-existing clients cannot trip into
+    /// the new methods without explicit negotiation.
     auxiliary_rest_to_ws_v1: bool,
     /// `true` when the client sent at least one feature token via the
     /// `X-Octos-Ui-Features` header or the `ui_feature` / `ui_features`
@@ -1801,20 +1807,69 @@ fn route_rpc_command(
     }
     // UPCR-2026-009 / -010 / -011 + M12 Phase D-1: when the method is
     // gated behind a feature flag and the connection did not negotiate
-    // that flag (and a feature header was present), reject with
-    // `method_not_supported` BEFORE attempting to deserialize the
-    // params. Doing the gate first means clients that targeted a
-    // capability-gated method without negotiating the feature see a
-    // clean `method_not_supported` (and can fall back to REST) instead
-    // of `invalid_params` for an unrelated payload shape — the spec
-    // contract is "we don't know about this method at all", not "we
-    // half-know it".
+    // that flag, reject with `method_not_supported` BEFORE attempting
+    // to deserialize the params. Doing the gate first means clients
+    // that targeted a capability-gated method without negotiating the
+    // feature see a clean `method_not_supported` (and can fall back
+    // to REST) instead of `invalid_params` for an unrelated payload
+    // shape — the spec contract is "we don't know about this method
+    // at all", not "we half-know it".
     //
-    // Connections that send no feature header at all retain the legacy
-    // "advertise full first-slice in `SessionOpened`" behaviour and so
-    // see the methods as available — the gate fires only when the
-    // client opted into negotiation per UPCR-2026-007 but skipped this
-    // feature.
+    // Two gate flavours coexist:
+    //
+    // 1. **Legacy header-present gates** (`session/hydrate`,
+    //    `thread/graph/get`, `turn/state/get`, `task/list`,
+    //    `task/cancel`, `task/restart_from_node`): pre-existing
+    //    capabilities that historically relied on
+    //    `header_present == true` to fire — clients that send NO
+    //    feature header at all see the full first-slice in
+    //    `SessionOpened.capabilities` per UPCR-2026-007 and so see
+    //    these methods as available. Changing that legacy behaviour
+    //    here is out of scope for Phase D-1.
+    //
+    // 2. **Strict opt-in gates** (M12 Phase D-1 auxiliary methods):
+    //    the rollout-flag contract is "no negotiation = no access".
+    //    A client that sends no feature header at all must NOT trip
+    //    into the new methods accidentally — otherwise the additive
+    //    Phase D-1 contract is broken for every pre-existing client.
+    //    These gates fire regardless of `header_present`.
+    //
+    // Codex review 2026-05-12: the original implementation collapsed
+    // both flavours under `if features.header_present { ... }`, which
+    // let no-header clients call `session/delete` and friends without
+    // negotiating the capability. The split below restores the
+    // strict-opt-in semantic for the new surface while preserving
+    // legacy behaviour for pre-existing gates that explicitly relied
+    // on it.
+
+    // Flavour 2: strict opt-in. Always reject when the capability is
+    // not negotiated, regardless of whether the client sent any
+    // feature header at all.
+    let strict_gated = match method_str {
+        octos_core::ui_protocol::methods::SESSION_LIST
+        | octos_core::ui_protocol::methods::SESSION_SNAPSHOT
+        | octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE
+        | octos_core::ui_protocol::methods::SESSION_STATUS_GET
+        | octos_core::ui_protocol::methods::SESSION_FILES_LIST
+        | octos_core::ui_protocol::methods::SESSION_TASKS_LIST
+        | octos_core::ui_protocol::methods::SESSION_WORKSPACE_GET
+        | octos_core::ui_protocol::methods::SESSION_TITLE_SET
+        | octos_core::ui_protocol::methods::SESSION_DELETE
+        | octos_core::ui_protocol::methods::SYSTEM_STATUS_GET
+        | octos_core::ui_protocol::methods::CONTENT_LIST
+        | octos_core::ui_protocol::methods::CONTENT_DELETE
+        | octos_core::ui_protocol::methods::CONTENT_BULK_DELETE => {
+            Some(features.auxiliary_rest_to_ws_v1)
+        }
+        _ => None,
+    };
+    if let Some(false) = strict_gated {
+        return Err(RpcError::method_not_supported(method_str));
+    }
+
+    // Flavour 1: legacy header-present gates. Fire only when the
+    // client opted into negotiation per UPCR-2026-007 but skipped a
+    // specific feature.
     if features.header_present {
         let gated = match method_str {
             octos_core::ui_protocol::methods::SESSION_HYDRATE => Some(features.session_hydrate),
@@ -1824,27 +1879,6 @@ fn route_rpc_command(
             | octos_core::ui_protocol::methods::TASK_CANCEL
             | octos_core::ui_protocol::methods::TASK_RESTART_FROM_NODE => {
                 Some(features.harness_task_control)
-            }
-            // M12 Phase D-1: capability-gate the twelve auxiliary
-            // REST→WS methods behind `auxiliary.rest_to_ws.v1`. Clients
-            // that did not negotiate the feature see
-            // `method_not_supported` so they fall back to REST. This is
-            // what makes Phase D-1 additive — no behaviour change for
-            // clients that haven't opted in.
-            octos_core::ui_protocol::methods::SESSION_LIST
-            | octos_core::ui_protocol::methods::SESSION_SNAPSHOT
-            | octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE
-            | octos_core::ui_protocol::methods::SESSION_STATUS_GET
-            | octos_core::ui_protocol::methods::SESSION_FILES_LIST
-            | octos_core::ui_protocol::methods::SESSION_TASKS_LIST
-            | octos_core::ui_protocol::methods::SESSION_WORKSPACE_GET
-            | octos_core::ui_protocol::methods::SESSION_TITLE_SET
-            | octos_core::ui_protocol::methods::SESSION_DELETE
-            | octos_core::ui_protocol::methods::SYSTEM_STATUS_GET
-            | octos_core::ui_protocol::methods::CONTENT_LIST
-            | octos_core::ui_protocol::methods::CONTENT_DELETE
-            | octos_core::ui_protocol::methods::CONTENT_BULK_DELETE => {
-                Some(features.auxiliary_rest_to_ws_v1)
             }
             _ => None,
         };
@@ -4349,6 +4383,42 @@ fn send_serialized_rpc_result<T: Serialize>(
 /// RPC error if exceeded.
 const AUX_REST_TO_WS_MAX_BODY_BYTES: usize = MAX_TEXT_FRAME_BYTES;
 
+/// What kind of resource the dispatcher was addressing when a REST 404
+/// came back. The bridge uses this to pick the right `RpcError` variant
+/// — session-scoped methods surface `UNKNOWN_SESSION` (-32100) so the
+/// client can reconcile against its session table; non-session methods
+/// (content/profile/system) surface the generic `RESOURCE_NOT_FOUND`
+/// (-32170) so a content row miss does not pollute the session error
+/// channel.
+///
+/// Codex review 2026-05-12: the original implementation mapped EVERY
+/// REST 404 to `RpcError::unknown_session(format!("{method}: not found"))`,
+/// which (a) put the method name into the `session_id` field of the
+/// error data and (b) misclassified content/profile 404s as session
+/// misses.
+#[derive(Debug, Clone)]
+enum RestResourceContext {
+    /// Session-scoped endpoint. `id` is the addressed session id.
+    Session { id: String },
+    /// Non-session resource. `resource_type` is a short tag
+    /// ("content", "profile", ...); `id` is the resource id the
+    /// client sent (empty when the request had no addressable id).
+    Resource { resource_type: String, id: String },
+}
+
+impl RestResourceContext {
+    fn session(id: impl Into<String>) -> Self {
+        Self::Session { id: id.into() }
+    }
+
+    fn resource(resource_type: impl Into<String>, id: impl Into<String>) -> Self {
+        Self::Resource {
+            resource_type: resource_type.into(),
+            id: id.into(),
+        }
+    }
+}
+
 /// Convert an axum `Response` from a REST handler into a parsed JSON
 /// [`Value`] suitable for embedding in a WS RPC result. Non-2xx
 /// responses are surfaced as typed RPC errors so the client sees the
@@ -4357,6 +4427,7 @@ const AUX_REST_TO_WS_MAX_BODY_BYTES: usize = MAX_TEXT_FRAME_BYTES;
 async fn rest_response_to_rpc_value(
     response: axum::response::Response,
     method: &str,
+    context: RestResourceContext,
 ) -> Result<Value, RpcError> {
     let status = response.status();
     let body = axum::body::to_bytes(response.into_body(), AUX_REST_TO_WS_MAX_BODY_BYTES)
@@ -4374,7 +4445,7 @@ async fn rest_response_to_rpc_value(
         } else {
             Some(detail)
         };
-        return Err(rest_status_to_rpc_error(method, status, detail));
+        return Err(rest_status_to_rpc_error(method, status, detail, &context));
     }
     if body.is_empty() {
         // REST 204 No Content (and equivalents like our `delete_session`
@@ -4389,6 +4460,7 @@ fn rest_status_to_rpc_error(
     method: &str,
     status: axum::http::StatusCode,
     detail: Option<String>,
+    context: &RestResourceContext,
 ) -> RpcError {
     let mut data = serde_json::Map::new();
     data.insert("rest_status".into(), json!(status.as_u16()));
@@ -4403,7 +4475,17 @@ fn rest_status_to_rpc_error(
     }
     use axum::http::StatusCode;
     let error = match status {
-        StatusCode::NOT_FOUND => RpcError::unknown_session(format!("{method}: not found")),
+        // Codex review 2026-05-12: split session-scoped 404 from
+        // generic 404. Session-scoped methods echo `session_id` in
+        // `data` per spec §10; non-session resources go through the
+        // new `RESOURCE_NOT_FOUND` slot so the resource_type + id
+        // reach the client without abusing the `session_id` field.
+        StatusCode::NOT_FOUND => match context {
+            RestResourceContext::Session { id } => RpcError::unknown_session(id.clone()),
+            RestResourceContext::Resource { resource_type, id } => {
+                RpcError::not_found(resource_type.clone(), id.clone())
+            }
+        },
         StatusCode::BAD_REQUEST => {
             RpcError::invalid_params(format!("{method}: REST returned 400 bad_request"))
         }
@@ -4418,7 +4500,18 @@ fn rest_status_to_rpc_error(
             status.as_u16()
         )),
     };
-    error.with_data(Value::Object(data))
+    // Merge the existing data (rest_status + optional detail) with
+    // whatever the typed variant already wrote (e.g.
+    // `unknown_session.data.kind = "unknown_session"`,
+    // `unknown_session.data.session_id = "..."`). Existing keys win so
+    // the typed-error contract is preserved.
+    let mut merged = data;
+    if let Some(Value::Object(existing)) = error.data.clone() {
+        for (k, v) in existing {
+            merged.insert(k, v);
+        }
+    }
+    error.with_data(Value::Object(merged))
 }
 
 /// Forward a parsed JSON body to the WS RPC result channel. Used by
@@ -4457,7 +4550,11 @@ async fn handle_session_list(
 ) {
     let response = super::handlers::list_sessions(State(state.clone()), headers.clone()).await;
     let method = octos_core::ui_protocol::methods::SESSION_LIST;
-    match rest_response_to_rpc_value(response, method).await {
+    // Collection endpoint — no addressable session id. Treat any
+    // (unexpected) 404 as a generic resource-not-found rather than
+    // an `UNKNOWN_SESSION` miss.
+    let context = RestResourceContext::resource("session", "");
+    match rest_response_to_rpc_value(response, method, context).await {
         Ok(sessions) => {
             send_aux_rpc_result(ws, id, method, json!({ "sessions": sessions }));
         }
@@ -4477,6 +4574,7 @@ async fn handle_session_status_get(
     let topic_params = axum::extract::Query(super::handlers::TopicQueryParams {
         topic: params.topic.clone(),
     });
+    let session_id_str = params.session_id.clone();
     let response = super::handlers::session_status(
         State(state.clone()),
         headers.clone(),
@@ -4485,7 +4583,8 @@ async fn handle_session_status_get(
     )
     .await;
     let method = octos_core::ui_protocol::methods::SESSION_STATUS_GET;
-    match rest_response_to_rpc_value(response, method).await {
+    let context = RestResourceContext::session(session_id_str);
+    match rest_response_to_rpc_value(response, method, context).await {
         Ok(status) => {
             send_aux_rpc_result(ws, id, method, json!({ "status": status }));
         }
@@ -4504,6 +4603,7 @@ async fn handle_session_files_list(
     params: SessionFilesListParams,
 ) {
     let identity_ext = identity.cloned().map(Extension);
+    let session_id_str = params.session_id.clone();
     let response = super::handlers::session_files(
         State(state.clone()),
         headers.clone(),
@@ -4512,7 +4612,8 @@ async fn handle_session_files_list(
     )
     .await;
     let method = octos_core::ui_protocol::methods::SESSION_FILES_LIST;
-    match rest_response_to_rpc_value(response, method).await {
+    let context = RestResourceContext::session(session_id_str);
+    match rest_response_to_rpc_value(response, method, context).await {
         Ok(files) => {
             send_aux_rpc_result(ws, id, method, json!({ "files": files }));
         }
@@ -4532,6 +4633,7 @@ async fn handle_session_tasks_list(
     let topic_params = axum::extract::Query(super::handlers::TopicQueryParams {
         topic: params.topic.clone(),
     });
+    let session_id_str = params.session_id.clone();
     let response = super::handlers::session_tasks(
         State(state.clone()),
         headers.clone(),
@@ -4540,7 +4642,8 @@ async fn handle_session_tasks_list(
     )
     .await;
     let method = octos_core::ui_protocol::methods::SESSION_TASKS_LIST;
-    match rest_response_to_rpc_value(response, method).await {
+    let context = RestResourceContext::session(session_id_str);
+    match rest_response_to_rpc_value(response, method, context).await {
         Ok(tasks) => {
             send_aux_rpc_result(ws, id, method, json!({ "tasks": tasks }));
         }
@@ -4559,6 +4662,7 @@ async fn handle_session_workspace_get(
     params: SessionWorkspaceGetParams,
 ) {
     let identity_ext = identity.cloned().map(Extension);
+    let session_id_str = params.session_id.clone();
     let response = super::handlers::session_workspace_contract(
         State(state.clone()),
         headers.clone(),
@@ -4567,7 +4671,8 @@ async fn handle_session_workspace_get(
     )
     .await;
     let method = octos_core::ui_protocol::methods::SESSION_WORKSPACE_GET;
-    match rest_response_to_rpc_value(response, method).await {
+    let context = RestResourceContext::session(session_id_str);
+    match rest_response_to_rpc_value(response, method, context).await {
         Ok(contracts) => {
             send_aux_rpc_result(ws, id, method, json!({ "contracts": contracts }));
         }
@@ -4589,6 +4694,7 @@ async fn handle_session_snapshot(
     // bootstrap calls (status, files, tasks). Run them concurrently
     // and surface the first error.
     let method = octos_core::ui_protocol::methods::SESSION_SNAPSHOT;
+    let session_id_str = params.session_id.clone();
     let topic_params = axum::extract::Query(super::handlers::TopicQueryParams {
         topic: params.topic.clone(),
     });
@@ -4614,21 +4720,39 @@ async fn handle_session_snapshot(
         topic_params,
     );
     let (status_resp, files_resp, tasks_resp) = tokio::join!(status_fut, files_fut, tasks_fut);
-    let status = match rest_response_to_rpc_value(status_resp, method).await {
+    let status = match rest_response_to_rpc_value(
+        status_resp,
+        method,
+        RestResourceContext::session(session_id_str.clone()),
+    )
+    .await
+    {
         Ok(v) => v,
         Err(error) => {
             let _ = send_rpc_error(ws, Some(id), error);
             return;
         }
     };
-    let files = match rest_response_to_rpc_value(files_resp, method).await {
+    let files = match rest_response_to_rpc_value(
+        files_resp,
+        method,
+        RestResourceContext::session(session_id_str.clone()),
+    )
+    .await
+    {
         Ok(v) => v,
         Err(error) => {
             let _ = send_rpc_error(ws, Some(id), error);
             return;
         }
     };
-    let tasks = match rest_response_to_rpc_value(tasks_resp, method).await {
+    let tasks = match rest_response_to_rpc_value(
+        tasks_resp,
+        method,
+        RestResourceContext::session(session_id_str),
+    )
+    .await
+    {
         Ok(v) => v,
         Err(error) => {
             let _ = send_rpc_error(ws, Some(id), error);
@@ -4672,6 +4796,7 @@ async fn handle_session_messages_page(
         topic: params.topic.clone(),
     });
     let identity_ext = identity.cloned().map(Extension);
+    let session_id_str = params.session_id.clone();
     let response = super::handlers::session_messages(
         State(state.clone()),
         headers.clone(),
@@ -4680,23 +4805,17 @@ async fn handle_session_messages_page(
         pagination,
     )
     .await;
-    let status = response.status();
-    if status == axum::http::StatusCode::NOT_FOUND {
-        // Per ADR: `UNKNOWN_SESSION` → empty page (matches REST's
-        // historical 404→empty client semantic).
-        send_aux_rpc_result(
-            ws,
-            id,
-            method,
-            json!({
-                "messages": [],
-                "has_more": false,
-                "next_offset": offset,
-            }),
-        );
-        return;
-    }
-    match rest_response_to_rpc_value(response, method).await {
+    // Codex review 2026-05-12: previously, this dispatcher mapped REST
+    // 404 to an empty page and dropped REST 503 onto the generic JSON
+    // path (which then surfaced `INTERNAL_ERROR`). Both diverged from
+    // the REST contract documented at `handlers.rs:767` (gateway
+    // proxy 404) and `handlers.rs:783` (standalone fallback 503).
+    // Mirror REST faithfully now: 404 → `UNKNOWN_SESSION` with the
+    // addressed `session_id` echoed in `data` per spec §10; 503 →
+    // `runtime_not_ready` so clients can distinguish "session does
+    // not exist" from "server has no gateway wired".
+    let context = RestResourceContext::session(session_id_str);
+    match rest_response_to_rpc_value(response, method, context).await {
         Ok(messages) => {
             let len = messages.as_array().map(|arr| arr.len()).unwrap_or(0);
             let has_more = len == limit;
@@ -4772,10 +4891,11 @@ async fn handle_session_title_set(
             .await
             .ok()
             .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok());
+        let context = RestResourceContext::session(session_id_str);
         let _ = send_rpc_error(
             ws,
             Some(id),
-            rest_status_to_rpc_error(method, status, detail),
+            rest_status_to_rpc_error(method, status, detail, &context),
         );
     }
 }
@@ -4788,6 +4908,7 @@ async fn handle_session_delete(
     params: SessionDeleteParams,
 ) {
     let method = octos_core::ui_protocol::methods::SESSION_DELETE;
+    let session_id_str = params.session_id.clone();
     let response = super::handlers::delete_session(
         State(state.clone()),
         headers.clone(),
@@ -4802,10 +4923,11 @@ async fn handle_session_delete(
             .await
             .ok()
             .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok());
+        let context = RestResourceContext::session(session_id_str);
         let _ = send_rpc_error(
             ws,
             Some(id),
-            rest_status_to_rpc_error(method, status, detail),
+            rest_status_to_rpc_error(method, status, detail, &context),
         );
     }
 }
@@ -4905,10 +5027,15 @@ async fn handle_content_list(
             }
         },
         Err((status, message)) => {
+            // `content/list` is a collection endpoint — no
+            // addressable id. Use the generic resource context so a
+            // (rare) 404 surfaces as `RESOURCE_NOT_FOUND` rather than
+            // `UNKNOWN_SESSION`.
+            let context = RestResourceContext::resource("content", "");
             let _ = send_rpc_error(
                 ws,
                 Some(id),
-                rest_status_to_rpc_error(method, status, Some(message)),
+                rest_status_to_rpc_error(method, status, Some(message), &context),
             );
         }
     }
@@ -4930,6 +5057,7 @@ async fn handle_content_delete(
         );
         return;
     };
+    let content_id = params.id.clone();
     let result = super::auth_handlers::delete_my_content(
         State(state.clone()),
         Extension(identity),
@@ -4948,10 +5076,15 @@ async fn handle_content_delete(
             );
         }
         Err((status, message)) => {
+            // Content row miss → `RESOURCE_NOT_FOUND` with the content
+            // id echoed in `data.identifier`. Previously this funnelled
+            // through `UNKNOWN_SESSION` and stuffed the method name in
+            // the `session_id` slot (codex review 2026-05-12).
+            let context = RestResourceContext::resource("content", content_id);
             let _ = send_rpc_error(
                 ws,
                 Some(id),
-                rest_status_to_rpc_error(method, status, Some(message)),
+                rest_status_to_rpc_error(method, status, Some(message), &context),
             );
         }
     }
@@ -4973,6 +5106,28 @@ async fn handle_content_bulk_delete(
         );
         return;
     };
+    // Codex review 2026-05-12: reject over-cap bulk-delete requests
+    // before they reach the catalog write-lock. The 1 MiB frame limit
+    // is a coarser secondary check; this per-method cap keeps a
+    // single oversized request from monopolizing the catalog for
+    // even a small bounded window. Mirrored in
+    // `octos-core::ui_protocol::CONTENT_BULK_DELETE_MAX_IDS`.
+    if params.ids.len() > octos_core::ui_protocol::CONTENT_BULK_DELETE_MAX_IDS {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!(
+                "{method}: ids count {} exceeds maximum of {}",
+                params.ids.len(),
+                octos_core::ui_protocol::CONTENT_BULK_DELETE_MAX_IDS,
+            ))
+            .with_data(json!({
+                "max_ids": octos_core::ui_protocol::CONTENT_BULK_DELETE_MAX_IDS,
+                "requested_ids": params.ids.len(),
+            })),
+        );
+        return;
+    }
     let result = super::auth_handlers::bulk_delete_my_content(
         State(state.clone()),
         Extension(identity),
@@ -4993,10 +5148,15 @@ async fn handle_content_bulk_delete(
             send_aux_rpc_result(ws, id, method, json!({ "deleted": deleted }));
         }
         Err((status, message)) => {
+            // Bulk-delete is a collection operation; no single id is
+            // the locus. Surface 404 (which the REST handler should
+            // never return for this method) through the generic
+            // resource context.
+            let context = RestResourceContext::resource("content", "");
             let _ = send_rpc_error(
                 ws,
                 Some(id),
-                rest_status_to_rpc_error(method, status, Some(message)),
+                rest_status_to_rpc_error(method, status, Some(message), &context),
             );
         }
     }
@@ -9164,6 +9324,196 @@ mod tests {
             let cmd = route_rpc_command(request, features).expect("aux method accepted");
             assert_eq!(cmd.method(), method);
         }
+    }
+
+    /// Codex review 2026-05-12 (BLOCK 1): a client that sends NO
+    /// feature header at all must still be rejected when it calls one
+    /// of the M12 Phase D-1 auxiliary methods. The original
+    /// implementation gated only when `features.header_present` was
+    /// true, which let pre-existing no-header clients trip into
+    /// `session/delete` / `content/delete` / etc. accidentally — that
+    /// breaks the strict opt-in contract.
+    #[test]
+    fn aux_rest_to_ws_v1_route_rpc_rejects_methods_with_no_feature_header_at_all() {
+        // No header, no query string — the legacy "advertise full
+        // first-slice in SessionOpened" path. `header_present` must
+        // be false (verified) and `auxiliary_rest_to_ws_v1` must be
+        // false (verified), and yet the gate must fire.
+        let headers = HeaderMap::new();
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(
+            !features.header_present,
+            "no header → header_present must be false"
+        );
+        assert!(
+            !features.auxiliary_rest_to_ws_v1,
+            "no header → auxiliary.rest_to_ws.v1 must be false"
+        );
+        for method in [
+            octos_core::ui_protocol::methods::SESSION_LIST,
+            octos_core::ui_protocol::methods::SESSION_SNAPSHOT,
+            octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE,
+            octos_core::ui_protocol::methods::SESSION_STATUS_GET,
+            octos_core::ui_protocol::methods::SESSION_FILES_LIST,
+            octos_core::ui_protocol::methods::SESSION_TASKS_LIST,
+            octos_core::ui_protocol::methods::SESSION_WORKSPACE_GET,
+            octos_core::ui_protocol::methods::SESSION_TITLE_SET,
+            octos_core::ui_protocol::methods::SESSION_DELETE,
+            octos_core::ui_protocol::methods::SYSTEM_STATUS_GET,
+            octos_core::ui_protocol::methods::CONTENT_LIST,
+            octos_core::ui_protocol::methods::CONTENT_DELETE,
+            octos_core::ui_protocol::methods::CONTENT_BULK_DELETE,
+        ] {
+            let request = RpcRequest::<Value>::new("req-no-header", method, Value::Null);
+            let result = route_rpc_command(request, features);
+            let err = result
+                .expect_err("aux method must be rejected when no feature header was sent at all");
+            assert_eq!(
+                err.code,
+                octos_core::ui_protocol::rpc_error_codes::METHOD_NOT_SUPPORTED,
+                "{method} must reject with METHOD_NOT_SUPPORTED even with no header",
+            );
+        }
+    }
+
+    /// Codex review 2026-05-12 (BLOCK 1, companion): the legacy
+    /// header-present gates (`session/hydrate`, `thread/graph/get`,
+    /// `turn/state/get`, `task/list`, `task/cancel`,
+    /// `task/restart_from_node`) must still pass through when no
+    /// header was sent at all — that's the documented
+    /// "advertise full first-slice in `SessionOpened`" fallback path.
+    /// Only the new M12 Phase D-1 surface flips to strict opt-in.
+    #[test]
+    fn legacy_header_present_gates_still_accept_methods_with_no_feature_header() {
+        // No header → all legacy gates fall through to
+        // `UiCommand::from_rpc_request`. The decode itself may fail
+        // because we send `Value::Null` as params, but the failure
+        // must come from `from_rpc_request`, not from the gate.
+        // Concretely: code must NOT be `METHOD_NOT_SUPPORTED`.
+        let headers = HeaderMap::new();
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(!features.header_present);
+        for method in [
+            octos_core::ui_protocol::methods::SESSION_HYDRATE,
+            octos_core::ui_protocol::methods::THREAD_GRAPH_GET,
+            octos_core::ui_protocol::methods::TURN_STATE_GET,
+            octos_core::ui_protocol::methods::TASK_LIST,
+            octos_core::ui_protocol::methods::TASK_CANCEL,
+            octos_core::ui_protocol::methods::TASK_RESTART_FROM_NODE,
+        ] {
+            let request = RpcRequest::<Value>::new("req-legacy", method, Value::Null);
+            let result = route_rpc_command(request, features);
+            // Either Ok (unlikely for Null params) or Err with a
+            // decode error — the key invariant is: NOT
+            // `METHOD_NOT_SUPPORTED`.
+            if let Err(err) = result {
+                assert_ne!(
+                    err.code,
+                    octos_core::ui_protocol::rpc_error_codes::METHOD_NOT_SUPPORTED,
+                    "{method} must NOT be rejected by capability gate when no header sent",
+                );
+            }
+        }
+    }
+
+    /// Codex review 2026-05-12 (MEDIUM 1): a REST 404 from a
+    /// session-scoped endpoint maps to `UNKNOWN_SESSION` with the
+    /// addressed session id in `data.session_id`. The original
+    /// implementation stuffed the method name into the session id
+    /// slot ("session/messages_page: not found"), defeating
+    /// reconciliation on the client side.
+    #[tokio::test]
+    async fn rest_status_to_rpc_error_404_session_context_echoes_session_id() {
+        let context = RestResourceContext::session("sess-abc");
+        let err = rest_status_to_rpc_error(
+            octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE,
+            axum::http::StatusCode::NOT_FOUND,
+            Some("session not found".into()),
+            &context,
+        );
+        assert_eq!(
+            err.code,
+            octos_core::ui_protocol::rpc_error_codes::UNKNOWN_SESSION,
+        );
+        let data = err.data.as_ref().expect("typed error data");
+        assert_eq!(
+            data.get("kind").and_then(Value::as_str),
+            Some("unknown_session")
+        );
+        assert_eq!(
+            data.get("session_id").and_then(Value::as_str),
+            Some("sess-abc"),
+            "session_id slot must carry the addressed session id, not the method name",
+        );
+        // The REST status + detail are still attached for debugging.
+        assert_eq!(data.get("rest_status").and_then(Value::as_u64), Some(404));
+        assert!(data.get("detail").is_some());
+    }
+
+    /// Codex review 2026-05-12 (MEDIUM 1, companion): a REST 404 from
+    /// a non-session resource (content row, profile row) maps to the
+    /// new `RESOURCE_NOT_FOUND` slot with `resource_type` +
+    /// `identifier` echoed in `data`. Before this fix every 404 hit
+    /// `UNKNOWN_SESSION` regardless of resource kind, which forced
+    /// content/profile misses through a session-shaped error.
+    #[tokio::test]
+    async fn rest_status_to_rpc_error_404_resource_context_uses_not_found_slot() {
+        let context = RestResourceContext::resource("content", "c-42");
+        let err = rest_status_to_rpc_error(
+            octos_core::ui_protocol::methods::CONTENT_DELETE,
+            axum::http::StatusCode::NOT_FOUND,
+            None,
+            &context,
+        );
+        assert_eq!(
+            err.code,
+            octos_core::ui_protocol::rpc_error_codes::RESOURCE_NOT_FOUND,
+            "non-session 404 must NOT collapse to UNKNOWN_SESSION",
+        );
+        let data = err.data.as_ref().expect("typed error data");
+        assert_eq!(data.get("kind").and_then(Value::as_str), Some("not_found"));
+        assert_eq!(
+            data.get("resource_type").and_then(Value::as_str),
+            Some("content"),
+        );
+        assert_eq!(data.get("identifier").and_then(Value::as_str), Some("c-42"),);
+        assert_eq!(data.get("rest_status").and_then(Value::as_u64), Some(404));
+    }
+
+    /// Codex review 2026-05-12 (BLOCK 2): REST 503 from the
+    /// standalone fallback (no gateway wired) must surface as
+    /// `runtime_not_ready` rather than collapsing to `INTERNAL_ERROR`.
+    /// This matches `handlers.rs:783` (standalone returns 503 when
+    /// neither the gateway nor a local store can answer).
+    #[tokio::test]
+    async fn rest_status_to_rpc_error_503_maps_to_runtime_not_ready() {
+        let context = RestResourceContext::session("sess-503");
+        let err = rest_status_to_rpc_error(
+            octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE,
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            Some("Sessions not available".into()),
+            &context,
+        );
+        assert_eq!(
+            err.code,
+            octos_core::ui_protocol::rpc_error_codes::RUNTIME_NOT_READY,
+        );
+        let data = err.data.as_ref().expect("typed error data");
+        assert_eq!(data.get("rest_status").and_then(Value::as_u64), Some(503));
+    }
+
+    /// Codex review 2026-05-12 (MEDIUM 3): `content/bulk_delete` must
+    /// reject requests carrying more than
+    /// `CONTENT_BULK_DELETE_MAX_IDS` ids early, before the catalog
+    /// write-lock is taken. The dispatcher uses the constant from
+    /// `octos-core` so the cap is shared with the params DTO docs.
+    #[test]
+    fn content_bulk_delete_max_ids_constant_is_mirrored_from_core() {
+        assert_eq!(
+            octos_core::ui_protocol::CONTENT_BULK_DELETE_MAX_IDS,
+            256,
+            "bulk-delete cap is documented at 256 in the ADR; bump both sides if changed",
+        );
     }
 
     // M11-E: `session_filesystem_profile_for_workspace` was deleted

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -23,26 +23,31 @@ use octos_agent::{
 use octos_core::ui_protocol::{
     ApprovalAutoResolvedEvent, ApprovalCancelledEvent, ApprovalCommandDetails,
     ApprovalDecidedEvent, ApprovalDecision, ApprovalId, ApprovalRenderHints,
-    ApprovalRequestedEvent, ApprovalTypedDetails, HydratedMessage, HydratedTurn, InputItem,
-    MessageDeltaEvent, MessagePersistedEvent, MessagePersistedSource, OutputCursor,
-    ReplayLossyEvent, RpcError, RpcErrorResponse, RpcRequest, RpcResponse,
-    SESSION_HYDRATE_INCLUDE_MAX, SessionHydrateParams, SessionHydrateResult, SessionOpenParams,
-    SessionOpenResult, SessionOpened, TaskCancelParams, TaskCancelResult, TaskListEntry,
-    TaskListParams, TaskListResult, TaskOutputDeltaEvent, TaskRestartFromNodeParams,
+    ApprovalRequestedEvent, ApprovalTypedDetails, ContentBulkDeleteParams, ContentDeleteParams,
+    ContentListParams, HydratedMessage, HydratedTurn, InputItem, MessageDeltaEvent,
+    MessagePersistedEvent, MessagePersistedSource, OutputCursor, ReplayLossyEvent, RpcError,
+    RpcErrorResponse, RpcRequest, RpcResponse, SESSION_HYDRATE_INCLUDE_MAX,
+    SESSION_MESSAGES_PAGE_DEFAULT_LIMIT, SESSION_MESSAGES_PAGE_MAX_LIMIT,
+    SESSION_MESSAGES_PAGE_MAX_OFFSET, SESSION_TITLE_SET_MAX_CHARS, SessionDeleteParams,
+    SessionFilesListParams, SessionHydrateParams, SessionHydrateResult, SessionListParams,
+    SessionMessagesPageParams, SessionOpenParams, SessionOpenResult, SessionOpened,
+    SessionSnapshotParams, SessionStatusGetParams, SessionTasksListParams, SessionTitleSetParams,
+    SessionWorkspaceGetParams, SystemStatusGetParams, TaskCancelParams, TaskCancelResult,
+    TaskListEntry, TaskListParams, TaskListResult, TaskOutputDeltaEvent, TaskRestartFromNodeParams,
     TaskRestartFromNodeResult, TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent,
     ThreadGraphEntry, ThreadGraphGetParams, ThreadGraphGetResult, ToolCompletedEvent,
     ToolProgressEvent, ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId,
     TurnInterruptParams, TurnInterruptResult, TurnLifecycleState, TurnSpawnCompleteEvent,
     TurnStartParams, TurnStateGetParams, TurnStateGetResult, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
-    UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1, UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
-    UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1, UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
-    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
-    UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1, UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UiArtifactPaneItem,
-    UiArtifactPaneSnapshot, UiCommand, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
-    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
-    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiWorkspacePaneEntry,
-    UiWorkspacePaneSnapshot, approval_cancelled_reasons, approval_kinds, hydrate_sections,
-    progress_kinds, thread_status,
+    UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
+    UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
+    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
+    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand,
+    UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot, UiGitStatusItem,
+    UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent, UiProgressMetadata,
+    UiProtocolCapabilities, UiWorkspacePaneEntry, UiWorkspacePaneSnapshot,
+    approval_cancelled_reasons, approval_kinds, hydrate_sections, progress_kinds, thread_status,
 };
 use octos_core::{AgentId, MAIN_PROFILE_ID, Message, MessageRole, SessionKey, TaskId};
 use serde::Serialize;
@@ -518,6 +523,17 @@ struct ConnectionUiFeatures {
     /// `message/persisted` shape is preserved and `turn/spawn_complete`
     /// is suppressed.
     spawn_complete: bool,
+    /// M12 Phase D-1 `auxiliary.rest_to_ws.v1` negotiated. Unlocks the
+    /// twelve auxiliary JSON-RPC methods (`session/list`,
+    /// `session/snapshot`, `session/messages_page`, `session/status.get`,
+    /// `session/files.list`, `session/tasks.list`,
+    /// `session/workspace.get`, `session/title.set`, `session/delete`,
+    /// `system/status.get`, `content/list`, `content/delete`,
+    /// `content/bulk_delete`) on the existing WS connection.
+    /// Capability-gated per ADR
+    /// `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`. REST endpoints
+    /// remain available for clients that do not negotiate this feature.
+    auxiliary_rest_to_ws_v1: bool,
     /// `true` when the client sent at least one feature token via the
     /// `X-Octos-Ui-Features` header or the `ui_feature` / `ui_features`
     /// query parameter (UPCR-2026-007). Distinguishes "no header at all"
@@ -551,6 +567,11 @@ impl ConnectionUiFeatures {
                 UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
             ),
             spawn_complete: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1),
+            auxiliary_rest_to_ws_v1: has_ui_feature(
+                headers,
+                query,
+                UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
+            ),
             header_present: has_any_ui_feature_token(headers, query),
         }
     }
@@ -595,6 +616,9 @@ impl ConnectionUiFeatures {
         }
         if self.spawn_complete {
             requested.push(UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1);
+        }
+        if self.auxiliary_rest_to_ws_v1 {
+            requested.push(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1);
         }
         UiProtocolCapabilities::for_negotiated_features(requested)
     }
@@ -1444,6 +1468,14 @@ pub async fn ws_handler(
     // sessions originated from a hosted subdomain.
     let routed_profile_id = super::handlers::routed_profile_id_from_headers(&state, &headers);
     let features = ConnectionUiFeatures::from_headers_and_query(&headers, uri.query());
+    // M12 Phase D-1: auxiliary REST→WS dispatchers reuse the same REST
+    // handlers in `handlers.rs` for business logic, which means they
+    // need the same axum extractor inputs the REST routes received.
+    // Snapshot the HeaderMap and AuthIdentity onto the connection so
+    // each dispatcher arm can re-build the extractor tuple without a
+    // round-trip back through the router. None of the existing dispatch
+    // arms read these; only the new aux-REST-to-WS arms do.
+    let auth_identity = identity.map(|Extension(identity)| identity);
     ws.on_upgrade(move |socket| {
         ui_protocol_connection(
             socket,
@@ -1451,6 +1483,8 @@ pub async fn ws_handler(
             connection_profile_id,
             routed_profile_id,
             features,
+            headers,
+            auth_identity,
         )
     })
 }
@@ -1461,6 +1495,8 @@ async fn ui_protocol_connection(
     connection_profile_id: Option<String>,
     routed_profile_id: Option<String>,
     features: ConnectionUiFeatures,
+    connection_headers: HeaderMap,
+    connection_identity: Option<AuthIdentity>,
 ) {
     let (ws_sink, mut ws_rx) = socket.split();
     // Decouple the network sink from request handlers via a bounded channel
@@ -1637,6 +1673,95 @@ async fn ui_protocol_connection(
                     ),
                 );
             }
+            // -------- M12 Phase D-1 auxiliary REST → WS dispatchers --------
+            //
+            // Each arm below delegates to the same REST handler in
+            // `crates/octos-cli/src/api/handlers.rs` (or
+            // `auth_handlers.rs`) that the REST route uses. We rebuild
+            // the axum extractor tuple from the snapshotted connection
+            // headers + identity, await the handler, and forward the
+            // JSON body as the WS RPC result. No business logic is
+            // duplicated; the REST endpoints stay unchanged.
+            UiCommand::SessionList(params) => {
+                handle_session_list(&ws, &state, &connection_headers, id, params).await;
+            }
+            UiCommand::SessionSnapshot(params) => {
+                handle_session_snapshot(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SessionMessagesPage(params) => {
+                handle_session_messages_page(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SessionStatusGet(params) => {
+                handle_session_status_get(&ws, &state, &connection_headers, id, params).await;
+            }
+            UiCommand::SessionFilesList(params) => {
+                handle_session_files_list(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SessionTasksList(params) => {
+                handle_session_tasks_list(&ws, &state, &connection_headers, id, params).await;
+            }
+            UiCommand::SessionWorkspaceGet(params) => {
+                handle_session_workspace_get(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::SessionTitleSet(params) => {
+                handle_session_title_set(&ws, &state, &connection_headers, id, params).await;
+            }
+            UiCommand::SessionDelete(params) => {
+                handle_session_delete(&ws, &state, &connection_headers, id, params).await;
+            }
+            UiCommand::SystemStatusGet(params) => {
+                handle_system_status_get(&ws, &state, id, params).await;
+            }
+            UiCommand::ContentList(params) => {
+                handle_content_list(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
+            }
+            UiCommand::ContentDelete(params) => {
+                handle_content_delete(&ws, &state, connection_identity.as_ref(), id, params).await;
+            }
+            UiCommand::ContentBulkDelete(params) => {
+                handle_content_bulk_delete(&ws, &state, connection_identity.as_ref(), id, params)
+                    .await;
+            }
         }
     }
 
@@ -1670,20 +1795,28 @@ fn route_rpc_command(
     request: RpcRequest<Value>,
     features: ConnectionUiFeatures,
 ) -> Result<UiCommand, RpcError> {
-    let command = UiCommand::from_rpc_request(request)?;
-    let method = command.method();
-    if !ui_protocol_server_supported_methods().contains(&method) {
-        return Err(RpcError::method_not_supported(method));
+    let method_str = request.method.as_str();
+    if !ui_protocol_server_supported_methods().contains(&method_str) {
+        return Err(RpcError::method_not_supported(method_str));
     }
-    // UPCR-2026-009 / -010 / -011: when the method is gated behind a feature
-    // flag and the connection did not negotiate that flag (and a feature
-    // header was present), reject with `method_not_supported`. Connections
-    // that send no feature header at all retain the legacy "advertise full
-    // first-slice in `SessionOpened`" behaviour and so see the methods as
-    // available — the gate fires only when the client opted into
-    // negotiation per UPCR-2026-007 but skipped this feature.
+    // UPCR-2026-009 / -010 / -011 + M12 Phase D-1: when the method is
+    // gated behind a feature flag and the connection did not negotiate
+    // that flag (and a feature header was present), reject with
+    // `method_not_supported` BEFORE attempting to deserialize the
+    // params. Doing the gate first means clients that targeted a
+    // capability-gated method without negotiating the feature see a
+    // clean `method_not_supported` (and can fall back to REST) instead
+    // of `invalid_params` for an unrelated payload shape — the spec
+    // contract is "we don't know about this method at all", not "we
+    // half-know it".
+    //
+    // Connections that send no feature header at all retain the legacy
+    // "advertise full first-slice in `SessionOpened`" behaviour and so
+    // see the methods as available — the gate fires only when the
+    // client opted into negotiation per UPCR-2026-007 but skipped this
+    // feature.
     if features.header_present {
-        let gated = match method {
+        let gated = match method_str {
             octos_core::ui_protocol::methods::SESSION_HYDRATE => Some(features.session_hydrate),
             octos_core::ui_protocol::methods::THREAD_GRAPH_GET => Some(features.thread_graph),
             octos_core::ui_protocol::methods::TURN_STATE_GET => Some(features.turn_state_get),
@@ -1692,13 +1825,34 @@ fn route_rpc_command(
             | octos_core::ui_protocol::methods::TASK_RESTART_FROM_NODE => {
                 Some(features.harness_task_control)
             }
+            // M12 Phase D-1: capability-gate the twelve auxiliary
+            // REST→WS methods behind `auxiliary.rest_to_ws.v1`. Clients
+            // that did not negotiate the feature see
+            // `method_not_supported` so they fall back to REST. This is
+            // what makes Phase D-1 additive — no behaviour change for
+            // clients that haven't opted in.
+            octos_core::ui_protocol::methods::SESSION_LIST
+            | octos_core::ui_protocol::methods::SESSION_SNAPSHOT
+            | octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE
+            | octos_core::ui_protocol::methods::SESSION_STATUS_GET
+            | octos_core::ui_protocol::methods::SESSION_FILES_LIST
+            | octos_core::ui_protocol::methods::SESSION_TASKS_LIST
+            | octos_core::ui_protocol::methods::SESSION_WORKSPACE_GET
+            | octos_core::ui_protocol::methods::SESSION_TITLE_SET
+            | octos_core::ui_protocol::methods::SESSION_DELETE
+            | octos_core::ui_protocol::methods::SYSTEM_STATUS_GET
+            | octos_core::ui_protocol::methods::CONTENT_LIST
+            | octos_core::ui_protocol::methods::CONTENT_DELETE
+            | octos_core::ui_protocol::methods::CONTENT_BULK_DELETE => {
+                Some(features.auxiliary_rest_to_ws_v1)
+            }
             _ => None,
         };
         if let Some(false) = gated {
-            return Err(RpcError::method_not_supported(method));
+            return Err(RpcError::method_not_supported(method_str));
         }
     }
-    Ok(command)
+    UiCommand::from_rpc_request(request)
 }
 
 fn ui_protocol_server_supported_methods() -> Vec<&'static str> {
@@ -4177,6 +4331,677 @@ fn send_serialized_rpc_result<T: Serialize>(
     }
 }
 
+// ===================== M12 Phase D-1 dispatchers =====================
+//
+// Each handler below mirrors a REST endpoint listed in
+// `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`. The strategy is to
+// invoke the existing REST handler function directly with the
+// connection's snapshotted `HeaderMap` and `AuthIdentity`, then forward
+// the resulting JSON body as the WS RPC result. This keeps the
+// auxiliary surface fed by exactly one code path (the REST handler in
+// `crates/octos-cli/src/api/handlers.rs` /
+// `crates/octos-cli/src/api/auth_handlers.rs`), so Phase D-5 retirement
+// later does not have to re-validate logic.
+
+/// Per-handler limit for extracting JSON bodies from a REST `Response`.
+/// Mirrors `MAX_TEXT_FRAME_BYTES` (1 MiB) so the WS write side cannot
+/// be fed a frame the peer would reject as oversize. Truncates with an
+/// RPC error if exceeded.
+const AUX_REST_TO_WS_MAX_BODY_BYTES: usize = MAX_TEXT_FRAME_BYTES;
+
+/// Convert an axum `Response` from a REST handler into a parsed JSON
+/// [`Value`] suitable for embedding in a WS RPC result. Non-2xx
+/// responses are surfaced as typed RPC errors so the client sees the
+/// same shape it would on REST today (404/400/503 → typed RpcError
+/// variants per the ADR's `Error envelope` mapping).
+async fn rest_response_to_rpc_value(
+    response: axum::response::Response,
+    method: &str,
+) -> Result<Value, RpcError> {
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), AUX_REST_TO_WS_MAX_BODY_BYTES)
+        .await
+        .map_err(|err| {
+            RpcError::internal_error(format!("{method}: read REST body failed: {err}"))
+        })?;
+    if !status.is_success() {
+        // Map common REST statuses to the ADR's error envelope. The
+        // body is included as `data.detail` for debugging but the
+        // message is the human-readable summary.
+        let detail = String::from_utf8_lossy(body.as_ref()).into_owned();
+        let detail = if detail.is_empty() {
+            None
+        } else {
+            Some(detail)
+        };
+        return Err(rest_status_to_rpc_error(method, status, detail));
+    }
+    if body.is_empty() {
+        // REST 204 No Content (and equivalents like our `delete_session`
+        // helper) becomes a `{}` result on the WS side.
+        return Ok(Value::Object(serde_json::Map::new()));
+    }
+    serde_json::from_slice::<Value>(body.as_ref())
+        .map_err(|err| RpcError::internal_error(format!("{method}: REST body was not JSON: {err}")))
+}
+
+fn rest_status_to_rpc_error(
+    method: &str,
+    status: axum::http::StatusCode,
+    detail: Option<String>,
+) -> RpcError {
+    let mut data = serde_json::Map::new();
+    data.insert("rest_status".into(), json!(status.as_u16()));
+    if let Some(detail) = detail {
+        // Cap detail at 2 KiB so error frames stay small even if the
+        // REST handler returns a verbose body.
+        let mut detail = detail;
+        if detail.len() > 2048 {
+            octos_core::truncate_utf8(&mut detail, 2048, "…");
+        }
+        data.insert("detail".into(), json!(detail));
+    }
+    use axum::http::StatusCode;
+    let error = match status {
+        StatusCode::NOT_FOUND => RpcError::unknown_session(format!("{method}: not found")),
+        StatusCode::BAD_REQUEST => {
+            RpcError::invalid_params(format!("{method}: REST returned 400 bad_request"))
+        }
+        StatusCode::SERVICE_UNAVAILABLE => RpcError::runtime_not_ready(format!(
+            "{method}: REST handler not configured on this server"
+        )),
+        StatusCode::CONFLICT => {
+            RpcError::invalid_params(format!("{method}: REST returned 409 conflict"))
+        }
+        _ => RpcError::internal_error(format!(
+            "{method}: REST returned status {}",
+            status.as_u16()
+        )),
+    };
+    error.with_data(Value::Object(data))
+}
+
+/// Forward a parsed JSON body to the WS RPC result channel. Used by
+/// every Phase D-1 dispatcher after extracting the REST handler body.
+fn send_aux_rpc_result(ws: &WsConnection, id: String, method: &str, body: Value) {
+    // The body shape MUST match the WS result schema documented in
+    // `octos-core/src/ui_protocol.rs`. For methods whose Result wraps
+    // the REST body under a single field (e.g. `SessionListResult.sessions`),
+    // callers are responsible for constructing that wrapper before
+    // invoking this helper; methods whose Result is a direct alias of
+    // the REST body pass it through verbatim.
+    if let Err(error) = send_rpc_result(ws, id, body) {
+        tracing::debug!(
+            target: "octos::ui_protocol::ws::aux",
+            method = %method,
+            ?error,
+            "aux REST→WS result send failed"
+        );
+    }
+}
+
+/// Build a synthetic `Path<String>` extractor from the session id in
+/// the WS params. Axum's `Path` is a tuple wrapper so we construct it
+/// directly via `Path(...)` — the REST handler treats it like an
+/// already-extracted route segment.
+fn axum_path(value: String) -> axum::extract::Path<String> {
+    axum::extract::Path(value)
+}
+
+async fn handle_session_list(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    id: String,
+    _params: SessionListParams,
+) {
+    let response = super::handlers::list_sessions(State(state.clone()), headers.clone()).await;
+    let method = octos_core::ui_protocol::methods::SESSION_LIST;
+    match rest_response_to_rpc_value(response, method).await {
+        Ok(sessions) => {
+            send_aux_rpc_result(ws, id, method, json!({ "sessions": sessions }));
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_session_status_get(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    id: String,
+    params: SessionStatusGetParams,
+) {
+    let topic_params = axum::extract::Query(super::handlers::TopicQueryParams {
+        topic: params.topic.clone(),
+    });
+    let response = super::handlers::session_status(
+        State(state.clone()),
+        headers.clone(),
+        axum_path(params.session_id),
+        topic_params,
+    )
+    .await;
+    let method = octos_core::ui_protocol::methods::SESSION_STATUS_GET;
+    match rest_response_to_rpc_value(response, method).await {
+        Ok(status) => {
+            send_aux_rpc_result(ws, id, method, json!({ "status": status }));
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_session_files_list(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    id: String,
+    params: SessionFilesListParams,
+) {
+    let identity_ext = identity.cloned().map(Extension);
+    let response = super::handlers::session_files(
+        State(state.clone()),
+        headers.clone(),
+        identity_ext,
+        axum_path(params.session_id),
+    )
+    .await;
+    let method = octos_core::ui_protocol::methods::SESSION_FILES_LIST;
+    match rest_response_to_rpc_value(response, method).await {
+        Ok(files) => {
+            send_aux_rpc_result(ws, id, method, json!({ "files": files }));
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_session_tasks_list(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    id: String,
+    params: SessionTasksListParams,
+) {
+    let topic_params = axum::extract::Query(super::handlers::TopicQueryParams {
+        topic: params.topic.clone(),
+    });
+    let response = super::handlers::session_tasks(
+        State(state.clone()),
+        headers.clone(),
+        axum_path(params.session_id),
+        topic_params,
+    )
+    .await;
+    let method = octos_core::ui_protocol::methods::SESSION_TASKS_LIST;
+    match rest_response_to_rpc_value(response, method).await {
+        Ok(tasks) => {
+            send_aux_rpc_result(ws, id, method, json!({ "tasks": tasks }));
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_session_workspace_get(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    id: String,
+    params: SessionWorkspaceGetParams,
+) {
+    let identity_ext = identity.cloned().map(Extension);
+    let response = super::handlers::session_workspace_contract(
+        State(state.clone()),
+        headers.clone(),
+        identity_ext,
+        axum_path(params.session_id),
+    )
+    .await;
+    let method = octos_core::ui_protocol::methods::SESSION_WORKSPACE_GET;
+    match rest_response_to_rpc_value(response, method).await {
+        Ok(contracts) => {
+            send_aux_rpc_result(ws, id, method, json!({ "contracts": contracts }));
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_session_snapshot(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    id: String,
+    params: SessionSnapshotParams,
+) {
+    // Snapshot is a single round trip that collapses the three REST
+    // bootstrap calls (status, files, tasks). Run them concurrently
+    // and surface the first error.
+    let method = octos_core::ui_protocol::methods::SESSION_SNAPSHOT;
+    let topic_params = axum::extract::Query(super::handlers::TopicQueryParams {
+        topic: params.topic.clone(),
+    });
+    let identity_ext = identity.cloned().map(Extension);
+    let status_fut = super::handlers::session_status(
+        State(state.clone()),
+        headers.clone(),
+        axum_path(params.session_id.clone()),
+        axum::extract::Query(super::handlers::TopicQueryParams {
+            topic: params.topic.clone(),
+        }),
+    );
+    let files_fut = super::handlers::session_files(
+        State(state.clone()),
+        headers.clone(),
+        identity_ext,
+        axum_path(params.session_id.clone()),
+    );
+    let tasks_fut = super::handlers::session_tasks(
+        State(state.clone()),
+        headers.clone(),
+        axum_path(params.session_id),
+        topic_params,
+    );
+    let (status_resp, files_resp, tasks_resp) = tokio::join!(status_fut, files_fut, tasks_fut);
+    let status = match rest_response_to_rpc_value(status_resp, method).await {
+        Ok(v) => v,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+    let files = match rest_response_to_rpc_value(files_resp, method).await {
+        Ok(v) => v,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+    let tasks = match rest_response_to_rpc_value(tasks_resp, method).await {
+        Ok(v) => v,
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+            return;
+        }
+    };
+    send_aux_rpc_result(
+        ws,
+        id,
+        method,
+        json!({
+            "status": status,
+            "files": files,
+            "tasks": tasks,
+        }),
+    );
+}
+
+async fn handle_session_messages_page(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    id: String,
+    params: SessionMessagesPageParams,
+) {
+    let method = octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE;
+    let limit = params
+        .limit
+        .unwrap_or(SESSION_MESSAGES_PAGE_DEFAULT_LIMIT)
+        .min(SESSION_MESSAGES_PAGE_MAX_LIMIT);
+    let offset = params
+        .offset
+        .unwrap_or(0)
+        .min(SESSION_MESSAGES_PAGE_MAX_OFFSET);
+    let pagination = axum::extract::Query(super::handlers::PaginationParams {
+        limit,
+        offset,
+        source: None,
+        since_seq: params.since_seq,
+        topic: params.topic.clone(),
+    });
+    let identity_ext = identity.cloned().map(Extension);
+    let response = super::handlers::session_messages(
+        State(state.clone()),
+        headers.clone(),
+        identity_ext,
+        axum_path(params.session_id),
+        pagination,
+    )
+    .await;
+    let status = response.status();
+    if status == axum::http::StatusCode::NOT_FOUND {
+        // Per ADR: `UNKNOWN_SESSION` → empty page (matches REST's
+        // historical 404→empty client semantic).
+        send_aux_rpc_result(
+            ws,
+            id,
+            method,
+            json!({
+                "messages": [],
+                "has_more": false,
+                "next_offset": offset,
+            }),
+        );
+        return;
+    }
+    match rest_response_to_rpc_value(response, method).await {
+        Ok(messages) => {
+            let len = messages.as_array().map(|arr| arr.len()).unwrap_or(0);
+            let has_more = len == limit;
+            let next_offset = offset.saturating_add(len);
+            send_aux_rpc_result(
+                ws,
+                id,
+                method,
+                json!({
+                    "messages": messages,
+                    "has_more": has_more,
+                    "next_offset": next_offset,
+                }),
+            );
+        }
+        Err(error) => {
+            let _ = send_rpc_error(ws, Some(id), error);
+        }
+    }
+}
+
+async fn handle_session_title_set(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    id: String,
+    params: SessionTitleSetParams,
+) {
+    let method = octos_core::ui_protocol::methods::SESSION_TITLE_SET;
+    let trimmed = params.title.trim();
+    if trimmed.is_empty() {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!("{method}: title must not be empty")),
+        );
+        return;
+    }
+    if trimmed.chars().count() > SESSION_TITLE_SET_MAX_CHARS {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!(
+                "{method}: title must be at most {SESSION_TITLE_SET_MAX_CHARS} chars"
+            )),
+        );
+        return;
+    }
+    let body = axum::Json(super::handlers::UpdateTitleRequest {
+        title: trimmed.to_string(),
+    });
+    let session_id_str = params.session_id.clone();
+    let response = super::handlers::update_session_title(
+        State(state.clone()),
+        headers.clone(),
+        axum_path(params.session_id),
+        body,
+    )
+    .await;
+    let status = response.status();
+    if status.is_success() {
+        send_aux_rpc_result(
+            ws,
+            id,
+            method,
+            json!({
+                "session_id": session_id_str,
+                "title": trimmed,
+            }),
+        );
+    } else {
+        let detail = axum::body::to_bytes(response.into_body(), AUX_REST_TO_WS_MAX_BODY_BYTES)
+            .await
+            .ok()
+            .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok());
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            rest_status_to_rpc_error(method, status, detail),
+        );
+    }
+}
+
+async fn handle_session_delete(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    id: String,
+    params: SessionDeleteParams,
+) {
+    let method = octos_core::ui_protocol::methods::SESSION_DELETE;
+    let response = super::handlers::delete_session(
+        State(state.clone()),
+        headers.clone(),
+        axum_path(params.session_id),
+    )
+    .await;
+    let status = response.status();
+    if status.is_success() {
+        send_aux_rpc_result(ws, id, method, json!({}));
+    } else {
+        let detail = axum::body::to_bytes(response.into_body(), AUX_REST_TO_WS_MAX_BODY_BYTES)
+            .await
+            .ok()
+            .and_then(|bytes| String::from_utf8(bytes.to_vec()).ok());
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            rest_status_to_rpc_error(method, status, detail),
+        );
+    }
+}
+
+async fn handle_system_status_get(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    id: String,
+    _params: SystemStatusGetParams,
+) {
+    let method = octos_core::ui_protocol::methods::SYSTEM_STATUS_GET;
+    let axum::Json(status) = super::handlers::status(State(state.clone())).await;
+    match serde_json::to_value(&status) {
+        Ok(value) => send_aux_rpc_result(ws, id, method, json!({ "status": value })),
+        Err(error) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::internal_error(format!("{method}: serialize status failed: {error}")),
+            );
+        }
+    }
+}
+
+async fn handle_content_list(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+    id: String,
+    params: ContentListParams,
+) {
+    let method = octos_core::ui_protocol::methods::CONTENT_LIST;
+    let Some(identity) = identity.cloned() else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::permission_denied(format!("{method}: authenticated user identity required")),
+        );
+        return;
+    };
+    // `ContentQuery` deserializes from the same JSON the REST query
+    // string built. Forwarding the `filters` object lets clients opt
+    // in to category / search / pagination without us redefining the
+    // struct here. Null / empty filters fall back to the REST default
+    // (`Default::default()`) so `content/list` with `{}` params works
+    // identically to `GET /api/my/content` with no query string.
+    let filters = if params.filters.is_null() {
+        Value::Object(serde_json::Map::new())
+    } else {
+        params.filters
+    };
+    let query: crate::content_catalog::ContentQuery = match serde_json::from_value(filters) {
+        Ok(q) => q,
+        Err(err) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params(format!("{method}: invalid filters: {err}")),
+            );
+            return;
+        }
+    };
+    let result = super::auth_handlers::my_content(
+        State(state.clone()),
+        headers.clone(),
+        Extension(identity),
+        axum::extract::Query(query),
+    )
+    .await;
+    match result {
+        Ok(axum::Json(value)) => match serde_json::to_value(&value) {
+            Ok(json_value) => {
+                let entries = json_value
+                    .get("entries")
+                    .cloned()
+                    .unwrap_or_else(|| json!([]));
+                let total = json_value.get("total").and_then(Value::as_u64).unwrap_or(0) as usize;
+                send_aux_rpc_result(
+                    ws,
+                    id,
+                    method,
+                    json!({
+                        "entries": entries,
+                        "total": total,
+                    }),
+                );
+            }
+            Err(error) => {
+                let _ = send_rpc_error(
+                    ws,
+                    Some(id),
+                    RpcError::internal_error(format!(
+                        "{method}: serialize content list failed: {error}"
+                    )),
+                );
+            }
+        },
+        Err((status, message)) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, Some(message)),
+            );
+        }
+    }
+}
+
+async fn handle_content_delete(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    identity: Option<&AuthIdentity>,
+    id: String,
+    params: ContentDeleteParams,
+) {
+    let method = octos_core::ui_protocol::methods::CONTENT_DELETE;
+    let Some(identity) = identity.cloned() else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::permission_denied(format!("{method}: authenticated user identity required")),
+        );
+        return;
+    };
+    let result = super::auth_handlers::delete_my_content(
+        State(state.clone()),
+        Extension(identity),
+        axum_path(params.id),
+    )
+    .await;
+    match result {
+        Ok(axum::Json(action)) => {
+            send_aux_rpc_result(
+                ws,
+                id,
+                method,
+                json!({
+                    "deleted": action.ok,
+                }),
+            );
+        }
+        Err((status, message)) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, Some(message)),
+            );
+        }
+    }
+}
+
+async fn handle_content_bulk_delete(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    identity: Option<&AuthIdentity>,
+    id: String,
+    params: ContentBulkDeleteParams,
+) {
+    let method = octos_core::ui_protocol::methods::CONTENT_BULK_DELETE;
+    let Some(identity) = identity.cloned() else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::permission_denied(format!("{method}: authenticated user identity required")),
+        );
+        return;
+    };
+    let result = super::auth_handlers::bulk_delete_my_content(
+        State(state.clone()),
+        Extension(identity),
+        axum::Json(super::auth_handlers::BulkDeleteRequest { ids: params.ids }),
+    )
+    .await;
+    match result {
+        Ok(axum::Json(action)) => {
+            // The REST handler stuffs the count into the user-facing
+            // message ("N item(s) deleted."). Parse it back out so the
+            // WS shape can return a typed integer per the ADR.
+            let deleted = action
+                .message
+                .as_deref()
+                .and_then(|msg| msg.split_whitespace().next())
+                .and_then(|first| first.parse::<usize>().ok())
+                .unwrap_or(0);
+            send_aux_rpc_result(ws, id, method, json!({ "deleted": deleted }));
+        }
+        Err((status, message)) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                rest_status_to_rpc_error(method, status, Some(message)),
+            );
+        }
+    }
+}
+
 fn task_query_store_or_error(
     state: &Arc<AppState>,
 ) -> Result<&crate::session_actor::SessionTaskQueryStore, RpcError> {
@@ -6358,6 +7183,7 @@ mod tests {
                 turn_state_get: false,
                 message_persisted: false,
                 spawn_complete: false,
+                auxiliary_rest_to_ws_v1: false,
                 header_present: true,
             },
         );
@@ -6408,6 +7234,7 @@ mod tests {
                 turn_state_get: false,
                 message_persisted: false,
                 spawn_complete: false,
+                auxiliary_rest_to_ws_v1: false,
                 header_present: true,
             },
         );
@@ -6503,6 +7330,7 @@ mod tests {
                 turn_state_get: false,
                 message_persisted: false,
                 spawn_complete: false,
+                auxiliary_rest_to_ws_v1: false,
                 header_present: true,
             },
         );
@@ -6553,6 +7381,7 @@ mod tests {
                 turn_state_get: false,
                 message_persisted: false,
                 spawn_complete: false,
+                auxiliary_rest_to_ws_v1: false,
                 header_present: true,
             },
         );
@@ -6596,6 +7425,7 @@ mod tests {
                 turn_state_get: false,
                 message_persisted: false,
                 spawn_complete: false,
+                auxiliary_rest_to_ws_v1: false,
                 header_present: true,
             },
         );
@@ -6682,6 +7512,7 @@ mod tests {
                 turn_state_get: false,
                 message_persisted: false,
                 spawn_complete: false,
+                auxiliary_rest_to_ws_v1: false,
                 header_present: true,
             },
         );
@@ -7973,6 +8804,7 @@ mod tests {
                 turn_state_get: false,
                 message_persisted: false,
                 spawn_complete: false,
+                auxiliary_rest_to_ws_v1: false,
                 header_present: true,
             },
             SessionOpenParams {
@@ -8158,6 +8990,180 @@ mod tests {
                 .any(|method| method == octos_core::ui_protocol::methods::TASK_CANCEL),
             "task/cancel must be gated by harness.task_control.v1"
         );
+    }
+
+    // ===== M12 Phase D-1 auxiliary REST → WS negotiation =====
+
+    #[test]
+    fn aux_rest_to_ws_v1_feature_token_parses_from_query_string() {
+        // Mirrors the existing `?ui_feature=session.workspace_cwd.v1`
+        // pattern (`e2e/scripts/soak-m11-multi.ts:21`). A client that
+        // appends `?ui_feature=auxiliary.rest_to_ws.v1` MUST be picked
+        // up by the per-connection feature snapshot.
+        let headers = HeaderMap::new();
+        let features = ConnectionUiFeatures::from_headers_and_query(
+            &headers,
+            Some("token=redacted&ui_feature=auxiliary.rest_to_ws.v1"),
+        );
+        assert!(features.auxiliary_rest_to_ws_v1);
+        assert!(features.header_present);
+        // Negative: an unrelated feature stays unflipped.
+        assert!(!features.harness_task_control);
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_feature_token_parses_from_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(features.auxiliary_rest_to_ws_v1);
+        assert!(features.header_present);
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_not_negotiated_when_only_other_features_requested() {
+        // Client requests `harness.task_control.v1` — the auxiliary
+        // capability must NOT be auto-enabled. Phase D-1 is strictly
+        // opt-in.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(features.harness_task_control);
+        assert!(!features.auxiliary_rest_to_ws_v1);
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_negotiated_capabilities_include_only_when_requested() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        let capabilities = features.negotiated_capabilities();
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1));
+        for method in [
+            octos_core::ui_protocol::methods::SESSION_LIST,
+            octos_core::ui_protocol::methods::SESSION_SNAPSHOT,
+            octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE,
+            octos_core::ui_protocol::methods::SESSION_STATUS_GET,
+            octos_core::ui_protocol::methods::SESSION_FILES_LIST,
+            octos_core::ui_protocol::methods::SESSION_TASKS_LIST,
+            octos_core::ui_protocol::methods::SESSION_WORKSPACE_GET,
+            octos_core::ui_protocol::methods::SESSION_TITLE_SET,
+            octos_core::ui_protocol::methods::SESSION_DELETE,
+            octos_core::ui_protocol::methods::SYSTEM_STATUS_GET,
+            octos_core::ui_protocol::methods::CONTENT_LIST,
+            octos_core::ui_protocol::methods::CONTENT_DELETE,
+            octos_core::ui_protocol::methods::CONTENT_BULK_DELETE,
+        ] {
+            assert!(
+                capabilities.supports_method(method),
+                "{method} must be advertised when auxiliary.rest_to_ws.v1 is negotiated"
+            );
+        }
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_negotiated_capabilities_omit_when_not_requested() {
+        let mut headers = HeaderMap::new();
+        // Request a different feature so `header_present == true`.
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        let capabilities = features.negotiated_capabilities();
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1));
+        for method in [
+            octos_core::ui_protocol::methods::SESSION_LIST,
+            octos_core::ui_protocol::methods::SESSION_SNAPSHOT,
+            octos_core::ui_protocol::methods::SESSION_MESSAGES_PAGE,
+            octos_core::ui_protocol::methods::SYSTEM_STATUS_GET,
+            octos_core::ui_protocol::methods::CONTENT_LIST,
+            octos_core::ui_protocol::methods::CONTENT_DELETE,
+            octos_core::ui_protocol::methods::CONTENT_BULK_DELETE,
+        ] {
+            assert!(
+                !capabilities.supports_method(method),
+                "{method} must NOT be advertised without auxiliary.rest_to_ws.v1"
+            );
+        }
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_route_rpc_rejects_methods_when_feature_not_negotiated() {
+        // A client that sent ANY feature header but NOT
+        // `auxiliary.rest_to_ws.v1` must see the aux methods rejected
+        // with `method_not_supported`, matching the existing gate for
+        // `task/list` behind `harness.task_control.v1`.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(features.header_present);
+        assert!(!features.auxiliary_rest_to_ws_v1);
+        for method in [
+            octos_core::ui_protocol::methods::SESSION_LIST,
+            octos_core::ui_protocol::methods::SESSION_SNAPSHOT,
+            octos_core::ui_protocol::methods::SESSION_DELETE,
+            octos_core::ui_protocol::methods::SYSTEM_STATUS_GET,
+            octos_core::ui_protocol::methods::CONTENT_LIST,
+        ] {
+            let request = RpcRequest::<Value>::new("req-1", method, Value::Null);
+            let result = route_rpc_command(request, features);
+            let err = result.expect_err("aux method must be rejected without feature");
+            assert_eq!(
+                err.code,
+                octos_core::ui_protocol::rpc_error_codes::METHOD_NOT_SUPPORTED,
+                "{method} must reject with METHOD_NOT_SUPPORTED"
+            );
+        }
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_route_rpc_accepts_methods_when_feature_negotiated() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            UI_FEATURES_HEADER,
+            UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1
+                .parse()
+                .expect("header value"),
+        );
+        let features = ConnectionUiFeatures::from_headers_and_query(&headers, None);
+        assert!(features.auxiliary_rest_to_ws_v1);
+        for (method, params) in [
+            (
+                octos_core::ui_protocol::methods::SESSION_LIST,
+                Value::Object(serde_json::Map::new()),
+            ),
+            (
+                octos_core::ui_protocol::methods::SYSTEM_STATUS_GET,
+                Value::Object(serde_json::Map::new()),
+            ),
+        ] {
+            let request = RpcRequest::<Value>::new("req-2", method, params);
+            let cmd = route_rpc_command(request, features).expect("aux method accepted");
+            assert_eq!(cmd.method(), method);
+        }
     }
 
     // M11-E: `session_filesystem_profile_for_workspace` was deleted

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -79,6 +79,21 @@ pub const UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1: &str = "event.spawn_complete.v1
 /// this feature, until M9-γ-3 deletes them.
 pub const UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1: &str = "projection.envelope.v1";
 
+/// Feature flag for M12 Phase D-1 auxiliary REST→WS migration.
+///
+/// Negotiated by clients that route auxiliary panel traffic (sidebar
+/// session list, right-rail snapshot/files/tasks, status pill, messages
+/// history scroll, workspace contract panel, title rename, session
+/// delete, content gallery) onto the existing
+/// `/api/ui-protocol/ws` JSON-RPC connection instead of the legacy REST
+/// endpoints on `/api/sessions/*`, `/api/status`, and `/api/my/content`.
+/// See `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`.
+///
+/// REST endpoints stay live for clients that do not negotiate this
+/// feature; D-1 is additive only. Phase D-5 retires the REST routes
+/// once `octos-web` has migrated (tracked separately).
+pub const UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1: &str = "auxiliary.rest_to_ws.v1";
+
 /// Server-known feature registry. Used by
 /// [`UiProtocolCapabilities::for_negotiated_features`] (UPCR-2026-007) to
 /// intersect a client's `X-Octos-Ui-Features` request with the names the
@@ -95,6 +110,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
     UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
     UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
+    UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
 ];
 
 /// Returns the feature flag that gates `method` per spec § 7 capability
@@ -115,6 +131,19 @@ fn method_capability_gate(method: &str) -> Option<&'static str> {
         methods::SESSION_HYDRATE => Some(UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1),
         methods::THREAD_GRAPH_GET => Some(UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1),
         methods::TURN_STATE_GET => Some(UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1),
+        methods::SESSION_LIST
+        | methods::SESSION_SNAPSHOT
+        | methods::SESSION_MESSAGES_PAGE
+        | methods::SESSION_STATUS_GET
+        | methods::SESSION_FILES_LIST
+        | methods::SESSION_TASKS_LIST
+        | methods::SESSION_WORKSPACE_GET
+        | methods::SESSION_TITLE_SET
+        | methods::SESSION_DELETE
+        | methods::SYSTEM_STATUS_GET
+        | methods::CONTENT_LIST
+        | methods::CONTENT_DELETE
+        | methods::CONTENT_BULK_DELETE => Some(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1),
         _ => None,
     }
 }
@@ -698,6 +727,42 @@ pub mod methods {
     /// legacy `/api/sessions/:id/events/stream` SSE frames bridged onto
     /// the unified v1 surface.
     pub const SESSION_EVENT: &str = "session/event";
+
+    // ---- M12 Phase D-1 auxiliary REST → WS surface ----
+    // Each method below replaces a REST endpoint listed in the ADR's
+    // inventory table (docs/adr/m12-phase-d-auxiliary-rest-to-ws.md).
+    // All twelve are capability-gated on
+    // `UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1`.
+
+    /// Replaces `GET /api/sessions` — sidebar session list.
+    pub const SESSION_LIST: &str = "session/list";
+    /// Replaces combined `GET /api/sessions/{id}/status` + `/files` +
+    /// `/tasks` — single right-rail bootstrap fetch.
+    pub const SESSION_SNAPSHOT: &str = "session/snapshot";
+    /// Replaces `GET /api/sessions/{id}/messages` — paginated history.
+    pub const SESSION_MESSAGES_PAGE: &str = "session/messages_page";
+    /// Replaces `GET /api/sessions/{id}/status` — status-pill poller.
+    pub const SESSION_STATUS_GET: &str = "session/status.get";
+    /// Replaces `GET /api/sessions/{id}/files` — files panel listing.
+    pub const SESSION_FILES_LIST: &str = "session/files.list";
+    /// Replaces `GET /api/sessions/{id}/tasks` — background tasks panel.
+    pub const SESSION_TASKS_LIST: &str = "session/tasks.list";
+    /// Replaces `GET /api/sessions/{id}/workspace-contract` — workspace
+    /// contract panel.
+    pub const SESSION_WORKSPACE_GET: &str = "session/workspace.get";
+    /// Replaces `PATCH /api/sessions/{id}/title` — manual title setter.
+    pub const SESSION_TITLE_SET: &str = "session/title.set";
+    /// Replaces `DELETE /api/sessions/{id}` — session deletion.
+    pub const SESSION_DELETE: &str = "session/delete";
+    /// Replaces `GET /api/status` — agent/server status (distinct from
+    /// `/api/auth/status` which stays REST).
+    pub const SYSTEM_STATUS_GET: &str = "system/status.get";
+    /// Replaces `GET /api/my/content` — content gallery listing.
+    pub const CONTENT_LIST: &str = "content/list";
+    /// Replaces `DELETE /api/my/content/{id}` — single-content deletion.
+    pub const CONTENT_DELETE: &str = "content/delete";
+    /// Replaces `POST /api/my/content/bulk-delete` — bulk-content deletion.
+    pub const CONTENT_BULK_DELETE: &str = "content/bulk_delete";
 }
 
 /// Reason codes for `approval/cancelled` notifications. The registry is
@@ -724,6 +789,19 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::SESSION_HYDRATE,
     methods::THREAD_GRAPH_GET,
     methods::TURN_STATE_GET,
+    methods::SESSION_LIST,
+    methods::SESSION_SNAPSHOT,
+    methods::SESSION_MESSAGES_PAGE,
+    methods::SESSION_STATUS_GET,
+    methods::SESSION_FILES_LIST,
+    methods::SESSION_TASKS_LIST,
+    methods::SESSION_WORKSPACE_GET,
+    methods::SESSION_TITLE_SET,
+    methods::SESSION_DELETE,
+    methods::SYSTEM_STATUS_GET,
+    methods::CONTENT_LIST,
+    methods::CONTENT_DELETE,
+    methods::CONTENT_BULK_DELETE,
 ];
 
 /// Notification methods defined by the v1alpha1 protocol model.
@@ -768,6 +846,19 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::SESSION_HYDRATE,
     methods::THREAD_GRAPH_GET,
     methods::TURN_STATE_GET,
+    methods::SESSION_LIST,
+    methods::SESSION_SNAPSHOT,
+    methods::SESSION_MESSAGES_PAGE,
+    methods::SESSION_STATUS_GET,
+    methods::SESSION_FILES_LIST,
+    methods::SESSION_TASKS_LIST,
+    methods::SESSION_WORKSPACE_GET,
+    methods::SESSION_TITLE_SET,
+    methods::SESSION_DELETE,
+    methods::SYSTEM_STATUS_GET,
+    methods::CONTENT_LIST,
+    methods::CONTENT_DELETE,
+    methods::CONTENT_BULK_DELETE,
 ];
 
 /// Protocol methods known but not implemented by the first server/runtime slice.
@@ -837,6 +928,7 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
             UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1,
             UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+            UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
         ])
     }
 
@@ -1869,6 +1961,233 @@ pub struct TurnStateGetResult {
     pub committed_seqs: Vec<u64>,
 }
 
+// ----- M12 Phase D-1 auxiliary REST → WS frames -----
+//
+// Each pair below mirrors a REST endpoint listed in the ADR's inventory
+// table (`docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`). Result payloads
+// are typed as opaque [`Value`] containers so the WS dispatchers can
+// forward the existing REST handler's JSON body byte-for-byte without
+// duplicating the REST DTO shapes (`SessionInfo`, `MessageInfo`,
+// `SessionFileInfo`, `BackgroundTaskInfo`, `WorkspaceContractStatus`,
+// `StatusResponse`, `ContentEntry`) into the protocol crate. The shapes
+// are unchanged from the REST contract — only the transport flips.
+
+/// Params for `session/list` — empty request.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionListParams {}
+
+/// Result for `session/list`. `sessions` is the JSON array the existing
+/// `GET /api/sessions` handler emits (one `SessionInfo` per entry, per
+/// `crates/octos-cli/src/api/handlers.rs:508`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionListResult {
+    pub sessions: Value,
+}
+
+/// Params for `session/snapshot` — combined bootstrap fetch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionSnapshotParams {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+}
+
+/// Result for `session/snapshot`. Each field is the JSON body the
+/// corresponding REST endpoint returns today (status / files / tasks).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionSnapshotResult {
+    pub status: Value,
+    pub files: Value,
+    pub tasks: Value,
+}
+
+/// Params for `session/messages_page` — paginated history fetch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionMessagesPageParams {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since_seq: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+}
+
+/// Default page size when `SessionMessagesPageParams::limit` is omitted.
+pub const SESSION_MESSAGES_PAGE_DEFAULT_LIMIT: usize = 100;
+/// Server-side clamp on `SessionMessagesPageParams::limit`. Matches the
+/// existing REST handler's `.min(500)` clamp at
+/// `crates/octos-cli/src/api/handlers.rs:685`.
+pub const SESSION_MESSAGES_PAGE_MAX_LIMIT: usize = 500;
+/// Server-side clamp on `SessionMessagesPageParams::offset`. Matches the
+/// existing REST handler's `.min(10_000)` clamp.
+pub const SESSION_MESSAGES_PAGE_MAX_OFFSET: usize = 10_000;
+
+/// Result for `session/messages_page`. `messages` mirrors the REST shape
+/// (`Vec<MessageInfo>`). `has_more` / `next_offset` are set by the
+/// dispatcher based on `messages.len() == limit`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionMessagesPageResult {
+    pub messages: Value,
+    pub has_more: bool,
+    pub next_offset: usize,
+}
+
+/// Params for `session/status.get` — status-pill poller.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionStatusGetParams {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+}
+
+/// Result for `session/status.get`. Mirrors the JSON body of
+/// `GET /api/sessions/{id}/status` (`{ active, has_deferred_files,
+/// has_bg_tasks }`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionStatusGetResult {
+    pub status: Value,
+}
+
+/// Params for `session/files.list`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionFilesListParams {
+    pub session_id: String,
+}
+
+/// Result for `session/files.list`. `files` matches
+/// `Vec<SessionFileInfo>` as emitted by `GET /api/sessions/{id}/files`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionFilesListResult {
+    pub files: Value,
+}
+
+/// Params for `session/tasks.list`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTasksListParams {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+}
+
+/// Result for `session/tasks.list`. `tasks` matches the JSON body of
+/// `GET /api/sessions/{id}/tasks` (a `BackgroundTaskInfo` array proxied
+/// from the gateway; empty in standalone mode).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionTasksListResult {
+    pub tasks: Value,
+}
+
+/// Params for `session/workspace.get`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionWorkspaceGetParams {
+    pub session_id: String,
+}
+
+/// Result for `session/workspace.get`. `contracts` matches
+/// `Vec<WorkspaceContractStatus>` as emitted by
+/// `GET /api/sessions/{id}/workspace-contract`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionWorkspaceGetResult {
+    pub contracts: Value,
+}
+
+/// Params for `session/title.set`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTitleSetParams {
+    pub session_id: String,
+    pub title: String,
+}
+
+/// Result for `session/title.set`. Echoes the resolved `session_id` and
+/// title so the SPA can roundtrip the rename in a single response (the
+/// REST `PATCH /api/sessions/{id}/title` returned `204 No Content`; the
+/// WS shape lifts the title into the response body for echo-correctness).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionTitleSetResult {
+    pub session_id: String,
+    pub title: String,
+}
+
+/// Server-side clamp on `SessionTitleSetParams::title` character count.
+/// Matches the existing REST handler's character cap at
+/// `crates/octos-cli/src/api/handlers.rs:1162`.
+pub const SESSION_TITLE_SET_MAX_CHARS: usize = 200;
+
+/// Params for `session/delete`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionDeleteParams {
+    pub session_id: String,
+}
+
+/// Result for `session/delete`. Empty (the REST `DELETE` returns
+/// `204 No Content`; on WS we send an empty object for consistency with
+/// other void RPCs).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionDeleteResult {}
+
+/// Params for `system/status.get`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemStatusGetParams {}
+
+/// Result for `system/status.get`. `status` is the JSON body of the
+/// existing `GET /api/status` handler (`StatusResponse` —
+/// `crates/octos-cli/src/api/handlers.rs:2592`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SystemStatusGetResult {
+    pub status: Value,
+}
+
+/// Params for `content/list`. `filters` is a free-form JSON object that
+/// mirrors the REST `ContentQuery` shape (category, search, from, to,
+/// sort, limit, offset, session_id) — see
+/// `crates/octos-cli/src/content_catalog.rs:96` and the dirs/session_id
+/// fields consumed by `GET /api/my/content`. Forwarded verbatim to the
+/// existing REST handler.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ContentListParams {
+    #[serde(default)]
+    pub filters: Value,
+}
+
+/// Result for `content/list`. Mirrors the JSON body of
+/// `GET /api/my/content` (`{ entries: ContentEntry[], total: number }`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContentListResult {
+    pub entries: Value,
+    pub total: usize,
+}
+
+/// Params for `content/delete`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentDeleteParams {
+    pub id: String,
+}
+
+/// Result for `content/delete`. `deleted` is `true` when the row was
+/// removed, `false` when the id was not in the catalog (the REST handler
+/// returns the same boolean inside its `ActionResponse.ok`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentDeleteResult {
+    pub deleted: bool,
+}
+
+/// Params for `content/bulk_delete`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentBulkDeleteParams {
+    pub ids: Vec<String>,
+}
+
+/// Result for `content/bulk_delete`. `deleted` is the number of catalog
+/// rows successfully removed — mirrors the count surfaced by the REST
+/// handler's `ActionResponse.message` ("N item(s) deleted.").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentBulkDeleteResult {
+    pub deleted: usize,
+}
+
 // ----- UPCR-2026-012 `message/persisted` -----
 
 /// Open registry for `MessagePersistedEvent.source`. Future variants must be
@@ -2251,6 +2570,20 @@ pub enum UiCommand {
     SessionHydrate(SessionHydrateParams),
     ThreadGraphGet(ThreadGraphGetParams),
     TurnStateGet(TurnStateGetParams),
+    // ---- M12 Phase D-1 auxiliary REST → WS frames ----
+    SessionList(SessionListParams),
+    SessionSnapshot(SessionSnapshotParams),
+    SessionMessagesPage(SessionMessagesPageParams),
+    SessionStatusGet(SessionStatusGetParams),
+    SessionFilesList(SessionFilesListParams),
+    SessionTasksList(SessionTasksListParams),
+    SessionWorkspaceGet(SessionWorkspaceGetParams),
+    SessionTitleSet(SessionTitleSetParams),
+    SessionDelete(SessionDeleteParams),
+    SystemStatusGet(SystemStatusGetParams),
+    ContentList(ContentListParams),
+    ContentDelete(ContentDeleteParams),
+    ContentBulkDelete(ContentBulkDeleteParams),
 }
 
 impl UiCommand {
@@ -2271,6 +2604,19 @@ impl UiCommand {
             Self::SessionHydrate(_) => methods::SESSION_HYDRATE,
             Self::ThreadGraphGet(_) => methods::THREAD_GRAPH_GET,
             Self::TurnStateGet(_) => methods::TURN_STATE_GET,
+            Self::SessionList(_) => methods::SESSION_LIST,
+            Self::SessionSnapshot(_) => methods::SESSION_SNAPSHOT,
+            Self::SessionMessagesPage(_) => methods::SESSION_MESSAGES_PAGE,
+            Self::SessionStatusGet(_) => methods::SESSION_STATUS_GET,
+            Self::SessionFilesList(_) => methods::SESSION_FILES_LIST,
+            Self::SessionTasksList(_) => methods::SESSION_TASKS_LIST,
+            Self::SessionWorkspaceGet(_) => methods::SESSION_WORKSPACE_GET,
+            Self::SessionTitleSet(_) => methods::SESSION_TITLE_SET,
+            Self::SessionDelete(_) => methods::SESSION_DELETE,
+            Self::SystemStatusGet(_) => methods::SYSTEM_STATUS_GET,
+            Self::ContentList(_) => methods::CONTENT_LIST,
+            Self::ContentDelete(_) => methods::CONTENT_DELETE,
+            Self::ContentBulkDelete(_) => methods::CONTENT_BULK_DELETE,
         }
     }
 
@@ -2295,6 +2641,19 @@ impl UiCommand {
             Self::SessionHydrate(params) => serde_json::to_value(params),
             Self::ThreadGraphGet(params) => serde_json::to_value(params),
             Self::TurnStateGet(params) => serde_json::to_value(params),
+            Self::SessionList(params) => serde_json::to_value(params),
+            Self::SessionSnapshot(params) => serde_json::to_value(params),
+            Self::SessionMessagesPage(params) => serde_json::to_value(params),
+            Self::SessionStatusGet(params) => serde_json::to_value(params),
+            Self::SessionFilesList(params) => serde_json::to_value(params),
+            Self::SessionTasksList(params) => serde_json::to_value(params),
+            Self::SessionWorkspaceGet(params) => serde_json::to_value(params),
+            Self::SessionTitleSet(params) => serde_json::to_value(params),
+            Self::SessionDelete(params) => serde_json::to_value(params),
+            Self::SystemStatusGet(params) => serde_json::to_value(params),
+            Self::ContentList(params) => serde_json::to_value(params),
+            Self::ContentDelete(params) => serde_json::to_value(params),
+            Self::ContentBulkDelete(params) => serde_json::to_value(params),
         }?;
 
         Ok(RpcRequest::new(id, method, params))
@@ -2337,9 +2696,50 @@ impl UiCommand {
             methods::SESSION_HYDRATE => Ok(Self::SessionHydrate(decode_params(method, params)?)),
             methods::THREAD_GRAPH_GET => Ok(Self::ThreadGraphGet(decode_params(method, params)?)),
             methods::TURN_STATE_GET => Ok(Self::TurnStateGet(decode_params(method, params)?)),
+            methods::SESSION_LIST => Ok(Self::SessionList(decode_optional_params(method, params)?)),
+            methods::SESSION_SNAPSHOT => Ok(Self::SessionSnapshot(decode_params(method, params)?)),
+            methods::SESSION_MESSAGES_PAGE => {
+                Ok(Self::SessionMessagesPage(decode_params(method, params)?))
+            }
+            methods::SESSION_STATUS_GET => {
+                Ok(Self::SessionStatusGet(decode_params(method, params)?))
+            }
+            methods::SESSION_FILES_LIST => {
+                Ok(Self::SessionFilesList(decode_params(method, params)?))
+            }
+            methods::SESSION_TASKS_LIST => {
+                Ok(Self::SessionTasksList(decode_params(method, params)?))
+            }
+            methods::SESSION_WORKSPACE_GET => {
+                Ok(Self::SessionWorkspaceGet(decode_params(method, params)?))
+            }
+            methods::SESSION_TITLE_SET => Ok(Self::SessionTitleSet(decode_params(method, params)?)),
+            methods::SESSION_DELETE => Ok(Self::SessionDelete(decode_params(method, params)?)),
+            methods::SYSTEM_STATUS_GET => Ok(Self::SystemStatusGet(decode_optional_params(
+                method, params,
+            )?)),
+            methods::CONTENT_LIST => Ok(Self::ContentList(decode_optional_params(method, params)?)),
+            methods::CONTENT_DELETE => Ok(Self::ContentDelete(decode_params(method, params)?)),
+            methods::CONTENT_BULK_DELETE => {
+                Ok(Self::ContentBulkDelete(decode_params(method, params)?))
+            }
             _ => Err(RpcError::method_not_found(method)),
         }
     }
+}
+
+/// Decode params that may be omitted entirely on the wire (i.e. the
+/// param object is `{}` or absent). Used for empty-request methods like
+/// `session/list` and `system/status.get` where the params struct has no
+/// required fields.
+fn decode_optional_params<T: DeserializeOwned + Default>(
+    method: &str,
+    params: Value,
+) -> Result<T, RpcError> {
+    if params.is_null() {
+        return Ok(T::default());
+    }
+    decode_params(method, params)
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -3932,6 +4332,10 @@ mod tests {
             UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1,
             "projection.envelope.v1"
         );
+        assert_eq!(
+            UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
+            "auxiliary.rest_to_ws.v1"
+        );
 
         assert_eq!(
             UI_PROTOCOL_COMMAND_METHODS,
@@ -3951,6 +4355,19 @@ mod tests {
                 "session/hydrate",
                 "thread/graph/get",
                 "turn/state/get",
+                "session/list",
+                "session/snapshot",
+                "session/messages_page",
+                "session/status.get",
+                "session/files.list",
+                "session/tasks.list",
+                "session/workspace.get",
+                "session/title.set",
+                "session/delete",
+                "system/status.get",
+                "content/list",
+                "content/delete",
+                "content/bulk_delete",
             ]
         );
         assert_eq!(
@@ -3997,6 +4414,19 @@ mod tests {
                 "session/hydrate",
                 "thread/graph/get",
                 "turn/state/get",
+                "session/list",
+                "session/snapshot",
+                "session/messages_page",
+                "session/status.get",
+                "session/files.list",
+                "session/tasks.list",
+                "session/workspace.get",
+                "session/title.set",
+                "session/delete",
+                "system/status.get",
+                "content/list",
+                "content/delete",
+                "content/bulk_delete",
             ]
         );
         assert!(UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS.is_empty());
@@ -4034,7 +4464,20 @@ mod tests {
                     "task/output/read",
                     "session/hydrate",
                     "thread/graph/get",
-                    "turn/state/get"
+                    "turn/state/get",
+                    "session/list",
+                    "session/snapshot",
+                    "session/messages_page",
+                    "session/status.get",
+                    "session/files.list",
+                    "session/tasks.list",
+                    "session/workspace.get",
+                    "session/title.set",
+                    "session/delete",
+                    "system/status.get",
+                    "content/list",
+                    "content/delete",
+                    "content/bulk_delete"
                 ],
                 "supported_notifications": [
                     "session/open",
@@ -4069,7 +4512,8 @@ mod tests {
                     "state.turn_state_get.v1",
                     "event.message_persisted.v1",
                     "event.spawn_complete.v1",
-                    "projection.envelope.v1"
+                    "projection.envelope.v1",
+                    "auxiliary.rest_to_ws.v1"
                 ]
             })
         );
@@ -6375,6 +6819,259 @@ mod tests {
         assert_eq!(rpc.method, methods::TURN_STATE_GET);
         let decoded = UiCommand::from_rpc_request(rpc).expect("decode state");
         assert_eq!(decoded, state);
+    }
+
+    // ===== M12 Phase D-1 auxiliary REST → WS frames =====
+
+    #[test]
+    fn aux_rest_to_ws_v1_feature_string_is_stable() {
+        assert_eq!(
+            UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
+            "auxiliary.rest_to_ws.v1"
+        );
+        assert!(UI_PROTOCOL_KNOWN_FEATURES.contains(&UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1));
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_methods_round_trip_through_rpc_envelope() {
+        // Each command is built, serialized via `into_rpc_request`,
+        // re-decoded via `from_rpc_request`, and asserted equal. The
+        // method string is checked against the `methods::` constant so
+        // a typo there shows up here, not at deploy.
+        let cases: Vec<(UiCommand, &str)> = vec![
+            (
+                UiCommand::SessionList(SessionListParams::default()),
+                methods::SESSION_LIST,
+            ),
+            (
+                UiCommand::SessionSnapshot(SessionSnapshotParams {
+                    session_id: "sess-1".into(),
+                    topic: Some("default".into()),
+                }),
+                methods::SESSION_SNAPSHOT,
+            ),
+            (
+                UiCommand::SessionMessagesPage(SessionMessagesPageParams {
+                    session_id: "sess-1".into(),
+                    limit: Some(50),
+                    offset: Some(0),
+                    since_seq: None,
+                    topic: None,
+                }),
+                methods::SESSION_MESSAGES_PAGE,
+            ),
+            (
+                UiCommand::SessionStatusGet(SessionStatusGetParams {
+                    session_id: "sess-1".into(),
+                    topic: None,
+                }),
+                methods::SESSION_STATUS_GET,
+            ),
+            (
+                UiCommand::SessionFilesList(SessionFilesListParams {
+                    session_id: "sess-1".into(),
+                }),
+                methods::SESSION_FILES_LIST,
+            ),
+            (
+                UiCommand::SessionTasksList(SessionTasksListParams {
+                    session_id: "sess-1".into(),
+                    topic: None,
+                }),
+                methods::SESSION_TASKS_LIST,
+            ),
+            (
+                UiCommand::SessionWorkspaceGet(SessionWorkspaceGetParams {
+                    session_id: "sess-1".into(),
+                }),
+                methods::SESSION_WORKSPACE_GET,
+            ),
+            (
+                UiCommand::SessionTitleSet(SessionTitleSetParams {
+                    session_id: "sess-1".into(),
+                    title: "Renamed".into(),
+                }),
+                methods::SESSION_TITLE_SET,
+            ),
+            (
+                UiCommand::SessionDelete(SessionDeleteParams {
+                    session_id: "sess-1".into(),
+                }),
+                methods::SESSION_DELETE,
+            ),
+            (
+                UiCommand::SystemStatusGet(SystemStatusGetParams::default()),
+                methods::SYSTEM_STATUS_GET,
+            ),
+            (
+                UiCommand::ContentList(ContentListParams {
+                    filters: serde_json::json!({ "limit": 10 }),
+                }),
+                methods::CONTENT_LIST,
+            ),
+            (
+                UiCommand::ContentDelete(ContentDeleteParams { id: "c-1".into() }),
+                methods::CONTENT_DELETE,
+            ),
+            (
+                UiCommand::ContentBulkDelete(ContentBulkDeleteParams {
+                    ids: vec!["c-1".into(), "c-2".into()],
+                }),
+                methods::CONTENT_BULK_DELETE,
+            ),
+        ];
+        assert_eq!(
+            cases.len(),
+            13,
+            "13 UiCommand arms cover the 12 methods (bulk + single delete share namespace)"
+        );
+        for (command, expected_method) in cases {
+            let rpc = command
+                .clone()
+                .into_rpc_request("req")
+                .expect("serialize command");
+            assert_eq!(rpc.method, expected_method);
+            let decoded = UiCommand::from_rpc_request(rpc).expect("decode command");
+            assert_eq!(decoded, command);
+        }
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_empty_param_methods_accept_null_params() {
+        // Wire shape per JSON-RPC 2.0 allows omitting params on
+        // no-arg methods. `session/list` and `system/status.get`
+        // accept either `{}` or absent params.
+        let session_list_null =
+            UiCommand::from_method_and_params(methods::SESSION_LIST, Value::Null)
+                .expect("session/list with null params");
+        assert!(matches!(session_list_null, UiCommand::SessionList(_)));
+
+        let system_status_null =
+            UiCommand::from_method_and_params(methods::SYSTEM_STATUS_GET, Value::Null)
+                .expect("system/status.get with null params");
+        assert!(matches!(system_status_null, UiCommand::SystemStatusGet(_)));
+
+        let content_list_null =
+            UiCommand::from_method_and_params(methods::CONTENT_LIST, Value::Null)
+                .expect("content/list with null params");
+        assert!(matches!(content_list_null, UiCommand::ContentList(_)));
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_result_dtos_round_trip_via_serde_json() {
+        // Each result struct serializes to a stable shape and decodes
+        // back. Opaque `Value` fields are forwarded byte-for-byte from
+        // the REST handler bodies so they may carry whatever shape the
+        // existing REST contract emits.
+        let listing = SessionListResult {
+            sessions: serde_json::json!([{ "id": "s-1", "message_count": 3 }]),
+        };
+        let value = serde_json::to_value(&listing).expect("serialize");
+        let decoded: SessionListResult = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded.sessions, listing.sessions);
+
+        let snapshot = SessionSnapshotResult {
+            status: serde_json::json!({ "active": false }),
+            files: serde_json::json!([]),
+            tasks: serde_json::json!([]),
+        };
+        let value = serde_json::to_value(&snapshot).expect("serialize");
+        let decoded: SessionSnapshotResult = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded.status, snapshot.status);
+        assert_eq!(decoded.files, snapshot.files);
+        assert_eq!(decoded.tasks, snapshot.tasks);
+
+        let page = SessionMessagesPageResult {
+            messages: serde_json::json!([]),
+            has_more: false,
+            next_offset: 0,
+        };
+        let value = serde_json::to_value(&page).expect("serialize");
+        let decoded: SessionMessagesPageResult =
+            serde_json::from_value(value).expect("deserialize");
+        assert!(!decoded.has_more);
+        assert_eq!(decoded.next_offset, 0);
+
+        let title = SessionTitleSetResult {
+            session_id: "s-1".into(),
+            title: "Renamed".into(),
+        };
+        let value = serde_json::to_value(&title).expect("serialize");
+        let decoded: SessionTitleSetResult = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded, title);
+
+        let delete = SessionDeleteResult::default();
+        let value = serde_json::to_value(&delete).expect("serialize");
+        let decoded: SessionDeleteResult = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded, delete);
+
+        let content = ContentListResult {
+            entries: serde_json::json!([{ "id": "c-1" }]),
+            total: 1,
+        };
+        let value = serde_json::to_value(&content).expect("serialize");
+        let decoded: ContentListResult = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded.entries, content.entries);
+        assert_eq!(decoded.total, content.total);
+
+        let bulk = ContentBulkDeleteResult { deleted: 5 };
+        let value = serde_json::to_value(&bulk).expect("serialize");
+        let decoded: ContentBulkDeleteResult = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(decoded, bulk);
+    }
+
+    #[test]
+    fn aux_rest_to_ws_v1_methods_are_capability_gated() {
+        // The 12 new methods must gate on
+        // `auxiliary.rest_to_ws.v1`. A connection that does not
+        // negotiate the feature must NOT see them in the advertised
+        // `supported_methods`.
+        let none = UiProtocolCapabilities::for_negotiated_features(Vec::<String>::new());
+        for method in [
+            methods::SESSION_LIST,
+            methods::SESSION_SNAPSHOT,
+            methods::SESSION_MESSAGES_PAGE,
+            methods::SESSION_STATUS_GET,
+            methods::SESSION_FILES_LIST,
+            methods::SESSION_TASKS_LIST,
+            methods::SESSION_WORKSPACE_GET,
+            methods::SESSION_TITLE_SET,
+            methods::SESSION_DELETE,
+            methods::SYSTEM_STATUS_GET,
+            methods::CONTENT_LIST,
+            methods::CONTENT_DELETE,
+            methods::CONTENT_BULK_DELETE,
+        ] {
+            assert!(
+                !none.supports_method(method),
+                "method {method} must NOT be advertised without aux_rest_to_ws_v1"
+            );
+        }
+
+        let with_feature = UiProtocolCapabilities::for_negotiated_features([
+            UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1,
+        ]);
+        for method in [
+            methods::SESSION_LIST,
+            methods::SESSION_SNAPSHOT,
+            methods::SESSION_MESSAGES_PAGE,
+            methods::SESSION_STATUS_GET,
+            methods::SESSION_FILES_LIST,
+            methods::SESSION_TASKS_LIST,
+            methods::SESSION_WORKSPACE_GET,
+            methods::SESSION_TITLE_SET,
+            methods::SESSION_DELETE,
+            methods::SYSTEM_STATUS_GET,
+            methods::CONTENT_LIST,
+            methods::CONTENT_DELETE,
+            methods::CONTENT_BULK_DELETE,
+        ] {
+            assert!(
+                with_feature.supports_method(method),
+                "method {method} must be advertised when aux_rest_to_ws_v1 is negotiated"
+            );
+        }
+        assert!(with_feature.supports_feature(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1));
     }
 
     // ===== UPCR-2026-014 M9-γ projection envelope golden tests =====

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -286,6 +286,15 @@ pub mod rpc_error_codes {
 
     /// Spec §10 / M9-FIX-04 backpressure signal; carries `retry_after_ms` in `data`.
     pub const RATE_LIMITED: i64 = -32160;
+
+    /// Generic not-found error for non-session-scoped resources (content
+    /// catalog rows, profile records, ...) returned by REST 404. Distinct
+    /// from `UNKNOWN_SESSION` (-32100) which is reserved for session-scoped
+    /// 404s. M12 Phase D-1 introduced this slot when the REST→WS bridge
+    /// began surfacing content/profile 404s as typed errors; before, every
+    /// REST 404 was force-mapped to `UNKNOWN_SESSION` regardless of
+    /// resource kind.
+    pub const RESOURCE_NOT_FOUND: i64 = -32170;
 }
 
 /// Logical event-ledger cursor used for resumable UI notification consumption.
@@ -595,6 +604,31 @@ impl RpcError {
         Self::new(rpc_error_codes::RUNTIME_NOT_READY, message)
     }
 
+    /// Generic REST 404 for non-session-scoped resources (content catalog
+    /// rows, profile records, ...). Distinct from
+    /// [`Self::unknown_session`] which carries `session_id` in `data` for
+    /// session-scoped misses. M12 Phase D-1 added this so the REST→WS
+    /// bridge can surface content/profile 404s without misclassifying
+    /// them as session misses.
+    ///
+    /// `resource_type` is a short tag identifying the resource ("content",
+    /// "profile", ...); `identifier` is the resource id the client sent.
+    /// Both are echoed in `data` so clients can reconcile without parsing
+    /// the message string.
+    pub fn not_found(resource_type: impl Into<String>, identifier: impl Into<String>) -> Self {
+        let resource_type = resource_type.into();
+        let identifier = identifier.into();
+        Self::new(
+            rpc_error_codes::RESOURCE_NOT_FOUND,
+            format!("{resource_type} not found: {identifier}"),
+        )
+        .with_data(serde_json::json!({
+            "kind": "not_found",
+            "resource_type": resource_type,
+            "identifier": identifier,
+        }))
+    }
+
     /// Result-side counterpart to `INVALID_PARAMS`. See
     /// [`rpc_error_codes::MALFORMED_RESULT`] for rationale.
     pub fn malformed_result(message: impl Into<String>) -> Self {
@@ -731,8 +765,10 @@ pub mod methods {
     // ---- M12 Phase D-1 auxiliary REST → WS surface ----
     // Each method below replaces a REST endpoint listed in the ADR's
     // inventory table (docs/adr/m12-phase-d-auxiliary-rest-to-ws.md).
-    // All twelve are capability-gated on
-    // `UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1`.
+    // All thirteen are capability-gated on
+    // `UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1`
+    // (`content/delete` and `content/bulk_delete` are distinct methods
+    // sharing the `content/*` namespace).
 
     /// Replaces `GET /api/sessions` — sidebar session list.
     pub const SESSION_LIST: &str = "session/list";
@@ -2174,11 +2210,23 @@ pub struct ContentDeleteResult {
     pub deleted: bool,
 }
 
-/// Params for `content/bulk_delete`.
+/// Params for `content/bulk_delete`. The `ids` vector is capped at
+/// [`CONTENT_BULK_DELETE_MAX_IDS`] entries; the WS dispatcher rejects
+/// over-cap requests with `INVALID_PARAMS` before any catalog write
+/// lock is taken, so a single oversized request cannot block other
+/// catalog readers.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ContentBulkDeleteParams {
     pub ids: Vec<String>,
 }
+
+/// Server-side cap on `ContentBulkDeleteParams::ids` length. Mirrored
+/// in `crates/octos-cli/src/api/ui_protocol.rs` as the dispatcher's
+/// early-reject threshold. Chosen so a single bulk-delete cannot
+/// monopolize the catalog write-lock for more than a small bounded
+/// window even if every id is valid; the 1 MiB WS frame limit is a
+/// coarser secondary check.
+pub const CONTENT_BULK_DELETE_MAX_IDS: usize = 256;
 
 /// Result for `content/bulk_delete`. `deleted` is the number of catalog
 /// rows successfully removed — mirrors the count surfaced by the REST
@@ -6923,7 +6971,13 @@ mod tests {
         assert_eq!(
             cases.len(),
             13,
-            "13 UiCommand arms cover the 12 methods (bulk + single delete share namespace)"
+            "13 UiCommand arms cover the 13 auxiliary methods \
+             (`session/list`, `session/snapshot`, `session/messages_page`, \
+             `session/status.get`, `session/files.list`, `session/tasks.list`, \
+             `session/workspace.get`, `session/title.set`, `session/delete`, \
+             `system/status.get`, `content/list`, `content/delete`, \
+             `content/bulk_delete`) — `content/delete` and `content/bulk_delete` \
+             are distinct methods"
         );
         for (command, expected_method) in cases {
             let rpc = command
@@ -7072,6 +7126,318 @@ mod tests {
             );
         }
         assert!(with_feature.supports_feature(UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1));
+    }
+
+    /// Codex review 2026-05-12 (MEDIUM 2): every M12 Phase D-1
+    /// request/result DTO must be pinned to a JSON-shape golden, not
+    /// just to a serde round-trip. A round-trip catches "can encode
+    /// and decode", but it does NOT catch "the field was renamed but
+    /// both ends agree on the rename" — exactly the failure mode we
+    /// care about when the WS bridge has to mirror REST DTOs that
+    /// live in a different crate. The literal-JSON asserts below
+    /// force a field rename (or a missing-field default flip) in any
+    /// REST DTO to fail this test before it lands.
+    #[test]
+    fn aux_rest_to_ws_v1_request_dtos_match_json_goldens() {
+        // session/list — empty params
+        assert_eq!(
+            serde_json::to_value(SessionListParams::default()).expect("serialize"),
+            serde_json::json!({}),
+        );
+        let parsed: SessionListParams =
+            serde_json::from_value(serde_json::json!({})).expect("decode");
+        assert_eq!(parsed, SessionListParams::default());
+
+        // session/snapshot
+        let p = SessionSnapshotParams {
+            session_id: "sess-1".into(),
+            topic: Some("topic-x".into()),
+        };
+        assert_eq!(
+            serde_json::to_value(&p).expect("serialize"),
+            serde_json::json!({ "session_id": "sess-1", "topic": "topic-x" }),
+        );
+        // Topic is optional — when absent, it must NOT serialize as
+        // `"topic": null`. Drift in the `skip_serializing_if`
+        // directive would flip the wire shape silently.
+        let p_no_topic = SessionSnapshotParams {
+            session_id: "sess-1".into(),
+            topic: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&p_no_topic).expect("serialize"),
+            serde_json::json!({ "session_id": "sess-1" }),
+        );
+
+        // session/messages_page
+        let p = SessionMessagesPageParams {
+            session_id: "sess-2".into(),
+            limit: Some(50),
+            offset: Some(10),
+            since_seq: Some(100),
+            topic: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&p).expect("serialize"),
+            serde_json::json!({
+                "session_id": "sess-2",
+                "limit": 50,
+                "offset": 10,
+                "since_seq": 100,
+            }),
+        );
+
+        // session/status.get
+        let p = SessionStatusGetParams {
+            session_id: "sess-3".into(),
+            topic: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&p).expect("serialize"),
+            serde_json::json!({ "session_id": "sess-3" }),
+        );
+
+        // session/files.list
+        assert_eq!(
+            serde_json::to_value(SessionFilesListParams {
+                session_id: "sess-4".into(),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "session_id": "sess-4" }),
+        );
+
+        // session/tasks.list
+        assert_eq!(
+            serde_json::to_value(SessionTasksListParams {
+                session_id: "sess-5".into(),
+                topic: Some("t".into()),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "session_id": "sess-5", "topic": "t" }),
+        );
+
+        // session/workspace.get
+        assert_eq!(
+            serde_json::to_value(SessionWorkspaceGetParams {
+                session_id: "sess-6".into(),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "session_id": "sess-6" }),
+        );
+
+        // session/title.set
+        assert_eq!(
+            serde_json::to_value(SessionTitleSetParams {
+                session_id: "sess-7".into(),
+                title: "New title".into(),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "session_id": "sess-7", "title": "New title" }),
+        );
+
+        // session/delete
+        assert_eq!(
+            serde_json::to_value(SessionDeleteParams {
+                session_id: "sess-8".into(),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "session_id": "sess-8" }),
+        );
+
+        // system/status.get — empty
+        assert_eq!(
+            serde_json::to_value(SystemStatusGetParams::default()).expect("serialize"),
+            serde_json::json!({}),
+        );
+
+        // content/list — free-form filters; default object is empty
+        assert_eq!(
+            serde_json::to_value(ContentListParams::default()).expect("serialize"),
+            serde_json::json!({ "filters": null }),
+        );
+        assert_eq!(
+            serde_json::to_value(ContentListParams {
+                filters: serde_json::json!({ "category": "image", "limit": 50 }),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "filters": { "category": "image", "limit": 50 } }),
+        );
+
+        // content/delete
+        assert_eq!(
+            serde_json::to_value(ContentDeleteParams { id: "c-1".into() }).expect("serialize"),
+            serde_json::json!({ "id": "c-1" }),
+        );
+
+        // content/bulk_delete
+        assert_eq!(
+            serde_json::to_value(ContentBulkDeleteParams {
+                ids: vec!["c-1".into(), "c-2".into()],
+            })
+            .expect("serialize"),
+            serde_json::json!({ "ids": ["c-1", "c-2"] }),
+        );
+    }
+
+    /// Codex review 2026-05-12 (MEDIUM 2): JSON golden assertions for
+    /// every aux result DTO. Pinned wire shapes — a rename of any
+    /// field below must show up in this test before it reaches a
+    /// downstream client. Each `assert_eq!` is the contract.
+    #[test]
+    fn aux_rest_to_ws_v1_result_dtos_match_json_goldens() {
+        // session/list — `{ sessions: <opaque> }`
+        assert_eq!(
+            serde_json::to_value(SessionListResult {
+                sessions: serde_json::json!([{ "id": "s-1" }]),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "sessions": [{ "id": "s-1" }] }),
+        );
+
+        // session/snapshot — `{ status, files, tasks }`
+        assert_eq!(
+            serde_json::to_value(SessionSnapshotResult {
+                status: serde_json::json!({ "active": true }),
+                files: serde_json::json!([{ "path": "f.txt" }]),
+                tasks: serde_json::json!([]),
+            })
+            .expect("serialize"),
+            serde_json::json!({
+                "status": { "active": true },
+                "files": [{ "path": "f.txt" }],
+                "tasks": [],
+            }),
+        );
+
+        // session/messages_page — `{ messages, has_more, next_offset }`
+        assert_eq!(
+            serde_json::to_value(SessionMessagesPageResult {
+                messages: serde_json::json!([]),
+                has_more: true,
+                next_offset: 200,
+            })
+            .expect("serialize"),
+            serde_json::json!({
+                "messages": [],
+                "has_more": true,
+                "next_offset": 200,
+            }),
+        );
+
+        // session/status.get — `{ status: <opaque> }`
+        assert_eq!(
+            serde_json::to_value(SessionStatusGetResult {
+                status: serde_json::json!({ "active": false }),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "status": { "active": false } }),
+        );
+
+        // session/files.list — `{ files: <opaque> }`
+        assert_eq!(
+            serde_json::to_value(SessionFilesListResult {
+                files: serde_json::json!([{ "path": "a.txt" }]),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "files": [{ "path": "a.txt" }] }),
+        );
+
+        // session/tasks.list — `{ tasks: <opaque> }`
+        assert_eq!(
+            serde_json::to_value(SessionTasksListResult {
+                tasks: serde_json::json!([]),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "tasks": [] }),
+        );
+
+        // session/workspace.get — `{ contracts: <opaque> }`
+        assert_eq!(
+            serde_json::to_value(SessionWorkspaceGetResult {
+                contracts: serde_json::json!([]),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "contracts": [] }),
+        );
+
+        // session/title.set — `{ session_id, title }`
+        assert_eq!(
+            serde_json::to_value(SessionTitleSetResult {
+                session_id: "s-1".into(),
+                title: "Hello".into(),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "session_id": "s-1", "title": "Hello" }),
+        );
+
+        // session/delete — empty object
+        assert_eq!(
+            serde_json::to_value(SessionDeleteResult::default()).expect("serialize"),
+            serde_json::json!({}),
+        );
+
+        // system/status.get — `{ status: <opaque> }`
+        assert_eq!(
+            serde_json::to_value(SystemStatusGetResult {
+                status: serde_json::json!({ "version": "0.1.1" }),
+            })
+            .expect("serialize"),
+            serde_json::json!({ "status": { "version": "0.1.1" } }),
+        );
+
+        // content/list — `{ entries, total }`
+        assert_eq!(
+            serde_json::to_value(ContentListResult {
+                entries: serde_json::json!([{ "id": "c-1" }]),
+                total: 7,
+            })
+            .expect("serialize"),
+            serde_json::json!({
+                "entries": [{ "id": "c-1" }],
+                "total": 7,
+            }),
+        );
+
+        // content/delete — `{ deleted: bool }`
+        assert_eq!(
+            serde_json::to_value(ContentDeleteResult { deleted: true }).expect("serialize"),
+            serde_json::json!({ "deleted": true }),
+        );
+
+        // content/bulk_delete — `{ deleted: usize }`
+        assert_eq!(
+            serde_json::to_value(ContentBulkDeleteResult { deleted: 12 }).expect("serialize"),
+            serde_json::json!({ "deleted": 12 }),
+        );
+    }
+
+    /// Codex review 2026-05-12 (MEDIUM 1): the new
+    /// `RpcError::not_found(resource_type, identifier)` constructor
+    /// must carry the resource tag + identifier in `data` so clients
+    /// can distinguish a content-row miss from a session miss without
+    /// parsing message strings. Pinned via JSON golden.
+    #[test]
+    fn rpc_error_not_found_carries_typed_resource_data() {
+        let err = RpcError::not_found("content", "c-99");
+        assert_eq!(err.code, rpc_error_codes::RESOURCE_NOT_FOUND);
+        let value = serde_json::to_value(&err).expect("serialize");
+        assert_eq!(value.get("code"), Some(&json!(-32170)));
+        let data = value.get("data").expect("data present");
+        assert_eq!(data.get("kind"), Some(&json!("not_found")));
+        assert_eq!(data.get("resource_type"), Some(&json!("content")));
+        assert_eq!(data.get("identifier"), Some(&json!("c-99")));
+    }
+
+    /// Codex review 2026-05-12 (MEDIUM 3): the bulk-delete cap is
+    /// part of the wire contract and must not drift silently. Pin
+    /// the constant value to 256 so a future bump shows up as a
+    /// test diff.
+    #[test]
+    fn content_bulk_delete_max_ids_constant_is_pinned() {
+        assert_eq!(
+            CONTENT_BULK_DELETE_MAX_IDS, 256,
+            "wire-contract cap; bump server dispatcher AND any client adapters together",
+        );
     }
 
     // ===== UPCR-2026-014 M9-γ projection envelope golden tests =====


### PR DESCRIPTION
## Summary

Adds thirteen additive JSON-RPC methods to `/api/ui-protocol/ws` behind a new opt-in capability `auxiliary.rest_to_ws.v1`. Phase D-1 of the M12 plan from ADR PR #910 / tracking issue #911.

- Server-side ONLY. `octos-web` is untouched (Phase D-2/D-3 in the client repo).
- REST endpoints are unchanged and remain authoritative — Phase D-1 is strictly additive. Phase D-5 retires REST once the client has migrated.
- No auth behavior changed (Phase D-4 will narrow the 401-reaper that motivated this ADR).
- Capability is opt-in: clients that don't send `?ui_feature=auxiliary.rest_to_ws.v1` (or the equivalent header) see the new methods as `method_not_supported` and continue to use REST. **Strict opt-in** — applies even when no feature header is sent at all (codex review 2026-05-12).

ADR: PR #910 / `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`
Tracking: closes the D-1 deliverable in issue #911

## Method → REST endpoint mapping

| WS method | Replaces REST endpoint |
| --- | --- |
| `session/list` | `GET /api/sessions` |
| `session/snapshot` | combined `GET /api/sessions/{id}/{status,files,tasks}` |
| `session/messages_page` | `GET /api/sessions/{id}/messages` |
| `session/status.get` | `GET /api/sessions/{id}/status` |
| `session/files.list` | `GET /api/sessions/{id}/files` |
| `session/tasks.list` | `GET /api/sessions/{id}/tasks` |
| `session/workspace.get` | `GET /api/sessions/{id}/workspace-contract` |
| `session/title.set` | `PATCH /api/sessions/{id}/title` |
| `session/delete` | `DELETE /api/sessions/{id}` |
| `system/status.get` | `GET /api/status` |
| `content/list` | `GET /api/my/content` |
| `content/delete` | `DELETE /api/my/content/{id}` |
| `content/bulk_delete` | `POST /api/my/content/bulk-delete` |

(13 methods. `content/delete` and `content/bulk_delete` are distinct methods sharing the `content/*` namespace.)

## Request/response shapes

All thirteen methods follow the JSON-RPC 2.0 envelope. Param structs live in `octos-core/src/ui_protocol.rs`; result payloads are typed wrappers around the REST handler's existing JSON body. Concretely:

- `session/list` → `{ sessions: SessionInfo[] }`
- `session/snapshot` → `{ status, files, tasks }` (one round trip; all three REST handlers awaited concurrently via `tokio::join!`)
- `session/messages_page` → `{ messages: MessageInfo[], has_more, next_offset }`. **REST 404 → `UNKNOWN_SESSION` typed error**, **REST 503 → `runtime_not_ready`** (codex review 2026-05-12 BLOCK 2 — the original implementation mapped 404 to an empty page, which diverged from the REST contract).
- `session/status.get`, `session/files.list`, `session/tasks.list`, `session/workspace.get` → mirror the REST body under one wrapper field each
- `session/title.set` → `{ session_id, title }` (the REST `PATCH` returned `204 No Content`; the WS shape lifts the title into the response body for echo-correctness)
- `session/delete` → `{}` (REST returned 204)
- `system/status.get` → `{ status: StatusResponse }`
- `content/list` → `{ entries, total }` (matches `ContentQueryResult`)
- `content/delete` → `{ deleted: bool }`
- `content/bulk_delete` → `{ deleted: usize }`. Request `ids` capped at `CONTENT_BULK_DELETE_MAX_IDS = 256`; over-cap requests rejected with `INVALID_PARAMS` before the catalog write-lock is taken (codex review 2026-05-12 MEDIUM 3).

## Capability negotiation

Same shape as the existing `session.workspace_cwd.v1` opt-in (see `e2e/scripts/soak-m11-multi.ts:21`). Client requests it via `?ui_feature=auxiliary.rest_to_ws.v1` or the `X-Octos-Ui-Features` header. The aux methods are **always gated on the negotiated capability** — a client that sends no feature header at all still sees `method_not_supported` for the new methods and falls back to REST.

`route_rpc_command` performs the capability gate **before** deserializing params — gated methods return `method_not_supported` for un-opted clients instead of `invalid_params` for the unrelated payload shape. The pre-existing `session/hydrate`, `thread/graph/get`, `turn/state/get`, and `task/*` gates retain their legacy header-present fallback to preserve compatibility for no-header clients on the first-server slice.

## Error envelope

Per ADR §10:
- `UNKNOWN_SESSION (-32100)` ← REST 404 from session-scoped endpoints; `data.session_id` carries the addressed id
- `RESOURCE_NOT_FOUND (-32170)` ← REST 404 from non-session endpoints (content/profile); `data.resource_type` + `data.identifier` carry the kind and id
- `INVALID_PARAMS (-32602)` ← REST 400 (also synthesized for client-side validation, e.g. empty title, over-cap bulk-delete)
- `METHOD_NOT_SUPPORTED (-32004)` ← capability not negotiated
- `INTERNAL_ERROR (-32603)` ← REST 5xx
- `runtime_not_ready (-32140)` ← REST 503 (catalog/manager not wired)

The 404-mapping split (session vs resource) was added at codex review 2026-05-12 (MEDIUM 1) so content-row misses don't get coerced into a session-shaped error and don't stuff the method name into the `session_id` slot.

## Test coverage

- `octos-core`: 83 passing (10 new unit tests + 2 updated wire-contract goldens, plus codex-fix goldens for every aux request/result DTO and the new `RESOURCE_NOT_FOUND` variant)
- `octos-cli` (api): 137 passing in `api::ui_protocol::tests` (7 original + 6 added at codex review covering strict-opt-in, no-header negative path, 404/503 mapping, and the bulk-delete cap)

Integration tests against a live daemon (golden ledger entries, soak harness) land in Phase D-2/D-3 alongside the typed client wrappers.

## Verification

- `cargo check --workspace` → clean
- `cargo test -p octos-cli --features api --lib 'api::'` → 516 passed
- `cargo test -p octos-core --lib 'ui_protocol::'` → 83 passed
- `cargo clippy -p octos-core --no-deps -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

(Pre-existing clippy lints in unrelated files — `content_catalog.rs`, `process_manager.rs`, etc. — are not in this PR's diff and were not introduced by this change.)

## Deviations from the ADR

- **Result wrapping**: the ADR proposed bare `Vec<SessionFileInfo>` etc. for endpoints that return arrays. The PR wraps each in a single-field object (`{ files: [...] }`, `{ tasks: [...] }`, `{ contracts: [...] }`) so the response shape is forward-extensible (the existing `session/hydrate`/`thread/graph/get` results all follow this convention).
- **`session/title.set`** returns `{ session_id, title }` instead of `{}`. The REST endpoint returned 204; the WS shape echoes the resolved values so the SPA can confirm the rename in the response without a re-query.
- **`session/messages_page` 404 semantics**: corrected at codex review to surface `UNKNOWN_SESSION` (rather than an empty page) so REST and WS semantics match. The ADR's "REST 404 → empty page" wording was originally documented as a client convenience; preserving that on the WS path would have masked real session misses behind a harmless-looking empty result. REST 503 maps to `runtime_not_ready` per the existing envelope mapping.
- **Method-gate-before-decode**: structurally cleaner fix for a pre-existing edge case in capability negotiation. The ADR didn't call it out explicitly but the behavior matches the spec contract.
- **Strict-opt-in gate**: the M12 Phase D-1 methods reject `method_not_supported` regardless of whether a feature header was sent (codex review 2026-05-12 BLOCK 1). The legacy `session/hydrate` / `task/*` gates keep their header-present fallback.

## Out of scope (tracked in #911)

- Client typed wrappers (Phase D-2)
- Panel-by-panel SPA cutover behind `aux_rest_to_ws_v1` flag (Phase D-3)
- Flipping flag default ON + narrowing 401 reaper (Phase D-4)
- Retiring REST endpoints (Phase D-5)
- TUI consumer (already speaks UI Protocol v1; opportunistic)
- Admin SPA (`/api/admin/*`)
- BLOB endpoints (`/api/upload`, `/api/files/*`, `/api/my/content/{id}/{thumbnail,body}`, `/api/preview/*`)

## Test plan

- [ ] Server soak with `?ui_feature=auxiliary.rest_to_ws.v1` — confirm `session/list` returns the same shape as `GET /api/sessions`
- [ ] Server soak WITHOUT the feature — confirm `session/list` returns `method_not_supported` (and REST `/api/sessions` keeps working unchanged)
- [ ] Server soak with NO feature header at all — confirm the aux methods still return `method_not_supported` (regression guard against the original BLOCK 1 finding)
- [ ] Capability negotiation — `session/open` capabilities include `auxiliary.rest_to_ws.v1` only when the client requests it
- [ ] Round-trip `session/snapshot` and confirm it matches a 3-way fetch of `status` + `files` + `tasks` over REST
- [ ] `session/messages_page` against an unknown session returns `UNKNOWN_SESSION` with `data.session_id` echoed (was: empty page)
- [ ] `session/messages_page` against a standalone-mode server (no gateway wired) returns `runtime_not_ready`
- [ ] `content/bulk_delete` with `ids.len() > 256` returns `INVALID_PARAMS` immediately without touching the catalog
