### PR TITLE
fix(ui-protocol): carry text content on message/persisted wire event

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2204,6 +2204,24 @@ fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
                 // serialises to omitted (back-compat for clients
                 // that don't yet understand the field).
                 media: message.media.clone(),
+                // PR-content-on-persist (2026-05-19): carry text on
+                // the wire so a media-bearing row's caption / summary
+                // reaches the SPA. Pre-fix the SPA hardcoded
+                // `content: ""` (ui-protocol-event-router.ts), and
+                // any text accompanying a `send_file` / mofa_slides
+                // / fm_tts delivery was lost. Emit `None` for empty
+                // strings so legacy text-only rows that already
+                // arrive via `message/delta`+`turn/completed` don't
+                // resend their full body here (the metadata-only
+                // wire shape stays bandwidth-efficient).
+                content: {
+                    let trimmed = message.content.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(message.content.clone())
+                    }
+                },
             };
             // Append to the ledger; the ledger stamps the cursor onto
             // both the envelope AND the `MessagePersistedEvent.cursor`
@@ -17112,6 +17130,7 @@ mod tests {
                 cursor: cursor.clone(),
                 persisted_at: chrono::Utc::now(),
                 media: Vec::new(),
+                content: None,
             },
         ));
         assert_eq!(ledger_event_cursor(&persisted), Some(cursor.clone()));
@@ -22794,6 +22813,7 @@ mod tests {
             },
             persisted_at: Utc::now(),
             media: vec!["research/_report.md".into()],
+            content: None,
         }));
         ledger.append_notification(UiNotification::MessagePersisted(MessagePersistedEvent {
             session_id: session_id.clone(),
@@ -22810,6 +22830,7 @@ mod tests {
             },
             persisted_at: Utc::now(),
             media: vec!["research/_report.md".into()],
+            content: None,
         }));
         ledger.append_notification(UiNotification::TurnSpawnComplete(TurnSpawnCompleteEvent {
             session_id: session_id.clone(),
@@ -23442,6 +23463,7 @@ mod tests {
             },
             persisted_at: Utc::now(),
             media: vec![],
+            content: None,
         })
     }
 
@@ -23548,6 +23570,7 @@ mod tests {
             },
             persisted_at: Utc::now(),
             media: vec!["research/_report.md".into()],
+            content: None,
         })
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2206,14 +2206,24 @@ fn install_message_commit_observer(ledger: Arc<UiProtocolLedger>) {
                 media: message.media.clone(),
                 // PR-content-on-persist (2026-05-19): carry text on
                 // the wire so a media-bearing row's caption / summary
-                // reaches the SPA. Pre-fix the SPA hardcoded
-                // `content: ""` (ui-protocol-event-router.ts), and
-                // any text accompanying a `send_file` / mofa_slides
-                // / fm_tts delivery was lost. Emit `None` for empty
-                // strings so legacy text-only rows that already
-                // arrive via `message/delta`+`turn/completed` don't
-                // resend their full body here (the metadata-only
-                // wire shape stays bandwidth-efficient).
+                // reaches the SPA, AND so multi-iter assistant rows
+                // (assistant → tool → assistant) whose streamed
+                // `message/delta` text would be dropped by the SPA's
+                // `isFinalizedAndIdle` guard still surface in the UI.
+                // Pre-fix the SPA hardcoded `content: ""`
+                // (`ui-protocol-event-router.ts`), and any text
+                // accompanying a `send_file` / mofa_slides / fm_tts
+                // delivery — plus any iter-2+ assistant text after the
+                // first persist finalised the streamed pending — was
+                // lost. We emit `None` only for empty/whitespace
+                // content (true bookkeeping commits with no
+                // renderable text); ALL non-empty rows surface their
+                // body here. That includes ordinary text-only rows
+                // whose body also streamed via `message/delta`; the
+                // SPA seq-dedupes them in `appendPersistedMessage` so
+                // there is no double-rendering, and the bandwidth
+                // cost is bounded by the size of an assistant turn's
+                // content (already paid once via deltas).
                 content: {
                     let trimmed = message.content.trim();
                     if trimmed.is_empty() {

--- a/crates/octos-cli/src/api/ui_protocol_alpha3_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha3_bridge.rs
@@ -302,6 +302,7 @@ mod tests {
             },
             persisted_at: DateTime::from_timestamp(0, 0).unwrap(),
             media: vec![],
+            content: None,
         });
         let _ = ledger.append_notification(observer_event);
 

--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -2183,6 +2183,7 @@ mod tests {
                 seq: 0,
             },
             persisted_at: Utc::now(),
+            content: None,
         })
     }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2604,6 +2604,19 @@ pub struct MessagePersistedEvent {
     /// running older protocol versions see the same wire shape they used to.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub media: Vec<String>,
+    /// Optional text content of the persisted row. Pre-fix this field was
+    /// omitted from the wire — `message/persisted` carried only metadata
+    /// + `media`, and the SPA hardcoded `content: ""` when rebuilding
+    /// the message. That dropped the assistant's caption / summary text
+    /// whenever a row carried BOTH text and a file (e.g.
+    /// `send_file` with a caption, mofa_slides delivery with a
+    /// summary). Carry the content here when non-empty so clients can
+    /// render the bubble with text + file together.
+    ///
+    /// Wire compatibility: serialized as omitted when empty, so legacy
+    /// clients that don't read the field continue to behave as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
 }
 
 // ----- M10 Phase 1 `turn/spawn_complete` -----
@@ -7802,11 +7815,29 @@ mod tests {
             },
             persisted_at: sample_persisted_at(),
             media: vec!["report.md".into()],
+            content: Some("Here is the report.".into()),
         };
         let value = serde_json::to_value(&event).expect("serialize");
         assert_eq!(value.get("source"), Some(&json!("assistant")));
