### PR TITLE
fix(api): strip untrusted X-Profile-Id + make authenticated identity authoritative (closes #995)

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -1428,6 +1428,65 @@ fn infer_profile_id_from_data_dir(data_dir: &std::path::Path) -> String {
         .to_string()
 }
 
+/// Decision: which profile id should the request resolve to, given the
+/// header-derived candidate (post-middleware — already stripped if the
+/// connection was untrusted), an identity-derived id, and the auth
+/// identity for an authorization check?
+///
+/// **Auth bypass fix (#995)**: the legacy precedence
+/// `header.or(identity)` let an authenticated request set
+/// `X-Profile-Id: <victim>` and read the victim's data dir. The current
+/// precedence is identity-first; if a header is *also* present (i.e.
+/// from a trusted proxy after the strip middleware ran), it must name
+/// a profile the identity is authorized to act on — otherwise we
+/// return `403`, never silently override.
+///
+/// - Unauthenticated request + header: legacy hint, pass through.
+/// - Authenticated + header MATCHES identity scope: use that profile
+///   (lets per-tenant Caddy ingress narrow admin auth to a tenant).
+/// - Authenticated + header is unauthorized: `403`.
+/// - Authenticated + no header: use identity's own profile.
+/// - Neither header nor identity: `BAD_REQUEST`.
+//
+// `clippy::result_large_err` is consistent with `resolve_profile_data_dir`
+// and the rest of this handler module — boxing the response just for this
+// helper would diverge from the surrounding style.
+#[allow(clippy::result_large_err)]
+pub(crate) fn decide_resolved_profile_id(
+    state: &AppState,
+    identity: Option<&AuthIdentity>,
+    header_profile_id: Option<&str>,
+    identity_profile_id: Option<&str>,
+) -> Result<String, Response> {
+    match (identity, header_profile_id) {
+        (Some(identity), Some(pid)) => {
+            if super::auth_handlers::is_authorized_for_profile(state, identity, pid) {
+                return Ok(pid.to_string());
+            }
+            tracing::warn!(
+                target: "octos::api::auth",
+                identity = ?identity,
+                requested_profile = %pid,
+                "X-Profile-Id denied — authenticated identity not authorized for the requested profile"
+            );
+            Err((StatusCode::FORBIDDEN, "forbidden").into_response())
+        }
+        (Some(_), None) => identity_profile_id.map(str::to_string).ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "missing X-Profile-Id and no authenticated profile context",
+            )
+                .into_response()
+        }),
+        (None, Some(pid)) => Ok(pid.to_string()),
+        (None, None) => Err((
+            StatusCode::BAD_REQUEST,
+            "missing X-Profile-Id and no authenticated profile context",
+        )
+            .into_response()),
+    }
+}
+
 async fn resolve_profile_data_dir(
     state: &AppState,
     headers: &HeaderMap,
@@ -1442,26 +1501,25 @@ async fn resolve_profile_data_dir(
                 None => None,
             };
 
-            if let Some(pid) = header_profile_id.as_deref().or(identity_profile_id) {
-                match ps.get(pid) {
-                    Ok(Some(profile)) => return Ok(ps.resolve_data_dir(&profile)),
-                    Ok(None) => {
-                        return Err((StatusCode::NOT_FOUND, "profile not found").into_response());
-                    }
-                    Err(error) => {
-                        return Err((
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("profile lookup failed: {error}"),
-                        )
-                            .into_response());
-                    }
+            let pid = decide_resolved_profile_id(
+                state,
+                identity,
+                header_profile_id.as_deref(),
+                identity_profile_id,
+            )?;
+            match ps.get(&pid) {
+                Ok(Some(profile)) => return Ok(ps.resolve_data_dir(&profile)),
+                Ok(None) => {
+                    return Err((StatusCode::NOT_FOUND, "profile not found").into_response());
+                }
+                Err(error) => {
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("profile lookup failed: {error}"),
+                    )
+                        .into_response());
                 }
             }
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "missing X-Profile-Id and no authenticated profile context",
-            )
-                .into_response());
         }
         return Err((StatusCode::SERVICE_UNAVAILABLE, "no profile store").into_response());
     }
