### PR TITLE
fix(api): URL-decode WS token query param (closes #1010)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3795,6 +3795,7 @@ dependencies = [
  "octos-pipeline",
  "octos-swarm",
  "open",
+ "percent-encoding",
  "quick-xml",
  "rand 0.8.5",
  "regex",

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -39,6 +39,14 @@ sha2 = { workspace = true }
 subtle = { workspace = true, optional = true }
 getrandom = "0.2"
 constant_time_eq = "0.3"
+# Issue #1010 — `extract_token` must percent-decode the `token=` query
+# param so a token containing `!`, `+`, `/`, `=`, `:` matches the value
+# stored on `AppState.auth_token` / the OTP session store. The
+# `Authorization: Bearer …` header path takes the bytes literally —
+# HTTP headers are NOT percent-encoded — so the WS path uses RFC 3986
+# percent-decode-only semantics (leaves `+` literal) to stay consistent
+# with REST.
+percent-encoding = "2"
 open = { workspace = true }
 zip = { workspace = true }
 quick-xml = { workspace = true }

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -820,6 +820,24 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 }
 
 /// Extract bearer token from request headers or query params.
+///
+/// Header path: `Authorization: Bearer <token>` — taken byte-for-byte
+/// (HTTP header values are NOT percent-encoded).
+///
+/// Query path: `?token=<value>` or `?_token=<value>` — used by SSE,
+/// `EventSource`, `<img src>`, and WebSocket clients that cannot set
+/// custom headers. Per [issue #1010](https://github.com/octos-org/octos/issues/1010),
+/// the raw query value is **percent-decoded** before comparison. The
+/// raw URI fragment may contain `%21` for `!`, `%2B` for `+`, `%2F`
+/// for `/`, etc. — without decoding, a token like
+/// `Octos-E2E-Strong-Token-2026-XYZ-123!` arrives as
+/// `…123%21`, never matches the stored token, and the auth middleware
+/// silently 401s the upgrade while REST callers (header path) work.
+///
+/// Decode semantics are RFC 3986 percent-decode-only — `+` stays
+/// literal `+`, only `%XX` triples are decoded — so the two auth paths
+/// accept the same token format. `application/x-www-form-urlencoded`
+/// (`+` → space) would break tokens containing `+`.
 fn extract_token(req: &axum::http::Request<axum::body::Body>) -> String {
     // Try Authorization header first
     let header_token = req
@@ -844,7 +862,14 @@ fn extract_token(req: &axum::http::Request<axum::body::Body>) -> String {
     if !header_token.is_empty() {
         header_token.to_string()
     } else {
-        query_token.to_string()
+        // RFC 3986 percent-decode (NOT form-decode — `+` stays literal).
+        // `decode_utf8_lossy` substitutes U+FFFD for invalid UTF-8
+        // sequences, which keeps the function infallible; downstream
+        // constant-time comparison against stored ASCII tokens still
+        // fails on garbage input.
+        percent_encoding::percent_decode_str(query_token)
+            .decode_utf8_lossy()
+            .into_owned()
     }
 }
 
@@ -1137,6 +1162,60 @@ mod tests {
             .body(axum::body::Body::empty())
             .unwrap();
         assert_eq!(extract_token(&req), "");
+    }
+
+    /// Issue [#1010](https://github.com/octos-org/octos/issues/1010):
+    /// browsers and curl percent-encode special characters in query
+    /// string values. The raw query string contains `%21` for `!`, so
+    /// the extractor must percent-decode the value before handing it to
+    /// `resolve_identity` — otherwise the comparison never matches the
+    /// stored token and WS auth silently 401s while REST (which carries
+    /// the token in the `Authorization` header) works.
+    #[test]
+    fn extract_token_query_param_is_percent_decoded_exclamation() {
+        let req = Request::builder()
+            .uri("/api/ui-protocol/ws?token=test-token-%21")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(extract_token(&req), "test-token-!");
+    }
+
+    /// Percent-decode-only semantics (RFC 3986), not `application/x-www-form-urlencoded`:
+    /// `+` stays literal `+` (matching the `Authorization: Bearer …`
+    /// header path, which never form-decodes), and `%2B` decodes to `+`.
+    #[test]
+    fn extract_token_query_param_keeps_plus_literal_and_decodes_pct2b() {
+        let req = Request::builder()
+            .uri("/api/ui-protocol/ws?token=test+token%2Bfoo")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(extract_token(&req), "test+token+foo");
+    }
+
+    /// Regression: tokens without any percent-encodable characters
+    /// continue to round-trip unchanged. Guards against an over-eager
+    /// decoder that mangles plain ASCII alphanumerics.
+    #[test]
+    fn extract_token_query_param_alphanumeric_unchanged() {
+        let req = Request::builder()
+            .uri("/api/ui-protocol/ws?token=simpleToken123")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(extract_token(&req), "simpleToken123");
+    }
+
+    /// A few extra characters that show up in real-world admin tokens
+    /// (`/`, `=`, `:`) and the percent-encoded equivalents should
+    /// round-trip cleanly. We pick the percent-encoded forms because
+    /// raw `:`/`/`/`=` in a query value are technically legal per RFC
+    /// 3986 but browsers/curl often encode them anyway.
+    #[test]
+    fn extract_token_query_param_decodes_common_special_chars() {
+        let req = Request::builder()
+            .uri("/api/ui-protocol/ws?token=A%2FB%3DC%3AD")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert_eq!(extract_token(&req), "A/B=C:D");
     }
 
     #[tokio::test]

--- a/crates/octos-cli/tests/ws_token_url_decode.rs
+++ b/crates/octos-cli/tests/ws_token_url_decode.rs
@@ -1,0 +1,208 @@
+//! Integration tests for [issue #1010](https://github.com/octos-org/octos/issues/1010):
+//! WS token auth must percent-decode the `?token=` query parameter so
+//! browsers / curl can pass tokens that contain `!`, `+`, `/`, `=`, `:`
+//! etc. without silent 401s.
+//!
+//! ## What this guards
+//!
+//! `extract_token` in `crates/octos-cli/src/api/router.rs` used to take
+//! the raw query string value and hand it to `resolve_identity`
+//! verbatim. Browsers and curl percent-encode special characters when
+//! they build the URL, so a token like
+//! `Octos-E2E-Strong-Token-2026-XYZ-123!` arrived at the server as
+//! `…123%21` and never matched the stored
+//! `AppState.auth_token = "…123!"`. REST callers were unaffected
+//! because the `Authorization: Bearer …` header path takes bytes
+//! literally (HTTP header values are NOT percent-encoded).
+//!
+//! ## How the assertions work
+//!
+//! `tower::oneshot` does not attach the `hyper::upgrade::OnUpgrade`
+//! extension, so a real WS upgrade is impossible in this harness. The
+//! contract we test is therefore "did the auth middleware accept or
+//! reject this token?":
+//!
+//! * Auth accepted ⇒ control reaches the WS handler ⇒ the missing
+//!   upgrade extension causes axum's `WebSocketUpgradeRejection`
+//!   path to return a **4xx that is NOT 401** (today: `400 Bad
+//!   Request` from `MethodNotGet`/`InvalidConnectionHeader` etc., or
+//!   `426 Upgrade Required`). The test only asserts `status != 401`,
+//!   so future axum versions that change the rejection status code
+//!   do not break this guard.
+//! * Auth rejected ⇒ the middleware short-circuits with **`401
+//!   Unauthorized`** before the handler runs.
+//!
+//! Pre-fix, every "auth accepted" assertion below failed with `401`
+//! because `extract_token` returned the percent-encoded literal.
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use octos_cli::api::{AppState, build_router};
+use tempfile::TempDir;
+use tower::util::ServiceExt;
+
+/// Build an `AppState` with a single stored admin token. The token is
+/// the literal pre-decoded value — exactly what a REST caller would
+/// pass in `Authorization: Bearer …`. The WS path must arrive at this
+/// same byte sequence after percent-decoding the `?token=` value.
+fn build_state_with_admin_token(_dir: &TempDir, token: &str) -> Arc<AppState> {
+    let store = Arc::new(octos_cli::profiles::ProfileStore::open(_dir.path()).unwrap());
+    Arc::new(AppState {
+        profile_store: Some(store),
+        auth_token: Some(token.into()),
+        ..AppState::empty_for_tests()
+    })
+}
+
+/// Issue #1010 — `!` is a sub-delim per RFC 3986 and browsers /
+/// `URLSearchParams.toString()` encode it to `%21` in query values.
+/// Pre-fix the server compared `"test-token-%21"` against the stored
+/// `"test-token-!"` and returned 401.
+#[tokio::test]
+async fn should_authenticate_ws_with_token_containing_exclamation() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state_with_admin_token(&dir, "test-token-!");
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/ui-protocol/ws?token=test-token-%21")
+                .header("connection", "Upgrade")
+                .header("upgrade", "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "WS upgrade with percent-encoded `!` token must NOT be rejected \
+         by the auth middleware — see issue #1010"
+    );
+}
+
+/// Issue #1010 — `+` and `%` ambiguity test.
+///
+/// `+` is a reserved-ish character with two competing decode rules:
+/// `application/x-www-form-urlencoded` decodes `+` → space, while RFC
+/// 3986 percent-decoding leaves `+` literal. The REST `Authorization:
+/// Bearer …` path is literal (no decoding at all), so the WS path
+/// MUST use RFC 3986 semantics — otherwise REST and WS accept
+/// different token formats and operators get confused.
+///
+/// Query value: `test+token%2Bfoo`
+///   * `+` stays literal `+`
+///   * `%2B` decodes to `+`
+///   * result: `test+token+foo`
+///
+/// Pre-fix the server compared `"test+token%2Bfoo"` against the stored
+/// `"test+token+foo"` and returned 401.
+#[tokio::test]
+async fn should_authenticate_ws_with_token_containing_plus_and_percent() {
+    let dir = TempDir::new().unwrap();
+    // Decoded form (what REST `Authorization: Bearer …` would receive).
+    let stored_token = "test+token+foo";
+    let state = build_state_with_admin_token(&dir, stored_token);
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/ui-protocol/ws?token=test+token%2Bfoo")
+                .header("connection", "Upgrade")
+                .header("upgrade", "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "WS upgrade with mixed `+` (literal) and `%2B` (decodes to `+`) \
+         must NOT be rejected — the WS path uses RFC 3986 percent-decode \
+         semantics so `+` stays literal, matching the REST header path \
+         which never decodes anything"
+    );
+}
+
+/// Regression — a plain alphanumeric token continues to authenticate.
+/// Guards against an over-eager decoder that mangles ASCII letters or
+/// numbers, or an off-by-one that drops a character on every request.
+#[tokio::test]
+async fn should_authenticate_ws_with_alphanumeric_token() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state_with_admin_token(&dir, "simpleToken123");
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/ui-protocol/ws?token=simpleToken123")
+                .header("connection", "Upgrade")
+                .header("upgrade", "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "WS upgrade with a plain alphanumeric token must continue to \
+         authenticate — pre-#1010 behaviour preserved"
+    );
+}
+
+/// Issue #1010 inverse — passing a URL-encoded version of a WRONG
+/// token must STILL return 401. The fix must not accidentally accept
+/// any token whose decoded form differs from the stored value.
+///
+/// Stored token: `correct-token!`. Client supplies `wrong-token%21`
+/// (`wrong-token!` after decoding) — still wrong, still 401.
+#[tokio::test]
+async fn should_reject_ws_with_wrong_decoded_token() {
+    let dir = TempDir::new().unwrap();
+    let state = build_state_with_admin_token(&dir, "correct-token!");
+    let app = build_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/ui-protocol/ws?token=wrong-token%21")
+                .header("connection", "Upgrade")
+                .header("upgrade", "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "WS upgrade with a wrong token (even after percent-decoding) \
+         must continue to 401 — the fix MUST NOT widen the accept set"
+    );
+}


