### PR TITLE
feat(harness): add PerFileNonSilent validator + wire mofa-podcast segments

### DIFF
--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -522,6 +522,19 @@ impl ValidatorRunner {
                 ValidatorSpec::AudioNonSilent { glob, min_ratio } => self.run_audio_non_silent(
                     invocation, validator, glob, *min_ratio, started_at, started,
                 ),
+                ValidatorSpec::PerFileNonSilent {
+                    glob,
+                    min_ratio,
+                    require_at_least,
+                } => self.run_per_file_non_silent(
+                    invocation,
+                    validator,
+                    glob,
+                    *min_ratio,
+                    *require_at_least,
+                    started_at,
+                    started,
+                ),
                 ValidatorSpec::MagicBytes { glob, format } => {
                     self.run_magic_bytes(invocation, validator, glob, *format, started_at, started)
                 }
@@ -1164,6 +1177,122 @@ impl ValidatorRunner {
                 validator,
                 ValidatorStatus::Fail,
                 format!("audio_non_silent failed: {}", failures.join("; ")),
+                started_at,
+                started,
+            )
+        }
+    }
+
+    /// Run a [`ValidatorSpec::PerFileNonSilent`] validator: every matched
+    /// file must independently pass the non-silent ratio threshold, and the
+    /// match count must meet `require_at_least`.
+    ///
+    /// Complements [`Self::run_audio_non_silent`], which only requires a
+    /// single match. Reuses the WAV/MP3 decoder via
+    /// [`decode_non_silent_ratio`]. Failure messages include the file's
+    /// basename (NOT the full path) so an LLM logger can reason about which
+    /// segment failed without leaking workspace layout.
+    #[allow(clippy::too_many_arguments)]
+    fn run_per_file_non_silent(
+        &self,
+        invocation: &ValidatorInvocation,
+        validator: &Validator,
+        pattern: &str,
+        min_ratio: f32,
+        require_at_least: usize,
+        started_at: DateTime<Utc>,
+        started: Instant,
+    ) -> ValidatorOutcome {
+        // Interpolate `${args.X}` ONLY (rejects path-traversal segments and
+        // absolute-path arg values). `${output.X}` is intentionally not
+        // supported here — callers wanting tool-output-driven globs should
+        // use the whole-file `AudioNonSilent` variant.
+        let resolved_pattern = match interpolate_args_path(pattern, invocation.input_args.as_ref())
+        {
+            Ok(value) => value,
+            Err(reason) => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                );
+            }
+        };
+        let matches = match glob_files(&invocation.workspace_root, &resolved_pattern) {
+            Ok(matches) => matches,
+            Err(reason) => {
+                return self.make_outcome(
+                    invocation,
+                    validator,
+                    ValidatorStatus::Error,
+                    reason,
+                    started_at,
+                    started,
+                );
+            }
+        };
+
+        // Enforce `require_at_least` as a hard floor on matched count
+        // FIRST — that lets us distinguish "tool emitted zero artifacts"
+        // (a true contract failure when the operator declared a minimum)
+        // from "tool emitted artifacts but one is silent" (the per-file
+        // gate below). The two failure modes warrant different remediation
+        // hints in the ledger.
+        if matches.len() < require_at_least {
+            return self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!(
+                    "per_file_non_silent: expected >={require_at_least} audio files, found {}",
+                    matches.len()
+                ),
+                started_at,
+                started,
+            );
+        }
+
+        let mut failures = Vec::new();
+        for path in &matches {
+            // Per-file basename for diagnostics. We deliberately avoid
+            // emitting the full absolute path so the failure message stays
+            // stable across hosts and doesn't surface a workspace temp
+            // directory (which leaks across CI runs).
+            let label = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("<unnamed>")
+                .to_string();
+            match decode_non_silent_ratio(path) {
+                Ok(ratio) if ratio >= min_ratio => {}
+                Ok(ratio) => failures.push(format!(
+                    "{label}: non_silent_ratio={ratio:.3} < min_ratio={min_ratio:.3}"
+                )),
+                Err(reason) => failures.push(format!("{label}: {reason}")),
+            }
+        }
+
+        if failures.is_empty() {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Pass,
+                format!(
+                    "per_file_non_silent: all {} match(es) met min_ratio={min_ratio:.3}",
+                    matches.len()
+                ),
+                started_at,
+                started,
+            )
+        } else {
+            self.make_outcome(
+                invocation,
+                validator,
+                ValidatorStatus::Fail,
+                format!("per_file_non_silent failed: {}", failures.join("; ")),
                 started_at,
                 started,
             )
@@ -2121,6 +2250,7 @@ fn validator_kind_label(spec: &ValidatorSpec) -> &'static str {
         ValidatorSpec::HttpProbe { .. } => "http_probe",
         ValidatorSpec::OminixVoiceExists { .. } => "ominix_voice_exists",
         ValidatorSpec::AudioNonSilent { .. } => "audio_non_silent",
+        ValidatorSpec::PerFileNonSilent { .. } => "per_file_non_silent",
         ValidatorSpec::MagicBytes { .. } => "magic_bytes",
         ValidatorSpec::HttpProbeUntil { .. } => "http_probe_until",
         ValidatorSpec::Sha256Match { .. } => "sha256_match",
@@ -2299,6 +2429,14 @@ mod tests {
                 min_ratio: 0.3
             }),
             "audio_non_silent"
