### PR TITLE
feat(hooks): path_filter + Coding kind defaults + EndTurn contract gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,6 +3719,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "which 7.0.3",
 ]
 
 [[package]]

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -25,6 +25,7 @@ eyre = { workspace = true }
 tracing = { workspace = true }
 metrics = { workspace = true }
 glob = { workspace = true }
+which = { workspace = true }
 regex = { workspace = true }
 ignore = { workspace = true }
 futures = { workspace = true }

--- a/crates/octos-agent/examples/robot_domain_hook.rs
+++ b/crates/octos-agent/examples/robot_domain_hook.rs
@@ -129,6 +129,8 @@ exit 0
         command: vec![script_path.to_string_lossy().to_string()],
         timeout_ms: 5000,
         tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
     }])
     .with_enricher(Arc::new(RobotSensorEnricher { bus: bus.clone() }));
 

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -28,6 +28,74 @@ use crate::tools::{TURN_ATTACHMENT_CTX, TurnAttachmentContext};
 const MAX_PARALLEL_TOOL_CALLS_PER_BATCH: usize = 8;
 const SHELL_RETRY_RECOVERY_THRESHOLD: usize = 4;
 
+/// Audit Gap-8 helper: consult the workspace-contract layer at EndTurn time
+/// and return a human-readable summary of failing validators when the
+/// contract is NOT ready. Returns `None` when the workspace has no
+/// policy-managed repos under `working_dir` (today's silent-success path).
+///
+/// This is the harness-side mirror of the LLM-callable
+/// `check_workspace_contract` tool — same source of truth
+/// (`inspect_workspace_contracts`), no parallel framework. Errors from the
+/// underlying inspector are swallowed with a warning so a transient git
+/// failure (e.g. corrupt `.git` directory) cannot block an otherwise
+/// successful task; the previous behaviour is preserved on inspector error.
+fn inspect_workspace_contract_failures(working_dir: &std::path::Path) -> Option<String> {
+    let contracts = match crate::workspace_git::inspect_workspace_contracts(working_dir) {
+        Ok(contracts) => contracts,
+        Err(err) => {
+            warn!(
+                workspace_root = %working_dir.display(),
+                error = %err,
+                "workspace contract inspector failed at EndTurn; treating as no-policy"
+            );
+            return None;
+        }
+    };
+
+    // Only fail on policy-managed repos that aren't ready.
+    let failing: Vec<_> = contracts
+        .iter()
+        .filter(|status| status.policy_managed && !status.ready)
+        .collect();
+    if failing.is_empty() {
+        return None;
+    }
+
+    let mut lines = Vec::with_capacity(failing.len() * 2);
+    // Lowercase "workspace contract" so the message matches the same
+    // grep predicate used by the existing spawn-task contract failure
+    // assertions (`error.contains("workspace contract")` in spawn.rs).
+    lines.push(format!(
+        "workspace contract not ready for {} repo(s):",
+        failing.len()
+    ));
+    for status in failing {
+        lines.push(format!("- {} (kind={})", status.repo_label, status.kind));
+        if let Some(ref error) = status.error {
+            lines.push(format!("    error: {error}"));
+        }
+        for check in &status.completion_checks {
+            if !check.passed {
+                let reason = check.reason.as_deref().unwrap_or("(no reason given)");
+                lines.push(format!("    completion failed: {} — {reason}", check.spec));
+            }
+        }
+        for check in &status.turn_end_checks {
+            if !check.passed {
+                let reason = check.reason.as_deref().unwrap_or("(no reason given)");
+                lines.push(format!("    turn_end failed: {} — {reason}", check.spec));
+            }
+        }
+        for missing in status.artifacts.iter().filter(|a| !a.present) {
+            lines.push(format!(
+                "    artifact missing: {} (pattern={})",
+                missing.name, missing.pattern
+            ));
+        }
+    }
+    Some(lines.join("\n"))
+}
+
 fn split_tool_calls(
     tool_calls: &[octos_core::ToolCall],
     batch_size: usize,
@@ -1363,8 +1431,25 @@ impl Agent {
                         }
 
                         self.emit_cost_update(turn.total_usage(), &response.usage);
+
+                        // Audit Gap-8: auto-fire `check_workspace_contract`
+                        // on Completion. The LLM-callable wrapper stays for
+                        // introspection but no longer the only enforcement
+                        // path — the harness consults the contract before
+                        // declaring SUCCESS.
+                        //
+                        // Workspaces without a policy-managed repo under the
+                        // working_dir stay Success unchanged (returns
+                        // `None`). When at least one policy-managed repo is
+                        // not ready, the result is demoted to `success =
+                        // false` and the failing validators are appended to
+                        // the result output so the caller (or LLM next turn)
+                        // sees the contract failure.
+                        let contract_failures =
+                            inspect_workspace_contract_failures(&task.context.working_dir);
+
                         self.reporter().report(ProgressEvent::TaskCompleted {
-                            success: true,
+                            success: contract_failures.is_none(),
                             iterations: iteration,
                             duration: task_start.elapsed(),
                         });
@@ -1375,14 +1460,28 @@ impl Agent {
                             iterations = iteration,
                             files_modified = files_modified.len(),
                             duration_ms = task_start.elapsed().as_millis() as u64,
+                            contract_failed = contract_failures.is_some(),
                             "task completed"
                         );
-                        return Ok(self.build_result(
+                        let mut result = self.build_result(
                             &response,
                             turn.total_usage().clone(),
                             files_modified,
                             files_to_send,
-                        ));
+                        );
+                        if let Some(failure_msg) = contract_failures {
+                            warn!(
+                                workspace_root = %task.context.working_dir.display(),
+                                "task EndTurn but workspace contract is not ready; demoting to ContractFailed"
+                            );
+                            result.success = false;
+                            if result.output.is_empty() {
+                                result.output = failure_msg;
+                            } else {
+                                result.output = format!("{}\n\n{}", result.output, failure_msg);
+                            }
+                        }
+                        return Ok(result);
                     }
                     StopReason::ToolUse => {
                         if let Err(e) = self
@@ -4274,5 +4373,212 @@ printf '{"output":"voice saved","success":true}\n'
         // Reset at start of process_message clears the flag, so a brand-new
         // burst is allowed and emits a warning (Ok), not a terminal Err.
         assert!(second.is_ok(), "second call should not error after reset");
+    }
+
+    // ----- Audit Gap-8: auto-fire check_workspace_contract on Completion -----
+
+    /// LLM stub that always returns a single EndTurn — used by the
+    /// Gap-8 tests to drive `run_task` straight to the contract-check
+    /// branch without iterating through tool calls.
+    struct EndTurnOnlyProvider;
+    #[async_trait]
+    impl LlmProvider for EndTurnOnlyProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<ChatResponse> {
+            Ok(ChatResponse {
+                content: Some("done".into()),
+                reasoning_content: None,
+                tool_calls: vec![],
+                stop_reason: StopReason::EndTurn,
+                usage: LlmTokenUsage::default(),
+                provider_index: None,
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    fn make_managed_slides_workspace(tmp_root: &std::path::Path, slug: &str, ready: bool) {
+        use crate::workspace_git::WorkspaceProjectKind;
+        use crate::workspace_policy::{WorkspacePolicy, write_workspace_policy};
+        let repo_root = tmp_root.join("slides").join(slug);
+        std::fs::create_dir_all(&repo_root).unwrap();
+        write_workspace_policy(
+            &repo_root,
+            &WorkspacePolicy::for_kind(WorkspaceProjectKind::Slides),
+        )
+        .unwrap();
+        // Every slides workspace requires script.js / memory.md / changelog.md
+        // for turn_end + output/deck.pptx + slide png for completion.
+        std::fs::write(repo_root.join("script.js"), "// slides").unwrap();
+        std::fs::write(repo_root.join("memory.md"), "# memory").unwrap();
+        std::fs::write(repo_root.join("changelog.md"), "# changelog").unwrap();
+        if ready {
+            std::fs::create_dir_all(repo_root.join("output/imgs")).unwrap();
+            std::fs::write(repo_root.join("output/deck.pptx"), "fake-deck").unwrap();
+            std::fs::write(repo_root.join("output/imgs/slide-01.png"), "fake-png").unwrap();
+        }
+    }
+
+    #[test]
+    fn should_return_none_when_workspace_has_no_policy_managed_repos() {
+        // Bare working_dir with no `slides/` or `sites/` subdir →
+        // inspect_workspace_contracts yields an empty Vec → helper returns
+        // None → loop_runner keeps Success.
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(inspect_workspace_contract_failures(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn should_return_none_when_all_managed_repos_are_ready() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_managed_slides_workspace(tmp.path(), "demo", true);
+
+        let failures = inspect_workspace_contract_failures(tmp.path());
+        assert!(
+            failures.is_none(),
+            "ready workspace should not produce contract failure summary: {:?}",
+            failures
+        );
+    }
+
+    #[test]
+    fn should_return_failure_summary_when_managed_repo_is_not_ready() {
+        let tmp = tempfile::tempdir().unwrap();
+        // slug=broken with NO output/ artifacts → completion checks fail.
+        make_managed_slides_workspace(tmp.path(), "broken", false);
+
+        let failures = inspect_workspace_contract_failures(tmp.path())
+            .expect("broken workspace must produce contract failure summary");
+        assert!(
+            failures.contains("slides/broken"),
+            "summary should name the failing repo:\n{}",
+            failures
+        );
+        assert!(
+            failures.contains("completion failed") || failures.contains("artifact missing"),
+            "summary should describe what failed:\n{}",
+            failures
+        );
+    }
+
+    #[test]
+    fn should_return_failure_summary_with_mixed_repos() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_managed_slides_workspace(tmp.path(), "ready-deck", true);
+        make_managed_slides_workspace(tmp.path(), "broken-deck", false);
+
+        let failures = inspect_workspace_contract_failures(tmp.path())
+            .expect("at least one broken repo must produce failures");
+        assert!(failures.contains("slides/broken-deck"));
+        // Only the broken repo should appear in the failures listing —
+        // ready-deck is not in the failing set.
+        assert!(
+            !failures.contains("ready-deck") || failures.contains("broken-deck"),
+            "ready-deck should not appear as a failure:\n{}",
+            failures
+        );
+    }
+
+    #[tokio::test]
+    async fn run_task_demotes_success_when_contract_fails() {
+        // End-to-end integration: an EndTurn that would otherwise be Success
+        // gets demoted to success=false when the working_dir contains a
+        // policy-managed repo that is not ready.
+        let dir = tempfile::tempdir().unwrap();
+        // Pre-populate a broken slides repo so contract != ready.
+        make_managed_slides_workspace(dir.path(), "demo", false);
+
+        let tools = ToolRegistry::with_builtins(dir.path());
+        let provider: Arc<dyn LlmProvider> = Arc::new(EndTurnOnlyProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("contract-demote"), provider, tools, memory);
+        let task = Task::new(
+            TaskKind::Code {
+                instruction: "Build it".into(),
+                files: vec![],
+            },
+            TaskContext {
+                working_dir: dir.path().to_path_buf(),
+                ..Default::default()
+            },
+        );
+
+        let result = agent.run_task(&task).await.unwrap();
+        assert!(
+            !result.success,
+            "broken workspace contract must demote task to failure"
+        );
+        assert!(
+            result.output.contains("workspace contract") || result.output.contains("slides/demo"),
+            "result output should explain the contract failure: {:?}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn run_task_keeps_success_when_workspace_has_no_policy() {
+        // No-policy workspace must stay Success (no regression).
+        let dir = tempfile::tempdir().unwrap();
+        let tools = ToolRegistry::with_builtins(dir.path());
+        let provider: Arc<dyn LlmProvider> = Arc::new(EndTurnOnlyProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("no-contract"), provider, tools, memory);
+        let task = Task::new(
+            TaskKind::Code {
+                instruction: "Hi".into(),
+                files: vec![],
+            },
+            TaskContext {
+                working_dir: dir.path().to_path_buf(),
+                ..Default::default()
+            },
+        );
+
+        let result = agent.run_task(&task).await.unwrap();
+        assert!(
+            result.success,
+            "no-policy workspace must keep Success (got {:?})",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn run_task_keeps_success_when_contract_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        // Fully-ready workspace.
+        make_managed_slides_workspace(dir.path(), "ready", true);
+
+        let tools = ToolRegistry::with_builtins(dir.path());
+        let provider: Arc<dyn LlmProvider> = Arc::new(EndTurnOnlyProvider);
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(AgentId::new("contract-ok"), provider, tools, memory);
+        let task = Task::new(
+            TaskKind::Code {
+                instruction: "All good".into(),
+                files: vec![],
+            },
+            TaskContext {
+                working_dir: dir.path().to_path_buf(),
+                ..Default::default()
+            },
+        );
+
+        let result = agent.run_task(&task).await.unwrap();
+        assert!(
+            result.success,
+            "ready workspace must keep Success (got {:?})",
+            result.output
+        );
     }
 }

--- a/crates/octos-agent/src/hooks.rs
+++ b/crates/octos-agent/src/hooks.rs
@@ -54,6 +54,28 @@ pub struct HookConfig {
     /// Only trigger for these tool names (tool events only). Empty = all tools.
     #[serde(default)]
     pub tool_filter: Vec<String>,
+    /// Only fire when the tool call's argument `path` matches one of these
+    /// glob patterns (tool events only). Empty = no path filtering applied
+    /// (today's behaviour: fire-for-all matching tools). Used by the M9
+    /// AfterTool coding-agent gate to scope `cargo check` to `**/*.rs`
+    /// edits, etc.
+    ///
+    /// Path extraction is tool-specific: `edit_file`, `write_file`, and
+    /// `diff_edit` all expose the target path at `args.path`. For tools
+    /// that do not surface a path (e.g. `shell`, `read_file`), a non-empty
+    /// `path_filter` causes the hook to be skipped — operators opt into
+    /// path-scoped filtering at their own risk.
+    ///
+    /// Invalid glob patterns are logged once at executor init and the
+    /// pattern is dropped; the remaining valid patterns still apply.
+    #[serde(default)]
+    pub path_filter: Vec<String>,
+    /// Optional binary that must be discoverable on `PATH` for this hook
+    /// to fire. Used by [`WorkspacePolicy::for_coding`] to gate optional
+    /// language hooks (`eslint`, `ruff`) without forcing operators to
+    /// install every linter. Absent or empty = no gating.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requires_bin: Option<String>,
 }
 
 fn default_timeout_ms() -> u64 {
@@ -575,6 +597,12 @@ pub enum HookResult {
 /// Executes hooks with circuit breaker protection.
 pub struct HookExecutor {
     hooks: Vec<HookConfig>,
+    /// Precompiled path-filter glob patterns per hook, parallel to `hooks`.
+    /// Each inner Vec is the parsed `glob::Pattern` list for the hook's
+    /// `path_filter` field. Invalid patterns are dropped at construction
+    /// time so the matcher loop stays infallible. Hooks with no
+    /// `path_filter` keep an empty inner Vec.
+    path_filters: Vec<Vec<glob::Pattern>>,
     /// Per-hook consecutive failure count.
     failures: Vec<AtomicU32>,
     failure_threshold: u32,
@@ -589,8 +617,13 @@ impl HookExecutor {
 
     pub fn with_threshold(hooks: Vec<HookConfig>, failure_threshold: u32) -> Self {
         let failures = (0..hooks.len()).map(|_| AtomicU32::new(0)).collect();
+        let path_filters = hooks
+            .iter()
+            .map(|hook| compile_path_filters(&hook.command, &hook.path_filter))
+            .collect();
         Self {
             hooks,
+            path_filters,
             failures,
             failure_threshold,
             enricher: None,
@@ -652,6 +685,42 @@ impl HookExecutor {
                 if !hook.tool_filter.iter().any(|f| f == tool_name) {
                     continue;
                 }
+            }
+
+            // Apply path_filter for tool events (Audit Gap-1 closure).
+            // Globs are matched against the path string from
+            // `arguments.path`. If the hook declares a non-empty
+            // `path_filter` and either (a) the tool's arguments do not
+            // surface a `path` field or (b) no glob matches, skip the
+            // hook. Falling through silently keeps the catch-all
+            // (empty path_filter) at today's behaviour.
+            if matches!(event, HookEvent::BeforeToolCall | HookEvent::AfterToolCall)
+                && !self.path_filters[i].is_empty()
+            {
+                let tool_path = payload_ref.arguments.as_ref().and_then(extract_tool_path);
+                let Some(tool_path) = tool_path else {
+                    continue;
+                };
+                let candidate = std::path::Path::new(&tool_path);
+                let matched = self.path_filters[i]
+                    .iter()
+                    .any(|pat| pat.matches_path(candidate));
+                if !matched {
+                    continue;
+                }
+            }
+
+            // Optional binary presence gate (`requires_bin`). When a hook
+            // declares a required binary, skip it if the binary is not on
+            // PATH. Used by `WorkspacePolicy::for_coding` to ship eslint /
+            // ruff hooks as opt-in defaults without forcing operators to
+            // install every linter. The lookup uses `which::which` once
+            // per call — cheap and cache-friendly via the OS path cache.
+            if let Some(bin) = hook.requires_bin.as_deref()
+                && !bin.is_empty()
+                && which::which(bin).is_err()
+            {
+                continue;
             }
 
             // Circuit breaker: skip if too many failures
@@ -846,6 +915,39 @@ impl HookExecutor {
             }
         }
     }
+}
+
+/// Compile the `path_filter` globs declared on a [`HookConfig`]. Invalid
+/// patterns log a warning and are dropped so the matcher stays infallible.
+/// Returns an empty Vec when the input is empty (caller uses Vec::is_empty
+/// as the "no filtering" predicate).
+fn compile_path_filters(command: &[String], patterns: &[String]) -> Vec<glob::Pattern> {
+    patterns
+        .iter()
+        .filter_map(|p| match glob::Pattern::new(p) {
+            Ok(pat) => Some(pat),
+            Err(e) => {
+                warn!(
+                    hook_command = ?command,
+                    pattern = %p,
+                    error = %e,
+                    "hook path_filter pattern is invalid; dropped"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+/// Extract the `path` argument from a tool's `arguments` JSON object. This
+/// matches the shape used by `edit_file`, `write_file`, and `diff_edit`
+/// (path at `args.path`). For tools that do not surface a path, returns
+/// `None` so the caller can skip the hook.
+fn extract_tool_path(args: &serde_json::Value) -> Option<String> {
+    args.as_object()
+        .and_then(|obj| obj.get("path"))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
 }
 
 /// Expand leading `~` or `~/` to the user's home directory.
@@ -1175,6 +1277,8 @@ mod tests {
             command: vec!["false".into()], // would fail if executed
             timeout_ms: 1000,
             tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
         }]);
         // Set failures at threshold so circuit breaker trips
         executor.failures[0].store(3, Ordering::Relaxed);
@@ -1226,6 +1330,8 @@ mod tests {
             command: vec!["check".into()],
             timeout_ms: 1000,
             tool_filter: vec!["shell".into(), "write_file".into()],
+            path_filter: vec![],
+            requires_bin: None,
         };
         assert!(hook.tool_filter.contains(&"shell".to_string()));
         assert!(!hook.tool_filter.contains(&"read_file".to_string()));
@@ -1296,6 +1402,8 @@ mod tests {
             command: vec!["true".into()],
             timeout_ms: 5000,
             tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
         }]);
         let payload = HookPayload::before_tool("shell", serde_json::json!({}), "tc1", None);
         let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
@@ -1311,6 +1419,8 @@ mod tests {
             command: vec!["false".into()],
             timeout_ms: 5000,
             tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
         }]);
         let payload = HookPayload::before_tool("shell", serde_json::json!({}), "tc1", None);
         let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
@@ -1324,6 +1434,8 @@ mod tests {
             command: vec!["false".into()],
             timeout_ms: 5000,
             tool_filter: vec!["write_file".into()],
+            path_filter: vec![],
+            requires_bin: None,
         }]);
         let payload = HookPayload::before_tool("read_file", serde_json::json!({}), "tc1", None);
         let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
@@ -1337,6 +1449,8 @@ mod tests {
             command: vec!["false".into()],
             timeout_ms: 5000,
             tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
         }]);
         let payload = HookPayload::before_tool("shell", serde_json::json!({}), "tc1", None);
         let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
@@ -1353,6 +1467,8 @@ mod tests {
                 command: vec!["sh".into(), "-c".into(), "exit 2".into()],
                 timeout_ms: 5000,
                 tool_filter: vec![],
+                path_filter: vec![],
+                requires_bin: None,
             }],
             3,
         );
@@ -1375,6 +1491,8 @@ mod tests {
                 command: vec!["sh".into(), "-c".into(), "exit 2".into()],
                 timeout_ms: 5000,
                 tool_filter: vec![],
+                path_filter: vec![],
+                requires_bin: None,
             }],
             3,
         );