### PR DESCRIPTION
## Summary

- **Closes #1010** — WS token auth silently 401'd whenever the operator's admin token contained a character that browsers / curl percent-encode in query strings (`!`, `+`, `%`, `=`, `/`, `:`, …). REST callers were unaffected because the `Authorization: Bearer …` header path takes bytes literally — HTTP header values are NOT percent-encoded.
- **Fix** — `extract_token` in `crates/octos-cli/src/api/router.rs` now percent-decodes the `?token=` / `?_token=` value before passing it to `resolve_identity`.
- **Decoder** — `percent_encoding::percent_decode_str(value).decode_utf8_lossy()` (`percent-encoding` v2, already in the lockfile as a transitive dep of `reqwest`/`url`).

## Decode semantics

**RFC 3986 percent-decode-only**, **not** `application/x-www-form-urlencoded`. Concretely:

| Input fragment | After decode |
| --- | --- |
| `test-token-%21` | `test-token-!` |
| `simpleToken123` | `simpleToken123` |
| `test+token%2Bfoo` | `test+token+foo` (`+` stays literal, `%2B` → `+`) |
| `A%2FB%3DC%3AD` | `A/B=C:D` |

Rationale: the REST `Authorization: Bearer …` path takes bytes literally — HTTP header values are never URL-encoded. To keep WS and REST accepting the **same** token format, the WS path must use the spec-defined "decode only `%XX`, leave everything else alone" rule. The form-encoded variant (`+` → space) would silently mangle any token containing a literal `+`, and would diverge from REST.

