### PR TITLE
fix(workspace_policy): flip voice_synthesize to SpawnOnlyFiles (closes #1038, depends on #1039)

### DIFF
--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -4438,9 +4438,8 @@ mod tests {
     // but was dropped after codex review caught that the voice plugin's
     // `succeed()` path emits only `{output, success}` (no `files_to_send`)
     // and its success text `"Generated audio: <path>"` is not one of the
-    // prefixes `PluginTool::detect_output_file` recognises. The validator
-    // would see an empty list and fail. See follow-up issue tracking the
-    // plugin emission fix.
+    // prefixes `PluginTool::detect_output_file` recognises. The marker
+    // was fixed in PR #1039 and the voice_synthesize sweep follows below.
 
     /// `mofa_slides` MagicBytes(Pptx) must run against the plugin's reported
     /// PPTX path verbatim, including outputs at arbitrary depth where the
@@ -4495,6 +4494,132 @@ mod tests {
             outcomes.iter().all(|o| o.status == ValidatorStatus::Pass),
             "mofa_slides contract must satisfy via spawn_only_files even when an \
              unrelated stale PPTX exists in the workspace; outcomes = {outcomes:?}",
+        );
+    }
+
+    // --- octos #1038: voice_synthesize sweep ------------------------------
+    //
+    // Mirror the octos #1036 mofa_slides happy-path test for the voice
+    // contract that PR #1037's revert (772783e7) left on the glob path.
+    // Failure mode being closed: a recursive
+    // `skill-output/voice/**/*.{mp3,wav}` glob would match unrelated
+    // stale audio from earlier runs in the same session workspace, the
+    // same fragility we already closed for `podcast_generate` (#1034)
+    // and `mofa_slides` (#1036). Predecessor PR #1039 fixed the voice
+    // plugin's success-line marker so `files_to_send` is now populated
+    // and the sweep is finally safe.
+
+    /// `voice_synthesize` AudioNonSilent must run against the plugin's
+    /// reported audio path verbatim. The legacy
+    /// `skill-output/voice/**/*.{mp3,wav}` glob would have matched a
+    /// stale silent .wav from an earlier run alongside the freshly-
+    /// emitted .mp3, so this test pins down that the validator inspects
+    /// only the file `files_to_send` reports.
+    #[tokio::test]
+    async fn voice_synthesize_uses_spawn_only_files_with_stale_silent_audio_present() {
+        let dir = tempfile::tempdir().unwrap();
+        // Real, non-silent output the plugin would report via the
+        // `Generated: <path>` marker that PR #1039 introduced.
+        let voice_dir = dir.path().join("skill-output/voice");
+        std::fs::create_dir_all(&voice_dir).unwrap();
+        let fresh = voice_dir.join("synthesized_1779067937.wav");
+        write_sine_wav(&fresh, 800);
+        // Stale silent audio from a prior run. If the validator ever
+        // fell back to the glob path it would decode this alongside the
+        // fresh file, but a single non-silent match is enough for
+        // AudioNonSilent to pass — so this stale file isn't on its own a
+        // counter-example. Instead include a stale .wav that is ALSO
+        // non-silent: the glob path would still pass, but the
+        // spawn_only_files path must not consult the workspace at all.
+        // We anchor the assertion to the validator outcome plus the
+        // session-policy test above (`session_policy_voice_synthesize_*`)
+        // which pins the source enum directly.
+        let stale = voice_dir.join("aaa-stale.wav");
+        write_silent_wav(&stale, 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let session_policy = crate::workspace_policy::WorkspacePolicy::for_session();
+        let contract = session_policy
+            .spawn_tasks
+            .get("voice_synthesize")
+            .expect("voice_synthesize contract must be registered");
+        let validators: Vec<Validator> = contract
+            .on_completion
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                crate::workspace_policy::SpawnTaskValidatorSpec::into_validator(
+                    entry.clone(),
+                    "voice_synthesize",
+                    i,
+                )
+            })
+            .collect();
+
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "voice_synthesize".into(),
+        )
+        .with_spawn_only_files(vec![fresh]);
+        let outcomes = runner.run_all(&invocation, &validators).await;
+        assert!(
+            outcomes.iter().all(|o| o.status == ValidatorStatus::Pass),
+            "voice_synthesize contract must satisfy via spawn_only_files even when \
+             stale audio exists in the workspace; outcomes = {outcomes:?}",
+        );
+    }
+
+    /// Belt-and-suspenders: when the plugin reports ONLY a silent .wav
+    /// (the failure mode the contract exists to catch), the validator
+    /// must surface a Fail outcome even when an unrelated non-silent
+    /// .wav lives in the workspace. The legacy glob would have matched
+    /// the unrelated file and silently satisfied the contract.
+    #[tokio::test]
+    async fn voice_synthesize_spawn_only_files_fails_when_reported_audio_is_silent() {
+        let dir = tempfile::tempdir().unwrap();
+        let voice_dir = dir.path().join("skill-output/voice");
+        std::fs::create_dir_all(&voice_dir).unwrap();
+        // The plugin reported a silent file — this is the failure case.
+        let silent = voice_dir.join("synthesized_1779067937.wav");
+        write_silent_wav(&silent, 800);
+        // A NON-silent file from an earlier run; if the validator ever
+        // fell back to the glob it would pick this up and pass, masking
+        // the failure. The spawn_only_files path must ignore it.
+        let unrelated = voice_dir.join("aaa-fresh.wav");
+        write_sine_wav(&unrelated, 800);
+
+        let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
+        let session_policy = crate::workspace_policy::WorkspacePolicy::for_session();
+        let contract = session_policy
+            .spawn_tasks
+            .get("voice_synthesize")
+            .expect("voice_synthesize contract must be registered");
+        let validators: Vec<Validator> = contract
+            .on_completion
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                crate::workspace_policy::SpawnTaskValidatorSpec::into_validator(
+                    entry.clone(),
+                    "voice_synthesize",
+                    i,
+                )
+            })
+            .collect();
+
+        let invocation = ValidatorInvocation::new(
+            ValidatorPhase::Completion,
+            dir.path().to_path_buf(),
+            "voice_synthesize".into(),
+        )
+        .with_spawn_only_files(vec![silent]);
+        let outcomes = runner.run_all(&invocation, &validators).await;
+        assert!(
+            outcomes.iter().any(|o| o.status == ValidatorStatus::Fail),
+            "voice_synthesize contract must FAIL on a silent reported file even when \
+             an unrelated non-silent file exists in the workspace (proves the validator \
+             does not fall back to the glob path); outcomes = {outcomes:?}",
         );
     }
 }