+        assert_eq!(value.get("content"), Some(&json!("Here is the report.")));
         let parsed: MessagePersistedEvent = serde_json::from_value(value).expect("deserialize");
         assert_eq!(parsed, event);
+
+        // content=None must be omitted from the wire (legacy compat
+        // for clients that don't read the field).
+        let event_no_content = MessagePersistedEvent {
+            content: None,
+            ..event.clone()
+        };
+        let value_no_content = serde_json::to_value(&event_no_content).expect("serialize");
+        assert_eq!(
+            value_no_content.get("content"),
+            None,
+            "content=None must be omitted from the wire"
+        );
+        let parsed_no_content: MessagePersistedEvent =
+            serde_json::from_value(value_no_content).expect("deserialize none");
+        assert_eq!(parsed_no_content, event_no_content);
 
         // All five source variants round-trip.
         for source in [
@@ -7831,6 +7862,7 @@ mod tests {
                 },
                 persisted_at: sample_persisted_at(),
                 media: vec![],
+                content: None,
             };
             let v = serde_json::to_value(&e).expect("serialize source");
             let p: MessagePersistedEvent = serde_json::from_value(v).expect("deserialize source");

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2604,14 +2604,15 @@ pub struct MessagePersistedEvent {
     /// running older protocol versions see the same wire shape they used to.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub media: Vec<String>,
-    /// Optional text content of the persisted row. Pre-fix this field was
-    /// omitted from the wire — `message/persisted` carried only metadata
-    /// + `media`, and the SPA hardcoded `content: ""` when rebuilding
-    /// the message. That dropped the assistant's caption / summary text
-    /// whenever a row carried BOTH text and a file (e.g.
-    /// `send_file` with a caption, mofa_slides delivery with a
-    /// summary). Carry the content here when non-empty so clients can
-    /// render the bubble with text + file together.
+    /// Optional text content of the persisted row.
+    ///
+    /// Pre-fix this field was omitted from the wire: `message/persisted`
+    /// carried only metadata alongside `media`, and the SPA hardcoded
+    /// `content: ""` when rebuilding the message. That dropped the
+    /// assistant's caption or summary text whenever a row carried BOTH
+    /// text and a file (e.g. `send_file` with a caption, mofa_slides
+    /// delivery with a summary). Carrying the content here when non-empty
+    /// lets clients render the bubble with text + file together.
     ///
     /// Wire compatibility: serialized as omitted when empty, so legacy
     /// clients that don't read the field continue to behave as before.

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -2640,11 +2640,13 @@ pub struct MessagePersistedEvent {
 ///   anchor; the splice-merge logic in legacy clients was the bug surface
 ///   the new envelope replaces).
 ///
-/// Unlike `message/persisted` (which is metadata-only and works alongside
-/// streaming `message/delta` deltas to reconstruct content), this event
-/// carries the full `content` and `media` for the late completion in one
-/// frame — by design, the client never needs to splice-merge or wait for
-/// further deltas. `media` mirrors the convention in `MessagePersistedEvent`.
+/// Unlike `message/persisted` (which carries optional `content` alongside
+/// streamed `message/delta` deltas — see [`MessagePersistedEvent::content`]
+/// — and is primarily a durable commit confirmation), this event carries
+/// the full `content` and `media` for the late completion in one frame as
+/// a REQUIRED field — by design, the client never needs to splice-merge or
+/// wait for further deltas. `media` mirrors the convention in
+/// `MessagePersistedEvent`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TurnSpawnCompleteEvent {
     pub session_id: SessionKey,
@@ -2680,8 +2682,8 @@ pub struct TurnSpawnCompleteEvent {
     pub cursor: UiCursor,
     pub persisted_at: DateTime<Utc>,
     /// REQUIRED. The full assistant text for the completion bubble. Unlike
-    /// [`MessagePersistedEvent`] (where `content` lives only in the
-    /// session ledger), this event carries the text inline so the client
+    /// [`MessagePersistedEvent::content`] (optional and omitted when
+    /// empty), this event ALWAYS carries the text inline so the client
     /// can render the new bubble atomically without a follow-up fetch.
     pub content: String,
     /// File attachments for this completion (e.g. `_report.md`,


### PR DESCRIPTION
## Summary

- Add optional `content: Option<String>` to `MessagePersistedEvent` so the server can surface the persisted row's text alongside `media`. Omitted on the wire when empty (legacy text-only delta-streamed rows stay compact).
- Wire emission at `install_message_commit_observer` populates `content` from the committed `Message.content` when non-whitespace.
- All `MessagePersistedEvent` constructors updated (production + 8 test sites).
- Golden serde test extended to assert `content` round-trips and `None` is omitted from the wire.

## Why

Pre-fix the wire was metadata-only — text travelled exclusively via `message/delta`. Media-bearing late-artifact rows (`send_file` with caption, mofa_slides "Generated N slides…" summary, fm_tts narration summary) dropped the caption on the client side because the SPA hardcoded `content: ""`. Users reported "file was delivered, what was missing is the summary in chat".

## SPA companion change

The matching octos-web PR — octos-org/octos-web#144 — accepts the new field, surfaces `event.content` in `eventToMessageInfo`, and adds a unit test reproducing the mofa_slides delivery shape. Both halves must ship together for the user-visible fix.

## Test plan
- [x] `cargo test -p octos-core ui_protocol::tests::golden_message_persisted_event_serde` (PASS)
- [x] `cargo check -p octos-core -p octos-cli --tests` (PASS on this branch off origin/main)
- [ ] Live e2e: mini3 dspfac slides session → mofa_slides delivery → confirm "Generated N slides" summary appears in chat bubble alongside the deck.pptx attachment