### PR TITLE
chore(scripts): fleet-install-skills.sh — routed, sha256-verified, per-profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ scripts/deploy.sh
 !docs/M9-ALPHA-SOLE-TRANSPORT-ADR.md
 !docs/M9-GAMMA-SERVER-PROJECTION-ADR.md
 !docs/M11-PROFILE-SESSION-RUNTIME-ADR.md
+!docs/SKILL_DEPLOYMENT.md
 !workstreams/M11-runtime-unification.md
 !workstreams/M11-SOAK-TESTS.md
 # Canonical product/engineering spec docs under api/. The UI Protocol v1

--- a/docs/SKILL_DEPLOYMENT.md
+++ b/docs/SKILL_DEPLOYMENT.md
@@ -1,0 +1,141 @@
+# Skill Fleet Deployment
+
+This document covers operator-side deployment of skill packages onto an
+octos fleet (e.g. the mini1-5 cluster). It supersedes the legacy
+`mofa-skills/scripts/deploy-mini.sh` raw-scp flow.
+
+Related docs: [`STRICT_ACCOUNT_SCOPED_SKILLS.md`](./STRICT_ACCOUNT_SCOPED_SKILLS.md)
+for the architectural decision to make skill installs per-profile only.
+
+## Why per-profile only
+
+Customer skills resolve from exactly one place:
+
+```
+~/.octos/profiles/<account-or-subaccount>/data/skills/
+```
+
+No parent-profile inheritance, no project-level fallback, no global
+customer-skill layer. See `STRICT_ACCOUNT_SCOPED_SKILLS.md` for the rationale.
+The global `~/.octos/skills/` directory is being deprecated; a parallel change
+in the agent loader (`octos-agent/src/plugins/loader.rs`) emits a deprecation
+warning when it sees that path on disk.
+
+## What replaces `deploy-mini.sh`
+
+`scripts/fleet-install-skills.sh` is the single canonical entry point for
+pushing mofa-skills onto the fleet. Differences from the old script:
+
+| Concern                | `deploy-mini.sh` (legacy)            | `fleet-install-skills.sh` (new)                              |
+|------------------------|--------------------------------------|---------------------------------------------------------------|
+| Transport              | raw `scp` of each file               | `rsync` to staging + `octos skills install <staging-path>`    |
+| sha256 verification    | none                                 | yes, via `manage_skills::download_binary` when manifest binaries are declared |
+| Install path           | hard-coded `~/.octos/profiles/dspfac/data/skills/` | resolved server-side by `--profile <id>`                      |
+| Multi-profile          | one profile per run                  | iterates every profile on the host (or explicit `--profile`)  |
+| Multi-host             | one host per invocation              | full fleet by default; subset via `--host`                    |
+| Failure isolation      | aborts on first failure              | logs and continues; summary table at the end                  |
+| Idempotency            | always re-copies                     | re-runnable; uses `--force` by default for deterministic state |
+| Dry-run                | none                                 | `--dry-run` prints every command without execution            |
+
+## How `fleet-install-skills.sh` works
+
+For each (host, profile, skill) triple, the script:
+
+1. `rsync -az --delete <mofa-skills>/<skill>/ <host>:/tmp/octos-fleet-install-staging/<skill>/`
+2. `ssh <host> "OCTOS_PROFILE_ID=<p> /Users/cloud/.octos/bin/octos skills --profile <p> install /tmp/octos-fleet-install-staging/<skill> --force"`
+3. Records OK / FAIL with the tail of stderr.
+4. Cleans up staging at the end of the host.
+
+The `octos skills install <local-path>` path
+(`crates/octos-cli/src/commands/skills.rs::install_from_local`) then:
+
+- Resolves the target directory via `resolve_profile_skills_dir` —
+  strictly per-account, per `STRICT_ACCOUNT_SCOPED_SKILLS.md`.
+- Copies the staged dir into the per-profile `data/skills/<skill>/`.
+- Runs `maybe_install_binary` — which, when the skill's `manifest.json`
+  declares a `binaries.<platform>.url` + `sha256`, downloads and
+  sha256-verifies the binary. Falls back to `cargo build --release` if
+  the skill ships source.
+- Writes `.source` for future `skills update` calls.
+
+The result: every install goes through the same code path the runtime
+`manage_skills` tool uses. `scp` is no longer in the picture.
+
+## CLI
+
+```
+scripts/fleet-install-skills.sh [OPTIONS]
+
+  --host LIST          Comma/space hosts (default: 69.194.3.{128,129,203,66,19})
+  --profile LIST       Comma-separated profile IDs (default: enumerate per host)
+  --skill LIST         Comma-separated skill names (default: all mofa-* with
+                       SKILL.md+manifest.json in MOFA_SKILLS_DIR)
+  --mofa-dir PATH      mofa-skills checkout (default: ~/home/mofa-skills)
+  --remote-bin PATH    octos binary on remote (default: /Users/cloud/.octos/bin/octos)
+  --remote-user USER   SSH user (default: cloud)
+  --no-force           Skip skills that already exist instead of overwriting
+  --dry-run            Print commands without executing
+  --verbose, -v        Echo each command before running
+  --help, -h           Show usage
+```
+
+Environment overrides: `OCTOS_FLEET_HOSTS`, `MOFA_SKILLS_DIR`,
+`OCTOS_REMOTE_BIN`, `OCTOS_REMOTE_USER`, `OCTOS_REMOTE_STAGING`.
+
+## Migration: hosts that already have `~/.octos/skills/` populated
+
+If a host has the legacy global directory, copy each skill into every
+profile's `data/skills/`, then remove the global dir. The loader will
+emit a deprecation warning on every startup until this is done.
+
+```sh
+# On the host:
+for skill in ~/.octos/skills/*/; do
+    name=$(basename "$skill")
+    for profile_data in ~/.octos/profiles/*/data; do
+        mkdir -p "$profile_data/skills"
+        cp -R "$skill" "$profile_data/skills/$name"
+    done
+done
+
+# Once verified the runtime sees the per-profile copies:
+rm -rf ~/.octos/skills/
+```
+
+After running `fleet-install-skills.sh` from your dev box, the per-profile
+copies become the canonical source — at that point you can purge the
+global dir without copying first.
+
+## Verification after deploy
+
+For each host:
+
+```sh
+ssh cloud@<host> 'ls -la ~/.octos/profiles/*/data/skills/'
+```
+
+You should see fresh mtimes on every (profile, skill) pair the script
+touched. The daemon log (`launchctl print gui/$(id -u)/io.octos.serve`,
+or wherever `io.octos.serve` writes its stderr) must NOT show
+`loaded unverified plugin` warnings — those only stop appearing after
+mofa-skills ships sha256-equipped manifests, which is the parallel PR
+tracked separately.
+
+## Tests
+
+`scripts/tests/test-fleet-install-skills.sh` runs entirely offline. It
+exercises the dry-run plan, error paths (unknown skill, missing
+mofa-dir), and the `--no-force` / env-override flags. Invoke directly:
+
+```sh
+bash scripts/tests/test-fleet-install-skills.sh
+```
+
+Also runs `shellcheck` against `scripts/fleet-install-skills.sh`.
+
+## Deprecation of `mofa-skills/scripts/deploy-mini.sh`
+
+The legacy script in `mofa-skills/scripts/deploy-mini.sh` now errors out
+with a redirect message pointing at `fleet-install-skills.sh`. The legacy
+behavior is gated behind `OCTOS_DEPRECATED_SCP=1` for emergencies; do not
+rely on it.