@@ -1399,6 +1517,8 @@ mod tests {
                 command: vec!["true".into()],
                 timeout_ms: 5000,
                 tool_filter: vec![],
+                path_filter: vec![],
+                requires_bin: None,
             }],
             3,
         );
@@ -1481,5 +1601,249 @@ mod tests {
         assert!(json.contains("*.rs"));
         assert!(!json.contains("truncated"));
         assert!(!json.contains("redacted"));
+    }
+
+    // ----- Path filter (Audit Gap-1) tests -----
+
+    /// Convenience constructor for path-filter tests so the cases that follow
+    /// stay focused on the filtering behaviour itself.
+    fn hook_with_path_filter(event: HookEvent, patterns: Vec<&str>) -> HookConfig {
+        HookConfig {
+            event,
+            // `false` would fail if the hook actually fires — perfect for
+            // "should this hook fire?" semantics.
+            command: vec!["false".into()],
+            timeout_ms: 5000,
+            tool_filter: vec![],
+            path_filter: patterns.into_iter().map(String::from).collect(),
+            requires_bin: None,
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_skip_hook_when_path_filter_does_not_match() {
+        let executor = HookExecutor::new(vec![hook_with_path_filter(
+            HookEvent::AfterToolCall,
+            vec!["**/*.rs"],
+        )]);
+        // edit_file on a Python path — `**/*.rs` glob should NOT match.
+        let payload = HookPayload::after_tool("edit_file", "tc1", "ok".into(), true, 10, None);
+        let mut payload = payload;
+        payload.arguments = Some(serde_json::json!({"path": "scripts/build.py"}));
+        let result = executor.run(HookEvent::AfterToolCall, &payload).await;
+        // Hook skipped -> Allow (not denied, not errored).
+        assert_eq!(result, HookResult::Allow);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_fire_hook_when_path_filter_matches() {
+        // `true` would succeed; deny-via-exit-1 only makes sense for before-
+        // hooks. Use a before-hook with `false` so a match yields Deny.
+        let mut cfg = hook_with_path_filter(HookEvent::BeforeToolCall, vec!["**/*.rs"]);
+        cfg.command = vec!["false".into()];
+        let executor = HookExecutor::new(vec![cfg]);
+        let mut payload = HookPayload::before_tool("edit_file", serde_json::json!({}), "tc1", None);
+        payload.arguments = Some(serde_json::json!({"path": "src/lib.rs"}));
+        let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert!(
+            matches!(result, HookResult::Deny(_)),
+            "matching glob should fire the hook (got {:?})",
+            result
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_fire_hook_when_path_filter_is_empty() {
+        // Empty path_filter — fire-for-all-matching-tools (today's
+        // backward-compat behaviour).
+        let cfg = HookConfig {
+            event: HookEvent::BeforeToolCall,
+            command: vec!["false".into()],
+            timeout_ms: 5000,
+            tool_filter: vec![],
+            path_filter: vec![], // explicit empty
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![cfg]);
+        let payload = HookPayload::before_tool(
+            "edit_file",
+            serde_json::json!({"path": "src/lib.rs"}),
+            "tc1",
+            None,
+        );
+        let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert!(
+            matches!(result, HookResult::Deny(_)),
+            "empty path_filter should fall through to today's behaviour (got {:?})",
+            result
+        );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_skip_hook_when_arguments_have_no_path_field() {
+        // Tool with `path_filter` set but a tool whose arguments lack a
+        // `path` key. The hook must be skipped (operator opted into
+        // path-scoped filtering and there is no path to test against).
+        let executor = HookExecutor::new(vec![hook_with_path_filter(
+            HookEvent::BeforeToolCall,
+            vec!["**/*.rs"],
+        )]);
+        let payload =
+            HookPayload::before_tool("shell", serde_json::json!({"command": "ls"}), "tc1", None);
+        let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert_eq!(result, HookResult::Allow);
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_match_any_pattern_in_path_filter() {
+        // Multiple globs: hook fires if ANY matches.
+        let mut cfg = hook_with_path_filter(HookEvent::BeforeToolCall, vec!["**/*.js", "**/*.ts"]);
+        cfg.command = vec!["false".into()];
+        let executor = HookExecutor::new(vec![cfg]);
+        let mut payload = HookPayload::before_tool("edit_file", serde_json::json!({}), "tc1", None);
+        payload.arguments = Some(serde_json::json!({"path": "frontend/src/app.ts"}));
+        let result = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert!(
+            matches!(result, HookResult::Deny(_)),
+            "second glob should match .ts file (got {:?})",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn should_drop_invalid_glob_patterns_at_init() {
+        // An invalid pattern should be dropped silently (logged once at
+        // init) without breaking the executor. Combine with a valid
+        // pattern so we can verify the valid one still works.
+        let cfg = HookConfig {
+            event: HookEvent::BeforeToolCall,
+            command: vec!["false".into()],
+            timeout_ms: 5000,
+            tool_filter: vec![],
+            path_filter: vec!["[unterminated".into(), "**/*.rs".into()],
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![cfg]);
+        // path_filters[0] should only contain the valid pattern.
+        assert_eq!(executor.path_filters[0].len(), 1);
+        assert_eq!(executor.path_filters[0][0].as_str(), "**/*.rs");
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn should_combine_tool_filter_and_path_filter() {
+        // tool_filter scopes by tool name; path_filter scopes by path.
+        // Both must be satisfied for the hook to fire.
+        let cfg = HookConfig {
+            event: HookEvent::BeforeToolCall,
+            command: vec!["false".into()],
+            timeout_ms: 5000,
+            tool_filter: vec!["edit_file".into()],
+            path_filter: vec!["**/*.rs".into()],
+            requires_bin: None,
+        };
+        let executor = HookExecutor::new(vec![cfg]);
+
+        // Right tool, right path → hook fires.
+        let mut payload = HookPayload::before_tool(
+            "edit_file",
+            serde_json::json!({"path": "src/lib.rs"}),
+            "tc1",
+            None,
+        );
+        payload.arguments = Some(serde_json::json!({"path": "src/lib.rs"}));
+        let r = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert!(matches!(r, HookResult::Deny(_)));
+
+        // Right tool, wrong path → skipped.
+        let mut payload = HookPayload::before_tool(
+            "edit_file",
+            serde_json::json!({"path": "README.md"}),
+            "tc1",
+            None,
+        );
+        payload.arguments = Some(serde_json::json!({"path": "README.md"}));
+        let r = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert_eq!(r, HookResult::Allow);
+
+        // Wrong tool → skipped (regardless of path).
+        let mut payload = HookPayload::before_tool(
+            "write_file",
+            serde_json::json!({"path": "src/lib.rs"}),
+            "tc1",
+            None,
+        );
+        payload.arguments = Some(serde_json::json!({"path": "src/lib.rs"}));
+        let r = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert_eq!(r, HookResult::Allow);
+    }
+
+    #[tokio::test]
+    async fn should_skip_hook_when_requires_bin_missing() {
+        // Sentinel binary that should not exist on any reasonable test
+        // environment. The hook must be skipped without trying to spawn
+        // anything.
+        let cfg = HookConfig {
+            event: HookEvent::BeforeToolCall,
+            command: vec!["false".into()],
+            timeout_ms: 5000,
+            tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: Some(
+                "definitely-not-a-real-binary-on-this-host-octos-wave3c-test".into(),
+            ),
+        };
+        let executor = HookExecutor::new(vec![cfg]);
+        let payload = HookPayload::before_tool("edit_file", serde_json::json!({}), "tc1", None);
+        let r = executor.run(HookEvent::BeforeToolCall, &payload).await;
+        assert_eq!(r, HookResult::Allow);
+    }
+
+    #[test]
+    fn should_deserialize_hook_config_with_path_filter() {
+        let json = r#"{
+            "event": "after_tool_call",
+            "command": ["cargo", "check"],
+            "tool_filter": ["edit_file", "write_file"],
+            "path_filter": ["**/*.rs"]
+        }"#;
+        let hook: HookConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(hook.path_filter, vec!["**/*.rs"]);
+        assert_eq!(hook.tool_filter.len(), 2);
+        assert!(hook.requires_bin.is_none());
+    }
+
+    #[test]
+    fn should_default_path_filter_to_empty_when_absent() {
+        let json = r#"{
+            "event": "after_tool_call",
+            "command": ["echo"]
+        }"#;
+        let hook: HookConfig = serde_json::from_str(json).unwrap();
+        assert!(hook.path_filter.is_empty());
+        assert!(hook.requires_bin.is_none());
+    }
+
+    #[test]
+    fn should_extract_path_from_arguments() {
+        let args = serde_json::json!({"path": "src/lib.rs", "content": "..."});
+        assert_eq!(extract_tool_path(&args).as_deref(), Some("src/lib.rs"));
+
+        // Missing path key
+        let args = serde_json::json!({"command": "ls"});
+        assert!(extract_tool_path(&args).is_none());
+
+        // Non-string path
+        let args = serde_json::json!({"path": 42});
+        assert!(extract_tool_path(&args).is_none());
+
+        // Non-object
+        let args = serde_json::json!([]);
+        assert!(extract_tool_path(&args).is_none());
     }
 }

--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -183,6 +183,8 @@ fn resolve_hook(def: &SkillHookDef, skill_dir: &Path) -> Option<HookConfig> {
         command,
         timeout_ms: def.timeout_ms,
         tool_filter: def.tool_filter.clone(),
+        path_filter: Vec::new(),
+        requires_bin: None,
     })
 }
 

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -3047,6 +3047,8 @@ mod tests {
             ],
             timeout_ms: 5000,
             tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
         }
     }
 
@@ -3063,6 +3065,8 @@ mod tests {
             ],
             timeout_ms: 5000,
             tool_filter: vec![],
+            path_filter: vec![],
+            requires_bin: None,
         }
     }
 

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -335,6 +335,13 @@ pub enum WorkspacePolicyKind {
     Slides,
     Sites,
     Session,
+    /// Coding workspaces — projects with a recognised manifest
+    /// (Cargo.toml / package.json / pyproject.toml). Inherits the
+    /// `Session` spawn-task contracts and adds AfterTool hooks that
+    /// run `cargo check` (and optionally eslint / ruff when present
+    /// on PATH) after `edit_file` / `write_file` / `diff_edit` calls
+    /// scoped to the language's file extensions. Audit Gap-1 + Q3.
+    Coding,
 }
 
 impl WorkspacePolicyKind {
@@ -343,6 +350,7 @@ impl WorkspacePolicyKind {
             Self::Slides => "slides",
             Self::Sites => "sites",
             Self::Session => "session",
+            Self::Coding => "coding",
         }
     }
 
@@ -779,6 +787,26 @@ impl WorkspacePolicy {
         }
     }
 
