### PR TITLE
feat(workspace-policy): domain validators (kills silent-failure bug class)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,6 +2574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "htmd"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,6 +3688,7 @@ dependencies = [
  "futures",
  "gix",
  "glob",
+ "hound",
  "htmd",
  "ignore",
  "lettre",
@@ -3700,6 +3707,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "similar",
+ "symphonia",
  "tar",
  "tempfile",
  "tokio",
@@ -5475,6 +5483,55 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,15 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png"]
 # PDF text extraction (pure Rust; read_file auto-detects %PDF- magic)
 pdf-extract = "0.9"
 
+# Audio decoding (pure Rust)
+# WAV: always-on (small dep, used by AudioNonSilent validator on .wav files).
+# MP3: gated behind the `audio_mp3` feature on octos-agent so non-audio
+# workspaces don't pay the symphonia dep cost. Without the feature, MP3
+# AudioNonSilent validators return an explicit "feature not enabled" error
+# rather than silently passing.
+hound = "3"
+symphonia = { version = "0.5", default-features = false, features = ["mp3"] }
+
 # Unix-specific (O_NOFOLLOW for symlink-safe file I/O)
 libc = "0.2"
 

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -48,10 +48,16 @@ pdf-extract = { workspace = true }
 tempfile = { workspace = true }
 lettre = { workspace = true }
 redb = { workspace = true }
+hound = { workspace = true }
+symphonia = { workspace = true, optional = true }
 
 [features]
 git = ["dep:gix", "dep:similar"]
 ast = ["dep:tree-sitter", "dep:tree-sitter-rust", "dep:tree-sitter-python", "dep:tree-sitter-javascript", "dep:tree-sitter-typescript"]
+# Enable MP3 decoding for the `AudioNonSilent` workspace-policy validator.
+# WAV decoding is always-on via `hound`; MP3 pulls in `symphonia` which is
+# heavier so we keep it opt-in for non-audio workspaces.
+audio_mp3 = ["dep:symphonia"]
 
 [lints]
 workspace = true

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -39,7 +39,7 @@ use crate::progress::ProgressEvent;
 use crate::task_supervisor::TaskRuntimeState;
 use crate::tools::spawn::{BackgroundResultKind, BackgroundResultPayload};
 use crate::tools::{ConcurrencyClass, TOOL_CTX, TURN_ATTACHMENT_CTX, ToolContext};
-use crate::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract};
+use crate::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract_with_args};
 
 /// Per-tool-call result returned from the in-process dispatcher. Kept as a
 /// tuple so the aggregation path can reuse today's `futures::join_all` style
@@ -515,13 +515,14 @@ impl Agent {
                                 success = true,
                                 "spawn_only background tool completed"
                             );
