### PR TITLE
fix(agent): validate fm_tts reported audio

### DIFF
--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -836,7 +836,15 @@ mod tests {
     #[tokio::test]
     async fn tts_contract_resolves_new_mp3_for_actor_delivery() {
         let temp = tempfile::tempdir().unwrap();
-        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+        let mut policy = WorkspacePolicy::for_session();
+        if let Some(task) = policy.spawn_tasks.get_mut("fm_tts") {
+            // This test exercises legacy artifact resolution for actor
+            // delivery. The default fm_tts validator now decodes the
+            // plugin-reported MP3 from files_to_send; validator behavior is
+            // covered separately and would reject these fake MP3 bytes.
+            task.on_completion.clear();
+        }
+        write_workspace_policy(temp.path(), &policy).unwrap();
         let output = temp.path().join("tts_result.mp3");
         std::fs::write(&output, vec![1u8; 2048]).unwrap();
 

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -849,6 +849,10 @@ impl WorkspacePolicy {
         // artifact source" the same way `slides_pptx` does for slides.
         artifacts.insert("image_png".into(), "**/*.png".into());
 
+        // fm_tts emits a single MP3 deliverable via the plugin protocol's
+        // files_to_send list. Validate that exact reported file instead of a
+        // broad workspace glob, which can match stale audio from an earlier
+        // call in the same session workspace.
         let tts_contract = WorkspaceSpawnTaskPolicy {
             artifact: Some("primary_audio".into()),
             artifacts: Vec::new(),
@@ -859,7 +863,14 @@ impl WorkspacePolicy {
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:TTS generation failed".into()],
-            on_completion: Vec::new(),
+            on_completion: vec![SpawnTaskValidatorSpec::Bare(
+                ValidatorSpec::AudioNonSilent {
+                    glob: String::new(),
+                    min_ratio: default_non_silent_ratio(),
+                    source: ValidatorFileSource::SpawnOnlyFiles,
+                    extension: Some("mp3".into()),
+                },
+            )],
         };
 
         let podcast_contract = WorkspaceSpawnTaskPolicy {
@@ -1717,6 +1728,33 @@ mod tests {
         assert!(task.artifacts.is_empty());
         assert!(task.on_complete.is_empty());
         assert!(task.on_deliver.is_empty());
+        let mut saw_tts_audio = false;
+        for entry in &task.on_completion {
+            if let SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
+                source,
+                extension,
+                glob,
+                ..
+            }) = entry
+            {
+                assert_eq!(
+                    *source,
+                    ValidatorFileSource::SpawnOnlyFiles,
+                    "fm_tts AudioNonSilent must consume plugin-reported files_to_send"
+                );
+                assert_eq!(
+                    extension.as_deref(),
+                    Some("mp3"),
+                    "fm_tts AudioNonSilent must validate the delivered MP3 artifact"
+                );
+                assert!(
+                    glob.is_empty(),
+                    "fm_tts must not use a workspace glob that can match stale audio: {glob}"
+                );
+                saw_tts_audio = true;
+            }
+        }
+        assert!(saw_tts_audio, "fm_tts contract must declare AudioNonSilent");
         assert_eq!(
             policy
                 .artifacts

--- a/crates/octos-agent/tests/abi_compat.rs
+++ b/crates/octos-agent/tests/abi_compat.rs
@@ -98,6 +98,17 @@ fn should_load_workspace_policy_v1_session_fixture() {
             .any(|line| line == "file_size_min:$artifact:1024"),
         "expected fm_tts verify action for artifact size",
     );
+    assert!(
+        tts.on_completion.iter().any(|entry| matches!(
+            entry,
+            SpawnTaskValidatorSpec::Bare(ValidatorSpec::AudioNonSilent {
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension,
+                ..
+            }) if extension.as_deref() == Some("mp3")
+        )),
+        "expected fm_tts AudioNonSilent validator over spawn_only_files mp3",
+    );
 
     // octos #1034: the podcast_generate contract opts into the
     // `spawn_only_files` source via the new ABI fields. The fixture is the

--- a/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
+++ b/crates/octos-agent/tests/fixtures/workspace_policy_v1_session.toml
@@ -29,6 +29,9 @@ on_verify = [
     "file_exists:$artifact",
     "file_size_min:$artifact:1024",
 ]
+on_completion = [
+    { kind = "audio_non_silent", source = "spawn_only_files", extension = "mp3", min_ratio = 0.3 },
+]
 on_failure = ["notify_user:TTS generation failed"]
 
 [spawn_tasks.podcast_generate]


### PR DESCRIPTION
## Summary
- add AudioNonSilent validation to the fm_tts session contract
- source validation from plugin-reported files_to_send instead of a stale-prone workspace glob
- update ABI fixture and artifact-resolution test so default CI does not decode fake MP3 bytes

## Test plan
- cargo fmt --all -- --check
- cargo test -p octos-agent --lib
- cargo test -p octos-agent --test abi_compat
- cargo clippy --workspace --all-targets -- -D warnings