### PR TITLE
fix(workspace_policy): use plugin files_to_send for validation (closes #1034)

### DIFF
--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -35,7 +35,9 @@ use tracing::{debug, warn};
 use crate::policy::{CommandPolicy, Decision, SafePolicy};
 use crate::subprocess_env::{EnvAllowlist, sanitize_command_env};
 use crate::tools::{ToolRegistry, ToolResult};
-use crate::workspace_policy::{MagicByteKind, Validator, ValidatorPhaseKind, ValidatorSpec};
+use crate::workspace_policy::{
+    MagicByteKind, Validator, ValidatorFileSource, ValidatorPhaseKind, ValidatorSpec,
+};
 
 /// Current schema version for [`ValidatorOutcome`] persistence.
 pub const VALIDATOR_RESULT_SCHEMA_VERSION: u32 = 1;
@@ -172,6 +174,18 @@ pub struct ValidatorInvocation {
     /// envelope. Used by `${output.<key>}` interpolation; absent when the
     /// tool emitted no named outputs (most legacy plugins).
     pub tool_output: Option<serde_json::Value>,
+    /// Optional `files_to_send` list from the originating spawn_only tool's
+    /// stdout envelope (the plugin protocol's authoritative list of files
+    /// the skill just produced). Consumed by file-list-driven validators
+    /// (`MagicBytes`, `AudioNonSilent`, `PerFileNonSilent`) when their spec
+    /// declares `source = "spawn_only_files"` — see issue octos #1034.
+    ///
+    /// Absent (defaulted to an empty `Vec`) for non-spawn contexts and for
+    /// spawn_only tools that emit no files. Validators that consult this
+    /// list and find it empty surface a `Fail` outcome so misconfigured
+    /// policies (e.g. opting into `spawn_only_files` from a turn-end
+    /// validator that has no plugin output) are caught early.
+    pub spawn_only_files: Vec<PathBuf>,
 }
 
 impl ValidatorInvocation {
@@ -184,6 +198,7 @@ impl ValidatorInvocation {
             repo_label,
             input_args: None,
             tool_output: None,
+            spawn_only_files: Vec::new(),
         }
     }
 
@@ -198,6 +213,14 @@ impl ValidatorInvocation {
     /// `${output.<key>}` template interpolation by domain validators.
     pub fn with_tool_output(mut self, output: serde_json::Value) -> Self {
         self.tool_output = Some(output);
+        self
+    }
+
+    /// Attach the plugin-reported `files_to_send` list so file-list-driven
+    /// validators with `source = "spawn_only_files"` (issue octos #1034)
+    /// can consume the authoritative path set the spawn_only tool emitted.
+    pub fn with_spawn_only_files(mut self, files: Vec<PathBuf>) -> Self {
+        self.spawn_only_files = files;
         self
     }
 }
@@ -519,25 +542,53 @@ impl ValidatorRunner {
                     )
                     .await
                 }
