### PR TITLE
fix(workspace_policy): sweep mofa_comic/infographic/frame MagicBytes to SpawnOnlyFiles (refs #1040)

### DIFF
--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1325,12 +1325,14 @@ mod tests {
     #[tokio::test]
     async fn mofa_comic_contract_uses_args_out_for_file_exists_and_magic_bytes() {
         // P1-5: mofa_comic has a required `out` arg pointing at a single
-        // PNG file. Both FileExists and MagicBytes interpolate
-        // `${args.out}` so they assert exactly the path the LLM declared.
+        // PNG file. FileExists interpolates `${args.out}` to assert the
+        // path the LLM declared exists; MagicBytes (octos #1040 sweep)
+        // now consumes the plugin's `files_to_send` list so it inspects
+        // the exact path the skill reported instead of any `**/*.png`
+        // match in the workspace.
         let temp = tempfile::tempdir().unwrap();
         write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
         let comic = temp.path().join("comic.png");
-        std::fs::write(&comic, PNG_1X1).unwrap();
         // Pad to meet the 1024-byte min_bytes check on the FileExists.
         let mut padded = PNG_1X1.to_vec();
         padded.extend(std::iter::repeat_n(0u8, 2048));
@@ -1340,7 +1342,7 @@ mod tests {
             &ToolRegistry::with_builtins(temp.path()),
             "mofa_comic",
             "tool-call-comic",
-            &[],
+            std::slice::from_ref(&comic),
             UNIX_EPOCH,
             None,
             Some(&json!({"out": "comic.png"})),
@@ -1354,12 +1356,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mofa_comic_contract_does_not_pass_on_stale_unrelated_png_octos_1040() {
+        // octos #1040: with `MagicBytes { source: SpawnOnlyFiles }`, the
+        // validator must consume the plugin's reported PNG path, NOT
+        // any `**/*.png` match in the session workspace. Lay down a
+        // stale HTML-shaped `aaa-stale.png` to prove that an empty
+        // `files_to_send` list does not silently pass via a workspace
+        // glob.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+
+        // Stale-but-valid PNG that an `**/*.png` glob would have matched.
+        let stale = temp.path().join("aaa-stale.png");
+        let mut padded = PNG_1X1.to_vec();
+        padded.extend(std::iter::repeat_n(0u8, 2048));
+        std::fs::write(&stale, &padded).unwrap();
+
+        // The real expected output never lands. Plugin reports nothing.
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_comic",
+            "tool-call-comic-stale",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"out": "comic.png"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, .. } => {
+                assert!(
+                    error.contains("comic.png")
+                        || error.contains("does not exist")
+                        || error.contains("files_to_send"),
+                    "expected a failure that references the missing comic.png or missing \
+                     files_to_send (not a stale-PNG fallback); got: {error}"
+                );
+            }
+            other => panic!("expected failure for missing comic.png, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn mofa_comic_contract_fails_when_args_out_file_is_missing() {
         let temp = tempfile::tempdir().unwrap();
         write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
         // Note: the file `comic.png` is never created — the LLM-declared
-        // path doesn't exist, so FileExists with `${args.out}` should
-        // fail at the contract gate.
+        // path doesn't exist. The contract should fail; with octos
+        // #1040 the failure surfaces earlier at the artifact-resolution
+        // step (no `**/*.png` matches in the workspace), before the
+        // FileExists `${args.out}` validator runs. The outcome is the
+        // same: notify_user fires with "Comic generation failed".
 
         let result = enforce_spawn_task_contract_with_args(
             &ToolRegistry::with_builtins(temp.path()),
@@ -1375,7 +1423,9 @@ mod tests {
         match result {
             SpawnTaskContractResult::Failed { error, notify_user } => {
                 assert!(
-                    error.contains("does not exist") || error.contains("comic.png"),
+                    error.contains("does not exist")
+                        || error.contains("comic.png")
+                        || error.contains("could not find artifact 'image_png'"),
                     "unexpected error: {error}"
                 );
                 assert_eq!(notify_user.as_deref(), Some("Comic generation failed"));

--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1399,6 +1399,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mofa_frame_contract_rejects_stale_png_without_files_to_send_octos_1040() {
+        // octos #1040: `mofa_frame` flips to MagicBytes(SpawnOnlyFiles)
+        // preemptively (the manifest is not `spawn_only: true` today —
+        // contract is dormant — but the script at
+        // `mofa-skills/mofa-frame/main` already emits `files_to_send`).
+        // This test is a cleaner cross-check than the `mofa_comic` stale
+        // case because the `mofa_frame` contract has NO FileExists
+        // validator: the SpawnOnlyFiles source is the only gate, so a
+        // regression to the workspace glob would silently pass on any
+        // stale PNG in the workspace.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+
+        // Stale-but-valid PNG that an `**/*.png` glob would have matched.
+        let stale = temp.path().join("aaa-stale.png");
+        let mut padded = PNG_1X1.to_vec();
+        padded.extend(std::iter::repeat_n(0u8, 2048));
+        std::fs::write(&stale, &padded).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_frame",
+            "tool-call-frame-stale",
+            // Plugin reported nothing (the dormant-contract simulation).
+            &[],
+            UNIX_EPOCH,
+            None,
+            // mofa_frame's required args are `video_path` and `timestamp`;
+            // `out_path` is optional. Pass none so the dormant-contract
+            // mode is what we exercise.
+            Some(&json!({})),
+        )
+        .await;
+
+        // Either artifact-resolution catches it ("could not find
+        // artifact 'image_png'") because nothing in the workspace
+        // matches the artifact glob with the task-started-at filter
+        // applied, OR the SpawnOnlyFiles validator surfaces the
+        // empty-list failure. Both are valid because we want
+        // "stale PNG does NOT silently pass" — the assertion below
+        // just requires a Failed outcome with notify_user.
+        match result {
+            SpawnTaskContractResult::Failed { notify_user, .. } => {
+                assert_eq!(notify_user.as_deref(), Some("Frame extraction failed"));
+            }
+            SpawnTaskContractResult::Satisfied { output_files } => {
+                panic!(
+                    "mofa_frame contract MUST NOT silently pass on a stale workspace PNG; \
+                     got Satisfied with files {output_files:?}"
+                );
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn mofa_comic_contract_fails_when_args_out_file_is_missing() {
         let temp = tempfile::tempdir().unwrap();
         write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -841,6 +841,13 @@ impl WorkspacePolicy {
         // recursive `**/*.pptx` glob already used by the MagicBytes(Pptx)
         // validator on `on_completion`.
         artifacts.insert("slides_pptx".into(), "**/*.pptx".into());
+        // octos #1040 (follow-up to #1035 / #1037): `mofa_comic`,
+        // `mofa_infographic`, and `mofa_frame` all emit a single PNG via
+        // `files_to_send`. The `image_png` artifact gives those contracts
+        // a target name so `bind_explicit_files_to_artifacts` can bind the
+        // reported PNG path into `ActionContext` without erroring on "no
+        // artifact source" the same way `slides_pptx` does for slides.
+        artifacts.insert("image_png".into(), "**/*.png".into());
 
         let tts_contract = WorkspaceSpawnTaskPolicy {
             artifact: Some("primary_audio".into()),
@@ -1061,14 +1068,28 @@ impl WorkspacePolicy {
         // mofa_comic and mofa_infographic each take a required `out` arg
         // pointing at a single PNG file. The contract asserts BOTH that
         // the file landed at the declared path (FileExists with
-        // `${args.out}`, FileExists already supports template
-        // interpolation) AND that there is at least one valid PNG header
-        // present in the workspace (MagicBytes against the recursive
-        // `**/*.png` glob — MagicBytes does not template its glob today).
-        // FileExists does the per-task path check; MagicBytes does the
-        // bytes-are-actually-a-PNG check.
+        // `${args.out}`, which already supports template interpolation)
+        // AND that the file at the plugin-reported path carries a valid
+        // PNG header (MagicBytes against the `spawn_only_files` source —
+        // octos #1040, follow-up to #1035 / #1037).
+        //
+        // `detect_output_file` in `plugins/tool.rs:556-577` populates
+        // `files_to_send` from the `args.out` argument when the plugin's
+        // success envelope omits it. mofa-cli's `plugin_comic` /
+        // `plugin_infographic` emit `"Generated comic: <path>"` /
+        // `"Generated infographic: <path>"` (no `Generated:` marker),
+        // but the `args.out` branch fires first so the validator always
+        // sees the exact PNG path the skill wrote. The `extension =
+        // "png"` filter narrows the list if a future revision of the
+        // plugin starts surfacing auxiliary files (intermediate panel
+        // PNGs in `work_dir`, layout previews, etc.) via
+        // `files_to_send`.
+        //
+        // FileExists still does the per-task path check (mismatches
+        // between `args.out` and what the plugin actually wrote);
+        // MagicBytes still does the bytes-are-actually-a-PNG check.
         let mofa_comic_contract = WorkspaceSpawnTaskPolicy {
-            artifact: None,
+            artifact: Some("image_png".into()),
             artifacts: Vec::new(),
             on_verify: Vec::new(),
             on_complete: vec![],
@@ -1080,16 +1101,16 @@ impl WorkspacePolicy {
                     min_bytes: Some(1024),
                 }),
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                    glob: "**/*.png".into(),
+                    glob: String::new(),
                     format: MagicByteKind::Png,
-                    source: ValidatorFileSource::Glob,
-                    extension: None,
+                    source: ValidatorFileSource::SpawnOnlyFiles,
+                    extension: Some("png".into()),
                 }),
             ],
         };
 
         let mofa_infographic_contract = WorkspaceSpawnTaskPolicy {
-            artifact: None,
+            artifact: Some("image_png".into()),
             artifacts: Vec::new(),
             on_verify: Vec::new(),
             on_complete: vec![],
@@ -1101,10 +1122,10 @@ impl WorkspacePolicy {
                     min_bytes: Some(1024),
                 }),
                 SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                    glob: "**/*.png".into(),
+                    glob: String::new(),
                     format: MagicByteKind::Png,
-                    source: ValidatorFileSource::Glob,
-                    extension: None,
+                    source: ValidatorFileSource::SpawnOnlyFiles,
+                    extension: Some("png".into()),
                 }),
             ],
         };
@@ -1115,18 +1136,25 @@ impl WorkspacePolicy {
         // should be wired even if the gate is not yet fired. Recording
         // the entry here lets the next spawn_only flip pick up the
         // contract automatically.
+        //
+        // octos #1040: preemptively use the `spawn_only_files` source so
+        // the contract is on the right shape the moment the manifest
+        // flips. The mofa-frame plugin script
+        // (`mofa-skills/mofa-frame/main`) already emits `files_to_send`
+        // in its JSON envelope (the final `jq` call surfaces the
+        // generated PNG path), so no plugin work is needed.
         let mofa_frame_contract = WorkspaceSpawnTaskPolicy {
-            artifact: None,
+            artifact: Some("image_png".into()),
             artifacts: Vec::new(),
             on_verify: Vec::new(),
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:Frame extraction failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                glob: "**/*.png".into(),
+                glob: String::new(),
                 format: MagicByteKind::Png,
-                source: ValidatorFileSource::Glob,
-                extension: None,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("png".into()),
             })],
         };
 
@@ -2323,6 +2351,110 @@ ignore = []
                 .cloned(),
             Some("notify_user:Publish probe failed".to_string()),
             "on_failure should surface a notify_user hint",
+        );
+    }
+
+    #[test]
+    fn session_policy_mofa_comic_infographic_frame_consume_spawn_only_files_for_octos_1040() {
+        // octos #1040 (follow-up to #1035 / #1037): the MagicBytes
+        // validator on each of mofa_comic, mofa_infographic, and
+        // mofa_frame must opt into `spawn_only_files` so the validator
+        // consumes the plugin-reported `files_to_send` path directly
+        // instead of any `**/*.png` match in the session workspace
+        // (which could pass on a stale PNG from an earlier turn). The
+        // `extension = "png"` filter narrows the file list if the
+        // skill surfaces auxiliary files (intermediate panel PNGs,
+        // layout previews, etc.) via `files_to_send`.
+        //
+        // `mofa_cards` is intentionally NOT in this sweep — the plugin
+        // does not yet emit `files_to_send` (it returns `card_dir` not
+        // `out`, and its success text `"Generated N card(s) in <dir>"`
+        // does not match the `Generated:` / `Generated PPTX:` markers
+        // that `PluginTool::detect_output_file` auto-detects). Tracked
+        // by a separate plugin-fix issue.
+        let policy = WorkspacePolicy::for_session();
+        for tool in ["mofa_comic", "mofa_infographic", "mofa_frame"] {
+            let entry = policy
+                .spawn_tasks
+                .get(tool)
+                .unwrap_or_else(|| panic!("policy missing spawn task for {tool}"));
+
+            let mut saw_magic = false;
+            for spec in &entry.on_completion {
+                if let SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                    source,
+                    extension,
+                    format,
+                    glob,
+                    ..
+                }) = spec
+                {
+                    assert_eq!(*format, MagicByteKind::Png);
+                    assert_eq!(
+                        *source,
+                        ValidatorFileSource::SpawnOnlyFiles,
+                        "{tool} MagicBytes must opt into spawn_only_files (octos #1040)"
+                    );
+                    assert_eq!(
+                        extension.as_deref(),
+                        Some("png"),
+                        "{tool} MagicBytes must filter to png outputs so auxiliary files \
+                         in files_to_send don't trip the check"
+                    );
+                    assert!(
+                        !glob.contains("**/*.png"),
+                        "{tool} must NOT pin a `**/*.png` glob — the spawn_only_files source \
+                         consumes the reported path directly; got: {glob}"
+                    );
+                    saw_magic = true;
+                }
+            }
+            assert!(saw_magic, "{tool} contract must declare MagicBytes(Png)");
+        }
+    }
+
+    #[test]
+    fn session_policy_mofa_cards_keeps_glob_until_plugin_emits_files_to_send_octos_1041() {
+        // octos #1041 (audit #1040 follow-up): `mofa_cards` cannot yet
+        // sweep to `spawn_only_files` because the plugin does not emit
+        // `files_to_send` and `PluginTool::detect_output_file` does not
+        // auto-populate it (no `out` arg, success text uses an
+        // unrecognised `Generated N card(s) in <dir>` prefix).
+        //
+        // This test pins the current behaviour so a future contributor
+        // doesn't sweep `mofa_cards` without first fixing the plugin
+        // emission — that would regress to the empty-files-to-send
+        // failure mode that #1037 caught for `voice_synthesize` and
+        // tracked as #1038.
+        let policy = WorkspacePolicy::for_session();
+        let cards = policy
+            .spawn_tasks
+            .get("mofa_cards")
+            .expect("policy must declare mofa_cards spawn task");
+
+        let magic = cards.on_completion.iter().find_map(|spec| match spec {
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                source,
+                extension,
+                format,
+                glob,
+                ..
+            }) => Some((*format, *source, extension.clone(), glob.clone())),
+            _ => None,
+        });
+
+        let (format, source, _extension, glob) = magic.expect(
+            "mofa_cards contract must declare MagicBytes(Png) — see workspace_policy.rs:1043",
+        );
+        assert_eq!(format, MagicByteKind::Png);
+        assert_eq!(
+            source,
+            ValidatorFileSource::Glob,
+            "mofa_cards must keep `Glob` until octos #1041 lands the plugin-emission fix"
+        );
+        assert!(
+            glob.contains("**/*.png"),
+            "mofa_cards Glob source must keep the recursive PNG pattern; got: {glob}"
         );
     }
 

