### PR TITLE
fix(slides): reconcile mofa_slides_contract artifact source (closes #998)

### DIFF
--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -728,6 +728,19 @@ impl WorkspacePolicy {
         let mut artifacts = BTreeMap::new();
         artifacts.insert("primary_audio".into(), "*.mp3".into());
         artifacts.insert("podcast_audio".into(), "**/podcast_full_*.*".into());
+        // Issue #998: `mofa_slides` plugin emits a `.pptx` via `files_to_send`
+        // (auto-detected by `PluginTool::detect_output_file` from the
+        // skill's "Generated PPTX: <path>" stdout marker or an explicit
+        // `out` arg — see `plugins/tool.rs:550-625, 1321-1361`). The
+        // contract layer's `bind_explicit_files_to_artifacts` requires a
+        // named artifact source to bind the reported file into
+        // `ActionContext`; without one it returns "workspace contract has
+        // no artifact source" (`workspace_contract.rs:333-336`) on every
+        // successful slides run. Declaring the artifact here gives the
+        // mofa_slides contract a target name to reference and matches the
+        // recursive `**/*.pptx` glob already used by the MagicBytes(Pptx)
+        // validator on `on_completion`.
+        artifacts.insert("slides_pptx".into(), "**/*.pptx".into());
 
         let tts_contract = WorkspaceSpawnTaskPolicy {
             artifact: Some("primary_audio".into()),
@@ -860,8 +873,22 @@ impl WorkspacePolicy {
         // the local-file-header / end-of-central-directory ZIP signature
         // is present at byte 0. The glob runs recursively so the policy
         // also catches slides written to nested subdirectories.
+        //
+        // Issue #998: the slides plugin reports its generated PPTX via
+        // `files_to_send` (parsed at `plugins/tool.rs:1321-1361` from a
+        // JSON envelope OR auto-detected from a "Generated PPTX: <path>"
+        // stdout marker — see `plugins/tool.rs:550-625` and the test at
+        // `plugins/tool.rs:2064-2103`). The contract layer's
+        // `bind_explicit_files_to_artifacts` (`workspace_contract.rs:329-357`)
+        // requires `artifact_sources()` to be non-empty so it can bind the
+        // reported PPTX into a named slot in `ActionContext`. Declaring
+        // `artifact: Some("slides_pptx")` matches the artifact entry
+        // registered above (`for_session` artifacts map) whose glob
+        // (`**/*.pptx`) is the same recursive pattern the on-completion
+        // MagicBytes validator uses, so the two checks see a consistent
+        // set of paths.
         let mofa_slides_contract = WorkspaceSpawnTaskPolicy {
-            artifact: None,
+            artifact: Some("slides_pptx".into()),
             artifacts: Vec::new(),
             on_verify: Vec::new(),
             on_complete: vec![],

--- a/crates/octos-agent/tests/validator_runner.rs
+++ b/crates/octos-agent/tests/validator_runner.rs
@@ -768,3 +768,73 @@ async fn should_block_command_validator_with_dangerous_pattern() {
             || outcome.reason.to_lowercase().contains("policy")
     );
 }
+
+#[tokio::test]
+async fn should_bind_files_to_send_to_artifact_for_mofa_slides_contract() {
+    // Issue #998 (P0 functional): `mofa_slides_contract` declared no artifact
+    // source in `for_session()`, so when the plugin reports `files_to_send`
+    // (auto-detected by `PluginTool::detect_output_file` for "Generated PPTX:
+    // <path>" stdout lines — see `plugins/tool.rs:2064-2103`), the contract
+    // layer entered `bind_explicit_files_to_artifacts` with an empty
+    // `artifact_sources()` list and returned "workspace contract has no
+    // artifact source" (`workspace_contract.rs:333-336`), failing every
+    // successful slides run at the post-tool gate.
+    //
+    // The contract must now bind the reported PPTX into a named artifact so
+    // `resolve_artifacts` produces a populated `ActionContext` and the typed
+    // MagicBytes(Pptx) validator runs against real artifact paths.
+    use octos_agent::workspace_contract::{SpawnTaskContractResult, enforce_spawn_task_contract};
+    use octos_agent::workspace_policy::WorkspacePolicy;
+    use std::time::UNIX_EPOCH;
+
+    let dir = tempdir().unwrap();
+    // Write the default session policy unmodified — this is the policy the
+    // bundled mofa_slides spawn task runs against today.
+    let policy = WorkspacePolicy::for_session();
+    octos_agent::workspace_policy::write_workspace_policy(dir.path(), &policy).unwrap();
+
+    // Lay down a real PPTX-shaped file under the slides plugin's typical
+    // output path so the MagicBytes(Pptx) validator declared on the
+    // `on_completion` list of `mofa_slides_contract` passes. The first two
+    // bytes of a real PPTX (a ZIP container) are `PK`, matching `0x50 0x4B`.
+    let out_dir = dir.path().join("output");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    let pptx_path = out_dir.join("deck.pptx");
+    let mut pptx = vec![0u8; 64];
+    pptx[0] = 0x50; // 'P'
+    pptx[1] = 0x4B; // 'K'
+    pptx[2] = 0x03;
+    pptx[3] = 0x04;
+    std::fs::write(&pptx_path, &pptx).unwrap();
+
+    let registry = ToolRegistry::with_builtins(dir.path());
+    // Pass the PPTX through `files_to_send` exactly as `PluginTool` does at
+    // `plugins/tool.rs:1321-1329` after parsing the plugin envelope.
+    let files_to_send = vec![pptx_path.clone()];
+    let result = enforce_spawn_task_contract(
+        &registry,
+        "mofa_slides",
+        "tool-call-slides-1",
+        &files_to_send,
+        UNIX_EPOCH,
+        None,
+    )
+    .await;
+
+    match result {
+        SpawnTaskContractResult::Satisfied { output_files } => {
+            assert!(
+                output_files
+                    .iter()
+                    .any(|p| p.ends_with("deck.pptx") || p.ends_with("output/deck.pptx")),
+                "satisfied result must surface the reported PPTX, got {output_files:?}"
+            );
+        }
+        SpawnTaskContractResult::Failed { error, .. } => panic!(
+            "mofa_slides contract must accept a valid PPTX via files_to_send, got Failed: {error}"
+        ),
+        SpawnTaskContractResult::NotConfigured { reason, .. } => panic!(
+            "mofa_slides contract must be configured in for_session policy, got NotConfigured: {reason:?}"
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #998 (P0 functional). The `mofa_slides` spawn-task contract was declared with `artifact: None` and `artifacts: Vec::new()` in `WorkspacePolicy::for_session` (`crates/octos-agent/src/workspace_policy.rs:863-874`), while the slides plugin reports the generated PPTX via `files_to_send` — either from a JSON `files_to_send` array on the plugin envelope (`crates/octos-agent/src/plugins/tool.rs:1321-1329`) or via the auto-detect path that scrapes "Generated PPTX: <path>" / "Generated: <path>" stdout markers (`crates/octos-agent/src/plugins/tool.rs:550-625, 1354-1361, 2064-2103`).

When `files_to_send` is non-empty, `resolve_artifacts` routes through `bind_explicit_files_to_artifacts` (`crates/octos-agent/src/workspace_contract.rs:265-281`), which requires `task_policy.artifact_sources()` to be non-empty so it can bind the reported file into a named slot on the `ActionContext`. With no artifact source declared, every successful slides run failed the post-tool gate with `"workspace contract has no artifact source"` (`crates/octos-agent/src/workspace_contract.rs:333-336`).

## Fix

- Add `slides_pptx -> **/*.pptx` to the session policy artifacts map (`for_session`).
- Set `mofa_slides_contract.artifact = Some("slides_pptx".into())`.

### Why this `Artifact::*` variant

The contract's `artifact` field is `Option<String>` referencing a named entry in `WorkspaceArtifactsPolicy.entries: BTreeMap<name, glob_pattern>`. The other slides-adjacent contracts in the same policy (`mofa-podcast`, `fm_tts`, `voice_synthesize`) all use the same shape: `artifact: Some("<named_pattern>")`. There is no `Artifact::PluginFilesToSend` variant in the data model — `files_to_send` is the runtime transport, and `bind_explicit_files_to_artifacts` binds those reported files into the contract's declared artifact slot.

I picked the recursive glob `**/*.pptx` because (a) it mirrors the glob already used by the on-completion `MagicBytes(Pptx)` validator on `mofa_slides_contract`, so the artifact resolver and the typed validator see a consistent set of paths, and (b) it matches both the test fixture (`slides/demo/output/deck.pptx`) and the slides-kind workspace's canonical layout (`output/deck.pptx`).

## Codex evidence (from issue #998)

| Location | Symptom |
| -------- | ------- |
| `crates/octos-agent/src/workspace_policy.rs:863-874` | `artifact: None, artifacts: Vec::new()` |
| `crates/octos-agent/src/plugins/tool.rs:1354, 2064-2103` | plugin emits via `files_to_send` |
| `crates/octos-agent/src/workspace_contract.rs:265, 333` | binding errors with `"workspace contract has no artifact source"` |

## Test plan

- [x] New `should_bind_files_to_send_to_artifact_for_mofa_slides_contract` in `crates/octos-agent/tests/validator_runner.rs` writes a real PPTX header to a fake output, threads it through `enforce_spawn_task_contract` exactly as the agent loop does, and asserts `Satisfied`. Pre-fix this returned `Failed { error: "workspace contract has no artifact source" }`.
- [x] `cargo build --workspace --features api` clean
- [x] `cargo test -p octos-agent` all green (1439 lib + 16 validator_runner + 13 abi_compat, etc.)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --features api` — no new warnings vs main baseline (37 warnings on both)

Codex review requested; do not admin-merge until reviewed.