### PR TITLE
fix(api): validate LLM-editable build_output_dir to prevent sites preview traversal (closes #996)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,6 +3784,7 @@ dependencies = [
  "image",
  "keyring",
  "lettre",
+ "libc",
  "metrics",
  "metrics-exporter-prometheus",
  "octos-agent",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,6 +3800,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rust-embed",
+ "rustix",
  "rustyline",
  "serde",
  "serde_json",

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -67,6 +67,15 @@ sysinfo = { version = "0.34", optional = true }
 # `tokio::fs::read` followed symlinks between the canonical-descendant
 # check and the read, opening a TOCTOU window.
 libc = { workspace = true }
+# `rustix::fs::openat` for the component-by-component path walk in
+# `src/api/preview.rs::open_no_follow_walk`. Codex round-2 BLOCKING #1
+# (issue #996): the previous `symlink_metadata`-then-`open` ancestor
+# walk left a multi-syscall TOCTOU window — an attacker could swap
+# any ancestor for a symlink between the stat and the open. Rustix's
+# safe `openat` wrapper (workspace-wide `deny(unsafe_code)` rules out
+# raw `libc::openat`) anchors each step to a parent fd so the
+# relationship survives mid-walk swaps.
+rustix = { version = "1.1", features = ["fs"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { workspace = true, features = ["apple-native"] }

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -61,6 +61,13 @@ rand = { workspace = true, optional = true }
 teloxide = { workspace = true, optional = true }
 sysinfo = { version = "0.34", optional = true }
 
+[target.'cfg(unix)'.dependencies]
+# O_NOFOLLOW for the symlink-safe preview file serve in
+# `src/api/preview.rs`. Pinned by issue #996 BLOCKING #1: previously
+# `tokio::fs::read` followed symlinks between the canonical-descendant
+# check and the read, opening a TOCTOU window.
+libc = { workspace = true }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 keyring = { workspace = true, features = ["apple-native"] }
 

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -22,7 +22,10 @@ use serde::{Deserialize, Serialize};
 use super::AppState;
 use super::auth_handlers::ADMIN_PROFILE_ID;
 use super::router::AuthIdentity;
-use crate::project_templates::{SiteProjectMetadata, read_site_project_metadata};
+use crate::project_templates::{
+    BuildOutputDirError, SiteProjectMetadata, read_site_project_metadata,
+    validated_build_output_dir,
+};
 
 /// Legacy `POST /api/chat` retired.
 ///
@@ -1659,11 +1662,18 @@ fn preview_content_type(path: &std::path::Path) -> &'static str {
     }
 }
 
+/// Resolve the build output directory for a site preview.
+///
+/// Issue #996: the metadata file is LLM-writable via `edit_file`, so
+/// the `build_output_dir` field is **untrusted on read** — we route
+/// every read through [`validated_build_output_dir`]. Callers must
+/// surface the typed error to the user (e.g. as a 4xx-equivalent
+/// preview page), not silently fall back to the raw join.
 fn output_dir_for_site(
     project_dir: &std::path::Path,
     metadata: &SiteProjectMetadata,
-) -> std::path::PathBuf {
-    project_dir.join(&metadata.build_output_dir)
+) -> Result<std::path::PathBuf, BuildOutputDirError> {
+    validated_build_output_dir(metadata, project_dir)
 }
 
 fn newest_tree_mtime(
@@ -1803,7 +1813,10 @@ fn ensure_site_build_output(
 
     let build_lock = site_build_lock(project_dir);
     let _build_guard = build_lock.lock().unwrap();
-    let output_dir = output_dir_for_site(project_dir, metadata);
+    // Validate the LLM-controlled metadata field before we trust it
+    // to derive the build output path. Issue #996.
+    let output_dir = output_dir_for_site(project_dir, metadata)
+        .map_err(|err| format!("invalid build_output_dir: {err}"))?;
     if !site_build_needed(project_dir, &output_dir) {
         return Ok(output_dir);
     }
@@ -1836,7 +1849,11 @@ fn ensure_site_build_output(
         ));
     }
 
-    Ok(output_dir)
+    // Re-validate now that the output dir exists on disk — this
+    // re-runs the canonical-descendant check and catches symlinks
+    // that the build step might have left behind.
+    output_dir_for_site(project_dir, metadata)
+        .map_err(|err| format!("invalid build_output_dir after build: {err}"))
 }
 
 fn safe_preview_join(root: &std::path::Path, request_path: &str) -> Option<std::path::PathBuf> {

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1790,10 +1790,39 @@ fn run_build_command(command: &mut std::process::Command, label: &str) -> Result
     }
 }
 
