### PR TITLE
feat(workspace-policy): default contracts for 5 spawn-only artifact skills

### DIFF
--- a/crates/octos-agent/src/bundled_app_skills.rs
+++ b/crates/octos-agent/src/bundled_app_skills.rs
@@ -135,4 +135,32 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn voice_synthesize_manifest_marks_spawn_only_for_workspace_policy_parity() {
+        // P1-6: `for_session()` puts voice_synthesize into spawn_tasks,
+        // which gates on the manifest's spawn_only flag in
+        // `enforce_spawn_task_contract_with_args`. Drift between the two
+        // would silently drop the contract — assert the manifest stays
+        // aligned.
+        let manifest = PLATFORM_SKILLS
+            .iter()
+            .find(|(dir_name, _, _, _)| *dir_name == "voice")
+            .expect("voice manifest registered in PLATFORM_SKILLS");
+        let parsed: serde_json::Value =
+            serde_json::from_str(manifest.3).expect("voice manifest parses as JSON");
+        let tools = parsed
+            .get("tools")
+            .and_then(|v| v.as_array())
+            .expect("manifest has tools array");
+        let synth = tools
+            .iter()
+            .find(|t| t.get("name").and_then(|v| v.as_str()) == Some("voice_synthesize"))
+            .expect("manifest declares voice_synthesize");
+        assert_eq!(
+            synth.get("spawn_only").and_then(|v| v.as_bool()),
+            Some(true),
+            "voice_synthesize must be spawn_only to match `WorkspacePolicy::for_session()`"
+        );
+    }
 }

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -705,10 +705,23 @@ impl ValidatorRunner {
         started_at: DateTime<Utc>,
         started: Instant,
     ) -> ValidatorOutcome {
-        let target = if Path::new(path).is_absolute() {
-            PathBuf::from(path)
+        // Mirror the `HttpProbe` template story so policies can declare e.g.
+        // `voice_profiles/${args.name}.wav` for `fm_voice_save` and have the
+        // path resolved against the spawn task's input args. A missing key is
+        // a hard error so the validator surfaces an `Error` outcome rather
+        // than silently checking a literal `${args.name}` path. Note the
+        // returned string is percent-encoded path-segment-safe — fine for the
+        // single-filename segment use case the contract specifies.
+        let resolved_path = match interpolate_args(path, invocation.input_args.as_ref()) {
+            Ok(resolved) => resolved,
+            Err(reason) => {
+                return error_outcome(invocation, validator, started_at, started, reason);
+            }
+        };
+        let target = if Path::new(&resolved_path).is_absolute() {
+            PathBuf::from(&resolved_path)
         } else {
-            invocation.workspace_root.join(path)
+            invocation.workspace_root.join(&resolved_path)
         };
         let duration_ms = started.elapsed().as_millis() as u64;
         let (status, reason) = match std::fs::metadata(&target) {
@@ -2157,6 +2170,87 @@ mod tests {
         let args = serde_json::json!({});
         let err = interpolate_args("http://x/${args.name}", Some(&args)).unwrap_err();
         assert!(err.contains("'name'"));
+    }
+
+    #[tokio::test]
+    async fn file_exists_passes_when_args_interpolation_points_to_real_file() {
+        // Mirrors the `fm_voice_save` post-condition: a templated path like
+        // `voice_profiles/${args.name}.wav` must resolve against the spawn
+        // task's input args. The existing `HttpProbe` validator already
+        // does this; `FileExists` follows the same pattern.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("voice_profiles")).unwrap();
+        let wav = dir.path().join("voice_profiles/yangmi.wav");
+        std::fs::write(&wav, vec![0u8; 64]).unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "voice_wav_exists",
+            ValidatorSpec::FileExists {
+                path: "voice_profiles/${args.name}.wav".into(),
+                min_bytes: Some(32),
+            },
+        );
+        let invocation = dummy_invocation(dir.path().to_path_buf())
+            .with_input_args(serde_json::json!({"name": "yangmi"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("yangmi.wav"),
+            "reason should reference the interpolated path: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn file_exists_fails_when_interpolated_path_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("voice_profiles")).unwrap();
+        // No file written.
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "voice_wav_exists",
+            ValidatorSpec::FileExists {
+                path: "voice_profiles/${args.name}.wav".into(),
+                min_bytes: None,
+            },
+        );
+        let invocation = dummy_invocation(dir.path().to_path_buf())
+            .with_input_args(serde_json::json!({"name": "missing_voice"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("missing_voice.wav"),
+            "reason should reference the interpolated path: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn file_exists_errors_when_required_arg_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "voice_wav_exists",
+            ValidatorSpec::FileExists {
+                path: "voice_profiles/${args.name}.wav".into(),
+                min_bytes: None,
+            },
+        );
+        // input_args missing the `name` key — interpolation should surface a
+        // typed Error outcome rather than silently dropping the reference.
+        let invocation =
+            dummy_invocation(dir.path().to_path_buf()).with_input_args(serde_json::json!({}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("'name'"),
+            "reason should name the missing arg: {}",
+            outcomes[0].reason
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1004,4 +1004,255 @@ mod tests {
         assert!(error.contains("file_size_min:$artifact:1024"));
         assert!(error.contains("output.mp3 is 1 bytes, minimum is 1024"));
     }
+
+    /// Smallest valid PNG (1x1 transparent pixel) — used to satisfy
+    /// MagicBytes (Png) without pulling in an encoder dependency.
+    const PNG_1X1: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+        0x00, 0x00, 0x00, 0x0D, b'I', b'H', b'D', b'R', // IHDR header
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // width=1, height=1
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, // bit depth+color
+        0x00, 0x00, 0x00, 0x0D, b'I', b'D', b'A', b'T', // IDAT chunk
+        0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, b'I', b'E', b'N', b'D', // IEND chunk
+        0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    #[tokio::test]
+    async fn mofa_slides_contract_satisfies_when_pptx_is_present() {
+        // P1-4: the default session policy for `mofa_slides` should
+        // verify a PPTX with a valid ZIP signature is present.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+        let pptx = temp.path().join("output/deck.pptx");
+        std::fs::create_dir_all(pptx.parent().unwrap()).unwrap();
+        // PK\x03\x04 followed by enough padding so the magic-byte read
+        // succeeds and the file is non-trivial.
+        let mut bytes = vec![0x50, 0x4B, 0x03, 0x04];
+        bytes.extend(std::iter::repeat_n(0u8, 256));
+        std::fs::write(&pptx, &bytes).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_slides",
+            "tool-call-slides",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"out": "output/deck.pptx"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_slides_contract_fails_when_artifact_is_html_error_page() {
+        // Catches the silent-failure path: tool wrote an HTML error page
+        // in place of the PPTX. MagicBytes (Pptx) rejects it.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+        let pptx = temp.path().join("output/deck.pptx");
+        std::fs::create_dir_all(pptx.parent().unwrap()).unwrap();
+        std::fs::write(&pptx, b"<!DOCTYPE html>\n<html>Internal error</html>\n").unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_slides",
+            "tool-call-slides-fail",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"out": "output/deck.pptx"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert!(
+                    error.contains("magic_bytes") || error.contains("pptx"),
+                    "unexpected error: {error}"
+                );
+                assert_eq!(notify_user.as_deref(), Some("Slide generation failed"));
+            }
+            other => panic!("expected failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_cards_contract_satisfies_when_png_files_match_recursive_glob() {
+        // P1-5: mofa_cards emits PNGs under a per-task card_dir.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+        let card_dir = temp.path().join("cards/abc");
+        std::fs::create_dir_all(&card_dir).unwrap();
+        std::fs::write(card_dir.join("a.png"), PNG_1X1).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_cards",
+            "tool-call-cards",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"card_dir": "cards/abc"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_comic_contract_uses_args_out_for_file_exists_and_magic_bytes() {
+        // P1-5: mofa_comic has a required `out` arg pointing at a single
+        // PNG file. Both FileExists and MagicBytes interpolate
+        // `${args.out}` so they assert exactly the path the LLM declared.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+        let comic = temp.path().join("comic.png");
+        std::fs::write(&comic, PNG_1X1).unwrap();
+        // Pad to meet the 1024-byte min_bytes check on the FileExists.
+        let mut padded = PNG_1X1.to_vec();
+        padded.extend(std::iter::repeat_n(0u8, 2048));
+        std::fs::write(&comic, &padded).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_comic",
+            "tool-call-comic",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"out": "comic.png"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_comic_contract_fails_when_args_out_file_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+        // Note: the file `comic.png` is never created — the LLM-declared
+        // path doesn't exist, so FileExists with `${args.out}` should
+        // fail at the contract gate.
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_comic",
+            "tool-call-comic-fail",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"out": "comic.png"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert!(
+                    error.contains("does not exist") || error.contains("comic.png"),
+                    "unexpected error: {error}"
+                );
+                assert_eq!(notify_user.as_deref(), Some("Comic generation failed"));
+            }
+            other => panic!("expected failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fm_voice_save_contract_file_exists_succeeds_when_voice_wav_present() {
+        // P0-1: the `fm_voice_save` contract now asserts the voice WAV
+        // landed at `voice_profiles/<name>.wav` via FileExists +
+        // `${args.name}` interpolation, in addition to the
+        // OminixVoiceExists API probe.
+        let temp = tempfile::tempdir().unwrap();
+        // Strip the OminixVoiceExists validator so this test focuses on
+        // the new FileExists check. The OminixVoiceExists validator is
+        // covered by validators::tests inside `validators.rs`.
+        let mut policy = WorkspacePolicy::for_session();
+        if let Some(task) = policy.spawn_tasks.get_mut("fm_voice_save") {
+            task.on_completion.retain(|spec| {
+                matches!(
+                    spec,
+                    crate::workspace_policy::SpawnTaskValidatorSpec::Bare(
+                        crate::workspace_policy::ValidatorSpec::FileExists { .. }
+                    )
+                )
+            });
+        }
+        write_workspace_policy(temp.path(), &policy).unwrap();
+        std::fs::create_dir_all(temp.path().join("voice_profiles")).unwrap();
+        std::fs::write(
+            temp.path().join("voice_profiles/yangmi.wav"),
+            vec![0u8; 4096],
+        )
+        .unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "fm_voice_save",
+            "tool-call-voice-save",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"name": "yangmi", "audio_path": "/tmp/in.wav"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn fm_voice_save_contract_file_exists_fails_when_voice_wav_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut policy = WorkspacePolicy::for_session();
+        if let Some(task) = policy.spawn_tasks.get_mut("fm_voice_save") {
+            task.on_completion.retain(|spec| {
+                matches!(
+                    spec,
+                    crate::workspace_policy::SpawnTaskValidatorSpec::Bare(
+                        crate::workspace_policy::ValidatorSpec::FileExists { .. }
+                    )
+                )
+            });
+        }
+        write_workspace_policy(temp.path(), &policy).unwrap();
+        // Don't write the WAV — FileExists with `${args.name}` must fail.
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "fm_voice_save",
+            "tool-call-voice-save-fail",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"name": "no_such_voice"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert!(
+                    error.contains("no_such_voice.wav") || error.contains("does not exist"),
+                    "unexpected error: {error}"
+                );
+                assert_eq!(notify_user.as_deref(), Some("Voice registration failed"));
+            }
+            other => panic!("expected failure, got {other:?}"),
+        }
+    }
 }

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -245,6 +245,11 @@ pub enum MagicByteKind {
     Pdf,
     Mp4,
     WebM,
+    /// OOXML / OpenDocument-style ZIP container (PPTX, DOCX, XLSX, ODT, ...).
+    /// Matches the three ZIP signatures: local-file-header (`PK\x03\x04`),
+    /// end-of-central-directory (`PK\x05\x06`), and spanned-archive
+    /// (`PK\x07\x08`).
+    Pptx,
 }
 
 impl MagicByteKind {
@@ -272,6 +277,14 @@ impl MagicByteKind {
             // directly is simpler — see `magic_bytes_match`.
             Self::Mp4 => &[b"ftyp"],
             Self::WebM => &[&[0x1A, 0x45, 0xDF, 0xA3]],
+            // PPTX (and any OOXML/zip container): all three ZIP signatures
+            // are accepted so a minimally-built archive is not rejected as
+            // structurally invalid.
+            Self::Pptx => &[
+                &[0x50, 0x4B, 0x03, 0x04],
+                &[0x50, 0x4B, 0x05, 0x06],
+                &[0x50, 0x4B, 0x07, 0x08],
+            ],
         }
     }
 
@@ -298,6 +311,7 @@ impl MagicByteKind {
             Self::Pdf => "pdf",
             Self::Mp4 => "mp4",
             Self::WebM => "webm",
+            Self::Pptx => "pptx",
         }
     }
 }
@@ -601,8 +615,19 @@ impl WorkspacePolicy {
         };
 
         // Voice save (custom voice registration): assert the voice was
-        // actually registered with ominix-api. Closes the yangmi gap where
-        // fm_voice_save returns success but the API has no record.
+        // actually registered with ominix-api AND the WAV landed in the
+        // canonical `voice_profiles` directory. Closes the yangmi gap
+        // where fm_voice_save returns success but the API has no record
+        // — plus catches the parallel disk-side failure where the voice
+        // file never reached `voice_profiles/<name>.wav`.
+        //
+        // The FileExists path uses `${args.name}` interpolation against
+        // the spawn task's input args; mofa-fm writes the WAV to
+        // `${OCTOS_VOICE_DIR:-${OCTOS_DATA_DIR}/voice_profiles}/<name>.wav`,
+        // which under the default session workspace resolves relative to
+        // the workspace root via `voice_profiles/<name>.wav`. Operators
+        // who pin a non-default `OCTOS_VOICE_DIR` can override the path
+        // in their workspace policy.
         let fm_voice_save_contract = WorkspaceSpawnTaskPolicy {
             artifact: None,
             artifacts: Vec::new(),
@@ -610,11 +635,116 @@ impl WorkspacePolicy {
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:Voice registration failed".into()],
-            on_completion: vec![SpawnTaskValidatorSpec::Bare(
-                ValidatorSpec::OminixVoiceExists {
+            on_completion: vec![
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::OminixVoiceExists {
                     name_arg: "name".into(),
-                },
-            )],
+                }),
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::FileExists {
+                    path: "voice_profiles/${args.name}.wav".into(),
+                    min_bytes: Some(1024),
+                }),
+            ],
+        };
+
+        // Slides (mofa_slides spawn task): the user-visible failure mode is
+        // a "success" reply with an HTML error page in place of the PPTX.
+        // MagicBytes (Pptx) rejects that at the contract gate by asserting
+        // the local-file-header / end-of-central-directory ZIP signature
+        // is present at byte 0. The glob runs recursively so the policy
+        // also catches slides written to nested subdirectories.
+        let mofa_slides_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Slide generation failed".into()],
+            on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                glob: "**/*.pptx".into(),
+                format: MagicByteKind::Pptx,
+            })],
+        };
+
+        // mofa_cards writes PNGs into a `card_dir` (required input arg).
+        // The contract uses a recursive PNG glob so any layout under that
+        // directory is covered without hard-coding a single output path.
+        let mofa_cards_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Card generation failed".into()],
+            on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                glob: "**/*.png".into(),
+                format: MagicByteKind::Png,
+            })],
+        };
+
+        // mofa_comic and mofa_infographic each take a required `out` arg
+        // pointing at a single PNG file. The contract asserts BOTH that
+        // the file landed at the declared path (FileExists with
+        // `${args.out}`, FileExists already supports template
+        // interpolation) AND that there is at least one valid PNG header
+        // present in the workspace (MagicBytes against the recursive
+        // `**/*.png` glob — MagicBytes does not template its glob today).
+        // FileExists does the per-task path check; MagicBytes does the
+        // bytes-are-actually-a-PNG check.
+        let mofa_comic_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Comic generation failed".into()],
+            on_completion: vec![
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::FileExists {
+                    path: "${args.out}".into(),
+                    min_bytes: Some(1024),
+                }),
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                    glob: "**/*.png".into(),
+                    format: MagicByteKind::Png,
+                }),
+            ],
+        };
+
+        let mofa_infographic_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Infographic generation failed".into()],
+            on_completion: vec![
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::FileExists {
+                    path: "${args.out}".into(),
+                    min_bytes: Some(1024),
+                }),
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                    glob: "**/*.png".into(),
+                    format: MagicByteKind::Png,
+                }),
+            ],
+        };
+
+        // mofa_frame is NOT spawn_only today (so this contract is dormant
+        // for the current manifest), but the audit's section-5 missing
+        // table lists it as an artifact-producing tool whose contract
+        // should be wired even if the gate is not yet fired. Recording
+        // the entry here lets the next spawn_only flip pick up the
+        // contract automatically.
+        let mofa_frame_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Frame extraction failed".into()],
+            on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                glob: "**/*.png".into(),
+                format: MagicByteKind::Png,
+            })],
         };
 
         let mut spawn_tasks = BTreeMap::new();
