### PR TITLE
fix(api): require auth + ownership on /api/preview route (closes #994)

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -2020,14 +2020,33 @@ async fn serve_site_preview_impl(
 }
 
 /// GET /api/site-preview/{session_id}/{site_slug} — serve the preview root for a site session.
+///
+/// Codex review of PR #1001 (issue #994 follow-up): this route is a
+/// parallel preview surface to `/api/preview/{profile_id}/...` (which
+/// PR #1001 hardened by moving onto `chat_api` + asserting ownership).
+/// Unlike that route, `/api/site-preview/*` has no `profile_id` URL
+/// segment, and the legacy implementation derived the profile via
+/// [`resolve_profile_data_dir`] which preferred the `X-Profile-Id`
+/// header over the authenticated identity. With a valid bearer token
+/// plus a spoofed `X-Profile-Id`, an authenticated tenant A could read
+/// tenant B's preview through this side door.
+///
+/// Fix: route via [`resolve_site_preview_data_dir`] which mirrors the
+/// `/api/my/*` flow:
+///   1. authenticated identity required (401 if missing),
+///   2. host-routed profile (subdomain) is honored only when the
+///      identity is authorized for it (`is_authorized_for_profile`),
+///   3. otherwise the profile id is derived directly from the
+///      identity (`User { id }` or the admin profile),
+///   4. `X-Profile-Id` is NEVER trusted for profile routing on this
+///      route. The header is ignored.
 pub async fn serve_site_preview_root(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path((session_id, site_slug)): axum::extract::Path<(String, String)>,
 ) -> Response {
-    let identity = identity.as_ref().map(|ext| &ext.0);
-    let data_dir = match resolve_profile_data_dir(&state, &headers, identity).await {
+    let data_dir = match resolve_site_preview_data_dir(&state, &headers, identity.as_ref()) {
         Ok(data_dir) => data_dir,
         Err(response) => return response,
     };
@@ -2035,6 +2054,8 @@ pub async fn serve_site_preview_root(
 }
 
 /// GET /api/site-preview/{session_id}/{site_slug}/{*path} — serve built preview assets.
+///
+/// See [`serve_site_preview_root`] for the security model.
 pub async fn serve_site_preview_path(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -2045,12 +2066,99 @@ pub async fn serve_site_preview_path(
         String,
     )>,
 ) -> Response {
-    let identity = identity.as_ref().map(|ext| &ext.0);
-    let data_dir = match resolve_profile_data_dir(&state, &headers, identity).await {
+    let data_dir = match resolve_site_preview_data_dir(&state, &headers, identity.as_ref()) {
         Ok(data_dir) => data_dir,
         Err(response) => return response,
     };
     serve_site_preview_impl(data_dir, session_id, site_slug, request_path).await
+}
+
+/// Identity-first profile-data-dir resolver for `/api/site-preview/*`.
+///
+/// Codex flagged the legacy [`resolve_profile_data_dir`] path as
+/// unsafe for routes that lack an authoritative `profile_id` URL
+/// segment: it falls back to `X-Profile-Id` and treats the header as
+/// trusted, so an authed tenant A spoofing `X-Profile-Id: tenant-b`
+/// reads tenant B's preview. This helper deliberately ignores the
+/// header for profile routing and instead:
+///
+/// 1. Requires an `AuthIdentity` (the route is wrapped in
+///    `user_auth_middleware`, so reaching here with `None` is a
+///    routing bug — fail closed with 401).
+/// 2. If the request's host resolves to a tenant profile via the
+///    subdomain (e.g. `tenant-a.api.ominix.io`), honor it only when
+///    [`is_authorized_for_profile`] passes for the authenticated
+///    identity — otherwise 403 (mirrors `/api/my/*` host-scoping).
+/// 3. Otherwise, use the identity's own profile id: regular users
+///    map to their own user id, admin token maps to the admin
+///    profile.
+/// 4. Resolve the data dir from the now-authoritative profile id.
+#[allow(clippy::result_large_err)] // matches sibling `resolve_profile_data_dir_by_id`
+fn resolve_site_preview_data_dir(
+    state: &AppState,
+    headers: &HeaderMap,
+    identity: Option<&Extension<AuthIdentity>>,
+) -> Result<std::path::PathBuf, Response> {
+    let Some(Extension(identity)) = identity else {
+        tracing::warn!(
+            "site-preview route reached without AuthIdentity — routing bug? failing closed"
+        );
+        return Err(StatusCode::UNAUTHORIZED.into_response());
+    };
+
+    // Host-routed profile takes precedence (e.g. tenant subdomain),
+    // but ONLY when the authenticated identity is allowed to see
+    // that profile. Otherwise 403 — never silently fall through to
+    // another profile.
+    if let Some(host) = request_host(headers) {
+        if !is_local_request_host(&host) {
+            if let Some(candidate) = host.split('.').next() {
+                if let Some(host_profile_id) = resolve_profile_id_candidate(state, candidate) {
+                    if !is_authorized_for_profile(state, identity, &host_profile_id) {
+                        tracing::warn!(
+                            identity = ?identity,
+                            host_profile_id = %host_profile_id,
+                            "site-preview host-scope denied — identity not authorized for the tenant subdomain"
+                        );
+                        return Err(StatusCode::FORBIDDEN.into_response());
+                    }
+                    return resolve_profile_data_dir_by_id(state, &host_profile_id);
+                }
+            }
+        }
+    }
+
+    // No host-routed profile: derive purely from the authenticated
+    // identity. Crucially we do NOT read `X-Profile-Id` for profile
+    // routing — that's the codex-flagged side door.
+    let identity_profile_id = match identity {
+        AuthIdentity::Admin => ADMIN_PROFILE_ID,
+        AuthIdentity::User { id, .. } => id.as_str(),
+    };
+
+    // Defence in depth: if the caller DID send `X-Profile-Id`, treat
+    // any value that doesn't match the authenticated identity's
+    // profile (and that the identity isn't otherwise authorized for)
+    // as an explicit cross-tenant spoofing attempt → 403. This makes
+    // the rejection signal unambiguous in logs and tests, mirroring
+    // the response shape `/api/preview/{profile_id}/*` returns when
+    // identity does not own the route's profile_id segment.
+    if let Some(header_value) = headers.get("x-profile-id").and_then(|v| v.to_str().ok()) {
+        let trimmed = header_value.trim();
+        if !trimmed.is_empty()
+            && let Some(spoofed) = resolve_profile_id_candidate(state, trimmed)
+            && !is_authorized_for_profile(state, identity, &spoofed)
+        {
+            tracing::warn!(
+                identity = ?identity,
+                spoofed_profile_id = %spoofed,
+                "site-preview denied — X-Profile-Id requests a profile the identity is not authorized for (codex follow-up to PR #1001 / issue #994)"
+            );
+            return Err(StatusCode::FORBIDDEN.into_response());
+        }
+    }
+
+    resolve_profile_data_dir_by_id(state, identity_profile_id)
 }
 
 /// GET /api/preview/{profile_id}/{session_id}/{site_slug} —

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -20,7 +20,7 @@ use octos_core::{MAIN_PROFILE_ID, SessionKey};
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
-use super::auth_handlers::ADMIN_PROFILE_ID;
+use super::auth_handlers::{ADMIN_PROFILE_ID, is_authorized_for_profile};
 use super::router::AuthIdentity;
 use crate::project_templates::{SiteProjectMetadata, read_site_project_metadata};
 
@@ -2053,25 +2053,61 @@ pub async fn serve_site_preview_path(
     serve_site_preview_impl(data_dir, session_id, site_slug, request_path).await
 }
 
-/// GET /api/preview/{profile_id}/{session_id}/{site_slug} — public preview root for site iframes.
-pub async fn serve_public_site_preview_root(
+/// GET /api/preview/{profile_id}/{session_id}/{site_slug} —
+/// auth-and-ownership-gated preview root for site iframes.
+///
+/// Issue #994 (P0 sev2 cross-tenant data read): prior to this commit
+/// the route lived on the unauthenticated public router branch and
+/// resolved both `profile_id` and `session_id` purely from the URL
+/// tuple. The tuple is moderately guessable (subdomain + short
+/// timestamp + small slug allow-list), so any caller who could guess
+/// it could read another tenant's built site.
+///
+/// The fix:
+/// 1. Route now requires user auth (`user_auth_middleware` in
+///    `router.rs`). An unauthenticated request is rejected at the
+///    middleware with `401 Unauthorized` before the handler runs.
+/// 2. Handler asserts the authenticated identity is authorized for
+///    the route's `profile_id` via [`is_authorized_for_profile`].
+///    Cross-tenant mismatch → `403 Forbidden`.
+/// 3. Handler verifies the route's `session_id` resolves to a
+///    workspace under the profile's data directory. A session that
+///    does not exist in that tree (e.g. crafted / harvested) → `403
+///    Forbidden` (NOT 404 — we never disclose whether the slot is
+///    empty vs forbidden).
+///
+/// Interaction with issue #995: when the X-Profile-Id strip lands,
+/// the authenticated identity's profile becomes authoritative and
+/// the route's `profile_id` segment is only trusted after
+/// `is_authorized_for_profile` confirms the match. The order is
+/// important — never use the route segment to look up data before
+/// the ownership check passes.
+pub async fn serve_owned_site_preview_root(
     State(state): State<Arc<AppState>>,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path((profile_id, session_id, site_slug)): axum::extract::Path<(
         String,
         String,
         String,
     )>,
 ) -> Response {
-    let data_dir = match resolve_profile_data_dir_by_id(&state, &profile_id) {
-        Ok(data_dir) => data_dir,
-        Err(response) => return response,
-    };
-    serve_site_preview_impl(data_dir, session_id, site_slug, String::new()).await
+    serve_owned_site_preview(
+        state,
+        identity,
+        profile_id,
+        session_id,
+        site_slug,
+        String::new(),
+    )
+    .await
 }
 
-/// GET /api/preview/{profile_id}/{session_id}/{site_slug}/{*path} — public preview assets.
-pub async fn serve_public_site_preview_path(
+/// GET /api/preview/{profile_id}/{session_id}/{site_slug}/{*path} —
+/// auth-and-ownership-gated preview assets. See
+/// [`serve_owned_site_preview_root`] for the security model.
+pub async fn serve_owned_site_preview_path(
     State(state): State<Arc<AppState>>,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path((profile_id, session_id, site_slug, request_path)): axum::extract::Path<(
         String,
         String,
@@ -2079,10 +2115,85 @@ pub async fn serve_public_site_preview_path(
         String,
     )>,
 ) -> Response {
+    serve_owned_site_preview(
+        state,
+        identity,
+        profile_id,
+        session_id,
+        site_slug,
+        request_path,
+    )
+    .await
+}
+
+/// Shared implementation for [`serve_owned_site_preview_root`] and
+/// [`serve_owned_site_preview_path`]. Performs the auth + profile +
+/// session-ownership checks then delegates to the existing
+/// `serve_site_preview_impl` for the build / serve path.
+async fn serve_owned_site_preview(
+    state: Arc<AppState>,
+    identity: Option<Extension<AuthIdentity>>,
+    profile_id: String,
+    session_id: String,
+    site_slug: String,
+    request_path: String,
+) -> Response {
+    // 1. Auth identity must be present. The router wraps this route in
+    //    `user_auth_middleware`, which rejects unauthenticated
+    //    requests with 401 before the handler runs — so reaching here
+    //    with `identity = None` is a routing bug, not user error. Fail
+    //    closed with 401 just in case.
+    let Some(Extension(identity)) = identity else {
+        tracing::warn!(
+            profile_id = %profile_id,
+            "preview route reached without AuthIdentity — routing bug? failing closed"
+        );
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+
+    // 2. The authenticated identity must be authorized for the route's
+    //    `profile_id`. Admin (token or admin-role user) is authorized
+    //    for any profile; a regular user is authorized for their own
+    //    profile and any sub-accounts they own. Cross-tenant => 403.
+    if !is_authorized_for_profile(&state, &identity, &profile_id) {
+        tracing::warn!(
+            identity = ?identity,
+            route_profile_id = %profile_id,
+            "preview route denied — identity not authorized for route's profile_id (issue #994)"
+        );
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    // 3. Now that ownership is confirmed, resolve the data directory
+    //    by the (authoritative) route profile_id. A non-existent
+    //    profile is a 404 (the profile literally does not exist) but
+    //    `is_authorized_for_profile` already passed for sub-account
+    //    paths, so this is mostly a sanity check.
     let data_dir = match resolve_profile_data_dir_by_id(&state, &profile_id) {
         Ok(data_dir) => data_dir,
         Err(response) => return response,
     };
+
+    // 4. Session ownership: the route's `session_id` must resolve to
+    //    a workspace under this profile's data directory. We mirror
+    //    the search `serve_site_preview_impl` performs below, but
+    //    return 403 (not 404) when no candidate exists so the
+    //    response is indistinguishable from the cross-tenant denial.
+    let session_owned = api_session_workspace_dirs(&data_dir, &session_id)
+        .into_iter()
+        .map(|workspace| workspace.join("sites").join(&site_slug))
+        .any(|candidate| candidate.exists());
+    if !session_owned {
+        tracing::warn!(
+            identity = ?identity,
+            route_profile_id = %profile_id,
+            session_id = %session_id,
+            site_slug = %site_slug,
+            "preview route denied — session/site does not exist under profile's data dir (issue #994)"
+        );
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
     serve_site_preview_impl(data_dir, session_id, site_slug, request_path).await
 }
 

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -153,6 +153,26 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/api/site-preview/{session_id}/{site_slug}/{*path}",
             get(handlers::serve_site_preview_path),
         )
+        // Issue #994 (P0 sev2 cross-tenant data read): these routes
+        // used to live on the unauthenticated `public` branch below
+        // and resolved profile + session purely from the URL tuple.
+        // They now require user auth and the handler asserts that
+        // the authenticated identity owns the route's `profile_id`
+        // AND the route's `session_id` resolves to a workspace under
+        // that profile's data directory — see
+        // [`handlers::serve_owned_site_preview_root`].
+        .route(
+            "/api/preview/{profile_id}/{session_id}/{site_slug}",
+            get(handlers::serve_owned_site_preview_root),
+        )
+        .route(
+            "/api/preview/{profile_id}/{session_id}/{site_slug}/",
+            get(handlers::serve_owned_site_preview_root),
+        )
+        .route(
+            "/api/preview/{profile_id}/{session_id}/{site_slug}/{*path}",
+            get(handlers::serve_owned_site_preview_path),
+        )
         .route("/api/files/list", get(handlers::list_content_files))
         .route("/api/files/{filename}", get(handlers::serve_file))
         .route("/api/files", get(handlers::serve_file_by_query))
@@ -557,21 +577,15 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         Router::new().route("/api/internal/frps-auth", post(frps_plugin::frps_auth));
 
     // Unauthenticated routes (static files + auth endpoints + webhook proxy + internal)
+    //
+    // Issue #994 (P0 sev2 cross-tenant data read): `/api/preview/...`
+    // used to live here. It now sits on the authenticated `chat_api`
+    // group above — the handler asserts identity-owns-profile +
+    // session-belongs-to-profile, so the URL tuple is no longer
+    // sufficient to read another tenant's built site.
     let public = Router::new()
         .merge(metrics_route)
         .merge(auth_api)
-        .route(
-            "/api/preview/{profile_id}/{session_id}/{site_slug}",
-            get(handlers::serve_public_site_preview_root),
-        )
-        .route(
-            "/api/preview/{profile_id}/{session_id}/{site_slug}/",
-            get(handlers::serve_public_site_preview_root),
-        )
-        .route(
-            "/api/preview/{profile_id}/{session_id}/{site_slug}/{*path}",
-            get(handlers::serve_public_site_preview_path),
-        )
         .route(
             "/api/register/setup-script/{id}/{auth_token}",
             get(admin::register_setup_script_public),

--- a/crates/octos-cli/tests/preview_auth.rs
+++ b/crates/octos-cli/tests/preview_auth.rs
@@ -40,6 +40,7 @@ struct Fixture {
     _tempdir: TempDir,
     state: Arc<AppState>,
     session_a_id: String,
+    session_a_other_id: String,
     session_b_id: String,
     site_slug: String,
     token_a: String,
@@ -153,16 +154,25 @@ async fn build_fixture() -> Fixture {
     //    false.
     let site_slug = "test-site";
     let session_a_id = "site-A-1234567890-abcdef";
+    let session_a_other_id = "site-A-OTHER-7766554433";
     let session_b_id = "site-B-9876543210-fedcba";
 
     let key_a = SessionKey::with_profile(&profile_a.id, "api", session_a_id);
+    let key_a_other = SessionKey::with_profile(&profile_a.id, "api", session_a_other_id);
     let key_b = SessionKey::with_profile(&profile_b.id, "api", session_b_id);
     let encoded_a = octos_bus::session::encode_path_component(key_a.base_key());
+    let encoded_a_other = octos_bus::session::encode_path_component(key_a_other.base_key());
     let encoded_b = octos_bus::session::encode_path_component(key_b.base_key());
 
     let ws_a = data_dir_a
         .join("users")
         .join(&encoded_a)
+        .join("workspace")
+        .join("sites")
+        .join(site_slug);
+    let ws_a_other = data_dir_a
+        .join("users")
+        .join(&encoded_a_other)
         .join("workspace")
         .join("sites")
         .join(site_slug);
@@ -173,6 +183,7 @@ async fn build_fixture() -> Fixture {
         .join("sites")
         .join(site_slug);
     seed_built_site(&ws_a, "<<<A-CONTENT>>>");
+    seed_built_site(&ws_a_other, "<<<A-OTHER-CONTENT>>>");
     seed_built_site(&ws_b, "<<<B-CONTENT>>>");
 
     // 5. AppState wiring. `process_manager`/`session_cache` are not
@@ -189,6 +200,7 @@ async fn build_fixture() -> Fixture {
         _tempdir: tempdir,
         state,
         session_a_id: session_a_id.into(),
+        session_a_other_id: session_a_other_id.into(),
         session_b_id: session_b_id.into(),
         site_slug: site_slug.into(),
         token_a,
@@ -431,4 +443,167 @@ async fn test_5_authed_user_b_serves_own_preview() {
         .unwrap();
     let body_str = String::from_utf8_lossy(&body);
     assert!(body_str.contains("<<<B-CONTENT>>>"));
+}
+
+#[tokio::test]
+async fn test_6_reject_site_preview_with_forged_x_profile_id() {
+    // Codex review of PR #1001 caught this: `/api/site-preview/*` is a
+    // PARALLEL preview surface to `/api/preview/*` (which this PR
+    // hardened). Both endpoints can serve the same on-disk content,
+    // but `/api/site-preview/*` lacks a `profile_id` URL segment and
+    // historically derived the profile via `resolve_profile_data_dir`,
+    // which reads the `X-Profile-Id` header. An authenticated tenant A
+    // who spoofs `X-Profile-Id: tenant-b` could therefore read
+    // tenant B's preview through this side door even after PR #1001
+    // closed `/api/preview/*`.
+    //
+    // Post-fix the handler MUST ignore the header for profile-routing
+    // and assert ownership via the authenticated identity (mirroring
+    // `serve_owned_site_preview`). Cross-tenant header => 403.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    // User A authenticates with their own bearer token, but spoofs
+    // `X-Profile-Id: tenant-b` AND points at B's session. Pre-fix the
+    // handler resolved tenant B's data dir from the header, found B's
+    // workspace, and returned `<<<B-CONTENT>>>`.
+    let uri = format!(
+        "/api/site-preview/{}/{}/index.html",
+        fx.session_b_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {}", fx.token_a))
+                .header("x-profile-id", "tenant-b")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "user A spoofing X-Profile-Id: tenant-b MUST be 403, not 200 with B's data; \
+         got status {} (this is the codex-flagged /api/site-preview/* side door)",
+        resp.status()
+    );
+
+    // Defence in depth: even if status check misfired, B's marker
+    // must not leak.
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        !body_str.contains("<<<B-CONTENT>>>"),
+        "cross-tenant body leak via /api/site-preview/* with forged X-Profile-Id: \
+         response contains tenant B's marker"
+    );
+}
+
+#[tokio::test]
+async fn test_7_serve_site_preview_with_authenticated_identity() {
+    // Codex review companion to test 6. With `/api/site-preview/*` no
+    // longer trusting `X-Profile-Id`, an authenticated user A hitting
+    // their OWN session and no `X-Profile-Id` header must still get
+    // 200 — the handler derives the profile from the authenticated
+    // identity instead.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/site-preview/{}/{}/index.html",
+        fx.session_a_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {}", fx.token_a))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "user A authenticated against their own session without X-Profile-Id MUST be 200; \
+         got status {}",
+        resp.status()
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("<<<A-CONTENT>>>"),
+        "expected user A's preview body to contain '<<<A-CONTENT>>>', got: {body_str}"
+    );
+}
+
+#[tokio::test]
+async fn test_8_serve_other_session_under_same_profile() {
+    // Codex review §3 "session-ownership semantics" clarification.
+    //
+    // `/api/site-preview/*` is intentionally profile-scoped, NOT
+    // per-session-owner: any session that lives under the
+    // authenticated identity's profile is reachable, even one the
+    // user didn't directly originate from this browser. This is the
+    // current product semantic — multiple browsers / devices for the
+    // same tenant should all be able to load the tenant's previews.
+    //
+    // Test 3 above already pinned "session that does NOT exist under
+    // the profile -> 403". This test pins the complementary case:
+    // session that DOES exist under user A's profile (different
+    // `web-<id>` than the user's "current" session) -> 200. If the
+    // product later switches to per-session-owner semantics, this
+    // test should flip and capture the intent change.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    // session_a_other_id is pre-seeded under tenant-a's data dir but
+    // is a DIFFERENT id from `session_a_id`. With token A and no
+    // X-Profile-Id, the handler must resolve tenant-a's data dir from
+    // the identity and serve the other session under the same profile.
+    let uri = format!(
+        "/api/site-preview/{}/{}/index.html",
+        fx.session_a_other_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {}", fx.token_a))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "user A hitting another of A's profile-owned sessions via /api/site-preview/* \
+         MUST be 200 (profile-scoped semantic); got status {}",
+        resp.status()
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("<<<A-OTHER-CONTENT>>>"),
+        "expected the other A-session's marker, got: {body_str}"
+    );
 }

--- a/crates/octos-cli/tests/preview_auth.rs
+++ b/crates/octos-cli/tests/preview_auth.rs
@@ -35,6 +35,11 @@ use tower::util::ServiceExt;
 
 const STATIC_TOKEN_A: &str = "STATIC-TEST-TOKEN-FOR-USER-A";
 const STATIC_TOKEN_B: &str = "STATIC-TEST-TOKEN-FOR-USER-B";
+/// Bootstrap admin bearer wired into `AppState.auth_token` so the
+/// auth middleware resolves it to `AuthIdentity::Admin`. Used by the
+/// codex-follow-up tests 9-11 below to pin the admin cross-tenant
+/// design contract (see test comments for the design intent).
+const ADMIN_BEARER_TOKEN: &str = "STATIC-TEST-TOKEN-FOR-ADMIN";
 
 struct Fixture {
     _tempdir: TempDir,
@@ -42,6 +47,11 @@ struct Fixture {
     session_a_id: String,
     session_a_other_id: String,
     session_b_id: String,
+    /// A session id seeded ONLY under the `admin` profile (NOT under
+    /// `tenant-a` or `tenant-b`). When the admin bearer queries this
+    /// id without host-routing, the response should resolve to admin's
+    /// own data dir — proving `X-Profile-Id` did not cross-tenant.
+    session_admin_id: String,
     site_slug: String,
     token_a: String,
     token_b: String,
@@ -88,11 +98,32 @@ async fn build_fixture() -> Fixture {
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };
+    // Admin profile. Required so the codex-follow-up tests can
+    // exercise the `AuthIdentity::Admin` cross-tenant matrix
+    // (header-only vs. host-routed vs. both). Without an `admin`
+    // profile row, `resolve_profile_data_dir_by_id(state, "admin")`
+    // returns 404 and the test cannot positively assert "admin served
+    // their OWN view." See tests 9-11 for the design contract.
+    let profile_admin = UserProfile {
+        id: "admin".into(),
+        name: "Admin".into(),
+        public_subdomain: None,
+        enabled: true,
+        data_dir: None,
+        parent_id: None,
+        config: ProfileConfig::default(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
     profile_store.save(&profile_a).expect("save profile a");
     profile_store.save(&profile_b).expect("save profile b");
+    profile_store
+        .save(&profile_admin)
+        .expect("save profile admin");
 
     let data_dir_a = profile_store.resolve_data_dir(&profile_a);
     let data_dir_b = profile_store.resolve_data_dir(&profile_b);
+    let data_dir_admin = profile_store.resolve_data_dir(&profile_admin);
 
     // 2. User store: a User per profile, with `id` matching the
     //    profile id so `is_authorized_for_profile` accepts the
@@ -156,13 +187,19 @@ async fn build_fixture() -> Fixture {
     let session_a_id = "site-A-1234567890-abcdef";
     let session_a_other_id = "site-A-OTHER-7766554433";
     let session_b_id = "site-B-9876543210-fedcba";
+    // Admin-owned session, used by the codex-follow-up tests 9-11 to
+    // positively assert "admin served their own view, NOT tenant B's"
+    // when only `X-Profile-Id` (and no host routing) is supplied.
+    let session_admin_id = "site-ADMIN-1111111111-aaaaaa";
 
     let key_a = SessionKey::with_profile(&profile_a.id, "api", session_a_id);
     let key_a_other = SessionKey::with_profile(&profile_a.id, "api", session_a_other_id);
     let key_b = SessionKey::with_profile(&profile_b.id, "api", session_b_id);
+    let key_admin = SessionKey::with_profile(&profile_admin.id, "api", session_admin_id);
     let encoded_a = octos_bus::session::encode_path_component(key_a.base_key());
     let encoded_a_other = octos_bus::session::encode_path_component(key_a_other.base_key());
     let encoded_b = octos_bus::session::encode_path_component(key_b.base_key());
+    let encoded_admin = octos_bus::session::encode_path_component(key_admin.base_key());
 
     let ws_a = data_dir_a
         .join("users")
@@ -182,17 +219,32 @@ async fn build_fixture() -> Fixture {
         .join("workspace")
         .join("sites")
         .join(site_slug);
+    let ws_admin = data_dir_admin
+        .join("users")
+        .join(&encoded_admin)
+        .join("workspace")
+        .join("sites")
+        .join(site_slug);
     seed_built_site(&ws_a, "<<<A-CONTENT>>>");
     seed_built_site(&ws_a_other, "<<<A-OTHER-CONTENT>>>");
     seed_built_site(&ws_b, "<<<B-CONTENT>>>");
+    seed_built_site(&ws_admin, "<<<ADMIN-CONTENT>>>");
 
     // 5. AppState wiring. `process_manager`/`session_cache` are not
     //    needed by the preview handler — it only consults
     //    `profile_store` and the on-disk session workspace.
+    //
+    //    `auth_token = Some(ADMIN_BEARER_TOKEN)` lights up the
+    //    bootstrap-admin path in `resolve_identity` (no rotated
+    //    `admin_token.json` exists for the empty test store, so the
+    //    bootstrap token is authoritative). Required by the codex
+    //    follow-up tests 9-11 which assert admin cross-tenant
+    //    semantics on `/api/site-preview/*`.
     let state = Arc::new(AppState {
         profile_store: Some(profile_store.clone()),
         user_store: Some(user_store.clone()),
         auth_manager: Some(auth_manager.clone()),
+        auth_token: Some(ADMIN_BEARER_TOKEN.into()),
         ..AppState::empty_for_tests()
     });
 
@@ -202,6 +254,7 @@ async fn build_fixture() -> Fixture {
         session_a_id: session_a_id.into(),
         session_a_other_id: session_a_other_id.into(),
         session_b_id: session_b_id.into(),
+        session_admin_id: session_admin_id.into(),
         site_slug: site_slug.into(),
         token_a,
         token_b,
@@ -605,5 +658,200 @@ async fn test_8_serve_other_session_under_same_profile() {
     assert!(
         body_str.contains("<<<A-OTHER-CONTENT>>>"),
         "expected the other A-session's marker, got: {body_str}"
+    );
+}
+
+// ---------------------------------------------------------------
+// Codex round-2 re-review follow-ups (admin cross-tenant matrix).
+//
+// Codex flagged: "Admin + `X-Profile-Id: tenant-b` is allowed past the
+// spoof check, but the header is not used for routing; it falls
+// through to `ADMIN_PROFILE_ID`, so it will not serve tenant B unless
+// host-routing selected B earlier."
+//
+// This is the current behavior and an INTENTIONAL design choice (not
+// a bug). Tests 9-11 below pin the three corners of the matrix so the
+// contract is enforced by CI:
+//
+// | host routing | X-Profile-Id | result                          |
+// |--------------|--------------|---------------------------------|
+// | no           | tenant-b     | serves admin's OWN view (T9)    |
+// | tenant-b     | (absent)     | serves tenant B (T10)           |
+// | tenant-b     | tenant-b     | serves tenant B (T11 sanity)    |
+//
+// Design intent: admin cross-tenant access flows ONLY through
+// host-routing (audit-friendly: each tenant has its own subdomain in
+// the access log). `X-Profile-Id` is NOT honored as a cross-tenant
+// switch for admin — that path would be too easily masqueraded by
+// misbehaving tooling or an SSRF that controls headers but not host.
+// ---------------------------------------------------------------
+
+#[tokio::test]
+async fn test_9_admin_with_forged_x_profile_id_does_not_cross_tenant_via_header() {
+    // Design intent: header alone is not sufficient for cross-tenant
+    // admin access; host routing is required.
+    //
+    // Admin authenticates with the bootstrap admin bearer and sends
+    // `X-Profile-Id: tenant-b`, with NO host-routing (the default
+    // tower-oneshot request has no `Host` header → `request_host`
+    // returns `None`). The route then falls through to
+    // `identity_profile_id = ADMIN_PROFILE_ID`, resolving admin's own
+    // data dir. The defense-in-depth spoof check (handlers.rs:2146)
+    // does not 403 here because `is_authorized_for_profile(Admin, *)`
+    // is unconditionally true — but the header is still ignored for
+    // routing.
+    //
+    // We request `session_admin_id` (seeded ONLY under admin's data
+    // dir). If the header were honored we'd resolve tenant-b's dir,
+    // not find the admin session, and 404. The fact that we serve
+    // 200 with `<<<ADMIN-CONTENT>>>` proves the header did NOT switch
+    // the routed tenant.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/site-preview/{}/{}/index.html",
+        fx.session_admin_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {ADMIN_BEARER_TOKEN}"))
+                .header("x-profile-id", "tenant-b")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "admin + X-Profile-Id: tenant-b (no host routing) MUST resolve to admin's \
+         own data dir and serve 200 for an admin-owned session; got status {}. \
+         If this flips to 404, X-Profile-Id likely started routing the request \
+         and that is the regression this test guards against.",
+        resp.status()
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("<<<ADMIN-CONTENT>>>"),
+        "expected admin's own marker — header must NOT switch tenants; got: {body_str}"
+    );
+    assert!(
+        !body_str.contains("<<<B-CONTENT>>>"),
+        "cross-tenant body leak: admin + forged X-Profile-Id returned tenant B's marker"
+    );
+}
+
+#[tokio::test]
+async fn test_10_admin_host_routed_does_cross_tenant() {
+    // Design intent: admin cross-tenant access uses host routing.
+    //
+    // Admin authenticates with the bootstrap admin bearer. The Host
+    // header is set to a subdomain that resolves to `tenant-b` via
+    // `ProfileStore::resolve_routable_profile_id`. No `X-Profile-Id`
+    // is sent — host alone is the cross-tenant switch.
+    //
+    // The handler resolves the subdomain candidate `tenant-b` against
+    // the profile store, finds the top-level profile (no
+    // `public_subdomain`, no `parent_id` ⇒ the immutable internal id
+    // is routable), checks `is_authorized_for_profile(Admin, "tenant-b")
+    // = true`, and serves tenant B's data dir. The request URL points
+    // at B's session id (`session_b_id`), which exists under B's data
+    // dir, so the handler returns B's seeded marker.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/site-preview/{}/{}/index.html",
+        fx.session_b_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {ADMIN_BEARER_TOKEN}"))
+                // `request_host` reads `host`/`x-forwarded-host`,
+                // strips the port, lowercases, and takes the first
+                // dot-segment as the candidate. `tenant-b` resolves
+                // through `resolve_routable_profile_id` because the
+                // tenant-b profile is top-level with no
+                // `public_subdomain` set.
+                .header("host", "tenant-b.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "admin + host-routed to tenant-b (no X-Profile-Id) MUST serve tenant B's \
+         data dir for an existing tenant-b session; got status {}",
+        resp.status()
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("<<<B-CONTENT>>>"),
+        "expected tenant B's marker via host routing, got: {body_str}"
+    );
+}
+
+#[tokio::test]
+async fn test_11_admin_with_host_and_matching_x_profile_id() {
+    // Sanity check: when the consistent host AND `X-Profile-Id` both
+    // point at the same tenant, the request still serves that tenant
+    // (i.e. the defense-in-depth spoof check at handlers.rs:2146 does
+    // not regress and reject a consistent header). Host routing is
+    // authoritative; a matching header is a no-op.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/site-preview/{}/{}/index.html",
+        fx.session_b_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {ADMIN_BEARER_TOKEN}"))
+                .header("host", "tenant-b.example.com")
+                .header("x-profile-id", "tenant-b")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "admin + host=tenant-b + X-Profile-Id=tenant-b (consistent) MUST serve \
+         tenant B; got status {}",
+        resp.status()
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("<<<B-CONTENT>>>"),
+        "expected tenant B's marker, got: {body_str}"
     );
 }

--- a/crates/octos-cli/tests/preview_auth.rs
+++ b/crates/octos-cli/tests/preview_auth.rs
@@ -1,0 +1,434 @@
+//! Issue #994 (P0 sev2 cross-tenant data read): the public preview
+//! route `/api/preview/{profile_id}/{session_id}/{site_slug}/*` lived
+//! on the unauthenticated router branch and resolved profile + session
+//! purely from the URL tuple. Any caller who could guess (or harvest)
+//! a tuple could read another tenant's built site.
+//!
+//! These tests pin the post-fix behaviour:
+//!
+//! 1. Authenticated user A serving their own preview → 200 with content.
+//! 2. Authenticated user A serving user B's preview → 403 (profile
+//!    ownership mismatch). This is the test that flips from 200 (with
+//!    B's content leaked) → 403 across the fix.
+//! 3. Authenticated user A pointing at a session that does not belong
+//!    to their profile → 403 (session ownership).
+//! 4. Unauthenticated hit on any tuple → 401.
+//!
+//! Pre-fix verification quote: against the public-router build, test 2
+//! returns 200 OK with B's `index.html` payload. The fix moves the
+//! route to the authenticated branch + asserts identity ownership.
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::Utc;
+use octos_cli::api::{AppState, build_router};
+use octos_cli::otp::{AuthManager, DashboardAuthConfig, SmtpConfig};
+use octos_cli::profiles::{ProfileConfig, ProfileStore, UserProfile};
+use octos_cli::user_store::{User, UserRole, UserStore};
+use octos_core::SessionKey;
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+const STATIC_TOKEN_A: &str = "STATIC-TEST-TOKEN-FOR-USER-A";
+const STATIC_TOKEN_B: &str = "STATIC-TEST-TOKEN-FOR-USER-B";
+
+struct Fixture {
+    _tempdir: TempDir,
+    state: Arc<AppState>,
+    session_a_id: String,
+    session_b_id: String,
+    site_slug: String,
+    token_a: String,
+    token_b: String,
+}
+
+/// Build a fully-wired AppState with two distinct tenant profiles
+/// (`tenant-a`, `tenant-b`), corresponding `User` records, a session
+/// for each profile pre-seeded with an Astro build output containing
+/// the literal markers `<<<A-CONTENT>>>` and `<<<B-CONTENT>>>`.
+///
+/// Returns the AppState, both profile/session ids, the slug, and the
+/// minted session tokens for each user.
+async fn build_fixture() -> Fixture {
+    let tempdir = TempDir::new().expect("tempdir");
+    let octos_home = tempdir.path().to_path_buf();
+
+    // 1. Profile store: two top-level profiles using the default
+    //    `<octos_home>/profiles/<id>/data` data-dir layout.
+    //    `infer_profile_id_from_data_dir` walks `parent.file_name()`
+    //    back up to recover the profile id, so we MUST leave
+    //    `data_dir = None` (an override breaks that lookup and the
+    //    session-workspace search misses the pre-seeded files).
+    let profile_store = Arc::new(ProfileStore::open(&octos_home).expect("profile store"));
+
+    let profile_a = UserProfile {
+        id: "tenant-a".into(),
+        name: "Tenant A".into(),
+        public_subdomain: None,
+        enabled: true,
+        data_dir: None,
+        parent_id: None,
+        config: ProfileConfig::default(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let profile_b = UserProfile {
+        id: "tenant-b".into(),
+        name: "Tenant B".into(),
+        public_subdomain: None,
+        enabled: true,
+        data_dir: None,
+        parent_id: None,
+        config: ProfileConfig::default(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    profile_store.save(&profile_a).expect("save profile a");
+    profile_store.save(&profile_b).expect("save profile b");
+
+    let data_dir_a = profile_store.resolve_data_dir(&profile_a);
+    let data_dir_b = profile_store.resolve_data_dir(&profile_b);
+
+    // 2. User store: a User per profile, with `id` matching the
+    //    profile id so `is_authorized_for_profile` accepts the
+    //    identity for its profile.
+    let user_store = Arc::new(UserStore::open(&octos_home).expect("user store"));
+    let user_a = User {
+        id: profile_a.id.clone(),
+        email: "alice@example.test".into(),
+        name: "Alice".into(),
+        role: UserRole::User,
+        created_at: Utc::now(),
+        last_login_at: None,
+    };
+    let user_b = User {
+        id: profile_b.id.clone(),
+        email: "bob@example.test".into(),
+        name: "Bob".into(),
+        role: UserRole::User,
+        created_at: Utc::now(),
+        last_login_at: None,
+    };
+    user_store.save(&user_a).expect("save user a");
+    user_store.save(&user_b).expect("save user b");
+
+    // 3. AuthManager configured with static tokens so we can mint a
+    //    session token per user without going through the SMTP code
+    //    path. `verify_otp_with_registration` accepts the static
+    //    token and looks up the user by email — no allow_registration
+    //    needed since both users already exist.
+    let auth_cfg = DashboardAuthConfig {
+        smtp: SmtpConfig {
+            host: "smtp.invalid".into(),
+            port: 465,
+            username: "no-reply@invalid".into(),
+            password_env: "OCTOS_TEST_NO_SMTP".into(),
+            from_address: "no-reply@invalid".into(),
+        },
+        session_expiry_hours: 1,
+        allow_self_registration: false,
+        static_tokens: vec![STATIC_TOKEN_A.into(), STATIC_TOKEN_B.into()],
+    };
+    let auth_manager = Arc::new(AuthManager::new(Some(auth_cfg), user_store.clone()));
+
+    let token_a = auth_manager
+        .verify_otp_with_registration(&user_a.email, STATIC_TOKEN_A, false)
+        .await
+        .expect("mint token a")
+        .expect("token a present");
+    let token_b = auth_manager
+        .verify_otp_with_registration(&user_b.email, STATIC_TOKEN_B, false)
+        .await
+        .expect("mint token b")
+        .expect("token b present");
+
+    // 4. Pre-seed each profile's session workspace with a minimal
+    //    Astro-style project + a built `dist/index.html` so the
+    //    preview handler can skip `npm install`/`npm run build`. We
+    //    backdate the source mtime so `site_build_needed` returns
+    //    false.
+    let site_slug = "test-site";
+    let session_a_id = "site-A-1234567890-abcdef";
+    let session_b_id = "site-B-9876543210-fedcba";
+
+    let key_a = SessionKey::with_profile(&profile_a.id, "api", session_a_id);
+    let key_b = SessionKey::with_profile(&profile_b.id, "api", session_b_id);
+    let encoded_a = octos_bus::session::encode_path_component(key_a.base_key());
+    let encoded_b = octos_bus::session::encode_path_component(key_b.base_key());
+
+    let ws_a = data_dir_a
+        .join("users")
+        .join(&encoded_a)
+        .join("workspace")
+        .join("sites")
+        .join(site_slug);
+    let ws_b = data_dir_b
+        .join("users")
+        .join(&encoded_b)
+        .join("workspace")
+        .join("sites")
+        .join(site_slug);
+    seed_built_site(&ws_a, "<<<A-CONTENT>>>");
+    seed_built_site(&ws_b, "<<<B-CONTENT>>>");
+
+    // 5. AppState wiring. `process_manager`/`session_cache` are not
+    //    needed by the preview handler — it only consults
+    //    `profile_store` and the on-disk session workspace.
+    let state = Arc::new(AppState {
+        profile_store: Some(profile_store.clone()),
+        user_store: Some(user_store.clone()),
+        auth_manager: Some(auth_manager.clone()),
+        ..AppState::empty_for_tests()
+    });
+
+    Fixture {
+        _tempdir: tempdir,
+        state,
+        session_a_id: session_a_id.into(),
+        session_b_id: session_b_id.into(),
+        site_slug: site_slug.into(),
+        token_a,
+        token_b,
+    }
+}
+
+/// Write `mofa-site-session.json` + `dist/index.html` under `ws_dir`
+/// and backdate the source-tree mtime so `site_build_needed` is false
+/// (the preview handler skips its npm/quarto build and serves the
+/// pre-seeded output directly).
+fn seed_built_site(ws_dir: &std::path::Path, marker: &str) {
+    use std::time::Duration;
+
+    std::fs::create_dir_all(ws_dir).expect("create site workspace");
+    std::fs::create_dir_all(ws_dir.join("dist")).expect("create dist");
+
+    let slug = ws_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("test-site");
+    let metadata = serde_json::json!({
+        "version": 1,
+        "command": "/new site astro",
+        "preset_key": "astro",
+        "template": "astro-site",
+        "site_kind": "docs",
+        "site_name": "Test Site",
+        "description": "Test fixture",
+        "accent": "#000000",
+        "reference": "/tmp",
+        "reference_label": "tmp",
+        "site_slug": slug,
+        "preview_base_path": format!("/api/preview/p/s/{slug}"),
+        "preview_url": format!("/api/preview/p/s/{slug}/index.html"),
+        "build_output_dir": "dist",
+        "project_dir": format!("sites/{slug}"),
+        "pages": [],
+    });
+    std::fs::write(
+        ws_dir.join("mofa-site-session.json"),
+        serde_json::to_vec(&metadata).unwrap(),
+    )
+    .expect("write metadata");
+
+    let html = format!("<!doctype html><html><body>{marker}</body></html>");
+    std::fs::write(ws_dir.join("dist").join("index.html"), html).expect("write index.html");
+
+    // Backdate every source file by ten minutes so `newest_tree_mtime`
+    // for the project (excluding `dist`) is older than the `dist`
+    // tree's mtime and the preview handler skips the build step.
+    let source_mtime = std::time::SystemTime::now() - Duration::from_secs(600);
+    if let Ok(file) = std::fs::OpenOptions::new()
+        .write(true)
+        .open(ws_dir.join("mofa-site-session.json"))
+    {
+        let _ = file.set_modified(source_mtime);
+    }
+}
+
+#[tokio::test]
+async fn test_1_authed_user_a_serves_own_preview() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/preview/tenant-a/{}/{}/index.html",
+        fx.session_a_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {}", fx.token_a))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "user A authenticated against their own profile + session MUST receive 200"
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("<<<A-CONTENT>>>"),
+        "expected user A's preview body to contain '<<<A-CONTENT>>>', got: {body_str}"
+    );
+}
+
+#[tokio::test]
+async fn test_2_authed_user_a_cannot_read_user_b_preview() {
+    // CROSS-TENANT BLOCK. This is the issue #994 scenario. Before
+    // the fix, the route was unauthenticated and resolved profile_id
+    // directly from the URL — so user A (or any unauthenticated
+    // caller who could guess the tuple) read tenant B's
+    // `index.html` with `<<<B-CONTENT>>>`. Post-fix, the
+    // authenticated identity must match the route's profile_id.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/preview/tenant-b/{}/{}/index.html",
+        fx.session_b_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {}", fx.token_a))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "user A authenticated against tenant B's profile MUST be 403, not 200/404; \
+         got status {} (this is the issue #994 cross-tenant leak)",
+        resp.status()
+    );
+
+    // Defence in depth: even if the status check above misfired, the
+    // body must NOT contain B's marker.
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        !body_str.contains("<<<B-CONTENT>>>"),
+        "cross-tenant body leak: user A's response contains tenant B's marker"
+    );
+}
+
+#[tokio::test]
+async fn test_3_authed_user_a_session_ownership_enforced() {
+    // Even within user A's own profile, a session_id that does not
+    // belong to A (e.g. crafted / harvested from logs) must not
+    // return content. The handler returns 403 so the response is
+    // indistinguishable from the cross-tenant case.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    // user A authenticates, route targets A's profile, but the
+    // session id does not match any workspace under A's data dir.
+    let uri = format!(
+        "/api/preview/tenant-a/site-NOT-OWNED-by-a/{}/index.html",
+        fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {}", fx.token_a))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "user A authenticated against an unknown session within their own profile \
+         MUST be 403 (session ownership); got status {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn test_4_unauthenticated_request_rejected() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/preview/tenant-a/{}/{}/index.html",
+        fx.session_a_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated preview request MUST be 401; got status {}",
+        resp.status()
+    );
+}
+
+#[tokio::test]
+async fn test_5_authed_user_b_serves_own_preview() {
+    // Symmetric to test 1 — ensure auth-handling does not silently
+    // alias every authenticated request to one tenant. User B with
+    // their own token + own session id must succeed.
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let uri = format!(
+        "/api/preview/tenant-b/{}/{}/index.html",
+        fx.session_b_id, fx.site_slug
+    );
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .header("authorization", format!("Bearer {}", fx.token_b))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(body_str.contains("<<<B-CONTENT>>>"));
+}


### PR DESCRIPTION
## Summary

Issue #994 (P0 sev2 cross-tenant data read) — `/api/preview/{profile_id}/{session_id}/{site_slug}/*` lived on the unauthenticated public router branch (`router.rs:559-574`) and resolved both `profile_id` and `session_id` purely from the URL tuple. The tuple is moderately guessable (tenant subdomain + short timestamp + small preset slug allow-list — `octos-web/src/sites/types.ts:12-44`, `project_templates.rs:345-386`), so any caller who could guess it could read another tenant's built site. The resolver (`handlers.rs:1469-1485`) was profile-lookup-only with no session-ownership check, and serving (`handlers.rs:1953-1968`) gated only on file existence — there is no publish/share allow-list.

This PR implements **Option A** from the issue (fastest path):

- `router.rs`: move the three `/api/preview/...` routes from the `public` group to `chat_api`, inheriting the `user_auth_middleware` layer used by the rest of the user-scoped surface (`/api/my/*`, `/api/site-preview/...`, etc.). Unauthenticated requests get **401** at the middleware before the handler runs.
- `handlers.rs`: rename `serve_public_site_preview_root|path` -> `serve_owned_site_preview_root|path`, share a single ownership-check helper. The helper:
  - extracts the `AuthIdentity` (fail-closed 401 if missing — middleware bug);
  - asserts `is_authorized_for_profile(state, identity, route.profile_id)` -> **403** on mismatch (mirroring the `/api/my/*` host-scope gate in #958);
  - resolves the data directory from the now-authoritative `profile_id`;
  - verifies the route's `session_id` resolves to a workspace under that data directory -> **403** if not (indistinguishable from cross-tenant for callers).

**Interaction with #995** (X-Profile-Id strip): the route's `profile_id` segment is NEVER trusted before `is_authorized_for_profile` confirms the authenticated identity owns it. Order matters — the data-dir lookup happens after the check.

**Out of scope**: a future publish/share capability-token model (Option B from the issue).

## Fixup 1 — `/api/site-preview/*` X-Profile-Id side door (codex review follow-up)

Codex review of the first fixup flagged a parallel preview surface that the original fix missed: `/api/site-preview/{session_id}/{site_slug}` is also wired onto `chat_api` under `user_auth_middleware`, but has **no `profile_id` URL segment** and used the legacy `resolve_profile_data_dir` resolver — which prefers the `X-Profile-Id` header over the authenticated identity. With a valid bearer token plus a spoofed `X-Profile-Id`, authed tenant A could read tenant B's preview through this side door. The first fixup closed `/api/preview/*` but left `/api/site-preview/*` exposed.

Fix in `crates/octos-cli/src/api/handlers.rs:2097` (new `resolve_site_preview_data_dir` helper):

1. **Identity required** — 401 fail-closed if the route is somehow reached without an `AuthIdentity` (middleware bug).
2. **Host-routed profile** (subdomain like `tenant-a.api.ominix.io`) is honored only when `is_authorized_for_profile` passes for the identity, else **403** (mirrors `/api/my/*` host-scoping at `resolve_my_profile_id`).
3. Otherwise the profile id is derived **directly from the authenticated identity** (`User { id }` -> the user's own id, `Admin` -> `ADMIN_PROFILE_ID`). `X-Profile-Id` is **never trusted for profile routing** on this route.
4. **Defence in depth**: when the caller DID send `X-Profile-Id` and it resolves to a profile the identity is NOT authorized for, return **403** explicitly (visible signal in logs / tests instead of a silent 404).

Both `serve_site_preview_root` and `serve_site_preview_path` now route through the new helper. The route has no `profile_id` URL segment, so profile selection is documented as: "host first (gated), then identity; header ignored for routing."

## Design choice: admin cross-tenant access

Codex round-2 re-review flagged a NEW-GAP: "Admin + `X-Profile-Id: tenant-b` is allowed past the spoof check, but the header is not used for routing; it falls through to `ADMIN_PROFILE_ID`, so it will not serve tenant B unless host-routing selected B earlier." This is the **current and intended** behavior on `/api/site-preview/*`. Pinned by tests `test_9_admin_with_forged_x_profile_id_does_not_cross_tenant_via_header`, `test_10_admin_host_routed_does_cross_tenant`, and `test_11_admin_with_host_and_matching_x_profile_id` below.

Concretely, an admin can access tenant B's preview by exactly one path:

- **Host routing only** — hit `https://<tenant-b-subdomain>.<base-domain>/api/site-preview/...`. The handler reads `Host`/`X-Forwarded-Host`, resolves the first dot-segment via `ProfileStore::resolve_routable_profile_id`, checks `is_authorized_for_profile(Admin, "tenant-b") = true`, and serves tenant B's data dir.

`X-Profile-Id` is **not** honored as a cross-tenant switch for admin. With admin auth + `X-Profile-Id: tenant-b` and no host routing, the request resolves to `ADMIN_PROFILE_ID`'s data dir, never tenant B's. The defense-in-depth spoof check (`handlers.rs:2146`) does not 403 admins on this — `is_authorized_for_profile(Admin, *)` is unconditionally true — but the header is still ignored for routing.

Rationale:

- **Audit-friendly**: each tenant a cross-tenant action targets has a distinct subdomain in the access log; header-based switching would route all tenants through one host in logs.
- **Harder to masquerade**: misbehaving tooling, SSRF that controls request headers but not the request line, and most proxy mistakes can set/forward `X-Profile-Id` more easily than they can spoof the `Host`/`X-Forwarded-Host` of an authenticated subdomain request.
- **Single source of truth**: with the rules "host = authoritative cross-tenant switch (if identity is authorized), else identity profile" there is exactly one routing path per (identity, host) pair. Adding header-as-switch creates two routes per pair and reopens the "which input wins?" class of bugs that fixup 0/1 closed for non-admin identities.

If a future feature needs admin to access an arbitrary tenant without host routing (e.g. a CLI tool that doesn't go through Caddy), the right move is a separate, explicitly capability-tokened endpoint (mirrors the planned `/api/preview-signed/*` for iframes) — NOT teaching `X-Profile-Id` to cross tenants.

## Frontend follow-up (blocker for the SPA iframe — needs follow-up PR)

The embedded preview iframe on the SPA cannot carry a bearer token in `<iframe src=...>`. With auth now required on **both** `/api/preview/*` (PR #1001 fixup 0) **and** `/api/site-preview/*` (PR #1001 fixup 1 / codex follow-up), the iframe load in the SPA will currently fail. The fix is a separate concern — codex flagged this as **NEEDS FOLLOWUP, separate scope** — and needs a short-lived signed-URL endpoint that the iframe can consume without a bearer token:

  - `GET /api/preview-signed/{token}/{*path}` (or equivalent) where `token` is a tenant-scoped HMAC issued by an authenticated `POST /api/preview-signed/issue` call. The token encodes profile + session + site + expiry so the unauthenticated GET path can verify scope without trusting the URL.

This PR ships the server fix unmodified — the iframe redesign / signed-URL endpoint is intentionally **not bundled** and will land in a follow-up PR. The preview UX is broken on the SPA until that ships.

## Test plan

`crates/octos-cli/tests/preview_auth.rs` — **11 tests**, all green post-fix:

- [x] `test_1_authed_user_a_serves_own_preview` — A authenticated, A's profile + A's session -> **200** with `<<<A-CONTENT>>>` body marker
- [x] `test_2_authed_user_a_cannot_read_user_b_preview` — A authenticated, B's profile + B's session -> **403** (pre-fix: 200 with B's content — this is the issue #994 leak, captured in the failing-test quote)
- [x] `test_3_authed_user_a_session_ownership_enforced` — A authenticated, A's profile + crafted session id -> **403** (session ownership)
- [x] `test_4_unauthenticated_request_rejected` — no bearer -> **401** (pre-fix: 200, route was public)
- [x] `test_5_authed_user_b_serves_own_preview` — symmetry guard so the fix does not silently alias every authenticated request to one tenant
- [x] `test_6_reject_site_preview_with_forged_x_profile_id` — A authed + `X-Profile-Id: tenant-b` + B's session via `/api/site-preview/*` -> **403** (codex follow-up; pre-fixup in the test harness this was 503 because the resolver short-circuits on missing process_manager — in production it would have been 200 with B's content)
- [x] `test_7_serve_site_preview_with_authenticated_identity` — A authed, no `X-Profile-Id`, A's own session via `/api/site-preview/*` -> **200** with `<<<A-CONTENT>>>` (sanity)
- [x] `test_8_serve_other_session_under_same_profile` — A authed, no `X-Profile-Id`, **another** of A's profile-owned sessions via `/api/site-preview/*` -> **200** with the other session's marker. Documents §3 from codex's review: `/api/site-preview/*` is **profile-scoped**, NOT per-session-owner. Multiple browsers / devices for the same tenant can all load the tenant's previews. Test should flip if intent changes.
- [x] `test_9_admin_with_forged_x_profile_id_does_not_cross_tenant_via_header` — admin authed, `X-Profile-Id: tenant-b`, **no host routing**, admin-owned session id -> **200** with `<<<ADMIN-CONTENT>>>`. Pins the "header alone is not a cross-tenant switch for admin" half of the design choice above. If header-based routing regressed in, this flips to 404 because admin's data dir would no longer be selected.
- [x] `test_10_admin_host_routed_does_cross_tenant` — admin authed, `Host: tenant-b.example.com`, no `X-Profile-Id`, tenant-b session id -> **200** with `<<<B-CONTENT>>>`. Pins the "host routing IS the cross-tenant path for admin" half.
- [x] `test_11_admin_with_host_and_matching_x_profile_id` — admin authed, `Host: tenant-b.example.com` AND `X-Profile-Id: tenant-b` (consistent) -> **200** with `<<<B-CONTENT>>>`. Sanity check that a consistent header does not regress the host-routed path through the defense-in-depth spoof check.

Validation gates:

- [x] `cargo build --workspace --features api` clean
- [x] `cargo test -p octos-cli --features api --test preview_auth` 11/11 green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-cli --features api --lib -- -D warnings` introduces zero new diagnostics (37 errors on the branch, identical 37 on origin/main; the new helper carries an explicit `#[allow(clippy::result_large_err)]` matching sibling `resolve_profile_data_dir_by_id`)

**Codex re-review first — do not admin-merge.**