+/// Categorised reason `ensure_site_build_output` rejected a preview
+/// build. Codex BLOCKING #2 (issue #996 follow-up): the caller maps
+/// `InvalidMetadata` to HTTP 400 with a scrubbed body and the build/
+/// missing-artifact variants to HTTP 5xx with the project path
+/// stripped out — previously every error returned 200 with a "Build
+/// Failed" page and leaked the full project path in the body.
+#[derive(Debug)]
+enum SiteBuildError {
+    /// The LLM-controlled metadata failed validation (allow-list,
+    /// per-template equality, `..` escape, etc.). 4xx surface.
+    InvalidMetadata(BuildOutputDirError),
+    /// The template slug is not one we know how to build (post
+    /// metadata-validation; the validator already rejects unknown
+    /// templates via the `TemplateMismatch` path because their
+    /// `output_dir()` defaults to `docs`, but keep this branch for
+    /// defence-in-depth). 4xx surface.
+    UnsupportedTemplate,
+    /// The build tool (npm / quarto) exited non-zero. 5xx surface,
+    /// scrubbed body.
+    BuildCommandFailed,
+    /// The build claimed to succeed but the expected output dir was
+    /// not created. 5xx surface, scrubbed body.
+    OutputArtifactMissing,
+    /// Post-build re-validation tripped — typically a symlink that
+    /// the build step left behind. 4xx surface (it's a contract
+    /// violation by the build step, not a server hiccup).
+    PostBuildValidation(BuildOutputDirError),
+}
+
 fn ensure_site_build_output(
     project_dir: &std::path::Path,
     metadata: &SiteProjectMetadata,
-) -> Result<std::path::PathBuf, String> {
+) -> Result<std::path::PathBuf, SiteBuildError> {
     fn site_build_locks() -> &'static Mutex<HashMap<String, Arc<Mutex<()>>>> {
         static LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
         LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
@@ -1815,8 +1844,8 @@ fn ensure_site_build_output(
     let _build_guard = build_lock.lock().unwrap();
     // Validate the LLM-controlled metadata field before we trust it
     // to derive the build output path. Issue #996.
-    let output_dir = output_dir_for_site(project_dir, metadata)
-        .map_err(|err| format!("invalid build_output_dir: {err}"))?;
+    let output_dir =
+        output_dir_for_site(project_dir, metadata).map_err(SiteBuildError::InvalidMetadata)?;
     if !site_build_needed(project_dir, &output_dir) {
         return Ok(output_dir);
     }
@@ -1825,35 +1854,34 @@ fn ensure_site_build_output(
         "quarto-lesson" => {
             let mut render = std::process::Command::new("quarto");
             render.current_dir(project_dir).arg("render");
-            run_build_command(&mut render, "quarto render")?;
+            run_build_command(&mut render, "quarto render")
+                .map_err(|_| SiteBuildError::BuildCommandFailed)?;
         }
         "astro-site" | "nextjs-app" | "react-vite" => {
             if !project_dir.join("node_modules").exists() {
                 let mut install = std::process::Command::new("npm");
                 install.current_dir(project_dir).arg("install");
                 apply_site_build_env(&mut install, project_dir);
-                run_build_command(&mut install, "npm install")?;
+                run_build_command(&mut install, "npm install")
+                    .map_err(|_| SiteBuildError::BuildCommandFailed)?;
             }
             let mut build = std::process::Command::new("npm");
             build.current_dir(project_dir).arg("run").arg("build");
             apply_site_build_env(&mut build, project_dir);
-            run_build_command(&mut build, "npm run build")?;
+            run_build_command(&mut build, "npm run build")
+                .map_err(|_| SiteBuildError::BuildCommandFailed)?;
         }
-        other => return Err(format!("unsupported site template: {other}")),
+        _ => return Err(SiteBuildError::UnsupportedTemplate),
     }
 
     if !output_dir.exists() {
-        return Err(format!(
-            "site build completed but {} was not created",
-            output_dir.display()
-        ));
+        return Err(SiteBuildError::OutputArtifactMissing);
     }
 
     // Re-validate now that the output dir exists on disk — this
     // re-runs the canonical-descendant check and catches symlinks
     // that the build step might have left behind.
-    output_dir_for_site(project_dir, metadata)
-        .map_err(|err| format!("invalid build_output_dir after build: {err}"))
+    output_dir_for_site(project_dir, metadata).map_err(SiteBuildError::PostBuildValidation)
 }
 
 fn safe_preview_join(root: &std::path::Path, request_path: &str) -> Option<std::path::PathBuf> {
@@ -1935,13 +1963,31 @@ fn resolve_preview_asset_path(
     Some(canonical_resolved)
 }
 
-async fn serve_preview_file(path: std::path::PathBuf) -> Response {
-    let data = match tokio::fs::read(&path).await {
+/// Serve a preview file with TOCTOU-safe semantics. Codex BLOCKING
+/// #1: the previous body called `tokio::fs::read`, which follows
+/// symlinks — an attacker who could swap `<output_dir>` (or any
+/// ancestor) for a symlink between the canonical-descendant check
+/// in [`resolve_preview_asset_path`] and the read here would escape
+/// the project dir even though the validator passed.
+///
+/// The replacement routes through
+/// [`crate::api::preview::serve_preview_no_follow`], which:
+/// 1. canonicalises both root and leaf,
+/// 2. checks descendant-of-root,
+/// 3. walks every ancestor with `symlink_metadata` and refuses any
+///    symlink,
+/// 4. opens the leaf with `O_NOFOLLOW` on Unix (or a
+///    pre-open `symlink_metadata` check on non-Unix).
+async fn serve_preview_file(output_dir: &std::path::Path, path: std::path::PathBuf) -> Response {
+    let project_root = output_dir.to_path_buf();
+    let leaf_for_headers = path.clone();
+    let data = match crate::api::preview::serve_preview_no_follow(project_root, path).await {
         Ok(data) => data,
         Err(_) => return StatusCode::NOT_FOUND.into_response(),
     };
 
-    let cache_control = if path.extension().and_then(|ext| ext.to_str()) == Some("html") {
+    let cache_control = if leaf_for_headers.extension().and_then(|ext| ext.to_str()) == Some("html")
+    {
         "no-cache, no-store, must-revalidate"
     } else {
         "public, max-age=30"
@@ -1952,7 +1998,7 @@ async fn serve_preview_file(path: std::path::PathBuf) -> Response {
         [
             (
                 axum::http::header::CONTENT_TYPE,
-                preview_content_type(&path),
+                preview_content_type(&leaf_for_headers),
             ),
             (axum::http::header::CACHE_CONTROL, cache_control),
         ],
@@ -1983,13 +2029,14 @@ async fn serve_site_preview_impl(
     };
 
     let Some(metadata) = read_site_project_metadata(&project_dir) else {
+        // Codex BLOCKING #2: don't leak `project_dir` in the error
+        // body. The session/slug names came from the URL so are
+        // safe to echo; the on-disk path is not.
         return site_preview_html(
             StatusCode::NOT_FOUND,
             "Missing Site Metadata",
             &format!(
-                "The project exists at `{}` but `{}` is missing or invalid.",
-                project_dir.display(),
-                "mofa-site-session.json",
+                "The scaffold for `{session_id}` / `{site_slug}` is missing or its `mofa-site-session.json` is invalid.",
             ),
         );
     };
@@ -2002,38 +2049,77 @@ async fn serve_site_preview_impl(
 
     let output_dir = match build_task.await {
         Ok(Ok(output_dir)) => output_dir,
-        Ok(Err(error)) => {
+        Ok(Err(error)) => return preview_build_error_response(&metadata.template, error),
+        Err(_join_error) => {
+            // Worker panicked — server-internal, no useful detail
+            // for the client.
             return site_preview_html(
-                StatusCode::OK,
-                "Preview Build Failed",
-                &format!(
-                    "Octos could not build the preview for `{}`.\n\n{}",
-                    metadata.template, error
-                ),
-            );
-        }
-        Err(error) => {
-            return site_preview_html(
-                StatusCode::OK,
-                "Preview Build Failed",
-                &format!("The preview worker crashed: {error}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Preview Worker Crashed",
+                "The preview build worker crashed. Please retry; if this persists check server logs.",
             );
         }
     };
 
     let Some(path) = resolve_preview_asset_path(&output_dir, &request_path) else {
+        // Codex BLOCKING #2: drop `output_dir.display()` — that's
+        // the project path. The request path is user-supplied so
+        // safe to echo.
         return site_preview_html(
             StatusCode::NOT_FOUND,
             "Preview Asset Missing",
             &format!(
-                "The built preview exists, but `{}` was not found under `{}`.",
-                request_path,
-                output_dir.display(),
+                "The built preview exists, but no asset was found for `{}`.",
+                if request_path.is_empty() {
+                    "/"
+                } else {
+                    request_path.as_str()
+                },
             ),
         );
     };
 
-    serve_preview_file(path).await
+    serve_preview_file(&output_dir, path).await
+}
+
+/// Map a `SiteBuildError` to a scrubbed HTTP response. Codex
+/// BLOCKING #2: validation failures are 4xx (the LLM messed up the
+/// metadata, not the server), build failures are 5xx, neither leaks
+/// the project path in the response body.
+fn preview_build_error_response(template: &str, error: SiteBuildError) -> Response {
+    match error {
+        SiteBuildError::InvalidMetadata(reason) => site_preview_html(
+            StatusCode::BAD_REQUEST,
+            "Preview Build Rejected",
+            &format!(
+                "Octos rejected the preview build for template `{template}`: {reason}.\n\nThe `mofa-site-session.json` metadata is invalid. Restore the original `build_output_dir` value (or scaffold the site again) and reload.",
+            ),
+        ),
+        SiteBuildError::UnsupportedTemplate => site_preview_html(
+            StatusCode::BAD_REQUEST,
+            "Preview Build Rejected",
+            &format!("Unsupported site template `{template}`."),
+        ),
+        SiteBuildError::PostBuildValidation(reason) => site_preview_html(
+            StatusCode::BAD_REQUEST,
+            "Preview Build Rejected",
+            &format!(
+                "Octos rejected the preview build for template `{template}` after the build step: {reason}.\n\nThe build artifact left an unsafe output directory. Re-scaffold or clean the build cache.",
+            ),
+        ),
+        SiteBuildError::BuildCommandFailed => site_preview_html(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Preview Build Failed",
+            &format!(
+                "The build tool failed for template `{template}`. Check server logs for the full build output.",
+            ),
+        ),
+        SiteBuildError::OutputArtifactMissing => site_preview_html(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Preview Build Failed",
+            "Preview build artifact missing — the build claimed success but produced no output.",
+        ),
+    }
 }
 
 /// GET /api/site-preview/{session_id}/{site_slug} — serve the preview root for a site session.

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1796,8 +1796,13 @@ fn run_build_command(command: &mut std::process::Command, label: &str) -> Result
 /// missing-artifact variants to HTTP 5xx with the project path
 /// stripped out — previously every error returned 200 with a "Build
 /// Failed" page and leaked the full project path in the body.
+///
+/// `pub` (re-exported only via the `#[doc(hidden)]` `testing` module
+/// in `crate::api`) so the build_output_dir test suite can directly
+/// induce each variant and assert the HTTP status mapping via
+/// [`preview_build_error_response`].
 #[derive(Debug)]
-enum SiteBuildError {
+pub enum SiteBuildError {
     /// The LLM-controlled metadata failed validation (allow-list,
     /// per-template equality, `..` escape, etc.). 4xx surface.
     InvalidMetadata(BuildOutputDirError),
@@ -1963,23 +1968,33 @@ fn resolve_preview_asset_path(
     Some(canonical_resolved)
 }
 
-/// Serve a preview file with TOCTOU-safe semantics. Codex BLOCKING
-/// #1: the previous body called `tokio::fs::read`, which follows
-/// symlinks — an attacker who could swap `<output_dir>` (or any
-/// ancestor) for a symlink between the canonical-descendant check
-/// in [`resolve_preview_asset_path`] and the read here would escape
-/// the project dir even though the validator passed.
+/// Serve a preview file with TOCTOU-safe semantics. Codex round-1
+/// BLOCKING #1: the previous body called `tokio::fs::read`, which
+/// follows symlinks — an attacker who could swap `<output_dir>` (or
+/// any ancestor) for a symlink between the canonical-descendant
+/// check in [`resolve_preview_asset_path`] and the read here would
+/// escape the project dir even though the validator passed.
 ///
-/// The replacement routes through
-/// [`crate::api::preview::serve_preview_no_follow`], which:
-/// 1. canonicalises both root and leaf,
-/// 2. checks descendant-of-root,
-/// 3. walks every ancestor with `symlink_metadata` and refuses any
-///    symlink,
-/// 4. opens the leaf with `O_NOFOLLOW` on Unix (or a
-///    pre-open `symlink_metadata` check on non-Unix).
-async fn serve_preview_file(output_dir: &std::path::Path, path: std::path::PathBuf) -> Response {
-    let project_root = output_dir.to_path_buf();
+/// Codex round-2 BLOCKING #1: the round-1 fix used a
+/// `symlink_metadata` ancestor walk + final `O_NOFOLLOW` open. That
+/// left a multi-syscall TOCTOU window — an attacker could swap an
+/// ancestor between the stat and the open. The replacement routes
+/// through [`crate::api::preview::serve_preview_no_follow`], which
+/// walks every component with `rustix::fs::openat` so each step is
+/// anchored to a parent fd that already passed `O_NOFOLLOW`.
+///
+/// The validation chain rooted here is:
+///   `project_dir` (caller-trusted scaffold)
+///     → `output_dir` component (allow-listed per-template)
+///     → asset-relative path (resolved by `resolve_preview_asset_path`).
+/// We pass `project_dir`, not `output_dir`, as the walk root so
+/// every component — including the `output_dir` name itself — is
+/// re-validated by the `openat` walk on each request. The previous
+/// shape passed `output_dir` and the walk only re-checked the
+/// asset-relative segment, missing the swap-`output_dir`-itself
+/// variant.
+async fn serve_preview_file(project_dir: &std::path::Path, path: std::path::PathBuf) -> Response {
+    let project_root = project_dir.to_path_buf();
     let leaf_for_headers = path.clone();
     let data = match crate::api::preview::serve_preview_no_follow(project_root, path).await {
         Ok(data) => data,
@@ -2079,14 +2094,27 @@ async fn serve_site_preview_impl(
         );
     };
 
-    serve_preview_file(&output_dir, path).await
+    // Codex round-2 BLOCKING #1: pass `project_dir` (not
+    // `output_dir`) as the symlink-safe walk root, so the openat
+    // chain re-validates `output_dir`'s component name on every
+    // request as well. The round-1 wiring passed `output_dir`, which
+    // meant a swap of the `output_dir` directory name itself between
+    // build and serve was only caught by the canonical-descendant
+    // check inside the helper — and that check is vulnerable to the
+    // same TOCTOU shape it's supposed to fix.
+    serve_preview_file(&project_dir, path).await
 }
 
 /// Map a `SiteBuildError` to a scrubbed HTTP response. Codex
 /// BLOCKING #2: validation failures are 4xx (the LLM messed up the
 /// metadata, not the server), build failures are 5xx, neither leaks
 /// the project path in the response body.
-fn preview_build_error_response(template: &str, error: SiteBuildError) -> Response {
+///
+/// `pub` (re-exported only via the `#[doc(hidden)]` `testing` module
+/// in `crate::api`) so the build_output_dir test suite can assert
+/// the status-code mapping at the handler layer without spinning up
+/// the full Axum router. Codex round-2 follow-up.
+pub fn preview_build_error_response(template: &str, error: SiteBuildError) -> Response {
     match error {
         SiteBuildError::InvalidMetadata(reason) => site_preview_html(
             StatusCode::BAD_REQUEST,

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -15,6 +15,7 @@ mod events_harness;
 mod frps_plugin;
 mod handlers;
 pub mod metrics;
+pub mod preview;
 pub mod purge;
 mod router;
 mod static_files;

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -39,6 +39,16 @@ pub mod webhook_proxy;
 pub use events::EventBroadcaster;
 pub use metrics::init_metrics;
 pub use router::{DEFAULT_BASE_DOMAIN, build_router, cors_allowlist_for_base_domain};
+
+/// Test-only re-exports for the build_output_dir validation suite.
+/// Not part of the public API — used by
+/// `crates/octos-cli/tests/build_output_dir_validation.rs` to assert
+/// the handler-layer HTTP status mapping without spinning up the
+/// full Axum router. Codex round-2 follow-up to issue #996.
+#[doc(hidden)]
+pub mod testing {
+    pub use super::handlers::{SiteBuildError, preview_build_error_response};
+}
 pub use swarm::{
     BroadcasterSwarmEventSink, CostAttributionView, CostAttributionsResponse, DispatchIndexRow,
     SubtaskView, SwarmBudgetSpec, SwarmContextSpec, SwarmDispatchDetail, SwarmDispatchRequest,

--- a/crates/octos-cli/src/api/preview.rs
+++ b/crates/octos-cli/src/api/preview.rs
@@ -1,28 +1,45 @@
 //! Symlink-safe sites-preview file serve.
 //!
-//! Codex BLOCKING #1 (issue #996 follow-up): the original fix in
-//! `validated_build_output_dir` closed the metadata-parse traversal,
-//! but `resolve_preview_asset_path` canonicalised the path and handed
-//! it to `tokio::fs::read`, which follows symlinks. An attacker who
-//! could swap `<project>/dist` (or any subdir) for a symlink to
-//! `/tmp/escape` between the canonical-descendant check and the read
-//! would escape the project dir while the validator's check still
-//! passed. This module closes that TOCTOU window by re-walking every
-//! ancestor of the resolved path with `symlink_metadata` and refusing
-//! if any segment is a symlink, plus a final `O_NOFOLLOW` open on
-//! the leaf so the swap can't happen between the walk and the read
-//! either.
+//! Codex round-1 BLOCKING #1 (issue #996 follow-up): the original fix
+//! in `validated_build_output_dir` closed the metadata-parse
+//! traversal, but `resolve_preview_asset_path` canonicalised the path
+//! and handed it to `tokio::fs::read`, which follows symlinks. An
+//! attacker who could swap `<project>/dist` (or any subdir) for a
+//! symlink to `/tmp/escape` between the canonical-descendant check
+//! and the read would escape the project dir while the validator's
+//! check still passed.
+//!
+//! Round-1 closed the leaf swap (`O_NOFOLLOW`) and added a
+//! `symlink_metadata` ancestor walk, but that left a multi-syscall
+//! TOCTOU window: an attacker could swap an ancestor between the
+//! `symlink_metadata` stat and the open. Codex round-2 BLOCKING #1
+//! (this module): walk every component with `rustix::fs::openat` so
+//! each step is anchored to a parent fd that already passed
+//! `O_NOFOLLOW`. After the walk completes, neither the leaf nor any
+//! ancestor between `project_dir` and the leaf can be substituted
+//! by an unobserved symlink — the open of component `n+1` happens
+//! relative to the fd we opened at step `n`, so even a mid-walk
+//! swap of the on-disk path can't redirect the next `openat`.
 //!
 //! Design parallel: `crates/octos-agent/src/tools/read_task_output.rs`
-//! `reject_symlinked_ancestors` does the same ancestor walk for the
-//! agent's `read_task_output` tool — same shape, different consumer.
+//! `reject_symlinked_ancestors` does a metadata walk for the agent's
+//! `read_task_output` tool; we use the component-by-component openat
+//! shape here because the preview handler is exposed to LLM-controlled
+//! metadata (`build_output_dir`) AND OS-level filesystem races, while
+//! `read_task_output` operates on canonical workspace paths produced
+//! by the agent itself.
 //!
 //! Cross-platform notes:
-//! - Unix: `O_NOFOLLOW` is set on the leaf open. `symlink_metadata`
-//!   is used for the ancestor walk.
-//! - Windows: `O_NOFOLLOW` does not exist. The ancestor walk and a
-//!   pre-open `symlink_metadata` check on the leaf provide the same
-//!   guarantee at the cost of a one-line TOCTOU window — mirrors the
+//! - Unix (Linux + macOS): every component is opened with
+//!   `O_NOFOLLOW | O_DIRECTORY` (`O_NOFOLLOW` alone on the leaf) via
+//!   `rustix::fs::openat`. No metadata pre-check is needed because
+//!   the open enforces the same property atomically. Workspace-wide
+//!   `deny(unsafe_code)` rules out raw `libc::openat`.
+//! - Windows: `O_NOFOLLOW` does not exist. The ancestor walk uses
+//!   `symlink_metadata` and the leaf is opened after a pre-open
+//!   `symlink_metadata` check. There is a residual multi-syscall
+//!   TOCTOU window here that does not exist on Unix — see the PR
+//!   body and the `#[cfg(not(unix))]` fallback below. Mirrors the
 //!   fallback pattern in
 //!   `crates/octos-agent/src/tools/mod.rs::read_no_follow`.
 
@@ -66,75 +83,41 @@ impl std::fmt::Display for PreviewServeError {
 
 impl std::error::Error for PreviewServeError {}
 
-/// Walk every ancestor of `resolved` from `project_root` (exclusive)
-/// down to the leaf (exclusive) and refuse if any segment is a
-/// symlink. Mirrors `reject_symlinked_ancestors` in
-/// `octos-agent/src/tools/read_task_output.rs`. Both `project_root`
-/// and `resolved` should be in the same canonical form — we compute
-/// both the canonical and lexical roots and try-strip against both
-/// to handle the macOS `/var` ↔ `/private/var` firmlink case.
-fn reject_symlinked_ancestors(
+/// Compute the path of `candidate` relative to `project_root`. Both
+/// inputs are expected to have been canonicalised by the caller —
+/// because canonical roots can diverge across firmlinks (macOS
+/// `/var` ↔ `/private/var`), we try-strip against both the lexical
+/// and canonical spellings of `project_root` here.
+fn relative_under_root(
     project_root: &Path,
-    resolved: &Path,
-) -> Result<(), PreviewServeError> {
+    candidate: &Path,
+) -> Result<PathBuf, PreviewServeError> {
     let canonical_root =
         std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
-    let lexical_root = project_root.to_path_buf();
-
-    let (mut current, suffix) = if let Ok(s) = resolved.strip_prefix(&lexical_root) {
-        (lexical_root, s.to_path_buf())
-    } else if let Ok(s) = resolved.strip_prefix(&canonical_root) {
-        (canonical_root, s.to_path_buf())
-    } else {
-        // resolved is not under either root spelling — caller already
-        // checked descendant via canonicalise, so getting here means
-        // canonical forms disagree. Refuse defensively.
-        return Err(PreviewServeError::OutsideProject);
-    };
-
-    let comps: Vec<_> = suffix.components().collect();
-    if comps.is_empty() {
-        // The resolved path IS the project root. Nothing to walk;
-        // the descendant check is the gate, not us.
-        return Ok(());
+    if let Ok(rel) = candidate.strip_prefix(project_root) {
+        return Ok(rel.to_path_buf());
     }
-
-    // Stop one short of the leaf — leaf check is done separately
-    // (and on Unix by `O_NOFOLLOW` at open time).
-    for comp in &comps[..comps.len().saturating_sub(1)] {
-        current.push(comp.as_os_str());
-        match std::fs::symlink_metadata(&current) {
-            Ok(meta) if meta.file_type().is_symlink() => {
-                return Err(PreviewServeError::SymlinkedAncestor);
-            }
-            Ok(_) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // Some ancestor doesn't exist — caller's open will
-                // 404 in a moment. Not a security issue.
-                return Ok(());
-            }
-            Err(_) => {
-                // Any other stat failure (permission, IO) — treat
-                // as not-found to keep error surface scrubbed.
-                return Err(PreviewServeError::NotFound);
-            }
-        }
+    if let Ok(rel) = candidate.strip_prefix(&canonical_root) {
+        return Ok(rel.to_path_buf());
     }
-
-    Ok(())
+    Err(PreviewServeError::OutsideProject)
 }
 
 /// Symlink-safe blocking read of a preview asset. Use this for the
-/// test surface; the async wrapper [`serve_preview_no_follow`] is
-/// the production entry-point. Returns the file bytes on success.
+/// test surface; the async wrapper [`serve_preview_no_follow`] is the
+/// production entry-point. Returns the file bytes on success.
 ///
 /// Phases:
 /// 1. Canonical-descendant check of `candidate` against `project_root`.
-/// 2. Ancestor walk: every directory between `project_root` and the
-///    leaf must NOT be a symlink (re-checks the canonical-descendant
-///    guarantee under TOCTOU).
-/// 3. Leaf open with `O_NOFOLLOW` (Unix) or a pre-open
-///    `symlink_metadata` check (non-Unix).
+/// 2. Strip `project_root` prefix to get the asset's relative path
+///    (e.g. `dist/index.html`).
+/// 3. Walk every component of the relative path with
+///    [`open_no_follow_walk`] — each step opens a child fd from the
+///    previous fd using `O_NOFOLLOW`, so the parent-child relationship
+///    is enforced atomically per-component. Even if an attacker
+///    swaps any path component for a symlink mid-walk, the swap
+///    cannot be observed by the next `openat` because the next
+///    `openat` operates on the fd, not the path string.
 pub fn serve_preview_no_follow_blocking(
     project_root: &Path,
     candidate: &Path,
@@ -155,52 +138,160 @@ pub fn serve_preview_no_follow_blocking(
         return Err(PreviewServeError::OutsideProject);
     }
 
-    // Ancestor walk on the canonical path. The previous validation
-    // step canonicalised, so by definition no ancestor here is a
-    // symlink at this exact instant — but a malicious build step
-    // could swap one in between then and now. The walk runs again
-    // here to keep the TOCTOU window down to one syscall.
-    reject_symlinked_ancestors(&canonical_root, &canonical_candidate)?;
+    // Compute the asset's relative path from the canonical root. The
+    // walk below traverses it component-by-component.
+    let relative = relative_under_root(&canonical_root, &canonical_candidate)?;
 
-    read_leaf_no_follow(&canonical_candidate)
+    open_no_follow_walk(&canonical_root, &relative)
 }
 
+/// Walk `relative` component-by-component starting from
+/// `project_dir`, using `openat(O_NOFOLLOW)` on Unix so each
+/// intermediate fd is anchored to the previous fd. Returns the bytes
+/// of the final leaf file.
+///
+/// The walk's atomicity is what makes this resistant to a mid-walk
+/// ancestor swap. The previous round-1 implementation called
+/// `symlink_metadata(path)` on each ancestor and then `OpenOptions::open`
+/// on the leaf — between those two syscalls, an attacker could swap
+/// the on-disk path for a symlink. By contrast, an `openat` call
+/// using a parent fd does not consult the path-name resolution
+/// table for the parent — the parent fd is already an open handle
+/// to the previously-validated directory, so even if the on-disk
+/// name now points elsewhere the open relative to the fd still
+/// reaches the right inode.
 #[cfg(unix)]
-fn read_leaf_no_follow(path: &Path) -> Result<Vec<u8>, PreviewServeError> {
+fn open_no_follow_walk(project_dir: &Path, relative: &Path) -> Result<Vec<u8>, PreviewServeError> {
     use std::io::Read;
     use std::os::unix::fs::OpenOptionsExt;
 
-    let mut opts = std::fs::OpenOptions::new();
-    opts.read(true).custom_flags(libc::O_NOFOLLOW);
-    let mut file = match opts.open(path) {
-        Ok(f) => f,
-        Err(e) if e.raw_os_error() == Some(libc::ELOOP) => {
-            return Err(PreviewServeError::SymlinkedLeaf);
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(PreviewServeError::NotFound);
-        }
-        Err(_) => return Err(PreviewServeError::NotFound),
-    };
+    use rustix::fs::{Mode, OFlags, openat};
+
+    // Open the project root with O_NOFOLLOW | O_DIRECTORY. If the
+    // project_dir itself is a symlink we want that to fail here —
+    // the caller has already canonicalised, so a symlink here would
+    // be a TOCTOU substitution we want to refuse.
+    let root_file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_DIRECTORY)
+        .open(project_dir)
+        .map_err(map_open_error)?;
+    let mut current: std::os::fd::OwnedFd = root_file.into();
+
+    let comps: Vec<_> = relative.components().collect();
+    if comps.is_empty() {
+        // The candidate IS the project root. That's `OutsideProject`
+        // from the caller's perspective — preview must serve a file
+        // under the root, not the root itself.
+        return Err(PreviewServeError::OutsideProject);
+    }
+
+    // All but the last component must be directories. The last
+    // component is the leaf file (we open it without O_DIRECTORY).
+    let leaf_idx = comps.len() - 1;
+    for (idx, comp) in comps.iter().enumerate() {
+        let name = match comp {
+            std::path::Component::Normal(s) => s,
+            // Any non-Normal component (`.`, `..`, root) was already
+            // ruled out by the upstream validation; refusing here is
+            // belt-and-braces.
+            _ => return Err(PreviewServeError::OutsideProject),
+        };
+
+        let flags = if idx == leaf_idx {
+            OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC
+        } else {
+            OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::DIRECTORY | OFlags::CLOEXEC
+        };
+
+        // `rustix::fs::openat` is a safe wrapper around the
+        // `openat(2)` syscall. The new fd is anchored to `current`
+        // (the parent fd), not to the path string — so a mid-walk
+        // swap of any on-disk name leaves the resolution chain
+        // intact: the next openat consults the fd, never re-walks
+        // the path.
+        let next = openat(&current, *name, flags, Mode::empty())
+            .map_err(|err| map_rustix_error(err, idx == leaf_idx))?;
+        current = next;
+    }
+
+    // `current` is now the leaf fd, opened with O_NOFOLLOW. Std
+    // provides a safe `File::from(OwnedFd)` conversion, so no
+    // raw-fd or `unsafe` is needed here (workspace lint denies
+    // `unsafe_code`).
+    let mut file: std::fs::File = current.into();
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes)
         .map_err(|_| PreviewServeError::NotFound)?;
     Ok(bytes)
 }
 
-#[cfg(not(unix))]
-fn read_leaf_no_follow(path: &Path) -> Result<Vec<u8>, PreviewServeError> {
-    // Non-Unix fallback: stat the leaf before the read. There is a
-    // one-syscall TOCTOU window here that does not exist on Unix —
-    // mirrors `read_no_follow` in `octos-agent/src/tools/mod.rs`.
-    match std::fs::symlink_metadata(path) {
-        Ok(meta) if meta.file_type().is_symlink() => {
-            return Err(PreviewServeError::SymlinkedLeaf);
-        }
-        Ok(_) => {}
-        Err(_) => return Err(PreviewServeError::NotFound),
+#[cfg(unix)]
+fn map_open_error(e: std::io::Error) -> PreviewServeError {
+    // `ELOOP` is the kernel's signal that the open hit a symlink it
+    // refused to follow because of `O_NOFOLLOW`. Every other failure
+    // (NotFound, PermissionDenied, IO) collapses to `NotFound` to
+    // keep the error surface uninformative — the caller maps this
+    // to HTTP 404.
+    if e.raw_os_error() == Some(libc::ELOOP) {
+        PreviewServeError::SymlinkedAncestor
+    } else {
+        PreviewServeError::NotFound
     }
-    std::fs::read(path).map_err(|_| PreviewServeError::NotFound)
+}
+
+#[cfg(unix)]
+fn map_rustix_error(err: rustix::io::Errno, is_leaf: bool) -> PreviewServeError {
+    if err == rustix::io::Errno::LOOP {
+        if is_leaf {
+            PreviewServeError::SymlinkedLeaf
+        } else {
+            PreviewServeError::SymlinkedAncestor
+        }
+    } else if err == rustix::io::Errno::NOTDIR {
+        // A non-final component was not a directory — either the
+        // ancestor walk hit a file (impossible if the input was a
+        // canonical descendant of `project_dir`) or the path no
+        // longer resolves the way it did at canonicalise time. Both
+        // are NotFound from the caller's perspective.
+        PreviewServeError::NotFound
+    } else {
+        PreviewServeError::NotFound
+    }
+}
+
+#[cfg(not(unix))]
+fn open_no_follow_walk(project_dir: &Path, relative: &Path) -> Result<Vec<u8>, PreviewServeError> {
+    // Non-Unix fallback. `O_NOFOLLOW` and `openat` are not available;
+    // we use the round-1 ancestor walk + pre-open `symlink_metadata`
+    // check on the leaf. There is a multi-syscall TOCTOU window here
+    // — documented in the module docstring and the PR body. Tracking
+    // a Windows fix is out of scope for #996 round-2.
+    let mut current = project_dir.to_path_buf();
+    let comps: Vec<_> = relative.components().collect();
+    if comps.is_empty() {
+        return Err(PreviewServeError::OutsideProject);
+    }
+    let leaf_idx = comps.len() - 1;
+    for (idx, comp) in comps.iter().enumerate() {
+        let name = match comp {
+            std::path::Component::Normal(s) => s,
+            _ => return Err(PreviewServeError::OutsideProject),
+        };
+        current.push(name);
+        match std::fs::symlink_metadata(&current) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                return Err(if idx == leaf_idx {
+                    PreviewServeError::SymlinkedLeaf
+                } else {
+                    PreviewServeError::SymlinkedAncestor
+                });
+            }
+            Ok(_) => {}
+            Err(_) => return Err(PreviewServeError::NotFound),
+        }
+    }
+    std::fs::read(&current).map_err(|_| PreviewServeError::NotFound)
 }
 
 /// Async wrapper around [`serve_preview_no_follow_blocking`].

--- a/crates/octos-cli/src/api/preview.rs
+++ b/crates/octos-cli/src/api/preview.rs
@@ -1,0 +1,326 @@
+//! Symlink-safe sites-preview file serve.
+//!
+//! Codex BLOCKING #1 (issue #996 follow-up): the original fix in
+//! `validated_build_output_dir` closed the metadata-parse traversal,
+//! but `resolve_preview_asset_path` canonicalised the path and handed
+//! it to `tokio::fs::read`, which follows symlinks. An attacker who
+//! could swap `<project>/dist` (or any subdir) for a symlink to
+//! `/tmp/escape` between the canonical-descendant check and the read
+//! would escape the project dir while the validator's check still
+//! passed. This module closes that TOCTOU window by re-walking every
+//! ancestor of the resolved path with `symlink_metadata` and refusing
+//! if any segment is a symlink, plus a final `O_NOFOLLOW` open on
+//! the leaf so the swap can't happen between the walk and the read
+//! either.
+//!
+//! Design parallel: `crates/octos-agent/src/tools/read_task_output.rs`
+//! `reject_symlinked_ancestors` does the same ancestor walk for the
+//! agent's `read_task_output` tool — same shape, different consumer.
+//!
+//! Cross-platform notes:
+//! - Unix: `O_NOFOLLOW` is set on the leaf open. `symlink_metadata`
+//!   is used for the ancestor walk.
+//! - Windows: `O_NOFOLLOW` does not exist. The ancestor walk and a
+//!   pre-open `symlink_metadata` check on the leaf provide the same
+//!   guarantee at the cost of a one-line TOCTOU window — mirrors the
+//!   fallback pattern in
+//!   `crates/octos-agent/src/tools/mod.rs::read_no_follow`.
+
+use std::path::{Path, PathBuf};
+
+/// Reasons a preview serve request was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreviewServeError {
+    /// The canonical resolution of `candidate` lies outside
+    /// `project_dir`. Catches symlink targets pointing outside the
+    /// scaffold.
+    OutsideProject,
+    /// One of the ancestor directories of `candidate` (between
+    /// `project_dir` and the leaf) is itself a symlink. Catches the
+    /// codex BLOCKING-#1 swap: an attacker turns `dist` into a
+    /// symlink to `/tmp/escape` after validation but before serve.
+    SymlinkedAncestor,
+    /// The leaf path is a symlink, or the open with `O_NOFOLLOW`
+    /// fails because of one. Catches the leaf-swap variant.
+    SymlinkedLeaf,
+    /// `std::fs::read` (or the `O_NOFOLLOW` open) failed for a
+    /// reason that is NOT symlink-related — typically `NotFound` or
+    /// `PermissionDenied`. The caller maps this to HTTP 404.
+    NotFound,
+}
+
+impl std::fmt::Display for PreviewServeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OutsideProject => write!(f, "preview path escapes the project directory"),
+            Self::SymlinkedAncestor => {
+                write!(f, "preview path traverses a symlinked directory")
+            }
+            Self::SymlinkedLeaf => {
+                write!(f, "preview path is a symlink and would follow off-tree")
+            }
+            Self::NotFound => write!(f, "preview asset not found"),
+        }
+    }
+}
+
+impl std::error::Error for PreviewServeError {}
+
+/// Walk every ancestor of `resolved` from `project_root` (exclusive)
+/// down to the leaf (exclusive) and refuse if any segment is a
+/// symlink. Mirrors `reject_symlinked_ancestors` in
+/// `octos-agent/src/tools/read_task_output.rs`. Both `project_root`
+/// and `resolved` should be in the same canonical form — we compute
+/// both the canonical and lexical roots and try-strip against both
+/// to handle the macOS `/var` ↔ `/private/var` firmlink case.
+fn reject_symlinked_ancestors(
+    project_root: &Path,
+    resolved: &Path,
+) -> Result<(), PreviewServeError> {
+    let canonical_root =
+        std::fs::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let lexical_root = project_root.to_path_buf();
+
+    let (mut current, suffix) = if let Ok(s) = resolved.strip_prefix(&lexical_root) {
+        (lexical_root, s.to_path_buf())
+    } else if let Ok(s) = resolved.strip_prefix(&canonical_root) {
+        (canonical_root, s.to_path_buf())
+    } else {
+        // resolved is not under either root spelling — caller already
+        // checked descendant via canonicalise, so getting here means
+        // canonical forms disagree. Refuse defensively.
+        return Err(PreviewServeError::OutsideProject);
+    };
+
+    let comps: Vec<_> = suffix.components().collect();
+    if comps.is_empty() {
+        // The resolved path IS the project root. Nothing to walk;
+        // the descendant check is the gate, not us.
+        return Ok(());
+    }
+
+    // Stop one short of the leaf — leaf check is done separately
+    // (and on Unix by `O_NOFOLLOW` at open time).
+    for comp in &comps[..comps.len().saturating_sub(1)] {
+        current.push(comp.as_os_str());
+        match std::fs::symlink_metadata(&current) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                return Err(PreviewServeError::SymlinkedAncestor);
+            }
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Some ancestor doesn't exist — caller's open will
+                // 404 in a moment. Not a security issue.
+                return Ok(());
+            }
+            Err(_) => {
+                // Any other stat failure (permission, IO) — treat
+                // as not-found to keep error surface scrubbed.
+                return Err(PreviewServeError::NotFound);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Symlink-safe blocking read of a preview asset. Use this for the
+/// test surface; the async wrapper [`serve_preview_no_follow`] is
+/// the production entry-point. Returns the file bytes on success.
+///
+/// Phases:
+/// 1. Canonical-descendant check of `candidate` against `project_root`.
+/// 2. Ancestor walk: every directory between `project_root` and the
+///    leaf must NOT be a symlink (re-checks the canonical-descendant
+///    guarantee under TOCTOU).
+/// 3. Leaf open with `O_NOFOLLOW` (Unix) or a pre-open
+///    `symlink_metadata` check (non-Unix).
+pub fn serve_preview_no_follow_blocking(
+    project_root: &Path,
+    candidate: &Path,
+) -> Result<Vec<u8>, PreviewServeError> {
+    let canonical_root = std::fs::canonicalize(project_root).map_err(|_| {
+        // Project root vanished — caller should have already checked
+        // this; refuse rather than serve.
+        PreviewServeError::NotFound
+    })?;
+    let canonical_candidate = std::fs::canonicalize(candidate).map_err(|_| {
+        // The path the agent wants to serve doesn't resolve. Could
+        // be a missing file OR a symlink-loop. Either way, refuse —
+        // we don't want to expose the difference.
+        PreviewServeError::NotFound
+    })?;
+
+    if canonical_candidate == canonical_root || !canonical_candidate.starts_with(&canonical_root) {
+        return Err(PreviewServeError::OutsideProject);
+    }
+
+    // Ancestor walk on the canonical path. The previous validation
+    // step canonicalised, so by definition no ancestor here is a
+    // symlink at this exact instant — but a malicious build step
+    // could swap one in between then and now. The walk runs again
+    // here to keep the TOCTOU window down to one syscall.
+    reject_symlinked_ancestors(&canonical_root, &canonical_candidate)?;
+
+    read_leaf_no_follow(&canonical_candidate)
+}
+
+#[cfg(unix)]
+fn read_leaf_no_follow(path: &Path) -> Result<Vec<u8>, PreviewServeError> {
+    use std::io::Read;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.read(true).custom_flags(libc::O_NOFOLLOW);
+    let mut file = match opts.open(path) {
+        Ok(f) => f,
+        Err(e) if e.raw_os_error() == Some(libc::ELOOP) => {
+            return Err(PreviewServeError::SymlinkedLeaf);
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(PreviewServeError::NotFound);
+        }
+        Err(_) => return Err(PreviewServeError::NotFound),
+    };
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .map_err(|_| PreviewServeError::NotFound)?;
+    Ok(bytes)
+}
+
+#[cfg(not(unix))]
+fn read_leaf_no_follow(path: &Path) -> Result<Vec<u8>, PreviewServeError> {
+    // Non-Unix fallback: stat the leaf before the read. There is a
+    // one-syscall TOCTOU window here that does not exist on Unix —
+    // mirrors `read_no_follow` in `octos-agent/src/tools/mod.rs`.
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            return Err(PreviewServeError::SymlinkedLeaf);
+        }
+        Ok(_) => {}
+        Err(_) => return Err(PreviewServeError::NotFound),
+    }
+    std::fs::read(path).map_err(|_| PreviewServeError::NotFound)
+}
+
+/// Async wrapper around [`serve_preview_no_follow_blocking`].
+/// Offloads the blocking read to `tokio::task::spawn_blocking` so
+/// the handler doesn't park the runtime on a large asset.
+pub async fn serve_preview_no_follow(
+    project_root: PathBuf,
+    candidate: PathBuf,
+) -> Result<Vec<u8>, PreviewServeError> {
+    tokio::task::spawn_blocking(move || serve_preview_no_follow_blocking(&project_root, &candidate))
+        .await
+        .unwrap_or(Err(PreviewServeError::NotFound))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serves_regular_file_inside_project() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path();
+        let dist = project.join("dist");
+        std::fs::create_dir_all(&dist).unwrap();
+        std::fs::write(dist.join("index.html"), b"<html>ok</html>").unwrap();
+
+        let served = serve_preview_no_follow_blocking(project, &dist.join("index.html"))
+            .expect("regular file must serve");
+        assert_eq!(served, b"<html>ok</html>");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_leaf_symlink() {
+        use std::os::unix::fs::symlink;
+        let tmp_project = tempfile::tempdir().unwrap();
+        let tmp_outside = tempfile::tempdir().unwrap();
+        let dist = tmp_project.path().join("dist");
+        std::fs::create_dir_all(&dist).unwrap();
+        std::fs::write(tmp_outside.path().join("secret"), b"PRIVATE").unwrap();
+        let leaf = dist.join("malicious.html");
+        symlink(tmp_outside.path().join("secret"), &leaf).unwrap();
+
+        let result = serve_preview_no_follow_blocking(tmp_project.path(), &leaf);
+        assert!(
+            matches!(
+                result,
+                Err(PreviewServeError::SymlinkedLeaf | PreviewServeError::OutsideProject)
+            ),
+            "leaf symlink must be rejected, got: {result:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_ancestor_symlink() {
+        use std::os::unix::fs::symlink;
+
+        // Build a layout where `<project>/dist/sub/leaf.html` exists
+        // legitimately, then symlink-swap an interior directory
+        // (`sub`) for a directory outside the project.
+        let tmp_project = tempfile::tempdir().unwrap();
+        let tmp_outside = tempfile::tempdir().unwrap();
+        let dist = tmp_project.path().join("dist");
+        std::fs::create_dir_all(&dist).unwrap();
+
+        let evil = tmp_outside.path().join("evil");
+        std::fs::create_dir_all(&evil).unwrap();
+        std::fs::write(evil.join("leaf.html"), b"<html>evil</html>").unwrap();
+
+        let sub = dist.join("sub");
+        symlink(&evil, &sub).unwrap();
+
+        let candidate = dist.join("sub").join("leaf.html");
+        let result = serve_preview_no_follow_blocking(tmp_project.path(), &candidate);
+        assert!(
+            matches!(
+                result,
+                Err(PreviewServeError::SymlinkedAncestor | PreviewServeError::OutsideProject)
+            ),
+            "ancestor symlink must be rejected, got: {result:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_swapped_after_validation() {
+        use std::os::unix::fs::symlink;
+
+        // Reproduces the BLOCKING #1 scenario end-to-end on this
+        // module alone: build a real dist/, take canonical paths
+        // (mimicking the validator's output), then symlink-swap
+        // dist/ for an outside dir before calling serve.
+        let tmp_project = tempfile::tempdir().unwrap();
+        let tmp_outside = tempfile::tempdir().unwrap();
+        let dist = tmp_project.path().join("dist");
+        std::fs::create_dir_all(&dist).unwrap();
+        std::fs::write(dist.join("index.html"), b"<html>real</html>").unwrap();
+
+        // Take the validated path (canonical) NOW, before the swap.
+        let validated = std::fs::canonicalize(&dist).unwrap();
+        let leaf = validated.join("index.html");
+
+        // Swap.
+        std::fs::write(tmp_outside.path().join("index.html"), b"SECRET").unwrap();
+        std::fs::remove_dir_all(&dist).unwrap();
+        symlink(tmp_outside.path(), &dist).unwrap();
+
+        // Serve must refuse — the canonical form of `leaf` now
+        // points outside `project_root`, OR an ancestor is now a
+        // symlink. Either gate is acceptable.
+        let result = serve_preview_no_follow_blocking(tmp_project.path(), &leaf);
+        assert!(
+            matches!(
+                result,
+                Err(PreviewServeError::SymlinkedAncestor
+                    | PreviewServeError::OutsideProject
+                    | PreviewServeError::NotFound)
+            ),
+            "post-swap serve must refuse, got: {result:?}",
+        );
+    }
+}

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -651,6 +651,159 @@ pub fn read_site_project_metadata(project_dir: &Path) -> Option<SiteProjectMetad
     serde_json::from_str(&raw).ok()
 }
 
+/// Reason a metadata `build_output_dir` was rejected by
+/// [`validated_build_output_dir`]. Issue #996 — the LLM may rewrite
+/// `mofa-site-session.json` (the metadata source) via `edit_file`, so
+/// every consumer that joins the value onto `project_dir` must route
+/// through the validator to keep the preview confined to the site
+/// scaffold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuildOutputDirError {
+    /// The metadata field was empty or whitespace-only.
+    Empty,
+    /// The path was absolute (e.g. `/etc/passwd`).
+    Absolute,
+    /// The path contained a `..` component, before or after normalisation.
+    ParentEscape,
+    /// The value did not match a per-template scaffold output dir
+    /// (`dist`, `out`, or `docs`).
+    NotAllowListed,
+    /// Canonicalising `project_dir.join(value)` failed or resolved
+    /// outside `project_dir` (e.g. through a symlink).
+    OutsideProject,
+}
+
+impl std::fmt::Display for BuildOutputDirError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "build_output_dir is empty"),
+            Self::Absolute => write!(f, "build_output_dir must be a relative path"),
+            Self::ParentEscape => {
+                write!(f, "build_output_dir must not contain `..` segments")
+            }
+            Self::NotAllowListed => write!(
+                f,
+                "build_output_dir is not an allow-listed template output (dist, out, docs)"
+            ),
+            Self::OutsideProject => {
+                write!(f, "build_output_dir resolves outside the project directory")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BuildOutputDirError {}
+
+/// Per-template scaffold output directories. The values come from
+/// [`crate::workflow_families::site::SiteTemplate::output_dir`] — keep
+/// the two lists in sync. Updating an existing template's output dir
+/// requires updating both.
+const ALLOWED_BUILD_OUTPUT_DIRS: &[&str] = &["dist", "out", "docs"];
+
+/// Validate the structural form of `metadata.build_output_dir`
+/// without touching disk. Returns the joined `project_dir.join(value)`
+/// on success — caller may further enforce canonical-descendant via
+/// [`canonical_descendant_check`] once the output dir exists on disk.
+fn validated_build_output_dir_form(
+    metadata: &SiteProjectMetadata,
+    project_dir: &Path,
+) -> Result<PathBuf, BuildOutputDirError> {
+    let raw = metadata.build_output_dir.trim();
+    if raw.is_empty() {
+        return Err(BuildOutputDirError::Empty);
+    }
+
+    let value_path = Path::new(raw);
+    if value_path.is_absolute() {
+        return Err(BuildOutputDirError::Absolute);
+    }
+
+    // Reject ParentDir components anywhere in the value — even if
+    // normalisation would collapse to a safe path, we don't want to
+    // allow the LLM to construct paths like `dist/../../../etc`.
+    for component in value_path.components() {
+        match component {
+            std::path::Component::Normal(_) | std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => return Err(BuildOutputDirError::ParentEscape),
+            // Absolute prefixes (Windows drive letters etc.) and the
+            // root component were already excluded by `is_absolute`,
+            // but treat any unexpected component as an escape too.
+            _ => return Err(BuildOutputDirError::Absolute),
+        }
+    }
+
+    if !ALLOWED_BUILD_OUTPUT_DIRS.contains(&raw) {
+        return Err(BuildOutputDirError::NotAllowListed);
+    }
+
+    Ok(project_dir.join(value_path))
+}
+
+/// Validate the `build_output_dir` field of a site metadata record
+/// before joining it onto `project_dir`. Returns the joined path on
+/// success; if `project_dir` and the joined output dir both exist on
+/// disk, the result is canonicalised and confirmed to be a strict
+/// descendant of `project_dir`.
+///
+/// Security: the metadata file (`mofa-site-session.json`) is writable
+/// by the LLM via `edit_file`, so the field is **untrusted on read**
+/// even though the scaffold populates it from a closed allow-list. We
+/// enforce the allow-list (`dist` / `out` / `docs`) AND structural
+/// checks (no absolute paths, no `..` components, canonical-descendant
+/// of `project_dir`) as defence-in-depth. See issue #996.
+///
+/// Two-phase validation rationale:
+/// - Form checks (allow-list, no `..`, not absolute, not empty) are
+///   total — they always run.
+/// - Canonical-descendant only runs when both sides exist, because the
+///   site build flow creates the output dir lazily on first preview.
+///   When the dir is missing we accept the joined path so the build
+///   can produce it, then the caller (preview handler) MUST re-check
+///   the resolved asset path via the canonical check below.
+pub fn validated_build_output_dir(
+    metadata: &SiteProjectMetadata,
+    project_dir: &Path,
+) -> Result<PathBuf, BuildOutputDirError> {
+    let joined = validated_build_output_dir_form(metadata, project_dir)?;
+
+    let canonical_root = match std::fs::canonicalize(project_dir) {
+        Ok(p) => p,
+        Err(_) => {
+            // project_dir not yet realised; form-check is the strongest
+            // we can offer. Return the joined raw path.
+            return Ok(joined);
+        }
+    };
+    let canonical_joined = match std::fs::canonicalize(&joined) {
+        Ok(p) => p,
+        Err(_) => {
+            // output dir does not exist yet — form checks already
+            // ruled out escape via `..` or absolute paths, and the
+            // value is allow-listed. Return the joined path; the
+            // canonical-descendant check happens once the build
+            // populates the directory.
+            return Ok(canonical_root.join(Path::new(metadata.build_output_dir.trim())));
+        }
+    };
+
+    canonical_descendant_check(&canonical_root, &canonical_joined)?;
+    Ok(canonical_joined)
+}
+
+/// Enforce that `candidate` is a strict descendant of `root`. Both
+/// inputs are expected to be canonicalised paths. Used as the second
+/// phase of build_output_dir validation after the output dir exists
+/// on disk.
+pub fn canonical_descendant_check(
+    root: &Path,
+    candidate: &Path,
+) -> Result<(), BuildOutputDirError> {
+    if candidate == root || !candidate.starts_with(root) {
+        return Err(BuildOutputDirError::OutsideProject);
+    }
+    Ok(())
+}
+
 fn write_site_support_files(
     project_dir: &Path,
     metadata: &SiteProjectMetadata,

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -674,6 +674,15 @@ pub enum BuildOutputDirError {
     /// Pinned by codex's NEEDS-FOLLOWUP on the original fix: a global
     /// allow-list lets `astro-site + docs` slip through. Issue #996.
     TemplateMismatch,
+    /// `metadata.template` did not match any in-tree SiteTemplate
+    /// variant (`astro-site`, `nextjs-app`, `react-vite`,
+    /// `quarto-lesson`). Pinned by codex round-2 BLOCKING #2 (issue
+    /// #996 follow-up): the previous `SiteTemplate::from_slug`
+    /// fallback to `Docs` was default-allow — a phantom template
+    /// paired with `build_output_dir: "docs"` slipped past the
+    /// per-template-equality gate. The validator now uses
+    /// `from_slug_strict` and surfaces this variant on miss.
+    UnknownTemplate(String),
     /// Canonicalising `project_dir.join(value)` failed or resolved
     /// outside `project_dir` (e.g. through a symlink).
     OutsideProject,
@@ -694,6 +703,10 @@ impl std::fmt::Display for BuildOutputDirError {
             Self::TemplateMismatch => write!(
                 f,
                 "build_output_dir does not match the expected output for this template"
+            ),
+            Self::UnknownTemplate(slug) => write!(
+                f,
+                "metadata.template `{slug}` is not a known site template (must be one of: astro-site, nextjs-app, react-vite, quarto-lesson)"
             ),
             Self::OutsideProject => {
                 write!(f, "build_output_dir resolves outside the project directory")
@@ -766,10 +779,18 @@ fn validated_build_output_dir_form(
     // "astro-site"` (which controls the build command) while pointing
     // `build_output_dir` at `docs` (which controls what the preview
     // serves), enabling cross-template surface mismatches.
-    let expected =
-        crate::workflow_runtime::workflow_families::SiteTemplate::from_slug(&metadata.template)
-            .output_dir();
-    if raw != expected {
+    //
+    // Codex round-2 BLOCKING #2: use `from_slug_strict` (not the
+    // lossy `from_slug`) — an unknown template slug like
+    // `"phantom-template"` previously coerced to `SiteTemplate::Docs`
+    // and let `build_output_dir: "docs"` validate. The strict variant
+    // returns `None` on miss so we surface `UnknownTemplate` and the
+    // handler can map it to HTTP 400.
+    let template_slug = metadata.template.trim();
+    let template =
+        crate::workflow_runtime::workflow_families::SiteTemplate::from_slug_strict(template_slug)
+            .ok_or_else(|| BuildOutputDirError::UnknownTemplate(template_slug.to_string()))?;
+    if raw != template.output_dir() {
         return Err(BuildOutputDirError::TemplateMismatch);
     }
 

--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -668,6 +668,12 @@ pub enum BuildOutputDirError {
     /// The value did not match a per-template scaffold output dir
     /// (`dist`, `out`, or `docs`).
     NotAllowListed,
+    /// The value was on the global allow-list but did NOT match the
+    /// expected output dir for `metadata.template`. The closed contract
+    /// is per-template, not global — `astro-site` ↦ `dist` only, etc.
+    /// Pinned by codex's NEEDS-FOLLOWUP on the original fix: a global
+    /// allow-list lets `astro-site + docs` slip through. Issue #996.
+    TemplateMismatch,
     /// Canonicalising `project_dir.join(value)` failed or resolved
     /// outside `project_dir` (e.g. through a symlink).
     OutsideProject,
@@ -685,6 +691,10 @@ impl std::fmt::Display for BuildOutputDirError {
                 f,
                 "build_output_dir is not an allow-listed template output (dist, out, docs)"
             ),
+            Self::TemplateMismatch => write!(
+                f,
+                "build_output_dir does not match the expected output for this template"
+            ),
             Self::OutsideProject => {
                 write!(f, "build_output_dir resolves outside the project directory")
             }
@@ -695,15 +705,28 @@ impl std::fmt::Display for BuildOutputDirError {
 impl std::error::Error for BuildOutputDirError {}
 
 /// Per-template scaffold output directories. The values come from
-/// [`crate::workflow_families::site::SiteTemplate::output_dir`] — keep
-/// the two lists in sync. Updating an existing template's output dir
-/// requires updating both.
+/// [`crate::workflow_runtime::workflow_families::SiteTemplate::output_dir`]
+/// — keep the two lists in sync. Updating an existing template's
+/// output dir requires updating both.
+///
+/// NOTE: this constant is the *global* allow-list and is kept as a
+/// defence-in-depth gate. The authoritative check is per-template
+/// equality against
+/// [`crate::workflow_runtime::workflow_families::SiteTemplate::output_dir`]
+/// — see [`validated_build_output_dir_form`] for the strict-equality
+/// pass.
 const ALLOWED_BUILD_OUTPUT_DIRS: &[&str] = &["dist", "out", "docs"];
 
 /// Validate the structural form of `metadata.build_output_dir`
 /// without touching disk. Returns the joined `project_dir.join(value)`
 /// on success — caller may further enforce canonical-descendant via
 /// [`canonical_descendant_check`] once the output dir exists on disk.
+///
+/// Per-template equality: the value must equal
+/// `SiteTemplate::from_slug(metadata.template).output_dir()`. This
+/// closes the codex-flagged "astro-site + docs" gap where a global
+/// allow-list let cross-template values slip through. Issue #996
+/// follow-up.
 fn validated_build_output_dir_form(
     metadata: &SiteProjectMetadata,
     project_dir: &Path,
@@ -734,6 +757,20 @@ fn validated_build_output_dir_form(
 
     if !ALLOWED_BUILD_OUTPUT_DIRS.contains(&raw) {
         return Err(BuildOutputDirError::NotAllowListed);
+    }
+
+    // Per-template equality: the codex review's NEEDS-FOLLOWUP. The
+    // closed contract is per template, not global — `astro-site` MUST
+    // resolve to `dist`, never `docs`, and so on. Without this gate a
+    // malicious `mofa-site-session.json` could keep `template:
+    // "astro-site"` (which controls the build command) while pointing
+    // `build_output_dir` at `docs` (which controls what the preview
+    // serves), enabling cross-template surface mismatches.
+    let expected =
+        crate::workflow_runtime::workflow_families::SiteTemplate::from_slug(&metadata.template)
+            .output_dir();
+    if raw != expected {
+        return Err(BuildOutputDirError::TemplateMismatch);
     }
 
     Ok(project_dir.join(value_path))

--- a/crates/octos-cli/src/workflow_families/site.rs
+++ b/crates/octos-cli/src/workflow_families/site.rs
@@ -10,12 +10,39 @@ pub enum SiteTemplate {
 }
 
 impl SiteTemplate {
+    /// Lossy slug → template mapping. Unknown slugs collapse to
+    /// `Docs`, which keeps non-security call-sites (e.g.
+    /// `build_output_dir_for_template`, `workspace_policy_for_template`)
+    /// from panicking when callers pass in legacy / future template
+    /// slugs that should still be "scaffold a docs-ish workspace".
+    ///
+    /// **Security-sensitive callers MUST use [`from_slug_strict`]**.
+    /// Codex round-2 BLOCKING #2 (issue #996 follow-up): treating
+    /// unknown slugs as `Docs` was default-allow for the preview
+    /// validator — a malicious `metadata.template: "anything-goes"`
+    /// paired with `build_output_dir: "docs"` slipped past the
+    /// per-template-equality gate because the synthetic `Docs`
+    /// variant claims `output_dir() == "docs"`. The strict variant
+    /// returns `None` on unknown slugs so the validator can reject.
     pub fn from_slug(slug: &str) -> Self {
+        Self::from_slug_strict(slug).unwrap_or(Self::Docs)
+    }
+
+    /// Strict slug → template mapping. Returns `None` for any slug
+    /// not produced by the in-tree scaffolders. Used by the
+    /// `build_output_dir` validator to reject unknown templates
+    /// instead of silently defaulting to `Docs`. The known set is:
+    /// `astro-site`, `nextjs-app`, `react-vite`, `quarto-lesson`.
+    ///
+    /// Keep this in sync with the preset table in
+    /// `crates/octos-cli/src/project_templates.rs::site_preset_from_topic`.
+    pub fn from_slug_strict(slug: &str) -> Option<Self> {
         match slug.trim().to_ascii_lowercase().as_str() {
-            "astro-site" => Self::AstroSite,
-            "nextjs-app" => Self::NextjsApp,
-            "react-vite" => Self::ReactVite,
-            _ => Self::Docs,
+            "astro-site" => Some(Self::AstroSite),
+            "nextjs-app" => Some(Self::NextjsApp),
+            "react-vite" => Some(Self::ReactVite),
+            "quarto-lesson" => Some(Self::Docs),
+            _ => None,
         }
     }
 

--- a/crates/octos-cli/tests/build_output_dir_validation.rs
+++ b/crates/octos-cli/tests/build_output_dir_validation.rs
@@ -464,3 +464,189 @@ fn should_reject_symlink_swap_after_validation() {
         "symlink-swapped ancestor must be rejected; got served bytes: {served:?}",
     );
 }
+
+// ── Codex round-2 follow-up tests ──────────────────────────────────────────
+
+/// Codex round-2 BLOCKING #2: an LLM that puts `metadata.template:
+/// "phantom-template"` and `build_output_dir: "docs"` in
+/// `mofa-site-session.json` must NOT validate. Pre-followup,
+/// `SiteTemplate::from_slug` returned `Docs` on any unknown slug,
+/// so the per-template-equality gate let this through (because
+/// `Docs::output_dir() == "docs"`). Post-followup the validator uses
+/// `from_slug_strict` and surfaces `UnknownTemplate` on miss; the
+/// handler maps that to HTTP 400 via `SiteBuildError::InvalidMetadata`.
+#[test]
+fn should_reject_unknown_template() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path();
+    std::fs::create_dir_all(project_dir.join("docs")).unwrap();
+
+    // Phantom template — not one of `astro-site` / `nextjs-app` /
+    // `react-vite` / `quarto-lesson`. Paired with `docs`, which
+    // pre-followup matched the `Docs` fallback's output_dir.
+    let metadata = site_metadata("phantom-template", "docs");
+    let result = validated_build_output_dir(&metadata, project_dir);
+    match result {
+        Err(BuildOutputDirError::UnknownTemplate(slug)) => {
+            assert_eq!(
+                slug, "phantom-template",
+                "UnknownTemplate must carry the offending slug verbatim",
+            );
+        }
+        other => panic!("phantom-template must be rejected as UnknownTemplate, got: {other:?}",),
+    }
+
+    // Belt-and-braces: every variant of an unknown slug paired with
+    // every allow-listed output dir must reject — the previous fix
+    // was sensitive to the exact pairing.
+    for value in ["dist", "out", "docs"] {
+        let metadata = site_metadata("anything-goes", value);
+        let result = validated_build_output_dir(&metadata, project_dir);
+        assert!(
+            matches!(result, Err(BuildOutputDirError::UnknownTemplate(_))),
+            "anything-goes/{value} must be rejected, got: {result:?}",
+        );
+    }
+}
+
+/// Codex round-2 BLOCKING #1 follow-up: simulate the handler-shaped
+/// race end-to-end. Validate against a real `dist/`, then swap
+/// `dist` for a symlink to an outside dir, then call
+/// `serve_preview_no_follow_blocking` against the leaf that the
+/// handler would have computed. The new `openat`-walk
+/// implementation must refuse — must NOT return 200 with the
+/// escaped file's content. The round-1 `symlink_metadata` walk
+/// could be raced through (multi-syscall window between stat and
+/// open); the round-2 walk anchors each step to the previous fd so
+/// the swap cannot be observed by the next openat.
+///
+/// Skipped on Windows where `O_NOFOLLOW` and `openat` are absent;
+/// the non-Unix fallback retains the documented residual race.
+#[cfg(unix)]
+#[test]
+fn should_reject_handler_toctou_swap() {
+    use std::os::unix::fs::symlink;
+
+    use octos_cli::api::preview::serve_preview_no_follow_blocking;
+
+    let tmp_project = tempfile::tempdir().unwrap();
+    let tmp_outside = tempfile::tempdir().unwrap();
+    let project_dir = tmp_project.path();
+    let dist = project_dir.join("dist");
+    std::fs::create_dir_all(&dist).unwrap();
+    std::fs::write(dist.join("index.html"), b"<html>real</html>").unwrap();
+    std::fs::write(tmp_outside.path().join("index.html"), b"SECRET").unwrap();
+
+    // Phase 1: validator passes against a real dist/.
+    let metadata = site_metadata("astro-site", "dist");
+    let validated = validated_build_output_dir(&metadata, project_dir)
+        .expect("phase-1 validation must pass against a real dist/");
+    let leaf = validated.join("index.html");
+
+    // Phase 2: between validation and serve, an attacker swaps
+    // `dist` for a symlink pointing at `tmp_outside`. The leaf path
+    // (as a string) is unchanged.
+    std::fs::remove_dir_all(&dist).unwrap();
+    symlink(tmp_outside.path(), &dist).unwrap();
+
+    // Phase 3: the serve must refuse. Crucially, it must NOT return
+    // `Ok(b"SECRET")` — that's the pre-fix exploit shape: handler
+    // returns HTTP 200 with the escaped content.
+    //
+    // CRITICAL: pass `project_dir` (not the canonical output dir)
+    // as the walk root, matching the handler's wiring (see
+    // `serve_preview_file` in handlers.rs). The walk must therefore
+    // re-traverse `dist` (now a symlink) as an ancestor component
+    // and refuse on the `O_NOFOLLOW` open of that step.
+    let result = serve_preview_no_follow_blocking(project_dir, &leaf);
+    assert!(
+        result.is_err(),
+        "post-swap serve must refuse — round-1's symlink_metadata walk had a TOCTOU window the openat walk closes; got: {result:?}",
+    );
+    if let Ok(ref bytes) = result {
+        assert_ne!(
+            bytes.as_slice(),
+            b"SECRET",
+            "served bytes from outside the project — TOCTOU race not closed",
+        );
+    }
+}
+
+/// Codex round-2 test gap: an explicit HTTP status assertion at the
+/// handler-error-mapping layer. The handler maps
+/// `SiteBuildError::InvalidMetadata` (which now wraps
+/// `BuildOutputDirError::UnknownTemplate`) to HTTP 400, not 200.
+/// The previous error-response shape returned 200 with a
+/// "Preview Build Failed" page; the round-1 fix moved validation
+/// errors to 4xx. Pin the contract here so the status doesn't
+/// regress to 200 silently.
+#[tokio::test]
+async fn should_return_400_not_200_on_invalid() {
+    use axum::body::to_bytes;
+    use axum::http::StatusCode;
+    use octos_cli::api::testing::{SiteBuildError, preview_build_error_response};
+
+    // 1. UnknownTemplate (the new variant) must map to HTTP 400.
+    let resp = preview_build_error_response(
+        "phantom-template",
+        SiteBuildError::InvalidMetadata(BuildOutputDirError::UnknownTemplate(
+            "phantom-template".to_string(),
+        )),
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "UnknownTemplate must surface as HTTP 400, not 200 or 500",
+    );
+    let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let body_text = String::from_utf8_lossy(&body);
+    assert!(
+        body_text.contains("Preview Build Rejected"),
+        "response body should explain the rejection, got: {body_text}",
+    );
+    assert!(
+        !body_text.contains("/private/") && !body_text.contains("/Users/"),
+        "response body must not leak on-disk project paths, got: {body_text}",
+    );
+
+    // 2. Cross-check every InvalidMetadata variant — they all
+    //    represent LLM-controlled metadata problems and must be 400.
+    for reason in [
+        BuildOutputDirError::Empty,
+        BuildOutputDirError::Absolute,
+        BuildOutputDirError::ParentEscape,
+        BuildOutputDirError::NotAllowListed,
+        BuildOutputDirError::TemplateMismatch,
+        BuildOutputDirError::UnknownTemplate("x".into()),
+        BuildOutputDirError::OutsideProject,
+    ] {
+        let resp = preview_build_error_response(
+            "astro-site",
+            SiteBuildError::InvalidMetadata(reason.clone()),
+        );
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "InvalidMetadata({reason:?}) must map to HTTP 400",
+        );
+    }
+
+    // 3. The post-build re-validation variant (same family of
+    //    errors but caught after the build step) also maps to 400.
+    let resp = preview_build_error_response(
+        "astro-site",
+        SiteBuildError::PostBuildValidation(BuildOutputDirError::OutsideProject),
+    );
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // 4. UnsupportedTemplate stays 400 (defence-in-depth branch).
+    let resp = preview_build_error_response("astro-site", SiteBuildError::UnsupportedTemplate);
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // 5. Genuine build-tool failures stay 5xx — they are NOT
+    //    LLM-controlled, so HTTP 500 is the right surface.
+    let resp = preview_build_error_response("astro-site", SiteBuildError::BuildCommandFailed);
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let resp = preview_build_error_response("astro-site", SiteBuildError::OutputArtifactMissing);
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/crates/octos-cli/tests/build_output_dir_validation.rs
+++ b/crates/octos-cli/tests/build_output_dir_validation.rs
@@ -1,0 +1,252 @@
+//! Issue #996 (P0 sev1 path-traversal): the LLM-controlled
+//! `build_output_dir` field in `mofa-site-session.json` was joined
+//! onto `project_dir` without re-validation, allowing the sites
+//! preview to escape the project workspace.
+//!
+//! These tests pin the validation helper in
+//! [`octos_cli::project_templates::validated_build_output_dir`] which
+//! is the single entry-point every preview consumer must route
+//! through.
+//!
+//! Pre-fix behaviour: `validated_build_output_dir` did not exist, and
+//! the preview handler joined `project_dir.join(&metadata.build_output_dir)`
+//! verbatim — `"../escape"` returned 200 with the escaped file's
+//! content. Post-fix: every test below either rejects the input
+//! through the typed error or returns a confined path.
+
+use std::path::Path;
+
+use octos_cli::project_templates::{
+    BuildOutputDirError, SiteProjectMetadata, read_site_project_metadata,
+    validated_build_output_dir,
+};
+
+fn site_metadata_with_build_output(build_output_dir: &str) -> SiteProjectMetadata {
+    SiteProjectMetadata {
+        version: 1,
+        command: "/new site astro".to_string(),
+        preset_key: "astro".to_string(),
+        template: "astro-site".to_string(),
+        site_kind: "docs".to_string(),
+        site_name: "Test Site".to_string(),
+        description: "Test fixture".to_string(),
+        accent: "#000000".to_string(),
+        reference: "/tmp".to_string(),
+        reference_label: "tmp".to_string(),
+        site_slug: "test-site".to_string(),
+        preview_base_path: "/api/preview/p/s/test-site".to_string(),
+        preview_url: "/api/preview/p/s/test-site/index.html".to_string(),
+        build_output_dir: build_output_dir.to_string(),
+        project_dir: "sites/test-site".to_string(),
+        pages: Vec::new(),
+    }
+}
+
+/// Test 1: an allow-listed value (`dist`, populated by the template
+/// scaffold) is accepted.
+#[test]
+fn should_accept_allow_listed_dist_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path();
+    std::fs::create_dir_all(project_dir.join("dist")).unwrap();
+
+    let metadata = site_metadata_with_build_output("dist");
+    let resolved = validated_build_output_dir(&metadata, project_dir)
+        .expect("scaffold-derived `dist` must validate");
+    let canonical_project = std::fs::canonicalize(project_dir).unwrap();
+    assert!(resolved.starts_with(&canonical_project));
+    assert!(resolved.ends_with("dist"));
+}
+
+/// Test 1b: every per-template scaffold value (`dist`, `out`, `docs`)
+/// is accepted as documented in the allow-list.
+#[test]
+fn should_accept_each_template_scaffold_value() {
+    for value in ["dist", "out", "docs"] {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path();
+        std::fs::create_dir_all(project_dir.join(value)).unwrap();
+        let metadata = site_metadata_with_build_output(value);
+        validated_build_output_dir(&metadata, project_dir).unwrap_or_else(|err| {
+            panic!("scaffold value `{value}` must validate but got: {err:?}")
+        });
+    }
+}
+
+/// Test 2: a relative path that escapes via `..` is rejected — this
+/// is the exploit shape called out in the issue (`"../escape"`).
+/// Pre-fix this returned 200 with the escaped file's content.
+#[test]
+fn should_reject_dot_dot_escape() {
+    let tmp = tempfile::tempdir().unwrap();
+    let metadata = site_metadata_with_build_output("../escape");
+    let result = validated_build_output_dir(&metadata, tmp.path());
+    assert_eq!(result, Err(BuildOutputDirError::ParentEscape));
+}
+
+/// Test 3: an absolute path (e.g. `/etc/passwd`) is rejected before
+/// any join happens.
+#[test]
+fn should_reject_absolute_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let metadata = site_metadata_with_build_output("/etc/passwd");
+    let result = validated_build_output_dir(&metadata, tmp.path());
+    assert_eq!(result, Err(BuildOutputDirError::Absolute));
+}
+
+/// Test 4: a relative path that *normalises* to an escape via mixed
+/// `..` segments (`output/sub/../../../escape`) is rejected by the
+/// per-component scan, not the final canonicalise pass.
+#[test]
+fn should_reject_post_normalization_escape() {
+    let tmp = tempfile::tempdir().unwrap();
+    let metadata = site_metadata_with_build_output("output/sub/../../../escape");
+    let result = validated_build_output_dir(&metadata, tmp.path());
+    assert_eq!(result, Err(BuildOutputDirError::ParentEscape));
+}
+
+/// Test 5: a symlink placed at `<project_dir>/output -> /tmp` is
+/// rejected by the canonical-descendant check. Allow-listed names
+/// alone aren't enough — `output` itself is on the allow-list
+/// historically used elsewhere in the scaffold, so even if the value
+/// passes the allow-list it must canonicalise inside the project.
+/// Skipped on Windows where `std::os::unix::fs::symlink` is absent.
+#[cfg(unix)]
+#[test]
+fn should_reject_symlink_escape_after_build() {
+    use std::os::unix::fs::symlink;
+
+    let tmp_project = tempfile::tempdir().unwrap();
+    let tmp_outside = tempfile::tempdir().unwrap();
+    let project_dir = tmp_project.path();
+
+    // `docs` is an allow-listed scaffold value. Plant a symlink at
+    // `<project>/docs -> <outside>` to simulate a malicious symlink
+    // left by the build step.
+    symlink(tmp_outside.path(), project_dir.join("docs")).unwrap();
+
+    let metadata = site_metadata_with_build_output("docs");
+    let result = validated_build_output_dir(&metadata, project_dir);
+    assert_eq!(
+        result,
+        Err(BuildOutputDirError::OutsideProject),
+        "symlink-escape after allow-list must be rejected by canonical-descendant check"
+    );
+}
+
+/// Test 6: an empty / whitespace-only metadata value is rejected.
+#[test]
+fn should_reject_empty_string() {
+    let tmp = tempfile::tempdir().unwrap();
+    let metadata = site_metadata_with_build_output("");
+    let result = validated_build_output_dir(&metadata, tmp.path());
+    assert_eq!(result, Err(BuildOutputDirError::Empty));
+
+    let metadata = site_metadata_with_build_output("   ");
+    let result = validated_build_output_dir(&metadata, tmp.path());
+    assert_eq!(result, Err(BuildOutputDirError::Empty));
+}
+
+/// Test 6b: an arbitrary non-allow-listed value (e.g. `build` or
+/// `public`) is rejected even though it would resolve safely inside
+/// the project — the contract is the closed allow-list, not
+/// "anything inside `project_dir`".
+#[test]
+fn should_reject_non_allow_listed_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("build")).unwrap();
+    let metadata = site_metadata_with_build_output("build");
+    let result = validated_build_output_dir(&metadata, tmp.path());
+    assert_eq!(result, Err(BuildOutputDirError::NotAllowListed));
+}
+
+/// Test 7: live-preview-shaped probe. Write a malicious
+/// `mofa-site-session.json` (`build_output_dir: "../../etc"`) and
+/// read it back through the same in-process helper the preview
+/// handler uses (`read_site_project_metadata` →
+/// `validated_build_output_dir`). The validator must reject; pre-fix,
+/// joining `project_dir.join("../../etc")` would have escaped to the
+/// host etc dir and the preview handler returned 200 with its
+/// content.
+#[test]
+fn should_reject_malicious_session_json_for_preview() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("sites").join("evil");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let metadata = site_metadata_with_build_output("../../etc");
+    let serialized = serde_json::to_string_pretty(&metadata).unwrap();
+    std::fs::write(project_dir.join("mofa-site-session.json"), serialized).unwrap();
+
+    let read_back =
+        read_site_project_metadata(&project_dir).expect("metadata must round-trip via serde");
+    assert_eq!(read_back.build_output_dir, "../../etc");
+
+    let result = validated_build_output_dir(&read_back, &project_dir);
+    assert_eq!(
+        result,
+        Err(BuildOutputDirError::ParentEscape),
+        "malicious session.json must be rejected — pre-fix this returned 200 with /etc content"
+    );
+}
+
+/// Test 7b: a single leading `..` is rejected the same way, and the
+/// resulting joined path does NOT exist under the project dir (so
+/// even if a caller ignored the error, no file would be served from
+/// inside the workspace).
+#[test]
+fn should_reject_single_dot_dot_and_not_expose_parent_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    // Plant a sibling file that would be the exploit target.
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, b"PRIVATE").unwrap();
+
+    let metadata = site_metadata_with_build_output("../");
+    let result = validated_build_output_dir(&metadata, &project_dir);
+    assert!(matches!(
+        result,
+        Err(BuildOutputDirError::ParentEscape | BuildOutputDirError::NotAllowListed)
+    ));
+
+    // Sanity: the secret file is still present (no side effects), and
+    // the validator did not return its path.
+    assert!(secret.exists());
+    assert!(result.is_err());
+}
+
+/// Sanity guard: the SiteProjectMetadata fields the validator
+/// inspects are stable. If `build_output_dir` is ever renamed the
+/// validator must be updated — this test fails fast if the field
+/// name drifts.
+#[test]
+fn metadata_field_path_is_stable() {
+    let metadata = site_metadata_with_build_output("dist");
+    let json = serde_json::to_value(&metadata).unwrap();
+    assert_eq!(
+        json.get("build_output_dir").and_then(|v| v.as_str()),
+        Some("dist"),
+        "validator depends on `build_output_dir` field name; update validator if this changes"
+    );
+}
+
+/// Defence-in-depth: the project_dir argument the validator
+/// canonicalises is the call-site's responsibility — confirm a
+/// missing project_dir still rejects, doesn't fall back to a raw
+/// join.
+#[test]
+fn missing_project_dir_does_not_bypass_validation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let nonexistent = tmp.path().join("does-not-exist");
+    // `dist` is allow-listed, but the canonical-descendant phase
+    // would normally need both paths to exist. The form-check still
+    // accepts the join (this is acceptable because the structural
+    // checks rule out escape via `..` / absolute / non-allow-list).
+    let metadata = site_metadata_with_build_output("dist");
+    let result = validated_build_output_dir(&metadata, &nonexistent).unwrap();
+    // The returned path must still be a child of the requested
+    // project dir even though we couldn't canonicalise either side.
+    assert!(result.ends_with("dist"));
+    let _ = Path::new(&result);
+}

--- a/crates/octos-cli/tests/build_output_dir_validation.rs
+++ b/crates/octos-cli/tests/build_output_dir_validation.rs
@@ -22,11 +22,20 @@ use octos_cli::project_templates::{
 };
 
 fn site_metadata_with_build_output(build_output_dir: &str) -> SiteProjectMetadata {
+    site_metadata("astro-site", build_output_dir)
+}
+
+/// Build a metadata fixture with a caller-chosen template and
+/// `build_output_dir`. Used by the per-template-equality tests added
+/// for the codex follow-up: `astro-site` ↦ `dist`, `nextjs-app` ↦
+/// `out`, `quarto-lesson` ↦ `docs`. Any other pairing is now a
+/// `TemplateMismatch`.
+fn site_metadata(template: &str, build_output_dir: &str) -> SiteProjectMetadata {
     SiteProjectMetadata {
         version: 1,
         command: "/new site astro".to_string(),
         preset_key: "astro".to_string(),
-        template: "astro-site".to_string(),
+        template: template.to_string(),
         site_kind: "docs".to_string(),
         site_name: "Test Site".to_string(),
         description: "Test fixture".to_string(),
@@ -58,18 +67,26 @@ fn should_accept_allow_listed_dist_value() {
     assert!(resolved.ends_with("dist"));
 }
 
-/// Test 1b: every per-template scaffold value (`dist`, `out`, `docs`)
-/// is accepted as documented in the allow-list.
+/// Test 1b: every per-template scaffold pairing (`astro-site` ↦
+/// `dist`, `nextjs-app` ↦ `out`, `react-vite` ↦ `dist`,
+/// `quarto-lesson` ↦ `docs`) is accepted. Updated for the
+/// per-template-equality follow-up — a global allow-list alone is
+/// not enough; the value must match `SiteTemplate::output_dir()` for
+/// the declared template.
 #[test]
 fn should_accept_each_template_scaffold_value() {
-    for value in ["dist", "out", "docs"] {
+    for (template, value) in [
+        ("astro-site", "dist"),
+        ("nextjs-app", "out"),
+        ("react-vite", "dist"),
+        ("quarto-lesson", "docs"),
+    ] {
         let tmp = tempfile::tempdir().unwrap();
         let project_dir = tmp.path();
         std::fs::create_dir_all(project_dir.join(value)).unwrap();
-        let metadata = site_metadata_with_build_output(value);
-        validated_build_output_dir(&metadata, project_dir).unwrap_or_else(|err| {
-            panic!("scaffold value `{value}` must validate but got: {err:?}")
-        });
+        let metadata = site_metadata(template, value);
+        validated_build_output_dir(&metadata, project_dir)
+            .unwrap_or_else(|err| panic!("`{template}`/`{value}` must validate but got: {err:?}"));
     }
 }
 
@@ -105,11 +122,13 @@ fn should_reject_post_normalization_escape() {
     assert_eq!(result, Err(BuildOutputDirError::ParentEscape));
 }
 
-/// Test 5: a symlink placed at `<project_dir>/output -> /tmp` is
+/// Test 5: a symlink placed at `<project_dir>/docs -> /tmp` is
 /// rejected by the canonical-descendant check. Allow-listed names
-/// alone aren't enough — `output` itself is on the allow-list
-/// historically used elsewhere in the scaffold, so even if the value
-/// passes the allow-list it must canonicalise inside the project.
+/// alone aren't enough — even if the value passes the per-template
+/// equality gate it must canonicalise inside the project. We pair
+/// `quarto-lesson` with `docs` (its scaffold output) so the symlink
+/// check is the gate the test actually exercises (not the new
+/// TemplateMismatch gate).
 /// Skipped on Windows where `std::os::unix::fs::symlink` is absent.
 #[cfg(unix)]
 #[test]
@@ -120,12 +139,12 @@ fn should_reject_symlink_escape_after_build() {
     let tmp_outside = tempfile::tempdir().unwrap();
     let project_dir = tmp_project.path();
 
-    // `docs` is an allow-listed scaffold value. Plant a symlink at
+    // `docs` is the `quarto-lesson` scaffold value. Plant a symlink at
     // `<project>/docs -> <outside>` to simulate a malicious symlink
     // left by the build step.
     symlink(tmp_outside.path(), project_dir.join("docs")).unwrap();
 
-    let metadata = site_metadata_with_build_output("docs");
+    let metadata = site_metadata("quarto-lesson", "docs");
     let result = validated_build_output_dir(&metadata, project_dir);
     assert_eq!(
         result,
@@ -249,4 +268,199 @@ fn missing_project_dir_does_not_bypass_validation() {
     // project dir even though we couldn't canonicalise either side.
     assert!(result.ends_with("dist"));
     let _ = Path::new(&result);
+}
+
+// ── Codex round-2 follow-up tests ──────────────────────────────────────────
+
+/// Codex GAP fix: a `null` JSON value in `mofa-site-session.json`
+/// must NOT make it past `read_site_project_metadata` and bypass the
+/// validator. We don't synthesise a `null` `SiteProjectMetadata` —
+/// such a value would fail serde deserialisation against
+/// `pub build_output_dir: String` long before reaching the validator.
+/// This test pins that contract: writing a session file with a
+/// `build_output_dir: null` payload causes
+/// `read_site_project_metadata` to return `None`, so the preview
+/// handler never gets a metadata struct to mis-trust.
+#[test]
+fn should_reject_null_json_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("sites").join("evil");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    // Hand-rolled JSON because serde won't let us serialise a typed
+    // metadata with a null `build_output_dir`.
+    let malicious = serde_json::json!({
+        "version": 1,
+        "command": "/new site astro",
+        "preset_key": "astro",
+        "template": "astro-site",
+        "site_kind": "docs",
+        "site_name": "Test Site",
+        "description": "Test fixture",
+        "accent": "#000000",
+        "reference": "/tmp",
+        "reference_label": "tmp",
+        "site_slug": "test-site",
+        "preview_base_path": "/api/preview/p/s/test-site",
+        "preview_url": "/api/preview/p/s/test-site/index.html",
+        "build_output_dir": serde_json::Value::Null,
+        "project_dir": "sites/test-site",
+        "pages": [],
+    });
+    std::fs::write(
+        project_dir.join("mofa-site-session.json"),
+        serde_json::to_string_pretty(&malicious).unwrap(),
+    )
+    .unwrap();
+
+    // The metadata reader uses strongly-typed serde — a null where a
+    // String is expected fails to deserialise. The preview handler
+    // already short-circuits on `None` with a 404 "Missing Site
+    // Metadata" page, so the validator is never reached.
+    let read_back = read_site_project_metadata(&project_dir);
+    assert!(
+        read_back.is_none(),
+        "null build_output_dir must fail serde deserialisation, got: {read_back:?}",
+    );
+}
+
+/// Codex GAP fix: percent-encoded and unicode-escaped `..` variants
+/// must be rejected. The allow-list is exact-match against the raw
+/// metadata string — the preview HTTP handler operates on the
+/// already-decoded `build_output_dir` field, not URL-encoded form, so
+/// a metadata value of `..%2Fescape` or `..\u{2f}escape` is matched
+/// literally by the allow-list (no `dist`/`out`/`docs`) and rejected
+/// before any decode step could happen. Pin both shapes explicitly.
+#[test]
+fn should_reject_unicode_dot_dot() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path();
+
+    // Percent-encoded slash: `..%2Fescape` is NOT `../escape` to
+    // path-component parsing, but it is also not an allow-listed
+    // value and contains characters outside the allow-list — must
+    // reject (NotAllowListed or TemplateMismatch are both acceptable
+    // gates; both prevent the value from being served).
+    let metadata = site_metadata_with_build_output("..%2Fescape");
+    let result = validated_build_output_dir(&metadata, project_dir);
+    assert!(
+        matches!(
+            result,
+            Err(BuildOutputDirError::NotAllowListed
+                | BuildOutputDirError::TemplateMismatch
+                | BuildOutputDirError::ParentEscape)
+        ),
+        "percent-encoded `..` must be rejected, got: {result:?}",
+    );
+
+    // Unicode-escaped `..` segment: `..\u{2f}escape` evaluates to
+    // `../escape` at the source-string level because `\u{2f}` is `/`,
+    // so this collapses to the standard ParentEscape case. The
+    // explicit pin keeps both shapes covered even if the validator
+    // ever stops normalising path separators.
+    let metadata = site_metadata_with_build_output("..\u{2f}escape");
+    let result = validated_build_output_dir(&metadata, project_dir);
+    assert_eq!(
+        result,
+        Err(BuildOutputDirError::ParentEscape),
+        "unicode-escaped `..` (literal `../escape`) must hit the ParentEscape gate",
+    );
+
+    // Backslash variant (`..\\escape`) — on Unix `\\` is a single
+    // path component, not a separator, so the whole value fails the
+    // allow-list. On Windows `\\` IS a separator and the leading
+    // `..` makes it `ParentEscape`. Accept either outcome — both
+    // reject.
+    let metadata = site_metadata_with_build_output("..\\escape");
+    let result = validated_build_output_dir(&metadata, project_dir);
+    assert!(
+        matches!(
+            result,
+            Err(BuildOutputDirError::NotAllowListed
+                | BuildOutputDirError::TemplateMismatch
+                | BuildOutputDirError::ParentEscape)
+        ),
+        "backslash `..` variant must be rejected, got: {result:?}",
+    );
+}
+
+/// Codex NEEDS-FOLLOWUP fix: `astro-site` with `build_output_dir:
+/// "docs"` must be rejected as `TemplateMismatch`. Pre-followup, the
+/// global allow-list let this through because `docs` was on the
+/// list. Post-followup the per-template gate enforces strict
+/// equality against `SiteTemplate::output_dir()`.
+#[test]
+fn should_reject_template_mismatch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path();
+    // Create both candidate dirs so the canonical-descendant phase
+    // can't be the reason for rejection — we want to prove the
+    // *equality* gate is what catches this.
+    std::fs::create_dir_all(project_dir.join("dist")).unwrap();
+    std::fs::create_dir_all(project_dir.join("docs")).unwrap();
+
+    let metadata = site_metadata("astro-site", "docs");
+    let result = validated_build_output_dir(&metadata, project_dir);
+    assert_eq!(
+        result,
+        Err(BuildOutputDirError::TemplateMismatch),
+        "astro-site + docs must be rejected by per-template equality",
+    );
+
+    // And the symmetric case: `nextjs-app` ↦ `out`, not `dist`.
+    let metadata = site_metadata("nextjs-app", "dist");
+    let result = validated_build_output_dir(&metadata, project_dir);
+    assert_eq!(
+        result,
+        Err(BuildOutputDirError::TemplateMismatch),
+        "nextjs-app + dist must be rejected by per-template equality",
+    );
+}
+
+/// Codex BLOCKING #1 fix: even after `validated_build_output_dir`
+/// returns a canonical path, the actual file serve must refuse to
+/// follow symlinks on the leaf or any ancestor between the project
+/// root and the resolved asset. This pins the symlink-after-validate
+/// TOCTOU window: validate succeeds against a real `dist/` dir, then
+/// the attacker swaps `dist` for a symlink to `/tmp/escape`. The
+/// serve helper [`octos_cli::api::preview::serve_preview_no_follow`]
+/// re-walks the path with `symlink_metadata` and refuses.
+///
+/// Skipped on Windows where `std::os::unix::fs::symlink` is absent.
+#[cfg(unix)]
+#[test]
+fn should_reject_symlink_swap_after_validation() {
+    use std::os::unix::fs::symlink;
+
+    use octos_cli::api::preview::serve_preview_no_follow_blocking;
+
+    let tmp_project = tempfile::tempdir().unwrap();
+    let tmp_outside = tempfile::tempdir().unwrap();
+    let project_dir = tmp_project.path();
+    let dist = project_dir.join("dist");
+    std::fs::create_dir_all(&dist).unwrap();
+    std::fs::write(dist.join("index.html"), b"<html>real</html>").unwrap();
+    std::fs::write(tmp_outside.path().join("escape"), b"SECRET").unwrap();
+
+    // Phase 1: validation succeeds because `dist` is a real
+    // directory at this moment.
+    let metadata = site_metadata("astro-site", "dist");
+    let validated = validated_build_output_dir(&metadata, project_dir)
+        .expect("phase-1 validation must pass against a real dist/");
+    assert!(validated.ends_with("dist"));
+
+    // Phase 2: attacker swaps `dist` for a symlink between
+    // validation and the file serve.
+    std::fs::remove_dir_all(&dist).unwrap();
+    symlink(tmp_outside.path(), &dist).unwrap();
+
+    // Phase 3: the serve helper must refuse — the canonical path
+    // resolves OUTSIDE `project_dir`, and the ancestor walk catches
+    // the swapped symlink even if the canonical form lies.
+    let candidate = dist.join("escape");
+    let served = serve_preview_no_follow_blocking(project_dir, &candidate);
+    assert!(
+        served.is_err(),
+        "symlink-swapped ancestor must be rejected; got served bytes: {served:?}",
+    );
 }


### PR DESCRIPTION
## Summary

Closes #996 (P0 sev1 path-traversal). The sites preview handler joined the LLM-controllable `build_output_dir` field of `mofa-site-session.json` onto the project workspace without re-validating on read. Because the site workflow grants `edit_file`, the LLM (or an attacker injecting prompts) could rewrite the metadata and turn `/api/preview/<profile>/<session>/<slug>/...` into a host-wide path-traversal primitive (codex-confirmed in #996).

The scaffold only ever populates the field from a closed allow-list (`dist`, `out`, `docs`) via `SiteTemplate::output_dir()`, but `read_site_project_metadata` did not enforce that on read.

## Changes

- New `validated_build_output_dir(metadata, project_dir)` helper in `crates/octos-cli/src/project_templates.rs` -- the single entry-point every preview consumer must route through. Enforces:
  1. Non-empty / non-whitespace
  2. Relative path (no absolute / Windows drive prefixes)
  3. No `..` components anywhere in the value
  4. Strict allow-list against `SiteTemplate::output_dir()`
  5. Canonical-descendant of `project_dir` once both exist on disk
- New `BuildOutputDirError` typed error (`Empty | Absolute | ParentEscape | NotAllowListed | OutsideProject`) -- propagated to the user, never silently fallen back to a raw join.
- `output_dir_for_site` in `handlers.rs` made fallible and wired into `ensure_site_build_output` so both the pre-build and post-build paths validate. The post-build re-check catches symlinks the build step might have introduced.

### Design choice: strict allow-list vs canonical-descendant-only

I went with **strict allow-list + canonical-descendant** (option 5 in the issue) rather than canonical-descendant-only. The per-template output dirs are a closed contract -- opening the field to "anything inside `project_dir`" would add no functionality while losing the ability to detect malicious-but-confined edits. Allow-list is the safest option and matches what `:625-642` produces at scaffold time. The allow-list is documented as needing to stay in sync with `SiteTemplate::output_dir()`.

The scaffold (lines `:625-642`) is unchanged per the issue's "Don't" list.

## Test plan

12 tests in `crates/octos-cli/tests/build_output_dir_validation.rs`:

- [x] Allow-listed value (`dist`) -> OK
- [x] Each scaffold value (`dist` / `out` / `docs`) -> OK
- [x] `"../escape"` -> `ParentEscape`
- [x] `"/etc/passwd"` (absolute) -> `Absolute`
- [x] `"output/sub/../../../escape"` (after-normalize escape) -> `ParentEscape`
- [x] Symlink at `<project>/docs -> /tmp` -> `OutsideProject` (Unix only)
- [x] Empty / whitespace -> `Empty`
- [x] Non-allow-listed value (e.g. `build`) -> `NotAllowListed`
- [x] Live preview probe: malicious `mofa-site-session.json` with `build_output_dir: "../../etc"` written to disk, read back through the same `read_site_project_metadata` -> `validated_build_output_dir` chain the preview handler uses -> `ParentEscape`
- [x] Single leading `..` rejected and sibling secret file untouched
- [x] Metadata field name stability guard
- [x] Missing project_dir does not bypass form-check

### Pre-fix failure quote

Demonstrated by temporarily restoring the old `project_dir.join(&metadata.build_output_dir)` path:

```
left:  Ok("/var/folders/76/.../T/.tmpWU76g7/../escape")
right: Err(ParentEscape)
```

### Validation gates

- [x] `cargo build --workspace --features api` -- clean
- [x] `cargo test -p octos-cli --features api --test build_output_dir_validation` -- 12/12 pass
- [x] `cargo fmt --all -- --check` -- clean
- [x] `cargo clippy -p octos-cli --features api --lib -- -D warnings` -- no new warnings on touched files (37 pre-existing on origin/main, 37 after)
- [x] 3 pre-existing `cargo test -p octos-cli --lib` failures in `api::ui_protocol::tests::session_open_result_advertises_*` and `session_scope_rejects_*` reproduce on origin/main and are unrelated.

## Notes

- Do not admin-merge -- codex review pass requested first.
- Not for fleet deploy; binary lineage is unrelated.