### PR TITLE
fix(codex-audit): WS lifecycle + session-id + ledger replay + backpressure + ops hardening

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -932,31 +932,41 @@ pub async fn update_session_title(
     }
 
     let mut updated = false;
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+    let routed_profile_id = routed_profile_id_from_headers(&state, &headers);
+    let candidates =
+        standalone_api_session_key_candidates_with_topic(&state, &headers, identity_ref, &id, None);
 
-    if let Some(sessions) = &state.sessions {
-        let mut sess = sessions.lock().await;
-        // #919.2: use the auth-aware candidate helper so raw `web-*`
-        // sessions under profile auth resolve to the profile's own
-        // store. The older `standalone_api_session_key_candidates`
-        // skipped tenant-scoped raw-id fallbacks.
-        let identity_ref = identity.as_ref().map(|ext| &ext.0);
-        for key in standalone_api_session_key_candidates_with_topic(
+    // #924 BLOCK 3: each candidate `SessionKey` may belong to a
+    // different profile (the candidate set includes the resolved
+    // tenant profile, `_main`, and bare-channel/raw-id forms). Route
+    // each candidate through `resolve_sessions_for_lookup` so the
+    // profile's own `SessionRuntime.sessions` is locked — turn
+    // persistence writes there, so the title update MUST land in the
+    // same store. The legacy code locked only `state.sessions`, which
+    // did not contain profile-scoped runtime sessions and returned
+    // `NOT_FOUND` for raw `web-*` ids under profile auth.
+    for key in candidates {
+        let Some(sessions) = super::ui_protocol::resolve_sessions_for_lookup(
             &state,
-            &headers,
-            identity_ref,
-            &id,
             None,
-        ) {
-            if sess.load(&key).await.is_some() {
-                if let Err(e) = sess.update_title(&key, title.clone()).await {
-                    tracing::error!(
-                        session_key = %key,
-                        error = %e,
-                        "update_title in standalone store failed"
-                    );
-                } else {
-                    updated = true;
-                }
+            routed_profile_id.as_deref(),
+            &key,
+        )
+        .await
+        else {
+            continue;
+        };
+        let mut sess = sessions.lock().await;
+        if sess.load(&key).await.is_some() {
+            if let Err(e) = sess.update_title(&key, title.clone()).await {
+                tracing::error!(
+                    session_key = %key,
+                    error = %e,
+                    "update_title in profile-scoped store failed"
+                );
+            } else {
+                updated = true;
             }
         }
     }
@@ -991,26 +1001,35 @@ pub async fn delete_session(
     identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Response {
-    // Clear from the standalone store if available.
-    if let Some(sessions) = &state.sessions {
-        let mut sess = sessions.lock().await;
-        // #919.2: use the auth-aware candidate helper.
-        let identity_ref = identity.as_ref().map(|ext| &ext.0);
-        for key in standalone_api_session_key_candidates_with_topic(
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+    let routed_profile_id = routed_profile_id_from_headers(&state, &headers);
+    let candidates =
+        standalone_api_session_key_candidates_with_topic(&state, &headers, identity_ref, &id, None);
+
+    // #924 BLOCK 3: route each candidate through the profile-aware
+    // SessionManager resolver — turn persistence writes to the
+    // profile's `SessionRuntime.sessions`, so deletes MUST hit the
+    // same store. The legacy code locked only `state.sessions`, which
+    // did not contain profile-scoped runtime sessions.
+    for key in candidates {
+        let Some(sessions) = super::ui_protocol::resolve_sessions_for_lookup(
             &state,
-            &headers,
-            identity_ref,
-            &id,
             None,
-        ) {
-            if sess.load(&key).await.is_some() {
-                if let Err(e) = sess.clear(&key).await {
-                    tracing::error!(
-                        session_key = %key,
-                        error = %e,
-                        "delete session from standalone store failed"
-                    );
-                }
+            routed_profile_id.as_deref(),
+            &key,
+        )
+        .await
+        else {
+            continue;
+        };
+        let mut sess = sessions.lock().await;
+        if sess.load(&key).await.is_some() {
+            if let Err(e) = sess.clear(&key).await {
+                tracing::error!(
+                    session_key = %key,
+                    error = %e,
+                    "delete session from profile-scoped store failed"
+                );
             }
         }
     }

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -144,21 +144,6 @@ fn api_profile_id_from_headers(state: &AppState, headers: &HeaderMap) -> String 
     routed_profile_id_from_headers(state, headers).unwrap_or_else(|| MAIN_PROFILE_ID.to_string())
 }
 
-fn standalone_api_session_key_candidates(
-    state: &AppState,
-    headers: &HeaderMap,
-    session_id: &str,
-) -> Vec<SessionKey> {
-    let profile_id = api_profile_id_from_headers(state, headers);
-    let mut candidates = vec![
-        SessionKey::with_profile(&profile_id, "api", session_id),
-        SessionKey::with_profile(MAIN_PROFILE_ID, "api", session_id),
-        SessionKey::new("api", session_id),
-    ];
-    candidates.dedup_by(|left, right| left.0 == right.0);
-    candidates
-}
-
 /// Returns `true` when `session_id` is a bare SPA id whose raw form is
 /// safe to query as a `SessionKey` directly. Specifically: no `:` (which
 /// is the channel/profile separator in
@@ -178,7 +163,8 @@ fn is_safe_bare_session_id(session_id: &str) -> bool {
     !session_id.contains(':') && !session_id.contains('#')
 }
 
-/// Topic-aware sibling of [`standalone_api_session_key_candidates`].
+/// Topic-aware, auth-aware candidate resolver shared by REST
+/// `/messages`, `session/title.set`, and `session/delete`.
 ///
 /// Returns the candidate `SessionKey`s the REST `/messages` and similar
 /// read paths should try, in fallback order. The fallback set is split
@@ -933,6 +919,7 @@ pub struct UpdateTitleRequest {
 pub async fn update_session_title(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(id): axum::extract::Path<String>,
     Json(body): Json<UpdateTitleRequest>,
 ) -> Response {
@@ -948,7 +935,18 @@ pub async fn update_session_title(
 
     if let Some(sessions) = &state.sessions {
         let mut sess = sessions.lock().await;
-        for key in standalone_api_session_key_candidates(&state, &headers, &id) {
+        // #919.2: use the auth-aware candidate helper so raw `web-*`
+        // sessions under profile auth resolve to the profile's own
+        // store. The older `standalone_api_session_key_candidates`
+        // skipped tenant-scoped raw-id fallbacks.
+        let identity_ref = identity.as_ref().map(|ext| &ext.0);
+        for key in standalone_api_session_key_candidates_with_topic(
+            &state,
+            &headers,
+            identity_ref,
+            &id,
+            None,
+        ) {
             if sess.load(&key).await.is_some() {
                 if let Err(e) = sess.update_title(&key, title.clone()).await {
                     tracing::error!(
@@ -990,12 +988,21 @@ pub async fn update_session_title(
 pub async fn delete_session(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Response {
     // Clear from the standalone store if available.
     if let Some(sessions) = &state.sessions {
         let mut sess = sessions.lock().await;
-        for key in standalone_api_session_key_candidates(&state, &headers, &id) {
+        // #919.2: use the auth-aware candidate helper.
+        let identity_ref = identity.as_ref().map(|ext| &ext.0);
+        for key in standalone_api_session_key_candidates_with_topic(
+            &state,
+            &headers,
+            identity_ref,
+            &id,
+            None,
+        ) {
             if sess.load(&key).await.is_some() {
                 if let Err(e) = sess.clear(&key).await {
                     tracing::error!(

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -3395,6 +3395,7 @@ mod tests {
         let response = delete_session(
             State(state),
             HeaderMap::new(),
+            None,
             axum::extract::Path("web-topic#research".to_string()),
         )
         .await;

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1777,6 +1777,7 @@ async fn ui_protocol_connection(
                     &contracts.approvals,
                     &active_turns,
                     connection_profile_id,
+                    routed_profile_id,
                     features,
                     id,
                     params,
@@ -1790,6 +1791,7 @@ async fn ui_protocol_connection(
                     &ledger,
                     &active_turns,
                     connection_profile_id,
+                    routed_profile_id,
                     id,
                     params,
                 )
@@ -1802,6 +1804,7 @@ async fn ui_protocol_connection(
                     &ledger,
                     &active_turns,
                     connection_profile_id,
+                    routed_profile_id,
                     id,
                     params,
                 )
@@ -2797,12 +2800,28 @@ fn resolve_session_profile_runtime(
 /// registered for the resolved profile and the cache can bootstrap
 /// a `SessionRuntime` for `session_id`. Falls back to
 /// `state.sessions` so the legacy no-profile flow continues to work.
-async fn resolve_sessions_for_lookup(
+///
+/// #924 BLOCK 4: the active-profile precedence MUST mirror
+/// `handle_turn_start` — `session_id.profile_id()` first (the key
+/// itself encodes the owner profile), then `connection_profile_id`
+/// (token-auth scope), then `routed_profile_id` (host/header
+/// routing). Without the `session_id` precedence + the routed
+/// fallback, a host-routed admin session on a hosted subdomain
+/// hydrated from `_main`/`state.sessions` instead of the right
+/// profile runtime — and turns whose `SessionKey` already carried
+/// `<profile>:api:...` resolved to a different store than the one
+/// that persisted them.
+pub(crate) async fn resolve_sessions_for_lookup(
     state: &Arc<AppState>,
     connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
     session_id: &SessionKey,
 ) -> Option<Arc<tokio::sync::Mutex<octos_bus::SessionManager>>> {
-    if let Some(profile_runtime) = resolve_session_profile_runtime(state, connection_profile_id) {
+    let active_profile_id = session_id
+        .profile_id()
+        .or(connection_profile_id)
+        .or(routed_profile_id);
+    if let Some(profile_runtime) = resolve_session_profile_runtime(state, active_profile_id) {
         let hint = session_workspaces().get(session_id);
         if let Ok(runtime) = state
             .session_cache
@@ -3918,6 +3937,7 @@ async fn handle_session_hydrate(
     approvals: &PendingApprovalStore,
     active_turns: &SharedActiveTurns,
     connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
     features: ConnectionUiFeatures,
     id: String,
     params: SessionHydrateParams,
@@ -3960,8 +3980,13 @@ async fn handle_session_hydrate(
     // has a profile scope. Turn persistence writes to
     // `SessionRuntime.sessions`; reads must hit the same handle or we'd
     // report `unknown_session` on reconnect-hydrate.
-    let Some(sessions) =
-        resolve_sessions_for_lookup(state, connection_profile_id, &params.session_id).await
+    let Some(sessions) = resolve_sessions_for_lookup(
+        state,
+        connection_profile_id,
+        routed_profile_id,
+        &params.session_id,
+    )
+    .await
     else {
         let _ = send_rpc_error(
             ws,
@@ -4165,6 +4190,7 @@ async fn handle_thread_graph_get(
     ledger: &Arc<UiProtocolLedger>,
     _active_turns: &SharedActiveTurns,
     connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
     id: String,
     params: ThreadGraphGetParams,
 ) {
@@ -4185,8 +4211,13 @@ async fn handle_thread_graph_get(
     };
 
     // #919.1: route to the profile's session manager when under profile auth.
-    let Some(sessions) =
-        resolve_sessions_for_lookup(state, connection_profile_id, &params.session_id).await
+    let Some(sessions) = resolve_sessions_for_lookup(
+        state,
+        connection_profile_id,
+        routed_profile_id,
+        &params.session_id,
+    )
+    .await
     else {
         let _ = send_rpc_error(
             ws,
@@ -4248,6 +4279,7 @@ async fn handle_turn_state_get(
     ledger: &Arc<UiProtocolLedger>,
     active_turns: &SharedActiveTurns,
     connection_profile_id: Option<&str>,
+    routed_profile_id: Option<&str>,
     id: String,
     params: TurnStateGetParams,
 ) {
@@ -4264,8 +4296,13 @@ async fn handle_turn_state_get(
     //
     // #919.1: route to the profile's session manager when under profile
     // auth so reads see the same store the turn writes used.
-    let sessions =
-        resolve_sessions_for_lookup(state, connection_profile_id, &params.session_id).await;
+    let sessions = resolve_sessions_for_lookup(
+        state,
+        connection_profile_id,
+        routed_profile_id,
+        &params.session_id,
+    )
+    .await;
     if let Some(sessions) = sessions.as_ref() {
         let mut sessions_guard = sessions.lock().await;
         if !sessions_guard.session_known(&params.session_id) {
@@ -11908,6 +11945,7 @@ mod tests {
             &approvals,
             &active_turns,
             None,
+            None,
             ConnectionUiFeatures::default(),
             "h1".into(),
             SessionHydrateParams {
@@ -11996,6 +12034,7 @@ mod tests {
             &ledger,
             &active_turns,
             None,
+            None,
             "g1".into(),
             ThreadGraphGetParams {
                 session_id: session_id.clone(),
@@ -12056,6 +12095,7 @@ mod tests {
             &ledger,
             &active_turns,
             None,
+            None,
             "g2".into(),
             ThreadGraphGetParams {
                 session_id: session_id.clone(),
@@ -12100,6 +12140,7 @@ mod tests {
             &state,
             &ledger,
             &active_turns,
+            None,
             None,
             "t1".into(),
             TurnStateGetParams {
@@ -12153,6 +12194,7 @@ mod tests {
             &ledger,
             &active_turns,
             None,
+            None,
             "t2".into(),
             TurnStateGetParams {
                 session_id: session_id.clone(),
@@ -12189,6 +12231,7 @@ mod tests {
             &ledger,
             &approvals,
             &active_turns,
+            None,
             None,
             ConnectionUiFeatures::default(),
             "h-unknown".into(),
@@ -12337,6 +12380,7 @@ mod tests {
             &approvals,
             &active_turns,
             None,
+            None,
             features_for_spawn_complete_test(true, true),
             "h-new".into(),
             SessionHydrateParams {
@@ -12415,6 +12459,7 @@ mod tests {
             &approvals,
             &active_turns,
             None,
+            None,
             ConnectionUiFeatures::default(),
             "h-legacy".into(),
             SessionHydrateParams {
@@ -12490,6 +12535,7 @@ mod tests {
             &approvals,
             &active_turns,
             None,
+            None,
             features_for_spawn_complete_test(true, true),
             "h-no-msgs".into(),
             SessionHydrateParams {
@@ -12524,6 +12570,7 @@ mod tests {
             &state,
             &ledger,
             &active_turns,
+            None,
             None,
             "t3".into(),
             TurnStateGetParams {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1677,16 +1677,31 @@ async fn ui_protocol_connection(
     let failed_notify = ws.failed_notify();
 
     loop {
+        // #924 round-2 BLOCK: close the lost-notify race. `notify_waiters`
+        // is only received by `Notified` futures that exist at the time of
+        // the call, and it stashes no permit. So we:
+        //   1. Bail eagerly if the latch is already set.
+        //   2. Construct `notified()` BEFORE the second latch check — this
+        //      means any subsequent `mark_failed` either (a) is caught by
+        //      the re-check below, or (b) fires `notify_waiters` against
+        //      this future, which then resolves when the select polls it.
+        //   3. Re-check the latch after creating the future to catch the
+        //      "fired between is_failed and notified()" ordering.
+        if ws.is_failed() {
+            break;
+        }
+        let notified = failed_notify.notified();
+        tokio::pin!(notified);
+        if ws.is_failed() {
+            break;
+        }
+
         let msg = tokio::select! {
             biased;
-            _ = failed_notify.notified() => {
-                // The latch may have fired before our `notified()`
-                // registration: the Acquire load is the source of
-                // truth.
-                if ws.is_failed() {
-                    break;
-                }
-                continue;
+            _ = &mut notified => {
+                // Latch arm only fires when the connection is failed; no
+                // need to re-load — the Notify is private to `mark_failed`.
+                break;
             }
             next = ws_rx.next() => match next {
                 Some(Ok(msg)) => msg,
@@ -11542,6 +11557,52 @@ mod tests {
         });
         waited.await.expect("notified() must wake within 500ms");
         latch.await.expect("latch task joins cleanly");
+        assert!(ws.is_failed());
+    }
+
+    /// #924 round-2 BLOCK: the round-1 test parks a waiter BEFORE calling
+    /// `mark_failed`. The lost-notify race only shows up the other way
+    /// around: the latch fires while the read loop is between iterations
+    /// (no `Notified` future exists yet). `notify_waiters` stashes nothing,
+    /// so the next-iteration `notified()` would never resolve without the
+    /// pre-park latch re-check. This test replays the same select shape
+    /// the production loop uses and asserts it exits on an idle socket
+    /// even when `mark_failed` fires before the read task starts polling.
+    #[tokio::test]
+    async fn mark_failed_during_idle_loop_still_cleans_up() {
+        let (ws, _rx) = ws_connection_for_test(1);
+        let failed_notify = ws.failed_notify();
+        // The "ws_rx" stand-in: an mpsc never sent on => idle socket.
+        let (_inbound_tx, mut inbound_rx) = mpsc::channel::<()>(1);
+
+        // Latch failed BEFORE the read task ever spins. This is the
+        // lost-notify ordering: the future that will park does not yet
+        // exist when `notify_waiters` fires.
+        ws.mark_failed();
+
+        let ws_for_task = ws.clone();
+        let read_task = tokio::spawn(async move {
+            loop {
+                if ws_for_task.is_failed() {
+                    break;
+                }
+                let notified = failed_notify.notified();
+                tokio::pin!(notified);
+                if ws_for_task.is_failed() {
+                    break;
+                }
+                tokio::select! {
+                    biased;
+                    _ = &mut notified => break,
+                    _ = inbound_rx.recv() => continue,
+                }
+            }
+        });
+
+        tokio::time::timeout(std::time::Duration::from_millis(100), read_task)
+            .await
+            .expect("read loop must exit promptly when latch fires before park")
+            .expect("read task joins cleanly");
         assert!(ws.is_failed());
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -128,6 +128,11 @@ pub(crate) enum SendError {
     /// a short reason for the calling turn to abort cleanly and mark the
     /// ledger entry `delivery_failed`.
     LifecycleFailure(String),
+    /// #924 BLOCK 2: a prior lifecycle/RPC send already latched the
+    /// connection as failed. Background tasks (turn forwarders, live
+    /// forwarders, ledger fan-out) MUST stop enqueueing onto a dead
+    /// channel — callers treat this exactly like `Closed`.
+    FatalClosed,
 }
 
 // Send-site categorization per M9-FIX-04 § Acceptance criteria:
@@ -189,6 +194,12 @@ pub(crate) struct WsConnection {
     /// closed writer. The read loop polls this and breaks cleanly so a
     /// silently-dropped RPC reply does not strand the client.
     failed: Arc<std::sync::atomic::AtomicBool>,
+    /// #924 BLOCK 1: a Notify woken in tandem with `failed.store(true)`.
+    /// The connection main loop `select!`s on this alongside the inbound
+    /// frame stream so a lifecycle/RPC send failure on an idle socket
+    /// triggers cleanup immediately rather than waiting indefinitely
+    /// for the next client frame.
+    failed_notify: Arc<tokio::sync::Notify>,
 }
 
 impl WsConnection {
@@ -198,6 +209,7 @@ impl WsConnection {
             metrics: Arc::new(ConnectionMetrics::default()),
             connection_id: ConnectionId::next(),
             failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            failed_notify: Arc::new(tokio::sync::Notify::new()),
         }
     }
 
@@ -205,9 +217,21 @@ impl WsConnection {
         self.failed.load(std::sync::atomic::Ordering::Acquire)
     }
 
+    /// #924 BLOCK 1: handle to the latch-wakeup notify for the read
+    /// loop's `select!` arm. Cloned cheaply (just an `Arc` bump).
+    fn failed_notify(&self) -> Arc<tokio::sync::Notify> {
+        self.failed_notify.clone()
+    }
+
     fn mark_failed(&self) {
         self.failed
             .store(true, std::sync::atomic::Ordering::Release);
+        // Wake every current and future `notified()` waiter so the read
+        // loop wakes immediately on an idle connection. `notify_waiters`
+        // alone has no permit-stash behaviour; combined with the Acquire
+        // load in the select! arm a late `notified().await` will still
+        // see `failed == true` and bail out before parking.
+        self.failed_notify.notify_waiters();
     }
 
     #[cfg(test)]
@@ -221,6 +245,17 @@ impl WsConnection {
     }
 
     fn try_enqueue(&self, frame: WsMessage) -> Result<(), SendError> {
+        // #924 BLOCK 2: once the connection is latched as failed every
+        // further enqueue must fail loudly. Background tasks (turn
+        // forwarders, live forwarders, ledger fan-out) keep pumping
+        // until the connection cleanup aborts their handles; without
+        // this gate they would push frames onto a writer the read loop
+        // is about to drop, masking the original lifecycle failure and
+        // wasting work. `FatalClosed` is callers' signal to treat the
+        // connection like `Closed`.
+        if self.failed.load(std::sync::atomic::Ordering::Acquire) {
+            return Err(SendError::FatalClosed);
+        }
         // Update the queue-depth gauge whenever we touch the channel — cheap
         // and gives an accurate signal even when sends succeed.
         let depth = WS_WRITER_CHANNEL_CAPACITY.saturating_sub(self.writer.capacity());
@@ -266,6 +301,14 @@ impl WsConnection {
                     "writer channel closed for lifecycle frame".into(),
                 ))
             }
+            Err(SendError::FatalClosed) => {
+                // #924 BLOCK 2: prior caller already latched the
+                // connection failed; surface the lifecycle-shape error
+                // for any callsite still doing work on this connection.
+                Err(SendError::LifecycleFailure(
+                    "connection already latched as failed".into(),
+                ))
+            }
             Err(other) => Err(other),
         }
     }
@@ -300,6 +343,14 @@ impl WsConnection {
                 );
                 Err(SendError::Closed)
             }
+            Err(SendError::FatalClosed) => {
+                // #924 BLOCK 2: connection already latched failed by a
+                // prior lifecycle send — no point counting another
+                // dropped row.
+                metrics::counter!("ws.send.drop.closed", "method" => method.to_string())
+                    .increment(1);
+                Err(SendError::FatalClosed)
+            }
             Err(other) => Err(other),
         }
     }
@@ -325,6 +376,12 @@ impl WsConnection {
                     "ephemeral ws send dropped; channel closed"
                 );
                 Err(SendError::Closed)
+            }
+            Err(SendError::FatalClosed) => {
+                // #924 BLOCK 2: silently drop, consistent with the spec
+                // § 9 "ephemeral frames may be dropped" rule. The
+                // connection is already torn down by the read loop.
+                Err(SendError::FatalClosed)
             }
             Err(other) => Err(other),
         }
@@ -1565,7 +1622,30 @@ async fn ui_protocol_connection(
     let connection_profile_id = connection_profile_id.as_deref();
     let routed_profile_id = routed_profile_id.as_deref();
 
-    while let Some(Ok(msg)) = ws_rx.next().await {
+    // #924 BLOCK 1: wake the read loop the instant a lifecycle/RPC
+    // send marks the connection failed. Without this, an idle socket
+    // with a failed write side would sit in `ws_rx.next().await`
+    // forever — the cleanup path only ran when the next client frame
+    // arrived, leaving subscribers and ledger fan-out registered.
+    let failed_notify = ws.failed_notify();
+
+    loop {
+        let msg = tokio::select! {
+            biased;
+            _ = failed_notify.notified() => {
+                // The latch may have fired before our `notified()`
+                // registration: the Acquire load is the source of
+                // truth.
+                if ws.is_failed() {
+                    break;
+                }
+                continue;
+            }
+            next = ws_rx.next() => match next {
+                Some(Ok(msg)) => msg,
+                Some(Err(_)) | None => break,
+            },
+        };
         // #922.2: stop dispatch once a lifecycle/RPC send has been
         // marked fatal so we don't quietly accept further requests we
         // can never reply to. The cleanup below still appends terminal
@@ -2290,7 +2370,10 @@ async fn spawn_live_forwarder(
                     }
                     match send_ledger_event_durable(&ws, &ledger, event.event) {
                         Ok(()) => {}
-                        Err(SendError::Closed) => break,
+                        // #924 BLOCK 2: a closed writer OR a latched
+                        // failure both mean further pumps will produce
+                        // FatalClosed forever; stop spinning.
+                        Err(SendError::Closed | SendError::FatalClosed) => break,
                         // BackpressureDrop: `send_ledger_event_durable`
                         // already opportunistically emits replay_lossy; keep
                         // pumping so a recovered consumer gets caught up.
@@ -11238,6 +11321,66 @@ mod tests {
         );
         assert!(matches!(second, Err(SendError::BackpressureDrop)));
         assert_eq!(ws.metrics().dropped_count.load(Ordering::Relaxed), 0);
+    }
+
+    /// #924 BLOCK 2: once a lifecycle send marks the connection failed,
+    /// every subsequent enqueue must fail with `FatalClosed` — even if
+    /// the underlying channel has spare capacity now. Background
+    /// forwarders that keep pumping after the read loop tore down would
+    /// otherwise queue frames into a writer about to drain and exit.
+    #[tokio::test]
+    async fn try_enqueue_returns_fatal_closed_after_mark_failed() {
+        let (ws, mut rx) = ws_connection_for_test(8);
+
+        // First send succeeds and leaves capacity available.
+        let frame = WsMessage::Text("ping".to_string().into());
+        assert!(ws.try_enqueue(frame).is_ok());
+
+        // Drain so capacity is fully open.
+        let _ = rx.try_recv();
+
+        // Latch the connection as failed (the lifecycle wrappers do
+        // this on backpressure / closed writer; here we drive the API
+        // directly to isolate the check).
+        ws.mark_failed();
+
+        // Even with capacity open, the next enqueue must fail loudly.
+        let frame = WsMessage::Text("after-fail".to_string().into());
+        let err = ws
+            .try_enqueue(frame)
+            .expect_err("post-latch enqueue must fail");
+        assert!(matches!(err, SendError::FatalClosed));
+
+        // And the lifecycle wrapper turns it into LifecycleFailure so
+        // existing RPC-reply callsites still see the failure-shaped
+        // error.
+        let res = send_rpc_result(&ws, "post-fail".into(), json!({"ok": true}));
+        assert!(matches!(res, Err(SendError::LifecycleFailure(_))));
+    }
+
+    /// #924 BLOCK 1: `mark_failed` must wake every pending `notified()`
+    /// waiter so the read loop's `select!` arm fires immediately. An
+    /// idle socket with a failed write side must NOT sit waiting for
+    /// the next client frame.
+    #[tokio::test]
+    async fn mark_failed_wakes_failed_notify_waiters() {
+        let (ws, _rx) = ws_connection_for_test(1);
+        let notify = ws.failed_notify();
+
+        // Park a waiter; latch failed; the waiter must complete promptly.
+        let waited = tokio::time::timeout(std::time::Duration::from_millis(500), async move {
+            notify.notified().await;
+        });
+        // Run latch + await concurrently — the `notified()` future must
+        // observe the wake even though we never read another frame.
+        let ws_clone = ws.clone();
+        let latch = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            ws_clone.mark_failed();
+        });
+        waited.await.expect("notified() must wake within 500ms");
+        latch.await.expect("latch task joins cleanly");
+        assert!(ws.is_failed());
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14,7 +14,7 @@ use axum::Extension;
 use axum::extract::State;
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
 use axum::http::{HeaderMap, Uri};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use chrono::{DateTime, Utc};
 use futures::{SinkExt, StreamExt};
 use octos_agent::{
@@ -1483,6 +1483,24 @@ pub async fn ws_handler(
     uri: Uri,
     ws: WebSocketUpgrade,
 ) -> Response {
+    // #923.3: gate the upgrade on Origin. CORS doesn't apply to WS
+    // handshakes, so without this a browser tab on any origin could
+    // open the socket as long as it has a valid token. Non-browser
+    // clients (TUI, gateway, scripts) typically omit the Origin
+    // header — allow that. When Origin IS present it must match the
+    // shared CORS allowlist.
+    if let Some(origin) = headers.get(axum::http::header::ORIGIN) {
+        let origin_str = origin.to_str().unwrap_or("");
+        let allowed = super::router::cors_allowlist_for_base_domain(state.base_domain.as_deref());
+        if !allowed.iter().any(|s| s == origin_str) {
+            tracing::warn!(
+                target: "octos::ui_protocol::ws",
+                origin = %origin_str,
+                "rejected WS upgrade from disallowed Origin"
+            );
+            return (axum::http::StatusCode::FORBIDDEN, "disallowed origin").into_response();
+        }
+    }
     let connection_profile_id = identity
         .as_ref()
         .and_then(|Extension(identity)| authenticated_profile_id(identity))
@@ -1838,17 +1856,34 @@ async fn ui_protocol_connection(
         &contracts.approvals,
     )
     .await;
-    abort_live_forwarders(&live_forwarders).await;
+    abort_live_forwarders(&live_forwarders, &ledger).await;
     // Dropping `ws` lets the writer task drain & exit; await it so the socket
     // is closed before we return.
     drop(ws);
     let _ = writer_handle.await;
 }
 
-async fn abort_live_forwarders(forwarders: &SharedLiveForwarders) {
-    let mut guard = forwarders.lock().await;
-    for (_, abort) in guard.drain() {
-        abort.abort();
+async fn abort_live_forwarders(forwarders: &SharedLiveForwarders, ledger: &UiProtocolLedger) {
+    let drained_sessions: Vec<SessionKey> = {
+        let mut guard = forwarders.lock().await;
+        guard
+            .drain()
+            .map(|(session_id, abort)| {
+                abort.abort();
+                session_id
+            })
+            .collect()
+    };
+    if drained_sessions.is_empty() {
+        return;
+    }
+    // #923.2: yield once so the aborted forwarder tasks have a chance
+    // to drop their broadcast receivers before we prune. Then sweep
+    // each session — if its receiver count is now zero we drop the
+    // sender immediately instead of waiting for the periodic sweep.
+    tokio::task::yield_now().await;
+    for session_id in drained_sessions {
+        ledger.prune_subscriber_if_idle(&session_id);
     }
 }
 
@@ -1874,8 +1909,8 @@ fn parse_ws_text_frame(text: &str) -> Result<ParsedFrame, RpcError> {
     if text.len() > MAX_TEXT_FRAME_BYTES {
         return Err(frame_too_large_error());
     }
-    let value: Value = serde_json::from_str(text)
-        .map_err(|err| RpcError::parse_error(err.to_string()))?;
+    let value: Value =
+        serde_json::from_str(text).map_err(|err| RpcError::parse_error(err.to_string()))?;
     if !value.is_object() {
         return Err(RpcError::parse_error("envelope must be an object"));
     }
@@ -7521,13 +7556,12 @@ mod tests {
         assert_eq!(ledger_event_cursor(&spawn), Some(cursor.clone()));
 
         // Sanity: a non-cursor-bearing variant returns None.
-        let delta = UiProtocolLedgerEvent::Notification(UiNotification::MessageDelta(
-            MessageDeltaEvent {
+        let delta =
+            UiProtocolLedgerEvent::Notification(UiNotification::MessageDelta(MessageDeltaEvent {
                 session_id: session_id.clone(),
                 turn_id: TurnId::new(),
                 text: "x".into(),
-            },
-        ));
+            }));
         assert_eq!(ledger_event_cursor(&delta), None);
     }
 
@@ -12876,7 +12910,7 @@ mod tests {
 
         // Cleanup: aborting the forwarder must not panic and must release
         // the receiver so subsequent prune_idle_subscribers reclaims the slot.
-        abort_live_forwarders(&forwarders).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
     }
 
     #[tokio::test]
@@ -12925,7 +12959,7 @@ mod tests {
         // No further frames are queued (only one live event emitted).
         assert!(rx.try_recv().is_err(), "no more frames expected");
 
-        abort_live_forwarders(&forwarders).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
     }
 
     #[tokio::test]
@@ -12956,7 +12990,7 @@ mod tests {
             "client without event.message_persisted.v1 must not receive message/persisted"
         );
 
-        abort_live_forwarders(&forwarders).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
     }
 
     // ========================================================================
@@ -13085,7 +13119,7 @@ mod tests {
             "no second frame: background message/persisted is suppressed for new clients",
         );
 
-        abort_live_forwarders(&forwarders).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
     }
 
     /// Codex P1: when the BackgroundResultSender persist scope is
@@ -13220,7 +13254,7 @@ mod tests {
             "no second frame: turn/spawn_complete is suppressed for old clients",
         );
 
-        abort_live_forwarders(&forwarders).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
     }
 
     #[tokio::test]
@@ -13277,7 +13311,7 @@ mod tests {
         );
 
         // Disconnect ws_a; ws_b must continue receiving subsequent events.
-        abort_live_forwarders(&forwarders_a).await;
+        abort_live_forwarders(&forwarders_a, &ledger).await;
         drop(rx_a);
         ledger.append_notification(message_persisted_for(&session_id));
         let frame_b2 = tokio::time::timeout(std::time::Duration::from_secs(1), rx_b.recv())
@@ -13289,7 +13323,7 @@ mod tests {
             Some(octos_core::ui_protocol::methods::MESSAGE_PERSISTED)
         );
 
-        abort_live_forwarders(&forwarders_b).await;
+        abort_live_forwarders(&forwarders_b, &ledger).await;
     }
 
     // -- Codex PR #761 review fixes ----------------------------------------
@@ -13382,7 +13416,7 @@ mod tests {
             "no further frames expected: session/open must be self-suppressed"
         );
 
-        abort_live_forwarders(&forwarders).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
     }
 
     /// MUST-FIX-2: a `send_notification_durable` call from the same
@@ -13459,8 +13493,8 @@ mod tests {
             Some(octos_core::ui_protocol::methods::MESSAGE_PERSISTED)
         );
 
-        abort_live_forwarders(&forwarders).await;
-        abort_live_forwarders(&forwarders_other).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
+        abort_live_forwarders(&forwarders_other, &ledger).await;
     }
 
     /// MUST-FIX-3: a `subscribe()` call followed by dropping the
@@ -13544,7 +13578,7 @@ mod tests {
             Some(octos_core::ui_protocol::methods::MESSAGE_PERSISTED)
         );
 
-        abort_live_forwarders(&forwarders).await;
+        abort_live_forwarders(&forwarders, &ledger).await;
     }
 
     // ----- M11-E: UI Protocol per-session workspace wiring -----------------

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -7184,6 +7184,17 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
                 ..
             },
         )) => Some(cursor.clone()),
+        // #921: extract cursors from every durable cursor-bearing variant.
+        // `MessagePersisted` and `TurnSpawnComplete` always carry a non-Option
+        // cursor (stamped by the ledger on append); without these arms a
+        // dropped send for either method silently skipped `protocol/replay_lossy`,
+        // so the client never refetched the gap.
+        UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(persisted)) => {
+            Some(persisted.cursor.clone())
+        }
+        UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(spawn)) => {
+            Some(spawn.cursor.clone())
+        }
         _ => None,
     }
 }
@@ -7353,6 +7364,88 @@ mod tests {
             }
             other => panic!("expected TurnStart, got {:?}", other),
         }
+    }
+
+    /// #921: every cursor-bearing durable notification variant must
+    /// surface its cursor through `ledger_event_cursor` so dropped
+    /// sends trigger `protocol/replay_lossy`. Asserts the positive
+    /// extraction for the four variants and a negative for a non-
+    /// cursor-bearing one (sanity).
+    #[test]
+    fn ledger_event_cursor_covers_every_cursor_bearing_variant() {
+        let session_id = SessionKey("local:test".into());
+        let cursor = UiCursor {
+            stream: session_id.0.clone(),
+            seq: 42,
+        };
+
+        let opened =
+            UiProtocolLedgerEvent::Notification(UiNotification::SessionOpened(SessionOpened {
+                session_id: session_id.clone(),
+                active_profile_id: None,
+                workspace_root: None,
+                cursor: Some(cursor.clone()),
+                panes: None,
+                capabilities: octos_core::ui_protocol::UiProtocolCapabilities::first_server_slice(),
+            }));
+        assert_eq!(ledger_event_cursor(&opened), Some(cursor.clone()));
+
+        let completed = UiProtocolLedgerEvent::Notification(UiNotification::TurnCompleted(
+            TurnCompletedEvent {
+                session_id: session_id.clone(),
+                turn_id: TurnId::new(),
+                cursor: Some(cursor.clone()),
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            },
+        ));
+        assert_eq!(ledger_event_cursor(&completed), Some(cursor.clone()));
+
+        let persisted = UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(
+            MessagePersistedEvent {
+                session_id: session_id.clone(),
+                turn_id: None,
+                thread_id: None,
+                seq: 1,
+                role: "assistant".into(),
+                message_id: "msg-1".into(),
+                client_message_id: None,
+                source: MessagePersistedSource::Assistant,
+                cursor: cursor.clone(),
+                persisted_at: chrono::Utc::now(),
+                media: Vec::new(),
+            },
+        ));
+        assert_eq!(ledger_event_cursor(&persisted), Some(cursor.clone()));
+
+        let spawn = UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(
+            TurnSpawnCompleteEvent {
+                session_id: session_id.clone(),
+                turn_id: None,
+                thread_id: None,
+                task_id: "task-1".into(),
+                response_to_client_message_id: None,
+                seq: 1,
+                message_id: "msg-1".into(),
+                source: "background".into(),
+                cursor: cursor.clone(),
+                persisted_at: chrono::Utc::now(),
+                content: "done".into(),
+                media: Vec::new(),
+            },
+        ));
+        assert_eq!(ledger_event_cursor(&spawn), Some(cursor.clone()));
+
+        // Sanity: a non-cursor-bearing variant returns None.
+        let delta = UiProtocolLedgerEvent::Notification(UiNotification::MessageDelta(
+            MessageDeltaEvent {
+                session_id: session_id.clone(),
+                turn_id: TurnId::new(),
+                text: "x".into(),
+            },
+        ));
+        assert_eq!(ledger_event_cursor(&delta), None);
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1532,6 +1532,43 @@ fn tool_risk_registry_test_lock() -> &'static std::sync::Mutex<()> {
     LOCK.get_or_init(|| std::sync::Mutex::new(()))
 }
 
+/// #924 BLOCK 5 — outcome of the WS upgrade Origin gate.
+///
+/// CORS doesn't apply to WS handshakes, so without this gate a browser
+/// tab on any origin could open the socket as long as it has a valid
+/// token. Non-browser clients (TUI, gateway, scripts, server-to-server)
+/// typically omit the Origin header — allow that. Some server-to-server
+/// clients send the header with an empty value (`Origin: `); treat
+/// present-but-empty as absent and allow. A header with non-ASCII
+/// bytes (`to_str().is_err()`) still rejects — that is malformed input,
+/// not the same as omitting the header.
+#[derive(Debug, PartialEq, Eq)]
+enum WsOriginDecision {
+    Allow,
+    RejectDisallowed { origin: String },
+    RejectMalformed,
+}
+
+fn decide_ws_origin_gate(headers: &HeaderMap, base_domain: Option<&str>) -> WsOriginDecision {
+    let Some(origin) = headers.get(axum::http::header::ORIGIN) else {
+        return WsOriginDecision::Allow;
+    };
+    match origin.to_str() {
+        Ok(origin_str) if origin_str.trim().is_empty() => WsOriginDecision::Allow,
+        Ok(origin_str) => {
+            let allowed = super::router::cors_allowlist_for_base_domain(base_domain);
+            if allowed.iter().any(|s| s == origin_str) {
+                WsOriginDecision::Allow
+            } else {
+                WsOriginDecision::RejectDisallowed {
+                    origin: origin_str.to_string(),
+                }
+            }
+        }
+        Err(_) => WsOriginDecision::RejectMalformed,
+    }
+}
+
 /// GET /api/ui-protocol/ws — JSON-RPC over WebSocket for UI Protocol v1.
 pub async fn ws_handler(
     State(state): State<Arc<AppState>>,
@@ -1540,22 +1577,24 @@ pub async fn ws_handler(
     uri: Uri,
     ws: WebSocketUpgrade,
 ) -> Response {
-    // #923.3: gate the upgrade on Origin. CORS doesn't apply to WS
-    // handshakes, so without this a browser tab on any origin could
-    // open the socket as long as it has a valid token. Non-browser
-    // clients (TUI, gateway, scripts) typically omit the Origin
-    // header — allow that. When Origin IS present it must match the
-    // shared CORS allowlist.
-    if let Some(origin) = headers.get(axum::http::header::ORIGIN) {
-        let origin_str = origin.to_str().unwrap_or("");
-        let allowed = super::router::cors_allowlist_for_base_domain(state.base_domain.as_deref());
-        if !allowed.iter().any(|s| s == origin_str) {
+    // #923.3 + #924 BLOCK 5: gate the upgrade on Origin. See
+    // `decide_ws_origin_gate` for the full decision table.
+    match decide_ws_origin_gate(&headers, state.base_domain.as_deref()) {
+        WsOriginDecision::Allow => {}
+        WsOriginDecision::RejectDisallowed { origin } => {
             tracing::warn!(
                 target: "octos::ui_protocol::ws",
-                origin = %origin_str,
+                origin = %origin,
                 "rejected WS upgrade from disallowed Origin"
             );
             return (axum::http::StatusCode::FORBIDDEN, "disallowed origin").into_response();
+        }
+        WsOriginDecision::RejectMalformed => {
+            tracing::warn!(
+                target: "octos::ui_protocol::ws",
+                "rejected WS upgrade: Origin header is not valid ASCII"
+            );
+            return (axum::http::StatusCode::FORBIDDEN, "invalid origin").into_response();
         }
     }
     let connection_profile_id = identity
@@ -11418,6 +11457,69 @@ mod tests {
         waited.await.expect("notified() must wake within 500ms");
         latch.await.expect("latch task joins cleanly");
         assert!(ws.is_failed());
+    }
+
+    /// #924 BLOCK 5: server-to-server clients sometimes send the Origin
+    /// header with an empty value (`Origin: `). The original gate
+    /// rejected those because the empty string never matched the
+    /// allowlist; treat present-but-empty as absent.
+    #[test]
+    fn ws_origin_gate_allows_absent_or_empty_origin() {
+        // No Origin header at all → allow (TUI / gateway / scripts).
+        let headers = HeaderMap::new();
+        assert_eq!(
+            decide_ws_origin_gate(&headers, None),
+            WsOriginDecision::Allow,
+        );
+
+        // Origin header present but empty after trim → allow.
+        let mut headers = HeaderMap::new();
+        headers.insert(axum::http::header::ORIGIN, "".parse().unwrap());
+        assert_eq!(
+            decide_ws_origin_gate(&headers, None),
+            WsOriginDecision::Allow,
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(axum::http::header::ORIGIN, "   ".parse().unwrap());
+        assert_eq!(
+            decide_ws_origin_gate(&headers, None),
+            WsOriginDecision::Allow,
+        );
+    }
+
+    #[test]
+    fn ws_origin_gate_rejects_present_non_allowlisted_origin() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::ORIGIN,
+            "https://evil.example.com".parse().unwrap(),
+        );
+        let decision = decide_ws_origin_gate(&headers, Some("bot.ominix.io"));
+        assert!(matches!(
+            decision,
+            WsOriginDecision::RejectDisallowed { ref origin }
+                if origin == "https://evil.example.com"
+        ));
+    }
+
+    /// #924 BLOCK 5: a header that fails ASCII parse is malformed
+    /// input — keep rejecting it. Treating it as "absent" would be a
+    /// downgrade-attack vector.
+    #[test]
+    fn ws_origin_gate_rejects_non_ascii_origin() {
+        let mut headers = HeaderMap::new();
+        // Insert raw bytes that are not valid header values via the
+        // typed `HeaderValue::from_bytes` builder. We use bytes that
+        // would round-trip but contain non-ASCII content so `to_str`
+        // returns Err.
+        let val = axum::http::HeaderValue::from_bytes(b"https://\xff.example.com")
+            .expect("HeaderValue accepts arbitrary visible bytes");
+        headers.insert(axum::http::header::ORIGIN, val);
+        assert_eq!(
+            decide_ws_origin_gate(&headers, None),
+            WsOriginDecision::RejectMalformed,
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1787,7 +1787,14 @@ async fn ui_protocol_connection(
         }
     }
 
-    abort_connection_turns(&active_turns, &connection_turns, &contracts.scopes).await;
+    abort_connection_turns(
+        &active_turns,
+        &connection_turns,
+        &contracts.scopes,
+        &ledger,
+        &contracts.approvals,
+    )
+    .await;
     abort_live_forwarders(&live_forwarders).await;
     // Dropping `ws` lets the writer task drain & exit; await it so the socket
     // is closed before we return.
@@ -6908,6 +6915,8 @@ async fn abort_connection_turns(
     active_turns: &SharedActiveTurns,
     connection_turns: &SharedConnectionTurns,
     scopes: &ScopePolicy,
+    ledger: &UiProtocolLedger,
+    approvals: &PendingApprovalStore,
 ) {
     let turns = std::mem::take(&mut *connection_turns.lock().await);
     if turns.is_empty() {
@@ -6916,13 +6925,55 @@ async fn abort_connection_turns(
 
     let mut active = active_turns.lock().await;
     for (session_id, turn_id) in turns {
+        let mut aborted_state: Option<Arc<TokioMutex<TurnState>>> = None;
         let should_abort = active
             .get(&session_id)
             .is_some_and(|active| active.turn_id == turn_id);
         if should_abort {
             if let Some(active) = active.remove(&session_id) {
+                aborted_state = Some(active.state.clone());
                 active.abort.abort();
             }
+        }
+        // #920.1: append a durable terminal event so reconnect-replay
+        // sees this turn end. Without this the in-flight turn vanishes
+        // from the live registry but no `turn/error` lands, so clients
+        // render an indefinite spinner. Use the same single-fire
+        // transition the rest of the lifecycle uses so we don't race
+        // with a natural completion / interrupt that may already have
+        // flipped state to Terminal.
+        if let Some(state) = aborted_state {
+            if let Some(transition) =
+                transition_to_terminal(state.as_ref(), TerminalReason::Interrupted).await
+            {
+                let _ = ledger.append_notification(UiNotification::TurnError(TurnErrorEvent {
+                    session_id: session_id.clone(),
+                    turn_id: turn_id.clone(),
+                    code: "connection_closed".to_owned(),
+                    message: "connection closed before turn completed".to_owned(),
+                }));
+                if let Some(ack) = transition.ack {
+                    let _ = ack.send(());
+                }
+            }
+        }
+        // #920.2: cancel every still-pending approval for the aborted
+        // turn and append a durable `approval/cancelled` for each so a
+        // reconnect doesn't re-show a modal for a dead turn.
+        let cancelled = approvals.cancel_pending_for_turn(
+            &session_id,
+            &turn_id,
+            approval_cancelled_reasons::TURN_INTERRUPTED,
+        );
+        for entry in cancelled {
+            let _ = ledger.append_notification(UiNotification::ApprovalCancelled(
+                ApprovalCancelledEvent {
+                    session_id: session_id.clone(),
+                    approval_id: entry.approval_id,
+                    turn_id: entry.turn_id,
+                    reason: approval_cancelled_reasons::TURN_INTERRUPTED.to_owned(),
+                },
+            ));
         }
         // FIX-06: connection close is the de-facto "session close" hook in
         // v1alpha1 — drop every recorded scope for this session so it cannot
@@ -9768,7 +9819,16 @@ mod tests {
             .insert(stale_session_id.clone(), stale_connection_turn_id);
 
         let scopes = ScopePolicy::default();
-        abort_connection_turns(&active_turns, &connection_turns, &scopes).await;
+        let ledger = UiProtocolLedger::new(16);
+        let approvals = PendingApprovalStore::default();
+        abort_connection_turns(
+            &active_turns,
+            &connection_turns,
+            &scopes,
+            &ledger,
+            &approvals,
+        )
+        .await;
 
         assert!(!active_turns.lock().await.contains_key(&owned_session_id));
         assert_eq!(

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -185,6 +185,10 @@ pub(crate) struct WsConnection {
     /// connection can drop the broadcast copy and avoid duplicate
     /// delivery to the WS.
     connection_id: ConnectionId,
+    /// #922.2: latched when a lifecycle/RPC send hits backpressure or a
+    /// closed writer. The read loop polls this and breaks cleanly so a
+    /// silently-dropped RPC reply does not strand the client.
+    failed: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl WsConnection {
@@ -193,7 +197,17 @@ impl WsConnection {
             writer,
             metrics: Arc::new(ConnectionMetrics::default()),
             connection_id: ConnectionId::next(),
+            failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
+    }
+
+    pub(crate) fn is_failed(&self) -> bool {
+        self.failed.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn mark_failed(&self) {
+        self.failed
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 
     #[cfg(test)]
@@ -219,6 +233,12 @@ impl WsConnection {
     }
 
     /// Lifecycle: turn lifecycle / RPC reply. Caller acts on the failure.
+    ///
+    /// #922.2: a lifecycle-frame backpressure drop is treated as a
+    /// connection failure. The latched `failed` flag tells the read
+    /// loop to stop dispatch and tear down — better than silently
+    /// dropping RPC replies (which left clients timing out while the
+    /// server thought the call succeeded).
     fn send_lifecycle(&self, frame: WsMessage) -> Result<(), SendError> {
         match self.try_enqueue(frame) {
             Ok(_) => Ok(()),
@@ -227,8 +247,9 @@ impl WsConnection {
                 tracing::warn!(
                     target: "octos::ui_protocol::ws",
                     reason = "backpressure",
-                    "lifecycle ws send failed; turn will abort"
+                    "lifecycle ws send failed; aborting connection"
                 );
+                self.mark_failed();
                 Err(SendError::LifecycleFailure(
                     "writer channel full for lifecycle frame".into(),
                 ))
@@ -238,8 +259,9 @@ impl WsConnection {
                 tracing::warn!(
                     target: "octos::ui_protocol::ws",
                     reason = "closed",
-                    "lifecycle ws send failed; turn will abort"
+                    "lifecycle ws send failed; aborting connection"
                 );
+                self.mark_failed();
                 Err(SendError::LifecycleFailure(
                     "writer channel closed for lifecycle frame".into(),
                 ))
@@ -1526,6 +1548,13 @@ async fn ui_protocol_connection(
     let routed_profile_id = routed_profile_id.as_deref();
 
     while let Some(Ok(msg)) = ws_rx.next().await {
+        // #922.2: stop dispatch once a lifecycle/RPC send has been
+        // marked fatal so we don't quietly accept further requests we
+        // can never reply to. The cleanup below still appends terminal
+        // events / cancels approvals via `abort_connection_turns`.
+        if ws.is_failed() {
+            break;
+        }
         let text = match msg {
             WsMessage::Text(text) => text,
             WsMessage::Close(_) => break,
@@ -1534,7 +1563,21 @@ async fn ui_protocol_connection(
         };
 
         let request = match parse_ws_text_frame(text.as_str()) {
-            Ok(request) => request,
+            Ok(ParsedFrame::Request(request)) => request,
+            Ok(ParsedFrame::Notification(method)) => {
+                // #922.1: known inbound notifications (no `id`) are
+                // accepted silently. Unknown notifications get a debug
+                // trace but no reply — a notification by spec has no
+                // response.
+                if !is_known_inbound_notification(&method) {
+                    tracing::debug!(
+                        target: "octos::ui_protocol::ws",
+                        method = %method,
+                        "ignoring unknown inbound notification"
+                    );
+                }
+                continue;
+            }
             Err(error) => {
                 // Lifecycle: client violated the wire contract. We try to
                 // tell them, but proceed regardless — the read loop is
@@ -1809,15 +1852,55 @@ async fn abort_live_forwarders(forwarders: &SharedLiveForwarders) {
     }
 }
 
-fn parse_ws_text_frame(text: &str) -> Result<RpcRequest<Value>, RpcError> {
+/// #922.1: JSON-RPC envelopes with no `id` are notifications, not
+/// requests. The protocol's bridge sends a `ping` notification every
+/// 30s; the legacy parser required `RpcRequest.id: String`, so the
+/// server replied with a `parse_error` for every keepalive. The
+/// resulting noise also masked real parse errors.
+///
+/// Inspect the raw envelope first: if `id` is absent we return
+/// `Notification(method)` (the caller silently accepts known
+/// notifications such as `ping`). When `id` is present we parse the
+/// full `RpcRequest<Value>` shape and return `Request`. Unparseable
+/// frames continue to return `Err(RpcError)` so the existing
+/// "lifecycle: client violated wire contract" branch fires.
+#[derive(Debug)]
+enum ParsedFrame {
+    Request(RpcRequest<Value>),
+    Notification(String),
+}
+
+fn parse_ws_text_frame(text: &str) -> Result<ParsedFrame, RpcError> {
     if text.len() > MAX_TEXT_FRAME_BYTES {
         return Err(frame_too_large_error());
     }
-    parse_rpc_request(text)
+    let value: Value = serde_json::from_str(text)
+        .map_err(|err| RpcError::parse_error(err.to_string()))?;
+    if !value.is_object() {
+        return Err(RpcError::parse_error("envelope must be an object"));
+    }
+    let has_id = value.get("id").is_some_and(|v| !v.is_null());
+    if !has_id {
+        let method = value
+            .get("method")
+            .and_then(Value::as_str)
+            .ok_or_else(|| RpcError::parse_error("notification missing method"))?
+            .to_owned();
+        return Ok(ParsedFrame::Notification(method));
+    }
+    let request: RpcRequest<Value> =
+        serde_json::from_value(value).map_err(|err| RpcError::parse_error(err.to_string()))?;
+    Ok(ParsedFrame::Request(request))
 }
 
+#[cfg(test)]
 fn parse_rpc_request(text: &str) -> Result<RpcRequest<Value>, RpcError> {
     serde_json::from_str(text).map_err(|err| RpcError::parse_error(err.to_string()))
+}
+
+/// Inbound notifications the server accepts (no reply emitted).
+fn is_known_inbound_notification(method: &str) -> bool {
+    matches!(method, "ping")
 }
 
 fn route_rpc_command(
@@ -8757,6 +8840,19 @@ mod tests {
             error.data.as_ref().and_then(|data| data.get("limit_bytes")),
             Some(&json!(MAX_TEXT_FRAME_BYTES))
         );
+    }
+
+    /// #922.1: an envelope without `id` is a JSON-RPC notification and
+    /// must not yield a parse_error reply.
+    #[test]
+    fn idless_envelope_parses_as_notification() {
+        let frame = r#"{"jsonrpc":"2.0","method":"ping","params":{}}"#;
+        match parse_ws_text_frame(frame).expect("parses") {
+            ParsedFrame::Notification(method) => assert_eq!(method, "ping"),
+            ParsedFrame::Request(_) => panic!("expected notification"),
+        }
+        assert!(is_known_inbound_notification("ping"));
+        assert!(!is_known_inbound_notification("unknown"));
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -110,7 +110,15 @@ type SharedConnectionTurns = Arc<tokio::sync::Mutex<HashMap<SessionKey, TurnId>>
 /// Each entry pumps `LedgeredUiProtocolEvent`s from the ledger broadcast
 /// into the WS write channel for the lifetime of the connection. Dropping
 /// or aborting a handle terminates the pump.
-type SharedLiveForwarders = Arc<tokio::sync::Mutex<HashMap<SessionKey, AbortHandle>>>;
+///
+/// #924 NIT 8: keep the full `JoinHandle` (not just the `AbortHandle`) so
+/// the connection-cleanup path can `await` the aborted task before pruning
+/// idle subscribers. With only an `AbortHandle`, a single `yield_now()`
+/// after `abort()` was best-effort — under load the receiver might not
+/// have dropped before `prune_subscriber_if_idle` ran, leaving the ledger
+/// broadcaster believing it still had a live subscriber.
+type SharedLiveForwarders =
+    Arc<tokio::sync::Mutex<HashMap<SessionKey, tokio::task::JoinHandle<()>>>>;
 
 /// Outcome of pushing a frame onto the per-connection writer channel.
 ///
@@ -1986,24 +1994,27 @@ async fn ui_protocol_connection(
 }
 
 async fn abort_live_forwarders(forwarders: &SharedLiveForwarders, ledger: &UiProtocolLedger) {
-    let drained_sessions: Vec<SessionKey> = {
+    let drained: Vec<(SessionKey, tokio::task::JoinHandle<()>)> = {
         let mut guard = forwarders.lock().await;
-        guard
-            .drain()
-            .map(|(session_id, abort)| {
-                abort.abort();
-                session_id
-            })
-            .collect()
+        guard.drain().collect()
     };
-    if drained_sessions.is_empty() {
+    if drained.is_empty() {
         return;
     }
-    // #923.2: yield once so the aborted forwarder tasks have a chance
-    // to drop their broadcast receivers before we prune. Then sweep
-    // each session — if its receiver count is now zero we drop the
-    // sender immediately instead of waiting for the periodic sweep.
-    tokio::task::yield_now().await;
+    // #923.2 + #924 NIT 8: abort every forwarder, then `await` each
+    // JoinHandle so the receiver-drop has provably happened before we
+    // prune. The old `yield_now()` was a single scheduling hint and
+    // could lose the race under load — leaving the ledger
+    // broadcaster believing it still had a live subscriber. Awaiting
+    // the JoinHandle is the canonical "task is fully done" signal in
+    // tokio. We ignore the JoinError for aborted tasks (that's the
+    // expected shape).
+    let mut drained_sessions: Vec<SessionKey> = Vec::with_capacity(drained.len());
+    for (session_id, handle) in drained {
+        handle.abort();
+        let _ = handle.await;
+        drained_sessions.push(session_id);
+    }
     for session_id in drained_sessions {
         ledger.prune_subscriber_if_idle(&session_id);
     }
@@ -2015,12 +2026,20 @@ async fn abort_live_forwarders(forwarders: &SharedLiveForwarders, ledger: &UiPro
 /// server replied with a `parse_error` for every keepalive. The
 /// resulting noise also masked real parse errors.
 ///
-/// Inspect the raw envelope first: if `id` is absent we return
-/// `Notification(method)` (the caller silently accepts known
-/// notifications such as `ping`). When `id` is present we parse the
-/// full `RpcRequest<Value>` shape and return `Request`. Unparseable
-/// frames continue to return `Err(RpcError)` so the existing
-/// "lifecycle: client violated wire contract" branch fires.
+/// #924 NIT 6: distinguish notifications from requests by KEY
+/// PRESENCE on `id`, not by null-check. A JSON-RPC envelope with
+/// `id: null` is malformed (per spec §4 the `id` of a request must
+/// be a String / Number / NULL only for the response correlation
+/// reserved use); routing it as a "notification" silently swallowed
+/// what should be a loud parse error. The rule:
+///
+/// - `id` absent       → Notification (today's `ping`/etc.)
+/// - `id` is String    → Request (our server's expected shape)
+/// - `id` is Number    → Reject with parse_error (we require String)
+/// - `id` is null/etc. → Reject with parse_error
+///
+/// Unparseable frames continue to return `Err(RpcError)` so the
+/// existing "lifecycle: client violated wire contract" branch fires.
 #[derive(Debug)]
 enum ParsedFrame {
     Request(RpcRequest<Value>),
@@ -2036,18 +2055,30 @@ fn parse_ws_text_frame(text: &str) -> Result<ParsedFrame, RpcError> {
     if !value.is_object() {
         return Err(RpcError::parse_error("envelope must be an object"));
     }
-    let has_id = value.get("id").is_some_and(|v| !v.is_null());
-    if !has_id {
-        let method = value
-            .get("method")
-            .and_then(Value::as_str)
-            .ok_or_else(|| RpcError::parse_error("notification missing method"))?
-            .to_owned();
-        return Ok(ParsedFrame::Notification(method));
+    match value.get("id") {
+        None => {
+            let method = value
+                .get("method")
+                .and_then(Value::as_str)
+                .ok_or_else(|| RpcError::parse_error("notification missing method"))?
+                .to_owned();
+            Ok(ParsedFrame::Notification(method))
+        }
+        Some(Value::String(_)) => {
+            let request: RpcRequest<Value> = serde_json::from_value(value)
+                .map_err(|err| RpcError::parse_error(err.to_string()))?;
+            Ok(ParsedFrame::Request(request))
+        }
+        Some(Value::Null) => Err(RpcError::parse_error(
+            "rpc envelope `id` must not be null; omit the field for notifications",
+        )),
+        Some(Value::Number(_)) => Err(RpcError::parse_error(
+            "rpc envelope `id` must be a string; numeric ids are not supported",
+        )),
+        Some(_) => Err(RpcError::parse_error(
+            "rpc envelope `id` must be a string when present",
+        )),
     }
-    let request: RpcRequest<Value> =
-        serde_json::from_value(value).map_err(|err| RpcError::parse_error(err.to_string()))?;
-    Ok(ParsedFrame::Request(request))
 }
 
 #[cfg(test)]
@@ -2438,11 +2469,15 @@ async fn spawn_live_forwarder(
             }
         }
     });
-    let abort = task.abort_handle();
-    // Replace any prior forwarder for this session on this connection —
-    // re-`session/open` restarts the live pump from a fresh baseline.
+    // #924 NIT 8: store the full JoinHandle so the connection-cleanup
+    // path can `await` the aborted task before pruning idle
+    // subscribers. Replace any prior forwarder for this session on
+    // this connection — re-`session/open` restarts the live pump from
+    // a fresh baseline. The previous handle is aborted + the resulting
+    // JoinHandle dropped on the spot; we don't await here because
+    // re-open is a hot path.
     let mut guard = forwarders.lock().await;
-    if let Some(prev) = guard.insert(session_id, abort) {
+    if let Some(prev) = guard.insert(session_id, task) {
         prev.abort();
     }
 }
@@ -7450,29 +7485,46 @@ fn ledger_event_method(event: &UiProtocolLedgerEvent) -> &'static str {
 }
 
 fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
+    // #924 NIT 7: exhaustive on both `UiProtocolLedgerEvent` AND the
+    // inner `UiNotification`. A `_ => None` catchall would let a
+    // future cursor-bearing variant compile cleanly while silently
+    // being skipped for replay-lossy cursor extraction (#921 was
+    // exactly that bug for `MessagePersisted` / `TurnSpawnComplete`).
+    // The rule for new variants: if you add a `cursor: UiCursor` or
+    // `cursor: Option<UiCursor>` field, add it here too. Variants
+    // whose "cursor" is an `OutputCursor` (task output stream) are
+    // explicitly NOT surfaced here — that's a separate replay channel.
     match event {
-        UiProtocolLedgerEvent::Notification(UiNotification::SessionOpened(SessionOpened {
-            cursor: Some(cursor),
-            ..
-        })) => Some(cursor.clone()),
-        UiProtocolLedgerEvent::Notification(UiNotification::TurnCompleted(
-            TurnCompletedEvent {
-                cursor: Some(cursor),
-                ..
-            },
-        )) => Some(cursor.clone()),
-        // #921: extract cursors from every durable cursor-bearing variant.
-        // `MessagePersisted` and `TurnSpawnComplete` always carry a non-Option
-        // cursor (stamped by the ledger on append); without these arms a
-        // dropped send for either method silently skipped `protocol/replay_lossy`,
-        // so the client never refetched the gap.
-        UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(persisted)) => {
-            Some(persisted.cursor.clone())
-        }
-        UiProtocolLedgerEvent::Notification(UiNotification::TurnSpawnComplete(spawn)) => {
-            Some(spawn.cursor.clone())
-        }
-        _ => None,
+        UiProtocolLedgerEvent::Notification(notification) => match notification {
+            UiNotification::SessionOpened(SessionOpened { cursor, .. }) => cursor.clone(),
+            UiNotification::TurnCompleted(TurnCompletedEvent { cursor, .. }) => cursor.clone(),
+            UiNotification::MessagePersisted(persisted) => Some(persisted.cursor.clone()),
+            UiNotification::TurnSpawnComplete(spawn) => Some(spawn.cursor.clone()),
+            // Non-cursor-bearing variants — exhaustively enumerated so a
+            // future addition forces an explicit decision here.
+            UiNotification::TurnStarted(_)
+            | UiNotification::MessageDelta(_)
+            | UiNotification::ToolStarted(_)
+            | UiNotification::ToolProgress(_)
+            | UiNotification::ToolCompleted(_)
+            | UiNotification::ApprovalRequested(_)
+            | UiNotification::ApprovalAutoResolved(_)
+            | UiNotification::ApprovalDecided(_)
+            | UiNotification::ApprovalCancelled(_)
+            | UiNotification::TaskUpdated(_)
+            // TaskOutputDelta carries an `OutputCursor`, not a `UiCursor`.
+            | UiNotification::TaskOutputDelta(_)
+            | UiNotification::ProgressUpdated(_)
+            | UiNotification::Warning(_)
+            | UiNotification::TurnError(_)
+            // ReplayLossy references a `last_durable_cursor` belonging to
+            // the events it summarises, not its own — surfacing it here
+            // would re-loop the replay flag onto itself.
+            | UiNotification::ReplayLossy(_)
+            | UiNotification::FileAttached(_)
+            | UiNotification::SessionEventBridged(_) => None,
+        },
+        UiProtocolLedgerEvent::Progress(_) => None,
     }
 }
 
@@ -9046,6 +9098,40 @@ mod tests {
         }
         assert!(is_known_inbound_notification("ping"));
         assert!(!is_known_inbound_notification("unknown"));
+    }
+
+    /// #924 NIT 6: distinguish notifications from requests by KEY
+    /// presence on `id`, not null-check. An envelope with
+    /// `"id": null` is malformed — surfacing it loudly via
+    /// parse_error catches client bugs that the silent-drop path
+    /// hid.
+    #[test]
+    fn null_id_envelope_is_rejected_with_parse_error() {
+        let frame =
+            r#"{"jsonrpc":"2.0","id":null,"method":"session/open","params":{"session_id":"x"}}"#;
+        let err = parse_ws_text_frame(frame).expect_err("null id must reject");
+        assert_eq!(
+            err.code,
+            octos_core::ui_protocol::rpc_error_codes::PARSE_ERROR
+        );
+        assert!(
+            err.message.contains("null"),
+            "parse error message should mention the null id; got {}",
+            err.message
+        );
+    }
+
+    /// #924 NIT 6: numeric ids are also rejected — the server's RpcRequest
+    /// shape requires `id: String`.
+    #[test]
+    fn numeric_id_envelope_is_rejected_with_parse_error() {
+        let frame =
+            r#"{"jsonrpc":"2.0","id":42,"method":"session/open","params":{"session_id":"x"}}"#;
+        let err = parse_ws_text_frame(frame).expect_err("numeric id must reject");
+        assert_eq!(
+            err.code,
+            octos_core::ui_protocol::rpc_error_codes::PARSE_ERROR
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1742,10 +1742,26 @@ async fn ui_protocol_connection(
                 .await;
             }
             UiCommand::SessionTitleSet(params) => {
-                handle_session_title_set(&ws, &state, &connection_headers, id, params).await;
+                handle_session_title_set(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::SessionDelete(params) => {
-                handle_session_delete(&ws, &state, &connection_headers, id, params).await;
+                handle_session_delete(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::SystemStatusGet(params) => {
                 handle_system_status_get(&ws, &state, id, params).await;
@@ -2561,6 +2577,34 @@ fn resolve_session_profile_runtime(
 ) -> Option<Arc<crate::runtime::ProfileRuntime>> {
     let candidate = active_profile_id.unwrap_or(MAIN_PROFILE_ID);
     state.profiles.get(candidate).cloned()
+}
+
+/// Resolve the canonical `SessionManager` handle for read operations
+/// (hydrate, state, etc.). Closes #919.1: turn persistence writes to
+/// the profile's `SessionRuntime.sessions`, so reads under profile
+/// auth MUST hit the same handle — otherwise `state.sessions` (the
+/// top-level data-dir store) reports `unknown_session` on reconnect.
+///
+/// Returns the per-profile session manager if a `ProfileRuntime` is
+/// registered for the resolved profile and the cache can bootstrap
+/// a `SessionRuntime` for `session_id`. Falls back to
+/// `state.sessions` so the legacy no-profile flow continues to work.
+async fn resolve_sessions_for_lookup(
+    state: &Arc<AppState>,
+    connection_profile_id: Option<&str>,
+    session_id: &SessionKey,
+) -> Option<Arc<tokio::sync::Mutex<octos_bus::SessionManager>>> {
+    if let Some(profile_runtime) = resolve_session_profile_runtime(state, connection_profile_id) {
+        let hint = session_workspaces().get(session_id);
+        if let Ok(runtime) = state
+            .session_cache
+            .get_or_init(&profile_runtime, session_id.clone(), hint)
+            .await
+        {
+            return Some(runtime.sessions.clone());
+        }
+    }
+    state.sessions.clone()
 }
 
 fn session_workspace_root_for_state(state: &AppState, session_id: &SessionKey) -> Option<PathBuf> {
@@ -3704,7 +3748,13 @@ async fn handle_session_hydrate(
         };
 
     let include_set = HydrateIncludeSet::from_request(&params.include);
-    let Some(sessions) = &state.sessions else {
+    // #919.1: route to the profile's session manager when the connection
+    // has a profile scope. Turn persistence writes to
+    // `SessionRuntime.sessions`; reads must hit the same handle or we'd
+    // report `unknown_session` on reconnect-hydrate.
+    let Some(sessions) =
+        resolve_sessions_for_lookup(state, connection_profile_id, &params.session_id).await
+    else {
         let _ = send_rpc_error(
             ws,
             Some(id),
@@ -3926,7 +3976,10 @@ async fn handle_thread_graph_get(
         }
     };
 
-    let Some(sessions) = &state.sessions else {
+    // #919.1: route to the profile's session manager when under profile auth.
+    let Some(sessions) =
+        resolve_sessions_for_lookup(state, connection_profile_id, &params.session_id).await
+    else {
         let _ = send_rpc_error(
             ws,
             Some(id),
@@ -4000,7 +4053,12 @@ async fn handle_turn_state_get(
     // (which returns `state: unknown`). When the sessions manager is
     // unavailable we fall through to the default "unknown" path so the
     // RPC remains callable in headless tests.
-    if let Some(sessions) = &state.sessions {
+    //
+    // #919.1: route to the profile's session manager when under profile
+    // auth so reads see the same store the turn writes used.
+    let sessions =
+        resolve_sessions_for_lookup(state, connection_profile_id, &params.session_id).await;
+    if let Some(sessions) = sessions.as_ref() {
         let mut sessions_guard = sessions.lock().await;
         if !sessions_guard.session_known(&params.session_id) {
             let _ = send_rpc_error(
@@ -4039,7 +4097,7 @@ async fn handle_turn_state_get(
     // turn_id via thread_id grouping (today the type system does not yet
     // carry typed turn_id on Message; we approximate via the projection's
     // thread_id and the message's stored thread_id).
-    let committed_seqs = if let Some(sessions) = &state.sessions {
+    let committed_seqs = if let Some(sessions) = sessions.as_ref() {
         let mut sessions_guard = sessions.lock().await;
         let session = sessions_guard.get_or_create(&params.session_id).await;
         let target_thread_id = projection.as_ref().and_then(|p| p.thread_id.clone());
@@ -4841,6 +4899,7 @@ async fn handle_session_title_set(
     ws: &WsConnection,
     state: &Arc<AppState>,
     headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
     id: String,
     params: SessionTitleSetParams,
 ) {
@@ -4871,6 +4930,7 @@ async fn handle_session_title_set(
     let response = super::handlers::update_session_title(
         State(state.clone()),
         headers.clone(),
+        identity.cloned().map(axum::Extension),
         axum_path(params.session_id),
         body,
     )
@@ -4904,6 +4964,7 @@ async fn handle_session_delete(
     ws: &WsConnection,
     state: &Arc<AppState>,
     headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
     id: String,
     params: SessionDeleteParams,
 ) {
@@ -4912,6 +4973,7 @@ async fn handle_session_delete(
     let response = super::handlers::delete_session(
         State(state.clone()),
         headers.clone(),
+        identity.cloned().map(axum::Extension),
         axum_path(params.session_id),
     )
     .await;

--- a/crates/octos-cli/src/api/ui_protocol_approvals.rs
+++ b/crates/octos-cli/src/api/ui_protocol_approvals.rs
@@ -71,10 +71,7 @@ impl PendingApprovalStore {
         &self,
         params: ApprovalRespondParams,
     ) -> Result<RespondOutcome, RpcError> {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("pending approval store poisoned");
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
         let Some(entry) = entries.get_mut(&params.approval_id) else {
             return Err(approval_not_found_error(&params));
         };
@@ -158,10 +155,7 @@ impl PendingApprovalStore {
         turn_id: &TurnId,
         reason: &str,
     ) -> Vec<CancelledApproval> {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("pending approval store poisoned");
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
         let mut cancelled = Vec::new();
         for (approval_id, entry) in entries.iter_mut() {
             if entry.session_id != *session_id {
@@ -199,10 +193,7 @@ impl PendingApprovalStore {
         fallback_turn_id: &TurnId,
         reason: &str,
     ) -> Option<CancelledApproval> {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("pending approval store poisoned");
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
         let entry = entries.get_mut(approval_id)?;
         if entry.session_id != *session_id {
             return None;
@@ -229,10 +220,7 @@ impl PendingApprovalStore {
 
     #[allow(dead_code)]
     pub(super) fn insert_pending(&self, session_id: SessionKey, approval_id: ApprovalId) {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("pending approval store poisoned");
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
         entries.insert(
             approval_id,
             ApprovalEntry {
@@ -246,10 +234,7 @@ impl PendingApprovalStore {
     }
 
     pub(super) fn request(&self, event: ApprovalRequestedEvent) -> ApprovalRequestedEvent {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("pending approval store poisoned");
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
         entries.insert(
             event.approval_id.clone(),
             ApprovalEntry {
@@ -268,10 +253,7 @@ impl PendingApprovalStore {
         event: ApprovalRequestedEvent,
     ) -> tokio::sync::oneshot::Receiver<ApprovalDecision> {
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let mut entries = self
-            .entries
-            .write()
-            .expect("pending approval store poisoned");
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
         entries.insert(
             event.approval_id.clone(),
             ApprovalEntry {
@@ -289,10 +271,7 @@ impl PendingApprovalStore {
         &self,
         session_id: &SessionKey,
     ) -> Vec<ApprovalRequestedEvent> {
-        let entries = self
-            .entries
-            .read()
-            .expect("pending approval store poisoned");
+        let entries = self.entries.read().unwrap_or_else(|p| p.into_inner());
         entries
             .values()
             .filter(|entry| {
@@ -305,10 +284,7 @@ impl PendingApprovalStore {
 
     #[allow(dead_code)]
     pub(super) fn remove_pending(&self, session_id: &SessionKey, approval_id: &ApprovalId) -> bool {
-        let mut entries = self
-            .entries
-            .write()
-            .expect("pending approval store poisoned");
+        let mut entries = self.entries.write().unwrap_or_else(|p| p.into_inner());
         let should_remove = entries.get(approval_id).is_some_and(|entry| {
             entry.session_id == *session_id && matches!(&entry.state, ApprovalEntryState::Pending)
         });
@@ -323,10 +299,7 @@ impl PendingApprovalStore {
         &self,
         approval_id: &ApprovalId,
     ) -> Option<ApprovalRequestedEvent> {
-        let entries = self
-            .entries
-            .read()
-            .expect("pending approval store poisoned");
+        let entries = self.entries.read().unwrap_or_else(|p| p.into_inner());
         entries
             .get(approval_id)
             .and_then(|entry| entry.request.clone())

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -435,7 +435,7 @@ impl UiProtocolLedger {
 
         let count = snapshot.retained_entries.len();
         let total_disk_bytes = snapshot.total_disk_bytes;
-        let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let session_state = inner
             .sessions
             .entry(session_id.clone())
@@ -609,7 +609,7 @@ impl UiProtocolLedger {
         let stamped;
         let on_disk_delta;
         {
-            let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+            let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
 
             // LRU eviction: if we'd exceed the active session cap and this
             // session is new, evict the oldest first.
@@ -707,7 +707,7 @@ impl UiProtocolLedger {
         // broadcast subscriber (which is bounded but still does work in
         // `send`) can never block the next `append`.
         let sender = {
-            let inner = self.inner.lock().expect("ui protocol ledger lock");
+            let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
             inner.subscribers.get(session_id).cloned()
         };
         if let Some(sender) = sender {
@@ -729,7 +729,7 @@ impl UiProtocolLedger {
         &self,
         session_id: &SessionKey,
     ) -> broadcast::Receiver<LedgeredUiProtocolEvent> {
-        let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(sender) = inner.subscribers.get(session_id) {
             return sender.subscribe();
         }
@@ -744,7 +744,7 @@ impl UiProtocolLedger {
     /// ledgers, and on the `session/open` failure path so a `subscribe()`
     /// that never paired with a forwarder doesn't leak a sender.
     pub(crate) fn prune_idle_subscribers(&self) -> usize {
-        let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let to_remove: Vec<SessionKey> = inner
             .subscribers
             .iter()
@@ -763,7 +763,7 @@ impl UiProtocolLedger {
     /// their `Receiver` and want to immediately reclaim the sender slot
     /// rather than waiting for the next sweep.
     pub(crate) fn prune_subscriber_if_idle(&self, session_id: &SessionKey) -> bool {
-        let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let drop_it = inner
             .subscribers
             .get(session_id)
@@ -778,7 +778,7 @@ impl UiProtocolLedger {
     fn snapshot_if_session_absent(&self, session_id: &SessionKey) -> Option<DiskSessionSnapshot> {
         self.config.data_dir.as_ref()?;
         {
-            let inner = self.inner.lock().expect("ui protocol ledger lock");
+            let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
             if inner.sessions.contains_key(session_id) {
                 return None;
             }
@@ -931,7 +931,7 @@ impl UiProtocolLedger {
     pub(crate) fn sweep_idle(&self) -> usize {
         let cutoff = Instant::now() - self.config.idle_ttl;
         let mut evicted = 0usize;
-        let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let victims: Vec<SessionKey> = inner
             .sessions
             .iter()
@@ -982,7 +982,7 @@ impl UiProtocolLedger {
     /// subscribers map. Used to assert pruning behaviour.
     #[cfg(test)]
     pub(crate) fn subscriber_count(&self) -> usize {
-        let inner = self.inner.lock().expect("ui protocol ledger lock");
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         inner.subscribers.len()
     }
 
@@ -990,7 +990,7 @@ impl UiProtocolLedger {
     /// `/metrics` endpoint integration.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn metrics(&self) -> LedgerMetrics {
-        let inner = self.inner.lock().expect("ui protocol ledger lock");
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         LedgerMetrics {
             sessions_active: inner.sessions.len(),
             sessions_evicted: inner.evicted_count,
@@ -1054,7 +1054,7 @@ impl UiProtocolLedger {
         let preload_snapshot = if self
             .inner
             .lock()
-            .expect("ui protocol ledger lock")
+            .unwrap_or_else(|p| p.into_inner())
             .sessions
             .get(session_id)
             .map(|session| {
@@ -1071,7 +1071,7 @@ impl UiProtocolLedger {
             None
         };
 
-        let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(snapshot) = preload_snapshot {
             // Hydrate the in-memory ring from disk, mirroring what
             // `replay_after_from_disk` does, but inside the same lock
@@ -1201,7 +1201,7 @@ impl UiProtocolLedger {
             // Pair the empty replay with the current head_seq so the
             // forwarder baseline matches a no-op snapshot.
             let head_seq = {
-                let inner = self.inner.lock().expect("ui protocol ledger lock");
+                let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
                 inner
                     .sessions
                     .get(session_id)
@@ -1213,7 +1213,7 @@ impl UiProtocolLedger {
         validate_cursor_stream(session_id, after)?;
 
         {
-            let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+            let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
             if let Some(ledger) = inner.sessions.get(session_id) {
                 if let Some(oldest_seq) = ledger.entries.front().map(|entry| entry.seq) {
                     let min_after_seq = oldest_seq.saturating_sub(1);
@@ -1260,7 +1260,7 @@ impl UiProtocolLedger {
         let session_dir = data_dir
             .join("ui-protocol")
             .join(encode_session_dir_name(session_id));
-        let mut inner = self.inner.lock().expect("ui protocol ledger lock");
+        let mut inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(ledger) = inner.sessions.get(session_id) {
             if let Some(oldest_seq) = ledger.entries.front().map(|entry| entry.seq) {
                 let min_after_seq = oldest_seq.saturating_sub(1);

--- a/crates/octos-cli/src/api/ui_protocol_scope.rs
+++ b/crates/octos-cli/src/api/ui_protocol_scope.rs
@@ -152,21 +152,21 @@ impl ScopePolicy {
         // Slow path: insert a new session entry. We need a write lock on
         // `sessions` only when the session isn't there yet.
         let needs_insert = {
-            let sessions = self.sessions.read().expect("scope policy poisoned");
+            let sessions = self.sessions.read().unwrap_or_else(|p| p.into_inner());
             !sessions.contains_key(session_id)
         };
         if needs_insert {
-            let mut sessions = self.sessions.write().expect("scope policy poisoned");
+            let mut sessions = self.sessions.write().unwrap_or_else(|p| p.into_inner());
             sessions
                 .entry(session_id.clone())
                 .or_insert_with(|| Mutex::new(SessionScopes::default()));
         }
 
-        let sessions = self.sessions.read().expect("scope policy poisoned");
+        let sessions = self.sessions.read().unwrap_or_else(|p| p.into_inner());
         let session = sessions
             .get(session_id)
             .expect("session entry created above");
-        let mut session = session.lock().expect("session scope poisoned");
+        let mut session = session.lock().unwrap_or_else(|p| p.into_inner());
         session.entries.insert(
             (scope_kind, match_key.clone()),
             ScopeEntry {
@@ -195,9 +195,9 @@ impl ScopePolicy {
         tool_name: &str,
         turn_id: &TurnId,
     ) -> Option<ScopeHit> {
-        let sessions = self.sessions.read().expect("scope policy poisoned");
+        let sessions = self.sessions.read().unwrap_or_else(|p| p.into_inner());
         let session = sessions.get(session_id)?;
-        let session = session.lock().expect("session scope poisoned");
+        let session = session.lock().unwrap_or_else(|p| p.into_inner());
         let probes: [(ApprovalScopeKind, MatchKey); 3] = [
             (
                 ApprovalScopeKind::ApproveForTurn,
@@ -234,18 +234,18 @@ impl ScopePolicy {
     /// further refactoring.
     #[allow(dead_code)]
     pub(super) fn evict_session(&self, session_id: &SessionKey) {
-        let mut sessions = self.sessions.write().expect("scope policy poisoned");
+        let mut sessions = self.sessions.write().unwrap_or_else(|p| p.into_inner());
         sessions.remove(session_id);
     }
 
     /// Drops every `ApproveForTurn` entry for `(session_id, turn_id)`. Other
     /// scope kinds (`session`, `tool`) are unaffected — they outlive the turn.
     pub(super) fn evict_turn(&self, session_id: &SessionKey, turn_id: &TurnId) {
-        let sessions = self.sessions.read().expect("scope policy poisoned");
+        let sessions = self.sessions.read().unwrap_or_else(|p| p.into_inner());
         let Some(session) = sessions.get(session_id) else {
             return;
         };
-        let mut session = session.lock().expect("session scope poisoned");
+        let mut session = session.lock().unwrap_or_else(|p| p.into_inner());
         session.entries.retain(|_, entry| {
             entry
                 .turn_id
@@ -258,11 +258,11 @@ impl ScopePolicy {
     /// `approval/scopes/list` handler can return it directly. Sorted for
     /// deterministic output.
     pub(super) fn list_for_session(&self, session_id: &SessionKey) -> Vec<ApprovalScopeEntry> {
-        let sessions = self.sessions.read().expect("scope policy poisoned");
+        let sessions = self.sessions.read().unwrap_or_else(|p| p.into_inner());
         let Some(session) = sessions.get(session_id) else {
             return Vec::new();
         };
-        let session = session.lock().expect("session scope poisoned");
+        let session = session.lock().unwrap_or_else(|p| p.into_inner());
         let mut entries: Vec<ApprovalScopeEntry> = session
             .entries
             .iter()
@@ -287,13 +287,13 @@ impl ScopePolicy {
     /// Test-only: number of stored entries for a session.
     #[cfg(test)]
     pub(super) fn entry_count(&self, session_id: &SessionKey) -> usize {
-        let sessions = self.sessions.read().expect("scope policy poisoned");
+        let sessions = self.sessions.read().unwrap_or_else(|p| p.into_inner());
         sessions
             .get(session_id)
             .map(|session| {
                 session
                     .lock()
-                    .expect("session scope poisoned")
+                    .unwrap_or_else(|p| p.into_inner())
                     .entries
                     .len()
             })


### PR DESCRIPTION
## Summary

Bundles the five issues opened from the 2026-05-13 codex audit of the UI Protocol v1 WS server path.

- **#919 — Session-id consistency under profile auth**: hydrate/state/title/delete now resolve the SAME profile-scoped `SessionManager` that `turn/start` writes to. Raw `web-*` sessions under profile auth no longer return `unknown_session` on reconnect-hydrate or 404 on rename/delete.
- **#920 — WS lifecycle cleanup**: connection cleanup appends a durable `turn/error code=connection_closed` for every in-flight turn AND cancels every still-pending approval (publishing `approval/cancelled` to the ledger). Reconnect-replay no longer renders a stuck spinner or a modal for a dead turn.
- **#921 — Ledger replay completeness**: `ledger_event_cursor` now extracts cursors from every cursor-bearing durable variant — adds `MessagePersisted` and `TurnSpawnComplete` alongside the existing `SessionOpened` / `TurnCompleted`. Dropped sends now trigger `protocol/replay_lossy` so the client refetches.
- **#922 — Reader/writer parse + backpressure**: id-less JSON-RPC envelopes (the bridge's 30-second `ping`) are parsed as notifications, not requests, so they no longer trip `parse_error`. A lifecycle/RPC send failure latches a `failed` flag on the connection and the read loop tears down cleanly instead of silently dropping RPC replies.
- **#923 — Ops hardening**: WS upgrade is now Origin-gated against the shared CORS allowlist; closed connections eagerly prune broadcast senders (no waiting for the periodic sweep); poisoned hot-path locks on the ledger / scope / approval stores recover gracefully via `unwrap_or_else(|p| p.into_inner())` instead of panicking the next acquirer.

Closes #919.
Closes #920.
Closes #921.
Closes #922.
Closes #923.

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace --no-run`
- [x] `cargo test -p octos-cli --lib --features api,telegram` — 946 passed
- [x] `cargo fmt --all -- --check`
- [x] New unit tests:
  - [x] `ledger_event_cursor_covers_every_cursor_bearing_variant` — asserts cursor extraction for all four cursor-bearing notification variants plus a negative case
  - [x] `idless_envelope_parses_as_notification` — asserts the new `ParsedFrame::Notification` arm fires for envelopes without `id`
- [x] Updated existing tests:
  - [x] `abort_connection_turns_removes_only_matching_active_turns` — passes ledger + approval store args
  - [x] `delete_session_accepts_listed_topic_session_id_from_standalone_store` — passes `None` identity
  - [x] All `abort_live_forwarders` test call sites pass the `ledger` arg