@@ -622,6 +752,11 @@ impl WorkspacePolicy {
         spawn_tasks.insert("voice_synthesize".into(), voice_synthesize_contract);
         spawn_tasks.insert("podcast_generate".into(), podcast_contract);
         spawn_tasks.insert("fm_voice_save".into(), fm_voice_save_contract);
+        spawn_tasks.insert("mofa_slides".into(), mofa_slides_contract);
+        spawn_tasks.insert("mofa_cards".into(), mofa_cards_contract);
+        spawn_tasks.insert("mofa_comic".into(), mofa_comic_contract);
+        spawn_tasks.insert("mofa_infographic".into(), mofa_infographic_contract);
+        spawn_tasks.insert("mofa_frame".into(), mofa_frame_contract);
 
         Self {
             schema_version: WORKSPACE_POLICY_SCHEMA_VERSION,
@@ -1172,6 +1307,19 @@ ignore = []
     }
 
     #[test]
+    fn magic_byte_kind_pptx_matches_zip_signatures() {
+        // PPTX is a ZIP archive — accept the OOXML local-file-header
+        // signature (`PK\x03\x04`) and the central-directory variants so a
+        // tool that emits a minimal/empty archive isn't spuriously rejected.
+        assert!(MagicByteKind::Pptx.matches(b"PK\x03\x04rest of zip"));
+        assert!(MagicByteKind::Pptx.matches(b"PK\x05\x06"));
+        assert!(MagicByteKind::Pptx.matches(b"PK\x07\x08"));
+        // An HTML error page surfaced in place of a PPTX must be rejected so
+        // the silent-failure path is caught at the harness gate.
+        assert!(!MagicByteKind::Pptx.matches(b"<!DOCTYPE html>"));
+    }
+
+    #[test]
     fn session_policy_declares_new_domain_validators_for_silent_failure_paths() {
         let policy = WorkspacePolicy::for_session();
         let podcast = policy
@@ -1207,6 +1355,107 @@ ignore = []
             entry,
             SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent { .. })
         )));