+    /// Default policy for a coding workspace (Audit Gap-1 + section 7 Q3).
+    ///
+    /// Inherits the [`for_session`] spawn-task contracts (so a coding workspace
+    /// that still spawns slides / podcast / fm_voice_save tasks keeps the
+    /// per-skill contract gates) and overlays only the `kind = Coding`
+    /// marker. The AfterTool `cargo check` / `eslint` / `ruff` hooks live in
+    /// [`coding_default_hooks`] so the host (chat.rs / gateway.rs / serve.rs)
+    /// can merge them into its `HookExecutor` without forking the hook runner.
+    ///
+    /// The split is deliberate: hooks are runtime side-effects executed by
+    /// the agent, while `WorkspacePolicy` is a serialized declaration shared
+    /// with the LLM. Stuffing process-launch hooks into the workspace policy
+    /// would (a) leak operator-side state into a contract the LLM can read
+    /// and (b) force every embedder of the policy struct (config_watcher,
+    /// session bootstrap, REST inspectors) to know how to run shells.
+    pub fn for_coding() -> Self {
+        let mut policy = Self::for_session();
+        policy.workspace.kind = WorkspacePolicyKind::Coding;
+        policy
+    }
     pub fn for_site_build_output(build_output_dir: &str) -> Self {
         let mut policy = Self::for_kind(WorkspaceProjectKind::Sites);
         policy.validation = ValidationPolicy {
@@ -802,6 +830,86 @@ impl WorkspacePolicy {
         };
         policy
     }
+}
+
+/// Detect the workspace policy kind for `cwd` by probing for well-known
+/// language manifests. Order: `Cargo.toml` → `package.json` → `pyproject.toml`
+/// → fallback [`WorkspacePolicyKind::Session`].
+///
+/// This is the entry point for Audit Gap-1's "the harness owns the contract"
+/// stance — the runtime decides whether a workspace is `Coding` based on
+/// observable filesystem signals, not LLM input. Operators who want to
+/// override the inference write an explicit `.octos-workspace.toml`.
+pub fn detect_workspace_policy_kind(cwd: &Path) -> WorkspacePolicyKind {
+    if cwd.join("Cargo.toml").is_file()
+        || cwd.join("package.json").is_file()
+        || cwd.join("pyproject.toml").is_file()
+    {
+        WorkspacePolicyKind::Coding
+    } else {
+        WorkspacePolicyKind::Session
+    }
+}
+
+/// Default `after_tool_call` hooks for a [`WorkspacePolicyKind::Coding`]
+/// workspace (Audit Gap-1 closure).
+///
+/// Each entry mirrors the canonical `cargo check` / `eslint` / `ruff`
+/// invocation an operator would write by hand. Hosts (chat.rs, gateway.rs,
+/// serve.rs) call this on bootstrap and merge the returned hooks into the
+/// HookExecutor they hand to the agent. Operator-defined hooks always merge
+/// AFTER these defaults, so an operator-written `cargo check` hook with
+/// stricter args overrides the default's behaviour by virtue of running too
+/// (both fire, but a stricter one denies before the cheaper one matters).
+///
+/// `requires_bin` gates each entry on a binary lookup — operators who do not
+/// have `eslint` or `ruff` installed see the hooks silently skip rather than
+/// failing every after-tool callback. `cargo` is assumed present in a Rust
+/// workspace (the detector keys on `Cargo.toml`) but is still gated so
+/// nothing breaks when a stub `Cargo.toml` lives alongside a non-cargo
+/// project.
+pub fn coding_default_hooks() -> Vec<crate::hooks::HookConfig> {
+    use crate::hooks::{HookConfig, HookEvent};
+    let edit_tools = vec![
+        "edit_file".to_string(),
+        "write_file".to_string(),
+        "diff_edit".to_string(),
+    ];
+    vec![
+        // Rust: `cargo check --message-format=short` on `.rs` edits.
+        HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec![
+                "cargo".into(),
+                "check".into(),
+                "--message-format=short".into(),
+            ],
+            timeout_ms: 60_000,
+            tool_filter: edit_tools.clone(),
+            path_filter: vec!["**/*.rs".into()],
+            requires_bin: Some("cargo".into()),
+        },
+        // JS/TS: ESLint with zero-warning policy. Skipped if eslint is
+        // not on PATH. Operators who use a different linter (biome, etc.)
+        // add their own hook; the default is best-effort and explicit.
+        HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec!["eslint".into(), "--max-warnings".into(), "0".into()],
+            timeout_ms: 60_000,
+            tool_filter: edit_tools.clone(),
+            path_filter: vec!["**/*.{js,ts,tsx,jsx}".into()],
+            requires_bin: Some("eslint".into()),
+        },
+        // Python: `ruff check` on `.py` edits.
+        HookConfig {
+            event: HookEvent::AfterToolCall,
+            command: vec!["ruff".into(), "check".into()],
+            timeout_ms: 60_000,
+            tool_filter: edit_tools,
+            path_filter: vec!["**/*.py".into()],
+            requires_bin: Some("ruff".into()),
+        },
+    ]
 }
 
 pub fn workspace_policy_path(project_root: &Path) -> PathBuf {
@@ -1490,5 +1598,124 @@ ignore = []
         let validator = full.into_validator("ignored", 99);
         assert_eq!(validator.id, "voice_optional");
         assert!(!validator.required);
+    }
+
+    // ----- WorkspacePolicyKind::Coding (Audit Gap-1 + section 7 Q3) -----
+
+    #[test]
+    fn should_detect_coding_kind_when_cargo_toml_is_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Cargo.toml"), "[package]\nname=\"x\"\n").unwrap();
+        assert_eq!(
+            detect_workspace_policy_kind(tmp.path()),
+            WorkspacePolicyKind::Coding
+        );
+    }
+
+    #[test]
+    fn should_detect_coding_kind_when_package_json_is_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("package.json"), "{}").unwrap();
+        assert_eq!(
+            detect_workspace_policy_kind(tmp.path()),
+            WorkspacePolicyKind::Coding
+        );
+    }
+
+    #[test]
+    fn should_detect_coding_kind_when_pyproject_toml_is_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("pyproject.toml"), "[project]\n").unwrap();
+        assert_eq!(
+            detect_workspace_policy_kind(tmp.path()),
+            WorkspacePolicyKind::Coding
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_session_kind_when_no_language_signal() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Just an unrelated file — no manifest probes match.
+        std::fs::write(tmp.path().join("README.md"), "# hi").unwrap();
+        assert_eq!(
+            detect_workspace_policy_kind(tmp.path()),
+            WorkspacePolicyKind::Session
+        );
+    }
+
+    #[test]
+    fn should_return_coding_policy_marker_for_coding_kind() {
+        let policy = WorkspacePolicy::for_coding();
+        assert_eq!(policy.workspace.kind, WorkspacePolicyKind::Coding);
+        // Inherits session spawn-task contracts so coding workspaces that
+        // still spawn slides/podcast keep the per-skill gate.
+        assert!(policy.spawn_tasks.contains_key("fm_tts"));
+        assert!(policy.spawn_tasks.contains_key("mofa_slides"));
+    }
+
+    #[test]
+    fn should_return_rust_check_hook_in_coding_defaults() {
+        let hooks = coding_default_hooks();
+        let cargo = hooks
+            .iter()
+            .find(|h| h.command.first().map(String::as_str) == Some("cargo"))
+            .expect("cargo check hook present");
+        assert_eq!(cargo.event, crate::hooks::HookEvent::AfterToolCall);
+        assert!(cargo.path_filter.iter().any(|p| p == "**/*.rs"));
+        assert!(cargo.tool_filter.iter().any(|t| t == "edit_file"));
+        assert!(cargo.tool_filter.iter().any(|t| t == "write_file"));
+        assert!(cargo.tool_filter.iter().any(|t| t == "diff_edit"));
+        assert_eq!(cargo.requires_bin.as_deref(), Some("cargo"));
+    }
+
+    #[test]
+    fn should_return_eslint_hook_gated_on_bin_in_coding_defaults() {
+        let hooks = coding_default_hooks();
+        let eslint = hooks
+            .iter()
+            .find(|h| h.command.first().map(String::as_str) == Some("eslint"))
+            .expect("eslint hook present");
+        // ESLint hook must be opt-out friendly via requires_bin — operators
+        // without eslint on PATH must NOT see hook failures every edit.
+        assert_eq!(eslint.requires_bin.as_deref(), Some("eslint"));
+        assert!(
+            eslint
+                .path_filter
+                .iter()
+                .any(|p| p.ends_with(".{js,ts,tsx,jsx}"))
+        );
+    }
+
+    #[test]
+    fn should_return_ruff_hook_gated_on_bin_in_coding_defaults() {
+        let hooks = coding_default_hooks();
+        let ruff = hooks
+            .iter()
+            .find(|h| h.command.first().map(String::as_str) == Some("ruff"))
+            .expect("ruff hook present");
+        assert_eq!(ruff.requires_bin.as_deref(), Some("ruff"));
+        assert!(ruff.path_filter.iter().any(|p| p == "**/*.py"));
+    }
+
+    #[test]
+    fn should_not_emit_coding_hooks_for_session_kind() {
+        // Session policies retain the legacy no-default-hooks behaviour so
+        // existing operators don't see a sudden new wave of cargo checks.
+        let session = WorkspacePolicy::for_session();
+        assert_eq!(session.workspace.kind, WorkspacePolicyKind::Session);
+        // The hooks helper is global (not method-on-policy); we assert that
+        // callers must opt in by inspecting the kind themselves.
+        assert_ne!(session.workspace.kind, WorkspacePolicyKind::Coding);
+    }
+
+    #[test]
+    fn should_serialize_coding_kind_as_kebab_case() {
+        let policy = WorkspacePolicy::for_coding();
+        let rendered = toml::to_string(&policy).unwrap();
+        assert!(
+            rendered.contains("kind = \"coding\""),
+            "expected kebab-case 'coding' in serialized policy:\n{}",
+            rendered
+        );
     }
 }

