### PR TITLE
fix(tools): decode upload-handle paths in resolve_path

### DIFF
--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -686,6 +686,16 @@ use std::path::{Component, Path};
 /// filesystem access except a single existence check for the upload
 /// whitelist).
 pub fn resolve_path(base_dir: &Path, user_path: &str) -> Result<PathBuf> {
+    // Upload-handle short-circuit. `/api/upload` returns paths in the
+    // form `up/<base64-payload>/<filename>` — opaque handles, not
+    // filesystem paths. The SPA echoes the handle into the LLM turn
+    // as an attachment, and the LLM passes it directly to `read_file`.
+    // Decode here so the rest of `resolve_path` sees a real absolute
+    // path inside the upload tmpdir.
+    if let Some(resolved) = octos_bus::file_handle::resolve_upload_reference(user_path) {
+        return Ok(normalize_path(&resolved));
+    }
+
     let candidate = PathBuf::from(user_path);
     if candidate.is_absolute() {
         if is_inside_upload_root(&candidate) {


### PR DESCRIPTION
`/api/upload` returns `up/<base64>/<filename>` handles. `resolve_path` now decodes via `octos_bus::file_handle::resolve_upload_reference` so `read_file` opens uploaded files the LLM references.