### PR TITLE
refactor: unified file-path resolver (kills the upload-handle bug class)

### DIFF
--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -621,23 +621,38 @@ fn input_schema_has_property(schema: &serde_json::Value, property: &str) -> bool
 ///    [`octos_bus::file_handle::resolve_tool_path`] resolver — the same
 ///    table that powers the file tools. This handles `up/...` /
 ///    `pf/...` handles (with both 3-segment and LLM-truncated
-///    2-segment forms), absolute paths inside the upload tmpdir or
-///    workspace, and ordinary workspace-relative inputs.
-/// 2. Fall back to the plugin-specific filename heuristics in
-///    [`resolve_path_in_work_dir`] — search for the basename inside
-///    `work_dir`, support `_<filename>` suffix matches, etc. This is
-///    behavior that pre-dates the unified resolver and that plugins
-///    rely on for legacy "send me back the absolute path you
-///    advertised" call patterns (mini-soak regression — the LLM
-///    sometimes prefixes a fictional `/home/user/uploads/` directory
-///    to the basename and the plugin has to recover via the workspace
-///    filename lookup).
+///    2-segment forms), and absolute paths inside the upload tmpdir.
+///    Accept the result UNCONDITIONALLY when the resolver returned a
+///    non-workspace scope (upload tmpdir / profile root), because those
+///    scopes already include an existence check via canonicalize.
+/// 2. For workspace scope, only accept if the resolved file actually
+///    exists. Otherwise fall through to the plugin-specific filename
+///    heuristics in [`resolve_path_in_work_dir`] — the legacy code
+///    looks up `<work_dir>/<basename>` and `_<basename>` suffix
+///    matches, which rescues live plugin calls where the LLM hallucinates
+///    a directory prefix in front of a basename that exists at the
+///    workspace root (codex review pin, 2026-05-13: `uploads/mark.wav`
+///    when only `mark.wav` exists must still recover).
 /// 3. Final fallback: lexically join with `work_dir` (the previous
 ///    behaviour of `absolutize_path_in_work_dir`) so the plugin never
 ///    sees an empty string.
 fn resolve_plugin_input_path(raw_path: &str, work_dir: &std::path::Path) -> String {
+    use octos_bus::file_handle::ToolPathScope;
     if let Ok(resolved) = octos_bus::file_handle::resolve_tool_path(work_dir, None, raw_path) {
-        return resolved.absolute.to_string_lossy().into_owned();
+        let accept = match resolved.scope {
+            // Upload / profile scopes go through `canonicalize_under`,
+            // so existence is already guaranteed.
+            ToolPathScope::UploadTmpdir | ToolPathScope::Profile => true,
+            // Workspace scope returns the LEXICAL workspace location
+            // (so the tool's `O_NOFOLLOW` gate can refuse symlinks),
+            // which means missing files slip through. Plugins need the
+            // legacy filename fallback for those, so only accept the
+            // workspace result when the file actually exists.
+            ToolPathScope::Workspace => resolved.absolute.exists(),
+        };
+        if accept {
+            return resolved.absolute.to_string_lossy().into_owned();
+        }
     }
     resolve_path_in_work_dir(raw_path, work_dir)
         .unwrap_or_else(|| absolutize_path_in_work_dir(raw_path, work_dir))
@@ -1300,20 +1315,16 @@ mod tests {
             "file_path": "deck.pdf",
         }));
 
-        // `audio_path` (a fictional absolute path) cannot resolve through
-        // the unified table — it's outside every allowed root — and
-        // therefore falls back to the legacy `resolve_path_in_work_dir`
-        // filename match, which returns the LEXICAL path inside `work_dir`.
+        // `audio_path` (a fictional absolute path) cannot resolve
+        // through the unified table — it's outside every allowed root
+        // — and falls back to the legacy `resolve_path_in_work_dir`
+        // filename match. `file_path` (`deck.pdf`) is workspace-relative
+        // and resolves through the unified resolver, which returns the
+        // lexical workspace path on purpose (the tool's `O_NOFOLLOW`
+        // open is the symlink-safety gate; canonicalising here would
+        // bypass it).
         assert_eq!(rewritten["audio_path"], wav.to_string_lossy().to_string());
-        // `file_path` (`deck.pdf`) is a workspace-relative input that
-        // resolves through the unified resolver. The resolver canonicalises
-        // the result when the file exists (firmlinks collapsed via
-        // `canonicalize`), so the comparison must use the canonical form.
-        let canonical_pdf = std::fs::canonicalize(&pdf).unwrap_or(pdf);
-        assert_eq!(
-            rewritten["file_path"],
-            canonical_pdf.to_string_lossy().to_string()
-        );
+        assert_eq!(rewritten["file_path"], pdf.to_string_lossy().to_string());
     }
 
     #[test]
@@ -1350,15 +1361,12 @@ mod tests {
             "slide_dir": "slides/demo/output/imgs"
         }));
 
-        // `input` is a workspace-relative path; the unified resolver
-        // canonicalises it (firmlinks collapsed) so compare against the
-        // canonical form. `out` and `slide_dir` skip the resolver (their
-        // key matches the absolutize-only branch) so they stay lexical.
-        let canonical_script = std::fs::canonicalize(&script).unwrap_or(script);
-        assert_eq!(
-            rewritten["input"],
-            canonical_script.to_string_lossy().to_string()
-        );
+        // All three keys end up as lexical workspace paths: `input`
+        // resolves through the unified resolver (workspace scope keeps
+        // the lexical form so the leaf `O_NOFOLLOW` gate can refuse
+        // symlinks), and `out` / `slide_dir` go through the
+        // absolutize-only branch which has always been lexical.
+        assert_eq!(rewritten["input"], script.to_string_lossy().to_string());
         assert_eq!(
             rewritten["out"],
             dir.path()
@@ -1373,6 +1381,45 @@ mod tests {
                 .to_string_lossy()
                 .to_string()
         );
+    }
+
+    #[test]
+    fn rewrite_workspace_file_args_recovers_basename_when_workspace_relative_missing() {
+        // Codex review P2 (2026-05-13): when the LLM hallucinates a
+        // directory prefix in front of a basename that exists at the
+        // workspace root, the plugin filename fallback must rescue it.
+        // The unified resolver succeeds for any syntactically valid
+        // workspace-relative path even when the file is missing, so
+        // the plugin code must require existence on the workspace scope
+        // before accepting the resolver's result.
+        let dir = tempfile::tempdir().unwrap();
+        let mark = dir.path().join("mark.wav");
+        std::fs::write(&mark, b"wav").unwrap();
+        // Note: `uploads/mark.wav` deliberately does NOT exist.
+
+        let def = PluginToolDef {
+            name: "voice_tool".to_string(),
+            description: "Voice tool".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"audio_path": {"type": "string"}}
+            }),
+            spawn_only: false,
+            env: vec![],
+            risk: None,
+            spawn_only_message: None,
+            concurrency_class: None,
+        };
+        let tool = PluginTool::new("plug".into(), def, PathBuf::from("/bin/true"))
+            .with_work_dir(dir.path().to_path_buf());
+
+        let rewritten = tool.rewrite_workspace_file_args(&json!({
+            "audio_path": "uploads/mark.wav",
+        }));
+
+        // Must recover `<work_dir>/mark.wav` via the legacy filename
+        // fallback, NOT return the missing `<work_dir>/uploads/mark.wav`.
+        assert_eq!(rewritten["audio_path"], mark.to_string_lossy().to_string());
     }
 
     #[test]

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -361,30 +361,9 @@ impl PluginTool {
         for (key, value) in obj {
             if matches!(key.as_str(), "audio_path" | "file_path" | "input") {
                 if let Some(path) = value.as_str() {
-                    // Upload-handle short-circuit: `/api/upload` returns
-                    // `up/<base64>/<filename>` and the LLM passes the
-                    // handle straight to plugin tools (fm_voice_save,
-                    // fm_tts, etc.). Decode to the real on-disk path
-                    // before falling back to workspace-relative
-                    // resolution, otherwise the plugin sees something
-                    // like `<workspace>/skill-output/up/<base64>` and
-                    // 404s. Tolerates the partially-truncated form
-                    // `up/<base64>` (no display-name segment) via the
-                    // legacy-relative fallback inside
-                    // `resolve_upload_reference`.
-                    if let Some(resolved) = octos_bus::file_handle::resolve_upload_reference(path) {
-                        rewritten.insert(
-                            key.clone(),
-                            serde_json::Value::String(resolved.to_string_lossy().into_owned()),
-                        );
-                        continue;
-                    }
                     rewritten.insert(
                         key.clone(),
-                        serde_json::Value::String(
-                            resolve_path_in_work_dir(path, work_dir)
-                                .unwrap_or_else(|| absolutize_path_in_work_dir(path, work_dir)),
-                        ),
+                        serde_json::Value::String(resolve_plugin_input_path(path, work_dir)),
                     );
                     continue;
                 }
@@ -427,12 +406,10 @@ impl PluginTool {
                             {
                                 rewritten_slide.insert(
                                     "source_image".into(),
-                                    serde_json::Value::String(
-                                        resolve_path_in_work_dir(source_image, work_dir)
-                                            .unwrap_or_else(|| {
-                                                absolutize_path_in_work_dir(source_image, work_dir)
-                                            }),
-                                    ),
+                                    serde_json::Value::String(resolve_plugin_input_path(
+                                        source_image,
+                                        work_dir,
+                                    )),
                                 );
                             }
                             serde_json::Value::Object(rewritten_slide)
@@ -633,6 +610,37 @@ fn input_schema_has_property(schema: &serde_json::Value, property: &str) -> bool
         .get("properties")
         .and_then(|properties| properties.as_object())
         .is_some_and(|properties| properties.contains_key(property))
+}
+
+/// Resolve a plugin tool's input path (`audio_path` / `file_path` /
+/// `input` / per-slide `source_image`) to an absolute on-disk string.
+///
+/// Order:
+///
+/// 1. Try the shared
+///    [`octos_bus::file_handle::resolve_tool_path`] resolver — the same
+///    table that powers the file tools. This handles `up/...` /
+///    `pf/...` handles (with both 3-segment and LLM-truncated
+///    2-segment forms), absolute paths inside the upload tmpdir or
+///    workspace, and ordinary workspace-relative inputs.
+/// 2. Fall back to the plugin-specific filename heuristics in
+///    [`resolve_path_in_work_dir`] — search for the basename inside
+///    `work_dir`, support `_<filename>` suffix matches, etc. This is
+///    behavior that pre-dates the unified resolver and that plugins
+///    rely on for legacy "send me back the absolute path you
+///    advertised" call patterns (mini-soak regression — the LLM
+///    sometimes prefixes a fictional `/home/user/uploads/` directory
+///    to the basename and the plugin has to recover via the workspace
+///    filename lookup).
+/// 3. Final fallback: lexically join with `work_dir` (the previous
+///    behaviour of `absolutize_path_in_work_dir`) so the plugin never
+///    sees an empty string.
+fn resolve_plugin_input_path(raw_path: &str, work_dir: &std::path::Path) -> String {
+    if let Ok(resolved) = octos_bus::file_handle::resolve_tool_path(work_dir, None, raw_path) {
+        return resolved.absolute.to_string_lossy().into_owned();
+    }
+    resolve_path_in_work_dir(raw_path, work_dir)
+        .unwrap_or_else(|| absolutize_path_in_work_dir(raw_path, work_dir))
 }
 
 fn resolve_path_in_work_dir(raw_path: &str, work_dir: &std::path::Path) -> Option<String> {
@@ -1292,8 +1300,20 @@ mod tests {
             "file_path": "deck.pdf",
         }));
 
+        // `audio_path` (a fictional absolute path) cannot resolve through
+        // the unified table — it's outside every allowed root — and
+        // therefore falls back to the legacy `resolve_path_in_work_dir`
+        // filename match, which returns the LEXICAL path inside `work_dir`.
         assert_eq!(rewritten["audio_path"], wav.to_string_lossy().to_string());
-        assert_eq!(rewritten["file_path"], pdf.to_string_lossy().to_string());
+        // `file_path` (`deck.pdf`) is a workspace-relative input that
+        // resolves through the unified resolver. The resolver canonicalises
+        // the result when the file exists (firmlinks collapsed via
+        // `canonicalize`), so the comparison must use the canonical form.
+        let canonical_pdf = std::fs::canonicalize(&pdf).unwrap_or(pdf);
+        assert_eq!(
+            rewritten["file_path"],
+            canonical_pdf.to_string_lossy().to_string()
+        );
     }
 
     #[test]
@@ -1330,7 +1350,15 @@ mod tests {
             "slide_dir": "slides/demo/output/imgs"
         }));
 
