### PR TITLE
fix(workspace_policy): sweep mofa_slides MagicBytes validator to SpawnOnlyFiles (refs #1036)

### DIFF
--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -4426,4 +4426,121 @@ mod tests {
             outcomes[0].reason
         );
     }
+
+    // --- octos #1036: voice_synthesize + mofa_slides sweep ----------------
+    //
+    // Mirror the octos #1034 podcast happy-path test for the two contracts
+    // that PR #1035 left on the glob path. The failure modes the sweep is
+    // closing:
+    //   - voice_synthesize: plugin writes to a work dir that does not
+    //     match `skill-output/voice/**/*.{mp3,wav}` (e.g. operator-set
+    //     OCTOS_WORK_DIR or a future per-voice subdirectory).
+    //   - mofa_slides: a recursive `**/*.pptx` glob would match unrelated
+    //     stale decks from earlier runs in the same session workspace.
+
+    /// `voice_synthesize` AudioNonSilent must run against the plugin's
+    /// reported file regardless of which subdirectory the WAV/MP3 landed
+    /// in, including a per-voice topic-suffixed path that the legacy glob
+    /// `skill-output/voice/**/*.{mp3,wav}` would not reach.
+    #[tokio::test]
+    async fn voice_synthesize_uses_spawn_only_files_at_non_default_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        // A per-voice directory the legacy glob (`skill-output/voice/**`)
+        // would NOT match — proves the validator consumes the reported
+        // path directly.
+        let voice_dir = dir.path().join("skill-output/voice-yangmi");
+        std::fs::create_dir_all(&voice_dir).unwrap();
+        let wav_path = voice_dir.join("yangmi.wav");
+        write_sine_wav(&wav_path, 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        // Lift the contract verbatim from `for_session()` so we exercise
+        // the production shape end-to-end.
+        let session_policy = crate::workspace_policy::WorkspacePolicy::for_session();
+        let contract = session_policy
+            .spawn_tasks
+            .get("voice_synthesize")
+            .expect("voice_synthesize contract must be registered");
+        let validators: Vec<Validator> = contract
+            .on_completion
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                crate::workspace_policy::SpawnTaskValidatorSpec::into_validator(
+                    entry.clone(),
+                    "voice_synthesize",
+                    i,
+                )
+            })
+            .collect();
+
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "voice_synthesize".into(),
+        )
+        .with_spawn_only_files(vec![wav_path]);
+        let outcomes = runner.run_all(&invocation, &validators).await;
+        assert!(
+            outcomes.iter().all(|o| o.status == ValidatorStatus::Pass),
+            "voice_synthesize contract must satisfy via spawn_only_files at a \
+             non-default directory; outcomes = {outcomes:?}",
+        );
+    }
+
+    /// `mofa_slides` MagicBytes(Pptx) must run against the plugin's reported
+    /// PPTX path verbatim, including outputs at arbitrary depth where the
+    /// session workspace may contain unrelated PPTXs from earlier runs.
+    #[tokio::test]
+    async fn mofa_slides_uses_spawn_only_files_at_arbitrary_depth() {
+        let dir = tempfile::tempdir().unwrap();
+        // Deeply-nested project-style path (`<project>/output/deck.pptx`).
+        // Lay down a SECOND stale PPTX elsewhere in the workspace — the
+        // legacy `**/*.pptx` glob would match either, but the
+        // spawn_only_files path must inspect only the reported file.
+        let project_out = dir.path().join("slides/demo/output");
+        std::fs::create_dir_all(&project_out).unwrap();
+        let pptx_path = project_out.join("deck.pptx");
+        let mut pptx_bytes = vec![0x50, 0x4B, 0x03, 0x04];
+        pptx_bytes.extend(std::iter::repeat_n(0u8, 256));
+        std::fs::write(&pptx_path, &pptx_bytes).unwrap();
+        // Stale, structurally-broken PPTX from a prior run. If the
+        // validator ever fell back to the glob path it would pick this
+        // up first (alphabetical glob order under `**`) and fail —
+        // satisfying the test only via the spawn_only_files path.
+        let stale = dir.path().join("aaa-stale.pptx");
+        std::fs::write(&stale, b"<!DOCTYPE html>\n<html>old error</html>\n").unwrap();
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let session_policy = crate::workspace_policy::WorkspacePolicy::for_session();
+        let contract = session_policy
+            .spawn_tasks
+            .get("mofa_slides")
+            .expect("mofa_slides contract must be registered");
+        let validators: Vec<Validator> = contract
+            .on_completion
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                crate::workspace_policy::SpawnTaskValidatorSpec::into_validator(
+                    entry.clone(),
+                    "mofa_slides",
+                    i,
+                )
+            })
+            .collect();
+
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "mofa_slides".into(),
+        )
+        .with_spawn_only_files(vec![pptx_path]);
+        let outcomes = runner.run_all(&invocation, &validators).await;
+        assert!(
+            outcomes.iter().all(|o| o.status == ValidatorStatus::Pass),
+            "mofa_slides contract must satisfy via spawn_only_files even when an \
+             unrelated stale PPTX exists in the workspace; outcomes = {outcomes:?}",
+        );
+    }
 }

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -4427,66 +4427,20 @@ mod tests {
         );
     }
 
