### PR TITLE
feat(api): emit tool_call_id on TaskUpdated + TurnSpawnComplete

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -662,6 +662,7 @@ impl Agent {
                                             task_id: Some(task_id.clone()),
                                             originating_client_message_id:
                                                 bg_originating_client_message_id.clone(),
+                                            tool_call_id: Some(bg_tc_id.clone()),
                                         })
                                         .await
                                     } else {
@@ -723,6 +724,7 @@ impl Agent {
                                                             originating_client_message_id:
                                                                 bg_originating_client_message_id
                                                                     .clone(),
+                                                            tool_call_id: Some(bg_tc_id.clone()),
                                                         })
                                                         .await;
                                                 }
@@ -767,6 +769,7 @@ impl Agent {
                                             task_id: Some(task_id.clone()),
                                             originating_client_message_id:
                                                 bg_originating_client_message_id.clone(),
+                                            tool_call_id: Some(bg_tc_id.clone()),
                                         })
                                         .await;
                                     }
@@ -795,6 +798,7 @@ impl Agent {
                                                 task_id: Some(task_id.clone()),
                                                 originating_client_message_id:
                                                     bg_originating_client_message_id.clone(),
+                                                tool_call_id: Some(bg_tc_id.clone()),
                                             })
                                             .await;
                                         }
@@ -852,6 +856,7 @@ impl Agent {
                                                     task_id: Some(task_id.clone()),
                                                     originating_client_message_id:
                                                         bg_originating_client_message_id.clone(),
+                                                    tool_call_id: Some(bg_tc_id.clone()),
                                                 })
                                                 .await;
                                             }
@@ -888,6 +893,7 @@ impl Agent {
                                                 task_id: Some(task_id.clone()),
                                                 originating_client_message_id:
                                                     bg_originating_client_message_id.clone(),
+                                                tool_call_id: Some(bg_tc_id.clone()),
                                             })
                                             .await;
                                         }
@@ -1022,6 +1028,7 @@ impl Agent {
                                                 task_id: Some(task_id.clone()),
                                                 originating_client_message_id:
                                                     bg_originating_client_message_id.clone(),
+                                                tool_call_id: Some(bg_tc_id.clone()),
                                             })
                                             .await;
                                         }
@@ -1131,6 +1138,7 @@ impl Agent {
                                                     task_id: Some(task_id.clone()),
                                                     originating_client_message_id:
                                                         bg_originating_client_message_id.clone(),
+                                                    tool_call_id: Some(bg_tc_id.clone()),
                                                 })
                                                 .await;
 
@@ -1204,6 +1212,7 @@ impl Agent {
                                                             originating_client_message_id:
                                                                 bg_originating_client_message_id
                                                                     .clone(),
+                                                            tool_call_id: Some(bg_tc_id.clone()),
                                                         })
                                                         .await;
                                                     }
@@ -1233,6 +1242,7 @@ impl Agent {
                                     task_id: Some(task_id.clone()),
                                     originating_client_message_id: bg_originating_client_message_id
                                         .clone(),
+                                    tool_call_id: Some(bg_tc_id.clone()),
                                 })
                                 .await;
                             }
