### PR TITLE
Require explicit files_to_send delivery

### DIFF
--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -6374,9 +6374,6 @@ impl SessionActor {
                     }
                 }
 
-                // Auto-deliver report files produced by the agent (e.g. from run_pipeline).
-                // This ensures the file reaches the user's channel (Telegram, web, etc.)
-                // without relying on the LLM to call send_file within its token budget.
                 if conv_response.files_modified.is_empty() {
                     tracing::debug!(session = %self.session_key, "no files_modified in conv_response");
                 } else {
@@ -6385,58 +6382,6 @@ impl SessionActor {
                         files = ?conv_response.files_modified.iter().map(|f| f.display().to_string()).collect::<Vec<_>>(),
                         "conv_response has files_modified"
                     );
-                }
-                for file in &conv_response.files_modified {
-                    if file.extension().and_then(|e| e.to_str()) == Some("md") {
-                        // Resolve relative paths to absolute so the file URL works
-                        let abs_file = if file.is_relative() {
-                            std::fs::canonicalize(file)
-                                .or_else(|_| std::fs::canonicalize(self.data_dir.join(file)))
-                                .unwrap_or_else(|_| file.clone())
-                        } else {
-                            file.clone()
-                        };
-                        info!(
-                            session = %self.session_key,
-                            file = %abs_file.display(),
-                            channel = %self.channel,
-                            chat_id = %self.chat_id,
-                            "auto-delivering report file"
-                        );
-                        // Codex pre-merge review of #748 P1: media metadata
-                        // must carry `thread_id` so `ApiChannel::send` does
-                        // NOT fall back to sticky-map lookup. Without this,
-                        // an A/B race where B's request seeds sticky after
-                        // A's user row but before A's report delivery causes
-                        // A's file row to land under B's bubble (same leak
-                        // class the rest of PR F closes elsewhere).
-                        let mut file_metadata = serde_json::json!({
-                            "topic": self.session_key.topic(),
-                        });
-                        let report_thread_id = client_message_id
-                            .as_deref()
-                            .filter(|s| !s.is_empty())
-                            .map(str::to_string);
-                        if let Some(tid) = report_thread_id.as_deref() {
-                            if let serde_json::Value::Object(ref mut m) = file_metadata {
-                                m.insert(
-                                    "thread_id".to_string(),
-                                    serde_json::Value::String(tid.to_string()),
-                                );
-                            }
-                        }
-                        let file_msg = OutboundMessage {
-                            channel: self.channel.clone(),
-                            chat_id: self.chat_id.clone(),
-                            content: String::new(),
-                            reply_to: None,
-                            media: vec![abs_file.to_string_lossy().into_owned()],
-                            metadata: file_metadata,
-                        };
-                        if let Err(e) = self.out_tx.send(file_msg).await {
-                            warn!(session = %self.session_key, error = %e, "failed to auto-deliver report file");
-                        }
-                    }
                 }
 
                 // Send reply

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -498,9 +498,9 @@ impl Tool for RunPipelineTool {
             .join("\n");
 
         // Find the report file from this pipeline run's actual files_modified.
-        // The session actor auto-delivers .md files via file_modified on ToolResult,
-        // so no LLM instruction needed.
-        // Ensure absolute path so session actor can find and deliver the file.
+        // Delivery is driven by files_to_send on ToolResult, so no LLM instruction
+        // or session-level markdown heuristics are needed.
+        // Ensure absolute path so the execution loop can find and deliver the file.
         let real_report_file = result
             .files_modified
             .iter()
@@ -552,7 +552,7 @@ impl Tool for RunPipelineTool {
             tracing::info!(file = %path.display(), "pipeline produced report file");
         }
 
-        // Also set files_to_send so the execution loop auto-delivers
+        // Explicitly set files_to_send so the execution loop auto-delivers.
         let files_to_send = report_file.iter().filter(|p| p.exists()).cloned().collect();
 
         // Surface per-node cost attribution in the structured side-channel so


### PR DESCRIPTION
## Summary
- Remove the session-level heuristic that auto-delivered every modified `.md` file as media
- Keep `files_modified` as audit/debug state and rely on explicit `files_to_send` for delivery
- Update `run_pipeline` comments to document the explicit delivery contract

## Validation
- `cargo fmt --all`
- `cargo test -p octos-agent --lib run_task_collects_files_to_send_without_file_modified`
- `cargo test -p octos-pipeline --lib tool`
- `cargo test -p octos-cli --lib test_background_notification_persists_media_to_history`
- `cargo clippy -p octos-cli -p octos-pipeline -p octos-agent --lib -- -D warnings`

Supersedes the remaining explicit-delivery portion of stale PR #379.