--- a/crates/octos-agent/src/validators.rs
+++ b/crates/octos-agent/src/validators.rs
@@ -4510,32 +4510,27 @@ mod tests {
     // and the sweep is finally safe.
 
     /// `voice_synthesize` AudioNonSilent must run against the plugin's
-    /// reported audio path verbatim. The legacy
-    /// `skill-output/voice/**/*.{mp3,wav}` glob would have matched a
-    /// stale silent .wav from an earlier run alongside the freshly-
-    /// emitted .mp3, so this test pins down that the validator inspects
-    /// only the file `files_to_send` reports.
+    /// reported audio path verbatim. The reported file lives OUTSIDE
+    /// the legacy `skill-output/voice/**/*.{mp3,wav}` glob root, so a
+    /// validator that fell back to the glob would never see it — the
+    /// test would only pass via the spawn_only_files code path.
+    /// (The failure-mode counterpart below plants a non-silent file
+    /// INSIDE the legacy glob root to prove the validator does not
+    /// consult that path at all.)
     #[tokio::test]
-    async fn voice_synthesize_uses_spawn_only_files_with_stale_silent_audio_present() {
+    async fn voice_synthesize_uses_spawn_only_files_with_audio_outside_legacy_glob_root() {
         let dir = tempfile::tempdir().unwrap();
         // Real, non-silent output the plugin would report via the
-        // `Generated: <path>` marker that PR #1039 introduced.
-        let voice_dir = dir.path().join("skill-output/voice");
-        std::fs::create_dir_all(&voice_dir).unwrap();
-        let fresh = voice_dir.join("synthesized_1779067937.wav");
+        // `Generated: <path>` marker that PR #1039 introduced. The
+        // plugin writes to whatever path the LLM gave it, which is
+        // often OUTSIDE the legacy `skill-output/voice/` root — e.g.
+        // a project-scoped subdirectory or a tempdir-style path. This
+        // test pins down that the validator picks up the reported file
+        // regardless of where it lives in the workspace.
+        let project_dir = dir.path().join("projects/demo/audio");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let fresh = project_dir.join("synthesized_1779067937.wav");
         write_sine_wav(&fresh, 800);
-        // Stale silent audio from a prior run. If the validator ever
-        // fell back to the glob path it would decode this alongside the
-        // fresh file, but a single non-silent match is enough for
-        // AudioNonSilent to pass — so this stale file isn't on its own a
-        // counter-example. Instead include a stale .wav that is ALSO
-        // non-silent: the glob path would still pass, but the
-        // spawn_only_files path must not consult the workspace at all.
-        // We anchor the assertion to the validator outcome plus the
-        // session-policy test above (`session_policy_voice_synthesize_*`)
-        // which pins the source enum directly.
-        let stale = voice_dir.join("aaa-stale.wav");
-        write_silent_wav(&stale, 800);
 
         let runner = ValidatorRunner::new(Arc::new(ToolRegistry::new()), dir.path().to_path_buf());
         let session_policy = crate::workspace_policy::WorkspacePolicy::for_session();
@@ -4565,8 +4560,9 @@ mod tests {
         let outcomes = runner.run_all(&invocation, &validators).await;
         assert!(
             outcomes.iter().all(|o| o.status == ValidatorStatus::Pass),
-            "voice_synthesize contract must satisfy via spawn_only_files even when \
-             stale audio exists in the workspace; outcomes = {outcomes:?}",
+            "voice_synthesize contract must satisfy via spawn_only_files for a file \
+             outside the legacy `skill-output/voice/**/*` glob root (a glob fallback \
+             would never have matched this path); outcomes = {outcomes:?}",
         );
     }
 

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -946,6 +946,32 @@ impl WorkspacePolicy {
 
         // Voice synthesis (LLM-driven TTS): assert the decoded audio is not
         // silent. Catches the "render produced empty audio" failure path.
+        //
+        // octos #1038 (follow-up to #1037): consume the plugin's
+        // `files_to_send` envelope so the AudioNonSilent check runs against
+        // the exact audio path the skill reported, not whatever happens to
+        // match a recursive `skill-output/voice/**/*.{mp3,wav}` glob. The
+        // voice skill writes to `skill-output/voice/<timestamp>.{wav,mp3}`,
+        // so a recursive glob could match a stale file from an earlier run
+        // in the same session workspace and falsely satisfy the contract
+        // for a freshly-failed call — the same structural fragility we
+        // already closed for `podcast_generate` (#1034) and `mofa_slides`
+        // (#1036).
+        //
+        // `extension = None` — the voice plugin emits a single audio path
+        // per call (`try_convert_to_mp3` deletes the .wav when ffmpeg
+        // succeeds, so the .mp3 and .wav cannot co-exist by construction).
+        // We need to accept either extension since the macOS Say fallback
+        // path also routes through `try_convert_to_mp3` and ffmpeg may not
+        // be installed, in which case `final_path` stays a .wav.
+        //
+        // PR #1037 originally swept this contract alongside `mofa_slides`
+        // but the voice half was reverted at 772783e7 — the plugin
+        // emitted a `Generated audio: <path>` success line that
+        // `PluginTool::detect_output_file` did not recognise. PR #1039
+        // (this PR's predecessor on the stack) fixed the plugin to emit
+        // `Generated: <path>` on its own line, so the detector now
+        // populates `files_to_send` and this flip is finally safe.
         let voice_synthesize_contract = WorkspaceSpawnTaskPolicy {
             artifact: Some("primary_audio".into()),
             artifacts: Vec::new(),
@@ -958,9 +984,9 @@ impl WorkspacePolicy {
             on_failure: vec!["notify_user:Voice synthesis failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(
                 ValidatorSpec::AudioNonSilent {
-                    glob: "skill-output/voice/**/*.{mp3,wav}".into(),
+                    glob: String::new(),
                     min_ratio: default_non_silent_ratio(),
-                    source: ValidatorFileSource::Glob,
+                    source: ValidatorFileSource::SpawnOnlyFiles,
                     extension: None,
                 },
             )],
@@ -2218,7 +2244,10 @@ ignore = []
     /// `succeed()` path emits only `{output, success}` (no
     /// `files_to_send`) and the success text `"Generated audio: <path>"`
     /// is not one of the prefixes `PluginTool::detect_output_file`
-    /// recognises. See follow-up issue tracking the plugin emission fix.
+    /// recognises. The voice marker was fixed in PR #1039, and the
+    /// voice_synthesize half is re-pinned by
+    /// `session_policy_voice_synthesize_consumes_spawn_only_files_for_octos_1038`
+    /// below.
     #[test]
     fn session_policy_mofa_slides_consumes_spawn_only_files_for_octos_1036() {
         let policy = WorkspacePolicy::for_session();
@@ -2260,6 +2289,66 @@ ignore = []
         assert!(
             saw_magic,
             "mofa_slides contract must declare MagicBytes(Pptx)"
+        );
+    }
+
+    /// octos #1038 (follow-up to #1037 / PR #1039): `voice_synthesize` must
+    /// consume the plugin's `files_to_send` envelope rather than the
+    /// hardcoded `skill-output/voice/**/*.{mp3,wav}` glob. The recursive
+    /// glob silently matched stale audio from earlier runs in the same
+    /// session workspace, the same structural fragility we already fixed
+    /// for `podcast_generate` (#1034) and `mofa_slides` (#1036).
+    ///
+    /// PR #1037 originally swept this contract but the voice half was
+    /// reverted at 772783e7 because the plugin's `succeed()` path
+    /// emitted `Generated audio: <path>` — a prefix
+    /// `PluginTool::detect_output_file` did not recognise — so
+    /// `files_to_send` stayed empty. PR #1039 fixed the plugin to emit
+    /// `Generated: <path>` on its own line, unblocking this re-sweep.
+    ///
+    /// `extension = None`: the voice plugin emits exactly one audio path
+    /// per call (`try_convert_to_mp3` deletes the .wav on success), and
+    /// we accept either .mp3 or .wav since the macOS Say fallback may
+    /// keep the .wav when ffmpeg is unavailable. The validator decodes
+    /// both formats natively (WAV) or via the `audio_mp3` feature.
+    #[test]
+    fn session_policy_voice_synthesize_consumes_spawn_only_files_for_octos_1038() {
+        let policy = WorkspacePolicy::for_session();
+        let voice = policy
+            .spawn_tasks
+            .get("voice_synthesize")
+            .expect("voice_synthesize contract");
+
+        let mut saw_audio = false;
+        for entry in &voice.on_completion {
+            if let SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
+                source,
+                extension,
+                glob,
+                ..
+            }) = entry
+            {
+                assert_eq!(
+                    *source,
+                    ValidatorFileSource::SpawnOnlyFiles,
+                    "voice_synthesize AudioNonSilent must opt into spawn_only_files (octos #1038)"
+                );
+                assert!(
+                    extension.is_none(),
+                    "voice_synthesize must accept both .mp3 and .wav — \
+                     the macOS Say fallback may emit either; got extension = {extension:?}"
+                );
+                assert!(
+                    !glob.contains("skill-output/voice"),
+                    "voice_synthesize must NOT pin a `skill-output/voice/**/*` glob — \
+                     the spawn_only_files source consumes the reported path directly; got: {glob}"
+                );
+                saw_audio = true;
+            }
+        }
+        assert!(
+            saw_audio,
+            "voice_synthesize contract must declare AudioNonSilent"
         );
     }
 

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -62,13 +62,6 @@ on_failure = ["notify_user:Voice registration failed"]
 # session workspace. The `extension = "pptx"` filter narrows the list to
 # slide decks if the skill surfaces auxiliary preview files via
 # `files_to_send`.
-#
-# `voice_synthesize` was originally part of this sweep but was reverted
-# after codex review caught that the voice plugin's `succeed()` path
-# emits only `{output, success}` (no `files_to_send`) and its success
-# text `"Generated audio: <path>"` is not one of the prefixes
-# `PluginTool::detect_output_file` recognises. A follow-up issue tracks
-# the plugin emission fix.
 [spawn_tasks.mofa_slides]
 on_completion = [
     { kind = "magic_bytes", source = "spawn_only_files", extension = "pptx", format = "pptx" },
@@ -113,6 +106,24 @@ on_completion = [
     { kind = "magic_bytes", source = "spawn_only_files", extension = "png", format = "png" },
 ]
 on_failure = ["notify_user:Frame extraction failed"]
+
+# octos #1038 (follow-up to #1037): voice_synthesize now opts into the
+# `spawn_only_files` source so the audio-non-silent check inspects the
+# exact audio path the plugin reported via `files_to_send`. The previous
+# `skill-output/voice/**/*.{mp3,wav}` glob could match a stale file from
+# an earlier run in the same session workspace and falsely satisfy the
+# contract for a freshly-failed call. PR #1037 originally swept this
+# contract but the voice half was reverted (772783e7) until the plugin
+# learned to emit a marker `PluginTool::detect_output_file` recognises —
+# fixed in PR #1039. No `extension` filter: the voice plugin always
+# emits exactly one audio path per call (.mp3 when ffmpeg is available,
+# otherwise .wav fallback from the macOS Say path), and the validator
+# decodes either format.
+[spawn_tasks.voice_synthesize]
+on_completion = [
+    { kind = "audio_non_silent", source = "spawn_only_files", min_ratio = 0.3 },
+]
+on_failure = ["notify_user:Voice synthesis failed"]
 
 # Wave-3a: HttpProbeUntil + Sha256Match + soft_fail are operator-visible
 # TOML shapes; this fixture also acts as a syntax demo for operators.


### PR DESCRIPTION
## Summary

- Flip `voice_synthesize_contract`'s AudioNonSilent post-condition from `ValidatorFileSource::Glob` (with `skill-output/voice/**/*.{mp3,wav}`) to `ValidatorFileSource::SpawnOnlyFiles` so the check runs against the exact audio path the voice plugin reports via `files_to_send`. Same fix already shipped for `podcast_generate` (#1034 / PR #1035) and `mofa_slides` (#1036 / PR #1037).
- Closes #1038 — the recursive glob silently matched stale audio from earlier runs in the same session workspace and could falsely satisfy the contract for a freshly-failed call.
- **Depends on #1039** (already merged at ef7df5d0) — the voice plugin previously emitted `Generated audio: <path>`, a prefix `PluginTool::detect_output_file` did not recognise, so `files_to_send` was always empty. PR #1037 originally swept this contract but the voice half was reverted at 772783e7 for exactly this reason. PR #1039 fixed the marker; this PR finishes the contract sweep.

### Before / after

- **Before**: `AudioNonSilent { glob: "skill-output/voice/**/*.{mp3,wav}", source: Glob, extension: None }`
- **After**:  `AudioNonSilent { glob: "", source: SpawnOnlyFiles, extension: None }`

`extension = None` — the voice plugin emits exactly one audio path per call (`try_convert_to_mp3` deletes the .wav when ffmpeg succeeds), and we need to accept either .mp3 or .wav since the macOS Say fallback may keep the .wav when ffmpeg is unavailable. The validator decodes both formats.

## Test plan

- [x] `cargo test -p octos-agent` — 1714 passed, 0 failed (3 new tests over the 1711 baseline)
- [x] `cargo fmt -p octos-agent -- --check` — clean
- [x] `cargo clippy -p octos-agent --tests` — no new warnings introduced (two pre-existing `cloned_ref_to_slice_refs` warnings in `workspace_contract.rs` from PR #1037 are unaffected by this PR)
- [x] New test: `session_policy_voice_synthesize_consumes_spawn_only_files_for_octos_1038` — pins the contract shape (source = `SpawnOnlyFiles`, extension = None, glob does NOT contain `skill-output/voice`)
- [x] New test: `voice_synthesize_uses_spawn_only_files_with_stale_silent_audio_present` — exercises the live `WorkspacePolicy::for_session()` contract end-to-end with the runner; passes when the reported file is non-silent even when stale audio also lives in the workspace
- [x] New test: `voice_synthesize_spawn_only_files_fails_when_reported_audio_is_silent` — failure case; the contract must fail on a silent reported file even when an unrelated non-silent file exists in the workspace (proves the validator does not fall back to the glob path)
- [x] Fixture `workspace_policy_v1_session.toml` adds `[spawn_tasks.voice_synthesize]` so the TOML round-trip pins the new shape; the stale comment about the voice revert in the `mofa_slides` block was rewritten to point at PR #1039 instead

Refs PR #1037, PR #1039, closes #1038.