@@ -1255,6 +1265,7 @@ impl Agent {
                                     task_id: Some(task_id.clone()),
                                     originating_client_message_id: bg_originating_client_message_id
                                         .clone(),
+                                    tool_call_id: Some(bg_tc_id.clone()),
                                 })
                                 .await;
                             }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -114,6 +114,15 @@ pub struct BackgroundResultPayload {
     /// `read_task_output` against it). `None` for legacy callers and
     /// tests that do not register tasks with the supervisor.
     pub task_id: Option<String>,
+    /// Originating `tool_call_id` (the spawn_only tool invocation that
+    /// produced this background task). Surfaced on the wire as
+    /// [`octos_core::ui_protocol::TurnSpawnCompleteEvent::tool_call_id`]
+    /// so the client can flip the in-flight chip from spinner to
+    /// checkmark directly off the envelope, without a race against a
+    /// `task/updated` watcher that builds `task_id → tool_call_id`
+    /// post-hoc. `None` for legacy callers and tests that do not track
+    /// the originating call.
+    pub tool_call_id: Option<String>,
     /// Issue #960 fix (M10 Phase 4 plumbing): the originating user
     /// message's `client_message_id` (cmid) — the same value the
     /// supervisor records as
@@ -2355,6 +2364,19 @@ impl Tool for SpawnTool {
             // which after fast-follow-up turns is the WRONG turn's
             // thread_id (cf. live mini3 trace, 2026-04-29).
             let originating_thread_id = ctx.reporter.thread_id().map(str::to_string);
+            // Snapshot the originating LLM `tool_call_id` (carried on
+            // `ToolContext.tool_id`) so the late-arriving terminal payload
+            // surfaces it on `TurnSpawnCompleteEvent.tool_call_id`. The
+            // client uses this to flip the in-flight chip from spinner to
+            // checkmark without a race against a `task/updated` watcher.
+            // Empty when the caller invoked the tool from a non-LLM
+            // context (synthetic harness, recovery path); in that case
+            // the field stays `None` on the wire.
+            let originating_tool_call_id = if ctx.tool_id.is_empty() {
+                None
+            } else {
+                Some(ctx.tool_id.clone())
+            };
             // M8 Runtime Parity W2.B1: capture parent caches into the
             // detached background closure so the bg child Agent gets the
             // same FileStateCache + Router + SummaryGenerator as the sync
@@ -2998,6 +3020,7 @@ impl Tool for SpawnTool {
                         // SPA reducer's thread-map keys on whichever shape
                         // its parent prompt row carries.
                         originating_client_message_id: originating_thread_id.clone(),
+                        tool_call_id: originating_tool_call_id.clone(),
                     },
                 )
                 .await
@@ -4009,6 +4032,7 @@ PY
             originating_thread_id: None,
             task_id: None,
             originating_client_message_id: None,
+            tool_call_id: None,
         };
 
         assert!(deliver_background_result(Some(sender), payload.clone()).await);

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -8396,6 +8396,10 @@ async fn run_m9_fixture_turn(
                         UiNotification::TaskUpdated(TaskUpdatedEvent {
                             session_id: session_id.clone(),
                             task_id: task_id.clone(),
+                            // Synthetic M9 fixture: no originating LLM
+                            // tool call. Carrying `None` keeps the wire
+                            // shape forward-compatible.
+                            tool_call_id: None,
                             title: "M9 task output fixture".to_owned(),
                             state: UiTaskRuntimeState::Running,
                             runtime_detail: Some(
@@ -8419,6 +8423,10 @@ async fn run_m9_fixture_turn(
                         UiNotification::TaskUpdated(TaskUpdatedEvent {
                             session_id: session_id.clone(),
                             task_id,
+                            // Synthetic M9 fixture: no originating LLM
+                            // tool call. Carrying `None` keeps the wire
+                            // shape forward-compatible.
+                            tool_call_id: None,
                             title: "M9 task output fixture".to_owned(),
                             state: UiTaskRuntimeState::Completed,
                             runtime_detail: Some("fixture complete".to_owned()),
@@ -8819,6 +8827,20 @@ async fn run_standalone_turn(
                     .originating_client_message_id
                     .clone()
                     .filter(|s| !s.is_empty());
+                // Originating LLM `tool_call_id`. The supervisor stores it
+                // on `BackgroundTask.tool_call_id`; the agent's spawn_only
+                // branch threads it through to the payload so the
+                // `turn/spawn_complete` envelope can carry it on the wire.
+                // The client uses it to flip the in-flight chip from
+                // spinner to checkmark without a race against a
+                // `task/updated` watcher that builds
+                // `task_id → tool_call_id` post-hoc. Empty strings collapse
+                // to `None` for the same reason as
+                // `originating_client_message_id`.
+                let originating_tool_call_id = payload
+                    .tool_call_id
+                    .clone()
+                    .filter(|s| !s.is_empty());
                 let turn_id = payload_turn_id.clone();
                 let ledger = payload_ledger.clone();
                 Box::pin(async move {
@@ -8912,6 +8934,7 @@ async fn run_standalone_turn(
                             turn_id: Some(turn_id.clone()),
                             thread_id: Some(thread_id.clone()),
                             task_id: task_id_value,
+                            tool_call_id: originating_tool_call_id.clone(),
                             // Issue #960 fix: M10 Phase 4 plumbing —
                             // surface the originating user prompt's
                             // `client_message_id` (captured at the
@@ -11233,6 +11256,7 @@ mod tests {
                 turn_id: None,
                 thread_id: None,
                 task_id: "task-1".into(),
+                tool_call_id: None,
                 response_to_client_message_id: None,
                 seq: 1,
                 message_id: "msg-1".into(),
@@ -16221,6 +16245,7 @@ mod tests {
             turn_id: None,
             thread_id: Some("cmid-user-1".into()),
             task_id: "task_abc".into(),
+            tool_call_id: Some("call_abc".into()),
             response_to_client_message_id: Some("cmid-user-1".into()),
             seq: 2,
             message_id: spawn_ack_message_id.clone(),
@@ -16380,6 +16405,7 @@ mod tests {
             turn_id: None,
             thread_id: Some("cmid-user-1".into()),
             task_id: "task_x".into(),
+            tool_call_id: None,
             response_to_client_message_id: Some("cmid-user-1".into()),
             seq: 1,
             message_id: format!("{}:1:0", session_id.0),
@@ -16903,6 +16929,7 @@ mod tests {
             turn_id: Some(TurnId::new()),
             thread_id: Some("thread-1".into()),
             task_id: "task_abc123".into(),
+            tool_call_id: Some("call_abc123".into()),
             response_to_client_message_id: Some("cmid-user-1".into()),
             seq: 0,
             message_id: "msg-spawn".into(),

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -155,6 +155,7 @@ fn map_task_started(context: &ProgressMappingContext, event: &Value) -> UiProgre
             TaskUpdatedEvent {
                 session_id: context.session_id.clone(),
                 task_id,
+                tool_call_id: string_field(event, &["tool_call_id"]),
                 title: string_field(event, &["title"]).unwrap_or_else(|| "Task".into()),
                 state: UiTaskRuntimeState::Running,
                 runtime_detail: Some("task started".into()),
@@ -213,6 +214,7 @@ fn map_task_updated(context: &ProgressMappingContext, event: &Value) -> UiProgre
     UiProgressMapping::notifications(vec![UiNotification::TaskUpdated(TaskUpdatedEvent {
         session_id: context.session_id.clone(),
         task_id,
+        tool_call_id: string_field(event, &["tool_call_id"]),
         title,
         state,
         runtime_detail: string_field(event, &["runtime_detail", "message", "status_message"]),
@@ -489,9 +491,14 @@ fn ui_task_runtime_state(state: &str) -> Option<UiTaskRuntimeState> {
 }
 
 pub(crate) fn background_task_to_progress_json(task: &octos_agent::BackgroundTask) -> Value {
+    // Carry `tool_call_id` on every `task_updated` snapshot so the
+    // mapper below threads it onto `TaskUpdatedEvent`. The client uses
+    // the wire-side mapping instead of racing a `task/updated` watcher
+    // to build `task_id → tool_call_id` post-hoc.
     json!({
         "type": "task_updated",
         "task_id": task.id,
+        "tool_call_id": task.tool_call_id,
         "title": task.tool_name,
         "state": task.lifecycle_state(),
         "runtime_detail": stable_task_runtime_detail(task),

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2462,6 +2462,15 @@ pub struct TurnSpawnCompleteEvent {
     /// populated — a `turn/spawn_complete` without a task_id is a server
     /// bug.
     pub task_id: String,
+    /// Originating tool call id (the spawn_only tool invocation that
+    /// produced this background task). Carrying it on the wire eliminates
+    /// the client-side race where a stale `task_id → tool_call_id` map
+    /// (built from `task/updated` watchers) would fail to flip the
+    /// in-flight chip from spinner to checkmark on completion. Optional
+    /// so legacy daemons and synthetic / fallback emission paths that
+    /// cannot resolve the originating call still parse.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
     /// The originating user message's `client_message_id`, i.e. the
     /// user-prompt anchor under which the new assistant bubble should be
     /// rendered. `None` only for legacy callers that did not propagate
@@ -3929,6 +3938,16 @@ pub enum TaskRuntimeState {
 pub struct TaskUpdatedEvent {
     pub session_id: SessionKey,
     pub task_id: TaskId,
+    /// Originating tool call id. Carrying it on the wire alongside
+    /// `task_id` lets the client flip the in-flight chip from spinner
+    /// to checkmark without a race against a `task/updated` -> watcher
+    /// -> TaskStore lookup chain (the chain that previously stayed cold
+    /// because the client bridge rejected `task/updated` envelopes that
+    /// lacked `turn_id`). Optional so legacy daemons and synthetic /
+    /// fallback emission paths that cannot resolve the originating call
+    /// still parse.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
     pub title: String,
     pub state: TaskRuntimeState,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4989,6 +5008,7 @@ mod tests {
         let task_cancelled = UiNotification::TaskUpdated(TaskUpdatedEvent {
             session_id: SessionKey("local:demo".into()),
             task_id: task_id.clone(),
+            tool_call_id: None,
             title: "spawn_only_runner".into(),
             state: TaskRuntimeState::Cancelled,
             runtime_detail: Some("user cancelled".into()),
@@ -6671,6 +6691,7 @@ mod tests {
         let event = UiNotification::TaskUpdated(TaskUpdatedEvent {
             session_id: SessionKey("local:demo".into()),
             task_id: TaskId(Uuid::from_u128(7)),
+            tool_call_id: None,
             title: "spawn_only_runner".into(),
             state: TaskRuntimeState::Cancelled,
             runtime_detail: Some("user cancelled".into()),
@@ -6951,6 +6972,7 @@ mod tests {
             turn_id: Some(sample_turn_id()),
             thread_id: Some("thread-1".into()),
             task_id: "task_abc123".into(),
+            tool_call_id: Some("call_abc123".into()),
             response_to_client_message_id: Some("cmid-user-1".into()),
             seq: 42,
             message_id: "msg-spawn-1".into(),
@@ -6968,6 +6990,7 @@ mod tests {
         // top-level object with snake_case keys; absent optional fields
         // omit cleanly.
         assert_eq!(value.get("task_id"), Some(&json!("task_abc123")));
+        assert_eq!(value.get("tool_call_id"), Some(&json!("call_abc123")));
         assert_eq!(
             value.get("response_to_client_message_id"),
             Some(&json!("cmid-user-1")),
@@ -6988,6 +7011,7 @@ mod tests {
             turn_id: None,
             thread_id: None,
             task_id: "task_zzz".into(),
+            tool_call_id: None,
             response_to_client_message_id: None,
             seq: 1,
             message_id: "msg-bare".into(),
@@ -7003,6 +7027,10 @@ mod tests {
         let bare_v = serde_json::to_value(&bare).expect("serialize bare");
         assert!(bare_v.get("turn_id").is_none(), "absent turn_id omits");
         assert!(bare_v.get("thread_id").is_none(), "absent thread_id omits");
+        assert!(
+            bare_v.get("tool_call_id").is_none(),
+            "absent tool_call_id omits",
+        );
         assert!(
             bare_v.get("response_to_client_message_id").is_none(),
             "absent response_to_client_message_id omits",
@@ -7021,6 +7049,106 @@ mod tests {
         assert_eq!(rpc.method, methods::TURN_SPAWN_COMPLETE);
         let decoded = UiNotification::from_rpc_notification(rpc).expect("notification deserialize");
         assert_eq!(decoded, notif);
+    }
+
+    /// Asserts the new `tool_call_id` field round-trips through serde on
+    /// both `task/updated` and `turn/spawn_complete`. The chip-flip
+    /// race in the client browser hinged on having this field on the
+    /// wire, so a regression here would silently re-introduce the bug
+    /// even if the constructors still type-check.
+    #[test]
+    fn task_updated_and_spawn_complete_events_round_trip_tool_call_id() {
+        // `TaskUpdatedEvent` with `tool_call_id` set.
+        let task_event = TaskUpdatedEvent {
+            session_id: SessionKey("local:demo".into()),
+            task_id: TaskId(Uuid::from_u128(0xDEADBEEF)),
+            tool_call_id: Some("call_podcast_generate_42".into()),
+            title: "podcast_generate".into(),
+            state: TaskRuntimeState::Completed,
+            runtime_detail: Some("rendered output.mp3".into()),
+        };
+        let task_value = serde_json::to_value(&task_event).expect("serialize task_updated");
+        assert_eq!(
+            task_value.get("tool_call_id"),
+            Some(&json!("call_podcast_generate_42")),
+            "tool_call_id must appear on the wire",
+        );
+        let parsed_task: TaskUpdatedEvent =
+            serde_json::from_value(task_value).expect("deserialize task_updated");
+        assert_eq!(parsed_task, task_event);
+
+        // `TaskUpdatedEvent` with `tool_call_id == None` omits on the wire
+        // (legacy daemons / synthetic paths).
+        let task_legacy = TaskUpdatedEvent {
+            session_id: SessionKey("local:demo".into()),
+            task_id: TaskId(Uuid::from_u128(1)),
+            tool_call_id: None,
+            title: "legacy".into(),
+            state: TaskRuntimeState::Running,
+            runtime_detail: None,
+        };
+        let legacy_value = serde_json::to_value(&task_legacy).expect("serialize legacy");
+        assert!(
+            legacy_value.get("tool_call_id").is_none(),
+            "absent tool_call_id must omit so legacy daemons parse",
+        );
+        // Defensive: a JSON payload from an even-older daemon that lacks
+        // the field entirely still parses via `#[serde(default)]`.
+        let bare_legacy_json = json!({
+            "session_id": "local:demo",
+            "task_id": TaskId(Uuid::from_u128(1)),
+            "title": "legacy",
+            "state": "running",
+        });
+        let parsed_legacy: TaskUpdatedEvent =
+            serde_json::from_value(bare_legacy_json).expect("deserialize legacy bare");
+        assert_eq!(parsed_legacy.tool_call_id, None);
+
+        // `TurnSpawnCompleteEvent` with `tool_call_id` set.
+        let spawn_event = TurnSpawnCompleteEvent {
+            session_id: SessionKey("local:demo".into()),
+            turn_id: None,
+            thread_id: None,
+            task_id: "task_podcast_42".into(),
+            tool_call_id: Some("call_podcast_generate_42".into()),
+            response_to_client_message_id: None,
+            seq: 7,
+            message_id: "msg-spawn-7".into(),
+            source: "background".into(),
+            cursor: UiCursor {
+                stream: "local:demo".into(),
+                seq: 7,
+            },
+            persisted_at: sample_persisted_at(),
+            content: "🎙 podcast delivered".into(),
+            media: vec!["output.mp3".into()],
+        };
+        let spawn_value = serde_json::to_value(&spawn_event).expect("serialize spawn_complete");
+        assert_eq!(
+            spawn_value.get("tool_call_id"),
+            Some(&json!("call_podcast_generate_42")),
+            "tool_call_id must appear on the wire",
+        );
+        let parsed_spawn: TurnSpawnCompleteEvent =
+            serde_json::from_value(spawn_value).expect("deserialize spawn_complete");
+        assert_eq!(parsed_spawn, spawn_event);
+
+        // Defensive: a `turn/spawn_complete` payload from an older daemon
+        // that lacks the field entirely still parses via
+        // `#[serde(default)]`.
+        let bare_spawn_json = json!({
+            "session_id": "local:demo",
+            "task_id": "task_legacy",
+            "seq": 1,
+            "message_id": "msg-legacy",
+            "source": "background",
+            "cursor": { "stream": "local:demo", "seq": 1 },
+            "persisted_at": "2026-01-01T00:00:00Z",
+            "content": "done",
+        });
+        let parsed_legacy_spawn: TurnSpawnCompleteEvent =
+            serde_json::from_value(bare_spawn_json).expect("deserialize legacy spawn bare");
+        assert_eq!(parsed_legacy_spawn.tool_call_id, None);
     }
 
     #[test]


### PR DESCRIPTION
## Why

User on deployed `octos serve` runs `podcast_generate` (spawn_only). Podcast finishes successfully but the in-flight chip never flips from spinner to checkmark.

Codex root-caused the chain:
1. Server emits `task/updated` with no `turn_id` field.
2. Client bridge at `ui-protocol-bridge.ts:809` rejects envelopes without `turn_id`.
3. So `handleTaskUpdated` never fires.
4. So the task-watcher (which would populate `TaskStore` with `task_id -> tool_call_id`) never starts polling.
5. So the eventual `turn/spawn_complete` lookup keyed on `task_id` misses and the chip stays a spinner.

Carrying `tool_call_id` on the wire alongside `task_id` collapses the whole chain. The chip flip becomes a single envelope-keyed lookup, with no client-side `TaskStore` race.

## Wire-level change

Two `Option<String>` fields with `#[serde(default, skip_serializing_if = "Option::is_none")]`:

- `octos_core::ui_protocol::TaskUpdatedEvent.tool_call_id`
- `octos_core::ui_protocol::TurnSpawnCompleteEvent.tool_call_id`

Optional on purpose so legacy daemons and synthetic / fallback emission paths still parse, and clients can roll out the new field at their own pace. **Forward-compatible in both directions** -- no breaking change to existing consumers.

## Server-side sourcing

- `BackgroundResultPayload` (octos-agent) gains its own `tool_call_id: Option<String>`. Populated in every emit site of the spawn_only branch in `agent/execution.rs` (10 sites) from `bg_tc_id` (the originating LLM tool_call_id captured at intercept).
- The `spawn` tool's background branch in `tools/spawn.rs` snapshots `ctx.tool_id` at spawn-time so the late-arriving terminal payload carries it.
- The api/serve consumer in `cli/src/api/ui_protocol.rs` reads `payload.tool_call_id` and stamps it onto `TurnSpawnCompleteEvent`.
- The `task_updated` progress JSON producer (`ui_protocol_progress.rs::background_task_to_progress_json`) carries `task.tool_call_id` so the mapper threads it onto `TaskUpdatedEvent`.

The supervisor's `BackgroundTask.tool_call_id` is the authoritative source -- it has stored this since M10 Phase 1. The change is just routing the value to the wire.

## Synthetic / fallback paths

The M9 protocol fixture, the legacy test fixture in `spawn.rs::test_direct_background_result_short_circuits_legacy_fallback`, and the hydrate/replay ledger tests pass `None`. Comment notes explain why.

## Tests

Added `task_updated_and_spawn_complete_events_round_trip_tool_call_id` in `octos-core/src/ui_protocol.rs`. Asserts:
- `tool_call_id` appears on the wire when populated.
- Absent `tool_call_id` omits cleanly from JSON.
- Legacy daemon payloads lacking the field entirely still deserialise via `#[serde(default)]`.

## Validation

- `cargo build --workspace --features api`: clean
- `cargo build --workspace --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"`: clean
- `cargo test -p octos-core`: 202 / 202 passed
- `cargo test -p octos-agent`: 1439 / 1439 passed
- `cargo test -p octos-cli --features api`: 1018 / 1018 of touched surfaces; 3 pre-existing failures on `origin/main` unrelated to this change (`session_open_result_advertises_full_protocol_when_no_header`, `session_open_result_advertises_intersection_when_header_subset`, `session_scope_rejects_unprofiled_session_id_when_authenticated` -- all `permission.profile.v1` / capability negotiation regressions verified against unmodified `origin/main`).
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --features api`: 37 warnings before & after -- no new warnings introduced on touched files.

## Deploy note

The new field is `Option<String>` with `skip_serializing_if = "Option::is_none"`. Clients can adopt the wire field at their own pace; rolling forward only the server is safe because:
- Legacy clients ignore unknown fields and continue to behave as today.
- Upgraded clients gain race-free chip flips immediately when the server upgrades.

## Don't / Out of scope

- `ToolStartedEvent` already carries `tool_call_id` -- no change needed.
- `TaskOutputDeltaEvent` consumed only for log output -- out of scope.
- Bridge & SPA changes are a parallel agent's responsibility.