### PR TITLE
fix(file-handle): accept two-segment upload handle (LLM strips display name)

### DIFF
--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -361,6 +361,26 @@ impl PluginTool {
         for (key, value) in obj {
             if matches!(key.as_str(), "audio_path" | "file_path" | "input") {
                 if let Some(path) = value.as_str() {
+                    // Upload-handle short-circuit: `/api/upload` returns
+                    // `up/<base64>/<filename>` and the LLM passes the
+                    // handle straight to plugin tools (fm_voice_save,
+                    // fm_tts, etc.). Decode to the real on-disk path
+                    // before falling back to workspace-relative
+                    // resolution, otherwise the plugin sees something
+                    // like `<workspace>/skill-output/up/<base64>` and
+                    // 404s. Tolerates the partially-truncated form
+                    // `up/<base64>` (no display-name segment) via the
+                    // legacy-relative fallback inside
+                    // `resolve_upload_reference`.
+                    if let Some(resolved) =
+                        octos_bus::file_handle::resolve_upload_reference(path)
+                    {
+                        rewritten.insert(
+                            key.clone(),
+                            serde_json::Value::String(resolved.to_string_lossy().into_owned()),
+                        );
+                        continue;
+                    }
                     rewritten.insert(
                         key.clone(),
                         serde_json::Value::String(

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -47,7 +47,14 @@ pub fn decode_file_handle(handle: &str) -> Option<FileHandleScope> {
     let mut parts = handle.splitn(3, '/');
     let prefix = parts.next()?;
     let payload = parts.next()?;
-    let _display_name = parts.next()?;
+    // The third segment is a human-readable display name appended at
+    // `encode_scoped_handle` time — purely decorative. LLMs frequently
+    // truncate the handle to `up/<base64>` (e.g. tab-complete suggests
+    // the path up to the last `/` and the trailing filename is
+    // dropped). Accepting the two-segment form rescues those calls
+    // because the payload alone carries the full relative path needed
+    // to locate the file under `temp_upload_root` / profile root.
+    let _display_name = parts.next();
     let relative = decode_relative_payload(payload)?;
 
     match prefix {


### PR DESCRIPTION
LLMs truncate `up/<base64>/<display>` handles to `up/<base64>` when echoing them into tool calls. The decoder now accepts the two-segment form so `read_file` and the plugin path rewriter both succeed against the real on-disk location.