--- a/scripts/fleet-install-skills.sh
+++ b/scripts/fleet-install-skills.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# fleet-install-skills.sh — Install mofa-skills onto every fleet mini through
+# `octos skills install`, so every install routes through the same code path
+# that verifies manifest sha256 sums and resolves the correct per-profile
+# install directory.
+#
+# This script REPLACES the legacy raw-scp deploy in mofa-skills/scripts/
+# deploy-mini.sh, which bypassed sha256 verification and hard-coded
+# operator-side profile paths.
+#
+# Usage:
+#   scripts/fleet-install-skills.sh
+#   scripts/fleet-install-skills.sh --host 69.194.3.128,69.194.3.129
+#   scripts/fleet-install-skills.sh --profile dspfac --skill mofa-cli,mofa-cards
+#   scripts/fleet-install-skills.sh --dry-run
+#
+# Environment:
+#   OCTOS_FLEET_HOSTS         Space-or-comma-separated host override (same as --host)
+#   MOFA_SKILLS_DIR           Path to mofa-skills checkout (default: ~/home/mofa-skills)
+#   OCTOS_REMOTE_BIN          Path to octos binary on remote (default:
+#                             /Users/cloud/.octos/bin/octos)
+#   OCTOS_REMOTE_USER         SSH user on remote hosts (default: cloud)
+#
+# Per host, per profile, per skill:
+#   1. rsync the local skill directory to a remote staging path
+#   2. SSH in, run `OCTOS_PROFILE_ID=<p> octos skills --profile <p> install
+#      <staging_path> --force` so the install routes through the same code
+#      path as the runtime tool (verifies manifest sha256, builds binaries,
+#      writes .source for `skills update`)
+#   3. On failure, log host+profile+skill+stderr tail and CONTINUE; do not
+#      abort the whole run on one failure
+#
+# After all hosts, print a summary table: OK / FAIL / SKIP per
+# (host x profile x skill).
+
+set -eEuo pipefail
+
+# ─── Defaults ────────────────────────────────────────────────────────────
+DEFAULT_HOSTS="69.194.3.128 69.194.3.129 69.194.3.203 69.194.3.66 69.194.3.19"
+DEFAULT_MOFA_DIR="$HOME/home/mofa-skills"
+DEFAULT_REMOTE_BIN="/Users/cloud/.octos/bin/octos"
+DEFAULT_REMOTE_USER="cloud"
+DEFAULT_REMOTE_STAGING="/tmp/octos-fleet-install-staging"
+
+HOSTS_ARG="${OCTOS_FLEET_HOSTS:-}"
+PROFILES_ARG=""
+SKILLS_ARG=""
+MOFA_DIR="${MOFA_SKILLS_DIR:-$DEFAULT_MOFA_DIR}"
+REMOTE_BIN="${OCTOS_REMOTE_BIN:-$DEFAULT_REMOTE_BIN}"
+REMOTE_USER="${OCTOS_REMOTE_USER:-$DEFAULT_REMOTE_USER}"
+REMOTE_STAGING="${OCTOS_REMOTE_STAGING:-$DEFAULT_REMOTE_STAGING}"
+DRY_RUN=false
+FORCE=true   # default: re-install on every run; idempotent because content hashes match
+VERBOSE=false
+
+# ─── Argument parsing ────────────────────────────────────────────────────
+usage() {
+    cat <<'USAGE'
+fleet-install-skills.sh — Install mofa-skills onto fleet minis via
+`octos skills install` (sha256-verified, per-profile).
+
+Usage:
+  fleet-install-skills.sh [OPTIONS]
+
+Options:
+  --host LIST          Comma-or-space separated hosts (default: mini1-5 IPs)
+                       Overrides OCTOS_FLEET_HOSTS
+  --profile LIST       Comma-separated profile IDs (default: every profile
+                       enumerated from ~/.octos/profiles/*/data on each host)
+  --skill LIST         Comma-separated skill names (default: every dir under
+                       MOFA_SKILLS_DIR with SKILL.md AND manifest.json)
+  --mofa-dir PATH      Path to mofa-skills checkout (default: ~/home/mofa-skills)
+  --remote-bin PATH    Path to octos binary on the remote
+                       (default: /Users/cloud/.octos/bin/octos)
+  --remote-user USER   SSH user (default: cloud)
+  --no-force           Do NOT pass --force; `octos skills install` will SKIP
+                       skills that already exist
+  --dry-run            Print every command that WOULD run; execute nothing
+  --verbose, -v        Echo each command before running it
+  --help, -h           Show this help
+
+Environment overrides:
+  OCTOS_FLEET_HOSTS         Same as --host
+  MOFA_SKILLS_DIR           Same as --mofa-dir
+  OCTOS_REMOTE_BIN          Same as --remote-bin
+  OCTOS_REMOTE_USER         Same as --remote-user
+  OCTOS_REMOTE_STAGING      Remote staging path (default: /tmp/octos-fleet-install-staging)
+
+Examples:
+  # Dry-run against the full fleet
+  scripts/fleet-install-skills.sh --dry-run
+
+  # Single host, single profile, single skill
+  scripts/fleet-install-skills.sh \
+      --host 69.194.3.129 --profile dspfac --skill mofa-cli
+
+  # Override host list via env
+  OCTOS_FLEET_HOSTS=69.194.3.66 scripts/fleet-install-skills.sh
+USAGE
+}
+
+needval() {
+    if [ $# -lt 2 ] || case "$2" in -*) true ;; *) false ;; esac; then
+        echo "ERROR: $1 requires a value" >&2
+        exit 1
+    fi
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --host)        needval "$@"; HOSTS_ARG="$2"; shift 2 ;;
+        --profile)     needval "$@"; PROFILES_ARG="$2"; shift 2 ;;
+        --skill)       needval "$@"; SKILLS_ARG="$2"; shift 2 ;;
+        --mofa-dir)    needval "$@"; MOFA_DIR="$2"; shift 2 ;;
+        --remote-bin)  needval "$@"; REMOTE_BIN="$2"; shift 2 ;;
+        --remote-user) needval "$@"; REMOTE_USER="$2"; shift 2 ;;
+        --no-force)    FORCE=false; shift ;;
+        --dry-run)     DRY_RUN=true; shift ;;
+        --verbose|-v)  VERBOSE=true; shift ;;
+        --help|-h)     usage; exit 0 ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+log()    { echo "    $*"; }
+warn()   { echo "    WARN: $*" >&2; }
+err()    { echo "    ERROR: $*" >&2; }
+section(){ echo ""; echo "==> $*"; }
+
+run_or_print() {
+    if [ "$VERBOSE" = "true" ]; then
+        echo "    \$ $*"
+    fi
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "    [dry-run] $*"
+        return 0
+    fi
+    "$@"
+}
+
+# Normalise a "a,b c" list into a newline-separated stream.
+list_to_lines() {
+    printf '%s' "$1" | tr ',' '\n' | tr ' ' '\n' | awk 'NF'
+}
+
+# SSH wrapper with ControlMaster reuse (see CLAUDE memory reference_minis_ssh.md).
+# Each call runs through the cached socket if present, falling back to a fresh
+# connection otherwise. -BatchMode forbids password prompts: the operator is
+# expected to have keys configured (mini4) or sshpass-wrapped aliases (mini1/2/3/5).
+ssh_remote() {
+    local host="$1"; shift
+    ssh \
+        -o ControlMaster=auto \
+        -o ControlPath="$HOME/.ssh/cm/%r@%h:%p" \
+        -o ControlPersist=60 \
+        -o BatchMode=yes \
+        -o StrictHostKeyChecking=no \
+        -o ConnectTimeout=10 \
+        "${REMOTE_USER}@${host}" \
+        "$@"
+}
+
+# shellcheck disable=SC2329  # invoked indirectly via run_or_print
+rsync_to_remote() {
+    local host="$1"; local src="$2"; local dest="$3"
+    rsync -az --delete \
+        -e "ssh -o ControlMaster=auto -o ControlPath=$HOME/.ssh/cm/%r@%h:%p -o ControlPersist=60 -o BatchMode=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10" \
+        "$src" "${REMOTE_USER}@${host}:${dest}"
+}
+
+# ─── Resolve hosts ───────────────────────────────────────────────────────
+if [ -z "$HOSTS_ARG" ]; then
+    HOSTS_ARG="$DEFAULT_HOSTS"
+fi
+HOSTS=()
+while IFS= read -r h; do
+    [ -n "$h" ] && HOSTS+=("$h")
+done < <(list_to_lines "$HOSTS_ARG")
+
+if [ ${#HOSTS[@]} -eq 0 ]; then
+    err "no hosts to process"
+    exit 1
+fi
+
+# ─── Resolve skills (catalog from MOFA_SKILLS_DIR) ───────────────────────
+ALL_SKILLS=()
+if [ ! -d "$MOFA_DIR" ]; then
+    err "MOFA_SKILLS_DIR does not exist: $MOFA_DIR"
+    exit 1
+fi
+# Canonical "all skills" = every dir under MOFA_SKILLS_DIR matching `mofa-*`
+# that contains BOTH SKILL.md and manifest.json. The deploy-mini.sh legacy
+# script used SKILL.md alone, but we tighten to manifest.json so we only
+# install skills with the metadata `octos skills install` expects.
+for d in "$MOFA_DIR"/mofa-*/; do
+    [ -d "$d" ] || continue
+    [ -f "$d/SKILL.md" ] || continue
+    [ -f "$d/manifest.json" ] || continue
+    ALL_SKILLS+=("$(basename "$d")")
+done
+
+if [ -n "$SKILLS_ARG" ]; then
+    SKILLS=()
+    while IFS= read -r s; do
+        [ -z "$s" ] && continue
+        if ! printf '%s\n' "${ALL_SKILLS[@]}" | grep -qx "$s"; then
+            err "unknown skill: '$s' (not under $MOFA_DIR with SKILL.md+manifest.json)"
+            exit 1
+        fi
+        SKILLS+=("$s")
+    done < <(list_to_lines "$SKILLS_ARG")
+else
+    SKILLS=("${ALL_SKILLS[@]}")
+fi
+
+if [ ${#SKILLS[@]} -eq 0 ]; then
+    err "no skills to install (looked in $MOFA_DIR for mofa-* with SKILL.md+manifest.json)"
+    exit 1
+fi
+
+# ─── Profile enumeration per host ────────────────────────────────────────
+# If --profile was given, every host installs into the same explicit set.
+# Otherwise, query each host: `ls ~/.octos/profiles/*/data` -> profile IDs.
+EXPLICIT_PROFILES=()
+if [ -n "$PROFILES_ARG" ]; then
+    while IFS= read -r p; do
+        [ -n "$p" ] && EXPLICIT_PROFILES+=("$p")
+    done < <(list_to_lines "$PROFILES_ARG")
+fi
+
+# Enumerate profiles on a single host. Echoes one profile ID per line.
+# On SSH failure prints nothing (caller handles empty as host-unreachable).
+enumerate_profiles() {
+    local host="$1"
+    # Sniff ~/.octos/profiles for any subdir that contains a `data` child.
+    # We don't trust globbing the operator's shell so we run a tiny `find`.
+    ssh_remote "$host" \
+        "find ~/.octos/profiles -mindepth 2 -maxdepth 2 -type d -name data 2>/dev/null \
+         | sed 's|.*/profiles/||; s|/data\$||' \
+         | sort -u" \
+        2>/dev/null || true
+}
+
+# ─── Plan summary ────────────────────────────────────────────────────────
+section "Fleet install plan"
+log "Hosts:        ${HOSTS[*]}"
+log "Skills:       ${SKILLS[*]}"
+log "Mofa dir:     $MOFA_DIR"
+log "Remote bin:   $REMOTE_BIN"
+log "Remote user:  $REMOTE_USER"
+log "Remote stage: $REMOTE_STAGING"
+if [ -n "$PROFILES_ARG" ]; then
+    log "Profiles:     ${EXPLICIT_PROFILES[*]} (explicit)"
+else
+    log "Profiles:     <enumerate per host>"
+fi
+if [ "$FORCE" = "true" ]; then
+    log "Force:        yes (--force on every install)"
+else
+    log "Force:        no (skip skills that already exist)"
+fi
+if [ "$DRY_RUN" = "true" ]; then
+    log "Mode:         DRY-RUN (no remote mutation)"
+fi
+
+mkdir -p "$HOME/.ssh/cm" 2>/dev/null || true
+
+# ─── Results matrix ──────────────────────────────────────────────────────
+# Each entry: "<host>|<profile>|<skill>|<status>|<note>"
+# Status is one of: OK, FAIL, SKIP
+RESULTS=()
+
+record() {
+    local host="$1" profile="$2" skill="$3" status="$4" note="${5:-}"
+    RESULTS+=("$host|$profile|$skill|$status|$note")
+}
+
+# ─── Per-host work ───────────────────────────────────────────────────────
+for host in "${HOSTS[@]}"; do
+    section "Host: $host"
+
+    # ── Profiles for this host ──
+    if [ ${#EXPLICIT_PROFILES[@]} -gt 0 ]; then
+        PROFILES=("${EXPLICIT_PROFILES[@]}")
+    else
+        PROFILES=()
+        if [ "$DRY_RUN" = "true" ]; then
+            # In dry-run we never SSH; show that we WOULD enumerate.
+            log "[dry-run] would enumerate profiles via SSH on $host"
+            PROFILES=("<dry-run-enumerated>")
+        else
+            log "Enumerating profiles via SSH..."
+            while IFS= read -r p; do
+                [ -n "$p" ] && PROFILES+=("$p")
+            done < <(enumerate_profiles "$host")
+            if [ ${#PROFILES[@]} -eq 0 ]; then
+                warn "no profiles found on $host (host unreachable or no profiles directory)"
+                for skill in "${SKILLS[@]}"; do
+                    record "$host" "<none>" "$skill" "SKIP" "no profiles"
+                done
+                continue
+            fi
+            log "Found profiles: ${PROFILES[*]}"
+        fi
+    fi
+
+    # ── Stage skills onto host (one rsync per skill) ──
+    if [ "$DRY_RUN" != "true" ]; then
+        run_or_print ssh_remote "$host" "mkdir -p '$REMOTE_STAGING'"
+    else
+        log "[dry-run] would: ssh $host mkdir -p $REMOTE_STAGING"
+    fi
+
+    for skill in "${SKILLS[@]}"; do
+        src="$MOFA_DIR/$skill"
+        if [ ! -d "$src" ]; then
+            warn "skill '$skill' missing locally at $src"
+            for p in "${PROFILES[@]}"; do
+                record "$host" "$p" "$skill" "FAIL" "missing locally"
+            done
+            continue
+        fi
+        # Stage to $REMOTE_STAGING/$skill (rsync with trailing-slash semantics
+        # so contents end up at the dest, not nested).
+        if [ "$DRY_RUN" = "true" ]; then
+            log "[dry-run] would: rsync $src/ -> $host:$REMOTE_STAGING/$skill/"
+        else
+            if ! run_or_print rsync_to_remote "$host" "$src/" "$REMOTE_STAGING/$skill/"; then
+                warn "rsync failed for skill=$skill on host=$host"
+                for p in "${PROFILES[@]}"; do
+                    record "$host" "$p" "$skill" "FAIL" "rsync staging failed"
+                done
+                continue
+            fi
+        fi
+
+        # Per-profile install via the routed CLI. This is THE point of the
+        # script: every install goes through `octos skills install <local-path>`
+        # so the per-profile dir is resolved server-side and (when the
+        # manifest declares binaries) the sha256 of the downloaded binary
+        # is verified.
+        for profile in "${PROFILES[@]}"; do
+            force_flag=""
+            [ "$FORCE" = "true" ] && force_flag="--force"
+            install_cmd="OCTOS_PROFILE_ID='$profile' '$REMOTE_BIN' skills --profile '$profile' install '$REMOTE_STAGING/$skill' $force_flag"
+
+            if [ "$DRY_RUN" = "true" ]; then
+                log "[dry-run] would: ssh $host -- $install_cmd"
+                record "$host" "$profile" "$skill" "OK" "dry-run"
+                continue
+            fi
+
+            # Capture stderr tail on failure for the summary.
+            tmp_err="$(mktemp -t octos-fleet-err.XXXXXX)"
+            if ssh_remote "$host" "$install_cmd" >/dev/null 2>"$tmp_err"; then
+                record "$host" "$profile" "$skill" "OK" ""
+                log "OK   $profile / $skill"
+            else
+                tail_msg=$(tail -n 3 "$tmp_err" | tr '\n' '|' | sed 's/|$//')
+                record "$host" "$profile" "$skill" "FAIL" "$tail_msg"
+                warn "FAIL $profile / $skill: $tail_msg"
+            fi
+            rm -f "$tmp_err"
+        done
+    done
+
+    # ── Cleanup staging ──
+    if [ "$DRY_RUN" != "true" ]; then
+        run_or_print ssh_remote "$host" "rm -rf '$REMOTE_STAGING'" || true
+    fi
+done
+
+# ─── Summary ─────────────────────────────────────────────────────────────
+section "Summary"
+ok_count=0
+fail_count=0
+skip_count=0
+printf '    %-18s  %-20s  %-22s  %-4s  %s\n' "HOST" "PROFILE" "SKILL" "RES" "NOTE"
+printf '    %-18s  %-20s  %-22s  %-4s  %s\n' "----" "-------" "-----" "---" "----"
+for row in "${RESULTS[@]}"; do
+    IFS='|' read -r host profile skill status note <<<"$row"
+    printf '    %-18s  %-20s  %-22s  %-4s  %s\n' "$host" "$profile" "$skill" "$status" "$note"
+    case "$status" in
+        OK)   ok_count=$((ok_count + 1)) ;;
+        FAIL) fail_count=$((fail_count + 1)) ;;
+        SKIP) skip_count=$((skip_count + 1)) ;;
+    esac
+done
+
+echo ""
+log "Totals: OK=$ok_count FAIL=$fail_count SKIP=$skip_count"
+if [ "$DRY_RUN" = "true" ]; then
+    log "(dry-run — no remote state was modified)"
+fi
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 2
+fi
+exit 0

--- a/scripts/tests/test-fleet-install-skills.sh
+++ b/scripts/tests/test-fleet-install-skills.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# test-fleet-install-skills.sh — Lint + dry-run smoke tests for
+# scripts/fleet-install-skills.sh.
+#
+# Runs entirely offline. Validates:
+#   1. shellcheck passes
+#   2. --help prints usage and exits 0
+#   3. Unknown skill rejected with exit 1
+#   4. Unknown skill error message mentions the bad name
+#   5. Missing MOFA_SKILLS_DIR rejected with exit 1
+#   6. --dry-run plan output covers every (host, skill) pair when explicit
+#   7. --no-force omits --force flag in dry-run command preview
+#
+# This test creates an isolated mofa-skills tree under a temp dir so it does
+# not depend on the operator's checkout.
+
+set -eEuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET="$ROOT_DIR/scripts/fleet-install-skills.sh"
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+fail() {
+    echo "  FAIL: $*" >&2
+    FAIL=$((FAIL + 1))
+}
+pass() {
+    echo "  OK:   $*"
+    PASS=$((PASS + 1))
+}
+
+# Build a fake mofa-skills tree the script can enumerate.
+make_fixture() {
+    local root="$1"
+    mkdir -p "$root"
+    for name in mofa-foo mofa-bar; do
+        mkdir -p "$root/$name"
+        : > "$root/$name/SKILL.md"
+        : > "$root/$name/manifest.json"
+    done
+    # Decoy: dir without manifest should NOT be picked up.
+    mkdir -p "$root/mofa-decoy"
+    : > "$root/mofa-decoy/SKILL.md"
+    # Decoy: non-mofa-* name with both files should NOT be picked up either.
+    mkdir -p "$root/other-skill"
+    : > "$root/other-skill/SKILL.md"
+    : > "$root/other-skill/manifest.json"
+}
+
+run_dry() {
+    local fixture="$1"; shift
+    MOFA_SKILLS_DIR="$fixture" bash "$TARGET" --dry-run "$@"
+}
+
+echo "==> fleet-install-skills.sh tests"
+echo "  target: $TARGET"
+
+# ─── 1. shellcheck ───────────────────────────────────────────────────────
+if command -v shellcheck >/dev/null 2>&1; then
+    if shellcheck "$TARGET"; then
+        pass "shellcheck"
+    else
+        fail "shellcheck reported issues"
+    fi
+else
+    echo "  SKIP: shellcheck not installed (install via brew or apt)"
+fi
+
+# ─── 2. --help exits 0 ───────────────────────────────────────────────────
+if bash "$TARGET" --help >/dev/null 2>&1; then
+    pass "--help exits 0"
+else
+    fail "--help did not exit 0"
+fi
+
+# ─── 3. Unknown skill rejected ───────────────────────────────────────────
+fixture="$(mktemp -d /tmp/fleet-test.XXXXXX)"
+trap 'rm -rf "${fixture:-}"' EXIT
+make_fixture "$fixture"
+
+if out=$(MOFA_SKILLS_DIR="$fixture" bash "$TARGET" --dry-run --skill ghost-skill 2>&1); then
+    fail "unknown-skill should have exited non-zero (got 0); output: $out"
+else
+    pass "unknown-skill exits non-zero"
+fi
+
+# ─── 4. Error message mentions the bad name ──────────────────────────────
+# Capture into a variable first; piping `bash <failing>` directly into grep
+# combines with pipefail and confuses the conditional.
+ghost_out=$(MOFA_SKILLS_DIR="$fixture" bash "$TARGET" --dry-run --skill ghost-skill 2>&1 || true)
+if echo "$ghost_out" | grep -q "ghost-skill"; then
+    pass "unknown-skill error mentions skill name"
+else
+    fail "unknown-skill error did not mention the skill name (got: $ghost_out)"
+fi
+
+# ─── 5. Missing MOFA_SKILLS_DIR rejected ─────────────────────────────────
+if out=$(MOFA_SKILLS_DIR="/nonexistent/octos/mofa" bash "$TARGET" --dry-run 2>&1); then
+    fail "missing mofa-dir should have exited non-zero; output: $out"
+else
+    pass "missing mofa-dir exits non-zero"
+fi
+
+# ─── 6. Plan covers every (host, profile, skill) ─────────────────────────
+out=$(run_dry "$fixture" \
+        --host h1,h2 \
+        --profile p1 \
+        --skill mofa-foo,mofa-bar 2>&1)
+# Expect 4 lines of "OK    dry-run" in the summary (2 hosts x 1 profile x 2 skills).
+ok_count=$(echo "$out" | grep -c "OK    dry-run" || true)
+if [ "$ok_count" -eq 4 ]; then
+    pass "plan has 4 (host x profile x skill) rows"
+else
+    fail "plan should have 4 OK rows, got $ok_count"
+    echo "$out" >&2
+fi
+
+# ─── 7. Decoy skills not picked up as defaults ───────────────────────────
+out=$(MOFA_SKILLS_DIR="$fixture" bash "$TARGET" --dry-run --host h1 --profile p1 2>&1)
+if echo "$out" | grep -q "mofa-decoy"; then
+    fail "default skill list pulled in mofa-decoy (no manifest.json)"
+elif echo "$out" | grep -q "other-skill"; then
+    fail "default skill list pulled in non-mofa-* dir"
+else
+    pass "default skill list excludes decoys"
+fi
+
+# ─── 8. --no-force omits --force flag ────────────────────────────────────
+out=$(run_dry "$fixture" \
+        --host h1 \
+        --profile p1 \
+        --skill mofa-foo \
+        --no-force 2>&1)
+if echo "$out" | grep -- "install" | grep -- "--force" >/dev/null; then
+    fail "--no-force still emitted --force flag"
+else
+    pass "--no-force omits --force from install command"
+fi
+
+# ─── 9. Default --force emits --force flag ───────────────────────────────
+out=$(run_dry "$fixture" \
+        --host h1 \
+        --profile p1 \
+        --skill mofa-foo 2>&1)
+if echo "$out" | grep -- "install" | grep -- "--force" >/dev/null; then
+    pass "default emits --force"
+else
+    fail "default did not emit --force"
+fi
+
+# ─── 10. OCTOS_FLEET_HOSTS env override ──────────────────────────────────
+out=$(MOFA_SKILLS_DIR="$fixture" OCTOS_FLEET_HOSTS="env-host-1,env-host-2" \
+        bash "$TARGET" --dry-run --profile p1 --skill mofa-foo 2>&1)
+if echo "$out" | grep -q "env-host-1" && echo "$out" | grep -q "env-host-2"; then
+    pass "OCTOS_FLEET_HOSTS env override applied"
+else
+    fail "OCTOS_FLEET_HOSTS env override not applied"
+    echo "$out" >&2
+fi
+
+echo ""
+echo "==> Results: PASS=$PASS  FAIL=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+echo "fleet-install-skills.sh tests passed"


### PR DESCRIPTION
## Summary

- Replace the operator-driven `mofa-skills/scripts/deploy-mini.sh` (raw scp, no sha256, hard-coded profile) with `scripts/fleet-install-skills.sh`. The new script routes every install through `octos skills --profile <p> install <local-path>`, so the per-profile target dir is resolved server-side and any binary declared in `manifest.json` is sha256-verified by `manage_skills::download_binary`.
- Add `docs/SKILL_DEPLOYMENT.md` covering the per-profile-only model, the migration steps for hosts that still have legacy `~/.octos/skills/`, and the expected post-deploy verification.
- Add `scripts/tests/test-fleet-install-skills.sh` (10 PASS/0 FAIL offline) + shellcheck.

## Cross-repo coupling

Companion PR in mofa-skills: https://github.com/mofa-org/mofa-skills/pull/57 — adds the deprecation banner to `scripts/deploy-mini.sh` and redirects operators to this new script.

## How it works

Per (host, profile, skill):

1. `rsync -az --delete <mofa-dir>/<skill>/ <host>:/tmp/octos-fleet-install-staging/<skill>/`
2. `ssh <host> "OCTOS_PROFILE_ID=<p> octos skills --profile <p> install /tmp/octos-fleet-install-staging/<skill> --force"`
3. Record OK/FAIL with the tail of stderr; failures do not abort the run.
4. Summary table at the end.

Defaults:
- Hosts: 69.194.3.{128,129,203,66,19} (mini1-5); override via `--host` or `OCTOS_FLEET_HOSTS`.
- Profile: enumerate `~/.octos/profiles/*/data` per host; override via `--profile`.
- Skills: every `mofa-*` dir under `MOFA_SKILLS_DIR` (default `~/home/mofa-skills`) that has BOTH `SKILL.md` and `manifest.json`.

SSH uses ControlMaster sockets at `~/.ssh/cm/%r@%h:%p` for connection reuse (per fleet SSH convention).

## Dry-run sample

```
==> Fleet install plan
    Hosts:        69.194.3.128 69.194.3.19
    Skills:       mofa-cli mofa-cards mofa-frame
    Mofa dir:     /Users/yuechen/home/mofa-skills
    Remote bin:   /Users/cloud/.octos/bin/octos
    Remote user:  cloud
    Remote stage: /tmp/octos-fleet-install-staging
    Profiles:     dspfac (explicit)
    Force:        yes (--force on every install)
    Mode:         DRY-RUN (no remote mutation)

==> Host: 69.194.3.128
    [dry-run] would: ssh 69.194.3.128 mkdir -p /tmp/octos-fleet-install-staging
    [dry-run] would: rsync /Users/yuechen/home/mofa-skills/mofa-cli/ -> 69.194.3.128:/tmp/octos-fleet-install-staging/mofa-cli/
    [dry-run] would: ssh 69.194.3.128 -- OCTOS_PROFILE_ID='dspfac' '/Users/cloud/.octos/bin/octos' skills --profile 'dspfac' install '/tmp/octos-fleet-install-staging/mofa-cli' --force
    [dry-run] would: rsync /Users/yuechen/home/mofa-skills/mofa-cards/ -> 69.194.3.128:/tmp/octos-fleet-install-staging/mofa-cards/
    [dry-run] would: ssh 69.194.3.128 -- OCTOS_PROFILE_ID='dspfac' '/Users/cloud/.octos/bin/octos' skills --profile 'dspfac' install '/tmp/octos-fleet-install-staging/mofa-cards' --force
```

## Deviations from spec

- The spec asked the script to run `octos skills install <skill_name>` and have the CLI find the local source. The actual `octos skills install` CLI does NOT take a bare skill name; it takes a path / URL / GitHub shorthand. So the script `rsync`s the local skill dir to remote staging first, then runs `octos skills --profile <p> install <staging-path> --force`. This still routes through `install_from_local` → `maybe_install_binary`, which is the sha256-verified path when the manifest declares `binaries.<platform>.url + sha256`.
- The `OCTOS_PROFILE_ID` env var is passed alongside `--profile <p>` since the CLI accepts both forms and some downstream code paths read the env var.

## Test plan

- [x] `shellcheck scripts/fleet-install-skills.sh` clean
- [x] `bash scripts/tests/test-fleet-install-skills.sh` — 10 PASS / 0 FAIL
- [x] `--dry-run` against full fleet (55 rows = 5 hosts x 11 skills x 1 dry-run-profile placeholder) — exit 0, no remote calls
- [x] `--dry-run --host h1,h2 --profile p1,p2 --skill mofa-cli,mofa-cards` — exits 0 with 4 OK rows in summary
- [x] Unknown skill rejected with exit 1, error names the bad skill
- [x] Missing `MOFA_SKILLS_DIR` rejected with exit 1
- [ ] Live install on a single safe target (mini2 + dspfac + mofa-cli) — gated by separate operator approval