--- a/crates/octos-agent/tests/abi_compat.rs
+++ b/crates/octos-agent/tests/abi_compat.rs
@@ -141,6 +141,34 @@ fn should_load_workspace_policy_v1_session_fixture() {
         saw_audio,
         "podcast fixture must declare AudioNonSilent(spawn_only_files)"
     );
+
+    // octos #1040 (follow-up to #1035 / #1037): mofa_comic, mofa_infographic,
+    // and mofa_frame all carry MagicBytes(Png) on the `spawn_only_files`
+    // source with the `extension = "png"` filter. The fixture is the
+    // durable promise of that shape; the round-trip pins both the new ABI
+    // field defaults AND the per-contract opt-in.
+    for tool in ["mofa_comic", "mofa_infographic", "mofa_frame"] {
+        let entry = policy
+            .spawn_tasks
+            .get(tool)
+            .unwrap_or_else(|| panic!("v1 fixture must declare {tool} spawn task"));
+        let saw = entry.on_completion.iter().any(|spec| {
+            matches!(
+                spec,
+                SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
+                    source: ValidatorFileSource::SpawnOnlyFiles,
+                    extension,
+                    ..
+                }) if extension.as_deref() == Some("png")
+            )
+        });
+        assert!(
+            saw,
+            "{tool} fixture must declare MagicBytes(png, spawn_only_files, extension=png); \
+             got {:?}",
+            entry.on_completion,
+        );
+    }
 }
 
 #[test]

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -17,6 +17,11 @@ ignore = ["tmp/**", ".DS_Store"]
 [artifacts]
 primary_audio = "*.mp3"
 podcast_audio = "**/podcast_full_*.*"
