### PR TITLE
feat(workspace-policy): wave-3a — HttpProbeUntil + Sha256Match + soft_fail

### DIFF
--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -53,8 +53,13 @@ const KILL_GRACE_PERIOD: Duration = Duration::from_millis(300);
 const DEFAULT_OMINIX_API_URL: &str = "http://127.0.0.1:8081";
 
 /// Default `required_tier` for legacy ledger records emitted before Wave-3a.
+///
+/// Sentinel value (`""`) — replaced with the tier derived from the legacy
+/// `required` field by [`ValidatorOutcome::normalize_legacy_tier`] after
+/// deserialize. We can't peek at sibling fields during a `serde(default = ...)`
+/// callback, so the normalization happens explicitly on every read path.
 fn default_required_tier() -> String {
-    "hard".to_string()
+    String::new()
 }
 
 /// Test-only override for the ominix-api base URL.
@@ -247,6 +252,20 @@ impl ValidatorOutcome {
     pub fn is_soft_warning(&self) -> bool {
         self.required_tier == "soft" && !matches!(self.status, ValidatorStatus::Pass)
     }
+
+    /// Backfill `required_tier` on records emitted before Wave-3a.
+    ///
+    /// Pre-Wave-3a ledger rows have no `required_tier` field, so
+    /// `serde(default)` initializes it to the empty-string sentinel.
+    /// Normalize the sentinel back to a tier derived from the legacy
+    /// `required` field — `required: true` → `"hard"`, `required: false` →
+    /// `"none"`. Idempotent: a Wave-3a-emitted record that already carries
+    /// `"hard"`/`"soft"`/`"none"` is left untouched.
+    fn normalize_legacy_tier(&mut self) {
+        if self.required_tier.is_empty() {
+            self.required_tier = if self.required { "hard" } else { "none" }.to_string();
+        }
+    }
 }
 
 /// Append-only JSONL ledger that persists validator outcomes for replay.
@@ -307,8 +326,9 @@ impl ValidatorLedger {
             if line.trim().is_empty() {
                 continue;
             }
-            let outcome: ValidatorOutcome = serde_json::from_str(&line)
+            let mut outcome: ValidatorOutcome = serde_json::from_str(&line)
                 .wrap_err_with(|| format!("parse ledger line failed: {line}"))?;
+            outcome.normalize_legacy_tier();
             outcomes.push(outcome);
         }
         Ok(outcomes)
@@ -1277,16 +1297,42 @@ impl ValidatorRunner {
             }
         };
 
-        // Cap per-probe timeout so a stuck connection never starves the
-        // polling loop. Floor at 1s for sub-second poll intervals so the
-        // probe still has a chance to complete the TCP handshake.
-        let per_probe_timeout_ms = poll_interval_ms.clamp(1_000, 5_000);
+        // Per-probe timeout caps how long a single HTTP attempt can stall
+        // before the polling loop reclaims control. Clamp to [1s, 5s] so
+        // (a) the probe always has enough budget to complete the TCP
+        // handshake even when `poll_interval_ms` is sub-second, and (b) a
+        // hung probe never overshoots the wall-clock deadline by more than
+        // 5s. We additionally cap each probe by the *remaining* deadline
+        // inside the loop so the validator never runs past `deadline_ms`.
+        let per_probe_timeout_floor_ms = poll_interval_ms.clamp(1_000, 5_000);
         let deadline = std::time::Instant::now() + Duration::from_millis(deadline_ms);
         let interval = Duration::from_millis(poll_interval_ms);
 
         let mut attempt: u32 = 0;