-                            match enforce_spawn_task_contract(
+                            match enforce_spawn_task_contract_with_args(
                                 &bg_tools,
                                 &bg_name,
                                 &bg_tc_id,
                                 &r.files_to_send,
                                 bg_started_at,
                                 Some((&bg_supervisor, &task_id)),
+                                Some(&bg_args),
                             )
                             .await
                             {

--- a/crates/octos-agent/src/tools/delegate.rs
+++ b/crates/octos-agent/src/tools/delegate.rs
@@ -673,6 +673,7 @@ impl Tool for DelegateTool {
                             &policy.validation.validators,
                             "delegate",
                             ValidatorPhase::Completion,
+                            None,
                         )
                         .await
                         .err()

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -1107,7 +1107,7 @@ mod path_tests {
         )
         .expect("firmlink-canonical upload path must be accepted");
         assert!(
-            resolved.starts_with(&std::fs::canonicalize(&upload_root).unwrap()),
+            resolved.starts_with(std::fs::canonicalize(&upload_root).unwrap()),
             "resolved path {} must canonicalize under upload root",
             resolved.display()
         );

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2073,6 +2073,7 @@ impl Tool for SpawnTool {
                             &policy.validation.validators,
                             "spawn-agent-mcp",
                             crate::validators::ValidatorPhase::Completion,
+                            None,
                         )
                         .await
                         {
@@ -2251,6 +2252,7 @@ impl Tool for SpawnTool {
                                     &policy.validation.validators,
                                     "spawn",
                                     crate::validators::ValidatorPhase::Completion,
+                                    None,
                                 )
                                 .await
                                 {
@@ -2581,6 +2583,7 @@ impl Tool for SpawnTool {
                             &policy.validation.validators,
                             "spawn",
                             crate::validators::ValidatorPhase::Completion,
+                            None,
                         )
                         .await
                         {

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -1173,6 +1173,12 @@ enum HttpProbeFailure {
 /// `<key>` is a dotted JSON path against the input args object. A missing key
 /// or a non-string/number value is a hard error so the validator surfaces an
 /// `Error` outcome rather than silently degrading the URL.
+///
+/// Substituted values are percent-encoded against
+/// [`URL_PATH_QUERY_RESERVED`] before being spliced into the template so an
+/// LLM- or user-controlled arg value cannot break out of the path/query
+/// segment it was placed into (e.g. inject a different host or query
+/// parameter). Templates are treated as URL fragments, not opaque strings.
 fn interpolate_args(
     template: &str,
     input_args: Option<&serde_json::Value>,
@@ -1189,11 +1195,28 @@ fn interpolate_args(
         let value = input_arg(input_args, key).ok_or_else(|| {
             format!("input arg '{key}' not found while interpolating template: {template}")
         })?;
-        out.push_str(&value);
+        out.push_str(&percent_encode_url_segment(&value));
         rest = &after[end + 1..];
     }
     out.push_str(rest);
     Ok(out)
+}
+
+/// Percent-encode bytes that have reserved meaning in URL path/query segments
+/// so an LLM-controlled arg value cannot break out of the segment it was
+/// placed into. Conservative: encodes everything outside the unreserved set
+/// defined in RFC 3986 plus the `~` allowed-in-unreserved character.
+fn percent_encode_url_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        let unreserved = byte.is_ascii_alphanumeric() || matches!(*byte, b'-' | b'_' | b'.' | b'~');
+        if unreserved {
+            out.push(*byte as char);
+        } else {
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
 }
 
 /// Fetch a single argument value from a spawn task's input args by dotted key.
@@ -1381,11 +1404,15 @@ fn decode_non_silent_ratio_wav(path: &Path) -> Result<f32, String> {
     let mut non_silent: u64 = 0;
     let denom = match spec.sample_format {
         hound::SampleFormat::Float => 1.0_f32,
-        // 16-bit PCM max magnitude; clip 24/32-bit at i32::MAX as a coarse normaliser.
+        // PCM full-scale magnitude per bit depth: (2^(bits-1)) - 1. The
+        // earlier coarse approximation (`i32::MAX` for both 24 and 32 bit)
+        // mis-normalized 24-bit samples by a factor of 256, so a perfectly
+        // loud 24-bit recording fell below the 0.01 non-silent floor.
         hound::SampleFormat::Int => match spec.bits_per_sample {
             8 => i8::MAX as f32,
             16 => i16::MAX as f32,
-            24 | 32 => i32::MAX as f32,
+            24 => ((1u32 << 23) - 1) as f32,
+            32 => i32::MAX as f32,
             other => {
                 return Err(format!("unsupported wav bits_per_sample={other}"));
             }
@@ -2130,5 +2157,29 @@ mod tests {
         let args = serde_json::json!({});
         let err = interpolate_args("http://x/${args.name}", Some(&args)).unwrap_err();
         assert!(err.contains("'name'"));
+    }
+
+    #[test]
+    fn interpolate_args_percent_encodes_reserved_characters() {
+        // An LLM-controlled value MUST NOT be able to break out of the URL
+        // segment it lands in. `?`, `&`, `/`, `#` etc. must be percent-
+        // encoded so the resulting URL has the literal value as a single
+        // path segment, not a structural separator.
+        let args = serde_json::json!({"name": "evil/../?inject=1"});
+        let out = interpolate_args("http://x/${args.name}", Some(&args)).unwrap();
+        // The interpolated segment should not contain raw `/`, `?`, or `=`.
+        let interpolated = out.strip_prefix("http://x/").expect("prefix preserved");
+        assert!(
+            !interpolated.contains('/'),
+            "raw `/` leaked: {interpolated}"
+        );
+        assert!(
+            !interpolated.contains('?'),
+            "raw `?` leaked: {interpolated}"
+        );
+        assert!(
+            !interpolated.contains('='),
+            "raw `=` leaked: {interpolated}"
+        );
     }
 }

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -35,15 +35,55 @@ use tracing::{debug, warn};
 use crate::policy::{CommandPolicy, Decision, SafePolicy};
 use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
 use crate::tools::{ToolRegistry, ToolResult};
-use crate::workspace_policy::{Validator, ValidatorPhaseKind, ValidatorSpec};
+use crate::workspace_policy::{MagicByteKind, Validator, ValidatorPhaseKind, ValidatorSpec};
 
 /// Current schema version for [`ValidatorOutcome`] persistence.
 pub const VALIDATOR_RESULT_SCHEMA_VERSION: u32 = 1;
 
 const EVIDENCE_SUBDIR: &str = ".octos/validator-evidence";
 const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 30_000;
+/// Default timeout for HTTP-probe validators when [`Validator::timeout_ms`]
+/// is absent. Picked so a stale local API surface fails fast rather than
+/// stalling the whole contract gate.
+const DEFAULT_HTTP_PROBE_TIMEOUT_MS: u64 = 5_000;
 const MAX_EVIDENCE_BYTES: usize = 512 * 1024;
 const KILL_GRACE_PERIOD: Duration = Duration::from_millis(300);
+
+/// Default ominix-api URL when the `OMINIX_API_URL` env override is absent.
+const DEFAULT_OMINIX_API_URL: &str = "http://127.0.0.1:8081";
+
+/// Test-only override for the ominix-api base URL.
+///
+/// Production reads the URL from the `OMINIX_API_URL` env var (or falls
+/// back to [`DEFAULT_OMINIX_API_URL`]). Tests cannot safely mutate env vars
+/// in 2024 edition under `deny(unsafe_code)`, so they install the address
+/// of an in-test HTTP server here instead.
+#[cfg(test)]
+static TEST_OMINIX_URL_OVERRIDE: std::sync::OnceLock<std::sync::Mutex<Option<String>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(test)]
+fn test_ominix_url_override() -> &'static std::sync::Mutex<Option<String>> {
+    TEST_OMINIX_URL_OVERRIDE.get_or_init(|| std::sync::Mutex::new(None))
+}
+
+fn ominix_api_base_url() -> String {
+    #[cfg(test)]
+    {
+        if let Ok(guard) = test_ominix_url_override().lock() {
+            if let Some(ref url) = *guard {
+                return url.clone();
+            }
+        }
+    }
+    std::env::var("OMINIX_API_URL").unwrap_or_else(|_| DEFAULT_OMINIX_API_URL.to_string())
+}
+
+/// Sample value, on a normalized -1.0..1.0 audio axis, above which a sample is
+/// considered "non-silent". Matches the existing `mofa-podcast` skill's
+/// non-silent heuristic so the validator and the skill agree on what counts
+/// as silence.
+const NON_SILENT_SAMPLE_FLOOR: f32 = 0.01;
 
 /// Phase in which a validator runs.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -97,11 +137,41 @@ impl ValidatorStatus {
 }
 
 /// Invocation context shared by a batch of validators for the same workspace.
+///
+/// `input_args` carries the originating spawn task's input JSON when this
+/// invocation is run as part of a spawn-task contract gate. Domain validators
+/// (`HttpProbe`, `OminixVoiceExists`) reference these args via
+/// `${args.<key>}` template interpolation so they can assert e.g. "the
+/// requested voice name is registered with ominix-api".
 #[derive(Clone, Debug)]
 pub struct ValidatorInvocation {
     pub phase: ValidatorPhase,
     pub workspace_root: PathBuf,
     pub repo_label: String,
+    /// Optional input args from the originating spawn task. Used by
+    /// `${args.<key>}` interpolation; absent for non-spawn contexts (e.g.
+    /// turn-end validators that don't reference task inputs).
+    pub input_args: Option<serde_json::Value>,
+}
+
+impl ValidatorInvocation {
+    /// Build a `ValidatorInvocation` for a context that does not carry spawn
+    /// task input args (e.g. turn-end validators, free-standing test setups).
+    pub fn new(phase: ValidatorPhase, workspace_root: PathBuf, repo_label: String) -> Self {
+        Self {
+            phase,
+            workspace_root,
+            repo_label,
+            input_args: None,
+        }
+    }
+
+    /// Attach spawn task input args for `${args.<key>}` template
+    /// interpolation by domain validators.
+    pub fn with_input_args(mut self, args: serde_json::Value) -> Self {
+        self.input_args = Some(args);
+        self
+    }
 }
 
 /// Typed durable outcome of a single validator run.
@@ -369,6 +439,34 @@ impl ValidatorRunner {
                 }
                 ValidatorSpec::FileExists { path, min_bytes } => self
                     .run_file_exists(invocation, validator, path, *min_bytes, started_at, started),
+                ValidatorSpec::HttpProbe {
+                    url_template,
+                    expected_status,
+                    expected_contains,
+                } => {
+                    self.run_http_probe(
+                        invocation,
+                        validator,
+                        url_template,
+                        *expected_status,
+                        expected_contains.as_deref(),
+                        started_at,
+                        started,
+                    )
+                    .await
+                }
+                ValidatorSpec::OminixVoiceExists { name_arg } => {
+                    self.run_ominix_voice_exists(
+                        invocation, validator, name_arg, started_at, started,
+                    )
+                    .await
+                }
+                ValidatorSpec::AudioNonSilent { glob, min_ratio } => self.run_audio_non_silent(
+                    invocation, validator, glob, *min_ratio, started_at, started,
+                ),
+                ValidatorSpec::MagicBytes { glob, format } => {
+                    self.run_magic_bytes(invocation, validator, glob, *format, started_at, started)
+                }
             };
 
             record_counter(&outcome, kind_label);
@@ -674,6 +772,323 @@ impl ValidatorRunner {
         }
     }
 
+    /// Run an HTTP-probe validator.
+    ///
+    /// Interpolates `${args.<key>}` against the spawn task's input args, then
+    /// performs a GET against the resulting URL and asserts the status code
+    /// (and optionally a substring of the body) matches the spec.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_http_probe(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        url_template: &str,
+        expected_status: u16,
+        expected_contains: Option<&str>,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let timeout_ms = validator
+            .timeout_ms
+            .unwrap_or(DEFAULT_HTTP_PROBE_TIMEOUT_MS);
+        let url = match interpolate_args(url_template, invocation.input_args.as_ref()) {
+            Ok(url) => url,
+            Err(reason) => {
+                return error_outcome(invocation, validator, started_at, started, reason);
+            }
+        };
+
+        match probe_http(&url, timeout_ms, expected_status, expected_contains).await {
+            Ok(reason) => self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Pass,
+                reason,
+                started_at,
+                started,
+            ),
+            Err(HttpProbeFailure::Timeout) => self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Timeout,
+                format!("http probe timed out after {timeout_ms}ms: {url}"),
+                started_at,
+                started,
+            ),
+            Err(HttpProbeFailure::Fail(reason)) => self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                reason,
+                started_at,
+                started,
+            ),
+            Err(HttpProbeFailure::Error(reason)) => self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Error,
+                reason,
+                started_at,
+                started,
+            ),
+        }
+    }
+
+    /// Run an OminixVoiceExists validator.
+    ///
+    /// Calls `GET ${OMINIX_API_URL:-http://127.0.0.1:8081}/v1/voices` and
+    /// asserts the JSON body's `voices[].name` array contains the voice
+    /// name resolved from the spawn task's input args.
+    async fn run_ominix_voice_exists(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        name_arg: &str,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let timeout_ms = validator
+            .timeout_ms
+            .unwrap_or(DEFAULT_HTTP_PROBE_TIMEOUT_MS);
+        let base = ominix_api_base_url();
+        let url = format!("{}/v1/voices", base.trim_end_matches('/'));
+        let voice_name = match input_arg(invocation.input_args.as_ref(), name_arg) {
+            Some(value) => value,
+            None => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    format!("ominix_voice_exists: input args missing key '{name_arg}'"),
+                    started_at,
+                    started,
+                );
+            }
+        };
+        match fetch_ominix_voices(&url, timeout_ms).await {
+            Ok(voices) => {
+                if voices.iter().any(|v| v == &voice_name) {
+                    self.make_outcome(
+                        invocation,
+                        validator,
+                        ValidatorStatus::Pass,
+                        format!(
+                            "ominix voice '{voice_name}' is registered (out of {} total)",
+                            voices.len()
+                        ),
+                        started_at,
+                        started,
+                    )
+                } else {
+                    let preview = if voices.is_empty() {
+                        "<none>".to_string()
+                    } else {
+                        voices.join(", ")
+                    };
+                    self.make_outcome(
+                        invocation,
+                        validator,
+                        ValidatorStatus::Fail,
+                        format!(
+                            "ominix voice '{voice_name}' is not registered. Available voices: {preview}"
+                        ),
+                        started_at,
+                        started,
+                    )
+                }
+            }
+            Err(HttpProbeFailure::Timeout) => self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Timeout,
+                format!("ominix /v1/voices timed out after {timeout_ms}ms: {url}"),
+                started_at,
+                started,
+            ),
+            Err(HttpProbeFailure::Fail(reason)) | Err(HttpProbeFailure::Error(reason)) => self
+                .make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                ),
+        }
+    }
+
+    /// Run an AudioNonSilent validator.
+    fn run_audio_non_silent(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        pattern: &str,
+        min_ratio: f32,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let matches = match glob_files(&invocation.workspace_root, pattern) {
+            Ok(matches) => matches,
+            Err(reason) => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                );
+            }
+        };
+        if matches.is_empty() {
+            return self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!("audio_non_silent: no files matched '{pattern}'"),
+                started_at,
+                started,
+            );
+        }
+
+        let mut passed_any = false;
+        let mut failures = Vec::new();
+        for path in &matches {
+            match decode_non_silent_ratio(path) {
+                Ok(ratio) if ratio >= min_ratio => {
+                    passed_any = true;
+                    break;
+                }
+                Ok(ratio) => failures.push(format!(
+                    "{}: non_silent_ratio={ratio:.3} < min_ratio={min_ratio:.3}",
+                    path.display()
+                )),
+                Err(reason) => failures.push(format!("{}: {reason}", path.display())),
+            }
+        }
+
+        if passed_any {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Pass,
+                format!("audio_non_silent: at least one file met min_ratio={min_ratio:.3}"),
+                started_at,
+                started,
+            )
+        } else {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!("audio_non_silent failed: {}", failures.join("; ")),
+                started_at,
+                started,
+            )
+        }
+    }
+
+    /// Run a MagicBytes validator.
+    fn run_magic_bytes(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        pattern: &str,
+        kind: MagicByteKind,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let matches = match glob_files(&invocation.workspace_root, pattern) {
+            Ok(matches) => matches,
+            Err(reason) => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                );
+            }
+        };
+        if matches.is_empty() {
+            return self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!("magic_bytes: no files matched '{pattern}'"),
+                started_at,
+                started,
+            );
+        }
+
+        let mut failures = Vec::new();
+        for path in &matches {
+            match read_magic_prefix(path) {
+                Ok(prefix) => {
+                    if !kind.matches(&prefix) {
+                        failures.push(format!(
+                            "{}: header does not match {} magic bytes",
+                            path.display(),
+                            kind.as_str()
+                        ));
+                    }
+                }
+                Err(reason) => {
+                    failures.push(format!("{}: read failed: {reason}", path.display()));
+                }
+            }
+        }
+        if failures.is_empty() {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Pass,
+                format!(
+                    "magic_bytes: all {} match(es) carry {} signature",
+                    matches.len(),
+                    kind.as_str()
+                ),
+                started_at,
+                started,
+            )
+        } else {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!("magic_bytes failed: {}", failures.join("; ")),
+                started_at,
+                started,
+            )
+        }
+    }
+
+    fn make_outcome(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        status: ValidatorStatus,
+        reason: String,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        ValidatorOutcome {
+            schema_version: VALIDATOR_RESULT_SCHEMA_VERSION,
+            validator_id: validator.id.clone(),
+            phase: invocation.phase,
+            kind: validator_kind_label(&validator.spec).to_string(),
+            repo_label: invocation.repo_label.clone(),
+            required: validator.required,
+            status,
+            reason,
+            duration_ms: started.elapsed().as_millis() as u64,
+            evidence_path: None,
+            stderr: None,
+            started_at,
+        }
+    }
+
     async fn write_evidence(
         &self,
         validator_id: &str,
@@ -743,6 +1158,346 @@ impl ValidatorRunner {
     }
 }
 
