### PR TITLE
feat(plugins): per-profile-only skills + opt-in sha256 enforcement

### DIFF
--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -61,6 +61,13 @@ pub struct PluginLoadOptions<'a> {
     /// opt in via `x-octos-host-config-keys: ["synthesis_config"]`. Tools
     /// without the opt-in never receive this struct.
     pub synthesis_config: Option<SynthesisConfig>,
+    /// Strict signature policy. When `true`, plugins without a declared
+    /// `manifest.sha256` are REJECTED at load time (instead of the legacy
+    /// "warn and proceed" path) AND every invocation re-hashes the verified
+    /// executable bytes and compares against the load-time hash before
+    /// spawning. When `false` (the default), the legacy permissive flow is
+    /// preserved for backward compatibility.
+    pub require_signed: bool,
 }
 
 impl PluginLoadResult {
@@ -109,6 +116,7 @@ impl PluginLoader {
             PluginLoadOptions {
                 work_dir,
                 synthesis_config: None,
+                require_signed: false,
             },
         )
     }
@@ -245,6 +253,7 @@ impl PluginLoader {
             PluginLoadOptions {
                 work_dir,
                 synthesis_config: None,
+                require_signed: false,
             },
         )
     }
@@ -271,6 +280,7 @@ impl PluginLoader {
     ) -> Result<(Vec<LoadedPluginTool>, SkillExtras)> {
         let work_dir = options.work_dir;
         let synthesis_config = options.synthesis_config;
+        let require_signed = options.require_signed;
         let manifest_path = plugin_dir.join("manifest.json");
         let content = std::fs::read_to_string(&manifest_path)
             .map_err(|e| eyre::eyre!("no manifest.json: {e}"))?;
@@ -327,10 +337,16 @@ impl PluginLoader {
         let exe_bytes = std::fs::read(&executable)
             .map_err(|e| eyre::eyre!("cannot read plugin executable: {e}"))?;
 
+        // Section C: capture the SHA-256 of the verified bytes so the
+        // pre-spawn re-hash gate (in `tool.rs::execute`) can compare against
+        // exactly what we approved at load time. The hash is computed once
+        // here and never recomputed — re-hashing only happens at invocation
+        // time, on the verified-exe path on disk.
+        let load_time_hash = format!("{:x}", Sha256::digest(&exe_bytes));
+
         match &manifest.sha256 {
             Some(expected_hash) => {
-                let actual_hash = format!("{:x}", Sha256::digest(&exe_bytes));
-                if actual_hash != expected_hash.to_lowercase() {
+                if load_time_hash != expected_hash.to_lowercase() {
                     eyre::bail!(
                         "plugin '{}' failed integrity check (hash mismatch)",
                         manifest.name,
@@ -342,6 +358,18 @@ impl PluginLoader {
                 );
             }
             None => {
+                // Section B: when `require_signed` is on, reject the plugin
+                // immediately instead of the legacy "warn and proceed". The
+                // operator opted into strict integrity and an undeclared
+                // hash means we cannot prove the bytes on disk came from a
+                // known good source.
+                if require_signed {
+                    eyre::bail!(
+                        "plugin '{}' rejected: `plugins.require_signed` is enabled \
+                         and manifest.json has no `sha256` field",
+                        manifest.name,
+                    );
+                }
                 warn!(
                     plugin = %manifest.name,
                     version = %manifest.version,
@@ -447,7 +475,15 @@ impl PluginLoader {
                 let mut tool = PluginTool::new(plugin_name.clone(), def, verified_exe.clone())
                     .with_blocked_env(blocked_env.clone())
                     .with_extra_env(extra_env.to_vec())
-                    .with_timeout(timeout);
+                    .with_timeout(timeout)
+                    // Section C: stash the load-time hash so the pre-spawn
+                    // re-hash gate in `tool::execute` can detect a TOCTOU
+                    // swap between load and invocation. The gate fires
+                    // unconditionally under `require_signed`; otherwise it
+                    // fires only when a manifest hash was declared (and
+                    // therefore the operator has signaled they care about
+                    // integrity for this plugin).
+                    .with_verified_sha256(load_time_hash.clone(), require_signed);
                 if let Some(dir) = work_dir {
                     tool = tool.with_work_dir(dir.to_path_buf());
                 }
@@ -947,6 +983,202 @@ mod tests {
         );
     }
 
+    /// Section B: a plugin without `manifest.sha256` is REJECTED at load
+    /// time when `require_signed = true` — instead of the legacy "warn and
+    /// proceed" path.
+    #[cfg(unix)]
+    #[test]
+    fn require_signed_rejects_unsigned_plugin() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("unsigned-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        // No `sha256` declared → unsigned.
+        let manifest = r#"{
+            "name": "unsigned-plugin",
+            "version": "1.0",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+
+        let exec_path = plugin_dir.join("unsigned-plugin");
+        std::fs::write(&exec_path, b"#!/bin/sh\necho unsigned").unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result = PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            result.tool_count, 0,
+            "unsigned plugin must be rejected under require_signed"
+        );
+    }
+
+    /// Section B: with `require_signed = true`, signed plugins (those that
+    /// declare a matching `manifest.sha256`) still load normally.
+    #[cfg(unix)]
+    #[test]
+    fn require_signed_accepts_signed_plugin() {
+        use sha2::{Digest, Sha256};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("signed-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let exec_content = b"#!/bin/sh\necho ok";
+        let hash = format!("{:x}", Sha256::digest(exec_content));
+        let manifest = format!(
+            r#"{{"name": "signed-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "t", "description": "d"}}]}}"#
+        );
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+        let exec_path = plugin_dir.join("signed-plugin");
+        std::fs::write(&exec_path, exec_content).unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result = PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            result.tool_count, 1,
+            "signed plugin must still load under require_signed"
+        );
+    }
+
+    /// Section B: with `require_signed = false` (the legacy default),
+    /// unsigned plugins still load with a warning — backward compatibility
+    /// is preserved.
+    #[cfg(unix)]
+    #[test]
+    fn require_signed_off_keeps_legacy_unsigned_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("unsigned-legacy");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let manifest = r#"{
+            "name": "unsigned-legacy",
+            "version": "1.0",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+        let exec_path = plugin_dir.join("unsigned-legacy");
+        std::fs::write(&exec_path, b"#!/bin/sh\necho legacy").unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result =
+            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+        assert_eq!(
+            result.tool_count, 1,
+            "unsigned plugin must still load under the legacy default"
+        );
+    }
+
+    /// Section C: when the verified-exe bytes on disk are swapped between
+    /// load and invocation, the pre-spawn re-hash gate refuses to spawn the
+    /// process. We simulate the swap by overwriting `.<name>_verified`
+    /// after `load_into` returns.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pre_spawn_rehash_detects_swap() {
+        use sha2::{Digest, Sha256};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("swap-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let exec_content = b"#!/bin/sh\necho original";
+        let hash = format!("{:x}", Sha256::digest(exec_content));
+        let manifest = format!(
+            r#"{{"name": "swap-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "swap_tool", "description": "d"}}]}}"#
+        );
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+        let exec_path = plugin_dir.join("swap-plugin");
+        std::fs::write(&exec_path, exec_content).unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result =
+            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+        assert_eq!(result.tool_count, 1);
+
+        // Swap the verified-exe bytes on disk so the re-hash gate fires.
+        let verified_exe = plugin_dir.join(".swap-plugin_verified");
+        assert!(
+            verified_exe.exists(),
+            "loader must write a verified-exe sibling"
+        );
+        std::fs::write(&verified_exe, b"#!/bin/sh\necho TAMPERED").unwrap();
+
+        // Execute the registered tool and assert the gate refused to spawn.
+        let tool = registry.get("swap_tool").expect("tool registered");
+        let result = tool.execute(&serde_json::json!({})).await.unwrap();
+        assert!(!result.success, "tampered plugin must not succeed");
+        assert!(
+            result.output.contains("hash mismatch"),
+            "refusal message must explain the cause; got: {}",
+            result.output
+        );
+    }
+
+    /// Section C: when the verified-exe bytes are intact, the re-hash gate
+    /// passes silently and the plugin spawns. We assert by invoking a
+    /// trivial plugin that writes a known JSON to stdout.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pre_spawn_rehash_allows_intact_executable() {
+        use sha2::{Digest, Sha256};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("intact-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let exec_content = b"#!/bin/sh\necho '{\"output\":\"ok\",\"success\":true}'";
+        let hash = format!("{:x}", Sha256::digest(exec_content));
+        let manifest = format!(
+            r#"{{"name": "intact-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "intact_tool", "description": "d"}}]}}"#
+        );
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+        let exec_path = plugin_dir.join("intact-plugin");
+        std::fs::write(&exec_path, exec_content).unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+
+        let tool = registry.get("intact_tool").expect("tool registered");
+        let result = tool.execute(&serde_json::json!({})).await.unwrap();
+        assert!(
+            result.success,
+            "intact plugin must succeed; output: {}",
+            result.output
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_is_executable_rejects_symlink() {
@@ -1324,6 +1556,7 @@ edition = "2021"
             PluginLoadOptions {
                 work_dir: None,
                 synthesis_config: Some(cfg),
+                require_signed: false,
             },
         )
         .unwrap();
@@ -1379,6 +1612,7 @@ edition = "2021"
             PluginLoadOptions {
                 work_dir: None,
                 synthesis_config: Some(cfg),
+                require_signed: false,
             },
         )
         .unwrap();

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 /// A plugin manifest (manifest.json).
 #[derive(Debug, Deserialize)]
@@ -15,7 +15,13 @@ pub struct PluginManifest {
     #[serde(default)]
     pub tools: Vec<PluginToolDef>,
     /// SHA-256 hash of the plugin executable for integrity verification.
-    #[serde(default)]
+    ///
+    /// Empty-string values (`""`) are rejected at parse time: a manifest that
+    /// goes to the trouble of declaring `sha256` must commit to an actual
+    /// hex digest. Operators who want the legacy "unverified" path simply
+    /// omit the field — which deserializes to `None` and (under
+    /// `plugins.require_signed = false`) still loads with a warning.
+    #[serde(default, deserialize_with = "deserialize_non_empty_sha256")]
     pub sha256: Option<String>,
     /// Pre-built binaries keyed by `{os}-{arch}` (e.g. "darwin-aarch64", "linux-x86_64").
     /// Each entry has `url` (download URL) and optional `sha256` (integrity hash).
@@ -45,6 +51,24 @@ impl PluginManifest {
         !self.mcp_servers.is_empty()
             || !self.hooks.is_empty()
             || self.prompts.as_ref().is_some_and(|p| !p.include.is_empty())
+    }
+}
+
+/// Reject empty-string `sha256` at parse time so callers cannot pass the
+/// integrity gate by declaring the field with no value. A missing field
+/// still deserializes to `None` (the legacy "unverified" path); only an
+/// explicit `""` is treated as a hard error.
+fn deserialize_non_empty_sha256<'de, D>(d: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    let maybe = Option::<String>::deserialize(d)?;
+    match maybe {
+        Some(s) if s.trim().is_empty() => Err(D::Error::custom(
+            "manifest.sha256 must be a non-empty hex digest (omit the field for unsigned plugins)",
+        )),
+        other => Ok(other),
     }
 }
 
@@ -456,6 +480,63 @@ mod tests {
         assert!(manifest.tools[0].accepts_host_config_key("synthesis_config"));
         // Other keys still rejected — explicit opt-in only.
         assert!(!manifest.tools[0].accepts_host_config_key("smtp_config"));
+    }
+
+    /// Section B: empty-string `sha256` is rejected at parse time. A
+    /// manifest that goes to the trouble of declaring the field must
+    /// commit to a real digest — operators who want unsigned plugins
+    /// simply omit the key.
+    #[test]
+    fn manifest_rejects_empty_sha256_at_parse_time() {
+        let json = r#"{
+            "name": "ghost",
+            "version": "1.0.0",
+            "sha256": "",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        let err = serde_json::from_str::<PluginManifest>(json)
+            .expect_err("empty sha256 must fail to parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-empty"),
+            "error must explain that sha256 cannot be empty; got: {msg}"
+        );
+    }
+
+    /// Section B: whitespace-only `sha256` is also rejected.
+    #[test]
+    fn manifest_rejects_whitespace_only_sha256() {
+        let json = r#"{
+            "name": "ghost",
+            "version": "1.0.0",
+            "sha256": "   ",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        let err = serde_json::from_str::<PluginManifest>(json)
+            .expect_err("whitespace sha256 must fail to parse");
+        assert!(err.to_string().contains("non-empty"));
+    }
+
+    /// Section B: an explicit `null` and a missing field both yield
+    /// `sha256 = None` (the legacy unverified path).
+    #[test]
+    fn manifest_accepts_missing_or_null_sha256_as_unsigned() {
+        let missing = r#"{
+            "name": "ghost",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        let m1: PluginManifest = serde_json::from_str(missing).unwrap();
+        assert!(m1.sha256.is_none());
+
+        let null_value = r#"{
+            "name": "ghost",
+            "version": "1.0.0",
+            "sha256": null,
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        let m2: PluginManifest = serde_json::from_str(null_value).unwrap();
+        assert!(m2.sha256.is_none());
     }
 
     #[test]

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -1,12 +1,13 @@
 //! Plugin tool: wraps a plugin executable as a Tool.
 
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use eyre::Result;
+use sha2::{Digest, Sha256};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
@@ -91,6 +92,16 @@ pub struct PluginTool {
     /// Only honoured when the tool's manifest opts in via
     /// `x-octos-host-config-keys: ["synthesis_config"]`.
     synthesis_config: Option<SynthesisConfig>,
+    /// Section C: SHA-256 (lowercase hex) of the verified-exe bytes computed
+    /// at load time. Stored alongside the executable path so the pre-spawn
+    /// re-hash gate in `execute()` can confirm the bytes have not been
+    /// swapped between load and exec (closes the load→exec TOCTOU window).
+    /// `None` when no hash was computed (legacy code paths).
+    verified_exe_sha256: Option<String>,
+    /// Section C: when `true`, the pre-spawn re-hash gate ALWAYS fires (and
+    /// `verified_exe_sha256` must be `Some`). When `false`, the gate is
+    /// skipped on unverified plugins to keep the legacy path cheap.
+    require_signed: bool,
 }
 
 impl PluginTool {
@@ -107,7 +118,20 @@ impl PluginTool {
             work_dir: None,
             timeout: Self::DEFAULT_TIMEOUT,
             synthesis_config: None,
+            verified_exe_sha256: None,
+            require_signed: false,
         }
+    }
+
+    /// Attach the load-time SHA-256 of the verified-exe bytes so the pre-spawn
+    /// re-hash gate in [`Self::execute`] can detect a swap between load and
+    /// exec. Pass `require_signed = true` when the host config has enabled
+    /// strict integrity — the gate will then run unconditionally and an
+    /// invocation with a missing hash hard-errors.
+    pub fn with_verified_sha256(mut self, hash: String, require_signed: bool) -> Self {
+        self.verified_exe_sha256 = Some(hash);
+        self.require_signed = require_signed;
+        self
     }
 
     /// Set environment variables to block from plugin execution.
@@ -143,6 +167,15 @@ impl PluginTool {
         self
     }
 
+    /// Section C: re-read the verified-exe bytes and recompute SHA-256.
+    /// Returned as lowercase hex to match what the loader stored. Errors
+    /// propagate as eyre wrappers so the caller can surface a precise
+    /// reason in the refusal output.
+    fn rehash_verified_exe(path: &Path) -> Result<String> {
+        let bytes = std::fs::read(path).map_err(|e| eyre::eyre!("read {}: {e}", path.display()))?;
+        Ok(format!("{:x}", Sha256::digest(&bytes)))
+    }
+
     /// Create a copy of this plugin tool with a different work directory.
     /// Used to give each user session its own workspace for plugin output.
     pub fn clone_with_work_dir(&self, work_dir: PathBuf) -> Self {
@@ -155,6 +188,8 @@ impl PluginTool {
             work_dir: Some(work_dir),
             timeout: self.timeout,
             synthesis_config: self.synthesis_config.clone(),
+            verified_exe_sha256: self.verified_exe_sha256.clone(),
+            require_signed: self.require_signed,
         }
     }
 
@@ -809,6 +844,66 @@ impl Tool for PluginTool {
             args_size = args.to_string().len(),
             "spawning plugin process"
         );
+
+        // Section C: pre-spawn re-hash gate. When a load-time hash was
+        // recorded — either because the manifest declared `sha256` OR
+        // because `require_signed` was on — re-read the verified-exe
+        // bytes, recompute SHA-256, and compare against what we approved
+        // at load time. A mismatch means the verified copy on disk has
+        // been swapped between load and invocation; refuse to run.
+        //
+        // When neither path applied (no manifest hash AND
+        // `require_signed = false`) the gate is skipped so the legacy
+        // unverified path stays cheap. Under `require_signed = true` the
+        // loader guarantees `verified_exe_sha256` is populated for every
+        // tool that reached the registry — the assertion below is a
+        // belt-and-braces hard error if something slipped past it.
+        if let Some(expected) = &self.verified_exe_sha256 {
+            match Self::rehash_verified_exe(&self.executable) {
+                Ok(actual) if actual == *expected => {
+                    tracing::debug!(
+                        plugin = %self.plugin_name,
+                        tool = %self.tool_def.name,
+                        "pre-spawn re-hash matched"
+                    );
+                }
+                Ok(actual) => {
+                    return Ok(ToolResult {
+                        output: format!(
+                            "Plugin '{}' refused to spawn: verified executable hash mismatch \
+                             (expected {expected}, got {actual}). The on-disk binary changed \
+                             between load and invocation.",
+                            self.plugin_name
+                        ),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+                Err(err) => {
+                    return Ok(ToolResult {
+                        output: format!(
+                            "Plugin '{}' refused to spawn: failed to re-hash verified executable: {err}",
+                            self.plugin_name
+                        ),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            }
+        } else if self.require_signed {
+            // Fail closed: strict policy is on but the load-time hash was
+            // never recorded. This indicates a wiring bug — never let an
+            // unhashed plugin invoke under `require_signed = true`.
+            return Ok(ToolResult {
+                output: format!(
+                    "Plugin '{}' refused to spawn: `plugins.require_signed` is enabled but \
+                     no load-time hash was recorded for this tool (internal wiring error).",
+                    self.plugin_name
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
 
         // M6 req 4: enforce manifest-declared `risk` field (UPCR-2026-001).
         // When the manifest declares `risk: "high"` or `risk: "critical"`,

--- a/crates/octos-agent/src/tools/manage_skills.rs
+++ b/crates/octos-agent/src/tools/manage_skills.rs
@@ -849,11 +849,37 @@ fn download_binary(dir: &std::path::Path, url: &str, sha256: Option<&str>) -> Re
     }
 
     let bytes = response.bytes()?;
+    install_bytes_into_dir(dir, url, &bytes, sha256)
+}
 
+/// Install in-memory bytes into `dir` (writes `<dir>/main`), optionally
+/// verifying SHA-256 against the supplied digest. The URL is consulted only
+/// for archive detection — passing a path-like URL is fine for tests.
+///
+/// Returns:
+/// - `Ok(true)` when the bytes were written.
+/// - `Ok(false)` when the SHA-256 check failed (hash mismatch) or when the
+///   archive contained no real files. The caller can fall through to other
+///   binary sources.
+/// - `Err(_)` on I/O or archive-extraction failures.
+///
+/// Splitting this out from [`download_binary`] makes the hash-verification
+/// path unit-testable without spinning up an HTTP server.
+///
+/// `pub` because the install-time hash gate is covered by an integration
+/// test in `crates/octos-agent/tests/manage_skills_hash.rs`. Not intended
+/// for external consumers — the surface may change without notice.
+#[doc(hidden)]
+pub fn install_bytes_into_dir(
+    dir: &std::path::Path,
+    url: &str,
+    bytes: &[u8],
+    sha256: Option<&str>,
+) -> Result<bool> {
     // Verify SHA-256 if provided (hash is of the downloaded file, archive or raw)
     if let Some(expected) = sha256 {
         use sha2::{Digest, Sha256};
-        let actual = format!("{:x}", Sha256::digest(&bytes));
+        let actual = format!("{:x}", Sha256::digest(bytes));
         if actual != expected.to_lowercase() {
             return Ok(false);
         }
@@ -866,7 +892,7 @@ fn download_binary(dir: &std::path::Path, url: &str, sha256: Option<&str>) -> Re
         // Skip macOS AppleDouble resource fork files (._* prefix) which
         // appear before the actual binary in archives created on macOS.
         use std::io::Read;
-        let gz = flate2::read::GzDecoder::new(&bytes[..]);
+        let gz = flate2::read::GzDecoder::new(bytes);
         let mut archive = tar::Archive::new(gz);
         let mut found = false;
         for entry in archive.entries()? {
@@ -893,7 +919,7 @@ fn download_binary(dir: &std::path::Path, url: &str, sha256: Option<&str>) -> Re
             return Ok(false);
         }
     } else {
-        std::fs::write(&dest, &bytes)?;
+        std::fs::write(&dest, bytes)?;
     }
 
     #[cfg(unix)]

--- a/crates/octos-agent/tests/manage_skills_hash.rs
+++ b/crates/octos-agent/tests/manage_skills_hash.rs
@@ -1,0 +1,172 @@
+//! Integration tests for the install-time archive SHA-256 gate in
+//! `manage_skills`. These cover Section D of the per-profile skills +
+//! signature enforcement PR:
+//!
+//! - **passing case** — archive bytes match the declared `binaries.<platform>.sha256`
+//!   → install succeeds and `<dir>/main` ends up with the archived payload.
+//! - **failing case** — the declared digest mismatches → install returns
+//!   `Ok(false)` and no `main` file is written.
+//! - **missing `binaries.<platform>` entry** — install path falls through
+//!   gracefully (no panic, no `main` file from this lane).
+//!
+//! The tests avoid network and HTTP-server scaffolding by exercising the
+//! split-out `install_bytes_into_dir` helper directly. The behavior under
+//! test is the SHA-256 verification step that originally lived inside
+//! `download_binary` (the network-bound function in `manage_skills.rs`).
+
+use sha2::{Digest, Sha256};
+use std::io::Write;
+
+use octos_agent::tools::manage_skills::install_bytes_into_dir;
+
+/// Build an in-memory `.tar.gz` archive containing one file named `main`
+/// with the supplied payload bytes. Returns the raw archive bytes — both
+/// `install_bytes_into_dir` and the SHA-256 in the matching manifest are
+/// computed from this exact buffer.
+fn build_targz_archive(payload: &[u8]) -> Vec<u8> {
+    let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    {
+        let mut tar = tar::Builder::new(&mut gz);
+        let mut header = tar::Header::new_gnu();
+        header.set_path("main").unwrap();
+        header.set_size(payload.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        tar.append(&header, payload).unwrap();
+        tar.finish().unwrap();
+    }
+    gz.finish().unwrap()
+}
+
+/// Passing case: archive bytes match the declared SHA-256 → install
+/// succeeds and `<dir>/main` carries the archived payload.
+#[test]
+fn install_bytes_into_dir_accepts_matching_sha256() {
+    let dir = tempfile::tempdir().unwrap();
+    let payload = b"#!/bin/sh\necho hello from skill\n";
+    let archive = build_targz_archive(payload);
+    let digest = format!("{:x}", Sha256::digest(&archive));
+
+    let ok = install_bytes_into_dir(
+        dir.path(),
+        "https://example.invalid/skill-v1.tar.gz",
+        &archive,
+        Some(&digest),
+    )
+    .expect("install_bytes_into_dir must not error on matching hash");
+    assert!(
+        ok,
+        "matching SHA-256 must result in `Ok(true)` (i.e. install accepted)"
+    );
+
+    let installed = dir.path().join("main");
+    assert!(installed.exists(), "`main` must be written");
+    let got = std::fs::read(&installed).unwrap();
+    assert_eq!(
+        got, payload,
+        "installed bytes must match the archive payload"
+    );
+}
+
+/// Failing case: declared digest does NOT match the archive bytes →
+/// `install_bytes_into_dir` returns `Ok(false)` (install refused) and
+/// `<dir>/main` is NOT written.
+#[test]
+fn install_bytes_into_dir_rejects_mismatched_sha256() {
+    let dir = tempfile::tempdir().unwrap();
+    let payload = b"#!/bin/sh\necho legitimate\n";
+    let archive = build_targz_archive(payload);
+    let bogus_digest = "0".repeat(64);
+
+    let ok = install_bytes_into_dir(
+        dir.path(),
+        "https://example.invalid/skill-v1.tar.gz",
+        &archive,
+        Some(&bogus_digest),
+    )
+    .expect("install_bytes_into_dir must return Ok(false) on mismatch, not Err");
+    assert!(
+        !ok,
+        "mismatched SHA-256 must produce `Ok(false)` so callers can fall through"
+    );
+
+    let installed = dir.path().join("main");
+    assert!(
+        !installed.exists(),
+        "no `main` must be written when the hash check fails (got {})",
+        installed.display()
+    );
+}
+
+/// Missing `binaries.<platform>` entry (i.e. caller passes `sha256: None`):
+/// archive is still installed (no signature gate to honour). This mirrors
+/// the legacy permissive path through `download_binary` — the manifest's
+/// `binaries` resolution layer skips the URL entirely when no entry exists
+/// for the current platform, but if a caller does invoke the install path
+/// without a digest the bytes still land.
+#[test]
+fn install_bytes_into_dir_no_hash_falls_back_gracefully() {
+    let dir = tempfile::tempdir().unwrap();
+    let payload = b"#!/bin/sh\necho no-hash\n";
+    let archive = build_targz_archive(payload);
+
+    let ok = install_bytes_into_dir(
+        dir.path(),
+        "https://example.invalid/skill-v1.tar.gz",
+        &archive,
+        None,
+    )
+    .expect("install_bytes_into_dir must not error when sha256 is None");
+    assert!(
+        ok,
+        "absent sha256 must take the legacy permissive path (install accepted)"
+    );
+
+    let installed = dir.path().join("main");
+    assert!(installed.exists(), "`main` must be written");
+}
+
+/// Bonus coverage: when the URL does not look like an archive the helper
+/// treats the bytes as a raw binary and writes them verbatim. The
+/// hash-check still gates installation — a mismatch refuses regardless of
+/// archive vs raw.
+#[test]
+fn install_bytes_into_dir_raw_binary_hash_check_applies() {
+    let dir = tempfile::tempdir().unwrap();
+    let payload = b"#!/usr/bin/env python\nprint('raw')\n";
+    let digest = format!("{:x}", Sha256::digest(payload));
+
+    // Passing case (raw URL ↔ payload hash matches).
+    let ok = install_bytes_into_dir(
+        dir.path(),
+        "https://example.invalid/raw-skill-binary",
+        payload,
+        Some(&digest),
+    )
+    .unwrap();
+    assert!(ok, "raw binary with matching hash must be accepted");
+    assert_eq!(std::fs::read(dir.path().join("main")).unwrap(), payload);
+
+    // Failing case (same URL, wrong hash).
+    let dir2 = tempfile::tempdir().unwrap();
+    let bogus = "f".repeat(64);
+    let ok = install_bytes_into_dir(
+        dir2.path(),
+        "https://example.invalid/raw-skill-binary",
+        payload,
+        Some(&bogus),
+    )
+    .unwrap();
+    assert!(!ok, "raw binary with bogus hash must be refused");
+    assert!(!dir2.path().join("main").exists());
+}
+
+/// Pull `Write` into scope so the test module compiles cleanly even when
+/// `flate2`'s Builder construction below changes its trait-bound surface
+/// in a future bump. The trait is intentionally unused at the top level —
+/// it's only referenced via the `tar::Builder` writer interface in
+/// [`build_targz_archive`].
+#[allow(dead_code)]
+fn _ensure_write_in_scope() -> Box<dyn Write> {
+    Box::new(std::io::sink())
+}

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -697,6 +697,11 @@ impl GatewayRuntime {
                         octos_agent::PluginLoadOptions {
                             work_dir: Some(&plugin_work_dir),
                             synthesis_config,
+                            // Section B: opt-in strict signature enforcement.
+                            // Honours top-level `plugins.require_signed`; default
+                            // is `false` (backward compatible — unsigned plugins
+                            // still load with a warning).
+                            require_signed: config.plugins.require_signed,
                         },
                     ) {
                         Ok(result) => plugin_result = result,

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -600,6 +600,12 @@ impl ProfileActorFactoryBuilder {
                     octos_agent::PluginLoadOptions {
                         work_dir: Some(&plugin_work_dir),
                         synthesis_config,
+                        // Section B: opt-in strict signature enforcement.
+                        // Honours `plugins.require_signed` from the
+                        // profile-derived config; default is `false`
+                        // (backward compatible — unsigned plugins still
+                        // load with a warning).
+                        require_signed: profile_config.plugins.require_signed,
                     },
                 ) {
                     Ok(result) => {

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -192,6 +192,33 @@ pub struct Config {
     /// precedence.
     #[serde(default)]
     pub appui: AppUiConfig,
+
+    /// Plugin loader policy. When `plugins.require_signed = true`, plugins
+    /// without a `manifest.sha256` declaration are rejected at load time
+    /// (instead of the legacy "warn and proceed" path). Default: false
+    /// (backward compatible). Production fleets should turn this on after
+    /// ensuring every shipped skill declares `sha256` in `manifest.json`.
+    #[serde(default)]
+    pub plugins: PluginsConfig,
+}
+
+/// Plugin loader policy.
+///
+/// All fields default to backward-compatible values so existing configs
+/// continue to load plugins exactly as they did before this struct was
+/// introduced. Set `require_signed = true` to enforce strict signature
+/// verification — plugins without `manifest.sha256` will be rejected at
+/// load time and re-hash gates apply on every invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct PluginsConfig {
+    /// When `true`, plugins must declare a `sha256` in their `manifest.json`
+    /// and that hash must match the bytes on disk both at load time and
+    /// before every invocation (pre-spawn re-hash closes the load→exec
+    /// TOCTOU window). When `false` (default), unsigned plugins still load
+    /// with a warning to preserve backward compatibility.
+    #[serde(default)]
+    pub require_signed: bool,
 }
 
 /// AppUi session defaults applied by `octos serve`'s API agent.
@@ -624,10 +651,16 @@ fn monitor_default_max_restart() -> u32 {
 impl Config {
     /// Directories to scan for plugins and skill packages with tools.
     ///
-    /// Scans both `.octos/plugins/` (legacy) and `.octos/skills/` (unified packages).
-    /// Skill packages that include a `manifest.json` are auto-discovered as tool
-    /// providers by `PluginLoader` (packages without manifest.json are skipped).
-    /// Resolve plugin/skill directories from a project directory (e.g. `~/.octos`).
+    /// Scans deployment-scoped dirs under `project_dir` (typically `octos_home`)
+    /// plus dirs added via `OCTOS_SKILLS_PATH`. The legacy HOME-rooted globals
+    /// (`~/.octos/skills`, `~/.octos/plugins`) are NO LONGER scanned — installs
+    /// are per-profile only under `<data_dir>/skills/`. The bundled platform
+    /// skills (`<octos_home>/platform-skills/`, admin-only) are loaded explicitly
+    /// in serve.rs.
+    ///
+    /// When this function detects that the legacy `~/.octos/skills` directory
+    /// still exists on disk it emits a one-shot `tracing::warn!` so operators
+    /// migrating from older deployments see a clear migration prompt.
     ///
     /// The `project_dir` is typically `octos_home` (for managed gateways) or
     /// `cwd/.octos` (for standalone `octos chat`). This is intentionally decoupled
@@ -649,16 +682,11 @@ impl Config {
             dirs.push(bundled);
         }
         // Note: platform-skills/ (voice, etc.) are admin-only — loaded explicitly in serve.rs
-        if let Some(home) = dirs::home_dir() {
-            let global_plugins = home.join(".octos").join("plugins");
-            if global_plugins.exists() {
-                dirs.push(global_plugins);
-            }
-            let global_skills = home.join(".octos").join("skills");
-            if global_skills.exists() {
-                dirs.push(global_skills);
-            }
-        }
+        // Legacy HOME-rooted globals (`~/.octos/skills`, `~/.octos/plugins`) are
+        // deprecated: all skill installs now live under `<data_dir>/skills/` for
+        // per-profile isolation. We still warn ONCE per process if the directory
+        // is present so operators migrating from older deployments notice it.
+        warn_once_if_legacy_global_skills_exist();
         // Extra dirs from OCTOS_SKILLS_PATH env var (colon-separated)
         if let Ok(extra) = std::env::var("OCTOS_SKILLS_PATH") {
             for p in extra.split(':') {
@@ -674,6 +702,32 @@ impl Config {
         dirs.dedup();
         dirs
     }
+}
+
+/// One-shot warning when `~/.octos/skills` still exists on disk after we
+/// stopped scanning it. Emitted at most once per process so operators see
+/// a single migration hint rather than spamming every profile bootstrap.
+fn warn_once_if_legacy_global_skills_exist() {
+    use std::sync::Once;
+    static WARN_ONCE: Once = Once::new();
+    WARN_ONCE.call_once(|| {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let legacy_skills = home.join(".octos").join("skills");
+        let legacy_plugins = home.join(".octos").join("plugins");
+        for legacy in [&legacy_skills, &legacy_plugins] {
+            if legacy.exists() {
+                tracing::warn!(
+                    path = %legacy.display(),
+                    "legacy global skill directory is no longer scanned; \
+                     migrate contents into your profile's `<data_dir>/skills/` \
+                     (e.g. `~/.octos/profiles/<id>/data/skills/`) — installs \
+                     are per-profile only"
+                );
+            }
+        }
+    });
 }
 
 /// Message queue mode for handling messages arriving during active agent runs.
@@ -1406,6 +1460,112 @@ mod tests {
         let json = r#"{"base_domain": "ocean.ominix.io"}"#;
         let config: Config = serde_json::from_str(json).unwrap();
         assert_eq!(config.base_domain.as_deref(), Some("ocean.ominix.io"));
+    }
+
+    /// Section A of the per-profile-skills migration: the legacy HOME-rooted
+    /// globals (`~/.octos/skills`, `~/.octos/plugins`) MUST NOT appear in the
+    /// scan list anymore. Installs live under `<data_dir>/skills/` for
+    /// per-profile isolation; HOME-rooted globals are deprecated.
+    ///
+    /// This test pivots `HOME` to a temp dir so it works on CI hosts where
+    /// the real `$HOME/.octos/skills` may or may not exist. The function
+    /// must NOT include those paths in its result, regardless of whether
+    /// the directories exist on disk.
+    #[test]
+    #[allow(unsafe_code)]
+    fn plugin_dirs_from_project_drops_legacy_home_rooted_globals() {
+        // Serialize env mutation so parallel tests don't fight over HOME.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let tmp = tempfile::tempdir().unwrap();
+        let fake_home = tmp.path();
+        let project_dir = fake_home.join("octos-home");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        // Plant legacy HOME-rooted globals that the OLD scan list would have
+        // included. The new scan list MUST NOT include them.
+        let legacy_skills = fake_home.join(".octos").join("skills");
+        let legacy_plugins = fake_home.join(".octos").join("plugins");
+        std::fs::create_dir_all(&legacy_skills).unwrap();
+        std::fs::create_dir_all(&legacy_plugins).unwrap();
+
+        // Pivot HOME for the duration of this assertion. dirs::home_dir()
+        // honors HOME on Unix; we restore the original after the check.
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: single-threaded inside the static LOCK above; restored on
+        // both the success and panic-unwind paths below.
+        unsafe { std::env::set_var("HOME", fake_home) };
+
+        let scan = Config::plugin_dirs_from_project(&project_dir);
+
+        // Restore HOME before assertions so a panic doesn't leak the override.
+        // SAFETY: see above.
+        match original_home {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+
+        assert!(
+            !scan.contains(&legacy_skills),
+            "`~/.octos/skills` must no longer be scanned; got: {scan:?}"
+        );
+        assert!(
+            !scan.contains(&legacy_plugins),
+            "`~/.octos/plugins` must no longer be scanned; got: {scan:?}"
+        );
+    }
+
+    /// Section B: `plugins.require_signed` deserializes from the new
+    /// `[plugins]` config block. Default is `false` (backward compatible).
+    #[test]
+    fn plugins_require_signed_deserialize_explicit_true() {
+        let json = r#"{"plugins": {"require_signed": true}}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(config.plugins.require_signed);
+    }
+
+    #[test]
+    fn plugins_require_signed_defaults_to_false_when_absent() {
+        let json = r#"{"provider": "anthropic"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(
+            !config.plugins.require_signed,
+            "missing `plugins` block must default to `require_signed = false` \
+             (backward compat)"
+        );
+    }
+
+    #[test]
+    fn plugins_require_signed_defaults_to_false_when_block_empty() {
+        let json = r#"{"plugins": {}}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(!config.plugins.require_signed);
+    }
+
+    /// Section A: `<octos_home>/plugins` and `<octos_home>/skills`
+    /// (deployment-scoped, not HOME-rooted) MUST still be scanned. M11-F
+    /// REG-5 added them so admin-installed plugins are visible to every
+    /// profile.
+    #[test]
+    fn plugin_dirs_from_project_keeps_deployment_scoped_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("octos-home");
+        let project_plugins = project_dir.join("plugins");
+        let project_skills = project_dir.join("skills");
+        std::fs::create_dir_all(&project_plugins).unwrap();
+        std::fs::create_dir_all(&project_skills).unwrap();
+
+        let scan = Config::plugin_dirs_from_project(&project_dir);
+
+        assert!(
+            scan.contains(&project_plugins),
+            "`<octos_home>/plugins` must still be scanned; got: {scan:?}"
+        );
+        assert!(
+            scan.contains(&project_skills),
+            "`<octos_home>/skills` must still be scanned; got: {scan:?}"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1475,6 +1475,7 @@ pub(crate) fn config_from_profile(
         credential_pool: None,
         content_routing: profile.config.content_routing.clone(),
         appui: Default::default(),
+        plugins: Default::default(),
     }
 }
 

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -493,13 +493,16 @@ impl ProfileRuntime {
         // M11-F regression fix REG-5: replace the hand-rolled
         // per-profile-only assembly with `Config::plugin_dirs_from_project`
         // (the canonical helper pre-M11-F serve.rs used) so the resulting
-        // set includes the *global* `~/.octos/plugins`, `~/.octos/skills`,
-        // `<octos_home>/plugins`, `<octos_home>/skills`, and the
-        // colon-separated `OCTOS_SKILLS_PATH` env var alongside the
-        // already-scanned `<octos_home>/bundled-app-skills/`. Platform
-        // skills (`<octos_home>/platform-skills/`, admin-only) and the
-        // per-profile `data_dir/skills/` are layered on top so the
+        // set includes the deployment-scoped `<octos_home>/plugins`,
+        // `<octos_home>/skills`, the colon-separated `OCTOS_SKILLS_PATH`
+        // env var, and the already-scanned `<octos_home>/bundled-app-skills/`.
+        // Platform skills (`<octos_home>/platform-skills/`, admin-only) and
+        // the per-profile `data_dir/skills/` are layered on top so the
         // gateway behaviour is matched 1:1.
+        //
+        // Legacy HOME-rooted globals (`~/.octos/plugins`, `~/.octos/skills`)
+        // are NO LONGER scanned — `Config::plugin_dirs_from_project` emits a
+        // one-shot migration warning on first detection.
         let plugin_work_dir = data_dir.join("skill-output");
         let _ = std::fs::create_dir_all(&plugin_work_dir);
         let mut plugin_dirs: Vec<PathBuf> = Config::plugin_dirs_from_project(&effective_octos_home);
@@ -521,6 +524,13 @@ impl ProfileRuntime {
                 PluginLoadOptions {
                     work_dir: Some(&plugin_work_dir),
                     synthesis_config: None,
+                    // Section B: honour the profile-derived
+                    // `plugins.require_signed`. Default is `false`
+                    // (backward compatible). Profile bootstrap reads
+                    // the flag from the flattened `Config` produced by
+                    // `config_from_profile` so operators can opt into
+                    // strict signature enforcement per deployment.
+                    require_signed: config.plugins.require_signed,
                 },
             ) {
                 Ok(result) => plugin_result = result,


### PR DESCRIPTION
## Summary

Lands the octos-side enforcement for the architectural decision that **skill installation is per-profile only** (option A). Four changes, one PR.

### A — Drop legacy HOME-rooted globals from `plugin_dirs_from_project`
- `~/.octos/skills` and `~/.octos/plugins` are no longer scanned.
- One-shot `tracing::warn!` on first call if either dir still exists on disk so operators see a migration prompt.
- Deployment-scoped dirs (`<octos_home>/plugins`, `<octos_home>/skills`, `<octos_home>/bundled-app-skills`) stay; per-profile `<data_dir>/skills/` is added by `runtime/profile.rs` on top.

### B — `plugins.require_signed` config flag
- New `pub plugins: PluginsConfig` field on top-level `Config` with `require_signed: bool` (default `false` — backward compatible).
- When `true`, the loader REJECTS plugins without `manifest.sha256` instead of the legacy "warn and proceed" path.
- Empty-string `sha256: ""` rejected at parse time in `PluginManifest` (whitespace-only too).
- Plumbed through `PluginLoadOptions` → `gateway_runtime.rs`, `profile_factory.rs`, `runtime/profile.rs`.

### C — Pre-spawn re-hash (closes load→exec TOCTOU)
- `PluginTool` now stashes the SHA-256 of the verified-exe bytes captured at load time.
- Before each `execute()` invocation, `PluginTool` re-reads `.<name>_verified`, recomputes SHA-256, and refuses to spawn on mismatch.
- Gate runs unconditionally under `require_signed`; otherwise only when a manifest hash was declared (keeps the unsigned path cheap).

### D — Integration test for install-time archive sha256
- Extracted `install_bytes_into_dir` from the network-bound `download_binary` so the hash-verification path is unit-testable.
- New `crates/octos-agent/tests/manage_skills_hash.rs`: passing case, mismatched-hash refusal, missing-hash fallback, raw-binary hash check.

## Backward compatibility

Hosts that relied on `~/.octos/skills` must copy their contents into each profile's `data/skills/` directory. The fleet deploy script PR (separate agent, parallel) handles this automatically; manual hosts get the warn-once message at startup. `plugins.require_signed` is opt-in — fleet should turn it on once shipped skills declare `sha256` in their manifests.

## Test plan
- [x] `cargo test -p octos-agent --lib plugins::loader::tests` — 24 tests pass (5 new)
- [x] `cargo test -p octos-agent --lib plugins::manifest::tests` — incl. 3 new sha256-parse tests
- [x] `cargo test -p octos-agent --test manage_skills_hash` — 4 new integration tests pass
- [x] `cargo test -p octos-cli --lib config::tests` — 5 new tests for `plugins.require_signed` + `plugin_dirs_from_project`
- [x] `cargo test -p octos-agent --lib && cargo test -p octos-agent --tests` — full sweep green (1333 lib + ~140 integration)
- [x] `cargo test -p octos-cli --lib` — 365 lib tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-agent -p octos-cli --all-targets -- -D warnings` clean