+        );
+        assert_eq!(
+            validator_kind_label(&ValidatorSpec::PerFileNonSilent {
+                glob: "**/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 1,
+            }),
+            "per_file_non_silent"
         );
         assert_eq!(
             validator_kind_label(&ValidatorSpec::MagicBytes {
@@ -3680,5 +3818,224 @@ mod tests {
         assert!(outcomes[0].required, "hard-required must serialize as true");
         assert_eq!(outcomes[0].required_tier, "hard");
         assert!(!outcomes[0].required_gate_passed());
+    }
+
+    // --- PerFileNonSilent --------------------------------------------------
+
+    /// Happy path: three sine-wave segments, all loud. The validator must
+    /// pass and the count of matched files must be surfaced in the reason
+    /// so operators can confirm the glob landed on the expected segments.
+    #[tokio::test]
+    async fn per_file_non_silent_passes_when_all_segments_are_loud() {
+        let dir = tempfile::tempdir().unwrap();
+        let seg_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&seg_dir).unwrap();
+        write_sine_wav(&seg_dir.join("seg_000_alice.wav"), 800);
+        write_sine_wav(&seg_dir.join("seg_001_bob.wav"), 800);
+        write_sine_wav(&seg_dir.join("seg_002_alice.wav"), 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_loud",
+            ValidatorSpec::PerFileNonSilent {
+                glob: "**/segments/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 1,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("3 match"),
+            "reason should surface match count: {}",
+            outcomes[0].reason
+        );
+    }
+
+    /// Adversarial path: one of three segments is silent. The validator
+    /// must fail AND surface the offending filename (basename) so an
+    /// operator/LLM can localize which segment to regenerate.
+    #[tokio::test]
+    async fn per_file_non_silent_fails_when_one_segment_is_silent() {
+        let dir = tempfile::tempdir().unwrap();
+        let seg_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&seg_dir).unwrap();
+        write_sine_wav(&seg_dir.join("seg_000_alice.wav"), 800);
+        // The bad apple — silent samples drag the per-file ratio to 0.0.
+        write_silent_wav(&seg_dir.join("seg_001_bob.wav"), 800);
+        write_sine_wav(&seg_dir.join("seg_002_alice.wav"), 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_silent_segment",
+            ValidatorSpec::PerFileNonSilent {
+                glob: "**/segments/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 1,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        // Must name the offending file so the failure is actionable.
+        assert!(
+            outcomes[0].reason.contains("seg_001_bob.wav"),
+            "failure must name the silent segment: {}",
+            outcomes[0].reason
+        );
+        // Must include BOTH the measured ratio and the threshold for
+        // ledger diagnostics — this mirrors the AudioNonSilent contract.
+        assert!(
+            outcomes[0].reason.contains("non_silent_ratio")
+                && outcomes[0].reason.contains("min_ratio"),
+            "failure must include measured and threshold ratios: {}",
+            outcomes[0].reason
+        );
+    }
+
+    /// Zero matches with a positive `require_at_least` must fail with a
+    /// message that surfaces both the expected minimum and the actual
+    /// count. Distinguishes "tool emitted zero artifacts" from
+    /// "tool emitted artifacts but one was silent".
+    #[tokio::test]
+    async fn per_file_non_silent_fails_when_match_count_below_require_at_least() {
+        let dir = tempfile::tempdir().unwrap();
+        // No segments dir at all.
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_min_count",
+            ValidatorSpec::PerFileNonSilent {
+                glob: "**/segments/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 1,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        // Message must surface BOTH the expected minimum and the actual
+        // count so operators see "expected >=1, found 0" verbatim.
+        assert!(
+            outcomes[0].reason.contains(">=1") && outcomes[0].reason.contains("found 0"),
+            "match-count failure must surface expected vs actual: {}",
+            outcomes[0].reason
+        );
+    }
+
+    /// `require_at_least = 0` (the serde default) is a deliberate escape
+    /// hatch: a per-file gate that doesn't ALSO demand a minimum count.
+    /// Zero matches must still be a Pass under that policy so a spawn
+    /// task can declare per-file invariants on optional intermediate
+    /// artifacts without forcing every run to produce them.
+    #[tokio::test]
+    async fn per_file_non_silent_passes_when_require_at_least_zero_and_no_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_optional",
+            ValidatorSpec::PerFileNonSilent {
+                glob: "**/segments/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 0,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    /// `${args.X}` interpolation must resolve against the spawn task's
+    /// input args, with path-traversal segments rejected. The happy path
+    /// here probes that the interpolated glob actually matches.
+    #[tokio::test]
+    async fn per_file_non_silent_glob_interpolates_args_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let seg_dir = dir.path().join("episode42/segments");
+        std::fs::create_dir_all(&seg_dir).unwrap();
+        write_sine_wav(&seg_dir.join("seg_000_host.wav"), 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_interp",
+            ValidatorSpec::PerFileNonSilent {
+                glob: "${args.episode_dir}/segments/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 1,
+            },
+        );
+        let invocation = dummy_invocation(dir.path().to_path_buf())
+            .with_input_args(serde_json::json!({"episode_dir": "episode42"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    /// Path-traversal in an arg value (`..`) must be rejected with an
+    /// Error outcome — not silently followed. Mirrors the
+    /// `interpolate_args_path` contract used by Sha256Match.
+    #[tokio::test]
+    async fn per_file_non_silent_rejects_path_traversal_arg_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_traversal",
+            ValidatorSpec::PerFileNonSilent {
+                glob: "${args.episode_dir}/segments/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 1,
+            },
+        );
+        let invocation = dummy_invocation(dir.path().to_path_buf())
+            .with_input_args(serde_json::json!({"episode_dir": "../etc"}));
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Error, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains(".."),
+            "error must surface the rejected segment: {}",
+            outcomes[0].reason
+        );
+    }
+
+    /// Confirms the placeholder filenames emitted by mofa-podcast
+    /// (`pause_after_*`, `pause_line_*`, `bgm_placeholder_line_*`) do NOT
+    /// fall under the `**/segments/seg_*.wav` glob, even though they
+    /// share the `segments/` directory. Without this exclusion the per-
+    /// file gate would fire on the intentionally-silent pause WAVs and
+    /// the podcast contract would never pass.
+    #[tokio::test]
+    async fn per_file_non_silent_glob_excludes_placeholder_filenames() {
+        let dir = tempfile::tempdir().unwrap();
+        let seg_dir = dir.path().join("segments");
+        std::fs::create_dir_all(&seg_dir).unwrap();
+        // One valid (loud) dialogue segment.
+        write_sine_wav(&seg_dir.join("seg_000_host.wav"), 800);
+        // Inter-speaker pause + line pause + BGM placeholder — all are
+        // legitimately silent because they ARE the pauses.
+        write_silent_wav(&seg_dir.join("pause_after_000.wav"), 800);
+        write_silent_wav(&seg_dir.join("pause_line_001.wav"), 800);
+        write_silent_wav(&seg_dir.join("bgm_placeholder_line_002.wav"), 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_segment_pattern",
+            ValidatorSpec::PerFileNonSilent {
+                glob: "**/segments/seg_*.wav".into(),
+                min_ratio: 0.3,
+                require_at_least: 1,
+            },
+        );
+        let outcomes = runner
+            .run_all(&dummy_invocation(dir.path().to_path_buf()), &[validator])
+            .await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("1 match"),
+            "glob must match exactly 1 dialogue segment, not the 4 files on disk: {}",
+            outcomes[0].reason
+        );
     }
 }

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1769,4 +1769,188 @@ mod tests {
         );
         assert!(warn.is_soft_warning());
     }
+
+    /// Helper used by the `podcast_generate` per-file-non-silent e2e
+    /// tests. PCM WAV with a sine wave loud enough to clear the
+    /// validator's non-silent-sample floor.
+    fn write_sine_wav_at(path: &std::path::Path, samples: usize) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 8_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create_dir_all");
+        let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+        let amplitude = i16::MAX / 2;
+        for index in 0..samples {
+            let phase = (index as f32) * std::f32::consts::TAU * 440.0 / 8000.0;
+            let value = (phase.sin() * amplitude as f32) as i16;
+            // Keep value away from zero crossings to ensure non-silent floor.
+            let value = if value.abs() < 4_000 { 4_000 } else { value };
+            writer.write_sample(value).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+    }
+
+    /// Companion to [`write_sine_wav_at`]: a WAV filled with PCM zeros so
+    /// the validator's non-silent ratio drops to 0.0. Used to drive the
+    /// per-file failure path.
+    fn write_silent_wav_at(path: &std::path::Path, samples: usize) {
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: 8_000,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        std::fs::create_dir_all(path.parent().expect("parent")).expect("create_dir_all");
+        let mut writer = hound::WavWriter::create(path, spec).expect("create wav");
+        for _ in 0..samples {
+            writer.write_sample(0i16).expect("write sample");
+        }
+        writer.finalize().expect("finalize wav");
+    }
+
+    /// Rewire the `podcast_generate` contract's MP3-targeted whole-file
+    /// validators to WAV equivalents so we can drive the gate with real
+    /// `hound` output (without requiring the `audio_mp3` feature). Keeps
+    /// the `PerFileNonSilent` validator unchanged so the segment-level
+    /// gate runs as configured.
+    fn retarget_podcast_contract_to_wav(policy: &mut crate::WorkspacePolicy) {
+        use crate::workspace_policy::{MagicByteKind, SpawnTaskValidatorSpec, ValidatorSpec};
+        let task = policy
+            .spawn_tasks
+            .get_mut("podcast_generate")
+            .expect("podcast_generate must exist in for_session policy");
+        for entry in task.on_completion.iter_mut() {
+            if let SpawnTaskValidatorSpec::Bare(spec) = entry {
+                match spec {
+                    ValidatorSpec::AudioNonSilent { glob, .. } => {
+                        *glob = "skill-output/mofa-podcast/*.wav".into();
+                    }
+                    ValidatorSpec::MagicBytes { glob, format } => {
+                        *glob = "skill-output/mofa-podcast/*.wav".into();
+                        *format = MagicByteKind::Wav;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    /// Wave-3b end-to-end: when every preserved segment WAV is non-silent
+    /// AND the assembled artifact is non-silent, the combined contract
+    /// gate (MagicBytes + AudioNonSilent whole-file + PerFileNonSilent
+    /// per-segment) must satisfy.
+    #[tokio::test]
+    async fn podcast_contract_satisfies_when_all_segments_and_final_mix_are_non_silent() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut policy = crate::WorkspacePolicy::for_session();
+        retarget_podcast_contract_to_wav(&mut policy);
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        // The assembled (whole-file) artifact. Drives MagicBytes + the
+        // whole-file AudioNonSilent.
+        let assembled = temp.path().join("skill-output/mofa-podcast/podcast.wav");
+        // 16-bit mono PCM at 8 kHz needs ~2000+ samples to clear the
+        // `file_size_min:$artifact:4096` policy gate.
+        write_sine_wav_at(&assembled, 4_000);
+
+        // The preserved per-segment WAVs that mofa-skills #59 leaves on
+        // disk after successful assembly. The PerFileNonSilent glob
+        // (`**/segments/seg_*.wav`) scopes to JUST these — placeholder
+        // pause/BGM files share the directory but are excluded.
+        let seg_dir = temp
+            .path()
+            .join("skill-output/mofa-podcast/episode_001/segments");
+        write_sine_wav_at(&seg_dir.join("seg_000_alice.wav"), 800);
+        write_sine_wav_at(&seg_dir.join("seg_001_bob.wav"), 800);
+        write_silent_wav_at(&seg_dir.join("pause_after_000.wav"), 400);
+        write_silent_wav_at(&seg_dir.join("pause_line_001.wav"), 400);
+        write_silent_wav_at(&seg_dir.join("bgm_placeholder_line_001.wav"), 400);
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "podcast_generate",
+            "tool-call-podcast-happy",
+            std::slice::from_ref(&assembled),
+            UNIX_EPOCH,
+            None,
+            None,
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { .. } => {}
+            other => panic!("expected satisfied, got {other:?}"),
+        }
+
+        // Both gates must have fired and persisted to the ledger so
+        // operators can confirm the combined contract ran. We assert on
+        // the typed `kind` discriminator so a future refactor of the
+        // reason string doesn't break this contract.
+        let ledger_path = temp.path().join(".octos").join("validator_outcomes.jsonl");
+        let ledger = crate::validators::ValidatorLedger::open(&ledger_path).unwrap();
+        let outcomes = ledger.read_all().unwrap();
+        assert!(
+            outcomes.iter().any(|o| o.kind == "audio_non_silent"),
+            "whole-file AudioNonSilent must have fired: {outcomes:?}"
+        );
+        assert!(
+            outcomes.iter().any(|o| o.kind == "per_file_non_silent"),
+            "per-segment PerFileNonSilent must have fired: {outcomes:?}"
+        );
+    }
+
+    /// Adversarial e2e: one segment WAV is silent. The whole-file
+    /// AudioNonSilent still passes (the silent gap is averaged out by
+    /// the surrounding loud assembled audio), but PerFileNonSilent
+    /// rejects the spawn task at the gate and surfaces the offending
+    /// segment basename in the typed failure error. This is the bug
+    /// class the variant was introduced to catch.
+    #[tokio::test]
+    async fn podcast_contract_fails_when_a_single_segment_is_silent_even_if_final_mix_is_loud() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut policy = crate::WorkspacePolicy::for_session();
+        retarget_podcast_contract_to_wav(&mut policy);
+        write_workspace_policy(temp.path(), &policy).unwrap();
+
+        // Final mix is fully loud — whole-file AudioNonSilent would
+        // accept it on its own.
+        let assembled = temp.path().join("skill-output/mofa-podcast/podcast.wav");
+        // 16-bit mono PCM at 8 kHz needs ~2000+ samples to clear the
+        // `file_size_min:$artifact:4096` policy gate.
+        write_sine_wav_at(&assembled, 4_000);
+
+        let seg_dir = temp
+            .path()
+            .join("skill-output/mofa-podcast/episode_002/segments");
+        write_sine_wav_at(&seg_dir.join("seg_000_alice.wav"), 800);
+        // The bad apple. PerFileNonSilent must catch this even though
+        // the whole-file validator above does not.
+        write_silent_wav_at(&seg_dir.join("seg_001_bob.wav"), 800);
+        write_sine_wav_at(&seg_dir.join("seg_002_alice.wav"), 800);
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "podcast_generate",
+            "tool-call-podcast-silent-seg",
+            std::slice::from_ref(&assembled),
+            UNIX_EPOCH,
+            None,
+            None,
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert!(
+                    error.contains("per_file_non_silent") && error.contains("seg_001_bob.wav"),
+                    "failure must surface the offending segment filename: {error}"
+                );
+                assert_eq!(notify_user.as_deref(), Some("Podcast generation failed"));
+            }
+            other => panic!("expected failure, got {other:?}"),
+        }
+    }
 }

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -771,6 +771,20 @@ impl WorkspacePolicy {
             // `bgm_placeholder_line_*.wav` — those filenames are emitted
             // by mofa-podcast as intentionally-silent inter-segment pauses
             // and would never pass a non-silent ratio check.
+            //
+            // Stale-segment concern: this glob does NOT apply the
+            // `task_started_at` look-back filter that `resolve_artifacts`
+            // uses (the validator runner doesn't see that timestamp).
+            // Same caveat applies to the pre-existing whole-file
+            // `AudioNonSilent` above (`skill-output/mofa-podcast/*.mp3`),
+            // so this is a shared harness invariant rather than a
+            // regression. In practice mofa-skills #59 clears
+            // `<output_dir>/segments/` at the start of every invocation
+            // (`generate_podcast::seg_dir` cleanup), so stale segments
+            // only matter for unusual concurrent-run workflows. A future
+            // follow-up can plumb `task_started_at` into the validator
+            // runner to filter per-file matches by mtime, which would
+            // close the gap for both validators in one shot.
             on_completion: vec![
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
                     glob: "skill-output/mofa-podcast/*.mp3".into(),

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -313,6 +313,41 @@ pub enum ValidatorSpec {
         #[serde(default = "default_non_silent_ratio")]
         min_ratio: f32,
     },
+    /// Assert that EVERY file matching `glob` independently meets
+    /// `non_silent_samples / total_samples >= min_ratio`, and that at least
+    /// `require_at_least` files were matched.
+    ///
+    /// Complements [`ValidatorSpec::AudioNonSilent`], which only requires a
+    /// single match to pass. The whole-file variant cannot catch a single
+    /// silent segment in a multi-segment podcast — the silent gap gets
+    /// averaged out by the surrounding speech in the final mix. By validating
+    /// each intermediate segment independently, `PerFileNonSilent` rejects a
+    /// silent segment before delivery, surfacing the offending filename in
+    /// the failure message so the spawn task can rerun the failing TTS call
+    /// on the next round.
+    ///
+    /// `${args.<key>}` interpolation is supported in the glob via
+    /// `interpolate_args_path` (path-traversal segments are rejected,
+    /// absolute-path values are rejected). `${output.<key>}` substitution is
+    /// intentionally NOT supported in this variant — see the
+    /// `decode_non_silent_ratio` doc-string for rationale.
+    ///
+    /// Field semantics:
+    /// * `glob` — workspace-relative glob matched via [`glob::glob`]. WAV and
+    ///   MP3 extensions are decoded; other extensions yield per-file errors.
+    /// * `min_ratio` — applied to EACH matched file. Defaults to
+    ///   [`default_non_silent_ratio`] (0.3).
+    /// * `require_at_least` — minimum number of files that MUST match.
+    ///   `0` (the serde default) disables the minimum so the validator can
+    ///   still pass when no files matched (consistent with optional
+    ///   intermediate artifacts that may not exist in every run).
+    PerFileNonSilent {
+        glob: String,
+        #[serde(default = "default_non_silent_ratio")]
+        min_ratio: f32,
+        #[serde(default)]
+        require_at_least: usize,
+    },
     /// Assert each file matching `glob` has the magic-byte prefix for the
     /// declared `format`. Catches "tool wrote 0 bytes" or "tool wrote an
     /// HTML error page in place of an MP3".
@@ -717,10 +752,25 @@ impl WorkspacePolicy {
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:Podcast generation failed".into()],
-            // Catch the two user-visible failure modes from the silent-MP3
-            // bug class: tool wrote zero bytes / an HTML error page in
-            // place of audio (MagicBytes), or tool generated a valid MP3
-            // header but a silent decoded stream (AudioNonSilent).
+            // Catch the three user-visible failure modes from the silent-MP3
+            // bug class:
+            //   1. tool wrote zero bytes / an HTML error page in place of
+            //      audio (MagicBytes).
+            //   2. tool generated a valid MP3 header but a silent decoded
+            //      stream (AudioNonSilent — whole final mix).
+            //   3. one of the intermediate segment WAVs is silent but the
+            //      surrounding non-silent segments mask the gap in the
+            //      assembled MP3 (PerFileNonSilent on the preserved
+            //      `<output_dir>/segments/seg_*.wav` files — mofa-podcast
+            //      preserves segments after successful assembly via the
+            //      Result-aware `SegmentDirCleanup` RAII guard introduced
+            //      in mofa-skills #59).
+            //
+            // The per-file glob `**/segments/seg_*.wav` deliberately
+            // EXCLUDES `pause_after_*.wav`, `pause_line_*.wav`, and
+            // `bgm_placeholder_line_*.wav` — those filenames are emitted
+            // by mofa-podcast as intentionally-silent inter-segment pauses
+            // and would never pass a non-silent ratio check.
             on_completion: vec![
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
                     glob: "skill-output/mofa-podcast/*.mp3".into(),
@@ -729,6 +779,11 @@ impl WorkspacePolicy {
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
                     glob: "skill-output/mofa-podcast/*.mp3".into(),
                     min_ratio: default_non_silent_ratio(),
+                }),
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::PerFileNonSilent {
+                    glob: "skill-output/mofa-podcast/**/segments/seg_*.wav".into(),
+                    min_ratio: default_non_silent_ratio(),
+                    require_at_least: 1,
                 }),
             ],
         };
@@ -1738,7 +1793,7 @@ ignore = []
             .spawn_tasks
             .get("podcast_generate")
             .expect("podcast contract");
-        // The two new domain validators should be declared so the
+        // The two whole-file domain validators must be declared so the
         // "silent MP3" / "wrote HTML instead of MP3" failure modes are
         // caught at the contract gate.
         assert!(podcast.on_completion.iter().any(|entry| matches!(
@@ -1749,6 +1804,40 @@ ignore = []
             entry,
             SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes { .. })
         )));
+        // The per-segment gate (PerFileNonSilent) catches the silent-
+        // segment failure mode that the whole-file AudioNonSilent cannot
+        // detect: one bad seg_NNN_<voice>.wav whose silent gap gets
+        // averaged out by the surrounding speech in the assembled MP3.
+        // mofa-skills #59 preserves segments after successful assembly
+        // via the Result-aware `SegmentDirCleanup` RAII guard so this
+        // glob actually matches when the harness runs.
+        let per_file = podcast
+            .on_completion
+            .iter()
+            .find_map(|entry| match entry {
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::PerFileNonSilent {
+                    glob,
+                    min_ratio,
+                    require_at_least,
+                }) => Some((glob.clone(), *min_ratio, *require_at_least)),
+                _ => None,
+            })
+            .expect("podcast_generate must declare PerFileNonSilent on segments");
+        assert!(
+            per_file.0.contains("segments/seg_*.wav"),
+            "PerFileNonSilent glob must scope to segment WAVs to exclude pause/BGM placeholders: {}",
+            per_file.0
+        );
+        assert!(
+            per_file.1 >= 0.3,
+            "min_ratio should be at least the harness default (0.3): {}",
+            per_file.1
+        );
+        assert!(
+            per_file.2 >= 1,
+            "require_at_least must enforce a non-zero floor so an empty segments dir surfaces as a contract failure (got {})",
+            per_file.2,
+        );
 
         let voice_save = policy
             .spawn_tasks