+/// Internal failure category for HTTP-probe validators.
+///
+/// Threaded back out of [`probe_http`] so the runner can map each category
+/// onto the correct typed [`ValidatorStatus`] (`Timeout`, `Fail`, `Error`).
+enum HttpProbeFailure {
+    Timeout,
+    Fail(String),
+    Error(String),
+}
+
+/// Substitute `${args.<key>}` references in `template` against `input_args`.
+///
+/// `<key>` is a dotted JSON path against the input args object. A missing key
+/// or a non-string/number value is a hard error so the validator surfaces an
+/// `Error` outcome rather than silently degrading the URL.
+fn interpolate_args(
+    template: &str,
+    input_args: Option<&serde_json::Value>,
+) -> Result<String, String> {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("${args.") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + "${args.".len()..];
+        let end = after
+            .find('}')
+            .ok_or_else(|| format!("unterminated ${{args.}} reference in template: {template}"))?;
+        let key = &after[..end];
+        let value = input_arg(input_args, key).ok_or_else(|| {
+            format!("input arg '{key}' not found while interpolating template: {template}")
+        })?;
+        out.push_str(&value);
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Fetch a single argument value from a spawn task's input args by dotted key.
+fn input_arg(input_args: Option<&serde_json::Value>, key: &str) -> Option<String> {
+    let mut value = input_args?;
+    for part in key.split('.') {
+        if part.is_empty() {
+            return None;
+        }
+        value = value.get(part)?;
+    }
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// Perform an HTTP GET probe and assert the response shape.
+async fn probe_http(
+    url: &str,
+    timeout_ms: u64,
+    expected_status: u16,
+    expected_contains: Option<&str>,
+) -> Result<String, HttpProbeFailure> {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(timeout_ms))
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            return Err(HttpProbeFailure::Error(format!(
+                "build http client failed: {err}"
+            )));
+        }
+    };
+    let response = match client.get(url).send().await {
+        Ok(response) => response,
+        Err(err) if err.is_timeout() => return Err(HttpProbeFailure::Timeout),
+        Err(err) => {
+            return Err(HttpProbeFailure::Error(format!(
+                "http probe request failed for {url}: {err}"
+            )));
+        }
+    };
+    let actual = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+    if actual != expected_status {
+        let preview = preview_body(&body);
+        return Err(HttpProbeFailure::Fail(format!(
+            "http probe got status {actual} (expected {expected_status}) at {url}; body preview: {preview}"
+        )));
+    }
+    if let Some(needle) = expected_contains {
+        if !body.contains(needle) {
+            let preview = preview_body(&body);
+            return Err(HttpProbeFailure::Fail(format!(
+                "http probe body at {url} did not contain '{needle}'; body preview: {preview}"
+            )));
+        }
+    }
+    Ok(format!(
+        "http probe {url} returned status {actual}{}",
+        match expected_contains {
+            Some(needle) => format!(" with substring '{needle}'"),
+            None => String::new(),
+        }
+    ))
+}
+
+fn preview_body(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "<empty>".to_string();
+    }
+    if trimmed.len() <= 200 {
+        return trimmed.to_string();
+    }
+    let mut end = 200;
+    while end > 0 && !trimmed.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &trimmed[..end])
+}
+
+/// Fetch ominix-api `/v1/voices` and extract the registered voice names.
+async fn fetch_ominix_voices(url: &str, timeout_ms: u64) -> Result<Vec<String>, HttpProbeFailure> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(timeout_ms))
+        .build()
+        .map_err(|err| HttpProbeFailure::Error(format!("build http client failed: {err}")))?;
+    let response = match client.get(url).send().await {
+        Ok(response) => response,
+        Err(err) if err.is_timeout() => return Err(HttpProbeFailure::Timeout),
+        Err(err) => {
+            return Err(HttpProbeFailure::Error(format!(
+                "ominix /v1/voices fetch failed at {url}: {err}"
+            )));
+        }
+    };
+    if !response.status().is_success() {
+        return Err(HttpProbeFailure::Error(format!(
+            "ominix /v1/voices returned status {} at {url}",
+            response.status().as_u16()
+        )));
+    }
+    let body = response.text().await.unwrap_or_default();
+    let parsed: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|err| HttpProbeFailure::Error(format!("ominix /v1/voices invalid JSON: {err}")))?;
+    let voices = parsed
+        .get("voices")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            HttpProbeFailure::Error(format!(
+                "ominix /v1/voices response missing 'voices' array (body preview: {})",
+                preview_body(&body)
+            ))
+        })?;
+    let names: Vec<String> = voices
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .get("name")
+                .and_then(|name| name.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    Ok(names)
+}
+
+/// Resolve a glob pattern against `workspace_root` and return matching files
+/// (skipping directories).
+fn glob_files(workspace_root: &Path, pattern: &str) -> Result<Vec<PathBuf>, String> {
+    let absolute_pattern = if Path::new(pattern).is_absolute() {
+        PathBuf::from(pattern)
+    } else {
+        workspace_root.join(pattern)
+    };
+    let mut matches = Vec::new();
+    for entry in glob::glob(&absolute_pattern.to_string_lossy())
+        .map_err(|err| format!("invalid glob '{pattern}': {err}"))?
+    {
+        let path = entry.map_err(|err| format!("glob '{pattern}' failed: {err}"))?;
+        if path.is_file() {
+            matches.push(path);
+        }
+    }
+    Ok(matches)
+}
+
+/// Read the first 32 bytes of a file for magic-byte sniffing.
+fn read_magic_prefix(path: &Path) -> Result<Vec<u8>, String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).map_err(|err| format!("open failed: {err}"))?;
+    let mut buf = [0u8; 32];
+    let n = file
+        .read(&mut buf)
+        .map_err(|err| format!("read failed: {err}"))?;
+    Ok(buf[..n].to_vec())
+}
+
+/// Decode `path` (WAV via [`hound`], or MP3 via the optional `audio_mp3`
+/// feature) and return the ratio of non-silent samples to total samples.
+fn decode_non_silent_ratio(path: &Path) -> Result<f32, String> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    match ext.as_str() {
+        "wav" | "wave" => decode_non_silent_ratio_wav(path),
+        "mp3" => decode_non_silent_ratio_mp3(path),
+        other => Err(format!(
+            "audio_non_silent: unsupported file extension '{other}' (supported: wav, mp3)"
+        )),
+    }
+}
+
+fn decode_non_silent_ratio_wav(path: &Path) -> Result<f32, String> {
+    let mut reader =
+        hound::WavReader::open(path).map_err(|err| format!("wav open failed: {err}"))?;
+    let spec = reader.spec();
+    let mut total: u64 = 0;
+    let mut non_silent: u64 = 0;
+    let denom = match spec.sample_format {
+        hound::SampleFormat::Float => 1.0_f32,
+        // 16-bit PCM max magnitude; clip 24/32-bit at i32::MAX as a coarse normaliser.
+        hound::SampleFormat::Int => match spec.bits_per_sample {
+            8 => i8::MAX as f32,
+            16 => i16::MAX as f32,
+            24 | 32 => i32::MAX as f32,
+            other => {
+                return Err(format!("unsupported wav bits_per_sample={other}"));
+            }
+        },
+    };
+    match spec.sample_format {
+        hound::SampleFormat::Float => {
+            for sample in reader.samples::<f32>() {
+                let value = sample.map_err(|err| format!("wav decode failed: {err}"))?;
+                total += 1;
+                if value.abs() > NON_SILENT_SAMPLE_FLOOR {
+                    non_silent += 1;
+                }
+            }
+        }
+        hound::SampleFormat::Int => {
+            for sample in reader.samples::<i32>() {
+                let value = sample.map_err(|err| format!("wav decode failed: {err}"))? as f32;
+                total += 1;
+                if (value / denom).abs() > NON_SILENT_SAMPLE_FLOOR {
+                    non_silent += 1;
+                }
+            }
+        }
+    }
+    if total == 0 {
+        return Err("wav file has zero samples".to_string());
+    }
+    Ok(non_silent as f32 / total as f32)
+}
+
+#[cfg(feature = "audio_mp3")]
+fn decode_non_silent_ratio_mp3(path: &Path) -> Result<f32, String> {
+    use symphonia::core::audio::SampleBuffer;
+    use symphonia::core::codecs::DecoderOptions;
+    use symphonia::core::formats::FormatOptions;
+    use symphonia::core::io::MediaSourceStream;
+    use symphonia::core::meta::MetadataOptions;
+    use symphonia::core::probe::Hint;
+
+    let file = std::fs::File::open(path).map_err(|err| format!("mp3 open failed: {err}"))?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    hint.with_extension("mp3");
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            mss,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .map_err(|err| format!("mp3 probe failed: {err}"))?;
+    let mut format = probed.format;
+    let track = format
+        .default_track()
+        .ok_or_else(|| "mp3 file has no default track".to_string())?;
+    let mut decoder = symphonia::default::get_codecs()
+        .make(&track.codec_params, &DecoderOptions::default())
+        .map_err(|err| format!("mp3 decoder init failed: {err}"))?;
+    let track_id = track.id;
+    let mut total: u64 = 0;
+    let mut non_silent: u64 = 0;
+    let mut sample_buf: Option<SampleBuffer<f32>> = None;
+    loop {
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            Err(symphonia::core::errors::Error::IoError(err))
+                if err.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break;
+            }
+            Err(symphonia::core::errors::Error::ResetRequired) => break,
+            Err(err) => return Err(format!("mp3 read failed: {err}")),
+        };
+        if packet.track_id() != track_id {
+            continue;
+        }
+        let decoded = match decoder.decode(&packet) {
+            Ok(decoded) => decoded,
+            Err(symphonia::core::errors::Error::IoError(_)) => break,
+            Err(symphonia::core::errors::Error::DecodeError(_)) => continue,
+            Err(err) => return Err(format!("mp3 decode failed: {err}")),
+        };
+        if sample_buf.is_none() {
+            let spec = *decoded.spec();
+            sample_buf = Some(SampleBuffer::new(decoded.capacity() as u64, spec));
+        }
+        if let Some(ref mut buf) = sample_buf {
+            buf.copy_interleaved_ref(decoded);
+            for &sample in buf.samples() {
+                total += 1;
+                if sample.abs() > NON_SILENT_SAMPLE_FLOOR {
+                    non_silent += 1;
+                }
+            }
+        }
+    }
+    if total == 0 {
+        return Err("mp3 file decoded zero samples".to_string());
+    }
+    Ok(non_silent as f32 / total as f32)
+}
+
+#[cfg(not(feature = "audio_mp3"))]
+fn decode_non_silent_ratio_mp3(_path: &Path) -> Result<f32, String> {
+    Err(
+        "audio_non_silent for .mp3 requires the 'audio_mp3' feature; \
+         enable it on octos-agent or use a .wav input"
+            .to_string(),
+    )
+}
+
 /// Build a representation of the command for the safety-policy check. This is
 /// not forwarded to a shell — we only use it to run the denylist matcher.
 fn build_command_string(cmd: &str, args: &[String]) -> String {
@@ -783,6 +1538,10 @@ fn validator_kind_label(spec: &ValidatorSpec) -> &'static str {
         ValidatorSpec::Command { .. } => "command",
         ValidatorSpec::ToolCall { .. } => "tool_call",
         ValidatorSpec::FileExists { .. } => "file_exists",
+        ValidatorSpec::HttpProbe { .. } => "http_probe",
+        ValidatorSpec::OminixVoiceExists { .. } => "ominix_voice_exists",
+        ValidatorSpec::AudioNonSilent { .. } => "audio_non_silent",
+        ValidatorSpec::MagicBytes { .. } => "magic_bytes",
     }
 }
 
