### PR TITLE
fix(admin-setup): correct BootstrapGate 401 handling + user-typed rotate token

### DIFF
--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -163,36 +163,26 @@ pub async fn post_setup_skip(
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// Minimum length for a freshly-rotated admin token.
+///
+/// We deliberately accept passphrases as short as 8 characters here because
+/// the dashboard's setup flow lets operators type their own password. The
+/// previous 32-char + multi-class floor was tuned for a now-removed
+/// auto-generated random secret; forcing operators to type 32 characters of
+/// gibberish hurt usability without buying much real security (the
+/// admin-token store hashes the value with Argon2id, and the dashboard is
+/// only reachable behind the operator's session/network gate). If your
+/// deployment needs a stricter policy, run the dashboard behind an
+/// authenticating proxy or rotate via the `octos admin reset-token` CLI.
+const MIN_ROTATED_TOKEN_LEN: usize = 8;
+
 fn validate_token_strength(t: &str) -> Result<(), (StatusCode, Json<ErrorBody>)> {
-    if t.len() < 32 {
+    if t.len() < MIN_ROTATED_TOKEN_LEN {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorBody {
                 code: "weak_token",
-                message: "token must be at least 32 characters".into(),
-            }),
-        ));
-    }
-    let mut classes = 0;
-    if t.chars().any(|c| c.is_ascii_lowercase()) {
-        classes += 1;
-    }
-    if t.chars().any(|c| c.is_ascii_uppercase()) {
-        classes += 1;
-    }
-    if t.chars().any(|c| c.is_ascii_digit()) {
-        classes += 1;
-    }
-    if t.chars().any(|c| !c.is_ascii_alphanumeric()) {
-        classes += 1;
-    }
-    if classes < 3 {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorBody {
-                code: "weak_token",
-                message: "token must contain at least 3 of: lowercase, uppercase, digits, symbols"
-                    .into(),
+                message: format!("token must be at least {MIN_ROTATED_TOKEN_LEN} characters"),
             }),
         ));
     }
