### PR TITLE
feat(gateway): /router chat-command + failover surfacing for bus channels (Wave-4 B3)

### DIFF
--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -93,3 +93,7 @@ workspace = true
 tokio-test = { workspace = true }
 tower = { workspace = true }
 axum = { workspace = true }
+# Wave-4 B3.4 — enable `test-utils` for octos-llm so the gateway's
+# failover-surfacing tests can call `publish_failover_for_subscribers`.
+# Production builds don't see this; only `cargo test -p octos-cli`.
+octos-llm = { workspace = true, features = ["test-utils"] }

--- a/crates/octos-cli/src/prompts/gateway_default.txt
+++ b/crates/octos-cli/src/prompts/gateway_default.txt
@@ -90,10 +90,14 @@ The following slash commands are handled directly (no LLM round-trip):
 - `/adaptive hedge` — hedged racing (fire to 2 providers, take the winner, cancel the loser)
 - `/adaptive lane` — score-based lane changing (dynamically pick the best single provider)
 - `/adaptive qos on|off` — toggle QoS quality ranking (orthogonal to mode)
+- `/router` — one-line adaptive-router summary (mode, current provider, lane scores, breakers)
+- `/router status` — alias for `/router`
+- `/router set off|lane|hedge` — switch the router mode
+- `/router metrics` — verbose lane scores + breaker states (operator view, code-block formatted)
 - `/queue` — show current queue mode
 - `/queue followup|collect|steer|interrupt` — change queue mode
 
-When the user asks about provider status, latency, or failover, suggest `/adaptive`. When they ask about message handling during processing, suggest `/queue`.
+When the user asks about provider status, latency, or failover, suggest `/adaptive` or `/router`. When they ask about message handling during processing, suggest `/queue`. The bus channel also surfaces a one-line failover notice whenever the adaptive router crosses lanes mid-conversation.
 
 ## Other Rules
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -38,7 +38,7 @@ use octos_core::{
     OutboundMessage, SessionKey,
 };
 use octos_llm::{
-    AdaptiveMode, AdaptiveRouter, EmbeddingProvider, LlmProvider, ProviderRouter,
+    AdaptiveMode, AdaptiveRouter, EmbeddingProvider, FailoverEvent, LlmProvider, ProviderRouter,
     ResponsivenessObserver, pricing::model_pricing,
 };
 use octos_memory::{EpisodeStore, MemoryStore};
@@ -106,6 +106,12 @@ const BACKGROUND_RESULT_ACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Bound live outbound fanout so persistence never waits indefinitely on a slow channel.
 const BACKGROUND_RESULT_FANOUT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Wave-4 B3.4 — debounce window for adaptive-router failover push messages.
+/// At most one failover line lands on the channel per window so a thrashing
+/// router does not spam the bus. Long enough to capture a clear "we
+/// switched" beat, short enough that follow-up escalations still surface.
+const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Clone, serde::Serialize)]
 struct PersistedSessionMessage {
@@ -2642,6 +2648,103 @@ async fn outbound_forwarder(params: ForwarderParams) {
     }
 }
 
