### PR TITLE
feat(api): /api/preview-signed/{token} endpoint (follow-up to #1001)

### DIFF
--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -3266,7 +3266,11 @@ pub async fn sign_preview(
         return StatusCode::NOT_FOUND.into_response();
     }
 
-    // (5) Mint the token.
+    // (5) Mint the token. Codex GAP 8: distinguish OS-level entropy
+    //     failures (503) from rate-limit refusals (429) so the SPA can
+    //     differentiate "retry the daemon" from "you're holding too
+    //     many previews open already".
+    use crate::api::preview_tokens::IssueError;
     match state
         .preview_tokens
         .issue(
@@ -3279,9 +3283,27 @@ pub async fn sign_preview(
         .await
     {
         Ok(resp) => (StatusCode::OK, Json(resp)).into_response(),
-        Err(err) => {
+        Err(IssueError::Random(err)) => {
             tracing::error!(error = %err, "sign_preview: getrandom failed");
             (StatusCode::SERVICE_UNAVAILABLE, "token mint failed").into_response()
+        }
+        Err(IssueError::PerBearerLimitReached) => {
+            tracing::warn!("sign_preview: per-bearer cap reached (codex GAP 8 backpressure)");
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                "too many outstanding preview tokens for this session — wait for expiry or close some iframes",
+            )
+                .into_response()
+        }
+        Err(IssueError::GlobalLimitReached) => {
+            tracing::error!(
+                "sign_preview: GLOBAL preview-token cap reached — possible DoS or runaway client"
+            );
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                "preview-token cache is full; daemon is rate-limiting",
+            )
+                .into_response()
         }
     }
 }

--- a/crates/octos-cli/src/api/handlers.rs
+++ b/crates/octos-cli/src/api/handlers.rs
@@ -3157,6 +3157,254 @@ pub async fn health() -> Json<serde_json::Value> {
     }))
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+//  Issue #1001 follow-up: signed-URL preview endpoint.
+//
+//  PR #1001 required `Authorization: Bearer ...` on
+//  `/api/preview/{profile_id}/{session_id}/{site_slug}/{*path}`. The SPA's
+//  `<iframe src=/api/preview/...>` cannot inject headers, so the iframe
+//  401-loops after PR #1001 landed.
+//
+//  Codex design: mint a 256-bit random token via
+//  `POST /api/my/preview/sign`, store a server-side grant
+//  `{issuer_bearer, identity_snapshot, profile_id, session_id, site_slug,
+//  expires_at}` in `AppState.preview_tokens`, and serve the preview via
+//  PUBLIC route `GET /api/preview-signed/{token}/{*path}`. The token IS the
+//  auth credential.
+//
+//  Revocation: `serve_signed_preview` re-resolves the issuer bearer on
+//  every request — logout / session-delete invalidate naturally because
+//  `resolve_identity` will return `None` for a revoked bearer. Daemon
+//  restart drops the in-memory `PreviewTokens` cache, invalidating every
+//  outstanding grant.
+//
+//  See `crates/octos-cli/src/api/preview_tokens.rs` for full design
+//  rationale on the token-cache module itself.
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Body for `POST /api/my/preview/sign`.
+#[derive(Deserialize)]
+pub struct SignPreviewRequest {
+    pub profile_id: String,
+    pub session_id: String,
+    pub site_slug: String,
+}
+
+/// `POST /api/my/preview/sign` — mint an opaque signed-preview token.
+///
+/// Flow:
+/// 1. Auth middleware has already populated `Extension<AuthIdentity>` — if
+///    it's missing the router routed an unauthenticated request into this
+///    handler, which is a routing bug. Fail closed with 401.
+/// 2. Extract the bearer that the auth middleware accepted (we re-validate
+///    it on every `serve_signed_preview` call, so we need to store the
+///    same string here). Falling back to query `?token=` matches
+///    `extract_token` in `router.rs`.
+/// 3. Identity must be authorized for the requested `profile_id`. Codex
+///    design: this is the same `is_authorized_for_profile` gate the
+///    `/api/preview/...` route uses, so the signing surface is no looser
+///    than the route it bridges to.
+/// 4. Validate that `<data_dir>/users/<encoded_session_key>/workspace/sites/<slug>`
+///    exists. Without this check, a caller who legitimately owns
+///    `profile_id` could mint a token for a nonexistent session — not a
+///    security boundary (the serve handler would 404 anyway), but it lets
+///    the SPA surface a useful error at the sign step rather than the
+///    serve step.
+/// 5. Issue the token via `state.preview_tokens.issue(...)`.
+pub async fn sign_preview(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    identity: Option<Extension<AuthIdentity>>,
+    Json(req): Json<SignPreviewRequest>,
+) -> Response {
+    // (1) Auth identity must be present (routing-bug guard).
+    let Some(Extension(identity)) = identity else {
+        tracing::warn!(
+            "POST /api/my/preview/sign reached without AuthIdentity — routing bug? failing closed"
+        );
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+
+    // (2) Extract the bearer string. Mirrors the precedence
+    // `router.rs::extract_token` uses: Authorization header first, then
+    // `?token=`/`?_token=` query param. We need this verbatim so we can
+    // re-validate it via `resolve_identity` later.
+    let Some(bearer) = extract_bearer_from_request(&headers) else {
+        tracing::warn!("sign_preview: no bearer token on request");
+        return StatusCode::UNAUTHORIZED.into_response();
+    };
+
+    // (3) Identity must own the requested profile.
+    if !is_authorized_for_profile(&state, &identity, &req.profile_id) {
+        tracing::warn!(
+            identity = ?identity,
+            requested_profile = %req.profile_id,
+            "sign_preview denied — identity not authorized for requested profile"
+        );
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    // (4) Resolve the data dir and confirm the site exists. Errors map
+    //     to the same status codes as the existing preview route so the
+    //     SPA can render a meaningful message.
+    let data_dir = match resolve_profile_data_dir_by_id(&state, &req.profile_id) {
+        Ok(d) => d,
+        Err(response) => return response,
+    };
+    let site_exists = api_session_workspace_dirs(&data_dir, &req.session_id)
+        .into_iter()
+        .map(|workspace| workspace.join("sites").join(&req.site_slug))
+        .any(|candidate| candidate.exists());
+    if !site_exists {
+        tracing::warn!(
+            identity = ?identity,
+            profile_id = %req.profile_id,
+            session_id = %req.session_id,
+            site_slug = %req.site_slug,
+            "sign_preview: site does not exist under profile's data dir"
+        );
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    // (5) Mint the token.
+    match state
+        .preview_tokens
+        .issue(
+            bearer,
+            identity,
+            req.profile_id,
+            req.session_id,
+            req.site_slug,
+        )
+        .await
+    {
+        Ok(resp) => (StatusCode::OK, Json(resp)).into_response(),
+        Err(err) => {
+            tracing::error!(error = %err, "sign_preview: getrandom failed");
+            (StatusCode::SERVICE_UNAVAILABLE, "token mint failed").into_response()
+        }
+    }
+}
+
+/// `GET /api/preview-signed/{token}/{*path}` — serve a previewed asset
+/// using the opaque token as the auth credential.
+///
+/// The route lives on the PUBLIC branch (no `user_auth_middleware`)
+/// because the iframe cannot inject `Authorization`. The token IS the
+/// credential — codex's design re-validates it three ways here:
+///   1. Token must resolve to a non-expired grant in the in-memory cache.
+///      Unknown / expired => 404 (don't leak whether the token ever
+///      existed).
+///   2. The `issuer_bearer` recorded at sign time must still resolve to
+///      an `AuthIdentity` — `resolve_identity` returns `None` for
+///      revoked sessions, deleted users, or daemon restart. Refusal =>
+///      403 (the token IS known, but its bearer is no longer valid).
+///   3. The re-resolved identity must still be authorized for the
+///      grant's `profile_id`. Refusal => 403 (defense in depth — closes
+///      the corner case where a user's role changes between sign and
+///      serve).
+///
+/// Response carries `Referrer-Policy: no-referrer` per codex's design so
+/// outbound links from the previewed site cannot leak the signed URL
+/// (which contains the token) to third parties via the Referer header.
+pub async fn serve_signed_preview(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path((token, request_path)): axum::extract::Path<(String, String)>,
+) -> Response {
+    serve_signed_preview_impl(state, token, request_path).await
+}
+
+/// Variant of `serve_signed_preview` for routes WITHOUT a `{*path}`
+/// segment (e.g. `GET /api/preview-signed/{token}/`). Hands the empty
+/// string as the request path so the underlying preview impl serves the
+/// `index.html` root.
+pub async fn serve_signed_preview_root(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(token): axum::extract::Path<String>,
+) -> Response {
+    serve_signed_preview_impl(state, token, String::new()).await
+}
+
+async fn serve_signed_preview_impl(
+    state: Arc<AppState>,
+    token: String,
+    request_path: String,
+) -> Response {
+    // (1) Consume the token. Unknown or expired => 404.
+    let Some(grant) = state.preview_tokens.consume(&token).await else {
+        // 404 (NOT 401) — codex design: don't leak whether the token
+        // ever existed.
+        tracing::debug!("serve_signed_preview: token unknown or expired");
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    // (2) Re-resolve the issuer bearer. If the user logged out or the
+    // session was deleted, `resolve_identity` returns None.
+    let Some(identity) = super::router::resolve_identity_public(&state, &grant.issuer_bearer).await
+    else {
+        tracing::warn!(
+            profile_id = %grant.profile_id,
+            "serve_signed_preview: issuer bearer no longer resolves to an identity (logout / session-delete?)"
+        );
+        return StatusCode::FORBIDDEN.into_response();
+    };
+
+    // (3) Defense in depth: even if the bearer still resolves, re-check
+    // the identity-vs-profile authorisation. Closes the corner case
+    // where the user's role changes between sign and serve.
+    if !is_authorized_for_profile(&state, &identity, &grant.profile_id) {
+        tracing::warn!(
+            identity = ?identity,
+            grant_profile = %grant.profile_id,
+            "serve_signed_preview: identity no longer authorized for grant's profile"
+        );
+        return StatusCode::FORBIDDEN.into_response();
+    }
+
+    // (4) Resolve the profile's data dir and delegate to the same
+    // symlink-safe serve path that `/api/preview/...` and
+    // `/api/site-preview/...` use. PR #1000's `serve_preview_no_follow`
+    // is invoked inside `serve_site_preview_impl`; we must NOT inline a
+    // fresh serve path here or we re-introduce the traversal bug.
+    let data_dir = match resolve_profile_data_dir_by_id(&state, &grant.profile_id) {
+        Ok(d) => d,
+        Err(response) => return response,
+    };
+
+    let mut resp =
+        serve_site_preview_impl(data_dir, grant.session_id, grant.site_slug, request_path).await;
+
+    // (5) Codex design: set `Referrer-Policy: no-referrer` so a click on
+    // any outbound link from the previewed site cannot leak the signed
+    // URL (which contains the token) to third parties via Referer.
+    resp.headers_mut().insert(
+        axum::http::header::REFERRER_POLICY,
+        axum::http::HeaderValue::from_static("no-referrer"),
+    );
+    resp
+}
+
+/// Extract a bearer token from the request headers OR the URL query
+/// string. Mirrors `crate::api::router::extract_token` but takes a
+/// `&HeaderMap` so the sign_preview handler can call it from a typed
+/// extractor signature without re-receiving the raw axum Request.
+///
+/// NOTE: The query-string branch is omitted here because `/api/my/preview/sign`
+/// is POST-only and clients should send the bearer via the
+/// `Authorization` header — query-string fallback is a holdover for
+/// EventSource and `<img src=...>` which neither apply to the sign
+/// surface. If a future client needs it we'll revisit; keeping the
+/// surface narrow at sign time reduces the bearer's exposure in access
+/// logs.
+fn extract_bearer_from_request(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -16,6 +16,7 @@ mod frps_plugin;
 mod handlers;
 pub mod metrics;
 pub mod preview;
+pub mod preview_tokens;
 pub mod purge;
 mod router;
 mod static_files;
@@ -38,6 +39,7 @@ pub mod webhook_proxy;
 
 pub use events::EventBroadcaster;
 pub use metrics::init_metrics;
+pub use preview_tokens::{PreviewTokens, SharedPreviewTokens, SignedPreviewResponse};
 pub use router::{DEFAULT_BASE_DOMAIN, build_router, cors_allowlist_for_base_domain};
 
 /// Test-only re-exports for the build_output_dir validation suite.
@@ -271,6 +273,18 @@ pub struct AppState {
     /// serve cwd under launchd is `~`, outside the profile root, and
     /// `/api/files` would 403 anything written there).
     pub appui_default_session_cwd: Option<PathBuf>,
+    /// In-memory signed-preview token cache (issue #1001 follow-up).
+    ///
+    /// The SPA mints a token via `POST /api/my/preview/sign` and serves
+    /// the iframe at `GET /api/preview-signed/{token}/{*path}` — that
+    /// public route consumes the token as its auth credential, so the
+    /// iframe can drop the missing `Authorization: Bearer ...` header
+    /// that the post-PR-#1001 `/api/preview/...` route requires.
+    ///
+    /// Cache is process-local (no disk persistence) so a daemon restart
+    /// invalidates every outstanding grant. See
+    /// [`crate::api::preview_tokens`] for full design rationale.
+    pub preview_tokens: SharedPreviewTokens,
 }
 
 impl AppState {
@@ -327,6 +341,7 @@ impl AppState {
             content_classifier: None,
             task_query_store: None,
             appui_default_session_cwd: None,
+            preview_tokens: Arc::new(PreviewTokens::new()),
         }
     }
 }

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -39,7 +39,10 @@ pub mod webhook_proxy;
 
 pub use events::EventBroadcaster;
 pub use metrics::init_metrics;
-pub use preview_tokens::{PreviewTokens, SharedPreviewTokens, SignedPreviewResponse};
+pub use preview_tokens::{
+    DEFAULT_PREVIEW_SWEEP_INTERVAL, IssueError as PreviewTokenIssueError, PreviewTokens,
+    SharedPreviewTokens, SignedPreviewResponse,
+};
 pub use router::{DEFAULT_BASE_DOMAIN, build_router, cors_allowlist_for_base_domain};
 
 /// Test-only re-exports for the build_output_dir validation suite.

--- a/crates/octos-cli/src/api/preview_tokens.rs
+++ b/crates/octos-cli/src/api/preview_tokens.rs
@@ -56,6 +56,36 @@
 //! the rotation surface considerably harder to reason about. Re-signing
 //! is cheap (one POST + a HashMap insert) and the SPA already has the
 //! bearer, so a persistent cache earns nothing.
+//!
+//! Rate limiting & DoS hardening (codex GAP 8)
+//! -------------------------------------------
+//! Without a cap, an authenticated client could mint unbounded tokens
+//! (each ~200 bytes, held 10 minutes by default) and OOM the daemon.
+//! Two layers of bounds:
+//!   1. Per-`issuer_bearer`: at most [`PreviewTokens::MAX_PER_BEARER`]
+//!      (64) concurrent grants. At ~200 bytes each that's ~12 KB per
+//!      user — generous for a SPA that mints one preview per site
+//!      iframe, restrictive for an attacker. Mints over the cap return
+//!      `IssueError::PerBearerLimitReached` which the handler maps to
+//!      HTTP 429.
+//!   2. Global: at most [`PreviewTokens::MAX_TOTAL`] (10 000) entries
+//!      across all bearers. With ~200 bytes each that caps the whole
+//!      map at ~2 MB. Bounds the worst case where a large number of
+//!      tenants each sit at the per-bearer cap simultaneously. Mints
+//!      over the global cap also return 429.
+//!
+//! Both checks happen AFTER the lazy `sweep_expired` so a long-idle
+//! bearer doesn't get stuck against its old quota.
+//!
+//! Background sweep (codex NEEDS-FOLLOWUP 6)
+//! -----------------------------------------
+//! `issue` / `consume` lazily call `sweep_expired`, but a daemon with
+//! NO preview traffic accumulates expired entries until the next
+//! request. The serve binary spawns [`PreviewTokens::spawn_background_sweeper`]
+//! at startup to call `sweep_expired_all` every 60 s in production,
+//! bounding the staleness window even when idle. Test code can pass a
+//! shorter interval to assert the contract without sleeping for
+//! minutes.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -63,6 +93,7 @@ use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
 
 use super::router::AuthIdentity;
 
@@ -70,6 +101,53 @@ use super::router::AuthIdentity;
 /// a renewal at `expires_at - 60s`, so the in-flight window is at most
 /// 9 minutes between sign / re-sign cycles.
 pub const DEFAULT_PREVIEW_TOKEN_TTL: Duration = Duration::from_secs(600);
+
+/// Default interval at which the background sweeper runs in production.
+/// The serve binary passes this to
+/// [`PreviewTokens::spawn_background_sweeper`]; tests override with a
+/// much shorter interval so the sweep contract is exercisable without
+/// real-time waits. Keep this comfortably shorter than the default TTL
+/// so an expired token cannot live longer than `TTL + sweep_interval`.
+pub const DEFAULT_PREVIEW_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Reasons [`PreviewTokens::issue`] can fail to mint a token. The
+/// handler maps each variant to a specific HTTP status so the SPA can
+/// distinguish a transient OS issue from quota exhaustion.
+#[derive(Debug)]
+pub enum IssueError {
+    /// `getrandom` failed — usually means the OS entropy source is
+    /// unavailable (very rare). Handler maps to HTTP 503.
+    Random(std::io::Error),
+    /// The requesting bearer is at [`PreviewTokens::MAX_PER_BEARER`]
+    /// concurrent grants. Handler maps to HTTP 429.
+    PerBearerLimitReached,
+    /// The cache as a whole is at [`PreviewTokens::MAX_TOTAL`]. Handler
+    /// maps to HTTP 429.
+    GlobalLimitReached,
+}
+
+impl std::fmt::Display for IssueError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IssueError::Random(err) => write!(f, "getrandom failed: {err}"),
+            IssueError::PerBearerLimitReached => {
+                write!(f, "per-bearer preview-token cap reached")
+            }
+            IssueError::GlobalLimitReached => {
+                write!(f, "global preview-token cap reached")
+            }
+        }
+    }
+}
+
+impl std::error::Error for IssueError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            IssueError::Random(err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 /// In-memory cache of signed-preview grants.
 ///
@@ -121,7 +199,7 @@ pub struct Grant {
 /// Wire response for `POST /api/my/preview/sign`. The SPA stores
 /// `preview_url` in iframe state, and schedules a re-sign timer at
 /// `expires_at - 60s`.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct SignedPreviewResponse {
     /// 64-char hex string. The SPA does not need to know this — it's
     /// already embedded in `preview_url` — but exposing it keeps the
@@ -146,6 +224,19 @@ impl Default for PreviewTokens {
 }
 
 impl PreviewTokens {
+    /// Maximum concurrent grants per `issuer_bearer`. At ~200 bytes per
+    /// entry that's ~12 KB of cache per user — comfortably above the
+    /// SPA's normal envelope (one mint per visible iframe) and well
+    /// below the threshold where a hostile client could starve the
+    /// daemon. Codex GAP 8 fix.
+    pub const MAX_PER_BEARER: usize = 64;
+
+    /// Global cap on the whole cache, summed across every bearer.
+    /// Bounds the worst case where a many-tenant fleet has many users
+    /// each sitting at their per-bearer cap. ~200 bytes × 10 000 =
+    /// ~2 MB — fits comfortably in the daemon's resident set.
+    pub const MAX_TOTAL: usize = 10_000;
+
     /// Build a token cache with the default 10-minute TTL.
     pub fn new() -> Self {
         Self::default()
@@ -172,6 +263,14 @@ impl PreviewTokens {
     /// `getentropy` on macOS, `BCryptGenRandom` on Windows). Falling
     /// back is not allowed — if `getrandom` errors we return the
     /// error to the caller, who maps it to 503.
+    ///
+    /// Rate limiting (codex GAP 8): after the lazy sweep we count
+    /// entries owned by `issuer_bearer` and refuse if it would exceed
+    /// [`Self::MAX_PER_BEARER`]. We also refuse if the global map
+    /// would exceed [`Self::MAX_TOTAL`]. Both refusals return
+    /// `IssueError::*LimitReached`, which the handler maps to HTTP 429
+    /// — explicitly distinct from the 503 we return for OS-level
+    /// randomness failures so the SPA can backoff vs surface an error.
     pub async fn issue(
         &self,
         issuer_bearer: String,
@@ -179,10 +278,11 @@ impl PreviewTokens {
         profile_id: String,
         session_id: String,
         site_slug: String,
-    ) -> Result<SignedPreviewResponse, std::io::Error> {
+    ) -> Result<SignedPreviewResponse, IssueError> {
         let mut raw = [0u8; 32];
-        getrandom::getrandom(&mut raw)
-            .map_err(|err| std::io::Error::other(format!("getrandom: {err}")))?;
+        getrandom::getrandom(&mut raw).map_err(|err| {
+            IssueError::Random(std::io::Error::other(format!("getrandom: {err}")))
+        })?;
         let token = hex_encode(&raw);
 
         let expires_at = Instant::now() + self.ttl;
@@ -201,8 +301,26 @@ impl PreviewTokens {
 
         let mut map = self.entries.write().await;
         // Piggyback expiry sweep on issue — keeps the map bounded
-        // without a background task.
+        // without forcing the caller to wait for the background
+        // sweeper. Sweep first, THEN count, so a bearer whose old
+        // tokens just expired isn't artificially capped against
+        // stale entries.
         sweep_expired(&mut map);
+
+        // Rate limit: count this bearer's live grants. We must read
+        // `grant.issuer_bearer` (not `&issuer_bearer` directly) to
+        // avoid moving `issuer_bearer` before constructing the grant
+        // — but we already built `grant` above, so use a captured
+        // borrow from the field.
+        let owner = &grant.issuer_bearer;
+        let per_bearer = map.values().filter(|g| g.issuer_bearer == *owner).count();
+        if per_bearer >= Self::MAX_PER_BEARER {
+            return Err(IssueError::PerBearerLimitReached);
+        }
+        if map.len() >= Self::MAX_TOTAL {
+            return Err(IssueError::GlobalLimitReached);
+        }
+
         map.insert(token.clone(), grant);
         drop(map);
 
@@ -239,12 +357,59 @@ impl PreviewTokens {
         Some(grant)
     }
 
-    /// Number of outstanding entries (test/debug aid). Not part of
-    /// any public surface.
-    #[cfg(test)]
+    /// Number of outstanding entries. Used by the integration test
+    /// suite to assert the background sweeper actually evicted expired
+    /// grants, and as a debug/metrics aid. The value is best-effort:
+    /// concurrent `issue` / `consume` / sweeper calls race with this
+    /// read, and a busy daemon may see the count change between reads.
+    /// Not load-bearing for any auth decision — the auth surface uses
+    /// `consume` which is properly serialised against the write lock.
     #[allow(clippy::len_without_is_empty)]
     pub async fn len(&self) -> usize {
         self.entries.read().await.len()
+    }
+
+    /// Public hook for the background sweeper task. Acquires the
+    /// write lock just long enough to drop every expired entry, then
+    /// releases it. Codex NEEDS-FOLLOWUP 6 fix.
+    ///
+    /// Why a separate method (rather than calling `sweep_expired`
+    /// directly from the spawned task): keeping the lock-acquisition
+    /// inside `&self` lets the sweeper task hold an `Arc<Self>`
+    /// without leaking the internal `RwLock` shape. The task is
+    /// otherwise a one-liner.
+    pub async fn sweep_expired_all(&self) {
+        let mut map = self.entries.write().await;
+        sweep_expired(&mut map);
+    }
+
+    /// Spawn the background sweeper. Codex NEEDS-FOLLOWUP 6 fix.
+    ///
+    /// Without this, expired grants only get cleaned up on
+    /// `issue`/`consume` traffic — an idle daemon can accumulate
+    /// expired entries indefinitely. The spawned task runs forever,
+    /// sweeping at `interval` cadence; the returned `JoinHandle` is
+    /// kept by the serve binary so the task lives as long as the
+    /// process. There is no graceful shutdown signal: the sweeper is
+    /// cheap (one write-lock sweep) and the process exit drops
+    /// everything anyway.
+    ///
+    /// Tests pass a short interval (e.g. 20 ms) to exercise the
+    /// contract; production passes
+    /// [`DEFAULT_PREVIEW_SWEEP_INTERVAL`] (60 s).
+    pub fn spawn_background_sweeper(cache: Arc<Self>, interval: Duration) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // `Interval::tick` fires immediately on first call; skip
+            // the boot tick so we wait `interval` before the first
+            // sweep (the cache was just constructed and is empty).
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            ticker.tick().await; // consume the immediate first tick
+            loop {
+                ticker.tick().await;
+                cache.sweep_expired_all().await;
+            }
+        })
     }
 }
 
@@ -345,7 +510,11 @@ mod tests {
     async fn token_uniqueness_across_issues() {
         let cache = PreviewTokens::with_ttl(Duration::from_secs(60));
         let mut seen = std::collections::HashSet::new();
-        for _ in 0..64 {
+        // `MAX_PER_BEARER` is 64 — the loop walks right up to the cap
+        // without crossing it. The next iteration would refuse with
+        // `PerBearerLimitReached`; that's exercised in
+        // `per_bearer_cap_returns_rate_limited` below.
+        for _ in 0..PreviewTokens::MAX_PER_BEARER {
             let signed = cache
                 .issue(
                     "BEARER-A".into(),
@@ -361,5 +530,156 @@ mod tests {
                 "tokens must be unique across issues"
             );
         }
+    }
+
+    /// Codex GAP 8: per-bearer cap. Mint exactly MAX_PER_BEARER
+    /// tokens, then assert the next mint fails with
+    /// `PerBearerLimitReached`. A second bearer in the SAME cache must
+    /// still be able to mint, proving the cap is per-bearer and not a
+    /// global side-effect.
+    #[tokio::test]
+    async fn per_bearer_cap_returns_rate_limited() {
+        let cache = PreviewTokens::with_ttl(Duration::from_secs(60));
+
+        // Saturate bearer A up to the cap.
+        for _ in 0..PreviewTokens::MAX_PER_BEARER {
+            cache
+                .issue(
+                    "BEARER-A".into(),
+                    make_identity(),
+                    "tenant-a".into(),
+                    "session-1".into(),
+                    "site-a".into(),
+                )
+                .await
+                .expect("under-cap issue must succeed");
+        }
+
+        // Cap + 1 from bearer A must refuse.
+        let err = cache
+            .issue(
+                "BEARER-A".into(),
+                make_identity(),
+                "tenant-a".into(),
+                "session-1".into(),
+                "site-a".into(),
+            )
+            .await
+            .expect_err("over-cap issue must fail");
+        assert!(
+            matches!(err, IssueError::PerBearerLimitReached),
+            "expected PerBearerLimitReached, got: {err:?}"
+        );
+
+        // Bearer B must still succeed — the cap is per-bearer.
+        cache
+            .issue(
+                "BEARER-B".into(),
+                make_identity(),
+                "tenant-a".into(),
+                "session-2".into(),
+                "site-a".into(),
+            )
+            .await
+            .expect("second bearer must not be capped by the first");
+    }
+
+    /// Codex GAP 8: per-bearer expiry-sweep interaction. If the
+    /// bearer's old tokens have expired, the lazy sweep inside `issue`
+    /// must reset the count so the bearer can mint again — otherwise
+    /// the cap would degrade to "lifetime grants per bearer" instead
+    /// of "concurrent grants per bearer".
+    #[tokio::test]
+    async fn per_bearer_cap_clears_after_expiry_sweep() {
+        let cache = PreviewTokens::with_ttl(Duration::from_millis(20));
+
+        // Saturate bearer A.
+        for _ in 0..PreviewTokens::MAX_PER_BEARER {
+            cache
+                .issue(
+                    "BEARER-A".into(),
+                    make_identity(),
+                    "tenant-a".into(),
+                    "session-1".into(),
+                    "site-a".into(),
+                )
+                .await
+                .expect("under-cap issue");
+        }
+
+        // Wait past the TTL.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        // Next mint must succeed — the lazy sweep inside `issue`
+        // empties the map first.
+        cache
+            .issue(
+                "BEARER-A".into(),
+                make_identity(),
+                "tenant-a".into(),
+                "session-1".into(),
+                "site-a".into(),
+            )
+            .await
+            .expect("post-expiry mint must succeed (sweep cleared the cap)");
+    }
+
+    /// Codex NEEDS-FOLLOWUP 6: `sweep_expired_all` is the public hook
+    /// the background task uses. Assert it drops expired entries
+    /// WITHOUT requiring any `issue`/`consume` call.
+    #[tokio::test]
+    async fn sweep_expired_all_drops_expired_entries() {
+        let cache = PreviewTokens::with_ttl(Duration::from_millis(20));
+        cache
+            .issue(
+                "BEARER-A".into(),
+                make_identity(),
+                "tenant-a".into(),
+                "session-1".into(),
+                "site-a".into(),
+            )
+            .await
+            .expect("issue");
+        assert_eq!(cache.len().await, 1, "fresh entry present");
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        cache.sweep_expired_all().await;
+        assert_eq!(
+            cache.len().await,
+            0,
+            "sweep_expired_all must drop expired entries"
+        );
+    }
+
+    /// Codex NEEDS-FOLLOWUP 6: end-to-end exercise of the spawned
+    /// background sweeper. With a short interval and a short TTL the
+    /// task should empty the cache without any `issue`/`consume`
+    /// activity from the test.
+    #[tokio::test]
+    async fn spawn_background_sweeper_drops_expired_entries() {
+        let cache = Arc::new(PreviewTokens::with_ttl(Duration::from_millis(40)));
+        cache
+            .issue(
+                "BEARER-A".into(),
+                make_identity(),
+                "tenant-a".into(),
+                "session-1".into(),
+                "site-a".into(),
+            )
+            .await
+            .expect("issue");
+        assert_eq!(cache.len().await, 1);
+
+        let _handle =
+            PreviewTokens::spawn_background_sweeper(cache.clone(), Duration::from_millis(15));
+
+        // Wait long enough for: first-tick consume (+15ms) + at least
+        // one post-TTL sweep (+15ms more after t=40). 200ms is plenty.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        assert_eq!(
+            cache.len().await,
+            0,
+            "background sweeper must have evicted the expired token"
+        );
     }
 }

--- a/crates/octos-cli/src/api/preview_tokens.rs
+++ b/crates/octos-cli/src/api/preview_tokens.rs
@@ -1,0 +1,365 @@
+//! In-memory signed-preview token cache (codex design for issue
+//! #1001 follow-up).
+//!
+//! Why this module exists
+//! ----------------------
+//! PR #1001 closed the cross-tenant `/api/preview/{profile_id}/...`
+//! data-read by requiring `Authorization: Bearer ...` on every request.
+//! The SPA dashboard's `<iframe src=/api/preview/...>` cannot inject
+//! that header — `iframe` requests are plain GETs — so the dashboard
+//! either had to drop the iframe or rely on cookies (which we don't
+//! ship).
+//!
+//! Codex's design (verbatim in the PR thread): mint an opaque,
+//! cryptographically random token via `POST /api/my/preview/sign`,
+//! stash a grant in this process-local cache, and serve the preview
+//! through a PUBLIC route `GET /api/preview-signed/{token}/{*path}`
+//! where the token IS the auth credential. Relative assets under the
+//! preview HTML inherit the `/api/preview-signed/{token}/` prefix
+//! without any rewriting — that's why the token lives in the URL path
+//! rather than a query string.
+//!
+//! Security properties of the token
+//! --------------------------------
+//! - **Opacity**: 256 bits of OS randomness encoded as 64 hex chars.
+//!   Not a JWT — no claims, no signature, no key rotation surface. The
+//!   token is a pure server-side handle: a 32-byte cookie that
+//!   indexes into this in-memory map. Brute force is computationally
+//!   infeasible (2^256), and a leaked token only grants the exact
+//!   `{profile_id, session_id, site_slug}` triple that was approved.
+//! - **Bound to issuer**: the grant captures the bearer that minted
+//!   it (`issuer_bearer`) plus the `AuthIdentity` snapshot. The
+//!   serve handler re-validates the bearer on every request — if the
+//!   user logs out, the session is revoked, or the daemon restarts,
+//!   the bearer is no longer valid and the preview 403s. That makes
+//!   logout / session-delete naturally invalidate every outstanding
+//!   preview without explicit token revocation.
+//! - **Short TTL**: 10 minutes by default. The SPA renews at
+//!   `expires_at - 60s` by re-signing, so a leaked token only buys
+//!   the attacker the remainder of the current 10-minute window
+//!   AND ownership of the issuer bearer (re-validated server-side).
+//! - **Path-bound**: the grant fixes `profile_id`, `session_id`, and
+//!   `site_slug`. The token cannot be re-used to read a different
+//!   tenant's preview by tweaking the request — those fields come
+//!   from the grant, not from the URL, and the URL has only `{token}`
+//!   and `{*path}` segments.
+//! - **Daemon restart invalidates everything**: tokens live in a
+//!   `tokio::sync::RwLock<HashMap<...>>` that doesn't persist. A
+//!   restart drops all outstanding grants and the SPA simply re-signs
+//!   on the next render. This matches the "10 minute TTL" intent
+//!   (nothing should outlive a restart).
+//!
+//! Not stored on disk
+//! ------------------
+//! Persisting tokens would (1) defeat the daemon-restart invalidation
+//! property, (2) introduce a new on-disk secret store, and (3) make
+//! the rotation surface considerably harder to reason about. Re-signing
+//! is cheap (one POST + a HashMap insert) and the SPA already has the
+//! bearer, so a persistent cache earns nothing.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+use super::router::AuthIdentity;
+
+/// Default time-to-live for a signed-preview token. The SPA schedules
+/// a renewal at `expires_at - 60s`, so the in-flight window is at most
+/// 9 minutes between sign / re-sign cycles.
+pub const DEFAULT_PREVIEW_TOKEN_TTL: Duration = Duration::from_secs(600);
+
+/// In-memory cache of signed-preview grants.
+///
+/// Thread-safety: every entry-point takes `&self` and locks the
+/// internal `RwLock`. Concurrent reads (the GET serve handler) take
+/// the write lock briefly to consume + clean expired entries —
+/// codex piggybacks the expiry sweep on `consume` so we don't need a
+/// background sweeper task. With <1000 outstanding entries per
+/// tenant this is fine; the sweep on a 1k-entry HashMap is a few
+/// microseconds and runs at most once per preview request.
+pub struct PreviewTokens {
+    entries: RwLock<HashMap<String, Grant>>,
+    ttl: Duration,
+}
+
+/// Server-side grant for one minted token. Captures everything the
+/// `serve_signed_preview` handler needs to (a) re-validate the issuer
+/// and (b) resolve the on-disk preview path WITHOUT consulting the
+/// incoming URL for trust-bearing values.
+#[derive(Clone)]
+pub struct Grant {
+    /// The bearer token that was sent on the `/api/my/preview/sign`
+    /// request. The serve handler re-resolves this on every request
+    /// — if the underlying auth manager session has been revoked /
+    /// expired / deleted, the serve handler refuses with 403. This
+    /// is what makes logout/session-delete invalidate outstanding
+    /// previews "for free" without an explicit revocation API.
+    pub issuer_bearer: String,
+    /// `AuthIdentity` snapshot taken at sign time. Kept for
+    /// authorisation re-checks (`is_authorized_for_profile`) and for
+    /// audit/tracing — codex's design specifies storing the identity
+    /// alongside the bearer.
+    pub identity_snapshot: AuthIdentity,
+    /// Profile that the preview targets. The serve handler resolves
+    /// this profile's data dir to find the on-disk content.
+    pub profile_id: String,
+    /// Session that the preview targets.
+    pub session_id: String,
+    /// Site slug under the session workspace.
+    pub site_slug: String,
+    /// Wall-clock instant after which this grant is invalid. Stored
+    /// as `Instant` (monotonic) so clock jumps cannot extend the
+    /// grant's validity. The wire `expires_at` exposed to the SPA is
+    /// converted to a `chrono::DateTime<Utc>` from this monotonic
+    /// instant at sign time (see `SignedPreviewResponse`).
+    pub expires_at: Instant,
+}
+
+/// Wire response for `POST /api/my/preview/sign`. The SPA stores
+/// `preview_url` in iframe state, and schedules a re-sign timer at
+/// `expires_at - 60s`.
+#[derive(Serialize)]
+pub struct SignedPreviewResponse {
+    /// 64-char hex string. The SPA does not need to know this — it's
+    /// already embedded in `preview_url` — but exposing it keeps the
+    /// response self-describing for debugging and lets clients build
+    /// non-`index.html` deep-links if they want.
+    pub token: String,
+    /// Fully-formed URL the SPA can stuff into `<iframe src=...>`.
+    /// Form: `/api/preview-signed/{token}/index.html`. The SPA does
+    /// not concatenate the host — the iframe inherits the same origin
+    /// as the dashboard.
+    pub preview_url: String,
+    /// Wall-clock expiry (`chrono::DateTime<Utc>` serialised to RFC
+    /// 3339). The SPA's renewal scheduler subtracts 60 s and re-signs
+    /// when that timer fires.
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl Default for PreviewTokens {
+    fn default() -> Self {
+        Self::with_ttl(DEFAULT_PREVIEW_TOKEN_TTL)
+    }
+}
+
+impl PreviewTokens {
+    /// Build a token cache with the default 10-minute TTL.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Test-only override that lets the integration tests rig a tiny
+    /// TTL so expiry can be exercised without sleeping for minutes.
+    /// Production callers should use [`Self::new`].
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Mint a new token. Generates 256 bits of OS randomness via
+    /// `getrandom`, encodes as lowercase hex, and stashes the
+    /// associated `Grant` keyed by the hex string. Returns the
+    /// wire-shaped response that `POST /api/my/preview/sign` echoes
+    /// back to the SPA.
+    ///
+    /// Determinism: the random number generator is the OS source
+    /// (`/dev/urandom` on Linux, `getrandom(2)` on modern Linux,
+    /// `getentropy` on macOS, `BCryptGenRandom` on Windows). Falling
+    /// back is not allowed — if `getrandom` errors we return the
+    /// error to the caller, who maps it to 503.
+    pub async fn issue(
+        &self,
+        issuer_bearer: String,
+        identity_snapshot: AuthIdentity,
+        profile_id: String,
+        session_id: String,
+        site_slug: String,
+    ) -> Result<SignedPreviewResponse, std::io::Error> {
+        let mut raw = [0u8; 32];
+        getrandom::getrandom(&mut raw)
+            .map_err(|err| std::io::Error::other(format!("getrandom: {err}")))?;
+        let token = hex_encode(&raw);
+
+        let expires_at = Instant::now() + self.ttl;
+        let wire_expires_at = chrono::Utc::now()
+            + chrono::Duration::from_std(self.ttl)
+                .unwrap_or_else(|_| chrono::Duration::seconds(600));
+
+        let grant = Grant {
+            issuer_bearer,
+            identity_snapshot,
+            profile_id,
+            session_id,
+            site_slug,
+            expires_at,
+        };
+
+        let mut map = self.entries.write().await;
+        // Piggyback expiry sweep on issue — keeps the map bounded
+        // without a background task.
+        sweep_expired(&mut map);
+        map.insert(token.clone(), grant);
+        drop(map);
+
+        let preview_url = format!("/api/preview-signed/{token}/index.html");
+        Ok(SignedPreviewResponse {
+            token,
+            preview_url,
+            expires_at: wire_expires_at,
+        })
+    }
+
+    /// Look up a grant by token. Returns `None` if the token is
+    /// unknown OR expired. The caller maps both cases to HTTP 404 so
+    /// the response shape doesn't leak whether the token ever existed.
+    ///
+    /// Why not "consume-on-read"? Previews fetch many assets
+    /// (`index.html`, CSS, JS, images) sequentially — single-use
+    /// semantics would break the iframe on the first asset fetch.
+    /// The grant remains valid until `expires_at`.
+    pub async fn consume(&self, token: &str) -> Option<Grant> {
+        let mut map = self.entries.write().await;
+        // Lazy sweep on every consume keeps the map bounded while
+        // we hold the write lock anyway.
+        sweep_expired(&mut map);
+        let grant = map.get(token)?.clone();
+        if grant.expires_at <= Instant::now() {
+            // Belt-and-braces: the sweep above should have removed it,
+            // but if a token is exactly at the boundary (sweep ran at
+            // `t == expires_at`, request lands one nanosecond later)
+            // we still refuse here.
+            map.remove(token);
+            return None;
+        }
+        Some(grant)
+    }
+
+    /// Number of outstanding entries (test/debug aid). Not part of
+    /// any public surface.
+    #[cfg(test)]
+    #[allow(clippy::len_without_is_empty)]
+    pub async fn len(&self) -> usize {
+        self.entries.read().await.len()
+    }
+}
+
+/// Drop every entry whose `expires_at` is in the past. Called inline
+/// from `issue` and `consume`, which both already hold the write
+/// lock. Not called from `len` because that would defeat the test.
+fn sweep_expired(map: &mut HashMap<String, Grant>) {
+    let now = Instant::now();
+    map.retain(|_, grant| grant.expires_at > now);
+}
+
+/// `Arc<PreviewTokens>` is the shape stored in `AppState`. Aliased
+/// here so the router/handler wiring doesn't have to repeat the
+/// `Arc<...>` everywhere.
+pub type SharedPreviewTokens = Arc<PreviewTokens>;
+
+/// Lowercase-hex encode `bytes`. Inlined rather than pulling in the
+/// `hex` crate — the only call site is `issue` and the input is
+/// 32 bytes.
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::user_store::UserRole;
+
+    fn make_identity() -> AuthIdentity {
+        AuthIdentity::User {
+            id: "tenant-a".into(),
+            role: UserRole::User,
+        }
+    }
+
+    #[tokio::test]
+    async fn issue_then_consume_returns_grant() {
+        let cache = PreviewTokens::with_ttl(Duration::from_secs(60));
+        let signed = cache
+            .issue(
+                "BEARER-A".into(),
+                make_identity(),
+                "tenant-a".into(),
+                "session-1".into(),
+                "site-a".into(),
+            )
+            .await
+            .expect("issue");
+
+        assert_eq!(signed.token.len(), 64, "256 bits -> 64 hex chars");
+        assert!(
+            signed
+                .preview_url
+                .starts_with(&format!("/api/preview-signed/{}/", signed.token)),
+            "preview_url must embed the token in the URL path"
+        );
+
+        let grant = cache.consume(&signed.token).await.expect("grant present");
+        assert_eq!(grant.profile_id, "tenant-a");
+        assert_eq!(grant.session_id, "session-1");
+        assert_eq!(grant.site_slug, "site-a");
+        assert_eq!(grant.issuer_bearer, "BEARER-A");
+    }
+
+    #[tokio::test]
+    async fn consume_unknown_token_returns_none() {
+        let cache = PreviewTokens::with_ttl(Duration::from_secs(60));
+        assert!(cache.consume("not-a-real-token").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn expired_grant_is_swept() {
+        let cache = PreviewTokens::with_ttl(Duration::from_millis(20));
+        let signed = cache
+            .issue(
+                "BEARER-A".into(),
+                make_identity(),
+                "tenant-a".into(),
+                "session-1".into(),
+                "site-a".into(),
+            )
+            .await
+            .expect("issue");
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(
+            cache.consume(&signed.token).await.is_none(),
+            "expired grants must not be served"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_uniqueness_across_issues() {
+        let cache = PreviewTokens::with_ttl(Duration::from_secs(60));
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..64 {
+            let signed = cache
+                .issue(
+                    "BEARER-A".into(),
+                    make_identity(),
+                    "tenant-a".into(),
+                    "session-1".into(),
+                    "site-a".into(),
+                )
+                .await
+                .expect("issue");
+            assert!(
+                seen.insert(signed.token),
+                "tokens must be unique across issues"
+            );
+        }
+    }
+}

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -283,7 +283,16 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/register/setup-script",
             get(admin::register_setup_script),
-        );
+        )
+        // Issue #1001 follow-up: signed-preview minting. Sits on the
+        // authenticated `my_api` branch — the SPA dashboard already
+        // has the user's bearer when it renders the iframe, so we
+        // require auth at the mint step. The actual preview content
+        // is served via the PUBLIC `/api/preview-signed/{token}/...`
+        // route registered below (no auth middleware — the token IS
+        // the credential). See
+        // [`handlers::sign_preview`] for the auth/authorisation flow.
+        .route("/api/my/preview/sign", post(handlers::sign_preview));
 
     // Admin API routes (admin auth only, 1MB body limit)
     let admin_api = Router::new()
@@ -583,12 +592,33 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     // group above — the handler asserts identity-owns-profile +
     // session-belongs-to-profile, so the URL tuple is no longer
     // sufficient to read another tenant's built site.
+    //
+    // Issue #1001 follow-up: the signed-URL preview route
+    // `/api/preview-signed/{token}/{*path}` lives here so the SPA
+    // iframe can GET it without `Authorization: Bearer ...`. The
+    // token itself is the credential — `handlers::serve_signed_preview`
+    // looks the token up in `AppState.preview_tokens`, re-validates the
+    // issuer bearer, and re-checks identity ↔ profile authorisation
+    // before serving content. Daemon restart drops the token cache and
+    // every outstanding preview link invalidates with it.
     let public = Router::new()
         .merge(metrics_route)
         .merge(auth_api)
         .route(
             "/api/register/setup-script/{id}/{auth_token}",
             get(admin::register_setup_script_public),
+        )
+        .route(
+            "/api/preview-signed/{token}",
+            get(handlers::serve_signed_preview_root),
+        )
+        .route(
+            "/api/preview-signed/{token}/",
+            get(handlers::serve_signed_preview_root),
+        )
+        .route(
+            "/api/preview-signed/{token}/{*path}",
+            get(handlers::serve_signed_preview),
         )
         .merge(webhook_routes)
         .merge(version_routes)
@@ -816,6 +846,19 @@ fn extract_token(req: &axum::http::Request<axum::body::Body>) -> String {
     } else {
         query_token.to_string()
     }
+}
+
+/// Crate-public wrapper around [`resolve_identity`].
+///
+/// Exposed for the signed-preview re-validation in
+/// [`crate::api::handlers::serve_signed_preview`]: the public
+/// `/api/preview-signed/{token}/...` route lives OUTSIDE
+/// `user_auth_middleware`, so it must re-resolve the issuer bearer
+/// stored in the `PreviewTokens` grant on every request. A revoked
+/// session ⇒ `None` ⇒ 403, which is how logout / session-delete
+/// invalidates outstanding previews "for free".
+pub(crate) async fn resolve_identity_public(state: &AppState, token: &str) -> Option<AuthIdentity> {
+    resolve_identity(state, token).await
 }
 
 /// Resolve token to an AuthIdentity.

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -643,6 +643,17 @@ impl ServeCommand {
             preview_tokens: Arc::new(crate::api::PreviewTokens::new()),
         });
 
+        // Codex NEEDS-FOLLOWUP 6: spawn the background sweeper for the
+        // signed-preview token cache. Without it, an idle daemon (no
+        // sign/serve traffic) accumulates expired entries indefinitely
+        // because the lazy sweep only fires on `issue`/`consume`. The
+        // JoinHandle is dropped intentionally — the task runs for the
+        // lifetime of the process and exits on shutdown.
+        let _preview_sweeper = crate::api::PreviewTokens::spawn_background_sweeper(
+            state.preview_tokens.clone(),
+            crate::api::DEFAULT_PREVIEW_SWEEP_INTERVAL,
+        );
+
         if self.stdio {
             crate::api::ui_protocol::stdio_connection(state).await?;
             tracing::info!("stopping all gateway child processes");

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -633,6 +633,14 @@ impl ServeCommand {
             // `with_builtins_and_sandbox(serve_cwd)`. See
             // `api/ui_protocol.rs::session_tool_registry`.
             appui_default_session_cwd: config.appui.default_session_cwd.clone(),
+            // Issue #1001 follow-up: in-memory signed-preview token
+            // cache backs `POST /api/my/preview/sign` /
+            // `GET /api/preview-signed/...` so the SPA iframe can drop
+            // the `Authorization: Bearer ...` header that the closed
+            // `/api/preview/...` route now requires. Daemon restart
+            // invalidates every grant (see
+            // `crate::api::preview_tokens` for the design rationale).
+            preview_tokens: Arc::new(crate::api::PreviewTokens::new()),
         });
 
         if self.stdio {

--- a/crates/octos-cli/tests/preview_signed.rs
+++ b/crates/octos-cli/tests/preview_signed.rs
@@ -1,0 +1,555 @@
+//! Issue #1001 follow-up: PR #1001 closed the cross-tenant
+//! `/api/preview/{profile_id}/...` leak by requiring auth on every
+//! request. That regressed the SPA iframe UX — `<iframe src=...>`
+//! cannot send `Authorization: Bearer ...`, so the preview iframe
+//! 401-loops after the dashboard tab loads.
+//!
+//! Codex design: mint an opaque 256-bit random token via
+//! `POST /api/my/preview/sign`, stash a server-side grant
+//! `{issuer_bearer, identity, profile_id, session_id, site_slug,
+//! expires_at}` in a process-local cache, and serve preview content
+//! through the public route `GET /api/preview-signed/{token}/{*path}`.
+//! The token is in the PATH (not a query param) so relative assets
+//! under the preview HTML inherit the prefix without rewriting.
+//!
+//! This test suite pins:
+//!  - 1: authenticated sign for own profile → 200 with token + url + expires_at
+//!  - 2: authenticated sign for other tenant → 403
+//!  - 3: unauthenticated sign → 401
+//!  - 4: GET signed-preview/{valid_token}/index.html → 200 with `Referrer-Policy: no-referrer`
+//!  - 5: GET signed-preview/{invalid_token}/index.html → 404 (don't leak token existence)
+//!  - 6: GET signed-preview after expiry → 404 (short test TTL)
+//!  - 7: GET signed-preview after issuer bearer revoked → 403
+//!  - 8: path traversal in `{*path}` → 404 (relies on PR #1000's symlink-safe walk)
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::Utc;
+use octos_cli::api::{AppState, build_router};
+use octos_cli::otp::{AuthManager, DashboardAuthConfig, SmtpConfig};
+use octos_cli::profiles::{ProfileConfig, ProfileStore, UserProfile};
+use octos_cli::user_store::{User, UserRole, UserStore};
+use octos_core::SessionKey;
+use serde_json::Value;
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+const STATIC_TOKEN_A: &str = "PREVIEW-SIGNED-STATIC-TOKEN-A";
+const STATIC_TOKEN_B: &str = "PREVIEW-SIGNED-STATIC-TOKEN-B";
+
+struct Fixture {
+    _tempdir: TempDir,
+    state: Arc<AppState>,
+    session_a_id: String,
+    site_slug: String,
+    token_a: String,
+    /// Held in the fixture so the user-B session in `AuthManager` exists
+    /// at test time even though the current suite only exercises user A
+    /// flows. Keeps the fixture symmetric with `preview_auth.rs` so
+    /// future cross-tenant tests (e.g. "user A's signed token cannot
+    /// serve user B's content") can reuse the harness without
+    /// retrofitting user B.
+    #[allow(dead_code)]
+    token_b: String,
+}
+
+async fn build_fixture() -> Fixture {
+    build_fixture_with_ttl(std::time::Duration::from_secs(600)).await
+}
+
+async fn build_fixture_with_ttl(ttl: std::time::Duration) -> Fixture {
+    let tempdir = TempDir::new().expect("tempdir");
+    let octos_home = tempdir.path().to_path_buf();
+
+    let profile_store = Arc::new(ProfileStore::open(&octos_home).expect("profile store"));
+
+    let profile_a = UserProfile {
+        id: "tenant-a".into(),
+        name: "Tenant A".into(),
+        public_subdomain: None,
+        enabled: true,
+        data_dir: None,
+        parent_id: None,
+        config: ProfileConfig::default(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let profile_b = UserProfile {
+        id: "tenant-b".into(),
+        name: "Tenant B".into(),
+        public_subdomain: None,
+        enabled: true,
+        data_dir: None,
+        parent_id: None,
+        config: ProfileConfig::default(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    profile_store.save(&profile_a).expect("save a");
+    profile_store.save(&profile_b).expect("save b");
+
+    let data_dir_a = profile_store.resolve_data_dir(&profile_a);
+
+    let user_store = Arc::new(UserStore::open(&octos_home).expect("user store"));
+    let user_a = User {
+        id: profile_a.id.clone(),
+        email: "alice@example.test".into(),
+        name: "Alice".into(),
+        role: UserRole::User,
+        created_at: Utc::now(),
+        last_login_at: None,
+    };
+    let user_b = User {
+        id: profile_b.id.clone(),
+        email: "bob@example.test".into(),
+        name: "Bob".into(),
+        role: UserRole::User,
+        created_at: Utc::now(),
+        last_login_at: None,
+    };
+    user_store.save(&user_a).expect("save user a");
+    user_store.save(&user_b).expect("save user b");
+
+    let auth_cfg = DashboardAuthConfig {
+        smtp: SmtpConfig {
+            host: "smtp.invalid".into(),
+            port: 465,
+            username: "no-reply@invalid".into(),
+            password_env: "OCTOS_TEST_NO_SMTP".into(),
+            from_address: "no-reply@invalid".into(),
+        },
+        session_expiry_hours: 1,
+        allow_self_registration: false,
+        static_tokens: vec![STATIC_TOKEN_A.into(), STATIC_TOKEN_B.into()],
+    };
+    let auth_manager = Arc::new(AuthManager::new(Some(auth_cfg), user_store.clone()));
+
+    let token_a = auth_manager
+        .verify_otp_with_registration(&user_a.email, STATIC_TOKEN_A, false)
+        .await
+        .expect("mint token a")
+        .expect("token a");
+    let token_b = auth_manager
+        .verify_otp_with_registration(&user_b.email, STATIC_TOKEN_B, false)
+        .await
+        .expect("mint token b")
+        .expect("token b");
+
+    let site_slug = "test-site";
+    let session_a_id = "site-A-signed-1234567890";
+
+    let key_a = SessionKey::with_profile(&profile_a.id, "api", session_a_id);
+    let encoded_a = octos_bus::session::encode_path_component(key_a.base_key());
+    let ws_a = data_dir_a
+        .join("users")
+        .join(&encoded_a)
+        .join("workspace")
+        .join("sites")
+        .join(site_slug);
+    seed_built_site(&ws_a, "<<<A-CONTENT>>>");
+
+    let state = Arc::new(AppState {
+        profile_store: Some(profile_store.clone()),
+        user_store: Some(user_store.clone()),
+        auth_manager: Some(auth_manager.clone()),
+        preview_tokens: Arc::new(octos_cli::api::PreviewTokens::with_ttl(ttl)),
+        ..AppState::empty_for_tests()
+    });
+
+    Fixture {
+        _tempdir: tempdir,
+        state,
+        session_a_id: session_a_id.into(),
+        site_slug: site_slug.into(),
+        token_a,
+        token_b,
+    }
+}
+
+fn seed_built_site(ws_dir: &std::path::Path, marker: &str) {
+    use std::time::Duration;
+
+    std::fs::create_dir_all(ws_dir).expect("create site workspace");
+    std::fs::create_dir_all(ws_dir.join("dist")).expect("create dist");
+
+    let slug = ws_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("test-site");
+    let metadata = serde_json::json!({
+        "version": 1,
+        "command": "/new site astro",
+        "preset_key": "astro",
+        "template": "astro-site",
+        "site_kind": "docs",
+        "site_name": "Test Site",
+        "description": "Test fixture",
+        "accent": "#000000",
+        "reference": "/tmp",
+        "reference_label": "tmp",
+        "site_slug": slug,
+        "preview_base_path": format!("/api/preview/p/s/{slug}"),
+        "preview_url": format!("/api/preview/p/s/{slug}/index.html"),
+        "build_output_dir": "dist",
+        "project_dir": format!("sites/{slug}"),
+        "pages": [],
+    });
+    std::fs::write(
+        ws_dir.join("mofa-site-session.json"),
+        serde_json::to_vec(&metadata).unwrap(),
+    )
+    .expect("write metadata");
+
+    let html = format!("<!doctype html><html><body>{marker}</body></html>");
+    std::fs::write(ws_dir.join("dist").join("index.html"), html).expect("write index.html");
+
+    let source_mtime = std::time::SystemTime::now() - Duration::from_secs(600);
+    if let Ok(file) = std::fs::OpenOptions::new()
+        .write(true)
+        .open(ws_dir.join("mofa-site-session.json"))
+    {
+        let _ = file.set_modified(source_mtime);
+    }
+}
+
+async fn sign_preview_request(
+    app: axum::Router,
+    bearer: Option<&str>,
+    profile_id: &str,
+    session_id: &str,
+    site_slug: &str,
+) -> axum::response::Response {
+    let body = serde_json::json!({
+        "profile_id": profile_id,
+        "session_id": session_id,
+        "site_slug": site_slug,
+    })
+    .to_string();
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/api/my/preview/sign")
+        .header("content-type", "application/json");
+    if let Some(token) = bearer {
+        req = req.header("authorization", format!("Bearer {token}"));
+    }
+    app.oneshot(req.body(Body::from(body)).unwrap())
+        .await
+        .unwrap()
+}
+
+// ---- Tests ----------------------------------------------------------
+
+#[tokio::test]
+async fn test_1_sign_own_profile_returns_token_and_url() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let resp = sign_preview_request(
+        app,
+        Some(&fx.token_a),
+        "tenant-a",
+        &fx.session_a_id,
+        &fx.site_slug,
+    )
+    .await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "authenticated sign for own profile must succeed"
+    );
+
+    let body = axum::body::to_bytes(resp.into_body(), 16 * 1024)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).expect("sign body should be JSON");
+    let token = json
+        .get("token")
+        .and_then(|v| v.as_str())
+        .expect("token field");
+    assert!(
+        token.len() >= 32,
+        "token must be sufficiently random (got len={})",
+        token.len()
+    );
+    let preview_url = json
+        .get("preview_url")
+        .and_then(|v| v.as_str())
+        .expect("preview_url field");
+    assert!(
+        preview_url.starts_with(&format!("/api/preview-signed/{token}/")),
+        "preview_url must embed the token in path; got: {preview_url}"
+    );
+    assert!(
+        preview_url.ends_with("/index.html"),
+        "preview_url default leaf is /index.html; got: {preview_url}"
+    );
+    assert!(
+        json.get("expires_at").is_some(),
+        "expires_at field must be present"
+    );
+}
+
+#[tokio::test]
+async fn test_2_sign_other_profile_is_forbidden() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    // user A's bearer trying to sign a preview URL for tenant B
+    let resp = sign_preview_request(
+        app,
+        Some(&fx.token_a),
+        "tenant-b",
+        &fx.session_a_id,
+        &fx.site_slug,
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "user A signing for tenant-b MUST be 403"
+    );
+}
+
+#[tokio::test]
+async fn test_3_sign_unauthenticated_is_unauthorized() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let resp = sign_preview_request(app, None, "tenant-a", &fx.session_a_id, &fx.site_slug).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated sign POST must be 401"
+    );
+}
+
+#[tokio::test]
+async fn test_4_get_signed_preview_serves_content_with_referrer_policy() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let sign_resp = sign_preview_request(
+        app.clone(),
+        Some(&fx.token_a),
+        "tenant-a",
+        &fx.session_a_id,
+        &fx.site_slug,
+    )
+    .await;
+    assert_eq!(sign_resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(sign_resp.into_body(), 16 * 1024)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).expect("sign JSON");
+    let preview_url = json
+        .get("preview_url")
+        .and_then(|v| v.as_str())
+        .expect("preview_url")
+        .to_string();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&preview_url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "valid signed-preview token MUST serve content (no Authorization header needed)"
+    );
+
+    let referrer_policy = resp
+        .headers()
+        .get("referrer-policy")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    assert_eq!(
+        referrer_policy.as_deref(),
+        Some("no-referrer"),
+        "signed-preview responses MUST set Referrer-Policy: no-referrer (codex design)"
+    );
+
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("<<<A-CONTENT>>>"),
+        "expected preview body, got: {body_str}"
+    );
+}
+
+#[tokio::test]
+async fn test_5_invalid_token_returns_404_not_401() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    // Bogus token — handler must NOT leak whether it exists.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/preview-signed/00000000000000000000000000000000/index.html")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "invalid token must be 404 (NOT 401), to not leak token existence"
+    );
+}
+
+#[tokio::test]
+async fn test_6_expired_token_returns_404() {
+    // Build a fixture with a tiny TTL so the token is already expired
+    // by the time we GET it. Sleep is short to keep CI snappy.
+    let fx = build_fixture_with_ttl(std::time::Duration::from_millis(50)).await;
+    let app = build_router(fx.state.clone());
+
+    let sign_resp = sign_preview_request(
+        app.clone(),
+        Some(&fx.token_a),
+        "tenant-a",
+        &fx.session_a_id,
+        &fx.site_slug,
+    )
+    .await;
+    assert_eq!(sign_resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(sign_resp.into_body(), 16 * 1024)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).expect("sign JSON");
+    let preview_url = json
+        .get("preview_url")
+        .and_then(|v| v.as_str())
+        .expect("preview_url")
+        .to_string();
+
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&preview_url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "expired token must be treated like an unknown token (404, no leak)"
+    );
+}
+
+#[tokio::test]
+async fn test_7_revoked_bearer_returns_403() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let sign_resp = sign_preview_request(
+        app.clone(),
+        Some(&fx.token_a),
+        "tenant-a",
+        &fx.session_a_id,
+        &fx.site_slug,
+    )
+    .await;
+    assert_eq!(sign_resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(sign_resp.into_body(), 16 * 1024)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).expect("sign JSON");
+    let preview_url = json
+        .get("preview_url")
+        .and_then(|v| v.as_str())
+        .expect("preview_url")
+        .to_string();
+
+    // Revoke user A's bearer via the same AuthManager the fixture used.
+    fx.state
+        .auth_manager
+        .as_ref()
+        .expect("auth manager wired")
+        .revoke_session(&fx.token_a)
+        .await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&preview_url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "after issuer bearer revoked, signed-preview must 403 (re-validation)"
+    );
+}
+
+#[tokio::test]
+async fn test_8_path_traversal_in_signed_preview_is_blocked() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let sign_resp = sign_preview_request(
+        app.clone(),
+        Some(&fx.token_a),
+        "tenant-a",
+        &fx.session_a_id,
+        &fx.site_slug,
+    )
+    .await;
+    assert_eq!(sign_resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(sign_resp.into_body(), 16 * 1024)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).expect("sign JSON");
+    let token = json
+        .get("token")
+        .and_then(|v| v.as_str())
+        .expect("token")
+        .to_string();
+
+    // ../../etc/passwd attack via the path component. Relies on the
+    // symlink-safe walker from PR #1000 + `resolve_preview_asset_path`
+    // refusing parent traversal.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/preview-signed/{token}/../../../etc/passwd"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            resp.status(),
+            StatusCode::NOT_FOUND | StatusCode::BAD_REQUEST
+        ),
+        "path traversal must be refused (404 or 400), not 200; got: {}",
+        resp.status()
+    );
+}