--- a/crates/octos-agent/tests/domain_hook.rs
+++ b/crates/octos-agent/tests/domain_hook.rs
@@ -52,6 +52,8 @@ async fn should_include_domain_data_when_enricher_registered() {
         command: vec![script_path.to_string_lossy().to_string()],
         timeout_ms: 5000,
         tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
     }])
     .with_enricher(Arc::new(StaticForceEnricher { force_n: 12.5 }));
 
@@ -103,6 +105,8 @@ async fn should_omit_domain_data_when_no_enricher() {
         command: vec![script_path.to_string_lossy().to_string()],
         timeout_ms: 5000,
         tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
     }]);
 
     let payload = HookPayload::before_spawn_verify(
@@ -156,6 +160,8 @@ async fn should_truncate_domain_data_at_max_payload_field_bytes() {
         command: vec![script_path.to_string_lossy().to_string()],
         timeout_ms: 5000,
         tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
     }])
     .with_enricher(Arc::new(OversizeEnricher));
 
@@ -242,6 +248,8 @@ exit 0
         command: vec![script_path.to_string_lossy().to_string()],
         timeout_ms: 5000,
         tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
     }])
     .with_enricher(Arc::new(DynamicForceEnricher {
         reading: std::sync::Mutex::new(55.2),
@@ -297,6 +305,8 @@ exit 0
         command: vec![script_path.to_string_lossy().to_string()],
         timeout_ms: 5000,
         tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
     }])
     .with_enricher(Arc::new(DynamicForceEnricher {
         reading: std::sync::Mutex::new(12.0),
@@ -367,6 +377,8 @@ exit 0
         command: vec![script_path.to_string_lossy().to_string()],
         timeout_ms: 5000,
         tool_filter: vec![],
+        path_filter: vec![],
+        requires_bin: None,
     }])
     .with_enricher(Arc::new(RobotEnricher));
 

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -898,6 +898,8 @@ mod tests {
             command: vec!["/bin/true".to_string()],
             timeout_ms: 1000,
             tool_filter: Vec::new(),
+            path_filter: Vec::new(),
+            requires_bin: None,
         };
         let executor = Arc::new(octos_agent::HookExecutor::new(vec![hook]));
         let profile = make_profile_with_hooks(data_dir, executor.clone()).await;

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -6476,6 +6476,8 @@ mod tests {
             ],
             timeout_ms: 5000,
             tool_filter: vec![],
