### PR TITLE
fix(cli): expose audio_mp3 feature passthrough

### DIFF
--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -85,6 +85,12 @@ qq-bot = ["octos-bus/qq-bot"]
 wechat = ["octos-bus/wechat"]
 git = ["octos-agent/git"]
 ast = ["octos-agent/ast"]
+# Mp3 decode for the AudioNonSilent workspace-contract validator (.mp3 files).
+# Without it, validators on .mp3 artifacts return "feature not enabled" — see
+# `crates/octos-agent/src/validators.rs`. Fleet builds that ship the podcast
+# / fm_tts skills should enable this so the contract layer accepts the mp3
+# outputs they produce.
+audio_mp3 = ["octos-agent/audio_mp3"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

octos-agent declares `audio_mp3 = ["dep:symphonia"]` but octos-cli had no passthrough, so fleet builds couldn't enable it. The AudioNonSilent workspace contract validator then rejects podcast/fm_tts mp3 outputs with:

```
audio_non_silent for .mp3 requires the 'audio_mp3' feature;
enable it on octos-agent or use a .wav input
```

Adds `audio_mp3 = ["octos-agent/audio_mp3"]` in `crates/octos-cli/Cargo.toml [features]`.

## Test plan
- [x] `cargo build -p octos-cli --features audio_mp3` clean