-                ValidatorSpec::AudioNonSilent { glob, min_ratio } => self.run_audio_non_silent(
-                    invocation, validator, glob, *min_ratio, started_at, started,
+                ValidatorSpec::AudioNonSilent {
+                    glob,
+                    min_ratio,
+                    source,
+                    extension,
+                } => self.run_audio_non_silent(
+                    invocation,
+                    validator,
+                    glob,
+                    *min_ratio,
+                    *source,
+                    extension.as_deref(),
+                    started_at,
+                    started,
                 ),
                 ValidatorSpec::PerFileNonSilent {
                     glob,
                     min_ratio,
                     require_at_least,
+                    source,
+                    extension,
                 } => self.run_per_file_non_silent(
                     invocation,
                     validator,
                     glob,
                     *min_ratio,
                     *require_at_least,
+                    *source,
+                    extension.as_deref(),
                     started_at,
                     started,
                 ),
-                ValidatorSpec::MagicBytes { glob, format } => {
-                    self.run_magic_bytes(invocation, validator, glob, *format, started_at, started)
-                }
+                ValidatorSpec::MagicBytes {
+                    glob,
+                    format,
+                    source,
+                    extension,
+                } => self.run_magic_bytes(
+                    invocation,
+                    validator,
+                    glob,
+                    *format,
+                    *source,
+                    extension.as_deref(),
+                    started_at,
+                    started,
+                ),
                 ValidatorSpec::HttpProbeUntil {
                     url_template,
                     expected_status,
@@ -1093,46 +1144,36 @@ impl ValidatorRunner {
     }
 
     /// Run an AudioNonSilent validator.
+    #[allow(clippy::too_many_arguments)]
     fn run_audio_non_silent(
         &self,
         invocation: &ValidatorInvocation,
         validator: &Validator,
         pattern: &str,
         min_ratio: f32,
+        source: ValidatorFileSource,
+        extension: Option<&str>,
         started_at: DateTime<Utc>,
         started: Instant,
     ) -> ValidatorOutcome {
-        // Interpolate `${args.X}` / `${output.X}` so policies can scope the
-        // glob to a per-invocation output dir (e.g.
-        // `${output.audio_dir}/**/*.wav`). A missing key is a hard error.
-        let resolved_pattern = match interpolate_template(
+        // Resolve the candidate file list. For `source = "glob"` (legacy
+        // default) the validator interpolates the glob and matches it
+        // against the workspace root. For `source = "spawn_only_files"`
+        // (issue octos #1034) the validator consumes the plugin-reported
+        // `files_to_send` list verbatim, optionally narrowed by extension —
+        // see [`resolve_validator_files`] for the shared resolution rules.
+        let (matches, pattern_for_diagnostics) = match resolve_validator_files(
+            invocation,
             pattern,
-            invocation.input_args.as_ref(),
-            invocation.tool_output.as_ref(),
+            source,
+            extension,
+            FileResolutionMode::TemplateBoth,
+            "audio_non_silent",
         ) {
-            Ok(value) => value,
-            Err(reason) => {
-                return self.make_outcome(
-                    invocation,
-                    validator,
-                    ValidatorStatus::Error,
-                    reason,
-                    started_at,
-                    started,
-                );
-            }
-        };
-        let matches = match glob_files(&invocation.workspace_root, &resolved_pattern) {
-            Ok(matches) => matches,
-            Err(reason) => {
-                return self.make_outcome(
-                    invocation,
-                    validator,
-                    ValidatorStatus::Error,
-                    reason,
-                    started_at,
-                    started,
-                );
+            Ok(resolution) => resolution,
+            Err(FileResolutionError { status, reason }) => {
+                return self
+                    .make_outcome(invocation, validator, status, reason, started_at, started);
             }
         };
         if matches.is_empty() {
@@ -1140,7 +1181,7 @@ impl ValidatorRunner {
                 invocation,
                 validator,
                 ValidatorStatus::Fail,
-                format!("audio_non_silent: no files matched '{resolved_pattern}'"),
+                format!("audio_non_silent: no files matched '{pattern_for_diagnostics}'"),
                 started_at,
                 started,
             );
@@ -1200,38 +1241,30 @@ impl ValidatorRunner {
         pattern: &str,
         min_ratio: f32,
         require_at_least: usize,
+        source: ValidatorFileSource,
+        extension: Option<&str>,
         started_at: DateTime<Utc>,
         started: Instant,
     ) -> ValidatorOutcome {
-        // Interpolate `${args.X}` ONLY (rejects path-traversal segments and
-        // absolute-path arg values). `${output.X}` is intentionally not
-        // supported here — callers wanting tool-output-driven globs should
-        // use the whole-file `AudioNonSilent` variant.
-        let resolved_pattern = match interpolate_args_path(pattern, invocation.input_args.as_ref())
-        {
-            Ok(value) => value,
-            Err(reason) => {
-                return self.make_outcome(
-                    invocation,
-                    validator,
-                    ValidatorStatus::Error,
-                    reason,
-                    started_at,
-                    started,
-                );
-            }
-        };
-        let matches = match glob_files(&invocation.workspace_root, &resolved_pattern) {
-            Ok(matches) => matches,
-            Err(reason) => {
-                return self.make_outcome(
-                    invocation,
-                    validator,
-                    ValidatorStatus::Error,
-                    reason,
-                    started_at,
-                    started,
-                );
+        // Resolve the candidate file list. Glob mode interpolates `${args.X}`
+        // ONLY (rejects path-traversal segments and absolute-path arg
+        // values). `${output.X}` is intentionally not supported in glob mode
+        // here — callers wanting tool-output-driven globs should use the
+        // whole-file `AudioNonSilent` variant. `spawn_only_files` mode
+        // (octos #1034) bypasses interpolation entirely and consumes the
+        // plugin-reported file list verbatim.
+        let (matches, _resolved_pattern) = match resolve_validator_files(
+            invocation,
+            pattern,
+            source,
+            extension,
+            FileResolutionMode::TemplateArgsOnly,
+            "per_file_non_silent",
+        ) {
+            Ok(resolution) => resolution,
+            Err(FileResolutionError { status, reason }) => {
+                return self
+                    .make_outcome(invocation, validator, status, reason, started_at, started);
             }
         };
 
@@ -1300,45 +1333,35 @@ impl ValidatorRunner {
     }
 
     /// Run a MagicBytes validator.
+    #[allow(clippy::too_many_arguments)]
     fn run_magic_bytes(
         &self,
         invocation: &ValidatorInvocation,
         validator: &Validator,
         pattern: &str,
         kind: MagicByteKind,
+        source: ValidatorFileSource,
+        extension: Option<&str>,
         started_at: DateTime<Utc>,
         started: Instant,
     ) -> ValidatorOutcome {
-        // Interpolate `${args.X}` / `${output.X}` so policies can pin the
-        // glob to a tool-emitted output path. Missing key → Error outcome.
-        let resolved_pattern = match interpolate_template(
+        // Resolve the candidate file list. Glob mode interpolates
+        // `${args.X}` / `${output.X}` so policies can pin the glob to a
+        // tool-emitted output path. `spawn_only_files` mode (octos #1034)
+        // bypasses interpolation and consumes the plugin-reported file list
+        // verbatim.
+        let (matches, pattern_for_diagnostics) = match resolve_validator_files(
+            invocation,
             pattern,
-            invocation.input_args.as_ref(),
-            invocation.tool_output.as_ref(),
+            source,
+            extension,
+            FileResolutionMode::TemplateBoth,
+            "magic_bytes",
         ) {
-            Ok(value) => value,
-            Err(reason) => {
-                return self.make_outcome(
-                    invocation,
-                    validator,
-                    ValidatorStatus::Error,
-                    reason,
-                    started_at,
-                    started,
-                );
-            }
-        };
-        let matches = match glob_files(&invocation.workspace_root, &resolved_pattern) {
-            Ok(matches) => matches,
-            Err(reason) => {
-                return self.make_outcome(
-                    invocation,
-                    validator,
-                    ValidatorStatus::Error,
-                    reason,
-                    started_at,
-                    started,
-                );
+            Ok(resolution) => resolution,
+            Err(FileResolutionError { status, reason }) => {
+                return self
+                    .make_outcome(invocation, validator, status, reason, started_at, started);
             }
         };
         if matches.is_empty() {
@@ -1346,7 +1369,7 @@ impl ValidatorRunner {
                 invocation,
                 validator,
                 ValidatorStatus::Fail,
-                format!("magic_bytes: no files matched '{resolved_pattern}'"),
+                format!("magic_bytes: no files matched '{pattern_for_diagnostics}'"),
                 started_at,
                 started,
             );
@@ -2007,6 +2030,128 @@ async fn fetch_ominix_voices(url: &str, timeout_ms: u64) -> Result<Vec<String>, 
     Ok(names)
 }
 
+/// Template-interpolation flavour used by [`resolve_validator_files`].
+///
+/// Mirrors the per-variant interpolation rules already in place before octos
+/// #1034: `MagicBytes` / `AudioNonSilent` substitute both `${args.X}` and
+/// `${output.X}`, while `PerFileNonSilent` substitutes `${args.X}` only via
+/// the path-traversal-safe [`interpolate_args_path`] helper.
+#[derive(Clone, Copy, Debug)]
+enum FileResolutionMode {
+    /// Interpolate both `${args.X}` and `${output.X}`. Used by `MagicBytes`
+    /// and `AudioNonSilent`.
+    TemplateBoth,
+    /// Interpolate `${args.X}` only via [`interpolate_args_path`]. Used by
+    /// `PerFileNonSilent`.
+    TemplateArgsOnly,
+}
+
+/// Error returned by [`resolve_validator_files`] when the file list cannot be
+/// produced (interpolation failure, invalid glob, etc.). The caller surfaces
+/// `status` + `reason` directly through `make_outcome`.
+#[derive(Clone, Debug)]
+struct FileResolutionError {
+    status: ValidatorStatus,
+    reason: String,
+}
+
+/// Resolve the candidate file list for a file-list-driven validator
+/// (`MagicBytes`, `AudioNonSilent`, `PerFileNonSilent`).
+///
+/// * `ValidatorFileSource::Glob` (legacy default) — interpolates the
+///   `pattern` per `mode` and matches the resolved glob against
+///   `invocation.workspace_root` via [`glob_files`]. Returns the matched
+///   path list and the resolved pattern (for diagnostics).
+/// * `ValidatorFileSource::SpawnOnlyFiles` (octos #1034) — bypasses the glob
+///   entirely and consumes `invocation.spawn_only_files` verbatim. If
+///   `extension` is set, only files whose extension matches (case-
+///   insensitive, no leading dot) are returned. The diagnostic pattern is
+///   synthesized from the optional extension filter so failure messages
+///   remain interpretable. Files that do NOT exist on disk are filtered out
+///   so the contract treats a stale `files_to_send` entry the same way the
+///   glob path treats a missing match.
+fn resolve_validator_files(
+    invocation: &ValidatorInvocation,
+    pattern: &str,
+    source: ValidatorFileSource,
+    extension: Option<&str>,
+    mode: FileResolutionMode,
+    validator_kind: &str,
+) -> Result<(Vec<PathBuf>, String), FileResolutionError> {
+    match source {
+        ValidatorFileSource::Glob => {
+            let resolved_pattern = match mode {
+                FileResolutionMode::TemplateBoth => interpolate_template(
+                    pattern,
+                    invocation.input_args.as_ref(),
+                    invocation.tool_output.as_ref(),
+                ),
+                FileResolutionMode::TemplateArgsOnly => {
+                    interpolate_args_path(pattern, invocation.input_args.as_ref())
+                }
+            }
+            .map_err(|reason| FileResolutionError {
+                status: ValidatorStatus::Error,
+                reason,
+            })?;
+            let matches =
+                glob_files(&invocation.workspace_root, &resolved_pattern).map_err(|reason| {
+                    FileResolutionError {
+                        status: ValidatorStatus::Error,
+                        reason,
+                    }
+                })?;
+            Ok((matches, resolved_pattern))
+        }
+        ValidatorFileSource::SpawnOnlyFiles => {
+            let normalized_ext = extension.map(normalize_extension_suffix);
+            let mut matches = Vec::new();
+            for path in &invocation.spawn_only_files {
+                if let Some(ref required) = normalized_ext {
+                    let actual = path
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .map(|s| s.to_ascii_lowercase())
+                        .unwrap_or_default();
+                    if &actual != required {
+                        continue;
+                    }
+                }
+                if path.is_file() {
+                    matches.push(path.clone());
+                }
+            }
+            let diagnostic_pattern = match normalized_ext.as_deref() {
+                Some(ext) => format!("spawn_only_files (extension={ext})"),
+                None => "spawn_only_files".to_string(),
+            };
+            // Surface a helpful Error outcome if a misconfigured policy
+            // opts into `spawn_only_files` but the validator runs in a
+            // context without any plugin-reported files (e.g. a turn-end
+            // pass). The caller turns the empty list into a domain-specific
+            // Fail message; this branch fires ONLY when the policy itself
+            // is asking for a list the invocation cannot produce.
+            if invocation.spawn_only_files.is_empty() {
+                return Err(FileResolutionError {
+                    status: ValidatorStatus::Fail,
+                    reason: format!(
+                        "{validator_kind}: source = \"spawn_only_files\" requested but the spawn_only \
+                         tool emitted no files_to_send"
+                    ),
+                });
+            }
+            Ok((matches, diagnostic_pattern))
+        }
+    }
+}
+
+/// Normalize an extension filter (`"mp3"`, `".MP3"`, `"Mp3"`) to a lowercase
+/// no-leading-dot form so [`resolve_validator_files`] can compare against
+/// `PathBuf::extension()` output uniformly.
+fn normalize_extension_suffix(ext: &str) -> String {
+    ext.trim_start_matches('.').to_ascii_lowercase()
+}
+
 /// Resolve a glob pattern against `workspace_root` and return matching files
 /// (skipping directories).
 fn glob_files(workspace_root: &Path, pattern: &str) -> Result<Vec<PathBuf>, String> {
@@ -2426,7 +2571,9 @@ mod tests {
         assert_eq!(
             validator_kind_label(&ValidatorSpec::AudioNonSilent {
                 glob: "*.wav".into(),
-                min_ratio: 0.3
+                min_ratio: 0.3,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             }),
             "audio_non_silent"
         );
@@ -2435,6 +2582,8 @@ mod tests {
                 glob: "**/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 1,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             }),
             "per_file_non_silent"
         );
@@ -2442,6 +2591,8 @@ mod tests {
             validator_kind_label(&ValidatorSpec::MagicBytes {
                 glob: "*.mp3".into(),
                 format: crate::workspace_policy::MagicByteKind::Mp3,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             }),
             "magic_bytes"
         );
@@ -2775,6 +2926,8 @@ mod tests {
             ValidatorSpec::AudioNonSilent {
                 glob: "*.wav".into(),
                 min_ratio: 0.3,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -2799,6 +2952,8 @@ mod tests {
             ValidatorSpec::AudioNonSilent {
                 glob: "*.wav".into(),
                 min_ratio: 0.3,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -2820,6 +2975,8 @@ mod tests {
             ValidatorSpec::MagicBytes {
                 glob: "*.mp3".into(),
                 format: crate::workspace_policy::MagicByteKind::Mp3,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -2839,6 +2996,8 @@ mod tests {
             ValidatorSpec::MagicBytes {
                 glob: "*.mp3".into(),
                 format: crate::workspace_policy::MagicByteKind::Mp3,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -3470,6 +3629,8 @@ mod tests {
             ValidatorSpec::MagicBytes {
                 glob: "${output.dir}/*.png".into(),
                 format: crate::workspace_policy::MagicByteKind::Png,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let invocation = ValidatorInvocation::new(
@@ -3495,6 +3656,8 @@ mod tests {
             ValidatorSpec::AudioNonSilent {
                 glob: "${output.audio_dir}/*.wav".into(),
                 min_ratio: 0.3,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let invocation = ValidatorInvocation::new(
@@ -3841,6 +4004,8 @@ mod tests {
                 glob: "**/segments/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 1,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -3874,6 +4039,8 @@ mod tests {
                 glob: "**/segments/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 1,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -3911,6 +4078,8 @@ mod tests {
                 glob: "**/segments/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 1,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -3941,6 +4110,8 @@ mod tests {
                 glob: "**/segments/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 0,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -3966,6 +4137,8 @@ mod tests {
                 glob: "${args.episode_dir}/segments/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 1,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let invocation = dummy_invocation(dir.path().to_path_buf())
@@ -3987,6 +4160,8 @@ mod tests {
                 glob: "${args.episode_dir}/segments/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 1,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let invocation = dummy_invocation(dir.path().to_path_buf())
@@ -4026,6 +4201,8 @@ mod tests {
                 glob: "**/segments/seg_*.wav".into(),
                 min_ratio: 0.3,
                 require_at_least: 1,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             },
         );
         let outcomes = runner
@@ -4035,6 +4212,217 @@ mod tests {
         assert!(
             outcomes[0].reason.contains("1 match"),
             "glob must match exactly 1 dialogue segment, not the 4 files on disk: {}",
+            outcomes[0].reason
+        );
+    }
+
+    // --- octos #1034: source = "spawn_only_files" --------------------------
+    //
+    // The validator family below covers the file-list-driven source that
+    // replaces the legacy glob when a contract opts in via
+    // `source = "spawn_only_files"`. The plugin protocol's `files_to_send`
+    // (already captured by `enforce_spawn_task_contract` and threaded into
+    // `ValidatorInvocation::spawn_only_files`) is the authoritative path
+    // set the skill produced — globbing the workspace can no longer race
+    // the topic-suffixed output directory naming.
+
+    /// MagicBytes + AudioNonSilent must accept a `files_to_send` list and
+    /// run their checks against each file directly, bypassing the glob.
+    /// This is the canonical happy-path for the octos #1034 refactor.
+    #[tokio::test]
+    async fn magic_bytes_uses_spawn_only_files_when_source_opted_in() {
+        let dir = tempfile::tempdir().unwrap();
+        // Topic-suffixed directory — the exact failure mode from the
+        // mini5 trace (chat topic 《逐玉》 → `mofa-podcast-zhuyu/`). A glob
+        // anchored at `skill-output/mofa-podcast/` would never reach this.
+        let podcast_dir = dir.path().join("skill-output/mofa-podcast-zhuyu");
+        std::fs::create_dir_all(&podcast_dir).unwrap();
+        let mp3_path = podcast_dir.join("podcast_full_1779067937.mp3");
+        let mut bytes = b"ID3".to_vec();
+        bytes.extend(std::iter::repeat_n(0u8, 128));
+        std::fs::write(&mp3_path, &bytes).unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "magic_bytes_spawn_only",
+            ValidatorSpec::MagicBytes {
+                // Glob is intentionally something that would NOT match
+                // anything on disk — proving the validator does not fall
+                // back to the glob path.
+                glob: String::new(),
+                format: crate::workspace_policy::MagicByteKind::Mp3,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("mp3".into()),
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_spawn_only_files(vec![mp3_path]);
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    #[tokio::test]
+    async fn audio_non_silent_uses_spawn_only_files_when_source_opted_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let podcast_dir = dir.path().join("skill-output/mofa-podcast-zhuyu");
+        std::fs::create_dir_all(&podcast_dir).unwrap();
+        // WAV here so the audio decoder path runs without the optional
+        // `audio_mp3` feature gate.
+        let wav_path = podcast_dir.join("podcast_full_1779067937.wav");
+        write_sine_wav(&wav_path, 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "audio_non_silent_spawn_only",
+            ValidatorSpec::AudioNonSilent {
+                glob: String::new(),
+                min_ratio: 0.3,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("wav".into()),
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_spawn_only_files(vec![wav_path]);
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    /// PerFileNonSilent also accepts the file list verbatim (for callers
+    /// whose intermediate artifacts ARE in `files_to_send`).
+    #[tokio::test]
+    async fn per_file_non_silent_uses_spawn_only_files_when_source_opted_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let podcast_dir = dir.path().join("skill-output/mofa-podcast-zhuyu/segments");
+        std::fs::create_dir_all(&podcast_dir).unwrap();
+        let a = podcast_dir.join("seg_000.wav");
+        let b = podcast_dir.join("seg_001.wav");
+        write_sine_wav(&a, 800);
+        write_sine_wav(&b, 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "per_file_spawn_only",
+            ValidatorSpec::PerFileNonSilent {
+                glob: String::new(),
+                min_ratio: 0.3,
+                require_at_least: 2,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("wav".into()),
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_spawn_only_files(vec![a, b]);
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    /// The extension filter must distinguish files by suffix so a contract
+    /// can pin "the mp3" without false-matching adjacent WAV intermediates
+    /// that may also live in `files_to_send`.
+    #[tokio::test]
+    async fn spawn_only_files_extension_filter_distinguishes_mp3_from_wav() {
+        let dir = tempfile::tempdir().unwrap();
+        let topic_dir = dir.path().join("skill-output/mofa-podcast-zhuyu");
+        std::fs::create_dir_all(&topic_dir).unwrap();
+        // Two files emitted by the plugin: an MP3 (the real deliverable)
+        // and a WAV intermediate the plugin also chose to expose.
+        let mp3 = topic_dir.join("podcast_full.mp3");
+        let mut bytes = b"ID3".to_vec();
+        bytes.extend(std::iter::repeat_n(0u8, 128));
+        std::fs::write(&mp3, &bytes).unwrap();
+        let wav = topic_dir.join("podcast_full.wav");
+        // Write a NON-mp3 byte pattern (RIFF/WAVE-shaped) so the magic
+        // check on the wav file would fail if it leaked through the
+        // filter — proving the extension filter actually gates the input.
+        std::fs::write(&wav, b"RIFF\0\0\0\0WAVE").unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "magic_bytes_mp3_only",
+            ValidatorSpec::MagicBytes {
+                glob: String::new(),
+                format: crate::workspace_policy::MagicByteKind::Mp3,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("mp3".into()),
+            },
+        );
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        // Both files are reported by the plugin — the filter selects the mp3.
+        .with_spawn_only_files(vec![mp3, wav]);
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    /// Regression guard: existing contracts that did NOT opt in keep the
+    /// glob path verbatim. The `spawn_only_files` invocation attached to
+    /// the call must not be consulted when `source = "glob"` (the default).
+    #[tokio::test]
+    async fn glob_source_still_used_when_not_opted_in_even_with_files_to_send_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_path = dir.path().join("a.png");
+        std::fs::write(&real_path, PNG_1X1).unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "magic_bytes_legacy_glob",
+            ValidatorSpec::MagicBytes {
+                glob: "*.png".into(),
+                format: crate::workspace_policy::MagicByteKind::Png,
+                source: ValidatorFileSource::Glob,
+                extension: None,
+            },
+        );
+        // Attach a `files_to_send` list pointing at a DIFFERENT path that
+        // does not exist on disk. The validator must ignore the list and
+        // still satisfy via the glob match.
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "test".into(),
+        )
+        .with_spawn_only_files(vec![dir.path().join("nonexistent.png")]);
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Pass, "{outcomes:?}");
+    }
+
+    /// A contract that opts into `spawn_only_files` from a context where
+    /// the spawn_only tool emitted no files must Fail (not Pass via empty
+    /// match) so a misconfigured policy surfaces early.
+    #[tokio::test]
+    async fn spawn_only_files_source_fails_when_files_to_send_list_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let validator = validator_with_spec(
+            "magic_bytes_no_files",
+            ValidatorSpec::MagicBytes {
+                glob: String::new(),
+                format: crate::workspace_policy::MagicByteKind::Mp3,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("mp3".into()),
+            },
+        );
+        let invocation = dummy_invocation(dir.path().to_path_buf());
+        let outcomes = runner.run_all(&invocation, &[validator]).await;
+        assert_eq!(outcomes[0].status, ValidatorStatus::Fail, "{outcomes:?}");
+        assert!(
+            outcomes[0].reason.contains("spawn_only_files"),
+            "reason should surface the source: {}",
             outcomes[0].reason
         );
     }

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -206,6 +206,11 @@ pub async fn enforce_spawn_task_contract_with_args_and_output(
         ValidatorPhase::Completion,
         input_args.cloned(),
         tool_named_outputs.cloned(),
+        // octos #1034: forward the plugin's `files_to_send` so the
+        // file-list-driven validators (`MagicBytes`, `AudioNonSilent`,
+        // `PerFileNonSilent`) declaring `source = "spawn_only_files"`
+        // can consume the authoritative path set the skill emitted.
+        Some(files_to_send.to_vec()),
     )
     .await
     {
@@ -563,6 +568,7 @@ pub async fn run_declared_validators(
         phase,
         input_args,
         None,
+        None,
     )
     .await
 }
@@ -572,6 +578,14 @@ pub async fn run_declared_validators(
 /// domain validators can resolve `${output.<key>}` references against
 /// tool-emitted values (e.g. `mofa_publish` emitting `deploy_url` for the
 /// HttpProbe to call).
+///
+/// `spawn_only_files` is the plugin-reported `files_to_send` list from the
+/// originating spawn_only tool. Consumed by file-list-driven validators
+/// (`MagicBytes`, `AudioNonSilent`, `PerFileNonSilent`) when their spec
+/// declares `source = "spawn_only_files"` (octos #1034). Pass `None` for
+/// callers that have no plugin output to forward (turn-end validators,
+/// non-spawn contexts).
+#[allow(clippy::too_many_arguments)]
 pub async fn run_declared_validators_with_output(
     tools: &ToolRegistry,
     workspace_root: &Path,
@@ -580,6 +594,7 @@ pub async fn run_declared_validators_with_output(
     phase: ValidatorPhase,
     input_args: Option<serde_json::Value>,
     tool_output: Option<serde_json::Value>,
+    spawn_only_files: Option<Vec<PathBuf>>,
 ) -> Result<Vec<ValidatorOutcome>, String> {
     if validators.is_empty() {
         return Ok(Vec::new());
@@ -621,6 +636,7 @@ pub async fn run_declared_validators_with_output(
         repo_label: repo_label_hint.to_string(),
         input_args,
         tool_output,
+        spawn_only_files: spawn_only_files.unwrap_or_default(),
     };
 
     let outcomes = runner.run_all(&invocation, &scoped).await;
@@ -1947,12 +1963,27 @@ mod tests {
         for entry in task.on_completion.iter_mut() {
             if let SpawnTaskValidatorSpec::Bare(spec) = entry {
                 match spec {
-                    ValidatorSpec::AudioNonSilent { glob, .. } => {
+                    ValidatorSpec::AudioNonSilent { glob, source, .. } => {
                         *glob = "skill-output/mofa-podcast/*.wav".into();
+                        // Switch the helper to glob mode so this contract
+                        // test still drives the validator off a filesystem
+                        // scan even when the production policy uses
+                        // `spawn_only_files` (octos #1034).
+                        *source = crate::workspace_policy::ValidatorFileSource::Glob;
                     }
-                    ValidatorSpec::MagicBytes { glob, format } => {
+                    ValidatorSpec::MagicBytes {
+                        glob,
+                        format,
+                        source,
+                        ..
+                    } => {
                         *glob = "skill-output/mofa-podcast/*.wav".into();
                         *format = MagicByteKind::Wav;
+                        // Switch the helper to glob mode so this contract
+                        // test still drives the validator off a filesystem
+                        // scan even when the production policy uses
+                        // `spawn_only_files` (octos #1034).
+                        *source = crate::workspace_policy::ValidatorFileSource::Glob;
                     }
                     _ => {}
                 }

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -246,6 +246,44 @@ fn is_default_phase(phase: &ValidatorPhaseKind) -> bool {
     *phase == ValidatorPhaseKind::default()
 }
 
+/// Where a file-list-driven validator (`MagicBytes`, `AudioNonSilent`,
+/// `PerFileNonSilent`) sources its candidate file paths.
+///
+/// Defaults to [`ValidatorFileSource::Glob`] so existing TOML contracts keep
+/// their historic behaviour: the validator resolves the `glob` field against
+/// the workspace root. Opting into [`ValidatorFileSource::SpawnOnlyFiles`]
+/// tells the validator to use the originating spawn_only tool's
+/// `files_to_send` list verbatim (the plugin protocol's authoritative list
+/// of files the skill just produced), optionally filtered by an extension
+/// suffix.
+///
+/// Issue octos #1034: the topic-suffixed plugin output paths
+/// (e.g. `mofa-podcast-zhuyu/`) break globbing because the per-topic
+/// directory name is unpredictable. `files_to_send` carries the exact path
+/// the plugin wrote and is the canonical source of truth.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidatorFileSource {
+    /// Resolve files by glob (the legacy behaviour). The validator's `glob`
+    /// field is matched against the workspace root.
+    #[default]
+    Glob,
+    /// Use the originating spawn_only tool's `files_to_send` list, optionally
+    /// filtered by a file extension supplied alongside (e.g. `extension =
+    /// "mp3"`). The `glob` field is IGNORED in this mode. When the file list
+    /// is empty (non-spawn-only contexts) the validator surfaces a `Fail`
+    /// outcome so misconfigured policies are caught early.
+    SpawnOnlyFiles,
+}
+
+impl ValidatorFileSource {
+    /// Predicate used by `skip_serializing_if` so a default value does not
+    /// pollute TOML output for contracts that did not opt in.
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Glob)
+    }
+}
+
 /// Lifecycle phase a validator runs in.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -308,10 +346,22 @@ pub enum ValidatorSpec {
     /// Assert that at least one file matching `glob` has decoded audio with
     /// `non_silent_samples / total_samples >= min_ratio`. WAV is supported
     /// natively. MP3 support requires the `audio_mp3` feature flag.
+    ///
+    /// When `source = "spawn_only_files"` (octos #1034) the validator skips
+    /// the glob entirely and consumes the originating spawn_only tool's
+    /// `files_to_send` list, optionally narrowed by `extension`
+    /// (e.g. `extension = "mp3"`). This is the canonical mode for plugins
+    /// that write to topic-suffixed output directories whose names a glob
+    /// cannot predict.
     AudioNonSilent {
+        #[serde(default)]
         glob: String,
         #[serde(default = "default_non_silent_ratio")]
         min_ratio: f32,
+        #[serde(default, skip_serializing_if = "ValidatorFileSource::is_default")]
+        source: ValidatorFileSource,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extension: Option<String>,
     },
     /// Assert that EVERY file matching `glob` independently meets
     /// `non_silent_samples / total_samples >= min_ratio`, and that at least
@@ -342,11 +392,21 @@ pub enum ValidatorSpec {
     ///   still pass when no files matched (consistent with optional
     ///   intermediate artifacts that may not exist in every run).
     PerFileNonSilent {
+        #[serde(default)]
         glob: String,
         #[serde(default = "default_non_silent_ratio")]
         min_ratio: f32,
         #[serde(default)]
         require_at_least: usize,
+        /// Where to source the candidate file list. See [`ValidatorFileSource`]
+        /// for the opt-in `spawn_only_files` mode (octos #1034) that bypasses
+        /// the glob and consumes the plugin's `files_to_send` list verbatim.
+        #[serde(default, skip_serializing_if = "ValidatorFileSource::is_default")]
+        source: ValidatorFileSource,
+        /// Optional extension filter applied to the file list when
+        /// `source = "spawn_only_files"`. Ignored when `source = "glob"`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extension: Option<String>,
     },
     /// Assert each file matching `glob` has the magic-byte prefix for the
     /// declared `format`. Catches "tool wrote 0 bytes" or "tool wrote an
@@ -354,7 +414,19 @@ pub enum ValidatorSpec {
     ///
     /// The format field is named `format` rather than `kind` to avoid
     /// colliding with serde's `kind` discriminator tag.
-    MagicBytes { glob: String, format: MagicByteKind },
+    ///
+    /// When `source = "spawn_only_files"` (octos #1034) the validator skips
+    /// the glob entirely and consumes the originating spawn_only tool's
+    /// `files_to_send` list, optionally narrowed by `extension`.
+    MagicBytes {
+        #[serde(default)]
+        glob: String,
+        format: MagicByteKind,
+        #[serde(default, skip_serializing_if = "ValidatorFileSource::is_default")]
+        source: ValidatorFileSource,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        extension: Option<String>,
+    },
     /// Polling HTTP probe — repeatedly GET a templated URL (with
     /// `${args.<key>}` interpolation against the spawn task's input args)
     /// until the expected status code (+ optional body substring) is
@@ -704,6 +776,8 @@ impl WorkspacePolicy {
                         spec: ValidatorSpec::MagicBytes {
                             glob: "**/*.pptx".into(),
                             format: MagicByteKind::Pptx,
+                            source: ValidatorFileSource::Glob,
+                            extension: None,
                         },
                     }],
                 },
@@ -805,8 +879,28 @@ impl WorkspacePolicy {
             //      Result-aware `SegmentDirCleanup` RAII guard introduced
             //      in mofa-skills #59).
             //
-            // The per-file glob `**/segments/seg_*.wav` deliberately
-            // EXCLUDES `pause_after_*.wav`, `pause_line_*.wav`, and
+            // octos #1034: switched (1) and (2) to consume the plugin's
+            // `files_to_send` list (the canonical authoritative path set
+            // emitted by the JSON envelope on stdout). The prior hardcoded
+            // glob `skill-output/mofa-podcast/**/*.mp3` could not match
+            // topic-suffixed output directories (e.g. `mofa-podcast-zhuyu/`
+            // for the chat topic 《逐玉》), and PR #1014's `*→**` widening
+            // did not cure the prefix mismatch. `files_to_send` carries
+            // the exact path the plugin wrote, so the validator no longer
+            // races the plugin's directory-naming logic.
+            //
+            // (3) still consumes a glob because the intermediate segment
+            // WAVs are scratch files the plugin does NOT report in
+            // `files_to_send` — they are preserved on disk so the
+            // PerFileNonSilent gate can inspect them, but the protocol's
+            // file list only carries the final deliverable MP3. The glob
+            // has been broadened to `**/segments/seg_*.wav` (no longer
+            // anchored at `skill-output/mofa-podcast/`) so it tracks the
+            // topic-suffixed output directory without re-needing a glob
+            // fix for every new directory name.
+            //
+            // The per-file glob deliberately EXCLUDES
+            // `pause_after_*.wav`, `pause_line_*.wav`, and
             // `bgm_placeholder_line_*.wav` — those filenames are emitted
             // by mofa-podcast as intentionally-silent inter-segment pauses
             // and would never pass a non-silent ratio check.
@@ -814,29 +908,31 @@ impl WorkspacePolicy {
             // Stale-segment concern: this glob does NOT apply the
             // `task_started_at` look-back filter that `resolve_artifacts`
             // uses (the validator runner doesn't see that timestamp).
-            // Same caveat applies to the pre-existing whole-file
-            // `AudioNonSilent` above (`skill-output/mofa-podcast/*.mp3`),
-            // so this is a shared harness invariant rather than a
-            // regression. In practice mofa-skills #59 clears
-            // `<output_dir>/segments/` at the start of every invocation
-            // (`generate_podcast::seg_dir` cleanup), so stale segments
-            // only matter for unusual concurrent-run workflows. A future
-            // follow-up can plumb `task_started_at` into the validator
-            // runner to filter per-file matches by mtime, which would
-            // close the gap for both validators in one shot.
+            // In practice mofa-skills #59 clears `<output_dir>/segments/`
+            // at the start of every invocation (`generate_podcast::seg_dir`
+            // cleanup), so stale segments only matter for unusual
+            // concurrent-run workflows. A future follow-up can plumb
+            // `task_started_at` into the validator runner to filter
+            // per-file matches by mtime, which would close the gap.
             on_completion: vec![
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                    glob: "skill-output/mofa-podcast/**/*.mp3".into(),
+                    glob: String::new(),
                     format: MagicByteKind::Mp3,
+                    source: ValidatorFileSource::SpawnOnlyFiles,
+                    extension: Some("mp3".into()),
                 }),
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
-                    glob: "skill-output/mofa-podcast/**/*.mp3".into(),
+                    glob: String::new(),
                     min_ratio: default_non_silent_ratio(),
+                    source: ValidatorFileSource::SpawnOnlyFiles,
+                    extension: Some("mp3".into()),
                 }),
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::PerFileNonSilent {
-                    glob: "skill-output/mofa-podcast/**/segments/seg_*.wav".into(),
+                    glob: "**/segments/seg_*.wav".into(),
                     min_ratio: default_non_silent_ratio(),
                     require_at_least: 1,
+                    source: ValidatorFileSource::Glob,
+                    extension: None,
                 }),
             ],
         };
@@ -857,6 +953,8 @@ impl WorkspacePolicy {
                 ValidatorSpec::AudioNonSilent {
                     glob: "skill-output/voice/**/*.{mp3,wav}".into(),
                     min_ratio: default_non_silent_ratio(),
+                    source: ValidatorFileSource::Glob,
+                    extension: None,
                 },
             )],
         };
@@ -923,6 +1021,8 @@ impl WorkspacePolicy {
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
                 glob: "**/*.pptx".into(),
                 format: MagicByteKind::Pptx,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             })],
         };
 
@@ -939,6 +1039,8 @@ impl WorkspacePolicy {
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
                 glob: "**/*.png".into(),
                 format: MagicByteKind::Png,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             })],
         };
 
@@ -966,6 +1068,8 @@ impl WorkspacePolicy {
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
                     glob: "**/*.png".into(),
                     format: MagicByteKind::Png,
+                    source: ValidatorFileSource::Glob,
+                    extension: None,
                 }),
             ],
         };
@@ -985,6 +1089,8 @@ impl WorkspacePolicy {
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
                     glob: "**/*.png".into(),
                     format: MagicByteKind::Png,
+                    source: ValidatorFileSource::Glob,
+                    extension: None,
                 }),
             ],
         };
@@ -1005,6 +1111,8 @@ impl WorkspacePolicy {
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
                 glob: "**/*.png".into(),
                 format: MagicByteKind::Png,
+                source: ValidatorFileSource::Glob,
+                extension: None,
             })],
         };
 
@@ -1853,6 +1961,91 @@ ignore = []
         assert!(!MagicByteKind::Pptx.matches(b"<!DOCTYPE html>"));
     }
 
+    /// octos #1034: the podcast contract's MagicBytes + AudioNonSilent
+    /// validators must be declared with `source = SpawnOnlyFiles` so the
+    /// plugin's reported `files_to_send` list drives the check rather than
+    /// a hardcoded glob that misses topic-suffixed output directories
+    /// (e.g. `mofa-podcast-zhuyu/` for the chat topic 《逐玉》). The
+    /// PerFileNonSilent validator stays on the glob path because the
+    /// intermediate segment WAVs are scratch files not exposed by the
+    /// plugin protocol's `files_to_send` envelope.
+    #[test]
+    fn session_policy_podcast_validators_consume_spawn_only_files_for_octos_1034() {
+        let policy = WorkspacePolicy::for_session();
+        let podcast = policy
+            .spawn_tasks
+            .get("podcast_generate")
+            .expect("podcast contract");
+
+        let mut saw_magic = false;
+        let mut saw_audio = false;
+        let mut saw_per_file = false;
+        for entry in &podcast.on_completion {
+            match entry {
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                    source,
+                    extension,
+                    ..
+                }) => {
+                    assert_eq!(
+                        *source,
+                        ValidatorFileSource::SpawnOnlyFiles,
+                        "podcast MagicBytes must opt into spawn_only_files (octos #1034)"
+                    );
+                    assert_eq!(
+                        extension.as_deref(),
+                        Some("mp3"),
+                        "podcast MagicBytes must filter to mp3 outputs"
+                    );
+                    saw_magic = true;
+                }
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
+                    source,
+                    extension,
+                    ..
+                }) => {
+                    assert_eq!(
+                        *source,
+                        ValidatorFileSource::SpawnOnlyFiles,
+                        "podcast AudioNonSilent must opt into spawn_only_files (octos #1034)"
+                    );
+                    assert_eq!(
+                        extension.as_deref(),
+                        Some("mp3"),
+                        "podcast AudioNonSilent must filter to mp3 outputs"
+                    );
+                    saw_audio = true;
+                }
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::PerFileNonSilent {
+                    source,
+                    glob,
+                    ..
+                }) => {
+                    assert_eq!(
+                        *source,
+                        ValidatorFileSource::Glob,
+                        "podcast PerFileNonSilent must stay on the glob path because \
+                         intermediate segment WAVs are not in the plugin's files_to_send"
+                    );
+                    assert!(
+                        !glob.starts_with("skill-output/mofa-podcast/"),
+                        "PerFileNonSilent glob must NOT anchor at the legacy \
+                         `skill-output/mofa-podcast/` prefix — topic-suffixed \
+                         directories like `mofa-podcast-zhuyu/` would never match: {glob}"
+                    );
+                    saw_per_file = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_magic, "podcast contract must declare MagicBytes");
+        assert!(saw_audio, "podcast contract must declare AudioNonSilent");
+        assert!(
+            saw_per_file,
+            "podcast contract must declare PerFileNonSilent"
+        );
+    }
+
     #[test]
     fn session_policy_declares_new_domain_validators_for_silent_failure_paths() {
         let policy = WorkspacePolicy::for_session();
@@ -1886,6 +2079,7 @@ ignore = []
                     glob,
                     min_ratio,
                     require_at_least,
+                    ..
                 }) => Some((glob.clone(), *min_ratio, *require_at_least)),
                 _ => None,
             })
@@ -2205,6 +2399,7 @@ ignore = []
                 ref glob,
                 min_ratio,
                 require_at_least,
+                ..
             } => {
                 assert_eq!(glob, "**/segments/seg_*.wav");
                 assert!((min_ratio - 0.3).abs() < f32::EPSILON);
@@ -2235,6 +2430,7 @@ ignore = []
                 ref glob,
                 min_ratio,
                 require_at_least,
+                ..
             } => {
                 assert_eq!(glob, "**/segments/seg_*.wav");
                 assert!(

--- a/crates/octos-agent/tests/abi_compat.rs
+++ b/crates/octos-agent/tests/abi_compat.rs
@@ -71,6 +71,10 @@ fn should_load_workspace_policy_v1_slides_fixture() {
 
 #[test]
 fn should_load_workspace_policy_v1_session_fixture() {
+    use octos_agent::workspace_policy::{
+        SpawnTaskValidatorSpec, ValidatorFileSource, ValidatorSpec,
+    };
+
     let temp = tempfile::tempdir().unwrap();
     copy_fixture_into_workspace("workspace_policy_v1_session.toml", temp.path());
 
@@ -93,6 +97,49 @@ fn should_load_workspace_policy_v1_session_fixture() {
             .iter()
             .any(|line| line == "file_size_min:$artifact:1024"),
         "expected fm_tts verify action for artifact size",
+    );
+
+    // octos #1034: the podcast_generate contract opts into the
+    // `spawn_only_files` source via the new ABI fields. The fixture is the
+    // durable promise of that shape — parsing it must populate `source =
+    // SpawnOnlyFiles` and `extension = Some("mp3")` on both the MagicBytes
+    // and AudioNonSilent validators so an older operator policy that
+    // committed the prior glob form will surface a clear deserialization
+    // error rather than silently fall back to the glob path.
+    let podcast = policy
+        .spawn_tasks
+        .get("podcast_generate")
+        .expect("podcast_generate spawn task contract");
+    let mut saw_magic = false;
+    let mut saw_audio = false;
+    for entry in &podcast.on_completion {
+        match entry {
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                source, extension, ..
+            }) => {
+                assert_eq!(*source, ValidatorFileSource::SpawnOnlyFiles);
+                assert_eq!(extension.as_deref(), Some("mp3"));
+                saw_magic = true;
+            }
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
+                source,
+                extension,
+                ..
+            }) => {
+                assert_eq!(*source, ValidatorFileSource::SpawnOnlyFiles);
+                assert_eq!(extension.as_deref(), Some("mp3"));
+                saw_audio = true;
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        saw_magic,
+        "podcast fixture must declare MagicBytes(spawn_only_files)"
+    );
+    assert!(
+        saw_audio,
+        "podcast fixture must declare AudioNonSilent(spawn_only_files)"
     );
 }
 

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -33,9 +33,16 @@ on_verify = [
     "file_size_min:$artifact:4096",
 ]
 on_failure = ["notify_user:Podcast generation failed"]
+# octos #1034: opt the magic-bytes + audio-non-silent validators into the
+# `spawn_only_files` source so the validator consumes the authoritative path
+# list the plugin reports via its JSON stdout envelope. Avoids the
+# topic-suffixed output directory race (`mofa-podcast-zhuyu/`, etc.) that
+# made the legacy hardcoded glob `skill-output/mofa-podcast/**/*.mp3`
+# unreliable. The `extension` filter narrows the list to mp3 outputs so
+# adjacent intermediate WAVs in `files_to_send` are ignored.
 on_completion = [
-    { kind = "magic_bytes", glob = "skill-output/mofa-podcast/**/*.mp3", format = "mp3" },
-    { kind = "audio_non_silent", glob = "skill-output/mofa-podcast/**/*.mp3", min_ratio = 0.3 },
+    { kind = "magic_bytes", source = "spawn_only_files", extension = "mp3", format = "mp3" },
+    { kind = "audio_non_silent", source = "spawn_only_files", extension = "mp3", min_ratio = 0.3 },
 ]
 
 [spawn_tasks.fm_voice_save]

--- a/crates/octos-agent/tests/validator_runner.rs
+++ b/crates/octos-agent/tests/validator_runner.rs
@@ -143,6 +143,7 @@ async fn should_block_ready_when_required_command_validator_fails() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -179,6 +180,7 @@ async fn should_warn_but_not_block_when_optional_validator_fails() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -212,6 +214,7 @@ async fn should_record_duration_and_evidence_path_for_command_validator() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -252,6 +255,7 @@ async fn should_expose_stderr_in_outcome_for_operator_visibility() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -302,6 +306,7 @@ async fn should_kill_child_process_on_validator_timeout() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
 
     let before = std::time::Instant::now();
@@ -353,6 +358,7 @@ async fn should_pass_file_exists_validator_when_file_meets_size_floor() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -377,6 +383,7 @@ async fn should_fail_file_exists_validator_when_size_under_floor() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -396,6 +403,7 @@ async fn should_pass_tool_call_validator_when_tool_succeeds() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -414,6 +422,7 @@ async fn should_fail_tool_call_validator_when_tool_reports_unsuccessful() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 
@@ -442,6 +451,7 @@ async fn should_persist_outcomes_and_replay_them_byte_for_byte() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let original = runner.run_all(&invocation, &validators).await;
     assert_eq!(original.len(), 2);
@@ -496,6 +506,7 @@ async fn should_strip_blocked_env_vars_from_command_validator_child() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     // Invoke via a helper that pre-seeds LD_PRELOAD on the spawned command.
     runner
@@ -758,6 +769,7 @@ async fn should_block_command_validator_with_dangerous_pattern() {
         repo_label: "slides/demo".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = runner.run_all(&invocation, &validators).await;
 

--- a/crates/octos-cli/src/commands/mcp_serve.rs
+++ b/crates/octos-cli/src/commands/mcp_serve.rs
@@ -531,6 +531,7 @@ async fn run_completion_validators(
         repo_label: format!("mcp-serve/{contract}"),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let outcomes = run_workspace_validators(
         &runner,

--- a/crates/octos-cli/src/workflows/slides_delivery.rs
+++ b/crates/octos-cli/src/workflows/slides_delivery.rs
@@ -13,7 +13,8 @@ use crate::workflow_runtime::{
     WorkflowInstance, WorkflowKind, WorkflowLimits, WorkflowPhase, WorkflowTerminalOutput,
 };
 use octos_agent::workspace_policy::{
-    MagicByteKind, Validator, ValidatorPhaseKind, ValidatorSpec, WorkspacePolicyWorkspace,
+    MagicByteKind, Validator, ValidatorFileSource, ValidatorPhaseKind, ValidatorSpec,
+    WorkspacePolicyWorkspace,
 };
 use octos_agent::{
     ValidationPolicy, WorkspaceArtifactsPolicy, WorkspacePolicy, WorkspacePolicyKind,
@@ -103,6 +104,8 @@ pub fn workspace_policy() -> WorkspacePolicy {
                 spec: ValidatorSpec::MagicBytes {
                     glob: "**/*.pptx".into(),
                     format: MagicByteKind::Pptx,
+                    source: ValidatorFileSource::Glob,
+                    extension: None,
                 },
             }],
         },

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -522,6 +522,11 @@ impl Swarm {
             ),
             input_args: None,
             tool_output: None,
+            // Swarm subtask invocations run AFTER their per-subtask
+            // workspace contract; the dispatcher has no spawn_only file
+            // list of its own to forward. Subtask-level validators that
+            // need a file source should stay on the glob path.
+            spawn_only_files: Vec::new(),
         };
 
         let outcomes = validator.runner.run_all(&invocation, &scoped).await;

--- a/crates/octos-swarm/tests/subtask_contracts.rs
+++ b/crates/octos-swarm/tests/subtask_contracts.rs
@@ -107,6 +107,7 @@ fn aggregate_validator(
         repo_label: "swarm-subtask-test".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     AggregateValidator {
         runner,

--- a/crates/octos-swarm/tests/swarm_dispatch.rs
+++ b/crates/octos-swarm/tests/swarm_dispatch.rs
@@ -453,6 +453,7 @@ async fn should_aggregate_validator_over_combined_output() {
         repo_label: "swarm-test".into(),
         input_args: None,
         tool_output: None,
+        spawn_only_files: Vec::new(),
     };
     let validator = Validator {
         id: "aggregate_exists".into(),


### PR DESCRIPTION
## Summary

- Add `source` enum to `MagicBytes` / `AudioNonSilent` / `PerFileNonSilent` validators so they can opt into consuming the plugin's `files_to_send` list verbatim (octos #1034) instead of glob-discovering the workspace.
- Plumb `Vec<PathBuf>` from `enforce_spawn_task_contract_with_args_and_output` through `ValidatorInvocation::spawn_only_files` and into a shared `resolve_validator_files` helper that the three validators delegate to.
- Switch the podcast contract's MagicBytes + AudioNonSilent to `source = "spawn_only_files"`, extension = `"mp3"` so topic-suffixed output directories (`mofa-podcast-zhuyu/`, ...) stop racing the validator.

## Background

`crates/octos-agent/src/workspace_policy.rs` hardcoded the glob `skill-output/mofa-podcast/**/*.mp3` for the MagicBytes / AudioNonSilent validators. PR #1014 widened `*` to `**`, but the per-topic directory name is unpredictable — the mini5 trace in #1034 shows the validator rejecting a real MP3 at `skill-output/mofa-podcast-zhuyu/podcast_full_1779067937.mp3` because the prefix mismatch was upstream of the glob's `**`. The plugin protocol already emits `files_to_send` (the canonical authoritative path list); we just weren't using it for validation.

## Design

`ValidatorFileSource` enum defaults to `Glob` so every existing contract keeps its historic behaviour. Opting in is a two-field TOML change:

```toml
[[spawn_tasks.podcast_generate.on_completion]]
kind = "magic_bytes"
source = "spawn_only_files"
extension = "mp3"
format = "mp3"
```

The shared `resolve_validator_files` helper centralizes both modes: glob mode runs the existing template-interpolated `glob_files`, `spawn_only_files` mode iterates `invocation.spawn_only_files` and filters by extension (case-insensitive, leading-dot tolerant). An opt-in policy that runs in a context without any spawn_only files surfaces a clear `Fail` outcome rather than silently passing.

The PerFileNonSilent on `**/segments/seg_*.wav` stays on the glob path because the intermediate segment WAVs are plugin-internal scratch files that aren't in `files_to_send`. Its glob is broadened from `skill-output/mofa-podcast/**/segments/seg_*.wav` to `**/segments/seg_*.wav` so the topic-suffixed directory tracks without another glob fix.

## Test plan

- [x] `cargo test -p octos-agent` — 1709 passed, 0 failed
- [x] `cargo test -p octos-swarm` — all green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p octos-agent --tests` clean
- [x] 6 new validator-level unit tests: spawn_only_files happy path (MagicBytes / AudioNonSilent / PerFileNonSilent), extension filter (mp3 vs wav), regression that `source = "glob"` ignores `files_to_send`, and the empty-list failure mode
- [x] 1 new contract-level test pins the podcast policy to `spawn_only_files`
- [x] ABI roundtrip test on `workspace_policy_v1_session.toml` asserts the new TOML shape deserializes with `ValidatorFileSource::SpawnOnlyFiles` + `extension = "mp3"`

Closes #1034.