### PR TITLE
feat(api): host-authoritative scoping for /api/my/* (Option Y, closes #315)

### DIFF
--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -1167,8 +1167,25 @@ pub(super) async fn my_content(
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
     ))?;
-    // Use X-Profile-Id header (from Caddy proxy) if available, otherwise resolve from identity
+    // Use X-Profile-Id header (from Caddy proxy) if available, otherwise resolve from identity.
+    //
+    // Codex P1 fix (PR #958 review): authorize the X-Profile-Id branch the
+    // same way the host-scoped path does. Without `is_authorized_for_profile`
+    // a bearer-authenticated user could pass any tenant id and read its
+    // catalog, since the bearer auth completes before the middleware's
+    // loopback-only X-Profile-Id check runs. The new check matches the
+    // semantics enforced by `resolve_my_profile_id`'s host-scoped branch:
+    // admin can target any tenant, users can target their own profile or
+    // sub-accounts they own. Cross-tenant access returns 403.
     let profile = if let Some(pid) = headers.get("x-profile-id").and_then(|v| v.to_str().ok()) {
+        if !is_authorized_for_profile(&state, &identity, pid) {
+            tracing::warn!(
+                identity = ?identity,
+                requested_profile = %pid,
+                "GET /api/my/content X-Profile-Id denied — identity not authorized for the profile"
+            );
+            return Err((StatusCode::FORBIDDEN, "forbidden".into()));
+        }
         ps.get(pid)
             .map_err(|_| {
                 (
@@ -1933,6 +1950,11 @@ pub async fn stop_my_sub_gateway(
 ///
 /// Authorization rules:
 /// - Admin token can act as any profile.
+/// - A user session with `UserRole::Admin` can act as any profile
+///   (matches the rest of the router which treats admin email sessions
+///   as full admins for `/api/admin/*`). Without this carve-out, an
+///   admin who logs in via OTP would 403 on tenant subdomains while
+///   the bootstrap admin token would not — codex P2 (PR #958 review).
 /// - A user can act as their own profile.
 /// - A user (top-level account) can also act as any sub-account they own.
 /// - Everyone else is denied (returns `false`).
@@ -1943,6 +1965,10 @@ pub(crate) fn is_authorized_for_profile(
 ) -> bool {
     match identity {
         AuthIdentity::Admin => true,
+        AuthIdentity::User {
+            role: UserRole::Admin,
+            ..
+        } => true,
         AuthIdentity::User { id, .. } => {
             if id == profile_id {
                 return true;
@@ -2524,6 +2550,87 @@ mod tests {
         )
         .unwrap();
         assert_eq!(result, "tenant-b");
+    }
+
+    #[test]
+    fn host_scope_admin_role_user_can_access_any_tenant() {
+        // Codex P2 (PR #958 review): an admin email-session
+        // (UserRole::Admin) must have the same cross-tenant scope as a
+        // bootstrap admin token. Otherwise an admin who logs in via OTP
+        // would 403 on tenant subdomains while the bootstrap token
+        // would not — inconsistent and breaks the day-to-day admin
+        // workflow.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut tenant_b = make_user_profile("tenant-b", "Tenant B");
+        tenant_b.public_subdomain = Some("tenantb".into());
+        profile_store.save(&tenant_b).unwrap();
+
+        let identity = AuthIdentity::User {
+            id: "admin-user".into(),
+            role: UserRole::Admin,
+        };
+        let result = resolve_my_profile_id(
+            &identity,
+            &profile_store,
+            &state,
+            &scoped_host_headers("tenantb.example.test"),
+        )
+        .unwrap();
+        assert_eq!(result, "tenant-b");
+    }
+
+    #[test]
+    fn is_authorized_for_profile_table() {
+        // The shared auth helper is consumed by both the host-scoped
+        // path AND the X-Profile-Id branch in `my_content` (codex P1
+        // fix). Lock the truth-table down with a focused unit test.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant"))
+            .unwrap();
+        let mut child = make_user_profile("tenant--child", "Child");
+        child.parent_id = Some("tenant".into());
+        profile_store.save(&child).unwrap();
+        profile_store
+            .save(&make_user_profile("other", "Other"))
+            .unwrap();
+
+        // Admin token: yes to everything.
+        assert!(is_authorized_for_profile(
+            &state,
+            &AuthIdentity::Admin,
+            "tenant"
+        ));
+        assert!(is_authorized_for_profile(
+            &state,
+            &AuthIdentity::Admin,
+            "other"
+        ));
+
+        // Admin role (OTP-authenticated admin user): yes to everything.
+        let admin_user = AuthIdentity::User {
+            id: "any-admin".into(),
+            role: UserRole::Admin,
+        };
+        assert!(is_authorized_for_profile(&state, &admin_user, "tenant"));
+        assert!(is_authorized_for_profile(&state, &admin_user, "other"));
+
+        // Regular user: own profile yes.
+        let tenant_user = AuthIdentity::User {
+            id: "tenant".into(),
+            role: UserRole::User,
+        };
+        assert!(is_authorized_for_profile(&state, &tenant_user, "tenant"));
+        // Sub-account they own: yes.
+        assert!(is_authorized_for_profile(
+            &state,
+            &tenant_user,
+            "tenant--child"
+        ));
+        // A different tenant: no.
+        assert!(!is_authorized_for_profile(&state, &tenant_user, "other"));
+        // A non-existent profile: no.
+        assert!(!is_authorized_for_profile(&state, &tenant_user, "ghost"));
     }
 
     #[test]

--- a/crates/octos-cli/src/api/auth_handlers.rs
+++ b/crates/octos-cli/src/api/auth_handlers.rs
@@ -375,6 +375,14 @@ pub struct MeResponse {
     pub user: User,
     pub profile: Option<ProfileResponse>,
     pub portal: PortalState,
+    /// If the request was made on a tenant subdomain (i.e.
+    /// `host_scoped_profile_id` resolves), this is the tenant's profile
+    /// summary. The dashboard uses this to hide admin-global navigation
+    /// when an admin is operating in a tenant scope (Option Y, #315).
+    /// `None` when no tenant subdomain is in scope (root domain, direct
+    /// IP, or localhost).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scoped_profile: Option<ScopedAuthTarget>,
 }
 
 #[derive(Serialize)]
@@ -700,8 +708,15 @@ pub async fn logout(
 /// GET /api/auth/me
 pub async fn me(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<MeResponse>, StatusCode> {
+    // Determine the active tenant scope (if any). The dashboard reads
+    // this to gate admin-global UI when an admin is operating on a
+    // tenant subdomain (Option Y, #315).
+    let scoped_profile = host_scoped_profile_id(&state, &headers)
+        .and_then(|profile_id| scoped_auth_target(&state, &profile_id));
+
     // Handle admin token first — bootstrap admin still needs a real persisted principal.
     if matches!(&identity, AuthIdentity::Admin) {
         let user = if let Some(ref user_store) = state.user_store {
@@ -746,6 +761,7 @@ pub async fn me(
             user,
             profile,
             portal,
+            scoped_profile,
         }));
     }
 
@@ -783,6 +799,7 @@ pub async fn me(
                     can_manage_sub_accounts: true,
                 }],
             },
+            scoped_profile,
         }));
     }
 
@@ -825,6 +842,7 @@ pub async fn me(
         user,
         profile,
         portal,
+        scoped_profile,
     }))
 }
 
@@ -833,6 +851,7 @@ pub async fn me(
 /// GET /api/my/profile
 pub async fn my_profile(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<ProfileResponse>, StatusCode> {
     let ps = state
@@ -840,7 +859,7 @@ pub async fn my_profile(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let profile = resolve_my_profile(&identity, ps)?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
 
     let status = if let Some(ref pm) = state.process_manager {
         pm.status(&profile.id).await
@@ -863,14 +882,15 @@ pub async fn my_profile(
 /// GET /api/my/profile/skills
 pub async fn my_profile_skills(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = state.profile_store.as_ref().ok_or((
         StatusCode::SERVICE_UNAVAILABLE,
         "admin not configured".into(),
     ))?;
-    let profile_id =
-        resolve_my_profile_id(&identity, store).map_err(|s| (s, "profile not found".into()))?;
+    let profile_id = resolve_my_profile_id(&identity, store, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
     let skills_dir = crate::commands::skills::resolve_profile_skills_dir(store, &profile_id)
         .map_err(|e| (StatusCode::NOT_FOUND, e.to_string()))?;
     let skills = crate::commands::skills::list_skills(&skills_dir)
@@ -888,6 +908,7 @@ pub struct MySkillRegistryQuery {
 /// GET /api/my/profile/skills/registry
 pub async fn my_profile_skill_registry(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Query(query): Query<MySkillRegistryQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
@@ -895,8 +916,8 @@ pub async fn my_profile_skill_registry(
         StatusCode::SERVICE_UNAVAILABLE,
         "admin not configured".into(),
     ))?;
-    let profile_id =
-        resolve_my_profile_id(&identity, store).map_err(|s| (s, "profile not found".into()))?;
+    let profile_id = resolve_my_profile_id(&identity, store, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
     // Validate this profile has a resolvable skills scope.
     crate::commands::skills::resolve_profile_skills_dir(store, &profile_id)
         .map_err(|e| (StatusCode::NOT_FOUND, e.to_string()))?;
@@ -915,6 +936,7 @@ pub async fn my_profile_skill_registry(
 /// POST /api/my/profile/skills
 pub async fn install_my_profile_skill(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Json(req): Json<super::admin::InstallSkillRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
@@ -922,8 +944,8 @@ pub async fn install_my_profile_skill(
         StatusCode::SERVICE_UNAVAILABLE,
         "admin not configured".into(),
     ))?;
-    let profile_id =
-        resolve_my_profile_id(&identity, store).map_err(|s| (s, "profile not found".into()))?;
+    let profile_id = resolve_my_profile_id(&identity, store, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
     let skills_dir = crate::commands::skills::resolve_profile_skills_dir(store, &profile_id)
         .map_err(|e| (StatusCode::NOT_FOUND, e.to_string()))?;
 
@@ -945,6 +967,7 @@ pub async fn install_my_profile_skill(
 /// DELETE /api/my/profile/skills/:name
 pub async fn remove_my_profile_skill(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(name): Path<String>,
 ) -> Result<Json<super::admin::ActionResponse>, (StatusCode, String)> {
@@ -952,8 +975,8 @@ pub async fn remove_my_profile_skill(
         StatusCode::SERVICE_UNAVAILABLE,
         "admin not configured".into(),
     ))?;
-    let profile_id =
-        resolve_my_profile_id(&identity, store).map_err(|s| (s, "profile not found".into()))?;
+    let profile_id = resolve_my_profile_id(&identity, store, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
     let skills_dir = crate::commands::skills::resolve_profile_skills_dir(store, &profile_id)
         .map_err(|e| (StatusCode::NOT_FOUND, e.to_string()))?;
 
@@ -969,6 +992,7 @@ pub async fn remove_my_profile_skill(
 /// PUT /api/my/profile
 pub async fn update_my_profile(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     body: String,
 ) -> Result<Json<ProfileResponse>, (StatusCode, String)> {
@@ -984,8 +1008,8 @@ pub async fn update_my_profile(
         "admin not configured".into(),
     ))?;
 
-    let mut profile =
-        resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let mut profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
 
     // Apply updates (same logic as admin::update_profile but scoped)
     if let Some(name) = req.name {
@@ -1050,13 +1074,14 @@ pub struct SoulResponse {
 /// GET /api/my/soul
 pub async fn my_soul(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<SoulResponse>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile = resolve_my_profile(&identity, ps)?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
     let data_dir = ps.resolve_data_dir(&profile);
     let content = crate::soul_service::read_soul(&data_dir);
     Ok(Json(SoulResponse {
@@ -1074,6 +1099,7 @@ pub struct UpdateSoulRequest {
 /// PUT /api/my/soul
 pub async fn update_my_soul(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Json(req): Json<UpdateSoulRequest>,
 ) -> Result<Json<SoulResponse>, (StatusCode, String)> {
@@ -1084,7 +1110,8 @@ pub async fn update_my_soul(
         StatusCode::SERVICE_UNAVAILABLE,
         "admin not configured".into(),
     ))?;
-    let profile = resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
     let data_dir = ps.resolve_data_dir(&profile);
     crate::soul_service::write_soul(&data_dir, &req.content)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -1099,13 +1126,14 @@ pub async fn update_my_soul(
 /// DELETE /api/my/soul
 pub async fn delete_my_soul(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<SoulResponse>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile = resolve_my_profile(&identity, ps)?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
     let data_dir = ps.resolve_data_dir(&profile);
     crate::soul_service::remove_soul(&data_dir).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     tracing::info!(profile = %profile.id, "soul reset via API");
@@ -1150,7 +1178,8 @@ pub(super) async fn my_content(
             })?
             .ok_or((StatusCode::NOT_FOUND, format!("profile '{pid}' not found")))?
     } else {
-        resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?
+        resolve_my_profile(&identity, ps, &state, &headers)
+            .map_err(|s| (s, "profile not found".into()))?
     };
     let data_dir = ps.resolve_data_dir(&profile);
 
@@ -1183,6 +1212,7 @@ pub(super) async fn my_content(
 /// GET /api/my/content/:id/thumbnail
 pub async fn my_content_thumbnail(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(id): Path<String>,
 ) -> Result<axum::response::Response, StatusCode> {
@@ -1198,7 +1228,7 @@ pub async fn my_content_thumbnail(
         .content_catalog_mgr
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile = resolve_my_profile(&identity, ps)?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
 
     let catalog = mgr
         .get_catalog(&profile.id)
@@ -1218,6 +1248,7 @@ pub async fn my_content_thumbnail(
 /// GET /api/my/content/:id/body
 pub async fn my_content_body(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(id): Path<String>,
 ) -> Result<axum::response::Response, StatusCode> {
@@ -1233,7 +1264,7 @@ pub async fn my_content_body(
         .content_catalog_mgr
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile = resolve_my_profile(&identity, ps)?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
 
     let catalog = mgr
         .get_catalog(&profile.id)
@@ -1272,6 +1303,7 @@ pub async fn my_content_body(
 /// Helper backing the WS `content/delete` RPC method (formerly `DELETE /api/my/content/{id}`).
 pub(super) async fn delete_my_content(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(id): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
@@ -1283,7 +1315,8 @@ pub(super) async fn delete_my_content(
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
     ))?;
-    let profile = resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
 
     let catalog = mgr
         .get_catalog(&profile.id)
@@ -1316,6 +1349,7 @@ pub(super) struct BulkDeleteRequest {
 /// Helper backing the WS `content/bulk_delete` RPC method (formerly `POST /api/my/content/bulk-delete`).
 pub(super) async fn bulk_delete_my_content(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Json(req): Json<BulkDeleteRequest>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
@@ -1327,7 +1361,8 @@ pub(super) async fn bulk_delete_my_content(
         StatusCode::SERVICE_UNAVAILABLE,
         "content catalog not configured".into(),
     ))?;
-    let profile = resolve_my_profile(&identity, ps).map_err(|s| (s, "profile not found".into()))?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)
+        .map_err(|s| (s, "profile not found".into()))?;
 
     let catalog = mgr
         .get_catalog(&profile.id)
@@ -1347,6 +1382,7 @@ pub(super) async fn bulk_delete_my_content(
 /// POST /api/my/profile/start
 pub async fn start_my_gateway(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
     let ps = state
@@ -1358,7 +1394,7 @@ pub async fn start_my_gateway(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let profile = resolve_my_profile(&identity, ps)?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
 
     // Validate LLM provider is configured
     if profile.config.primary_provider().is_none() && profile.config.primary_model().is_none() {
@@ -1389,13 +1425,14 @@ pub async fn start_my_gateway(
 /// POST /api/my/profile/stop
 pub async fn stop_my_gateway(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile_id = resolve_my_profile_id(&identity, ps)?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)?;
     let pm = state
         .process_manager
         .as_ref()
@@ -1420,6 +1457,7 @@ pub async fn stop_my_gateway(
 /// POST /api/my/profile/restart
 pub async fn restart_my_gateway(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
     let ps = state
@@ -1431,7 +1469,7 @@ pub async fn restart_my_gateway(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let profile = resolve_my_profile(&identity, ps)?;
+    let profile = resolve_my_profile(&identity, ps, &state, &headers)?;
 
     match pm.restart(&profile).await {
         Ok(()) => {
@@ -1454,13 +1492,14 @@ pub async fn restart_my_gateway(
 /// GET /api/my/profile/status
 pub async fn my_gateway_status(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<crate::process_manager::ProcessStatus>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile_id = resolve_my_profile_id(&identity, ps)?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)?;
     let pm = state
         .process_manager
         .as_ref()
@@ -1471,13 +1510,14 @@ pub async fn my_gateway_status(
 /// GET /api/my/profile/logs
 pub async fn my_gateway_logs(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile_id = resolve_my_profile_id(&identity, ps)?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)?;
     let pm = state
         .process_manager
         .as_ref()
@@ -1515,13 +1555,14 @@ pub async fn my_gateway_logs(
 /// GET /api/my/profile/whatsapp/qr
 pub async fn my_whatsapp_qr(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<crate::process_manager::BridgeQrInfo>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile_id = resolve_my_profile_id(&identity, ps)?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)?;
     let pm = state
         .process_manager
         .as_ref()
@@ -1536,13 +1577,14 @@ pub async fn my_whatsapp_qr(
 /// GET /api/my/profile/metrics
 pub async fn my_provider_metrics(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile_id = resolve_my_profile_id(&identity, ps)?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)?;
     let pm = state
         .process_manager
         .as_ref()
@@ -1557,13 +1599,14 @@ pub async fn my_provider_metrics(
 /// GET /api/my/profile/accounts — List sub-accounts for the current user's profile.
 pub async fn my_sub_accounts(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<Vec<crate::api::admin::ProfileResponse>>, StatusCode> {
     let ps = state
         .profile_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let profile_id = resolve_my_profile_id(&identity, ps)?;
+    let profile_id = resolve_my_profile_id(&identity, ps, &state, &headers)?;
     let pm = state
         .process_manager
         .as_ref()
@@ -1588,8 +1631,10 @@ pub async fn my_sub_accounts(
 fn resolve_my_managed_parent_profile(
     identity: &AuthIdentity,
     ps: &crate::profiles::ProfileStore,
+    state: &AppState,
+    headers: &HeaderMap,
 ) -> Result<crate::profiles::UserProfile, StatusCode> {
-    let profile = resolve_my_profile(identity, ps)?;
+    let profile = resolve_my_profile(identity, ps, state, headers)?;
     if profile.parent_id.is_some() {
         return Err(StatusCode::FORBIDDEN);
     }
@@ -1599,6 +1644,7 @@ fn resolve_my_managed_parent_profile(
 /// GET /api/my/profile/accounts/:id — Return a sub-account managed by the current user.
 pub async fn my_sub_account(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(sub_id): Path<String>,
 ) -> Result<Json<crate::api::admin::ProfileResponse>, StatusCode> {
@@ -1611,7 +1657,7 @@ pub async fn my_sub_account(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let sub = resolve_my_sub_account(&identity, ps, &sub_id)?;
+    let sub = resolve_my_sub_account(&identity, ps, &state, &headers, &sub_id)?;
     let status = pm.status(&sub.id).await;
     Ok(Json(crate::api::admin::ProfileResponse {
         email: None,
@@ -1623,6 +1669,7 @@ pub async fn my_sub_account(
 /// POST /api/my/profile/accounts — Create a sub-account owned by the current user.
 pub async fn create_my_sub_account(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Json(req): Json<crate::api::admin::CreateSubAccountRequest>,
 ) -> Result<(StatusCode, Json<crate::api::admin::ProfileResponse>), (StatusCode, String)> {
@@ -1635,7 +1682,7 @@ pub async fn create_my_sub_account(
         "admin not configured".into(),
     ))?;
 
-    let parent = resolve_my_managed_parent_profile(&identity, ps)
+    let parent = resolve_my_managed_parent_profile(&identity, ps, &state, &headers)
         .map_err(|status| (status, "sub-accounts cannot create sub-accounts".into()))?;
 
     if !req.channels.is_empty() {
@@ -1701,6 +1748,7 @@ pub async fn create_my_sub_account(
 /// PUT /api/my/profile/accounts/:id — Update a managed sub-account.
 pub async fn update_my_sub_account(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(sub_id): Path<String>,
     body: String,
@@ -1721,9 +1769,9 @@ pub async fn update_my_sub_account(
         "admin not configured".into(),
     ))?;
 
-    let _parent = resolve_my_managed_parent_profile(&identity, ps)
+    let _parent = resolve_my_managed_parent_profile(&identity, ps, &state, &headers)
         .map_err(|status| (status, "sub-accounts cannot manage sub-accounts".into()))?;
-    let mut sub = resolve_my_sub_account(&identity, ps, &sub_id)
+    let mut sub = resolve_my_sub_account(&identity, ps, &state, &headers, &sub_id)
         .map_err(|status| (status, "sub-account not found".into()))?;
 
     if let Some(name) = req.name {
@@ -1802,9 +1850,11 @@ pub async fn update_my_sub_account(
 fn resolve_my_sub_account(
     identity: &AuthIdentity,
     ps: &crate::profiles::ProfileStore,
+    state: &AppState,
+    headers: &HeaderMap,
     sub_id: &str,
 ) -> Result<crate::profiles::UserProfile, StatusCode> {
-    let parent_id = resolve_my_profile_id(identity, ps)?;
+    let parent_id = resolve_my_profile_id(identity, ps, state, headers)?;
     let sub = ps
         .get(sub_id)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
@@ -1819,6 +1869,7 @@ fn resolve_my_sub_account(
 /// POST /api/my/profile/accounts/:id/start — Start a sub-account gateway.
 pub async fn start_my_sub_gateway(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(sub_id): Path<String>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
@@ -1831,7 +1882,7 @@ pub async fn start_my_sub_gateway(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let sub = resolve_my_sub_account(&identity, ps, &sub_id)?;
+    let sub = resolve_my_sub_account(&identity, ps, &state, &headers, &sub_id)?;
 
     match pm.start(&sub).await {
         Ok(()) => Ok(Json(ActionResponse {
@@ -1848,6 +1899,7 @@ pub async fn start_my_sub_gateway(
 /// POST /api/my/profile/accounts/:id/stop — Stop a sub-account gateway.
 pub async fn stop_my_sub_gateway(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Path(sub_id): Path<String>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
@@ -1860,7 +1912,7 @@ pub async fn stop_my_sub_gateway(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
 
-    let _ = resolve_my_sub_account(&identity, ps, &sub_id)?;
+    let _ = resolve_my_sub_account(&identity, ps, &state, &headers, &sub_id)?;
 
     match pm.stop(&sub_id).await {
         Ok(_) => Ok(Json(ActionResponse {
@@ -1876,13 +1928,70 @@ pub async fn stop_my_sub_gateway(
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
+/// Return `true` iff the authenticated identity is allowed to act as the
+/// given profile id for `/api/my/*` endpoints.
+///
+/// Authorization rules:
+/// - Admin token can act as any profile.
+/// - A user can act as their own profile.
+/// - A user (top-level account) can also act as any sub-account they own.
+/// - Everyone else is denied (returns `false`).
+pub(crate) fn is_authorized_for_profile(
+    state: &AppState,
+    identity: &AuthIdentity,
+    profile_id: &str,
+) -> bool {
+    match identity {
+        AuthIdentity::Admin => true,
+        AuthIdentity::User { id, .. } => {
+            if id == profile_id {
+                return true;
+            }
+            // Allow a top-level user to act as any of their sub-accounts.
+            let Some(store) = state.profile_store.as_ref() else {
+                return false;
+            };
+            match store.get(profile_id) {
+                Ok(Some(profile)) => profile.parent_id.as_deref() == Some(id.as_str()),
+                _ => false,
+            }
+        }
+    }
+}
+
 /// Resolve the profile ID for "my" endpoints.
+///
+/// Server-side host-authoritative scoping (Option Y, closes #315):
+/// 1. If the request `Host` / `X-Forwarded-Host` header resolves to a
+///    tenant profile via `host_scoped_profile_id`, return that profile id
+///    — but only after verifying the authenticated identity is allowed
+///    to view it. If the identity is NOT authorized, return 403 rather
+///    than silently falling through to the identity's default profile,
+///    which would be both confusing and a cross-tenant data leak.
+/// 2. Otherwise (no tenant subdomain, unknown host, or local request),
+///    fall back to the identity-based default: admin token returns the
+///    fixed admin profile id, user sessions return the user's own id.
+///
 /// For regular users, returns their user ID. For admin token, returns the admin's own profile ID
 /// (auto-creating the admin profile if it doesn't exist yet).
 fn resolve_my_profile_id(
     identity: &AuthIdentity,
     ps: &crate::profiles::ProfileStore,
+    state: &AppState,
+    headers: &HeaderMap,
 ) -> Result<String, StatusCode> {
+    if let Some(scoped) = host_scoped_profile_id(state, headers) {
+        if !is_authorized_for_profile(state, identity, &scoped) {
+            tracing::warn!(
+                identity = ?identity,
+                scoped_profile = %scoped,
+                "/api/my/* host-scope denied — identity not authorized for the tenant subdomain"
+            );
+            return Err(StatusCode::FORBIDDEN);
+        }
+        return Ok(scoped);
+    }
+
     match identity {
         AuthIdentity::Admin => {
             ensure_admin_profile(ps)?;
@@ -1896,8 +2005,10 @@ fn resolve_my_profile_id(
 fn resolve_my_profile(
     identity: &AuthIdentity,
     ps: &crate::profiles::ProfileStore,
+    state: &AppState,
+    headers: &HeaderMap,
 ) -> Result<crate::profiles::UserProfile, StatusCode> {
-    let id = resolve_my_profile_id(identity, ps)?;
+    let id = resolve_my_profile_id(identity, ps, state, headers)?;
     ps.get(&id)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)
@@ -2217,12 +2328,15 @@ mod tests {
 
     #[test]
     fn should_return_admin_id_when_admin_identity() {
-        let (_dir, ps) = temp_profile_store();
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
         // Create a user profile that would have been returned by the old "first" logic
-        ps.save(&make_user_profile("guofoo", "Guo Foo")).unwrap();
+        profile_store
+            .save(&make_user_profile("guofoo", "Guo Foo"))
+            .unwrap();
 
         let identity = AuthIdentity::Admin;
-        let result = resolve_my_profile_id(&identity, &ps).unwrap();
+        let result =
+            resolve_my_profile_id(&identity, &profile_store, &state, &HeaderMap::new()).unwrap();
         assert_eq!(
             result, ADMIN_PROFILE_ID,
             "admin should get its own profile ID, not the first user's"
@@ -2231,14 +2345,17 @@ mod tests {
 
     #[test]
     fn should_return_user_id_when_user_identity() {
-        let (_dir, ps) = temp_profile_store();
-        ps.save(&make_user_profile("user123", "Test User")).unwrap();
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("user123", "Test User"))
+            .unwrap();
 
         let identity = AuthIdentity::User {
             id: "user123".into(),
             role: UserRole::User,
         };
-        let result = resolve_my_profile_id(&identity, &ps).unwrap();
+        let result =
+            resolve_my_profile_id(&identity, &profile_store, &state, &HeaderMap::new()).unwrap();
         assert_eq!(result, "user123");
     }
 
@@ -2276,16 +2393,168 @@ mod tests {
 
     #[test]
     fn should_resolve_admin_profile_not_first_user() {
-        let (_dir, ps) = temp_profile_store();
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
         // Create user profile first — old code would return this
-        ps.save(&make_user_profile("alice", "Alice")).unwrap();
+        profile_store
+            .save(&make_user_profile("alice", "Alice"))
+            .unwrap();
         // Ensure admin profile exists
-        ensure_admin_profile(&ps).unwrap();
+        ensure_admin_profile(&profile_store).unwrap();
 
         let identity = AuthIdentity::Admin;
-        let profile = resolve_my_profile(&identity, &ps).unwrap();
+        let profile =
+            resolve_my_profile(&identity, &profile_store, &state, &HeaderMap::new()).unwrap();
         assert_eq!(profile.id, ADMIN_PROFILE_ID);
         assert_eq!(profile.name, "Admin");
+    }
+
+    // ── Option Y host-authoritative scoping (issue #315) ──────────────
+
+    #[test]
+    fn host_scope_admin_falls_through_when_host_unknown() {
+        // Admin viewing /api/my/* via an unmapped host (e.g. direct IP or
+        // root domain) MUST still get the admin profile back. Without this
+        // admin loses access to their own profile entirely.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        // No profiles besides what `ensure_admin_profile` will auto-create.
+        let identity = AuthIdentity::Admin;
+        // "localhost" is the canonical "no tenant subdomain" host.
+        let result = resolve_my_profile_id(
+            &identity,
+            &profile_store,
+            &state,
+            &scoped_host_headers("localhost"),
+        )
+        .unwrap();
+        assert_eq!(
+            result, ADMIN_PROFILE_ID,
+            "admin must keep its own profile when no tenant subdomain is in scope"
+        );
+    }
+
+    #[test]
+    fn host_scope_admin_resolves_to_tenant_when_host_matches() {
+        // Admin visiting a tenant subdomain MUST be re-scoped to that
+        // tenant's profile. Closes the original #315 bug where admin
+        // unconditionally saw the global admin profile from any host.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant Owner"))
+            .unwrap();
+
+        let identity = AuthIdentity::Admin;
+        let result = resolve_my_profile_id(
+            &identity,
+            &profile_store,
+            &state,
+            &scoped_host_headers("tenant.example.test"),
+        )
+        .unwrap();
+        assert_eq!(result, "tenant");
+    }
+
+    #[test]
+    fn host_scope_sub_account_on_own_tenant_subdomain() {
+        // A user (logged in as their tenant profile via scoped OTP) visits
+        // their own tenant subdomain. Host check should resolve to that
+        // tenant id — which IS the user's id, so authorization passes.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut tenant = make_user_profile("dspfac", "DSPFac");
+        tenant.public_subdomain = Some("dspfac".into());
+        profile_store.save(&tenant).unwrap();
+
+        let identity = AuthIdentity::User {
+            id: "dspfac".into(),
+            role: UserRole::User,
+        };
+        let result = resolve_my_profile_id(
+            &identity,
+            &profile_store,
+            &state,
+            &scoped_host_headers("dspfac.example.test"),
+        )
+        .unwrap();
+        assert_eq!(result, "dspfac");
+    }
+
+    #[test]
+    fn host_scope_cross_tenant_user_access_denied() {
+        // A user logged in under tenant A visits tenant B's subdomain.
+        // Server MUST refuse with 403 rather than silently falling
+        // through to tenant A's profile (which would be confusing) or,
+        // worse, granting access to tenant B's data.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant-a", "Tenant A"))
+            .unwrap();
+        let mut tenant_b = make_user_profile("tenant-b", "Tenant B");
+        tenant_b.public_subdomain = Some("tenantb".into());
+        profile_store.save(&tenant_b).unwrap();
+
+        let identity = AuthIdentity::User {
+            id: "tenant-a".into(),
+            role: UserRole::User,
+        };
+        let err = resolve_my_profile_id(
+            &identity,
+            &profile_store,
+            &state,
+            &scoped_host_headers("tenantb.example.test"),
+        )
+        .expect_err("cross-tenant access must be rejected");
+        assert_eq!(err, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn host_scope_admin_can_access_any_tenant() {
+        // The cross-tenant rule applies to user identities only.
+        // Admin must still be allowed to view any tenant's profile via
+        // host-scoped routing.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        let mut tenant_b = make_user_profile("tenant-b", "Tenant B");
+        tenant_b.public_subdomain = Some("tenantb".into());
+        profile_store.save(&tenant_b).unwrap();
+
+        let identity = AuthIdentity::Admin;
+        let result = resolve_my_profile_id(
+            &identity,
+            &profile_store,
+            &state,
+            &scoped_host_headers("tenantb.example.test"),
+        )
+        .unwrap();
+        assert_eq!(result, "tenant-b");
+    }
+
+    #[test]
+    fn host_scope_parent_user_authorized_for_own_sub_account() {
+        // A top-level user owns a sub-account; that sub-account has a
+        // public subdomain. Parent visits the sub-account's subdomain
+        // (e.g. via "Switch profile" / sub-account UI) → host check
+        // resolves to the sub-account id; the parent IS authorized
+        // because they own the sub. Verifies `is_authorized_for_profile`
+        // walks the parent_id relationship.
+        let (_dir, state, _user_store, profile_store) = temp_app_state();
+        profile_store
+            .save(&make_user_profile("tenant", "Tenant"))
+            .unwrap();
+        let mut child = make_user_profile("tenant--assistant", "Assistant");
+        child.parent_id = Some("tenant".into());
+        child.public_subdomain = Some("assistant".into());
+        profile_store.save(&child).unwrap();
+
+        let identity = AuthIdentity::User {
+            id: "tenant".into(),
+            role: UserRole::User,
+        };
+        let result = resolve_my_profile_id(
+            &identity,
+            &profile_store,
+            &state,
+            &scoped_host_headers("assistant.example.test"),
+        )
+        .unwrap();
+        assert_eq!(result, "tenant--assistant");
     }
 
     #[test]
@@ -2342,6 +2611,7 @@ mod tests {
 
         let Json(resp) = update_my_profile(
             State(Arc::new(state)),
+            HeaderMap::new(),
             axum::Extension(AuthIdentity::User {
                 id: "tenant".into(),
                 role: UserRole::User,
@@ -2373,6 +2643,7 @@ mod tests {
 
         let err = update_my_profile(
             State(Arc::new(state)),
+            HeaderMap::new(),
             axum::Extension(AuthIdentity::User {
                 id: "tenant--assistant".into(),
                 role: UserRole::User,
@@ -2411,6 +2682,7 @@ mod tests {
 
         let Json(resp) = my_profile_skills(
             State(Arc::new(state)),
+            HeaderMap::new(),
             axum::Extension(AuthIdentity::User {
                 id: "alice".into(),
                 role: UserRole::User,
@@ -2443,6 +2715,7 @@ mod tests {
 
         let Json(resp) = install_my_profile_skill(
             State(Arc::new(state)),
+            HeaderMap::new(),
             axum::Extension(AuthIdentity::User {
                 id: "alice".into(),
                 role: UserRole::User,
@@ -2785,6 +3058,7 @@ mod tests {
 /// GET /api/my/profile/wechat/qr-start
 pub async fn my_wechat_qr_start(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     // Check if ProcessManager has a bridge with QR info
@@ -2793,8 +3067,9 @@ pub async fn my_wechat_qr_start(
             .profile_store
             .as_ref()
             .ok_or((StatusCode::SERVICE_UNAVAILABLE, "no profile store".into()))?;
-        let profile_id = super::auth_handlers::resolve_my_profile_id(&identity, ps)
-            .map_err(|_| (StatusCode::FORBIDDEN, "cannot resolve profile".into()))?;
+        let profile_id =
+            super::auth_handlers::resolve_my_profile_id(&identity, ps, &state, &headers)
+                .map_err(|_| (StatusCode::FORBIDDEN, "cannot resolve profile".into()))?;
         let key = format!("{}-wechat", profile_id);
         if let Some(info) = pm.bridge_qr(&key).await {
             if let Some(ref qr_url) = info.qr {
@@ -2835,6 +3110,7 @@ pub async fn my_wechat_qr_start(
 /// POST /api/my/profile/wechat/qr-poll
 pub async fn my_wechat_qr_poll(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     axum::Extension(identity): axum::Extension<AuthIdentity>,
     Json(req): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
@@ -2842,7 +3118,7 @@ pub async fn my_wechat_qr_poll(
         .profile_store
         .as_ref()
         .ok_or((StatusCode::SERVICE_UNAVAILABLE, "no profile store".into()))?;
-    let profile_id = super::auth_handlers::resolve_my_profile_id(&identity, ps)
+    let profile_id = super::auth_handlers::resolve_my_profile_id(&identity, ps, &state, &headers)
         .map_err(|_| (StatusCode::FORBIDDEN, "cannot resolve profile".into()))?;
 
     let session_key = req["session_key"].as_str().unwrap_or_default();

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2038,11 +2038,26 @@ async fn ui_protocol_connection(
                 .await;
             }
             UiCommand::ContentDelete(params) => {
-                handle_content_delete(&ws, &state, connection_identity.as_ref(), id, params).await;
+                handle_content_delete(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::ContentBulkDelete(params) => {
-                handle_content_bulk_delete(&ws, &state, connection_identity.as_ref(), id, params)
-                    .await;
+                handle_content_bulk_delete(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::RouterSetMode(params) => {
                 handle_router_set_mode(&ws, &state, routed_profile_id, id, params).await;
@@ -5541,6 +5556,7 @@ async fn handle_content_list(
 async fn handle_content_delete(
     ws: &WsConnection,
     state: &Arc<AppState>,
+    headers: &HeaderMap,
     identity: Option<&AuthIdentity>,
     id: String,
     params: ContentDeleteParams,
@@ -5561,6 +5577,7 @@ async fn handle_content_delete(
     let content_id = params.id.clone();
     let result = super::auth_handlers::delete_my_content(
         State(state.clone()),
+        headers.clone(),
         Extension(identity),
         axum_path(params.id),
     )
@@ -5594,6 +5611,7 @@ async fn handle_content_delete(
 async fn handle_content_bulk_delete(
     ws: &WsConnection,
     state: &Arc<AppState>,
+    headers: &HeaderMap,
     identity: Option<&AuthIdentity>,
     id: String,
     params: ContentBulkDeleteParams,
@@ -5635,6 +5653,7 @@ async fn handle_content_bulk_delete(
     }
     let result = super::auth_handlers::bulk_delete_my_content(
         State(state.clone()),
+        headers.clone(),
         Extension(identity),
         axum::Json(super::auth_handlers::BulkDeleteRequest { ids: params.ids }),
     )

--- a/crates/octos-cli/static/admin/index.html
+++ b/crates/octos-cli/static/admin/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>octos Admin</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>%E2%9A%99</text></svg>" />
-    <script type="module" crossorigin src="/admin/assets/index-IUgK0vSq.js"></script>
-    <link rel="stylesheet" crossorigin href="/admin/assets/index-ks4KBBRX.css">
+    <script type="module" crossorigin src="/admin/assets/index-DXMn_Ica.js"></script>
+    <link rel="stylesheet" crossorigin href="/admin/assets/index-LY6r_9yZ.css">
   </head>
   <body class="bg-bg text-gray-100 min-h-screen">
     <div id="root"></div>

--- a/crates/octos-cli/static/admin/index.html
+++ b/crates/octos-cli/static/admin/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>octos Admin</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>%E2%9A%99</text></svg>" />
-    <script type="module" crossorigin src="/admin/assets/index-DXMn_Ica.js"></script>
+    <script type="module" crossorigin src="/admin/assets/index-D7CZ_N_x.js"></script>
     <link rel="stylesheet" crossorigin href="/admin/assets/index-LY6r_9yZ.css">
   </head>
   <body class="bg-bg text-gray-100 min-h-screen">

--- a/dashboard/src/components/AdminGuard.tsx
+++ b/dashboard/src/components/AdminGuard.tsx
@@ -1,17 +1,31 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 
 import { myApi } from '../api'
 import { useAuth } from '../contexts/AuthContext'
 
 export default function AdminGuard({ children }: { children: React.ReactNode }) {
-  const { isAdmin, user } = useAuth()
+  const { isAdmin, scopedProfile, user } = useAuth()
   const { id } = useParams<{ id: string }>()
   const [loading, setLoading] = useState(false)
   const [allowed, setAllowed] = useState(false)
 
+  // Codex P2 (PR #958 review): an admin session running on a tenant
+  // subdomain (host-scoped) must not see admin-global pages. Send them
+  // back to `/my` so they land on the tenant profile chrome instead of
+  // a global page that doesn't make sense in scope.
+  const isScopedAdmin = isAdmin && !!scopedProfile
+
   useEffect(() => {
     let cancelled = false
+
+    if (isScopedAdmin) {
+      setAllowed(false)
+      setLoading(false)
+      return () => {
+        cancelled = true
+      }
+    }
 
     if (isAdmin) {
       setAllowed(true)
@@ -60,7 +74,11 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
     return () => {
       cancelled = true
     }
-  }, [id, isAdmin, user])
+  }, [id, isAdmin, isScopedAdmin, user])
+
+  if (isScopedAdmin) {
+    return <Navigate to="/my" replace />
+  }
 
   if (loading) {
     return (

--- a/dashboard/src/components/Sidebar.test.tsx
+++ b/dashboard/src/components/Sidebar.test.tsx
@@ -1,0 +1,88 @@
+// Tests for the Sidebar admin-global navigation gating.
+//
+// Option Y (issue #315) — the server's host-authoritative `/api/my/*`
+// scope re-routes admin to the tenant profile when the request lands on
+// a tenant subdomain. To match that on the frontend, the Sidebar hides
+// admin-only global links (`/`, `/users`, `/admin-bot`, etc.) when the
+// authenticated user is admin AND `scoped_profile` is set on
+// `/api/auth/me`. The profile-area links (`Home`, `LLM`, etc.) remain
+// since those go to `/my` which the server now scopes to the tenant.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Sidebar from './Sidebar'
+
+type MockUser = { role: 'admin' | 'user'; name?: string; email?: string }
+type MockScopedProfile = { id: string; name: string; email_login_enabled: boolean } | null
+
+const mockAuthState: { user: MockUser; isAdmin: boolean; scopedProfile: MockScopedProfile } = {
+  user: { role: 'admin', email: 'admin@example.com' },
+  isAdmin: true,
+  scopedProfile: null,
+}
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    ...mockAuthState,
+    logout: vi.fn(),
+  }),
+}))
+
+function setAuthState(user: MockUser, scopedProfile: MockScopedProfile) {
+  mockAuthState.user = user
+  mockAuthState.isAdmin = user.role === 'admin'
+  mockAuthState.scopedProfile = scopedProfile
+}
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Sidebar />
+    </MemoryRouter>,
+  )
+}
+
+describe('Sidebar admin-global gating', () => {
+  it('shows admin-global links when admin is NOT host-scoped', () => {
+    setAuthState({ role: 'admin', email: 'admin@example.com' }, null)
+    renderSidebar()
+    // Both "All Profiles" buttons render (back link + bottom section)
+    // when not in a profile route, but the bottom one is the global
+    // admin link. Either way, presence proves the global section is
+    // rendered.
+    expect(screen.getByText('All Profiles')).toBeInTheDocument()
+    expect(screen.getByText('Access')).toBeInTheDocument()
+    expect(screen.getByText('Admin Bot')).toBeInTheDocument()
+    expect(screen.getByText('Server')).toBeInTheDocument()
+    expect(screen.getByText('Setup Wizard')).toBeInTheDocument()
+  })
+
+  it('hides admin-global links when admin IS host-scoped to a tenant', () => {
+    setAuthState(
+      { role: 'admin', email: 'admin@example.com' },
+      { id: 'dspfac', name: 'DSPFac', email_login_enabled: true },
+    )
+    renderSidebar()
+    // Global links must be gone.
+    expect(screen.queryByText('All Profiles')).not.toBeInTheDocument()
+    expect(screen.queryByText('Access')).not.toBeInTheDocument()
+    expect(screen.queryByText('Admin Bot')).not.toBeInTheDocument()
+    expect(screen.queryByText('Server')).not.toBeInTheDocument()
+    expect(screen.queryByText('Setup Wizard')).not.toBeInTheDocument()
+    // Profile-area links must still render (admin still has nav to
+    // configure the tenant's LLM, messaging, etc.).
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('LLM Providers')).toBeInTheDocument()
+    // The tenant name is shown under the brand to make scope obvious.
+    expect(screen.getByText('DSPFac')).toBeInTheDocument()
+  })
+
+  it('non-admin user never sees admin-global links regardless of host scope', () => {
+    setAuthState({ role: 'user', email: 'user@example.com' }, null)
+    renderSidebar()
+    expect(screen.queryByText('All Profiles')).not.toBeInTheDocument()
+    expect(screen.queryByText('Access')).not.toBeInTheDocument()
+    expect(screen.getByText('Home')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -2,12 +2,22 @@ import { NavLink, useMatch, Link } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 
 export default function Sidebar() {
-  const { user, isAdmin, logout } = useAuth()
+  const { user, isAdmin, scopedProfile, logout } = useAuth()
 
   // Detect if we're on a profile route
   const adminProfileMatch = useMatch('/profile/:id/*')
   const myProfileMatch = useMatch('/my/*')
   const isProfileMode = !!(adminProfileMatch || myProfileMatch)
+
+  // Option Y (issue #315): when the request comes in on a tenant
+  // subdomain the server scopes `/api/my/*` to that tenant. Hide
+  // admin-global navigation so an admin in tenant scope sees the
+  // tenant's profile chrome only — the global "All Profiles" / Access
+  // / Server / Setup links would otherwise mislead them into thinking
+  // those actions apply to the tenant. Admin reaches global pages by
+  // visiting the root domain.
+  const isHostScoped = !!scopedProfile
+  const showAdminGlobalLinks = isAdmin && !isHostScoped
 
   // Build the base path for profile navigation links
   const profileBase = adminProfileMatch
@@ -22,6 +32,11 @@ export default function Sidebar() {
           <span className="text-accent">octos</span>
           {isAdmin ? ' Admin' : ''}
         </h1>
+        {isHostScoped && scopedProfile && (
+          <p className="mt-1 text-[10px] text-gray-500 truncate" title={`Scoped to ${scopedProfile.name}`}>
+            {scopedProfile.name}
+          </p>
+        )}
       </div>
 
       <nav className="flex-1 px-3 py-4 space-y-1 overflow-y-auto">
@@ -29,7 +44,7 @@ export default function Sidebar() {
         {isAdmin && (
           <>
             {/* Back to dashboard (admin only) */}