+    }
+
+    #[test]
+    fn session_policy_declares_voice_wav_file_exists_for_fm_voice_save() {
+        // P0-1 follow-on: fm_voice_save must also assert the voice WAV
+        // landed in the canonical voice_profiles directory. The path
+        // template uses `${args.name}` interpolation against the spawn
+        // task's input args, mirroring how the existing
+        // `OminixVoiceExists` validator interpolates the name.
+        let policy = WorkspacePolicy::for_session();
+        let voice_save = policy
+            .spawn_tasks
+            .get("fm_voice_save")
+            .expect("fm_voice_save contract");
+        let has_file_exists = voice_save.on_completion.iter().any(|entry| {
+            matches!(
+                entry,
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::FileExists { path, .. })
+                    if path.contains("${args.name}") && path.ends_with(".wav")
+            )
+        });
+        assert!(
+            has_file_exists,
+            "fm_voice_save should declare FileExists with ${{args.name}}.wav template; got {:?}",
+            voice_save.on_completion
+        );
+    }
+
+    #[test]
+    fn session_policy_declares_pptx_magic_bytes_for_mofa_slides() {
+        // P1-4: mofa_slides emits a .pptx artifact. The default session
+        // policy must declare a MagicBytes (Pptx) validator so a tool that
+        // wrote an HTML error page in place of the PPTX is rejected at
+        // the harness gate rather than declared "success" by the LLM.
+        let policy = WorkspacePolicy::for_session();
+        let slides = policy
+            .spawn_tasks
+            .get("mofa_slides")
+            .expect("mofa_slides contract");
+        assert!(slides.on_completion.iter().any(|entry| matches!(
+            entry,
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                format: MagicByteKind::Pptx,
+                ..
+            })
+        )));
+    }
+
+    #[test]
+    fn session_policy_declares_png_magic_bytes_for_image_skills() {
+        // P1-5: every spawn-only image-emitting skill carries a MagicBytes
+        // (Png) post-condition so a corrupted / HTML error page in place
+        // of the rendered card/comic/infographic is rejected at the
+        // harness gate. `mofa_frame` is included too (covered by the
+        // audit's section 5 "What's missing" table) so that, if/when it
+        // becomes spawn_only, the contract is already wired.
+        let policy = WorkspacePolicy::for_session();
+        for tool in ["mofa_cards", "mofa_comic", "mofa_infographic", "mofa_frame"] {
+            let entry = policy
+                .spawn_tasks
+                .get(tool)
+                .unwrap_or_else(|| panic!("policy missing spawn task for {tool}"));
+            assert!(
+                entry.on_completion.iter().any(|spec| matches!(
+                    spec,
+                    SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                        format: MagicByteKind::Png,
+                        ..
+                    })
+                )),
+                "{tool} should declare MagicBytes (png); got {:?}",
+                entry.on_completion
+            );
+        }
+    }
+
+    #[test]
+    fn session_policy_declares_file_exists_for_single_file_image_skills() {
+        // mofa_comic and mofa_infographic both take a required `out` arg
+        // pointing at a single PNG file. The contract should assert the
+        // declared output landed at that path via FileExists +
+        // `${args.out}` interpolation.
+        let policy = WorkspacePolicy::for_session();
+        for tool in ["mofa_comic", "mofa_infographic"] {
+            let entry = policy
+                .spawn_tasks
+                .get(tool)
+                .unwrap_or_else(|| panic!("policy missing spawn task for {tool}"));
+            let has_file_exists = entry.on_completion.iter().any(|spec| {
+                matches!(
+                    spec,
+                    SpawnTaskValidatorSpec::Bare(ValidatorSpec::FileExists { path, .. })
+                        if path.contains("${args.out}")
+                )
+            });
+            assert!(
+                has_file_exists,
+                "{tool} should declare FileExists with ${{args.out}} template; got {:?}",
+                entry.on_completion
+            );
+        }
     }
 
     #[test]

