### PR TITLE
feat(api): Wave4-A — adaptive router status protocol + honor enabled flag

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -1145,3 +1145,164 @@ negotiated.
 
 The capability schema version remains `2`; this is an additive feature
 flag and does not bump the schema version.
+
+## 15. Wave4-A — Adaptive Router + Queue Surface
+
+The router/queue notifications and commands ship without a feature
+flag — they are additive on the existing capabilities envelope. Clients
+that don't recognize the methods drop them at the JSON-RPC parser. The
+schema version remains `2`.
+
+### 15.1 `router/status` (notification)
+
+Adaptive routing snapshot pushed adjacent to `turn/started` and
+`turn/completed`. No-op on connections whose session profile has no
+`AdaptiveRouter` attached (single-provider config or
+`adaptive_routing.enabled = false`).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "router/status",
+  "params": {
+    "kind": "router_status",
+    "session_id": "local:demo",
+    "provider_name": "zai/glm-5-turbo",
+    "mode": "lane",
+    "qos_ranking": true,
+    "lane_scores": { "ollama/llama3.2": 0.62, "zai/glm-5-turbo": 0.21 },
+    "circuit_breakers": { "ollama/llama3.2": "closed", "zai/glm-5-turbo": "closed" }
+  }
+}
+```
+
+`lane_scores` keys are deterministic (`BTreeMap` lex-sorted) so a client
+that diffs successive snapshots gets stable key order. `mode` is the
+lowercase string rendering of `AdaptiveMode` (`off` | `hedge` | `lane`).
+`circuit_breakers` values are `"closed"` / `"open"` / `"half_open"` (the
+last is reserved for a future tri-state breaker).
+
+### 15.2 `router/failover` (notification)
+
+Adaptive router crossed lanes. Emitted as durable so a reconnecting
+client can catch up.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "router/failover",
+  "params": {
+    "kind": "router_failover",
+    "session_id": "local:demo",
+    "from_provider": "zai/glm-5-turbo",
+    "to_provider": "ollama/llama3.2",
+    "reason": "chat_error: 429 rate limited",
+    "elapsed_ms": 12345
+  }
+}
+```
+
+`reason` is free-text from `AdaptiveRouter`. `elapsed_ms` is the wall
+time from initial provider attempt to failover decision.
+
+### 15.3 `queue/state` (notification — client-emitted today)
+
+Pending-queue snapshot. The queue is client-side (`octos-web`
+`runtime/ui-protocol-send.ts`); the server never emits this variant.
+The wire shape is defined here so a future server-side queue (or a TUI
+client) can publish into the same DOM event channel:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "queue/state",
+  "params": {
+    "kind": "queue_state",
+    "session_id": "local:demo",
+    "pending_count": 3,
+    "head_client_message_id": "cmid-12345"
+  }
+}
+```
+
+`head_client_message_id` is omitted when the queue is empty (the
+in-flight turn has landed).
+
+### 15.4 `router/set_mode` (RPC request)
+
+Runtime mode toggle. Mode change is session-scoped — it persists for
+the lifetime of the `AdaptiveRouter` (process lifetime today), not
+across restarts.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-set-mode",
+  "method": "router/set_mode",
+  "params": {
+    "session_id": "local:demo",
+    "mode": "hedge"
+  }
+}
+```
+
+Response (success):
+
+```json
+{ "jsonrpc": "2.0", "id": "req-set-mode", "result": { "mode": "hedge" } }
+```
+
+Errors:
+
+- `INVALID_PARAMS` with no `data` — unknown mode string. The valid set
+  is `off` / `hedge` / `lane`.
+- `INVALID_PARAMS` with `data: { "kind": "runtime_unavailable" }` —
+  this session's profile has no `AdaptiveRouter` attached.
+
+### 15.5 `router/get_metrics` (RPC request)
+
+On-demand snapshot mirroring `router/status` (same payload shape minus
+the `session_id` echo). Lets a client poll without subscribing to the
+push channel.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-get-metrics",
+  "method": "router/get_metrics",
+  "params": { "session_id": "local:demo" }
+}
+```
+
+Response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-get-metrics",
+  "result": {
+    "provider_name": "zai/glm-5-turbo",
+    "mode": "lane",
+    "qos_ranking": true,
+    "lane_scores": { "zai/glm-5-turbo": 0.21 },
+    "circuit_breakers": { "zai/glm-5-turbo": "closed" }
+  }
+}
+```
+
+Error shape identical to `router/set_mode` (`runtime_unavailable` data
+tag when no router is attached).
+
+### 15.6 Behavioral guarantees
+
+- `router/status` emitted at `turn/started` and `turn/completed`. Never
+  in the middle of a turn (use `router/get_metrics` to poll).
+- `router/failover` published per-attempt — emitting BEFORE the retry,
+  so a transition is observable even when the retry itself fails.
+- The router's failover broadcast channel is **non-blocking**: slow
+  subscribers observe `RecvError::Lagged` and skip; the router NEVER
+  stalls on a stuck client.
+- `adaptive_routing.enabled = false` (or absence of the block) means
+  no `AdaptiveRouter` is built — `router/*` methods return
+  `runtime_unavailable`. This was a config-correctness fix in Wave4-A
+  (the previous behavior was silent default-ON).

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2044,6 +2044,12 @@ async fn ui_protocol_connection(
                 handle_content_bulk_delete(&ws, &state, connection_identity.as_ref(), id, params)
                     .await;
             }
+            UiCommand::RouterSetMode(params) => {
+                handle_router_set_mode(&ws, &state, routed_profile_id, id, params).await;
+            }
+            UiCommand::RouterGetMetrics(params) => {
+                handle_router_get_metrics(&ws, &state, routed_profile_id, id, params).await;
+            }
         }
     }
 
@@ -5807,6 +5813,127 @@ fn task_cancel_rpc_error(task_id: &TaskId, error: octos_agent::TaskCancelError) 
     }
 }
 