-    // --- octos #1036: voice_synthesize + mofa_slides sweep ----------------
+    // --- octos #1036: mofa_slides sweep -----------------------------------
     //
-    // Mirror the octos #1034 podcast happy-path test for the two contracts
-    // that PR #1035 left on the glob path. The failure modes the sweep is
-    // closing:
-    //   - voice_synthesize: plugin writes to a work dir that does not
-    //     match `skill-output/voice/**/*.{mp3,wav}` (e.g. operator-set
-    //     OCTOS_WORK_DIR or a future per-voice subdirectory).
-    //   - mofa_slides: a recursive `**/*.pptx` glob would match unrelated
-    //     stale decks from earlier runs in the same session workspace.
-
-    /// `voice_synthesize` AudioNonSilent must run against the plugin's
-    /// reported file regardless of which subdirectory the WAV/MP3 landed
-    /// in, including a per-voice topic-suffixed path that the legacy glob
-    /// `skill-output/voice/**/*.{mp3,wav}` would not reach.
-    #[tokio::test]
-    async fn voice_synthesize_uses_spawn_only_files_at_non_default_directory() {
-        let dir = tempfile::tempdir().unwrap();
-        // A per-voice directory the legacy glob (`skill-output/voice/**`)
-        // would NOT match — proves the validator consumes the reported
-        // path directly.
-        let voice_dir = dir.path().join("skill-output/voice-yangmi");
-        std::fs::create_dir_all(&voice_dir).unwrap();
-        let wav_path = voice_dir.join("yangmi.wav");
-        write_sine_wav(&wav_path, 800);
-
-        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
-        // Lift the contract verbatim from `for_session()` so we exercise
-        // the production shape end-to-end.
-        let session_policy = crate::workspace_policy::WorkspacePolicy::for_session();
-        let contract = session_policy
-            .spawn_tasks
-            .get("voice_synthesize")
-            .expect("voice_synthesize contract must be registered");
-        let validators: Vec<Validator> = contract
-            .on_completion
-            .iter()
-            .enumerate()
-            .map(|(i, entry)| {
-                crate::workspace_policy::SpawnTaskValidatorSpec::into_validator(
-                    entry.clone(),
-                    "voice_synthesize",
-                    i,
-                )
-            })
-            .collect();
-
-        let invocation = ValidatorInvocation::new(
-            ValidatorPhase::Completion,
-            dir.path().to_path_buf(),
-            "voice_synthesize".into(),
-        )
-        .with_spawn_only_files(vec![wav_path]);
-        let outcomes = runner.run_all(&invocation, &validators).await;
-        assert!(
-            outcomes.iter().all(|o| o.status == ValidatorStatus::Pass),
-            "voice_synthesize contract must satisfy via spawn_only_files at a \
-             non-default directory; outcomes = {outcomes:?}",
-        );
-    }
+    // Mirror the octos #1034 podcast happy-path test for the mofa_slides
+    // contract that PR #1035 left on the glob path. Failure mode being
+    // closed: a recursive `**/*.pptx` glob would match unrelated stale
+    // decks from earlier runs in the same session workspace.
+    //
+    // The `voice_synthesize` contract was originally part of this sweep
+    // but was dropped after codex review caught that the voice plugin's
+    // `succeed()` path emits only `{output, success}` (no `files_to_send`)
+    // and its success text `"Generated audio: <path>"` is not one of the
+    // prefixes `PluginTool::detect_output_file` recognises. The validator
+    // would see an empty list and fail. See follow-up issue tracking the
+    // plugin emission fix.
 
     /// `mofa_slides` MagicBytes(Pptx) must run against the plugin's reported
     /// PPTX path verbatim, including outputs at arbitrary depth where the

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1227,6 +1227,10 @@ mod tests {
     async fn mofa_slides_contract_satisfies_when_pptx_is_present() {
         // P1-4: the default session policy for `mofa_slides` should
         // verify a PPTX with a valid ZIP signature is present.
+        //
+        // octos #1036: the contract now consumes the plugin's
+        // `files_to_send` directly (the spawn_only_files source). Mirror
+        // the live call path by passing the reported PPTX in the slice.
         let temp = tempfile::tempdir().unwrap();
         write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
         let pptx = temp.path().join("output/deck.pptx");
@@ -1241,7 +1245,7 @@ mod tests {
             &ToolRegistry::with_builtins(temp.path()),
             "mofa_slides",
             "tool-call-slides",
-            &[],
+            &[pptx.clone()],
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "output/deck.pptx"})),
@@ -1258,6 +1262,11 @@ mod tests {
     async fn mofa_slides_contract_fails_when_artifact_is_html_error_page() {
         // Catches the silent-failure path: tool wrote an HTML error page
         // in place of the PPTX. MagicBytes (Pptx) rejects it.
+        //
+        // octos #1036: the contract now consumes the plugin's
+        // `files_to_send` directly. Pass the HTML-shaped "PPTX" via the
+        // file list so the magic-bytes check inspects the exact path
+        // the skill reported.
         let temp = tempfile::tempdir().unwrap();
         write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
         let pptx = temp.path().join("output/deck.pptx");
@@ -1268,7 +1277,7 @@ mod tests {
             &ToolRegistry::with_builtins(temp.path()),
             "mofa_slides",
             "tool-call-slides-fail",
-            &[],
+            &[pptx.clone()],
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "output/deck.pptx"})),

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -939,6 +939,17 @@ impl WorkspacePolicy {
 
         // Voice synthesis (LLM-driven TTS): assert the decoded audio is not
         // silent. Catches the "render produced empty audio" failure path.
+        //
+        // octos #1036 (follow-up to #1034 / PR #1035): consume the plugin's
+        // `files_to_send` list directly rather than globbing the workspace.
+        // The legacy glob `skill-output/voice/**/*.{mp3,wav}` was anchored at
+        // a directory the plugin does not actually guarantee — the voice
+        // skill writes to `$OCTOS_WORK_DIR/<filename>.{wav,mp3}` (see
+        // `crates/platform-skills/voice/src/main.rs:558-660`), and any
+        // operator-customised work dir or future per-voice subdirectory
+        // (`skill-output/voice-yangmi/...`) would silently slip past the
+        // validator. `extension = None` keeps both the initial `.wav` and
+        // the converted `.mp3` in scope since the plugin may report either.
         let voice_synthesize_contract = WorkspaceSpawnTaskPolicy {
             artifact: Some("primary_audio".into()),
             artifacts: Vec::new(),
@@ -951,9 +962,9 @@ impl WorkspacePolicy {
             on_failure: vec!["notify_user:Voice synthesis failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(
                 ValidatorSpec::AudioNonSilent {
-                    glob: "skill-output/voice/**/*.{mp3,wav}".into(),
+                    glob: String::new(),
                     min_ratio: default_non_silent_ratio(),
-                    source: ValidatorFileSource::Glob,
+                    source: ValidatorFileSource::SpawnOnlyFiles,
                     extension: None,
                 },
             )],
@@ -1011,6 +1022,20 @@ impl WorkspacePolicy {
         // (`**/*.pptx`) is the same recursive pattern the on-completion
         // MagicBytes validator uses, so the two checks see a consistent
         // set of paths.
+        //
+        // octos #1036 (follow-up to #1034 / PR #1035): consume the plugin's
+        // `files_to_send` envelope so the MagicBytes check runs against the
+        // exact PPTX path the skill reported, not whatever happens to match
+        // a recursive `**/*.pptx` glob. Two failure modes the prior glob
+        // could mask:
+        //   1. A stale `.pptx` from an earlier run in the same session
+        //      workspace passing the contract for a freshly-failed call.
+        //   2. The plugin writing the deck to a non-default subdirectory
+        //      that an operator-customised workspace policy would otherwise
+        //      need to anticipate in its glob.
+        // The `extension = "pptx"` filter narrows the file list to slide
+        // decks if the skill also surfaces auxiliary files (preview PNGs,
+        // etc.) via `files_to_send`.
         let mofa_slides_contract = WorkspaceSpawnTaskPolicy {
             artifact: Some("slides_pptx".into()),
             artifacts: Vec::new(),
@@ -1019,10 +1044,10 @@ impl WorkspacePolicy {
             on_deliver: vec![],
             on_failure: vec!["notify_user:Slide generation failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                glob: "**/*.pptx".into(),
+                glob: String::new(),
                 format: MagicByteKind::Pptx,
-                source: ValidatorFileSource::Glob,
-                extension: None,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("pptx".into()),
             })],
         };
 
@@ -2163,6 +2188,101 @@ ignore = []
                 ..
             })
         )));
+    }
+
+    /// octos #1036 (follow-up to #1034 / PR #1035): both `voice_synthesize`
+    /// and `mofa_slides` must consume the plugin's `files_to_send` envelope
+    /// rather than a hardcoded glob. The legacy globs
+    /// (`skill-output/voice/**/*.{mp3,wav}` and `**/*.pptx`) silently
+    /// missed files whenever the plugin wrote to a directory the policy
+    /// didn't anticipate, the same structural fragility we already fixed
+    /// for `podcast_generate`.
+    #[test]
+    fn session_policy_voice_synthesize_consumes_spawn_only_files_for_octos_1036() {
+        let policy = WorkspacePolicy::for_session();
+        let voice = policy
+            .spawn_tasks
+            .get("voice_synthesize")
+            .expect("voice_synthesize contract");
+
+        let mut saw_audio = false;
+        for entry in &voice.on_completion {
+            if let SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
+                source,
+                extension,
+                glob,
+                ..
+            }) = entry
+            {
+                assert_eq!(
+                    *source,
+                    ValidatorFileSource::SpawnOnlyFiles,
+                    "voice_synthesize AudioNonSilent must opt into spawn_only_files (octos #1036)"
+                );
+                // The voice plugin emits both WAV and MP3 variants — both must
+                // satisfy the non-silent check, so the extension filter is
+                // intentionally unset.
+                assert!(
+                    extension.is_none(),
+                    "voice_synthesize AudioNonSilent must accept both wav and mp3 \
+                     outputs (extension must remain unset); got: {extension:?}"
+                );
+                assert!(
+                    !glob.contains("skill-output/voice/"),
+                    "voice_synthesize must NOT pin the legacy `skill-output/voice/**` \
+                     glob — that anchor is the bug we are sweeping away; got: {glob}"
+                );
+                saw_audio = true;
+            }
+        }
+        assert!(
+            saw_audio,
+            "voice_synthesize contract must declare AudioNonSilent"
+        );
+    }
+
+    #[test]
+    fn session_policy_mofa_slides_consumes_spawn_only_files_for_octos_1036() {
+        let policy = WorkspacePolicy::for_session();
+        let slides = policy
+            .spawn_tasks
+            .get("mofa_slides")
+            .expect("mofa_slides contract");
+
+        let mut saw_magic = false;
+        for entry in &slides.on_completion {
+            if let SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                source,
+                extension,
+                format,
+                glob,
+                ..
+            }) = entry
+            {
+                assert_eq!(*format, MagicByteKind::Pptx);
+                assert_eq!(
+                    *source,
+                    ValidatorFileSource::SpawnOnlyFiles,
+                    "mofa_slides MagicBytes must opt into spawn_only_files (octos #1036)"
+                );
+                assert_eq!(
+                    extension.as_deref(),
+                    Some("pptx"),
+                    "mofa_slides MagicBytes must filter to pptx outputs so auxiliary \
+                     files in files_to_send don't trip the check"
+                );
+                assert!(
+                    !glob.contains("**/*.pptx"),
+                    "mofa_slides must NOT pin a `**/*.pptx` glob — the spawn_only_files \
+                     source consumes the reported path directly; got: {glob}"
+                );
+                saw_magic = true;
+            }
+        }
+        assert!(
+            saw_magic,
+            "mofa_slides contract must declare MagicBytes(Pptx)"
+        );
     }
 
     #[test]

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -939,17 +939,6 @@ impl WorkspacePolicy {
 
         // Voice synthesis (LLM-driven TTS): assert the decoded audio is not
         // silent. Catches the "render produced empty audio" failure path.
-        //
-        // octos #1036 (follow-up to #1034 / PR #1035): consume the plugin's
-        // `files_to_send` list directly rather than globbing the workspace.
-        // The legacy glob `skill-output/voice/**/*.{mp3,wav}` was anchored at
-        // a directory the plugin does not actually guarantee — the voice
-        // skill writes to `$OCTOS_WORK_DIR/<filename>.{wav,mp3}` (see
-        // `crates/platform-skills/voice/src/main.rs:558-660`), and any
-        // operator-customised work dir or future per-voice subdirectory
-        // (`skill-output/voice-yangmi/...`) would silently slip past the
-        // validator. `extension = None` keeps both the initial `.wav` and
-        // the converted `.mp3` in scope since the plugin may report either.
         let voice_synthesize_contract = WorkspaceSpawnTaskPolicy {
             artifact: Some("primary_audio".into()),
             artifacts: Vec::new(),
@@ -962,9 +951,9 @@ impl WorkspacePolicy {
             on_failure: vec!["notify_user:Voice synthesis failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(
                 ValidatorSpec::AudioNonSilent {
-                    glob: String::new(),
+                    glob: "skill-output/voice/**/*.{mp3,wav}".into(),
                     min_ratio: default_non_silent_ratio(),
-                    source: ValidatorFileSource::SpawnOnlyFiles,
+                    source: ValidatorFileSource::Glob,
                     extension: None,
                 },
             )],
@@ -2190,57 +2179,18 @@ ignore = []
         )));
     }
 
