### PR TITLE
chore(fmt): rustfmt drift on tool.rs + ui_protocol.rs (unblocks PR check job)

### DIFF
--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -372,9 +372,7 @@ impl PluginTool {
                     // `up/<base64>` (no display-name segment) via the
                     // legacy-relative fallback inside
                     // `resolve_upload_reference`.
-                    if let Some(resolved) =
-                        octos_bus::file_handle::resolve_upload_reference(path)
-                    {
+                    if let Some(resolved) = octos_bus::file_handle::resolve_upload_reference(path) {
                         rewritten.insert(
                             key.clone(),
                             serde_json::Value::String(resolved.to_string_lossy().into_owned()),

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1617,10 +1617,7 @@ fn decide_ws_origin_gate(headers: &HeaderMap, base_domain: Option<&str>) -> WsOr
                     let expected_suffix = format!(".{base}");
                     if let Some(tenant) = host.strip_suffix(&expected_suffix) {
                         // Single label only: non-empty, no dots, no port.
-                        if !tenant.is_empty()
-                            && !tenant.contains('.')
-                            && !tenant.contains(':')
-                        {
+                        if !tenant.is_empty() && !tenant.contains('.') && !tenant.contains(':') {
                             return WsOriginDecision::Allow;
                         }
                     }
@@ -11922,8 +11919,7 @@ mod tests {
             axum::http::header::ORIGIN,
             "https://attacker.dspfac.ocean.ominix.io".parse().unwrap(),
         );
-        let decision =
-            decide_ws_origin_gate(&headers, Some("ocean.ominix.io"));
+        let decision = decide_ws_origin_gate(&headers, Some("ocean.ominix.io"));
         assert!(matches!(
             decision,
             WsOriginDecision::RejectDisallowed { .. }
@@ -11939,8 +11935,7 @@ mod tests {
             axum::http::header::ORIGIN,
             "https://dspfac.ocean.ominix.io:8443".parse().unwrap(),
         );
-        let decision =
-            decide_ws_origin_gate(&headers, Some("ocean.ominix.io"));
+        let decision = decide_ws_origin_gate(&headers, Some("ocean.ominix.io"));
         assert!(matches!(
             decision,
             WsOriginDecision::RejectDisallowed { .. }


### PR DESCRIPTION
Pure mechanical `cargo fmt --all`. Unblocks the failing `check` job on PRs #934, #935, #936 — all three inherit drift introduced by #932 + #928 (which landed without local fmt).

No logic change.