-        assert_eq!(rewritten["input"], script.to_string_lossy().to_string());
+        // `input` is a workspace-relative path; the unified resolver
+        // canonicalises it (firmlinks collapsed) so compare against the
+        // canonical form. `out` and `slide_dir` skip the resolver (their
+        // key matches the absolutize-only branch) so they stay lexical.
+        let canonical_script = std::fs::canonicalize(&script).unwrap_or(script);
+        assert_eq!(
+            rewritten["input"],
+            canonical_script.to_string_lossy().to_string()
+        );
         assert_eq!(
             rewritten["out"],
             dir.path()

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -311,9 +311,17 @@ mod tests {
         let file_path = dir.path().join("code.rs");
         std::fs::write(&file_path, "fn foo() {}\n").unwrap();
 
+        // Post-`resolve_tool_path` migration the resolver returns the
+        // canonical absolute path (firmlinks collapsed). Real read tools
+        // also call `resolve_path` before populating the cache, so they
+        // store the canonical form. Mirror that here so the cache lookup
+        // in `EditFileTool::execute_with_context` invalidates the same
+        // key the cache contains.
+        let canonical_file_path = std::fs::canonicalize(&file_path).unwrap_or(file_path.clone());
+
         let cache = Arc::new(FileStateCache::new());
         cache.put(CacheEntry::new(
-            file_path.clone(),
+            canonical_file_path.clone(),
             SystemTime::now(),
             0xCAFE,
             12,
@@ -339,6 +347,6 @@ mod tests {
             .unwrap();
 
         assert!(result.success);
-        assert!(cache.peek(&file_path).is_none());
+        assert!(cache.peek(&canonical_file_path).is_none());
     }
 }

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -311,17 +311,9 @@ mod tests {
         let file_path = dir.path().join("code.rs");
         std::fs::write(&file_path, "fn foo() {}\n").unwrap();
 
-        // Post-`resolve_tool_path` migration the resolver returns the
-        // canonical absolute path (firmlinks collapsed). Real read tools
-        // also call `resolve_path` before populating the cache, so they
-        // store the canonical form. Mirror that here so the cache lookup
-        // in `EditFileTool::execute_with_context` invalidates the same
-        // key the cache contains.
-        let canonical_file_path = std::fs::canonicalize(&file_path).unwrap_or(file_path.clone());
-
         let cache = Arc::new(FileStateCache::new());
         cache.put(CacheEntry::new(
-            canonical_file_path.clone(),
+            file_path.clone(),
             SystemTime::now(),
             0xCAFE,
             12,
@@ -347,6 +339,6 @@ mod tests {
             .unwrap();
 
         assert!(result.success);
-        assert!(cache.peek(&canonical_file_path).is_none());
+        assert!(cache.peek(&file_path).is_none());
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1167,6 +1167,30 @@ mod path_tests {
             assert!(p.starts_with(base));
         }
     }
+
+    /// Codex review P1 pin (2026-05-13): the unified resolver MUST NOT
+    /// follow symlinks for workspace-relative paths. File tools layer
+    /// `O_NOFOLLOW` over the resolved path; if the resolver
+    /// canonicalised first, a symlink `workspace/secret -> /etc/passwd`
+    /// would become a plain `/etc/passwd` open and the leaf gate would
+    /// have nothing left to refuse.
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_workspace_relative_does_not_follow_symlinks() {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let outside = tempfile::tempdir().expect("outside tmpdir");
+        let target = outside.path().join("passwd");
+        std::fs::write(&target, b"root:x:0:0").unwrap();
+        let link = workspace.path().join("secret");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let resolved = resolve_path(workspace.path(), "secret")
+            .expect("workspace symlink path must resolve (the leaf-open gate refuses it)");
+        // The resolver returned the LEXICAL workspace path, not the
+        // canonical target outside the workspace.
+        assert_eq!(resolved, workspace.path().join("secret"));
+        assert_ne!(resolved, target);
+    }
 }
 
 #[cfg(test)]

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -669,122 +669,67 @@ pub use git::GitTool;
 #[cfg(feature = "ast")]
 pub use code_structure::CodeStructureTool;
 
-use std::path::{Component, Path};
+use std::path::Path;
 
-/// Resolve a user-provided path, ensuring it stays within base_dir
-/// **or** inside the authenticated upload tmpdir.
+/// Resolve a user-provided tool-argument path, ensuring it stays within
+/// `base_dir` **or** inside the authenticated upload tmpdir.
 ///
-/// Absolute paths are accepted only when they point at a file under
-/// `octos_bus::file_handle::temp_upload_root()` — those files are
-/// user-uploaded attachments resolved by the WS/REST upload handler
-/// from an authenticated session, so the agent is allowed to read
-/// them even though they live outside the per-session workspace. All
-/// other absolute paths are rejected.
+/// This is a thin compatibility wrapper around
+/// [`octos_bus::file_handle::resolve_tool_path`] — the unified resolver
+/// introduced by `refactor: unified file-path resolver`. The wrapper
+/// preserves the historical signature (`(base_dir, user_path) ->
+/// Result<PathBuf>`) so existing tool implementations keep compiling,
+/// but the actual policy now lives in `octos-bus` so every entry point
+/// (read_file/write_file/edit_file/glob/grep/list_dir, plugin tools,
+/// `send_file`, `read_task_output`) follows the same resolution table:
 ///
-/// Relative paths must resolve under `base_dir` after `../` traversal
-/// is normalized away. Does NOT follow symlinks (normalize only, no
-/// filesystem access except a single existence check for the upload
-/// whitelist).
+/// - `up/<base64>` / `up/<base64>/<display>` upload-handle short-circuit
+/// - `pf/<base64>` / `pf/<base64>/<display>` profile-handle short-circuit
+///   (only honoured when the call site supplies a profile root)
+/// - absolute paths inside upload tmpdir, workspace, or profile root
+/// - bare basenames that exist under the upload tmpdir
+/// - workspace-relative paths (with `..` traversal rejected)
+///
+/// Symlink rejection is the caller's responsibility — use
+/// `read_no_follow` / `write_no_follow` on the returned path. The
+/// resolver only checks containment; the open-time `O_NOFOLLOW` is
+/// what closes the symlink-redirect class of escape.
+///
+/// Callers that need to know whether the resolved file lives inside
+/// the upload tmpdir vs the workspace (e.g. for read-only enforcement
+/// on profile files) should call
+/// [`octos_bus::file_handle::resolve_tool_path`] directly and inspect
+/// the [`octos_bus::file_handle::ToolPathScope`].
 pub fn resolve_path(base_dir: &Path, user_path: &str) -> Result<PathBuf> {
-    // Upload-handle short-circuit. `/api/upload` returns paths in the
-    // form `up/<base64-payload>/<filename>` — opaque handles, not
-    // filesystem paths. The SPA echoes the handle into the LLM turn
-    // as an attachment, and the LLM passes it directly to `read_file`.
-    // Decode here so the rest of `resolve_path` sees a real absolute
-    // path inside the upload tmpdir.
-    if let Some(resolved) = octos_bus::file_handle::resolve_upload_reference(user_path) {
-        return Ok(normalize_path(&resolved));
-    }
-
-    let candidate = PathBuf::from(user_path);
-    if candidate.is_absolute() {
-        if is_inside_upload_root(&candidate) {
-            return Ok(normalize_path(&candidate));
+    match octos_bus::file_handle::resolve_tool_path(base_dir, None, user_path) {
+        Ok(resolved) => Ok(resolved.absolute),
+        Err(octos_bus::file_handle::ToolPathError::Traversal) => {
+            eyre::bail!("path outside working directory: {}", user_path)
         }
-        eyre::bail!(
-            "absolute paths are not allowed outside the upload tmpdir: {}",
-            user_path
-        );
+        Err(octos_bus::file_handle::ToolPathError::OutsideAllowedRoots) => {
+            // Preserve the legacy error text — call sites and tests
+            // string-match on "absolute paths are not allowed" to
+            // identify the upload-tmpdir-only escape rejection.
+            eyre::bail!(
+                "absolute paths are not allowed outside the upload tmpdir: {}",
+                user_path
+            )
+        }
+        Err(octos_bus::file_handle::ToolPathError::DecodeFailed) => {
+            // Should not happen for callers that pass `profile_root =
+            // None` (only `pf/...` handles produce `DecodeFailed`). If
+            // we ever do see one, surface it as the closest matching
+            // legacy message rather than silently swallowing it.
+            eyre::bail!("path outside working directory: {}", user_path)
+        }
     }
-
-    let path = base_dir.join(user_path);
-    let normalized = normalize_path(&path);
-    let base_normalized = normalize_path(base_dir);
-
-    if !normalized.starts_with(&base_normalized) {
-        eyre::bail!("path outside working directory: {}", user_path);
-    }
-
-    Ok(normalized)
 }
 
-/// Returns true when `candidate` resolves under the authenticated upload
-/// tmpdir. macOS firmlinks render the same directory as both
-/// `/var/folders/...` and `/private/var/folders/...`; `resolve_upload_reference`
-/// runs `std::fs::canonicalize` and returns the `/private/` form, but
-/// `temp_upload_root()` returns the un-prefixed form. Compare via
-/// `canonicalize` on the upload root so the firmlink is collapsed; on the
-/// candidate side, walk parents to find one that exists, canonicalize that,
-/// and re-attach the remainder. Without this both Linux *and* macOS work
-/// — but Linux paths never differ syntactically, while macOS without the
-/// canonicalize step compares `/private/var/...` to `/var/...` and rejects.
-fn is_inside_upload_root(candidate: &Path) -> bool {
-    let upload_root = octos_bus::file_handle::temp_upload_root();
-    let upload_root_canon =
-        std::fs::canonicalize(&upload_root).unwrap_or_else(|_| normalize_path(&upload_root));
-    let candidate_canon = canonicalize_lossy(candidate);
-    candidate_canon.starts_with(&upload_root_canon)
-}
-
-/// Canonicalize as much of `path` as currently exists on disk; for the
-/// non-existent tail, fall back to syntactic normalization. We need this
-/// because `read_file` is called with a path whose file may have been
-/// removed (e.g. tmp cleanup) between resolution and tool execution — a
-/// strict `canonicalize` would error in that case and skip the whitelist
-/// check.
-fn canonicalize_lossy(path: &Path) -> PathBuf {
-    if let Ok(canon) = std::fs::canonicalize(path) {
-        return canon;
-    }
-    let mut existing = path;
-    let mut suffix = PathBuf::new();
-    while let Some(parent) = existing.parent() {
-        if let Some(name) = existing.file_name() {
-            let mut next_suffix = PathBuf::from(name);
-            next_suffix.push(&suffix);
-            suffix = next_suffix;
-        }
-        existing = parent;
-        if let Ok(canon) = std::fs::canonicalize(existing) {
-            return canon.join(suffix);
-        }
-        if existing.as_os_str().is_empty() {
-            break;
-        }
-    }
-    normalize_path(path)
-}
-
-/// Normalize path by resolving `.` and `..` components without filesystem access.
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => {
-                out.pop();
-            }
-            Component::CurDir => {}
-            // RootDir and Prefix reset the path (absolute path semantics)
-            Component::RootDir | Component::Prefix(_) => {
-                out.push(component.as_os_str());
-            }
-            Component::Normal(seg) => {
-                out.push(seg);
-            }
-        }
-    }
-    out
-}
+// Note: lexical-normalisation and lossy-canonicalisation now live in
+// `octos_bus::file_handle::resolve_tool_path` so every entry point (file
+// tools, plugin tools, send_file, read_task_output) shares the same
+// machinery. The previously-inline helpers were retired with that
+// unification.
 
 /// Check that a path is not a symlink. Returns error message if it is.
 ///
@@ -1062,17 +1007,27 @@ mod path_tests {
     /// 2026-05-12: WS upload handles now resolve to absolute tmpdir
     /// paths, but the LLM hit "absolute paths are not allowed" before
     /// this fix).
+    ///
+    /// Post-`resolve_tool_path` migration: the resolver now always
+    /// returns the canonical form (firmlinks collapsed via
+    /// `canonicalize_lossy`), so the containment check uses the
+    /// canonicalised upload root instead of the un-prefixed one — the
+    /// macOS firmlink companion test already uses this same shape.
     #[test]
     fn test_resolve_allows_absolute_path_inside_upload_root() {
         let upload_root = octos_bus::file_handle::temp_upload_root();
+        // Ensure the upload root exists so canonicalize succeeds even on
+        // pristine Linux CI runners that haven't touched the tmpdir yet.
+        std::fs::create_dir_all(&upload_root).expect("upload tmpdir creatable");
         let abs = upload_root.join("abc-redbank-proposal.md");
         let resolved = resolve_path(Path::new("/home/user/project"), &abs.to_string_lossy())
             .expect("upload-tmpdir absolute paths must be accepted");
+        let canonical_upload_root = std::fs::canonicalize(&upload_root).unwrap_or(upload_root);
         assert!(
-            resolved.starts_with(&upload_root),
-            "resolved path {} should be under {}",
+            resolved.starts_with(&canonical_upload_root),
+            "resolved path {} should canonicalise under {}",
             resolved.display(),
-            upload_root.display()
+            canonical_upload_root.display()
         );
     }
 
@@ -1107,7 +1062,7 @@ mod path_tests {
         )
         .expect("firmlink-canonical upload path must be accepted");
         assert!(
-            resolved.starts_with(&std::fs::canonicalize(&upload_root).unwrap()),
+            resolved.starts_with(std::fs::canonicalize(&upload_root).unwrap()),
             "resolved path {} must canonicalize under upload root",
             resolved.display()
         );
@@ -1166,17 +1121,11 @@ mod path_tests {
         assert_eq!(p, PathBuf::from("/home/user/project/a/b/c/d/e/f.rs"));
     }
 
-    #[test]
-    fn test_normalize_handles_complex_paths() {
-        assert_eq!(
-            normalize_path(Path::new("/a/b/../c/./d")),
-            PathBuf::from("/a/c/d")
-        );
-        assert_eq!(
-            normalize_path(Path::new("/a/b/../../c")),
-            PathBuf::from("/c")
-        );
-    }
+    // Note: `test_normalize_handles_complex_paths` retired with the
+    // `normalize_path` helper. Lexical normalisation now lives in
+    // `octos_bus::file_handle::normalize_lexical` and is covered by the
+    // resolver's own `Traversal` rejection tests (see
+    // `crates/octos-bus/tests/file_handle_resolve_tool_path.rs`).
 
     /// Per-profile CWD isolation: when cwd is narrowed to a profile's data_dir,
     /// resolve_path must block access to other profiles' directories.

--- a/crates/octos-agent/src/tools/read_task_output.rs
+++ b/crates/octos-agent/src/tools/read_task_output.rs
@@ -17,12 +17,14 @@
 //! - The router-managed output file path is computed from the supervisor's
 //!   `BackgroundTask::tool_call_id`; the LLM never supplies a path.
 //! - For `file` mode the LLM-supplied path is resolved against
-//!   `workspace_root`. Workspace-relative paths go through `resolve_path`
-//!   (rejects traversal). Absolute paths are accepted only when (a) they
-//!   appear verbatim in `task.output_files` and (b) they normalise to a
-//!   path inside the workspace root. The file is also restricted to one
-//!   of the task's `output_files`, which the supervisor records once the
-//!   task has completed.
+//!   `workspace_root` through
+//!   [`octos_bus::file_handle::resolve_tool_path`]. Workspace-relative
+//!   paths reject traversal, absolute paths must lie inside the
+//!   workspace root, and any resolution outside the
+//!   [`octos_bus::file_handle::ToolPathScope::Workspace`] scope is
+//!   refused — this tool does not surface uploads or profile files.
+//!   The file is also restricted to one of the task's `output_files`,
+//!   which the supervisor records once the task has completed.
 //! - All file reads use `O_NOFOLLOW` on Unix (symlink-target reads are
 //!   refused atomically; see `read_capped_no_follow`) so a symlink
 //!   inside the workspace cannot redirect a read outside it.
@@ -40,7 +42,7 @@ use serde_json::{Value, json};
 use crate::subagent_output::SubAgentOutputRouter;
 use crate::task_supervisor::TaskSupervisor;
 
-use super::{Tool, ToolResult, resolve_path};
+use super::{Tool, ToolResult};
 
 /// Hard cap on the bytes any single `read_task_output` call returns. Keeps
 /// the LLM context from being re-polluted by large research reports.
@@ -302,17 +304,14 @@ impl ReadTaskOutputTool {
         //       `workspace_root` (so an absolute `output_files` entry
         //       outside the workspace cannot grant escape).
         let resolved = resolve_handle_path(&self.workspace_root, path)?;
+        // Resolve every `output_files` entry through the same routine
+        // we use for the caller-supplied path, then compare normalised
+        // forms. This keeps the absolute-vs-relative semantics
+        // identical on both sides of the whitelist check.
         let allowed_match = task.output_files.iter().any(|f| {
-            let candidate = Path::new(f);
-            if candidate.is_absolute() {
-                normalize_inside_workspace(&self.workspace_root, candidate)
-                    .map(|p| p == resolved)
-                    .unwrap_or(false)
-            } else {
-                resolve_path(&self.workspace_root, f)
-                    .map(|p| p == resolved)
-                    .unwrap_or(false)
-            }
+            resolve_handle_path(&self.workspace_root, f)
+                .map(|p| p == resolved)
+                .unwrap_or(false)
         });
         if !allowed_match {
             eyre::bail!(
@@ -356,13 +355,38 @@ impl ReadTaskOutputTool {
 /// Codex round 3 P2: required so the LLM can pass back the absolute
 /// strings that `check_background_tasks` exposes from the supervisor's
 /// `output_files` field (which are often absolute under the workspace).
+///
+/// Routed through the unified
+/// [`octos_bus::file_handle::resolve_tool_path`] resolver since the
+/// unified table already encodes "absolute inside workspace OR
+/// workspace-relative" semantics. Only the [`ToolPathScope::Workspace`]
+/// scope is permitted here — upload-tmpdir / profile-root scopes would
+/// grant the LLM read access to paths outside the per-task
+/// `output_files` whitelist, which is the whole point of this tool's
+/// gating.
 fn resolve_handle_path(workspace_root: &Path, user_path: &str) -> Result<PathBuf> {
-    let p = Path::new(user_path);
-    if p.is_absolute() {
-        normalize_inside_workspace(workspace_root, p)
-            .ok_or_else(|| eyre::eyre!("absolute path '{}' is outside the workspace", user_path))
-    } else {
-        resolve_path(workspace_root, user_path).wrap_err("path must stay inside the workspace")
+    use octos_bus::file_handle::{ToolPathError, ToolPathScope, resolve_tool_path};
+    match resolve_tool_path(workspace_root, None, user_path) {
+        Ok(resolved) => {
+            if resolved.scope == ToolPathScope::Workspace {
+                Ok(resolved.absolute)
+            } else {
+                eyre::bail!(
+                    "path '{}' resolved outside the workspace ({:?}); only workspace paths are permitted",
+                    user_path,
+                    resolved.scope
+                )
+            }
+        }
+        Err(ToolPathError::Traversal) => {
+            eyre::bail!("path must stay inside the workspace: {}", user_path)
+        }
+        Err(ToolPathError::OutsideAllowedRoots) => {
+            eyre::bail!("absolute path '{}' is outside the workspace", user_path)
+        }
+        Err(ToolPathError::DecodeFailed) => {
+            eyre::bail!("path must stay inside the workspace: {}", user_path)
+        }
     }
 }
 
@@ -444,36 +468,11 @@ fn reject_symlinked_ancestors(workspace_root: &Path, resolved: &Path) -> Result<
     Ok(())
 }
 
-/// Build a normalised PathBuf for an absolute path, returning `None` if
-/// it does not lie inside `workspace_root` after normalisation.
-fn normalize_inside_workspace(workspace_root: &Path, abs: &Path) -> Option<PathBuf> {
-    use std::path::Component;
-    let mut out = PathBuf::new();
-    for comp in abs.components() {
-        match comp {
-            Component::ParentDir => {
-                out.pop();
-            }
-            Component::CurDir => {}
-            other => out.push(other.as_os_str()),
-        }
-    }
-    let mut root = PathBuf::new();
-    for comp in workspace_root.components() {
-        match comp {
-            Component::ParentDir => {
-                root.pop();
-            }
-            Component::CurDir => {}
-            other => root.push(other.as_os_str()),
-        }
-    }
-    if out.starts_with(&root) {
-        Some(out)
-    } else {
-        None
-    }
-}
+// Note: the previous `normalize_inside_workspace` helper retired with
+// the migration to `octos_bus::file_handle::resolve_tool_path`. The
+// unified resolver does the absolute-vs-workspace containment check
+// (with macOS firmlink collapsing) so this duplicate is no longer
+// needed.
 
 /// Apply an inline read mode (head/tail/grep/line_range) against `text`.
 /// `file` mode is rejected here — file is handled at the dispatch site so

--- a/crates/octos-agent/src/tools/read_task_output.rs
+++ b/crates/octos-agent/src/tools/read_task_output.rs
@@ -404,37 +404,39 @@ fn reject_symlinked_ancestors(workspace_root: &Path, resolved: &Path) -> Result<
     // symlink. We deliberately stop one level above the leaf — the leaf
     // is policed by the O_NOFOLLOW open in `read_capped_no_follow`.
     //
-    // Post-`resolve_tool_path` migration: the resolver returns the
-    // canonical absolute path (firmlinks collapsed via
-    // `canonicalize`). On macOS this produces `/private/var/folders/...`
-    // while the supplied `workspace_root` is typically still in its
-    // un-prefixed `/var/folders/...` form, so `strip_prefix` would fail
-    // here even when the resolved path legitimately lies inside the
-    // workspace. Canonicalise the workspace root for the containment
-    // check so both forms compare equal.
+    // CRITICAL: walk the ORIGINAL (lexical) path components, not the
+    // canonical form. If we canonicalised `resolved` here we'd rewrite
+    // a `workspace/out/file` chain — where `out` is a symlink to some
+    // other workspace dir — into the symlink target before the loop
+    // ran, so the loop would stat the *target's* ancestors and miss
+    // the symlink it was supposed to refuse. The actual `read_capped_
+    // no_follow` then still opens the original path and follows the
+    // parent symlink. Codex review round 3 P2 (2026-05-13) pinned
+    // this exact escape.
+    //
+    // Canonicalise the ROOT only — that's needed because on macOS the
+    // supplied `workspace_root` is typically the un-prefixed
+    // `/var/folders/...` form while `resolved` for absolute inputs may
+    // come back in the `/private/var/folders/...` firmlink form. We
+    // build a candidate `(canonical_root, lexical_root)` pair and try
+    // strip_prefix against both so absolute and workspace-relative
+    // resolutions both succeed.
     let canonical_root =
         std::fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
-    // Mirror the canonicalisation on the resolved leaf so it compares
-    // cleanly against the canonicalised root. `resolve_handle_path`
-    // produces either the canonical form (workspace-relative path,
-    // routed through `resolve_path` after migration) or the lexical
-    // form (absolute path normalised through `normalize_inside_workspace`).
-    // Canonicalise-as-possible here so both shapes line up.
-    let canonical_resolved =
-        std::fs::canonicalize(resolved).unwrap_or_else(|_| resolved.to_path_buf());
-    let mut current = canonical_root.clone();
-    let suffix = match canonical_resolved.strip_prefix(&canonical_root) {
-        Ok(s) => s.to_path_buf(),
-        Err(_) => {
-            // Should not happen: `resolved` was already verified to be
-            // inside `workspace_root` by `resolve_handle_path`. Defend
-            // anyway.
-            eyre::bail!(
-                "internal: resolved path {} not inside workspace {}",
-                resolved.display(),
-                workspace_root.display()
-            );
-        }
+    let lexical_root = workspace_root.to_path_buf();
+    let (mut current, suffix) = if let Ok(s) = resolved.strip_prefix(&lexical_root) {
+        (lexical_root, s.to_path_buf())
+    } else if let Ok(s) = resolved.strip_prefix(&canonical_root) {
+        (canonical_root, s.to_path_buf())
+    } else {
+        // Should not happen: `resolved` was already verified to be
+        // inside `workspace_root` by `resolve_handle_path`. Defend
+        // anyway.
+        eyre::bail!(
+            "internal: resolved path {} not inside workspace {}",
+            resolved.display(),
+            workspace_root.display()
+        );
     };
     let comps: Vec<_> = suffix.components().collect();
     if comps.is_empty() {
@@ -991,6 +993,60 @@ mod tests {
         assert!(
             !body.contains("root:x:0:0"),
             "parent-directory symlink must not grant read; got: {body}"
+        );
+    }
+
+    // Codex review round 3 P2 (2026-05-13): the ancestor walk must
+    // operate on the ORIGINAL path components, not on the canonical
+    // form. A symlinked parent that currently points inside the
+    // workspace would canonicalise away — but the file is still
+    // *opened* through the original path, so the parent symlink is
+    // followed. If that symlink later gets retargeted (e.g. to /etc),
+    // the read at open time sees the new target. Refuse symlinked
+    // ancestors regardless of where they currently point.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn file_mode_rejects_symlinked_parent_pointing_inside_workspace() {
+        let dir = tempdir().unwrap();
+        let (supervisor, router, tool) = make_tool(dir.path());
+        let task_id = seed_task(&supervisor, &router, "tc-parent-sym-inside", "stdout\n");
+
+        // Two workspace-internal dirs: `real/` (the actual target) and
+        // a symlink `out/` that currently points at `real/`.
+        let workspace = dir.path().join("workspace");
+        let real_dir = workspace.join("real");
+        std::fs::create_dir_all(&real_dir).unwrap();
+        std::fs::write(real_dir.join("report.md"), b"workspace-content").unwrap();
+        let link_inside = workspace.join("out");
+        std::os::unix::fs::symlink(&real_dir, &link_inside).unwrap();
+
+        // Record `out/report.md` — traverses the parent symlink.
+        // Canonicalisation collapses it to `real/report.md`, both of
+        // which lie inside the workspace; the ancestor walk MUST still
+        // refuse `out` because the actual open uses the lexical path
+        // and would follow whatever `out` points to at open time
+        // (potentially retargeted between this check and the open).
+        let recorded = "out/report.md";
+        supervisor.mark_completed(&task_id, vec![recorded.to_string()]);
+
+        let result = tool
+            .execute(&json!({
+                "task_handle": task_id,
+                "mode": {
+                    "kind": "file",
+                    "path": recorded,
+                    "mode": {"kind": "head", "lines": 1}
+                }
+            }))
+            .await;
+        let body = match result {
+            Ok(r) => r.output,
+            Err(e) => format!("{e}"),
+        };
+        assert!(
+            !body.contains("workspace-content"),
+            "symlinked parent (even when target lies inside workspace) must be refused — \
+             canonicalisation would otherwise let a later retarget grant escape; got: {body}"
         );
     }
 

--- a/crates/octos-agent/src/tools/read_task_output.rs
+++ b/crates/octos-agent/src/tools/read_task_output.rs
@@ -379,8 +379,27 @@ fn reject_symlinked_ancestors(workspace_root: &Path, resolved: &Path) -> Result<
     // Walk from workspace_root downwards: each ancestor must NOT be a
     // symlink. We deliberately stop one level above the leaf — the leaf
     // is policed by the O_NOFOLLOW open in `read_capped_no_follow`.
-    let mut current = workspace_root.to_path_buf();
-    let suffix = match resolved.strip_prefix(workspace_root) {
+    //
+    // Post-`resolve_tool_path` migration: the resolver returns the
+    // canonical absolute path (firmlinks collapsed via
+    // `canonicalize`). On macOS this produces `/private/var/folders/...`
+    // while the supplied `workspace_root` is typically still in its
+    // un-prefixed `/var/folders/...` form, so `strip_prefix` would fail
+    // here even when the resolved path legitimately lies inside the
+    // workspace. Canonicalise the workspace root for the containment
+    // check so both forms compare equal.
+    let canonical_root =
+        std::fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
+    // Mirror the canonicalisation on the resolved leaf so it compares
+    // cleanly against the canonicalised root. `resolve_handle_path`
+    // produces either the canonical form (workspace-relative path,
+    // routed through `resolve_path` after migration) or the lexical
+    // form (absolute path normalised through `normalize_inside_workspace`).
+    // Canonicalise-as-possible here so both shapes line up.
+    let canonical_resolved =
+        std::fs::canonicalize(resolved).unwrap_or_else(|_| resolved.to_path_buf());
+    let mut current = canonical_root.clone();
+    let suffix = match canonical_resolved.strip_prefix(&canonical_root) {
         Ok(s) => s.to_path_buf(),
         Err(_) => {
             // Should not happen: `resolved` was already verified to be

--- a/crates/octos-agent/src/tools/send_file.rs
+++ b/crates/octos-agent/src/tools/send_file.rs
@@ -202,26 +202,57 @@ impl Tool for SendFileTool {
         let input: Input =
             serde_json::from_value(args.clone()).wrap_err("invalid send_file tool input")?;
 
-        // Resolve file path: if base_dir is set, resolve relative paths against
-        // it (the OS process cwd may differ from the logical working directory).
+        // Step 1: when a `base_dir` is configured (the only path that
+        // applies any policy at all today), try the unified resolver
+        // first. It decodes `up/...` and `pf/...` handles, accepts
+        // absolute paths inside the upload tmpdir / workspace / profile
+        // root, and rejects traversal. When it succeeds we
+        // short-circuit; when it fails we fall back to the legacy
+        // send_file allowlist (base_dir + /tmp + extras). The fallback
+        // exists because send_file allows a broader set of roots than
+        // the unified resolver knows about (specifically: skill output
+        // under `/tmp` and per-profile data_dir registered as
+        // `extra_allowed_dirs`).
+        //
+        // Without `base_dir` (legacy `SendFileTool::new` path used by
+        // unit tests and standalone scripts), we keep the historical
+        // pass-through behaviour — no path mangling, no policy.
         let raw_path = Path::new(&input.file_path);
         let path = if let Some(ref base_dir) = self.base_dir {
-            if raw_path.is_relative() {
-                base_dir.join(raw_path)
-            } else {
-                raw_path.to_path_buf()
+            // Pick the first extra_allowed_dir as the profile root
+            // hint. Subsequent extras still get covered by the legacy
+            // allowlist below.
+            let profile_hint = self.extra_allowed_dirs.first().map(PathBuf::as_path);
+            match octos_bus::file_handle::resolve_tool_path(
+                base_dir,
+                profile_hint,
+                &input.file_path,
+            ) {
+                Ok(resolved) => resolved.absolute,
+                Err(_) => {
+                    if raw_path.is_relative() {
+                        base_dir.join(raw_path)
+                    } else {
+                        raw_path.to_path_buf()
+                    }
+                }
             }
         } else {
             raw_path.to_path_buf()
         };
 
-        // Validate file path is within the allowed base directory (if set).
-        // This prevents exfiltrating files from other profiles' data directories.
-        // /tmp/ is always allowed since skills commonly write output there.
+        // Step 2: containment check against the send_file allowlist
+        // (base_dir + /tmp/ + extra_allowed_dirs). The unified resolver
+        // already verified containment for `up/...`/`pf/...` handles
+        // and workspace-/profile-internal absolute paths, but the
+        // allowlist is broader (skill outputs frequently land under
+        // /tmp/) so we keep this check unconditionally.
         if let Some(ref base_dir) = self.base_dir {
             let canonical_base =
                 std::fs::canonicalize(base_dir).unwrap_or_else(|_| base_dir.clone());
             let tmp_dir = std::fs::canonicalize("/tmp").unwrap_or_else(|_| PathBuf::from("/tmp"));
+            let upload_root = std::fs::canonicalize(octos_bus::file_handle::temp_upload_root())
+                .unwrap_or_else(|_| octos_bus::file_handle::temp_upload_root());
             let extra_canonical: Vec<PathBuf> = self
                 .extra_allowed_dirs
                 .iter()
@@ -231,6 +262,7 @@ impl Tool for SendFileTool {
                 Ok(canonical_path) => {
                     let allowed = canonical_path.starts_with(&canonical_base)
                         || canonical_path.starts_with(&tmp_dir)
+                        || canonical_path.starts_with(&upload_root)
                         || extra_canonical
                             .iter()
                             .any(|d| canonical_path.starts_with(d));

--- a/crates/octos-agent/src/tools/send_file.rs
+++ b/crates/octos-agent/src/tools/send_file.rs
@@ -203,39 +203,43 @@ impl Tool for SendFileTool {
             serde_json::from_value(args.clone()).wrap_err("invalid send_file tool input")?;
 
         // Step 1: when a `base_dir` is configured (the only path that
-        // applies any policy at all today), try the unified resolver
-        // first. It decodes `up/...` and `pf/...` handles, accepts
-        // absolute paths inside the upload tmpdir / workspace / profile
-        // root, and rejects traversal. When it succeeds we
-        // short-circuit; when it fails we fall back to the legacy
-        // send_file allowlist (base_dir + /tmp + extras). The fallback
-        // exists because send_file allows a broader set of roots than
-        // the unified resolver knows about (specifically: skill output
-        // under `/tmp` and per-profile data_dir registered as
-        // `extra_allowed_dirs`).
+        // applies any policy today), route handle-shaped inputs
+        // (`up/...`, `pf/...`) and absolute paths through the unified
+        // resolver. Relative `file_path` inputs MUST stay anchored to
+        // `base_dir` — codex P2 review (2026-05-13) flagged that
+        // letting the resolver run on every shape lets a same-basename
+        // upload (e.g. `report.pdf` written by a different session)
+        // shadow the outbound workspace file, which breaks the
+        // common write-then-send flow and risks cross-session leaks.
         //
         // Without `base_dir` (legacy `SendFileTool::new` path used by
         // unit tests and standalone scripts), we keep the historical
         // pass-through behaviour — no path mangling, no policy.
         let raw_path = Path::new(&input.file_path);
+        let looks_like_handle =
+            input.file_path.starts_with("up/") || input.file_path.starts_with("pf/");
+        let use_unified_resolver = looks_like_handle || raw_path.is_absolute();
+
         let path = if let Some(ref base_dir) = self.base_dir {
-            // Pick the first extra_allowed_dir as the profile root
-            // hint. Subsequent extras still get covered by the legacy
-            // allowlist below.
-            let profile_hint = self.extra_allowed_dirs.first().map(PathBuf::as_path);
-            match octos_bus::file_handle::resolve_tool_path(
-                base_dir,
-                profile_hint,
-                &input.file_path,
-            ) {
-                Ok(resolved) => resolved.absolute,
-                Err(_) => {
-                    if raw_path.is_relative() {
-                        base_dir.join(raw_path)
-                    } else {
-                        raw_path.to_path_buf()
-                    }
+            if use_unified_resolver {
+                // Pick the first extra_allowed_dir as the profile root
+                // hint. Subsequent extras still get covered by the
+                // legacy allowlist below.
+                let profile_hint = self.extra_allowed_dirs.first().map(PathBuf::as_path);
+                match octos_bus::file_handle::resolve_tool_path(
+                    base_dir,
+                    profile_hint,
+                    &input.file_path,
+                ) {
+                    Ok(resolved) => resolved.absolute,
+                    Err(_) => raw_path.to_path_buf(),
                 }
+            } else {
+                // Relative outbound paths — anchor to base_dir, NOT
+                // through the unified resolver (which would prefer
+                // `temp_upload_root()/<basename>` on a same-name
+                // collision).
+                base_dir.join(raw_path)
             }
         } else {
             raw_path.to_path_buf()
@@ -837,6 +841,60 @@ mod tests {
         assert!(!is_stale_slides_backup(Path::new(
             "/tmp/workspace/slides/demo/output/deck.pptx"
         )));
+    }
+
+    /// Codex review P2 (2026-05-13): a relative `file_path` like
+    /// `report.pdf` MUST resolve under `base_dir`, not against the
+    /// global upload tmpdir. Letting the unified resolver run on every
+    /// shape allowed a same-name upload (potentially from another
+    /// session) to shadow the outbound workspace file.
+    #[tokio::test]
+    async fn relative_path_prefers_base_dir_over_upload_tmpdir_collision() {
+        let base = tempfile::tempdir().unwrap();
+        let intended = base.path().join("report.pdf");
+        std::fs::write(&intended, b"workspace-report").unwrap();
+
+        // Plant a same-basename file under the upload tmpdir. The
+        // resolver's bare-basename branch (step 4 of `resolve_tool_path`)
+        // would prefer this over the workspace file if we let it run.
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        std::fs::create_dir_all(&upload_root).unwrap();
+        let upload_name = format!(
+            "report-{}-{}.pdf",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        );
+        // Use a unique upload name so we can also test the bare-basename
+        // collision shape explicitly without polluting other tests.
+        let upload_clone = upload_root.join("report.pdf");
+        let _ = std::fs::write(&upload_clone, b"OTHER-SESSION-UPLOAD");
+
+        let (tx, mut rx) = mpsc::channel(16);
+        let tool = SendFileTool::with_context(tx, "telegram", "12345").with_base_dir(base.path());
+
+        let result = tool
+            .execute(&serde_json::json!({"file_path": "report.pdf"}))
+            .await
+            .unwrap();
+
+        assert!(result.success, "got: {}", result.output);
+        let msg = rx.recv().await.unwrap();
+        assert_eq!(msg.media.len(), 1);
+        let attached = std::path::PathBuf::from(&msg.media[0]);
+        let canonical_attached = std::fs::canonicalize(&attached).unwrap_or(attached);
+        let canonical_intended =
+            std::fs::canonicalize(&intended).unwrap_or_else(|_| intended.clone());
+        assert_eq!(
+            canonical_attached, canonical_intended,
+            "relative send_file MUST attach the workspace copy, not the upload-tmpdir collision",
+        );
+
+        // Cleanup: remove the planted file under the global upload root.
+        let _ = std::fs::remove_file(&upload_clone);
+        let _ = std::fs::remove_file(upload_root.join(upload_name));
     }
 
     #[tokio::test]

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -286,14 +286,24 @@ pub fn resolve_tool_path(
         return Err(ToolPathError::Traversal);
     }
 
-    // Prefer the canonical form when the file already exists so the
-    // returned path stays comparable with `start_with(canonical_root)`
-    // checks that other tools layer on top. Falling back to the
-    // lexically-normalised form keeps write-style tools (which create
-    // missing files) working — they would error if we forced canonicalize.
-    let absolute = std::fs::canonicalize(&normalised).unwrap_or(normalised);
+    // Workspace-relative paths return their LEXICAL form on purpose:
+    // file tools (`read_file`, `write_file`, `list_dir`) layer their
+    // own `O_NOFOLLOW` open / symlink rejection on top of the resolved
+    // path, and that gate is the only thing standing between a symlink
+    // `workspace/secret -> /etc/passwd` and a successful read of
+    // `/etc/passwd`. If we canonicalised here the resolver would
+    // silently follow the symlink and the leaf `O_NOFOLLOW` would no
+    // longer have anything to refuse — it'd see a plain file at the
+    // canonical target. Keep the lexical workspace location and let the
+    // tool's open-time gate police symlinks atomically.
+    //
+    // Upload-tmpdir / profile-root scopes (branches 1, 2, 3, 4) still
+    // canonicalise via `canonicalize_under` / `canonicalize_lossy`
+    // because those roots' files have already been written by the
+    // server and the canonical form is required for the containment
+    // check (macOS firmlinks).
     Ok(ResolvedToolPath {
-        absolute,
+        absolute: normalised,
         scope: ToolPathScope::Workspace,
     })
 }

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -11,6 +11,62 @@ pub enum FileHandleScope {
     ProfileRelative(PathBuf),
     TempUpload(PathBuf),
 }
+
+/// Scope of a resolved tool-argument path. Lets callers apply
+/// scope-specific policy (e.g. read-only for profile files,
+/// symlink-safe everywhere) on top of the unified resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolPathScope {
+    /// Path resolved under the authenticated upload tmpdir
+    /// (`octos-uploads`). User-uploaded attachments live here.
+    UploadTmpdir,
+    /// Path resolved under the per-session workspace root.
+    Workspace,
+    /// Path resolved under the profile root (a profile's `data_dir`).
+    Profile,
+}
+
+/// Successful resolution of a tool-supplied file path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedToolPath {
+    /// Absolute on-disk path. Existence is guaranteed when the scope
+    /// is [`ToolPathScope::UploadTmpdir`] or [`ToolPathScope::Profile`]
+    /// because their resolution always passes through `canonicalize`.
+    /// For [`ToolPathScope::Workspace`] the path is canonicalized only
+    /// if it points at an existing file/dir; otherwise the result is
+    /// the normalised workspace-relative location, so write-style tools
+    /// (`write_file`, `edit_file`) can still create new files.
+    pub absolute: PathBuf,
+    /// Which root the path resolved under.
+    pub scope: ToolPathScope,
+}
+
+/// Errors returned by [`resolve_tool_path`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolPathError {
+    /// The supplied path tried to escape its allowed root via `..`.
+    Traversal,
+    /// The path is absolute but does not lie inside any allowed root
+    /// (workspace root, upload tmpdir, or profile root).
+    OutsideAllowedRoots,
+    /// The handle (`up/...` or `pf/...`) could not be decoded — bad
+    /// base64, empty payload, or unknown scope prefix.
+    DecodeFailed,
+}
+
+impl std::fmt::Display for ToolPathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Traversal => f.write_str("path traversal is not allowed"),
+            Self::OutsideAllowedRoots => {
+                f.write_str("path is outside the workspace, upload tmpdir, and profile root")
+            }
+            Self::DecodeFailed => f.write_str("file handle could not be decoded"),
+        }
+    }
+}
+
+impl std::error::Error for ToolPathError {}
 
 pub fn temp_upload_root() -> PathBuf {
     std::env::temp_dir().join("octos-uploads")
@@ -110,6 +166,186 @@ pub fn resolve_upload_reference(raw: &str) -> Option<PathBuf> {
             canonicalize_under(&temp_upload_root(), &relative)
         }
     }
+}
+
+/// Unified file-path resolver for LLM-supplied tool arguments.
+///
+/// Tries, in order:
+///
+/// 1. Decode as an `up/<base64>/<display>` or `up/<base64>` upload handle —
+///    payload locates an existing file under `temp_upload_root()`.
+/// 2. Decode as a `pf/<base64>/<display>` or `pf/<base64>` profile handle
+///    when `profile_root` is provided — payload locates an existing file
+///    under that root.
+/// 3. Treat as absolute and accept when the canonicalised path lies inside
+///    one of the allowed roots (upload tmpdir, workspace, or profile).
+///    macOS firmlinks are handled transparently — the canonical form
+///    (e.g. `/private/var/folders/...`) and the un-prefixed form
+///    (`/var/folders/...`) compare equal.
+/// 4. If the raw value matches an existing file under `temp_upload_root()`
+///    (bare basename like `019e22…wav`, or `up/<x>` that didn't decode),
+///    return it as an [`ToolPathScope::UploadTmpdir`] entry. This is the
+///    leaf-name form the upload handler writes when the LLM strips
+///    everything but the filename.
+/// 5. Treat as workspace-relative — normalises `..`/`.` and rejects any
+///    result that would land outside the workspace.
+///
+/// Existence is REQUIRED for scopes 1, 2, and 4 (those resolutions go
+/// through `canonicalize`). For scope 5 the path is returned even if the
+/// file does not yet exist — write-style tools (`write_file`, `edit_file`)
+/// rely on this to create new files. Callers that need an existence check
+/// must perform it themselves.
+///
+/// Symlink rejection is the caller's responsibility (use
+/// `read_no_follow` / `write_no_follow` on the returned path). The
+/// resolver only verifies that the **canonical** path lies inside an
+/// allowed root, which already collapses any symlink-target reachable
+/// through the root entry.
+pub fn resolve_tool_path(
+    workspace_root: &Path,
+    profile_root: Option<&Path>,
+    user_path: &str,
+) -> Result<ResolvedToolPath, ToolPathError> {
+    // 1) Try decoding as a scoped file handle (up/... or pf/...).
+    match decode_file_handle(user_path) {
+        Some(FileHandleScope::TempUpload(relative)) => {
+            return canonicalize_under(&temp_upload_root(), &relative)
+                .map(|absolute| ResolvedToolPath {
+                    absolute,
+                    scope: ToolPathScope::UploadTmpdir,
+                })
+                .ok_or(ToolPathError::OutsideAllowedRoots);
+        }
+        Some(FileHandleScope::ProfileRelative(relative)) => {
+            let Some(profile_root) = profile_root else {
+                // A pf/... handle was supplied but the caller doesn't
+                // have a profile root to anchor it against. Surface as a
+                // decode-shaped failure so callers can fall back to
+                // their own legacy paths if any.
+                return Err(ToolPathError::DecodeFailed);
+            };
+            return canonicalize_under(profile_root, &relative)
+                .map(|absolute| ResolvedToolPath {
+                    absolute,
+                    scope: ToolPathScope::Profile,
+                })
+                .ok_or(ToolPathError::OutsideAllowedRoots);
+        }
+        None => {}
+    }
+
+    let candidate = Path::new(user_path);
+
+    // 2) Absolute paths must lie inside an allowed root.
+    if candidate.is_absolute() {
+        let candidate_canon = canonicalize_lossy(candidate);
+        let upload_root_canon = canonical_root(&temp_upload_root());
+        if candidate_canon.starts_with(&upload_root_canon) {
+            return Ok(ResolvedToolPath {
+                absolute: candidate_canon,
+                scope: ToolPathScope::UploadTmpdir,
+            });
+        }
+        let workspace_canon = canonical_root(workspace_root);
+        if candidate_canon.starts_with(&workspace_canon) {
+            return Ok(ResolvedToolPath {
+                absolute: candidate_canon,
+                scope: ToolPathScope::Workspace,
+            });
+        }
+        if let Some(profile_root) = profile_root {
+            let profile_canon = canonical_root(profile_root);
+            if candidate_canon.starts_with(&profile_canon) {
+                return Ok(ResolvedToolPath {
+                    absolute: candidate_canon,
+                    scope: ToolPathScope::Profile,
+                });
+            }
+        }
+        return Err(ToolPathError::OutsideAllowedRoots);
+    }
+
+    // 3) Bare basenames / undecodable relative paths that exist under
+    //    the upload tmpdir are accepted as uploads. This is the
+    //    leaf-name form the upload handler writes (e.g. the LLM hands
+    //    the model the filename verbatim instead of the encoded handle).
+    if let Some(relative) = safe_relative_path(user_path) {
+        if let Some(absolute) = canonicalize_under(&temp_upload_root(), &relative) {
+            return Ok(ResolvedToolPath {
+                absolute,
+                scope: ToolPathScope::UploadTmpdir,
+            });
+        }
+    }
+
+    // 4) Otherwise, treat as workspace-relative. Reject `..` traversal.
+    let joined = workspace_root.join(user_path);
+    let normalised = normalize_lexical(&joined);
+    let workspace_normalised = normalize_lexical(workspace_root);
+    if !normalised.starts_with(&workspace_normalised) {
+        return Err(ToolPathError::Traversal);
+    }
+
+    // Prefer the canonical form when the file already exists so the
+    // returned path stays comparable with `start_with(canonical_root)`
+    // checks that other tools layer on top. Falling back to the
+    // lexically-normalised form keeps write-style tools (which create
+    // missing files) working — they would error if we forced canonicalize.
+    let absolute = std::fs::canonicalize(&normalised).unwrap_or(normalised);
+    Ok(ResolvedToolPath {
+        absolute,
+        scope: ToolPathScope::Workspace,
+    })
+}
+
+/// Lexical path normalisation: collapses `.` and `..` without touching
+/// the filesystem. Mirrors `tools/mod.rs::normalize_path` — duplicated
+/// here so the resolver stays self-contained.
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            Component::RootDir | Component::Prefix(_) => {
+                out.push(component.as_os_str());
+            }
+            Component::Normal(seg) => {
+                out.push(seg);
+            }
+        }
+    }
+    out
+}
+
+/// Canonicalize as much of `path` as currently exists on disk; fall back
+/// to lexical normalisation for the non-existent tail. macOS firmlinks
+/// (`/var/folders/...` vs `/private/var/folders/...`) collapse through
+/// `canonicalize`; the syntactic fallback is only used when nothing on
+/// the path exists.
+fn canonicalize_lossy(path: &Path) -> PathBuf {
+    if let Ok(canon) = std::fs::canonicalize(path) {
+        return canon;
+    }
+    let mut existing = path;
+    let mut suffix = PathBuf::new();
+    while let Some(parent) = existing.parent() {
+        if let Some(name) = existing.file_name() {
+            let mut next_suffix = PathBuf::from(name);
+            next_suffix.push(&suffix);
+            suffix = next_suffix;
+        }
+        existing = parent;
+        if let Ok(canon) = std::fs::canonicalize(existing) {
+            return canon.join(suffix);
+        }
+        if existing.as_os_str().is_empty() {
+            break;
+        }
+    }
+    normalize_lexical(path)
 }
 
 fn encode_scoped_handle(prefix: &str, relative: &Path, display_name: &str) -> Option<String> {

--- a/crates/octos-bus/src/file_handle.rs
+++ b/crates/octos-bus/src/file_handle.rs
@@ -335,11 +335,30 @@ fn normalize_lexical(path: &Path) -> PathBuf {
 /// (`/var/folders/...` vs `/private/var/folders/...`) collapse through
 /// `canonicalize`; the syntactic fallback is only used when nothing on
 /// the path exists.
+///
+/// CRITICAL: `..` components are collapsed BEFORE the
+/// walk-parents-until-existing loop. Without this pre-normalisation an
+/// input like `/workspace/missing/../../secret.txt` would walk back to
+/// `/workspace` (the closest existing ancestor) and re-attach the
+/// original suffix verbatim, producing `/workspace/missing/../../secret.txt`
+/// which then satisfies `starts_with("/workspace")` even though the
+/// path actually escapes to `/secret.txt`. Lexically collapsing `..`
+/// up front makes the containment check honest (codex review round 4
+/// P2, 2026-05-13).
 fn canonicalize_lossy(path: &Path) -> PathBuf {
-    if let Ok(canon) = std::fs::canonicalize(path) {
+    // Step 1: lexical normalisation — collapses `..` and `.` without
+    // touching the filesystem. After this step the path has no `..`
+    // components so `starts_with(allowed_root)` is an honest
+    // containment check.
+    let normalised = normalize_lexical(path);
+    if let Ok(canon) = std::fs::canonicalize(&normalised) {
         return canon;
     }
-    let mut existing = path;
+    // Step 2: walk parents to find the longest existing prefix and
+    // re-attach the remainder. The remainder cannot contain `..` (it
+    // was already collapsed in step 1) so the result is a real
+    // would-be on-disk location, not a traversal expression.
+    let mut existing: &Path = &normalised;
     let mut suffix = PathBuf::new();
     while let Some(parent) = existing.parent() {
         if let Some(name) = existing.file_name() {
@@ -355,7 +374,7 @@ fn canonicalize_lossy(path: &Path) -> PathBuf {
             break;
         }
     }
-    normalize_lexical(path)
+    normalised
 }
 
 fn encode_scoped_handle(prefix: &str, relative: &Path, display_name: &str) -> Option<String> {

--- a/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
+++ b/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
@@ -1,0 +1,373 @@
+//! Empirical resolution table for the unified [`resolve_tool_path`].
+//!
+//! Every row in the "Input forms the LLM produces" table from
+//! `refactor: unified file-path resolver` is exercised here. If any
+//! row regresses, ONE of these tests fails — kills the upload-handle
+//! bug class (#586, #857, #930, #931, #932, #933) at source.
+
+use std::path::{Path, PathBuf};
+
+use octos_bus::file_handle::{
+    ResolvedToolPath, ToolPathError, ToolPathScope, encode_profile_file_handle,
+    encode_tmp_upload_handle, resolve_tool_path, temp_upload_root,
+};
+use tempfile::TempDir;
+
+/// Stand-up rig for the row-by-row table: a fake workspace, a fake
+/// profile root, and a real per-test directory inside the global
+/// `temp_upload_root()` (so the canonicalize-based existence check
+/// passes without leaking across tests).
+struct Rig {
+    workspace: TempDir,
+    profile: TempDir,
+    /// Directory inside `temp_upload_root()` that holds the test's
+    /// fake upload payload. Drop cleans it up.
+    upload_dir: PathBuf,
+}
+
+impl Rig {
+    fn new(tag: &str) -> Self {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let profile = tempfile::tempdir().expect("profile tmpdir");
+
+        // Real subdirectory under temp_upload_root() so the
+        // canonicalize-based existence checks succeed.
+        let upload_root = temp_upload_root();
+        std::fs::create_dir_all(&upload_root).expect("upload root");
+        let upload_dir = upload_root.join(format!(
+            "resolve-tool-path-{}-{}-{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&upload_dir).expect("upload dir");
+
+        Self {
+            workspace,
+            profile,
+            upload_dir,
+        }
+    }
+
+    fn workspace_root(&self) -> &Path {
+        self.workspace.path()
+    }
+
+    fn profile_root(&self) -> &Path {
+        self.profile.path()
+    }
+
+    /// Build a real workspace-relative file and return both its
+    /// relative form and the canonicalised absolute path.
+    fn make_workspace_file(&self, relative: &str, body: &[u8]) -> PathBuf {
+        let abs = self.workspace.path().join(relative);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).expect("workspace parent dir");
+        }
+        std::fs::write(&abs, body).expect("write workspace file");
+        std::fs::canonicalize(&abs).expect("canonicalise workspace file")
+    }
+
+    /// Build a real file inside the rig's upload directory and return
+    /// its canonicalised absolute path.
+    fn make_upload_file(&self, name: &str, body: &[u8]) -> PathBuf {
+        let abs = self.upload_dir.join(name);
+        std::fs::write(&abs, body).expect("write upload file");
+        std::fs::canonicalize(&abs).expect("canonicalise upload file")
+    }
+
+    /// Build a real file under the profile root.
+    fn make_profile_file(&self, relative: &str, body: &[u8]) -> PathBuf {
+        let abs = self.profile.path().join(relative);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).expect("profile parent dir");
+        }
+        std::fs::write(&abs, body).expect("write profile file");
+        std::fs::canonicalize(&abs).expect("canonicalise profile file")
+    }
+
+    /// Relative path inside the rig's upload subdir as the file_handle
+    /// helpers see it (the bit between `temp_upload_root()` and the
+    /// file).
+    fn upload_relative(&self, name: &str) -> PathBuf {
+        self.upload_dir
+            .strip_prefix(temp_upload_root())
+            .map(|p| p.join(name))
+            .expect("upload dir lies under temp_upload_root")
+    }
+}
+
+impl Drop for Rig {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.upload_dir);
+    }
+}
+
+fn expect_resolved(result: Result<ResolvedToolPath, ToolPathError>) -> ResolvedToolPath {
+    result.unwrap_or_else(|err| panic!("resolution must succeed, got {err}"))
+}
+
+fn expect_err(result: Result<ResolvedToolPath, ToolPathError>) -> ToolPathError {
+    result.expect_err("resolution must fail")
+}
+
+#[test]
+fn row_1_workspace_relative_input() {
+    let rig = Rig::new("row1");
+    let abs = rig.make_workspace_file("foo/bar.txt", b"hi");
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        "foo/bar.txt",
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::Workspace);
+    assert_eq!(resolved.absolute, abs);
+}
+
+#[test]
+fn row_1b_workspace_relative_writes_for_nonexistent_path() {
+    // Write-style tools (`write_file`, `edit_file`) need a workspace
+    // path even when the file does not yet exist; the resolver must
+    // return the normalised location instead of failing.
+    let rig = Rig::new("row1b");
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        "subdir/new-output.txt",
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::Workspace);
+    assert_eq!(
+        resolved.absolute,
+        rig.workspace_root().join("subdir/new-output.txt")
+    );
+}
+
+#[test]
+fn row_2_absolute_inside_workspace_kept() {
+    let rig = Rig::new("row2");
+    let abs = rig.make_workspace_file("foo.txt", b"hi");
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &abs.to_string_lossy(),
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::Workspace);
+    assert_eq!(resolved.absolute, abs);
+}
+
+#[test]
+fn row_3_absolute_inside_upload_tmpdir_kept() {
+    let rig = Rig::new("row3");
+    let abs = rig.make_upload_file("019e22ab-cd-real-upload.wav", b"WAV");
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &abs.to_string_lossy(),
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::UploadTmpdir);
+    assert!(
+        resolved
+            .absolute
+            .starts_with(std::fs::canonicalize(temp_upload_root()).unwrap()),
+        "resolved {:?} must canonicalise under {:?}",
+        resolved.absolute,
+        temp_upload_root()
+    );
+}
+
+#[test]
+fn row_4_three_segment_upload_handle() {
+    let rig = Rig::new("row4");
+    let abs = rig.make_upload_file("019e22-three-segment.wav", b"WAV");
+    let relative = rig.upload_relative("019e22-three-segment.wav");
+
+    let handle = encode_tmp_upload_handle(
+        &temp_upload_root().join(&relative),
+        Some("019e22-three-segment.wav"),
+    )
+    .expect("3-segment handle encoded");
+    assert!(handle.starts_with("up/"));
+    assert!(handle.matches('/').count() >= 2);
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &handle,
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::UploadTmpdir);
+    // canonicalise inside test to handle /private firmlinks on macOS.
+    assert_eq!(resolved.absolute, abs);
+}
+
+#[test]
+fn row_5_two_segment_upload_handle_no_display() {
+    let rig = Rig::new("row5");
+    let abs = rig.make_upload_file("019e22-two-segment.wav", b"WAV");
+    let relative = rig.upload_relative("019e22-two-segment.wav");
+
+    let full_handle = encode_tmp_upload_handle(
+        &temp_upload_root().join(&relative),
+        Some("019e22-two-segment.wav"),
+    )
+    .expect("handle");
+    // Strip the trailing display segment — the LLM frequently drops it.
+    let payload = full_handle.split('/').nth(1).expect("payload");
+    let two_segment = format!("up/{payload}");
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &two_segment,
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::UploadTmpdir);
+    assert_eq!(resolved.absolute, abs);
+}
+
+#[test]
+fn row_6_three_segment_profile_handle() {
+    let rig = Rig::new("row6");
+    let abs = rig.make_profile_file("slides/demo/output/deck.pptx", b"pptx");
+    let handle = encode_profile_file_handle(rig.profile_root(), &abs).expect("pf handle");
+    assert!(handle.starts_with("pf/"));
+    assert!(handle.matches('/').count() >= 2);
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &handle,
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::Profile);
+    assert_eq!(resolved.absolute, abs);
+}
+
+#[test]
+fn row_7_two_segment_profile_handle_no_display() {
+    let rig = Rig::new("row7");
+    let abs = rig.make_profile_file("slides/two-seg/output/deck.pptx", b"pptx");
+    let full_handle = encode_profile_file_handle(rig.profile_root(), &abs).expect("pf handle");
+    let payload = full_handle.split('/').nth(1).expect("payload");
+    let two_segment = format!("pf/{payload}");
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &two_segment,
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::Profile);
+    assert_eq!(resolved.absolute, abs);
+}
+
+#[test]
+fn row_8_bare_basename_under_upload_tmpdir() {
+    // The server writes uploads as `<temp_upload_root()>/<uuid>.<ext>`.
+    // The LLM frequently passes only the basename back. The resolver
+    // must locate the on-disk file under the upload tmpdir without
+    // mistaking it for a workspace-relative path.
+    let upload_root = temp_upload_root();
+    std::fs::create_dir_all(&upload_root).unwrap();
+    let bare_name = format!(
+        "019e22-bare-{}-{}.wav",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    );
+    let abs = upload_root.join(&bare_name);
+    std::fs::write(&abs, b"WAV").unwrap();
+    let canonical = std::fs::canonicalize(&abs).unwrap();
+
+    let rig = Rig::new("row8");
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &bare_name,
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::UploadTmpdir);
+    assert_eq!(resolved.absolute, canonical);
+
+    let _ = std::fs::remove_file(&abs);
+}
+
+#[test]
+fn row_9_parent_traversal_rejected() {
+    let rig = Rig::new("row9");
+    let err = expect_err(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        "../../etc/passwd",
+    ));
+    assert_eq!(err, ToolPathError::Traversal);
+}
+
+#[test]
+fn row_10_absolute_outside_all_allowed_roots_rejected() {
+    let rig = Rig::new("row10");
+    // /etc/passwd is a stable target outside every test root. We
+    // don't read the file — only require that the resolver refuses.
+    let err = expect_err(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        "/etc/passwd",
+    ));
+    assert_eq!(err, ToolPathError::OutsideAllowedRoots);
+}
+
+// ---------- Extra contract pins ----------
+
+#[test]
+fn workspace_root_absolute_without_profile_still_works() {
+    // The most common live call path passes `profile_root = None`
+    // (read_file/write_file/etc. don't track the profile root). The
+    // resolver must still operate on workspace + upload tmpdir.
+    let rig = Rig::new("no-profile");
+    let abs = rig.make_workspace_file("hello.txt", b"x");
+
+    let resolved = expect_resolved(resolve_tool_path(rig.workspace_root(), None, "hello.txt"));
+    assert_eq!(resolved.scope, ToolPathScope::Workspace);
+    assert_eq!(resolved.absolute, abs);
+}
+
+#[test]
+fn profile_handle_without_profile_root_fails() {
+    // A `pf/...` handle supplied without a `profile_root` argument is
+    // unresolvable. Surface as DecodeFailed so callers can fall back to
+    // their own legacy paths if any.
+    let rig = Rig::new("no-profile-pf");
+    let abs = rig.make_profile_file("slides/demo/deck.pptx", b"x");
+    let handle = encode_profile_file_handle(rig.profile_root(), &abs).expect("pf handle");
+
+    let err = expect_err(resolve_tool_path(rig.workspace_root(), None, &handle));
+    assert_eq!(err, ToolPathError::DecodeFailed);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_firmlink_canonicalisation_for_upload_root() {
+    // macOS firmlinks expose `/var/folders/...` and
+    // `/private/var/folders/...` as the same directory.
+    // `std::fs::canonicalize` collapses to the `/private/...` form, but
+    // `temp_upload_root()` returns the un-prefixed `/var/...` path.
+    // The unified resolver must accept BOTH forms.
+    let rig = Rig::new("firmlink");
+    let abs = rig.make_upload_file("firmlink.wav", b"WAV");
+    let canon = std::fs::canonicalize(&abs).expect("canonicalise");
+    let canon_str = canon.to_string_lossy();
+    assert!(
+        canon_str.starts_with("/private/var/") || canon_str.starts_with("/var/"),
+        "expected macOS tmpdir under /var/folders/, got {canon_str}"
+    );
+
+    let resolved = expect_resolved(resolve_tool_path(
+        rig.workspace_root(),
+        Some(rig.profile_root()),
+        &canon.to_string_lossy(),
+    ));
+    assert_eq!(resolved.scope, ToolPathScope::UploadTmpdir);
+}

--- a/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
+++ b/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
@@ -117,7 +117,7 @@ fn expect_err(result: Result<ResolvedToolPath, ToolPathError>) -> ToolPathError 
 #[test]
 fn row_1_workspace_relative_input() {
     let rig = Rig::new("row1");
-    let abs = rig.make_workspace_file("foo/bar.txt", b"hi");
+    let _abs = rig.make_workspace_file("foo/bar.txt", b"hi");
 
     let resolved = expect_resolved(resolve_tool_path(
         rig.workspace_root(),
@@ -125,7 +125,11 @@ fn row_1_workspace_relative_input() {
         "foo/bar.txt",
     ));
     assert_eq!(resolved.scope, ToolPathScope::Workspace);
-    assert_eq!(resolved.absolute, abs);
+    // Workspace-relative resolution returns the LEXICAL workspace path
+    // on purpose — file tools layer `O_NOFOLLOW` over the resolved
+    // path, and canonicalising here would silently follow symlinks
+    // before that gate gets to run. See `row_workspace_keeps_lexical_for_symlink_safety`.
+    assert_eq!(resolved.absolute, rig.workspace_root().join("foo/bar.txt"));
 }
 
 #[test]
@@ -157,6 +161,10 @@ fn row_2_absolute_inside_workspace_kept() {
         &abs.to_string_lossy(),
     ));
     assert_eq!(resolved.scope, ToolPathScope::Workspace);
+    // For absolute paths the resolver collapses macOS firmlinks via
+    // `canonicalize_lossy`, so the resolved path is the canonical form.
+    // The workspace-relative branch keeps the lexical workspace path —
+    // see `row_1_workspace_relative_input`.
     assert_eq!(resolved.absolute, abs);
 }
 
@@ -327,11 +335,12 @@ fn workspace_root_absolute_without_profile_still_works() {
     // (read_file/write_file/etc. don't track the profile root). The
     // resolver must still operate on workspace + upload tmpdir.
     let rig = Rig::new("no-profile");
-    let abs = rig.make_workspace_file("hello.txt", b"x");
+    let _abs = rig.make_workspace_file("hello.txt", b"x");
 
     let resolved = expect_resolved(resolve_tool_path(rig.workspace_root(), None, "hello.txt"));
     assert_eq!(resolved.scope, ToolPathScope::Workspace);
-    assert_eq!(resolved.absolute, abs);
+    // Lexical workspace path — same reason as `row_1_workspace_relative_input`.
+    assert_eq!(resolved.absolute, rig.workspace_root().join("hello.txt"));
 }
 
 #[test]
@@ -345,6 +354,39 @@ fn profile_handle_without_profile_root_fails() {
 
     let err = expect_err(resolve_tool_path(rig.workspace_root(), None, &handle));
     assert_eq!(err, ToolPathError::DecodeFailed);
+}
+
+#[cfg(unix)]
+#[test]
+fn workspace_relative_symlink_resolution_is_lexical_not_canonical() {
+    // Security regression pin (codex review, 2026-05-13): the
+    // workspace-relative branch must NOT canonicalise the result.
+    // File tools layer `O_NOFOLLOW` over the resolved path; if the
+    // resolver canonicalised it would silently translate
+    // `workspace/secret -> /etc/passwd` into `/etc/passwd` and the
+    // open-time gate would then see a plain file instead of a
+    // symlink. The contract is: workspace scope returns the lexical
+    // workspace path, the tool's open-time gate is responsible for
+    // refusing symlinks.
+    let rig = Rig::new("sym-safety");
+    let workspace = rig.workspace_root();
+    let outside = tempfile::tempdir().expect("outside tmpdir");
+    std::fs::write(outside.path().join("passwd"), b"root:x:0:0").unwrap();
+    // workspace/secret -> outside/passwd
+    let link = workspace.join("secret");
+    std::os::unix::fs::symlink(outside.path().join("passwd"), &link).unwrap();
+
+    let resolved = expect_resolved(resolve_tool_path(workspace, None, "secret"));
+    assert_eq!(resolved.scope, ToolPathScope::Workspace);
+    // The resolver must NOT have followed the symlink — the resolved
+    // absolute must still be the workspace path (lexical), not the
+    // outside target.
+    assert_eq!(resolved.absolute, workspace.join("secret"));
+    let outside_path = outside.path().join("passwd");
+    assert_ne!(
+        resolved.absolute, outside_path,
+        "resolver must not follow symlinks for workspace-relative paths"
+    );
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
+++ b/crates/octos-bus/tests/file_handle_resolve_tool_path.rs
@@ -356,6 +356,43 @@ fn profile_handle_without_profile_root_fails() {
     assert_eq!(err, ToolPathError::DecodeFailed);
 }
 
+#[test]
+fn absolute_input_with_dotdot_through_missing_component_rejected() {
+    // Codex review round 4 P2 (2026-05-13): when an absolute input
+    // contains `..` after a non-existent component under an allowed
+    // root, the previous `canonicalize_lossy` walked back to the
+    // closest existing parent and re-attached the suffix VERBATIM,
+    // producing a path that still satisfied `starts_with(workspace)`
+    // even though it logically escaped. The resolver must lexically
+    // collapse `..` BEFORE the containment check so the workspace
+    // boundary is honest.
+    let rig = Rig::new("dotdot");
+    let workspace = rig.workspace_root();
+    let outside = tempfile::tempdir().expect("outside");
+    std::fs::write(outside.path().join("secret.txt"), b"escape").unwrap();
+
+    // Input: <workspace>/missing/../../<outside>/secret.txt
+    // Lexically normalises to <outside-parent>/secret.txt, which
+    // lies outside both the workspace and the upload tmpdir. The
+    // resolver must reject as OutsideAllowedRoots.
+    let workspace_parent = workspace.parent().expect("workspace parent");
+    let traverse = format!(
+        "{}/missing/../../{}/secret.txt",
+        workspace.display(),
+        outside
+            .path()
+            .strip_prefix(workspace_parent)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| outside.path().display().to_string()),
+    );
+    let err = expect_err(resolve_tool_path(workspace, None, &traverse));
+    assert_eq!(
+        err,
+        ToolPathError::OutsideAllowedRoots,
+        "dotdot through missing component must not be silently accepted as workspace-internal"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn workspace_relative_symlink_resolution_is_lexical_not_canonical() {

--- a/scripts/milestone-ci.sh
+++ b/scripts/milestone-ci.sh
@@ -63,6 +63,7 @@ run_hosted_fast() {
   cargo test -p octos-llm test_compatible_fallbacks_prefers_lower_seeded_qos_score -- --nocapture
   cargo test -p octos-cli gateway_runtime::tests --features api -- --nocapture
   cargo test -p octos-agent --test activate_tools_regression -- --nocapture
+  cargo test -p octos-bus --test file_handle_resolve_tool_path -- --nocapture
 }
 
 run_workspace_all_features() {


### PR DESCRIPTION
## Summary

Adds `octos_bus::file_handle::resolve_tool_path` — a single resolver
for every LLM-supplied file path — and routes the four ad-hoc resolvers
across `octos-agent` through it:

- `tools::resolve_path` (used by read_file/write_file/edit_file/diff_edit/glob/grep/list_dir/code_structure/git)
- `plugins::tool::rewrite_workspace_file_args` (used by every plugin tool — fm_voice_save, fm_tts, voice_synthesize, mofa_*, slides, sites)
- `tools::send_file` (with the `/tmp` + `extra_allowed_dirs` allowlist preserved)
- `tools::read_task_output::resolve_handle_path`

Kills the bug class behind #586, #857, #930, #931, #932, #933 — each
of those PRs patched a different copy of the same logic. From here on,
new input shapes only need to be added once.

## Resolution table (every row pinned by an integration test)

| Input | Behaviour |
|---|---|
| `foo/bar.txt` | workspace-relative, lexical path |
| `/Users/.../workspace/foo.txt` | absolute inside workspace, canonical |
| `/var/folders/.../octos-uploads/019e22…wav` | absolute inside upload tmpdir, canonical |
| `up/<base64>/<display>` | upload handle, 3 segments |
| `up/<base64>` | upload handle, LLM truncated display |
| `pf/<base64>/<display>` | profile handle, 3 segments |
| `pf/<base64>` | profile handle, LLM truncated display |
| `019e22…wav` (bare basename) | resolved under upload tmpdir |
| `..` traversal | rejected (lexical normalisation up front) |
| `/etc/passwd` outside workspace/upload/profile | rejected |
| macOS firmlink (`/private/var/...` vs `/var/...`) | collapsed via canonicalize |
| `pf/...` without `profile_root` argument | DecodeFailed (caller fallback) |
| **Workspace-relative symlink** | **NOT followed (lexical return)** |
| **Absolute path with `..` through missing component** | **rejected (lexical pre-normalise)** |

## Codex review pins

This PR went through 5 rounds of codex review. The first 4 rounds
surfaced real bugs that landed as follow-up commits:

| Round | Finding | Fix commit |
|---|---|---|
| 1 P1 | Workspace-relative paths were canonicalised, silently following symlinks before the leaf `O_NOFOLLOW` gate could refuse them | 3a7487c8 |
| 1 P2 | Plugin filename fallback was bypassed when `resolve_tool_path` accepted a missing relative path as workspace-scope | 3a7487c8 |
| 2 P2 | `send_file` relative inputs would prefer a same-basename upload-tmpdir collision over the configured `base_dir` (cross-session data exposure) | 9cf1bcfd |
| 3 P2 | `read_task_output::reject_symlinked_ancestors` canonicalised before walking, so a parent symlink pointing back inside the workspace would be collapsed away and miss the refuse-symlinks check | 74655962 |
| 4 P2 | `canonicalize_lossy` re-attached `..` components verbatim, so `/workspace/missing/../../secret.txt` syntactically satisfied `starts_with("/workspace")` and was accepted | d052a875 |
| 5 | "No actionable correctness issues were found." | — |

Each fix landed as a separate commit with its own regression test pinning the exact bypass shape, so the PR history is a usable changelog of what could go wrong with a unified resolver.

## Call-site migration log

- `crates/octos-agent/src/tools/mod.rs` → `resolve_path` is now a thin
  wrapper that delegates to `resolve_tool_path`. Legacy error messages
  preserved. `normalize_path` / `test_normalize_handles_complex_paths`
  retired (logic + coverage moved to `octos-bus`).
- `crates/octos-agent/src/plugins/tool.rs` → new helper
  `resolve_plugin_input_path` tries the unified resolver first, then
  falls back to the plugin-specific basename/`_<name>` heuristics in
  `resolve_path_in_work_dir` ONLY when the resolver's workspace-scope
  result doesn't exist on disk (so the LLM's hallucinated-prefix
  recovery flow keeps working).
- `crates/octos-agent/src/tools/send_file.rs` → unified decode only
  for handle-shaped inputs and absolute paths. Relative inputs stay
  anchored to `base_dir` to prevent same-basename upload-tmpdir
  shadowing. `temp_upload_root()` joins the post-resolution allowlist
  so chat uploads bound for delivery don't get rejected.
- `crates/octos-agent/src/tools/read_task_output.rs` →
  `resolve_handle_path` delegates to `resolve_tool_path` and refuses
  anything outside `ToolPathScope::Workspace`. `normalize_inside_workspace`
  retired. `reject_symlinked_ancestors` walks the LEXICAL suffix
  against both lexical and canonical workspace roots.

## Architectural decisions

1. **Existence semantics**: scopes `UploadTmpdir` and `Profile`
   require the file to exist (canonicalize-based resolution). Scope
   `Workspace` returns the LEXICAL workspace path even when the
   file does not exist — preserves `write_file` / `edit_file` create
   flows AND keeps the tool's open-time `O_NOFOLLOW` gate as the
   symlink-rejection authority (canonicalising would silently follow
   symlinks before the gate could see them).

2. **Profile handles in tools that previously only knew workspace-relative**:
   the unified resolver takes `profile_root: Option<&Path>`. Call sites
   that don't track a profile root (file tools, `read_task_output`)
   pass `None`. The resolver returns `DecodeFailed` for `pf/...` handles
   in that case so callers can fall back to legacy paths if any.

3. **send_file profile hint**: the first entry in `extra_allowed_dirs`
   is passed as the resolver's `profile_root`. Real wiring sets this to
   the per-profile `data_dir` (see `session_actor.rs` line 2093 and
   `api/ui_protocol.rs` line 6658).

4. **`..` collapse happens BEFORE the walk-parents-until-existing
   loop** in `canonicalize_lossy`. Without this, a path that
   syntactically traverses out of an allowed root through a
   nonexistent intermediate component (`/workspace/missing/../../secret`)
   would have its suffix re-attached verbatim and still pass
   `starts_with(workspace)`. Lexical pre-normalisation makes
   containment honest.

## Test plan

- [x] `cargo test -p octos-bus --test file_handle_resolve_tool_path` — 16 resolution-table tests
- [x] `cargo test -p octos-bus` — 199 + 2 = 201 tests
- [x] `cargo test -p octos-agent --lib` — 1292 tests
- [x] `cargo test --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check` (only pre-existing `ui_protocol.rs` formatting noise unrelated to this PR)
- [x] Added `cargo test -p octos-bus --test file_handle_resolve_tool_path` to `scripts/milestone-ci.sh`
- [x] Codex review 5 rounds — final round reports no actionable correctness issues