### PR TITLE
fix(ws): accept raw web-N session_id under profile auth (critical OTP regression)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2329,13 +2329,16 @@ fn validate_authenticated_session_scope(
             connection_profile_id,
             Some(session_profile_id),
         )),
-        None => Err(
-            RpcError::invalid_params("session_id must include the authenticated profile")
-                .with_data(json!({
-                    "expected_profile_id": connection_profile_id,
-                    "auth_scope_violation": true,
-                })),
-        ),
+        // SPA convention: a fresh session uses a raw `web-N` id with no
+        // profile prefix. Accept it under profile auth — the auth layer
+        // is the gate, the session_id is just an opaque per-tab handle.
+        // PR #857 originally landed this. PR #926 inadvertently added
+        // `auth_scope_violation: true` here, which the new 1008
+        // close-on-auth-scope-violation path then weaponized — every
+        // OTP-authenticated browser session was 1008-closed on
+        // `session/open` and the SPA fell into a reconnect storm.
+        // Mini5 OTP-flow probe (2026-05-13) reproduced this.
+        None => Ok(()),
     }
 }
 


### PR DESCRIPTION
## Critical regression — OTP browsers couldn't open any session

PR #926's `send_scope_error` (close-frame 1008 on auth_scope_violation) combined with `validate_authenticated_session_scope`'s `None` arm (still returning Err with `auth_scope_violation: true` tag) caused **every OTP-authenticated browser session to enter a 1008 reconnect storm** on the first `session/open` RPC.

Symptom (live on mini5 before this fix):
- Empty session history sidebar
- Messages return no answer
- Network panel shows WS endlessly opening + closing

## Root cause

`validate_authenticated_session_scope`'s `None` arm was rejecting raw `web-N` session IDs (the SPA's convention for fresh per-tab sessions) with `invalid_params + auth_scope_violation: true`. PR #857 originally made this arm `Ok(())` — that fix was silently reverted, likely during PR #924's session-id consistency refactor.

## Fix

Make the `None` arm return `Ok(())`. The auth layer is the gate; the session_id is just an opaque per-tab handle.

## Verified on mini5

| | WS frames | OPEN/CLOSE/ERR | Response |
|---|---|---|---|
| Pre-fix | 6 in 30s | 5/5/0 | empty |
| Post-fix | 107 in 30s | 1/0/0 | full Beijing-weather streamed reply |

Probe: `e2e/tests/mini5-user-token-probe.spec.ts` (non-admin OTP-token, per `feedback_admin_token_masks_bugs.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)