-        let mut last_summary;
+        let mut last_summary = "no response yet".to_string();
         loop {
+            // Top-of-loop deadline guard: surface a Fail with the last
+            // response summary as soon as the wall-clock deadline is hit,
+            // even if `probe_http` would otherwise consume another timeout
+            // budget. Critical for short deadlines (< per-probe floor).
+            let now = std::time::Instant::now();
+            let remaining_ms = deadline.saturating_duration_since(now).as_millis() as u64;
+            if remaining_ms == 0 {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Fail,
+                    format!(
+                        "http_probe_until {url} did not match in {deadline_ms}ms; last response: {last_summary}"
+                    ),
+                    started_at,
+                    started,
+                );
+            }
+            // Bound the per-probe timeout by remaining deadline so a hung
+            // final probe cannot push the validator past `deadline_ms`.
+            let per_probe_timeout_ms = per_probe_timeout_floor_ms.min(remaining_ms.max(1));
+
             attempt += 1;
             match probe_http(
                 &url,
@@ -1337,17 +1383,19 @@ impl ValidatorRunner {
 
     /// Run a [`Sha256Match`] validator.
     ///
-    /// Resolves `sha256` against `${args.<key>}` first so a tool that passes
-    /// its expected hash through input args can wire a manifest-derived
-    /// checksum into the contract. Each file matching the glob must have a
-    /// digest equal to the (lowercased, hex) expected value; a single
-    /// mismatch is a [`Fail`]. Empty glob is a [`Fail`] so a contract that
-    /// expects an artifact under a path never silently passes.
+    /// Resolves BOTH `glob` and `sha256` against `${args.<key>}` first so a
+    /// tool that passes its expected hash through input args can scope the
+    /// check to a per-invocation artifact path (e.g. the freshly-installed
+    /// skill binary) and wire a manifest-derived checksum into the contract
+    /// in one step. Each file matching the glob must have a digest equal to
+    /// the (lowercased, hex) expected value; a single mismatch is a [`Fail`].
+    /// Empty glob is a [`Fail`] so a contract that expects an artifact under
+    /// a path never silently passes.
     fn run_sha256_match(
         &self,
         invocation: &ValidatorInvocation,
         validator: &Validator,
-        pattern: &str,
+        glob_template: &str,
         sha256_template: &str,
         started_at: DateTime<Utc>,
         started: Instant,
@@ -1373,7 +1421,18 @@ impl ValidatorRunner {
                 ),
             );
         }
-        let matches = match glob_files(&invocation.workspace_root, pattern) {
+        // Interpolate the glob so a per-invocation contract (e.g.
+        // `${args.skill_dir}/main`) can scope the digest check to the
+        // artifact this specific spawn task produced. Uses the path-safe
+        // interpolator so embedded `/` separators survive — operators
+        // pinning a literal glob like `skills/*/main` are unaffected.
+        let pattern = match interpolate_args_path(glob_template, invocation.input_args.as_ref()) {
+            Ok(pattern) => pattern,
+            Err(reason) => {
+                return error_outcome(invocation, validator, started_at, started, reason);
+            }
+        };
+        let matches = match glob_files(&invocation.workspace_root, &pattern) {
             Ok(matches) => matches,
             Err(reason) => {
                 return self.make_outcome(
@@ -1546,6 +1605,9 @@ enum HttpProbeFailure {
 /// also resolves `${output.<key>}` against the spawn task's `named_outputs`.
 /// See [`interpolate_template`] for the canonical doc-comment on
 /// percent-encoding semantics and missing-key error policy.
+///
+/// Use [`interpolate_args_path`] for glob/path templates where
+/// percent-encoding would break the segment separator.
 #[cfg(test)]
 fn interpolate_args(
     template: &str,
@@ -1613,6 +1675,57 @@ fn interpolate_template(
         } else {
             out.push_str(&value);
         }
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Path-safe counterpart to [`interpolate_args`] for glob templates.
+///
+/// Same key lookup semantics, but values are inserted verbatim instead of
+/// percent-encoded so embedded `/` separators (e.g. `${args.skill_dir}` =
+/// `"skills/example"`) survive into the resulting glob. Path traversal
+/// attempts that try to escape the workspace root are rejected explicitly so
+/// an LLM-controlled arg value cannot wire the validator at, say, a
+/// `${args.skill_dir}/main` template that resolves to `/etc/passwd`. The
+/// caller is expected to thread the resulting glob through `glob_files`
+/// (which resolves relative paths against the workspace root, blunting
+/// further traversal).
+fn interpolate_args_path(
+    template: &str,
+    input_args: Option<&serde_json::Value>,
+) -> Result<String, String> {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find("${args.") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + "${args.".len()..];
+        let end = after
+            .find('}')
+            .ok_or_else(|| format!("unterminated ${{args.}} reference in template: {template}"))?;
+        let key = &after[..end];
+        let value = input_arg(input_args, key).ok_or_else(|| {
+            format!("input arg '{key}' not found while interpolating template: {template}")
+        })?;
+        // Reject path-traversal segments so an LLM-controlled arg value can
+        // never escape the workspace root via `${args.X}/...`. We
+        // intentionally accept `/` as a segment separator (otherwise common
+        // contracts like `${args.skill_dir}/main` can't work) but block
+        // `..` segments and absolute-path leakage.
+        for segment in value.split('/') {
+            if segment == ".." {
+                return Err(format!(
+                    "input arg '{key}' contains '..' segment which is rejected for path templates: {value}"
+                ));
+            }
+        }
+        if value.starts_with('/') {
+            return Err(format!(
+                "input arg '{key}' must be a relative path, got absolute: {value}"
+            ));
+        }
+        out.push_str(&value);
         rest = &after[end + 1..];
     }
     out.push_str(rest);
@@ -3056,6 +3169,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn http_probe_until_caps_per_probe_timeout_by_remaining_deadline() {
+        // Codex review surface: with a 100ms deadline and a 1s per-probe
+        // floor, the validator must NOT consume the full 1s for the last
+        // probe — it should cap by the remaining deadline so the validator
+        // returns ≈ at the wall-clock deadline. We point the probe at an
+        // unreachable port; without the cap, a single probe would block for
+        // 1s before failing. With the cap, the validator returns Fail in
+        // well under 1s.
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        // Bind + immediately drop a listener so the port is closed.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let url = format!("http://{addr}/never-reachable");
+        let validator = validator_with_spec(
+            "probe_until_short_deadline",
+            ValidatorSpec::HttpProbeUntil {
+                url_template: url,
+                expected_status: 200,
+                expected_contains: None,
+                poll_interval_ms: 50,
+                deadline_ms: 100,
+            },
+        );
+        let before = std::time::Instant::now();
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        let elapsed = before.elapsed();
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        // Without the remaining-deadline cap, a single probe would block
+        // ≈1s. With the cap, the validator returns within a few hundred ms
+        // of the 100ms deadline. Allow generous headroom for cold CI.
+        assert!(
+            elapsed < std::time::Duration::from_millis(1_500),
+            "deadline overrun: elapsed = {elapsed:?} (deadline 100ms, per-probe floor 1000ms)"
+        );
+    }
+
+    #[tokio::test]
     async fn http_probe_until_fails_with_last_response_when_deadline_expires() {
         // Always returns a 503; the probe must exhaust the deadline and
         // surface a Fail outcome with the last response summary in the
@@ -3279,6 +3433,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sha256_match_interpolates_glob_against_input_args_with_path_separators() {
+        // Codex review surface: `Sha256Match.glob` must accept `${args.X}`
+        // where the value contains `/` separators so the contract can scope
+        // the digest check to a per-invocation artifact path
+        // (e.g. `${args.skill_dir}/main`). Verifies the workspace policy
+        // entry for `manage_skills` is functional rather than catastrophically
+        // matching every binary in the workspace.
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills/example_v1");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let payload = b"installed skill binary v1\n";
+        std::fs::write(skill_dir.join("main"), payload).unwrap();
+
+        // Drop an unrelated binary at a sibling path; the test must not
+        // cross-contaminate with its digest, proving the glob is scoped.
+        let other_dir = dir.path().join("skills/unrelated");
+        std::fs::create_dir_all(&other_dir).unwrap();
+        std::fs::write(other_dir.join("main"), b"different binary").unwrap();
+
+        let expected = {
+            use sha2::{Digest, Sha256};
+            format!("{:x}", Sha256::digest(payload))
+        };
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let invocation =
+            dummy_invocation(dir.path().to_path_buf()).with_input_args(serde_json::json!({
+                "skill_dir": "skills/example_v1",
+                "expected_sha256": expected.clone(),
+            }));
+        let validator = validator_with_spec(
+            "sha_scoped_to_skill_dir",
+            ValidatorSpec::Sha256Match {
+                glob: "${args.skill_dir}/main".into(),
+                sha256: "${args.expected_sha256}".into(),
+            },
+        );
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn sha256_match_rejects_traversal_segments_in_interpolated_glob() {
+        // Codex review surface: ${args.X} in a glob template must not be
+        // a vector for path-traversal escape from the workspace root.
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let invocation =
+            dummy_invocation(dir.path().to_path_buf()).with_input_args(serde_json::json!({
+                "skill_dir": "../../etc",
+                "expected_sha256": "0".repeat(64),
+            }));
+        let validator = validator_with_spec(
+            "sha_traversal",
+            ValidatorSpec::Sha256Match {
+                glob: "${args.skill_dir}/main".into(),
+                sha256: "${args.expected_sha256}".into(),
+            },
+        );
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains(".."),
+            "traversal rejection should surface the offending segment: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
     async fn sha256_match_errors_when_expected_hex_is_malformed() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("payload.bin"), b"contents").unwrap();
@@ -3361,6 +3583,77 @@ mod tests {
             "soft_fail outcomes must not block the required gate"
         );
         assert!(outcomes[0].is_soft_warning());
+    }
+
+    #[tokio::test]
+    async fn soft_fail_with_required_false_persists_as_soft_warning() {
+        // Codex review surface: covers the surprising case where the
+        // operator writes `required = false, soft_fail = true`. The truth
+        // table maps this to `Required::Soft` (warning, not pure optional),
+        // and the persisted outcome must carry `required_tier = "soft"` so
+        // dashboards can split it from `required = false, soft_fail = false`
+        // (purely informational) outcomes.
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = Validator {
+            id: "soft_optional_warn".into(),
+            required: false,
+            soft_fail: true,
+            timeout_ms: None,
+            phase: ValidatorPhaseKind::Completion,
+            spec: ValidatorSpec::FileExists {
+                path: "missing-sub-artifact.md".into(),
+                min_bytes: None,
+            },
+        };
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        assert!(
+            !outcomes[0].required,
+            "soft_fail surfaces as required=false"
+        );
+        assert_eq!(
+            outcomes[0].required_tier, "soft",
+            "(required=false, soft_fail=true) must record tier=soft, not none"
+        );
+        assert!(outcomes[0].required_gate_passed());
+        assert!(outcomes[0].is_soft_warning());
+    }
+
+    #[tokio::test]
+    async fn legacy_ledger_record_without_required_tier_normalizes_on_replay() {
+        // Codex review surface: legacy outcomes (pre-Wave-3a) have no
+        // `required_tier` field. `read_all` must normalize the empty
+        // sentinel into a tier derived from the legacy `required` field —
+        // `required = true` → "hard", `required = false` → "none" — so
+        // dashboards never see a misclassified "hard" for an old optional
+        // failure.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy_ledger.jsonl");
+        // Two legacy records: one was hard-required (`required = true`),
+        // one was purely optional (`required = false`). Neither carries
+        // `required_tier`.
+        let legacy_hard = r#"{"schema_version":1,"validator_id":"old_hard","phase":"completion","kind":"file_exists","repo_label":"slides/x","required":true,"status":"pass","reason":"ok","duration_ms":12,"started_at":"2026-04-01T00:00:00Z"}"#;
+        let legacy_optional = r#"{"schema_version":1,"validator_id":"old_optional","phase":"completion","kind":"file_exists","repo_label":"slides/x","required":false,"status":"fail","reason":"missing","duration_ms":3,"started_at":"2026-04-01T00:00:00Z"}"#;
+        std::fs::write(&path, format!("{legacy_hard}\n{legacy_optional}\n")).unwrap();
+        let ledger = ValidatorLedger::open(&path).unwrap();
+        let outcomes = ledger.read_all().unwrap();
+        assert_eq!(outcomes.len(), 2);
+        let hard = outcomes
+            .iter()
+            .find(|o| o.validator_id == "old_hard")
+            .unwrap();
+        assert_eq!(hard.required_tier, "hard");
+        let optional = outcomes
+            .iter()
+            .find(|o| o.validator_id == "old_optional")
+            .unwrap();
+        assert_eq!(
+            optional.required_tier, "none",
+            "legacy required=false must normalize to tier=none, not the default tier=hard"
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -52,6 +52,11 @@ const KILL_GRACE_PERIOD: Duration = Duration::from_millis(300);
 /// Default ominix-api URL when the `OMINIX_API_URL` env override is absent.
 const DEFAULT_OMINIX_API_URL: &str = "http://127.0.0.1:8081";
 
+/// Default `required_tier` for legacy ledger records emitted before Wave-3a.
+fn default_required_tier() -> String {
+    "hard".to_string()
+}
+
 /// Test-only override for the ominix-api base URL.
 ///
 /// Production reads the URL from the `OMINIX_API_URL` env var (or falls
@@ -205,7 +210,15 @@ pub struct ValidatorOutcome {
     pub phase: ValidatorPhase,
     pub kind: String,
     pub repo_label: String,
+    /// True iff a non-`Pass` outcome from this validator demotes the spawn
+    /// task — i.e. the originating [`Required::Hard`] tier. Soft/None map to
+    /// `false` so legacy replay readers see them as warnings, matching the
+    /// pre-Wave-3a `required: false` semantics.
     pub required: bool,
+    /// Explicit gate-strength tier. Defaults to `"hard"` on replay of records
+    /// emitted before Wave-3a so legacy ledgers de-serialize cleanly.
+    #[serde(default = "default_required_tier")]
+    pub required_tier: String,
     pub status: ValidatorStatus,
     pub reason: String,
     pub duration_ms: u64,
@@ -226,6 +239,13 @@ impl ValidatorOutcome {
             return true;
         }
         matches!(self.status, ValidatorStatus::Pass)
+    }
+
+    /// True iff this outcome's gate strength is the soft tier (added in
+    /// Wave-3a so partial-artifact contracts can warn-and-continue without
+    /// demoting the spawn task).
+    pub fn is_soft_warning(&self) -> bool {
+        self.required_tier == "soft" && !matches!(self.status, ValidatorStatus::Pass)
     }
 }
 
@@ -485,6 +505,29 @@ impl ValidatorRunner {
                 ValidatorSpec::MagicBytes { glob, format } => {
                     self.run_magic_bytes(invocation, validator, glob, *format, started_at, started)
                 }
+                ValidatorSpec::HttpProbeUntil {
+                    url_template,
+                    expected_status,
+                    expected_contains,
+                    poll_interval_ms,
+                    deadline_ms,
+                } => {
+                    self.run_http_probe_until(
+                        invocation,
+                        validator,
+                        url_template,
+                        *expected_status,
+                        expected_contains.as_deref(),
+                        *poll_interval_ms,
+                        *deadline_ms,
+                        started_at,
+                        started,
+                    )
+                    .await
+                }
+                ValidatorSpec::Sha256Match { glob, sha256 } => {
+                    self.run_sha256_match(invocation, validator, glob, sha256, started_at, started)
+                }
             };
 
             record_counter(&outcome, kind_label);
@@ -630,7 +673,8 @@ impl ValidatorRunner {
                     phase: invocation.phase,
                     kind: validator_kind_label(&validator.spec).to_string(),
                     repo_label: invocation.repo_label.clone(),
-                    required: validator.required,
+                    required: validator.tier().is_hard(),
+                    required_tier: validator.tier().as_str().to_string(),
                     status,
                     reason,
                     duration_ms,
@@ -657,7 +701,8 @@ impl ValidatorRunner {
                     phase: invocation.phase,
                     kind: validator_kind_label(&validator.spec).to_string(),
                     repo_label: invocation.repo_label.clone(),
-                    required: validator.required,
+                    required: validator.tier().is_hard(),
+                    required_tier: validator.tier().as_str().to_string(),
                     status: ValidatorStatus::Timeout,
                     reason: format!("command validator timed out after {timeout_ms}ms"),
                     duration_ms,
@@ -708,7 +753,8 @@ impl ValidatorRunner {
                     phase: invocation.phase,
                     kind: validator_kind_label(&validator.spec).to_string(),
                     repo_label: invocation.repo_label.clone(),
-                    required: validator.required,
+                    required: validator.tier().is_hard(),
+                    required_tier: validator.tier().as_str().to_string(),
                     status,
                     reason,
                     duration_ms,
@@ -732,7 +778,8 @@ impl ValidatorRunner {
                     phase: invocation.phase,
                     kind: validator_kind_label(&validator.spec).to_string(),
                     repo_label: invocation.repo_label.clone(),
-                    required: validator.required,
+                    required: validator.tier().is_hard(),
+                    required_tier: validator.tier().as_str().to_string(),
                     status: ValidatorStatus::Timeout,
                     reason: format!("tool validator '{tool}' timed out after {timeout_ms}ms"),
                     duration_ms,
@@ -831,7 +878,8 @@ impl ValidatorRunner {
             phase: invocation.phase,
             kind: validator_kind_label(&validator.spec).to_string(),
             repo_label: invocation.repo_label.clone(),
-            required: validator.required,
+            required: validator.tier().is_hard(),
+            required_tier: validator.tier().as_str().to_string(),
             status,
             reason,
             duration_ms,
@@ -1197,6 +1245,195 @@ impl ValidatorRunner {
         }
     }
 
+    /// Run a polling [`HttpProbeUntil`] validator.
+    ///
+    /// Repeatedly probes the interpolated URL on a fixed cadence until the
+    /// expected status+substring contract holds, or the wall-clock deadline
+    /// expires. Each probe re-uses the [`probe_http`] helper that
+    /// [`HttpProbe`] uses, so SSRF posture and timeout semantics match the
+    /// single-shot variant. Per-probe timeout defaults to the smaller of the
+    /// poll interval and 5s so a stuck probe never starves the loop.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_http_probe_until(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        url_template: &str,
+        expected_status: u16,
+        expected_contains: Option<&str>,
+        poll_interval_ms: u64,
+        deadline_ms: u64,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let url = match interpolate_template(
+            url_template,
+            invocation.input_args.as_ref(),
+            invocation.tool_output.as_ref(),
+        ) {
+            Ok(url) => url,
+            Err(reason) => {
+                return error_outcome(invocation, validator, started_at, started, reason);
+            }
+        };
+
+        // Cap per-probe timeout so a stuck connection never starves the
+        // polling loop. Floor at 1s for sub-second poll intervals so the
+        // probe still has a chance to complete the TCP handshake.
+        let per_probe_timeout_ms = poll_interval_ms.clamp(1_000, 5_000);
+        let deadline = std::time::Instant::now() + Duration::from_millis(deadline_ms);
+        let interval = Duration::from_millis(poll_interval_ms);
+
+        let mut attempt: u32 = 0;
+        let mut last_summary;
+        loop {
+            attempt += 1;
+            match probe_http(
+                &url,
+                per_probe_timeout_ms,
+                expected_status,
+                expected_contains,
+            )
+            .await
+            {
+                Ok(reason) => {
+                    return self.make_outcome(
+                        invocation,
+                        validator,
+                        ValidatorStatus::Pass,
+                        format!("http_probe_until matched on attempt {attempt}: {reason}"),
+                        started_at,
+                        started,
+                    );
+                }
+                Err(HttpProbeFailure::Timeout) => {
+                    last_summary = format!("attempt {attempt}: per-probe timeout");
+                }
+                Err(HttpProbeFailure::Fail(reason)) => {
+                    last_summary = format!("attempt {attempt}: {reason}");
+                }
+                Err(HttpProbeFailure::Error(reason)) => {
+                    last_summary = format!("attempt {attempt}: transport error: {reason}");
+                }
+            }
+
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Fail,
+                    format!(
+                        "http_probe_until {url} did not match in {deadline_ms}ms; last response: {last_summary}"
+                    ),
+                    started_at,
+                    started,
+                );
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            tokio::time::sleep(interval.min(remaining)).await;
+        }
+    }
+
+    /// Run a [`Sha256Match`] validator.
+    ///
+    /// Resolves `sha256` against `${args.<key>}` first so a tool that passes
+    /// its expected hash through input args can wire a manifest-derived
+    /// checksum into the contract. Each file matching the glob must have a
+    /// digest equal to the (lowercased, hex) expected value; a single
+    /// mismatch is a [`Fail`]. Empty glob is a [`Fail`] so a contract that
+    /// expects an artifact under a path never silently passes.
+    fn run_sha256_match(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        pattern: &str,
+        sha256_template: &str,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        let expected_hex = match interpolate_template(
+            sha256_template,
+            invocation.input_args.as_ref(),
+            invocation.tool_output.as_ref(),
+        ) {
+            Ok(value) => value.trim().to_ascii_lowercase(),
+            Err(reason) => {
+                return error_outcome(invocation, validator, started_at, started, reason);
+            }
+        };
+        if expected_hex.len() != 64 || !expected_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return error_outcome(
+                invocation,
+                validator,
+                started_at,
+                started,
+                format!(
+                    "sha256_match: expected hex-encoded 64-char SHA-256 digest, got '{expected_hex}'"
+                ),
+            );
+        }
+        let matches = match glob_files(&invocation.workspace_root, pattern) {
+            Ok(matches) => matches,
+            Err(reason) => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                );
+            }
+        };
+        if matches.is_empty() {
+            return self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!("sha256_match: no files matched '{pattern}'"),
+                started_at,
+                started,
+            );
+        }
+        let mut failures = Vec::new();
+        for path in &matches {
+            match compute_sha256_hex(path) {
+                Ok(actual) => {
+                    if actual != expected_hex {
+                        failures.push(format!(
+                            "{}: actual={actual} != expected={expected_hex}",
+                            path.display()
+                        ));
+                    }
+                }
+                Err(reason) => failures.push(format!("{}: {reason}", path.display())),
+            }
+        }
+        if failures.is_empty() {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Pass,
+                format!(
+                    "sha256_match: all {} match(es) carry expected digest {expected_hex}",
+                    matches.len()
+                ),
+                started_at,
+                started,
+            )
+        } else {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!("sha256_match failed: {}", failures.join("; ")),
+                started_at,
+                started,
+            )
+        }
+    }
+
     fn make_outcome(
         &self,
         invocation: &ValidatorInvocation,
@@ -1212,7 +1449,8 @@ impl ValidatorRunner {
             phase: invocation.phase,
             kind: validator_kind_label(&validator.spec).to_string(),
             repo_label: invocation.repo_label.clone(),
-            required: validator.required,
+            required: validator.tier().is_hard(),
+            required_tier: validator.tier().as_str().to_string(),
             status,
             reason,
             duration_ms: started.elapsed().as_millis() as u64,
@@ -1558,6 +1796,28 @@ fn read_magic_prefix(path: &Path) -> Result<Vec<u8>, String> {
     Ok(buf[..n].to_vec())
 }
 
+/// Compute the SHA-256 digest of a file, streaming chunked reads so large
+/// artifacts don't blow the validator process's memory budget. Returns the
+/// lowercase hex encoding so callers can compare against the
+/// canonical-form manifest digest with `==`.
+fn compute_sha256_hex(path: &Path) -> Result<String, String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).map_err(|err| format!("open failed: {err}"))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buf)
+            .map_err(|err| format!("read failed: {err}"))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
 /// Decode `path` (WAV via [`hound`], or MP3 via the optional `audio_mp3`
 /// feature) and return the ratio of non-silent samples to total samples.
 fn decode_non_silent_ratio(path: &Path) -> Result<f32, String> {
@@ -1729,7 +1989,8 @@ fn error_outcome(
         phase: invocation.phase,
         kind: validator_kind_label(&validator.spec).to_string(),
         repo_label: invocation.repo_label.clone(),
-        required: validator.required,
+        required: validator.tier().is_hard(),
+        required_tier: validator.tier().as_str().to_string(),
         status: ValidatorStatus::Error,
         reason,
         duration_ms: started.elapsed().as_millis() as u64,
@@ -1748,6 +2009,8 @@ fn validator_kind_label(spec: &ValidatorSpec) -> &'static str {
         ValidatorSpec::OminixVoiceExists { .. } => "ominix_voice_exists",
         ValidatorSpec::AudioNonSilent { .. } => "audio_non_silent",
         ValidatorSpec::MagicBytes { .. } => "magic_bytes",
+        ValidatorSpec::HttpProbeUntil { .. } => "http_probe_until",
+        ValidatorSpec::Sha256Match { .. } => "sha256_match",
     }
 }
 
@@ -1799,6 +2062,10 @@ fn record_counter(outcome: &ValidatorOutcome, kind_label: &'static str) {
         "phase" => outcome.phase.as_str().to_string(),
         "kind" => kind_label.to_string(),
         "required" => outcome.required.to_string(),
+        // The Wave-3a explicit tier — "hard" / "soft" / "none". Lets
+        // operators dashboard soft warnings separately from purely optional
+        // ones, even though both share `required = false`.
+        "tier" => outcome.required_tier.clone(),
     )
     .increment(1);
 
@@ -1806,6 +2073,9 @@ fn record_counter(outcome: &ValidatorOutcome, kind_label: &'static str) {
         counter!("octos_workspace_validator_required_failed_total").increment(1);
     } else if !outcome.required && outcome.status != ValidatorStatus::Pass {
         counter!("octos_workspace_validator_optional_warning_total").increment(1);
+        if outcome.required_tier == "soft" {
+            counter!("octos_workspace_validator_soft_warning_total").increment(1);
+        }
     }
 }
 
@@ -1948,6 +2218,7 @@ mod tests {
             kind: "command".into(),
             repo_label: "slides/x".into(),
             required: true,
+            required_tier: "hard".into(),
             status: ValidatorStatus::Pass,
             reason: String::new(),
             duration_ms: 0,
@@ -1964,6 +2235,7 @@ mod tests {
         assert!(!outcome.required_gate_passed());
 
         outcome.required = false;
+        outcome.required_tier = "none".into();
         outcome.status = ValidatorStatus::Fail;
         assert!(outcome.required_gate_passed());
     }
@@ -1983,6 +2255,7 @@ mod tests {
         Validator {
             id: id.into(),
             required: true,
+            soft_fail: false,
             timeout_ms: Some(2000),
             phase: ValidatorPhaseKind::Completion,
             spec,
@@ -2577,6 +2850,38 @@ mod tests {
         );
     }
 
+    // ---------------------------------------------------------------------
+    // Wave-3a: HttpProbeUntil — polling HTTP probe
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn http_probe_until_passes_on_first_successful_attempt() {
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\n{\"ok\":\"done\"}";
+        let addr = spawn_test_http_server(vec![response]);
+        let url = format!("http://{addr}/status");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_until_immediate",
+            ValidatorSpec::HttpProbeUntil {
+                url_template: url,
+                expected_status: 200,
+                expected_contains: Some("done".into()),
+                poll_interval_ms: 50,
+                deadline_ms: 2_000,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("attempt 1"),
+            "first-attempt success should be surfaced: {}",
+            outcomes[0].reason
+        );
+    }
+
     #[tokio::test]
     async fn http_probe_resolves_output_url_template() {
         // mofa_publish-style scenario: tool emits a fully-formed deploy_url;
@@ -2719,6 +3024,147 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn http_probe_until_passes_after_polling_through_pending_responses() {
+        // First two responses are 503s (so the probe must retry); the third
+        // returns the expected 200 + substring. The polling loop must keep
+        // probing until the success arrives.
+        let pending = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 7\r\n\r\npending";
+        let ready = "HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\ncomplete";
+        let addr = spawn_test_http_server(vec![pending, pending, ready]);
+        let url = format!("http://{addr}/status");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_until_after_retry",
+            ValidatorSpec::HttpProbeUntil {
+                url_template: url,
+                expected_status: 200,
+                expected_contains: Some("complete".into()),
+                poll_interval_ms: 50,
+                deadline_ms: 5_000,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("attempt 3"),
+            "expected retry path before success: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn http_probe_until_fails_with_last_response_when_deadline_expires() {
+        // Always returns a 503; the probe must exhaust the deadline and
+        // surface a Fail outcome with the last response summary in the
+        // message so the LLM/operator can debug in one round.
+        let pending = "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 7\r\n\r\npending";
+        let addr = spawn_test_http_server(vec![pending; 64]);
+        let url = format!("http://{addr}/status");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "probe_until_deadline",
+            ValidatorSpec::HttpProbeUntil {
+                url_template: url,
+                expected_status: 200,
+                expected_contains: None,
+                poll_interval_ms: 50,
+                deadline_ms: 200,
+            },
+        );
+        let before = std::time::Instant::now();
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        let elapsed = before.elapsed();
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        // Reason must reference the deadline and the last server reply so
+        // the failure is debuggable from the ledger alone.
+        assert!(
+            outcomes[0].reason.contains("200ms")
+                && outcomes[0].reason.to_lowercase().contains("503"),
+            "deadline + last response should be in reason: {}",
+            outcomes[0].reason
+        );
+        // The validator must not wildly overshoot the deadline; allow ample
+        // headroom for CI scheduling jitter on cold runners.
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "deadline overrun: elapsed = {elapsed:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn http_probe_until_interpolates_args_into_url_template() {
+        // Same interpolation contract as HttpProbe: ${args.<key>} resolves
+        // against the spawn task's input args (URL-encoded path segment).
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK";
+        let addr = spawn_test_http_server(vec![response]);
+        let url_template = format!("http://{addr}/jobs/${{args.task_id}}");
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_input_args(serde_json::json!({"task_id": "abc-123"}));
+        let validator = validator_with_spec(
+            "probe_until_interp",
+            ValidatorSpec::HttpProbeUntil {
+                url_template,
+                expected_status: 200,
+                expected_contains: None,
+                poll_interval_ms: 50,
+                deadline_ms: 2_000,
+            },
+        );
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("/jobs/abc-123"),
+            "interpolated URL should surface in reason: {}",
+            outcomes[0].reason
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Wave-3a: Sha256Match
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn sha256_match_passes_for_explicit_hex_digest_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("payload.bin");
+        let bytes = b"hello, sha256 world".to_vec();
+        std::fs::write(&path, &bytes).unwrap();
+        let expected = {
+            use sha2::{Digest, Sha256};
+            format!("{:x}", Sha256::digest(&bytes))
+        };
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "sha_ok",
+            ValidatorSpec::Sha256Match {
+                glob: "payload.bin".into(),
+                sha256: expected.clone(),
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains(&expected),
+            "matched digest should surface in reason: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
     async fn magic_bytes_glob_interpolates_output_key() {
         // MagicBytes pinned to a tool-emitted output directory.
         let dir = tempfile::tempdir().unwrap();
@@ -2767,5 +3213,179 @@ mod tests {
         .with_tool_output(serde_json::json!({"audio_dir": "clips"}));
         let outcomes = runner.run_all(&invocation, &[validator]).await;
         assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn sha256_match_fails_when_digest_does_not_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("payload.bin");
+        std::fs::write(&path, b"actual contents").unwrap();
+        // A clearly different hash — all-zero is convenient as a sentinel
+        // and ensures the validator surfaces a real mismatch, not a parser
+        // error.
+        let expected = "0".repeat(64);
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "sha_mismatch",
+            ValidatorSpec::Sha256Match {
+                glob: "payload.bin".into(),
+                sha256: expected,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        // Reason must surface BOTH the actual and the expected digest so
+        // operators can diagnose the mismatch from the ledger.
+        assert!(
+            outcomes[0].reason.contains("actual=") && outcomes[0].reason.contains("expected="),
+            "mismatch reason should expose both digests: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn sha256_match_interpolates_expected_hex_from_input_args() {
+        // Lifts the inline `manage_skills::download_binary` checksum onto the
+        // canonical validator path: a spawn task passes its manifest's
+        // `sha256` field through input args, and the validator resolves it
+        // via `${args.expected_sha256}` before hashing the artifact.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skill_main");
+        let bytes = b"#!/bin/sh\nexit 0\n";
+        std::fs::write(&path, bytes).unwrap();
+        let expected = {
+            use sha2::{Digest, Sha256};
+            format!("{:x}", Sha256::digest(bytes))
+        };
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let invocation = dummy_invocation(dir.path().to_path_buf())
+            .with_input_args(serde_json::json!({"expected_sha256": expected.clone()}));
+        let validator = validator_with_spec(
+            "sha_manifest_interp",
+            ValidatorSpec::Sha256Match {
+                glob: "skill_main".into(),
+                sha256: "${args.expected_sha256}".into(),
+            },
+        );
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains(&expected),
+            "interpolated digest should surface in reason: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn sha256_match_errors_when_expected_hex_is_malformed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("payload.bin"), b"contents").unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "sha_malformed",
+            ValidatorSpec::Sha256Match {
+                glob: "payload.bin".into(),
+                // 32 chars, not 64 — must surface a typed Error rather than
+                // silently treating a truncated/typo hash as a hash mismatch.
+                sha256: "deadbeefcafef00d".repeat(2),
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("sha256_match"),
+            "error reason should mention the validator: {}",
+            outcomes[0].reason
+        );
+    }
+
+    #[tokio::test]
+    async fn sha256_match_fails_when_no_file_matches_glob() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "sha_missing",
+            ValidatorSpec::Sha256Match {
+                glob: "skill_main".into(),
+                sha256: "0".repeat(64),
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        assert!(outcomes[0].reason.contains("no files matched"));
+    }
+
+    // ---------------------------------------------------------------------
+    // Wave-3a: Required::Soft / soft_fail
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn soft_fail_validator_does_not_block_required_gate_when_failing() {
+        // A failing validator with `soft_fail = true` records the failure to
+        // the ledger BUT does not demote the spawn task. The
+        // `required_gate_passed()` invariant on the persisted outcome must
+        // hold so the workspace contract gate ignores it.
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = Validator {
+            id: "sub_artifact_warn".into(),
+            // Hard-required *would* block — but soft_fail flips it to a
+            // warning-only outcome even though `required = true`.
+            required: true,
+            soft_fail: true,
+            timeout_ms: None,
+            phase: ValidatorPhaseKind::Completion,
+            spec: ValidatorSpec::FileExists {
+                path: "sub-artifact.md".into(),
+                min_bytes: None,
+            },
+        };
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        assert!(
+            !outcomes[0].required,
+            "soft_fail must serialize as required = false so legacy replayers \
+             see it as a warning, not a hard-fail"
+        );
+        assert_eq!(outcomes[0].required_tier, "soft");
+        assert!(
+            outcomes[0].required_gate_passed(),
+            "soft_fail outcomes must not block the required gate"
+        );
+        assert!(outcomes[0].is_soft_warning());
+    }
+
+    #[tokio::test]
+    async fn hard_required_validator_still_blocks_gate_when_failing() {
+        // Symmetry probe: with `soft_fail = false` (the default), a failing
+        // required validator demotes the gate as before.
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = Validator {
+            id: "primary_required".into(),
+            required: true,
+            soft_fail: false,
+            timeout_ms: None,
+            phase: ValidatorPhaseKind::Completion,
+            spec: ValidatorSpec::FileExists {
+                path: "primary-artifact.md".into(),
+                min_bytes: None,
+            },
+        };
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail);
+        assert!(outcomes[0].required, "hard-required must serialize as true");
+        assert_eq!(outcomes[0].required_tier, "hard");
+        assert!(!outcomes[0].required_gate_passed());
     }
 }

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1363,6 +1363,7 @@ mod tests {
         publish.on_completion = vec![SpawnTaskValidatorSpec::Full(Validator {
             id: "mofa_publish.deploy_url_probe".into(),
             required: true,
+            soft_fail: false,
             timeout_ms: Some(2000),
             phase: ValidatorPhaseKind::Completion,
             spec: ValidatorSpec::HttpProbe {
@@ -1407,6 +1408,67 @@ mod tests {
         }
     }
 
+    // ---------------------------------------------------------------------
+    // Wave-3a: end-to-end contract gate exercises the three new variants
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn enforce_spawn_task_contract_with_args_runs_sha256_match_via_interpolation() {
+        // End-to-end probe through `enforce_spawn_task_contract_with_args`
+        // for the new `Sha256Match` variant. Mirrors how `manage_skills`
+        // would wire its manifest-declared hash through input args.
+        let temp = tempfile::tempdir().unwrap();
+        let bytes = b"manage_skills binary payload\n";
+        let expected_hex = {
+            use sha2::{Digest, Sha256};
+            format!("{:x}", Sha256::digest(bytes))
+        };
+
+        let skill_dir = temp.path().join("skills/example");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let binary_path = skill_dir.join("main");
+        std::fs::write(&binary_path, bytes).unwrap();
+
+        // Sole spawn-task contract: Sha256Match resolves the expected hash
+        // through args, and no artifact source / on_verify means the
+        // contract gate only runs the typed validators.
+        let mut policy = WorkspacePolicy::for_session();
+        policy.spawn_tasks.insert(
+            "manage_skills_test".into(),
+            WorkspaceSpawnTaskPolicy {
+                artifact: None,
+                artifacts: Vec::new(),
+                on_verify: Vec::new(),
+                on_complete: Vec::new(),
+                on_deliver: Vec::new(),
+                on_failure: vec!["notify_user:skill install verification failed".into()],
+                on_completion: vec![crate::workspace_policy::SpawnTaskValidatorSpec::Bare(
+                    crate::workspace_policy::ValidatorSpec::Sha256Match {
+                        glob: "skills/example/main".into(),
+                        sha256: "${args.expected_sha256}".into(),
+                    },
+                )],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "manage_skills_test",
+            "tool-call-sha-ok",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"expected_sha256": expected_hex.clone()})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected satisfied, got {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn mofa_publish_contract_fails_when_probe_returns_soft_404_html() {
         // 200 OK with a body that lacks `<!DOCTYPE` (e.g. a JSON soft-404
@@ -1439,6 +1501,57 @@ mod tests {
                     "unexpected error: {error}"
                 );
                 assert_eq!(notify_user.as_deref(), Some("Publish probe failed"));
+            }
+            other => panic!("expected failure, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn enforce_spawn_task_contract_with_args_fails_when_sha256_does_not_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill_dir = temp.path().join("skills/example");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("main"), b"actual contents").unwrap();
+
+        let mut policy = WorkspacePolicy::for_session();
+        policy.spawn_tasks.insert(
+            "manage_skills_test".into(),
+            WorkspaceSpawnTaskPolicy {
+                artifact: None,
+                artifacts: Vec::new(),
+                on_verify: Vec::new(),
+                on_complete: Vec::new(),
+                on_deliver: Vec::new(),
+                on_failure: vec!["notify_user:install verification failed".into()],
+                on_completion: vec![crate::workspace_policy::SpawnTaskValidatorSpec::Bare(
+                    crate::workspace_policy::ValidatorSpec::Sha256Match {
+                        glob: "skills/example/main".into(),
+                        sha256: "${args.expected_sha256}".into(),
+                    },
+                )],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let wrong_hex = "f".repeat(64);
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "manage_skills_test",
+            "tool-call-sha-fail",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"expected_sha256": wrong_hex})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert!(
+                    error.contains("sha256_match") || error.contains("expected="),
+                    "expected sha256 mismatch error, got: {error}"
+                );
+                assert_eq!(notify_user.as_deref(), Some("install verification failed"));
             }
             other => panic!("expected failure, got {other:?}"),
         }
@@ -1539,6 +1652,7 @@ mod tests {
                 on_completion: vec![SpawnTaskValidatorSpec::Full(Validator {
                     id: "fake_publish.target_exists".into(),
                     required: true,
+                    soft_fail: false,
                     timeout_ms: None,
                     phase: ValidatorPhaseKind::Completion,
                     spec: ValidatorSpec::FileExists {
@@ -1567,5 +1681,92 @@ mod tests {
             SpawnTaskContractResult::Satisfied { .. } => {}
             other => panic!("expected named_outputs path to satisfy contract, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn enforce_spawn_task_contract_with_args_treats_soft_fail_validator_as_warning() {
+        // Wire-target end-to-end probe for `Required::Soft`: a hard-required
+        // validator that's also `soft_fail` MUST surface a Fail outcome to
+        // the ledger but NOT demote the spawn task. Mirrors the
+        // `synthesize_research`/`deep_search` partial-artifact contract.
+        let temp = tempfile::tempdir().unwrap();
+        // Drop a primary report so the hard-required validator passes; the
+        // soft-fail one points at a non-existent sub-artifact and warns.
+        let primary = temp.path().join("primary.md");
+        std::fs::write(&primary, b"primary report").unwrap();
+
+        let mut policy = WorkspacePolicy::for_session();
+        policy.spawn_tasks.insert(
+            "partial_artifact_task".into(),
+            WorkspaceSpawnTaskPolicy {
+                artifact: None,
+                artifacts: Vec::new(),
+                on_verify: Vec::new(),
+                on_complete: Vec::new(),
+                on_deliver: Vec::new(),
+                on_failure: vec!["notify_user:partial failed".into()],
+                on_completion: vec![
+                    // Hard-required: must pass for the spawn task to satisfy.
+                    crate::workspace_policy::SpawnTaskValidatorSpec::Full(Validator {
+                        id: "primary_required".into(),
+                        required: true,
+                        soft_fail: false,
+                        timeout_ms: None,
+                        phase: ValidatorPhaseKind::Completion,
+                        spec: crate::workspace_policy::ValidatorSpec::FileExists {
+                            path: "primary.md".into(),
+                            min_bytes: None,
+                        },
+                    }),
+                    // Soft-fail: surfaces as a warning without demoting the
+                    // gate even though `required = true`.
+                    crate::workspace_policy::SpawnTaskValidatorSpec::Full(Validator {
+                        id: "sub_artifact_warn".into(),
+                        required: true,
+                        soft_fail: true,
+                        timeout_ms: None,
+                        phase: ValidatorPhaseKind::Completion,
+                        spec: crate::workspace_policy::ValidatorSpec::FileExists {
+                            path: "sub-artifact.md".into(),
+                            min_bytes: None,
+                        },
+                    }),
+                ],
+            },
+        );
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "partial_artifact_task",
+            "tool-call-soft-fail",
+            &[],
+            UNIX_EPOCH,
+            None,
+            None,
+        )
+        .await;
+
+        // Soft-fail validator must NOT demote the task even though it
+        // failed. The ledger still records the failure for operator
+        // visibility (covered by validators::tests::soft_fail_*).
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected satisfied (soft-fail must not block), got {other:?}"),
+        }
+
+        let ledger_path = temp.path().join(".octos").join("validator_outcomes.jsonl");
+        let ledger = crate::validators::ValidatorLedger::open(&ledger_path).unwrap();
+        let outcomes = ledger.read_all().unwrap();
+        let warn = outcomes
+            .iter()
+            .find(|o| o.validator_id == "sub_artifact_warn")
+            .expect("soft-fail warning should persist to the ledger");
+        assert_eq!(warn.required_tier, "soft");
+        assert!(
+            !warn.required,
+            "soft-fail must surface as required = false to legacy replayers"
+        );
+        assert!(warn.is_soft_warning());
     }
 }

--- a/crates/octos-agent/src/workspace_git.rs
+++ b/crates/octos-agent/src/workspace_git.rs
@@ -733,7 +733,12 @@ fn latest_validator_outcomes(project_root: &Path, declared: &[Validator]) -> Vec
 
 fn required_validators_satisfied(declared: &[Validator], outcomes: &[ValidatorOutcome]) -> bool {
     for validator in declared {
-        if !validator.required {
+        // Only hard-required validators (`required = true` AND `soft_fail =
+        // false`) block readiness — soft-fail validators surface warnings
+        // through the ledger but never demote the contract gate, matching
+        // `run_declared_validators`' filter at
+        // `workspace_contract.rs::run_declared_validators`.
+        if !validator.tier().is_hard() {
             continue;
         }
         let outcome = outcomes

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -938,9 +938,21 @@ impl WorkspacePolicy {
         // and the inline `download_binary` check at
         // `tools/manage_skills.rs:836` can be retired in a follow-up PR.
         //
-        // The expected digest is interpolated through `${args.expected_sha256}`
-        // so the spawn-task input args carry the manifest-declared hash —
-        // no per-skill workspace policy edit needed.
+        // The glob is scoped to *this* invocation's installed skill via
+        // `${args.skill_dir}` so a workspace with multiple installed skills
+        // is not spuriously failed against an unrelated binary's digest.
+        // The expected digest is interpolated through
+        // `${args.expected_sha256}` so the spawn-task input args carry the
+        // manifest-declared hash — no per-skill workspace policy edit
+        // needed.
+        //
+        // Caveat: this matches the *final extracted binary*, not the
+        // downloaded archive. For tarball-distributed skills, the manifest
+        // digest of the archive will NOT match a `Sha256Match` on
+        // `${args.skill_dir}/main`. The inline `download_binary` check in
+        // `tools/manage_skills.rs` is the source-of-truth for archive
+        // verification; this validator is complementary and asserts the
+        // post-extraction binary integrity for raw-binary distributions.
         let manage_skills_contract = WorkspaceSpawnTaskPolicy {
             artifact: None,
             artifacts: Vec::new(),
@@ -949,7 +961,7 @@ impl WorkspacePolicy {
             on_deliver: vec![],
             on_failure: vec!["notify_user:Skill install verification failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::Sha256Match {
-                glob: "skills/*/main".into(),
+                glob: "${args.skill_dir}/main".into(),
                 sha256: "${args.expected_sha256}".into(),
             })],
         };

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -132,13 +132,29 @@ pub struct ValidationPolicy {
 /// Each validator is identified by a stable `id`, produces a typed
 /// [`crate::validators::ValidatorOutcome`], and may be `required` (a failure
 /// blocks terminal success) or optional (a failure produces a warning only).
+///
+/// Wave-3a introduced an explicit [`Required::Soft`] tier — surfaced via the
+/// `soft_fail` companion field — so partial-artifact contracts can warn and
+/// continue without demoting the spawn task. The historic boolean
+/// `required` field is preserved verbatim for serde + ABI back-compat; the
+/// runtime collapses both fields into a single [`Required`] gate value via
+/// [`Validator::tier`].
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Validator {
     /// Stable identifier, unique within the validator list.
     pub id: String,
-    /// Required validators block terminal success when they fail.
-    #[serde(default = "default_required")]
+    /// Required validators block terminal success when they fail. Soft-fail
+    /// validators (see [`Self::soft_fail`]) ignore this flag.
+    #[serde(default = "default_required_bool")]
     pub required: bool,
+    /// When `true`, a failed outcome surfaces as a warning + ledger entry
+    /// but does NOT demote the spawn task — even if `required` is also
+    /// `true`. Defaults to `false` so existing policies preserve the
+    /// hard-fail semantics they have today. Use this to declare partial-
+    /// artifact contracts (e.g. "the primary report is hard-required, the
+    /// sub-artifacts are soft").
+    #[serde(default, skip_serializing_if = "is_default_false")]
+    pub soft_fail: bool,
     /// Optional per-validator timeout in milliseconds. Applies to command and
     /// tool validators. File-existence validators ignore the timeout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -150,8 +166,80 @@ pub struct Validator {
     pub spec: ValidatorSpec,
 }
 
-fn default_required() -> bool {
+impl Validator {
+    /// Collapse `required` + `soft_fail` into the operator-visible
+    /// gate-strength tier. The mapping is:
+    ///
+    /// | `required` | `soft_fail` | `tier()`         |
+    /// | ---------- | ----------- | ---------------- |
+    /// | `true`     | `false`     | [`Required::Hard`] |
+    /// | `true`     | `true`      | [`Required::Soft`] |
+    /// | `false`    | `false`     | [`Required::None`] |
+    /// | `false`    | `true`      | [`Required::Soft`] |
+    ///
+    /// `soft_fail = true` always overrides the hard semantics so the
+    /// validator never demotes its spawn task.
+    pub fn tier(&self) -> Required {
+        if self.soft_fail {
+            Required::Soft
+        } else if self.required {
+            Required::Hard
+        } else {
+            Required::None
+        }
+    }
+}
+
+/// Operator-facing strength label for a validator's gate over terminal
+/// success. Surfaced through [`Validator::tier`] and the persisted ledger
+/// outcome record so dashboards can split hard, soft, and informational
+/// failures.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Required {
+    /// A failure of this validator demotes the spawn task to `Failed`.
+    /// Equivalent to the historic `required: true`.
+    #[default]
+    Hard,
+    /// A failure surfaces a warning + persists to the ledger but does NOT
+    /// demote the spawn task. Use for sub-artifacts and partial-artifact
+    /// contracts where the primary deliverable is hard-required but
+    /// auxiliary outputs are nice-to-have.
+    Soft,
+    /// A failure is fully optional — same gate behaviour as `Soft`, but
+    /// operator-visible as "this validator is informational only".
+    /// Equivalent to the historic `required: false` with `soft_fail = false`.
+    None,
+}
+
+impl Required {
+    /// Does a non-`Pass` outcome from this validator block terminal success?
+    pub fn is_hard(self) -> bool {
+        matches!(self, Self::Hard)
+    }
+
+    /// Should a non-`Pass` outcome surface as a warning (without demoting
+    /// the spawn task)? True for both `Soft` and `None` — operators are free
+    /// to filter on the explicit tier via the persisted outcome record.
+    pub fn is_warning_only(self) -> bool {
+        matches!(self, Self::Soft | Self::None)
+    }
+
+    /// Stable label for metrics + ledger records.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Hard => "hard",
+            Self::Soft => "soft",
+            Self::None => "none",
+        }
+    }
+}
+
+fn default_required_bool() -> bool {
     true
+}
+
+fn is_default_false(value: &bool) -> bool {
+    !*value
 }
 
 fn is_default_phase(phase: &ValidatorPhaseKind) -> bool {
@@ -232,6 +320,40 @@ pub enum ValidatorSpec {
     /// The format field is named `format` rather than `kind` to avoid
     /// colliding with serde's `kind` discriminator tag.
     MagicBytes { glob: String, format: MagicByteKind },
+    /// Polling HTTP probe — repeatedly GET a templated URL (with
+    /// `${args.<key>}` interpolation against the spawn task's input args)
+    /// until the expected status code (+ optional body substring) is
+    /// observed or the deadline expires.
+    ///
+    /// Closes the silent-failure path where a spawn task kicks off an
+    /// asynchronous external operation (training a voice, deploying a site)
+    /// whose completion the harness must verify without baking polling logic
+    /// into every skill. Emits [`crate::validators::ValidatorStatus::Pass`]
+    /// on the first success; [`Fail`] (with the last response summary in
+    /// the message) when the deadline expires; [`Timeout`] only if a single
+    /// probe within the deadline window itself times out at the HTTP level.
+    HttpProbeUntil {
+        url_template: String,
+        #[serde(default = "default_http_probe_status")]
+        expected_status: u16,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_contains: Option<String>,
+        /// Interval between probe attempts in milliseconds.
+        #[serde(default = "default_http_probe_until_interval_ms")]
+        poll_interval_ms: u64,
+        /// Hard wall-clock deadline in milliseconds. Once reached the
+        /// validator emits a [`Fail`] outcome surfacing the most recent
+        /// response so the LLM/operator can debug in one round.
+        #[serde(default = "default_http_probe_until_deadline_ms")]
+        deadline_ms: u64,
+    },
+    /// Assert a single file's SHA-256 digest equals `sha256`. Accepts either
+    /// an explicit hex digest OR a `${args.<key>}` template so the spawn task
+    /// can supply the expected hash through its input args (e.g. a manifest
+    /// `sha256` field captured at install time). Lifts the inline
+    /// `manage_skills::download_binary` checksum check onto the canonical
+    /// validator path so it shows up in the contract diagnostics ledger.
+    Sha256Match { glob: String, sha256: String },
 }
 
 /// File-format signature used by [`ValidatorSpec::MagicBytes`].
@@ -318,6 +440,14 @@ impl MagicByteKind {
 
 fn default_http_probe_status() -> u16 {
     200
+}
+
+fn default_http_probe_until_interval_ms() -> u64 {
+    2_000
+}
+
+fn default_http_probe_until_deadline_ms() -> u64 {
+    30_000
 }
 
 fn default_non_silent_ratio() -> f32 {
@@ -452,6 +582,7 @@ impl SpawnTaskValidatorSpec {
             Self::Bare(spec) => Validator {
                 id: format!("{task_name}.on_completion[{index}]"),
                 required: true,
+                soft_fail: false,
                 timeout_ms: None,
                 phase: ValidatorPhaseKind::Completion,
                 spec,
@@ -783,6 +914,7 @@ impl WorkspacePolicy {
             on_completion: vec![SpawnTaskValidatorSpec::Full(Validator {
                 id: "mofa_publish.deploy_url_probe".into(),
                 required: false,
+                soft_fail: false,
                 timeout_ms: None,
                 phase: ValidatorPhaseKind::Completion,
                 spec: ValidatorSpec::HttpProbe {
@@ -796,6 +928,116 @@ impl WorkspacePolicy {
             })],
         };
 
+        // Wave-3a wire target for the new `Sha256Match` variant.
+        //
+        // `manage_skills` is NOT spawn_only today, so this entry is dormant
+        // until either (a) the harness wires an `AfterTool` phase (audit
+        // Gap-1) that fires post-call validators against the synchronous
+        // tool, or (b) `manage_skills` itself flips to spawn_only. Recording
+        // it now means the canonical SHA-256 check is declared in one place
+        // and the inline `download_binary` check at
+        // `tools/manage_skills.rs:836` can be retired in a follow-up PR.
+        //
+        // The expected digest is interpolated through `${args.expected_sha256}`
+        // so the spawn-task input args carry the manifest-declared hash —
+        // no per-skill workspace policy edit needed.
+        let manage_skills_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Skill install verification failed".into()],
+            on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::Sha256Match {
+                glob: "skills/*/main".into(),
+                sha256: "${args.expected_sha256}".into(),
+            })],
+        };
+
+        // Wave-3a wire target for the `soft_fail` tier.
+        //
+        // Both `synthesize_research` and `deep_search` produce a primary
+        // report (hard-required) plus optional sub-artifacts. Today neither
+        // tool is spawn_only, so these contracts are dormant until either
+        // the runtime flips them or a follow-up wires the post-tool
+        // validator phase. The shape — a hard FileExists for the primary
+        // plus a soft FileExists for any sub-artifact — is the canonical
+        // template for partial-artifact contracts.
+        //
+        // `${args.research_dir}` lets the contract scope the check to the
+        // research subdirectory each invocation produces, without baking a
+        // global path into the policy. The same shape works for the
+        // deep_search index file at `${args.research_dir}/_search_results.md`.
+        let synthesize_research_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Research synthesis failed".into()],
+            on_completion: vec![
+                // Primary report — block delivery if it's missing.
+                SpawnTaskValidatorSpec::Full(Validator {
+                    id: "synthesize_research.primary_report".into(),
+                    required: true,
+                    soft_fail: false,
+                    timeout_ms: None,
+                    phase: ValidatorPhaseKind::Completion,
+                    spec: ValidatorSpec::FileExists {
+                        path: "${args.research_dir}/synthesis.md".into(),
+                        min_bytes: Some(256),
+                    },
+                }),
+                // Sub-artifacts — warn but don't demote on absence.
+                SpawnTaskValidatorSpec::Full(Validator {
+                    id: "synthesize_research.partials_warn".into(),
+                    required: true,
+                    soft_fail: true,
+                    timeout_ms: None,
+                    phase: ValidatorPhaseKind::Completion,
+                    spec: ValidatorSpec::FileExists {
+                        path: "${args.research_dir}/_search_results.md".into(),
+                        min_bytes: None,
+                    },
+                }),
+            ],
+        };
+
+        let deep_search_contract = WorkspaceSpawnTaskPolicy {
+            artifact: None,
+            artifacts: Vec::new(),
+            on_verify: Vec::new(),
+            on_complete: vec![],
+            on_deliver: vec![],
+            on_failure: vec!["notify_user:Deep search failed".into()],
+            on_completion: vec![
+                // Primary index — block delivery if it's missing.
+                SpawnTaskValidatorSpec::Full(Validator {
+                    id: "deep_search.primary_index".into(),
+                    required: true,
+                    soft_fail: false,
+                    timeout_ms: None,
+                    phase: ValidatorPhaseKind::Completion,
+                    spec: ValidatorSpec::FileExists {
+                        path: "${args.research_dir}/_search_results.md".into(),
+                        min_bytes: None,
+                    },
+                }),
+                // Per-source sub-artifacts — warn but don't demote.
+                SpawnTaskValidatorSpec::Full(Validator {
+                    id: "deep_search.sources_warn".into(),
+                    required: true,
+                    soft_fail: true,
+                    timeout_ms: None,
+                    phase: ValidatorPhaseKind::Completion,
+                    spec: ValidatorSpec::FileExists {
+                        path: "${args.research_dir}/01_source.md".into(),
+                        min_bytes: None,
+                    },
+                }),
+            ],
+        };
+
         let mut spawn_tasks = BTreeMap::new();
         spawn_tasks.insert("fm_tts".into(), tts_contract.clone());
         spawn_tasks.insert("voice_synthesize".into(), voice_synthesize_contract);
@@ -807,6 +1049,9 @@ impl WorkspacePolicy {
         spawn_tasks.insert("mofa_infographic".into(), mofa_infographic_contract);
         spawn_tasks.insert("mofa_frame".into(), mofa_frame_contract);
         spawn_tasks.insert("mofa_publish".into(), mofa_publish_contract);
+        spawn_tasks.insert("manage_skills".into(), manage_skills_contract);
+        spawn_tasks.insert("synthesize_research".into(), synthesize_research_contract);
+        spawn_tasks.insert("deep_search".into(), deep_search_contract);
 
         Self {
             schema_version: WORKSPACE_POLICY_SCHEMA_VERSION,
@@ -1355,6 +1600,7 @@ ignore = []
             Validator {
                 id: "cmd".into(),
                 required: true,
+                soft_fail: false,
                 timeout_ms: Some(3000),
                 phase: ValidatorPhaseKind::Completion,
                 spec: ValidatorSpec::Command {
@@ -1365,6 +1611,7 @@ ignore = []
             Validator {
                 id: "file".into(),
                 required: false,
+                soft_fail: false,
                 timeout_ms: None,
                 phase: ValidatorPhaseKind::TurnEnd,
                 spec: ValidatorSpec::FileExists {
@@ -1375,6 +1622,7 @@ ignore = []
             Validator {
                 id: "tool".into(),
                 required: true,
+                soft_fail: false,
                 timeout_ms: Some(5000),
                 phase: ValidatorPhaseKind::Completion,
                 spec: ValidatorSpec::ToolCall {
@@ -1402,6 +1650,8 @@ ignore = []
         let parsed: Validator = toml::from_str(toml).unwrap();
         assert_eq!(parsed.id, "x");
         assert!(parsed.required, "required defaults to true");
+        assert!(!parsed.soft_fail, "soft_fail defaults to false");
+        assert_eq!(parsed.tier(), Required::Hard);
         assert_eq!(parsed.phase, ValidatorPhaseKind::Completion);
         assert!(parsed.timeout_ms.is_none());
     }
@@ -1682,6 +1932,8 @@ ignore = []
         let validator = bare.into_validator("fm_voice_save", 0);
         assert_eq!(validator.id, "fm_voice_save.on_completion[0]");
         assert!(validator.required);
+        assert!(!validator.soft_fail);
+        assert_eq!(validator.tier(), Required::Hard);
         assert_eq!(validator.phase, ValidatorPhaseKind::Completion);
         match validator.spec {
             ValidatorSpec::OminixVoiceExists { ref name_arg } => {
@@ -1703,6 +1955,199 @@ ignore = []
         let validator = full.into_validator("ignored", 99);
         assert_eq!(validator.id, "voice_optional");
         assert!(!validator.required);
+        assert_eq!(validator.tier(), Required::None);
+    }
+
+    // -----------------------------------------------------------------
+    // Wave-3a: HttpProbeUntil + Sha256Match + soft_fail TOML roundtrips
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn http_probe_until_roundtrips_through_toml_with_default_intervals() {
+        // Operators must be able to declare a polling probe in TOML with
+        // only the URL set; the runtime fills the poll/deadline defaults.
+        let toml = r#"
+            id = "voice_train_done"
+            kind = "http_probe_until"
+            url_template = "http://x/v1/train/status?task_id=${args.task_id}"
+            expected_contains = "complete"
+        "#;
+        let parsed: Validator = toml::from_str(toml).unwrap();
+        match parsed.spec {
+            ValidatorSpec::HttpProbeUntil {
+                ref url_template,
+                expected_status,
+                ref expected_contains,
+                poll_interval_ms,
+                deadline_ms,
+            } => {
+                assert_eq!(
+                    url_template,
+                    "http://x/v1/train/status?task_id=${args.task_id}"
+                );
+                assert_eq!(expected_status, 200);
+                assert_eq!(expected_contains.as_deref(), Some("complete"));
+                assert_eq!(poll_interval_ms, 2_000);
+                assert_eq!(deadline_ms, 30_000);
+            }
+            ref other => panic!("expected HttpProbeUntil, got {other:?}"),
+        }
+        // Round-trip the validator through TOML to confirm fields survive.
+        let rendered = toml::to_string_pretty(&parsed).unwrap();
+        let reparsed: Validator = toml::from_str(&rendered).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn sha256_match_roundtrips_through_toml() {
+        let toml = r#"
+            id = "skill_main_hash"
+            kind = "sha256_match"
+            glob = "skill_main"
+            sha256 = "${args.expected_sha256}"
+        "#;
+        let parsed: Validator = toml::from_str(toml).unwrap();
+        match parsed.spec {
+            ValidatorSpec::Sha256Match {
+                ref glob,
+                ref sha256,
+            } => {
+                assert_eq!(glob, "skill_main");
+                assert_eq!(sha256, "${args.expected_sha256}");
+            }
+            ref other => panic!("expected Sha256Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn soft_fail_validator_roundtrips_through_toml() {
+        // The soft_fail companion field is the Wave-3a serde contract for
+        // partial-artifact contracts: hard-required validators that should
+        // surface as warnings rather than demote the spawn task.
+        let toml = r#"
+            id = "sub_artifact_warn"
+            required = true
+            soft_fail = true
+            kind = "file_exists"
+            path = "sub-artifact.md"
+        "#;
+        let parsed: Validator = toml::from_str(toml).unwrap();
+        assert!(parsed.required, "required field preserved verbatim");
+        assert!(parsed.soft_fail, "soft_fail toggled on");
+        assert_eq!(parsed.tier(), Required::Soft);
+        // Round-trip: soft_fail must serialize and deserialize cleanly.
+        let rendered = toml::to_string_pretty(&parsed).unwrap();
+        assert!(
+            rendered.contains("soft_fail = true"),
+            "soft_fail = true should be emitted in TOML: {rendered}"
+        );
+        let reparsed: Validator = toml::from_str(&rendered).unwrap();
+        assert_eq!(reparsed, parsed);
+    }
+
+    #[test]
+    fn soft_fail_default_false_is_omitted_from_serialized_toml() {
+        // Existing operator policies (no soft_fail field) must round-trip
+        // byte-for-byte: soft_fail = false is the default and shouldn't
+        // surface in the rendered TOML.
+        let toml = r#"
+            id = "primary_required"
+            kind = "file_exists"
+            path = "primary.md"
+        "#;
+        let parsed: Validator = toml::from_str(toml).unwrap();
+        assert!(!parsed.soft_fail);
+        let rendered = toml::to_string_pretty(&parsed).unwrap();
+        assert!(
+            !rendered.contains("soft_fail"),
+            "default soft_fail = false must not be emitted: {rendered}"
+        );
+    }
+
+    #[test]
+    fn validator_tier_collapses_required_and_soft_fail_correctly() {
+        // The 4-case truth table from `Validator::tier`'s rustdoc.
+        let make = |required: bool, soft_fail: bool| Validator {
+            id: "x".into(),
+            required,
+            soft_fail,
+            timeout_ms: None,
+            phase: ValidatorPhaseKind::Completion,
+            spec: ValidatorSpec::FileExists {
+                path: "x".into(),
+                min_bytes: None,
+            },
+        };
+        assert_eq!(make(true, false).tier(), Required::Hard);
+        assert_eq!(make(true, true).tier(), Required::Soft);
+        assert_eq!(make(false, false).tier(), Required::None);
+        assert_eq!(make(false, true).tier(), Required::Soft);
+    }
+
+    // -----------------------------------------------------------------
+    // Wave-3a: `for_session()` wire targets
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn session_policy_declares_sha256_match_contract_for_manage_skills() {
+        // Wire target for the Wave-3a `Sha256Match` variant: lifts the
+        // inline SHA-256 check in `tools/manage_skills.rs::download_binary`
+        // onto the canonical validator path so it surfaces in the contract
+        // diagnostics ledger. The validator interpolates the expected digest
+        // through `${args.expected_sha256}` so the manage_skills tool can
+        // pass the manifest-declared hash without hard-coding it in the
+        // workspace policy.
+        let policy = WorkspacePolicy::for_session();
+        let task = policy
+            .spawn_tasks
+            .get("manage_skills")
+            .expect("manage_skills spawn-task contract should be reserved");
+        let has_sha = task.on_completion.iter().any(|entry| {
+            matches!(
+                entry,
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::Sha256Match { sha256, .. })
+                    if sha256.contains("${args.expected_sha256}")
+            )
+        });
+        assert!(
+            has_sha,
+            "manage_skills contract should declare Sha256Match interpolated against args.expected_sha256; got {:?}",
+            task.on_completion
+        );
+    }
+
+    #[test]
+    fn session_policy_declares_soft_fail_sub_artifacts_for_research_skills() {
+        // Wire target for the Wave-3a `soft_fail` tier: `synthesize_research`
+        // and `deep_search` produce a primary report PLUS optional sub-
+        // artifacts. The primary is hard-required (block delivery if it's
+        // missing); the sub-artifacts are soft-fail so a partial-artifact
+        // run still completes with operator-visible warnings.
+        let policy = WorkspacePolicy::for_session();
+        for tool in ["synthesize_research", "deep_search"] {
+            let task = policy
+                .spawn_tasks
+                .get(tool)
+                .unwrap_or_else(|| panic!("policy missing spawn task for {tool}"));
+            let mut saw_hard = false;
+            let mut saw_soft = false;
+            for entry in &task.on_completion {
+                let validator = entry.clone().into_validator(tool, 0);
+                match validator.tier() {
+                    Required::Hard => saw_hard = true,
+                    Required::Soft => saw_soft = true,
+                    Required::None => {}
+                }
+            }
+            assert!(
+                saw_hard,
+                "{tool} contract should declare a hard-required validator for the primary report"
+            );
+            assert!(
+                saw_soft,
+                "{tool} contract should declare a soft-fail validator for optional sub-artifacts"
+            );
+        }
     }
 
     // ----- WorkspacePolicyKind::Coding (Audit Gap-1 + section 7 Q3) -----

--- a/crates/octos-agent/tests/child_primitive_contracts.rs
+++ b/crates/octos-agent/tests/child_primitive_contracts.rs
@@ -118,6 +118,7 @@ fn policy_with_required_validator(required_file_path: &str) -> WorkspacePolicy {
             validators: vec![Validator {
                 id: "required-artifact".into(),
                 required: true,
+                soft_fail: false,
                 timeout_ms: None,
                 phase: ValidatorPhaseKind::Completion,
                 spec: ValidatorSpec::FileExists {

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -43,3 +43,33 @@ on_completion = [
     { kind = "ominix_voice_exists", name_arg = "name" },
 ]
 on_failure = ["notify_user:Voice registration failed"]
+
+# Wave-3a: HttpProbeUntil + Sha256Match + soft_fail are operator-visible
+# TOML shapes; this fixture also acts as a syntax demo for operators.
+
+[spawn_tasks.manage_skills]
+on_completion = [
+    { kind = "sha256_match", glob = "skills/*/main", sha256 = "${args.expected_sha256}" },
+]
+on_failure = ["notify_user:Skill install verification failed"]
+
+[[spawn_tasks.deep_search.on_completion]]
+id = "deep_search.primary_index"
+required = true
+kind = "file_exists"
+path = "${args.research_dir}/_search_results.md"
+
+[[spawn_tasks.deep_search.on_completion]]
+id = "deep_search.sources_warn"
+required = true
+soft_fail = true
+kind = "file_exists"
+path = "${args.research_dir}/01_source.md"
+
+[[spawn_tasks.deep_search.on_completion]]
+id = "deep_search.async_ready_probe"
+kind = "http_probe_until"
+url_template = "http://127.0.0.1:8081/v1/jobs/${args.job_id}"
+expected_contains = "complete"
+poll_interval_ms = 1000
+deadline_ms = 20000

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -49,7 +49,7 @@ on_failure = ["notify_user:Voice registration failed"]
 
 [spawn_tasks.manage_skills]
 on_completion = [
-    { kind = "sha256_match", glob = "skills/*/main", sha256 = "${args.expected_sha256}" },
+    { kind = "sha256_match", glob = "${args.skill_dir}/main", sha256 = "${args.expected_sha256}" },
 ]
 on_failure = ["notify_user:Skill install verification failed"]
 

--- a/crates/octos-agent/tests/validator_runner.rs
+++ b/crates/octos-agent/tests/validator_runner.rs
@@ -22,6 +22,7 @@ fn command_validator(id: &str, cmd: &str, args: &[&str]) -> Validator {
     Validator {
         id: id.to_string(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(5000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::Command {
@@ -35,6 +36,7 @@ fn file_exists_validator(id: &str, path: &str, min_bytes: Option<u64>) -> Valida
     Validator {
         id: id.to_string(),
         required: true,
+        soft_fail: false,
         timeout_ms: None,
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {
@@ -48,6 +50,7 @@ fn tool_call_validator(id: &str, tool: &str, args: Value) -> Validator {
     Validator {
         id: id.to_string(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(5000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::ToolCall {
@@ -125,6 +128,7 @@ async fn should_block_ready_when_required_command_validator_fails() {
     let validators = vec![Validator {
         id: "cmd_fail".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(3000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::Command {
@@ -160,6 +164,7 @@ async fn should_warn_but_not_block_when_optional_validator_fails() {
     let validators = vec![Validator {
         id: "optional_fail".into(),
         required: false,
+        soft_fail: false,
         timeout_ms: Some(3000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {
@@ -192,6 +197,7 @@ async fn should_record_duration_and_evidence_path_for_command_validator() {
     let validators = vec![Validator {
         id: "echo_cmd".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(3000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::Command {
@@ -231,6 +237,7 @@ async fn should_expose_stderr_in_outcome_for_operator_visibility() {
     let validators = vec![Validator {
         id: "stderr_cmd".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(3000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::Command {
@@ -273,6 +280,7 @@ async fn should_kill_child_process_on_validator_timeout() {
     let validators = vec![Validator {
         id: "timeout_cmd".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(300),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::Command {
@@ -468,6 +476,7 @@ async fn should_strip_blocked_env_vars_from_command_validator_child() {
     let validators = vec![Validator {
         id: "env_probe".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(5000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::Command {
@@ -522,6 +531,7 @@ async fn should_block_spawn_task_contract_when_required_validator_fails() {
     policy.validation.validators = vec![Validator {
         id: "min_bytes_gate".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: None,
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {
@@ -600,6 +610,7 @@ async fn should_not_block_spawn_task_contract_when_optional_validator_fails() {
     policy.validation.validators = vec![Validator {
         id: "optional_warn".into(),
         required: false,
+        soft_fail: false,
         timeout_ms: None,
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {
@@ -665,6 +676,7 @@ async fn should_reflect_required_validator_fail_in_inspect_ready_flag() {
     policy.validation.validators = vec![Validator {
         id: "gate".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: None,
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {
@@ -702,6 +714,7 @@ async fn should_reflect_required_validator_fail_in_inspect_ready_flag() {
         kind: "file_exists".into(),
         repo_label: "slides/demo".into(),
         required: true,
+        required_tier: "hard".into(),
         status: ValidatorStatus::Pass,
         reason: "manual seed".into(),
         duration_ms: 0,
@@ -731,6 +744,7 @@ async fn should_block_command_validator_with_dangerous_pattern() {
     let validators = vec![Validator {
         id: "dangerous".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: Some(3000),
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::Command {

--- a/crates/octos-cli/tests/mcp_serve_integration.rs
+++ b/crates/octos-cli/tests/mcp_serve_integration.rs
@@ -459,6 +459,7 @@ async fn should_populate_validator_results_when_workspace_policy_declares_valida
             validators: vec![Validator {
                 id: "deck-exists".into(),
                 required: true,
+                soft_fail: false,
                 timeout_ms: None,
                 phase: ValidatorPhaseKind::Completion,
                 spec: ValidatorSpec::FileExists {

--- a/crates/octos-pipeline/src/context.rs
+++ b/crates/octos-pipeline/src/context.rs
@@ -215,6 +215,7 @@ mod tests {
             vec![Validator {
                 id: "design-file".into(),
                 required: true,
+                soft_fail: false,
                 timeout_ms: None,
                 phase: ValidatorPhaseKind::Completion,
                 spec: ValidatorSpec::FileExists {

--- a/crates/octos-pipeline/tests/workspace_contract.rs
+++ b/crates/octos-pipeline/tests/workspace_contract.rs
@@ -210,6 +210,7 @@ fn policy_with_required_validator(required_file_path: &str) -> WorkspacePolicy {
     policy.validation.validators = vec![Validator {
         id: "required-artifact".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: None,
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {

--- a/crates/octos-swarm/tests/subtask_contracts.rs
+++ b/crates/octos-swarm/tests/subtask_contracts.rs
@@ -85,6 +85,7 @@ fn required_file_validator(id: &str, path: &str) -> Validator {
     Validator {
         id: id.into(),
         required: true,
+        soft_fail: false,
         timeout_ms: None,
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -457,6 +457,7 @@ async fn should_aggregate_validator_over_combined_output() {
     let validator = Validator {
         id: "aggregate_exists".into(),
         required: true,
+        soft_fail: false,
         timeout_ms: None,
         phase: ValidatorPhaseKind::Completion,
         spec: ValidatorSpec::FileExists {


### PR DESCRIPTION
## Summary

Wave-3a of the harness-engineering audit follow-up. Three new declarative
validator variants close the audit's Gap-3 (polling probes), Gap-4
(SHA-256), and Gap-6 (soft-fail tier).

- **HttpProbeUntil** — polls a templated URL until expected status (+
  optional substring) matches or a deadline expires. Re-uses
  `HttpProbe`'s `${args.X}` interpolation and SSRF posture. Default
  2s poll interval, 30s deadline.
- **Sha256Match** — asserts each file matching a glob has the declared
  SHA-256 digest. Accepts either explicit hex or `${args.<key>}` for
  manifest-derived digests. Wired into `for_session()` as a dormant
  `manage_skills` contract, lifting the inline check in
  `tools/manage_skills.rs:836` onto the canonical validator path.
- **`Validator.soft_fail`** — companion boolean that flips a failing
  required validator into a warning-only outcome (still persisted to
  the ledger, never demotes the spawn task). Collapsed into a typed
  `Required::Hard | Soft | None` tier via `Validator::tier()`.
  Wired into `synthesize_research` and `deep_search` so primary
  reports stay hard-required while sub-artifacts surface as soft
  warnings.

Schema choice: kept the historic `required: bool` field intact so
existing operator TOML round-trips byte-for-byte; the new `soft_fail`
field is `#[serde(default, skip_serializing_if = "is_default_false")]`
so non-soft policies render unchanged.

Outcome records gain a `required_tier: \"hard\"|\"soft\"|\"none\"` field
(defaulting to `\"hard\"` for legacy replay) plus a new
`octos_workspace_validator_soft_warning_total` counter for dashboards.

## Test plan

- [x] `cargo test -p octos-agent --lib` — 1325 → 1346 (+21 tests)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p octos-agent --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all green except the pre-existing
  flaky `test_06_send_file_sandbox_escape` in `octos-pipeline`
  (verified failing on `origin/main` too via `git stash` probe)

## TDD coverage per variant + wire target

- `validators::tests::http_probe_until_*` — happy path, polling
  retries, deadline expiry, args interpolation.
- `validators::tests::sha256_match_*` — explicit hex pass, mismatch,
  args interpolation, malformed-hex error, empty-glob fail.
- `validators::tests::soft_fail_*` + `hard_required_*` — gate
  semantics for both tiers.
- `workspace_policy::tests::session_policy_declares_sha256_match_*`
  + `*_soft_fail_sub_artifacts_for_research_skills` — `for_session()`
  wire-target assertions.
- `workspace_contract::tests::enforce_spawn_task_contract_with_args_*`
  — end-to-end through `enforce_spawn_task_contract_with_args`.