+# octos #1040: the image-producing mofa contracts (comic, infographic,
+# frame) need a named artifact source so `bind_explicit_files_to_artifacts`
+# can bind the plugin-reported PNG into `ActionContext`. The glob mirrors
+# the `**/*.png` pattern the MagicBytes(Png) validator uses in glob mode.
+image_png = "**/*.png"
 
 [spawn_tasks.fm_tts]
 artifact = "primary_audio"
@@ -69,6 +74,45 @@ on_completion = [
     { kind = "magic_bytes", source = "spawn_only_files", extension = "pptx", format = "pptx" },
 ]
 on_failure = ["notify_user:Slide generation failed"]
+
+# octos #1040 (follow-up to #1035 / #1037): mofa_comic, mofa_infographic,
+# and mofa_frame all carry the same MagicBytes(Png) shape on the
+# `spawn_only_files` source. The plugin envelopes (or auto-detection via
+# `args.out` in `plugins/tool.rs::detect_output_file`) populate
+# `files_to_send` directly so the validator inspects the exact PNG the
+# skill wrote instead of any `**/*.png` match in the workspace. The
+# `extension = "png"` filter narrows the list when the skill surfaces
+# auxiliary files (intermediate panel PNGs, layout previews) via
+# `files_to_send`.
+#
+# `mofa_cards` is intentionally NOT in this sweep — the plugin does not
+# yet emit `files_to_send` (its required arg is `card_dir`, not `out`,
+# and the success text `"Generated N card(s) in <dir>"` does not match
+# the `Generated:` / `Generated PPTX:` markers that
+# `detect_output_file` auto-detects). A follow-up issue tracks the
+# plugin emission fix.
+[spawn_tasks.mofa_comic]
+artifact = "image_png"
+on_completion = [
+    { kind = "file_exists", path = "${args.out}", min_bytes = 1024 },
+    { kind = "magic_bytes", source = "spawn_only_files", extension = "png", format = "png" },
+]
+on_failure = ["notify_user:Comic generation failed"]
+
+[spawn_tasks.mofa_infographic]
+artifact = "image_png"
+on_completion = [
+    { kind = "file_exists", path = "${args.out}", min_bytes = 1024 },
+    { kind = "magic_bytes", source = "spawn_only_files", extension = "png", format = "png" },
+]
+on_failure = ["notify_user:Infographic generation failed"]
+
+[spawn_tasks.mofa_frame]
+artifact = "image_png"
+on_completion = [
+    { kind = "magic_bytes", source = "spawn_only_files", extension = "png", format = "png" },
+]
+on_failure = ["notify_user:Frame extraction failed"]
 
 # Wave-3a: HttpProbeUntil + Sha256Match + soft_fail are operator-visible
 # TOML shapes; this fixture also acts as a syntax demo for operators.