@@ -931,6 +1690,34 @@ mod tests {
             }),
             "file_exists"
         );
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::HttpProbe {
+                url_template: "http://x".into(),
+                expected_status: 200,
+                expected_contains: None,
+            }),
+            "http_probe"
+        );
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::OminixVoiceExists {
+                name_arg: "name".into()
+            }),
+            "ominix_voice_exists"
+        );
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::AudioNonSilent {
+                glob: "*.wav".into(),
+                min_ratio: 0.3
+            }),
+            "audio_non_silent"
+        );
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::MagicBytes {
+                glob: "*.mp3".into(),
+                format: crate::workspace_policy::MagicByteKind::Mp3,
+            }),
+            "magic_bytes"
+        );
     }
 
     #[test]
@@ -973,5 +1760,375 @@ mod tests {
         outcome.required = false;
         outcome.status = ValidatorStatus::Fail;
         assert!(outcome.required_gate_passed());
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers for the domain-validator tests (HTTP probe, audio, magic bytes)
+    // ---------------------------------------------------------------------
+
+    use std::io::{Read, Write as IoWrite};
+    use std::net::TcpListener;
+
+    fn dummy_invocation(workspace_root: PathBuf) -> ValidatorInvocation {
+        ValidatorInvocation::new(ValidatorPhase::Completion, workspace_root, "test".into())
+    }
+
+    fn validator_with_spec(id: &str, spec: ValidatorSpec) -> Validator {
+        Validator {
+            id: id.into(),
+            required: true,
+            timeout_ms: Some(2000),
+            phase: ValidatorPhaseKind::Completion,
+            spec,
+        }
+    }
+
+    /// Tiny synchronous HTTP server scripted via `responses`. Spawns a thread,
+    /// listens on `127.0.0.1:0`, replies to each accepted connection in order,
+    /// and exits once `responses.len()` connections have been served. Returns
+    /// the listener's bound `host:port` for the test to point validators at.
+    fn spawn_test_http_server(responses: Vec<&'static str>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr").to_string();
+        std::thread::spawn(move || {
+            for body in responses {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(body.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn http_probe_passes_on_expected_status_and_substring() {
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n\r\n{\"ok\":\"yangmi\"}";
+        let addr = spawn_test_http_server(vec![response]);
+        let url = format!("http://{addr}/voices/yangmi");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_ok",
+            ValidatorSpec::HttpProbe {
+                url_template: url.clone(),
+                expected_status: 200,
+                expected_contains: Some("yangmi".into()),
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn http_probe_fails_on_404_status() {
+        let response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+        let addr = spawn_test_http_server(vec![response]);
+        let url = format!("http://{addr}/missing");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_404",
+            ValidatorSpec::HttpProbe {
+                url_template: url,
+                expected_status: 200,
+                expected_contains: None,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        assert!(outcomes[0].reason.contains("got status 404"));
+    }
+
+    #[tokio::test]
+    async fn http_probe_fails_when_body_missing_expected_substring() {
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nNOPE";
+        let addr = spawn_test_http_server(vec![response]);
+        let url = format!("http://{addr}/x");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_no_substring",
+            ValidatorSpec::HttpProbe {
+                url_template: url,
+                expected_status: 200,
+                expected_contains: Some("yangmi".into()),
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        assert!(outcomes[0].reason.contains("did not contain 'yangmi'"));
+    }
+
+    #[tokio::test]
+    async fn http_probe_interpolates_args_into_url_template() {
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK";
+        let addr = spawn_test_http_server(vec![response]);
+        let url_template = format!("http://{addr}/voices/${{args.name}}");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_input_args(serde_json::json!({"name": "yangmi"}));
+        let validator = validator_with_spec(
+            "probe_interp",
+            ValidatorSpec::HttpProbe {
+                url_template,
+                expected_status: 200,
+                expected_contains: None,
+            },
+        );
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        // The successful reason should reference the interpolated URL.
+        assert!(
+            outcomes[0].reason.contains("/voices/yangmi"),
+            "missing interpolated value in: {}",
+            outcomes[0].reason
+        );
+    }
+
+    /// RAII guard that installs an ominix-api URL override in
+    /// [`TEST_OMINIX_URL_OVERRIDE`] and clears it on drop.
+    struct OminixUrlGuard;
+
+    impl OminixUrlGuard {
+        fn install(url: String) -> Self {
+            *test_ominix_url_override().lock().unwrap() = Some(url);
+            Self
+        }
+    }
+
+    impl Drop for OminixUrlGuard {
+        fn drop(&mut self) {
+            *test_ominix_url_override().lock().unwrap() = None;
+        }
+    }
+
+    /// Serialize ominix tests on the shared URL override slot. Using an
+    /// async-aware `tokio::sync::Mutex` here so the guard can safely cross
+    /// `.await` points (the test holds it across the in-test HTTP probe).
+    fn ominix_test_lock() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
+
+    #[tokio::test]
+    async fn ominix_voice_exists_passes_when_name_in_voice_list() {
+        let _serial = ominix_test_lock().lock().await;
+        let body = "{\"voices\":[{\"name\":\"vivian\",\"aliases\":[]},{\"name\":\"serena\"}]}";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let leaked: &'static str = Box::leak(response.into_boxed_str());
+        let addr = spawn_test_http_server(vec![leaked]);
+        let _guard = OminixUrlGuard::install(format!("http://{addr}"));
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_input_args(serde_json::json!({"name": "vivian"}));
+        let validator = validator_with_spec(
+            "voice_pass",
+            ValidatorSpec::OminixVoiceExists {
+                name_arg: "name".into(),
+            },
+        );
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn ominix_voice_exists_fails_with_available_list_on_missing_name() {
+        let _serial = ominix_test_lock().lock().await;
+        let body = "{\"voices\":[{\"name\":\"vivian\"},{\"name\":\"serena\"}]}";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let leaked: &'static str = Box::leak(response.into_boxed_str());
+        let addr = spawn_test_http_server(vec![leaked]);
+        let _guard = OminixUrlGuard::install(format!("http://{addr}"));
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_input_args(serde_json::json!({"name": "yangmi"}));
+        let validator = validator_with_spec(
+            "voice_fail",
+            ValidatorSpec::OminixVoiceExists {
+                name_arg: "name".into(),
+            },
+        );
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        // Failure message must surface the available list so the LLM can
+        // react in one round.
+        assert!(
+            outcomes[0].reason.contains("yangmi"),
+            "missing requested name in reason: {}",
+            outcomes[0].reason
+        );
+        assert!(
+            outcomes[0].reason.contains("vivian") && outcomes[0].reason.contains("serena"),
+            "missing available list in reason: {}",
+            outcomes[0].reason
+        );
+    }
+
+    /// Generate a WAV file at `path` filled with silence.
+    fn write_silent_wav(path: &Path, samples: usize) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 8_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+        for _ in 0..samples {
+            writer.write_sample(0i16).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+    }
+
+    /// Generate a WAV sine wave at `path`. Loud enough that every sample is
+    /// above [`NON_SILENT_SAMPLE_FLOOR`].
+    fn write_sine_wav(path: &Path, samples: usize) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 8_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+        let amplitude = i16::MAX / 2;
+        for index in 0..samples {
+            let phase = (index as f32) * std::f32::consts::TAU * 440.0 / 8000.0;
+            let value = (phase.sin() * amplitude as f32) as i16;
+            // Keep value away from zero crossings to ensure non-silent floor.
+            let value = if value.abs() < 4_000 { 4_000 } else { value };
+            writer.write_sample(value).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+    }
+
+    #[tokio::test]
+    async fn audio_non_silent_fails_for_silent_wav() {
+        let dir = tempfile::tempdir().unwrap();
+        let audio_path = dir.path().join("silent.wav");
+        write_silent_wav(&audio_path, 800);
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "silent_audio",
+            ValidatorSpec::AudioNonSilent {
+                glob: "*.wav".into(),
+                min_ratio: 0.3,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("non_silent_ratio"),
+            "reason should expose ratio: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn audio_non_silent_passes_for_sine_wav() {
+        let dir = tempfile::tempdir().unwrap();
+        let audio_path = dir.path().join("sine.wav");
+        write_sine_wav(&audio_path, 800);
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "loud_audio",
+            ValidatorSpec::AudioNonSilent {
+                glob: "*.wav".into(),
+                min_ratio: 0.3,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn magic_bytes_passes_for_valid_mp3_id3_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("song.mp3");
+        let mut bytes = b"ID3".to_vec();
+        bytes.extend(std::iter::repeat_n(0u8, 128));
+        std::fs::write(&path, &bytes).unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "mp3_ok",
+            ValidatorSpec::MagicBytes {
+                glob: "*.mp3".into(),
+                format: crate::workspace_policy::MagicByteKind::Mp3,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn magic_bytes_fails_when_file_is_actually_gif() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("not_mp3.mp3");
+        std::fs::write(&path, b"GIF87a\0\0\0").unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "mp3_bad",
+            ValidatorSpec::MagicBytes {
+                glob: "*.mp3".into(),
+                format: crate::workspace_policy::MagicByteKind::Mp3,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        assert!(outcomes[0].reason.contains("does not match mp3"));
+    }
+
+    #[test]
+    fn interpolate_args_substitutes_simple_key() {
+        let args = serde_json::json!({"name": "yangmi"});
+        let out = interpolate_args("http://x/${args.name}", Some(&args)).unwrap();
+        assert_eq!(out, "http://x/yangmi");
+    }
+
+    #[test]
+    fn interpolate_args_errors_when_key_missing() {
+        let args = serde_json::json!({});
+        let err = interpolate_args("http://x/${args.name}", Some(&args)).unwrap_err();
+        assert!(err.contains("'name'"));
     }
 }

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -47,6 +47,34 @@ pub async fn enforce_spawn_task_contract(
     task_started_at: SystemTime,
     supervisor: Option<(&TaskSupervisor, &str)>,
 ) -> SpawnTaskContractResult {
+    enforce_spawn_task_contract_with_args(
+        tools,
+        tool_name,
+        tool_call_id,
+        files_to_send,
+        task_started_at,
+        supervisor,
+        None,
+    )
+    .await
+}
+
+/// Variant of [`enforce_spawn_task_contract`] that threads the originating
+/// spawn task's input args so domain validators (`HttpProbe`,
+/// `OminixVoiceExists`) can resolve `${args.<key>}` references against them.
+///
+/// Production callers in the agent loop should prefer this entry point — the
+/// args-less variant exists for legacy call sites that don't yet have the
+/// input JSON in scope.
+pub async fn enforce_spawn_task_contract_with_args(
+    tools: &ToolRegistry,
+    tool_name: &str,
+    tool_call_id: &str,
+    files_to_send: &[PathBuf],
+    task_started_at: SystemTime,
+    supervisor: Option<(&TaskSupervisor, &str)>,
+    input_args: Option<&serde_json::Value>,
+) -> SpawnTaskContractResult {
     let required_by_default = default_session_policy_requires_contract(tool_name);
     let Some(workspace_root) = tools.workspace_root() else {
         return SpawnTaskContractResult::NotConfigured {
@@ -124,12 +152,21 @@ pub async fn enforce_spawn_task_contract(
     // failure above — we treat a required validator failure as a hard contract
     // error and return Failed without entering the delivery phase. Optional
     // failures surface as warning counters through the ledger.
+    //
+    // Merge workspace-wide validators with the per-spawn-task
+    // `on_completion` list so domain validators declared inline next to the
+    // spawn task contract run in the same gate.
+    let mut combined_validators: Vec<Validator> = policy.validation.validators.clone();
+    for (index, entry) in task_policy.on_completion.iter().enumerate() {
+        combined_validators.push(entry.clone().into_validator(tool_name, index));
+    }
     match run_declared_validators(
         tools,
         workspace_root,
-        &policy.validation.validators,
+        &combined_validators,
         tool_name,
         ValidatorPhase::Completion,
+        input_args.cloned(),
     )
     .await
     {
@@ -208,6 +245,17 @@ fn resolve_artifacts(
 
     let artifact_sources = task_policy.artifact_sources();
     if artifact_sources.is_empty() {
+        // Contract declares no artifact-source — this is allowed for
+        // spawn tasks that produce no on-disk file (e.g. `fm_voice_save`
+        // which mutates an external API). Skip artifact resolution and
+        // hand the validator runner an empty resolved context; typed
+        // validators in `on_completion` will still run.
+        if task_policy.on_verify.is_empty() && task_policy.delivery_actions().is_empty() {
+            return Ok(ResolvedArtifacts {
+                context: ActionContext::default(),
+                paths: Vec::new(),
+            });
+        }
         return Err("workspace contract has no artifact source".into());
     }
 
@@ -452,12 +500,18 @@ fn default_session_policy_requires_contract(tool_name: &str) -> bool {
 /// `Err(reason)` if any required validator fails — the caller treats this as
 /// a contract-gate failure, matching the behaviour of a missing declared
 /// artifact.
+///
+/// `input_args` carries the originating spawn task's input JSON so that
+/// domain validators (`HttpProbe`, `OminixVoiceExists`) can resolve
+/// `${args.<key>}` references. Pass `None` for non-spawn contexts (e.g.
+/// turn-end validators that don't reference task inputs).
 pub async fn run_declared_validators(
     tools: &ToolRegistry,
     workspace_root: &Path,
     validators: &[Validator],
     repo_label_hint: &str,
     phase: ValidatorPhase,
+    input_args: Option<serde_json::Value>,
 ) -> Result<Vec<ValidatorOutcome>, String> {
     if validators.is_empty() {
         return Ok(Vec::new());
@@ -497,6 +551,7 @@ pub async fn run_declared_validators(
         phase,
         workspace_root: workspace_root.to_path_buf(),
         repo_label: repo_label_hint.to_string(),
+        input_args,
     };
 
     let outcomes = runner.run_all(&invocation, &scoped).await;
@@ -625,7 +680,17 @@ mod tests {
     #[tokio::test]
     async fn podcast_contract_resolves_generated_audio_for_actor_delivery() {
         let temp = tempfile::tempdir().unwrap();
-        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+        // The default session contract now declares MP3-specific
+        // `magic_bytes` + `audio_non_silent` domain validators on
+        // `podcast_generate`. This test only exercises the artifact-
+        // resolution path, so we strip the per-task validators to focus
+        // on the legacy contract semantics. Tests for the new validators
+        // live in the inline `validators` module.
+        let mut policy = WorkspacePolicy::for_session();
+        if let Some(task) = policy.spawn_tasks.get_mut("podcast_generate") {
+            task.on_completion.clear();
+        }
+        write_workspace_policy(temp.path(), &policy).unwrap();
         let output = temp
             .path()
             .join("skill-output/mofa-podcast/podcast_full_123.wav");
@@ -675,6 +740,7 @@ mod tests {
                 on_complete: Vec::new(),
                 on_deliver: Vec::new(),
                 on_failure: Vec::new(),
+                on_completion: Vec::new(),
             },
         );
         write_workspace_policy(temp.path(), &policy).unwrap();
@@ -728,6 +794,7 @@ mod tests {
                 on_complete: vec!["file_exists:missing.txt".into()],
                 on_deliver: vec!["notify_user:bundle delivered".into()],
                 on_failure: Vec::new(),
+                on_completion: Vec::new(),
             },
         );
         write_workspace_policy(temp.path(), &policy).unwrap();
@@ -780,6 +847,7 @@ mod tests {
                 on_complete: vec!["send_file:$legacy".into()],
                 on_deliver: vec!["send_file:$report".into(), "send_file:$audio".into()],
                 on_failure: Vec::new(),
+                on_completion: Vec::new(),
             },
         );
         write_workspace_policy(temp.path(), &policy).unwrap();
@@ -845,6 +913,7 @@ mod tests {
                 on_complete: Vec::new(),
                 on_deliver: Vec::new(),
                 on_failure: Vec::new(),
+                on_completion: Vec::new(),
             },
         );
         write_workspace_policy(temp.path(), &policy).unwrap();

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -18,7 +18,7 @@ pub const WORKSPACE_POLICY_FILE: &str = ".octos-workspace.toml";
 /// `docs/OCTOS_HARNESS_ABI_VERSIONING.md` for the stable and experimental
 /// fields per version. Older policy files that omit the field are accepted
 /// as v1 on deserialization.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WorkspacePolicy {
     /// Durable ABI schema version for this policy. Defaults to
     /// [`WORKSPACE_POLICY_SCHEMA_VERSION`] when absent so pre-versioned
@@ -47,7 +47,7 @@ pub struct WorkspacePolicy {
 /// compact before the first LLM call, and how aggressively to prune stale
 /// tool outputs. When absent, the runtime falls back to the legacy extractive
 /// path and behaves exactly as before M6.3.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CompactionPolicy {
     /// Durable ABI schema version. See
     /// [`COMPACTION_POLICY_SCHEMA_VERSION`]. Missing in legacy files;
@@ -111,7 +111,7 @@ pub enum CompactionSummarizerKind {
 }
 
 /// Tiered validation checks run at different points in the turn lifecycle.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ValidationPolicy {
     /// Tier 1: cheap checks run every turn (< 100ms). e.g. file_exists, build exit code.
     #[serde(default)]
@@ -132,7 +132,7 @@ pub struct ValidationPolicy {
 /// Each validator is identified by a stable `id`, produces a typed
 /// [`crate::validators::ValidatorOutcome`], and may be `required` (a failure
 /// blocks terminal success) or optional (a failure produces a warning only).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Validator {
     /// Stable identifier, unique within the validator list.
     pub id: String,
@@ -170,7 +170,7 @@ pub enum ValidatorPhaseKind {
 }
 
 /// The typed body of a [`Validator`].
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ValidatorSpec {
     /// Run a subprocess command. Dispatched via the shell-safety layer and
@@ -194,6 +194,120 @@ pub enum ValidatorSpec {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         min_bytes: Option<u64>,
     },
+    /// HTTP probe — call URL (with `${args.<path>}` template interpolation
+    /// against the spawn task's input args), assert the response is the
+    /// expected status code, optionally assert a substring is present in the
+    /// response body. Default timeout 5s (overridden by
+    /// [`Validator::timeout_ms`]).
+    HttpProbe {
+        url_template: String,
+        #[serde(default = "default_http_probe_status")]
+        expected_status: u16,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_contains: Option<String>,
+    },
+    /// Specialization of `HttpProbe` for the common case of asserting
+    /// ominix-api has registered a custom voice. Calls
+    /// `GET ${OMINIX_API_URL:-http://127.0.0.1:8081}/v1/voices` and
+    /// asserts the response's `voices[].name` array contains the
+    /// interpolated `name_arg` value. Surfaces the available list in the
+    /// failure message so the LLM can react in one round.
+    OminixVoiceExists {
+        /// Argument key in the spawn task's input args (e.g. `name`) that
+        /// holds the voice name to look up.
+        name_arg: String,
+    },
+    /// Assert that at least one file matching `glob` has decoded audio with
+    /// `non_silent_samples / total_samples >= min_ratio`. WAV is supported
+    /// natively. MP3 support requires the `audio_mp3` feature flag.
+    AudioNonSilent {
+        glob: String,
+        #[serde(default = "default_non_silent_ratio")]
+        min_ratio: f32,
+    },
+    /// Assert each file matching `glob` has the magic-byte prefix for the
+    /// declared `format`. Catches "tool wrote 0 bytes" or "tool wrote an
+    /// HTML error page in place of an MP3".
+    ///
+    /// The format field is named `format` rather than `kind` to avoid
+    /// colliding with serde's `kind` discriminator tag.
+    MagicBytes { glob: String, format: MagicByteKind },
+}
+
+/// File-format signature used by [`ValidatorSpec::MagicBytes`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MagicByteKind {
+    Mp3,
+    Wav,
+    Png,
+    Jpeg,
+    Pdf,
+    Mp4,
+    WebM,
+}
+
+impl MagicByteKind {
+    /// Return the alternative magic-byte prefixes for this file format.
+    /// A file matches if any prefix is present at the start of the byte
+    /// stream.
+    pub fn prefixes(self) -> &'static [&'static [u8]] {
+        match self {
+            // MP3 with ID3v2 tag, or a raw MPEG frame sync (0xFF Fx/Ex/Dx).
+            Self::Mp3 => &[
+                b"ID3",
+                &[0xFF, 0xFB],
+                &[0xFF, 0xFA],
+                &[0xFF, 0xF3],
+                &[0xFF, 0xF2],
+                &[0xFF, 0xE3],
+                &[0xFF, 0xE2],
+            ],
+            Self::Wav => &[b"RIFF"],
+            Self::Png => &[&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]],
+            Self::Jpeg => &[&[0xFF, 0xD8, 0xFF]],
+            Self::Pdf => &[b"%PDF-"],
+            // MP4: 4-byte size prefix followed by 'ftyp'. Most MP4s also
+            // start with 'ftyp' offset by 4 bytes, but checking the brand
+            // directly is simpler — see `magic_bytes_match`.
+            Self::Mp4 => &[b"ftyp"],
+            Self::WebM => &[&[0x1A, 0x45, 0xDF, 0xA3]],
+        }
+    }
+
+    /// Does `data` start with one of the prefixes for this format?
+    ///
+    /// For MP4, the `ftyp` marker lives at offset 4 (after the box-size
+    /// prefix), so the check is byte-position aware. For other formats the
+    /// prefix is at the beginning.
+    pub fn matches(self, data: &[u8]) -> bool {
+        if self == Self::Mp4 {
+            // MP4: bytes 4..8 must be 'ftyp'.
+            return data.len() >= 8 && &data[4..8] == b"ftyp";
+        }
+        let prefixes = self.prefixes();
+        prefixes.iter().any(|p| data.starts_with(p))
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Mp3 => "mp3",
+            Self::Wav => "wav",
+            Self::Png => "png",
+            Self::Jpeg => "jpeg",
+            Self::Pdf => "pdf",
+            Self::Mp4 => "mp4",
+            Self::WebM => "webm",
+        }
+    }
+}
+
+fn default_http_probe_status() -> u16 {
+    200
+}
+
+fn default_non_silent_ratio() -> f32 {
+    0.3
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -263,7 +377,7 @@ pub struct WorkspaceArtifactsPolicy {
     pub entries: BTreeMap<String, String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WorkspaceSpawnTaskPolicy {
     #[serde(default)]
     pub artifact: Option<String>,
@@ -279,6 +393,49 @@ pub struct WorkspaceSpawnTaskPolicy {
     pub on_deliver: Vec<String>,
     #[serde(default)]
     pub on_failure: Vec<String>,
+    /// Per-spawn-task typed validators run at the completion gate, in
+    /// addition to the workspace-wide `[validation].validators`. Each entry
+    /// is auto-tagged as required+completion phase; pass an explicit
+    /// `Validator` struct (with `id`, `required`, etc.) for finer control.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub on_completion: Vec<SpawnTaskValidatorSpec>,
+}
+
+/// TOML-friendly wrapper for the per-spawn-task `on_completion` validator
+/// list. Accepts either:
+///
+/// * A bare `ValidatorSpec` table (no `id`/`required`/`phase`) — auto-tagged
+///   as required + completion phase + a synthetic `id` derived from the
+///   spawn task name and validator index.
+/// * A full `Validator` table with `id`, `required`, `timeout_ms`, etc.
+///
+/// Both forms surface to the runner as a [`Validator`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SpawnTaskValidatorSpec {
+    /// Full Validator struct with `id`, `required`, etc.
+    Full(Validator),
+    /// Bare spec table — id, required, and phase are auto-filled by
+    /// [`SpawnTaskValidatorSpec::into_validator`].
+    Bare(ValidatorSpec),
+}
+
+impl SpawnTaskValidatorSpec {
+    /// Lower this entry into a fully-formed `Validator` using `task_name`
+    /// and `index` to synthesize a stable id when only a bare spec was
+    /// provided.
+    pub fn into_validator(self, task_name: &str, index: usize) -> Validator {
+        match self {
+            Self::Full(validator) => validator,
+            Self::Bare(spec) => Validator {
+                id: format!("{task_name}.on_completion[{index}]"),
+                required: true,
+                timeout_ms: None,
+                phase: ValidatorPhaseKind::Completion,
+                spec,
+            },
+        }
+    }
 }
 
 impl WorkspaceSpawnTaskPolicy {
@@ -394,6 +551,7 @@ impl WorkspacePolicy {
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:TTS generation failed".into()],
+            on_completion: Vec::new(),
         };
 
         let podcast_contract = WorkspaceSpawnTaskPolicy {
@@ -406,6 +564,7 @@ impl WorkspacePolicy {
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:Podcast generation failed".into()],
+            on_completion: Vec::new(),
         };
 
         let mut spawn_tasks = BTreeMap::new();
@@ -700,6 +859,7 @@ mod tests {
             on_complete: Vec::new(),
             on_deliver: Vec::new(),
             on_failure: Vec::new(),
+            on_completion: Vec::new(),
         };
 
         assert_eq!(task.artifact_sources(), vec!["report", "audio"]);
@@ -714,6 +874,7 @@ mod tests {
             on_complete: Vec::new(),
             on_deliver: Vec::new(),
             on_failure: Vec::new(),
+            on_completion: Vec::new(),
         };
 
         assert_eq!(task.artifact_sources(), vec!["primary_audio"]);
@@ -728,6 +889,7 @@ mod tests {
             on_complete: Vec::new(),
             on_deliver: Vec::new(),
             on_failure: Vec::new(),
+            on_completion: Vec::new(),
         };
 
         let rendered = toml::to_string_pretty(&task).unwrap();
@@ -745,6 +907,7 @@ mod tests {
             on_complete: vec!["notify_user:legacy".into()],
             on_deliver: vec!["notify_user:deliver".into()],
             on_failure: Vec::new(),
+            on_completion: Vec::new(),
         };
 
         assert_eq!(
@@ -762,6 +925,7 @@ mod tests {
             on_complete: vec!["notify_user:legacy".into()],
             on_deliver: Vec::new(),
             on_failure: Vec::new(),
+            on_completion: Vec::new(),
         };
 
         assert_eq!(task.delivery_actions(), &["notify_user:legacy".to_string()]);
@@ -934,5 +1098,59 @@ ignore = []
         write_workspace_policy_if_absent(temp.path(), &WorkspacePolicy::for_session()).unwrap();
         let after = std::fs::read_to_string(&path).unwrap();
         assert_eq!(after, sentinel);
+    }
+
+    #[test]
+    fn magic_byte_kind_matches_recognized_prefixes() {
+        assert!(MagicByteKind::Mp3.matches(b"ID3\0\0"));
+        assert!(MagicByteKind::Mp3.matches(&[0xFF, 0xFB, 0x90, 0x00]));
+        assert!(!MagicByteKind::Mp3.matches(b"GIF87a"));
+
+        assert!(MagicByteKind::Wav.matches(b"RIFFxxxxWAVE"));
+        assert!(!MagicByteKind::Wav.matches(b"ID3xxxx"));
+
+        assert!(MagicByteKind::Pdf.matches(b"%PDF-1.4"));
+        assert!(MagicByteKind::Png.matches(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]));
+        assert!(MagicByteKind::Jpeg.matches(&[0xFF, 0xD8, 0xFF, 0xE0]));
+
+        // MP4: 'ftyp' must appear at byte offset 4 (after size prefix).
+        let mp4: [u8; 16] = [
+            0, 0, 0, 0x20, b'f', b't', b'y', b'p', b'i', b's', b'o', b'm', 0, 0, 0, 0,
+        ];
+        assert!(MagicByteKind::Mp4.matches(&mp4));
+    }
+
+    #[test]
+    fn spawn_task_validator_spec_roundtrips_through_toml_bare_and_full_forms() {
+        // Bare form: just the spec table. id, required, phase auto-filled.
+        let bare_toml = r#"
+            kind = "ominix_voice_exists"
+            name_arg = "name"
+        "#;
+        let bare: SpawnTaskValidatorSpec = toml::from_str(bare_toml).unwrap();
+        let validator = bare.into_validator("fm_voice_save", 0);
+        assert_eq!(validator.id, "fm_voice_save.on_completion[0]");
+        assert!(validator.required);
+        assert_eq!(validator.phase, ValidatorPhaseKind::Completion);
+        match validator.spec {
+            ValidatorSpec::OminixVoiceExists { ref name_arg } => {
+                assert_eq!(name_arg, "name");
+            }
+            _ => panic!("expected OminixVoiceExists"),
+        }
+
+        // Full form: explicit id, required, phase.
+        let full_toml = r#"
+            id = "voice_optional"
+            required = false
+            phase = "completion"
+            kind = "magic_bytes"
+            glob = "*.mp3"
+            format = "mp3"
+        "#;
+        let full: SpawnTaskValidatorSpec = toml::from_str(full_toml).unwrap();
+        let validator = full.into_validator("ignored", 99);
+        assert_eq!(validator.id, "voice_optional");
+        assert!(!validator.required);
     }
 }

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -564,13 +564,64 @@ impl WorkspacePolicy {
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:Podcast generation failed".into()],
-            on_completion: Vec::new(),
+            // Catch the two user-visible failure modes from the silent-MP3
+            // bug class: tool wrote zero bytes / an HTML error page in
+            // place of audio (MagicBytes), or tool generated a valid MP3
+            // header but a silent decoded stream (AudioNonSilent).
+            on_completion: vec![
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                    glob: "skill-output/mofa-podcast/*.mp3".into(),
+                    format: MagicByteKind::Mp3,
+                }),
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
+                    glob: "skill-output/mofa-podcast/*.mp3".into(),
+                    min_ratio: default_non_silent_ratio(),
+                }),
+            ],
+        };
+
+        // Voice synthesis (LLM-driven TTS): assert the decoded audio is not
+        // silent. Catches the "render produced empty audio" failure path.
+        let voice_synthesize_contract = WorkspaceSpawnTaskPolicy {
+            artifact: Some("primary_audio".into()),
+            artifacts: Vec::new(),
+            on_verify: vec![
+                "file_exists:$artifact".into(),
+                "file_size_min:$artifact:1024".into(),
+            ],
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Voice synthesis failed".into()],
+            on_completion: vec![SpawnTaskValidatorSpec::Bare(
+                ValidatorSpec::AudioNonSilent {
+                    glob: "skill-output/voice/*.{mp3,wav}".into(),
+                    min_ratio: default_non_silent_ratio(),
+                },
+            )],
+        };
+
+        // Voice save (custom voice registration): assert the voice was
+        // actually registered with ominix-api. Closes the yangmi gap where
+        // fm_voice_save returns success but the API has no record.
+        let fm_voice_save_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Voice registration failed".into()],
+            on_completion: vec![SpawnTaskValidatorSpec::Bare(
+                ValidatorSpec::OminixVoiceExists {
+                    name_arg: "name".into(),
+                },
+            )],
         };
 
         let mut spawn_tasks = BTreeMap::new();
         spawn_tasks.insert("fm_tts".into(), tts_contract.clone());
-        spawn_tasks.insert("voice_synthesize".into(), tts_contract);
+        spawn_tasks.insert("voice_synthesize".into(), voice_synthesize_contract);
         spawn_tasks.insert("podcast_generate".into(), podcast_contract);
+        spawn_tasks.insert("fm_voice_save".into(), fm_voice_save_contract);
 
         Self {
             schema_version: WORKSPACE_POLICY_SCHEMA_VERSION,
@@ -1118,6 +1169,44 @@ ignore = []
             0, 0, 0, 0x20, b'f', b't', b'y', b'p', b'i', b's', b'o', b'm', 0, 0, 0, 0,
         ];
         assert!(MagicByteKind::Mp4.matches(&mp4));
+    }
+
+    #[test]
+    fn session_policy_declares_new_domain_validators_for_silent_failure_paths() {
+        let policy = WorkspacePolicy::for_session();
+        let podcast = policy
+            .spawn_tasks
+            .get("podcast_generate")
+            .expect("podcast contract");
+        // The two new domain validators should be declared so the
+        // "silent MP3" / "wrote HTML instead of MP3" failure modes are
+        // caught at the contract gate.
+        assert!(podcast.on_completion.iter().any(|entry| matches!(
+            entry,
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent { .. })
+        )));
+        assert!(podcast.on_completion.iter().any(|entry| matches!(
+            entry,
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes { .. })
+        )));
+
+        let voice_save = policy
+            .spawn_tasks
+            .get("fm_voice_save")
+            .expect("fm_voice_save contract");
+        assert!(voice_save.on_completion.iter().any(|entry| matches!(
+            entry,
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::OminixVoiceExists { .. })
+        )));
+
+        let voice_synth = policy
+            .spawn_tasks
+            .get("voice_synthesize")
+            .expect("voice_synthesize contract");
+        assert!(voice_synth.on_completion.iter().any(|entry| matches!(
+            entry,
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent { .. })
+        )));
     }
 
     #[test]

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -33,3 +33,13 @@ on_verify = [
     "file_size_min:$artifact:4096",
 ]
 on_failure = ["notify_user:Podcast generation failed"]
+on_completion = [
+    { kind = "magic_bytes", glob = "skill-output/mofa-podcast/*.mp3", format = "mp3" },
+    { kind = "audio_non_silent", glob = "skill-output/mofa-podcast/*.mp3", min_ratio = 0.3 },
+]
+
+[spawn_tasks.fm_voice_save]
+on_completion = [
+    { kind = "ominix_voice_exists", name_arg = "name" },
+]
+on_failure = ["notify_user:Voice registration failed"]

--- a/crates/octos-agent/tests/validator_runner.rs
+++ b/crates/octos-agent/tests/validator_runner.rs
@@ -137,6 +137,7 @@ async fn should_block_ready_when_required_command_validator_fails() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -170,6 +171,7 @@ async fn should_warn_but_not_block_when_optional_validator_fails() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -200,6 +202,7 @@ async fn should_record_duration_and_evidence_path_for_command_validator() {
         phase: ValidatorPhase::TurnEnd,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -237,6 +240,7 @@ async fn should_expose_stderr_in_outcome_for_operator_visibility() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -284,6 +288,7 @@ async fn should_kill_child_process_on_validator_timeout() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
 
     let before = std::time::Instant::now();
@@ -333,6 +338,7 @@ async fn should_pass_file_exists_validator_when_file_meets_size_floor() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -355,6 +361,7 @@ async fn should_fail_file_exists_validator_when_size_under_floor() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -372,6 +379,7 @@ async fn should_pass_tool_call_validator_when_tool_succeeds() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -388,6 +396,7 @@ async fn should_fail_tool_call_validator_when_tool_reports_unsuccessful() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -414,6 +423,7 @@ async fn should_persist_outcomes_and_replay_them_byte_for_byte() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let original = runner.run_all(&invocation, &validators).await;
     assert_eq!(original.len(), 2);
@@ -465,6 +475,7 @@ async fn should_strip_blocked_env_vars_from_command_validator_child() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     // Invoke via a helper that pre-seeds LD_PRELOAD on the spawned command.
     runner
@@ -516,6 +527,7 @@ async fn should_block_spawn_task_contract_when_required_validator_fails() {
             on_complete: Vec::new(),
             on_deliver: Vec::new(),
             on_failure: vec!["notify_user:validator gate failed".into()],
+            on_completion: Vec::new(),
         },
     );
     write_workspace_policy(dir.path(), &policy).unwrap();
@@ -593,6 +605,7 @@ async fn should_not_block_spawn_task_contract_when_optional_validator_fails() {
             on_complete: Vec::new(),
             on_deliver: Vec::new(),
             on_failure: Vec::new(),
+            on_completion: Vec::new(),
         },
     );
     write_workspace_policy(dir.path(), &policy).unwrap();
@@ -718,6 +731,7 @@ async fn should_block_command_validator_with_dangerous_pattern() {
         phase: ValidatorPhase::Completion,
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
+        input_args: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 

--- a/crates/octos-cli/src/commands/mcp_serve.rs
+++ b/crates/octos-cli/src/commands/mcp_serve.rs
@@ -529,6 +529,7 @@ async fn run_completion_validators(
         phase: ValidatorPhase::Completion,
         workspace_root: workspace_root.to_path_buf(),
         repo_label: format!("mcp-serve/{contract}"),
+        input_args: None,
     };
     let outcomes = run_workspace_validators(
         &runner,

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -1111,6 +1111,7 @@ impl PipelineExecutor {
                 &policy.validation.validators,
                 "pipeline",
                 ValidatorPhase::Completion,
+                None,
             )
             .await?;
         }
@@ -1187,6 +1188,7 @@ impl PipelineExecutor {
             &scoped,
             &format!("pipeline-node-{node_id}"),
             ValidatorPhase::Completion,
+            None,
         )
         .await
         .map(|_| ())

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -520,6 +520,7 @@ impl Swarm {
                 "{}/subtask/{}",
                 validator.invocation.repo_label, contract.contract_id
             ),
+            input_args: None,
         };
 
         let outcomes = validator.runner.run_all(&invocation, &scoped).await;

--- a/crates/octos-swarm/tests/subtask_contracts.rs
+++ b/crates/octos-swarm/tests/subtask_contracts.rs
@@ -104,6 +104,7 @@ fn aggregate_validator(
         phase: ValidatorPhase::Completion,
         workspace_root: workspace_dir.to_path_buf(),
         repo_label: "swarm-subtask-test".into(),
+        input_args: None,
     };
     AggregateValidator {
         runner,

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -451,6 +451,7 @@ async fn should_aggregate_validator_over_combined_output() {
         phase: ValidatorPhase::Completion,
         workspace_root: workspace_dir.path().to_path_buf(),
         repo_label: "swarm-test".into(),
+        input_args: None,
     };
     let validator = Validator {
         id: "aggregate_exists".into(),


### PR DESCRIPTION
## Summary

Adds four typed domain validators to the existing workspace-policy contract layer (NOT a parallel system) so the harness catches the silent-failure bug class at the spawn-task completion gate, before the LLM is told the task succeeded:

- **HttpProbe** — GET a templated URL (with `${args.<key>}` interpolation), assert status + optional body substring.
- **OminixVoiceExists** — assert `/v1/voices` on ominix-api contains the requested voice name; surfaces the available list in the failure reason so the LLM can react in one round.
- **AudioNonSilent** — decode WAV (always-on via `hound`) or MP3 (gated behind `audio_mp3` feature via `symphonia`) and assert `non_silent_samples / total_samples >= min_ratio`.
- **MagicBytes** — assert files matching a glob carry the expected file-format header (Mp3 / Wav / Png / Jpeg / Pdf / Mp4 / WebM). Catches "wrote 0 bytes" and "wrote an HTML error page in place of audio".

Schema lives at the workspace layer (operator-owned `.octos-workspace.toml`), NOT in per-skill `manifest.json`. The session default contract now declares these validators on `podcast_generate`, `voice_synthesize`, and `fm_voice_save` so the yangmi + silent-MP3 failure paths are caught out-of-the-box.

Extends `WorkspaceSpawnTaskPolicy` with an `on_completion: Vec<SpawnTaskValidatorSpec>` field for per-task validators (accepts either bare spec tables or full `Validator` structs). Threads `input_args` through `ValidatorInvocation` and a new `enforce_spawn_task_contract_with_args` entry point so `${args.<key>}` template interpolation works.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace --no-run` clean
- [x] `cargo test -p octos-agent` — 1542 tests pass (18 new validator unit tests + 1 new policy roundtrip test + existing 1523)
- [x] `cargo test -p octos-agent --test abi_compat` — 13 pass (updated `workspace_policy_v1_session.toml` fixture round-trips)
- [x] `cargo build -p octos-agent --features audio_mp3` clean (symphonia MP3 path compiles)
- [x] Synthetic audio failure caught: silent WAV decoded ratio=0.000 < min_ratio=0.300

🤖 Generated with [Claude Code](https://claude.com/claude-code)