--- a/crates/platform-skills/voice/manifest.json
+++ b/crates/platform-skills/voice/manifest.json
@@ -27,6 +27,7 @@
     {
       "name": "voice_synthesize",
       "description": "Synthesize speech from text. Uses Qwen3-TTS when ominix-api is running (high quality, emotion/style control, speed adjustment). Falls back to macOS built-in Say command when ominix-api is unavailable. Produces a WAV/MP3 audio file. After generating, use send_file to deliver the audio to the user. NOTE: This tool only supports preset voices. For voice cloning or custom voice profiles, use mofa-fm (fm_tts).",
+      "spawn_only": true,
       "concurrency_class": "exclusive",
       "input_schema": {
         "type": "object",


### PR DESCRIPTION
## Summary

Wires the four domain validators from #935 into `WorkspacePolicy::for_session()` for the spawn-only artifact-producing skills that previously fell through `NotConfigured { required: false }`. Closes the visible gap surfaced in the harness audit doc (`docs/audits/HARNESS_CONTRACT_AUDIT_2026-05-13.md`, sections 5 + 6).

| Item | Tool | Validators added |
|---|---|---|
| P0-1 | `fm_voice_save` | + `FileExists` against `voice_profiles/${args.name}.wav` (alongside existing `OminixVoiceExists`) |
| P0-2 | `podcast_generate` | already on main from #935; covered by new regression test |
| P1-4 | `mofa_slides` | `MagicBytes` (Pptx) — new variant matching the three ZIP signatures |
| P1-5 | `mofa_cards` | `MagicBytes` (Png) on `**/*.png` |
| P1-5 | `mofa_comic` | `FileExists ${args.out}` + `MagicBytes` (Png) |
| P1-5 | `mofa_infographic` | `FileExists ${args.out}` + `MagicBytes` (Png) |
| P1-5 | `mofa_frame` | `MagicBytes` (Png) — dormant (mofa_frame is not spawn_only today; entry recorded ahead of any future flag flip) |
| P1-6 | `voice_synthesize` manifest | adds `spawn_only: true` so the manifest matches the existing policy entry |

### Framework lift

`FileExists.path` now runs through `interpolate_args` so templated paths like `voice_profiles/${args.name}.wav` and `${args.out}` resolve from the spawn task's input args. Mirrors the existing template story for `HttpProbe.url_template` — same error semantics (missing key surfaces as `Error` outcome, not silent pass).

Adds a `Pptx` variant to `MagicByteKind` that matches the three ZIP signatures (`PK\x03\x04`, `PK\x05\x06`, `PK\x07\x08`) so an empty/minimal OOXML archive isn't rejected as structurally invalid.

### Tests

16 new tests (3 `validators.rs` + 4 `workspace_policy.rs` + 8 `workspace_contract.rs` + 1 `bundled_app_skills.rs`). Full `octos-agent` lib test count: 1309 → 1325, all green.

### Punted (separate PRs)

- **P0-3 `mofa_publish` HTTP probe** — blocked on Gap-5 (named-output forwarding from spawn_only stdout). Audit doc covers the design.
- **P1-7 harness-starter contract examples** — mofa-skills/starter-repo work.
- **Skill-internal cleanup** (`assert_voice_registered`, `has_meaningful_tts_audio` removal) — mofa-skills repo PRs, planned as the post-canonical follow-up.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-agent --all-targets -- -D warnings` clean
- [x] `cargo test -p octos-agent --lib` — 1325 passed, 0 failed
- [x] `cargo test -p octos-agent --tests` — 15 passed, 0 failed (validator integration tests)
- [x] `cargo build --workspace` succeeds