## Tests

**4 inline unit tests** in `router::tests::extract_token_query_param_*`:
1. `extract_token_query_param_is_percent_decoded_exclamation`
2. `extract_token_query_param_keeps_plus_literal_and_decodes_pct2b`
3. `extract_token_query_param_alphanumeric_unchanged` (regression)
4. `extract_token_query_param_decodes_common_special_chars` (`/`, `=`, `:`)

**4 integration tests** in `crates/octos-cli/tests/ws_token_url_decode.rs` exercising the full WS-upgrade path through `build_router`:
1. `should_authenticate_ws_with_token_containing_exclamation`
2. `should_authenticate_ws_with_token_containing_plus_and_percent`
3. `should_authenticate_ws_with_alphanumeric_token` (regression)
4. `should_reject_ws_with_wrong_decoded_token` (must NOT widen accept set)

Pre-fix RED quote, integration test 1: `assertion 'left != right' failed: left: 401, right: 401` (auth middleware short-circuits before the WS handler).

Pre-fix RED quote, unit test 1: `left: "test-token-%21", right: "test-token-!"` — confirms the raw query value was being compared literally.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo build --workspace --features octos-cli/api` clean
- [x] `cargo test -p octos-cli --features api --test ws_token_url_decode` — 4 / 4 pass
- [x] `cargo test -p octos-cli --features api --lib api::router::tests::` — 35 / 35 pass (includes 4 new + 7 existing extract_token unit tests)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-cli --features api --tests` — no new warnings in `router.rs` or `ws_token_url_decode.rs`
- [x] Pre-existing failures: 3 unrelated tests in `api::ui_protocol::tests::session_*` fail on `origin/main@9c2fac5d` too (capabilities-schema test fixtures out of sync with the `permission.profile.v1` / `runtime.policy_stamp.v1` features landed in #1004 / #1002). Verified via `git stash && cargo test` on the bare main.

## Scope

- One-line decoder at the call site — no API-surface change.
- No behaviour change for the REST `Authorization: Bearer …` header path.
- New crate dep `percent-encoding = "2"` (already in `Cargo.lock` as a transitive dep, zero-cost addition).