### PR TITLE
fix(installer): surface install_pkg failures + detect missing brew

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -293,6 +293,24 @@ pkg_hint() {
 # Install a package using the command from pkg_hint.
 # Usage: install_pkg <package>
 # Returns 0 on success, 1 on failure.
+#
+# Pre-2026-05-18: this helper silenced stderr (`eval "$cmd" >/dev/null 2>&1`)
+# and printed only "<pkg> install failed" on a non-zero exit. That hid the
+# most common real-world failure on a fresh macOS host — `brew install`
+# returns "command not found: brew" because Homebrew itself isn't installed
+# — and let operators believe their fleet was correctly bootstrapped while
+# silently shipping without Node.js / ffmpeg / chromium. Live mini2/3/5
+# regression 2026-05-18 (mofa-slides `input=script.js` codepath broken on
+# three hosts; not noticed for weeks).
+#
+# Now:
+#   * On macOS, if the install command starts with `brew` and `brew` is
+#     not in PATH, refuse early with the canonical Homebrew bootstrap
+#     hint instead of running an `eval "brew …"` that's guaranteed to
+#     fail.
+#   * Capture the eval's stderr to a tempfile and surface the LAST few
+#     lines on failure, so the operator sees the actual reason rather
+#     than just "<pkg> install failed".
 install_pkg() {
     local pkg="$1"
     local cmd
@@ -301,12 +319,34 @@ install_pkg() {
         warn "don't know how to install $pkg on this system"
         return 1
     fi
+    # macOS gate: if the install plan calls `brew` and brew is missing,
+    # do not even try — the eval would emit "command not found: brew"
+    # to stderr, which the legacy code silenced. Tell the operator
+    # exactly what to run first.
+    if [ "$OS" = "Darwin" ] && [[ "$cmd" == brew* ]] && ! command -v brew >/dev/null 2>&1; then
+        warn "$pkg install failed: Homebrew is not installed on this host"
+        hint "Install Homebrew first, then re-run this script:"
+        hint '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+        hint "then: $cmd"
+        return 1
+    fi
     echo "    Installing $pkg..."
-    if eval "$cmd" >/dev/null 2>&1; then
+    local stderr_log
+    stderr_log=$(mktemp -t octos-install-pkg-stderr.XXXXXX)
+    if eval "$cmd" >/dev/null 2>"$stderr_log"; then
+        rm -f "$stderr_log"
         return 0
     else
         warn "$pkg install failed"
         hint "$cmd"
+        if [ -s "$stderr_log" ]; then
+            # Surface the LAST 5 lines of stderr so the operator can see
+            # the proximate cause without scrolling through a brew/apt
+            # download log.
+            hint "Captured error output (last 5 lines):"
+            tail -5 "$stderr_log" 2>/dev/null | sed 's/^/    /' >&2 || true
+        fi
+        rm -f "$stderr_log"
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
- `install_pkg` on macOS now detects missing Homebrew **before** running an `eval "brew …"` that's guaranteed to fail, and prints the canonical Homebrew bootstrap one-liner.
- `install_pkg` captures stderr to a tempfile and surfaces the last 5 lines on failure. The legacy `2>&1` redirect hid every real error.

## Why
Three production minis (mini2/3/5) silently shipped without Node.js, ffmpeg, and chromium because:
1. `eval "brew install node" >/dev/null 2>&1` returned "command not found: brew" (Homebrew wasn't installed) — and that error was silenced.
2. Installer continued past the failure with `|| true`, marking node "optional".
3. Operator saw only `warn "node install failed"` with no hint why → assumed it was a known limitation.

mofa-slides' `input=script.js` codepath silently broke fleet-wide on those hosts.

## Test plan
- [x] `bash -n scripts/install.sh` passes (syntax check)
- [ ] Run on a host where brew is missing → verify clean message + bootstrap hint instead of silent failure
- [ ] Run on a host where brew is present but `brew install <pkg>` fails for network reasons → verify the captured stderr lines appear