### PR TITLE
feat(workspace-policy): spawn_only named_outputs + ${output.X} interpolation + mofa_publish probe

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -123,6 +123,34 @@ fn relativize_workspace_path(path: &str, workspace_root: Option<&std::path::Path
     }
 }
 
+/// Decide what `content` to put on the spawn-only background-result payload
+/// when the workspace contract reports `Satisfied`.
+///
+/// Wave-3b regression guard: a contract entry with no declared artifact
+/// (e.g. `mofa_publish`, whose deliverable is a live URL, not a file)
+/// returns `Satisfied { output_files: [] }`. Before this fix the handler
+/// fell through to `content: String::new()`, dropping the tool's stdout
+/// text (the deploy URL itself for `mofa_publish`) and the user saw a
+/// blank completion.
+///
+/// Rule:
+///
+/// - When `output_files` is non-empty: emit empty content; the files
+///   themselves carry the deliverable. This matches the legacy
+///   file-attached behaviour for `fm_tts` / `podcast_generate` / etc.
+/// - When `output_files` is empty: emit the tool's stdout `output` as
+///   content. The contract verified the artifact-shaped portion of the
+///   deliverable (e.g. the HttpProbe asserting deploy_url returned
+///   `<!DOCTYPE`), but the user-visible text payload (the live URL) is
+///   what the LLM/user actually consumes.
+pub(super) fn satisfied_completion_content(output_files: &[String], tool_output: &str) -> String {
+    if output_files.is_empty() {
+        tool_output.to_string()
+    } else {
+        String::new()
+    }
+}
+
 /// Produce the composite system-prompt text (worker prompt + realtime sensor
 /// summary) used at the top of every agent turn. Centralizing this in
 /// `execution.rs` keeps the message-building policy in a single location so
