### PR TITLE
fix(plugins): codex review rounds 2-7 follow-up to PR #944

### DIFF
--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -318,30 +318,40 @@ impl PluginLoader {
             );
         }
 
-        // Resolve extras (MCP servers, hooks, prompt fragments) regardless of tools.
-        let mut extras = resolve_extras(&manifest, plugin_dir);
-
-        // Section B (codex review round-3): under strict signing, the
+        // Section B (codex review round-3 + round-4 P2 + P2-bis): the
         // current `manifest.sha256` semantics anchor only the executable
         // bytes — manifest-side declarations (MCP servers, lifecycle
-        // hooks, prompt fragments) are NOT covered by the digest. A
-        // malicious patcher could edit `manifest.json` to add executable
-        // extras without invalidating the executable hash; the strict
-        // policy must refuse to mint trust for that code path until the
-        // signed material covers the manifest too. We therefore DROP
-        // extras for every tools-bearing skill that goes through the
-        // strict path. Operators who depend on extras must either run
-        // with permissive mode or ship those declarations via a
-        // separately-trusted host config (`mcp_servers` + `hooks` on
-        // `Config`/`ProfileConfig`).
-        if require_signed && manifest.has_extras() {
-            warn!(
-                plugin = %manifest.name,
-                "dropping manifest extras (MCP servers / hooks / prompts) under \
-                 `plugins.require_signed`: the digest does not cover them"
-            );
-            extras = SkillExtras::default();
-        }
+        // hooks, prompt fragments, and the auto-injected SKILL.md for
+        // spawn-only skills) are NOT covered by the digest. A malicious
+        // patcher could edit `manifest.json` (or replace SKILL.md
+        // contents alongside it) to add executable / prompt code paths
+        // without invalidating the executable hash. The strict policy
+        // must refuse to mint trust for those paths until the signed
+        // material covers the manifest too.
+        //
+        // We therefore SKIP `resolve_extras` entirely under strict mode
+        // so:
+        //   1. no glob expansion / file reads against the skill dir
+        //      (closing the load-time DoS surface flagged in round-4),
+        //   2. no auto-injected SKILL.md for spawn-only skills,
+        //   3. no MCP servers / hooks / prompts on the returned extras.
+        // Operators who need extras must either run with permissive mode
+        // or ship those declarations via a separately-trusted host
+        // config (`mcp_servers` + `hooks` on `Config`/`ProfileConfig`).
+        let mut extras = if require_signed {
+            if manifest.has_extras() || manifest.tools.iter().any(|t| t.spawn_only) {
+                warn!(
+                    plugin = %manifest.name,
+                    "dropping manifest extras + auto-SKILL.md under \
+                     `plugins.require_signed`: the digest does not cover them"
+                );
+            }
+            SkillExtras::default()
+        } else {
+            // Permissive mode: resolve extras the legacy way (MCP, hooks,
+            // SKILL.md auto-inject for spawn-only, prompt globs).
+            resolve_extras(&manifest, plugin_dir)
+        };
 
         // If no tools declared, skip executable search entirely.
         if manifest.tools.is_empty() {
@@ -1229,6 +1239,61 @@ mod tests {
             result.hooks.is_empty(),
             "unsigned hook extras must be dropped under strict signing; got: {:?}",
             result.hooks
+        );
+    }
+
+    /// Section B (codex review round-4 P2): under strict signing, a
+    /// signed spawn-only plugin's SKILL.md auto-injected prompt fragment
+    /// is ALSO dropped. The fragment lives outside the executable digest,
+    /// so it's not covered by `manifest.sha256` — and an unsigned edit to
+    /// SKILL.md would otherwise still slip into the agent system prompt.
+    #[cfg(unix)]
+    #[test]
+    fn require_signed_drops_auto_skill_md_for_spawn_only() {
+        use sha2::{Digest, Sha256};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("spawn-only-signed");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let exec_content = b"#!/bin/sh\necho ok";
+        let hash = format!("{:x}", Sha256::digest(exec_content));
+        let manifest = format!(
+            r#"{{
+                "name": "spawn-only-signed",
+                "version": "1.0",
+                "sha256": "{hash}",
+                "tools": [{{
+                    "name": "do_thing",
+                    "description": "d",
+                    "spawn_only": true
+                }}]
+            }}"#
+        );
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+        std::fs::write(plugin_dir.join("SKILL.md"), b"# UNSIGNED PROMPT").unwrap();
+        let exec_path = plugin_dir.join("spawn-only-signed");
+        std::fs::write(&exec_path, exec_content).unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result = PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(result.tool_count, 1);
+        assert!(
+            result.prompt_fragments.is_empty(),
+            "auto-SKILL.md must be dropped under strict signing; got: {:?}",
+            result.prompt_fragments
         );
     }
 

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -284,6 +284,11 @@ impl PluginLoader {
         let manifest_path = plugin_dir.join("manifest.json");
         let content = std::fs::read_to_string(&manifest_path)
             .map_err(|e| eyre::eyre!("no manifest.json: {e}"))?;
+        // Section C (codex review round-5 P1.1): compute manifest digest at
+        // load time so the pre-spawn re-hash gate can detect manifest
+        // tampering between load and invocation. Strict mode propagates
+        // this hash to `PluginTool` below; permissive mode discards it.
+        let manifest_load_hash = format!("{:x}", Sha256::digest(content.as_bytes()));
         let manifest: PluginManifest = serde_json::from_str(&content)
             .map_err(|e| eyre::eyre!("invalid manifest.json: {e}"))?;
 
@@ -550,6 +555,16 @@ impl PluginLoader {
                 // unconditionally (`require_signed` propagated to the tool).
                 if manifest.sha256.is_some() || require_signed {
                     tool = tool.with_verified_sha256(load_time_hash.clone(), require_signed);
+                }
+                // Section C (codex review round-5 P1.1): also stash the
+                // manifest digest under strict mode so a runtime manifest
+                // swap (changing `risk`, `env`, schemas) is detected at
+                // the pre-spawn gate.
+                if require_signed {
+                    tool = tool.with_manifest_sha256(
+                        manifest_load_hash.clone(),
+                        manifest_path.clone(),
+                    );
                 }
                 if let Some(dir) = work_dir {
                     tool = tool.with_work_dir(dir.to_path_buf());
@@ -1446,6 +1461,59 @@ mod tests {
         assert!(
             result.output.contains("hash mismatch"),
             "refusal message must explain the cause; got: {}",
+            result.output
+        );
+    }
+
+    /// Section C (codex review round-5 P1.1): under strict signing, a
+    /// manifest tampered with between load and invocation is detected by
+    /// the pre-spawn gate. We swap the manifest.json bytes on disk
+    /// AFTER `load_into` returns and assert the next `execute()` refuses.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pre_spawn_rehash_detects_manifest_swap_under_strict() {
+        use sha2::{Digest, Sha256};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("manifest-swap");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let exec_content = b"#!/bin/sh\necho '{\"output\":\"ok\",\"success\":true}'";
+        let hash = format!("{:x}", Sha256::digest(exec_content));
+        let manifest = format!(
+            r#"{{"name": "manifest-swap", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "ms_tool", "description": "d"}}]}}"#
+        );
+        std::fs::write(plugin_dir.join("manifest.json"), &manifest).unwrap();
+        let exec_path = plugin_dir.join("manifest-swap");
+        std::fs::write(&exec_path, exec_content).unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: true,
+            },
+        )
+        .unwrap();
+
+        // Swap manifest.json on disk to a different value. Note: we keep
+        // the same `name` so registry lookup still works, but altered
+        // `version` ensures the bytes differ.
+        let tampered = manifest.replace("\"version\": \"1.0\"", "\"version\": \"99.9\"");
+        std::fs::write(plugin_dir.join("manifest.json"), tampered).unwrap();
+
+        let tool = registry.get("ms_tool").expect("tool registered");
+        let result = tool.execute(&serde_json::json!({})).await.unwrap();
+        assert!(!result.success, "tampered manifest must not succeed");
+        assert!(
+            result.output.contains("manifest.json hash mismatch"),
+            "refusal message must call out the manifest mismatch; got: {}",
             result.output
         );
     }

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -290,13 +290,30 @@ impl PluginLoader {
         // Resolve extras (MCP servers, hooks, prompt fragments) regardless of tools.
         let extras = resolve_extras(&manifest, plugin_dir);
 
+        // Section B (codex review P1.2 + follow-up): under strict signing,
+        // REJECT any extras-only manifest before we let it install MCP
+        // servers / hooks / prompts. The `manifest.sha256` field's semantics
+        // currently anchor the executable bytes — there is no canonical hash
+        // input for extras-only skills, and even a manifest that declares a
+        // non-empty `sha256` would never see those bytes hashed below
+        // because of the `tools.is_empty()` early return. Under strict mode
+        // we refuse to mint trust for that code path entirely; the operator
+        // can split executable + extras into separate skills if they need a
+        // verifiable extras-only payload (future work).
+        if require_signed && manifest.tools.is_empty() && manifest.has_extras() {
+            eyre::bail!(
+                "plugin '{}' rejected: `plugins.require_signed` is enabled \
+                 and extras-only skills (no tools) cannot anchor a verifiable \
+                 hash. Split the executable + extras into separate skills.",
+                manifest.name,
+            );
+        }
         // Section B (codex review P1.2): under strict signing, REJECT any
-        // unsigned skill — including extras-only ones. MCP server commands
-        // and lifecycle hooks resolved from `manifest.json` introduce
-        // executable code paths the operator did not authorize via a hash.
-        // The check must run before the `tools.is_empty()` early-return
-        // below; otherwise an extras-only skill would slip past strict
-        // mode entirely.
+        // unsigned skill that declares tools. MCP server commands and
+        // lifecycle hooks resolved from `manifest.json` introduce executable
+        // code paths the operator did not authorize via a hash. The check
+        // runs BEFORE the executable search so we never read or write any
+        // bytes for an unsigned plugin under strict mode.
         if require_signed && manifest.sha256.is_none() {
             eyre::bail!(
                 "plugin '{}' rejected: `plugins.require_signed` is enabled \
@@ -1081,6 +1098,87 @@ mod tests {
         assert_eq!(
             result.tool_count, 1,
             "signed plugin must still load under require_signed"
+        );
+    }
+
+    /// Section B (codex review follow-up): under strict signing, an
+    /// extras-only skill (no tools, but with MCP servers / hooks / prompts)
+    /// is rejected because the `manifest.sha256` field can never anchor a
+    /// hash check for its executable extras — the load path otherwise
+    /// returns extras unconditionally on `tools.is_empty()`.
+    #[test]
+    fn require_signed_rejects_extras_only_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("extras-only");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        // Extras-only manifest: declares an MCP server but NO tools, and
+        // even claims a fake `sha256`. Under strict mode we must reject
+        // because hashing the executable bytes never happens for skills
+        // with no tools.
+        let manifest = r#"{
+            "name": "extras-only",
+            "version": "1.0",
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+            "mcp_servers": [{
+                "command": "/bin/echo",
+                "args": ["mcp"]
+            }],
+            "tools": []
+        }"#;
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result = PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            result.tool_count, 0,
+            "extras-only skill must be rejected under require_signed"
+        );
+        assert!(
+            result.mcp_servers.is_empty(),
+            "rejected skill's MCP servers must not be installed; got: {:?}",
+            result.mcp_servers
+        );
+    }
+
+    /// Section B (codex review follow-up): under permissive mode, an
+    /// extras-only skill still loads its extras as it always did — this
+    /// is a backward-compatibility check.
+    #[test]
+    fn require_signed_off_keeps_extras_only_skill_loading() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("extras-only-legacy");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let manifest = r#"{
+            "name": "extras-only-legacy",
+            "version": "1.0",
+            "mcp_servers": [{
+                "command": "/bin/echo",
+                "args": ["mcp"]
+            }],
+            "tools": []
+        }"#;
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result =
+            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+        assert_eq!(result.tool_count, 0, "extras-only skill registers no tools");
+        assert_eq!(
+            result.mcp_servers.len(),
+            1,
+            "extras-only skill must surface its MCP server under permissive mode"
         );
     }
 

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -290,6 +290,21 @@ impl PluginLoader {
         // Resolve extras (MCP servers, hooks, prompt fragments) regardless of tools.
         let extras = resolve_extras(&manifest, plugin_dir);
 
+        // Section B (codex review P1.2): under strict signing, REJECT any
+        // unsigned skill — including extras-only ones. MCP server commands
+        // and lifecycle hooks resolved from `manifest.json` introduce
+        // executable code paths the operator did not authorize via a hash.
+        // The check must run before the `tools.is_empty()` early-return
+        // below; otherwise an extras-only skill would slip past strict
+        // mode entirely.
+        if require_signed && manifest.sha256.is_none() {
+            eyre::bail!(
+                "plugin '{}' rejected: `plugins.require_signed` is enabled \
+                 and manifest.json has no `sha256` field",
+                manifest.name,
+            );
+        }
+
         // If no tools declared, skip executable search entirely.
         if manifest.tools.is_empty() {
             if manifest.has_extras() {
@@ -475,15 +490,19 @@ impl PluginLoader {
                 let mut tool = PluginTool::new(plugin_name.clone(), def, verified_exe.clone())
                     .with_blocked_env(blocked_env.clone())
                     .with_extra_env(extra_env.to_vec())
-                    .with_timeout(timeout)
-                    // Section C: stash the load-time hash so the pre-spawn
-                    // re-hash gate in `tool::execute` can detect a TOCTOU
-                    // swap between load and invocation. The gate fires
-                    // unconditionally under `require_signed`; otherwise it
-                    // fires only when a manifest hash was declared (and
-                    // therefore the operator has signaled they care about
-                    // integrity for this plugin).
-                    .with_verified_sha256(load_time_hash.clone(), require_signed);
+                    .with_timeout(timeout);
+                // Section C (codex review P2): stash the load-time hash ONLY
+                // when the operator opted into integrity for this plugin —
+                // either the manifest declared `sha256` (the author signaled
+                // care) OR `require_signed = true` (the host signaled care).
+                // For legacy unsigned plugins under permissive mode we skip
+                // the rehash gate entirely so we don't add a full executable
+                // read to every invocation and so the verified-copy refresh
+                // path stays cheap. Under strict mode the rehash gate fires
+                // unconditionally (`require_signed` propagated to the tool).
+                if manifest.sha256.is_some() || require_signed {
+                    tool = tool.with_verified_sha256(load_time_hash.clone(), require_signed);
+                }
                 if let Some(dir) = work_dir {
                     tool = tool.with_work_dir(dir.to_path_buf());
                 }

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -287,19 +287,15 @@ impl PluginLoader {
         let manifest: PluginManifest = serde_json::from_str(&content)
             .map_err(|e| eyre::eyre!("invalid manifest.json: {e}"))?;
 
-        // Resolve extras (MCP servers, hooks, prompt fragments) regardless of tools.
-        let extras = resolve_extras(&manifest, plugin_dir);
-
         // Section B (codex review P1.2 + follow-up): under strict signing,
-        // REJECT any extras-only manifest before we let it install MCP
-        // servers / hooks / prompts. The `manifest.sha256` field's semantics
-        // currently anchor the executable bytes — there is no canonical hash
-        // input for extras-only skills, and even a manifest that declares a
-        // non-empty `sha256` would never see those bytes hashed below
-        // because of the `tools.is_empty()` early return. Under strict mode
-        // we refuse to mint trust for that code path entirely; the operator
-        // can split executable + extras into separate skills if they need a
-        // verifiable extras-only payload (future work).
+        // REJECT any extras-only manifest before we resolve extras or
+        // install anything. The `manifest.sha256` field anchors executable
+        // bytes — there is no canonical hash input for an extras-only
+        // skill, and a manifest with empty `tools` would never see those
+        // bytes hashed below because of the `tools.is_empty()` early
+        // return. Under strict mode we refuse to mint trust for that code
+        // path entirely; the operator must split executable + extras into
+        // separate skills if they need a verifiable extras-only payload.
         if require_signed && manifest.tools.is_empty() && manifest.has_extras() {
             eyre::bail!(
                 "plugin '{}' rejected: `plugins.require_signed` is enabled \
@@ -309,7 +305,7 @@ impl PluginLoader {
             );
         }
         // Section B (codex review P1.2): under strict signing, REJECT any
-        // unsigned skill that declares tools. MCP server commands and
+        // tools-bearing skill that omits `sha256`. MCP server commands and
         // lifecycle hooks resolved from `manifest.json` introduce executable
         // code paths the operator did not authorize via a hash. The check
         // runs BEFORE the executable search so we never read or write any
@@ -320,6 +316,31 @@ impl PluginLoader {
                  and manifest.json has no `sha256` field",
                 manifest.name,
             );
+        }
+
+        // Resolve extras (MCP servers, hooks, prompt fragments) regardless of tools.
+        let mut extras = resolve_extras(&manifest, plugin_dir);
+
+        // Section B (codex review round-3): under strict signing, the
+        // current `manifest.sha256` semantics anchor only the executable
+        // bytes — manifest-side declarations (MCP servers, lifecycle
+        // hooks, prompt fragments) are NOT covered by the digest. A
+        // malicious patcher could edit `manifest.json` to add executable
+        // extras without invalidating the executable hash; the strict
+        // policy must refuse to mint trust for that code path until the
+        // signed material covers the manifest too. We therefore DROP
+        // extras for every tools-bearing skill that goes through the
+        // strict path. Operators who depend on extras must either run
+        // with permissive mode or ship those declarations via a
+        // separately-trusted host config (`mcp_servers` + `hooks` on
+        // `Config`/`ProfileConfig`).
+        if require_signed && manifest.has_extras() {
+            warn!(
+                plugin = %manifest.name,
+                "dropping manifest extras (MCP servers / hooks / prompts) under \
+                 `plugins.require_signed`: the digest does not cover them"
+            );
+            extras = SkillExtras::default();
         }
 
         // If no tools declared, skip executable search entirely.
@@ -539,7 +560,6 @@ impl PluginLoader {
             .collect();
 
         // Return extras with spawn_only info
-        let mut extras = extras;
         extras.spawn_only_tools = spawn_only_names;
         extras.spawn_only_messages = spawn_only_msgs;
 
@@ -1148,6 +1168,110 @@ mod tests {
             result.mcp_servers.is_empty(),
             "rejected skill's MCP servers must not be installed; got: {:?}",
             result.mcp_servers
+        );
+    }
+
+    /// Section B (codex review round-3): under strict signing, a
+    /// tools-bearing skill that ALSO declares MCP servers / hooks /
+    /// prompts in its manifest loads ONLY its tools — the unsigned
+    /// extras are dropped because `manifest.sha256` does not cover the
+    /// manifest itself. This prevents a manifest-only patch from
+    /// installing executable extras while keeping the executable hash
+    /// matching.
+    #[cfg(unix)]
+    #[test]
+    fn require_signed_drops_extras_on_mixed_signed_manifest() {
+        use sha2::{Digest, Sha256};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("mixed-signed");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let exec_content = b"#!/bin/sh\necho ok";
+        let hash = format!("{:x}", Sha256::digest(exec_content));
+        let manifest = format!(
+            r#"{{
+                "name": "mixed-signed",
+                "version": "1.0",
+                "sha256": "{hash}",
+                "mcp_servers": [{{
+                    "command": "/bin/echo",
+                    "args": ["unauthorized"]
+                }}],
+                "tools": [{{"name": "t", "description": "d"}}]
+            }}"#
+        );
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+        let exec_path = plugin_dir.join("mixed-signed");
+        std::fs::write(&exec_path, exec_content).unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result = PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(result.tool_count, 1, "signed tool still registers");
+        assert!(
+            result.mcp_servers.is_empty(),
+            "unsigned MCP extras must be dropped under strict signing; got: {:?}",
+            result.mcp_servers
+        );
+        assert!(
+            result.hooks.is_empty(),
+            "unsigned hook extras must be dropped under strict signing; got: {:?}",
+            result.hooks
+        );
+    }
+
+    /// Section B (codex review round-3): under permissive mode, the same
+    /// mixed manifest installs both the tool AND the extras (legacy
+    /// behaviour — no regression).
+    #[cfg(unix)]
+    #[test]
+    fn require_signed_off_keeps_mixed_extras_on_signed_manifest() {
+        use sha2::{Digest, Sha256};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("mixed-permissive");
+        std::fs::create_dir(&plugin_dir).unwrap();
+
+        let exec_content = b"#!/bin/sh\necho ok";
+        let hash = format!("{:x}", Sha256::digest(exec_content));
+        let manifest = format!(
+            r#"{{
+                "name": "mixed-permissive",
+                "version": "1.0",
+                "sha256": "{hash}",
+                "mcp_servers": [{{
+                    "command": "/bin/echo",
+                    "args": ["legacy-mcp"]
+                }}],
+                "tools": [{{"name": "t2", "description": "d"}}]
+            }}"#
+        );
+        std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
+        let exec_path = plugin_dir.join("mixed-permissive");
+        std::fs::write(&exec_path, exec_content).unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut registry = ToolRegistry::new();
+        let result =
+            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+        assert_eq!(result.tool_count, 1);
+        assert_eq!(
+            result.mcp_servers.len(),
+            1,
+            "permissive mode preserves extras for backward compat"
         );
     }
 

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -98,6 +98,19 @@ pub struct PluginTool {
     /// swapped between load and exec (closes the load→exec TOCTOU window).
     /// `None` when no hash was computed (legacy code paths).
     verified_exe_sha256: Option<String>,
+    /// Section C (codex review round-5 P1.1): SHA-256 (lowercase hex) of
+    /// the manifest.json bytes computed at load time. Under strict
+    /// signing this acts as a "load-time tamper anchor" — manifest
+    /// declarations (`risk`, `env`, tool schemas) are NOT covered by
+    /// `manifest.sha256`, so we hash the manifest separately at load
+    /// time and re-check on every invocation. A mismatch catches runtime
+    /// tampering of the manifest after the runtime started. Tampering
+    /// BEFORE the loader runs remains an operator responsibility
+    /// (filesystem integrity tooling).
+    manifest_sha256: Option<String>,
+    /// Section C: the resolved manifest.json path so the pre-spawn
+    /// re-hash gate can rehash it. Set alongside `manifest_sha256`.
+    manifest_path: Option<PathBuf>,
     /// Section C: when `true`, the pre-spawn re-hash gate ALWAYS fires (and
     /// `verified_exe_sha256` must be `Some`). When `false`, the gate is
     /// skipped on unverified plugins to keep the legacy path cheap.
@@ -119,6 +132,8 @@ impl PluginTool {
             timeout: Self::DEFAULT_TIMEOUT,
             synthesis_config: None,
             verified_exe_sha256: None,
+            manifest_sha256: None,
+            manifest_path: None,
             require_signed: false,
         }
     }
