### PR TITLE
fix(voice): emit Generated: marker so plugin output flows into files_to_send (closes #1038)

### DIFF
--- a/crates/platform-skills/voice/src/main.rs
+++ b/crates/platform-skills/voice/src/main.rs
@@ -630,8 +630,16 @@ fn handle_synthesize(input_json: &str) {
                         let duration_secs = size.saturating_sub(44) as f64 / 48000.0;
                         eprintln!("Converting to MP3...");
                         let final_path = try_convert_to_mp3(&output_path);
+                        // `Generated: <path>` on its own line is the marker
+                        // `PluginTool::detect_output_file` parses to populate
+                        // `files_to_send` (it splits on lines and treats the
+                        // entire rest-of-line as the path). The user-readable
+                        // summary stays on the next line so the LLM still
+                        // sees the duration/size/follow-up hint.
+                        // octos #1038: replaced legacy `Generated audio: …`
+                        // single-line text which the detector did not match.
                         succeed(&format!(
-                            "Generated audio: {final_path} ({duration_secs:.1}s, {size} bytes). Use send_file to deliver it to the user."
+                            "Generated: {final_path}\nSynthesized audio ({duration_secs:.1}s, {size} bytes). Use send_file to deliver it to the user."
                         ));
                     }
                     Err(e) => {
@@ -675,8 +683,12 @@ fn handle_synthesize(input_json: &str) {
                 let duration_secs = size.saturating_sub(44) as f64 / 48000.0;
                 eprintln!("Converting to MP3...");
                 let final_path = try_convert_to_mp3(&output_path);
+                // octos #1038: `Generated: <path>` on its own line is the
+                // marker `PluginTool::detect_output_file` parses to populate
+                // `files_to_send`. See the Qwen3 site above for the rationale.
                 succeed(&format!(
-                    "Generated audio (macOS Say): {final_path} ({duration_secs:.1}s, {size} bytes). \
+                    "Generated: {final_path}\n\
+                     Synthesized audio with macOS Say ({duration_secs:.1}s, {size} bytes). \
                      Note: using built-in macOS voice — install ominix-api for higher-quality Qwen3-TTS. \
                      Use send_file to deliver it to the user."
                 ));


### PR DESCRIPTION
## Summary

- The `voice_synthesize` success path printed `Generated audio: <path> (Xs, Y bytes). Use send_file …` as a single line. `PluginTool::detect_output_file` strips the prefixes `Generated PPTX:` and `Generated:` from each output line and treats the rest as a path — `Generated audio:` is not one of them, so `files_to_send` was never populated for voice_synthesize.
- This blocked PR #1037's voice_synthesize sweep: flipping the contract to `ValidatorFileSource::SpawnOnlyFiles` would assert against an empty file list and fail. Codex review caught the gap (BLOCKING) and the voice half of #1037 was reverted at 772783e7, tracked here in #1038.
- Fix: emit two lines from `succeed()` — `Generated: <final_path>` on its own line (the marker the harness already recognises), followed by the user-readable summary the LLM continues to read. Both call sites covered: the Qwen3-TTS happy path (formerly `Generated audio:`) and the macOS Say fallback (formerly `Generated audio (macOS Say):`).

`try_convert_to_mp3` deletes the .wav and returns the .mp3 path on success, falling back to the .wav otherwise — so each `succeed()` call always emits exactly one absolute path. The two formats cannot co-exist by construction, so there is no risk of the detector picking up the wrong file.

A follow-up PR will flip `voice_synthesize_contract` from `ValidatorFileSource::Glob` to `SpawnOnlyFiles` now that the plugin actually surfaces its output file via `files_to_send`.

## Test plan

- [x] `cargo build -p voice --release` — clean
- [x] `cargo test -p voice` — 12 passed, 0 failed
- [x] `cargo fmt -p voice -- --check` — clean
- [ ] Validator flip will be exercised in the follow-up PR's `cargo test -p octos-agent` suite (1711+ tests)

Refs PR #1037, closes #1038.