### PR TITLE
Fix M16 tool-output evidence and secret cleanup

### DIFF
--- a/crates/octos-cli/src/api/context_manager.rs
+++ b/crates/octos-cli/src/api/context_manager.rs
@@ -6,8 +6,8 @@
 //! and fork-sanitizer contracts that SessionActor can wire into the production
 //! turn loop in later M16 workstreams.
 
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::collections::{HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
 
 use chrono::Utc;
 use octos_core::{Message, MessageRole, ToolCall};
@@ -17,6 +17,7 @@ use sha2::{Digest, Sha256};
 
 const CONTEXT_MANAGER_SCHEMA: &str = "octos.context-manager.v1";
 const DEFAULT_TOOL_OUTPUT_POLICY_ID: &str = "tool-output-v1";
+const TOOL_OUTPUT_UI_PREVIEW_MAX_BYTES: usize = 512;
 const SYNTHETIC_MISSING_TOOL_OUTPUT: &str =
     "[tool output missing: aborted before result was recorded]";
 
@@ -217,11 +218,20 @@ pub(crate) struct ToolOutputEnvelope {
     pub(crate) tool_name: String,
     pub(crate) raw_sha256: String,
     pub(crate) raw_artifact_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) ui_preview: Option<ToolOutputPreviewLink>,
     pub(crate) original_bytes: usize,
     pub(crate) model_visible_content: String,
     pub(crate) model_visible_bytes: usize,
     pub(crate) truncation_reason: Option<ToolOutputTruncationReason>,
     pub(crate) policy_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct ToolOutputPreviewLink {
+    pub(crate) preview_ref: String,
+    pub(crate) content: String,
+    pub(crate) bytes: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -376,6 +386,7 @@ pub(crate) struct ContextManager {
     last_compaction_id: Option<ContextCompactionId>,
     recovery_state: ContextRecoveryState,
     tool_output_policy: ToolOutputPolicy,
+    tool_output_artifacts: HashMap<String, Vec<u8>>,
     compactions: Vec<ContextCompactionRecord>,
 }
 
@@ -399,6 +410,7 @@ pub(crate) fn persist_context_manager_snapshot(
     session_id: &str,
     manager: &ContextManager,
 ) -> Result<PathBuf, String> {
+    persist_tool_output_artifacts(data_dir, manager)?;
     let path = context_ledger_path(data_dir, session_id);
     let parent = path
         .parent()
@@ -434,6 +446,65 @@ pub(crate) fn persist_context_manager_snapshot(
         ));
     }
     Ok(path)
+}
+
+fn context_ledger_artifact_path(data_dir: &Path, artifact_ref: &str) -> Result<PathBuf, String> {
+    let root = data_dir.join("context_ledgers");
+    let mut path = root.clone();
+    for component in Path::new(artifact_ref).components() {
+        match component {
+            Component::Normal(part) => path.push(part),
+            _ => {
+                return Err(format!(
+                    "invalid context artifact reference contains non-normal component: {artifact_ref}"
+                ));
+            }
+        }
+    }
+    Ok(path)
+}
+
+fn persist_tool_output_artifacts(data_dir: &Path, manager: &ContextManager) -> Result<(), String> {
+    for (artifact_ref, bytes) in &manager.tool_output_artifacts {
+        let path = context_ledger_artifact_path(data_dir, artifact_ref)?;
+        atomic_write_bytes(&path, bytes)?;
+    }
+    Ok(())
+}
+
+fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("context artifact path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent).map_err(|err| {
+        format!(
+            "create context artifact directory {} failed: {err}",
+            parent.display()
+        )
+    })?;
+    let tmp_name = format!(
+        "{}.tmp-{}-{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("tool-output.txt"),
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let tmp_path = parent.join(tmp_name);
+    std::fs::write(&tmp_path, bytes).map_err(|err| {
+        format!(
+            "write context artifact {} failed: {err}",
+            tmp_path.display()
+        )
+    })?;
+    if let Err(err) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!(
+            "install context artifact {} failed: {err}",
+            path.display()
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn load_context_manager_snapshot(
@@ -519,6 +590,7 @@ impl ContextManager {
             last_compaction_id: None,
             recovery_state: ContextRecoveryState::Exact,
             tool_output_policy: ToolOutputPolicy::default(),
+            tool_output_artifacts: HashMap::new(),
             compactions: Vec::new(),
         }
     }
@@ -577,6 +649,7 @@ impl ContextManager {
             last_compaction_id: None,
             recovery_state: ContextRecoveryState::Rebuilt,
             tool_output_policy: ToolOutputPolicy::default(),
+            tool_output_artifacts: HashMap::new(),
             compactions: Vec::new(),
         }
     }
@@ -677,6 +750,7 @@ impl ContextManager {
             last_compaction_id: snapshot.state.last_compaction_id,
             recovery_state: snapshot.state.recovery_state,
             tool_output_policy: ToolOutputPolicy::default(),
+            tool_output_artifacts: HashMap::new(),
             compactions: snapshot.compactions,
         }
     }