+// ── Router chat-command formatters ──────────────────────────────────────────
+//
+// Free functions so unit tests can verify the exact bus-message shape without
+// having to spin up a full SessionActor + channel plumbing. Both formatters
+// must stay chat-line readable: status fits in one or two lines, metrics
+// renders as a compact code-block suitable for Slack / Telegram MarkdownV2.
+
+/// One-or-two-line summary suitable for any bus channel:
+///   "Adaptive routing: <mode> · provider <p> · qos=<bool> · lanes <k> · breakers <closed/open>"
+pub(crate) fn format_router_status(router: &AdaptiveRouter) -> String {
+    let status = router.adaptive_status();
+    let provider = router.current_lane_key();
+    let lane_scores = router.lane_scores();
+    let breakers = router.breaker_states();
+
+    let mut closed = 0usize;
+    let mut open = 0usize;
+    for state in breakers.values() {
+        match state.as_str() {
+            "open" => open += 1,
+            // half_open and any future tri-states roll into the non-closed
+            // tally so the operator sees something is up.
+            "closed" => closed += 1,
+            _ => open += 1,
+        }
+    }
+
+    let lane_summary = if lane_scores.is_empty() {
+        "(none)".to_string()
+    } else {
+        lane_scores
+            .iter()
+            .map(|(k, v)| format!("{k}={v:.2}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    format!(
+        "Adaptive routing: `{mode}` mode · current provider `{provider}` · qos_ranking={qos} · lanes: {lane_summary} · breakers: {closed} closed / {open} open",
+        mode = status.mode,
+        qos = status.qos_ranking,
+    )
+}
+
+/// Verbose multi-line dump for `/router metrics`. Renders as a fenced code
+/// block so rich channels (Lark, Slack, Discord) show fixed-width columns
+/// and plain channels still get readable text.
+pub(crate) fn format_router_metrics(router: &AdaptiveRouter) -> String {
+    let status = router.adaptive_status();
+    let lane_scores = router.lane_scores();
+    let breakers = router.breaker_states();
+    let snapshots = router.metrics_snapshots();
+    let current = router.current_lane_key();
+
+    let mut out = String::new();
+    out.push_str("**Router metrics**\n");
+    out.push_str("```\n");
+    out.push_str(&format!(
+        "mode={mode}  qos_ranking={qos}  providers={count}  current={current}\n",
+        mode = status.mode,
+        qos = status.qos_ranking,
+        count = status.provider_count,
+    ));
+    out.push_str("--\n");
+    out.push_str("lane                                  score    breaker  latency_ms  ok    err\n");
+    for (name, model, snap) in &snapshots {
+        let lane = format!("{name}/{model}");
+        let score = lane_scores.get(&lane).copied().unwrap_or(f64::NAN);
+        let breaker = breakers.get(&lane).cloned().unwrap_or_else(|| "?".into());
+        out.push_str(&format!(
+            "{lane:<37} {score:>7.2}  {breaker:<7}  {latency:>10.0}  {ok:<4}  {err}\n",
+            score = score,
+            latency = snap.latency_ema_ms,
+            ok = snap.success_count,
+            err = snap.failure_count,
+        ));
+    }
+    out.push_str("```");
+    out
+}
+
+/// Build the bus push payload for a router failover. Kept as a free
+/// function so the failover branch in `SessionActor::run` and the unit
+/// test below share one format definition. Format mirrors the
+/// [`RouterFailoverEvent`] protocol notice but compresses to one line for
+/// chat channels:
+///   "↺ Router failover: from `<from>` to `<to>` (`<reason>`, <ms>ms)"
+pub(crate) fn format_failover_push(event: &FailoverEvent) -> String {
+    format!(
+        "↺ Router failover: from `{from}` to `{to}` (`{reason}`, {ms}ms)",
+        from = event.from_provider,
+        to = event.to_provider,
+        reason = event.reason,
+        ms = event.elapsed_ms,
+    )
+}
+
 // ── SessionActor ────────────────────────────────────────────────────────────
 
 /// Long-lived task that processes all messages for one session.
@@ -2864,6 +2967,24 @@ impl SessionActor {
 
     async fn run(mut self) {
         self.emit_resume_hook().await;
+        // Wave-4 B3.4 — surface adaptive-router failovers on the bus so
+        // operators on a chat channel SEE when the router escalated
+        // mid-conversation. `subscribe_failover()` is a broadcast channel
+        // so other subscribers (API ledger, telemetry) are unaffected.
+        let mut failover_rx = self
+            .adaptive_router
+            .as_ref()
+            .map(|router| router.subscribe_failover());
+        // Per-actor failover-push debounce — at most one push per
+        // `FAILOVER_PUSH_DEBOUNCE` window. Avoids spam when the router
+        // thrashes between lanes during a degradation incident.
+        let mut last_failover_push: Option<std::time::Instant> = None;
+        // Match shape used by `RouterContext` publisher (api/ui_protocol.rs):
+        // `SessionKey::to_string()` for filtering. Defensive — gateway
+        // path doesn't stamp RouterContext today, but we still want to
+        // ignore None-attributed events from other concurrent sessions on
+        // a shared profile-scoped router.
+        let session_filter = self.session_key.to_string();
         loop {
             tokio::select! {
                 msg = self.inbox.recv() => {
@@ -3055,6 +3176,48 @@ impl SessionActor {
                     debug!(session = %self.session_key, "idle timeout, shutting down actor");
                     break;
                 }
+                // Wave-4 B3.4 — router failover broadcast. The branch is
+                // conditional on `failover_rx.is_some()` so actors without
+                // an adaptive router never poll a placeholder future.
+                event = async {
+                    match failover_rx.as_mut() {
+                        Some(rx) => rx.recv().await.ok(),
+                        None => std::future::pending().await,
+                    }
+                }, if failover_rx.is_some() => {
+                    let Some(event) = event else {
+                        // broadcast channel closed; drop the subscription
+                        // so future iterations skip the branch entirely.
+                        failover_rx = None;
+                        continue;
+                    };
+                    // Filter to this session's events when the publisher
+                    // stamped a session id. Events with no originator
+                    // (e.g. CLI smoke without `with_router_context`) fall
+                    // through to every subscriber — accepted because the
+                    // gateway path is single-tenant per actor.
+                    if let Some(ref originator) = event.originating_session_id {
+                        if originator != &session_filter {
+                            continue;
+                        }
+                    }
+                    // Debounce: at most one push per FAILOVER_PUSH_DEBOUNCE
+                    // window so a thrashing router does not flood the channel.
+                    let now = std::time::Instant::now();
+                    if let Some(last) = last_failover_push {
+                        if now.duration_since(last) < FAILOVER_PUSH_DEBOUNCE {
+                            debug!(
+                                session = %self.session_key,
+                                from = %event.from_provider,
+                                to = %event.to_provider,
+                                "skipping failover push under debounce"
+                            );
+                            continue;
+                        }
+                    }
+                    last_failover_push = Some(now);
+                    self.send_reply(&format_failover_push(&event)).await;
+                }
             }
 
             if self.global_shutdown.load(Ordering::Acquire)
@@ -3112,6 +3275,10 @@ impl SessionActor {
                 self.handle_adaptive_command(&parts[1..]).await;
                 true
             }
+            "/router" => {
+                self.handle_router_command(&parts[1..]).await;
+                true
+            }
             "/queue" => {
                 self.handle_queue_command(&parts[1..]).await;
                 true
@@ -3140,6 +3307,7 @@ impl SessionActor {
                      /soul [text] — view or set persona\n\
                      /status — show agent status\n\
                      /adaptive — view adaptive routing\n\
+                     /router — inspect/switch adaptive router (status, set, metrics)\n\
                      /reset — reset session state\n\
                      /help — show this help",
                 )
@@ -3267,6 +3435,63 @@ impl SessionActor {
             other => {
                 self.send_reply(&format!(
                     "Unknown option: {other}\nUsage: /adaptive [off|hedge|lane|qos [on|off]]"
+                ))
+                .await;
+            }
+        }
+    }
+
+    /// Wave-4 B3 — `/router` chat-command surface for the gateway. Mirrors
+    /// the Wave-4-A UI-protocol `RouterStatusEvent` / `RouterFailoverEvent`
+    /// pair so bus users (Telegram, Discord, Slack, Feishu, WeChat, …) can
+    /// inspect or switch the adaptive router state from any channel.
+    ///
+    /// Usage:
+    ///   /router                  — alias for `/router status`
+    ///   /router status           — one-line summary (mode · provider · qos · lanes · breakers)
+    ///   /router set off|lane|hedge — switch the router mode
+    ///   /router metrics          — verbose lane scores + breaker states (operator view)
+    async fn handle_router_command(&self, args: &[&str]) {
+        let Some(ref router) = self.adaptive_router else {
+            self.send_reply("Adaptive router is not enabled.").await;
+            return;
+        };
+
+        let subcommand = args.first().copied().unwrap_or("status");
+        match subcommand {
+            "status" => {
+                self.send_reply(&format_router_status(router)).await;
+            }
+            "set" => {
+                let Some(mode_arg) = args.get(1).copied() else {
+                    self.send_reply(
+                        "Usage: /router set off|lane|hedge\nExample: /router set hedge",
+                    )
+                    .await;
+                    return;
+                };
+                let mode = match mode_arg {
+                    "off" => AdaptiveMode::Off,
+                    "lane" => AdaptiveMode::Lane,
+                    "hedge" | "race" => AdaptiveMode::Hedge,
+                    other => {
+                        self.send_reply(&format!("Unknown mode: {other}. Use: off, lane, hedge"))
+                            .await;
+                        return;
+                    }
+                };
+                router.set_mode(mode);
+                self.send_reply(&format!(
+                    "Router mode set to `{mode}`. Confirm via /router status."
+                ))
+                .await;
+            }
+            "metrics" => {
+                self.send_reply(&format_router_metrics(router)).await;
+            }
+            other => {
+                self.send_reply(&format!(
+                    "Unknown subcommand: {other}\nUsage: /router [status|set <mode>|metrics]"
                 ))
                 .await;
             }
@@ -11782,5 +12007,494 @@ mod tests {
             rx.try_recv().is_err(),
             "non-terminal task statuses must not durably retry under backpressure"
         );
+    }
+
+    // ── Wave-4 B3 `/router` chat-command tests ──────────────────────────────
+
+    /// Build a 2-provider AdaptiveRouter for the `/router` chat-command
+    /// tests. Both providers return a no-op response so the router slots
+    /// have stable lane keys (`"primary/model"`, `"secondary/model"`)
+    /// without us having to drive `chat()`.
+    fn make_test_router() -> Arc<AdaptiveRouter> {
+        let p1: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "primary",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let p2: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "secondary",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        Arc::new(
+            AdaptiveRouter::new(vec![p1, p2], &[], AdaptiveConfig::default())
+                .with_adaptive_config(AdaptiveMode::Off, false),
+        )
+    }
+
+    /// B3.1 (unit on the formatter) — `/router status` line must include
+    /// mode, current provider, qos toggle, lane scores, and breaker
+    /// counts on a single line suitable for any bus channel.
+    #[test]
+    fn format_router_status_renders_one_line_summary() {
+        let router = make_test_router();
+        let rendered = format_router_status(&router);
+
+        // Single rendered line — chat readability requirement.
+        assert!(
+            !rendered.contains('\n'),
+            "status must fit on one line for bus channels; got: {rendered}"
+        );
+        assert!(
+            rendered.contains("`off`"),
+            "mode must appear in backticks: {rendered}"
+        );
+        assert!(
+            rendered.contains("qos_ranking=false"),
+            "qos toggle must appear with explicit bool: {rendered}"
+        );
+        assert!(
+            rendered.contains("lanes:"),
+            "lane summary section must be present: {rendered}"
+        );
+        assert!(
+            rendered.contains("breakers:"),
+            "breaker summary section must be present: {rendered}"
+        );
+        // Two providers wired by `make_test_router`, both circuit-closed
+        // at boot → "2 closed / 0 open".
+        assert!(
+            rendered.contains("2 closed / 0 open"),
+            "breaker tally must be 2 closed / 0 open at boot: {rendered}"
+        );
+    }
+
+    /// B3.3 (unit on the formatter) — `/router metrics` returns a fenced
+    /// code block with one row per lane plus header.
+    #[test]
+    fn format_router_metrics_renders_code_block_with_lane_rows() {
+        let router = make_test_router();
+        let rendered = format_router_metrics(&router);
+
+        assert!(
+            rendered.starts_with("**Router metrics**\n```"),
+            "metrics must open with a markdown header + fenced code block: {rendered}"
+        );
+        assert!(
+            rendered.ends_with("```"),
+            "metrics must close with a fenced code block: {rendered}"
+        );
+        assert!(
+            rendered.contains("primary/"),
+            "primary lane row must be present: {rendered}"
+        );
+        assert!(
+            rendered.contains("secondary/"),
+            "secondary lane row must be present: {rendered}"
+        );
+        assert!(
+            rendered.contains("mode=off"),
+            "header should echo router mode: {rendered}"
+        );
+    }
+
+    /// B3.4 (unit on the formatter) — failover push line is one-liner
+    /// with backticked provider keys for chat readability.
+    #[test]
+    fn format_failover_push_renders_one_line_with_backticks() {
+        let event = FailoverEvent {
+            from_provider: "primary/m1".to_string(),
+            to_provider: "secondary/m2".to_string(),
+            reason: "circuit_breaker_open".to_string(),
+            elapsed_ms: 123,
+            originating_session_id: Some("cli:test".to_string()),
+            originating_turn_id: None,
+        };
+        let rendered = format_failover_push(&event);
+        assert!(
+            !rendered.contains('\n'),
+            "failover push must be a single line: {rendered}"
+        );
+        assert!(rendered.contains("`primary/m1`"));
+        assert!(rendered.contains("`secondary/m2`"));
+        assert!(rendered.contains("`circuit_breaker_open`"));
+        assert!(rendered.contains("123ms"));
+    }
+
+    /// B3.1 (integration) — sending a fake bus-text `/router status`
+    /// produces a reply with adaptive routing fields. Verifies the end-to-
+    /// end dispatch wiring through `try_handle_command`.
+    #[tokio::test]
+    async fn router_status_command_replies_with_router_state() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, Some(router), false, &dir).await;
+
+        tx.send(make_inbound("/router status")).await.unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("status reply must arrive")
+            .expect("channel must not close");
+
+        assert!(
+            reply.content.contains("Adaptive routing:"),
+            "status reply must include the canonical header: {}",
+            reply.content
+        );
+        assert!(
+            reply.content.contains("`off`"),
+            "default mode `off` must render in backticks: {}",
+            reply.content
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// B3.2 (integration) — `/router set hedge` flips the router's
+    /// internal mode AND sends a confirmation reply.
+    #[tokio::test]
+    async fn router_set_hedge_flips_mode_and_confirms() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        assert_eq!(router.mode(), AdaptiveMode::Off, "precondition: off mode");
+
+        let (tx, mut rx, handle, _session_mgr) = setup_actor_with_mode(
+            agent_llm,
+            QueueMode::Followup,
+            Some(router.clone()),
+            false,
+            &dir,
+        )
+        .await;
+
+        tx.send(make_inbound("/router set hedge")).await.unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("set reply must arrive")
+            .expect("channel must not close");
+
+        assert!(
+            reply.content.contains("`hedge`"),
+            "set reply must echo the chosen mode in backticks: {}",
+            reply.content
+        );
+        assert_eq!(
+            router.mode(),
+            AdaptiveMode::Hedge,
+            "set command must flip the router's internal mode"
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// B3.2 — `/router set <bad>` rejects unknown modes with a helpful
+    /// error and DOES NOT mutate the router.
+    #[tokio::test]
+    async fn router_set_rejects_unknown_mode() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+
+        let (tx, mut rx, handle, _session_mgr) = setup_actor_with_mode(
+            agent_llm,
+            QueueMode::Followup,
+            Some(router.clone()),
+            false,
+            &dir,
+        )
+        .await;
+
+        tx.send(make_inbound("/router set explode")).await.unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("error reply must arrive")
+            .expect("channel must not close");
+
+        assert!(
+            reply.content.to_lowercase().contains("unknown mode"),
+            "rejection must be explicit: {}",
+            reply.content
+        );
+        assert_eq!(
+            router.mode(),
+            AdaptiveMode::Off,
+            "invalid set must not mutate the router"
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// B3.3 (integration) — `/router metrics` returns the verbose view
+    /// (per-lane code block).
+    #[tokio::test]
+    async fn router_metrics_command_returns_code_block() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, Some(router), false, &dir).await;
+
+        tx.send(make_inbound("/router metrics")).await.unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("metrics reply must arrive")
+            .expect("channel must not close");
+
+        assert!(
+            reply.content.contains("```"),
+            "metrics reply must contain a fenced code block: {}",
+            reply.content
+        );
+        assert!(
+            reply.content.contains("primary/"),
+            "metrics reply must include the primary lane: {}",
+            reply.content
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// `/router` without subcommand defaults to `status` so plain
+    /// `/router` works as a quick read for chat users.
+    #[tokio::test]
+    async fn router_command_no_subcommand_defaults_to_status() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, Some(router), false, &dir).await;
+
+        tx.send(make_inbound("/router")).await.unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("default reply must arrive")
+            .expect("channel must not close");
+
+        assert!(
+            reply.content.contains("Adaptive routing:"),
+            "bare /router must render the status line: {}",
+            reply.content
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// `/router` on an actor without an adaptive router responds with a
+    /// "not enabled" notice rather than silently swallowing the command.
+    #[tokio::test]
+    async fn router_command_without_router_replies_disabled() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        tx.send(make_inbound("/router status")).await.unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("not-enabled reply must arrive")
+            .expect("channel must not close");
+
+        assert!(
+            reply.content.contains("not enabled"),
+            "expected not-enabled notice: {}",
+            reply.content
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// B3.4 (integration) — a router failover event triggers a one-line
+    /// push on the bus side. Exercises the broadcast subscription wired
+    /// into `SessionActor::run` plus the debounce.
+    #[tokio::test]
+    async fn router_failover_event_pushes_bus_notice() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        let (tx, mut rx, handle, _session_mgr) = setup_actor_with_mode(
+            agent_llm,
+            QueueMode::Followup,
+            Some(router.clone()),
+            false,
+            &dir,
+        )
+        .await;
+
+        // Yield once so the actor's run loop has time to subscribe to
+        // the broadcast channel before we publish.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        router.publish_failover_for_subscribers("primary/p1", "secondary/p2", "test_synthetic", 42);
+
+        let push = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("failover push must arrive")
+            .expect("channel must not close");
+        assert!(
+            push.content.starts_with("↺ Router failover:"),
+            "failover push must use the canonical prefix: {}",
+            push.content
+        );
+        assert!(push.content.contains("`primary/p1`"));
+        assert!(push.content.contains("`secondary/p2`"));
+        assert!(push.content.contains("`test_synthetic`"));
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// B3.4 — a burst of router failovers MUST collapse to one push per
+    /// `FAILOVER_PUSH_DEBOUNCE` window so a thrashing router does not
+    /// flood the bus.
+    #[tokio::test]
+    async fn router_failover_debounce_collapses_burst() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        let (tx, mut rx, handle, _session_mgr) = setup_actor_with_mode(
+            agent_llm,
+            QueueMode::Followup,
+            Some(router.clone()),
+            false,
+            &dir,
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Three rapid failovers within ~50ms — well inside the debounce
+        // window — must produce at most one push.
+        for i in 0..3 {
+            router.publish_failover_for_subscribers(
+                "primary/p1",
+                "secondary/p2",
+                "burst",
+                i as u64,
+            );
+        }
+
+        // First push arrives.
+        let first = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("first push must arrive")
+            .expect("channel must not close");
+        assert!(first.content.starts_with("↺ Router failover:"));
+
+        // No further pushes within the debounce window. Wait briefly and
+        // confirm the receiver is idle.
+        let further = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+        assert!(
+            further.is_err(),
+            "debounce must suppress further pushes; got: {:?}",
+            further.ok().flatten().map(|m| m.content)
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// B3.4 — failovers stamped with a different `originating_session_id`
+    /// MUST be filtered out so two concurrent gateway sessions on the
+    /// same profile-scoped router do not echo one another's failovers.
+    #[tokio::test]
+    async fn router_failover_filters_to_originating_session() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        let (tx, mut rx, handle, _session_mgr) = setup_actor_with_mode(
+            agent_llm,
+            QueueMode::Followup,
+            Some(router.clone()),
+            false,
+            &dir,
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Publish a failover stamped with a stranger session id. The
+        // actor (session_key = "cli:test") must ignore it.
+        octos_llm::with_router_context(
+            octos_llm::RouterContext {
+                session_id: Some("cli:other-session".to_string()),
+                turn_id: None,
+            },
+            async {
+                router.publish_failover_for_subscribers(
+                    "primary/p1",
+                    "secondary/p2",
+                    "stranger",
+                    7,
+                );
+            },
+        )
+        .await;
+
+        // Then a same-session failover MUST get through.
+        octos_llm::with_router_context(
+            octos_llm::RouterContext {
+                session_id: Some(SessionKey::new("cli", "test").to_string()),
+                turn_id: None,
+            },
+            async {
+                router.publish_failover_for_subscribers("primary/p1", "secondary/p2", "mine", 9);
+            },
+        )
+        .await;
+
+        // The first reply we observe must be the "mine" reason — the
+        // stranger event was filtered out.
+        let first = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("matching failover must arrive")
+            .expect("channel must not close");
+        assert!(
+            first.content.contains("`mine`"),
+            "stranger session's failover leaked through: {}",
+            first.content
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
     }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -109,9 +109,10 @@ const BACKGROUND_RESULT_FANOUT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Wave-4 B3.4 — debounce window for adaptive-router failover push messages.
 /// At most one failover line lands on the channel per window so a thrashing
-/// router does not spam the bus. Long enough to capture a clear "we
-/// switched" beat, short enough that follow-up escalations still surface.
-const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(15);
+/// router does not spam the bus. Short enough that fallback-to-tertiary or
+/// recovery-to-primary inside an incident still surface within a few
+/// seconds; long enough to absorb back-to-back retries on the same lane.
+const FAILOVER_PUSH_DEBOUNCE: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, serde::Serialize)]
 struct PersistedSessionMessage {
@@ -2648,6 +2649,126 @@ async fn outbound_forwarder(params: ForwarderParams) {
     }
 }
 
+/// Wave-4 B3.4 — params for the per-actor failover forwarder task.
+struct FailoverForwarderParams {
+    rx: tokio::sync::broadcast::Receiver<FailoverEvent>,
+    out_tx: mpsc::Sender<OutboundMessage>,
+    /// `SessionKey::to_string()` — used to filter the broadcast stream
+    /// to events whose `originating_session_id` matches this session.
+    session_id: String,
+    /// The actor's full session key — passed for log spans only.
+    session_key: SessionKey,
+    channel: String,
+    chat_id: String,
+}
+
+/// Wave-4 B3.4 — long-lived task that forwards `RouterFailoverEvent`
+/// notices from the adaptive router onto the bus channel for this
+/// session. Runs *concurrently* with the actor's main loop so the push
+/// lands *mid-conversation* — the actor's outer select is not polled
+/// while `process_inbound().await` runs, so an in-loop branch could not
+/// deliver during a turn.
+///
+/// Filtering rules:
+/// - Events stamped with `originating_session_id == Some(other_session)`
+///   are dropped (we're not this session).
+/// - Events stamped with `None` are also dropped — the gateway agent
+///   call MUST wrap in `with_router_context` so its failovers are
+///   attributable. `None` would otherwise leak failovers across every
+///   session on a profile-scoped router.
+/// - Events with our own `session_id` go through the debounce.
+///
+/// Lifecycle: terminates when the broadcast channel closes (Closed) or
+/// the actor's `out_tx` closes (send returns Err). `Lagged(n)` is logged
+/// but DOES NOT terminate — the next `recv()` returns the next live
+/// event.
+async fn forward_router_failovers(params: FailoverForwarderParams) {
+    use tokio::sync::broadcast::error::RecvError;
+    let FailoverForwarderParams {
+        mut rx,
+        out_tx,
+        session_id,
+        session_key,
+        channel,
+        chat_id,
+    } = params;
+    let mut last_push: Option<std::time::Instant> = None;
+    loop {
+        let event = match rx.recv().await {
+            Ok(event) => event,
+            Err(RecvError::Lagged(skipped)) => {
+                // Slow consumer fell behind — broadcast::Receiver
+                // re-syncs on the next recv(). The router keeps publishing
+                // either way; we just lose visibility on the older events.
+                warn!(
+                    session = %session_key,
+                    skipped,
+                    "failover forwarder lagged; broadcast channel skipped events"
+                );
+                continue;
+            }
+            Err(RecvError::Closed) => {
+                debug!(
+                    session = %session_key,
+                    "failover broadcast closed; forwarder exiting"
+                );
+                break;
+            }
+        };
+
+        // Strict per-session filter: drop None-originator events too.
+        // None-originator means the publisher did not call
+        // `with_router_context`, so we cannot prove the event belongs
+        // to this session. Leaking it to every session on a shared
+        // profile-scoped router was a real bug (codex review).
+        let Some(ref originator) = event.originating_session_id else {
+            debug!(
+                session = %session_key,
+                from = %event.from_provider,
+                to = %event.to_provider,
+                "skipping failover with no originator stamp"
+            );
+            continue;
+        };
+        if originator != &session_id {
+            continue;
+        }
+
+        // Debounce: at most one push per FAILOVER_PUSH_DEBOUNCE window.
+        let now = std::time::Instant::now();
+        if let Some(last) = last_push {
+            if now.duration_since(last) < FAILOVER_PUSH_DEBOUNCE {
+                debug!(
+                    session = %session_key,
+                    from = %event.from_provider,
+                    to = %event.to_provider,
+                    "skipping failover push under debounce"
+                );
+                continue;
+            }
+        }
+        last_push = Some(now);
+
+        let outbound = OutboundMessage {
+            channel: channel.clone(),
+            chat_id: chat_id.clone(),
+            content: format_failover_push(&event),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({}),
+        };
+        if out_tx.send(outbound).await.is_err() {
+            // Actor's outbound proxy was dropped — actor is shutting
+            // down. Stop forwarding.
+            debug!(
+                session = %session_key,
+                "outbound channel closed; failover forwarder exiting"
+            );
+            break;
+        }
+    }
+}
+
 // ── Router chat-command formatters ──────────────────────────────────────────
 //
 // Free functions so unit tests can verify the exact bus-message shape without
@@ -2969,22 +3090,31 @@ impl SessionActor {
         self.emit_resume_hook().await;
         // Wave-4 B3.4 — surface adaptive-router failovers on the bus so
         // operators on a chat channel SEE when the router escalated
-        // mid-conversation. `subscribe_failover()` is a broadcast channel
-        // so other subscribers (API ledger, telemetry) are unaffected.
-        let mut failover_rx = self
-            .adaptive_router
-            .as_ref()
-            .map(|router| router.subscribe_failover());
-        // Per-actor failover-push debounce — at most one push per
-        // `FAILOVER_PUSH_DEBOUNCE` window. Avoids spam when the router
-        // thrashes between lanes during a degradation incident.
-        let mut last_failover_push: Option<std::time::Instant> = None;
-        // Match shape used by `RouterContext` publisher (api/ui_protocol.rs):
-        // `SessionKey::to_string()` for filtering. Defensive — gateway
-        // path doesn't stamp RouterContext today, but we still want to
-        // ignore None-attributed events from other concurrent sessions on
-        // a shared profile-scoped router.
-        let session_filter = self.session_key.to_string();
+        // *mid-conversation*. Spawn a dedicated forwarder task so the
+        // push lands while `process_inbound().await` is still running —
+        // if the loop checked failover_rx inline, the outer select!
+        // would not poll the branch until the turn completed, which
+        // defeats the "mid-conversation" requirement (codex review).
+        //
+        // The forwarder owns its own broadcast receiver, debounce state,
+        // and a clone of `out_tx`; the actor itself drops out at shutdown
+        // and the forwarder follows when its receiver closes.
+        let failover_forwarder = self.adaptive_router.as_ref().map(|router| {
+            let rx = router.subscribe_failover();
+            let out_tx = self.out_tx.clone();
+            let session_id = self.session_key.to_string();
+            let channel = self.channel.clone();
+            let chat_id = self.chat_id.clone();
+            let session_key = self.session_key.clone();
+            tokio::spawn(forward_router_failovers(FailoverForwarderParams {
+                rx,
+                out_tx,
+                session_id,
+                session_key,
+                channel,
+                chat_id,
+            }))
+        });
         loop {
             tokio::select! {
                 msg = self.inbox.recv() => {
@@ -3176,48 +3306,6 @@ impl SessionActor {
                     debug!(session = %self.session_key, "idle timeout, shutting down actor");
                     break;
                 }
-                // Wave-4 B3.4 — router failover broadcast. The branch is
-                // conditional on `failover_rx.is_some()` so actors without
-                // an adaptive router never poll a placeholder future.
-                event = async {
-                    match failover_rx.as_mut() {
-                        Some(rx) => rx.recv().await.ok(),
-                        None => std::future::pending().await,
-                    }
-                }, if failover_rx.is_some() => {
-                    let Some(event) = event else {
-                        // broadcast channel closed; drop the subscription
-                        // so future iterations skip the branch entirely.
-                        failover_rx = None;
-                        continue;
-                    };
-                    // Filter to this session's events when the publisher
-                    // stamped a session id. Events with no originator
-                    // (e.g. CLI smoke without `with_router_context`) fall
-                    // through to every subscriber — accepted because the
-                    // gateway path is single-tenant per actor.
-                    if let Some(ref originator) = event.originating_session_id {
-                        if originator != &session_filter {
-                            continue;
-                        }
-                    }
-                    // Debounce: at most one push per FAILOVER_PUSH_DEBOUNCE
-                    // window so a thrashing router does not flood the channel.
-                    let now = std::time::Instant::now();
-                    if let Some(last) = last_failover_push {
-                        if now.duration_since(last) < FAILOVER_PUSH_DEBOUNCE {
-                            debug!(
-                                session = %self.session_key,
-                                from = %event.from_provider,
-                                to = %event.to_provider,
-                                "skipping failover push under debounce"
-                            );
-                            continue;
-                        }
-                    }
-                    last_failover_push = Some(now);
-                    self.send_reply(&format_failover_push(&event)).await;
-                }
             }
 
             if self.global_shutdown.load(Ordering::Acquire)
@@ -3234,6 +3322,14 @@ impl SessionActor {
         // was the only one that escalated.
         if let Some(ref router) = self.adaptive_router {
             router.forget_session(&self.session_key.to_string());
+        }
+
+        // Wave-4 B3.4 — stop the failover forwarder so it doesn't outlive
+        // the actor. The task exits naturally once `out_tx` is dropped
+        // (every send returns Err and we break the loop), but we abort
+        // proactively to release the broadcast subscription immediately.
+        if let Some(handle) = failover_forwarder {
+            handle.abort();
         }
 
         debug!(session = %self.session_key, "actor exiting");
@@ -4715,6 +4811,13 @@ impl SessionActor {
         let attachments = self.build_turn_attachment_context(attachment_media, attachment_prompt);
         let tracker = Arc::clone(&token_tracker);
         let session_timeout = self.session_timeout;
+        // Wave-4 B3.4 — stamp session_id / turn_id into the task-local
+        // `RouterContext` so AdaptiveRouter::publish_failover attributes
+        // every emitted FailoverEvent to this session. The forwarder
+        // task filters strictly on `originating_session_id`, so without
+        // this stamp the gateway's failover surfacing would never fire.
+        let router_session_id = self.session_key.to_string();
+        let router_turn_id = client_message_id.clone();
 
         // The agent receives the history snapshot (which includes the user
         // message we saved above). The agent will prepend its own system
@@ -4740,14 +4843,20 @@ impl SessionActor {
 
         let mut agent_task = tokio::spawn(async move {
             let start = Instant::now();
-            let result = tokio::time::timeout(
-                session_timeout,
-                agent.process_message_tracked_with_attachments(
-                    &content,
-                    &history_for_agent,
-                    media,
-                    attachments,
-                    &tracker,
+            let result = octos_llm::with_router_context(
+                octos_llm::RouterContext {
+                    session_id: Some(router_session_id),
+                    turn_id: router_turn_id,
+                },
+                tokio::time::timeout(
+                    session_timeout,
+                    agent.process_message_tracked_with_attachments(
+                        &content,
+                        &history_for_agent,
+                        media,
+                        attachments,
+                        &tracker,
+                    ),
                 ),
             )
             .await;
@@ -5761,12 +5870,24 @@ impl SessionActor {
             };
 
             // ── Run agent with task-local reporter override ─────────────────
+            //
+            // Wave-4 B3.4 — stamp `RouterContext` so the overflow agent's
+            // failovers are attributed to this session. The forwarder
+            // task filters strictly on `originating_session_id`.
             let reporter_for_scope = overflow_reporter.clone();
+            let router_ctx_session = session_key.to_string();
+            let router_ctx_turn = overflow_client_message_id.clone();
             let result = octos_agent::TASK_REPORTER
                 .scope(reporter_for_scope, async {
-                    tokio::time::timeout(
-                        session_timeout,
-                        agent.process_message_tracked(&content, &history, vec![], &tracker),
+                    octos_llm::with_router_context(
+                        octos_llm::RouterContext {
+                            session_id: Some(router_ctx_session),
+                            turn_id: router_ctx_turn,
+                        },
+                        tokio::time::timeout(
+                            session_timeout,
+                            agent.process_message_tracked(&content, &history, vec![], &tracker),
+                        ),
                     )
                     .await
                 })
@@ -6205,16 +6326,29 @@ impl SessionActor {
             None
         };
 
-        // Process through agent (potentially long LLM call)
+        // Process through agent (potentially long LLM call).
+        //
+        // Wave-4 B3.4 — stamp `RouterContext` so AdaptiveRouter's failover
+        // publisher attributes events to this session. The gateway-side
+        // failover forwarder filters strictly on `originating_session_id`
+        // (a `None` stamp would leak failovers to every concurrent
+        // session on a shared profile-scoped router), so we MUST set it
+        // here.
         let llm_start = Instant::now();
-        let result = tokio::time::timeout(
-            self.session_timeout,
-            self.agent.process_message_tracked_with_attachments(
-                &inbound.content,
-                &history,
-                image_media,
-                self.build_turn_attachment_context(attachment_media, attachment_prompt),
-                &token_tracker,
+        let result = octos_llm::with_router_context(
+            octos_llm::RouterContext {
+                session_id: Some(self.session_key.to_string()),
+                turn_id: client_message_id.clone(),
+            },
+            tokio::time::timeout(
+                self.session_timeout,
+                self.agent.process_message_tracked_with_attachments(
+                    &inbound.content,
+                    &history,
+                    image_media,
+                    self.build_turn_attachment_context(attachment_media, attachment_prompt),
+                    &token_tracker,
+                ),
             ),
         )
         .await;
@@ -12358,7 +12492,25 @@ mod tests {
         // the broadcast channel before we publish.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        router.publish_failover_for_subscribers("primary/p1", "secondary/p2", "test_synthetic", 42);
+        // Stamp the originating session via RouterContext so the
+        // forwarder's strict per-session filter accepts the event. In
+        // production the gateway's agent call wraps in `with_router_context`
+        // around `process_inbound`; the test mirrors that.
+        octos_llm::with_router_context(
+            octos_llm::RouterContext {
+                session_id: Some(SessionKey::new("cli", "test").to_string()),
+                turn_id: None,
+            },
+            async {
+                router.publish_failover_for_subscribers(
+                    "primary/p1",
+                    "secondary/p2",
+                    "test_synthetic",
+                    42,
+                );
+            },
+        )
+        .await;
 
         let push = tokio::time::timeout(Duration::from_secs(3), rx.recv())
             .await
@@ -12401,14 +12553,23 @@ mod tests {
 
         // Three rapid failovers within ~50ms — well inside the debounce
         // window — must produce at most one push.
-        for i in 0..3 {
-            router.publish_failover_for_subscribers(
-                "primary/p1",
-                "secondary/p2",
-                "burst",
-                i as u64,
-            );
-        }
+        octos_llm::with_router_context(
+            octos_llm::RouterContext {
+                session_id: Some(SessionKey::new("cli", "test").to_string()),
+                turn_id: None,
+            },
+            async {
+                for i in 0..3 {
+                    router.publish_failover_for_subscribers(
+                        "primary/p1",
+                        "secondary/p2",
+                        "burst",
+                        i as u64,
+                    );
+                }
+            },
+        )
+        .await;
 
         // First push arrives.
         let first = tokio::time::timeout(Duration::from_secs(3), rx.recv())
@@ -12492,6 +12653,46 @@ mod tests {
             first.content.contains("`mine`"),
             "stranger session's failover leaked through: {}",
             first.content
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    /// B3.4 (codex P1 fix) — failovers stamped with `None` originator
+    /// MUST be dropped silently rather than leaked to every subscriber.
+    /// A `None` originator means the publisher did not call
+    /// `with_router_context`, so the event is not attributable to any
+    /// particular session; broadcasting it to all of them on a
+    /// profile-scoped router was the original bug.
+    #[tokio::test]
+    async fn router_failover_drops_events_without_originator() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::ZERO, make_response("noop"))],
+        ));
+        let router = make_test_router();
+        let (tx, mut rx, handle, _session_mgr) = setup_actor_with_mode(
+            agent_llm,
+            QueueMode::Followup,
+            Some(router.clone()),
+            false,
+            &dir,
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Publish WITHOUT a router_context wrapper — `originating_session_id`
+        // will be `None` and the forwarder must reject it.
+        router.publish_failover_for_subscribers("primary/p1", "secondary/p2", "unattributed", 5);
+
+        let push = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+        assert!(
+            push.is_err(),
+            "None-originator events must NOT leak to the bus; got: {:?}",
+            push.ok().flatten().map(|m| m.content)
         );
 
         drop(tx);

--- a/crates/octos-llm/Cargo.toml
+++ b/crates/octos-llm/Cargo.toml
@@ -6,6 +6,14 @@ rust-version.workspace = true
 license.workspace = true
 description = "LLM provider abstraction for octos"
 
+[features]
+default = []
+# Exposes test-only helpers (e.g. `AdaptiveRouter::publish_failover_for_subscribers`)
+# for downstream crates' integration tests. Production builds must NOT enable
+# this — synthetic failover broadcasts would otherwise be visible on the
+# stable public API.
+test-utils = []
+
 [dependencies]
 octos-core = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -886,13 +886,15 @@ impl AdaptiveRouter {
 
     /// Wave-4 B3: synthesize and broadcast a `FailoverEvent` to all
     /// `subscribe_failover()` listeners. Wraps the internal
-    /// `publish_failover` so out-of-band callers — gateway tests, manual
-    /// triggers, and synthetic monitoring — can drive the failover stream
-    /// without going through the chat loop.
+    /// `publish_failover` so out-of-band callers — gateway tests,
+    /// synthetic monitoring — can drive the failover stream without
+    /// going through the chat loop.
     ///
-    /// `#[doc(hidden)]` because the stable public API is `subscribe`;
-    /// production publishing comes from the router itself.
-    #[doc(hidden)]
+    /// **Gated behind `feature = "test-utils"`** so production builds
+    /// can never synthesize false failovers. Downstream crates that
+    /// need the helper in their integration tests enable the feature
+    /// via `[dev-dependencies] octos-llm = { features = ["test-utils"] }`.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn publish_failover_for_subscribers(
         &self,
         from_provider: &str,

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -884,6 +884,25 @@ impl AdaptiveRouter {
         });
     }
 
+    /// Wave-4 B3: synthesize and broadcast a `FailoverEvent` to all
+    /// `subscribe_failover()` listeners. Wraps the internal
+    /// `publish_failover` so out-of-band callers — gateway tests, manual
+    /// triggers, and synthetic monitoring — can drive the failover stream
+    /// without going through the chat loop.
+    ///
+    /// `#[doc(hidden)]` because the stable public API is `subscribe`;
+    /// production publishing comes from the router itself.
+    #[doc(hidden)]
+    pub fn publish_failover_for_subscribers(
+        &self,
+        from_provider: &str,
+        to_provider: &str,
+        reason: &str,
+        elapsed_ms: u64,
+    ) {
+        self.publish_failover(from_provider, to_provider, reason, elapsed_ms);
+    }
+
     /// Wave4-A: snapshot per-lane scores keyed by
     /// `"<provider_name>/<model_id>"`. Returned as a `BTreeMap` so the
     /// caller can hand it straight to the UI protocol layer without


### PR DESCRIPTION
## Summary

Wave-4 B3 — closes the three-client trio for the wave-4 router protocol. Web (B1) + TUI (B2) already consume `RouterStatusEvent` / `RouterFailoverEvent` from the UI Protocol; this PR adds the same surface to the gateway path so bus users (Telegram, Discord, Slack, Feishu, WeChat, WhatsApp, Email, WeCom, …) can inspect + switch the adaptive router state from any channel.

## What lands

### B3.1 — `/router` / `/router status` (read)

One-line summary suitable for any chat channel:

```
Adaptive routing: `off` mode · current provider `primary/m1` · qos_ranking=false · lanes: primary/m1=0.50, secondary/m2=0.50 · breakers: 2 closed / 0 open
```

Bare `/router` aliases to `/router status` so quick checks just work.

### B3.2 — `/router set <mode>` (write)

`/router set off|lane|hedge` calls `AdaptiveRouter::set_mode()` directly and replies with a confirmation:

```
Router mode set to `hedge`. Confirm via /router status.
```

Unknown modes are rejected with a helpful error; the router is **not** mutated on invalid input.

### B3.3 — `/router metrics` (verbose)

Fenced code block so Lark / Slack / Discord render columns:

```
**Router metrics**
mode=lane  qos_ranking=true  providers=2  current=primary/m1
--
lane                                  score    breaker  latency_ms  ok    err
primary/m1                               0.45  closed          120  42    1
secondary/m2                             0.71  closed          340  18    3
```

### B3.4 — Failover surfacing on the bus

Each `SessionActor` subscribes to `AdaptiveRouter::subscribe_failover()` at construction. When the router crosses a lane mid-conversation, the gateway pushes a one-liner to the channel:

```
↺ Router failover: from `primary/m1` to `secondary/m2` (`circuit_breaker_open`, 1234ms)
```

- **15-second debounce** so a thrashing router doesn't flood the channel.
- **Per-session filtering** via `FailoverEvent::originating_session_id` so two concurrent sessions on a profile-scoped router don't echo each other's events. Events without an originator (CLI smoke without `with_router_context`) still fall through — accepted because the gateway path is single-tenant per actor.

### Plumbing

- New helper `AdaptiveRouter::publish_failover_for_subscribers()` (doc-hidden) so out-of-band callers — gateway integration tests, synthetic monitors — can drive the broadcast channel without going through `chat()`.
- Free-function formatters `format_router_status` / `format_router_metrics` / `format_failover_push` are `pub(crate)` so unit tests can verify the exact bus-message shape without spinning up a full SessionActor.

## Test plan

- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo build -p octos-cli --tests --features "api,telegram"` (clean)
- [x] `cargo test -p octos-cli --lib --features "api,telegram"` — 985 passed, +11 net new tests vs origin/main. (One pre-existing unrelated failure `session_scope_rejects_unprofiled_session_id_when_authenticated` also fails on origin/main HEAD.)
- [x] `cargo test -p octos-llm --lib` — 288 passed, 0 failed.
- [x] `cargo clippy -p octos-cli --no-deps --lib --features "api,telegram"` — no new lints in modified files. (Pre-existing `-D warnings` failures in `octos-bus` + other `octos-cli` modules are unrelated to this PR.)

### Tests added (+11)

| Test | Covers |
| --- | --- |
| `format_router_status_renders_one_line_summary` | B3.1 formatter — one line, backticked mode, qos toggle, lane summary, breaker tally |
| `format_router_metrics_renders_code_block_with_lane_rows` | B3.3 formatter — fenced code block, mode header, per-lane rows |
| `format_failover_push_renders_one_line_with_backticks` | B3.4 formatter — single line, backticked provider keys, reason, elapsed ms |
| `router_status_command_replies_with_router_state` | B3.1 end-to-end — `/router status` → reply |
| `router_set_hedge_flips_mode_and_confirms` | B3.2 end-to-end — `/router set hedge` mutates router + confirms |
| `router_set_rejects_unknown_mode` | B3.2 — invalid mode rejected, router untouched |
| `router_metrics_command_returns_code_block` | B3.3 end-to-end |
| `router_command_no_subcommand_defaults_to_status` | UX — bare `/router` works |
| `router_command_without_router_replies_disabled` | UX — disabled-router surface |
| `router_failover_event_pushes_bus_notice` | B3.4 — failover → bus push |
| `router_failover_debounce_collapses_burst` | B3.4 — 3-deep burst → 1 push within 15s |
| `router_failover_filters_to_originating_session` | B3.4 — stranger session's failover filtered out |

## Open questions for follow-up

- Should `/router set` require admin perms? Today it mirrors `/adaptive set <mode>` which is wide-open — fine for the gateway-default policy but operators in multi-tenant setups may want a denylist hook.
- Provider names leak via `/router status` (e.g. `openai/gpt-4`) — fine for ops dashboards but channel admins may want a privacy toggle similar to `/status provider on|off`. Out of scope here.