### PR TITLE
fix(server): bridge system-prompt stacking + spawn child send_file + per-session prompt on AppUI

### DIFF
--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -770,6 +770,24 @@ impl ContextManager {
         message: &Message,
         source_ref: Option<TranscriptSourceRef>,
     ) -> Vec<TranscriptItemId> {
+        // The agent's runtime System prompt is composed per turn via
+        // `compose_system_prompt()` and placed at `messages[0]` by the
+        // agent loop; it is NOT a piece of session state the
+        // ContextManager should own. Recording it here makes every
+        // entry point (bridge per-turn recording, persisted-message
+        // merge, boot replay via from_session_history, fork) stack a
+        // `SystemInstruction` item across turns / restarts. `for_prompt`
+        // then re-emits them all and `normalize_system_messages`
+        // concatenates them into a 4×-bloated `messages[0]`.
+        //
+        // The legitimate use of SystemInstruction items (compaction
+        // summaries) flows through `compact_context`, not through this
+        // recording API. Skipping System here is therefore safe across
+        // all callers: bridge recording, persisted-message merging,
+        // boot replay, and snapshot reconstruction.
+        if message.role == MessageRole::System {
+            return Vec::new();
+        }
         let mut ids = Vec::new();
         match message.role {
             MessageRole::System => ids.push(self.record_item_with_source_ref(

--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -545,8 +545,17 @@ impl ContextManager {
         thread_id: Option<String>,
         fork: ForkedChildContext,
     ) -> Self {
-        let next_item_seq = fork
+        // Drop any `SystemInstruction` items inherited from a polluted
+        // parent context. They are no longer owned by the manager (see
+        // `record_message_with_source_ref` early-return) and forking
+        // them into the child would re-stack the LLM prompt as soon as
+        // the child's `for_prompt` runs.
+        let items: Vec<_> = fork
             .items
+            .into_iter()
+            .filter(|item| !matches!(item.kind, TranscriptItemKind::SystemInstruction { .. }))
+            .collect();
+        let next_item_seq = items
             .iter()
             .filter_map(|item| {
                 item.id
@@ -563,7 +572,7 @@ impl ContextManager {
             thread_id,
             generation: fork.parent_generation + 1,
             next_item_seq,
-            items: fork.items,
+            items,
             last_checkpoint_id: None,
             last_compaction_id: None,
             recovery_state: ContextRecoveryState::Rebuilt,
@@ -637,8 +646,21 @@ impl ContextManager {
     }
 
     pub(crate) fn from_snapshot(snapshot: ContextSnapshot) -> Self {
-        let next_item_seq = snapshot
+        // Strip `SystemInstruction` items inherited from a polluted
+        // snapshot. Pre-fix daemons (between 28552bb9d landing and the
+        // System-skip fix on `record_message_with_source_ref`) stacked
+        // one SystemInstruction per turn into the manager and
+        // persisted it; reloading those snapshots without filtering
+        // would resurrect the duplicates on the next `for_prompt`.
+        // `SystemInstruction` items are no longer owned by the manager,
+        // so dropping them here is the snapshot-side complement to the
+        // recording-side early-return.
+        let items: Vec<_> = snapshot
             .items
+            .into_iter()
+            .filter(|item| !matches!(item.kind, TranscriptItemKind::SystemInstruction { .. }))
+            .collect();
+        let next_item_seq = items
             .iter()
             .filter_map(|item| item.id.as_str().strip_prefix("ctxitem_"))
             .filter_map(|suffix| suffix.parse::<u64>().ok())
@@ -650,7 +672,7 @@ impl ContextManager {
             thread_id: snapshot.state.thread_id,
             generation: snapshot.state.generation,
             next_item_seq,
-            items: snapshot.items,
+            items,
             last_checkpoint_id: snapshot.state.last_checkpoint_id,
             last_compaction_id: snapshot.state.last_compaction_id,
             recovery_state: snapshot.state.recovery_state,
@@ -1740,8 +1762,13 @@ mod tests {
     #[test]
     fn records_context_state_checkpoint_and_snapshot_hash() {
         let mut manager = ContextManager::new("coding:local:test", Some("thread-1".into()));
-        manager.record_message(&Message::system("You are Octos."));
+        // System messages are intentionally not recorded as
+        // SystemInstruction items — they belong to the agent's runtime
+        // prompt composition. See `record_message_with_source_ref`
+        // early-return. Use User + Assistant to exercise checkpoint /
+        // snapshot machinery.
         manager.record_message(&Message::user("Review this project"));
+        manager.record_message(&Message::assistant("On it."));
         let before_checkpoint = manager.transcript_hash();
 
         let checkpoint = manager.checkpoint("before_sampling");
@@ -2384,8 +2411,13 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(fork.sanitizer_hash.starts_with("sha256:"));
+        // SystemInstruction items are no longer recorded into the
+        // manager (see `record_message_with_source_ref` early-return)
+        // — the agent re-applies its runtime System at the bridge.
+        // The fork therefore never carries a SystemInstruction either.
         assert!(
-            fork.items
+            !fork
+                .items
                 .iter()
                 .any(|item| matches!(item.kind, TranscriptItemKind::SystemInstruction { .. }))
         );
@@ -2564,7 +2596,11 @@ mod tests {
     fn durable_context_ledger_round_trips_active_compacted_generation() {
         let temp = tempfile::tempdir().expect("tempdir");
         let session_id = "coding:local:tui#coding";
-        let mut history = vec![Message::system("system")];
+        // System messages are intentionally skipped by
+        // `record_message_with_source_ref` (the agent re-applies its
+        // runtime System at the bridge), so seed history with
+        // user/assistant pairs only.
+        let mut history = vec![];
         for index in 0..6 {
             history.push(Message::user(format!("u{index}")));
             history.push(Message::assistant(format!("a{index}")));
@@ -2587,9 +2623,18 @@ mod tests {
         let snapshot_json: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&path).expect("read persisted snapshot"))
                 .expect("parse persisted snapshot");
+        // source_index[0] anchors at the source_seq of the first item
+        // retained AFTER compaction (keep_recent_items: 4 above keeps
+        // the last 4 messages of the user/assistant pairs). With
+        // System messages now intentionally skipped at record time
+        // (`record_message_with_source_ref` early-return), 12 items go
+        // in (u0..a5) at source_seqs 0..11; compaction keeps the last
+        // 4 (source_seqs 8..11), so the snapshot's source_index begins
+        // at 8 rather than 0. The atomic materialization invariant
+        // still holds — the source_index is present and consistent.
         assert_eq!(
             snapshot_json["source_index"][0]["source_seq"],
-            serde_json::json!(0),
+            serde_json::json!(8),
             "context snapshot must atomically materialize the normalized source index"
         );
 
@@ -2778,11 +2823,15 @@ mod tests {
             ..PromptBuildPolicy::default()
         });
 
+        // System messages are no longer owned by the manager (see
+        // `record_message_with_source_ref` early-return) — the agent's
+        // runtime System is re-applied at the bridge boundary instead.
+        // Frame.messages therefore should NOT contain a System.
         assert!(
-            frame
+            !frame
                 .messages
                 .iter()
-                .any(|message| message.role == MessageRole::System && message.content == "system")
+                .any(|message| message.role == MessageRole::System)
         );
         assert!(
             !frame

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14322,7 +14322,25 @@ async fn run_standalone_turn(
     let llm_provider: Arc<dyn octos_llm::LlmProvider> = session_runtime.profile.llm.clone();
     let memory_store: Arc<octos_memory::EpisodeStore> = session_runtime.profile.memory.clone();
     let agent_config = session_runtime.agent.agent_config();
-    let system_prompt_base = session_runtime.agent.system_prompt_snapshot();
+    // Per-session system prompt override. Gateway path already reads
+    // `data_dir/session_prompts/<topic>.md` for structured-template
+    // sessions (`/new slides X`, `/new site X`) via
+    // `gateway_runtime::compose_session_prompt`, but the AppUI/WS turn
+    // path never had the equivalent wiring — so slides/site sessions on
+    // the web UI fell back to the generic agent prompt and lost their
+    // workflow guidance. `read_session_prompt` is the canonical reader
+    // in `project_templates.rs`; fall back to the agent's snapshot when
+    // the session has no topic prompt on disk (every non-template
+    // session).
+    let system_prompt_base = session_id
+        .topic()
+        .and_then(|topic| {
+            crate::project_templates::read_session_prompt(
+                &session_runtime.profile.data_dir,
+                topic,
+            )
+        })
+        .unwrap_or_else(|| session_runtime.agent.system_prompt_snapshot());
 
     // Wave4-A: emit an initial `router/status` snapshot adjacent to
     // `turn/started` so clients can render the routing pill before the
@@ -14708,6 +14726,31 @@ async fn run_standalone_turn(
             });
         tool_registry.set_background_result_sender(background_result_sender.clone());
 
+        // Build the SendFile channel + path config UP HERE (before
+        // SpawnTool construction) so we can hand the same `out_tx` and
+        // base-dir set to BOTH the parent SendFileTool registration
+        // AND the spawn-child SendFileTool factory. Pre-fix the child
+        // registry only inherited builtins + plugins + pipeline_factory
+        // — `send_file` was missing, and spawn preflight failed with
+        // "required tool(s) not available on this host: send_file"
+        // whenever a workspace-contract subagent declared `send_file`
+        // among allowed_tools (e.g. mofa_slides post-completion
+        // delivery). Live reproducer on mini3 dspfac session
+        // slides-1779207239761-u8pt1j.
+        let (out_tx, mut out_rx) =
+            mpsc::channel::<octos_core::OutboundMessage>(SEND_FILE_CHANNEL_CAPACITY);
+        let send_file_base = workspace_root
+            .clone()
+            .unwrap_or_else(|| bg_data_dir.clone());
+        let send_file_extras: Vec<PathBuf> = {
+            let mut v = vec![bg_data_dir.clone()];
+            if plugin_root_dir != bg_data_dir {
+                v.push(plugin_root_dir.clone());
+            }
+            v
+        };
+        let send_file_context_session = bg_session_id.0.clone();
+
         let (spawn_inbound_tx, _spawn_inbound_rx) = mpsc::channel::<InboundMessage>(32);
         let mut spawn_tool = octos_agent::SpawnTool::with_context(
             llm_provider.clone(),
@@ -14799,40 +14842,50 @@ async fn run_standalone_turn(
                 )))
             },
         ));
+        // Child SendFileTool factory: every spawned subagent's registry
+        // gets a fresh `SendFileTool` wired to the SAME `out_tx`
+        // channel as the parent, so spawn_only `files_to_send`
+        // deliveries land via the canonical AppUI persist loop below.
+        // Pre-fix (commit 28552bb9d added spawn on AppUI but no child
+        // factory) the child registry was missing `send_file`, breaking
+        // any subagent that the workspace contract auto-delivered via
+        // it.
+        {
+            let factory_out_tx = out_tx.clone();
+            let factory_base = send_file_base.clone();
+            let factory_extras = send_file_extras.clone();
+            let factory_session = send_file_context_session.clone();
+            spawn_tool = spawn_tool.with_child_tool_factory(Arc::new(move || {
+                let mut tool = octos_agent::SendFileTool::new(factory_out_tx.clone())
+                    .with_base_dir(factory_base.clone());
+                for extra in &factory_extras {
+                    tool = tool.with_extra_allowed_dir(extra.clone());
+                }
+                tool.set_context("api", &factory_session);
+                Arc::new(tool) as Arc<dyn octos_agent::tools::Tool>
+            }));
+        }
         tool_registry.register(spawn_tool);
         tool_registry.add_base_tools(["spawn", "check_background_tasks", "read_task_output"]);
 
-        // Wire `send_file` for the legacy non-contract `files_to_send` path
-        // and any explicit agent calls. The spawn_only auto-background
-        // branch falls back to `send_file` when the workspace contract is
-        // `NotConfigured` (`execution.rs:549`) — without this registration,
-        // tools like `deep_search` (no default api-mode workspace policy)
-        // emit `files_to_send` that have nowhere to land.
-        let (out_tx, mut out_rx) =
-            mpsc::channel::<octos_core::OutboundMessage>(SEND_FILE_CHANNEL_CAPACITY);
-        // Mirror gateway's session_actor.rs:2087 base/extra split: use the
-        // session workspace root as the base_dir (so a spawn_only tool
-        // returning `files_to_send: ["output/report.md"]` resolves under
-        // the user's workspace), and keep `data_dir` as an extra-allowed
-        // directory for pipeline-generated artefacts. Fall back to
-        // `data_dir` as base when the session has no workspace (rare —
-        // CLI clients without `session.workspace_cwd.v1` capability).
-        let send_file_base = workspace_root
-            .clone()
-            .unwrap_or_else(|| bg_data_dir.clone());
-        let mut send_file_tool = octos_agent::SendFileTool::new(out_tx)
-            .with_base_dir(send_file_base)
-            .with_extra_allowed_dir(bg_data_dir.clone());
-        // Profiles with a custom `data_dir` outside `bg_data_dir` host
-        // their plugin output under a path the default extras above would
-        // reject. Add `plugin_root_dir` (resolved per-profile via
-        // `routed_profile_id` or `session_id.profile_id()`) as an extra
-        // allowed dir so spawn_only `send_file` deliveries from those
-        // profiles still pass the path-scoping check.
-        if plugin_root_dir != bg_data_dir {
-            send_file_tool = send_file_tool.with_extra_allowed_dir(plugin_root_dir.clone());
+        // Wire the PARENT `send_file` for the legacy non-contract
+        // `files_to_send` path and any explicit agent calls. The
+        // spawn_only auto-background branch falls back to `send_file`
+        // when the workspace contract is `NotConfigured`
+        // (`execution.rs:549`) — without this registration, tools like
+        // `deep_search` (no default api-mode workspace policy) emit
+        // `files_to_send` that have nowhere to land.
+        //
+        // The `out_tx`/`send_file_base`/`send_file_extras`/`send_file_context_session`
+        // bindings were created above (before SpawnTool construction)
+        // so the SAME deps are used by both the parent tool and the
+        // child factory wired into `spawn_tool`.
+        let mut send_file_tool =
+            octos_agent::SendFileTool::new(out_tx).with_base_dir(send_file_base.clone());
+        for extra in &send_file_extras {
+            send_file_tool = send_file_tool.with_extra_allowed_dir(extra.clone());
         }
-        send_file_tool.set_context("api", &bg_session_id.0);
+        send_file_tool.set_context("api", &send_file_context_session);
         tool_registry.register(send_file_tool);
 
         // Drain `OutboundMessage`s emitted by `send_file` calls and persist

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1956,24 +1956,40 @@ impl PromptContextManager for AppUiPromptContextBridge {
                 .any(|(left, right)| !prompt_message_matches(left, right));
         *messages = frame.messages;
         if let Some(system) = runtime_system {
-            // Always re-insert the runtime System at index 0, even if
-            // the frame already leads with a System (which would be a
-            // compaction-summary System emitted by `for_prompt`'s
-            // compaction path — see `context_manager.rs:1159`). The
-            // runtime System (agent persona + slides workflow
-            // guidance, etc.) and the compaction summary serve
-            // different purposes and must both reach the LLM.
-            // `normalize_system_messages` (`message_repair.rs:92`)
-            // merges consecutive Systems into a single `messages[0]`
-            // before the provider call, so the LLM still sees one
-            // System message; this preserves both contributions.
+            // Re-apply the agent's runtime System prompt. Two cases:
             //
-            // Safe to insert unconditionally because
+            //   a) `frame.messages` leads with a System message
+            //      (e.g. a `[Conversation summary]` emitted by
+            //      `for_prompt`'s compaction path —
+            //      `context_manager.rs:1159`). Concatenate the runtime
+            //      System CONTENT into that existing System rather
+            //      than inserting a second one. We do this in-place to
+            //      avoid producing two consecutive `System` messages
+            //      because `normalize_system_messages` runs BEFORE
+            //      this bridge (`loop_compaction.rs:35`) — anything we
+            //      emit here goes straight to the provider, and
+            //      multi-System payloads are rejected by Anthropic
+            //      (single `system` field) and other providers.
+            //
+            //   b) `frame.messages` does not lead with a System.
+            //      Insert the runtime System at index 0.
+            //
+            // Safe to merge unconditionally because
             // `record_message_with_source_ref` early-returns for
-            // System (see `context_manager.rs:752`), so the frame
-            // cannot contain the runtime System itself — only a
-            // compaction summary or nothing.
-            messages.insert(0, system);
+            // `System` role (`context_manager.rs:752`) so the frame
+            // can only contain compaction summaries or no System at
+            // all — never the runtime System itself.
+            match messages.first_mut() {
+                Some(first) if first.role == MessageRole::System => {
+                    let existing = std::mem::take(&mut first.content);
+                    first.content = if existing.is_empty() {
+                        system.content
+                    } else {
+                        format!("{}\n\n{}", system.content, existing)
+                    };
+                }
+                _ => messages.insert(0, system),
+            }
         }
         scratch.observed_messages = messages.len();
         {

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1819,6 +1819,12 @@ fn tool_call_slices_match(
 struct AppUiLoopPromptScratch {
     manager: ContextManager,
     observed_messages: usize,
+    /// Cached runtime System captured at TurnStart. Reused on every
+    /// `Iteration` phase within the same turn so the merge logic does
+    /// not re-capture an already-merged `messages[0]` (which would
+    /// duplicate the compaction summary content on each iteration).
+    /// Cleared/replaced when a new TurnStart phase fires.
+    runtime_system: Option<Message>,
 }
 
 struct AppUiPromptContextBridge {
@@ -1892,6 +1898,7 @@ impl PromptContextManager for AppUiPromptContextBridge {
             *scratch_guard = Some(AppUiLoopPromptScratch {
                 manager,
                 observed_messages: messages.len(),
+                runtime_system: None,
             });
         }
         let scratch = scratch_guard
@@ -1936,18 +1943,21 @@ impl PromptContextManager for AppUiPromptContextBridge {
             publish_appui_context_status(&self.session_id, &scratch.manager);
         }
 
-        // Capture the caller's runtime System prompt (composed by
-        // `compose_system_prompt()` and placed at `messages[0]` by the
-        // agent loop) BEFORE we overwrite `messages` with the manager's
-        // frame. After replacement we re-insert it at index 0 if the
-        // frame did not already lead with a System message — the
-        // manager intentionally does not own the per-turn runtime
-        // System (see `record_prompt_messages_not_covered_by_context`),
-        // and the LLM call requires the runtime System to be present.
-        let runtime_system = messages
-            .first()
-            .filter(|m| m.role == MessageRole::System)
-            .cloned();
+        // Capture the caller's runtime System ONCE per turn at
+        // TurnStart, then reuse across iterations. Pre-fix the bridge
+        // re-captured `messages[0]` on every iteration, but after the
+        // first in-place merge `messages[0]` already contained
+        // `runtime + compaction_summary`. Re-capturing that on the
+        // next iteration and merging again with a fresh frame summary
+        // duplicated the summary. The TurnStart cache holds the
+        // original, untainted runtime System for the rest of the turn.
+        if request.phase == PromptContextPhase::TurnStart {
+            scratch.runtime_system = messages
+                .first()
+                .filter(|m| m.role == MessageRole::System)
+                .cloned();
+        }
+        let runtime_system = scratch.runtime_system.clone();
         let frame = scratch.manager.for_prompt(&policy);
         let prompt_replaced = messages.len() != frame.messages.len()
             || messages

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -14379,10 +14379,7 @@ async fn run_standalone_turn(
     // augments rather than replaces.
     let agent_snapshot = session_runtime.agent.system_prompt_snapshot();
     let system_prompt_base = match session_id.topic().and_then(|topic| {
-        crate::project_templates::read_session_prompt(
-            &session_runtime.profile.data_dir,
-            topic,
-        )
+        crate::project_templates::read_session_prompt(&session_runtime.profile.data_dir, topic)
     }) {
         Some(session_prompt) => format!("{agent_snapshot}\n\n{session_prompt}"),
         None => agent_snapshot,

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1757,9 +1757,24 @@ fn record_prompt_messages_not_covered_by_context(
     let known_messages = manager.for_prompt(policy).messages;
     let covered = covered_prompt_message_indices(messages, &known_messages);
     for (index, message) in messages.iter().enumerate() {
-        if !covered[index] {
-            manager.record_message(message);
+        if covered[index] {
+            continue;
         }
+        // Skip System messages: the agent freshly composes its runtime
+        // System prompt on every turn via `compose_system_prompt()` and
+        // prepends it to `messages[0]`. Recording that as a
+        // `SystemInstruction` item makes the manager accumulate one
+        // duplicate per turn — `for_prompt` then re-emits all of them
+        // into every LLM call, which `normalize_system_messages` later
+        // concatenates into a single 4×-bloated `messages[0]`. The
+        // runtime System is re-applied at the end of `prepare_prompt`,
+        // so dropping it here does not lose it. (Regression introduced
+        // by commit 28552bb9d which added the AppUI/gateway bridges
+        // without exempting the per-turn runtime System.)
+        if message.role == MessageRole::System {
+            continue;
+        }
+        manager.record_message(message);
     }
 }
 
@@ -1921,6 +1936,18 @@ impl PromptContextManager for AppUiPromptContextBridge {
             publish_appui_context_status(&self.session_id, &scratch.manager);
         }
 
+        // Capture the caller's runtime System prompt (composed by
+        // `compose_system_prompt()` and placed at `messages[0]` by the
+        // agent loop) BEFORE we overwrite `messages` with the manager's
+        // frame. After replacement we re-insert it at index 0 if the
+        // frame did not already lead with a System message — the
+        // manager intentionally does not own the per-turn runtime
+        // System (see `record_prompt_messages_not_covered_by_context`),
+        // and the LLM call requires the runtime System to be present.
+        let runtime_system = messages
+            .first()
+            .filter(|m| m.role == MessageRole::System)
+            .cloned();
         let frame = scratch.manager.for_prompt(&policy);
         let prompt_replaced = messages.len() != frame.messages.len()
             || messages
@@ -1928,6 +1955,12 @@ impl PromptContextManager for AppUiPromptContextBridge {
                 .zip(frame.messages.iter())
                 .any(|(left, right)| !prompt_message_matches(left, right));
         *messages = frame.messages;
+        if let Some(system) = runtime_system {
+            let already_leads = matches!(messages.first(), Some(m) if m.role == MessageRole::System);
+            if !already_leads {
+                messages.insert(0, system);
+            }
+        }
         scratch.observed_messages = messages.len();
         {
             let mut canonical = self

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1956,10 +1956,24 @@ impl PromptContextManager for AppUiPromptContextBridge {
                 .any(|(left, right)| !prompt_message_matches(left, right));
         *messages = frame.messages;
         if let Some(system) = runtime_system {
-            let already_leads = matches!(messages.first(), Some(m) if m.role == MessageRole::System);
-            if !already_leads {
-                messages.insert(0, system);
-            }
+            // Always re-insert the runtime System at index 0, even if
+            // the frame already leads with a System (which would be a
+            // compaction-summary System emitted by `for_prompt`'s
+            // compaction path — see `context_manager.rs:1159`). The
+            // runtime System (agent persona + slides workflow
+            // guidance, etc.) and the compaction summary serve
+            // different purposes and must both reach the LLM.
+            // `normalize_system_messages` (`message_repair.rs:92`)
+            // merges consecutive Systems into a single `messages[0]`
+            // before the provider call, so the LLM still sees one
+            // System message; this preserves both contributions.
+            //
+            // Safe to insert unconditionally because
+            // `record_message_with_source_ref` early-returns for
+            // System (see `context_manager.rs:752`), so the frame
+            // cannot contain the runtime System itself — only a
+            // compaction summary or nothing.
+            messages.insert(0, system);
         }
         scratch.observed_messages = messages.len();
         {
@@ -14322,25 +14336,31 @@ async fn run_standalone_turn(
     let llm_provider: Arc<dyn octos_llm::LlmProvider> = session_runtime.profile.llm.clone();
     let memory_store: Arc<octos_memory::EpisodeStore> = session_runtime.profile.memory.clone();
     let agent_config = session_runtime.agent.agent_config();
-    // Per-session system prompt override. Gateway path already reads
+    // Per-session system prompt override. Gateway path reads
     // `data_dir/session_prompts/<topic>.md` for structured-template
-    // sessions (`/new slides X`, `/new site X`) via
-    // `gateway_runtime::compose_session_prompt`, but the AppUI/WS turn
-    // path never had the equivalent wiring — so slides/site sessions on
-    // the web UI fell back to the generic agent prompt and lost their
-    // workflow guidance. `read_session_prompt` is the canonical reader
-    // in `project_templates.rs`; fall back to the agent's snapshot when
-    // the session has no topic prompt on disk (every non-template
-    // session).
-    let system_prompt_base = session_id
-        .topic()
-        .and_then(|topic| {
-            crate::project_templates::read_session_prompt(
-                &session_runtime.profile.data_dir,
-                topic,
-            )
-        })
-        .unwrap_or_else(|| session_runtime.agent.system_prompt_snapshot());
+    // sessions (`/new slides X`, `/new site X`) and CONCATENATES the
+    // session prompt onto its base prompt (see
+    // `gateway_runtime.rs:1864-1878` — `format!("{base}\n\n{session_prompt}")`).
+    // The AppUI/WS turn path never had any wiring for the session
+    // prompt, so slides/site sessions on the web UI fell back to the
+    // generic agent prompt and lost their workflow guidance.
+    //
+    // Mirror the gateway pattern: append the session prompt onto the
+    // profile snapshot rather than replacing it. The snapshot carries
+    // the profile's memory bank, skills index, persona, and other
+    // dynamic context — none of which the session prompt should
+    // supplant. The session prompt is workflow-specific guidance that
+    // augments rather than replaces.
+    let agent_snapshot = session_runtime.agent.system_prompt_snapshot();
+    let system_prompt_base = match session_id.topic().and_then(|topic| {
+        crate::project_templates::read_session_prompt(
+            &session_runtime.profile.data_dir,
+            topic,
+        )
+    }) {
+        Some(session_prompt) => format!("{agent_snapshot}\n\n{session_prompt}"),
+        None => agent_snapshot,
+    };
 
     // Wave4-A: emit an initial `router/status` snapshot adjacent to
     // `turn/started` so clients can render the routing pill before the

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -642,10 +642,17 @@ impl PromptContextManager for SessionActorPromptContextBridge {
                 .any(|(left, right)| !prompt_message_matches(left, right));
         *messages = frame.messages;
         if let Some(system) = runtime_system {
-            let already_leads = matches!(messages.first(), Some(m) if m.role == MessageRole::System);
-            if !already_leads {
-                messages.insert(0, system);
-            }
+            // Always re-insert. The frame may legitimately start with a
+            // compaction-summary System emitted by `for_prompt`; the
+            // runtime System (agent persona + workflow guidance) is a
+            // separate concern. `normalize_system_messages` merges
+            // consecutive Systems into a single `messages[0]` before
+            // the provider call, so both contributions reach the LLM.
+            // Safe to insert unconditionally because
+            // `context_manager::record_message_with_source_ref` early-
+            // returns for System role, so the frame cannot contain the
+            // runtime System itself.
+            messages.insert(0, system);
         }
         scratch.observed_messages = messages.len();
         {
@@ -2723,6 +2730,39 @@ impl ActorFactory {
             let pipeline_factory = pipeline_factory.clone();
             spawn_tool =
                 spawn_tool.with_child_tool_factory(Arc::new(move || pipeline_factory.create()));
+        }
+        // Child SendFileTool factory (gateway parity with AppUI). Every
+        // spawned subagent's registry gets a fresh `SendFileTool` wired
+        // to the SAME `proxy_tx` channel as the parent, so spawn_only
+        // `files_to_send` deliveries land via the canonical session
+        // persist path. Pre-fix the gateway child registry was missing
+        // `send_file` (only `with_builtins + plugins + pipeline_factory`),
+        // and any workspace-contract subagent declaring `send_file` in
+        // `allowed_tools` (slides post-completion delivery, etc.) hit
+        // spawn preflight "required tool(s) not available on this host:
+        // send_file" at `spawn.rs:1344` — same regression as on the
+        // AppUI path, surfaced by codex review of PR #1079.
+        {
+            // `channel` / `chat_id` are `&'a str` from `SpawnParams`;
+            // the child factory closure outlives this stack frame, so
+            // own them as `String` before capture.
+            let factory_proxy_tx = proxy_tx.clone();
+            let factory_channel: String = channel.to_string();
+            let factory_chat_id: String = chat_id.to_string();
+            let factory_topic = session_key.topic().map(str::to_string);
+            let factory_base = user_workspace.clone();
+            let factory_extra = self.data_dir.clone();
+            spawn_tool = spawn_tool.with_child_tool_factory(Arc::new(move || {
+                let tool = SendFileTool::with_context(
+                    factory_proxy_tx.clone(),
+                    factory_channel.clone(),
+                    factory_chat_id.clone(),
+                )
+                .with_topic(factory_topic.clone())
+                .with_base_dir(factory_base.clone())
+                .with_extra_allowed_dir(factory_extra.clone());
+                Arc::new(tool) as Arc<dyn octos_agent::tools::Tool>
+            }));
         }
 
         // Wire direct background result injection (bypasses InboundMessage relay)

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -508,6 +508,10 @@ fn tool_call_slices_match(
 struct LoopPromptContextScratch {
     manager: ContextManager,
     observed_messages: usize,
+    /// Cached runtime System captured at TurnStart, reused across
+    /// iterations to avoid re-capturing an already-merged `messages[0]`
+    /// (see analogue in `AppUiLoopPromptScratch`).
+    runtime_system: Option<Message>,
 }
 
 struct SessionActorPromptContextBridge {
@@ -581,6 +585,7 @@ impl PromptContextManager for SessionActorPromptContextBridge {
             *scratch_guard = Some(LoopPromptContextScratch {
                 manager,
                 observed_messages: messages.len(),
+                runtime_system: None,
             });
         }
         let scratch = scratch_guard
@@ -625,15 +630,17 @@ impl PromptContextManager for SessionActorPromptContextBridge {
             publish_context_manager_status(&self.session_key, &scratch.manager);
         }
 
-        // Capture the caller's runtime System prompt before frame
-        // replacement; re-insert it at index 0 if the frame did not
-        // already lead with one. See the AppUI bridge analogue in
+        // Capture runtime System once per turn at TurnStart, reuse on
+        // every Iteration. See the AppUI analogue in
         // `api::ui_protocol::AppUiPromptContextBridge::prepare_prompt`
-        // for the same fix and the rationale.
-        let runtime_system = messages
-            .first()
-            .filter(|m| m.role == MessageRole::System)
-            .cloned();
+        // for the duplication concern that motivates the cache.
+        if request.phase == PromptContextPhase::TurnStart {
+            scratch.runtime_system = messages
+                .first()
+                .filter(|m| m.role == MessageRole::System)
+                .cloned();
+        }
+        let runtime_system = scratch.runtime_system.clone();
         let frame = scratch.manager.for_prompt(&policy);
         let prompt_replaced = messages.len() != frame.messages.len()
             || messages

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -448,9 +448,22 @@ fn record_prompt_messages_not_covered_by_context(
     let known_messages = manager.for_prompt(policy).messages;
     let covered = covered_prompt_message_indices(messages, &known_messages);
     for (index, message) in messages.iter().enumerate() {
-        if !covered[index] {
-            manager.record_message(message);
+        if covered[index] {
+            continue;
         }
+        // Mirror of the same exemption in
+        // `api::ui_protocol::record_prompt_messages_not_covered_by_context`:
+        // skip System messages. The agent's runtime System prompt is
+        // re-composed on every turn and prepended fresh to
+        // `messages[0]`; recording it here makes the manager stack one
+        // `SystemInstruction` item per turn, which `for_prompt` then
+        // re-emits and `normalize_system_messages` concatenates into a
+        // multi-copy blob. The runtime System is re-applied at the end
+        // of `prepare_prompt`, so dropping it here does not lose it.
+        if message.role == MessageRole::System {
+            continue;
+        }
+        manager.record_message(message);
     }
 }
 
@@ -612,6 +625,15 @@ impl PromptContextManager for SessionActorPromptContextBridge {
             publish_context_manager_status(&self.session_key, &scratch.manager);
         }
 
+        // Capture the caller's runtime System prompt before frame
+        // replacement; re-insert it at index 0 if the frame did not
+        // already lead with one. See the AppUI bridge analogue in
+        // `api::ui_protocol::AppUiPromptContextBridge::prepare_prompt`
+        // for the same fix and the rationale.
+        let runtime_system = messages
+            .first()
+            .filter(|m| m.role == MessageRole::System)
+            .cloned();
         let frame = scratch.manager.for_prompt(&policy);
         let prompt_replaced = messages.len() != frame.messages.len()
             || messages
@@ -619,6 +641,12 @@ impl PromptContextManager for SessionActorPromptContextBridge {
                 .zip(frame.messages.iter())
                 .any(|(left, right)| !prompt_message_matches(left, right));
         *messages = frame.messages;
+        if let Some(system) = runtime_system {
+            let already_leads = matches!(messages.first(), Some(m) if m.role == MessageRole::System);
+            if !already_leads {
+                messages.insert(0, system);
+            }
+        }
         scratch.observed_messages = messages.len();
         {
             let mut canonical = self

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -642,17 +642,25 @@ impl PromptContextManager for SessionActorPromptContextBridge {
                 .any(|(left, right)| !prompt_message_matches(left, right));
         *messages = frame.messages;
         if let Some(system) = runtime_system {
-            // Always re-insert. The frame may legitimately start with a
-            // compaction-summary System emitted by `for_prompt`; the
-            // runtime System (agent persona + workflow guidance) is a
-            // separate concern. `normalize_system_messages` merges
-            // consecutive Systems into a single `messages[0]` before
-            // the provider call, so both contributions reach the LLM.
-            // Safe to insert unconditionally because
-            // `context_manager::record_message_with_source_ref` early-
-            // returns for System role, so the frame cannot contain the
-            // runtime System itself.
-            messages.insert(0, system);
+            // Merge in place when the frame leads with a System (e.g.
+            // compaction summary). `normalize_system_messages` runs
+            // BEFORE this bridge in the agent loop
+            // (`loop_compaction.rs:35`), so multi-System payloads
+            // produced here would reach the provider unmerged.
+            // Anthropic in particular rejects them outright. See the
+            // AppUI analogue in `api::ui_protocol::AppUiPromptContextBridge::prepare_prompt`
+            // for the rationale.
+            match messages.first_mut() {
+                Some(first) if first.role == MessageRole::System => {
+                    let existing = std::mem::take(&mut first.content);
+                    first.content = if existing.is_empty() {
+                        system.content
+                    } else {
+                        format!("{}\n\n{}", system.content, existing)
+                    };
+                }
+                _ => messages.insert(0, system),
+            }
         }
         scratch.observed_messages = messages.len();
         {


### PR DESCRIPTION
## Summary

Four regressions traced to commit `28552bb9d "feat(appui): add M14-M18 stdio parity soaks (#1060)"`. Live reproducer: mini3 dspfac slides session `slides-1779207239761-u8pt1j` hit all four simultaneously, causing the LLM to call `mofa_slides` repeatedly without successful delivery and 466 KB stacked system prompts after 4 turns.

Three independent diagnostic agents converged on the same commit.

## Changes

### 1. Stop stacking the runtime System prompt every turn
**File**: `crates/octos-cli/src/api/ui_protocol.rs` (AppUI bridge), `crates/octos-cli/src/session_actor.rs` (gateway bridge)

- `record_prompt_messages_not_covered_by_context` now skips `MessageRole::System`. The contiguous-window match in the previous code couldn't recognize the System slot, so it flagged `messages[0]` as "uncovered" and recorded it as a fresh `SystemInstruction` item every turn. After N turns the manager held N copies; `for_prompt` re-emitted them all; `normalize_system_messages` concatenated them into a 4×-bloated `messages[0]`.
- After `*messages = frame.messages`, re-insert the caller's runtime System at index 0 if the frame didn't already lead with one. The runtime System (composed by `compose_system_prompt()` per turn) is the agent's responsibility, not the manager's.

### 2. Wire SendFileTool into the spawn-child registry (AppUI)
**File**: `crates/octos-cli/src/api/ui_protocol.rs`

`SpawnTool::with_context(...)` on the AppUI path got `with_child_prompt_context_manager_factory` but no `with_child_tool_factory` for SendFileTool, so the spawned child registry had `with_builtins + plugins + pipeline_factory` and no `send_file`. Workspace-contract subagents declaring `send_file` in `allowed_tools` (mofa_slides post-completion delivery) tripped the preflight at `spawn.rs:1344`.

Lift `out_tx` / `send_file_base` / `send_file_extras` / `send_file_context_session` above the SpawnTool builder so the same deps feed both the parent SendFileTool AND a new `with_child_tool_factory` closure for children.

### 3. Wire `read_session_prompt` on the AppUI turn path
**File**: `crates/octos-cli/src/api/ui_protocol.rs`

Gateway already reads `data_dir/session_prompts/<topic>.md` for `/new slides X` / `/new site X` sessions. The AppUI/WS turn path called `session_runtime.agent.system_prompt_snapshot()` unconditionally — so slides/site sessions on the web UI fell back to the generic agent prompt and lost their workflow guidance. Use `session_id.topic()` + `project_templates::read_session_prompt` with fall-through to the agent snapshot.

## Test plan
- [x] `cargo test -p octos-cli --lib project_templates` → 14 pass
- [x] `cargo test -p octos-agent --lib` → 1469 pass (spawn, contract validators, registry)
- [x] `cargo check --workspace` clean
- [ ] Codex review
- [ ] Build + deploy + verify on mini3 dspfac slides session

## Files changed
- `crates/octos-cli/src/api/ui_protocol.rs`
- `crates/octos-cli/src/session_actor.rs`

## Diagnostic agents
Three parallel agents independently bisected — all converged on commit `28552bb9d`. Findings synthesized into surgical fixes that preserve the new ContextManager bridge architecture (per request: don't disable, fix it).