@@ -921,9 +995,19 @@ impl ContextManager {
             self.tool_output_policy.model_visible_max_bytes,
             ToolOutputTruncationReason::MaxBytes,
         );
-        let raw_artifact_ref = (original_bytes
-            > self.tool_output_policy.inline_raw_threshold_bytes)
+        let raw_artifact_ref = (truncation_reason.is_some()
+            || original_bytes > self.tool_output_policy.inline_raw_threshold_bytes)
             .then(|| format!("tool-output/{raw_sha256}.txt"));
+        if let Some(artifact_ref) = raw_artifact_ref.as_ref() {
+            self.tool_output_artifacts
+                .insert(artifact_ref.clone(), raw_output.as_bytes().to_vec());
+        }
+        let ui_preview_content = tool_output_preview(&model_visible_content);
+        let ui_preview = Some(ToolOutputPreviewLink {
+            preview_ref: format!("appui/tool-output-preview/{tool_call_id}"),
+            bytes: ui_preview_content.len(),
+            content: ui_preview_content,
+        });
         self.record_item_with_source_ref(
             TranscriptItemKind::ToolOutput {
                 envelope: ToolOutputEnvelope {
@@ -931,6 +1015,7 @@ impl ContextManager {
                     tool_name: tool_name.into(),
                     raw_sha256,
                     raw_artifact_ref,
+                    ui_preview,
                     original_bytes,
                     model_visible_bytes: model_visible_content.len(),
                     model_visible_content,
@@ -1321,6 +1406,11 @@ impl ContextManager {
         }
 
         if let Some(max_tokens) = policy.max_prompt_token_estimate {
+            truncate_tool_outputs_for_context_pressure(
+                &mut entries,
+                max_tokens,
+                &mut truncated_item_ids,
+            );
             trim_prompt_entries_preserving_invariants(
                 &mut entries,
                 max_tokens,
@@ -1544,6 +1634,34 @@ fn trim_prompt_entries_preserving_invariants(
     }
 }
 
+fn truncate_tool_outputs_for_context_pressure(
+    entries: &mut [PromptMessageEntry],
+    max_tokens: usize,
+    truncated_item_ids: &mut Vec<TranscriptItemId>,
+) {
+    if estimate_entries_tokens(entries) <= max_tokens {
+        return;
+    }
+    let max_tool_bytes = (max_tokens.saturating_mul(4) / 2).max(1);
+    for entry in entries.iter_mut() {
+        if entry.message.role != MessageRole::Tool || entry.message.content.len() <= max_tool_bytes
+        {
+            continue;
+        }
+        let (content, reason) = truncate_utf8(
+            &entry.message.content,
+            max_tool_bytes,
+            ToolOutputTruncationReason::ContextWindowPressure,
+        );
+        if reason.is_some() {
+            entry.message.content = content;
+            for item_id in &entry.source_item_ids {
+                push_unique_item_id(truncated_item_ids, item_id.clone());
+            }
+        }
+    }
+}
+
 fn first_removable_prompt_group(entries: &[PromptMessageEntry]) -> Option<(usize, usize)> {
     let start = entries
         .iter()
@@ -1674,6 +1792,15 @@ fn truncate_utf8(
     let mut truncated = value[..end].to_owned();
     truncated.push_str("\n[truncated]");
     (truncated, Some(reason))
+}
+
+fn tool_output_preview(value: &str) -> String {
+    truncate_utf8(
+        value,
+        TOOL_OUTPUT_UI_PREVIEW_MAX_BYTES,
+        ToolOutputTruncationReason::MaxBytes,
+    )
+    .0
 }
 
 fn estimate_items_tokens(items: &[TranscriptItem]) -> usize {
@@ -1917,6 +2044,10 @@ mod tests {
                 .unwrap()
                 .starts_with("tool-output/sha256:")
         );
+        let preview = envelope.ui_preview.as_ref().expect("ui preview link");
+        assert_eq!(preview.preview_ref, "appui/tool-output-preview/call-1");
+        assert_eq!(preview.content, envelope.model_visible_content);
+        assert_eq!(preview.bytes, preview.content.len());
         assert!(envelope.raw_sha256.starts_with("sha256:"));
     }
 
@@ -2381,6 +2512,94 @@ mod tests {
     }
 
     #[test]
+    fn durable_context_ledger_persists_tool_output_sidecar_and_preview_link() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let session_id = "coding:local:tui#tool-output";
+        let policy = ToolOutputPolicy {
+            policy_id: "test-policy".into(),
+            inline_raw_threshold_bytes: 8,
+            model_visible_max_bytes: 10,
+        };
+        let mut manager = ContextManager::new(session_id, None).with_tool_output_policy(policy);
+        manager.record_message(&assistant_tool_call("call-1"));
+        manager.record_tool_output("call-1", "shell", "0123456789abcdef");
+
+        let envelope = match &manager.items()[1].kind {
+            TranscriptItemKind::ToolOutput { envelope } => envelope,
+            other => panic!("expected tool output, got {other:?}"),
+        };
+        let artifact_ref = envelope
+            .raw_artifact_ref
+            .as_deref()
+            .expect("large output should have sidecar ref");
+        let preview_ref = envelope
+            .ui_preview
+            .as_ref()
+            .expect("ui preview link")
+            .preview_ref
+            .clone();
+
+        let snapshot_path = persist_context_manager_snapshot(temp.path(), session_id, &manager)
+            .expect("persist context manager");
+        let artifact_path =
+            context_ledger_artifact_path(temp.path(), artifact_ref).expect("artifact path");
+
+        assert!(snapshot_path.exists());
+        assert_eq!(
+            std::fs::read_to_string(&artifact_path).expect("read sidecar"),
+            "0123456789abcdef"
+        );
+        assert_eq!(preview_ref, "appui/tool-output-preview/call-1");
+
+        let loaded = load_context_manager_snapshot(temp.path(), session_id)
+            .expect("load snapshot")
+            .expect("snapshot exists");
+        let frame = loaded.for_prompt(&PromptBuildPolicy::default());
+        let tool_message = frame
+            .messages
+            .iter()
+            .find(|message| message.role == MessageRole::Tool)
+            .expect("tool message");
+        assert_eq!(tool_message.content, "0123456789\n[truncated]");
+        assert_eq!(
+            frame.report.truncated_item_ids.len(),
+            1,
+            "replay should preserve the same model-visible truncation evidence"
+        );
+    }
+
+    #[test]
+    fn prompt_context_pressure_truncates_tool_output_before_dropping_groups() {
+        let policy = ToolOutputPolicy {
+            policy_id: "test-policy".into(),
+            inline_raw_threshold_bytes: 1024,
+            model_visible_max_bytes: 1024,
+        };
+        let mut manager = ContextManager::new("s", None).with_tool_output_policy(policy);
+        manager.record_message(&Message::system("system"));
+        manager.record_message(&Message::user("recent user"));
+        manager.record_message(&assistant_tool_call("call-pressure"));
+        let tool_item_id = manager.record_tool_output("call-pressure", "shell", &"x".repeat(200));
+
+        let frame = manager.for_prompt(&PromptBuildPolicy {
+            max_prompt_token_estimate: Some(40),
+            ..PromptBuildPolicy::default()
+        });
+
+        let tool_message = frame
+            .messages
+            .iter()
+            .find(|message| message.role == MessageRole::Tool)
+            .expect("tool output should remain");
+        assert!(tool_message.content.ends_with("[truncated]"));
+        assert!(tool_message.content.len() < 200);
+        assert!(
+            frame.report.truncated_item_ids.contains(&tool_item_id),
+            "context-pressure truncation should report the affected tool output item"
+        );
+    }
+
+    #[test]
     fn fork_child_history_drops_parent_reasoning_tool_calls_outputs_and_context_injections() {
         let mut manager = ContextManager::new("s", None);
         manager.record_message(&Message::system("system"));
@@ -2445,6 +2664,7 @@ mod tests {
                     tool_name: String::new(),
                     raw_sha256: String::new(),
                     raw_artifact_ref: None,
+                    ui_preview: None,
                     original_bytes: 0,
                     model_visible_content: String::new(),
                     model_visible_bytes: 0,

--- a/e2e/scripts/m16-live-tui-tmux-soak.sh
+++ b/e2e/scripts/m16-live-tui-tmux-soak.sh
@@ -24,6 +24,11 @@ fixture_dir="$out_dir/fixtures"
 cli_fixture="$fixture_dir/review-cli-specialist.mjs"
 mcp_fixture="$fixture_dir/review-mcp-specialist.mjs"
 provider_key_source="${OCTOS_M16_NATIVE_PROVIDER_KEY_SOURCE:-$repo_root/e2e/test-results-m15-native-review-start-stdio/20260516T191424Z/data/profiles/m15-native.json}"
+live_provider_config_path="$data_dir/profiles/$profile_id.json"
+secret_cleanup_report="$out_dir/m16-secret-cleanup.json"
+cleanup_secrets_done=0
+cleanup_stop_done=0
+tmux_session_started=0
 
 usage() {
   cat <<'USAGE'
@@ -252,7 +257,7 @@ deepseek_key_from_source() {
 
 write_profile_config() {
   mkdir -p "$data_dir/profiles"
-  node - "$data_dir/profiles/$profile_id.json" "$profile_id" <<'NODE'
+  node - "$live_provider_config_path" "$profile_id" <<'NODE'
 const fs = require('fs');
 const [file, profileId] = process.argv.slice(2);
 const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
@@ -316,50 +321,43 @@ fs.writeFileSync(file, `${JSON.stringify(profile, null, 2)}\n`);
 NODE
 }
 
-scrub_secrets() {
-  # Walks every artifact / runtime tree the soak writes and redacts
-  # provider keys in place. Writes a `secret-scan-report.txt` next to
-  # the soak evidence with per-file redaction counts (no secret values
-  # are printed). #1024 — the prior implementation matched only a
-  # narrow `sk-[A-Za-z0-9]{20,}` pattern and emitted no report, so
-  # provider-specific shapes (`sk-ant-*`, `sk-proj-*`, gemini bearer
-  # tokens, JWT-shaped Anthropic OAuth) could slip through unscanned.
-  node - "$out_dir" "$data_dir" "$runtime_root" <<'NODE'
+cleanup_runtime_secrets() {
+  if [[ "${cleanup_secrets_done:-0}" == "1" ]]; then
+    return 0
+  fi
+  cleanup_secrets_done=1
+  local removed_provider_config=0
+  if [[ -f "$live_provider_config_path" ]]; then
+    rm -f "$live_provider_config_path" || true
+    removed_provider_config=1
+  fi
+  unset DEEPSEEK_API_KEY
+  node - "$out_dir" "$runtime_root" "$data_dir" "$secret_cleanup_report" "$live_provider_config_path" "$removed_provider_config" <<'NODE'
 const fs = require('fs');
 const path = require('path');
-const roots = process.argv.slice(2);
-
+const [outDir, runtimeRoot, dataDir, reportPath, providerConfigPath, removedProviderConfigRaw] = process.argv.slice(2);
+const roots = [outDir, runtimeRoot, dataDir].filter(Boolean);
 const patterns = [
-  // OpenAI / DeepSeek / generic OpenAI-compatible
-  /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9._\-]{20,}/g,
-  // Anthropic OAuth bearer tokens (sk-ant-oat01-...)
-  /sk-ant-oat01-[A-Za-z0-9._\-]{20,}/g,
-  // Google Gemini AIza... keys
-  /AIza[0-9A-Za-z_\-]{30,}/g,
-  // Twilio account/auth pairs
-  /AC[0-9a-f]{32}/g,
-  // Generic Bearer secrets in headers/log lines
-  /Bearer [A-Za-z0-9._\-]{32,}/g,
+  { name: 'openai_compatible', re: /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9._\-]{20,}/g },
+  { name: 'anthropic_oauth', re: /sk-ant-oat01-[A-Za-z0-9._\-]{20,}/g },
+  { name: 'google_ai', re: /AIza[0-9A-Za-z_\-]{30,}/g },
+  { name: 'twilio', re: /AC[0-9a-f]{32}/g },
+  { name: 'bearer', re: /Bearer [A-Za-z0-9._\-]{32,}/g },
 ];
-
-const scanExtensions = /\.(json|jsonl|log|txt|md|env|sh|mjs|yaml|yml|toml|conf|ini)$/i;
+const textSuffixes = new Set([
+  '.json', '.jsonl', '.log', '.txt', '.md', '.env', '.sh', '.mjs', '.js',
+  '.toml', '.yaml', '.yml', '.conf', '.ini',
+]);
 const skipDirs = new Set(['.git', 'node_modules', 'target', '__pycache__']);
+const scannedRoots = [];
+const scannedFiles = [];
+const redactedFiles = [];
+const seenFiles = new Set();
+let redactionsTotal = 0;
 
-const report = [];
-let totalRedactions = 0;
-let filesScanned = 0;
-
-function redact(text) {
-  let next = text;
-  let count = 0;
-  for (const pattern of patterns) {
-    pattern.lastIndex = 0;
-    next = next.replace(pattern, (match) => {
-      count += 1;
-      return '<redacted>';
-    });
-  }
-  return { next, count };
+function isTextFile(filePath) {
+  return textSuffixes.has(path.extname(filePath).toLowerCase())
+    || ['launch-command.txt', 'launch.sh'].includes(path.basename(filePath));
 }
 
 function walk(p) {
@@ -372,59 +370,105 @@ function walk(p) {
     }
     return;
   }
-  if (!scanExtensions.test(p)) return;
-  filesScanned += 1;
+  if (!isTextFile(p)) return;
+  const resolved = path.resolve(p);
+  if (seenFiles.has(resolved) || resolved === path.resolve(reportPath)) return;
+  seenFiles.add(resolved);
   let text;
   try {
     text = fs.readFileSync(p, 'utf8');
   } catch {
     return;
   }
-  const { next, count } = redact(text);
-  if (count > 0) {
+  let next = text;
+  let redactions = 0;
+  for (const pattern of patterns) {
+    pattern.re.lastIndex = 0;
+    next = next.replace(pattern.re, () => {
+      redactions += 1;
+      redactionsTotal += 1;
+      return `<redacted:${pattern.name}>`;
+    });
+  }
+  scannedFiles.push(p);
+  if (next !== text) {
     fs.writeFileSync(p, next);
-    report.push({ path: p, count });
-    totalRedactions += count;
+    redactedFiles.push({ path: p, redactions });
   }
 }
 
-for (const root of roots) walk(root);
-
-// Emit the report under the FIRST root (out_dir). Pass arg-0 (out_dir)
-// is the canonical evidence directory.
-const evidenceRoot = roots[0];
-if (evidenceRoot && fs.existsSync(evidenceRoot)) {
-  const lines = [
-    `# M16 tmux soak secret-scan report`,
-    `roots: ${roots.join(', ')}`,
-    `files_scanned: ${filesScanned}`,
-    `total_redactions: ${totalRedactions}`,
-    '',
-    ...report.map((entry) => `${entry.count}\t${entry.path}`),
-  ];
-  try {
-    fs.writeFileSync(path.join(evidenceRoot, 'secret-scan-report.txt'), `${lines.join('\n')}\n`);
-  } catch {
-    // Don't crash the trap on report write failure.
-  }
+for (const root of roots) {
+  if (!fs.existsSync(root)) continue;
+  scannedRoots.push(root);
+  walk(root);
 }
 
-// Non-zero exit on detected redactions would block the soak validator
-// from running; surface the count via the report only.
+const report = {
+  schema: 'octos.m16.secret_cleanup.v1',
+  scanned_roots: scannedRoots,
+  scanned_files: scannedFiles,
+  scanned_file_count: scannedFiles.length,
+  redacted_files: redactedFiles,
+  redacted_file_count: redactedFiles.length,
+  redactions_total: redactionsTotal,
+  removed_live_provider_config: Boolean(Number(removedProviderConfigRaw || '0')),
+  live_provider_config_path: providerConfigPath,
+};
+fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+
+const legacyLines = [
+  '# M16 tmux soak secret-scan report',
+  `roots: ${roots.join(', ')}`,
+  `files_scanned: ${scannedFiles.length}`,
+  `total_redactions: ${redactionsTotal}`,
+  '',
+  ...redactedFiles.map((entry) => `${entry.redactions}\t${entry.path}`),
+];
+try {
+  fs.writeFileSync(path.join(outDir, 'secret-scan-report.txt'), `${legacyLines.join('\n')}\n`);
+} catch {
+  // Best-effort compatibility report; the JSON report is canonical.
+}
 NODE
 }
 
+stop_tui_session() {
+  if [[ "${cleanup_stop_done:-0}" == "1" ]]; then
+    return 0
+  fi
+  cleanup_stop_done=1
+  if [[ "${tmux_session_started:-0}" == "1" && "${OCTOS_M16_UX_KEEP_SESSION:-0}" != "1" && -x "$tui_runner" ]]; then
+    "$tui_runner" stop || true
+  fi
+}
+
+cleanup_on_exit() {
+  local status="${1:-$?}"
+  stop_tui_session
+  cleanup_runtime_secrets || true
+  return "$status"
+}
+
+cleanup_on_signal() {
+  local status="$1"
+  trap - EXIT
+  cleanup_on_exit "$status"
+  exit "$status"
+}
+
 run_soak() {
-  command -v tmux >/dev/null 2>&1 || die "tmux is required"
-  [[ -x "$tui_runner" ]] || die "octos-tui tmux runner not found or not executable: $tui_runner"
-  ensure_binaries
   mkdir -p "$out_dir" "$runtime_root" "$data_dir" "$workdir"
-  # Register the secret scrub BEFORE any provider config / key is
-  # written so a startup failure between mkdir and the actual write
-  # still emits a clean evidence tree. Catching INT/TERM as well
-  # closes the gap #1024 flagged where Ctrl-C during the bootstrap
-  # left the unscanned provider config behind.
-  trap scrub_secrets EXIT INT TERM
+  # Register cleanup before writing live provider config, so startup failures
+  # and signals still remove/redact runtime evidence before validation.
+  trap 'cleanup_on_exit $?' EXIT
+  trap 'cleanup_on_signal 130' INT
+  trap 'cleanup_on_signal 143' TERM
+  if [[ "${OCTOS_M16_UX_INJECT_FAIL_AFTER_PROFILE_WRITE:-0}" != "1" ]]; then
+    command -v tmux >/dev/null 2>&1 || die "tmux is required"
+    [[ -x "$tui_runner" ]] || die "octos-tui tmux runner not found or not executable: $tui_runner"
+    ensure_binaries
+  fi
   write_review_workspace_fixture
   write_review_fixtures
   write_replay
@@ -436,6 +480,10 @@ run_soak() {
   [[ -n "$provider_key" && "$provider_key" != "<redacted>" ]] || die "missing provider key; set OCTOS_M16_NATIVE_API_KEY, OCTOS_M15_NATIVE_API_KEY, DEEPSEEK_API_KEY, or OCTOS_M16_NATIVE_PROVIDER_KEY_SOURCE"
   write_profile_config
   export DEEPSEEK_API_KEY="$provider_key"
+  if [[ "${OCTOS_M16_UX_INJECT_FAIL_AFTER_PROFILE_WRITE:-0}" == "1" ]]; then
+    echo "Injected failure after provider config write" >&2
+    return 97
+  fi
 
   local backend_command
   backend_command="env OCTOS_REVIEW_CLI_SPECIALIST_ARGV_JSON=$(shell_quote "[\"$cli_fixture\"]") OCTOS_REVIEW_MCP_TIMEOUT_SECS=30 $(shell_quote "$octos_bin") serve --stdio --data-dir $(shell_quote "$data_dir") --cwd $(shell_quote "$workdir") --swarm-backend stdio --swarm-backend-cmd $(shell_quote "$mcp_fixture")"
@@ -458,15 +506,13 @@ run_soak() {
   export OCTOS_TUI_M15_UX_ROWS="${OCTOS_M16_UX_ROWS:-40}"
 
   "$tui_runner" start
+  tmux_session_started=1
   local status=0
   "$tui_runner" drive || status=$?
   "$tui_runner" capture || true
+  stop_tui_session
+  cleanup_runtime_secrets
   python3 "$script_dir/validate-m16-tmux-orchestration.py" --out-dir "$out_dir" || status=$?
-  if [[ "${OCTOS_M16_UX_KEEP_SESSION:-0}" != "1" ]]; then
-    "$tui_runner" stop || true
-  fi
-  scrub_secrets
-  trap - EXIT
 
   echo "M16 UX soak artifacts: $out_dir"
   return "$status"
@@ -475,54 +521,64 @@ run_soak() {
 self_test() {
   bash -n "$0"
   python3 -m py_compile "$script_dir/validate-m16-tmux-orchestration.py"
-  # #1024: exercise scrub_secrets against a synthetic tree so the
-  # broadened pattern set + report emission stay regression-tested.
-  local fixture_root
-  fixture_root="$(mktemp -d -t m16-scrub-test-XXXXXX)"
-  trap 'rm -rf "$fixture_root"' RETURN
-  local old_out_dir="${out_dir:-}"
-  local old_data_dir="${data_dir:-}"
-  local old_runtime_root="${runtime_root:-}"
-  out_dir="$fixture_root/out"
-  data_dir="$fixture_root/data"
-  runtime_root="$fixture_root/runtime"
-  mkdir -p "$out_dir" "$data_dir" "$runtime_root"
-  cat > "$data_dir/profile.json" <<JSON
-{ "api_key": "sk-test-${RANDOM}1234567890ABCDEFG1234567890" }
-JSON
-  cat > "$runtime_root/log.txt" <<TXT
+  local tmp_root
+  tmp_root="$(mktemp -d -t m16-cleanup-test-XXXXXX)"
+  trap 'rm -rf "$tmp_root"' RETURN
+  mkdir -p "$tmp_root/out" "$tmp_root/runtime/preexisting"
+  cat > "$tmp_root/out/seed.env" <<TXT
+OPENAI_API_KEY=sk-test-1234567890ABCDEFG1234567890
+ANTHROPIC_OAUTH_JWT=sk-ant-oat01-jwthdr.octosjwtpayloadABCDEFGH.octosjwtsignatureIJKLMNOP
+TXT
+  cat > "$tmp_root/runtime/preexisting/log.txt" <<TXT
 auth: Bearer abcdefghijklmnopqrstuvwxyz0123456789ABCD
 google: AIzaSyA-1234567890abcdefghijklmnopqrstuv
 TXT
-  cat > "$out_dir/anthropic.env" <<TXT
-ANTHROPIC_API_KEY=sk-ant-oat01-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
-# codex P1+P3 follow-up to #1089: dotted JWT-shaped OAuth tokens must
-# be scrubbed in full, not just up to the first \`.\` separator. The
-# first JWT segment below is intentionally short so the old (no-\`.\`)
-# regex cannot match the prefix-with-segment as a 20+ char run either;
-# without dot-aware redaction the entire token survives. The residual
-# grep then matches distinctive payload and signature markers so any
-# regression that drops \`.\` from the char class fails this self-test.
-ANTHROPIC_OAUTH_JWT=sk-ant-oat01-jwthdr.octosjwtpayloadABCDEFGH.octosjwtsignatureIJKLMNOP
-TXT
-  scrub_secrets
-  if grep -RIEq -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij|octosjwtpayload|octosjwtsignature' "$fixture_root"; then
-    echo "scrub_secrets self-test FAIL: residual secrets in $fixture_root" >&2
-    grep -RIEn -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij|octosjwtpayload|octosjwtsignature' "$fixture_root" || true
-    out_dir="$old_out_dir"; data_dir="$old_data_dir"; runtime_root="$old_runtime_root"
+  local output_file="$tmp_root/injected-failure.out"
+  set +e
+  OCTOS_M16_UX_OUT_DIR="$tmp_root/out" \
+    OCTOS_M16_UX_RUNTIME_ROOT="$tmp_root/runtime" \
+    OCTOS_M16_UX_DATA_DIR="$tmp_root/runtime/data" \
+    OCTOS_M16_UX_WORKDIR="$tmp_root/runtime/workspace" \
+    OCTOS_M16_UX_INJECT_FAIL_AFTER_PROFILE_WRITE=1 \
+    OCTOS_M16_NATIVE_API_KEY="sk-testm16cleanup000000000000" \
+    OCTOS_M16_BUILD=0 \
+    "$0" run >"$output_file" 2>&1
+  local status=$?
+  set -e
+  [[ "$status" == "97" ]] || die "self-test expected injected failure status 97, got $status"
+  [[ ! -f "$tmp_root/runtime/data/profiles/coding.json" ]] || die "self-test provider config was not removed"
+  if grep -RIEq -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij|octosjwtpayload|octosjwtsignature' "$tmp_root/out" "$tmp_root/runtime"; then
+    echo "secret cleanup self-test FAIL: residual secrets in $tmp_root" >&2
+    grep -RIEn -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij|octosjwtpayload|octosjwtsignature' "$tmp_root/out" "$tmp_root/runtime" || true
     return 1
   fi
-  if [[ ! -s "$out_dir/secret-scan-report.txt" ]]; then
-    echo "scrub_secrets self-test FAIL: secret-scan-report.txt missing or empty" >&2
-    out_dir="$old_out_dir"; data_dir="$old_data_dir"; runtime_root="$old_runtime_root"
+  node - "$tmp_root/out/m16-secret-cleanup.json" <<'NODE'
+const fs = require('fs');
+const reportPath = process.argv[2];
+if (!fs.existsSync(reportPath)) {
+  throw new Error(`missing cleanup report: ${reportPath}`);
+}
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+if (report.schema !== 'octos.m16.secret_cleanup.v1') {
+  throw new Error(`unexpected cleanup schema: ${report.schema}`);
+}
+if (!report.removed_live_provider_config) {
+  throw new Error('cleanup report did not record provider config removal');
+}
+if (!report.scanned_roots.some((root) => root.endsWith('/out'))) {
+  throw new Error('cleanup report did not scan evidence output tree');
+}
+if (!report.scanned_roots.some((root) => root.endsWith('/runtime'))) {
+  throw new Error('cleanup report did not scan runtime tree');
+}
+if (report.redactions_total < 4 || report.redacted_file_count < 2) {
+  throw new Error(`cleanup report did not record expected redactions: ${JSON.stringify(report)}`);
+}
+NODE
+  if [[ ! -s "$tmp_root/out/secret-scan-report.txt" ]]; then
+    echo "secret cleanup self-test FAIL: legacy secret-scan-report.txt missing" >&2
     return 1
   fi
-  if ! grep -q '^total_redactions: [1-9]' "$out_dir/secret-scan-report.txt"; then
-    echo "scrub_secrets self-test FAIL: report did not record redactions" >&2
-    out_dir="$old_out_dir"; data_dir="$old_data_dir"; runtime_root="$old_runtime_root"
-    return 1
-  fi
-  out_dir="$old_out_dir"; data_dir="$old_data_dir"; runtime_root="$old_runtime_root"
   echo "Self-test passed"
 }
 

--- a/e2e/scripts/validate-m16-tmux-orchestration.py
+++ b/e2e/scripts/validate-m16-tmux-orchestration.py
@@ -41,11 +41,12 @@ EVIDENCE_FILES = (
     "appui-transcript.jsonl",
     "input-replay.log",
     "launch-command.txt",
+    "m16-secret-cleanup.json",
     "summary.env",
     "terminal-size.json",
 )
 ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
-SECRET_RE = re.compile(r"sk-[A-Za-z0-9]{20,}")
+SECRET_RE = re.compile(r"(?:sk-[A-Za-z0-9_-]{16,}|AIza[0-9A-Za-z_-]{20,})")
 
 
 def utc_now() -> str:
@@ -66,6 +67,16 @@ def read_summary_env(path: Path) -> dict[str, str]:
         key, value = line.split("=", 1)
         values[key] = value
     return values
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        value = json.loads(read_text(path))
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
 
 
 def likely_text_file(path: Path) -> bool:
@@ -167,11 +178,24 @@ class Validator:
             for row in self.transcript_rows
             if isinstance(row.get("frame"), dict)
         ]
-        summary = read_summary_env(out_dir / "summary.env")
+        self.summary = read_summary_env(out_dir / "summary.env")
+        self.cleanup_report = load_json(out_dir / "m16-secret-cleanup.json")
         scan_roots = [out_dir]
-        if runtime_root := summary.get("runtime_root"):
+        if runtime_root := self.summary.get("runtime_root"):
             scan_roots.append(Path(runtime_root))
+        self.secret_scan_roots = scan_roots
         self.secret_leaks = secret_leaks_under(scan_roots)
+        self.secret_scan = {
+            "scanned_roots": [str(root) for root in scan_roots if root.exists()],
+            "cleanup_scanned_roots": self.cleanup_report.get("scanned_roots", []),
+            "cleanup_scanned_file_count": self.cleanup_report.get("scanned_file_count", 0),
+            "redacted_file_count": self.cleanup_report.get("redacted_file_count", 0),
+            "redactions_total": self.cleanup_report.get("redactions_total", 0),
+            "removed_live_provider_config": self.cleanup_report.get(
+                "removed_live_provider_config", False
+            ),
+            "leak_paths": self.secret_leaks,
+        }
 
     def add(self, check_id: str, passed: bool, detail: str, evidence: list[str]) -> None:
         self.checks.append(
@@ -218,6 +242,33 @@ class Validator:
             if ok
             else f"backend evidence does not prove octos serve --stdio review/start without leaked secrets; secret leaks={self.secret_leaks or 'none'}",
             ["launch-command.txt", "appui-transcript.jsonl", "summary.env"],
+        )
+
+    def check_secret_cleanup_and_scan(self) -> None:
+        cleanup_roots = [str(root) for root in self.cleanup_report.get("scanned_roots", [])]
+        expected_roots = [str(root) for root in self.secret_scan_roots if root.exists()]
+        missing_roots = [
+            root
+            for root in expected_roots
+            if root not in cleanup_roots and str(Path(root).resolve()) not in cleanup_roots
+        ]
+        report_ok = self.cleanup_report.get("schema") == "octos.m16.secret_cleanup.v1"
+        removed_config = bool(self.cleanup_report.get("removed_live_provider_config"))
+        scanned_files = int(self.cleanup_report.get("scanned_file_count") or 0)
+        no_leaks = not self.secret_leaks
+        ok = report_ok and removed_config and scanned_files > 0 and not missing_roots and no_leaks
+        self.add(
+            "full_tree_secret_cleanup_and_scan",
+            ok,
+            "cleanup removed live provider config and validator scanned evidence/runtime trees without provider-key leaks"
+            if ok
+            else (
+                "secret cleanup/scan incomplete: "
+                f"report_ok={report_ok} removed_config={removed_config} "
+                f"scanned_files={scanned_files} missing_roots={missing_roots or 'none'} "
+                f"leak_paths={self.secret_leaks or 'none'}"
+            ),
+            ["m16-secret-cleanup.json", "summary.env"],
         )
 
     def check_prompt(self) -> None:
@@ -383,6 +434,7 @@ class Validator:
     def run(self) -> dict[str, Any]:
         self.require_files()
         self.check_real_backend()
+        self.check_secret_cleanup_and_scan()
         self.check_prompt()
         self.check_protocol_orchestration()
         self.check_visible_traces()
@@ -396,6 +448,7 @@ class Validator:
             "jsonl_parse_warnings": {
                 "appui_transcript_invalid_lines": self.transcript_invalid,
             },
+            "secret_scan": self.secret_scan,
             "checks": self.checks,
             "failures": failures,
             "evidence": {name: str(self.out_dir / name) for name in (*CAPTURE_FILES, *EVIDENCE_FILES)},


### PR DESCRIPTION
## Summary
- persist raw tool-output sidecars and UI preview links for truncated ContextManager tool outputs
- report context-pressure tool-output truncation before dropping prompt groups
- harden M16 live tmux soak cleanup with full evidence/runtime secret scanning and injected-failure self-test

Closes #982.
Closes #1024.

## Tests
- cargo test -p octos-cli context_manager --features api
- e2e/scripts/m16-live-tui-tmux-soak.sh self-test
- cargo fmt --check -p octos-cli
- git diff --check