### PR TITLE
feat(api): wire model id into cost_update so chat bubble footer renders

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -939,7 +939,7 @@ impl Agent {
 
                     match response.stop_reason {
                         StopReason::EndTurn | StopReason::StopSequence => {
-                            self.emit_cost_update(turn.total_usage(), &response.usage);
+                            self.emit_cost_update(turn.total_usage(), &response);
                             return Ok(ConversationResponse {
                                 content: response.content.unwrap_or_default(),
                                 reasoning_content: response.reasoning_content.clone(),
@@ -1033,7 +1033,7 @@ impl Agent {
                                             decision = %outcome.decision,
                                             "shell spiral terminal: returning recovered content as final assistant reply"
                                         );
-                                        self.emit_cost_update(turn.total_usage(), &response.usage);
+                                        self.emit_cost_update(turn.total_usage(), &response);
                                         return Ok(ConversationResponse {
                                             content: terminal_content,
                                             reasoning_content: None,
@@ -1056,7 +1056,7 @@ impl Agent {
                                     // identical noise.
                                     let warning_content = self.dedup_loop_warning(warning)?;
                                     // Don't execute the tools — break out with a message
-                                    self.emit_cost_update(turn.total_usage(), &response.usage);
+                                    self.emit_cost_update(turn.total_usage(), &response);
                                     return Ok(ConversationResponse {
                                         content: warning_content,
                                         reasoning_content: None,
@@ -1146,7 +1146,7 @@ impl Agent {
                                     decision = %outcome.decision,
                                     "shell spiral terminal: returning recovered content as final assistant reply"
                                 );
-                                self.emit_cost_update(turn.total_usage(), &response.usage);
+                                self.emit_cost_update(turn.total_usage(), &response);
                                 return Ok(ConversationResponse {
                                     content: terminal_content,
                                     reasoning_content: None,
@@ -1168,7 +1168,7 @@ impl Agent {
                             }
 
                             if self.tools.spawn_only_was_invoked() {
-                                self.emit_cost_update(turn.total_usage(), &response.usage);
+                                self.emit_cost_update(turn.total_usage(), &response);
                                 let background_tools = response
                                     .tool_calls
                                     .iter()
@@ -1205,7 +1205,7 @@ impl Agent {
                             }
                         }
                         StopReason::MaxTokens => {
-                            self.emit_cost_update(turn.total_usage(), &response.usage);
+                            self.emit_cost_update(turn.total_usage(), &response);
                             return Ok(ConversationResponse {
                                 content: response.content.unwrap_or_default(),
                                 reasoning_content: response.reasoning_content.clone(),
@@ -1223,7 +1223,7 @@ impl Agent {
                         StopReason::ContentFiltered => {
                             // After retries in call_llm_with_hooks, content is still filtered.
                             // Return a user-visible message instead of empty content.
-                            self.emit_cost_update(turn.total_usage(), &response.usage);
+                            self.emit_cost_update(turn.total_usage(), &response);
                             warn!("content filtered by provider safety/moderation after retries");
                             return Ok(ConversationResponse {
                                 content: response.content.unwrap_or_else(|| {
@@ -1430,7 +1430,7 @@ impl Agent {
                             }
                         }
 
-                        self.emit_cost_update(turn.total_usage(), &response.usage);
+                        self.emit_cost_update(turn.total_usage(), &response);
 
                         // Audit Gap-8: auto-fire `check_workspace_contract`
                         // on Completion. The LLM-callable wrapper stays for
@@ -1509,7 +1509,7 @@ impl Agent {
                         }
                     }
                     StopReason::MaxTokens => {
-                        self.emit_cost_update(turn.total_usage(), &response.usage);
+                        self.emit_cost_update(turn.total_usage(), &response);
                         self.reporter().report(ProgressEvent::TaskCompleted {
                             success: false,
                             iterations: iteration,
@@ -1524,7 +1524,7 @@ impl Agent {
                     }
                     StopReason::ContentFiltered => {
                         warn!("content filtered by provider safety/moderation in task");
-                        self.emit_cost_update(turn.total_usage(), &response.usage);
+                        self.emit_cost_update(turn.total_usage(), &response);
                         self.reporter().report(ProgressEvent::TaskCompleted {
                             success: false,
                             iterations: iteration,

--- a/crates/octos-agent/src/agent/streaming.rs
+++ b/crates/octos-agent/src/agent/streaming.rs
@@ -243,21 +243,38 @@ impl Agent {
         ))
     }
 
-    pub(super) fn emit_cost_update(
-        &self,
-        total_usage: &TokenUsage,
-        response_usage: &octos_llm::TokenUsage,
-    ) {
-        let pricing = octos_llm::pricing::model_pricing(self.llm.model_id());
+    pub(super) fn emit_cost_update(&self, total_usage: &TokenUsage, response: &ChatResponse) {
+        let response_usage = &response.usage;
+        // Codex round-1 P2: for failover / routed responses the slot that
+        // produced this response may not match `self.llm.model_id()`
+        // (which exposes the chain's "active" slot). Resolve via
+        // `provider_metadata_for_index` so the footer reflects the model
+        // that actually answered. `provider_metadata_for_index` falls
+        // back to the active slot's metadata when `provider_index` is
+        // `None`, matching the legacy `model_id()` behaviour.
+        let metadata = self
+            .llm
+            .provider_metadata_for_index(response.provider_index);
+        let pricing = octos_llm::pricing::model_pricing(&metadata.model);
         let response_cost =
             pricing.map(|p| p.cost(response_usage.input_tokens, response_usage.output_tokens));
         let session_cost =
             pricing.map(|p| p.cost(total_usage.input_tokens, total_usage.output_tokens));
+        // Carry the model id so chat clients can render
+        // `model · tokens_in / tokens_out · duration` footers. Skip the
+        // synthesis if the provider returns an empty identifier — empty
+        // strings would only confuse the client renderer.
+        let model = if metadata.model.is_empty() {
+            None
+        } else {
+            Some(metadata.model.clone())
+        };
         self.reporter().report(ProgressEvent::CostUpdate {
             session_input_tokens: total_usage.input_tokens,
             session_output_tokens: total_usage.output_tokens,
             response_cost,
             session_cost,
+            model,
         });
     }
 

--- a/crates/octos-agent/src/progress.rs
+++ b/crates/octos-agent/src/progress.rs
@@ -134,6 +134,12 @@ pub enum ProgressEvent {
         response_cost: Option<f64>,
         /// Cumulative session cost.
         session_cost: Option<f64>,
+        /// Model identifier that produced this response. Forwarded by the
+        /// API bridge into `metadata.token_cost.model` so chat clients can
+        /// render `model · tokens_in / tokens_out · duration` footers.
+        /// `None` when the reporter cannot resolve a model id (e.g.
+        /// synthetic test fixtures).
+        model: Option<String>,
     },
 }
 

--- a/crates/octos-cli/src/api/events.rs
+++ b/crates/octos-cli/src/api/events.rs
@@ -121,14 +121,23 @@ pub(crate) fn event_to_json(event: &ProgressEvent, thread_id: Option<&str>) -> s
             session_input_tokens,
             session_output_tokens,
             session_cost,
+            model,
             ..
         } => {
-            serde_json::json!({
+            // Always serialize the cost_update payload as an object so we
+            // can attach the optional `model` identifier without
+            // disturbing the historical field order. Clients without the
+            // new field continue to ignore unknown keys.
+            let mut payload = serde_json::json!({
                 "type": "cost_update",
                 "input_tokens": session_input_tokens,
                 "output_tokens": session_output_tokens,
                 "session_cost": session_cost,
-            })
+            });
+            if let Some(model) = model.as_deref() {
+                payload["model"] = serde_json::Value::String(model.to_string());
+            }
+            payload
         }
         ProgressEvent::Thinking { iteration } => {
             serde_json::json!({"type": "thinking", "iteration": iteration})
@@ -299,12 +308,17 @@ mod tests {
             session_output_tokens: 50,
             response_cost: Some(0.001),
             session_cost: Some(0.005),
+            model: None,
         };
         let json = event_to_json(&event, None);
         assert_eq!(json["type"], "cost_update");
         assert_eq!(json["input_tokens"], 100);
         assert_eq!(json["output_tokens"], 50);
         assert_eq!(json["session_cost"], 0.005);
+        assert!(
+            json.get("model").is_none(),
+            "model must be omitted when the reporter has no model id, got {json}",
+        );
     }
 
     #[test]
@@ -314,10 +328,29 @@ mod tests {
             session_output_tokens: 100,
             response_cost: None,
             session_cost: None,
+            model: None,
         };
         let json = event_to_json(&event, None);
         assert_eq!(json["type"], "cost_update");
         assert!(json["session_cost"].is_null());
+    }
+
+    /// New: when the agent emit layer populates `model`, the JSON wire
+    /// payload must carry the identifier so the UI Protocol mapper can
+    /// thread it through to `metadata.token_cost.model`. This is the
+    /// first link in the chain that ends with the chat bubble footer.
+    #[test]
+    fn event_to_json_cost_update_carries_model_when_set() {
+        let event = ProgressEvent::CostUpdate {
+            session_input_tokens: 12,
+            session_output_tokens: 7,
+            response_cost: None,
+            session_cost: None,
+            model: Some("deepseek-v4-pro".into()),
+        };
+        let json = event_to_json(&event, None);
+        assert_eq!(json["type"], "cost_update");
+        assert_eq!(json["model"], "deepseek-v4-pro");
     }
 
     #[test]
@@ -393,6 +426,7 @@ mod tests {
                     session_output_tokens: 0,
                     response_cost: None,
                     session_cost: None,
+                    model: None,
                 },
                 "cost_update",
             ),

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -371,6 +371,12 @@ fn map_cost_update(context: &ProgressMappingContext, event: &Value) -> UiProgres
     update.response_cost = f64_field(event, &["response_cost"]);
     update.session_cost = f64_field(event, &["session_cost"]);
     update.currency = string_field(event, &["currency"]);
+    // Carry the model id forward when the agent emit layer populated it
+    // — the chat client renders `model · tokens_in / tokens_out · duration`
+    // footers from `metadata.token_cost.model`. Legacy clients that
+    // sniff `metadata.label` continue to work (we still emit the field
+    // omitted when absent).
+    update.model = string_field(event, &["model"]);
 
     let mut metadata = UiProgressMetadata::token_cost(update);
     metadata.message = string_field(event, &["message", "status"]);
@@ -669,6 +675,37 @@ mod tests {
         assert_eq!(cost.input_tokens, Some(10));
         assert_eq!(cost.output_tokens, Some(4));
         assert_eq!(cost.session_cost, Some(0.0012));
+        // Back-compat: payloads without a `model` field land with
+        // `cost.model = None` and the client can fall back to the
+        // historical `metadata.label` sniff.
+        assert_eq!(cost.model, None);
+    }
+
+    /// New: chat bubble footer needs the model id to render
+    /// `model · tokens_in / tokens_out · duration`. The cost_update
+    /// mapper must thread the field from the wire payload into
+    /// `metadata.token_cost.model` so the UI Protocol consumer can
+    /// read it without going through the legacy `metadata.label`
+    /// sidecar.
+    #[test]
+    fn ui_protocol_progress_cost_update_carries_model_into_token_cost_metadata() {
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "cost_update",
+                "input_tokens": 120,
+                "output_tokens": 45,
+                "model": "deepseek-v4-pro"
+            }),
+        );
+
+        let status = mapping.status.expect("cost status");
+        let cost = status
+            .event
+            .metadata
+            .token_cost
+            .expect("token cost metadata");
+        assert_eq!(cost.model.as_deref(), Some("deepseek-v4-pro"));
     }
 
     #[test]

--- a/crates/octos-cli/src/stream_reporter.rs
+++ b/crates/octos-cli/src/stream_reporter.rs
@@ -175,14 +175,25 @@ impl ProgressReporter for ChannelStreamReporter {
                 session_input_tokens,
                 session_output_tokens,
                 session_cost,
+                model,
                 ..
             } => {
+                // Codex round-1 P2: every wire-shape mapper for
+                // `cost_update` must carry `model` so the chat bubble
+                // footer (`model · tokens_in / tokens_out · duration`)
+                // works regardless of which reporter the turn uses.
+                // Without this, channel-stream consumers see naked
+                // token counts even after the agent emit layer
+                // attached a model id.
                 let mut payload = serde_json::json!({
                     "type": "cost_update",
                     "input_tokens": session_input_tokens,
                     "output_tokens": session_output_tokens,
                     "session_cost": session_cost,
                 });
+                if let Some(model) = model.as_deref() {
+                    payload["model"] = serde_json::Value::String(model.to_string());
+                }
                 inject_thread_id(&mut payload, thread_id);
                 StreamProgressEvent::RawSse {
                     json: payload.to_string(),
@@ -910,6 +921,7 @@ mod tests {
             session_output_tokens: 20,
             response_cost: None,
             session_cost: None,
+            model: None,
         });
 
         let mut raw_payloads: Vec<String> = Vec::new();
@@ -937,6 +949,64 @@ mod tests {
                 "payload `{json}` missing `thread_id` field",
             );
         }
+    }
+
+    /// The channel stream reporter feeds API/channel clients that read
+    /// the wire payload directly. Codex round-1 P2 — when the agent
+    /// emit layer attaches a `model` id to `CostUpdate`, this reporter
+    /// must thread it through so the chat bubble footer (`model ·
+    /// tokens_in / tokens_out · duration`) works for channel
+    /// consumers, not just the UI-protocol bridge.
+    #[test]
+    fn cost_update_carries_model_into_raw_sse_payload() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        reporter.report(ProgressEvent::CostUpdate {
+            session_input_tokens: 12,
+            session_output_tokens: 7,
+            response_cost: None,
+            session_cost: None,
+            model: Some("deepseek-v4-pro".into()),
+        });
+
+        let StreamProgressEvent::RawSse { json } = rx.try_recv().unwrap() else {
+            panic!("expected RawSse for CostUpdate");
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "cost_update");
+        assert_eq!(parsed["model"], "deepseek-v4-pro");
+    }
+
+    /// Symmetric to the test above: a `CostUpdate` without `model`
+    /// must not synthesise a `model` field on the wire — the field is
+    /// strictly opt-in so legacy parsers that key on field presence
+    /// don't trip.
+    #[test]
+    fn cost_update_omits_model_when_absent() {
+        use octos_agent::progress::ProgressEvent;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let reporter = ChannelStreamReporter::new(tx);
+
+        reporter.report(ProgressEvent::CostUpdate {
+            session_input_tokens: 12,
+            session_output_tokens: 7,
+            response_cost: None,
+            session_cost: None,
+            model: None,
+        });
+
+        let StreamProgressEvent::RawSse { json } = rx.try_recv().unwrap() else {
+            panic!("expected RawSse for CostUpdate");
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            parsed.get("model").is_none(),
+            "model field must be omitted when the emit layer didn't set one, got {parsed}",
+        );
     }
 
     /// When the reporter is constructed without a thread_id (or with an

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3385,6 +3385,12 @@ pub struct UiTokenCostUpdate {
     pub session_cost: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub currency: Option<String>,
+    /// Model identifier that produced this cost update. Populated by the
+    /// agent emit layer from `LlmProvider::model_id()` so chat clients can
+    /// render `model · tokens_in / tokens_out · duration` footers without
+    /// scraping the legacy `metadata.label` field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 impl UiTokenCostUpdate {
@@ -3399,6 +3405,7 @@ impl UiTokenCostUpdate {
             response_cost: None,
             session_cost: None,
             currency: None,
+            model: None,
         }
     }
 }
@@ -6197,6 +6204,44 @@ mod tests {
                     }
                 }
             })
+        );
+
+        let decoded_notification: RpcNotification<Value> =
+            serde_json::from_value(wire).expect("deserialize wire");
+        let decoded = UiNotification::from_rpc_notification(decoded_notification)
+            .expect("decode progress/updated");
+        assert_eq!(decoded, event);
+    }
+
+    /// The chat bubble footer renders `model · tokens_in / tokens_out · duration`
+    /// by reading `metadata.token_cost.model`. The wire shape must survive a
+    /// round trip so the WebSocket bridge can faithfully relay the model id
+    /// the agent emit layer attached.
+    #[test]
+    fn progress_updated_token_cost_round_trip_preserves_model() {
+        let mut token_cost = UiTokenCostUpdate::new();
+        token_cost.input_tokens = Some(80);
+        token_cost.output_tokens = Some(20);
+        token_cost.model = Some("deepseek-v4-pro".into());
+
+        let metadata = UiProgressMetadata::token_cost(token_cost);
+        let turn_id = TurnId(Uuid::from_u128(11));
+        let event = UiNotification::ProgressUpdated(ProgressUpdatedEvent::new(
+            SessionKey("local:demo".into()),
+            Some(turn_id.clone()),
+            metadata,
+        ));
+
+        let wire = serde_json::to_value(
+            event
+                .clone()
+                .into_rpc_notification()
+                .expect("serialize progress/updated"),
+        )
+        .expect("serialize wire");
+        assert_eq!(
+            wire["params"]["metadata"]["token_cost"]["model"],
+            json!("deepseek-v4-pro"),
         );
 
         let decoded_notification: RpcNotification<Value> =

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -1004,6 +1004,7 @@ mod tests {
                     session_output_tokens: 110,
                     response_cost: Some(0.0008),
                     session_cost: Some(0.0008),
+                    model: Some("claude-sonnet".into()),
                 });
             })
             .await;


### PR DESCRIPTION
## Summary

The assistant bubble footer (`model · tokens_in / tokens_out · duration`) went blank after PR #93 narrowed `MessagePersistedEvent` to metadata-only and moved model + tokens + duration onto `progress/updated{kind:"token_cost_update"}` notifications. The new wire shape carries token counts in `metadata.token_cost`, but **the model id was never threaded into that structure** — the web router fell back to scraping `metadata.label`, which `cost_update` frames don't populate, so the footer collapsed to bare token counts.

This PR threads the model id end-to-end on the wire so the footer can render.

- `octos-core`: add `model: Option<String>` to `UiTokenCostUpdate` (`skip_serializing_if = Option::is_none` — strictly additive)
- `octos-agent`: `ProgressEvent::CostUpdate` gains a `model` field; `emit_cost_update` resolves it via `LlmProvider::provider_metadata_for_index(response.provider_index)` so failover / routed responses surface the model that actually answered, not `self.llm.model_id()` post-hoc
- `octos-cli`: `event_to_json::cost_update` + `ChannelStreamReporter::report::CostUpdate` forward the new field; `map_cost_update` extracts it back into `UiTokenCostUpdate.model` for the UI Protocol bridge

## Why two reporters?

Codex round-1 review flagged that `ChannelStreamReporter::report::CostUpdate` was destructuring with `..` and would silently drop the field — so the footer would only work for the UI Protocol v1 bridge but break for channel-streaming clients. Both reporters now forward the field; both are pinned by tests.

## Test plan

- [x] `cargo test --workspace --lib` — 200 octos-core, 1435 octos-agent, 386 octos-cli, 165 octos-pipeline, etc. all green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-core -p octos-agent -p octos-cli --all-targets -- -D warnings` clean
- [x] `bash scripts/build-dashboard.sh` succeeds (unaffected but verified)
- [x] Codex review round 1: 0 P0/P1, 2 P2 — both addressed in this PR
- [x] New unit tests for every reporter that touches `cost_update` (4 new tests across core/cli/cli)
- [ ] Manual smoke: fleet redeploy + UX inspection (queued — see below)

## Wire-format compatibility

Strictly additive on the wire. Daemons / clients without the new field behave exactly as before. The web side PR ([octos-web companion]) reads the new field with a fallback to `metadata.label` for back-compat — so the web PR can land before this one without regressing.

## Deployment

**Daemon redeploy required on the fleet** for the new field to appear on the wire. The client-side PR can land before the daemon is bumped, but the footer won't show a model name until both sides are deployed.

[octos-web companion]: https://github.com/octos-org/octos-web/pull/new/feat/cost-update-carry-model