@@ -545,10 +573,24 @@ impl Agent {
                             .await
                             {
                                 SpawnTaskContractResult::Satisfied { output_files } => {
+                                    // Wave-3b regression guard: when a contract
+                                    // declares no artifact (e.g. `mofa_publish`,
+                                    // whose deliverable is a live URL, not a
+                                    // file), `output_files` is empty. Falling
+                                    // through with `content: String::new()`
+                                    // would drop the tool's stdout text (the
+                                    // deploy URL itself, in the publish case)
+                                    // and the user would see a blank completion.
+                                    // Surface the tool's text output as content
+                                    // when there are no files to attach —
+                                    // matches the legacy text-fallback path for
+                                    // contracts that don't declare artifacts.
+                                    let satisfied_content =
+                                        satisfied_completion_content(&output_files, &r.output);
                                     let result_persisted = if let Some(ref sender) = bg_sender {
                                         sender(BackgroundResultPayload {
                                             task_label: bg_name.clone(),
-                                            content: String::new(),
+                                            content: satisfied_content,
                                             kind: BackgroundResultKind::Notification,
                                             media: output_files.clone(),
                                             envelope_media: vec![],
@@ -1646,7 +1688,7 @@ fn panic_result(tool_call: &octos_core::ToolCall, reason: &str) -> ToolCallResul
 mod tests {
     use super::{
         build_spawn_only_produced_files_message, relativize_workspace_path,
-        should_auto_send_tool_files,
+        satisfied_completion_content, should_auto_send_tool_files,
     };
 
     #[test]
@@ -1759,5 +1801,39 @@ mod tests {
             relativize_workspace_path("/u/me/ws/a.md", None),
             "/u/me/ws/a.md"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // Wave-3b: `Satisfied { output_files: [] }` text-fallback regression.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn satisfied_completion_keeps_tool_text_when_no_output_files() {
+        // codex P1 regression guard: a contract with no declared artifact
+        // (e.g. mofa_publish, whose deliverable is a URL) returns
+        // `Satisfied { output_files: [] }`. The background completion
+        // payload must surface the tool's stdout text (the deploy URL),
+        // not an empty string.
+        let result = satisfied_completion_content(&[], "https://deployed.example.com");
+        assert_eq!(result, "https://deployed.example.com");
+    }
+
+    #[test]
+    fn satisfied_completion_emits_empty_content_when_files_carry_deliverable() {
+        // Legacy artifact-carrying contracts (fm_tts, podcast_generate,
+        // mofa_slides, ...) still emit empty content because the files
+        // themselves are the deliverable.
+        let files = vec!["/tmp/a.mp3".to_string(), "/tmp/b.mp3".to_string()];
+        let result = satisfied_completion_content(&files, "skill text result");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn satisfied_completion_keeps_empty_text_when_no_files_and_no_text() {
+        // Defensive: empty tool output with empty output_files stays empty
+        // — the legacy "no output produced" branch downstream will surface
+        // a typed failure via the `r.success` check, not here.
+        let result = satisfied_completion_content(&[], "");
+        assert_eq!(result, "");
     }
 }

--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -39,7 +39,9 @@ use crate::progress::ProgressEvent;
 use crate::task_supervisor::TaskRuntimeState;
 use crate::tools::spawn::{BackgroundResultKind, BackgroundResultPayload};
 use crate::tools::{ConcurrencyClass, TOOL_CTX, TURN_ATTACHMENT_CTX, ToolContext};
-use crate::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract_with_args};
+use crate::workspace_contract::{
+    SpawnTaskContractResult, enforce_spawn_task_contract_with_args_and_output,
+};
 
 /// Per-tool-call result returned from the in-process dispatcher. Kept as a
 /// tuple so the aggregation path can reuse today's `futures::join_all` style
@@ -515,7 +517,22 @@ impl Agent {
                                 success = true,
                                 "spawn_only background tool completed"
                             );
-                            match enforce_spawn_task_contract_with_args(
+                            // Forward the tool's `named_outputs` map (parsed
+                            // from its stdout envelope by the plugin
+                            // wrapper) so validators can resolve
+                            // `${output.<key>}` references against
+                            // tool-emitted values (e.g. `mofa_publish`
+                            // emitting `deploy_url`).
+                            let named_outputs_value = r.named_outputs.as_ref().map(|map| {
+                                serde_json::Value::Object(
+                                    map.iter()
+                                        .map(|(k, v)| {
+                                            (k.clone(), serde_json::Value::String(v.clone()))
+                                        })
+                                        .collect(),
+                                )
+                            });
+                            match enforce_spawn_task_contract_with_args_and_output(
                                 &bg_tools,
                                 &bg_name,
                                 &bg_tc_id,
@@ -523,6 +540,7 @@ impl Agent {
                                 bg_started_at,
                                 Some((&bg_supervisor, &task_id)),
                                 Some(&bg_args),
+                                named_outputs_value.as_ref(),
                             )
                             .await
                             {

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -612,6 +612,76 @@ fn input_schema_has_property(schema: &serde_json::Value, property: &str) -> bool
         .is_some_and(|properties| properties.contains_key(property))
 }
 
+/// Parse the optional `named_outputs` field from a spawn_only plugin's
+/// stdout envelope.
+///
+/// Returns:
+/// - `Ok(None)` when the field is absent or `null`.
+/// - `Ok(Some(map))` when the field is a JSON object whose entries pass
+///   validation (keys match `[a-z][a-z0-9_]*`, values are strings).
+/// - `Err(message)` when the field is present but malformed: not an object,
+///   contains a non-string value, an empty key, or a key shape violation.
+///
+/// The contract layer threads the returned map into `ValidatorInvocation`
+/// so `${output.<key>}` interpolation can resolve against tool-emitted
+/// values. Values are restricted to strings in v1; nested JSON support is
+/// deferred.
+fn parse_named_outputs(
+    raw: Option<&serde_json::Value>,
+) -> Result<Option<std::collections::HashMap<String, String>>, String> {
+    let Some(value) = raw else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let object = value
+        .as_object()
+        .ok_or_else(|| "named_outputs must be a JSON object".to_string())?;
+    if object.is_empty() {
+        return Ok(None);
+    }
+    let mut map = std::collections::HashMap::with_capacity(object.len());
+    for (key, entry) in object {
+        if !is_valid_named_output_key(key) {
+            return Err(format!(
+                "named_outputs key '{key}' does not match required shape [a-z][a-z0-9_]*"
+            ));
+        }
+        let string_value = entry.as_str().ok_or_else(|| {
+            format!(
+                "named_outputs value for '{key}' must be a string, got {}",
+                value_kind_label(entry)
+            )
+        })?;
+        map.insert(key.clone(), string_value.to_string());
+    }
+    Ok(Some(map))
+}
+
+/// Validate a `named_outputs` key matches `[a-z][a-z0-9_]*`.
+fn is_valid_named_output_key(key: &str) -> bool {
+    let mut bytes = key.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() {
+        return false;
+    }
+    bytes.all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_')
+}
+
+fn value_kind_label(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
 /// Resolve a plugin tool's input path (`audio_path` / `file_path` /
 /// `input` / per-slide `source_image`) to an absolute on-disk string.
 ///
@@ -1163,6 +1233,29 @@ impl Tool for PluginTool {
                 })
                 .unwrap_or_default();
 
+            // Parse named_outputs: spawn_only plugins can surface structured
+            // values (e.g. `mofa_publish` emitting `deploy_url`) the contract
+            // layer threads to validators for `${output.<key>}` interpolation.
+            //
+            // Malformed payloads must NOT silently drop the field — surface
+            // a typed failure so the contract layer rejects the result.
+            let named_outputs = match parse_named_outputs(parsed.get("named_outputs")) {
+                Ok(value) => value,
+                Err(reason) => {
+                    tracing::warn!(
+                        plugin = %self.plugin_name,
+                        tool = %self.tool_def.name,
+                        error = %reason,
+                        "rejecting spawn_only result: malformed named_outputs"
+                    );
+                    return Ok(ToolResult {
+                        output: format!("plugin emitted malformed named_outputs: {reason}"),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            };
+
             // Auto-deliver output file when plugin didn't report it.
             // Check multiple locations: work_dir, cwd, and the output text itself.
             let file_modified = if file_modified.is_none() && files_to_send.is_empty() {
@@ -1177,6 +1270,7 @@ impl Tool for PluginTool {
                 success,
                 file_modified,
                 files_to_send,
+                named_outputs,
                 ..Default::default()
             });
         }
@@ -2622,5 +2716,180 @@ mod tests {
         assert!(result.success);
         assert_eq!(result.output, "ran");
         assert!(last.lock().unwrap().is_none());
+    }
+
+    // -------------------------------------------------------------------
+    // Wave-3b: spawn_only stdout envelope extension — `named_outputs`.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn parse_named_outputs_returns_none_when_field_absent() {
+        // Tool that doesn't emit named_outputs should parse cleanly to None
+        // so existing spawn_only callers stay byte-identical.
+        let envelope = json!({"success": true, "output": "ok"});
+        let parsed = parse_named_outputs(envelope.get("named_outputs")).unwrap();
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn parse_named_outputs_returns_none_when_field_is_null() {
+        let envelope = json!({"named_outputs": null});
+        let parsed = parse_named_outputs(envelope.get("named_outputs")).unwrap();
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn parse_named_outputs_returns_none_when_object_is_empty() {
+        let envelope = json!({"named_outputs": {}});
+        let parsed = parse_named_outputs(envelope.get("named_outputs")).unwrap();
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn parse_named_outputs_maps_string_values() {
+        let envelope = json!({
+            "named_outputs": {
+                "deploy_url": "https://example.com/site",
+                "repo": "octos/site",
+            }
+        });
+        let parsed = parse_named_outputs(envelope.get("named_outputs"))
+            .unwrap()
+            .expect("expected Some(map)");
+        assert_eq!(
+            parsed.get("deploy_url").map(String::as_str),
+            Some("https://example.com/site")
+        );
+        assert_eq!(parsed.get("repo").map(String::as_str), Some("octos/site"));
+    }
+
+    #[test]
+    fn parse_named_outputs_rejects_non_object_payload() {
+        let envelope = json!({"named_outputs": ["a", "b"]});
+        let err = parse_named_outputs(envelope.get("named_outputs")).unwrap_err();
+        assert!(err.contains("must be a JSON object"), "{err}");
+    }
+
+    #[test]
+    fn parse_named_outputs_rejects_non_string_value() {
+        // v1: nested JSON not supported. Numbers, bools, arrays, objects
+        // must surface as errors so the contract layer sees a typed
+        // failure rather than silently dropping the field.
+        let envelope = json!({
+            "named_outputs": {"deploy_count": 42}
+        });
+        let err = parse_named_outputs(envelope.get("named_outputs")).unwrap_err();
+        assert!(err.contains("must be a string"), "{err}");
+        assert!(err.contains("deploy_count"), "{err}");
+    }
+
+    #[test]
+    fn parse_named_outputs_rejects_key_starting_with_digit() {
+        let envelope = json!({"named_outputs": {"1deploy": "x"}});
+        let err = parse_named_outputs(envelope.get("named_outputs")).unwrap_err();
+        assert!(err.contains("required shape"), "{err}");
+    }
+
+    #[test]
+    fn parse_named_outputs_rejects_uppercase_key() {
+        let envelope = json!({"named_outputs": {"DeployUrl": "x"}});
+        let err = parse_named_outputs(envelope.get("named_outputs")).unwrap_err();
+        assert!(err.contains("required shape"), "{err}");
+    }
+
+    #[test]
+    fn parse_named_outputs_rejects_key_with_hyphen() {
+        let envelope = json!({"named_outputs": {"deploy-url": "x"}});
+        let err = parse_named_outputs(envelope.get("named_outputs")).unwrap_err();
+        assert!(err.contains("required shape"), "{err}");
+    }
+
+    #[test]
+    fn parse_named_outputs_rejects_empty_key() {
+        let envelope = json!({"named_outputs": {"": "x"}});
+        let err = parse_named_outputs(envelope.get("named_outputs")).unwrap_err();
+        assert!(err.contains("required shape"), "{err}");
+    }
+
+    #[test]
+    fn parse_named_outputs_accepts_underscore_and_digits_after_first_char() {
+        let envelope = json!({"named_outputs": {"deploy_url_v2": "x", "out1": "y"}});
+        let parsed = parse_named_outputs(envelope.get("named_outputs"))
+            .unwrap()
+            .expect("expected map");
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn execute_with_named_outputs_threads_field_into_tool_result() {
+        // End-to-end: plugin emits {"named_outputs": {...}} on stdout, the
+        // PluginTool wrapper forwards it through ToolResult so the
+        // spawn_only contract path can read it.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"success\":true,\"output\":\"deployed\",\"named_outputs\":{\"deploy_url\":\"http://example.com/site\"}}'\n",
+        );
+
+        let def = make_tool_def("publish_tool", "publish");
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let result = tool.execute(&json!({})).await.expect("execute should ok");
+        assert!(result.success);
+        assert_eq!(result.output, "deployed");
+        let named = result.named_outputs.expect("named_outputs should be set");
+        assert_eq!(
+            named.get("deploy_url").map(String::as_str),
+            Some("http://example.com/site")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn execute_with_malformed_named_outputs_returns_failure() {
+        // A plugin emitting a non-string value in named_outputs must
+        // surface as a typed failure so the contract layer rejects it.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"success\":true,\"output\":\"ok\",\"named_outputs\":{\"count\":42}}'\n",
+        );
+
+        let def = make_tool_def("bad_tool", "emits bad named outputs");
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let result = tool.execute(&json!({})).await.expect("execute should ok");
+        assert!(!result.success);
+        assert!(
+            result.output.contains("named_outputs") || result.output.contains("must be a string"),
+            "unexpected output: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[cfg(unix)]
+    async fn execute_without_named_outputs_leaves_tool_result_none() {
+        // Backward compat: legacy plugins that don't emit named_outputs
+        // must continue to produce ToolResult.named_outputs = None.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let script_path = dir.path().join("script.sh");
+        write_test_script(
+            &script_path,
+            "#!/bin/sh\necho '{\"success\":true,\"output\":\"done\"}'\n",
+        );
+
+        let def = make_tool_def("legacy_tool", "legacy");
+        let tool =
+            PluginTool::new("p".into(), def, script_path).with_timeout(Duration::from_secs(5));
+
+        let result = tool.execute(&json!({})).await.expect("execute should ok");
+        assert!(result.success);
+        assert!(result.named_outputs.is_none());
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -412,6 +412,14 @@ pub struct ToolResult {
     /// panel can render real per-node attribution. Absent (`None`) for
     /// every tool that does not opt in — keeps legacy callers byte-identical.
     pub structured_metadata: Option<serde_json::Value>,
+    /// Optional named outputs the tool wants the contract layer to read.
+    /// spawn_only plugin tools emit this via `"named_outputs": {"key": "value"}`
+    /// in their stdout JSON envelope. The contract layer forwards each entry
+    /// to validators so `${output.<key>}` interpolation can resolve against
+    /// tool-emitted values (e.g. `mofa_publish` emitting `deploy_url`).
+    /// Values are restricted to strings in v1; key shape must match
+    /// `[a-z][a-z0-9_]*`. Absent (`None`) when the tool emits nothing.
+    pub named_outputs: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Trait for implementing tools.

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -143,6 +143,12 @@ impl ValidatorStatus {
 /// (`HttpProbe`, `OminixVoiceExists`) reference these args via
 /// `${args.<key>}` template interpolation so they can assert e.g. "the
 /// requested voice name is registered with ominix-api".
+///
+/// `tool_output` carries the spawn task tool's `named_outputs` map (e.g.
+/// `mofa_publish` emits `deploy_url`). Domain validators reference these via
+/// `${output.<key>}` interpolation so they can probe the live URL the tool
+/// just produced. Absent for non-spawn contexts and for tools that emit no
+/// named outputs.
 #[derive(Clone, Debug)]
 pub struct ValidatorInvocation {
     pub phase: ValidatorPhase,
@@ -152,6 +158,10 @@ pub struct ValidatorInvocation {
     /// `${args.<key>}` interpolation; absent for non-spawn contexts (e.g.
     /// turn-end validators that don't reference task inputs).
     pub input_args: Option<serde_json::Value>,
+    /// Optional `named_outputs` map from the spawn task tool's stdout
+    /// envelope. Used by `${output.<key>}` interpolation; absent when the
+    /// tool emitted no named outputs (most legacy plugins).
+    pub tool_output: Option<serde_json::Value>,
 }
 
 impl ValidatorInvocation {
@@ -163,6 +173,7 @@ impl ValidatorInvocation {
             workspace_root,
             repo_label,
             input_args: None,
+            tool_output: None,
         }
     }
 
@@ -170,6 +181,13 @@ impl ValidatorInvocation {
     /// interpolation by domain validators.
     pub fn with_input_args(mut self, args: serde_json::Value) -> Self {
         self.input_args = Some(args);
+        self
+    }
+
+    /// Attach spawn task tool output (the `named_outputs` map) for
+    /// `${output.<key>}` template interpolation by domain validators.
+    pub fn with_tool_output(mut self, output: serde_json::Value) -> Self {
+        self.tool_output = Some(output);
         self
     }
 }
@@ -498,8 +516,38 @@ impl ValidatorRunner {
         let timeout_ms = validator.timeout_ms.unwrap_or(DEFAULT_COMMAND_TIMEOUT_MS);
         let timeout_duration = Duration::from_millis(timeout_ms);
 
+        // Interpolate `${args.X}` and `${output.X}` references in both the
+        // executable path and each argv element. argv elements are passed
+        // as separate slots (no shell concatenation), so substitution is
+        // safe — and necessary if a policy wants to reference a tool-
+        // emitted path (e.g. `${output.patch_path}` for a `git apply`
+        // check). A missing key surfaces as an Error outcome.
+        let resolved_cmd = match interpolate_template(
+            cmd,
+            invocation.input_args.as_ref(),
+            invocation.tool_output.as_ref(),
+        ) {
+            Ok(value) => value,
+            Err(reason) => {
+                return error_outcome(invocation, validator, started_at, started, reason);
+            }
+        };
+        let mut resolved_args = Vec::with_capacity(args.len());
+        for arg in args {
+            match interpolate_template(
+                arg,
+                invocation.input_args.as_ref(),
+                invocation.tool_output.as_ref(),
+            ) {
+                Ok(value) => resolved_args.push(value),
+                Err(reason) => {
+                    return error_outcome(invocation, validator, started_at, started, reason);
+                }
+            }
+        }
+
         // Shell-safety layer: SafePolicy denies the known-dangerous patterns.
-        let command_string = build_command_string(cmd, args);
+        let command_string = build_command_string(&resolved_cmd, &resolved_args);
         let decision = self
             .policy
             .check(&command_string, &invocation.workspace_root);
@@ -516,9 +564,9 @@ impl ValidatorRunner {
             }
         }
 
-        let mut command = Command::new(cmd);
+        let mut command = Command::new(&resolved_cmd);
         command
-            .args(args)
+            .args(&resolved_args)
             .current_dir(&invocation.workspace_root)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -712,7 +760,15 @@ impl ValidatorRunner {
         // than silently checking a literal `${args.name}` path. Note the
         // returned string is percent-encoded path-segment-safe — fine for the
         // single-filename segment use case the contract specifies.
-        let resolved_path = match interpolate_args(path, invocation.input_args.as_ref()) {
+        //
+        // `${output.X}` resolves against the spawn task's `named_outputs` map
+        // (verbatim, not percent-encoded) so a tool that emits a structured
+        // path can drive the FileExists check directly.
+        let resolved_path = match interpolate_template(
+            path,
+            invocation.input_args.as_ref(),
+            invocation.tool_output.as_ref(),
+        ) {
             Ok(resolved) => resolved,
             Err(reason) => {
                 return error_outcome(invocation, validator, started_at, started, reason);
@@ -787,9 +843,11 @@ impl ValidatorRunner {
 
     /// Run an HTTP-probe validator.
     ///
-    /// Interpolates `${args.<key>}` against the spawn task's input args, then
-    /// performs a GET against the resulting URL and asserts the status code
-    /// (and optionally a substring of the body) matches the spec.
+    /// Interpolates `${args.<key>}` and `${output.<key>}` against the spawn
+    /// task's input args and `named_outputs` respectively, then performs a
+    /// GET against the resulting URL and asserts the status code (and
+    /// optionally a substring of the body, which is itself interpolated)
+    /// matches the spec.
     #[allow(clippy::too_many_arguments)]
     async fn run_http_probe(
         &self,
@@ -804,14 +862,37 @@ impl ValidatorRunner {
         let timeout_ms = validator
             .timeout_ms
             .unwrap_or(DEFAULT_HTTP_PROBE_TIMEOUT_MS);
-        let url = match interpolate_args(url_template, invocation.input_args.as_ref()) {
+        let url = match interpolate_template(
+            url_template,
+            invocation.input_args.as_ref(),
+            invocation.tool_output.as_ref(),
+        ) {
             Ok(url) => url,
             Err(reason) => {
                 return error_outcome(invocation, validator, started_at, started, reason);
             }
         };
 
-        match probe_http(&url, timeout_ms, expected_status, expected_contains).await {
+        // Interpolate the body-substring assertion too so policies can
+        // reference tool-emitted values (e.g. expected_contains carrying
+        // `${output.repo}` to assert the deployment HTML mentions the
+        // emitted repo slug).
+        let resolved_contains = match expected_contains {
+            Some(raw) => match interpolate_template(
+                raw,
+                invocation.input_args.as_ref(),
+                invocation.tool_output.as_ref(),
+            ) {
+                Ok(value) => Some(value),
+                Err(reason) => {
+                    return error_outcome(invocation, validator, started_at, started, reason);
+                }
+            },
+            None => None,
+        };
+        let expected_contains_ref = resolved_contains.as_deref();
+
+        match probe_http(&url, timeout_ms, expected_status, expected_contains_ref).await {
             Ok(reason) => self.make_outcome(
                 invocation,
                 validator,
@@ -940,7 +1021,27 @@ impl ValidatorRunner {
         started_at: DateTime<Utc>,
         started: Instant,
     ) -> ValidatorOutcome {
-        let matches = match glob_files(&invocation.workspace_root, pattern) {
+        // Interpolate `${args.X}` / `${output.X}` so policies can scope the
+        // glob to a per-invocation output dir (e.g.
+        // `${output.audio_dir}/**/*.wav`). A missing key is a hard error.
+        let resolved_pattern = match interpolate_template(
+            pattern,
+            invocation.input_args.as_ref(),
+            invocation.tool_output.as_ref(),
+        ) {
+            Ok(value) => value,
+            Err(reason) => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                );
+            }
+        };
+        let matches = match glob_files(&invocation.workspace_root, &resolved_pattern) {
             Ok(matches) => matches,
             Err(reason) => {
                 return self.make_outcome(
@@ -958,7 +1059,7 @@ impl ValidatorRunner {
                 invocation,
                 validator,
                 ValidatorStatus::Fail,
-                format!("audio_non_silent: no files matched '{pattern}'"),
+                format!("audio_non_silent: no files matched '{resolved_pattern}'"),
                 started_at,
                 started,
             );
@@ -1011,7 +1112,26 @@ impl ValidatorRunner {
         started_at: DateTime<Utc>,
         started: Instant,
     ) -> ValidatorOutcome {
-        let matches = match glob_files(&invocation.workspace_root, pattern) {
+        // Interpolate `${args.X}` / `${output.X}` so policies can pin the
+        // glob to a tool-emitted output path. Missing key → Error outcome.
+        let resolved_pattern = match interpolate_template(
+            pattern,
+            invocation.input_args.as_ref(),
+            invocation.tool_output.as_ref(),
+        ) {
+            Ok(value) => value,
+            Err(reason) => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                );
+            }
+        };
+        let matches = match glob_files(&invocation.workspace_root, &resolved_pattern) {
             Ok(matches) => matches,
             Err(reason) => {
                 return self.make_outcome(
@@ -1029,7 +1149,7 @@ impl ValidatorRunner {
                 invocation,
                 validator,
                 ValidatorStatus::Fail,
-                format!("magic_bytes: no files matched '{pattern}'"),
+                format!("magic_bytes: no files matched '{resolved_pattern}'"),
                 started_at,
                 started,
             );
@@ -1183,32 +1303,78 @@ enum HttpProbeFailure {
 
 /// Substitute `${args.<key>}` references in `template` against `input_args`.
 ///
-/// `<key>` is a dotted JSON path against the input args object. A missing key
-/// or a non-string/number value is a hard error so the validator surfaces an
-/// `Error` outcome rather than silently degrading the URL.
-///
-/// Substituted values are percent-encoded against
-/// [`URL_PATH_QUERY_RESERVED`] before being spliced into the template so an
-/// LLM- or user-controlled arg value cannot break out of the path/query
-/// segment it was placed into (e.g. inject a different host or query
-/// parameter). Templates are treated as URL fragments, not opaque strings.
+/// This thin wrapper preserves the legacy single-source signature for the
+/// inline test suite; production callers use [`interpolate_template`] which
+/// also resolves `${output.<key>}` against the spawn task's `named_outputs`.
+/// See [`interpolate_template`] for the canonical doc-comment on
+/// percent-encoding semantics and missing-key error policy.
+#[cfg(test)]
 fn interpolate_args(
     template: &str,
     input_args: Option<&serde_json::Value>,
 ) -> Result<String, String> {
+    interpolate_template(template, input_args, None)
+}
+
+/// Substitute `${args.<key>}` and `${output.<key>}` references in `template`.
+///
+/// Two interpolation sources, two trust levels:
+///
+/// - `${args.<key>}` resolves against the originating spawn task's input
+///   args (LLM-controlled). Values are percent-encoded into URL-segment-safe
+///   form so an LLM-supplied value cannot break out of the path/query slot
+///   it lands in.
+/// - `${output.<key>}` resolves against the spawn task tool's `named_outputs`
+///   map (tool-controlled, trust boundary equal to the tool itself). Values
+///   are spliced in verbatim because the canonical use case is a tool that
+///   emits a full URL (e.g. `mofa_publish` emitting `deploy_url`) that the
+///   downstream HTTP probe needs to call exactly as-is. Percent-encoding
+///   would corrupt the URL.
+///
+/// A missing key in either source surfaces as `Error` outcome (matches the
+/// `${args.X}` semantics shipped in #935): the validator runner translates
+/// this `Err` into a typed Error result rather than silently substituting
+/// the empty string.
+///
+/// Mixed templates resolve both sources in a single pass, e.g.
+/// `https://${output.host}/voices/${args.name}` works in one call. Order
+/// inside the template is preserved.
+fn interpolate_template(
+    template: &str,
+    input_args: Option<&serde_json::Value>,
+    tool_output: Option<&serde_json::Value>,
+) -> Result<String, String> {
     let mut out = String::with_capacity(template.len());
     let mut rest = template;
-    while let Some(start) = rest.find("${args.") {
+    loop {
+        let next_args = rest.find("${args.");
+        let next_output = rest.find("${output.");
+        let (start, prefix_len, source, source_label, encode) = match (next_args, next_output) {
+            (None, None) => break,
+            (Some(a), None) => (a, "${args.".len(), input_args, "input arg", true),
+            (None, Some(o)) => (o, "${output.".len(), tool_output, "output", false),
+            (Some(a), Some(o)) => {
+                if a <= o {
+                    (a, "${args.".len(), input_args, "input arg", true)
+                } else {
+                    (o, "${output.".len(), tool_output, "output", false)
+                }
+            }
+        };
         out.push_str(&rest[..start]);
-        let after = &rest[start + "${args.".len()..];
+        let after = &rest[start + prefix_len..];
         let end = after
             .find('}')
-            .ok_or_else(|| format!("unterminated ${{args.}} reference in template: {template}"))?;
+            .ok_or_else(|| format!("unterminated reference in template: {template}"))?;
         let key = &after[..end];
-        let value = input_arg(input_args, key).ok_or_else(|| {
-            format!("input arg '{key}' not found while interpolating template: {template}")
+        let value = input_arg(source, key).ok_or_else(|| {
+            format!("{source_label} '{key}' not found while interpolating template: {template}")
         })?;
-        out.push_str(&percent_encode_url_segment(&value));
+        if encode {
+            out.push_str(&percent_encode_url_segment(&value));
+        } else {
+            out.push_str(&value);
+        }
         rest = &after[end + 1..];
     }
     out.push_str(rest);
@@ -2275,5 +2441,331 @@ mod tests {
             !interpolated.contains('='),
             "raw `=` leaked: {interpolated}"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // Wave-3b: `${output.X}` template interpolation tests.
+    // -------------------------------------------------------------------
+
+    /// Minimal valid PNG signature + chunk (1x1 transparent) used by the
+    /// MagicBytes test below. Only the leading PNG signature bytes are
+    /// inspected by the validator, but a full chunk-set keeps the file
+    /// recognizable to image tools.
+    const PNG_1X1: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, b'I', b'H', b'D',
+        b'R', 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0D, b'I', b'D', b'A', b'T', 0x78, 0x9C, 0x62, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, b'I',
+        b'E', b'N', b'D', 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    #[test]
+    fn interpolate_template_substitutes_output_key_verbatim() {
+        // Tool-emitted values (`${output.X}`) come from a trusted source
+        // and represent full URLs / paths. Percent-encoding would corrupt
+        // them, so the substitution must be verbatim.
+        let output = serde_json::json!({"deploy_url": "https://example.com/path?ref=main"});
+        let out = interpolate_template("${output.deploy_url}", None, Some(&output)).unwrap();
+        assert_eq!(out, "https://example.com/path?ref=main");
+    }
+
+    #[test]
+    fn interpolate_template_errors_when_output_key_missing() {
+        // Mirror the `${args.X}` semantics: a missing key surfaces as a
+        // hard error so the validator can produce an `Error` outcome
+        // rather than silently degrading the URL.
+        let output = serde_json::json!({});
+        let err = interpolate_template("${output.deploy_url}", None, Some(&output)).unwrap_err();
+        assert!(err.contains("'deploy_url'"), "{err}");
+        assert!(err.contains("output"), "{err}");
+    }
+
+    #[test]
+    fn interpolate_template_errors_when_tool_output_is_none() {
+        let err = interpolate_template("${output.deploy_url}", None, None).unwrap_err();
+        assert!(err.contains("'deploy_url'"), "{err}");
+    }
+
+    #[test]
+    fn interpolate_template_mixes_args_and_output_in_one_template() {
+        // A single template can reference both sources in any order.
+        let args = serde_json::json!({"name": "yangmi"});
+        let output = serde_json::json!({"host": "https://api.example.com"});
+        let out = interpolate_template(
+            "${output.host}/voices/${args.name}/check",
+            Some(&args),
+            Some(&output),
+        )
+        .unwrap();
+        assert_eq!(out, "https://api.example.com/voices/yangmi/check");
+    }
+
+    #[test]
+    fn interpolate_template_keeps_args_percent_encoding_when_output_is_present() {
+        // Mixed template: args path segment is percent-encoded even
+        // though the template also references a tool output. Confirms the
+        // two interpolation sources remain logically distinct.
+        let args = serde_json::json!({"name": "evil/../?inject=1"});
+        let output = serde_json::json!({"host": "https://api.example.com"});
+        let out = interpolate_template("${output.host}/x/${args.name}", Some(&args), Some(&output))
+            .unwrap();
+        let segment = out
+            .strip_prefix("https://api.example.com/x/")
+            .expect("prefix preserved");
+        assert!(
+            !segment.contains('/'),
+            "args `/` leaked into segment: {segment}"
+        );
+        assert!(
+            !segment.contains('?'),
+            "args `?` leaked into segment: {segment}"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_exists_resolves_output_template() {
+        // `${output.X}` works inside FileExists for tools that emit a
+        // structured artifact path.
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("publish/out");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let index = out_dir.join("index.html");
+        std::fs::write(&index, vec![0u8; 64]).unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "published_index",
+            ValidatorSpec::FileExists {
+                path: "${output.publish_dir}/index.html".into(),
+                min_bytes: Some(8),
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({"publish_dir": "publish/out"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn file_exists_errors_when_required_output_key_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "needs_output",
+            ValidatorSpec::FileExists {
+                path: "${output.publish_dir}/index.html".into(),
+                min_bytes: None,
+            },
+        );
+        // tool_output missing the `publish_dir` key entirely.
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("'publish_dir'"),
+            "{}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn http_probe_resolves_output_url_template() {
+        // mofa_publish-style scenario: tool emits a fully-formed deploy_url;
+        // HttpProbe probes that URL verbatim (no percent-encoding).
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n\r\n<!DOCTYPE html>";
+        let addr = spawn_test_http_server(vec![response]);
+        let url_template = "${output.deploy_url}".to_string();
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_deploy",
+            ValidatorSpec::HttpProbe {
+                url_template,
+                expected_status: 200,
+                expected_contains: Some("<!DOCTYPE".into()),
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({
+            "deploy_url": format!("http://{addr}/site"),
+        }));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn http_probe_errors_when_output_deploy_url_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_deploy_missing",
+            ValidatorSpec::HttpProbe {
+                url_template: "${output.deploy_url}".into(),
+                expected_status: 200,
+                expected_contains: None,
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("'deploy_url'"),
+            "{}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn http_probe_expected_contains_interpolates_args_and_output() {
+        // mofa_publish-style scenario where the deployed page mentions
+        // both an LLM-supplied slug (args.repo_slug) and a tool-emitted
+        // commit sha (output.commit_sha). Both must interpolate in the
+        // expected_contains assertion.
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 26\r\n\r\nrepo=octos-site sha=abc123";
+        let addr = spawn_test_http_server(vec![response]);
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_mixed",
+            ValidatorSpec::HttpProbe {
+                url_template: format!("http://{addr}/"),
+                expected_status: 200,
+                expected_contains: Some("sha=${output.commit_sha}".into()),
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_input_args(serde_json::json!({"repo_slug": "octos-site"}))
+        .with_tool_output(serde_json::json!({"commit_sha": "abc123"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn command_args_interpolate_output_key() {
+        // Command's argv can reference output values for tools that emit
+        // a path (e.g. propose_patch emitting `patch_path` → `git apply
+        // --check ${output.patch_path}`). Verbatim substitution so the
+        // path stays usable as a real filesystem argument.
+        let dir = tempfile::tempdir().unwrap();
+        let path_arg = dir.path().join("deploy.txt");
+        std::fs::write(&path_arg, b"x").unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "cmd_with_output",
+            ValidatorSpec::Command {
+                cmd: "test".into(),
+                args: vec!["-f".into(), "${output.target_path}".into()],
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({
+            "target_path": path_arg.to_string_lossy().to_string(),
+        }));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn command_args_error_when_output_key_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "cmd_missing_output",
+            ValidatorSpec::Command {
+                cmd: "true".into(),
+                args: vec!["${output.missing}".into()],
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("'missing'"),
+            "{}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn magic_bytes_glob_interpolates_output_key() {
+        // MagicBytes pinned to a tool-emitted output directory.
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("publish");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        std::fs::write(out_dir.join("a.png"), PNG_1X1).unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "magic_bytes_output",
+            ValidatorSpec::MagicBytes {
+                glob: "${output.dir}/*.png".into(),
+                format: crate::workspace_policy::MagicByteKind::Png,
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({"dir": "publish"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn audio_non_silent_glob_interpolates_output_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_dir = dir.path().join("clips");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        write_sine_wav(&out_dir.join("a.wav"), 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "audio_output_glob",
+            ValidatorSpec::AudioNonSilent {
+                glob: "${output.audio_dir}/*.wav".into(),
+                min_ratio: 0.3,
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_tool_output(serde_json::json!({"audio_dir": "clips"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
     }
 }

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -47,13 +47,14 @@ pub async fn enforce_spawn_task_contract(
     task_started_at: SystemTime,
     supervisor: Option<(&TaskSupervisor, &str)>,
 ) -> SpawnTaskContractResult {
-    enforce_spawn_task_contract_with_args(
+    enforce_spawn_task_contract_with_args_and_output(
         tools,
         tool_name,
         tool_call_id,
         files_to_send,
         task_started_at,
         supervisor,
+        None,
         None,
     )
     .await
@@ -63,9 +64,11 @@ pub async fn enforce_spawn_task_contract(
 /// spawn task's input args so domain validators (`HttpProbe`,
 /// `OminixVoiceExists`) can resolve `${args.<key>}` references against them.
 ///
-/// Production callers in the agent loop should prefer this entry point — the
-/// args-less variant exists for legacy call sites that don't yet have the
-/// input JSON in scope.
+/// Production callers in the agent loop should prefer
+/// [`enforce_spawn_task_contract_with_args_and_output`] (which also threads
+/// the tool's `named_outputs` for `${output.<key>}` interpolation). This
+/// entry point exists for callers that have args but no tool output to
+/// forward.
 pub async fn enforce_spawn_task_contract_with_args(
     tools: &ToolRegistry,
     tool_name: &str,
@@ -74,6 +77,39 @@ pub async fn enforce_spawn_task_contract_with_args(
     task_started_at: SystemTime,
     supervisor: Option<(&TaskSupervisor, &str)>,
     input_args: Option<&serde_json::Value>,
+) -> SpawnTaskContractResult {
+    enforce_spawn_task_contract_with_args_and_output(
+        tools,
+        tool_name,
+        tool_call_id,
+        files_to_send,
+        task_started_at,
+        supervisor,
+        input_args,
+        None,
+    )
+    .await
+}
+
+/// Full variant of [`enforce_spawn_task_contract`] that threads BOTH the
+/// originating spawn task's input args (for `${args.<key>}` interpolation)
+/// AND the tool's `named_outputs` (for `${output.<key>}` interpolation).
+///
+/// `tool_named_outputs` is a JSON object built from the tool's stdout
+/// envelope; pass `None` for tools that emit nothing. The contract layer
+/// forwards it verbatim to [`run_declared_validators_with_output`] so the
+/// validator runner can interpolate templated URLs (e.g. `mofa_publish`
+/// emitting `deploy_url` then `HttpProbe { url_template = "${output.deploy_url}" }`).
+#[allow(clippy::too_many_arguments)]
+pub async fn enforce_spawn_task_contract_with_args_and_output(
+    tools: &ToolRegistry,
+    tool_name: &str,
+    tool_call_id: &str,
+    files_to_send: &[PathBuf],
+    task_started_at: SystemTime,
+    supervisor: Option<(&TaskSupervisor, &str)>,
+    input_args: Option<&serde_json::Value>,
+    tool_named_outputs: Option<&serde_json::Value>,
 ) -> SpawnTaskContractResult {
     let required_by_default = default_session_policy_requires_contract(tool_name);
     let Some(workspace_root) = tools.workspace_root() else {
@@ -160,13 +196,14 @@ pub async fn enforce_spawn_task_contract_with_args(
     for (index, entry) in task_policy.on_completion.iter().enumerate() {
         combined_validators.push(entry.clone().into_validator(tool_name, index));
     }
-    match run_declared_validators(
+    match run_declared_validators_with_output(
         tools,
         workspace_root,
         &combined_validators,
         tool_name,
         ValidatorPhase::Completion,
         input_args.cloned(),
+        tool_named_outputs.cloned(),
     )
     .await
     {
@@ -505,6 +542,9 @@ fn default_session_policy_requires_contract(tool_name: &str) -> bool {
 /// domain validators (`HttpProbe`, `OminixVoiceExists`) can resolve
 /// `${args.<key>}` references. Pass `None` for non-spawn contexts (e.g.
 /// turn-end validators that don't reference task inputs).
+///
+/// Thin wrapper for non-spawn-only callers that have no tool output to
+/// forward. Spawn-only callers should use [`run_declared_validators_with_output`].
 pub async fn run_declared_validators(
     tools: &ToolRegistry,
     workspace_root: &Path,
@@ -512,6 +552,32 @@ pub async fn run_declared_validators(
     repo_label_hint: &str,
     phase: ValidatorPhase,
     input_args: Option<serde_json::Value>,
+) -> Result<Vec<ValidatorOutcome>, String> {
+    run_declared_validators_with_output(
+        tools,
+        workspace_root,
+        validators,
+        repo_label_hint,
+        phase,
+        input_args,
+        None,
+    )
+    .await
+}
+
+/// Variant of [`run_declared_validators`] that also threads the spawn
+/// task's `named_outputs` (`tool_output`) into the validator invocation so
+/// domain validators can resolve `${output.<key>}` references against
+/// tool-emitted values (e.g. `mofa_publish` emitting `deploy_url` for the
+/// HttpProbe to call).
+pub async fn run_declared_validators_with_output(
+    tools: &ToolRegistry,
+    workspace_root: &Path,
+    validators: &[Validator],
+    repo_label_hint: &str,
+    phase: ValidatorPhase,
+    input_args: Option<serde_json::Value>,
+    tool_output: Option<serde_json::Value>,
 ) -> Result<Vec<ValidatorOutcome>, String> {
     if validators.is_empty() {
         return Ok(Vec::new());
@@ -552,6 +618,7 @@ pub async fn run_declared_validators(
         workspace_root: workspace_root.to_path_buf(),
         repo_label: repo_label_hint.to_string(),
         input_args,
+        tool_output,
     };
 
     let outcomes = runner.run_all(&invocation, &scoped).await;
@@ -1253,6 +1320,252 @@ mod tests {
                 assert_eq!(notify_user.as_deref(), Some("Voice registration failed"));
             }
             other => panic!("expected failure, got {other:?}"),
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Wave-3b: named_outputs end-to-end through enforce_spawn_task_contract.
+    // -------------------------------------------------------------------
+
+    /// Tiny synchronous HTTP server scripted via `responses`. Re-used from
+    /// the validators test module to drive end-to-end probes.
+    fn spawn_test_http_server(responses: Vec<&'static str>) -> String {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr").to_string();
+        std::thread::spawn(move || {
+            for body in responses {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let _ = stream.write_all(body.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        addr
+    }
+
+    /// Build a `mofa_publish` policy with the HttpProbe forced to
+    /// `required = true` so the test gate fails on a missing
+    /// named_output. Mirrors the eventual post-mofa-skills-follow-up
+    /// state of the policy.
+    fn mofa_publish_required_policy(url_template: &str) -> WorkspacePolicy {
+        use crate::Validator;
+        use crate::workspace_policy::{SpawnTaskValidatorSpec, ValidatorPhaseKind, ValidatorSpec};
+
+        let mut policy = WorkspacePolicy::for_session();
+        let publish = policy.spawn_tasks.entry("mofa_publish".into()).or_default();
+        publish.on_failure = vec!["notify_user:Publish probe failed".into()];
+        publish.on_completion = vec![SpawnTaskValidatorSpec::Full(Validator {
+            id: "mofa_publish.deploy_url_probe".into(),
+            required: true,
+            timeout_ms: Some(2000),
+            phase: ValidatorPhaseKind::Completion,
+            spec: ValidatorSpec::HttpProbe {
+                url_template: url_template.to_string(),
+                expected_status: 200,
+                expected_contains: Some("<!DOCTYPE".into()),
+            },
+        })];
+        policy
+    }
+
+    #[tokio::test]
+    async fn mofa_publish_contract_satisfies_when_named_outputs_deploy_url_serves_doctype() {
+        // End-to-end: tool emits `named_outputs.deploy_url`; contract
+        // probes that URL; server returns a 200 with `<!DOCTYPE` body.
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 14\r\n\r\n<!DOCTYPE html>";
+        let addr = spawn_test_http_server(vec![response]);
+        let temp = tempfile::tempdir().unwrap();
+        // Force the validator to `required = true` so a missing/failing
+        // probe blocks the contract.
+        write_workspace_policy(
+            temp.path(),
+            &mofa_publish_required_policy("${output.deploy_url}"),
+        )
+        .unwrap();
+
+        let result = enforce_spawn_task_contract_with_args_and_output(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_publish",
+            "tool-call-publish-ok",
+            &[],
+            UNIX_EPOCH,
+            None,
+            None,
+            Some(&json!({"deploy_url": format!("http://{addr}/site")})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_publish_contract_fails_when_probe_returns_soft_404_html() {
+        // 200 OK with a body that lacks `<!DOCTYPE` (e.g. a JSON soft-404
+        // wrapper) must fail the contract.
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 18\r\n\r\n{\"error\":\"missing\"}";
+        let addr = spawn_test_http_server(vec![response]);
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(
+            temp.path(),
+            &mofa_publish_required_policy("${output.deploy_url}"),
+        )
+        .unwrap();
+
+        let result = enforce_spawn_task_contract_with_args_and_output(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_publish",
+            "tool-call-publish-soft-404",
+            &[],
+            UNIX_EPOCH,
+            None,
+            None,
+            Some(&json!({"deploy_url": format!("http://{addr}/missing")})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert!(
+                    error.contains("<!DOCTYPE") || error.contains("did not contain"),
+                    "unexpected error: {error}"
+                );
+                assert_eq!(notify_user.as_deref(), Some("Publish probe failed"));
+            }
+            other => panic!("expected failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_publish_contract_fails_when_named_outputs_deploy_url_missing() {
+        // The skill claimed success but emitted NO named_outputs.
+        // With a `required = true` probe, the contract should reject
+        // the result because `${output.deploy_url}` is unresolvable.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(
+            temp.path(),
+            &mofa_publish_required_policy("${output.deploy_url}"),
+        )
+        .unwrap();
+
+        let result = enforce_spawn_task_contract_with_args_and_output(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_publish",
+            "tool-call-publish-missing-url",
+            &[],
+            UNIX_EPOCH,
+            None,
+            None,
+            // tool_output absent — emulates the current mofa_publish
+            // skill (before the mofa-skills repo follow-up).
+            None,
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, .. } => {
+                assert!(
+                    error.contains("deploy_url"),
+                    "error should name the missing output key: {error}"
+                );
+            }
+            other => panic!("expected failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_publish_default_contract_does_not_block_when_skill_not_yet_emitting_output() {
+        // Until the mofa-skills repo follow-up lands, mofa_publish does
+        // NOT yet emit `named_outputs.deploy_url`. The default contract
+        // ships the probe as `required = false` so the missing key
+        // produces a diagnostic ledger entry but does NOT fail the gate.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args_and_output(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_publish",
+            "tool-call-publish-default-policy",
+            &[],
+            UNIX_EPOCH,
+            None,
+            None,
+            // No named_outputs from the skill (current state).
+            None,
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!(
+                "default mofa_publish policy must not block users until mofa-skills \
+                 catches up; got {other:?}"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_only_envelope_named_outputs_threads_through_contract_to_validator() {
+        // Wave-3b protocol invariant: a spawn_only tool emits
+        // `named_outputs` on stdout → the contract forwards it to the
+        // validator runner → the runner uses `${output.X}` interpolation
+        // to drive (in this case) a FileExists check against a tool-
+        // emitted path. Validates the full chain end-to-end without
+        // depending on HTTP.
+        use crate::Validator;
+        use crate::workspace_policy::{
+            SpawnTaskValidatorSpec, ValidatorPhaseKind, ValidatorSpec, WorkspaceSpawnTaskPolicy,
+        };
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut policy = WorkspacePolicy::for_session();
+        policy.spawn_tasks.insert(
+            "fake_publish".into(),
+            WorkspaceSpawnTaskPolicy {
+                artifact: None,
+                artifacts: Vec::new(),
+                on_verify: Vec::new(),
+                on_complete: vec![],
+                on_deliver: vec![],
+                on_failure: vec!["notify_user:Fake publish failed".into()],
+                on_completion: vec![SpawnTaskValidatorSpec::Full(Validator {
+                    id: "fake_publish.target_exists".into(),
+                    required: true,
+                    timeout_ms: None,
+                    phase: ValidatorPhaseKind::Completion,
+                    spec: ValidatorSpec::FileExists {
+                        path: "${output.target_path}".into(),
+                        min_bytes: None,
+                    },
+                })],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+        std::fs::write(temp.path().join("artifact.txt"), b"x").unwrap();
+
+        let result = enforce_spawn_task_contract_with_args_and_output(
+            &ToolRegistry::with_builtins(temp.path()),
+            "fake_publish",
+            "tool-call-fake",
+            &[],
+            UNIX_EPOCH,
+            None,
+            None,
+            Some(&json!({"target_path": "artifact.txt"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected named_outputs path to satisfy contract, got {other:?}"),
         }
     }
 }

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -747,6 +747,47 @@ impl WorkspacePolicy {
             })],
         };
 
+        // mofa_publish (audit P0-3): probe the live `deploy_url` the skill
+        // emits via `named_outputs.deploy_url` after a successful publish.
+        // The probe asserts both a 200 status AND that the body carries an
+        // `<!DOCTYPE` prefix — guarding against the "200 OK with a soft
+        // 404 / SPA-shell error page" failure mode the audit calls out.
+        //
+        // `required = false` (NOT the default of true) because:
+        //
+        // 1. The mofa_publish skill in `mofa-skills/mofa-publish/` does
+        //    not yet emit `named_outputs.deploy_url`. Once that lands
+        //    (separate PR in the mofa-skills repo) this entry flips to
+        //    `required = true` so the canonical probe blocks bad
+        //    deployments.
+        // 2. Surfacing `${output.deploy_url}` against an empty
+        //    `named_outputs` map would produce a hard `Error` outcome on
+        //    every mofa_publish call until the skill catches up; setting
+        //    `required = false` keeps the validator running as a
+        //    diagnostic (recorded to the ledger) without blocking.
+        let mofa_publish_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Publish probe failed".into()],
+            on_completion: vec![SpawnTaskValidatorSpec::Full(Validator {
+                id: "mofa_publish.deploy_url_probe".into(),
+                required: false,
+                timeout_ms: None,
+                phase: ValidatorPhaseKind::Completion,
+                spec: ValidatorSpec::HttpProbe {
+                    url_template: "${output.deploy_url}".into(),
+                    expected_status: 200,
+                    // Sentinel rejecting a 200-with-soft-404 body. mofa_publish
+                    // ships an HTML site; the document type prefix should
+                    // always be present on a real deployed page.
+                    expected_contains: Some("<!DOCTYPE".into()),
+                },
+            })],
+        };
+
         let mut spawn_tasks = BTreeMap::new();
         spawn_tasks.insert("fm_tts".into(), tts_contract.clone());
         spawn_tasks.insert("voice_synthesize".into(), voice_synthesize_contract);
@@ -757,6 +798,7 @@ impl WorkspacePolicy {
         spawn_tasks.insert("mofa_comic".into(), mofa_comic_contract);
         spawn_tasks.insert("mofa_infographic".into(), mofa_infographic_contract);
         spawn_tasks.insert("mofa_frame".into(), mofa_frame_contract);
+        spawn_tasks.insert("mofa_publish".into(), mofa_publish_contract);
 
         Self {
             schema_version: WORKSPACE_POLICY_SCHEMA_VERSION,
@@ -1429,6 +1471,69 @@ ignore = []
                 entry.on_completion
             );
         }
+    }
+
+    #[test]
+    fn session_policy_declares_http_probe_for_mofa_publish() {
+        // P0-3 (audit): mofa_publish emits a live `deploy_url` via
+        // named_outputs; the contract must declare an HttpProbe against
+        // `${output.deploy_url}` so a 200-with-soft-404 deployment is
+        // rejected at the harness gate. The validator runs as
+        // non-required pending the mofa-skills repo follow-up that
+        // teaches the skill to emit `named_outputs.deploy_url`.
+        let policy = WorkspacePolicy::for_session();
+        let publish = policy
+            .spawn_tasks
+            .get("mofa_publish")
+            .expect("policy must declare mofa_publish spawn task");
+        let probe = publish
+            .on_completion
+            .iter()
+            .find_map(|entry| match entry {
+                SpawnTaskValidatorSpec::Full(validator) => match &validator.spec {
+                    ValidatorSpec::HttpProbe {
+                        url_template,
+                        expected_status,
+                        expected_contains,
+                    } => Some((
+                        validator.required,
+                        url_template.clone(),
+                        *expected_status,
+                        expected_contains.clone(),
+                    )),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .expect("mofa_publish must declare an HttpProbe Full validator");
+        assert_eq!(
+            probe.1, "${output.deploy_url}",
+            "HttpProbe must target the tool-emitted deploy_url",
+        );
+        assert_eq!(probe.2, 200, "must assert 200 status");
+        assert!(
+            probe
+                .3
+                .as_deref()
+                .map(|needle| needle.contains("<!DOCTYPE"))
+                .unwrap_or(false),
+            "expected_contains must carry the <!DOCTYPE soft-404 sentinel; got {:?}",
+            probe.3,
+        );
+        assert!(
+            !probe.0,
+            "validator must be non-required until the mofa-skills repo teaches \
+             mofa_publish to emit named_outputs.deploy_url",
+        );
+        assert_eq!(
+            publish
+                .on_failure
+                .iter()
+                .find(|action| action.starts_with("notify_user:"))
+                .cloned(),
+            Some("notify_user:Publish probe failed".to_string()),
+            "on_failure should surface a notify_user hint",
+        );
     }
 
     #[test]

--- a/crates/octos-agent/tests/validator_runner.rs
+++ b/crates/octos-agent/tests/validator_runner.rs
@@ -138,6 +138,7 @@ async fn should_block_ready_when_required_command_validator_fails() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -172,6 +173,7 @@ async fn should_warn_but_not_block_when_optional_validator_fails() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -203,6 +205,7 @@ async fn should_record_duration_and_evidence_path_for_command_validator() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -241,6 +244,7 @@ async fn should_expose_stderr_in_outcome_for_operator_visibility() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -289,6 +293,7 @@ async fn should_kill_child_process_on_validator_timeout() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
 
     let before = std::time::Instant::now();
@@ -339,6 +344,7 @@ async fn should_pass_file_exists_validator_when_file_meets_size_floor() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -362,6 +368,7 @@ async fn should_fail_file_exists_validator_when_size_under_floor() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -380,6 +387,7 @@ async fn should_pass_tool_call_validator_when_tool_succeeds() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -397,6 +405,7 @@ async fn should_fail_tool_call_validator_when_tool_reports_unsuccessful() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -424,6 +433,7 @@ async fn should_persist_outcomes_and_replay_them_byte_for_byte() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let original = runner.run_all(&invocation, &validators).await;
     assert_eq!(original.len(), 2);
@@ -476,6 +486,7 @@ async fn should_strip_blocked_env_vars_from_command_validator_child() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     // Invoke via a helper that pre-seeds LD_PRELOAD on the spawned command.
     runner
@@ -732,6 +743,7 @@ async fn should_block_command_validator_with_dangerous_pattern() {
         workspace_root: dir.path().to_path_buf(),
         repo_label: "slides/demo".into(),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 

--- a/crates/octos-cli/src/commands/mcp_serve.rs
+++ b/crates/octos-cli/src/commands/mcp_serve.rs
@@ -530,6 +530,7 @@ async fn run_completion_validators(
         workspace_root: workspace_root.to_path_buf(),
         repo_label: format!("mcp-serve/{contract}"),
         input_args: None,
+        tool_output: None,
     };
     let outcomes = run_workspace_validators(
         &runner,

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -457,6 +457,7 @@ impl Tool for RunPipelineTool {
             file_modified: report_file,
             files_to_send,
             structured_metadata,
+            named_outputs: None,
         })
     }
 }

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -521,6 +521,7 @@ impl Swarm {
                 validator.invocation.repo_label, contract.contract_id
             ),
             input_args: None,
+            tool_output: None,
         };
 
         let outcomes = validator.runner.run_all(&invocation, &scoped).await;

--- a/crates/octos-swarm/tests/subtask_contracts.rs
+++ b/crates/octos-swarm/tests/subtask_contracts.rs
@@ -105,6 +105,7 @@ fn aggregate_validator(
         workspace_root: workspace_dir.to_path_buf(),
         repo_label: "swarm-subtask-test".into(),
         input_args: None,
+        tool_output: None,
     };
     AggregateValidator {
         runner,

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -452,6 +452,7 @@ async fn should_aggregate_validator_over_combined_output() {
         workspace_root: workspace_dir.path().to_path_buf(),
         repo_label: "swarm-test".into(),
         input_args: None,
+        tool_output: None,
     };
     let validator = Validator {
         id: "aggregate_exists".into(),


### PR DESCRIPTION
## Summary

Wave-3b harness-audit follow-up. Extends the spawn_only stdout envelope
with an optional `named_outputs` field so tools can surface structured
values, threads those values into the validator runner via
`${output.<key>}` template interpolation, and wires the canonical
`mofa_publish` HTTP probe into the default session policy.

Closes audit P0-3 on the harness side (mofa-skills repo follow-up still
needs to teach the skill to emit `named_outputs.deploy_url`).

## Protocol extension

Before:
```json
{"success": true, "output": "...", "files_to_send": [...]}
```

After:
```json
{
  "success": true,
  "output": "...",
  "files_to_send": [...],
  "named_outputs": {"deploy_url": "https://..."}
}
```

- `named_outputs` is OPTIONAL (absent → today's behaviour).
- Values are STRINGS only in v1 (nested JSON deferred). Reject at parse.
- Keys must match `[a-z][a-z0-9_]*`. Reject at parse.
- Malformed payload (non-object, non-string value, bad key shape) surfaces
  as a typed failure so the contract layer rejects the spawn_only result
  instead of silently dropping the field.

## ${output.X} interpolation

Inventory of string-interpolating fields the new prefix now resolves
against (all share one `interpolate_template` codepath):

- `Command.cmd` + every `args[]` slot
- `HttpProbe.url_template`
- `HttpProbe.expected_contains` (was a literal-only string before)
- `FileExists.path`
- `MagicBytes.glob`
- `AudioNonSilent.glob`

Trust-boundary distinction preserved:

- `${args.X}` → percent-encoded (LLM-controlled, URL-segment safe).
- `${output.X}` → spliced VERBATIM (tool-controlled, canonical use is a
  full URL the probe must call as-is; percent-encoding would corrupt it).

Missing key in either source → typed `Error` outcome (matches
`${args.X}` semantics from #935). Templates can mix both prefixes in
one pass.

## mofa_publish wiring

`WorkspacePolicy::for_session()` now declares:

```rust
spawn_tasks.mofa_publish = {
  on_completion = [HttpProbe {
    url_template = "${output.deploy_url}",
    expected_status = 200,
    expected_contains = Some("<!DOCTYPE"),  // soft-404 sentinel
  }],
  on_failure = ["notify_user:Publish probe failed"],
}
```

The probe asserts BOTH a 200 status AND a `<!DOCTYPE` body prefix,
guarding against the "200 OK with a JSON soft-404 body" failure mode
the audit calls out (section 6 P0-3).

**`required = false` intentionally.** The mofa_publish skill does NOT
yet emit `named_outputs.deploy_url` — a separate mofa-skills repo PR
is needed for that. Until then `${output.deploy_url}` would surface
`Error` on every call; `required = false` keeps the validator running
as a diagnostic without blocking users. Flip to `required = true` once
the skill catches up.

## Mofa-skills repo follow-up (NOT in this PR)

- `mofa_publish/src/main.rs` must emit `{"named_outputs":{"deploy_url":"..."}}`
  on its stdout envelope after a successful publish.
- Optional future emitters (separate PRs):
  - `mofa_slides` → `"deck_path"` so MagicBytes can scope to the actual
    emitted PPTX instead of the recursive `**/*.pptx` glob.
  - `mofa_cards` → `"card_dir"` for the same reason.

## Test coverage

+34 lib tests vs the wave-3a baseline (1325 → 1359):

- `plugins::tool::tests` — 11 parser tests covering absent / null /
  empty / valid / bad key shape (digit, uppercase, hyphen, empty) /
  non-string value / underscore-and-digits, plus 3 end-to-end
  `execute()` tests proving the field threads through `ToolResult`,
  malformed payloads return failure, legacy plugins stay `None`.
- `validators::tests` — 11 `${output.X}` tests covering verbatim
  substitution, missing-key error, mixed `args+output` templates,
  percent-encoding boundary preserved across prefixes, FileExists /
  HttpProbe / Command / MagicBytes / AudioNonSilent each interpolating
  output, `expected_contains` mixing args+output.
- `workspace_policy::tests` — 1 test asserting the mofa_publish
  HttpProbe is registered with the right shape (URL template, status,
  DOCTYPE sentinel, non-required).
- `workspace_contract::tests` — 4 end-to-end tests (deploy_url
  satisfies the gate, soft-404 body fails, missing named_outputs fails
  with `required=true`, default policy doesn't block users) + 1
  generic test for the named_outputs → validator pipeline (FileExists
  probing a tool-emitted path).

Plus 7 mechanical updates to existing test sites that constructed
`ValidatorInvocation` with field literals (added `tool_output: None`).

## Backward compatibility

- `ToolResult::named_outputs` defaults to `None`; all existing
  `..Default::default()` constructors stay byte-identical.
- `enforce_spawn_task_contract` and `enforce_spawn_task_contract_with_args`
  remain as thin wrappers around the new
  `enforce_spawn_task_contract_with_args_and_output` entry point.
- `run_declared_validators` stays as a thin wrapper around
  `run_declared_validators_with_output`.
- Existing plugin envelopes that don't emit `named_outputs` parse
  cleanly to `ToolResult.named_outputs = None`; their validators see
  `invocation.tool_output = None` and behave as before.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p octos-agent --lib` (1359 passed)
- [x] `cargo test -p octos-agent` (lib + integration)
- [x] `cargo test -p octos-swarm` / `octos-pipeline`
- [ ] mofa-skills repo follow-up: teach `mofa_publish` to emit
      `named_outputs.deploy_url`, then flip `required = true` here.