### PR TITLE
fix(workspace_policy): recursive globs for podcast/voice validators

### DIFF
--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -826,11 +826,11 @@ impl WorkspacePolicy {
             // close the gap for both validators in one shot.
             on_completion: vec![
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                    glob: "skill-output/mofa-podcast/*.mp3".into(),
+                    glob: "skill-output/mofa-podcast/**/*.mp3".into(),
                     format: MagicByteKind::Mp3,
                 }),
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
-                    glob: "skill-output/mofa-podcast/*.mp3".into(),
+                    glob: "skill-output/mofa-podcast/**/*.mp3".into(),
                     min_ratio: default_non_silent_ratio(),
                 }),
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::PerFileNonSilent {
@@ -855,7 +855,7 @@ impl WorkspacePolicy {
             on_failure: vec!["notify_user:Voice synthesis failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(
                 ValidatorSpec::AudioNonSilent {
-                    glob: "skill-output/voice/*.{mp3,wav}".into(),
+                    glob: "skill-output/voice/**/*.{mp3,wav}".into(),
                     min_ratio: default_non_silent_ratio(),
                 },
             )],

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -34,8 +34,8 @@ on_verify = [
 ]
 on_failure = ["notify_user:Podcast generation failed"]
 on_completion = [
-    { kind = "magic_bytes", glob = "skill-output/mofa-podcast/*.mp3", format = "mp3" },
-    { kind = "audio_non_silent", glob = "skill-output/mofa-podcast/*.mp3", min_ratio = 0.3 },
+    { kind = "magic_bytes", glob = "skill-output/mofa-podcast/**/*.mp3", format = "mp3" },
+    { kind = "audio_non_silent", glob = "skill-output/mofa-podcast/**/*.mp3", min_ratio = 0.3 },
 ]
 
 [spawn_tasks.fm_voice_save]


### PR DESCRIPTION
## Summary

Podcast generation showed as failed on mini5 even when the mp3 was produced correctly:
```
✗ Podcast generation failed: required validator failure:
  podcast_generate.on_completion[0]: magic_bytes: no files matched 'skill-output/mofa-podcast/*.mp3'
```

Root cause: mofa-podcast writes to `mofa-podcast/<topic>/podcast_full_*.mp3`. The `glob` crate treats `*` as non-recursive. Validator misses mp3 living one level deeper.

Verified mini5: session `web-1778975075557-mep5d7` mp3 at `mofa-podcast/hello-world/podcast_full_1778975114.mp3`; flat-layout session passed because mp3 sat directly under `mofa-podcast/`.

## Fix

3 sites, all `*` → `**/*`:
- `workspace_policy.rs:829, 833` — podcast MagicBytes + AudioNonSilent
- `workspace_policy.rs:858` — voice AudioNonSilent (same risk for `voice/<name>/...`)
- `tests/fixtures/workspace_policy_v1_session.toml:37-38` — matching

Already-recursive contracts (`mofa_slides_contract: **/*.pptx`, `mofa_cards_contract: **/*.png`) served as template.

## Test plan
- [x] `cargo build -p octos-agent --features audio_mp3` clean
- [x] `cargo test -p octos-agent --lib workspace_policy::tests` — 47 passed