+            path_filter: Vec::new(),
+            requires_bin: None,
         }
     }
 

--- a/crates/octos-pipeline/tests/deadline_enforcement.rs
+++ b/crates/octos-pipeline/tests/deadline_enforcement.rs
@@ -304,6 +304,8 @@ async fn should_fire_spawn_failure_hook_when_deadline_action_is_escalate() {
         command: cmd,
         timeout_ms: 3000,
         tool_filter: vec![],
+        path_filter: Vec::new(),
+        requires_bin: None,
     };
     let hook = Arc::new(HookExecutor::new(vec![hook_cfg]));
 


### PR DESCRIPTION
## Summary

Closes audit Gap-1 (AfterTool), Gap-8 (auto-fire on Completion), and Gap-10 (Preflight — already covered by `before_tool_call`) by polishing the existing hook system instead of inventing a parallel framework. Per the user's pushback: hooks already do most of this; we just close the gaps.

### A. Hook `path_filter` + `requires_bin` (Gap-1 closure)
- `HookConfig.path_filter: Vec<String>` — glob patterns matched against `arguments.path` for tool events. Empty = today's behaviour (fire-for-all). Compiled once at executor construction via `glob::Pattern`; invalid patterns log + drop.
- `HookConfig.requires_bin: Option<String>` — skip when the binary is absent on PATH. Gates the eslint/ruff defaults so operators without them installed see silent-skip.
- Path extraction is tool-specific: `edit_file`, `write_file`, `diff_edit` all expose `args.path`. Tools without a path arg (`shell`, `read_file`) skip when `path_filter` is non-empty.

