### PR TITLE
fix(deploy): add audio_mp3 to canonical fleet feature flags (closes #1025)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -31,7 +31,7 @@ jobs:
           echo "OCTOS_BUILD_DATE=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
 
       - name: Build octos CLI
-        run: cargo build --release -p octos-cli --features "api,telegram,discord,feishu,twilio,wecom,wecom-bot"
+        run: cargo build --release -p octos-cli --features "api,telegram,discord,feishu,twilio,wecom,wecom-bot,audio_mp3"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci-self-hosted.yml
+++ b/.github/workflows/ci-self-hosted.yml
@@ -21,7 +21,7 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CARGO_TERM_COLOR: always
-  FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"
+  FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
 
 jobs:
   fast-linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CARGO_TERM_COLOR: always
-  FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"
+  FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
   SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p pipeline-guard -p skill-evolve"
 
 jobs:
@@ -294,7 +294,7 @@ jobs:
           shared-key: matrix-feature
 
       - name: Check octos-cli with matrix feature
-        run: cargo check -p octos-cli --no-default-features --features api,telegram,discord,slack,whatsapp,feishu,email,matrix
+        run: cargo check -p octos-cli --no-default-features --features api,telegram,discord,slack,whatsapp,feishu,email,matrix,audio_mp3
 
   check-arm:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -50,7 +50,7 @@ jobs:
         run: cargo release ${{ inputs.bump }} --execute --no-confirm
 
       - name: Build octos CLI
-        run: cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"
+        run: cargo build --release -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
 
       - name: Build app-skill binaries
         run: cargo build --release -p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p pipeline-guard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"
+  FEATURES: "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
   SKILL_CRATES: "-p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p pipeline-guard"
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,15 @@ cargo clippy --workspace         # Lint
 cargo fmt --all                  # Format
 cargo fmt --all -- --check       # Check formatting
 cargo install --path crates/octos-cli \
-    --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot"
+    --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"
                                           # Install CLI locally with the
                                           # canonical feature default
                                           # (matches scripts/milestone-ci.sh).
                                           # `api` is required for `octos serve`.
+                                          # `audio_mp3` is required for the
+                                          # `podcast_generate` workspace
+                                          # contract to validate mp3 output
+                                          # (see #1025).
 ```
 
 ## Architecture

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p crates/octos-core/src && echo "" > crates/octos-core/src/lib.rs && 
 
 RUN cargo build --release --bin octos \
       -p octos-cli \
-      --features api,telegram,discord,slack,whatsapp,feishu,email \
+      --features api,telegram,discord,slack,whatsapp,feishu,email,audio_mp3 \
       2>/dev/null || true
 
 # Copy full source and build
@@ -55,7 +55,7 @@ COPY . .
 RUN find crates -name '*.rs' -exec touch {} + && \
     cargo build --release --bin octos \
       -p octos-cli \
-      --features api,telegram,discord,slack,whatsapp,feishu,email,matrix
+      --features api,telegram,discord,slack,whatsapp,feishu,email,matrix,audio_mp3
 
 # ============================================================
 # Stage 2: Minimal runtime image

--- a/scripts/frp/bootstrap-tenant.sh
+++ b/scripts/frp/bootstrap-tenant.sh
@@ -160,7 +160,7 @@ if [ "$SKIP_BUILD" = false ]; then
     echo ""
     echo "==> Step 2: Building octos (release, all features)..."
     (cd "$REPO_ROOT" && cargo build --release -p octos-cli \
-        --features "api,telegram,whatsapp,feishu,twilio,wecom" 2>&1 | tail -3)
+        --features "api,telegram,whatsapp,feishu,twilio,wecom,audio_mp3" 2>&1 | tail -3)
 
     # Also build app-skills
     (cd "$REPO_ROOT" && cargo build --release \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1235,7 +1235,7 @@ case "$TRIPLE" in
         err "macOS x86_64 does not have pre-built binaries yet."
         hint "Build from source with the canonical feature set:"
         hint "  cargo install --path crates/octos-cli \\"
-        hint "      --features \"api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot\""
+        hint "      --features \"api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3\""
         hint "(matches scripts/milestone-ci.sh; \`api\` is required for \`octos serve\`.)"
         ;;
 esac

--- a/scripts/local-tenant-deploy.sh
+++ b/scripts/local-tenant-deploy.sh
@@ -310,7 +310,7 @@ case "$MODE" in
         echo "    Mode: minimal (CLI + chat only)"
         ;;
     full)
-        CLI_FEATURES="api,telegram,discord,slack,whatsapp,feishu,email,twilio,wecom"
+        CLI_FEATURES="api,telegram,discord,slack,whatsapp,feishu,email,twilio,wecom,audio_mp3"
         echo "    Mode: full (all channels + dashboard + skills)"
         ;;
 esac

--- a/scripts/milestone-ci.sh
+++ b/scripts/milestone-ci.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-FEATURES="${FEATURES:-api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot}"
+FEATURES="${FEATURES:-api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3}"
 SKILL_CRATES="${SKILL_CRATES:--p news_fetch -p deep-search -p deep-crawl -p send-email -p account-manager -p voice -p clock -p weather -p skill-evolve}"
 
 usage() {

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -99,7 +99,7 @@ section "Build"
 if [ "$SKIP_BUILD" = true ]; then
     skip "release build (--skip-build)"
 else
-    BUILD_FLAGS="--features telegram,whatsapp,feishu,twilio,api"
+    BUILD_FLAGS="--features telegram,whatsapp,feishu,twilio,api,audio_mp3"
     echo "  Building octos-cli ($PROFILE) with $BUILD_FLAGS"
 
     if [ "$PROFILE" = "release" ]; then


### PR DESCRIPTION
## Summary

PR #1014's recursive `**/*.mp3` glob unmasked a pre-existing feature-flag gap: the `audio_non_silent` validator needs the optional `audio_mp3` Cargo feature, which gates the `symphonia` MP3 decoder dep at `crates/octos-agent/Cargo.toml:61`. The canonical fleet build command never included `audio_mp3`, so every `podcast_generate` invocation on the fleet now hard-fails workspace contract validation despite the mp3 being correctly produced.

Reproduced live on mini5 (binary `74693f4e`, 2026-05-17T21:46:04). Filed as #1025.

## Fix

Add `audio_mp3` to all 12 canonical feature-flag sites:

**Scripts/docs (5):**
- `scripts/milestone-ci.sh` — CI default
- `scripts/pre-release.sh` — release builds
- `scripts/install.sh` — operator install hint
- `scripts/frp/bootstrap-tenant.sh` — tenant bootstrap
- `CLAUDE.md` — developer install snippet

**Codex round-1 additions (7):**
- `.github/workflows/release.yml` + `release-dispatch.yml` + `build-linux.yml` — release artifacts
- `.github/workflows/ci.yml` + `ci-self-hosted.yml` — CI builds
- `Dockerfile` (both build stages) — Docker images
- `scripts/local-tenant-deploy.sh` — manual tenant deploys

## Verified live

Rebuilt with new flag set (`3570bc8d`), deployed to mini5, re-ran the original podcast prompt via WS probe at 21:52:52. Result:

- `fm_tts` × 2 spawn_only tools completed `success=true`
- MP3 files produced: `yangmi_*1779054792.mp3`, `douwentao_*1779054792.mp3`
- **Zero workspace contract rejections** — `audio_non_silent` validator now passes on mp3

## Test plan

- [x] Rebuild + deploy mini5
- [x] Live probe: mp3 produced, validator passed
- [ ] Roll to mini1/2/3 once merged

Closes #1025
🤖 Generated with [Claude Code](https://claude.com/claude-code)