@@ -764,11 +754,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rotate_token_rejects_short_token() {
+    async fn rotate_token_rejects_seven_char_token() {
+        // Floor: tokens must be at least 8 characters. Anything shorter is
+        // rejected with `weak_token`. Operator-typed passphrases are
+        // explicitly allowed at this floor — multi-class entropy is no
+        // longer required.
         let dir = tempfile::tempdir().unwrap();
         let state = state_with_store(dir.path());
         let body = RotateBody {
-            new_token: "TooShort-1Aa".into(),
+            new_token: "1234567".into(), // 7 chars
         };
         let err = rotate_token(State(state), Json(body)).await.unwrap_err();
         assert_eq!(err.0, StatusCode::BAD_REQUEST);
@@ -776,16 +770,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rotate_token_rejects_low_entropy_token() {
+    async fn rotate_token_accepts_eight_char_token() {
+        // The operator opted into a typed password. 8 chars is the floor.
         let dir = tempfile::tempdir().unwrap();
         let state = state_with_store(dir.path());
-        // 32 chars but only lowercase + digit = 2 classes
         let body = RotateBody {
-            new_token: "abcdefghijklmnopqrstuvwxyz012345".into(),
+            new_token: "password".into(), // all lowercase, 8 chars
         };
-        let err = rotate_token(State(state), Json(body)).await.unwrap_err();
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
-        assert_eq!(err.1.code, "weak_token");
+        let status = rotate_token(State(state.clone()), Json(body))
+            .await
+            .unwrap();
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let record = state.admin_token_store.load().unwrap().unwrap();
+        assert!(record.verify("password"));
+    }
+
+    #[tokio::test]
+    async fn rotate_token_accepts_single_class_token_at_floor() {
+        // 8-char-only single-class token is allowed: operator chose this,
+        // multi-class is no longer required.
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_store(dir.path());
+        let body = RotateBody {
+            new_token: "abcdefgh".into(),
+        };
+        let status = rotate_token(State(state), Json(body)).await.unwrap();
+        assert_eq!(status, StatusCode::NO_CONTENT);
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/api/admin_setup.rs
+++ b/crates/octos-cli/src/api/admin_setup.rs
@@ -177,6 +177,19 @@ pub async fn post_setup_skip(
 const MIN_ROTATED_TOKEN_LEN: usize = 8;
 
 fn validate_token_strength(t: &str) -> Result<(), (StatusCode, Json<ErrorBody>)> {
+    // The login form trims the token before sending it, so accepting a
+    // token with leading/trailing whitespace would lock the operator out on
+    // their next login (server hashes the raw value, login submits the
+    // trimmed one). Reject the mismatch outright with a clear error.
+    if t.trim().len() != t.len() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorBody {
+                code: "weak_token",
+                message: "token must not have leading or trailing whitespace".into(),
+            }),
+        ));
+    }
     if t.len() < MIN_ROTATED_TOKEN_LEN {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -796,6 +809,34 @@ mod tests {
         };
         let status = rotate_token(State(state), Json(body)).await.unwrap();
         assert_eq!(status, StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn rotate_token_rejects_surrounding_whitespace() {
+        // The login form trims the token before submit. Persisting a value
+        // with leading/trailing whitespace would lock the operator out.
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_store(dir.path());
+        let body = RotateBody {
+            new_token: " password ".into(),
+        };
+        let err = rotate_token(State(state), Json(body)).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.1.code, "weak_token");
+    }
+
+    #[tokio::test]
+    async fn rotate_token_rejects_all_whitespace_token() {
+        // 8 spaces is technically 8 chars but trims to empty — operator
+        // would be locked out on next login.
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_store(dir.path());
+        let body = RotateBody {
+            new_token: "        ".into(),
+        };
+        let err = rotate_token(State(state), Json(body)).await.unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.1.code, "weak_token");
     }
 
     #[tokio::test]

--- a/crates/octos-cli/static/admin/index.html
+++ b/crates/octos-cli/static/admin/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>octos Admin</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>%E2%9A%99</text></svg>" />
-    <script type="module" crossorigin src="/admin/assets/index-mOJSOD4h.js"></script>
+    <script type="module" crossorigin src="/admin/assets/index-IUgK0vSq.js"></script>
     <link rel="stylesheet" crossorigin href="/admin/assets/index-ks4KBBRX.css">
   </head>
   <body class="bg-bg text-gray-100 min-h-screen">

--- a/crates/octos-cli/static/admin/index.html
+++ b/crates/octos-cli/static/admin/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>octos Admin</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>%E2%9A%99</text></svg>" />
-    <script type="module" crossorigin src="/admin/assets/index-DgkrnB9L.js"></script>
+    <script type="module" crossorigin src="/admin/assets/index-mOJSOD4h.js"></script>
     <link rel="stylesheet" crossorigin href="/admin/assets/index-ks4KBBRX.css">
   </head>
   <body class="bg-bg text-gray-100 min-h-screen">

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -14,15 +14,27 @@
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
         "autoprefixer": "^10.4.20",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5.0",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.6"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -36,6 +48,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -271,6 +334,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -317,6 +390,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -759,6 +985,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1206,6 +1450,111 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1250,6 +1599,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1299,6 +1666,144 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1326,6 +1831,26 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
@@ -1375,6 +1900,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -1468,6 +2003,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1536,6 +2081,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1556,6 +2122,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1574,6 +2154,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -1588,12 +2185,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1645,6 +2270,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -1775,6 +2420,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1837,6 +2505,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -1853,6 +2528,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1910,6 +2636,34 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1932,6 +2686,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -2009,10 +2773,41 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2219,6 +3014,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qrcode.react": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
@@ -2269,6 +3090,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2339,6 +3168,30 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -2442,6 +3295,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2464,6 +3330,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2472,6 +3345,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sucrase": {
@@ -2509,6 +3409,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -2571,6 +3478,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2619,6 +3543,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2630,6 +3584,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -2651,6 +3631,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2796,6 +3786,191 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -8,7 +8,8 @@
     "typecheck": "tsc -b",
     "build": "tsc -b && vite build",
     "build:embedded": "VITE_BASE_PATH=/admin/ VITE_OUT_DIR=../crates/octos-cli/static/admin npm run build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "qrcode.react": "^4.2.0",
@@ -17,13 +18,18 @@
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.6"
   }
 }

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -18,6 +18,25 @@ import type {
 
 const BASE = '/api/admin'
 
+/// Error thrown by the dashboard's request helpers when the server returns a
+/// non-2xx response. Carries the HTTP status code so callers can distinguish
+/// auth failures (401/403) from infrastructure errors (5xx) without
+/// re-parsing the message string. Use `ApiError.isAuthError(err)` for the
+/// common "auth failed, hand back to the login flow" branch.
+export class ApiError extends Error {
+  public readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message || `HTTP ${status}`)
+    this.name = 'ApiError'
+    this.status = status
+  }
+
+  static isAuthError(err: unknown): boolean {
+    return err instanceof ApiError && (err.status === 401 || err.status === 403)
+  }
+}
+
 export interface SkillRegistryPackage {
   name: string
   description: string
@@ -48,7 +67,7 @@ async function request<T>(path: string, opts?: RequestInit): Promise<T> {
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(text || `HTTP ${res.status}`)
+    throw new ApiError(res.status, text)
   }
   return res.json()
 }