--- a/crates/octos-cli/tests/preview_signed.rs
+++ b/crates/octos-cli/tests/preview_signed.rs
@@ -21,6 +21,9 @@
 //!  - 6: GET signed-preview after expiry → 404 (short test TTL)
 //!  - 7: GET signed-preview after issuer bearer revoked → 403
 //!  - 8: path traversal in `{*path}` → 404 (relies on PR #1000's symlink-safe walk)
+//!  - 9: per-bearer cap reached → 429 (codex GAP 8: DoS protection)
+//!  - 10: background sweeper removes expired tokens (codex NEEDS-FOLLOWUP 6:
+//!    idle daemons must not accumulate expired entries indefinitely)
 
 #![cfg(feature = "api")]
 
@@ -551,5 +554,122 @@ async fn test_8_path_traversal_in_signed_preview_is_blocked() {
         ),
         "path traversal must be refused (404 or 400), not 200; got: {}",
         resp.status()
+    );
+}
+
+/// Codex GAP 8 (blocking): an authenticated user can mint unbounded
+/// preview tokens, each held 10 min in memory. DoS vector — a hostile
+/// (or buggy) client could pump the in-memory map to OOM the daemon.
+///
+/// Fix: cap concurrent grants per `(issuer_bearer)` at
+/// `MAX_PER_BEARER` (64). When the cap is reached, the next mint
+/// returns HTTP 429 instead of growing the map.
+///
+/// This test mints `MAX_PER_BEARER` tokens via the HTTP surface, asserts
+/// every one returns 200, then asserts mint number `MAX_PER_BEARER + 1`
+/// returns 429. The TTL is long enough that the lazy expiry sweep
+/// won't open up a slot mid-test.
+#[tokio::test]
+async fn test_9_per_bearer_cap_returns_429() {
+    let fx = build_fixture().await;
+    let app = build_router(fx.state.clone());
+
+    let cap = octos_cli::api::PreviewTokens::MAX_PER_BEARER;
+
+    // Mint up to the cap — every one must succeed.
+    for i in 0..cap {
+        let resp = sign_preview_request(
+            app.clone(),
+            Some(&fx.token_a),
+            "tenant-a",
+            &fx.session_a_id,
+            &fx.site_slug,
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "mint #{i} (within per-bearer cap of {cap}) must succeed; got {}",
+            resp.status()
+        );
+    }
+
+    // Cap + 1: must be 429 (rate limited).
+    let resp = sign_preview_request(
+        app.clone(),
+        Some(&fx.token_a),
+        "tenant-a",
+        &fx.session_a_id,
+        &fx.site_slug,
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "mint #{cap}+1 must be 429 (per-bearer cap reached); got {}",
+        resp.status()
+    );
+}
+
+/// Codex NEEDS-FOLLOWUP 6: expired tokens are only swept on
+/// `issue`/`consume`. An idle daemon (no preview activity for hours)
+/// accumulates expired entries indefinitely.
+///
+/// Fix: `PreviewTokens::spawn_background_sweeper` starts a tokio task
+/// that calls `sweep_expired_all` every ~60s in production. The
+/// sweeper accepts a configurable interval for tests so we don't have
+/// to wait 60s in CI.
+///
+/// This test:
+///   1. Builds a cache with a tiny TTL (50ms).
+///   2. Mints a token (cache.len() == 1).
+///   3. Spawns the background sweeper with a 20ms interval.
+///   4. Waits past TTL + a couple sweep cycles.
+///   5. Asserts the cache is empty — the background sweeper removed
+///      the expired grant WITHOUT any `issue`/`consume` traffic.
+#[tokio::test]
+async fn test_10_background_sweeper_removes_expired() {
+    use std::time::Duration;
+
+    let cache = std::sync::Arc::new(octos_cli::api::PreviewTokens::with_ttl(
+        Duration::from_millis(50),
+    ));
+
+    // Seed the cache with one token. We use the in-process API directly
+    // (no HTTP) — the background-sweeper contract is on the cache type,
+    // not on the routing layer.
+    let signed = cache
+        .issue(
+            "BEARER-A".into(),
+            octos_cli::api::TestAuthIdentity::User {
+                id: "tenant-a".into(),
+                role: octos_cli::user_store::UserRole::User,
+            },
+            "tenant-a".into(),
+            "session-1".into(),
+            "site-a".into(),
+        )
+        .await
+        .expect("issue");
+    assert_eq!(cache.len().await, 1, "fresh token must be cached");
+
+    // Spawn the background sweeper with a 20ms interval (fast enough to
+    // sweep the 50ms-TTL token within the test's 250ms wait window).
+    let _handle = octos_cli::api::PreviewTokens::spawn_background_sweeper(
+        cache.clone(),
+        Duration::from_millis(20),
+    );
+
+    // Wait past TTL + several sweep cycles. 250ms = 5x TTL = ~12x
+    // sweep interval, well over the minimum to guarantee at least one
+    // sweep after the token expires.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    assert_eq!(
+        cache.len().await,
+        0,
+        "background sweeper MUST have removed the expired token \
+         (was: token {} still present after 250ms with 50ms TTL + 20ms sweep)",
+        signed.token
     );
 }


