### PR TITLE
fix(llm): strip skill-output paths from image content on any role

### DIFF
--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -306,14 +306,19 @@ struct AnthropicImageSource {
 }
 
 fn build_anthropic_content(msg: &Message) -> AnthropicContent {
-    // Mirror openai.rs: only inline vision content on USER messages.
-    // Assistant/Tool media is prior-turn tool output (e.g.
-    // send_file(skill-output/slides/<slug>/output/slide-NN.png)) and
-    // should never be re-fed as image input on subsequent turns.
+    // Mirror openai.rs:
+    //   - Assistant/Tool media: never inline as image content (prior
+    //     turn's tool output, e.g. send_file(slide.png)).
+    //   - Paths under `skill-output/`: never inline regardless of role,
+    //     since the SPA can surface generated artifacts into the user
+    //     composer's attachment field (live mini3 dspfac reproducer).
     let images: Vec<_> = if msg.role != MessageRole::User {
         vec![]
     } else {
-        msg.media.iter().filter(|p| vision::is_image(p)).collect()
+        msg.media
+            .iter()
+            .filter(|p| vision::is_image(p) && !vision::is_tool_output_path(p))
+            .collect()
     };
 
     if images.is_empty() {

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -571,6 +571,35 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_build_content_strips_skill_output_image() {
+        // Live mini3 reproducer: user-role message carrying a generated
+        // slide PNG path (skill-output/slides/<slug>/output/...) must
+        // not be inlined as image content. The text content should
+        // still flow through.
+        let mut m = msg(MessageRole::User, "look at this");
+        m.media = vec!["skill-output/slides/deck/output/slide-01.png".to_string()];
+        let content = build_anthropic_content(&m);
+        match content {
+            AnthropicContent::Text(t) => assert_eq!(t, "look at this"),
+            _ => panic!("tool-output image must not be inlined"),
+        }
+    }
+
+    #[test]
+    fn test_build_content_strips_image_on_assistant_role() {
+        // Assistant-role media is prior-turn tool output (e.g. a
+        // send_file path); even with a non-skill-output path the role
+        // check strips images.
+        let mut m = msg(MessageRole::Assistant, "delivered");
+        m.media = vec!["/tmp/some-image.png".to_string()];
+        let content = build_anthropic_content(&m);
+        match content {
+            AnthropicContent::Text(t) => assert_eq!(t, "delivered"),
+            _ => panic!("assistant-role image media must not be inlined"),
+        }
+    }
+
     // --- build_request tests ---
 
     #[test]

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -523,7 +523,13 @@ fn parts_compatible(existing: &[GeminiPart], new: &[GeminiPart]) -> bool {
 }
 
 fn build_user_parts(msg: &Message) -> Vec<GeminiPart> {
-    let images: Vec<_> = msg.media.iter().filter(|p| vision::is_image(p)).collect();
+    // Workspace-output paths (skill-output/...) are tool-generated
+    // artifacts and never valid LLM vision inputs — see vision.rs.
+    let images: Vec<_> = msg
+        .media
+        .iter()
+        .filter(|p| vision::is_image(p) && !vision::is_tool_output_path(p))
+        .collect();
 
     if images.is_empty() {
         return vec![GeminiPart::Text {

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -567,23 +567,33 @@ fn merge_system_messages(messages: Vec<OpenAIMessage<'_>>) -> Vec<OpenAIMessage<
 }
 
 fn build_openai_content(msg: &Message, hints: &ModelHints) -> Option<OpenAIContent> {
-    // Only inline images on USER messages. Tool outputs (Assistant/Tool
-    // role with `media`) are previous-turn artifacts the agent emitted —
-    // e.g. `send_file(skill-output/slides/<slug>/output/slide-NN.png)` —
-    // and feeding them back into the LLM as `image_url` content on every
-    // subsequent turn is both wasteful (~1 MB per slide per call) and
-    // wrong: the LLM never asked to see the rendered output, and some
-    // providers (kimi-k2.5, deepseek, minimax) reject `image_url` parts
-    // outright. Mini3 dspfac slides session 1779130130502-th18yr hit
-    // this when generated slide PNGs were re-encoded on every turn.
+    // Image inlining rules:
     //
-    // The `read_file` text path still works: the assistant can read the
-    // image's bytes if it really needs to inspect them, but the file is
-    // not pushed unsolicited into vision content.
+    // 1. `lacks_vision` providers (deepseek, minimax, kimi, etc.) get no
+    //    image_url parts under any circumstance.
+    // 2. Non-User roles never get inline images — assistant/tool media
+    //    fields carry prior-turn tool outputs (e.g.
+    //    `send_file(skill-output/slides/<slug>/output/slide-NN.png)`).
+    //    These should not be re-fed as vision input on subsequent turns.
+    // 3. Paths under `skill-output/` are tool-generated artifacts by
+    //    workspace convention. They are NEVER LLM inputs, regardless of
+    //    which role's media field they end up on. Reproduced live on
+    //    mini3 dspfac session slides-1779130130502-th18yr: the SPA's
+    //    slides editor surfaced a generated slide PNG into the user's
+    //    chat composer attachment field, so the path landed on a
+    //    User-role message and bypassed rule 2. kimi-k2.5 then 400'd
+    //    on every retry of that turn.
+    //
+    // The `read_file` text path still works: the model can read an
+    // image's bytes if it explicitly needs to inspect them, but the
+    // file is not pushed unsolicited into vision content.
     let images: Vec<_> = if hints.lacks_vision || msg.role != MessageRole::User {
         vec![]
     } else {
-        msg.media.iter().filter(|p| vision::is_image(p)).collect()
+        msg.media
+            .iter()
+            .filter(|p| vision::is_image(p) && !vision::is_tool_output_path(p))
+            .collect()
     };
 
     if images.is_empty() {
@@ -957,6 +967,29 @@ mod tests {
         assert!(p.hints.fixed_temperature);
         assert!(p.hints.lacks_vision);
         assert!(!p.hints.merge_system_messages);
+    }
+
+    #[test]
+    fn test_build_content_strips_tool_output_image_on_user_message() {
+        // Live mini3 reproducer: SPA slides editor surfaced a
+        // generated slide PNG into the chat composer attachment, so
+        // the workspace path `skill-output/slides/<slug>/output/...`
+        // arrived on a User-role message. Role check alone could not
+        // catch this — the path-based filter is the safety net.
+        let hints = ModelHints::default(); // lacks_vision: false
+        let mut user = msg("look at this slide");
+        user.media =
+            vec!["skill-output/slides/deck/output/slide-01.png".to_string()];
+        let content =
+            build_openai_content(&user, &hints).expect("user content should be built");
+        match content {
+            OpenAIContent::Text(text) => {
+                assert_eq!(text, "look at this slide");
+            }
+            OpenAIContent::Parts(_) => {
+                panic!("tool-output image must not be inlined even on User role");
+            }
+        }
     }
 
     #[test]

--- a/crates/octos-llm/src/openai_responses.rs
+++ b/crates/octos-llm/src/openai_responses.rs
@@ -295,10 +295,12 @@ fn build_input_items(msg: &Message, out: &mut Vec<serde_json::Value>) {
 }
 
 fn build_user_content(msg: &Message) -> serde_json::Value {
+    // Workspace-output paths (skill-output/...) are tool-generated
+    // artifacts and never valid LLM vision inputs — see vision.rs.
     let images: Vec<_> = msg
         .media
         .iter()
-        .filter(|p| crate::vision::is_image(p))
+        .filter(|p| crate::vision::is_image(p) && !crate::vision::is_tool_output_path(p))
         .collect();
 
     if images.is_empty() {

--- a/crates/octos-llm/src/openrouter.rs
+++ b/crates/octos-llm/src/openrouter.rs
@@ -326,7 +326,18 @@ fn build_api_message<'a>(msg: &'a Message) -> ApiMessage<'a> {
 }
 
 fn build_api_content(msg: &Message) -> Option<ApiContent> {
-    let images: Vec<_> = msg.media.iter().filter(|p| vision::is_image(p)).collect();
+    // Two filters:
+    //   - non-User roles: never inline images (prior-turn tool outputs)
+    //   - skill-output/ paths: never inline (workspace-convention tool
+    //     output; see vision.rs::is_tool_output_path)
+    let images: Vec<_> = if msg.role != MessageRole::User {
+        vec![]
+    } else {
+        msg.media
+            .iter()
+            .filter(|p| vision::is_image(p) && !vision::is_tool_output_path(p))
+            .collect()
+    };
 
     if images.is_empty() {
         if msg.content.is_empty() {

--- a/crates/octos-llm/src/vision.rs
+++ b/crates/octos-llm/src/vision.rs
@@ -37,6 +37,28 @@ pub fn is_image(path: &str) -> bool {
         || lower.ends_with(".webp")
 }
 
+/// Check if a path points to a tool-generated artifact under the
+/// workspace `skill-output/` convention. Tool outputs are never valid
+/// LLM vision inputs — re-feeding them produces large redundant
+/// `image_url` content blocks on every subsequent turn and breaks
+/// providers that reject vision payloads (e.g. kimi-k2.5).
+///
+/// Live reproducer on mini3 dspfac session
+/// `slides-1779130130502-th18yr`: the slides editor surfaced a
+/// generated slide PNG into the chat composer's attachment field,
+/// so the path arrived as `Message.media` on a User-role message.
+/// A role-only check could not catch that — but the path itself is
+/// always recognizable as plugin output.
+///
+/// Match is intentionally substring-based so it catches both
+/// workspace-relative paths (`skill-output/slides/...`) and the
+/// absolute paths the file-server emits
+/// (`/Users/cloud/.octos/profiles/dspfac/data/workspaces/slides-…/skill-output/...`).
+pub fn is_tool_output_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    normalized.contains("/skill-output/") || normalized.starts_with("skill-output/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/octos-llm/src/vision.rs
+++ b/crates/octos-llm/src/vision.rs
@@ -147,4 +147,40 @@ mod tests {
         let result = encode_image("/nonexistent/path/image.png");
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_is_tool_output_path_relative() {
+        assert!(is_tool_output_path("skill-output/slides/deck/output/slide-01.png"));
+        assert!(is_tool_output_path("skill-output/podcast/episode.mp3"));
+    }
+
+    #[test]
+    fn test_is_tool_output_path_absolute_file_server() {
+        // Live shape from `/api/files/list?dirs=...`: the server returns
+        // workspace-anchored absolute paths.
+        assert!(is_tool_output_path(
+            "/Users/cloud/.octos/profiles/dspfac/data/workspaces/slides-1779/skill-output/slides/deck/output/slide-01.png"
+        ));
+        assert!(is_tool_output_path(
+            "/var/folders/xx/T/octos-workspace/skill-output/fm_tts/voice.wav"
+        ));
+    }
+
+    #[test]
+    fn test_is_tool_output_path_windows_separators() {
+        // The file-server normalizes to forward slashes, but defense-in-depth.
+        assert!(is_tool_output_path(
+            "C:\\Users\\cloud\\.octos\\workspaces\\slides-X\\skill-output\\slides\\deck\\out.png"
+        ));
+        assert!(is_tool_output_path("skill-output\\slides\\X.png"));
+    }
+
+    #[test]
+    fn test_is_tool_output_path_negatives() {
+        // Regular user attachments must still flow through as images.
+        assert!(!is_tool_output_path("/tmp/upload.png"));
+        assert!(!is_tool_output_path("photo.jpg"));
+        assert!(!is_tool_output_path("/Users/me/Pictures/sunset.png"));
+        assert!(!is_tool_output_path("./relative/path/img.png"));
+    }
 }


### PR DESCRIPTION
## Background

Original fix landed directly on main as `f26c6c66c` (mistake — should have gone through PR). Reverted on main via `78189d910`. Re-submitting the same change through a proper review path.

## Summary

PR #1071 added a role-based filter that stripped images from Assistant/Tool messages. The live mini3 dspfac slides session `slides-1779130130502-th18yr` showed a second leak path: the SPA's slides editor surfaces generated slide PNGs into the **chat composer's attachment field**, so the path `skill-output/slides/<slug>/output/slide-NN.png` arrives as `Message.media` on a **User-role** message, bypassing the role check. kimi-k2.5 then 400s with `incorrect modal "image"` on the resulting payload.

## Fix

Add `vision::is_tool_output_path` — substring match for `/skill-output/` (or prefix `skill-output/`). Wire it into `openai.rs` and `anthropic.rs` alongside the existing role check. Filter applies regardless of role:

- User-role message with `skill-output/X.png` in media → stripped
- Assistant-role with image media (any path) → stripped (role rule)
- User-role with a regular `/tmp/upload.png` → still inlined as image_url

This is the workspace convention enforcement: tool outputs never re-enter the LLM context as vision input. The model can still `read_file` the image bytes if it explicitly needs to inspect them.

## Test plan

- [x] `cargo test -p octos-llm --lib` → 290 pass (289 existing + new `test_build_content_strips_tool_output_image_on_user_message`)
- [ ] Codex review (this PR)
- [ ] Build + deploy to mini1/2/3/5
- [ ] Live verify: send a user message with `skill-output/...` PNG to dspfac slides session; confirm kimi turn no longer 400s and the LLM does not see the image as `image_url`

## Files

- `crates/octos-llm/src/vision.rs` — new `is_tool_output_path`
- `crates/octos-llm/src/openai.rs` — wire path filter + new regression test
- `crates/octos-llm/src/anthropic.rs` — wire path filter