### PR TITLE
fix(pipeline+slides): scope run_pipeline to deep_research, slides default to inline array

### DIFF
--- a/crates/octos-cli/src/project_templates.rs
+++ b/crates/octos-cli/src/project_templates.rs
@@ -149,11 +149,10 @@ WORKFLOW (follow in order):
 RULES:
 - ALWAYS use mofa_slides TOOL. NEVER shell to run mofa. NEVER.
 - In slides sessions, `mofa_slides` is already active. Call it directly. Do not call `activate_tools(["mofa_slides"])`.
-- BEFORE calling mofa_slides: run shell("node --check slides/{slug}/script.js") to validate syntax. Fix any errors before proceeding.
-- ALWAYS use input parameter: mofa_slides(input="slides/{slug}/script.js", out="slides/{slug}/output/deck.pptx", slide_dir="slides/{slug}/output/imgs")
+- ALWAYS pass `slides` inline as a JSON array. The `input=slides/{slug}/script.js` parameter requires Node.js on the host, which is not guaranteed in production (only mini1 had `node` as of 2026-05-18; mini2/3/5 fall back to the inline path). Read `slides/{slug}/script.js` with `read_file` to assemble the array, then call `mofa_slides({{slides: [...], out: "slides/{slug}/output/deck.pptx", slide_dir: "slides/{slug}/output/imgs"}})`.
+- NEVER call `run_pipeline` from a slides session. There is no sanctioned DOT template for slide generation — `run_pipeline` is for `deep_research` only. For partial regeneration ("first N slides", "redo slide 3"), trim the inline `slides` array to just those entries and call `mofa_slides` again; do NOT improvise a custom DOT pipeline.
 - AFTER mofa_slides succeeds, the runtime auto-delivers slides/{slug}/output/deck.pptx to the chat. Do not call send_file for the same deck unless delivery actually failed. Do not ask the user whether you should send it.
 - Deliver exactly one final PPTX deck artifact. Do not stop at a filesystem path or ask for extra confirmation after generation succeeds.
-- NEVER pass slides array inline. ALWAYS use the input file.
 - On failure: report error, do NOT retry via shell.
 - If `mofa_slides` is not available in the current tool list, explicitly tell the user slide generation is unavailable on this host. Do NOT retry via shell, run_pipeline, or alternative binaries.
 - Read slides/{slug}/memory.md before each response for context.

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -251,10 +251,15 @@ impl Tool for RunPipelineTool {
     }
 
     fn description(&self) -> &str {
-        "Execute a multi-step pipeline defined as an inline DOT graph. Each node runs a \
-         specialized agent with its own prompt, model, and output limits. \
-         ALWAYS write inline DOT graphs — do NOT use pre-built pipeline names. \
-         This lets you pick optimal models per node (cheap for search, high-output for synthesis)."
+        "Run a sanctioned multi-step pipeline by NAME. The only currently \
+         sanctioned pipeline is `deep_research` — use it when the user asks \
+         for in-depth, multi-source, source-citing research that needs \
+         parallel search workers + synthesis. Do NOT compose your own \
+         inline DOT graph for ad-hoc tasks (slides, media, code edits, \
+         partial regenerations, etc.) — those have purpose-built tools \
+         (`mofa_slides`, `podcast_generate`, etc.). If no purpose-built \
+         tool exists for what the user asked, surface that as a limitation \
+         rather than improvising a custom pipeline."
     }
 
     fn tags(&self) -> &[&str] {
@@ -262,25 +267,26 @@ impl Tool for RunPipelineTool {
     }
 
     fn input_schema(&self) -> serde_json::Value {
-        let adaptive_hints = include_str!("prompts/adaptive_hints.txt");
-        let node_attrs = include_str!("prompts/node_attrs.txt");
-        let example = include_str!("prompts/example_dot.txt");
-
-        let pipeline_desc = format!(
-            "Inline DOT graph. ALWAYS write a custom digraph.\n\n\
-             Do NOT specify model= attributes — the system selects optimal models automatically.\n\
-             Focus on writing good prompts, choosing tools, and structuring the pipeline.\n\n\
-             {node_attrs}\n\n\
-             {adaptive_hints}\n\n\
-             {example}"
-        );
+        let pipeline_desc =
+            "Name of the sanctioned pipeline to run. The only currently \
+             sanctioned name is `deep_research`. Do NOT pass an inline \
+             DOT graph here — inline DOT was the legacy free-form \
+             contract; the executor still accepts it for operator \
+             debugging but agent-driven runs MUST use the name form. If \
+             you find yourself wanting to compose your own DOT, the \
+             correct response is to use the purpose-built tool for that \
+             domain (`mofa_slides` for slides, `podcast_generate` for \
+             podcasts, `voice_synthesize` for TTS, etc.), or tell the \
+             user no such tool exists for their request."
+                .to_string();
 
         serde_json::json!({
             "type": "object",
             "properties": {
                 "pipeline": {
                     "type": "string",
-                    "description": pipeline_desc
+                    "description": pipeline_desc,
+                    "enum": ["deep_research"]
                 },
                 "input": {
                     "type": "string",


### PR DESCRIPTION
## Summary
- `RunPipelineTool::description()` rewritten to advertise *named templates only* (`deep_research`). JSON schema gains `"enum": ["deep_research"]`.
- Slides system prompt flips from `input=script.js` (requires Node.js, only mini1 has it) to inline `slides` array (universal), and explicitly bans `run_pipeline` from slides sessions.

## Why
Live mini3 regression 2026-05-18 on `/slides/slides-1779130130502-th18yr`: user asked "first 3 slides only", LLM composed a custom `digraph` to fan out to Gemini per-slide. Two prompt drifts compounded:

1. Tool description in EVERY session said "ALWAYS write inline DOT graphs — do NOT use pre-built pipeline names" — the LLM was specifically told to compose ad-hoc pipelines.
2. Slides session prompt said "ALWAYS use input=script.js… NEVER pass slides inline" — but the `input=` codepath requires `node`, and `node` is only present on mini1 (deploy gap, separate issue).

Together, the LLM had no working path: `mofa_slides(input=…)` fails for lack of node; the tool-spec encouraged composing a `run_pipeline` workaround instead.

## Test plan
- [x] `cargo test -p octos-cli --features api --lib project_templates` → 13/13 passed
- [x] `cargo check -p octos-pipeline` clean
- [ ] Fleet deploy + retest slides partial-regen on mini3