@@ -4022,4 +4080,174 @@ mod tests {
     // The `appui_default_session_cwd` workspace-hint forwarding the
     // M11-F regression-fix test asserted is now exercised directly
     // through the WS turn dispatcher (`ui_protocol::run_standalone_turn`).
+
+    // ── #995 — `decide_resolved_profile_id` precedence + auth ──────────
+    //
+    // The legacy precedence was `header.or(identity)` (handlers.rs:1442
+    // before the fix), letting any authenticated request set
+    // `X-Profile-Id: <victim>` and walk into the victim's data dir. The
+    // current logic is identity-first; if a header is also present
+    // (i.e. coming from a trusted reverse proxy after the strip
+    // middleware ran) it must name a profile the identity is authorized
+    // for — otherwise we return `403`, never silently override.
+
+    use crate::api::auth_handlers::ADMIN_PROFILE_ID;
+    use crate::profiles::{ProfileStore, UserProfile};
+    use crate::user_store::UserRole;
+
+    fn make_profile(id: &str, parent_id: Option<&str>) -> UserProfile {
+        UserProfile {
+            id: id.into(),
+            name: id.into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: parent_id.map(Into::into),
+            public_subdomain: None,
+            config: Default::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    /// Build a minimal `AppState` for `decide_resolved_profile_id` unit
+    /// tests with a profile_store containing the listed profiles.
+    fn state_with_profiles(profiles: &[(&str, Option<&str>)]) -> (tempfile::TempDir, AppState) {
+        let dir = tempfile::tempdir().unwrap();
+        let ps = ProfileStore::open(dir.path()).unwrap();
+        for (id, parent) in profiles {
+            ps.save(&make_profile(id, *parent)).unwrap();
+        }
+        let state = AppState {
+            profile_store: Some(Arc::new(ps)),
+            ..AppState::empty_for_tests()
+        };
+        (dir, state)
+    }
+
+    #[test]
+    fn decide_uses_identity_when_no_header_present() {
+        let (_dir, state) = state_with_profiles(&[("alice", None)]);
+        let identity = AuthIdentity::User {
+            id: "alice".into(),
+            role: UserRole::User,
+        };
+        let pid = decide_resolved_profile_id(&state, Some(&identity), None, Some("alice")).unwrap();
+        assert_eq!(pid, "alice");
+    }
+
+    #[test]
+    fn decide_uses_header_when_identity_is_authorized_admin() {
+        // Admin token can be narrowed to a specific tenant via X-Profile-Id
+        // when the request comes from the loopback Caddy ingress. This is
+        // the legitimate post-fix behaviour for hosted subdomains.
+        let (_dir, state) = state_with_profiles(&[("alice", None)]);
+        let identity = AuthIdentity::Admin;
+        let pid = decide_resolved_profile_id(
+            &state,
+            Some(&identity),
+            Some("alice"),
+            Some(ADMIN_PROFILE_ID),
+        )
+        .unwrap();
+        assert_eq!(pid, "alice");
+    }
+
+    #[test]
+    fn decide_uses_header_when_identity_owns_sub_account_named_in_header() {
+        let (_dir, state) = state_with_profiles(&[("owner", None), ("owner-sub", Some("owner"))]);
+        let identity = AuthIdentity::User {
+            id: "owner".into(),
+            role: UserRole::User,
+        };
+        let pid =
+            decide_resolved_profile_id(&state, Some(&identity), Some("owner-sub"), Some("owner"))
+                .unwrap();
+        assert_eq!(pid, "owner-sub");
+    }
+
+    #[test]
+    fn decide_rejects_header_when_authenticated_identity_unauthorized_for_it() {
+        // #995 pre-fix bypass: authenticated as alice, header says bob.
+        // Pre-fix: `header.or(identity)` returned "bob" silently.
+        // Post-fix: 403, no leak.
+        let (_dir, state) = state_with_profiles(&[("alice", None), ("bob", None)]);
+        let identity = AuthIdentity::User {
+            id: "alice".into(),
+            role: UserRole::User,
+        };
+        let err = decide_resolved_profile_id(&state, Some(&identity), Some("bob"), Some("alice"))
+            .expect_err("must reject cross-tenant header");
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn decide_rejects_header_pointing_to_unrelated_sub_account() {
+        // Owner authenticated → cannot use header to act as another
+        // owner's sub-account (parent_id mismatch).
+        let (_dir, state) = state_with_profiles(&[
+            ("owner-a", None),
+            ("owner-b", None),
+            ("owner-b-sub", Some("owner-b")),
+        ]);
+        let identity = AuthIdentity::User {
+            id: "owner-a".into(),
+            role: UserRole::User,
+        };
+        let err = decide_resolved_profile_id(
+            &state,
+            Some(&identity),
+            Some("owner-b-sub"),
+            Some("owner-a"),
+        )
+        .expect_err("must reject foreign sub-account");
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn decide_allows_user_with_admin_role_to_target_any_profile() {
+        // A user account flagged as `UserRole::Admin` is fully
+        // privileged — `is_authorized_for_profile` short-circuits to
+        // `true` in that branch. Codify the contract so a future
+        // refactor can't quietly break the admin path.
+        let (_dir, state) = state_with_profiles(&[("alice", None), ("bob", None)]);
+        let identity = AuthIdentity::User {
+            id: "alice".into(),
+            role: UserRole::Admin,
+        };
+        let pid = decide_resolved_profile_id(&state, Some(&identity), Some("bob"), Some("alice"))
+            .unwrap();
+        assert_eq!(pid, "bob");
+    }
+
+    #[test]
+    fn decide_falls_back_to_header_when_unauthenticated() {
+        // Pre-auth callers (e.g. webhook proxies, public preview) still
+        // use the header as a hint. Their handlers do their own
+        // authorization downstream; the contract here is only
+        // "don't 403 just because no identity is present."
+        let (_dir, state) = state_with_profiles(&[("alice", None)]);
+        let pid = decide_resolved_profile_id(&state, None, Some("alice"), None).unwrap();
+        assert_eq!(pid, "alice");
+    }
+
+    #[test]
+    fn decide_returns_bad_request_when_no_signal_at_all() {
+        let (_dir, state) = state_with_profiles(&[]);
+        let err = decide_resolved_profile_id(&state, None, None, None)
+            .expect_err("no identity AND no header must fail");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn decide_returns_bad_request_when_authenticated_but_no_identity_profile_id_resolved() {
+        // Edge case: identity is `Some(_)` but the caller could not
+        // resolve a profile id for it (e.g. admin in a setup-wizard
+        // state where `ensure_admin_profile` hasn't run yet). We must
+        // not fall through to a stripped-empty header.
+        let (_dir, state) = state_with_profiles(&[]);
+        let identity = AuthIdentity::Admin;
+        let err = decide_resolved_profile_id(&state, Some(&identity), None, None)
+            .expect_err("must signal missing context");
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -127,6 +127,47 @@ pub(crate) fn routed_profile_id_from_headers(
         .and_then(|candidate| resolve_profile_id_candidate(state, candidate))
 }
 
+/// #995 follow-up — authorization-aware wrapper around
+/// [`routed_profile_id_from_headers`].
+///
+/// On TRUSTED hops (loopback by default, or
+/// `OCTOS_TRUSTED_PROXY_CIDRS`-matched addresses) the strip middleware
+/// preserves the operator-set `X-Profile-Id`, so authenticated requests
+/// can still smuggle a victim-profile id past the routing layer. This
+/// helper closes that gap: when both a header-resolved profile id AND
+/// an authenticated identity are present, the identity MUST be
+/// authorized for the target profile. Admin tokens (`AuthIdentity::Admin`)
+/// and admin-role user sessions short-circuit to `Ok`; owner→sub-account
+/// is also permitted via the parent_id check in
+/// [`super::auth_handlers::is_authorized_for_profile`]. Mismatch is a
+/// hard `403`.
+///
+/// Unauthenticated requests pass through unchanged — the call site is
+/// responsible for its own downstream authorization (e.g. webhook
+/// proxies or public preview routes).
+#[allow(clippy::result_large_err)]
+pub(crate) fn authorized_routed_profile_id_from_headers(
+    state: &AppState,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+) -> Result<Option<String>, Response> {
+    let Some(profile_id) = routed_profile_id_from_headers(state, headers) else {
+        return Ok(None);
+    };
+    if let Some(identity) = identity {
+        if !super::auth_handlers::is_authorized_for_profile(state, identity, &profile_id) {
+            tracing::warn!(
+                target: "octos::api::auth",
+                identity = ?identity,
+                requested_profile = %profile_id,
+                "routed_profile_id denied — authenticated identity not authorized for the requested profile (#995 follow-up)"
+            );
+            return Err((StatusCode::FORBIDDEN, "forbidden").into_response());
+        }
+    }
+    Ok(Some(profile_id))
+}
+
 /// Resolve API port for a specific profile, or fall back to first available.
 /// Profile is identified by X-Profile-Id header (set by Caddy from subdomain).
 async fn resolve_api_port(state: &AppState, headers: &HeaderMap) -> Option<(String, u16)> {
@@ -143,8 +184,61 @@ async fn resolve_api_port(state: &AppState, headers: &HeaderMap) -> Option<(Stri
     pm.first_api_port().await
 }
 
+/// #995 follow-up — authorization-aware wrapper around
+/// [`resolve_api_port`]. Returns `Err(403)` when the header-resolved
+/// profile is not one the authenticated identity is authorized for.
+///
+/// The header authorization check runs FIRST — even if no
+/// `process_manager` is wired (standalone mode) the call site still
+/// needs to authorize a cross-tenant `X-Profile-Id`, because the
+/// authorization gate is the only thing keeping a forged header from
+/// reaching the standalone path's storage helpers downstream.
+///
+/// Falls back to the gateway's first available port when no header
+/// resolved to a profile, matching the legacy `resolve_api_port`
+/// contract — that fallback never touches a tenant-scoped route, so
+/// there is no header to authorize.
+#[allow(clippy::result_large_err)]
+async fn resolve_api_port_authorized(
+    state: &AppState,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+) -> Result<Option<(String, u16)>, Response> {
+    let authorized_profile_id =
+        authorized_routed_profile_id_from_headers(state, headers, identity)?;
+
+    let pm = match state.process_manager.as_ref() {
+        Some(pm) => pm,
+        None => return Ok(None),
+    };
+
+    if let Some(profile_id) = authorized_profile_id {
+        if let Some(port) = pm.api_port(&profile_id).await {
+            return Ok(Some((profile_id, port)));
+        }
+        tracing::warn!(profile = profile_id, "no API port for requested profile");
+    }
+
+    Ok(pm.first_api_port().await)
+}
+
 fn api_profile_id_from_headers(state: &AppState, headers: &HeaderMap) -> String {
     routed_profile_id_from_headers(state, headers).unwrap_or_else(|| MAIN_PROFILE_ID.to_string())
+}
+
+/// #995 follow-up — authorization-aware variant of
+/// [`api_profile_id_from_headers`]. Returns `Err(403)` when the header
+/// resolves to a profile the identity is not authorized for.
+#[allow(clippy::result_large_err)]
+fn api_profile_id_from_headers_authorized(
+    state: &AppState,
+    headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
+) -> Result<String, Response> {
+    Ok(
+        authorized_routed_profile_id_from_headers(state, headers, identity)?
+            .unwrap_or_else(|| MAIN_PROFILE_ID.to_string()),
+    )
 }
 
 /// Returns `true` when `session_id` is a bare SPA id whose raw form is
@@ -295,13 +389,27 @@ fn is_internal_session_topic(topic: &str) -> bool {
 // Helper for `ui_protocol::handle_session_list` (M12 Phase D-5).
 // The REST route `GET /api/sessions` was retired; this function survives
 // as the implementation backing the WS `session/list` RPC method.
-pub async fn list_sessions(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+pub async fn list_sessions(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
+) -> Response {
     // Collect sessions from both the standalone store and gateway profiles.
     let mut all: Vec<SessionInfo> = Vec::new();
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+
+    // #995 follow-up — Layer-2 authorization for the routed profile.
+    // Pre-fix this prefix went straight to `routed_profile_id_from_headers`,
+    // so a trusted-hop request with `X-Profile-Id: <victim>` listed the
+    // victim's sessions even when authenticated as another tenant.
+    let profile_id = match api_profile_id_from_headers_authorized(&state, &headers, identity_ref) {
+        Ok(pid) => pid,
+        Err(response) => return response,
+    };
 
     if let Some(sessions) = &state.sessions {
         let sess = sessions.lock().await;
-        let prefix = format!("{}:api:", api_profile_id_from_headers(&state, &headers));
+        let prefix = format!("{profile_id}:api:");
         // Use `list_top_level_sessions` (skips `child-*` and `*.tasks` at the
         // directory walk) so a user dir with tens of thousands of spawn
         // children does not turn this listing into an O(N) hang. The
@@ -326,7 +434,14 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>, headers: HeaderMa
     }
 
     // Also fetch from gateway if available.
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    // #995 follow-up — routed_profile_id used to walk the per-profile
+    // gateway is authorized above; the `resolve_api_port_authorized`
+    // call re-checks header authorization belt-and-suspenders.
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let proxy_resp = super::webhook_proxy::api_get_proxy(&state, port, "/sessions").await;
         if proxy_resp.status().is_success() {
             if let Ok(body) = axum::body::to_bytes(proxy_resp.into_body(), 10 * 1024 * 1024).await {
@@ -432,6 +547,7 @@ pub async fn session_messages(
 ) -> Response {
     let limit = params.limit.min(500);
     let offset = params.offset.min(10_000);
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
 
     // source=full: always proxy to gateway, which owns the canonical JSONL history.
     let use_full = params.source.as_deref() == Some("full");
@@ -471,7 +587,6 @@ pub async fn session_messages(
             // unlocks the unprofiled fallbacks even when the request
             // resolved to a hosted profile (admin already has read-all
             // privileges, so this is no privilege escalation).
-            let identity_ref = identity.as_ref().map(|ext| &ext.0);
             let candidate_keys = standalone_api_session_key_candidates_with_topic(
                 &state,
                 &headers,
@@ -512,7 +627,13 @@ pub async fn session_messages(
     } // !use_full
 
     // Proxy to gateway.
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    // #995 follow-up — authorize routed profile against identity
+    // before walking the gateway.
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let path = session_messages_proxy_path(
             &id,
             limit,
@@ -552,11 +673,20 @@ pub struct MessageInfo {
 pub async fn session_status(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(id): axum::extract::Path<String>,
     axum::extract::Query(params): axum::extract::Query<TopicQueryParams>,
 ) -> Response {
-    // Proxy to gateway (session actors live there)
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+    // Proxy to gateway (session actors live there).
+    // #995 follow-up — authorize routed profile against identity
+    // before walking the gateway. Pre-fix the gateway routing read the
+    // raw header.
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let encoded_id = encode_api_session_path_id(&id);
         let mut path = format!("/sessions/{encoded_id}/status");
         append_topic_query(&mut path, params.topic.as_deref());
@@ -578,11 +708,18 @@ pub async fn session_status(
 pub async fn session_tasks(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(id): axum::extract::Path<String>,
     axum::extract::Query(params): axum::extract::Query<TopicQueryParams>,
 ) -> Response {
-    // Proxy to gateway (task supervisor lives there)
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+    // Proxy to gateway (task supervisor lives there).
+    // #995 follow-up — authorize routed profile against identity.
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let encoded_id = encode_api_session_path_id(&id);
         let mut path = format!("/sessions/{encoded_id}/tasks");
         append_topic_query(&mut path, params.topic.as_deref());
@@ -608,10 +745,19 @@ pub async fn session_tasks(
 pub async fn cancel_task(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(task_id): axum::extract::Path<String>,
 ) -> Response {
-    // Gateway-mode: forward to the gateway process that owns the supervisor.
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+    // Gateway-mode: forward to the gateway process that owns the
+    // supervisor. #995 follow-up — authorize routed profile against
+    // identity before forwarding (a forged header could otherwise
+    // cancel a victim's task on a TRUSTED hop).
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let path = format!("/tasks/{}/cancel", encode_api_session_path_id(&task_id));
         return super::webhook_proxy::api_post_proxy_json(
             &state,
@@ -682,12 +828,21 @@ pub struct RestartFromNodeRequest {
 pub async fn restart_task_from_node(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(task_id): axum::extract::Path<String>,
     body: Option<Json<RestartFromNodeRequest>>,
 ) -> Response {
     let body = body.map(|Json(b)| b).unwrap_or_default();
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
 
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    // #995 follow-up — authorize routed profile against identity. A
+    // forged header could otherwise relaunch a victim's task on a
+    // TRUSTED hop.
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let path = format!(
             "/tasks/{}/restart-from-node",
             encode_api_session_path_id(&task_id)
@@ -936,7 +1091,17 @@ pub async fn update_session_title(
 
     let mut updated = false;
     let identity_ref = identity.as_ref().map(|ext| &ext.0);
-    let routed_profile_id = routed_profile_id_from_headers(&state, &headers);
+    // #995 follow-up — authorize routed profile against identity
+    // before using it as `SessionManager` routing context. Pre-fix the
+    // raw header value flowed straight into `resolve_sessions_for_lookup`
+    // and the gateway proxy below, letting a forged
+    // `X-Profile-Id: <victim>` rename a victim's sessions on a TRUSTED
+    // hop.
+    let routed_profile_id =
+        match authorized_routed_profile_id_from_headers(&state, &headers, identity_ref) {
+            Ok(pid) => pid,
+            Err(response) => return response,
+        };
     let candidates =
         standalone_api_session_key_candidates_with_topic(&state, &headers, identity_ref, &id, None);
 
@@ -976,7 +1141,12 @@ pub async fn update_session_title(
 
     // Proxy to gateway too, since the session may live in the per-profile
     // SessionManager rather than the serve-process store.
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    // #995 follow-up — same `resolve_api_port_authorized` gate.
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let path = format!("/sessions/{}/title", encode_api_session_path_id(&id));
         let body_json = serde_json::json!({ "title": title }).to_string();
         let _ = super::webhook_proxy::api_patch_proxy(&state, port, &path, body_json).await;
@@ -1005,7 +1175,15 @@ pub async fn delete_session(
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Response {
     let identity_ref = identity.as_ref().map(|ext| &ext.0);
-    let routed_profile_id = routed_profile_id_from_headers(&state, &headers);
+    // #995 follow-up — authorize routed profile against identity
+    // before using it as `SessionManager` routing context. Pre-fix a
+    // forged `X-Profile-Id: <victim>` would delete victim's sessions
+    // on a TRUSTED hop.
+    let routed_profile_id =
+        match authorized_routed_profile_id_from_headers(&state, &headers, identity_ref) {
+            Ok(pid) => pid,
+            Err(response) => return response,
+        };
     let candidates =
         standalone_api_session_key_candidates_with_topic(&state, &headers, identity_ref, &id, None);
 
@@ -1039,7 +1217,12 @@ pub async fn delete_session(
 
     // Also proxy delete to gateway — sessions may live in the gateway's
     // SessionManager (per-profile data dir), not just the serve process's store.
-    if let Some((_profile_id, port)) = resolve_api_port(&state, &headers).await {
+    // #995 follow-up — same `resolve_api_port_authorized` gate.
+    let api_port = match resolve_api_port_authorized(&state, &headers, identity_ref).await {
+        Ok(port) => port,
+        Err(response) => return response,
+    };
+    if let Some((_profile_id, port)) = api_port {
         let path = format!("/sessions/{}", encode_api_session_path_id(&id));
         let _ = super::webhook_proxy::api_delete_proxy(&state, port, &path).await;
     }
@@ -3720,7 +3903,7 @@ mod tests {
             ..AppState::empty_for_tests()
         });
 
-        let response = list_sessions(State(state), HeaderMap::new()).await;
+        let response = list_sessions(State(state), HeaderMap::new(), None).await;
         assert_eq!(response.status(), StatusCode::OK);
         let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
             .await
@@ -3778,7 +3961,7 @@ mod tests {
         });
 
         let start = std::time::Instant::now();
-        let response = list_sessions(State(state), HeaderMap::new()).await;
+        let response = list_sessions(State(state), HeaderMap::new(), None).await;
         let elapsed = start.elapsed();
 
         assert_eq!(response.status(), StatusCode::OK);
@@ -3917,6 +4100,7 @@ mod tests {
         let response = cancel_task(
             State(state),
             HeaderMap::new(),
+            None,
             axum::extract::Path(task_id.clone()),
         )
         .await;
@@ -3939,6 +4123,7 @@ mod tests {
         let response = cancel_task(
             State(state),
             HeaderMap::new(),
+            None,
             axum::extract::Path("does-not-exist".to_string()),
         )
         .await;
@@ -3961,8 +4146,13 @@ mod tests {
             task_query_store: Some(store),
             ..AppState::empty_for_tests()
         });
-        let response =
-            cancel_task(State(state), HeaderMap::new(), axum::extract::Path(task_id)).await;
+        let response = cancel_task(
+            State(state),
+            HeaderMap::new(),
+            None,
+            axum::extract::Path(task_id),
+        )
+        .await;
         assert_eq!(response.status(), StatusCode::CONFLICT);
     }
 
@@ -3972,6 +4162,7 @@ mod tests {
         let response = cancel_task(
             State(Arc::clone(&state)),
             HeaderMap::new(),
+            None,
             axum::extract::Path("any".to_string()),
         )
         .await;
@@ -3998,6 +4189,7 @@ mod tests {
         let response = restart_task_from_node(
             State(state),
             HeaderMap::new(),
+            None,
             axum::extract::Path(task_id.clone()),
             Some(Json(RestartFromNodeRequest {
                 node_id: Some("design".into()),
@@ -4036,6 +4228,7 @@ mod tests {
         let response = restart_task_from_node(
             State(state),
             HeaderMap::new(),
+            None,
             axum::extract::Path("nope".into()),
             Some(Json(RestartFromNodeRequest::default())),
         )
@@ -4054,6 +4247,7 @@ mod tests {
         let response = restart_task_from_node(
             State(state),
             HeaderMap::new(),
+            None,
             axum::extract::Path(task_id),
             Some(Json(RestartFromNodeRequest::default())),
         )

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -222,13 +222,20 @@ async fn resolve_api_port_authorized(
     Ok(pm.first_api_port().await)
 }
 
-fn api_profile_id_from_headers(state: &AppState, headers: &HeaderMap) -> String {
-    routed_profile_id_from_headers(state, headers).unwrap_or_else(|| MAIN_PROFILE_ID.to_string())
-}
-
-/// #995 follow-up — authorization-aware variant of
-/// [`api_profile_id_from_headers`]. Returns `Err(403)` when the header
-/// resolves to a profile the identity is not authorized for.
+/// #995 follow-up round 3 — authorization-aware profile resolver for
+/// the API channel. Returns `Err(403)` when the header resolves to a
+/// profile the identity is not authorized for; falls back to
+/// `MAIN_PROFILE_ID` when no header is present (matching the legacy
+/// `api_profile_id_from_headers` contract, retired in this round).
+///
+/// The raw (unauthorized) variant was deleted because the only
+/// remaining caller — the standalone candidate walk in
+/// [`standalone_api_session_key_candidates_with_topic`] — is now
+/// reachable on a trusted hop AND must therefore reject cross-tenant
+/// headers up-front. Codex round-2 review called out the raw variant
+/// as bypass-prone for exactly this reason; the function now exists
+/// only in its `_authorized` form so future call sites can't
+/// reintroduce the same bug.
 #[allow(clippy::result_large_err)]
 fn api_profile_id_from_headers_authorized(
     state: &AppState,
@@ -299,14 +306,28 @@ fn is_safe_bare_session_id(session_id: &str) -> bool {
 /// The dedup pass collapses duplicates when the topic is empty (in
 /// which case the bare-key and raw-id forms coincide with their
 /// no-topic counterparts).
+///
+/// **#995 follow-up round 3 — authorization is REQUIRED**. This helper
+/// now uses [`api_profile_id_from_headers_authorized`] internally, so
+/// a cross-tenant `X-Profile-Id` on a trusted hop produces an `Err`
+/// `Response` (403) instead of resolving to the victim profile id.
+/// Every caller already authorized via
+/// [`authorized_routed_profile_id_from_headers`] at the handler
+/// entry, so this is defense-in-depth: if a future caller is added
+/// that forgets to gate up-front, the candidate walk itself rejects
+/// the cross-tenant header rather than building candidates against
+/// the victim profile. Codex round-2 review specifically called out
+/// the standalone `session_messages` path as bypass-prone for exactly
+/// this reason.
+#[allow(clippy::result_large_err)]
 fn standalone_api_session_key_candidates_with_topic(
     state: &AppState,
     headers: &HeaderMap,
     identity: Option<&AuthIdentity>,
     session_id: &str,
     topic: Option<&str>,
-) -> Vec<SessionKey> {
-    let profile_id = api_profile_id_from_headers(state, headers);
+) -> Result<Vec<SessionKey>, Response> {
+    let profile_id = api_profile_id_from_headers_authorized(state, headers, identity)?;
     let topic = topic.unwrap_or_default();
 
     // Always probe the resolved profile's own canonical key first.
@@ -356,7 +377,7 @@ fn standalone_api_session_key_candidates_with_topic(
         }
     }
     candidates.dedup_by(|left, right| left.0 == right.0);
-    candidates
+    Ok(candidates)
 }
 
 fn encode_api_session_path_id(id: &str) -> String {
@@ -552,6 +573,23 @@ pub async fn session_messages(
     // source=full: always proxy to gateway, which owns the canonical JSONL history.
     let use_full = params.source.as_deref() == Some("full");
 
+    // #995 follow-up round 3 — Layer-2 authorization gate BEFORE any
+    // standalone-store candidate walk. Pre-fix, the standalone path at
+    // lines 587-620 built candidate `SessionKey`s using the raw
+    // `api_profile_id_from_headers` (which trusts whatever
+    // `X-Profile-Id` the request carries on a trusted hop) and returned
+    // messages from those candidates before ever hitting the gateway
+    // gate at the bottom of this function. The result: an authenticated
+    // non-admin user on a loopback hop could read another tenant's
+    // session messages by forging `X-Profile-Id`. Codex round-2 quote:
+    // "Passing `identity` only affects fallback breadth; it does not
+    // reject cross-tenant headers." This call rejects cross-tenant
+    // headers up-front; admin / owner / self continue past it.
+    if let Err(response) = authorized_routed_profile_id_from_headers(&state, &headers, identity_ref)
+    {
+        return response;
+    }
+
     // Try standalone store first in local mode.
     if !use_full {
         if let Some(sessions) = &state.sessions {
@@ -587,13 +625,16 @@ pub async fn session_messages(
             // unlocks the unprofiled fallbacks even when the request
             // resolved to a hosted profile (admin already has read-all
             // privileges, so this is no privilege escalation).
-            let candidate_keys = standalone_api_session_key_candidates_with_topic(
+            let candidate_keys = match standalone_api_session_key_candidates_with_topic(
                 &state,
                 &headers,
                 identity_ref,
                 &id,
                 params.topic.as_deref(),
-            );
+            ) {
+                Ok(keys) => keys,
+                Err(response) => return response,
+            };
             let mut sess = sessions.lock().await;
             let mut chosen: Option<&SessionKey> = None;
             for key in &candidate_keys {
@@ -1102,8 +1143,16 @@ pub async fn update_session_title(
             Ok(pid) => pid,
             Err(response) => return response,
         };
-    let candidates =
-        standalone_api_session_key_candidates_with_topic(&state, &headers, identity_ref, &id, None);
+    let candidates = match standalone_api_session_key_candidates_with_topic(
+        &state,
+        &headers,
+        identity_ref,
+        &id,
+        None,
+    ) {
+        Ok(keys) => keys,
+        Err(response) => return response,
+    };
 
     // #924 BLOCK 3: each candidate `SessionKey` may belong to a
     // different profile (the candidate set includes the resolved
@@ -1184,8 +1233,16 @@ pub async fn delete_session(
             Ok(pid) => pid,
             Err(response) => return response,
         };
-    let candidates =
-        standalone_api_session_key_candidates_with_topic(&state, &headers, identity_ref, &id, None);
+    let candidates = match standalone_api_session_key_candidates_with_topic(
+        &state,
+        &headers,
+        identity_ref,
+        &id,
+        None,
+    ) {
+        Ok(keys) => keys,
+        Err(response) => return response,
+    };
 
     // #924 BLOCK 3: route each candidate through the profile-aware
     // SessionManager resolver — turn persistence writes to the
@@ -3450,7 +3507,8 @@ mod tests {
             Some(&AuthIdentity::Admin),
             "telegram:123",
             None,
-        );
+        )
+        .expect("admin identity is always authorized");
         let keys: Vec<&str> = candidates.iter().map(|k| k.0.as_str()).collect();
         assert!(
             !keys.iter().any(|k| *k == "telegram:123"),
@@ -3574,7 +3632,8 @@ mod tests {
         // is returned.
         let candidates = standalone_api_session_key_candidates_with_topic(
             &state, &headers, None, "web-7c9e", None,
-        );
+        )
+        .expect("unauthenticated → no header authorization check required");
         let keys: Vec<&str> = candidates.iter().map(|k| k.0.as_str()).collect();
         // Profiled key must come first so existing chat-history reads keep
         // hitting the canonical write target before walking fallbacks.

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -49,6 +49,23 @@ pub use router::{DEFAULT_BASE_DOMAIN, build_router, cors_allowlist_for_base_doma
 pub mod testing {
     pub use super::handlers::{SiteBuildError, preview_build_error_response};
 }
+
+// #995 follow-up round 3 — Integration tests in
+// `crates/octos-cli/tests/x_profile_id_strip.rs` need to drive
+// `handlers::session_messages` directly: the REST route
+// `GET /api/sessions/{id}/messages` was retired in M12 Phase D-5, so
+// there's no `build_router` path to hit the bypass shape codex flagged.
+// The function (already `pub`) and its query params type are exposed
+// here for that purpose, plus `AuthIdentity` so tests can construct
+// non-admin and admin identities directly without booting a real auth
+// middleware stack.
+#[doc(hidden)]
+pub use handlers::{
+    PaginationParams as TestSessionMessagesPaginationParams,
+    session_messages as test_session_messages,
+};
+#[doc(hidden)]
+pub use router::AuthIdentity as TestAuthIdentity;
 pub use swarm::{
     BroadcasterSwarmEventSink, CostAttributionView, CostAttributionsResponse, DispatchIndexRow,
     SubtaskView, SwarmBudgetSpec, SwarmContextSpec, SwarmDispatchDetail, SwarmDispatchRequest,

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -896,15 +896,20 @@ async fn user_auth_middleware(
     // 2. Accept X-Profile-Id header for chat API routes (proxy auth).
     // The reverse proxy (Caddy) sets this header to identify the profile,
     // so requests through the proxy are implicitly authenticated.
-    // SECURITY: Only accept this header from loopback addresses to prevent
-    // profile impersonation via misconfigured reverse proxy or SSRF.
-    let is_loopback = req
+    // SECURITY: Only accept this header from a TRUSTED proxy address —
+    // loopback by default, plus any CIDR listed in
+    // `OCTOS_TRUSTED_PROXY_CIDRS`. The Layer-1 strip middleware uses
+    // the SAME helper (`is_trusted_proxy_addr`), so operators who run
+    // an off-host reverse proxy can opt the auth path in via the same
+    // env var that controls the strip path — keeping the two layers
+    // consistent (#995 follow-up).
+    let remote_ip = req
         .extensions()
         .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-        .map(|ci| ci.0.ip().is_loopback())
-        .unwrap_or(false);
+        .map(|ci| ci.0.ip());
+    let is_trusted_hop = is_trusted_proxy_addr(remote_ip);
 
-    if !profile_id.is_empty() && is_loopback {
+    if !profile_id.is_empty() && is_trusted_hop {
         // Validate that the profile actually exists to prevent spoofing.
         if let Some(ref store) = state.profile_store {
             if store.get(&profile_id).ok().flatten().is_none() {
@@ -934,10 +939,10 @@ async fn user_auth_middleware(
         }
     }
 
-    if !profile_id.is_empty() && !is_loopback {
+    if !profile_id.is_empty() && !is_trusted_hop {
         tracing::warn!(
             profile_id = %profile_id,
-            "X-Profile-Id header rejected: request not from loopback address"
+            "X-Profile-Id header rejected: request not from a trusted proxy address (#995 follow-up)"
         );
     }
 

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -594,12 +594,187 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .merge(version_routes)
         .merge(internal_routes);
 
+    // Layer 1 defence for issue #995 — the strip middleware runs OUTSIDE
+    // every other route layer so an unauthenticated request can never
+    // see an attacker-supplied `X-Profile-Id` on its way to a handler
+    // (handler-level Layer 2 in `handlers::decide_resolved_profile_id`
+    // is the second line of defence). Loopback / private connections are
+    // considered trusted; everything else has the header stripped before
+    // any handler / auth middleware runs.
     public
         .merge(protected)
         .fallback(static_files::static_handler)
+        .layer(middleware::from_fn(strip_untrusted_profile_id_middleware))
         .layer(TraceLayer::new_for_http())
         .layer(cors)
         .with_state(state)
+}
+
+/// Cached parsed list of trusted-proxy CIDRs from `OCTOS_TRUSTED_PROXY_CIDRS`.
+///
+/// Initialised once on first call. Empty if the env var is unset or no
+/// entries parse. Each entry is `(network address as 16-byte big-endian, prefix bits)`,
+/// with IPv4 mapped into the IPv4-in-IPv6 prefix (`::ffff:0:0/96`) so the
+/// matcher can run a single big-endian bit comparison regardless of family.
+fn trusted_proxy_cidrs() -> &'static [TrustedProxyCidr] {
+    use std::sync::OnceLock;
+    static CACHE: OnceLock<Vec<TrustedProxyCidr>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let raw = std::env::var("OCTOS_TRUSTED_PROXY_CIDRS").unwrap_or_default();
+            let mut out = Vec::new();
+            for entry in raw.split(',') {
+                let entry = entry.trim();
+                if entry.is_empty() {
+                    continue;
+                }
+                match parse_cidr(entry) {
+                    Some(cidr) => out.push(cidr),
+                    None => tracing::warn!(
+                        target: "octos::api::auth",
+                        cidr = %entry,
+                        "OCTOS_TRUSTED_PROXY_CIDRS entry could not be parsed; ignoring"
+                    ),
+                }
+            }
+            out
+        })
+        .as_slice()
+}
+
+/// Parsed trusted-proxy CIDR — IPv4 entries are normalised into the
+/// IPv4-mapped-IPv6 space so a single 128-bit big-endian comparison
+/// handles both families.
+#[derive(Clone, Copy, Debug)]
+struct TrustedProxyCidr {
+    network: [u8; 16],
+    prefix_bits: u8,
+}
+
+fn parse_cidr(entry: &str) -> Option<TrustedProxyCidr> {
+    let (addr, prefix) = entry.split_once('/')?;
+    let addr: std::net::IpAddr = addr.trim().parse().ok()?;
+    let prefix: u8 = prefix.trim().parse().ok()?;
+
+    let (octets, max_prefix) = match addr {
+        std::net::IpAddr::V4(v4) => {
+            // Map IPv4 into ::ffff:V4 (16 bytes, big-endian).
+            let mut buf = [0u8; 16];
+            buf[10] = 0xff;
+            buf[11] = 0xff;
+            buf[12..16].copy_from_slice(&v4.octets());
+            (buf, 32u8)
+        }
+        std::net::IpAddr::V6(v6) => (v6.octets(), 128u8),
+    };
+
+    if prefix > max_prefix {
+        return None;
+    }
+
+    // For IPv4 entries the prefix is on the last 32 bits, so add the
+    // 96-bit IPv4-mapped prefix.
+    let effective_prefix = match addr {
+        std::net::IpAddr::V4(_) => 96 + prefix,
+        std::net::IpAddr::V6(_) => prefix,
+    };
+
+    Some(TrustedProxyCidr {
+        network: mask_to_prefix(octets, effective_prefix),
+        prefix_bits: effective_prefix,
+    })
+}
+
+fn mask_to_prefix(octets: [u8; 16], prefix_bits: u8) -> [u8; 16] {
+    let mut out = octets;
+    let full_bytes = (prefix_bits / 8) as usize;
+    let remaining_bits = prefix_bits % 8;
+    for byte in out.iter_mut().skip(full_bytes) {
+        *byte = 0;
+    }
+    if full_bytes < 16 && remaining_bits > 0 {
+        let mask = 0xffu8 << (8 - remaining_bits);
+        out[full_bytes] = octets[full_bytes] & mask;
+    }
+    out
+}
+
+fn ip_matches_cidr(ip: std::net::IpAddr, cidr: &TrustedProxyCidr) -> bool {
+    let octets = match ip {
+        std::net::IpAddr::V4(v4) => {
+            let mut buf = [0u8; 16];
+            buf[10] = 0xff;
+            buf[11] = 0xff;
+            buf[12..16].copy_from_slice(&v4.octets());
+            buf
+        }
+        std::net::IpAddr::V6(v6) => v6.octets(),
+    };
+    mask_to_prefix(octets, cidr.prefix_bits) == cidr.network
+}
+
+/// Decide whether a remote address is a trusted reverse-proxy.
+///
+/// The wildcard Caddy ingress in `scripts/install.sh` runs on the same
+/// host as the daemon and `reverse_proxy localhost:NN`, so the
+/// `X-Profile-Id` it sets always arrives over loopback. The fleet's
+/// trust model is therefore: loopback ⇒ trusted, anything else ⇒ untrusted
+/// unless the operator explicitly opts in via `OCTOS_TRUSTED_PROXY_CIDRS`
+/// (a comma-separated list of CIDRs).
+///
+/// `None` for the remote addr means we couldn't read `ConnectInfo` —
+/// e.g. axum tests built with `into_make_service()` rather than
+/// `into_make_service_with_connect_info()`. In production this never
+/// happens (`commands::serve` always uses the connect-info variant); in
+/// tests we treat missing connect-info as untrusted so the strip path
+/// is exercised. Tests that want to simulate a loopback hop must use
+/// `into_make_service_with_connect_info::<SocketAddr>()`.
+pub(crate) fn is_trusted_proxy_addr(addr: Option<std::net::IpAddr>) -> bool {
+    let Some(addr) = addr else {
+        return false;
+    };
+    if addr.is_loopback() {
+        return true;
+    }
+    let cidrs = trusted_proxy_cidrs();
+    cidrs.iter().any(|cidr| ip_matches_cidr(addr, cidr))
+}
+
+/// Middleware: strip `X-Profile-Id` from requests that did not originate
+/// from a trusted proxy.
+///
+/// This is the Layer 1 defence for issue #995. The header is meant to be
+/// set by the operator's Caddy ingress, which talks to the daemon over
+/// loopback — so anything not from loopback / a configured trusted
+/// proxy is treated as forged and the header is removed before any
+/// handler or downstream middleware can see it.
+async fn strip_untrusted_profile_id_middleware(
+    mut req: axum::http::Request<axum::body::Body>,
+    next: Next,
+) -> axum::response::Response {
+    let remote_ip = req
+        .extensions()
+        .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip());
+
+    if !is_trusted_proxy_addr(remote_ip) && req.headers().contains_key("x-profile-id") {
+        let raw = req
+            .headers()
+            .get("x-profile-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        req.headers_mut().remove("x-profile-id");
+        tracing::warn!(
+            target: "octos::api::auth",
+            remote_addr = ?remote_ip,
+            stripped_value = %raw,
+            uri = %req.uri(),
+            "X-Profile-Id stripped: request not from a trusted proxy (#995 hardening)"
+        );
+    }
+
+    next.run(req).await
 }
 
 /// Constant-time byte comparison to prevent timing attacks on auth tokens (no length leak).
@@ -1169,5 +1344,103 @@ mod tests {
         let list = cors_allowlist_for_base_domain(Some("bot.ominix.io"));
         assert!(!list.iter().any(|s| s.contains("evil.example.com")));
         assert!(!list.iter().any(|s| s.contains("ocean.ominix.io")));
+    }
+
+    // ── #995 — `is_trusted_proxy_addr` + CIDR parser ───────────────────
+
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn is_trusted_proxy_addr_accepts_ipv4_loopback() {
+        assert!(is_trusted_proxy_addr(Some(IpAddr::V4(Ipv4Addr::LOCALHOST))));
+    }
+
+    #[test]
+    fn is_trusted_proxy_addr_accepts_ipv6_loopback() {
+        assert!(is_trusted_proxy_addr(Some(IpAddr::V6(Ipv6Addr::LOCALHOST))));
+    }
+
+    #[test]
+    fn is_trusted_proxy_addr_rejects_public_ipv4() {
+        // 1.1.1.1 (Cloudflare DNS) is not in any default-trusted block,
+        // so without `OCTOS_TRUSTED_PROXY_CIDRS` it must be rejected.
+        assert!(!is_trusted_proxy_addr(Some(IpAddr::V4(Ipv4Addr::new(
+            1, 1, 1, 1
+        )))));
+    }
+
+    #[test]
+    fn is_trusted_proxy_addr_rejects_missing_connect_info() {
+        // Tests using `into_make_service()` (no ConnectInfo) end up here.
+        // We treat missing ConnectInfo as untrusted so the strip path
+        // actually fires under unit tests. Production wires
+        // `into_make_service_with_connect_info::<SocketAddr>()`.
+        assert!(!is_trusted_proxy_addr(None));
+    }
+
+    #[test]
+    fn is_trusted_proxy_addr_rejects_rfc1918_when_env_unset() {
+        // Defence-in-depth: by default we only trust loopback. RFC1918
+        // private blocks are NOT auto-trusted because a corp VPN may
+        // assign them to attacker workstations. Operators with a real
+        // upstream proxy on the LAN can opt in via
+        // `OCTOS_TRUSTED_PROXY_CIDRS`.
+        assert!(!is_trusted_proxy_addr(Some(IpAddr::V4(Ipv4Addr::new(
+            10, 0, 0, 1
+        )))));
+        assert!(!is_trusted_proxy_addr(Some(IpAddr::V4(Ipv4Addr::new(
+            192, 168, 1, 1
+        )))));
+    }
+
+    #[test]
+    fn parse_cidr_accepts_ipv4_block() {
+        let cidr = parse_cidr("10.0.0.0/8").expect("valid CIDR");
+        assert!(ip_matches_cidr(
+            IpAddr::V4(Ipv4Addr::new(10, 9, 8, 7)),
+            &cidr
+        ));
+        assert!(!ip_matches_cidr(
+            IpAddr::V4(Ipv4Addr::new(11, 0, 0, 1)),
+            &cidr
+        ));
+    }
+
+    #[test]
+    fn parse_cidr_accepts_single_ipv4_with_32_bit_prefix() {
+        let cidr = parse_cidr("192.168.42.7/32").expect("valid CIDR");
+        assert!(ip_matches_cidr(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 42, 7)),
+            &cidr
+        ));
+        assert!(!ip_matches_cidr(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 42, 8)),
+            &cidr
+        ));
+    }
+
+    #[test]
+    fn parse_cidr_rejects_oversize_prefix() {
+        // /33 is illegal for IPv4 — parse_cidr must return None rather
+        // than constructing a CIDR that vacuously matches everything.
+        assert!(parse_cidr("10.0.0.0/33").is_none());
+    }
+
+    #[test]
+    fn parse_cidr_accepts_ipv6_block() {
+        let cidr = parse_cidr("fd00::/8").expect("valid CIDR");
+        assert!(ip_matches_cidr("fd12::1".parse::<IpAddr>().unwrap(), &cidr));
+        assert!(!ip_matches_cidr(
+            "2001:db8::1".parse::<IpAddr>().unwrap(),
+            &cidr
+        ));
+    }
+
+    #[test]
+    fn parse_cidr_rejects_malformed_entry() {
+        assert!(parse_cidr("not-an-ip").is_none());
+        assert!(parse_cidr("10.0.0.0").is_none()); // missing prefix
+        assert!(parse_cidr("10.0.0.0/abc").is_none()); // non-numeric prefix
+        assert!(parse_cidr("").is_none());
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1833,7 +1833,7 @@ pub async fn ws_handler(
     identity: Option<Extension<AuthIdentity>>,
     headers: HeaderMap,
     uri: Uri,
-    ws: WebSocketUpgrade,
+    ws: Result<WebSocketUpgrade, axum::extract::ws::rejection::WebSocketUpgradeRejection>,
 ) -> Response {
     // #923.3 + #924 BLOCK 5: gate the upgrade on Origin. See
     // `decide_ws_origin_gate` for the full decision table.
@@ -1866,7 +1866,39 @@ pub async fn ws_handler(
     // connection so per-session resolution (notably plugin work_dir →
     // file-API root) can pick the right profile data dir even for admin
     // sessions originated from a hosted subdomain.
+    //
+    // #995 follow-up — when the request carries an authenticated
+    // identity AND the headers (Host or surviving `X-Profile-Id`)
+    // resolve to a tenant profile, the identity MUST be authorized for
+    // that profile. Pre-fix, an authenticated user-A could open a WS
+    // upgrade against a TRUSTED hop with `X-Profile-Id: B` and have
+    // `routed_profile_id` propagate through session/gateway routing.
+    // Mismatch is a hard `403` — the upgrade does NOT proceed.
+    //
+    // The `WebSocketUpgrade` extractor is wrapped in `Result<…>` so
+    // the authorization gate runs even when the upgrade prerequisites
+    // are missing (notably under `tower::oneshot` in tests, which has
+    // no `hyper::upgrade::OnUpgrade` extension). In production the
+    // upgrade extractor never fails on a real WS request; the wrapper
+    // is purely so the 403 can be observed end-to-end in unit tests.
     let routed_profile_id = super::handlers::routed_profile_id_from_headers(&state, &headers);
+    if let (Some(Extension(identity_inner)), Some(profile_id)) =
+        (identity.as_ref(), routed_profile_id.as_ref())
+    {
+        if !super::auth_handlers::is_authorized_for_profile(&state, identity_inner, profile_id) {
+            tracing::warn!(
+                target: "octos::ui_protocol::ws",
+                identity = ?identity_inner,
+                requested_profile = %profile_id,
+                "WS upgrade denied — authenticated identity not authorized for the routed profile (#995 follow-up)"
+            );
+            return (axum::http::StatusCode::FORBIDDEN, "forbidden").into_response();
+        }
+    }
+    let ws = match ws {
+        Ok(ws) => ws,
+        Err(rejection) => return rejection.into_response(),
+    };
     let features = ConnectionUiFeatures::from_headers_and_query(&headers, uri.query());
     // M12 Phase D-1: auxiliary REST→WS dispatchers reuse the same REST
     // handlers in `handlers.rs` for business logic, which means they
@@ -2181,7 +2213,15 @@ async fn ui_protocol_connection(
             // JSON body as the WS RPC result. No business logic is
             // duplicated; the REST endpoints stay unchanged.
             UiCommand::SessionList(params) => {
-                handle_session_list(&ws, &state, &connection_headers, id, params).await;
+                handle_session_list(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::SessionSnapshot(params) => {
                 handle_session_snapshot(
@@ -2206,7 +2246,15 @@ async fn ui_protocol_connection(
                 .await;
             }
             UiCommand::SessionStatusGet(params) => {
-                handle_session_status_get(&ws, &state, &connection_headers, id, params).await;
+                handle_session_status_get(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::SessionFilesList(params) => {
                 handle_session_files_list(
@@ -2220,7 +2268,15 @@ async fn ui_protocol_connection(
                 .await;
             }
             UiCommand::SessionTasksList(params) => {
-                handle_session_tasks_list(&ws, &state, &connection_headers, id, params).await;
+                handle_session_tasks_list(
+                    &ws,
+                    &state,
+                    &connection_headers,
+                    connection_identity.as_ref(),
+                    id,
+                    params,
+                )
+                .await;
             }
             UiCommand::SessionWorkspaceGet(params) => {
                 handle_session_workspace_get(
@@ -2582,7 +2638,7 @@ pub(crate) async fn stdio_connection(state: Arc<AppState>) -> eyre::Result<()> {
                 }
             }
             UiCommand::SessionList(params) => {
-                handle_session_list(&ws, &state, &connection_headers, id, params).await;
+                handle_session_list(&ws, &state, &connection_headers, None, id, params).await;
             }
             UiCommand::SessionSnapshot(params) => {
                 handle_session_snapshot(&ws, &state, &connection_headers, None, id, params).await;
@@ -2592,13 +2648,13 @@ pub(crate) async fn stdio_connection(state: Arc<AppState>) -> eyre::Result<()> {
                     .await;
             }
             UiCommand::SessionStatusGet(params) => {
-                handle_session_status_get(&ws, &state, &connection_headers, id, params).await;
+                handle_session_status_get(&ws, &state, &connection_headers, None, id, params).await;
             }
             UiCommand::SessionFilesList(params) => {
                 handle_session_files_list(&ws, &state, &connection_headers, None, id, params).await;
             }
             UiCommand::SessionTasksList(params) => {
-                handle_session_tasks_list(&ws, &state, &connection_headers, id, params).await;
+                handle_session_tasks_list(&ws, &state, &connection_headers, None, id, params).await;
             }
             UiCommand::SessionWorkspaceGet(params) => {
                 handle_session_workspace_get(&ws, &state, &connection_headers, None, id, params)
@@ -7248,10 +7304,13 @@ async fn handle_session_list(
     ws: &WsConnection,
     state: &Arc<AppState>,
     headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
     id: String,
     _params: SessionListParams,
 ) {
-    let response = super::handlers::list_sessions(State(state.clone()), headers.clone()).await;
+    let identity_ext = identity.cloned().map(Extension);
+    let response =
+        super::handlers::list_sessions(State(state.clone()), headers.clone(), identity_ext).await;
     let method = octos_core::ui_protocol::methods::SESSION_LIST;
     // Collection endpoint — no addressable session id. Treat any
     // (unexpected) 404 as a generic resource-not-found rather than
@@ -7271,6 +7330,7 @@ async fn handle_session_status_get(
     ws: &WsConnection,
     state: &Arc<AppState>,
     headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
     id: String,
     params: SessionStatusGetParams,
 ) {
@@ -7278,9 +7338,11 @@ async fn handle_session_status_get(
         topic: params.topic.clone(),
     });
     let session_id_str = params.session_id.clone();
+    let identity_ext = identity.cloned().map(Extension);
     let response = super::handlers::session_status(
         State(state.clone()),
         headers.clone(),
+        identity_ext,
         axum_path(params.session_id),
         topic_params,
     )
@@ -7330,6 +7392,7 @@ async fn handle_session_tasks_list(
     ws: &WsConnection,
     state: &Arc<AppState>,
     headers: &HeaderMap,
+    identity: Option<&AuthIdentity>,
     id: String,
     params: SessionTasksListParams,
 ) {
@@ -7337,9 +7400,11 @@ async fn handle_session_tasks_list(
         topic: params.topic.clone(),
     });
     let session_id_str = params.session_id.clone();
+    let identity_ext = identity.cloned().map(Extension);
     let response = super::handlers::session_tasks(
         State(state.clone()),
         headers.clone(),
+        identity_ext,
         axum_path(params.session_id),
         topic_params,
     )
@@ -7405,6 +7470,7 @@ async fn handle_session_snapshot(
     let status_fut = super::handlers::session_status(
         State(state.clone()),
         headers.clone(),
+        identity.cloned().map(Extension),
         axum_path(params.session_id.clone()),
         axum::extract::Query(super::handlers::TopicQueryParams {
             topic: params.topic.clone(),
@@ -7419,6 +7485,7 @@ async fn handle_session_snapshot(
     let tasks_fut = super::handlers::session_tasks(
         State(state.clone()),
         headers.clone(),
+        identity.cloned().map(Extension),
         axum_path(params.session_id),
         topic_params,
     );

--- a/crates/octos-cli/tests/x_profile_id_strip.rs
+++ b/crates/octos-cli/tests/x_profile_id_strip.rs
@@ -32,10 +32,14 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
+use axum::Extension;
 use axum::body::Body;
 use axum::extract::ConnectInfo;
-use axum::http::{Request, StatusCode};
-use octos_cli::api::{AppState, build_router};
+use axum::http::{HeaderMap, HeaderValue, Request, StatusCode};
+use octos_cli::api::{
+    AppState, TestAuthIdentity, TestSessionMessagesPaginationParams, build_router,
+    test_session_messages,
+};
 use tempfile::TempDir;
 use tower::util::ServiceExt;
 
@@ -625,5 +629,219 @@ async fn ws_upgrade_with_cross_tenant_header_on_trusted_hop_is_403() {
         "WS upgrade with cross-tenant X-Profile-Id on TRUSTED hop must \
          be denied before any frames are exchanged — GAP-6 of #995 \
          follow-up review"
+    );
+}
+
+/// Marker content stored in tenant B's session — used by the admin
+/// happy-path test to confirm the response body actually carries B's
+/// data (not an empty page from a cross-tenant 403 silently mapped to
+/// `[]`, and not an accidental fall-through to tenant A's history).
+const TENANT_B_MARKER: &str = "tenant-b-session-marker-payload";
+
+/// Build an `AppState` wired with a real `SessionManager` + a
+/// `profile_store`. Persists a single user message with
+/// [`TENANT_B_MARKER`] under tenant B's canonical
+/// `<profile>:api:<session_id>` key so `session_messages` can return
+/// it when authorized. Returns `(state, session_id)`.
+async fn build_state_with_sessions_for_tenant_b(
+    dir: &TempDir,
+    profiles: &[(&str, Option<&str>)],
+    tenant_b_id: &str,
+    session_id: &str,
+) -> Arc<AppState> {
+    let profile_store = Arc::new(octos_cli::profiles::ProfileStore::open(dir.path()).unwrap());
+    for (id, parent) in profiles {
+        let profile = octos_cli::profiles::UserProfile {
+            id: (*id).into(),
+            name: (*id).into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: parent.map(|p| p.into()),
+            public_subdomain: None,
+            config: Default::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        profile_store.save(&profile).unwrap();
+    }
+
+    let sessions_dir = dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    let manager = octos_bus::SessionManager::open(&sessions_dir).unwrap();
+    let sessions = Arc::new(tokio::sync::Mutex::new(manager));
+
+    // Persist tenant B's marker message under the canonical profiled
+    // key — the same shape `session_messages` probes first. Use a
+    // dedicated scope so the lock drops before we hand the manager to
+    // the AppState (the helper holds an exclusive lock during seed).
+    {
+        let key = octos_core::SessionKey::with_profile(tenant_b_id, "api", session_id);
+        let mut sess = sessions.lock().await;
+        sess.add_message(&key, octos_core::Message::user(TENANT_B_MARKER))
+            .await
+            .unwrap();
+    }
+
+    Arc::new(AppState {
+        profile_store: Some(profile_store),
+        sessions: Some(sessions),
+        auth_token: Some("admin-secret".into()),
+        ..AppState::empty_for_tests()
+    })
+}
+
+/// **#995 follow-up ROUND 3 — `session_messages` STANDALONE PATH.**
+///
+/// Codex round-2 review flagged the standalone `session_messages`
+/// path (`handlers.rs:306` → `api_profile_id_from_headers` raw) as
+/// the last bypass-prone surface in this PR:
+///
+/// > Passing `identity` only affects fallback breadth; it does not
+/// > reject cross-tenant headers. WS upgrade likely mitigates current
+/// > external reachability, but the handler remains bypass-prone /
+/// > re-exposure fragile.
+///
+/// This test reproduces the exact bypass shape: authenticated
+/// non-admin user `alice` on a TRUSTED (loopback) hop with
+/// `X-Profile-Id: bob`. Pre-fix, the handler built candidate
+/// `SessionKey`s using bob's profile id (the forged header) and
+/// returned bob's messages with `200 OK`. Post-fix, the
+/// `authorized_routed_profile_id_from_headers` gate at the top of
+/// `session_messages` (and the matching gate inside
+/// `standalone_api_session_key_candidates_with_topic` for
+/// defense-in-depth) rejects the request with `403` before any
+/// candidate is constructed.
+#[tokio::test]
+async fn should_reject_session_messages_cross_tenant_header_on_trusted_hop() {
+    let dir = TempDir::new().unwrap();
+    let session_id = "web-tenant-b-secret";
+    let state = build_state_with_sessions_for_tenant_b(
+        &dir,
+        &[("alice", None), ("bob", None)],
+        "bob",
+        session_id,
+    )
+    .await;
+
+    // Non-admin user identity for `alice`. `AuthIdentity::User` with
+    // `UserRole::User` so `is_authorized_for_profile` does not
+    // short-circuit on the admin-role branch.
+    let identity = Some(Extension(TestAuthIdentity::User {
+        id: "alice".into(),
+        role: octos_cli::user_store::UserRole::User,
+    }));
+
+    // The strip-middleware Layer 1 isn't relevant here (we're calling
+    // the handler directly, which is what the WS dispatcher does
+    // post-upgrade with the original headers preserved on a trusted
+    // hop). What matters is Layer 2: the handler MUST reject the
+    // cross-tenant header even though the request appears to come
+    // from loopback / a trusted proxy.
+    let mut headers = HeaderMap::new();
+    headers.insert("x-profile-id", HeaderValue::from_static("bob"));
+
+    let response = test_session_messages(
+        axum::extract::State(state),
+        headers,
+        identity,
+        axum::extract::Path(session_id.to_string()),
+        axum::extract::Query(TestSessionMessagesPaginationParams {
+            limit: 100,
+            offset: 0,
+            source: None,
+            since_seq: None,
+            topic: None,
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "authenticated non-admin user with X-Profile-Id pointing to a \
+         different tenant must be rejected with 403 BEFORE any session \
+         candidate is built. Got {} — this is the bypass shape codex \
+         round-2 flagged.",
+        response.status()
+    );
+
+    // Belt-and-suspenders: drain the body and confirm the response is
+    // NOT carrying tenant B's marker. A status-only check would miss
+    // a future regression where the 403 path accidentally serializes
+    // the candidate payload.
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body_str = std::str::from_utf8(&body).unwrap_or("<non-utf8>");
+    assert!(
+        !body_str.contains(TENANT_B_MARKER),
+        "403 response body must NOT contain tenant B's marker; got: {body_str}"
+    );
+}
+
+/// **#995 follow-up ROUND 3 — admin happy path on standalone
+/// `session_messages`.**
+///
+/// Admin auth + a cross-tenant `X-Profile-Id` on a TRUSTED hop is the
+/// legitimate per-tenant narrowing flow Caddy uses (admin token in
+/// front of a tenant subdomain). `is_authorized_for_profile`
+/// short-circuits to `true` on `AuthIdentity::Admin`, so the request
+/// MUST proceed past the new authorization gate and actually return
+/// tenant B's messages with `200 OK`.
+///
+/// Codex round 2 specifically flagged the predecessor test ("only
+/// asserts not 403/401"). This test goes further: it asserts
+/// `StatusCode::OK` AND that the response body literally contains
+/// [`TENANT_B_MARKER`], so a regression that silently substitutes
+/// tenant A's data (or returns an empty page) is caught.
+#[tokio::test]
+async fn should_serve_session_messages_when_admin_with_cross_tenant_header_on_trusted_hop() {
+    let dir = TempDir::new().unwrap();
+    let session_id = "web-tenant-b-canonical";
+    let state = build_state_with_sessions_for_tenant_b(
+        &dir,
+        &[("alice", None), ("bob", None)],
+        "bob",
+        session_id,
+    )
+    .await;
+
+    let identity = Some(Extension(TestAuthIdentity::Admin));
+
+    let mut headers = HeaderMap::new();
+    headers.insert("x-profile-id", HeaderValue::from_static("bob"));
+
+    let response = test_session_messages(
+        axum::extract::State(state),
+        headers,
+        identity,
+        axum::extract::Path(session_id.to_string()),
+        axum::extract::Query(TestSessionMessagesPaginationParams {
+            limit: 100,
+            offset: 0,
+            source: None,
+            since_seq: None,
+            topic: None,
+        }),
+    )
+    .await;
+
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body_str = std::str::from_utf8(&body).unwrap_or("<non-utf8>");
+
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "admin + cross-tenant X-Profile-Id on TRUSTED hop must serve \
+         the targeted tenant's messages with 200 OK (legitimate Caddy \
+         narrowing flow). Got status {status}, body {body_str}"
+    );
+    assert!(
+        body_str.contains(TENANT_B_MARKER),
+        "admin response must contain tenant B's marker `{TENANT_B_MARKER}`; \
+         got body: {body_str}"
     );
 }

--- a/crates/octos-cli/tests/x_profile_id_strip.rs
+++ b/crates/octos-cli/tests/x_profile_id_strip.rs
@@ -1,0 +1,241 @@
+//! Integration tests for the `X-Profile-Id` header strip middleware (issue
+//! [#995](https://github.com/octos-org/octos/issues/995)) and the handler
+//! precedence flip in `handlers::decide_resolved_profile_id`.
+//!
+//! ## What this guards
+//!
+//! Before the fix, `crates/octos-cli/src/api/handlers.rs:1442` resolved
+//! the request profile via `header.or(identity)` — an authenticated user
+//! could attach `X-Profile-Id: <victim>` and the daemon would walk
+//! straight into the victim's data dir. Both layers of the fix are
+//! exercised:
+//!
+//! 1. **Strip middleware** — non-loopback requests carrying
+//!    `X-Profile-Id` have the header removed before any handler sees it.
+//!    Hosted clients with no admin token and no Caddy ingress in front
+//!    are the attacker model.
+//! 2. **Handler authorization** — even if a trusted proxy DOES pass the
+//!    header through (the production Caddy path), the handler now
+//!    checks the authenticated identity owns the profile, returning
+//!    403 on mismatch instead of silently overriding.
+//!
+//! ## Why a `200`-only happy path isn't enough
+//!
+//! `tower::oneshot` builds requests without `ConnectInfo`, which the
+//! strip middleware treats as untrusted (see `is_trusted_proxy_addr`).
+//! Tests built this way DO exercise the strip path — and that's
+//! exactly what we want for the bypass guard: the `X-Profile-Id` MUST
+//! be stripped before any handler can latch onto it.
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use octos_cli::api::{AppState, build_router};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+/// Build an `AppState` with a `profile_store` containing the listed
+/// profiles. The store is shared with the auth manager (so OTP login
+/// can grant sessions for these ids) and the X-Profile-Id branch in
+/// `is_authorized_for_profile` can resolve sub-account parentage.
+fn build_state(_dir: &TempDir, profiles: &[(&str, Option<&str>)]) -> Arc<AppState> {
+    let store = Arc::new(octos_cli::profiles::ProfileStore::open(_dir.path()).unwrap());
+    for (id, parent) in profiles {
+        let profile = octos_cli::profiles::UserProfile {
+            id: (*id).into(),
+            name: (*id).into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: parent.map(|p| p.into()),
+            public_subdomain: None,
+            config: Default::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        store.save(&profile).unwrap();
+    }
+
+    Arc::new(AppState {
+        profile_store: Some(store),
+        auth_token: Some("admin-secret".into()),
+        ..AppState::empty_for_tests()
+    })
+}
+
+/// Sanity smoke: building the router with the strip middleware doesn't
+/// regress the public-health endpoint. Public routes must remain
+/// reachable regardless of header strip behaviour.
+#[tokio::test]
+async fn health_endpoint_remains_reachable_with_strip_middleware() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state(&dir, &[]);
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+/// The Layer 1 strip middleware: a non-loopback request carrying
+/// `X-Profile-Id` reaches the auth middleware with the header REMOVED.
+///
+/// We can't probe header presence from outside the daemon, so we
+/// exercise this through the auth middleware's `X-Profile-Id`-as-auth
+/// branch. That branch (router.rs ~711-744) accepts the header only
+/// when the request comes from loopback AND the profile exists. With
+/// `tower::oneshot` (no ConnectInfo → "untrusted") the strip middleware
+/// runs first and removes the header — so the request reaches the auth
+/// middleware with NO header to honor. The expected result is `401`,
+/// not the legacy `200` of the proxy-auth path.
+#[tokio::test]
+async fn untrusted_request_with_x_profile_id_falls_into_unauthorized_path() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state(&dir, &[("victim", None)]);
+    let app = build_router(state);
+
+    // No bearer token, no admin auth — the only signal we send is the
+    // forged `X-Profile-Id: victim`. Pre-fix the auth middleware would
+    // also have rejected this (the loopback check at router.rs:712-716
+    // catches the *auth* path), but the *handler* path inside
+    // `resolve_profile_data_dir` would have read the same raw header.
+    //
+    // The strip middleware closes both doors at once: the auth-path
+    // rejection is `401`, the handler-path rejection is `BAD_REQUEST` /
+    // `403`. Either way, no `200` with victim's data.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/files/list")
+                .header("x-profile-id", "victim")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "untrusted request with forged X-Profile-Id must be rejected, not honored"
+    );
+}
+
+/// Pre-fix bypass evidence: an authenticated request that sets
+/// `X-Profile-Id: <victim>` MUST NOT walk into the victim's data dir.
+/// Even if the strip middleware preserves the header (e.g. via a
+/// trusted proxy), the handler-layer authorization in
+/// `decide_resolved_profile_id` blocks the cross-tenant override.
+///
+/// Pre-fix (`header.or(identity)`): the daemon returned the victim's
+/// data dir / listings — silently. This test is the post-fix guard:
+/// the handler must NOT report a 200 with the victim's files.
+#[tokio::test]
+async fn authenticated_request_with_cross_tenant_x_profile_id_is_denied() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state(&dir, &[("alice", None), ("victim", None)]);
+    let app = build_router(state);
+
+    // Authenticate as the bootstrap admin token — that gives us a
+    // valid AuthIdentity::Admin. Admin is the most generous identity
+    // and would have surfaced the bypass most visibly pre-fix. With
+    // admin auth the strip middleware does NOT strip the header from a
+    // loopback path (loopback is trusted), so the handler-layer
+    // authorization check is what's under test here.
+    //
+    // Note: in `tower::oneshot` there's no ConnectInfo, so the strip
+    // middleware treats it as untrusted and removes the header. That
+    // already proves the Layer 1 guard. To exercise Layer 2 directly
+    // we cover it in the handlers.rs unit tests on
+    // `decide_resolved_profile_id`; this integration test asserts the
+    // end-to-end result for the bypass shape: status code MUST NOT be
+    // a 200 with victim's data.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/files/list")
+                .header("authorization", "Bearer admin-secret")
+                .header("x-profile-id", "victim")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Admin auth + stripped header + no process_manager → the handler
+    // hits the `resolve_api_port` -> SERVICE_UNAVAILABLE branch
+    // (gateway not configured under tests). The contract here is
+    // explicitly NOT 200: even when the legacy bypass would have
+    // resolved to "victim", the post-fix path can't honor the header
+    // because it never reaches the handler.
+    assert_ne!(
+        resp.status(),
+        StatusCode::OK,
+        "pre-fix bypass returned 200 with victim's data dir contents — \
+         post-fix this MUST be a non-success status"
+    );
+    // The exact code depends on environment: SERVICE_UNAVAILABLE when
+    // `process_manager` is absent (the test default), or
+    // FORBIDDEN/NOT_FOUND in fuller wirings. Pin to the family.
+    assert!(
+        resp.status().is_client_error() || resp.status().is_server_error(),
+        "non-success expected, got {}",
+        resp.status()
+    );
+}
+
+/// Even reaching the WS upgrade endpoint with a forged header on an
+/// unauthenticated, non-loopback request must not let the connection
+/// upgrade with a victim profile id pinned.
+///
+/// The WS handler stashes `routed_profile_id_from_headers(...)` onto
+/// the connection at upgrade time (ui_protocol.rs:1869). With the
+/// strip middleware in place the header is gone before the WS handler
+/// sees it, so the connection cannot be implicitly bound to the
+/// victim's profile through a forged header.
+#[tokio::test]
+async fn ws_upgrade_attempt_without_auth_with_forged_x_profile_id_fails() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state(&dir, &[("victim", None)]);
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/ui-protocol/ws")
+                .header("x-profile-id", "victim")
+                .header("connection", "Upgrade")
+                .header("upgrade", "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Without auth, without ConnectInfo (→ untrusted) and with the
+    // header stripped, the auth middleware rejects with 401. Pre-fix
+    // the auth middleware also rejected here (loopback check at
+    // router.rs:712), so this isn't a regression-only test —  it's a
+    // defence-in-depth assertion that the strip middleware doesn't
+    // accidentally open the WS handler to forged profile ids.
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "WS upgrade with forged header on untrusted hop must be 401"
+    );
+}

--- a/crates/octos-cli/tests/x_profile_id_strip.rs
+++ b/crates/octos-cli/tests/x_profile_id_strip.rs
@@ -29,13 +29,38 @@
 
 #![cfg(feature = "api")]
 
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use axum::body::Body;
+use axum::extract::ConnectInfo;
 use axum::http::{Request, StatusCode};
 use octos_cli::api::{AppState, build_router};
 use tempfile::TempDir;
 use tower::util::ServiceExt;
+
+/// Loopback `SocketAddr` for tests that need a TRUSTED hop (Caddy
+/// ingress is `127.0.0.1:NN` in production). `is_trusted_proxy_addr`
+/// returns `true` for any address whose `is_loopback()` is `true`,
+/// without consulting `OCTOS_TRUSTED_PROXY_CIDRS`.
+fn loopback_socket_addr() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 65432)
+}
+
+/// External `SocketAddr` for tests that need an UNTRUSTED hop. Cloudflare's
+/// `1.1.1.1` is outside any default-trusted block.
+fn external_socket_addr() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)), 4444)
+}
+
+/// Inject a `ConnectInfo<SocketAddr>` extension into the request. axum
+/// normally wires this up via `into_make_service_with_connect_info`,
+/// but for `tower::ServiceExt::oneshot` we have to attach the value
+/// manually so the strip middleware + auth middleware see a remote IP.
+fn with_connect_info(mut req: Request<Body>, addr: SocketAddr) -> Request<Body> {
+    req.extensions_mut().insert(ConnectInfo(addr));
+    req
+}
 
 /// Build an `AppState` with a `profile_store` containing the listed
 /// profiles. The store is shared with the auth manager (so OTP login
@@ -63,6 +88,84 @@ fn build_state(_dir: &TempDir, profiles: &[(&str, Option<&str>)]) -> Arc<AppStat
         auth_token: Some("admin-secret".into()),
         ..AppState::empty_for_tests()
     })
+}
+
+/// Build an `AppState` wired with a real `AuthManager` + `UserStore`
+/// + `ProfileStore`. Used by the trusted-hop tests that need a
+/// non-admin authenticated identity. `users` describes
+/// `(user_id, email, role)`, and `profiles` describes
+/// `(profile_id, parent_id)` matching the `build_state` helper.
+fn build_state_with_users(
+    dir: &TempDir,
+    users: &[(&str, &str, octos_cli::user_store::UserRole)],
+    profiles: &[(&str, Option<&str>)],
+) -> (Arc<AppState>, Arc<octos_cli::otp::AuthManager>) {
+    let profile_store = Arc::new(octos_cli::profiles::ProfileStore::open(dir.path()).unwrap());
+    for (id, parent) in profiles {
+        let profile = octos_cli::profiles::UserProfile {
+            id: (*id).into(),
+            name: (*id).into(),
+            enabled: true,
+            data_dir: None,
+            parent_id: parent.map(|p| p.into()),
+            public_subdomain: None,
+            config: Default::default(),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        profile_store.save(&profile).unwrap();
+    }
+
+    let user_store = Arc::new(octos_cli::user_store::UserStore::open(dir.path()).unwrap());
+    for (id, email, role) in users {
+        let user = octos_cli::user_store::User {
+            id: (*id).into(),
+            email: (*email).into(),
+            name: (*id).into(),
+            role: role.clone(),
+            created_at: chrono::Utc::now(),
+            last_login_at: None,
+        };
+        user_store.save(&user).unwrap();
+    }
+
+    // Use a static token so we don't need an SMTP send round-trip to
+    // mint a session.
+    let auth_config = octos_cli::otp::DashboardAuthConfig {
+        smtp: octos_cli::otp::SmtpConfig {
+            host: "unused".into(),
+            port: 587,
+            username: "unused@example.com".into(),
+            password_env: "UNUSED_PASSWORD".into(),
+            from_address: "unused@example.com".into(),
+        },
+        session_expiry_hours: 24,
+        allow_self_registration: false,
+        static_tokens: vec!["e2e-static-bypass".into()],
+    };
+    let auth_manager = Arc::new(octos_cli::otp::AuthManager::new(
+        Some(auth_config),
+        user_store.clone(),
+    ));
+
+    let state = Arc::new(AppState {
+        profile_store: Some(profile_store),
+        user_store: Some(user_store),
+        auth_manager: Some(auth_manager.clone()),
+        auth_token: Some("admin-secret".into()),
+        ..AppState::empty_for_tests()
+    });
+    (state, auth_manager)
+}
+
+/// Mint a session token for `email` via the configured static-token
+/// bypass. Panics if the static token is not configured on the auth
+/// manager (test setup bug).
+async fn mint_session_token(mgr: &octos_cli::otp::AuthManager, email: &str) -> String {
+    mgr.verify_otp_with_registration(email, "e2e-static-bypass", false)
+        .await
+        .expect("verify must succeed under static-token bypass")
+        .expect("session token must be issued")
 }
 
 /// Sanity smoke: building the router with the strip middleware doesn't
@@ -237,5 +340,290 @@ async fn ws_upgrade_attempt_without_auth_with_forged_x_profile_id_fails() {
         resp.status(),
         StatusCode::UNAUTHORIZED,
         "WS upgrade with forged header on untrusted hop must be 401"
+    );
+}
+
+// ── #995 follow-up — trusted-hop coverage ───────────────────────────
+//
+// The original PR only tested the untrusted hop (no ConnectInfo → the
+// strip middleware fires and erases the header). Codex pointed out
+// that Layer-2 (`decide_resolved_profile_id` + `is_authorized_for_profile`)
+// was untested end-to-end because the admin-token harness short-circuits
+// authorization in `is_authorized_for_profile`. These tests fix that
+// by attaching a `ConnectInfo` (loopback or external) and using a
+// non-admin authenticated identity.
+
+/// **TRUSTED + PRESERVE.** A request originating from `127.0.0.1`
+/// with a matching `X-Profile-Id` passes the strip middleware
+/// unchanged. The auth middleware's proxy-auth branch (header-as-auth)
+/// then accepts it and the request resolves to that profile. No 401,
+/// no 403 — this is the production Caddy-on-loopback flow.
+#[tokio::test]
+async fn loopback_request_preserves_x_profile_id_and_authorizes_as_proxy() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state(&dir, &[("alice", None)]);
+    let app = build_router(state).into_service();
+
+    // No `Authorization` header — the auth middleware will fall through
+    // to the proxy-auth branch which accepts the `X-Profile-Id` because
+    // the hop is trusted. The handler will hit a 503 (no
+    // process_manager) which is fine; the contract here is "no 401 / no
+    // 403", i.e. the strip middleware did NOT strip and the proxy-auth
+    // branch did accept.
+    let req = with_connect_info(
+        Request::builder()
+            .method("GET")
+            .uri("/api/files/list")
+            .header("x-profile-id", "alice")
+            .body(Body::empty())
+            .unwrap(),
+        loopback_socket_addr(),
+    );
+
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "loopback hop must not strip the legitimate X-Profile-Id; \
+         expected proxy-auth to accept and the handler to run"
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "no identity is even authenticated yet, so 403 would be wrong; \
+         got {}",
+        resp.status()
+    );
+}
+
+/// **TRUSTED + AUTHENTICATED USER + CROSS-TENANT HEADER.** This is the
+/// exact bypass shape from #995, exercised through the full router
+/// (Layer 1 PASS + Layer 2 must DENY). A real OTP-issued session for
+/// `alice` attaches `X-Profile-Id: bob` on a loopback hop. The strip
+/// middleware preserves the header (trusted hop), the auth middleware
+/// promotes the bearer to `AuthIdentity::User { id: "alice", role: User }`,
+/// the handler's `decide_resolved_profile_id` (or
+/// `authorized_routed_profile_id_from_headers`) sees the cross-tenant
+/// header, calls `is_authorized_for_profile`, and returns `403`.
+///
+/// The pre-fix code path returned the victim's data dir contents
+/// silently. The non-admin identity is critical here — the admin
+/// short-circuit in `is_authorized_for_profile` would have masked the
+/// bug.
+#[tokio::test]
+async fn authenticated_non_admin_with_cross_tenant_header_on_trusted_hop_is_403() {
+    let dir = TempDir::new().unwrap();
+    let (state, auth_manager) = build_state_with_users(
+        &dir,
+        &[
+            (
+                "alice",
+                "alice@example.com",
+                octos_cli::user_store::UserRole::User,
+            ),
+            (
+                "bob",
+                "bob@example.com",
+                octos_cli::user_store::UserRole::User,
+            ),
+        ],
+        &[("alice", None), ("bob", None)],
+    );
+    let token = mint_session_token(&auth_manager, "alice@example.com").await;
+    let app = build_router(state).into_service();
+
+    // Target a route that authorizes the routed profile via
+    // `resolve_api_port_authorized` (cancel_task uses that gate first,
+    // independent of whether a `process_manager` is wired).
+    let req = with_connect_info(
+        Request::builder()
+            .method("POST")
+            .uri("/api/tasks/some-task-id/cancel")
+            .header("authorization", format!("Bearer {token}"))
+            .header("x-profile-id", "bob")
+            .body(Body::empty())
+            .unwrap(),
+        loopback_socket_addr(),
+    );
+
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "authenticated non-admin user with X-Profile-Id pointing to \
+         a different tenant on a TRUSTED hop must be 403 — this is the \
+         exact #995 bypass shape"
+    );
+}
+
+/// **TRUSTED + ADMIN + CROSS-TENANT HEADER.** Admin tokens are
+/// legitimately allowed to narrow scope via `X-Profile-Id` on a
+/// loopback hop — that's how the operator's Caddy ingress
+/// authenticates the per-tenant subdomain. The admin
+/// short-circuit in `is_authorized_for_profile` returns `true`, so
+/// the request proceeds past Layer 2 authorization. The handler then
+/// hits a 503 because no `process_manager` is wired in the test
+/// fixture, but the contract here is "must NOT be 403" — admin is
+/// always allowed.
+#[tokio::test]
+async fn admin_with_cross_tenant_header_on_trusted_hop_is_not_403() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state(&dir, &[("alice", None), ("bob", None)]);
+    let app = build_router(state).into_service();
+
+    // Target a route that authorizes the routed profile via
+    // `resolve_api_port_authorized` so the admin short-circuit in
+    // `is_authorized_for_profile` is what's under test (admin must
+    // PASS the gate, not be denied).
+    let req = with_connect_info(
+        Request::builder()
+            .method("POST")
+            .uri("/api/tasks/some-task-id/cancel")
+            .header("authorization", "Bearer admin-secret")
+            .header("x-profile-id", "bob")
+            .body(Body::empty())
+            .unwrap(),
+        loopback_socket_addr(),
+    );
+
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "admin auth + cross-tenant header on TRUSTED hop must NOT be \
+         403 — this is the legitimate per-tenant narrowing flow that \
+         Caddy uses. Got {}",
+        resp.status()
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "admin auth must be honored, not rejected; got {}",
+        resp.status()
+    );
+}
+
+/// **EXTERNAL HOP + AUTHENTICATED USER + CROSS-TENANT HEADER.** When
+/// the request comes from a non-trusted address (e.g. an attacker who
+/// somehow reached the daemon directly), the Layer-1 strip middleware
+/// removes the header BEFORE the auth middleware sees it. The auth
+/// middleware then promotes the bearer to alice's identity, no
+/// `X-Profile-Id` is left for the handler to honor, and the request
+/// resolves to alice's own profile — never bob's. This exercises both
+/// Layer 1 (strip on untrusted hop) and Layer 2 (authorization)
+/// passing.
+#[tokio::test]
+async fn authenticated_non_admin_with_cross_tenant_header_on_external_hop_is_stripped() {
+    let dir = TempDir::new().unwrap();
+    let (state, auth_manager) = build_state_with_users(
+        &dir,
+        &[
+            (
+                "alice",
+                "alice@example.com",
+                octos_cli::user_store::UserRole::User,
+            ),
+            (
+                "bob",
+                "bob@example.com",
+                octos_cli::user_store::UserRole::User,
+            ),
+        ],
+        &[("alice", None), ("bob", None)],
+    );
+    let token = mint_session_token(&auth_manager, "alice@example.com").await;
+    let app = build_router(state).into_service();
+
+    let req = with_connect_info(
+        Request::builder()
+            .method("POST")
+            .uri("/api/tasks/some-task-id/cancel")
+            .header("authorization", format!("Bearer {token}"))
+            .header("x-profile-id", "bob")
+            .body(Body::empty())
+            .unwrap(),
+        external_socket_addr(),
+    );
+
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+
+    // The header was stripped on the external hop, so the handler
+    // resolves to alice's own profile (the identity path), not bob.
+    // The standalone path (no `process_manager`) returns 503 from the
+    // task supervisor; the contract here is the negative one: must
+    // NOT be 403 (no cross-tenant header reached the handler), must
+    // NOT succeed (no task with that id exists in this fixture, so
+    // even a properly-scoped lookup fails closed).
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "header was stripped before auth, so there is no cross-tenant \
+         header to deny; got {}",
+        resp.status()
+    );
+    assert!(
+        !resp.status().is_success(),
+        "external hop must never succeed in reading another tenant's \
+         data via a forged header; got {}",
+        resp.status()
+    );
+}
+
+/// **WS UPGRADE + TRUSTED + AUTHENTICATED USER + CROSS-TENANT HEADER.**
+/// The WS upgrade in `ui_protocol.rs:ws_handler` stashes
+/// `routed_profile_id_from_headers(...)` on the connection. On a
+/// TRUSTED hop the strip middleware preserves the header, so without
+/// the GAP-6 fix the connection would carry alice's identity AND bob's
+/// `routed_profile_id` into every downstream RPC. After the fix the
+/// upgrade returns 403 at the authorization gate, never completing the
+/// websocket handshake.
+#[tokio::test]
+async fn ws_upgrade_with_cross_tenant_header_on_trusted_hop_is_403() {
+    let dir = TempDir::new().unwrap();
+    let (state, auth_manager) = build_state_with_users(
+        &dir,
+        &[
+            (
+                "alice",
+                "alice@example.com",
+                octos_cli::user_store::UserRole::User,
+            ),
+            (
+                "bob",
+                "bob@example.com",
+                octos_cli::user_store::UserRole::User,
+            ),
+        ],
+        &[("alice", None), ("bob", None)],
+    );
+    let token = mint_session_token(&auth_manager, "alice@example.com").await;
+    let app = build_router(state).into_service();
+
+    let req = with_connect_info(
+        Request::builder()
+            .method("GET")
+            .uri("/api/ui-protocol/ws")
+            .header("authorization", format!("Bearer {token}"))
+            .header("x-profile-id", "bob")
+            .header("connection", "Upgrade")
+            .header("upgrade", "websocket")
+            .header("sec-websocket-version", "13")
+            .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .body(Body::empty())
+            .unwrap(),
+        loopback_socket_addr(),
+    );
+
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "WS upgrade with cross-tenant X-Profile-Id on TRUSTED hop must \
+         be denied before any frames are exchanged — GAP-6 of #995 \
+         follow-up review"
     );
 }


### PR DESCRIPTION
## Summary

P0 sev1 auth bypass: `X-Profile-Id` was trusted before any authorization check, letting authenticated users read another tenant's data dir by attaching `X-Profile-Id: <victim>`. Codex confirmed.

Two-layer fix:

- **Layer 1 — `strip_untrusted_profile_id_middleware` (router.rs)**: removes `X-Profile-Id` from any request that did not originate from loopback (or a CIDR allow-listed via `OCTOS_TRUSTED_PROXY_CIDRS`) before any handler or downstream auth middleware can read it.
- **Layer 2 — `decide_resolved_profile_id` (handlers.rs)**: replaces the legacy `header.or(identity)` precedence with identity-first authorization. If a header still arrives (i.e. preserved by Layer 1 because the request came from a trusted proxy), it must name a profile the authenticated identity is authorized for via `is_authorized_for_profile`. Mismatch is a hard `403`, never a silent override.

## Why two layers

The wildcard Caddy at `scripts/install.sh:1750-1763` legitimately sets `X-Profile-Id` from the request host on the same-host loopback hop, so we can't reject the header unconditionally. Layer 1 enforces the trust boundary at the proxy edge; Layer 2 catches mistakes in the trust model (e.g. an operator opens an off-host proxy without setting the env var, or a future regression weakens Layer 1).

## Call sites covered (all flow through `resolve_profile_data_dir` → `decide_resolved_profile_id`)

- `session_files` / `session_workspace_contract` — REST `:807, :845`
- `resolve_file_access_data_dir` — `:873, :887`
- `upload_site_files` — `:1148`
- `serve_file` / `serve_file_by_query` — `:1316, :1331`
- `serve_site_preview_*` — `:2030, :2049`
- `list_content_files` — `:2105`
- WS dispatchers (`session/files.list`, `session/workspace.get`, `session/snapshot`) — `ui_protocol.rs:7310, :7369, :7413`

`routed_profile_id_from_headers` and `host_scoped_profile_id` are NOT changed — host-header routing is correct (TLS-authenticated at Caddy). The `X-Profile-Id`-as-auth branch in `user_auth_middleware` was already loopback-gated and remains so.

## Trusted-proxy model

- **Loopback** (`127.0.0.0/8`, `::1`) → trusted by default. Matches the fleet's Caddy-on-the-same-host topology.
- **`OCTOS_TRUSTED_PROXY_CIDRS`** → comma-separated CIDRs (v4 or v6) for operators who run an off-host proxy. Parser rejects oversize prefixes and malformed entries.
- **Missing `ConnectInfo`** (axum tests built with `into_make_service()`) → treated as untrusted, so the strip path is exercised under unit tests. Production wires `into_make_service_with_connect_info::<SocketAddr>()`.

## Test coverage

- **`api::handlers::tests::decide_*`** (9 tests) — full decision table for `decide_resolved_profile_id`.
- **`api::router::tests::is_trusted_proxy_addr_*` / `parse_cidr_*`** (10 tests) — trusted-proxy classifier and CIDR parser.
- **`crates/octos-cli/tests/x_profile_id_strip.rs`** (4 tests) — full router stack: forged header on untrusted hop → `401`; authenticated + cross-tenant header → non-success; WS upgrade with forged header → `401`; `/health` regression guard.

Pre-fix evidence (captured under a temporary revert): unit test `decide_rejects_header_when_authenticated_identity_unauthorized_for_it` panicked with `"must reject cross-tenant header: \"bob\""` — the legacy `header.or(identity)` returned the victim's profile id (`"bob"`) when authenticated as `alice`, matching the bypass shape Codex confirmed.

## Test plan

- [x] `cargo build --workspace --features api` clean
- [x] `cargo test -p octos-cli --features api --lib` — 1037 passed (3 pre-existing `ui_protocol::session_open_*` capability-list failures also present on `origin/main`, unrelated to this fix)
- [x] `cargo test -p octos-cli --features api --test x_profile_id_strip` — 4/4 pass
- [x] `cargo test -p octos-cli --features api --tests` per-binary — all 9 integration test binaries pass (cli_tests, coding_multi_session, content_classifier_wiring, credential_pool_wiring, mcp_serve_integration, skill_compat_gate, speculative_overflow_delivery, swarm_api, x_profile_id_strip)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-cli --features api --lib` — 36 warnings, identical count to `origin/main`
- [ ] Codex review (per #995 dispatcher request — do not admin-merge)