### PR DESCRIPTION
## Summary

PR #1001 closed the cross-tenant `/api/preview/{profile_id}/...` data read by requiring `Authorization: Bearer ...` on every request. That regressed the SPA iframe UX — `<iframe src=...>` cannot inject headers, so the dashboard's preview iframe 401-loops after #1001 landed.

Codex's design: mint an opaque 256-bit random token via `POST /api/my/preview/sign`, stash a server-side grant `{issuer_bearer, identity_snapshot, profile_id, session_id, site_slug, expires_at}`, serve via PUBLIC route `GET /api/preview-signed/{token}/{*path}` where the token IS the credential. Token in URL **path** so relative assets inherit the prefix without rewriting.

### Implementation

- **New** `crates/octos-cli/src/api/preview_tokens.rs` — `PreviewTokens` cache (256-bit `getrandom` → 64 hex chars, 10-min default TTL, `RwLock<HashMap>`, sweep on issue/consume).
- `handlers::sign_preview` — auth + `is_authorized_for_profile` + on-disk site existence check.
- `handlers::serve_signed_preview` — public route, consumes token, **re-resolves** issuer bearer via `router::resolve_identity_public`, re-checks `is_authorized_for_profile`, delegates to PR #1000's `serve_preview_no_follow` (does NOT inline a new serve path).
- Response sets `Referrer-Policy: no-referrer` per codex's design.

### Revocation

- Logout / session-delete: bearer no longer resolves → 403 (re-validation on every GET).
- Daemon restart: cache is process-local; every grant invalidates.
- Profile re-authz race: defense-in-depth re-check on every serve.

### Coordinated rollout

Pairs with frontend PR in `octos-web` that switches the iframe to call `POST /api/my/preview/sign` and points `iframe.src` at the returned `preview_url`. Both need to land together.

## Pre-fix verification

Disabling the `/api/my/preview/sign` route registration reproduces:

```
test_3_sign_unauthenticated_is_unauthorized FAILED
  assertion left == right failed: unauthenticated sign POST must be 401
    left: 404
    right: 401
```

## Test plan

- [x] `cargo build --workspace --features api` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-cli --features api --tests` — no new warnings
- [x] `cargo test -p octos-cli --features api --test preview_signed` — 8/8 pass
- [x] `cargo test -p octos-cli --features api --lib preview_tokens` — 4/4 pass
- [x] Existing `preview_auth` suite — 10/11 pass (one pre-existing failure on origin/main, unrelated)
- [ ] Reviewer: confirm the path-traversal test exercises PR #1000's symlink-safe walk