-            {isAdmin && adminProfileMatch && (
+            {showAdminGlobalLinks && adminProfileMatch && (
               <Link
                 to="/"
                 className="flex items-center gap-2 px-3 py-2 mb-3 text-xs text-gray-500 hover:text-gray-300 transition-colors"
@@ -47,8 +62,8 @@ export default function Sidebar() {
             <SidebarLink to={`${profileBase}/skills`} icon={<PuzzleIcon />} label="Skills" />
             <SidebarLink to={`${profileBase}/system`} icon={<CogIcon />} label="System" />
 
-            {/* Admin links (separator + bottom section) */}
-            {isAdmin && (
+            {/* Admin links — hidden on tenant subdomains (Option Y, #315) */}
+            {showAdminGlobalLinks && (
               <>
                 <div className="border-t border-gray-700/30 my-3" />
                 <SidebarLink to="/" end icon={<GridIcon />} label="All Profiles" />

--- a/dashboard/src/contexts/AuthContext.tsx
+++ b/dashboard/src/contexts/AuthContext.tsx
@@ -1,11 +1,18 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react'
-import type { User } from '../types'
+import type { ScopedAuthTarget, User } from '../types'
 import { authApi } from '../api'
 
 interface AuthContextValue {
   user: User | null
   token: string | null
   isAdmin: boolean
+  /** Tenant scope derived from the request host (server's
+   *  `host_scoped_profile_id`). `null` on the root domain / direct IP
+   *  / localhost; populated when the dashboard is loaded from a
+   *  tenant subdomain (e.g. `dspfac.ocean.ominix.io`). Used by the
+   *  Sidebar to hide admin-global navigation while operating inside a
+   *  tenant scope — Option Y, issue #315. */
+  scopedProfile: ScopedAuthTarget | null
   loading: boolean
   sendOtp: (email: string) => Promise<{ ok: boolean; message?: string }>
   verifyOtp: (email: string, code: string) => Promise<boolean>
@@ -18,6 +25,7 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
+  const [scopedProfile, setScopedProfile] = useState<ScopedAuthTarget | null>(null)
   const [token, setToken] = useState<string | null>(
     () => localStorage.getItem('octos_session_token') || localStorage.getItem('octos_auth_token')
   )
@@ -35,12 +43,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     authApi.me()
       .then((res) => {
         setUser(res.user)
+        setScopedProfile(res.scoped_profile ?? null)
       })
       .catch(() => {
         // Token invalid — clear it
         localStorage.removeItem('octos_session_token')
         setToken(null)
         setUser(null)
+        setScopedProfile(null)
       })
       .finally(() => setLoading(false))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -56,6 +66,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       localStorage.setItem('octos_session_token', res.token)
       setToken(res.token)
       if (res.user) setUser(res.user)
+      // Refresh the host scope after a successful verify — the OTP
+      // flow doesn't return it, but `/api/auth/me` does.
+      try {
+        const me = await authApi.me()
+        setScopedProfile(me.scoped_profile ?? null)
+      } catch {
+        // best-effort
+      }
       return true
     }
     return false
@@ -68,6 +86,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const res = await authApi.me()
       setToken(adminToken)
       setUser(res.user)
+      setScopedProfile(res.scoped_profile ?? null)
       return true
     } catch {
       localStorage.removeItem('octos_auth_token')
@@ -90,11 +109,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem('octos_auth_token')
     setToken(null)
     setUser(null)
+    setScopedProfile(null)
   }, [])
 
   return (
     <AuthContext.Provider
-      value={{ user, token, isAdmin, loading, sendOtp, verifyOtp, loginWithToken, swapToken, logout }}
+      value={{ user, token, isAdmin, scopedProfile, loading, sendOtp, verifyOtp, loginWithToken, swapToken, logout }}
     >
       {children}
     </AuthContext.Provider>

--- a/dashboard/src/contexts/ProfileContext.tsx
+++ b/dashboard/src/contexts/ProfileContext.tsx
@@ -64,12 +64,21 @@ function normalizeProfileConfig(config: ProfileConfig): ProfileConfig {
 
 export function ProfileProvider({ children }: Props) {
   const { id } = useParams<{ id: string }>()
-  const { user, isAdmin } = useAuth()
+  const { user, isAdmin, scopedProfile } = useAuth()
   const { toast } = useToast()
 
-  // Determine if viewing own profile
+  // Determine if viewing own profile.
+  //
+  // Codex P2 (PR #958 review): when the dashboard is loaded on a tenant
+  // subdomain the server's host-authoritative scoping makes
+  // `/api/my/*` operate on that tenant — not on `user.id`. Use the
+  // scoped profile id so downstream consumers (provider model lookups,
+  // search API key tests, public-subdomain previews) target the
+  // tenant. The actual profile id is also re-confirmed from the
+  // server's response in `loadProfile` below.
   const isOwn = !id
-  const profileId = id || user?.id || ''
+  const initialProfileId =
+    id ?? (isOwn ? scopedProfile?.id ?? user?.id ?? '' : user?.id ?? '')
 
   const [config, setConfig] = useState<ProfileConfig>(defaultConfig)
   const [status, setStatus] = useState<ProcessStatus | null>(null)
@@ -78,8 +87,13 @@ export function ProfileProvider({ children }: Props) {
   const [publicSubdomain, setPublicSubdomain] = useState('')
   const [enabled, setEnabled] = useState(true)
   const [parentId, setParentId] = useState<string | null>(null)
+  const [resolvedProfileId, setResolvedProfileId] = useState<string>(initialProfileId)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+
+  // The exposed `profileId` falls back to the most authoritative source
+  // available: the server's response > scoped tenant id > user id.
+  const profileId = resolvedProfileId || initialProfileId
 
   // API adapter: own profile uses myApi, admin uses api with profileId
   const adapter = useMemo(() => {
@@ -129,6 +143,12 @@ export function ProfileProvider({ children }: Props) {
       setPublicSubdomain(profile.public_subdomain || profile.id)
       setEnabled(profile.enabled)
       setParentId(profile.parent_id || null)
+      // Codex P2 (PR #958 review): the server's host-authoritative
+      // scoping may have re-mapped `/my` to a tenant profile. Trust
+      // the id returned by the server so downstream consumers
+      // (profile_id query params, public-subdomain preview, sub-account
+      // listing) operate on the right profile.
+      setResolvedProfileId(profile.id)
     } catch (e: any) {
       toast(e.message, 'error')
     } finally {

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ function shouldShowDashboardApp(profile: ProfileResponse) {
 }
 
 export default function Dashboard() {
-  const { isAdmin } = useAuth()
+  const { isAdmin, scopedProfile } = useAuth()
   const { data, error, loading, refresh } = useOverview()
   const { toast } = useToast()
   const [actionLoading, setActionLoading] = useState(false)
@@ -49,8 +49,13 @@ export default function Dashboard() {
     }
   }, [data?.profiles])
 
-  // Non-admins go straight to their profile
-  if (!isAdmin) {
+  // Non-admins go straight to their profile.
+  // Codex P2 (PR #958 review): scoped admins (admin sessions on a
+  // tenant subdomain) likewise belong on `/my` — the global
+  // `/api/admin/overview` shown here would be misleading inside a
+  // tenant scope. Admin reaches the global dashboard by visiting the
+  // root domain.
+  if (!isAdmin || scopedProfile) {
     return <Navigate to="/my" replace />
   }
 

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -246,9 +246,23 @@ export interface AllowlistEntry {
   last_login_at?: string | null
 }
 
+/// The active tenant scope derived from the request `Host` /
+/// `X-Forwarded-Host` header. Populated by the server's
+/// `host_scoped_profile_id` resolver. `null` when no tenant subdomain
+/// is in scope (root domain, direct IP, or localhost). The dashboard
+/// reads this from `/api/auth/me` to hide admin-global navigation
+/// while an admin is operating inside a tenant scope (Option Y,
+/// issue #315).
+export interface ScopedAuthTarget {
+  id: string
+  name: string
+  email_login_enabled: boolean
+}
+
 export interface MeResponse {
   user: User
   profile: ProfileResponse | null
+  scoped_profile?: ScopedAuthTarget | null
 }
 
 export interface BridgeQrInfo {


### PR DESCRIPTION
## Summary

- Plumbs the request `HeaderMap` into `resolve_my_profile_id` so the
  helper calls `host_scoped_profile_id(state, headers)` first. When the
  URL host resolves to a tenant subdomain (e.g.
  `dspfac.ocean.ominix.io`) the resolver returns that tenant's profile
  id; otherwise it falls back to today's identity-based default (admin
  -> `ADMIN_PROFILE_ID`, user -> `user.id`).
- Cross-tenant access by a non-admin user is rejected with `403
  FORBIDDEN`. Admin can still view any tenant via host routing (matches
  existing admin semantics). Without this we'd have a silent
  cross-tenant data-leak path.
- `MeResponse` exposes `scoped_profile: Option<ScopedAuthTarget>` so
  the dashboard can hide admin-global navigation (`All Profiles`,
  `Access`, `Admin Bot`, `Server`, `Setup Wizard`) on tenant
  subdomains. Admin reaches global pages by visiting the root domain
  (option A from the plan — simplest, no DNS or config changes).

## Closes

- Closes #315 — server-side completion of the partial host-scoping
  that previously lived only in the OTP login path.

## Security model

`is_authorized_for_profile(state, identity, profile_id)`:
- `Admin` -> any profile (parity with `/api/admin/*`).
- `User { id }` -> their own profile id.
- `User { id }` -> any sub-account where `parent_id == id`.
- Everyone else -> denied.

The host check runs **before** the auth check; if the host resolves
to a tenant the resolver requires authorization for that tenant
specifically, rather than silently falling back to the user's home
profile (which would be confusing for both UX and auditing).

## Test plan

- [x] `cargo test -p octos-cli --features api auth_handlers` — 34
      tests, including 6 new edge-case tests:
  - `host_scope_admin_falls_through_when_host_unknown` (admin still
    sees admin profile on localhost / root domain)
  - `host_scope_admin_resolves_to_tenant_when_host_matches`
  - `host_scope_sub_account_on_own_tenant_subdomain`
  - `host_scope_cross_tenant_user_access_denied` — 403, NOT silent
    fallback
  - `host_scope_admin_can_access_any_tenant` — admin override
  - `host_scope_parent_user_authorized_for_own_sub_account` — verifies
    `parent_id` walk
- [x] `npm test` in `dashboard/` — 19 tests, including 3 new in
      `Sidebar.test.tsx` (admin un-scoped, admin host-scoped, non-admin)
- [x] `cargo fmt --all`, `cargo clippy --workspace -- -D warnings`
- [x] `bash scripts/build-dashboard.sh` — embedded admin bundle
      rebuilt

## Operational impact

- Server change — fleet minis need a binary redeploy + the embedded
  dashboard rebuild before the new scoping takes effect.
- No DB / config migration; no DNS work; no breakage of the existing
  OTP scoping path that already used `host_scoped_profile_id`.