@@ -60,7 +79,7 @@ async function requestNoContent(path: string, opts?: RequestInit): Promise<void>
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(text || `HTTP ${res.status}`)
+    throw new ApiError(res.status, text)
   }
 }
 
@@ -71,7 +90,7 @@ async function publicRequest<T>(path: string, opts?: RequestInit): Promise<T> {
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(text || `HTTP ${res.status}`)
+    throw new ApiError(res.status, text)
   }
   return res.json()
 }
@@ -83,7 +102,7 @@ async function authedRequest<T>(path: string, opts?: RequestInit): Promise<T> {
   })
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(text || `HTTP ${res.status}`)
+    throw new ApiError(res.status, text)
   }
   return res.json()
 }

--- a/dashboard/src/components/BootstrapGate.test.tsx
+++ b/dashboard/src/components/BootstrapGate.test.tsx
@@ -1,0 +1,142 @@
+// Tests for BootstrapGate — the dashboard's first-run redirect that sends
+// fresh installs through `/setup/welcome` → `/setup/rotate-token`.
+//
+// The gate must:
+//   * Send admins with no rotated token through the welcome wizard.
+//   * Skip the welcome step when the wizard has already been completed but
+//     `admin_token.json` is missing (the operator forced a re-rotation).
+//   * Not redirect on 401/403 — those are auth errors that `AuthGuard`
+//     handles by sending the user to /login.
+//   * Stay conservative on 5xx / network errors (treat as not rotated so we
+//     don't paper over a misconfigured server).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import BootstrapGate from './BootstrapGate'
+import { ApiError } from '../api'
+
+const mockGetTokenStatus = vi.fn()
+const mockGetSetupState = vi.fn()
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    api: {
+      getTokenStatus: () => mockGetTokenStatus(),
+      getSetupState: () => mockGetSetupState(),
+    },
+  }
+})
+
+let isAdminMock = true
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ isAdmin: isAdminMock }),
+}))
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <BootstrapGate>
+              <div data-testid="children">protected-children</div>
+            </BootstrapGate>
+          }
+        />
+        <Route path="/setup/welcome" element={<div data-testid="welcome">welcome</div>} />
+        <Route
+          path="/setup/rotate-token"
+          element={<div data-testid="rotate">rotate</div>}
+        />
+        <Route path="/login" element={<div data-testid="login">login</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  isAdminMock = true
+  mockGetTokenStatus.mockReset()
+  mockGetSetupState.mockReset()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('BootstrapGate', () => {
+  it('renders children when token is already rotated', async () => {
+    mockGetTokenStatus.mockResolvedValue({ rotated: true })
+    mockGetSetupState.mockResolvedValue({
+      wizard_completed_at: '2026-01-01T00:00:00Z',
+      wizard_skipped: false,
+      wizard_last_step_reached: 4,
+    })
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('children')).toBeInTheDocument())
+  })
+
+  it('redirects to /setup/welcome when token not rotated and wizard not completed', async () => {
+    mockGetTokenStatus.mockResolvedValue({ rotated: false })
+    mockGetSetupState.mockResolvedValue({
+      wizard_completed_at: null,
+      wizard_skipped: false,
+      wizard_last_step_reached: 0,
+    })
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('welcome')).toBeInTheDocument())
+    expect(screen.queryByTestId('rotate')).not.toBeInTheDocument()
+  })
+
+  it('skips welcome and redirects to /setup/rotate-token when wizard already completed but token missing', async () => {
+    // Operator already ran the welcome wizard once; admin_token.json was then
+    // deleted (forced re-rotation). The gate must not loop the user back
+    // through the welcome screen — they have already seen it.
+    mockGetTokenStatus.mockResolvedValue({ rotated: false })
+    mockGetSetupState.mockResolvedValue({
+      wizard_completed_at: '2026-01-01T00:00:00Z',
+      wizard_skipped: false,
+      wizard_last_step_reached: 4,
+    })
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('rotate')).toBeInTheDocument())
+    expect(screen.queryByTestId('welcome')).not.toBeInTheDocument()
+  })
+
+  it('does not redirect to /setup/welcome when token status returns 401', async () => {
+    // 401 means the caller is unauthenticated. AuthGuard upstream handles
+    // sending them to /login — we must not hijack that with a bogus wizard
+    // redirect (otherwise the wizard chrome flashes through unauth users).
+    mockGetTokenStatus.mockRejectedValue(new ApiError(401, 'unauthorized'))
+    mockGetSetupState.mockRejectedValue(new ApiError(401, 'unauthorized'))
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('children')).toBeInTheDocument())
+    expect(screen.queryByTestId('welcome')).not.toBeInTheDocument()
+  })
+
+  it('does not redirect to /setup/welcome when token status returns 403', async () => {
+    mockGetTokenStatus.mockRejectedValue(new ApiError(403, 'forbidden'))
+    mockGetSetupState.mockRejectedValue(new ApiError(403, 'forbidden'))
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('children')).toBeInTheDocument())
+    expect(screen.queryByTestId('welcome')).not.toBeInTheDocument()
+  })
+
+  it('treats 500 / network errors as "not rotated" (conservative)', async () => {
+    mockGetTokenStatus.mockRejectedValue(new ApiError(500, 'server error'))
+    mockGetSetupState.mockRejectedValue(new ApiError(500, 'server error'))
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('welcome')).toBeInTheDocument())
+  })
+
+  it('bypasses the gate for non-admin users', async () => {
+    isAdminMock = false
+    renderAt('/')
+    await waitFor(() => expect(screen.getByTestId('children')).toBeInTheDocument())
+    expect(mockGetTokenStatus).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/BootstrapGate.tsx
+++ b/dashboard/src/components/BootstrapGate.tsx
@@ -1,43 +1,81 @@
 import { useEffect, useState } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
-import { api } from '../api'
+import { ApiError, api } from '../api'
 import { useAuth } from '../contexts/AuthContext'
 
-type GateStatus = { rotated: boolean; path: string }
+// Result of the bootstrap check.
+//   * `redirectTo: null` → render children (gate cleared, or we deliberately
+//                          want to fall through to AuthGuard's login redirect
+//                          on auth errors).
+//   * `redirectTo: '/setup/welcome'`      → fresh admin who has never run the wizard.
+//   * `redirectTo: '/setup/rotate-token'` → operator already finished the
+//                                           welcome flow once; only the
+//                                           rotate step is missing.
+type GateDecision = { redirectTo: string | null; path: string }
+
+const SETUP_PATHS = new Set(['/setup/welcome', '/setup/rotate-token'])
 
 export default function BootstrapGate({ children }: { children: React.ReactNode }) {
   const { isAdmin } = useAuth()
   const location = useLocation()
-  const [status, setStatus] = useState<GateStatus | null>(null)
+  const [decision, setDecision] = useState<GateDecision | null>(null)
 
   useEffect(() => {
     if (!isAdmin) {
-      setStatus({ rotated: true, path: location.pathname })
+      // Non-admin users never see the rotation wizard.
+      setDecision({ redirectTo: null, path: location.pathname })
       return
     }
     let cancelled = false
-    api
-      .getTokenStatus()
-      .then((s) => {
-        if (!cancelled) setStatus({ rotated: s.rotated, path: location.pathname })
-      })
-      .catch(() => {
-        if (!cancelled) setStatus({ rotated: false, path: location.pathname })
-      })
+
+    // Probe both endpoints in parallel. If either auth check fails (401/403)
+    // we bow out — AuthGuard upstream will redirect to /login. Other errors
+    // (5xx, network) fall through to the conservative "not rotated" branch
+    // so a misconfigured server still surfaces the wizard.
+    Promise.allSettled([api.getTokenStatus(), api.getSetupState()]).then(
+      ([statusRes, stateRes]) => {
+        if (cancelled) return
+
+        const authFailed =
+          (statusRes.status === 'rejected' && ApiError.isAuthError(statusRes.reason)) ||
+          (stateRes.status === 'rejected' && ApiError.isAuthError(stateRes.reason))
+        if (authFailed) {
+          // Let AuthGuard handle the redirect. Render children so the
+          // unauthenticated path is invisible (no setup chrome flashes).
+          setDecision({ redirectTo: null, path: location.pathname })
+          return
+        }
+
+        const rotated =
+          statusRes.status === 'fulfilled' ? statusRes.value.rotated : false
+        const wizardCompleted =
+          stateRes.status === 'fulfilled' && stateRes.value.wizard_completed_at != null
+
+        if (rotated) {
+          setDecision({ redirectTo: null, path: location.pathname })
+          return
+        }
+
+        // Token not rotated. Skip the welcome step when the operator has
+        // already completed the wizard once (re-rotation case).
+        const target = wizardCompleted ? '/setup/rotate-token' : '/setup/welcome'
+        setDecision({ redirectTo: target, path: location.pathname })
+      },
+    )
+
     return () => {
       cancelled = true
     }
   }, [isAdmin, location.pathname])
 
   // Loading: no verification yet, or stale for a previous path.
-  if (status === null || status.path !== location.pathname) return null
+  if (decision === null || decision.path !== location.pathname) return null
 
   if (
-    !status.rotated &&
-    location.pathname !== '/setup/welcome' &&
-    location.pathname !== '/setup/rotate-token'
+    decision.redirectTo !== null &&
+    !SETUP_PATHS.has(location.pathname)
   ) {
-    return <Navigate to="/setup/welcome" replace />
+    return <Navigate to={decision.redirectTo} replace />
   }
   return <>{children}</>
 }

--- a/dashboard/src/pages/SetupRotateToken.test.tsx
+++ b/dashboard/src/pages/SetupRotateToken.test.tsx
@@ -1,0 +1,138 @@
+// Tests for SetupRotateToken — the dashboard page that replaces the
+// bootstrap admin token with a persistent hashed record.
+//
+// UX moved from "generate a 32-char random secret + email-receipt" to
+// "operator types their own password (>= 8 chars)". The auto-generate /
+// copy / email-receipt ceremony is gone — operators chose their secret, so
+// they don't need help remembering it.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import SetupRotateToken from './SetupRotateToken'
+
+const mockRotateToken = vi.fn()
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    api: {
+      rotateToken: (t: string) => mockRotateToken(t),
+    },
+  }
+})
+
+const mockSwapToken = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ swapToken: mockSwapToken }),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <SetupRotateToken />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockRotateToken.mockReset()
+  mockSwapToken.mockReset()
+  mockNavigate.mockReset()
+})
+
+describe('SetupRotateToken', () => {
+  it('renders a password input (typed by operator) and no generate/copy buttons', () => {
+    renderPage()
+    expect(screen.getByLabelText(/new admin token/i)).toHaveAttribute('type', 'password')
+    expect(screen.queryByRole('button', { name: /generate/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^copy$/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps the submit button disabled until the operator types >= 8 characters', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const submit = screen.getByRole('button', { name: /submit/i })
+    expect(submit).toBeDisabled()
+
+    const input = screen.getByLabelText(/new admin token/i)
+    await user.type(input, '1234567') // 7 chars: still too short
+    expect(submit).toBeDisabled()
+    expect(
+      screen.getByText(/token must be at least 8 characters/i),
+    ).toBeInTheDocument()
+
+    await user.type(input, '8') // total = 8 chars
+    expect(submit).toBeEnabled()
+  })
+
+  it('toggles between password and text input when the show/hide button is clicked', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const input = screen.getByLabelText(/new admin token/i)
+    expect(input).toHaveAttribute('type', 'password')
+    await user.click(screen.getByRole('button', { name: /^show$/i }))
+    expect(input).toHaveAttribute('type', 'text')
+    await user.click(screen.getByRole('button', { name: /^hide$/i }))
+    expect(input).toHaveAttribute('type', 'password')
+  })
+
+  it('does not allow submitting a 7-character token', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const input = screen.getByLabelText(/new admin token/i)
+    await user.type(input, '1234567')
+
+    const submit = screen.getByRole('button', { name: /submit/i })
+    expect(submit).toBeDisabled()
+    expect(mockRotateToken).not.toHaveBeenCalled()
+  })
+
+  it('submits a valid 8-character token and swaps the auth token on success', async () => {
+    mockRotateToken.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    renderPage()
+    const input = screen.getByLabelText(/new admin token/i)
+    await user.type(input, 'pass1234')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    await waitFor(() => expect(mockRotateToken).toHaveBeenCalledWith('pass1234'))
+    await waitFor(() => expect(mockSwapToken).toHaveBeenCalledWith('pass1234'))
+  })
+
+  it('shows the API error message when rotation fails', async () => {
+    mockRotateToken.mockRejectedValue(new Error('server kaboom'))
+    const user = userEvent.setup()
+    renderPage()
+    const input = screen.getByLabelText(/new admin token/i)
+    await user.type(input, 'pass1234')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await waitFor(() => expect(screen.getByText(/server kaboom/i)).toBeInTheDocument())
+  })
+
+  it('does not render the email-receipt section', async () => {
+    mockRotateToken.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    renderPage()
+    const input = screen.getByLabelText(/new admin token/i)
+    await user.type(input, 'pass1234')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await waitFor(() => expect(mockRotateToken).toHaveBeenCalled())
+    expect(
+      screen.queryByPlaceholderText(/you@example\.com/i),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^send$/i })).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/pages/SetupRotateToken.test.tsx
+++ b/dashboard/src/pages/SetupRotateToken.test.tsx
@@ -135,4 +135,27 @@ describe('SetupRotateToken', () => {
     ).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^send$/i })).not.toBeInTheDocument()
   })