@@ -2028,6 +2117,70 @@ ignore = []
                 assert_eq!(sha256, "${args.expected_sha256}");
             }
             ref other => panic!("expected Sha256Match, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn per_file_non_silent_roundtrips_through_toml() {
+        // Operator-visible TOML shape. `require_at_least` is the
+        // distinguishing field vs. AudioNonSilent — defaulted via serde so
+        // an operator can omit it and still get sensible behaviour.
+        let toml = r#"
+            id = "podcast_segments_non_silent"
+            kind = "per_file_non_silent"
+            glob = "**/segments/seg_*.wav"
+            min_ratio = 0.3
+            require_at_least = 1
+        "#;
+        let parsed: Validator = toml::from_str(toml).unwrap();
+        match parsed.spec {
+            ValidatorSpec::PerFileNonSilent {
+                ref glob,
+                min_ratio,
+                require_at_least,
+            } => {
+                assert_eq!(glob, "**/segments/seg_*.wav");
+                assert!((min_ratio - 0.3).abs() < f32::EPSILON);
+                assert_eq!(require_at_least, 1);
+            }
+            ref other => panic!("expected PerFileNonSilent, got {other:?}"),
+        }
+        // Round-trip the validator through TOML to confirm fields survive.
+        let rendered = toml::to_string_pretty(&parsed).unwrap();
+        let reparsed: Validator = toml::from_str(&rendered).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn per_file_non_silent_defaults_require_at_least_and_min_ratio_when_omitted() {
+        // `require_at_least` and `min_ratio` are both `#[serde(default)]`
+        // so operator policies can declare just the glob and inherit the
+        // harness-wide defaults (0 / 0.3). This keeps the TOML shape
+        // minimal for the common "optional intermediate artifact" case.
+        let toml = r#"
+            id = "podcast_segments_non_silent"
+            kind = "per_file_non_silent"
+            glob = "**/segments/seg_*.wav"
+        "#;
+        let parsed: Validator = toml::from_str(toml).unwrap();
+        match parsed.spec {
+            ValidatorSpec::PerFileNonSilent {
+                ref glob,
+                min_ratio,
+                require_at_least,
+            } => {
+                assert_eq!(glob, "**/segments/seg_*.wav");
+                assert!(
+                    (min_ratio - default_non_silent_ratio()).abs() < f32::EPSILON,
+                    "min_ratio must default to {} when omitted, got {min_ratio}",
+                    default_non_silent_ratio()
+                );
+                assert_eq!(
+                    require_at_least, 0,
+                    "require_at_least must default to 0 when omitted"
+                );
+            }
+            ref other => panic!("expected PerFileNonSilent, got {other:?}"),
         }
     }
 

--- a/docs/app-skill-dev-guide.md
+++ b/docs/app-skill-dev-guide.md
@@ -771,12 +771,13 @@ Every `ValidatorSpec` variant currently merged. Source: `crates/octos-agent/src/
 | `FileExists { path, min_bytes? }` | `{kind: "file_exists", path, min_bytes}` | `${args.X}` (percent-encoded for the single-filename segment use case) + `${output.X}` (verbatim) | Assert a file exists (and optionally meets a min byte count). |
 | `HttpProbe { url_template, expected_status?, expected_contains? }` | `{kind: "http_probe", url_template, expected_status, expected_contains}` | `${args.X}` (percent-encoded) + `${output.X}` (verbatim) | Single-shot GET → status + optional body substring. PR #935. |
 | `OminixVoiceExists { name_arg }` | `{kind: "ominix_voice_exists", name_arg}` | `name_arg` looked up in input args | Specialised probe of `${OMINIX_API_URL}/v1/voices` asserting the named voice is registered. PR #935. |
-| `AudioNonSilent { glob, min_ratio? }` | `{kind: "audio_non_silent", glob, min_ratio}` | none (glob is literal) | Decode WAV (or MP3 with the `audio_mp3` feature) and assert at least `min_ratio` of samples are non-silent across the whole file. PR #935. |
+| `AudioNonSilent { glob, min_ratio? }` | `{kind: "audio_non_silent", glob, min_ratio}` | `${args.X}` + `${output.X}` (glob template) | Decode WAV (or MP3 with the `audio_mp3` feature) and assert at least `min_ratio` of samples are non-silent across the whole file. Passes if ANY matched file is non-silent. PR #935. |
+| `PerFileNonSilent { glob, min_ratio?, require_at_least? }` | `{kind: "per_file_non_silent", glob, min_ratio, require_at_least}` | `${args.X}` only (path-traversal-rejected) | Per-segment companion to `AudioNonSilent`: EVERY matched file must independently meet `min_ratio`, and the match count must meet `require_at_least` (0 = no minimum). Failure message surfaces the offending file's basename. PR #955. |
 | `MagicBytes { glob, format }` | `{kind: "magic_bytes", glob, format}` | none | Assert each file matching `glob` starts with the magic-byte prefix for `format`. Catches "wrote an HTML error page in place of an MP3" failures. PR #935. Supported formats: `mp3`, `wav`, `png`, `jpeg`, `pdf`, `mp4`, `web_m`, `pptx` (three ZIP signatures). |
 | `HttpProbeUntil { url_template, expected_status?, expected_contains?, poll_interval_ms?, deadline_ms? }` | `{kind: "http_probe_until", ...}` | same as `HttpProbe` | Polling HTTP probe; closes silent-failure paths for asynchronous external operations (training a voice, deploying a site). Default 2s interval / 30s deadline. PR #943. |
 | `Sha256Match { glob, sha256 }` | `{kind: "sha256_match", glob, sha256}` | `${args.X}` for both fields | Assert a single file's SHA-256 digest matches. Accepts either an explicit hex digest or an interpolated arg (e.g. the manifest's `sha256` captured at install). PR #943. |
 
-**`AudioNonSilent` is whole-file only** — a per-segment variant (`PerFileNonSilent`) is on the open list; it is **not yet merged**. For per-segment silence guarantees today, gate the artifact via a `MagicBytes` + `AudioNonSilent` pair and accept that mid-clip silence can pass.
+**Whole-file vs per-segment audio gates.** `AudioNonSilent` passes when ANY matched file is non-silent, which means a multi-segment artifact (e.g. an assembled podcast MP3) can mask a single silent intermediate segment because the silent gap gets averaged out by the surrounding speech. When per-segment guarantees matter, pair `AudioNonSilent` (whole file) with `PerFileNonSilent` (each segment) on the same spawn task. The canonical example is `podcast_generate`, which gates BOTH the final MP3 and each preserved `<output_dir>/segments/seg_*.wav` after mofa-skills #59 made segments visible after assembly.
 
 ### Interpolation: `${args.X}` vs `${output.X}`
 
@@ -1238,7 +1239,7 @@ Their `SKILL.md` says "Replace with a real ... when adapting the starter." Use t
 - [ ] No silent-failure paths in skill code — surface as `success: false` or rely on a harness validator (don't write your own post-condition check)
 - [ ] If `spawn_only: true` and the harness needs to validate a structured output (e.g. a deploy URL), the binary emits `named_outputs` with keys matching `[a-z][a-z0-9_]*` and string values
 - [ ] Workspace contract entry exists in `WorkspacePolicy::for_session()` or `.octos-workspace.toml` (see [Part 7](#part-7-workspace-contract))
-- [ ] If the skill produces audio, the contract declares `AudioNonSilent` (whole-file) — and `PerFileNonSilent` if per-segment guarantees are needed (PerFileNonSilent is not yet merged; track in the audit doc)
+- [ ] If the skill produces audio, the contract declares `AudioNonSilent` (whole-file) — and `PerFileNonSilent` if per-segment guarantees are needed (PR #955)
 - [ ] Standalone test passes: `echo '{"param": "val"}' | ./main my_tool`
 - [ ] Gateway test passes: skill loads and agent can invoke it
 - [ ] `cargo clippy -D warnings` clean (for Rust skills)


### PR DESCRIPTION
## Summary

- Add `ValidatorSpec::PerFileNonSilent { glob, min_ratio, require_at_least }` to the harness alongside `AudioNonSilent`. Runner enforces a per-file non-silent ratio threshold AND a minimum-match-count floor.
- Wire it into `WorkspacePolicy::for_session()::podcast_generate` as a third `on_completion` validator, scoped to `skill-output/mofa-podcast/**/segments/seg_*.wav` so it catches a silent intermediate segment that the whole-file `AudioNonSilent` cannot detect (the silent gap gets averaged out by surrounding speech in the assembled MP3).
- Glob deliberately excludes `pause_after_*`, `pause_line_*`, `bgm_placeholder_line_*` placeholders — those filenames are emitted by mofa-podcast as legitimately-silent inter-segment pauses.

## Why

Codex review of mofa-skills #58 surfaced this as a P2: harness's whole-file `AudioNonSilent` can't catch a single silent segment in a multi-segment podcast. Two independent codex passes converged on the same finding.

Now that mofa-skills #59 preserves segments after successful assembly (via Result-aware RAII `SegmentDirCleanup`), the harness can validate them per-file.

## Variant shape

```rust
ValidatorSpec::PerFileNonSilent {
    glob: String,
    #[serde(default = "default_non_silent_ratio")]
    min_ratio: f32,
    #[serde(default)]
    require_at_least: usize,
}
```

`min_ratio` is `f32` (not `f64`) to match the existing `AudioNonSilent` variant and reuse `decode_non_silent_ratio` without lossy conversion. `require_at_least = 0` (the serde default) makes the variant a pure per-file gate; setting it to `>= 1` also enforces a match-count floor.

## Tests added (10)

- `validators::tests::per_file_non_silent_passes_when_all_segments_are_loud`
- `validators::tests::per_file_non_silent_fails_when_one_segment_is_silent` (asserts the offending filename + ratio + threshold surface in the failure message)
- `validators::tests::per_file_non_silent_fails_when_match_count_below_require_at_least` ("expected >=1, found 0")
- `validators::tests::per_file_non_silent_passes_when_require_at_least_zero_and_no_matches` (optional-intermediate escape hatch)
- `validators::tests::per_file_non_silent_glob_interpolates_args_key` (`${args.X}` interpolation works)
- `validators::tests::per_file_non_silent_rejects_path_traversal_arg_value` (`../etc` arg value -> Error outcome)
- `validators::tests::per_file_non_silent_glob_excludes_placeholder_filenames` (mofa-podcast pause/BGM placeholders correctly excluded)
- `workspace_policy::tests::per_file_non_silent_roundtrips_through_toml`
- `workspace_policy::tests::per_file_non_silent_defaults_require_at_least_and_min_ratio_when_omitted`
- `workspace_contract::tests::podcast_contract_satisfies_when_all_segments_and_final_mix_are_non_silent` + `..._fails_when_a_single_segment_is_silent_even_if_final_mix_is_loud` (combined-gate e2e via `enforce_spawn_task_contract_with_args`; confirms both `audio_non_silent` and `per_file_non_silent` outcomes persist to the validator ledger when both fire)

Plus the existing `session_policy_declares_new_domain_validators_for_silent_failure_paths` was strengthened to assert the segments glob, min_ratio floor, and `require_at_least >= 1` on `podcast_generate`.

Test delta in `octos-agent --lib`: 1425 -> 1435 (+10).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p octos-agent --all-targets -- -D warnings`
- [x] `cargo test -p octos-agent --lib` (1435 / 1435 pass)
- [x] `cargo test -p octos-agent --tests` (15 / 15 pass)
- [x] `cargo check --workspace --all-targets`