### B. `WorkspacePolicyKind::Coding` (Gap-1 declarative side, Q3)
- New variant alongside Slides/Sites/Session.
- `detect_workspace_policy_kind(cwd)` probes `Cargo.toml` → `package.json` → `pyproject.toml` → fallback Session.
- `WorkspacePolicy::for_coding()` inherits the Session spawn-task contract graph.
- `coding_default_hooks()` returns 3 AfterTool hooks (`cargo check --message-format=short` on `**/*.rs`, `eslint --max-warnings 0` on `**/*.{js,ts,tsx,jsx}` (gated by binary), `ruff check` on `**/*.py` (gated by binary)) for hosts to merge into their HookExecutor. Kept as freestanding helper so the serialized policy struct doesn't leak process-launch state.

### C. Auto-fire `check_workspace_contract` on Completion (Gap-8)
- `inspect_workspace_contract_failures()` helper in `loop_runner.rs`.
- Wired in the EndTurn arm of `run_task` (~line 1366), right before `build_result`. Demotes success → false and appends a failure summary when any policy-managed repo under `working_dir` is not ready. Workspaces without policy stay unchanged.

### Test count delta
- `hooks.rs`: +11 tests (path_filter match/no-match/empty/absent; precedence with tool_filter; invalid glob; requires_bin; deserialize roundtrips)
- `workspace_policy.rs`: +9 tests (Coding detection per language; `for_coding()` marker; default hook shape; kebab-case serialization)
- `loop_runner.rs`: +7 tests (helper truth-table + 3 end-to-end `run_task` integration tests)

Full `octos-agent` lib suite: 1353 tests pass, 1 ignored. `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` both clean.

## Test plan
- [x] `cargo test -p octos-agent --lib hooks::`
- [x] `cargo test -p octos-agent --lib workspace_policy::`
- [x] `cargo test -p octos-agent --lib loop_runner::tests::`
- [x] `cargo test -p octos-agent --lib` (1353 passed, 1 ignored)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p octos-agent --all-targets -- -D warnings`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --lib`