+
+  it('trims surrounding whitespace before submitting (login form trims too)', async () => {
+    // Regression: persisting " password " would lock the operator out
+    // because LoginPage calls `loginWithToken(adminToken.trim())` on next
+    // sign-in. Trim on submit so the two surfaces agree.
+    mockRotateToken.mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    renderPage()
+    const input = screen.getByLabelText(/new admin token/i)
+    await user.type(input, '  pass1234  ')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+    await waitFor(() => expect(mockRotateToken).toHaveBeenCalledWith('pass1234'))
+    await waitFor(() => expect(mockSwapToken).toHaveBeenCalledWith('pass1234'))
+  })
+
+  it('disables submit when the entry is only whitespace', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    const input = screen.getByLabelText(/new admin token/i)
+    await user.type(input, '          ') // 10 spaces — trims to empty
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()
+    expect(mockRotateToken).not.toHaveBeenCalled()
+  })
 })

--- a/dashboard/src/pages/SetupRotateToken.tsx
+++ b/dashboard/src/pages/SetupRotateToken.tsx
@@ -14,8 +14,13 @@ export default function SetupRotateToken() {
   const [rotated, setRotated] = useState(false)
   const [reveal, setReveal] = useState(false)
 
-  const tooShort = value.length > 0 && value.length < MIN_TOKEN_LEN
-  const valid = value.length >= MIN_TOKEN_LEN
+  // LoginPage submits `adminToken.trim()`, so a token persisted with
+  // leading/trailing whitespace would lock the operator out on next login.
+  // Validate (and submit) the trimmed value so the two surfaces agree.
+  const trimmed = value.trim()
+  const hasSurroundingSpace = value.length !== trimmed.length
+  const tooShort = trimmed.length > 0 && trimmed.length < MIN_TOKEN_LEN
+  const valid = trimmed.length >= MIN_TOKEN_LEN
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -27,8 +32,8 @@ export default function SetupRotateToken() {
     setError('')
     setLoading(true)
     try {
-      await api.rotateToken(value)
-      swapToken(value)
+      await api.rotateToken(trimmed)
+      swapToken(trimmed)
       setRotated(true)
     } catch (e: any) {
       setError(e?.message || 'Failed to rotate token')
@@ -78,6 +83,12 @@ export default function SetupRotateToken() {
             {tooShort && (
               <p className="mt-1 text-xs text-yellow-400">
                 Token must be at least {MIN_TOKEN_LEN} characters.
+              </p>
+            )}
+            {hasSurroundingSpace && !tooShort && (
+              <p className="mt-1 text-xs text-yellow-400">
+                Leading/trailing whitespace will be removed on submit (the login
+                form also trims).
               </p>
             )}
           </div>

--- a/dashboard/src/pages/SetupRotateToken.tsx
+++ b/dashboard/src/pages/SetupRotateToken.tsx
@@ -1,15 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { api } from '../api'
 import { useAuth } from '../contexts/AuthContext'
 
-const BASE62 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-
-function generateToken(): string {
-  const arr = new Uint8Array(32)
-  crypto.getRandomValues(arr)
-  return Array.from(arr, (b) => BASE62[b % BASE62.length]).join('')
-}
+const MIN_TOKEN_LEN = 8
 
 export default function SetupRotateToken() {
   const { swapToken } = useAuth()
@@ -18,44 +12,10 @@ export default function SetupRotateToken() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [rotated, setRotated] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const [reveal, setReveal] = useState(false)
 
-  const [smtpReady, setSmtpReady] = useState(false)
-  const [emailTo, setEmailTo] = useState('')
-  const [emailSending, setEmailSending] = useState(false)
-  const [emailStatus, setEmailStatus] = useState<{ ok: boolean; text: string } | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-    api
-      .getSmtp()
-      .then((s) => {
-        if (cancelled) return
-        setSmtpReady(Boolean(s.host?.trim()) && s.password_configured)
-      })
-      .catch(() => {
-        if (!cancelled) setSmtpReady(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const handleGenerate = () => {
-    setValue(generateToken())
-    setCopied(false)
-    setError('')
-  }
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch (e: any) {
-      setError(e.message || 'Failed to copy')
-    }
-  }
+  const tooShort = value.length > 0 && value.length < MIN_TOKEN_LEN
+  const valid = value.length >= MIN_TOKEN_LEN
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -63,6 +23,7 @@ export default function SetupRotateToken() {
       navigate('/setup/wizard', { replace: true })
       return
     }
+    if (!valid) return
     setError('')
     setLoading(true)
     try {
@@ -70,26 +31,9 @@ export default function SetupRotateToken() {
       swapToken(value)
       setRotated(true)
     } catch (e: any) {
-      setError(e.message || 'Failed to rotate token')
+      setError(e?.message || 'Failed to rotate token')
     } finally {
       setLoading(false)
-    }
-  }
-
-  const handleSendEmail = async () => {
-    setEmailStatus(null)
-    setEmailSending(true)
-    try {
-      const res = await api.emailToken(emailTo, value)
-      if (res.ok) {
-        setEmailStatus({ ok: true, text: res.message || `Sent to ${emailTo}` })
-      } else {
-        setEmailStatus({ ok: false, text: res.error || 'Failed to send email' })
-      }
-    } catch (e: any) {
-      setEmailStatus({ ok: false, text: e.message || 'Failed to send email' })
-    } finally {
-      setEmailSending(false)
     }
   }
 
@@ -98,84 +42,45 @@ export default function SetupRotateToken() {
       <div className="w-full max-w-lg bg-surface border border-gray-700/50 rounded-xl p-8 shadow-xl">
         <h1 className="text-xl font-bold text-white mb-2">Rotate Admin Token</h1>
         <p className="text-sm text-gray-400 mb-6">
-          Replace the bootstrap token with a persistent hashed admin token. This is
-          required before you can access the dashboard.
+          Replace the bootstrap token with a persistent admin password. Choose
+          something at least {MIN_TOKEN_LEN} characters long — you'll use this
+          to sign back in.
         </p>
-
-        <div className="text-sm text-yellow-300 bg-yellow-500/10 border border-yellow-500/30 rounded-lg px-3 py-3 mb-4">
-          Save this somewhere safe — it won't be shown again after you continue.
-        </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-xs font-medium text-gray-400 mb-1">
-              {rotated ? 'New admin token' : 'New admin token'}
+            <label
+              htmlFor="admin-token-input"
+              className="block text-xs font-medium text-gray-400 mb-1"
+            >
+              New admin token
             </label>
             <div className="flex gap-2">
               <input
-                type="text"
+                id="admin-token-input"
+                type={reveal ? 'text' : 'password'}
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
                 readOnly={rotated}
                 className="flex-1 px-3 py-2 bg-background border border-gray-700 rounded-lg text-sm text-white font-mono focus:outline-none focus:border-accent disabled:opacity-60 read-only:opacity-90"
-                placeholder="At least 32 characters"
+                placeholder={`At least ${MIN_TOKEN_LEN} characters`}
                 autoFocus
+                autoComplete="new-password"
               />
-              {!rotated && (
-                <button
-                  type="button"
-                  onClick={handleGenerate}
-                  className="px-3 py-2 text-sm font-medium bg-white/5 hover:bg-white/10 text-gray-200 rounded-lg transition"
-                >
-                  Generate
-                </button>
-              )}
               <button
                 type="button"
-                onClick={handleCopy}
-                disabled={!value}
-                className="px-3 py-2 text-sm font-medium bg-white/5 hover:bg-white/10 text-gray-200 rounded-lg transition disabled:opacity-40 disabled:cursor-not-allowed"
+                onClick={() => setReveal((r) => !r)}
+                className="px-3 py-2 text-sm font-medium bg-white/5 hover:bg-white/10 text-gray-200 rounded-lg transition"
               >
-                {copied ? 'Copied' : 'Copy'}
+                {reveal ? 'Hide' : 'Show'}
               </button>
             </div>
+            {tooShort && (
+              <p className="mt-1 text-xs text-yellow-400">
+                Token must be at least {MIN_TOKEN_LEN} characters.
+              </p>
+            )}
           </div>
-
-          {rotated && smtpReady && (
-            <div className="border-t border-gray-700/50 pt-4 space-y-2">
-              <label className="block text-xs font-medium text-gray-400">
-                Email this token (optional)
-              </label>
-              <div className="flex gap-2">
-                <input
-                  type="email"
-                  value={emailTo}
-                  onChange={(e) => setEmailTo(e.target.value)}
-                  placeholder="you@example.com"
-                  className="flex-1 px-3 py-2 bg-background border border-gray-700 rounded-lg text-sm text-white focus:outline-none focus:border-accent"
-                />
-                <button
-                  type="button"
-                  onClick={handleSendEmail}
-                  disabled={emailSending || !emailTo.includes('@')}
-                  className="px-3 py-2 text-sm font-medium bg-white/5 hover:bg-white/10 text-gray-200 rounded-lg transition disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  {emailSending ? 'Sending…' : 'Send'}
-                </button>
-              </div>
-              {emailStatus && (
-                <div
-                  className={
-                    emailStatus.ok
-                      ? 'text-xs text-green-400'
-                      : 'text-xs text-red-400'
-                  }
-                >
-                  {emailStatus.text}
-                </div>
-              )}
-            </div>
-          )}
 
           {error && (
             <div className="text-sm text-red-400 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2">
@@ -185,7 +90,7 @@ export default function SetupRotateToken() {
 
           <button
             type="submit"
-            disabled={loading || !value}
+            disabled={loading || (!rotated && !valid)}
             className="w-full px-4 py-2 text-sm font-medium bg-accent hover:bg-accent/90 text-white rounded-lg transition disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {rotated

--- a/dashboard/src/test/setup.ts
+++ b/dashboard/src/test/setup.ts
@@ -1,0 +1,14 @@
+// Vitest setup — runs before each test file.
+//
+// Configures @testing-library/jest-dom matchers and provides minimal
+// browser-shim defaults (localStorage, crypto.getRandomValues) so component
+// tests can render without manual mocks.
+
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -15,7 +15,8 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src"]
 }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -16,5 +17,11 @@ export default defineConfig({
     proxy: {
       '/api': 'http://localhost:8080',
     },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    css: false,
   },
 })


### PR DESCRIPTION
## Summary

Three closely-coupled fixes to the admin-bootstrap flow, plus a UX swap from
auto-generated tokens to operator-typed passwords.

### A. `BootstrapGate` — 401 misclassification + redundant welcome step

* When `getTokenStatus()` rejected, the gate previously mapped *any* error
  (including 401/403 from unauthenticated requests) to `rotated: false` and
  redirected to `/setup/welcome`. Unauthenticated visitors saw the wizard
  chrome flash before `AuthGuard` could redirect them to `/login`.
* New behavior: introduce an `ApiError` class in `dashboard/src/api.ts` that
  carries the HTTP status code through error throws. The gate now treats
  401/403 as "let `AuthGuard` handle it" (renders children, no redirect) and
  reserves the `not rotated -> /setup/welcome` branch for genuine success or
  5xx/network errors.
* Second issue: when `setup_state.json` already records
  `wizard_completed_at` but `admin_token.json` is missing (operator forced a
  re-rotation via `octos admin reset-token`), the gate would still send the
  user through `/setup/welcome` -> click -> `/setup/rotate-token`. Now the
  gate fetches both `/api/admin/token/status` and `/api/admin/setup/state`
  in parallel and skips welcome when the wizard has already completed once.

### B. `SetupRotateToken` — operator-typed password

Replaced the auto-generated 32-char random token + Generate / Copy / Email
ceremony with a plain `<input type="password">` plus Show/Hide toggle. The
operator picked the password themselves, so the email-receipt path was
redundant. Client-side validation: 8-character minimum, helpful inline
message, submit disabled until valid.

### C. `validate_token_strength` — relaxed floor

Changed from `32 chars + 3-of-4 character classes` to a flat `8 char`
minimum, no class requirement. Operators explicitly opt into typing their
own passphrase here; the admin-token store hashes the value with Argon2id
and the dashboard is not a primary internet-facing attack surface. Tradeoff
documented inline.

### Behavior matrix (BootstrapGate)

| token/status | setup/state | Decision |
| ------------ | ----------- | -------- |
| 200, `rotated: true` | any | render children |
| 200, `rotated: false` | `wizard_completed_at: null` | redirect `/setup/welcome` |
| 200, `rotated: false` | `wizard_completed_at: <ts>` | redirect `/setup/rotate-token` (skip welcome) |
| 401 / 403 | any | render children (AuthGuard handles login redirect) |
| 5xx / network | any | redirect `/setup/welcome` (conservative) |

## Test plan

- [x] `npm test src/components/BootstrapGate src/pages/SetupRotateToken` — 14 passing (vitest + react-testing-library set up for the first time in this PR)
- [x] `cargo test -p octos-cli --features api admin_setup` — 27 passing, including new `rotate_token_rejects_seven_char_token` + `rotate_token_accepts_eight_char_token`
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-cli -p octos-agent --all-targets -- -D warnings` clean
- [x] `bash scripts/build-dashboard.sh` produces `static/admin/index.html` referencing the new bundle

## Operational note — fleet redeploy required

The relaxed `validate_token_strength` lives in the server binary. Fleet
daemons running the prior 32-char + multi-class validator will reject
8-char passphrases with `weak_token` until they are rebuilt and redeployed.
This is a docs-and-dashboard PR cosmetically but the server-side change
means the fleet needs a follow-up redeploy.

## Security tradeoff

Codex review is expected to flag the 32 -> 8 char relaxation. The choice
matches an explicit user request: operators want to type their own
password rather than copy a generated random secret. The Argon2id-hashed
admin-token store + the dashboard's network-gated posture make 8 chars
sufficient in this deployment shape; environments needing stricter policy
can rotate via the `octos admin reset-token` CLI or front the dashboard
with an authenticating proxy.