+/// Wave4-A: resolve the per-session `AdaptiveRouter` (if any) by routing
+/// through the same `resolve_session_profile_runtime` path used by
+/// `session/open` and `turn/start`. Returns `None` for sessions whose
+/// profile has no router attached — single-provider config or
+/// `adaptive_routing.enabled = false`.
+fn resolve_router_for_session(
+    state: &Arc<AppState>,
+    session_id: &SessionKey,
+    routed_profile_id: Option<&str>,
+) -> Option<Arc<octos_llm::AdaptiveRouter>> {
+    let active_profile_id = session_id
+        .profile_id()
+        .map(ToOwned::to_owned)
+        .or_else(|| routed_profile_id.map(ToOwned::to_owned));
+    let profile_runtime = resolve_session_profile_runtime(state, active_profile_id.as_deref())?;
+    profile_runtime.adaptive_router.clone()
+}
+
+/// Wave4-A handler for `router/set_mode`. Parses `params.mode` into the
+/// `AdaptiveMode` enum (lowercase string), dispatches to
+/// `AdaptiveRouter::set_mode`, and returns a typed ack.
+///
+/// Returns `INVALID_PARAMS` for unknown modes and a typed
+/// `runtime_unavailable` data tag when the session has no router (so
+/// the client can disable its mode-switcher UI).
+async fn handle_router_set_mode(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    routed_profile_id: Option<&str>,
+    id: String,
+    params: octos_core::ui_protocol::RouterSetModeParams,
+) {
+    let method = octos_core::ui_protocol::methods::ROUTER_SET_MODE;
+    let mode = match params.mode.as_str() {
+        "off" => octos_llm::AdaptiveMode::Off,
+        "hedge" => octos_llm::AdaptiveMode::Hedge,
+        "lane" => octos_llm::AdaptiveMode::Lane,
+        other => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::invalid_params(format!(
+                    "{method}: unknown mode '{other}' (expected off | hedge | lane)"
+                )),
+            );
+            return;
+        }
+    };
+    let Some(router) = resolve_router_for_session(state, &params.session_id, routed_profile_id)
+    else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!(
+                "{method}: no adaptive router attached to this session"
+            ))
+            .with_data(json!({ "kind": "runtime_unavailable" })),
+        );
+        return;
+    };
+    router.set_mode(mode);
+    let result = octos_core::ui_protocol::RouterSetModeResult { mode: params.mode };
+    let value = match serde_json::to_value(&result) {
+        Ok(v) => v,
+        Err(error) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::malformed_result(format!("{method}: serialize result: {error}")),
+            );
+            return;
+        }
+    };
+    let _ = send_rpc_result(ws, id, value);
+}
+
+/// Wave4-A handler for `router/get_metrics`. Returns the same payload
+/// shape as the `router/status` notification (lane scores, breaker
+/// states, mode, current provider).
+async fn handle_router_get_metrics(
+    ws: &WsConnection,
+    state: &Arc<AppState>,
+    routed_profile_id: Option<&str>,
+    id: String,
+    params: octos_core::ui_protocol::RouterGetMetricsParams,
+) {
+    let method = octos_core::ui_protocol::methods::ROUTER_GET_METRICS;
+    let Some(router) = resolve_router_for_session(state, &params.session_id, routed_profile_id)
+    else {
+        let _ = send_rpc_error(
+            ws,
+            Some(id),
+            RpcError::invalid_params(format!(
+                "{method}: no adaptive router attached to this session"
+            ))
+            .with_data(json!({ "kind": "runtime_unavailable" })),
+        );
+        return;
+    };
+    let status = router.adaptive_status();
+    let result = octos_core::ui_protocol::RouterGetMetricsResult {
+        provider_name: router.current_lane_key(),
+        mode: status.mode.to_string(),
+        qos_ranking: status.qos_ranking,
+        lane_scores: router.lane_scores(),
+        circuit_breakers: router.breaker_states(),
+    };
+    let value = match serde_json::to_value(&result) {
+        Ok(v) => v,
+        Err(error) => {
+            let _ = send_rpc_error(
+                ws,
+                Some(id),
+                RpcError::malformed_result(format!("{method}: serialize result: {error}")),
+            );
+            return;
+        }
+    };
+    let _ = send_rpc_result(ws, id, value);
+}
+
 fn task_relaunch_rpc_error(task_id: &TaskId, error: octos_agent::TaskRelaunchError) -> RpcError {
     match error {
         octos_agent::TaskRelaunchError::NotFound => RpcError::unknown_task_id(task_id),
@@ -6326,6 +6453,25 @@ async fn run_standalone_turn(
     let memory_store: Arc<octos_memory::EpisodeStore> = session_runtime.profile.memory.clone();
     let agent_config = session_runtime.agent.agent_config();
     let system_prompt_base = session_runtime.agent.system_prompt_snapshot();
+
+    // Wave4-A: emit an initial `router/status` snapshot adjacent to
+    // `turn/started` so clients can render the routing pill before the
+    // first token. No-op when this profile has no `AdaptiveRouter`
+    // attached (single-provider or `enabled = false`).
+    let adaptive_router_ref = session_runtime.profile.adaptive_router.clone();
+    emit_router_status_lifecycle(&ws, &ledger, &session_id, adaptive_router_ref.as_ref());
+
+    // Wave4-A: subscribe to the AdaptiveRouter's broadcast channel and
+    // forward `FailoverEvent`s as `router/failover` notifications for
+    // the duration of this turn. The abort handle ends the forwarder
+    // when the turn ends — see the `.abort()` call near
+    // `try_emit_terminal()` below.
+    let failover_forwarder = spawn_router_failover_forwarder(
+        ws.clone(),
+        ledger.clone(),
+        session_id.clone(),
+        adaptive_router_ref.clone(),
+    );
 
     let history: Vec<Message> = {
         let mut sessions = sessions.lock().await;
@@ -7043,6 +7189,19 @@ async fn run_standalone_turn(
     }
 
     let _ = agent_task.await;
+
+    // Wave4-A: emit a final `router/status` snapshot adjacent to
+    // `turn/completed` so clients see the actual provider that ran
+    // the turn + any breaker / lane-score deltas. No-op when no
+    // AdaptiveRouter is attached.
+    emit_router_status_lifecycle(&ws, &ledger, &session_id, adaptive_router_ref.as_ref());
+
+    // Wave4-A: tear down the failover forwarder task. Aborting is safe
+    // even if the task already exited (broadcast channel close path).
+    if let Some(handle) = failover_forwarder {
+        handle.abort();
+    }
+
     // FIX-06: a turn that ends — for any reason — must drop its
     // `approve_for_turn` policy entries so a subsequent turn can't reuse
     // them. The state-machine entry itself is intentionally retained here
@@ -7452,6 +7611,100 @@ fn send_turn_error(
     )
 }
 
+/// Wave4-A: build a `RouterStatusEvent` from an `AdaptiveRouter` snapshot.
+/// `router` is `None` for sessions without an adaptive router attached;
+/// callers MUST skip emission in that case.
+pub(crate) fn build_router_status_event(
+    session_id: &SessionKey,
+    router: &Arc<octos_llm::AdaptiveRouter>,
+) -> octos_core::ui_protocol::RouterStatusEvent {
+    let status = router.adaptive_status();
+    octos_core::ui_protocol::RouterStatusEvent {
+        session_id: session_id.clone(),
+        provider_name: router.current_lane_key(),
+        mode: status.mode.to_string(),
+        qos_ranking: status.qos_ranking,
+        lane_scores: router.lane_scores(),
+        circuit_breakers: router.breaker_states(),
+    }
+}
+
+/// Wave4-A: emit a `RouterStatus` notification on the lifecycle path
+/// (same delivery semantics as `turn/started` — failure is logged but
+/// non-fatal for the turn). No-op when `router` is `None`.
+fn emit_router_status_lifecycle(
+    ws: &WsConnection,
+    ledger: &UiProtocolLedger,
+    session_id: &SessionKey,
+    router: Option<&Arc<octos_llm::AdaptiveRouter>>,
+) {
+    let Some(router) = router else {
+        return;
+    };
+    let event = build_router_status_event(session_id, router);
+    let notif = UiNotification::RouterStatus(event);
+    let method = notif.method().to_string();
+    if let Err(error) = send_notification_lifecycle(ws, ledger, notif) {
+        tracing::debug!(
+            target: "octos::ui_protocol::ws",
+            method = %method,
+            error = ?error,
+            "router/status emission failed; non-fatal for turn"
+        );
+    }
+}
+
+/// Wave4-A: spawn a background task that forwards `FailoverEvent` from
+/// the AdaptiveRouter's broadcast channel onto the connection as
+/// `router/failover` notifications. The task lives for the duration of
+/// the turn — it ends naturally when the broadcast channel sender is
+/// dropped or when the calling task exits (the `tokio::spawn` is
+/// orphaned but the channel close terminates the loop).
+///
+/// Returns the `AbortHandle` so the caller can stop the forwarder when
+/// the turn ends. Returning `None` when no router is attached.
+fn spawn_router_failover_forwarder(
+    ws: WsConnection,
+    ledger: Arc<UiProtocolLedger>,
+    session_id: SessionKey,
+    router: Option<Arc<octos_llm::AdaptiveRouter>>,
+) -> Option<AbortHandle> {
+    let router = router?;
+    let mut rx = router.subscribe_failover();
+    let join = tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(event) => {
+                    let notif = UiNotification::RouterFailover(
+                        octos_core::ui_protocol::RouterFailoverEvent {
+                            session_id: session_id.clone(),
+                            from_provider: event.from_provider,
+                            to_provider: event.to_provider,
+                            reason: event.reason,
+                            elapsed_ms: event.elapsed_ms,
+                        },
+                    );
+                    // Best-effort durable — failover events should be
+                    // ledger-persisted so a reconnecting client can
+                    // catch up, but if the client is gone we don't
+                    // care (the turn is what matters).
+                    let _ = send_notification_durable(&ws, &ledger, notif);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    tracing::debug!(
+                        target: "octos::ui_protocol::ws",
+                        skipped,
+                        "router failover subscriber lagged — events dropped"
+                    );
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+    Some(join.abort_handle())
+}
+
 fn send_rpc_result(ws: &WsConnection, id: String, result: Value) -> Result<(), SendError> {
     let frame = frame_for(&RpcResponse::success(id, result))
         .ok_or_else(|| SendError::LifecycleFailure("rpc result serialization".into()))?;
@@ -7676,7 +7929,12 @@ fn ledger_event_cursor(event: &UiProtocolLedgerEvent) -> Option<UiCursor> {
             // would re-loop the replay flag onto itself.
             | UiNotification::ReplayLossy(_)
             | UiNotification::FileAttached(_)
-            | UiNotification::SessionEventBridged(_) => None,
+            | UiNotification::SessionEventBridged(_)
+            // Wave4-A: router/queue notifications don't carry their own
+            // cursor — they're stateless lifecycle pushes.
+            | UiNotification::RouterStatus(_)
+            | UiNotification::RouterFailover(_)
+            | UiNotification::QueueState(_) => None,
         },
         UiProtocolLedgerEvent::Progress(_) => None,
     }
@@ -15047,6 +15305,170 @@ mod tests {
                 .contains("tier-2 operator default visible to session"),
             "expected operator-default sentinel content, got: {}",
             result.output
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // Wave4-A: router/status build + router/set_mode emission tests.
+    // ----------------------------------------------------------------
+
+    /// Mock provider for router-emission tests: never called, just lets
+    /// `AdaptiveRouter::new` accept two slots so the lane-scoring + breaker
+    /// snapshot paths fire end-to-end.
+    struct Wave4AStubProvider {
+        name: &'static str,
+        model: &'static str,
+    }
+
+    #[async_trait::async_trait]
+    impl octos_llm::LlmProvider for Wave4AStubProvider {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> eyre::Result<octos_llm::ChatResponse> {
+            Err(eyre::eyre!("stub not callable in tests"))
+        }
+        fn model_id(&self) -> &str {
+            self.model
+        }
+        fn provider_name(&self) -> &str {
+            self.name
+        }
+    }
+
+    /// Wave4-A: `build_router_status_event` captures the current
+    /// AdaptiveRouter snapshot in the wire shape expected by the
+    /// notification path. The lane-scores map is deterministic
+    /// (BTreeMap order), the mode reflects `set_mode()`, and the
+    /// breaker map carries the same keys.
+    #[test]
+    fn build_router_status_event_captures_current_router_snapshot() {
+        let router = Arc::new(octos_llm::AdaptiveRouter::new(
+            vec![
+                Arc::new(Wave4AStubProvider {
+                    name: "zai",
+                    model: "glm-5-turbo",
+                }),
+                Arc::new(Wave4AStubProvider {
+                    name: "ollama",
+                    model: "llama3.2",
+                }),
+            ],
+            &[],
+            octos_llm::AdaptiveConfig::default(),
+        ));
+        router.set_mode(octos_llm::AdaptiveMode::Lane);
+
+        let session_id = SessionKey("local:wave4a-test".into());
+        let event = build_router_status_event(&session_id, &router);
+
+        assert_eq!(event.session_id, session_id);
+        assert_eq!(event.mode, "lane");
+        assert!(
+            event.lane_scores.contains_key("zai/glm-5-turbo"),
+            "lane_scores must include each slot — got {:?}",
+            event.lane_scores.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            event.lane_scores.contains_key("ollama/llama3.2"),
+            "lane_scores must include each slot — got {:?}",
+            event.lane_scores.keys().collect::<Vec<_>>()
+        );
+
+        // Deterministic order — BTreeMap iter is lex-sorted.
+        let keys: Vec<&String> = event.lane_scores.keys().collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(
+            keys, sorted,
+            "lane_scores keys MUST be in BTreeMap (lex-sorted) order"
+        );
+
+        // Initially all breakers are closed (no failures yet).
+        for (lane, state) in &event.circuit_breakers {
+            assert_eq!(
+                state, "closed",
+                "lane {lane} should report 'closed' before any failures — got {state}"
+            );
+        }
+    }
+
+    /// Wave4-A: handler dispatches set_mode → router. We exercise the
+    /// downcalled router directly (the handler is small enough that the
+    /// failure mode we care about is "calls the wrong method on the
+    /// wrong router"). The full integration round-trip is covered by
+    /// the core `router_set_mode_command_round_trips` test.
+    #[tokio::test]
+    async fn router_set_mode_handler_dispatches_to_router() {
+        let router = Arc::new(octos_llm::AdaptiveRouter::new(
+            vec![
+                Arc::new(Wave4AStubProvider {
+                    name: "p1",
+                    model: "m1",
+                }),
+                Arc::new(Wave4AStubProvider {
+                    name: "p2",
+                    model: "m2",
+                }),
+            ],
+            &[],
+            octos_llm::AdaptiveConfig::default(),
+        ));
+        assert_eq!(router.mode(), octos_llm::AdaptiveMode::Off);
+        router.set_mode(octos_llm::AdaptiveMode::Hedge);
+        assert_eq!(router.mode(), octos_llm::AdaptiveMode::Hedge);
+        router.set_mode(octos_llm::AdaptiveMode::Lane);
+        assert_eq!(router.mode(), octos_llm::AdaptiveMode::Lane);
+        router.set_mode(octos_llm::AdaptiveMode::Off);
+        assert_eq!(router.mode(), octos_llm::AdaptiveMode::Off);
+    }
+
+    /// Wave4-A: the failover broadcast subscriber receives events
+    /// emitted by the router's internal `publish_failover` path,
+    /// reshaped into the wire form expected by the API layer.
+    #[tokio::test]
+    async fn router_failover_subscriber_receives_events_with_session_id() {
+        let router = Arc::new(octos_llm::AdaptiveRouter::new(
+            vec![
+                Arc::new(Wave4AStubProvider {
+                    name: "p1",
+                    model: "m1",
+                }),
+                Arc::new(Wave4AStubProvider {
+                    name: "p2",
+                    model: "m2",
+                }),
+            ],
+            &[],
+            octos_llm::AdaptiveConfig::default(),
+        ));
+        let mut rx = router.subscribe_failover();
+
+        // Drive a failover by calling the internal publish (the public
+        // path is exercised in octos-llm's tests; here we verify the
+        // subscriber surface is what the api layer expects).
+        // The internal `publish_failover` is private — we trip a real
+        // failover by calling `chat()` on a router where the primary
+        // fails. Since the stub provider always errors, both
+        // providers fail; chat() returns an error. But the failover
+        // attempt itself publishes one event.
+        use octos_llm::LlmProvider as _;
+        let messages = vec![Message::user("hi")];
+        let cfg = octos_llm::ChatConfig::default();
+        let _ = router.chat(&messages, &[], &cfg).await;
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("failover event not received within timeout")
+            .expect("failover channel closed unexpectedly");
+        assert_eq!(event.from_provider, "p1/m1");
+        assert_eq!(event.to_provider, "p2/m2");
+        assert!(
+            event.reason.contains("chat_error"),
+            "failover reason should describe the upstream error — got {}",
+            event.reason
         );
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -6459,7 +6459,7 @@ async fn run_standalone_turn(
     // first token. No-op when this profile has no `AdaptiveRouter`
     // attached (single-provider or `enabled = false`).
     let adaptive_router_ref = session_runtime.profile.adaptive_router.clone();
-    emit_router_status_lifecycle(&ws, &ledger, &session_id, adaptive_router_ref.as_ref());
+    emit_router_status_durable(&ws, &ledger, &session_id, adaptive_router_ref.as_ref());
 
     // Wave4-A: subscribe to the AdaptiveRouter's broadcast channel and
     // forward `FailoverEvent`s as `router/failover` notifications for
@@ -6933,13 +6933,24 @@ async fn run_standalone_turn(
             "turn/start carries rewrite_for; current build forwards the prompt without in-place ledger rewrite (β-1 advisory)"
         );
     }
+    // Wave4-A (Codex P1): stamp the originating session/turn id into a
+    // tokio task_local so the AdaptiveRouter's failover publisher can
+    // attribute events to the right session. Without this, sessions
+    // sharing a profile-scoped router would re-emit one another's
+    // failovers (the router fans out to all subscribers).
+    let router_ctx = octos_llm::RouterContext {
+        session_id: Some(session_id.0.clone()),
+        turn_id: Some(turn_id.0.to_string()),
+    };
     let agent_task = tokio::spawn(async move {
-        let result = octos_agent::tools::TOOL_APPROVAL_CTX
-            .scope(
+        let result = octos_llm::with_router_context(
+            router_ctx,
+            octos_agent::tools::TOOL_APPROVAL_CTX.scope(
                 approval_requester,
                 request_agent.process_message(&prompt, &history, turn_media_paths),
-            )
-            .await;
+            ),
+        )
+        .await;
 
         match result {
             Ok(response) => {
@@ -7194,13 +7205,13 @@ async fn run_standalone_turn(
     // `turn/completed` so clients see the actual provider that ran
     // the turn + any breaker / lane-score deltas. No-op when no
     // AdaptiveRouter is attached.
-    emit_router_status_lifecycle(&ws, &ledger, &session_id, adaptive_router_ref.as_ref());
+    emit_router_status_durable(&ws, &ledger, &session_id, adaptive_router_ref.as_ref());
 
-    // Wave4-A: tear down the failover forwarder task. Aborting is safe
-    // even if the task already exited (broadcast channel close path).
-    if let Some(handle) = failover_forwarder {
-        handle.abort();
-    }
+    // Wave4-A (Codex P1): tear down the failover forwarder task AND
+    // await its JoinHandle so the detached task cannot outlive the
+    // turn — without the await, the forwarder could keep forwarding
+    // to a half-torn-down writer.
+    stop_failover_forwarder(failover_forwarder).await;
 
     // FIX-06: a turn that ends — for any reason — must drop its
     // `approve_for_turn` policy entries so a subsequent turn can't reuse
@@ -7629,10 +7640,17 @@ pub(crate) fn build_router_status_event(
     }
 }
 
-/// Wave4-A: emit a `RouterStatus` notification on the lifecycle path
-/// (same delivery semantics as `turn/started` — failure is logged but
-/// non-fatal for the turn). No-op when `router` is `None`.
-fn emit_router_status_lifecycle(
+/// Wave4-A: emit a `RouterStatus` notification on the durable path.
+///
+/// Codex P1: this MUST NOT use lifecycle delivery — `send_lifecycle`
+/// latches the connection as `failed` on backpressure / closed, which
+/// the read loop interprets as "tear down everything". A status pill
+/// frame missing under backpressure is not worth killing the turn.
+/// Durable delivery still ledgers the frame for reconnect-replay but
+/// degrades gracefully under push pressure.
+///
+/// No-op when `router` is `None`.
+fn emit_router_status_durable(
     ws: &WsConnection,
     ledger: &UiProtocolLedger,
     session_id: &SessionKey,
@@ -7644,37 +7662,59 @@ fn emit_router_status_lifecycle(
     let event = build_router_status_event(session_id, router);
     let notif = UiNotification::RouterStatus(event);
     let method = notif.method().to_string();
-    if let Err(error) = send_notification_lifecycle(ws, ledger, notif) {
+    if let Err(error) = send_notification_durable(ws, ledger, notif) {
         tracing::debug!(
             target: "octos::ui_protocol::ws",
             method = %method,
             error = ?error,
-            "router/status emission failed; non-fatal for turn"
+            "router/status durable enqueue failed; non-fatal for turn"
         );
     }
 }
 
 /// Wave4-A: spawn a background task that forwards `FailoverEvent` from
 /// the AdaptiveRouter's broadcast channel onto the connection as
-/// `router/failover` notifications. The task lives for the duration of
-/// the turn — it ends naturally when the broadcast channel sender is
-/// dropped or when the calling task exits (the `tokio::spawn` is
-/// orphaned but the channel close terminates the loop).
+/// `router/failover` notifications.
 ///
-/// Returns the `AbortHandle` so the caller can stop the forwarder when
-/// the turn ends. Returning `None` when no router is attached.
+/// Codex P1: the AdaptiveRouter is *profile*-scoped, so a single
+/// broadcast fans out to every concurrent session on the profile. The
+/// forwarder MUST filter on
+/// `event.originating_session_id == this session_id` — otherwise
+/// concurrent sessions on the same profile re-attribute each other's
+/// failovers under their own id (wrong for the audit-log replay and
+/// the user-facing toast).
+///
+/// Codex P1 (lifecycle): the forwarder is detached but the caller
+/// stores the `JoinHandle` and awaits it on turn end via
+/// [`stop_failover_forwarder`]. A hard-close send error breaks the
+/// loop, so the forwarder cannot keep forwarding to a stale writer.
+///
+/// Returns the `JoinHandle` so the caller can stop *and await* the
+/// forwarder when the turn ends. Returns `None` when no router is
+/// attached.
 fn spawn_router_failover_forwarder(
     ws: WsConnection,
     ledger: Arc<UiProtocolLedger>,
     session_id: SessionKey,
     router: Option<Arc<octos_llm::AdaptiveRouter>>,
-) -> Option<AbortHandle> {
+) -> Option<tokio::task::JoinHandle<()>> {
     let router = router?;
     let mut rx = router.subscribe_failover();
+    let session_id_str = session_id.0.clone();
     let join = tokio::spawn(async move {
         loop {
             match rx.recv().await {
                 Ok(event) => {
+                    // Codex P1: filter on originating_session_id. When
+                    // the publisher provided a session id, only forward
+                    // events that match this forwarder's session. When
+                    // it didn't (test paths / CLI smoke), pass through
+                    // so headless tests still observe failover events.
+                    if let Some(originating) = event.originating_session_id.as_deref() {
+                        if originating != session_id_str {
+                            continue;
+                        }
+                    }
                     let notif = UiNotification::RouterFailover(
                         octos_core::ui_protocol::RouterFailoverEvent {
                             session_id: session_id.clone(),
@@ -7684,11 +7724,26 @@ fn spawn_router_failover_forwarder(
                             elapsed_ms: event.elapsed_ms,
                         },
                     );
-                    // Best-effort durable — failover events should be
-                    // ledger-persisted so a reconnecting client can
-                    // catch up, but if the client is gone we don't
-                    // care (the turn is what matters).
-                    let _ = send_notification_durable(&ws, &ledger, notif);
+                    // Best-effort durable — failover events ledger for
+                    // reconnect-replay. Hard-close errors (FatalClosed,
+                    // Closed) mean the client is gone; break out so
+                    // this task can't outlive the connection (Codex P1).
+                    match send_notification_durable(&ws, &ledger, notif) {
+                        Ok(()) => {}
+                        Err(SendError::FatalClosed) | Err(SendError::Closed) => {
+                            tracing::debug!(
+                                target: "octos::ui_protocol::ws",
+                                "failover forwarder: connection closed; exiting"
+                            );
+                            break;
+                        }
+                        Err(SendError::LifecycleFailure(_)) | Err(SendError::BackpressureDrop) => {
+                            // Drop surfaced as a `replay_lossy`
+                            // opportunistic emission inside
+                            // `send_notification_durable`. Continue.
+                            continue;
+                        }
+                    }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
                     tracing::debug!(
@@ -7702,7 +7757,20 @@ fn spawn_router_failover_forwarder(
             }
         }
     });
-    Some(join.abort_handle())
+    Some(join)
+}
+
+/// Wave4-A (Codex P1): abort + await the failover forwarder so the
+/// detached task cannot outlive the connection or forward a frame to a
+/// half-torn-down writer. `abort()` is best-effort; the subsequent
+/// `await` is what guarantees the task has actually stopped before
+/// turn cleanup returns. Awaiting an aborted JoinHandle returns a
+/// `JoinError` we ignore.
+async fn stop_failover_forwarder(handle: Option<tokio::task::JoinHandle<()>>) {
+    if let Some(handle) = handle {
+        handle.abort();
+        let _ = handle.await;
+    }
 }
 
 fn send_rpc_result(ws: &WsConnection, id: String, result: Value) -> Result<(), SendError> {

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -1498,6 +1498,9 @@ fn notification_session_id(notification: &UiNotification) -> &SessionKey {
         UiNotification::TurnSpawnComplete(event) => &event.session_id,
         UiNotification::FileAttached(event) => &event.session_id,
         UiNotification::SessionEventBridged(event) => &event.session_id,
+        UiNotification::RouterStatus(event) => &event.session_id,
+        UiNotification::RouterFailover(event) => &event.session_id,
+        UiNotification::QueueState(event) => &event.session_id,
     }
 }
 

--- a/crates/octos-cli/src/qos_catalog.rs
+++ b/crates/octos-cli/src/qos_catalog.rs
@@ -116,18 +116,30 @@ pub(crate) fn build_adaptive_provider_chain(
                 }
             }
         }
-        if providers.len() > 1 {
-            let adaptive_config = config
+        // Adaptive routing must be *opt-in*: when `adaptive_routing` is
+        // absent or `enabled = false`, fall back to the plain static
+        // `ProviderChain`. This kills the silent default-ON behavior the
+        // previous implementation had (router wrapping always when
+        // `providers.len() > 1`).
+        let adaptive_enabled = config
+            .adaptive_routing
+            .as_ref()
+            .map(|c| c.enabled)
+            .unwrap_or(false);
+        if providers.len() > 1 && adaptive_enabled {
+            let ar_config = config
                 .adaptive_routing
                 .as_ref()
-                .map(AdaptiveConfig::from)
-                .unwrap_or_default();
-            let ar_config = config.adaptive_routing.as_ref();
-            info!("adaptive routing enabled ({} providers)", providers.len());
-            let mode = ar_config
-                .map(|c| c.mode.into())
-                .unwrap_or(AdaptiveMode::Lane);
-            let qos = ar_config.map(|c| c.qos_ranking).unwrap_or(true);
+                .expect("adaptive_enabled implies adaptive_routing.is_some()");
+            let adaptive_config = AdaptiveConfig::from(ar_config);
+            info!(
+                "adaptive routing enabled ({} providers, mode={:?}, qos={})",
+                providers.len(),
+                ar_config.mode,
+                ar_config.qos_ranking
+            );
+            let mode: AdaptiveMode = ar_config.mode.into();
+            let qos = ar_config.qos_ranking;
             let router = Arc::new(
                 AdaptiveRouter::new(providers, &costs, adaptive_config)
                     .with_adaptive_config(mode, qos),
@@ -135,6 +147,13 @@ pub(crate) fn build_adaptive_provider_chain(
             adaptive_router_ref = Some(router.clone());
             router
         } else {
+            if providers.len() > 1 {
+                info!(
+                    "adaptive routing disabled (enabled=false or omitted) — \
+                     falling back to static ProviderChain ({} providers)",
+                    providers.len()
+                );
+            }
             Arc::new(ProviderChain::new(providers))
         }
     };
@@ -483,7 +502,13 @@ mod tests {
                     strong: true,
                 },
             ],
-            adaptive_routing: Some(AdaptiveRoutingConfig::default()),
+            // A1: AdaptiveRoutingConfig::default() now has `enabled = false`
+            // and is a *no-op*. Tests that exercise the adaptive code path
+            // must opt in explicitly.
+            adaptive_routing: Some(AdaptiveRoutingConfig {
+                enabled: true,
+                ..AdaptiveRoutingConfig::default()
+            }),
             ..Default::default()
         };
 
@@ -653,5 +678,129 @@ mod tests {
             .expect("ollama lane should be in persisted catalog");
         assert_eq!(persisted_ollama.context_window, 128_000);
         assert_eq!(persisted_ollama.max_output, 8_192);
+    }
+
+    /// A1 regression: `adaptive_routing.enabled = false` MUST NOT
+    /// instantiate an `AdaptiveRouter`. Before this fix, the helper
+    /// silently defaulted to `mode=Lane, qos=true` whenever
+    /// `providers.len() > 1`, ignoring `enabled` entirely — which the
+    /// investigation report called out as a config-correctness bug.
+    #[test]
+    fn build_adaptive_provider_chain_respects_disabled_flag() {
+        use crate::config::{AdaptiveRoutingConfig, Config, FallbackModel};
+        use octos_core::Message;
+        use octos_llm::{ChatConfig, ChatResponse, LlmProvider, ToolSpec};
+        use std::sync::Arc;
+
+        struct StubProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for StubProvider {
+            async fn chat(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSpec],
+                _config: &ChatConfig,
+            ) -> eyre::Result<ChatResponse> {
+                Err(eyre::eyre!("stub not callable in tests"))
+            }
+            fn model_id(&self) -> &str {
+                "stub-model"
+            }
+            fn provider_name(&self) -> &str {
+                "stub"
+            }
+        }
+
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().to_path_buf();
+
+        // Two providers AND adaptive_routing.enabled = false →
+        // no AdaptiveRouter must be built. Previously this would have
+        // wrapped silently because providers.len() > 1.
+        let config = Config {
+            provider: Some("stub".into()),
+            fallback_models: vec![FallbackModel {
+                provider: "ollama".into(),
+                model: Some("llama3.2".into()),
+                base_url: None,
+                api_key_env: None,
+                model_hints: None,
+                api_type: None,
+                cost_per_m: Some(0.5),
+                strong: true,
+            }],
+            adaptive_routing: Some(AdaptiveRoutingConfig {
+                enabled: false,
+                ..AdaptiveRoutingConfig::default()
+            }),
+            ..Default::default()
+        };
+
+        let base: Arc<dyn LlmProvider> = Arc::new(StubProvider);
+        let bundle =
+            build_adaptive_provider_chain(base, &config, &data_dir, false, ExporterMode::Disabled);
+
+        assert!(
+            bundle.adaptive_router.is_none(),
+            "enabled = false MUST NOT instantiate an AdaptiveRouter"
+        );
+    }
+
+    /// A1 regression: when `adaptive_routing` is entirely absent from
+    /// the config (`None`), the helper must NOT silently default-ON.
+    /// Previously the unwrap_or path quietly picked `Lane + qos=true`.
+    #[test]
+    fn build_adaptive_provider_chain_defaults_off_when_config_absent() {
+        use crate::config::{Config, FallbackModel};
+        use octos_core::Message;
+        use octos_llm::{ChatConfig, ChatResponse, LlmProvider, ToolSpec};
+        use std::sync::Arc;
+
+        struct StubProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for StubProvider {
+            async fn chat(
+                &self,
+                _messages: &[Message],
+                _tools: &[ToolSpec],
+                _config: &ChatConfig,
+            ) -> eyre::Result<ChatResponse> {
+                Err(eyre::eyre!("stub not callable in tests"))
+            }
+            fn model_id(&self) -> &str {
+                "stub-model"
+            }
+            fn provider_name(&self) -> &str {
+                "stub"
+            }
+        }
+
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().to_path_buf();
+
+        let config = Config {
+            provider: Some("stub".into()),
+            fallback_models: vec![FallbackModel {
+                provider: "ollama".into(),
+                model: Some("llama3.2".into()),
+                base_url: None,
+                api_key_env: None,
+                model_hints: None,
+                api_type: None,
+                cost_per_m: Some(0.5),
+                strong: true,
+            }],
+            adaptive_routing: None,
+            ..Default::default()
+        };
+
+        let base: Arc<dyn LlmProvider> = Arc::new(StubProvider);
+        let bundle =
+            build_adaptive_provider_chain(base, &config, &data_dir, false, ExporterMode::Disabled);
+
+        assert!(
+            bundle.adaptive_router.is_none(),
+            "missing adaptive_routing block MUST default to OFF (no router)"
+        );
     }
 }

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -799,6 +799,27 @@ pub mod methods {
     pub const CONTENT_DELETE: &str = "content/delete";
     /// Replaces `POST /api/my/content/bulk-delete` — bulk-content deletion.
     pub const CONTENT_BULK_DELETE: &str = "content/bulk_delete";
+
+    // ---- Wave4-A: adaptive routing + queue state ----
+
+    /// Wave4-A `router/status` — adaptive routing snapshot notification.
+    /// Emitted by the server adjacent to `turn/started` and `turn/completed`
+    /// so the client always has a fresh status without polling.
+    pub const ROUTER_STATUS: &str = "router/status";
+    /// Wave4-A `router/failover` — adaptive router crossed lanes.
+    pub const ROUTER_FAILOVER: &str = "router/failover";
+    /// Wave4-A `router/set_mode` — runtime mode toggle command. Mode
+    /// change is session-scoped, not process-global.
+    pub const ROUTER_SET_MODE: &str = "router/set_mode";
+    /// Wave4-A `router/get_metrics` — on-demand snapshot of the
+    /// `AdaptiveStatus` plus full lane scores / breaker map. Returns
+    /// the same payload shape as the `router/status` notification but
+    /// as an RPC result.
+    pub const ROUTER_GET_METRICS: &str = "router/get_metrics";
+    /// Wave4-A `queue/state` — pending-queue snapshot. Client-emitted
+    /// today; the constant is defined so type-checked code paths across
+    /// the workspace can reference one source of truth.
+    pub const QUEUE_STATE: &str = "queue/state";
 }
 
 /// Reason codes for `approval/cancelled` notifications. The registry is
@@ -838,6 +859,8 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::CONTENT_LIST,
     methods::CONTENT_DELETE,
     methods::CONTENT_BULK_DELETE,
+    methods::ROUTER_SET_MODE,
+    methods::ROUTER_GET_METRICS,
 ];
 
 /// Notification methods defined by the v1alpha1 protocol model.
@@ -863,6 +886,9 @@ pub const UI_PROTOCOL_NOTIFICATION_METHODS: &[&str] = &[
     methods::TURN_SPAWN_COMPLETE,
     methods::FILE_ATTACHED,
     methods::SESSION_EVENT,
+    methods::ROUTER_STATUS,
+    methods::ROUTER_FAILOVER,
+    methods::QUEUE_STATE,
 ];
 
 /// Request methods currently handled by the first server/runtime slice.
@@ -895,6 +921,8 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::CONTENT_LIST,
     methods::CONTENT_DELETE,
     methods::CONTENT_BULK_DELETE,
+    methods::ROUTER_SET_MODE,
+    methods::ROUTER_GET_METRICS,
 ];
 
 /// Protocol methods known but not implemented by the first server/runtime slice.
@@ -2236,6 +2264,50 @@ pub struct ContentBulkDeleteResult {
     pub deleted: usize,
 }
 
+// ----- Wave4-A `router/*` + `queue/state` -----
+
+/// Wave4-A `router/set_mode` params. `mode` is the lowercase string
+/// rendering of `octos_llm::AdaptiveMode` — `"off"`, `"hedge"`, or
+/// `"lane"`. The string is intentional (a) so the wire stays decoupled
+/// from `octos-llm`'s enum variant numeric layout and (b) so client
+/// implementations don't have to negotiate over numeric values.
+///
+/// Mode change is session-scoped — it persists for the lifetime of the
+/// `AdaptiveRouter` (process lifetime today), not across restarts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouterSetModeParams {
+    pub session_id: SessionKey,
+    pub mode: String,
+}
+
+/// Wave4-A `router/set_mode` result.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouterSetModeResult {
+    /// New mode actually committed by the router (echo of `params.mode`
+    /// when the call succeeded). Returned so clients can confirm the
+    /// transition before swapping their pill state.
+    pub mode: String,
+}
+
+/// Wave4-A `router/get_metrics` params.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouterGetMetricsParams {
+    pub session_id: SessionKey,
+}
+
+/// Wave4-A `router/get_metrics` result. Identical wire shape to
+/// [`RouterStatusEvent`] (excluding the redundant `session_id` echo)
+/// so a client can use the same code path for both — the notification
+/// is a push variant of the same snapshot.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouterGetMetricsResult {
+    pub provider_name: String,
+    pub mode: String,
+    pub qos_ranking: bool,
+    pub lane_scores: BTreeMap<String, f64>,
+    pub circuit_breakers: BTreeMap<String, String>,
+}
+
 // ----- UPCR-2026-012 `message/persisted` -----
 
 /// Open registry for `MessagePersistedEvent.source`. Future variants must be
@@ -2632,6 +2704,9 @@ pub enum UiCommand {
     ContentList(ContentListParams),
     ContentDelete(ContentDeleteParams),
     ContentBulkDelete(ContentBulkDeleteParams),
+    // ---- Wave4-A: adaptive router controls ----
+    RouterSetMode(RouterSetModeParams),
+    RouterGetMetrics(RouterGetMetricsParams),
 }
 
 impl UiCommand {
@@ -2665,6 +2740,8 @@ impl UiCommand {
             Self::ContentList(_) => methods::CONTENT_LIST,
             Self::ContentDelete(_) => methods::CONTENT_DELETE,
             Self::ContentBulkDelete(_) => methods::CONTENT_BULK_DELETE,
+            Self::RouterSetMode(_) => methods::ROUTER_SET_MODE,
+            Self::RouterGetMetrics(_) => methods::ROUTER_GET_METRICS,
         }
     }
 
@@ -2702,6 +2779,8 @@ impl UiCommand {
             Self::ContentList(params) => serde_json::to_value(params),
             Self::ContentDelete(params) => serde_json::to_value(params),
             Self::ContentBulkDelete(params) => serde_json::to_value(params),
+            Self::RouterSetMode(params) => serde_json::to_value(params),
+            Self::RouterGetMetrics(params) => serde_json::to_value(params),
         }?;
 
         Ok(RpcRequest::new(id, method, params))
@@ -2770,6 +2849,10 @@ impl UiCommand {
             methods::CONTENT_DELETE => Ok(Self::ContentDelete(decode_params(method, params)?)),
             methods::CONTENT_BULK_DELETE => {
                 Ok(Self::ContentBulkDelete(decode_params(method, params)?))
+            }
+            methods::ROUTER_SET_MODE => Ok(Self::RouterSetMode(decode_params(method, params)?)),
+            methods::ROUTER_GET_METRICS => {
+                Ok(Self::RouterGetMetrics(decode_params(method, params)?))
             }
             _ => Err(RpcError::method_not_found(method)),
         }
@@ -3900,6 +3983,70 @@ pub struct SessionEventBridgedEvent {
     pub topic: Option<String>,
 }
 
+/// Wave4-A — adaptive router status snapshot pushed alongside `turn/started`
+/// and `turn/completed`. Mirrors `octos_llm::AdaptiveStatus` plus the
+/// information needed by clients to render the routing pill / lane debug
+/// view.
+///
+/// `lane_scores` carries one entry per active lane keyed by
+/// `"<provider_name>/<model_id>"` (the same key used in
+/// `model_catalog.json`). `circuit_breakers` carries the same keys mapped
+/// to a string-rendered breaker state (`"closed"`, `"open"`, `"half_open"`)
+/// so the wire shape stays stable when the underlying enum gains variants.
+///
+/// `BTreeMap` is intentional — deterministic wire order keeps the
+/// web-client diff path stable across re-renders.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouterStatusEvent {
+    pub session_id: SessionKey,
+    /// Currently selected provider, in `"<provider_name>/<model_id>"` form.
+    pub provider_name: String,
+    /// Active adaptive mode (`off` | `hedge` | `lane`).
+    pub mode: String,
+    /// QoS quality-ranking toggle (orthogonal to mode).
+    pub qos_ranking: bool,
+    /// Per-lane scores, sorted by lane key for deterministic wire output.
+    pub lane_scores: BTreeMap<String, f64>,
+    /// Per-lane circuit-breaker state — `"closed"`, `"open"`, or
+    /// `"half_open"`. Lanes absent from this map have no breaker
+    /// observed yet (cold start).
+    pub circuit_breakers: BTreeMap<String, String>,
+}
+
+/// Wave4-A — emitted when the adaptive router fails over from one lane
+/// to another. `from_provider` / `to_provider` use the same
+/// `"<provider_name>/<model_id>"` key shape as
+/// [`RouterStatusEvent::lane_scores`]. `reason` is free-text from the
+/// router (e.g. "circuit_breaker_open", "score_drop"). `elapsed_ms` is
+/// the wall time from initial provider attempt to failover decision.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RouterFailoverEvent {
+    pub session_id: SessionKey,
+    pub from_provider: String,
+    pub to_provider: String,
+    pub reason: String,
+    pub elapsed_ms: u64,
+}
+
+/// Wave4-A — current send-queue depth observed by the client/server
+/// FIFO. `head_client_message_id` identifies the in-flight turn whose
+/// completion will release the next queued frame. `None` when the queue
+/// is empty (after the in-flight turn lands).
+///
+/// **Server emission status:** the queue itself is client-side today
+/// (`octos-web/src/runtime/ui-protocol-send.ts` per-session FIFO). The
+/// server never emits this variant — the web bridge manufactures it
+/// locally using the existing DOM event pattern so other clients can
+/// observe queue state uniformly. The variant is defined here so the
+/// type shape is identical across client implementations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueueStateEvent {
+    pub session_id: SessionKey,
+    pub pending_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_client_message_id: Option<String>,
+}
+
 /// Draft notification payloads for UI protocol v1.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
@@ -3935,6 +4082,18 @@ pub enum UiNotification {
     /// `/api/sessions/:id/events/stream` SSE frames bridged onto the
     /// unified v1 ledger.
     SessionEventBridged(SessionEventBridgedEvent),
+    /// Wave4-A: adaptive routing snapshot emitted on `turn/started` and
+    /// `turn/completed` so clients can render the routing pill / lane
+    /// debug view without polling.
+    RouterStatus(RouterStatusEvent),
+    /// Wave4-A: adaptive router crossed a lane (failover). The status
+    /// emitted at the next turn boundary will reflect the new lane, but
+    /// clients that want to surface the transition itself (toast, status
+    /// pill flash) subscribe to this notification.
+    RouterFailover(RouterFailoverEvent),
+    /// Wave4-A: queue-state snapshot. Client-manufactured today — server
+    /// never emits this. See [`QueueStateEvent`] docs.
+    QueueState(QueueStateEvent),
 }
 
 impl UiNotification {
@@ -3961,6 +4120,9 @@ impl UiNotification {
             Self::TurnSpawnComplete(_) => methods::TURN_SPAWN_COMPLETE,
             Self::FileAttached(_) => methods::FILE_ATTACHED,
             Self::SessionEventBridged(_) => methods::SESSION_EVENT,
+            Self::RouterStatus(_) => methods::ROUTER_STATUS,
+            Self::RouterFailover(_) => methods::ROUTER_FAILOVER,
+            Self::QueueState(_) => methods::QUEUE_STATE,
         }
     }
 
@@ -3988,6 +4150,9 @@ impl UiNotification {
             Self::TurnSpawnComplete(params) => serde_json::to_value(params),
             Self::FileAttached(params) => serde_json::to_value(params),
             Self::SessionEventBridged(params) => serde_json::to_value(params),
+            Self::RouterStatus(params) => serde_json::to_value(params),
+            Self::RouterFailover(params) => serde_json::to_value(params),
+            Self::QueueState(params) => serde_json::to_value(params),
         }?;
 
         Ok(RpcNotification::new(method, params))
@@ -4037,6 +4202,9 @@ impl UiNotification {
             }
             methods::FILE_ATTACHED => Ok(Self::FileAttached(decode_params(method, params)?)),
             methods::SESSION_EVENT => Ok(Self::SessionEventBridged(decode_params(method, params)?)),
+            methods::ROUTER_STATUS => Ok(Self::RouterStatus(decode_params(method, params)?)),
+            methods::ROUTER_FAILOVER => Ok(Self::RouterFailover(decode_params(method, params)?)),
+            methods::QUEUE_STATE => Ok(Self::QueueState(decode_params(method, params)?)),
             _ => Err(RpcError::method_not_found(method)),
         }
     }
@@ -4416,6 +4584,8 @@ mod tests {
                 "content/list",
                 "content/delete",
                 "content/bulk_delete",
+                "router/set_mode",
+                "router/get_metrics",
             ]
         );
         assert_eq!(
@@ -4442,6 +4612,9 @@ mod tests {
                 "turn/spawn_complete",
                 "file/attached",
                 "session/event",
+                "router/status",
+                "router/failover",
+                "queue/state",
             ]
         );
         assert_eq!(
@@ -4475,6 +4648,8 @@ mod tests {
                 "content/list",
                 "content/delete",
                 "content/bulk_delete",
+                "router/set_mode",
+                "router/get_metrics",
             ]
         );
         assert!(UI_PROTOCOL_FIRST_SERVER_UNSUPPORTED_METHODS.is_empty());
@@ -4525,7 +4700,9 @@ mod tests {
                     "system/status.get",
                     "content/list",
                     "content/delete",
-                    "content/bulk_delete"
+                    "content/bulk_delete",
+                    "router/set_mode",
+                    "router/get_metrics"
                 ],
                 "supported_notifications": [
                     "session/open",
@@ -4548,7 +4725,10 @@ mod tests {
                     "message/persisted",
                     "turn/spawn_complete",
                     "file/attached",
-                    "session/event"
+                    "session/event",
+                    "router/status",
+                    "router/failover",
+                    "queue/state"
                 ],
                 "supported_features": [
                     "approval.typed.v1",
@@ -7767,6 +7947,236 @@ mod tests {
         assert!(
             UI_PROTOCOL_KNOWN_FEATURES.contains(&UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1),
             "projection.envelope.v1 must be registered for capability negotiation"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Wave4-A: router/status, router/failover, queue/state, router/set_mode,
+    // router/get_metrics round-trip + wire-shape tests.
+    // ------------------------------------------------------------------
+
+    /// Wave4-A: `router/status` notification round-trips through JSON-RPC
+    /// with deterministic `BTreeMap` ordering and the correct wire tag.
+    #[test]
+    fn router_status_notification_round_trips_with_deterministic_order() {
+        let mut lane_scores = BTreeMap::new();
+        lane_scores.insert("zai/glm-5-turbo".into(), 0.21);
+        lane_scores.insert("dashscope/qwen3.5-plus".into(), 0.41);
+        lane_scores.insert("ollama/llama3.2".into(), 0.62);
+
+        let mut breakers = BTreeMap::new();
+        breakers.insert("zai/glm-5-turbo".into(), "closed".into());
+        breakers.insert("dashscope/qwen3.5-plus".into(), "half_open".into());
+        breakers.insert("ollama/llama3.2".into(), "open".into());
+
+        let notif = UiNotification::RouterStatus(RouterStatusEvent {
+            session_id: SessionKey("local:demo".into()),
+            provider_name: "zai/glm-5-turbo".into(),
+            mode: "lane".into(),
+            qos_ranking: true,
+            lane_scores: lane_scores.clone(),
+            circuit_breakers: breakers.clone(),
+        });
+
+        // Method tag matches the constant.
+        assert_eq!(notif.method(), methods::ROUTER_STATUS);
+
+        // Round-trip through JSON-RPC notification envelope.
+        let rpc = notif
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize router/status");
+        assert_eq!(rpc.method, methods::ROUTER_STATUS);
+
+        let json = serde_json::to_string(&rpc).expect("to_string");
+        let parsed_rpc: RpcNotification<Value> = serde_json::from_str(&json).expect("from_str rpc");
+        let decoded =
+            UiNotification::from_rpc_notification(parsed_rpc).expect("decode router/status");
+        assert_eq!(decoded, notif);
+
+        // BTreeMap ordering is deterministic — the first key in the wire
+        // payload must be the lex-smallest, so a re-serialization byte-
+        // matches.
+        let wire_keys: Vec<String> = serde_json::to_value(&notif)
+            .expect("value")
+            .get("lane_scores")
+            .and_then(|v| v.as_object())
+            .map(|obj| obj.keys().cloned().collect())
+            .unwrap_or_default();
+        assert_eq!(
+            wire_keys,
+            vec![
+                "dashscope/qwen3.5-plus".to_string(),
+                "ollama/llama3.2".to_string(),
+                "zai/glm-5-turbo".to_string(),
+            ],
+            "lane_scores keys must be in BTreeMap (lex-sorted) order"
+        );
+    }
+
+    /// Wave4-A: `router/failover` round-trips with the failover metadata
+    /// the AdaptiveRouter emits when it crosses a lane.
+    #[test]
+    fn router_failover_notification_round_trips() {
+        let notif = UiNotification::RouterFailover(RouterFailoverEvent {
+            session_id: SessionKey("local:demo".into()),
+            from_provider: "zai/glm-5-turbo".into(),
+            to_provider: "dashscope/qwen3.5-plus".into(),
+            reason: "circuit_breaker_open".into(),
+            elapsed_ms: 12_345,
+        });
+        assert_eq!(notif.method(), methods::ROUTER_FAILOVER);
+
+        let rpc = notif
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize router/failover");
+        let json = serde_json::to_string(&rpc).expect("to_string");
+        let parsed_rpc: RpcNotification<Value> = serde_json::from_str(&json).expect("from_str");
+        let decoded =
+            UiNotification::from_rpc_notification(parsed_rpc).expect("decode router/failover");
+        assert_eq!(decoded, notif);
+    }
+
+    /// Wave4-A: `queue/state` round-trips with `head_client_message_id`
+    /// both populated (in-flight) and absent (queue idle).
+    #[test]
+    fn queue_state_notification_round_trips_with_and_without_head() {
+        // In-flight: head_client_message_id present.
+        let notif_active = UiNotification::QueueState(QueueStateEvent {
+            session_id: SessionKey("local:demo".into()),
+            pending_count: 3,
+            head_client_message_id: Some("cmid-12345".into()),
+        });
+        assert_eq!(notif_active.method(), methods::QUEUE_STATE);
+        let rpc = notif_active
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize active");
+        let json = serde_json::to_string(&rpc).expect("to_string active");
+        // head_client_message_id is on the wire when populated.
+        assert!(json.contains("head_client_message_id"));
+        assert!(json.contains("cmid-12345"));
+
+        let parsed: RpcNotification<Value> = serde_json::from_str(&json).expect("from_str active");
+        let decoded =
+            UiNotification::from_rpc_notification(parsed).expect("decode queue/state active");
+        assert_eq!(decoded, notif_active);
+
+        // Empty queue: head_client_message_id absent.
+        let notif_empty = UiNotification::QueueState(QueueStateEvent {
+            session_id: SessionKey("local:demo".into()),
+            pending_count: 0,
+            head_client_message_id: None,
+        });
+        let rpc = notif_empty
+            .clone()
+            .into_rpc_notification()
+            .expect("serialize empty");
+        let json = serde_json::to_string(&rpc).expect("to_string empty");
+        assert!(
+            !json.contains("head_client_message_id"),
+            "head_client_message_id must be omitted when None — got {json}"
+        );
+
+        let parsed: RpcNotification<Value> = serde_json::from_str(&json).expect("from_str empty");
+        let decoded =
+            UiNotification::from_rpc_notification(parsed).expect("decode queue/state empty");
+        assert_eq!(decoded, notif_empty);
+    }
+
+    /// Wave4-A: `router/set_mode` command round-trips and dispatches
+    /// through the standard `UiCommand` request shape.
+    #[test]
+    fn router_set_mode_command_round_trips() {
+        let command = UiCommand::RouterSetMode(RouterSetModeParams {
+            session_id: SessionKey("local:demo".into()),
+            mode: "hedge".into(),
+        });
+        assert_eq!(command.method(), methods::ROUTER_SET_MODE);
+
+        let rpc = command
+            .clone()
+            .into_rpc_request("req-set-mode")
+            .expect("serialize router/set_mode");
+        assert_eq!(rpc.method, methods::ROUTER_SET_MODE);
+        assert_eq!(rpc.params["mode"], json!("hedge"));
+
+        let json = serde_json::to_string(&rpc).expect("to_string");
+        let parsed_rpc: RpcRequest<Value> = serde_json::from_str(&json).expect("from_str");
+        let decoded = UiCommand::from_rpc_request(parsed_rpc).expect("decode router/set_mode");
+        assert_eq!(decoded, command);
+    }
+
+    /// Wave4-A: `router/get_metrics` request + result round-trip. Mirrors
+    /// the wire shape of the `router/status` notification so clients can
+    /// reuse the deserializer.
+    #[test]
+    fn router_get_metrics_command_and_result_round_trip() {
+        let command = UiCommand::RouterGetMetrics(RouterGetMetricsParams {
+            session_id: SessionKey("local:demo".into()),
+        });
+        assert_eq!(command.method(), methods::ROUTER_GET_METRICS);
+
+        let rpc = command
+            .clone()
+            .into_rpc_request("req-get-metrics")
+            .expect("serialize router/get_metrics");
+        let json = serde_json::to_string(&rpc).expect("to_string");
+        let parsed_rpc: RpcRequest<Value> = serde_json::from_str(&json).expect("from_str");
+        let decoded = UiCommand::from_rpc_request(parsed_rpc).expect("decode router/get_metrics");
+        assert_eq!(decoded, command);
+
+        // Result round-trips with deterministic BTreeMap order.
+        let mut lane_scores = BTreeMap::new();
+        lane_scores.insert("a/b".into(), 0.1);
+        lane_scores.insert("c/d".into(), 0.2);
+        let mut breakers = BTreeMap::new();
+        breakers.insert("a/b".into(), "closed".into());
+        breakers.insert("c/d".into(), "closed".into());
+        let result = RouterGetMetricsResult {
+            provider_name: "a/b".into(),
+            mode: "lane".into(),
+            qos_ranking: false,
+            lane_scores: lane_scores.clone(),
+            circuit_breakers: breakers.clone(),
+        };
+        let json = serde_json::to_string(&result).expect("serialize result");
+        let parsed: RouterGetMetricsResult =
+            serde_json::from_str(&json).expect("deserialize result");
+        assert_eq!(parsed.provider_name, result.provider_name);
+        assert_eq!(parsed.lane_scores, lane_scores);
+        assert_eq!(parsed.circuit_breakers, breakers);
+    }
+
+    /// Wave4-A: capability advertisement carries the three new notification
+    /// methods (`router/status`, `router/failover`, `queue/state`) so
+    /// clients that negotiate at handshake time can subscribe.
+    #[test]
+    fn wave4a_router_methods_are_in_capabilities() {
+        let caps = UiProtocolCapabilities::first_server_slice();
+        assert!(
+            caps.supported_notifications
+                .contains(&methods::ROUTER_STATUS.to_owned()),
+            "router/status must be advertised as a supported notification"
+        );
+        assert!(
+            caps.supported_notifications
+                .contains(&methods::ROUTER_FAILOVER.to_owned()),
+            "router/failover must be advertised as a supported notification"
+        );
+        assert!(
+            caps.supported_notifications
+                .contains(&methods::QUEUE_STATE.to_owned()),
+            "queue/state must be advertised as a supported notification"
+        );
+        assert!(
+            caps.supports_method(methods::ROUTER_SET_MODE),
+            "router/set_mode must be a supported command method"
+        );
+        assert!(
+            caps.supports_method(methods::ROUTER_GET_METRICS),
+            "router/get_metrics must be a supported command method"
         );
     }
 }

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -527,6 +527,23 @@ pub struct AdaptiveStatus {
     pub provider_count: usize,
 }
 
+/// Wave4-A: per-router failover broadcast event. Pushed onto a
+/// `tokio::sync::broadcast::Sender<FailoverEvent>` whenever the
+/// adaptive router crosses from one lane to another inside `chat()` /
+/// `chat_stream()`. Subscribers (API layer, telemetry) consume events
+/// without blocking the router — the broadcast channel drops the
+/// oldest event on a slow consumer.
+///
+/// Identifiers use the `<provider_name>/<model_id>` shape so they line
+/// up with the `lane_scores` keys in `RouterStatusEvent`.
+#[derive(Debug, Clone)]
+pub struct FailoverEvent {
+    pub from_provider: String,
+    pub to_provider: String,
+    pub reason: String,
+    pub elapsed_ms: u64,
+}
+
 /// Adaptive provider router with metrics-driven selection.
 ///
 /// Drop-in replacement for `ProviderChain`. Tracks latency and error rates
@@ -573,6 +590,14 @@ pub struct AdaptiveRouter {
     /// Id of the credential currently in use per slot. Updated at acquire
     /// time so failure notifications can identify the right credential.
     current_credential_ids: Mutex<Vec<Option<String>>>,
+    /// Wave4-A: lock-free broadcast channel for failover events. Senders
+    /// publish into it from the `chat()` / `chat_stream()` failover loops;
+    /// API-layer subscribers consume in a separate tokio task. The channel
+    /// drops the oldest event under back-pressure (per
+    /// `tokio::sync::broadcast` semantics) so a slow subscriber can NEVER
+    /// stall the router's hot path. A capacity of 64 absorbs short bursts
+    /// without forcing immediate drops.
+    failover_tx: tokio::sync::broadcast::Sender<FailoverEvent>,
 }
 
 impl AdaptiveRouter {
@@ -613,6 +638,11 @@ impl AdaptiveRouter {
             })
             .collect();
         let slot_count = slots.len();
+        // Wave4-A: capacity 64 absorbs short failover bursts without
+        // dropping the oldest event. Slow subscribers fall behind and
+        // observe a `RecvError::Lagged` — they MUST NOT stall the
+        // router's hot path.
+        let (failover_tx, _) = tokio::sync::broadcast::channel(64);
         Self {
             slots,
             config,
@@ -630,6 +660,91 @@ impl AdaptiveRouter {
             decision_callback: RwLock::new(None),
             credential_pools: RwLock::new(vec![None; slot_count]),
             current_credential_ids: Mutex::new(vec![None; slot_count]),
+            failover_tx,
+        }
+    }
+
+    /// Wave4-A: subscribe to failover events. The subscriber receives a
+    /// `FailoverEvent` each time the router crosses a lane in
+    /// `chat()` / `chat_stream()`. The channel is `broadcast`-based, so
+    /// every active subscriber gets every event; slow consumers may
+    /// observe `RecvError::Lagged(n)` and MUST handle it (skip to head
+    /// of channel; consider re-reading `adaptive_status()` to recover).
+    pub fn subscribe_failover(&self) -> tokio::sync::broadcast::Receiver<FailoverEvent> {
+        self.failover_tx.subscribe()
+    }
+
+    /// Wave4-A: publish a `FailoverEvent` (internal). `send` returns
+    /// `Ok(receiver_count)` or `Err` when there are zero active
+    /// subscribers — both outcomes are non-fatal for the router, so we
+    /// ignore the result entirely.
+    fn publish_failover(
+        &self,
+        from_provider: &str,
+        to_provider: &str,
+        reason: &str,
+        elapsed_ms: u64,
+    ) {
+        let _ = self.failover_tx.send(FailoverEvent {
+            from_provider: from_provider.to_string(),
+            to_provider: to_provider.to_string(),
+            reason: reason.to_string(),
+            elapsed_ms,
+        });
+    }
+
+    /// Wave4-A: snapshot per-lane scores keyed by
+    /// `"<provider_name>/<model_id>"`. Returned as a `BTreeMap` so the
+    /// caller can hand it straight to the UI protocol layer without
+    /// re-sorting.
+    pub fn lane_scores(&self) -> std::collections::BTreeMap<String, f64> {
+        self.slots
+            .iter()
+            .map(|s| {
+                (
+                    format!("{}/{}", s.provider.provider_name(), s.provider.model_id()),
+                    self.score(s),
+                )
+            })
+            .collect()
+    }
+
+    /// Wave4-A: snapshot per-lane circuit-breaker state keyed by the same
+    /// `"<provider_name>/<model_id>"` shape as [`lane_scores`]. Values
+    /// are the string rendering — `"closed"`, `"open"`, or `"half_open"`
+    /// — so the wire shape stays stable across enum changes.
+    ///
+    /// We don't have a tri-state breaker yet (today it's
+    /// `consecutive_failures` past `failure_threshold`); `"half_open"`
+    /// is reserved for when one lands.
+    pub fn breaker_states(&self) -> std::collections::BTreeMap<String, String> {
+        self.slots
+            .iter()
+            .map(|s| {
+                let key = format!("{}/{}", s.provider.provider_name(), s.provider.model_id());
+                let state = if s.metrics.is_circuit_open(self.config.failure_threshold) {
+                    "open"
+                } else {
+                    "closed"
+                };
+                (key, state.to_string())
+            })
+            .collect()
+    }
+
+    /// Wave4-A: friendly accessor for the currently-selected lane in the
+    /// `"<provider_name>/<model_id>"` form expected by
+    /// `RouterStatusEvent::provider_name`. Falls back to `"unknown"`
+    /// when `last_selected` is out of range (cold-start race).
+    pub fn current_lane_key(&self) -> String {
+        let idx = self.last_selected.load(Ordering::Relaxed) as usize;
+        match self.slots.get(idx) {
+            Some(slot) => format!(
+                "{}/{}",
+                slot.provider.provider_name(),
+                slot.provider.model_id()
+            ),
+            None => "unknown".to_string(),
         }
     }
 
@@ -1561,6 +1676,10 @@ impl LlmProvider for AdaptiveRouter {
         }
 
         // ── Single-provider path (Off / Lane / fallthrough) ────────────
+        // Wave4-A: track wall time from the first attempt so the failover
+        // event's `elapsed_ms` reflects the user-visible latency before
+        // the lane change, not just the time spent in the failover loop.
+        let failover_started = Instant::now();
         match self.try_chat(start_idx, messages, tools, config).await {
             Ok(resp) => Ok(resp),
             Err(e) => {
@@ -1592,6 +1711,28 @@ impl LlmProvider for AdaptiveRouter {
                         "Switching to {}...",
                         self.slots[idx].provider.provider_name()
                     ));
+                    // Wave4-A: publish per-attempt failover events. We
+                    // emit BEFORE the retry so a client can render the
+                    // transition even if the retry never succeeds.
+                    let from_key = format!(
+                        "{}/{}",
+                        self.slots[start_idx].provider.provider_name(),
+                        self.slots[start_idx].provider.model_id()
+                    );
+                    let to_key = format!(
+                        "{}/{}",
+                        self.slots[idx].provider.provider_name(),
+                        self.slots[idx].provider.model_id()
+                    );
+                    self.publish_failover(
+                        &from_key,
+                        &to_key,
+                        &format!("chat_error: {last_error}"),
+                        failover_started
+                            .elapsed()
+                            .as_millis()
+                            .min(u128::from(u64::MAX)) as u64,
+                    );
                     match self.try_chat(idx, messages, tools, config).await {
                         Ok(resp) => return Ok(resp),
                         Err(e) => {
@@ -1619,6 +1760,9 @@ impl LlmProvider for AdaptiveRouter {
         let _classifier_decision = self.classify_turn(messages);
         let (start_idx, _is_probe) = self.select_provider();
 
+        // Wave4-A: failover elapsed-time anchor — see equivalent comment
+        // in `chat()` above.
+        let failover_started = Instant::now();
         match self
             .try_chat_stream(start_idx, messages, tools, config)
             .await
@@ -1652,6 +1796,25 @@ impl LlmProvider for AdaptiveRouter {
                         "Switching to {}...",
                         self.slots[idx].provider.provider_name()
                     ));
+                    let from_key = format!(
+                        "{}/{}",
+                        self.slots[start_idx].provider.provider_name(),
+                        self.slots[start_idx].provider.model_id()
+                    );
+                    let to_key = format!(
+                        "{}/{}",
+                        self.slots[idx].provider.provider_name(),
+                        self.slots[idx].provider.model_id()
+                    );
+                    self.publish_failover(
+                        &from_key,
+                        &to_key,
+                        &format!("stream_error: {last_error}"),
+                        failover_started
+                            .elapsed()
+                            .as_millis()
+                            .min(u128::from(u64::MAX)) as u64,
+                    );
                     match self.try_chat_stream(idx, messages, tools, config).await {
                         Ok(stream) => return Ok(stream),
                         Err(e) => {
@@ -3008,6 +3171,195 @@ mod tests {
             fail_drift,
             warm_good.metrics.error_rate,
             warm_fail.metrics.error_rate,
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Wave4-A: failover broadcast channel tests.
+    // ------------------------------------------------------------------
+
+    /// Wave4-A: subscribers receive a `FailoverEvent` when the router
+    /// crosses a lane in `chat()`. The first provider fails forcing
+    /// a failover to the second.
+    #[tokio::test]
+    async fn failover_broadcast_publishes_event_on_lane_change() {
+        let config = AdaptiveConfig {
+            failure_threshold: 5,
+            probe_probability: 0.0,
+            ..Default::default()
+        };
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "primary",
+                    model: "m1",
+                    latency_ms: 0,
+                    fail: true,
+                    error_msg: "primary down",
+                }),
+                Arc::new(MockProvider {
+                    name: "fallback",
+                    model: "m2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            config,
+        );
+
+        let mut rx = router.subscribe_failover();
+
+        let messages = vec![Message::user("hello")];
+        let tools: Vec<ToolSpec> = vec![];
+        let cfg = ChatConfig::default();
+        let _ = router.chat(&messages, &tools, &cfg).await.unwrap();
+
+        // Wave4-A: the failover loop SHOULD have published at least one
+        // event. Wait up to 100ms — broadcast::Sender::send is sync but
+        // the chat loop yields, so we give the scheduler one tick.
+        let event = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+            .await
+            .expect("broadcast channel receive timed out")
+            .expect("broadcast channel was closed without an event");
+        assert_eq!(event.from_provider, "primary/m1");
+        assert_eq!(event.to_provider, "fallback/m2");
+        assert!(
+            event.reason.contains("chat_error"),
+            "reason should describe the underlying chat error — got {}",
+            event.reason
+        );
+    }
+
+    /// Wave4-A: the broadcast channel MUST NOT block the router under
+    /// back-pressure. A slow subscriber falls behind and observes
+    /// `RecvError::Lagged` — but the router keeps publishing.
+    ///
+    /// We construct a 64-deep burst (channel capacity) and verify that
+    /// the router survives without blocking and a fresh subscriber can
+    /// still read events afterwards.
+    #[tokio::test]
+    async fn failover_broadcast_does_not_block_router_under_backpressure() {
+        let router = AdaptiveRouter::new(
+            vec![Arc::new(MockProvider {
+                name: "p1",
+                model: "m1",
+                latency_ms: 0,
+                fail: false,
+                error_msg: "",
+            })],
+            &[],
+            AdaptiveConfig::default(),
+        );
+
+        // Subscribe but never drain — the channel capacity is 64, so the
+        // 65th publish will start dropping the oldest event.
+        let _stuck_rx = router.subscribe_failover();
+
+        // Publish 100 events directly (the public API doesn't accept
+        // direct publish; we go through the same internal entry point
+        // the failover loops use).
+        for i in 0..100 {
+            router.publish_failover("from/m1", "to/m2", "test-burst", i);
+        }
+
+        // A fresh subscriber sees nothing of the previous 100 events
+        // (broadcast::Receiver only sees events sent AFTER subscribe()),
+        // but the channel must still be usable.
+        let mut fresh_rx = router.subscribe_failover();
+        router.publish_failover("from/m1", "to/m2", "post-burst", 999);
+        let event = tokio::time::timeout(std::time::Duration::from_millis(100), fresh_rx.recv())
+            .await
+            .expect("fresh subscriber receive timed out")
+            .expect("fresh subscriber channel closed");
+        assert_eq!(event.elapsed_ms, 999);
+        assert_eq!(event.reason, "post-burst");
+    }
+
+    /// Wave4-A: `lane_scores()` returns one entry per slot keyed by
+    /// `"<provider_name>/<model_id>"` in BTreeMap order.
+    #[test]
+    fn lane_scores_returns_deterministic_per_slot_snapshot() {
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "zai",
+                    model: "glm-5-turbo",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "ollama",
+                    model: "llama3.2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig::default(),
+        );
+
+        let scores = router.lane_scores();
+        let keys: Vec<&String> = scores.keys().collect();
+        assert_eq!(
+            keys,
+            vec![
+                &"ollama/llama3.2".to_string(),
+                &"zai/glm-5-turbo".to_string(),
+            ],
+            "lane_scores keys must be sorted (BTreeMap order)"
+        );
+    }
+
+    /// Wave4-A: `breaker_states()` reports `"closed"` initially and
+    /// `"open"` once the consecutive-failure threshold trips.
+    #[tokio::test]
+    async fn breaker_states_reports_open_after_threshold() {
+        let config = AdaptiveConfig {
+            failure_threshold: 1,
+            probe_probability: 0.0,
+            ..Default::default()
+        };
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "fail",
+                    model: "m1",
+                    latency_ms: 0,
+                    fail: true,
+                    error_msg: "always_down",
+                }),
+                Arc::new(MockProvider {
+                    name: "ok",
+                    model: "m2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            config,
+        );
+
+        // Initially closed.
+        let states = router.breaker_states();
+        assert_eq!(states.get("fail/m1").map(String::as_str), Some("closed"));
+        assert_eq!(states.get("ok/m2").map(String::as_str), Some("closed"));
+
+        // Trip primary's breaker.
+        let _ = router
+            .chat(&[Message::user("hi")], &[], &ChatConfig::default())
+            .await
+            .unwrap();
+
+        let states = router.breaker_states();
+        assert_eq!(
+            states.get("fail/m1").map(String::as_str),
+            Some("open"),
+            "primary breaker should be open after failure_threshold trips"
         );
     }
 }

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -536,12 +536,59 @@ pub struct AdaptiveStatus {
 ///
 /// Identifiers use the `<provider_name>/<model_id>` shape so they line
 /// up with the `lane_scores` keys in `RouterStatusEvent`.
+///
+/// **Codex P1 (Wave4-A review)**: the AdaptiveRouter is *profile*-
+/// scoped — every session on the same profile shares the same router
+/// instance ([`ProfileRuntime`]). Without an originating identifier
+/// here, two concurrent sessions on the same profile would each
+/// re-emit one another's failovers as if it were their own. The
+/// optional `originating_session_id` / `originating_turn_id` fields
+/// let the API-layer forwarder filter to events whose context matches
+/// its own session — see
+/// [`with_router_context`] for the publisher-side hookup.
 #[derive(Debug, Clone)]
 pub struct FailoverEvent {
     pub from_provider: String,
     pub to_provider: String,
     pub reason: String,
     pub elapsed_ms: u64,
+    /// Originating session id (free-form `SessionKey` string), captured
+    /// via [`ROUTER_CONTEXT`] at publish time. `None` when chat() was
+    /// invoked outside a context-aware scope (CLI smoke tests, etc.).
+    pub originating_session_id: Option<String>,
+    /// Originating turn id (UUID v7 hex), captured via [`ROUTER_CONTEXT`]
+    /// at publish time.
+    pub originating_turn_id: Option<String>,
+}
+
+/// Wave4-A: per-task context the API layer pushes BEFORE calling
+/// `provider.chat()`. Read inside `AdaptiveRouter::publish_failover` to
+/// stamp the originating session onto every emitted `FailoverEvent`.
+///
+/// Subscribers filter on this so a session B subscriber doesn't surface
+/// session A's failover under session B. The context is `Cell`-style —
+/// fork-friendly with `with_router_context`.
+#[derive(Debug, Clone, Default)]
+pub struct RouterContext {
+    pub session_id: Option<String>,
+    pub turn_id: Option<String>,
+}
+
+tokio::task_local! {
+    /// Wave4-A: see [`RouterContext`]. Default `RouterContext::default()`
+    /// when no scope wraps the chat() call (test paths, CLI smoke).
+    pub static ROUTER_CONTEXT: RouterContext;
+}
+
+/// Wave4-A: run `fut` with the given `RouterContext` accessible via
+/// [`ROUTER_CONTEXT`]. The API layer wraps `run_standalone_turn`'s
+/// chat() path with this so the originating session id reaches the
+/// router's failover publisher.
+pub async fn with_router_context<F, T>(ctx: RouterContext, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    ROUTER_CONTEXT.scope(ctx, fut).await
 }
 
 /// Adaptive provider router with metrics-driven selection.
@@ -678,6 +725,12 @@ impl AdaptiveRouter {
     /// `Ok(receiver_count)` or `Err` when there are zero active
     /// subscribers — both outcomes are non-fatal for the router, so we
     /// ignore the result entirely.
+    ///
+    /// Reads [`ROUTER_CONTEXT`] (Codex P1): if the caller's task-local
+    /// scope provides a `RouterContext`, stamps its `session_id` /
+    /// `turn_id` onto the event so subscribers can filter to the
+    /// originating session. Falls back to `None` outside such scopes
+    /// (test paths / CLI smoke).
     fn publish_failover(
         &self,
         from_provider: &str,
@@ -685,11 +738,16 @@ impl AdaptiveRouter {
         reason: &str,
         elapsed_ms: u64,
     ) {
+        let (originating_session_id, originating_turn_id) = ROUTER_CONTEXT
+            .try_with(|ctx| (ctx.session_id.clone(), ctx.turn_id.clone()))
+            .unwrap_or_default();
         let _ = self.failover_tx.send(FailoverEvent {
             from_provider: from_provider.to_string(),
             to_provider: to_provider.to_string(),
             reason: reason.to_string(),
             elapsed_ms,
+            originating_session_id,
+            originating_turn_id,
         });
     }
 
@@ -3361,5 +3419,117 @@ mod tests {
             Some("open"),
             "primary breaker should be open after failure_threshold trips"
         );
+    }
+
+    /// Wave4-A (Codex P1): the failover publisher reads `ROUTER_CONTEXT`
+    /// via task_local and stamps the originating session/turn id onto
+    /// every emitted `FailoverEvent`. Subscribers filter on this so
+    /// concurrent sessions on the same profile-scoped router don't
+    /// receive each other's failovers.
+    #[tokio::test]
+    async fn failover_event_carries_originating_session_from_router_context() {
+        let config = AdaptiveConfig {
+            failure_threshold: 5,
+            probe_probability: 0.0,
+            ..Default::default()
+        };
+        let router = Arc::new(AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "primary",
+                    model: "m1",
+                    latency_ms: 0,
+                    fail: true,
+                    error_msg: "primary down",
+                }),
+                Arc::new(MockProvider {
+                    name: "fallback",
+                    model: "m2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            config,
+        ));
+        let mut rx = router.subscribe_failover();
+
+        let router_clone = router.clone();
+        let ctx = RouterContext {
+            session_id: Some("local:session-A".into()),
+            turn_id: Some("turn-A".into()),
+        };
+        let messages = vec![Message::user("hello")];
+        let cfg = ChatConfig::default();
+        let _ = with_router_context(ctx, async move {
+            router_clone.chat(&messages, &[], &cfg).await.unwrap()
+        })
+        .await;
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("failover event timed out")
+            .expect("broadcast channel closed");
+        assert_eq!(event.from_provider, "primary/m1");
+        assert_eq!(event.to_provider, "fallback/m2");
+        assert_eq!(
+            event.originating_session_id.as_deref(),
+            Some("local:session-A"),
+            "publisher must stamp originating session from ROUTER_CONTEXT"
+        );
+        assert_eq!(
+            event.originating_turn_id.as_deref(),
+            Some("turn-A"),
+            "publisher must stamp originating turn from ROUTER_CONTEXT"
+        );
+    }
+
+    /// Wave4-A (Codex P1): without a wrapping `ROUTER_CONTEXT` scope
+    /// (CLI smoke / test paths), the publisher falls back to `None` so
+    /// existing callers don't break.
+    #[tokio::test]
+    async fn failover_event_originating_id_is_none_outside_context_scope() {
+        let config = AdaptiveConfig {
+            failure_threshold: 5,
+            probe_probability: 0.0,
+            ..Default::default()
+        };
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "primary",
+                    model: "m1",
+                    latency_ms: 0,
+                    fail: true,
+                    error_msg: "primary down",
+                }),
+                Arc::new(MockProvider {
+                    name: "fallback",
+                    model: "m2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            config,
+        );
+        let mut rx = router.subscribe_failover();
+
+        let _ = router
+            .chat(&[Message::user("hi")], &[], &ChatConfig::default())
+            .await
+            .unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(200), rx.recv())
+            .await
+            .expect("failover event timed out")
+            .expect("broadcast channel closed");
+        assert_eq!(
+            event.originating_session_id, None,
+            "outside ROUTER_CONTEXT scope, originating_session_id must be None"
+        );
+        assert_eq!(event.originating_turn_id, None);
     }
 }

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -41,8 +41,9 @@ pub mod registry;
 
 pub use adaptive::{
     AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus, BaselineEntry, FailoverEvent,
-    MetricsSnapshot, ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics, SharedPolicy,
-    SharedProviderMetrics, StatusCallback, derive_cold_start_catalog,
+    MetricsSnapshot, ModelCatalogEntry, ModelType, QosCatalog, RouterContext, SharedMetrics,
+    SharedPolicy, SharedProviderMetrics, StatusCallback, derive_cold_start_catalog,
+    with_router_context,
 };
 pub use catalog::{ModelCapabilities, ModelCatalog, ModelCost, ModelInfo};
 pub use config::{ChatConfig, ResponseFormat, ToolChoice};

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -40,9 +40,9 @@ pub mod openrouter;
 pub mod registry;
 
 pub use adaptive::{
-    AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus, BaselineEntry, MetricsSnapshot,
-    ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics, SharedPolicy, SharedProviderMetrics,
-    StatusCallback, derive_cold_start_catalog,
+    AdaptiveConfig, AdaptiveMode, AdaptiveRouter, AdaptiveStatus, BaselineEntry, FailoverEvent,
+    MetricsSnapshot, ModelCatalogEntry, ModelType, QosCatalog, SharedMetrics, SharedPolicy,
+    SharedProviderMetrics, StatusCallback, derive_cold_start_catalog,
 };
 pub use catalog::{ModelCapabilities, ModelCatalog, ModelCost, ModelInfo};
 pub use config::{ChatConfig, ResponseFormat, ToolChoice};


### PR DESCRIPTION
## Summary

Adds the UI Protocol surface for adaptive routing so clients can render the routing pill / lane debug view without polling. Fixes the silent default-ON behavior of `adaptive_routing.enabled` along the way.

### A1 — Honor `enabled: false`
- `build_adaptive_provider_chain` (qos_catalog.rs:129) previously wrapped in `AdaptiveRouter` whenever `providers.len() > 1`, regardless of `adaptive_routing.enabled`. Now returns the plain `ProviderChain` when the flag is `false` OR the entire block is absent (was a silent default-ON).
- Config snippet that now correctly disables: `{ "adaptive_routing": { "enabled": false } }`.

### A2 — UI Protocol additions (`octos-core`)

3 notifications + 1 command + 1 RPC method:

```rust
UiNotification::RouterStatus(RouterStatusEvent)        // session_id, provider_name, mode, qos_ranking, BTreeMap lane_scores, BTreeMap circuit_breakers
UiNotification::RouterFailover(RouterFailoverEvent)    // session_id, from/to_provider, reason, elapsed_ms
UiNotification::QueueState(QueueStateEvent)            // session_id, pending_count, head_client_message_id

UiCommand::RouterSetMode(RouterSetModeParams)          // session_id, mode (lowercase string)
UiCommand::RouterGetMetrics(RouterGetMetricsParams)    // → RouterGetMetricsResult (same shape as RouterStatus)
```

`BTreeMap<String, _>` is intentional — deterministic wire order keeps the web-client diff path stable. Golden tests + capability advertisement updated.

### A3 — Server emission

- `AdaptiveRouter::subscribe_failover()` returns `tokio::sync::broadcast::Receiver<FailoverEvent>` (capacity 64, non-blocking — slow subscribers observe `RecvError::Lagged`, never stall the router).
- `lane_scores()`, `breaker_states()`, `current_lane_key()` accessors for the wire-shape mapping.
- `chat()` / `chat_stream()` publish a `FailoverEvent` each time the failover loop hands off to a fallback provider.
- API layer subscribes per turn (`spawn_router_failover_forwarder`), forwards events as `router/failover` notifications.
- `emit_router_status_durable` fires `router/status` adjacent to both `turn/started` and `turn/completed`. No-op when this profile's `adaptive_router` is `None`.
- New handlers: `handle_router_set_mode`, `handle_router_get_metrics`. Both return `runtime_unavailable` typed errors when no router is attached to the session.
- **`queue/state` is structurally a notification but server doesn't emit it today** — the web bridge manufactures it locally based on its own FIFO depth. The variant exists so client-side fan-out can use the same DOM event pattern.

### Codex review P1 fixes (round 1)

- **P1-1**: `router/status` was using lifecycle delivery, which latches `mark_failed()` on backpressure. Switched to durable delivery — frame is ledgered for reconnect-replay, drop on backpressure becomes a `replay_lossy` opportunistic emit, not a turn abort.
- **P1-2**: `FailoverEvent` lacked originating identity. The AdaptiveRouter is profile-scoped (`ProfileRuntime` shares one router across sessions), so without an originating tag, concurrent sessions on the same profile re-emitted each other's failovers. Added `originating_session_id` / `originating_turn_id` populated via a new `tokio::task_local!` (`ROUTER_CONTEXT`). New public API: `octos_llm::RouterContext` + `octos_llm::with_router_context(ctx, fut)`. Subscribers filter on this so cross-session bleed is impossible.
- **P1-3**: failover forwarder was detached with only `AbortHandle`. Now returns `JoinHandle<()>`; turn end calls `stop_failover_forwarder(handle).await` so the task is provably stopped before cleanup returns. Plus the loop breaks on `SendError::Closed | FatalClosed` so even without external abort, a closed writer terminates the loop.

### Test count delta
- `octos-core`: +6 unit tests.
- `octos-llm`: +6 unit tests (broadcast send/recv, back-pressure non-blocking, `lane_scores()`, `breaker_states()`, originating-session stamping with and without ROUTER_CONTEXT).
- `octos-cli` (qos_catalog): +2.
- `octos-cli` (api/ui_protocol): +3.

Spec updated: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md §15` (new Wave4-A section).

### Open work for B1/B2/B3 to consume
- **B1 (web)**: subscribe to `router/status` on the WS connection, replace the dead `crew:mode_update` listener with a real handler. Lane scores + breaker state are now on the wire.
- **B2 (web)**: manufacture `queue/state` from the existing per-session FIFO in `octos-web/src/runtime/ui-protocol-send.ts` — same DOM event channel.
- **B3 (web/TUI)**: send `router/set_mode` for the mode-toggle UI, send `router/get_metrics` for on-demand polling. Both return `runtime_unavailable` if the profile has no AdaptiveRouter (single-provider config); UI should gate the mode-switcher on that.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p octos-core -p octos-llm` (clean)
- [x] `cargo test -p octos-core --lib` (199/199 pass)
- [x] `cargo test -p octos-llm --lib` (283/283 pass)
- [x] `cargo test -p octos-cli --lib` (362/362 pass; non-api)
- [x] `cargo test -p octos-cli --features api --lib` (972/973 pass; 1 pre-existing failure on `session_scope_rejects_unprofiled_session_id_when_authenticated` confirmed against main)
- [x] Codex review round 1 (3 P1 blockers identified, all addressed in fix(api) commit)