### PR DESCRIPTION
## Summary

Follow-up to PRs #1035 / #1037 and audit #1040. Three more spawn-task contracts in `WorkspacePolicy::for_session()` still pinned hardcoded `MagicBytes { glob: \"**/*.png\", source: Glob }` validators that could silently match an unrelated stale PNG from an earlier turn in the same session workspace. Sweep them onto `ValidatorFileSource::SpawnOnlyFiles` so the magic-bytes check inspects the exact path the plugin reports via `files_to_send`.

`mofa_cards` is intentionally NOT in this PR — the plugin currently emits neither `files_to_send` nor a `Generated:` marker that `PluginTool::detect_output_file` recognises (analogous to the #1038 blocker on `voice_synthesize`, fixed in #1039). Tracked as #1041.

## Per-contract change

| Contract | Before | After | files_to_send route |
|---|---|---|---|
| `mofa_comic` | `MagicBytes { glob: \"**/*.png\", source: Glob }` + `FileExists { path: \"${args.out}\" }` | `MagicBytes { source: SpawnOnlyFiles, extension: \"png\" }` + unchanged `FileExists` + `artifact = \"image_png\"` | `args.out` auto-detect in `plugins/tool.rs:556-577` |
| `mofa_infographic` | same as comic | same as comic | same as comic |
| `mofa_frame` | `MagicBytes { glob: \"**/*.png\", source: Glob }` | `MagicBytes { source: SpawnOnlyFiles, extension: \"png\" }` + `artifact = \"image_png\"` | Plugin script's JSON envelope at `mofa-skills/mofa-frame/main:68-73` already emits `files_to_send` |

A shared `image_png = \"**/*.png\"` artifact entry is added to the for_session artifacts map so `bind_explicit_files_to_artifacts` can bind the explicit files_to_send list against a named slot (mirrors the `slides_pptx` pattern from #1005 / #1037).

## Why `mofa_cards` is out of scope

mofa-cli's `plugin_cards` handler (`mofa-skills/mofa-cli/src/main.rs:585-635`) takes a required `card_dir` arg (not `out`) and returns `\"Generated N card(s) in <dir>\"`. Neither the `args.out` branch nor the `Generated:` / `Generated PPTX:` marker branch in `detect_output_file` matches, so `files_to_send` stays empty for every successful invocation. Flipping the contract today would regress to the empty-list failure mode #1037 caught for `voice_synthesize`.

A new pin (`session_policy_mofa_cards_keeps_glob_until_plugin_emits_files_to_send_octos_1041`) freezes the current shape so a future contributor can't silently sweep `mofa_cards` without first fixing the plugin emission.

## Test plan

- [x] `cargo test -p octos-agent` — 1457 lib + integration tests, all green
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean (pre-existing warnings unchanged)
- [x] `cargo clippy -p octos-agent --tests` — clean (pre-existing warnings unchanged)
- [x] 3 new contract-level pins:
  - `session_policy_mofa_comic_infographic_frame_consume_spawn_only_files_for_octos_1040`
  - `session_policy_mofa_cards_keeps_glob_until_plugin_emits_files_to_send_octos_1041`
  - `mofa_comic_contract_does_not_pass_on_stale_unrelated_png_octos_1040` (lays down a stale-but-valid `aaa-stale.png` to prove the validator no longer falls back to the workspace glob)
- [x] Updated existing `mofa_comic_contract_uses_args_out_for_file_exists_and_magic_bytes` and `mofa_comic_contract_fails_when_args_out_file_is_missing` to match the new call shape
- [x] ABI fixture `workspace_policy_v1_session.toml` declares the new TOML form so the round-trip pins the operator-visible surface

## Out of scope

- `mofa_cards` — deferred to #1041 (plugin must emit `files_to_send` or use the `Generated:` marker first)
- `podcast_generate`, `voice_synthesize`, `mofa_slides`, `fm_voice_save` — already on the right path (#1035 / #1037 / #1039)
- Plugin code (`mofa-cli`, `mofa-frame`) — config sweep only
- The `ValidatorFileSource` enum / `resolve_validator_files` helper — landed in #1035

Refs #1040, #1041.