-    /// octos #1036 (follow-up to #1034 / PR #1035): both `voice_synthesize`
-    /// and `mofa_slides` must consume the plugin's `files_to_send` envelope
-    /// rather than a hardcoded glob. The legacy globs
-    /// (`skill-output/voice/**/*.{mp3,wav}` and `**/*.pptx`) silently
-    /// missed files whenever the plugin wrote to a directory the policy
-    /// didn't anticipate, the same structural fragility we already fixed
-    /// for `podcast_generate`.
-    #[test]
-    fn session_policy_voice_synthesize_consumes_spawn_only_files_for_octos_1036() {
-        let policy = WorkspacePolicy::for_session();
-        let voice = policy
-            .spawn_tasks
-            .get("voice_synthesize")
-            .expect("voice_synthesize contract");
-
-        let mut saw_audio = false;
-        for entry in &voice.on_completion {
-            if let SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
-                source,
-                extension,
-                glob,
-                ..
-            }) = entry
-            {
-                assert_eq!(
-                    *source,
-                    ValidatorFileSource::SpawnOnlyFiles,
-                    "voice_synthesize AudioNonSilent must opt into spawn_only_files (octos #1036)"
-                );
-                // The voice plugin emits both WAV and MP3 variants — both must
-                // satisfy the non-silent check, so the extension filter is
-                // intentionally unset.
-                assert!(
-                    extension.is_none(),
-                    "voice_synthesize AudioNonSilent must accept both wav and mp3 \
-                     outputs (extension must remain unset); got: {extension:?}"
-                );
-                assert!(
-                    !glob.contains("skill-output/voice/"),
-                    "voice_synthesize must NOT pin the legacy `skill-output/voice/**` \
-                     glob — that anchor is the bug we are sweeping away; got: {glob}"
-                );
-                saw_audio = true;
-            }
-        }
-        assert!(
-            saw_audio,
-            "voice_synthesize contract must declare AudioNonSilent"
-        );
-    }
-
+    /// octos #1036 (follow-up to #1034 / PR #1035): `mofa_slides` must
+    /// consume the plugin's `files_to_send` envelope rather than a
+    /// hardcoded glob. The legacy `**/*.pptx` glob silently matched stale
+    /// PPTXs from earlier runs in the same session workspace, the same
+    /// structural fragility we already fixed for `podcast_generate`.
+    ///
+    /// `voice_synthesize` was originally part of this sweep but was
+    /// dropped after codex review caught that the voice plugin's
+    /// `succeed()` path emits only `{output, success}` (no
+    /// `files_to_send`) and the success text `"Generated audio: <path>"`
+    /// is not one of the prefixes `PluginTool::detect_output_file`
+    /// recognises. See follow-up issue tracking the plugin emission fix.
     #[test]
     fn session_policy_mofa_slides_consumes_spawn_only_files_for_octos_1036() {
         let policy = WorkspacePolicy::for_session();

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -51,6 +51,31 @@ on_completion = [
 ]
 on_failure = ["notify_user:Voice registration failed"]
 
+# octos #1036 (follow-up to #1034): voice_synthesize + mofa_slides now also
+# opt into the `spawn_only_files` source so the validator consumes the
+# plugin's reported file list rather than globbing the workspace. The
+# voice contract leaves `extension` unset because the plugin emits both
+# `.wav` (initial PCM render) and `.mp3` (post-convert) variants and both
+# must satisfy the non-silent-audio check; the slides contract pins
+# `extension = "pptx"` so auxiliary preview files emitted alongside the
+# deck don't trip the magic-bytes check.
+[spawn_tasks.voice_synthesize]
+artifact = "primary_audio"
+on_verify = [
+    "file_exists:$artifact",
+    "file_size_min:$artifact:1024",
+]
+on_failure = ["notify_user:Voice synthesis failed"]
+on_completion = [
+    { kind = "audio_non_silent", source = "spawn_only_files", min_ratio = 0.3 },
+]
+
+[spawn_tasks.mofa_slides]
+on_completion = [
+    { kind = "magic_bytes", source = "spawn_only_files", extension = "pptx", format = "pptx" },
+]
+on_failure = ["notify_user:Slide generation failed"]
+
 # Wave-3a: HttpProbeUntil + Sha256Match + soft_fail are operator-visible
 # TOML shapes; this fixture also acts as a syntax demo for operators.
 

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -51,25 +51,19 @@ on_completion = [
 ]
 on_failure = ["notify_user:Voice registration failed"]
 
-# octos #1036 (follow-up to #1034): voice_synthesize + mofa_slides now also
-# opt into the `spawn_only_files` source so the validator consumes the
-# plugin's reported file list rather than globbing the workspace. The
-# voice contract leaves `extension` unset because the plugin emits both
-# `.wav` (initial PCM render) and `.mp3` (post-convert) variants and both
-# must satisfy the non-silent-audio check; the slides contract pins
-# `extension = "pptx"` so auxiliary preview files emitted alongside the
-# deck don't trip the magic-bytes check.
-[spawn_tasks.voice_synthesize]
-artifact = "primary_audio"
-on_verify = [
-    "file_exists:$artifact",
-    "file_size_min:$artifact:1024",
-]
-on_failure = ["notify_user:Voice synthesis failed"]
-on_completion = [
-    { kind = "audio_non_silent", source = "spawn_only_files", min_ratio = 0.3 },
-]
-
+# octos #1036 (follow-up to #1034): mofa_slides now opts into the
+# `spawn_only_files` source so the magic-bytes check inspects the exact
+# PPTX path the plugin reported instead of any `**/*.pptx` match in the
+# session workspace. The `extension = "pptx"` filter narrows the list to
+# slide decks if the skill surfaces auxiliary preview files via
+# `files_to_send`.
+#
+# `voice_synthesize` was originally part of this sweep but was reverted
+# after codex review caught that the voice plugin's `succeed()` path
+# emits only `{output, success}` (no `files_to_send`) and its success
+# text `"Generated audio: <path>"` is not one of the prefixes
+# `PluginTool::detect_output_file` recognises. A follow-up issue tracks
+# the plugin emission fix.
 [spawn_tasks.mofa_slides]
 on_completion = [
     { kind = "magic_bytes", source = "spawn_only_files", extension = "pptx", format = "pptx" },


### PR DESCRIPTION
## Summary

Follow-up to PR #1035 / issue #1034. The `mofa_slides` spawn-task contract in `WorkspacePolicy::for_session()` still pinned a hardcoded `**/*.pptx` glob that the validator could match against unrelated stale PPTXs from earlier runs in the same session workspace. Sweep it onto the `ValidatorFileSource::SpawnOnlyFiles` source that PR #1035 introduced so the magic-bytes check inspects the exact PPTX path the plugin reported via `files_to_send`.

### `mofa_slides`

- **Before**: `MagicBytes { glob: "**/*.pptx", source: Glob, ... }`
- **After**: `MagicBytes { glob: "", source: SpawnOnlyFiles, extension: Some("pptx"), ... }`

A recursive `**/*.pptx` glob can match an unrelated stale PPTX from an earlier run in the same session workspace. The validator now inspects the exact path the skill reported via `files_to_send`. The `extension = "pptx"` filter narrows the file list to slide decks if the skill also surfaces auxiliary files (preview PNGs, etc.).

## Note on `voice_synthesize` (originally part of this PR, now dropped)

The PR originally also swept `voice_synthesize` to `SpawnOnlyFiles`. That half was reverted after codex review caught a **BLOCKING** correctness bug:

> `voice_synthesize` does not actually populate `files_to_send`. The voice skill prints JSON with only `output` and `success` in `succeed()` at `crates/platform-skills/voice/src/main.rs:309`, and the success text is `Generated audio...` at lines 634/679. `PluginTool::detect_output_file` only detects `out`, `Generated PPTX:`, or `Generated:` at `crates/octos-agent/src/plugins/tool.rs:680`. So the new `SpawnOnlyFiles` validator will see an empty list and fail.

The voice plugin needs to emit `files_to_send` (or use a marker prefix `detect_output_file` already recognises) before the contract can be swept. Tracked in **#1038**.

## Test plan

- [x] `cargo test -p octos-agent` — 1711 passed, 0 failed
- [x] `cargo build --workspace` — clean
- [x] One new contract-level pin in `workspace_policy.rs`:
  - `session_policy_mofa_slides_consumes_spawn_only_files_for_octos_1036`
- [x] One new validator-runner happy-path test in `validators.rs`:
  - `mofa_slides_uses_spawn_only_files_at_arbitrary_depth` (lays down a stale HTML-shaped `aaa-stale.pptx` alongside the real one to prove the validator does NOT fall back to the workspace glob)
- [x] Updated existing `mofa_slides_contract_satisfies_when_pptx_is_present` and `mofa_slides_contract_fails_when_artifact_is_html_error_page` to pass the PPTX via `files_to_send` (matching the live call path out of `enforce_spawn_task_contract_with_args_and_output`)
- [x] Test fixture `workspace_policy_v1_session.toml` adds an entry for `mofa_slides` so the TOML round-trip pins the new shape

## Out of scope

- `voice_synthesize` — deferred to #1038 (voice plugin must surface its output path first)
- `podcast_generate`, `fm_voice_save` — already on the right path
- The `ValidatorFileSource` enum / `resolve_validator_files` helper — those came in PR #1035 and already work
- Plugin code (`voice`, `mofa-slides`, etc.) — config sweep only

Refs #1036 (mofa_slides half).