### PR TITLE
fix(api): gate session/files.list + session/workspace.get with host_scoped_profile_id (closes #999)

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -998,12 +998,28 @@ pub async fn session_files(
     identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Response {
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+
+    // Issue #999 — gateway-mode tenant-leak guard. Pre-fix the
+    // `state.sessions.is_some()` branch short-circuited to
+    // `sess.data_dir()` (the gateway/standalone top-level) BEFORE
+    // checking the host-routed profile. An authenticated non-admin
+    // user on a TRUSTED hop with a cross-tenant `X-Profile-Id` (or a
+    // host-routed cross-tenant subdomain) walked straight into the
+    // victim profile's workspace listing. Layer-2 authorization runs
+    // up-front now, mirroring `session_messages` (#1002): a forged
+    // cross-tenant header is `403` regardless of which side of the
+    // sessions / no-sessions branch resolves the data_dir below.
+    if let Err(response) = authorized_routed_profile_id_from_headers(&state, &headers, identity_ref)
+    {
+        return response;
+    }
+
     let data_dir = if let Some(sessions) = &state.sessions {
         let sess = sessions.lock().await;
         sess.data_dir()
     } else {
-        let identity = identity.as_ref().map(|ext| &ext.0);
-        match resolve_profile_data_dir(&state, &headers, identity).await {
+        match resolve_profile_data_dir(&state, &headers, identity_ref).await {
             Ok(data_dir) => data_dir,
             Err(response) => return response,
         }
@@ -1036,12 +1052,26 @@ pub async fn session_workspace_contract(
     identity: Option<Extension<AuthIdentity>>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Response {
+    let identity_ref = identity.as_ref().map(|ext| &ext.0);
+
+    // Issue #999 — gateway-mode tenant-leak guard. Same shape as the
+    // companion `session_files` handler above: pre-fix the
+    // `state.sessions.is_some()` branch short-circuited to
+    // `sess.data_dir()` BEFORE checking the host-routed profile, so a
+    // cross-tenant header on a TRUSTED hop exposed the victim
+    // profile's workspace-contract statuses. The Layer-2 gate runs
+    // up-front; `state.sessions.data_dir()` only resolves when the
+    // routed profile is authorized (admin / owner / self).
+    if let Err(response) = authorized_routed_profile_id_from_headers(&state, &headers, identity_ref)
+    {
+        return response;
+    }
+
     let data_dir = if let Some(sessions) = &state.sessions {
         let sess = sessions.lock().await;
         sess.data_dir()
     } else {
-        let identity = identity.as_ref().map(|ext| &ext.0);
-        match resolve_profile_data_dir(&state, &headers, identity).await {
+        match resolve_profile_data_dir(&state, &headers, identity_ref).await {
             Ok(data_dir) => data_dir,
             Err(response) => return response,
         }

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -59,10 +59,18 @@ pub mod testing {
 // here for that purpose, plus `AuthIdentity` so tests can construct
 // non-admin and admin identities directly without booting a real auth
 // middleware stack.
+//
+// Issue #999 — `session_files` and `session_workspace_contract` are
+// exposed via the same harness for the same reason: the legacy REST
+// routes `GET /api/sessions/{id}/files` and
+// `GET /api/sessions/{id}/workspace-contract` were retired, so the
+// only way to exercise the gateway-mode tenant-leak bypass shape end
+// -to-end is to call the WS handlers directly.
 #[doc(hidden)]
 pub use handlers::{
-    PaginationParams as TestSessionMessagesPaginationParams,
+    PaginationParams as TestSessionMessagesPaginationParams, session_files as test_session_files,
     session_messages as test_session_messages,
+    session_workspace_contract as test_session_workspace_contract,
 };
 #[doc(hidden)]
 pub use router::AuthIdentity as TestAuthIdentity;

--- a/crates/octos-cli/tests/x_profile_id_strip.rs
+++ b/crates/octos-cli/tests/x_profile_id_strip.rs
@@ -38,7 +38,7 @@ use axum::extract::ConnectInfo;
 use axum::http::{HeaderMap, HeaderValue, Request, StatusCode};
 use octos_cli::api::{
     AppState, TestAuthIdentity, TestSessionMessagesPaginationParams, build_router,
-    test_session_messages,
+    test_session_files, test_session_messages, test_session_workspace_contract,
 };
 use tempfile::TempDir;
 use tower::util::ServiceExt;
@@ -843,5 +843,137 @@ async fn should_serve_session_messages_when_admin_with_cross_tenant_header_on_tr
         body_str.contains(TENANT_B_MARKER),
         "admin response must contain tenant B's marker `{TENANT_B_MARKER}`; \
          got body: {body_str}"
+    );
+}
+
+/// **Issue #999 — `session/files.list` GATEWAY-MODE TENANT LEAK.**
+///
+/// Pre-fix `handlers.rs::session_files` short-circuited to
+/// `state.sessions.lock().data_dir()` whenever a `SessionManager` was
+/// wired — the gateway/standalone top-level — BEFORE checking the
+/// host-routed profile. An authenticated non-admin user on a TRUSTED
+/// hop with `X-Profile-Id: <victim>` walked straight past the routing
+/// layer into whatever workspaces lived under that data_dir, with
+/// **`200 OK`** as the response. The correct fix mirrors
+/// `session_messages` (#1002): the
+/// `authorized_routed_profile_id_from_headers` gate runs FIRST and
+/// rejects a cross-tenant header with `403` regardless of which side
+/// of the sessions / no-sessions branch ultimately resolves the
+/// `data_dir` below.
+///
+/// Pre-fix expectation: this test returns `200` (the bypass shape).
+/// Post-fix expectation: `403` BEFORE any filesystem walk runs.
+#[tokio::test]
+async fn should_reject_session_files_list_cross_tenant() {
+    let dir = TempDir::new().unwrap();
+    let session_id = "web-tenant-b-files";
+    // Reuse the tenant-B harness — `state.sessions` is wired and the
+    // SessionManager already has tenant B's marker message persisted.
+    // The shape under test is `session_files` (workspace filesystem
+    // listing) not `session_messages`, but the AppState shape and the
+    // bypass surface are identical.
+    let state = build_state_with_sessions_for_tenant_b(
+        &dir,
+        &[("alice", None), ("bob", None)],
+        "bob",
+        session_id,
+    )
+    .await;
+
+    // Plant a marker file under the path the pre-fix walker would
+    // enumerate. `api_session_workspace_dirs` walks
+    // `<data_dir>/users/<encoded_session_key>/workspace/` — by
+    // dropping a file there we can prove a pre-fix 200 response
+    // would have leaked that file's name, while the post-fix path
+    // returns 403 before any filesystem walk runs. The plant is
+    // best-effort; the contract under test is `status == 403`
+    // regardless of whether the plant path is reachable.
+    let bare_key = octos_core::SessionKey::new("api", session_id);
+    let encoded = octos_bus::session::encode_path_component(bare_key.base_key());
+    let workspace = dir.path().join("users").join(&encoded).join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::write(workspace.join("tenant-b-leak-marker.txt"), b"leak").unwrap();
+
+    let identity = Some(Extension(TestAuthIdentity::User {
+        id: "alice".into(),
+        role: octos_cli::user_store::UserRole::User,
+    }));
+
+    let mut headers = HeaderMap::new();
+    headers.insert("x-profile-id", HeaderValue::from_static("bob"));
+
+    let response = test_session_files(
+        axum::extract::State(state),
+        headers,
+        identity,
+        axum::extract::Path(session_id.to_string()),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "authenticated non-admin user with cross-tenant X-Profile-Id \
+         must be 403 BEFORE the handler walks `state.sessions.data_dir()` \
+         — issue #999. Pre-fix this returned 200 with the workspace \
+         listing under the gateway top-level data dir."
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let body_str = std::str::from_utf8(&body).unwrap_or("<non-utf8>");
+    assert!(
+        !body_str.contains("tenant-b-leak-marker"),
+        "403 response body must NOT contain the planted marker filename; \
+         got: {body_str}"
+    );
+}
+
+/// **Issue #999 — `session/workspace.get` GATEWAY-MODE TENANT LEAK.**
+///
+/// Sibling test to `should_reject_session_files_list_cross_tenant`
+/// targeting `handlers.rs::session_workspace_contract`. The pre-fix
+/// shape is identical: `state.sessions.is_some()` bypassed
+/// host-routing entirely and walked
+/// `<gateway top-level data_dir>/users/.../workspace/` for repo
+/// contracts. Same Layer-2 gate, same contract: cross-tenant header
+/// on a TRUSTED hop is `403`.
+#[tokio::test]
+async fn should_reject_session_workspace_get_cross_tenant() {
+    let dir = TempDir::new().unwrap();
+    let session_id = "web-tenant-b-workspace";
+    let state = build_state_with_sessions_for_tenant_b(
+        &dir,
+        &[("alice", None), ("bob", None)],
+        "bob",
+        session_id,
+    )
+    .await;
+
+    let identity = Some(Extension(TestAuthIdentity::User {
+        id: "alice".into(),
+        role: octos_cli::user_store::UserRole::User,
+    }));
+
+    let mut headers = HeaderMap::new();
+    headers.insert("x-profile-id", HeaderValue::from_static("bob"));
+
+    let response = test_session_workspace_contract(
+        axum::extract::State(state),
+        headers,
+        identity,
+        axum::extract::Path(session_id.to_string()),
+    )
+    .await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "authenticated non-admin user with cross-tenant X-Profile-Id \
+         must be 403 BEFORE `session_workspace_contract` walks any \
+         repository under `state.sessions.data_dir()` — issue #999. \
+         Pre-fix this returned 200 with the workspace-contract \
+         statuses from the gateway top-level data dir."
     );
 }


### PR DESCRIPTION
## Summary

P1 gateway-mode tenant-leak (issue #999). Two WS handlers short-circuited to `state.sessions.lock().data_dir()` BEFORE checking the host-routed profile:

- `crates/octos-cli/src/api/handlers.rs:995` — `session_files` (backs `session/files.list`)
- `crates/octos-cli/src/api/handlers.rs:1049` — `session_workspace_contract` (backs `session/workspace.get`)

An authenticated non-admin user on a TRUSTED hop with a cross-tenant `X-Profile-Id` (or via a host-routed cross-tenant subdomain) walked straight past the routing layer into the victim profile's workspace listing / repository contracts, with `200 OK` as the response. The correct host-scope-first pattern was already in place at `list_content_files` (`handlers.rs:2746`).

## Fix

Both handlers now call `authorized_routed_profile_id_from_headers` up-front. A cross-tenant header is rejected with `403` before the filesystem walk runs; admin / owner-of-sub-account / self continue past the gate.

This builds on the broader `X-Profile-Id` strip + handler authorization landed in PR #1002 (closes #995). The pattern mirrors `session_messages` (the round-3 fix in #1002) exactly — call the `_authorized` helper first, fail-closed on mismatch.

## Codex evidence

Codex audit confirmed the bypass: pre-fix the two handlers ignored the host-routed profile entirely whenever `state.sessions.is_some()` (the standalone / per-tenant-daemon deployment shape), reading workspaces under the daemon's gateway top-level data_dir regardless of the requested tenant.

## Tests

`crates/octos-cli/tests/x_profile_id_strip.rs` gains two regression guards extending the existing #995 suite (11 → 13 tests):

- `should_reject_session_files_list_cross_tenant`
- `should_reject_session_workspace_get_cross_tenant`

Both reproduce the bypass shape (alice + `X-Profile-Id: bob` on loopback against an `AppState` with `state.sessions` wired) and assert `403`. Pre-fix both returned `200`; post-fix both return `403`.

The `should_reject_session_files_list_cross_tenant` test additionally plants a marker file under the path the pre-fix walker would enumerate, so a regression that flips back to `200` is caught with a body-content assertion.

## Test plan

- [x] `cargo build --workspace --features api` clean
- [x] `cargo test -p octos-cli --features api --test x_profile_id_strip` — all 13 green (11 existing + 2 new)
- [x] `cargo fmt --all -- --check` clean
- [x] No new clippy warnings (only pre-existing doc-list-indent warnings on the test file's earlier sections)
- [x] Pre-fix RED confirmed: stash the handler diff and the two new tests fail with `left: 200, right: 403`