@@ -131,6 +146,18 @@ impl PluginTool {
     pub fn with_verified_sha256(mut self, hash: String, require_signed: bool) -> Self {
         self.verified_exe_sha256 = Some(hash);
         self.require_signed = require_signed;
+        self
+    }
+
+    /// Section C (codex review round-5 P1.1): attach the load-time
+    /// SHA-256 of the manifest.json bytes. Only consulted under
+    /// `require_signed`. A mismatch at invocation refuses to spawn —
+    /// catches manifest tampering between load and invocation (which
+    /// could otherwise reduce `risk`, expand `env`, or alter tool
+    /// schemas without invalidating the executable hash).
+    pub fn with_manifest_sha256(mut self, hash: String, manifest_path: PathBuf) -> Self {
+        self.manifest_sha256 = Some(hash);
+        self.manifest_path = Some(manifest_path);
         self
     }
 
@@ -176,6 +203,103 @@ impl PluginTool {
         Ok(format!("{:x}", Sha256::digest(&bytes)))
     }
 
+    /// Section C (codex review round-5 P2 + P1.1): single source of truth
+    /// for the pre-spawn re-hash gate. Returns `Some(ToolResult)` when
+    /// the gate refuses (executable mismatch / manifest mismatch /
+    /// missing hash under strict mode / I/O error); `None` when the
+    /// gate passes or is intentionally skipped.
+    ///
+    /// Called twice in `execute()`: once before the approval round-trip
+    /// (so a tampered-at-load binary or manifest is detected
+    /// immediately) and once immediately before `cmd.spawn()` (so the
+    /// approval delay window cannot be used to swap either file).
+    fn check_verified_exe_hash(&self) -> Option<ToolResult> {
+        // Executable check.
+        if let Some(expected) = &self.verified_exe_sha256 {
+            match Self::rehash_verified_exe(&self.executable) {
+                Ok(actual) if actual == *expected => {
+                    tracing::debug!(
+                        plugin = %self.plugin_name,
+                        tool = %self.tool_def.name,
+                        "pre-spawn re-hash matched"
+                    );
+                }
+                Ok(actual) => {
+                    return Some(ToolResult {
+                        output: format!(
+                            "Plugin '{}' refused to spawn: verified executable hash mismatch \
+                             (expected {expected}, got {actual}). The on-disk binary changed \
+                             between load and invocation.",
+                            self.plugin_name
+                        ),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+                Err(err) => {
+                    return Some(ToolResult {
+                        output: format!(
+                            "Plugin '{}' refused to spawn: failed to re-hash verified executable: {err}",
+                            self.plugin_name
+                        ),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            }
+        } else if self.require_signed {
+            // Fail closed: strict policy is on but the load-time hash was
+            // never recorded. This indicates a wiring bug — never let an
+            // unhashed plugin invoke under `require_signed = true`.
+            return Some(ToolResult {
+                output: format!(
+                    "Plugin '{}' refused to spawn: `plugins.require_signed` is enabled but \
+                     no load-time hash was recorded for this tool (internal wiring error).",
+                    self.plugin_name
+                ),
+                success: false,
+                ..Default::default()
+            });
+        }
+
+        // Section C (codex review round-5 P1.1): manifest check. Under
+        // strict signing, we hashed manifest.json at load time and
+        // stored the digest. A mismatch now means the manifest was
+        // tampered with between load and invocation — refuse to spawn
+        // because `manifest.tools[].risk` / `env` / schemas may have
+        // been altered to bypass the approval gate or to widen the env
+        // allowlist.
+        if let (Some(expected), Some(path)) = (&self.manifest_sha256, &self.manifest_path) {
+            match Self::rehash_verified_exe(path) {
+                Ok(actual) if actual == *expected => {}
+                Ok(actual) => {
+                    return Some(ToolResult {
+                        output: format!(
+                            "Plugin '{}' refused to spawn: manifest.json hash mismatch \
+                             (expected {expected}, got {actual}). The manifest changed \
+                             between load and invocation.",
+                            self.plugin_name
+                        ),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+                Err(err) => {
+                    return Some(ToolResult {
+                        output: format!(
+                            "Plugin '{}' refused to spawn: failed to re-hash manifest.json: {err}",
+                            self.plugin_name
+                        ),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
     /// Create a copy of this plugin tool with a different work directory.
     /// Used to give each user session its own workspace for plugin output.
     pub fn clone_with_work_dir(&self, work_dir: PathBuf) -> Self {
@@ -189,6 +313,8 @@ impl PluginTool {
             timeout: self.timeout,
             synthesis_config: self.synthesis_config.clone(),
             verified_exe_sha256: self.verified_exe_sha256.clone(),
+            manifest_sha256: self.manifest_sha256.clone(),
+            manifest_path: self.manifest_path.clone(),
             require_signed: self.require_signed,
         }
     }
@@ -926,53 +1052,13 @@ impl Tool for PluginTool {
         // `require_signed = false`) the gate is skipped so the legacy
         // unverified path stays cheap. Under `require_signed = true` the
         // loader guarantees `verified_exe_sha256` is populated for every
-        // tool that reached the registry — the assertion below is a
-        // belt-and-braces hard error if something slipped past it.
-        if let Some(expected) = &self.verified_exe_sha256 {
-            match Self::rehash_verified_exe(&self.executable) {
-                Ok(actual) if actual == *expected => {
-                    tracing::debug!(
-                        plugin = %self.plugin_name,
-                        tool = %self.tool_def.name,
-                        "pre-spawn re-hash matched"
-                    );
-                }
-                Ok(actual) => {
-                    return Ok(ToolResult {
-                        output: format!(
-                            "Plugin '{}' refused to spawn: verified executable hash mismatch \
-                             (expected {expected}, got {actual}). The on-disk binary changed \
-                             between load and invocation.",
-                            self.plugin_name
-                        ),
-                        success: false,
-                        ..Default::default()
-                    });
-                }
-                Err(err) => {
-                    return Ok(ToolResult {
-                        output: format!(
-                            "Plugin '{}' refused to spawn: failed to re-hash verified executable: {err}",
-                            self.plugin_name
-                        ),
-                        success: false,
-                        ..Default::default()
-                    });
-                }
-            }
-        } else if self.require_signed {
-            // Fail closed: strict policy is on but the load-time hash was
-            // never recorded. This indicates a wiring bug — never let an
-            // unhashed plugin invoke under `require_signed = true`.
-            return Ok(ToolResult {
-                output: format!(
-                    "Plugin '{}' refused to spawn: `plugins.require_signed` is enabled but \
-                     no load-time hash was recorded for this tool (internal wiring error).",
-                    self.plugin_name
-                ),
-                success: false,
-                ..Default::default()
-            });
+        // tool that reached the registry.
+        //
+        // First call: detect a tampered-at-load binary before we issue an
+        // approval prompt that the user might wait on for minutes. Cheap
+        // up-front rejection of obvious tampering.
+        if let Some(refusal) = self.check_verified_exe_hash() {
+            return Ok(refusal);
         }
 
         // M6 req 4: enforce manifest-declared `risk` field (UPCR-2026-001).
@@ -1132,6 +1218,16 @@ impl Tool for PluginTool {
         }
 
         let effective_args = self.prepare_effective_args(args, ctx.as_ref());
+
+        // Section C (codex review round-5 P2): RE-CHECK the verified-exe
+        // hash immediately before spawn. The approval round-trip above
+        // can take arbitrarily long; if the verified copy on disk was
+        // swapped while the user was being prompted, we must NOT spawn
+        // the swapped bytes. This second check closes the
+        // approval→spawn TOCTOU window.
+        if let Some(refusal) = self.check_verified_exe_hash() {
+            return Ok(refusal);
+        }
 
         let mut child = match cmd.spawn() {
             Ok(child) => child,

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -390,6 +390,10 @@ pub struct SpawnTool {
     plugin_dirs: Vec<PathBuf>,
     /// Extra environment variables for plugin processes.
     plugin_extra_env: Vec<(String, String)>,
+    /// Section B (codex review P1.1): inherit the parent's strict-signing
+    /// policy so subagents enforce the same integrity gate when loading
+    /// plugin tools. Defaults to `false` (legacy permissive path).
+    plugin_require_signed: bool,
     /// Additional per-child tools that cannot live in octos-agent builtins.
     child_tool_factories: Vec<ChildToolFactory>,
     /// Shared task supervisor so background subagents show up in task tracking.
@@ -451,6 +455,7 @@ impl SpawnTool {
             hook_context_template: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),
+            plugin_require_signed: false,
             child_tool_factories: Vec::new(),
             task_supervisor: None,
             session_key: None,
@@ -490,6 +495,7 @@ impl SpawnTool {
             hook_context_template: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),
+            plugin_require_signed: false,
             child_tool_factories: Vec::new(),
             task_supervisor: None,
             session_key: None,
@@ -556,6 +562,14 @@ impl SpawnTool {
     ) -> Self {
         self.plugin_dirs = dirs;
         self.plugin_extra_env = extra_env;
+        self
+    }
+
+    /// Section B (codex review P1.1): inherit the parent's strict-signing
+    /// policy. When `true`, subagent plugin loads honour the same
+    /// `plugins.require_signed` gate as the parent.
+    pub fn with_plugin_require_signed(mut self, require_signed: bool) -> Self {
+        self.plugin_require_signed = require_signed;
         self
     }
 
@@ -2135,12 +2149,19 @@ impl Tool for SpawnTool {
             // Sync mode: run subagent inline and return the result directly
             let mut tools = ToolRegistry::with_builtins(&self.working_dir);
             // Load plugin tools so subagents can use fm_tts, etc.
+            // Section B (codex review P1.1): honour the parent's
+            // require_signed policy so unsigned plugins are rejected here
+            // when strict mode is on.
             if !self.plugin_dirs.is_empty() {
-                let _ = crate::plugins::PluginLoader::load_into_with_work_dir(
+                let _ = crate::plugins::PluginLoader::load_into_with_options(
                     &mut tools,
                     &self.plugin_dirs,
                     &self.plugin_extra_env,
-                    Some(&self.working_dir),
+                    crate::plugins::PluginLoadOptions {
+                        work_dir: Some(&self.working_dir),
+                        synthesis_config: None,
+                        require_signed: self.plugin_require_signed,
+                    },
                 );
             }
             for factory in &self.child_tool_factories {
@@ -2318,6 +2339,7 @@ impl Tool for SpawnTool {
             let task_label = label.clone();
             let plugin_dirs = self.plugin_dirs.clone();
             let plugin_extra_env = self.plugin_extra_env.clone();
+            let plugin_require_signed = self.plugin_require_signed;
             let child_tool_factories = self.child_tool_factories.clone();
             let task_supervisor = self.task_supervisor.clone();
             let worker_config = self.worker_config.clone();
@@ -2441,12 +2463,18 @@ impl Tool for SpawnTool {
 
                 let mut tools = ToolRegistry::with_builtins(&working_dir);
                 // Load plugin tools so subagents can use fm_tts, etc.
+                // Section B (codex review P1.1): inherit the parent's
+                // require_signed gate.
                 if !plugin_dirs.is_empty() {
-                    let _ = crate::plugins::PluginLoader::load_into_with_work_dir(
+                    let _ = crate::plugins::PluginLoader::load_into_with_options(
                         &mut tools,
                         &plugin_dirs,
                         &plugin_extra_env,
-                        Some(&working_dir),
+                        crate::plugins::PluginLoadOptions {
+                            work_dir: Some(&working_dir),
+                            synthesis_config: None,
+                            require_signed: plugin_require_signed,
+                        },
                     );
                 }
                 for factory in &child_tool_factories {
@@ -3092,6 +3120,7 @@ mod tests {
             hook_context_template: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),
+            plugin_require_signed: false,
             child_tool_factories: Vec::new(),
             task_supervisor: None,
             session_key: None,

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -288,7 +288,10 @@ impl ChatCommand {
             }
         }
 
-        // Pipeline tool (DOT-based multi-step workflows, with plugin access)
+        // Pipeline tool (DOT-based multi-step workflows, with plugin access).
+        // Section B (codex review follow-up): propagate
+        // `plugins.require_signed` so pipeline workers enforce the same
+        // gate as the main session.
         let pipeline_tool = octos_pipeline::RunPipelineTool::new(
             llm.clone(),
             memory.clone(),
@@ -296,7 +299,8 @@ impl ChatCommand {
             data_dir.clone(),
         )
         .with_provider_policy(tools.provider_policy().cloned())
-        .with_plugin_dirs(plugin_dirs);
+        .with_plugin_dirs(plugin_dirs)
+        .with_plugin_require_signed(config.plugins.require_signed);
         tools.register(pipeline_tool);
         tools.mark_spawn_only(
             "run_pipeline",

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -258,11 +258,23 @@ impl ChatCommand {
             eprintln!("Bootstrapped {n} platform skills");
         }
 
-        // Load plugins (includes app-skills from .octos/skills/)
+        // Load plugins (includes app-skills from .octos/skills/).
+        // Section B (codex review P1.1): honour `plugins.require_signed`
+        // from the resolved Config so an operator who opts into strict
+        // signing has it enforced on `octos chat` too.
         let plugin_dirs = Config::plugin_dirs_from_project(&cwd.join(".octos"));
         let mut plugin_result = octos_agent::PluginLoadResult::default();
         if !plugin_dirs.is_empty() {
-            match octos_agent::PluginLoader::load_into(&mut tools, &plugin_dirs, &[]) {
+            match octos_agent::PluginLoader::load_into_with_options(
+                &mut tools,
+                &plugin_dirs,
+                &[],
+                octos_agent::PluginLoadOptions {
+                    work_dir: None,
+                    synthesis_config: None,
+                    require_signed: config.plugins.require_signed,
+                },
+            ) {
                 Ok(result) => plugin_result = result,
                 Err(e) => eprintln!("Warning: plugin loading failed: {e}"),
             }

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -166,7 +166,7 @@ impl GatewayRuntime {
             cmd.profile.as_deref().map(|p| p.display().to_string())
         );
         let mut admin_mode = false;
-        let config = if let Some(ref profile_path) = cmd.profile {
+        let mut config = if let Some(ref profile_path) = cmd.profile {
             // Load config from profile JSON (single source of truth)
             let content = std::fs::read_to_string(profile_path)
                 .wrap_err_with(|| format!("failed to read profile: {}", profile_path.display()))?;
@@ -216,6 +216,12 @@ impl GatewayRuntime {
         } else {
             Config::load(&cwd, &data_dir)?
         };
+        // Section B (codex review round-5 P1.2): the `--profile` path
+        // bypasses `Config::from_file`, so call the same env-var OR-merge
+        // helper here. A host-level `plugins.require_signed = true`
+        // propagates to spawned gateways via
+        // `OCTOS_PLUGINS_REQUIRE_SIGNED=1` (set by `ProcessManager`).
+        crate::config::merge_env_plugin_policy_pub(&mut config);
 
         // Track whether any CLI override (`--model`, `--provider`,
         // `--base-url`) was supplied; `ProfileRuntime::bootstrap` is
@@ -289,10 +295,20 @@ impl GatewayRuntime {
         let profile_runtime: Option<Arc<ProfileRuntime>> = if let Some(profile) =
             resolved_profile.as_ref().filter(|_| !cli_llm_override)
         {
-            // Section B (codex review round-3): thread the host's
-            // `plugins.require_signed` into the per-profile bootstrap so
-            // strict signing applies even when the profile JSON omits
-            // the flag.
+            // Section B (codex review round-3 + round-5 P1.2): thread the
+            // host's `plugins.require_signed` into the per-profile
+            // bootstrap so strict signing applies even when the profile
+            // JSON omits the flag.
+            //
+            // In the `--profile` managed path `config` is derived from the
+            // profile JSON, so `config.plugins.require_signed` mirrors
+            // whatever the profile declared. The host-level policy
+            // reaches this branch via `OCTOS_PLUGINS_REQUIRE_SIGNED`
+            // (set by `ProcessManager` in `octos serve`), which
+            // `Config::from_file` already OR-merges onto `config.plugins`
+            // for the `--config` path. We forward `config.plugins` here
+            // and `bootstrap_with_host_plugins` then OR-merges it onto
+            // the profile-derived config, closing the loop.
             match ProfileRuntime::bootstrap_with_host_plugins(
                 profile,
                 &data_dir,

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1175,6 +1175,10 @@ impl GatewayRuntime {
             memory_store: Some(memory_store.clone()),
             plugin_dirs: plugin_dirs_for_spawn.clone(),
             plugin_extra_env: plugin_env.clone(),
+            // Section B (codex review P1.1): propagate the host
+            // strict-signing policy so SpawnTool subagents enforce the
+            // same gate.
+            plugin_require_signed: config.plugins.require_signed,
             llm_strong: super::profile_factory::build_strong_chain(&config, &provider_name, false)
                 .unwrap_or_else(|_| llm_for_compaction.clone()),
             task_query_store: task_query_store.clone(),

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1227,6 +1227,10 @@ impl GatewayRuntime {
                     sandbox_config: sandbox_config.clone(),
                     task_query_store: task_query_store.clone(),
                     subagent_output_router: subagent_output_router.clone(),
+                    // Section B (codex review round-4): clone the host's
+                    // plugin policy so child profiles inherit the
+                    // strict-signing gate even when their JSON omits it.
+                    host_plugins: config.plugins.clone(),
                 });
 
         // Start config watcher for hot-reload

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -289,11 +289,16 @@ impl GatewayRuntime {
         let profile_runtime: Option<Arc<ProfileRuntime>> = if let Some(profile) =
             resolved_profile.as_ref().filter(|_| !cli_llm_override)
         {
-            match ProfileRuntime::bootstrap(
+            // Section B (codex review round-3): thread the host's
+            // `plugins.require_signed` into the per-profile bootstrap so
+            // strict signing applies even when the profile JSON omits
+            // the flag.
+            match ProfileRuntime::bootstrap_with_host_plugins(
                 profile,
                 &data_dir,
                 Some(&effective_octos_home),
                 crate::runtime::BootstrapRole::Gateway,
+                Some(&config.plugins),
             )
             .await
             {

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -902,6 +902,10 @@ impl GatewayRuntime {
                 let plugins_c = plugin_dirs_for_spawn.clone();
                 let router_c = provider_router.clone();
                 let octos_home_c = cmd.octos_home.clone();
+                // Section B (codex review follow-up): capture the host's
+                // strict-signing flag so per-session `RunPipelineTool`
+                // instances honour the same `plugins.require_signed` gate.
+                let plugin_require_signed_c = config.plugins.require_signed;
 
                 struct DefaultPipelineToolFactory {
                     llm: Arc<dyn LlmProvider>,
@@ -912,6 +916,7 @@ impl GatewayRuntime {
                     plugin_dirs: Vec<PathBuf>,
                     router: Option<Arc<ProviderRouter>>,
                     octos_home: Option<PathBuf>,
+                    plugin_require_signed: bool,
                 }
 
                 impl crate::session_actor::PipelineToolFactory for DefaultPipelineToolFactory {
@@ -923,7 +928,8 @@ impl GatewayRuntime {
                             self.data_dir.clone(),
                         )
                         .with_provider_policy(self.policy.clone())
-                        .with_plugin_dirs(self.plugin_dirs.clone());
+                        .with_plugin_dirs(self.plugin_dirs.clone())
+                        .with_plugin_require_signed(self.plugin_require_signed);
                         if let Some(ref router) = self.router {
                             pt = pt.with_provider_router(router.clone());
                         }
@@ -943,6 +949,7 @@ impl GatewayRuntime {
                     plugin_dirs: plugins_c,
                     router: router_c,
                     octos_home: octos_home_c,
+                    plugin_require_signed: plugin_require_signed_c,
                 })
                     as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
             }

--- a/crates/octos-cli/src/commands/gateway/mod.rs
+++ b/crates/octos-cli/src/commands/gateway/mod.rs
@@ -272,6 +272,7 @@ mod tests {
             plugin_prompt_fragments: vec![],
             no_retry: false,
             sandbox_config: octos_agent::SandboxConfig::default(),
+            host_plugins: Default::default(),
         };
 
         let factory = builder.build("botfather--researcher").await.unwrap();

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -794,6 +794,7 @@ impl ProfileActorFactoryBuilder {
                 plugin_dirs: Vec<PathBuf>,
                 router: Option<Arc<ProviderRouter>>,
                 octos_home: PathBuf,
+                plugin_require_signed: bool,
             }
 
             impl crate::session_actor::PipelineToolFactory for ChildPipelineToolFactory {
@@ -806,6 +807,7 @@ impl ProfileActorFactoryBuilder {
                     )
                     .with_provider_policy(self.policy.clone())
                     .with_plugin_dirs(self.plugin_dirs.clone())
+                    .with_plugin_require_signed(self.plugin_require_signed)
                     .with_octos_home(self.octos_home.clone());
                     if let Some(ref router) = self.router {
                         pt = pt.with_provider_router(router.clone());
@@ -822,6 +824,9 @@ impl ProfileActorFactoryBuilder {
                 plugin_dirs: plugin_dirs.clone(),
                 router: provider_router.clone(),
                 octos_home: self.project_dir.clone(),
+                // Section B (codex review follow-up): propagate the
+                // profile's strict-signing policy.
+                plugin_require_signed: profile_config.plugins.require_signed,
             })
                 as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
 

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -886,6 +886,10 @@ impl ProfileActorFactoryBuilder {
             memory_store: Some(self.memory_store.clone()),
             plugin_dirs: actor_plugin_dirs,
             plugin_extra_env: actor_plugin_env,
+            // Section B (codex review P1.1): propagate the profile's
+            // strict-signing policy to SpawnTool subagents so unsigned
+            // plugins are also rejected under spawn.
+            plugin_require_signed: profile_config.plugins.require_signed,
             llm_strong,
             task_query_store: self.task_query_store.clone(),
             subagent_output_router: self.subagent_output_router.clone(),

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -506,6 +506,11 @@ pub(super) struct ProfileActorFactoryBuilder {
     /// M8 fix-first item 8 (gap 2): shared SubAgentOutputRouter cloned
     /// into every ActorFactory built by this builder.
     pub(super) subagent_output_router: Arc<octos_agent::SubAgentOutputRouter>,
+    /// Section B (codex review round-4): host-level plugin policy, OR'd
+    /// with the profile's own `plugins.require_signed` so a host config
+    /// can mandate strict signing even when individual profile JSONs omit
+    /// the flag. Mirrors `ProfileRuntime::bootstrap_with_host_plugins`.
+    pub(super) host_plugins: crate::config::PluginsConfig,
 }
 
 impl ProfileActorFactoryBuilder {
@@ -516,7 +521,15 @@ impl ProfileActorFactoryBuilder {
             .ok_or_else(|| eyre::eyre!("target profile '{profile_id}' not found"))?;
         let effective_profile =
             crate::profiles::resolve_effective_profile(&self.profile_store, &profile)?;
-        let profile_config = crate::profiles::config_from_profile(&effective_profile, None, None);
+        let mut profile_config =
+            crate::profiles::config_from_profile(&effective_profile, None, None);
+        // Section B (codex review round-4): OR-merge the host's
+        // `plugins.require_signed` onto the profile-derived flag so a
+        // child profile that omits the new `plugins` block still honours
+        // the host-level strict-signing policy.
+        if self.host_plugins.require_signed {
+            profile_config.plugins.require_signed = true;
+        }
         let (llm, provider_name, adaptive_router, llm_strong) =
             build_llm_stack(&profile_config, self.no_retry)?;
         let llm_for_compaction = llm.clone();

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -406,11 +406,16 @@ impl ServeCommand {
                 continue;
             }
             let profile_data_dir = profile_store.resolve_data_dir(profile);
-            match crate::runtime::ProfileRuntime::bootstrap(
+            // Section B (codex review round-3): thread the host's
+            // strict-signing policy so the per-profile plugin load honors
+            // `plugins.require_signed = true` from the top-level config
+            // even when individual profile JSONs omit the field.
+            match crate::runtime::ProfileRuntime::bootstrap_with_host_plugins(
                 profile,
                 &profile_data_dir,
                 Some(&data_dir),
                 crate::runtime::BootstrapRole::Serve,
+                Some(&config.plugins),
             )
             .await
             {

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -447,7 +447,12 @@ impl ServeCommand {
         let process_manager = Arc::new(
             crate::process_manager::ProcessManager::new(profile_store.clone())
                 .with_bridge_js(bridge_js_path)
-                .with_serve_config(self.port, auth_token.clone()),
+                .with_serve_config(self.port, auth_token.clone())
+                // Section B (codex review round-5 P1.2): every spawned
+                // gateway inherits the host's strict-signing policy via
+                // an env var. `Config::from_file` OR-merges it onto the
+                // gateway's effective `plugins.require_signed`.
+                .with_host_plugins_require_signed(config.plugins.require_signed),
         );
         process_manager.set_self_ref();
 

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -785,6 +785,27 @@ impl Config {
     }
 }
 
+/// Section B (codex review round-5 P1.2): OR-merge
+/// `OCTOS_PLUGINS_REQUIRE_SIGNED` (set by `ProcessManager` when the parent
+/// serve enabled strict signing) onto the loaded Config. Spawned gateway
+/// processes pick up the policy via env, even when the profile JSON they
+/// load omits the new `plugins` block.
+pub(crate) fn merge_env_plugin_policy_pub(config: &mut Config) {
+    merge_env_plugin_policy(config)
+}
+
+fn merge_env_plugin_policy(config: &mut Config) {
+    if let Ok(v) = std::env::var("OCTOS_PLUGINS_REQUIRE_SIGNED") {
+        let on = matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        );
+        if on {
+            config.plugins.require_signed = true;
+        }
+    }
+}
+
 /// One-shot warning when `~/.octos/skills` still exists on disk after we
 /// stopped scanning it. Emitted at most once per process so operators see
 /// a single migration hint rather than spamming every profile bootstrap.
@@ -1006,9 +1027,13 @@ impl Config {
             }
         }
 
-        // No config found, use defaults
+        // No config found, use defaults. Even on the no-file path, honour
+        // `OCTOS_PLUGINS_REQUIRE_SIGNED` so spawned gateways without a
+        // config.json still inherit the host's strict-signing policy.
         tracing::info!("no config.json found, using defaults");
-        Ok((Self::default(), None))
+        let mut config = Self::default();
+        merge_env_plugin_policy(&mut config);
+        Ok((config, None))
     }
 
     /// Load config from a specific file.
@@ -1027,6 +1052,14 @@ impl Config {
 
         // Expand environment variables in config values
         config.expand_env_vars();
+
+        // Section B (codex review round-5 P1.2): the host's
+        // `plugins.require_signed` policy must reach spawned gateway
+        // processes too. `ProcessManager` sets `OCTOS_PLUGINS_REQUIRE_SIGNED=1`
+        // when the parent serve was launched with strict signing; we
+        // OR-merge that into every Config so a profile JSON that omits
+        // the new block still inherits the strict policy.
+        merge_env_plugin_policy(&mut config);
 
         // Log if migration changed something (don't silently rewrite user's config)
         if migrated {

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -209,6 +209,17 @@ pub struct Config {
 /// introduced. Set `require_signed = true` to enforce strict signature
 /// verification — plugins without `manifest.sha256` will be rejected at
 /// load time and re-hash gates apply on every invocation.
+///
+/// # Bundled / first-party skills caveat
+///
+/// First-party skills shipped under `crates/app-skills/*/manifest.json` and
+/// `crates/platform-skills/*/manifest.json` currently do NOT declare
+/// `sha256`. Enabling `require_signed = true` on a clean install will
+/// therefore drop those tools (deep-search, weather, send-email, voice,
+/// etc.) until the manifests are populated with the binaries' digests as
+/// part of the release process. Production deployments that depend on
+/// first-party skills should defer enabling this flag until the bundled
+/// manifests ship `sha256`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct PluginsConfig {
@@ -217,6 +228,9 @@ pub struct PluginsConfig {
     /// before every invocation (pre-spawn re-hash closes the load→exec
     /// TOCTOU window). When `false` (default), unsigned plugins still load
     /// with a warning to preserve backward compatibility.
+    ///
+    /// See the [`PluginsConfig`] struct docs for a note on bundled
+    /// first-party skills that ship without `sha256` today.
     #[serde(default)]
     pub require_signed: bool,
 }

--- a/crates/octos-cli/src/config_watcher.rs
+++ b/crates/octos-cli/src/config_watcher.rs
@@ -87,7 +87,14 @@ impl ConfigWatcher {
     }
 
     /// Parse config from the first non-empty buffer.
-    /// Tries `Config` format first, then `UserProfile` format (for --profile mode).
+    ///
+    /// Sniffs the JSON shape first so a `UserProfile` is parsed as such
+    /// instead of silently coercing to a default-everything `Config`. Without
+    /// this discrimination, `Config` (which has `#[serde(default)]` on every
+    /// field) succeeds first and returns an all-defaults blob — masking
+    /// every non-Config field including the new `config.plugins` block.
+    /// That regression would skip the policy-change restart for profile
+    /// files (codex review round-8 P2).
     ///
     /// Section B (codex review round-7 P2): apply the same
     /// `OCTOS_PLUGINS_REQUIRE_SIGNED` env-merge that `Config::from_file`
@@ -97,12 +104,39 @@ impl ConfigWatcher {
     /// every unrelated edit.
     fn parse_first(buffers: &[(PathBuf, Vec<u8>)]) -> Option<Config> {
         let (path, bytes) = buffers.first()?;
-        // Try Config format first
+        // Discrimination: a UserProfile JSON has top-level "id" + "config"
+        // keys; a top-level Config does not. Try UserProfile first when the
+        // shape matches so the watcher actually sees the profile's nested
+        // `config.plugins` block rather than silently falling back to a
+        // default-everything Config from the all-`serde(default)` shape.
+        let looks_like_profile = serde_json::from_slice::<serde_json::Value>(bytes)
+            .ok()
+            .and_then(|v| v.as_object().cloned())
+            .is_some_and(|map| map.contains_key("id") && map.contains_key("config"));
+        if looks_like_profile {
+            match serde_json::from_slice::<UserProfile>(bytes) {
+                Ok(profile) => {
+                    let mut c = crate::profiles::config_from_profile(&profile, None, None);
+                    crate::config::merge_env_plugin_policy_pub(&mut c);
+                    return Some(c);
+                }
+                Err(e) => {
+                    warn!(
+                        "config reload: profile-shaped JSON failed to parse for {}: {e}",
+                        path.display()
+                    );
+                    // fall through to Config attempt
+                }
+            }
+        }
+        // Try Config format
         if let Ok(mut c) = serde_json::from_slice::<Config>(bytes) {
             crate::config::merge_env_plugin_policy_pub(&mut c);
             return Some(c);
         }
-        // Try UserProfile format (for --profile mode)
+        // Last-chance: try UserProfile even on non-profile-shaped JSON to
+        // preserve legacy behavior if a profile lacks the discriminator
+        // keys for some reason.
         match serde_json::from_slice::<UserProfile>(bytes) {
             Ok(profile) => {
                 let mut c = crate::profiles::config_from_profile(&profile, None, None);

--- a/crates/octos-cli/src/config_watcher.rs
+++ b/crates/octos-cli/src/config_watcher.rs
@@ -129,6 +129,13 @@ impl ConfigWatcher {
         if old.hooks != new.hooks {
             restart_fields.push("hooks".into());
         }
+        // Section B (codex review round-6 P2): plugin loader policy
+        // (`plugins.require_signed`) is consumed only during plugin
+        // load. A toggle in a running gateway must trigger a restart
+        // so the stale registry is flushed and the new gate applies.
+        if old.plugins != new.plugins {
+            restart_fields.push("plugins".into());
+        }
 
         // Queue mode change requires restart (affects message processing loop)
         let old_queue_mode = old.gateway.as_ref().map(|g| &g.queue_mode);

--- a/crates/octos-cli/src/config_watcher.rs
+++ b/crates/octos-cli/src/config_watcher.rs
@@ -88,15 +88,27 @@ impl ConfigWatcher {
 
     /// Parse config from the first non-empty buffer.
     /// Tries `Config` format first, then `UserProfile` format (for --profile mode).
+    ///
+    /// Section B (codex review round-7 P2): apply the same
+    /// `OCTOS_PLUGINS_REQUIRE_SIGNED` env-merge that `Config::from_file`
+    /// does so the diff doesn't see spurious "plugins changed from true
+    /// to false" transitions on a hot edit. Without this, a gateway
+    /// spawned with the env-forced policy would emit a bogus restart on
+    /// every unrelated edit.
     fn parse_first(buffers: &[(PathBuf, Vec<u8>)]) -> Option<Config> {
         let (path, bytes) = buffers.first()?;
         // Try Config format first
-        if let Ok(c) = serde_json::from_slice::<Config>(bytes) {
+        if let Ok(mut c) = serde_json::from_slice::<Config>(bytes) {
+            crate::config::merge_env_plugin_policy_pub(&mut c);
             return Some(c);
         }
         // Try UserProfile format (for --profile mode)
         match serde_json::from_slice::<UserProfile>(bytes) {
-            Ok(profile) => Some(crate::profiles::config_from_profile(&profile, None, None)),
+            Ok(profile) => {
+                let mut c = crate::profiles::config_from_profile(&profile, None, None);
+                crate::config::merge_env_plugin_policy_pub(&mut c);
+                Some(c)
+            }
             Err(e) => {
                 warn!("config reload failed for {}: {e}", path.display());
                 None

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -328,14 +328,9 @@ impl ProcessManager {
             }
         }
 
-        // Section B (codex review round-5 P1.2): mirror the host's
-        // strict-signing policy to every spawned gateway. `Config::from_file`
-        // OR-merges `OCTOS_PLUGINS_REQUIRE_SIGNED` onto whatever the
-        // profile JSON declares so a host-only `plugins.require_signed = true`
-        // still propagates to managed sub-gateways.
-        if self.host_plugins_require_signed {
-            cmd.env("OCTOS_PLUGINS_REQUIRE_SIGNED", "1");
-        }
+        // (Section B host-signing env is set AFTER the profile env loop
+        // below so a profile cannot silently override it — see
+        // `cmd.env("OCTOS_PLUGINS_REQUIRE_SIGNED", "1")` further down.)
 
         // Inject email config as env vars for the send_email plugin.
         // The dashboard sets email config in the profile JSON, but the
@@ -366,7 +361,28 @@ impl ProcessManager {
                 );
                 continue;
             }
+            // Section B (codex review round-6 P1): the host's strict-signing
+            // env is reserved for the parent serve to control. A profile
+            // env_vars entry with this key would otherwise silently turn
+            // off the host policy in the spawned gateway — refuse it.
+            if key.eq_ignore_ascii_case("OCTOS_PLUGINS_REQUIRE_SIGNED") {
+                tracing::warn!(
+                    profile = %profile.id,
+                    var = %key,
+                    "skipping profile env var that would override host plugin policy"
+                );
+                continue;
+            }
             cmd.env(key, value);
+        }
+
+        // Section B (codex review round-5 P1.2 + round-6 P1): mirror the
+        // host's strict-signing policy to every spawned gateway AFTER the
+        // profile env loop so a profile env_vars entry can never silently
+        // disable the host policy. `Config::from_file` OR-merges the env
+        // var onto whatever the profile JSON declares.
+        if self.host_plugins_require_signed {
+            cmd.env("OCTOS_PLUGINS_REQUIRE_SIGNED", "1");
         }
 
         tracing::debug!(profile = %profile.id, "start: spawning gateway subprocess");

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -306,6 +306,21 @@ impl ProcessManager {
                             .iter()
                             .any(|blocked| key.eq_ignore_ascii_case(blocked))
                         {
+                            // Section B (codex review round-7 P3): the
+                            // host's strict-signing env var is reserved
+                            // for the parent serve. Refuse a parent
+                            // profile env_vars entry that would override
+                            // it (sub-account inheritance otherwise lets
+                            // a parent silently flip strict signing on).
+                            if key.eq_ignore_ascii_case("OCTOS_PLUGINS_REQUIRE_SIGNED") {
+                                tracing::warn!(
+                                    profile = %profile.id,
+                                    parent = %parent_id,
+                                    var = %key,
+                                    "skipping parent env var that would override host plugin policy"
+                                );
+                                continue;
+                            }
                             cmd.env(key, value);
                         }
                     }

--- a/crates/octos-cli/src/process_manager.rs
+++ b/crates/octos-cli/src/process_manager.rs
@@ -47,6 +47,12 @@ pub struct ProcessManager {
     admin_token: Option<String>,
     /// Weak self-reference for auto-restart from spawned tasks.
     self_ref: std::sync::Mutex<Option<std::sync::Weak<ProcessManager>>>,
+    /// Section B (codex review round-5 P1.2): host-level
+    /// `plugins.require_signed` policy that spawned gateway processes
+    /// must inherit. When `true`, every gateway gets
+    /// `OCTOS_PLUGINS_REQUIRE_SIGNED=1` in its env so its `Config::from_file`
+    /// OR-merges the flag onto whatever the profile JSON declared.
+    host_plugins_require_signed: bool,
 }
 
 struct GatewayProcess {
@@ -128,7 +134,17 @@ impl ProcessManager {
             serve_port: None,
             admin_token: None,
             self_ref: std::sync::Mutex::new(None),
+            host_plugins_require_signed: false,
         }
+    }
+
+    /// Section B (codex review round-5 P1.2): mirror the host's
+    /// `plugins.require_signed` onto every spawned gateway via
+    /// `OCTOS_PLUGINS_REQUIRE_SIGNED=1`. Default is `false` (legacy
+    /// permissive path).
+    pub fn with_host_plugins_require_signed(mut self, require_signed: bool) -> Self {
+        self.host_plugins_require_signed = require_signed;
+        self
     }
 
     /// Store a weak self-reference for auto-restart from spawned monitor tasks.
@@ -310,6 +326,15 @@ impl ProcessManager {
             if let Some(ref token) = self.admin_token {
                 cmd.env("OCTOS_ADMIN_TOKEN", token);
             }
+        }
+
+        // Section B (codex review round-5 P1.2): mirror the host's
+        // strict-signing policy to every spawned gateway. `Config::from_file`
+        // OR-merges `OCTOS_PLUGINS_REQUIRE_SIGNED` onto whatever the
+        // profile JSON declares so a host-only `plugins.require_signed = true`
+        // still propagates to managed sub-gateways.
+        if self.host_plugins_require_signed {
+            cmd.env("OCTOS_PLUGINS_REQUIRE_SIGNED", "1");
         }
 
         // Inject email config as env vars for the send_email plugin.

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -116,6 +116,13 @@ pub struct ProfileConfig {
     /// tokens with persistent cooldowns and rotation strategies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_pool: Option<CredentialPoolConfig>,
+    /// Plugin loader policy. Mirrors the top-level `plugins` block in
+    /// `config.json` so per-profile gateways can opt into strict signature
+    /// enforcement independently of the host-level setting. Default
+    /// (`PluginsConfig::default()`) preserves backward compatibility —
+    /// unsigned plugins still load with a warning.
+    #[serde(default)]
+    pub plugins: crate::config::PluginsConfig,
 }
 
 /// Search configuration persisted in the profile contract.
@@ -1475,7 +1482,12 @@ pub(crate) fn config_from_profile(
         credential_pool: None,
         content_routing: profile.config.content_routing.clone(),
         appui: Default::default(),
-        plugins: Default::default(),
+        // Carry the profile-declared plugin loader policy through to the
+        // flattened `Config` so callers reading
+        // `config.plugins.require_signed` see the same value the profile
+        // JSON declared. Defaults to permissive when the profile omits
+        // the field.
+        plugins: profile.config.plugins.clone(),
     }
 }
 

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1708,6 +1708,13 @@ pub fn diff_profiles(old: &UserProfile, new: &UserProfile) -> ProfileChange {
     if oc.credential_pool != nc.credential_pool {
         restart_fields.push("credential_pool".into());
     }
+    // Section B (codex review round-6): plugin loader policy changes
+    // (e.g. flipping `plugins.require_signed`) only take effect during
+    // bootstrap, so a toggle must trigger a gateway restart to flush
+    // the stale plugin registry and apply the new gate.
+    if oc.plugins != nc.plugins {
+        restart_fields.push("plugins".into());
+    }
 
     if !restart_fields.is_empty() {
         return ProfileChange::RestartRequired(restart_fields);

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -342,8 +342,32 @@ impl ProfileRuntime {
         octos_home: Option<&Path>,
         role: BootstrapRole,
     ) -> Result<Arc<Self>> {
-        // Step 1: derive the per-profile Config.
-        let config = config_from_profile(profile, None, None);
+        Self::bootstrap_with_host_plugins(profile, data_dir, octos_home, role, None).await
+    }
+
+    /// Section B (codex review round-3): bootstrap a profile runtime while
+    /// honouring the host-level `plugins.require_signed` policy. When the
+    /// caller (e.g. `octos serve`) has the top-level [`Config`] in scope,
+    /// it passes the host plugin policy here so the per-profile plugin
+    /// load enforces strict signing even when the profile JSON doesn't
+    /// repeat the setting. Profile-level `plugins.require_signed` is OR'd
+    /// with the host setting — neither side can silently relax the other.
+    pub async fn bootstrap_with_host_plugins(
+        profile: &UserProfile,
+        data_dir: &Path,
+        octos_home: Option<&Path>,
+        role: BootstrapRole,
+        host_plugins: Option<&crate::config::PluginsConfig>,
+    ) -> Result<Arc<Self>> {
+        // Step 1: derive the per-profile Config. Apply the host plugin
+        // policy on top of the profile-derived one before any downstream
+        // step inspects `config.plugins.require_signed`.
+        let mut config = config_from_profile(profile, None, None);
+        if let Some(host) = host_plugins {
+            if host.require_signed {
+                config.plugins.require_signed = true;
+            }
+        }
 
         // Step 2: resolve the provider name. `config_from_profile`
         // populates `provider`/`model` from `llm.primary` when set,
@@ -1348,6 +1372,64 @@ mod tests {
             rt.plugin_dirs.contains(&global_plugins),
             "plugin_dirs should include `<octos_home>/plugins`; got: {:?}",
             rt.plugin_dirs
+        );
+    }
+
+    /// Section B (codex review round-3): the host's `plugins.require_signed`
+    /// policy must reach the per-profile bootstrap so an unsigned skill
+    /// installed under `<data_dir>/skills/` is rejected even when the
+    /// profile JSON omits the flag. We plant an unsigned skill and assert
+    /// it does NOT load when `bootstrap_with_host_plugins` is invoked
+    /// with `host_plugins.require_signed = true`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn profile_runtime_bootstrap_honours_host_require_signed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _key = ScopedEnvKey::set("OCTOS_HOST_SIGN_KEY");
+        let tmp = tempfile::tempdir().unwrap();
+        let octos_home = tmp.path().join("octos-home");
+        let data_dir = octos_home.join("profiles").join("sigtest").join("data");
+        let skills_dir = data_dir.join("skills");
+        std::fs::create_dir_all(&skills_dir).unwrap();
+
+        // Plant an unsigned per-profile skill — manifest omits sha256.
+        let plugin_dir = skills_dir.join("unsigned-skill");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            r#"{
+                "name": "unsigned-skill",
+                "version": "1.0",
+                "tools": [{"name": "ut", "description": "d"}]
+            }"#,
+        )
+        .unwrap();
+        let exec_path = plugin_dir.join("unsigned-skill");
+        std::fs::write(&exec_path, b"#!/bin/sh\necho unsigned").unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let profile = fixture_profile("sigtest", "OCTOS_HOST_SIGN_KEY");
+        let host_plugins = crate::config::PluginsConfig {
+            require_signed: true,
+        };
+
+        let rt = ProfileRuntime::bootstrap_with_host_plugins(
+            &profile,
+            &data_dir,
+            Some(&octos_home),
+            BootstrapRole::Serve,
+            Some(&host_plugins),
+        )
+        .await
+        .expect("bootstrap should succeed (the rejection only suppresses the plugin)");
+
+        let specs = rt.tool_specs.specs();
+        let registered: Vec<&str> = specs.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            !registered.iter().any(|n| n == &"ut"),
+            "unsigned skill tool `ut` must NOT load when host strict policy is on; \
+             registered: {registered:?}"
         );
     }
 

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1825,6 +1825,10 @@ pub struct ActorFactory {
     pub plugin_dirs: Vec<std::path::PathBuf>,
     /// Extra environment variables for plugin processes in subagents.
     pub plugin_extra_env: Vec<(String, String)>,
+    /// Section B (codex review P1.1): inherit the host's
+    /// `plugins.require_signed` policy so SpawnTool subagents enforce the
+    /// same strict-signing gate as their parent.
+    pub plugin_require_signed: bool,
     /// Session-scoped background task lookup for API inspection.
     pub task_query_store: SessionTaskQueryStore,
     /// M8 fix-first item 8 (gap 2): shared SubAgentOutputRouter — one
@@ -2182,7 +2186,8 @@ impl ActorFactory {
         }
         if !self.plugin_dirs.is_empty() {
             spawn_tool = spawn_tool
-                .with_plugin_dirs(self.plugin_dirs.clone(), self.plugin_extra_env.clone());
+                .with_plugin_dirs(self.plugin_dirs.clone(), self.plugin_extra_env.clone())
+                .with_plugin_require_signed(self.plugin_require_signed);
         }
         if let Some(ref hooks) = self.hooks {
             spawn_tool = spawn_tool.with_hooks(hooks.clone());
@@ -10532,6 +10537,7 @@ mod tests {
             memory_store: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),
+            plugin_require_signed: false,
             task_query_store: SessionTaskQueryStore::default(),
             subagent_output_router: Arc::new(octos_agent::SubAgentOutputRouter::new(
                 dir.path().join("subagent-outputs"),

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -314,6 +314,10 @@ pub struct ExecutorConfig {
     pub working_dir: PathBuf,
     pub provider_policy: Option<octos_agent::ToolPolicy>,
     pub plugin_dirs: Vec<PathBuf>,
+    /// Section B (codex review P1.1): pipeline-level strict-signing policy.
+    /// When `true`, the per-node `CodergenHandler` rejects unsigned plugins
+    /// at cache build time. Defaults to `false` (legacy permissive path).
+    pub plugin_require_signed: bool,
     /// Optional status bridge for live progress updates to messaging channels.
     pub status_bridge: Option<PipelineStatusBridge>,
     /// Shared shutdown signal — set to true to cancel all pipeline workers.
@@ -1276,6 +1280,7 @@ impl PipelineExecutor {
         )
         .with_provider_policy(self.config.provider_policy.clone())
         .with_plugin_dirs(self.config.plugin_dirs.clone())
+        .with_plugin_require_signed(self.config.plugin_require_signed)
         // M8 parity (W1.A1): propagate the host context so per-node
         // Agents inherit the parent session's FileStateCache /
         // SubAgentOutputRouter / AgentSummaryGenerator. Empty context
@@ -2772,6 +2777,7 @@ mod tests {
             working_dir: PathBuf::from("/tmp"),
             provider_policy: None,
             plugin_dirs: vec![],
+            plugin_require_signed: false,
             status_bridge: None,
             shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             max_parallel_workers: 8,
@@ -2917,6 +2923,7 @@ mod tests {
             working_dir: PathBuf::from("/tmp"),
             provider_policy: None,
             plugin_dirs: vec![],
+            plugin_require_signed: false,
             status_bridge: None,
             shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             max_parallel_workers: 8,

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -66,14 +66,31 @@ impl CachedPluginRegistration {
 /// throw-away registry. Errors are downgraded to a warn (matching the
 /// legacy pipeline behaviour) and an empty registration is cached so
 /// the warning fires at most once per handler lifetime.
-fn build_cached_plugin_registration(plugin_dirs: &[PathBuf]) -> CachedPluginRegistration {
+fn build_cached_plugin_registration(
+    plugin_dirs: &[PathBuf],
+    require_signed: bool,
+) -> CachedPluginRegistration {
     if plugin_dirs.is_empty() {
         return CachedPluginRegistration::default();
     }
 
     let started = std::time::Instant::now();
     let mut staging = ToolRegistry::new();
-    let load_result = octos_agent::PluginLoader::load_into(&mut staging, plugin_dirs, &[]);
+    // Section B (codex review P1.1): honour the pipeline's
+    // strict-signing policy. Default is `false` (legacy permissive
+    // path) but operators who opt into `plugins.require_signed` on
+    // their host config expect the pipeline cache to enforce the
+    // same gate.
+    let load_result = octos_agent::PluginLoader::load_into_with_options(
+        &mut staging,
+        plugin_dirs,
+        &[],
+        octos_agent::PluginLoadOptions {
+            work_dir: None,
+            synthesis_config: None,
+            require_signed,
+        },
+    );
     let elapsed = started.elapsed();
 
     let load_result = match load_result {
@@ -252,6 +269,13 @@ pub struct CodergenHandler {
     provider_router: Option<Arc<ProviderRouter>>,
     provider_policy: Option<octos_agent::ToolPolicy>,
     plugin_dirs: Vec<PathBuf>,
+    /// Section B (codex review P1.1): pipeline-level strict-signing
+    /// policy. Defaults to `false` (legacy permissive path). When the
+    /// host has opted into `plugins.require_signed`, the
+    /// `CodergenHandler` builder threads it through via
+    /// [`Self::with_plugin_require_signed`] so the plugin-load cache
+    /// enforces the same gate.
+    plugin_require_signed: bool,
     shutdown: Arc<std::sync::atomic::AtomicBool>,
     /// Declared compaction policy to propagate onto child Agents
     /// (coding-blue FA-7). `None` = legacy path, no compaction runner
@@ -293,6 +317,7 @@ impl CodergenHandler {
             provider_router: None,
             provider_policy: None,
             plugin_dirs: Vec::new(),
+            plugin_require_signed: false,
             shutdown,
             compaction_policy: None,
             compaction_workspace: None,
@@ -300,6 +325,18 @@ impl CodergenHandler {
             host_context: crate::host_context::PipelineHostContext::default(),
             plugin_cache: Arc::new(OnceLock::new()),
         }
+    }
+
+    /// Section B (codex review P1.1): opt into strict signature
+    /// enforcement for the pipeline's plugin-load cache. Set this
+    /// when the host config carries `plugins.require_signed = true`.
+    pub fn with_plugin_require_signed(mut self, require_signed: bool) -> Self {
+        self.plugin_require_signed = require_signed;
+        // Mirror `with_plugin_dirs`: a policy change must invalidate the
+        // cache so a builder reordering doesn't surface a stale permissive
+        // registration.
+        self.plugin_cache = Arc::new(OnceLock::new());
+        self
     }
 
     /// M8 parity (W1.A1): attach the parent session's
@@ -411,7 +448,12 @@ impl CodergenHandler {
     /// load and an `Arc::clone`.
     fn cached_plugin_registration(&self) -> Arc<CachedPluginRegistration> {
         self.plugin_cache
-            .get_or_init(|| Arc::new(build_cached_plugin_registration(&self.plugin_dirs)))
+            .get_or_init(|| {
+                Arc::new(build_cached_plugin_registration(
+                    &self.plugin_dirs,
+                    self.plugin_require_signed,
+                ))
+            })
             .clone()
     }
 

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -24,6 +24,12 @@ pub struct RunPipelineTool {
     working_dir: PathBuf,
     provider_policy: Option<ToolPolicy>,
     plugin_dirs: Vec<PathBuf>,
+    /// Section B (codex review P1.1): pipeline-level strict-signing
+    /// policy. Defaults to `false` (legacy permissive path). When the
+    /// host has opted into `plugins.require_signed`, this is set via
+    /// [`Self::with_plugin_require_signed`] so per-node plugin loads
+    /// enforce the same gate.
+    plugin_require_signed: bool,
     discovery: PipelineDiscovery,
     /// Per-message status bridge (set via `set_status_bridge` before each call).
     status_bridge: std::sync::Mutex<Option<PipelineStatusBridge>>,
@@ -52,6 +58,7 @@ impl RunPipelineTool {
             working_dir,
             provider_policy: None,
             plugin_dirs: Vec::new(),
+            plugin_require_signed: false,
             discovery,
             status_bridge: std::sync::Mutex::new(None),
             cost_accountant: None,
@@ -144,6 +151,14 @@ impl RunPipelineTool {
 
     pub fn with_plugin_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         self.plugin_dirs = dirs;
+        self
+    }
+
+    /// Section B (codex review P1.1): opt into strict signature
+    /// enforcement for pipeline-spawned plugin loads. Inherited from
+    /// `plugins.require_signed` on the host config.
+    pub fn with_plugin_require_signed(mut self, require_signed: bool) -> Self {
+        self.plugin_require_signed = require_signed;
         self
     }
 
@@ -329,6 +344,7 @@ impl Tool for RunPipelineTool {
             working_dir: self.working_dir.clone(),
             provider_policy: self.provider_policy.clone(),
             plugin_dirs: self.plugin_dirs.clone(),
+            plugin_require_signed: self.plugin_require_signed,
             status_bridge,
             shutdown: shutdown.clone(),
             max_parallel_workers: 8,

--- a/crates/octos-pipeline/tests/checkpoint_resume.rs
+++ b/crates/octos-pipeline/tests/checkpoint_resume.rs
@@ -109,6 +109,7 @@ fn base_config(
         working_dir,
         provider_policy: None,
         plugin_dirs: vec![],
+        plugin_require_signed: false,
         status_bridge: None,
         shutdown: Arc::new(AtomicBool::new(false)),
         max_parallel_workers: 1,

--- a/crates/octos-pipeline/tests/deadline_enforcement.rs
+++ b/crates/octos-pipeline/tests/deadline_enforcement.rs
@@ -113,6 +113,7 @@ fn base_config(
         working_dir,
         provider_policy: None,
         plugin_dirs: vec![],
+        plugin_require_signed: false,
         status_bridge: None,
         shutdown: Arc::new(AtomicBool::new(false)),
         max_parallel_workers: 1,

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -57,6 +57,7 @@ async fn make_config(provider: Arc<dyn LlmProvider>, dir: &TempDir) -> ExecutorC
         working_dir: dir.path().to_path_buf(),
         provider_policy: None,
         plugin_dirs: vec![],
+        plugin_require_signed: false,
         status_bridge: None,
         shutdown: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         max_parallel_workers: 8,

--- a/crates/octos-pipeline/tests/workspace_contract.rs
+++ b/crates/octos-pipeline/tests/workspace_contract.rs
@@ -155,6 +155,7 @@ fn base_config(dir: &TempDir, memory: Arc<EpisodeStore>, ctx: PipelineContext) -
         working_dir: dir.path().to_path_buf(),
         provider_policy: None,
         plugin_dirs: vec![],
+        plugin_require_signed: false,
         status_bridge: None,
         shutdown: Arc::new(AtomicBool::new(false)),
         max_parallel_workers: 4,


### PR DESCRIPTION
## Summary

Follow-up to merged PR #944. Lands the codex-review fixes that surfaced after the original PR was already merged — 7 codex rounds total, P1+P2 bypasses on `plugins.require_signed` and the load→exec/approval→spawn TOCTOU windows.

### Round 2: Initial enforcement fixes
- Thread `plugins.require_signed` through every plugin load path (`octos chat`, `SpawnTool`, pipeline `RunPipelineTool`, profile bootstrap)
- `ProfileConfig` carries `plugins: PluginsConfig` so per-profile JSON can override
- Reject unsigned extras-only skills under strict mode (was bypassed by `tools.is_empty()` early return)
- Skip rehash gate for legacy unsigned plugins (was incurring full executable read on every invocation)

### Round 3: Drop manifest extras under strict signing
- `manifest.sha256` covers executable only — strict mode now drops MCP servers / hooks / prompts (round 4 below extends this to SKIP `resolve_extras` entirely)
- `ProfileRuntime::bootstrap_with_host_plugins` accepts host policy override
- `serve.rs` + `gateway/gateway_runtime.rs` pass `config.plugins` to per-profile bootstrap

### Round 4: Carry host policy into child profiles + skip resolve_extras
- `ProfileActorFactoryBuilder` carries `host_plugins: PluginsConfig`, OR-merges onto child profile's flattened Config
- Strict mode bypasses `resolve_extras` entirely (no glob expansion, no auto-injected SKILL.md for spawn-only)

### Round 5: Manifest hash + post-approval rehash + env policy
- `PluginTool` stashes SHA-256 of `manifest.json` at load time; pre-spawn gate re-checks both executable AND manifest hashes
- `execute()` runs the rehash gate TWICE: pre-approval (cheap rejection) AND immediately before `cmd.spawn()` (closes approval→spawn TOCTOU)
- `ProcessManager::with_host_plugins_require_signed` mirrors host policy via `OCTOS_PLUGINS_REQUIRE_SIGNED=1` env var
- `Config::from_file` + `Config::load_with_path` OR-merge the env var; gateway_runtime calls the same helper for the `--profile` path

### Round 6: Env precedence + watcher restart detection
- `ProcessManager` sets `OCTOS_PLUGINS_REQUIRE_SIGNED` AFTER profile env loop + rejects profile entries with the reserved key
- `diff_profiles` + `ConfigWatcher::diff_and_emit` emit `RestartRequired(["plugins"])` on policy toggle
- Documented bundled first-party skill caveat on `PluginsConfig`

### Round 7: Watcher env merge + parent profile filter
- `ConfigWatcher::parse_first` applies the same env-merge so unrelated hot edits don't trigger bogus "plugins changed" restarts
- Parent-profile env merge path also rejects reserved env var so sub-accounts can't inherit strict signing from parent

## Test plan
- [x] `cargo test -p octos-agent --lib` — 1430 lib tests pass (incl. all new strict-signing tests)
- [x] `cargo test -p octos-cli --lib` — 366 lib tests pass
- [x] `cargo test -p octos-agent --test manage_skills_hash` — 4 integration tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-agent -p octos-cli -p octos-pipeline --all-targets -- -D warnings` clean
- [x] 7 rounds of `codex exec review --base origin/main` — each round's P1s addressed before next pass