### PR TITLE
fix(appui): honor permission/profile/set runtime_mode override (#951)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -4833,12 +4833,22 @@ fn permission_selection_allowed(
     state: &AppState,
     selection: octos_core::ui_protocol::PermissionProfileSelection,
     approval_policy: Option<octos_agent::ApprovalPolicy>,
+    requested_runtime_mode: Option<&str>,
 ) -> bool {
     use octos_core::ui_protocol::{
         PermissionNetworkPolicy as Network, PermissionProfileMode as Mode,
     };
 
-    state.deployment_mode == crate::config::DeploymentMode::Local
+    let request_wants_tenant_or_cloud = matches!(
+        requested_runtime_mode
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("tenant") | Some("cloud")
+    );
+    let server_is_local = state.deployment_mode == crate::config::DeploymentMode::Local;
+    let effective_local = server_is_local && !request_wants_tenant_or_cloud;
+
+    effective_local
         || (selection.mode != Mode::DangerFullAccess
             && selection.network != Network::Allow
             && approval_policy != Some(octos_agent::ApprovalPolicy::Never))
@@ -4904,7 +4914,12 @@ fn permission_profile_set_result(
         parse_permission_approval_policy(params.update.approval_policy.as_deref())?
             .or(previous_state.approval_policy);
     let requested = params.update.apply_to(previous);
-    if !permission_selection_allowed(state, requested, approval_policy) {
+    if !permission_selection_allowed(
+        state,
+        requested,
+        approval_policy,
+        params.runtime_mode.as_deref(),
+    ) {
         return Err(permission_profile_disallowed_error(
             state,
             requested,
@@ -16068,12 +16083,13 @@ mod tests {
         let denied = permission_profile_set_result(
             &tenant,
             PermissionProfileSetParams {
-                session_id,
+                session_id: session_id.clone(),
                 update: PermissionProfileUpdate {
                     mode: Some(Mode::DangerFullAccess),
                     network: Some(Network::Allow),
                     approval_policy: Some("never".into()),
                 },
+                runtime_mode: None,
             },
         )
         .expect_err("danger rejected outside local");
@@ -16081,6 +16097,55 @@ mod tests {
         assert_eq!(
             denied.data.as_ref().and_then(|data| data.get("kind")),
             Some(&json!("permission_profile_disallowed"))
+        );
+
+        // Even when the server runs in Local mode, an explicit
+        // `runtime_mode: "tenant"` in the request must tighten the gate so
+        // dangerous mode is rejected. This is the M12 soak negative-probe
+        // contract (#951).
+        let tenant_request_denied = permission_profile_set_result(
+            &local,
+            PermissionProfileSetParams {
+                session_id: session_id.clone(),
+                update: PermissionProfileUpdate {
+                    mode: Some(Mode::DangerFullAccess),
+                    network: Some(Network::Allow),
+                    approval_policy: Some("never".into()),
+                },
+                runtime_mode: Some("tenant".into()),
+            },
+        )
+        .expect_err("tenant runtime_mode override rejects danger");
+        assert_eq!(
+            tenant_request_denied.code,
+            rpc_error_codes::PERMISSION_DENIED
+        );
+        assert_eq!(
+            tenant_request_denied
+                .data
+                .as_ref()
+                .and_then(|data| data.get("kind")),
+            Some(&json!("permission_profile_disallowed"))
+        );
+
+        // Reverse direction must not relax: server in Tenant + request
+        // `runtime_mode: "solo"` still rejects danger.
+        let solo_override_denied = permission_profile_set_result(
+            &tenant,
+            PermissionProfileSetParams {
+                session_id,
+                update: PermissionProfileUpdate {
+                    mode: Some(Mode::DangerFullAccess),
+                    network: Some(Network::Allow),
+                    approval_policy: Some("never".into()),
+                },
+                runtime_mode: Some("solo".into()),
+            },
+        )
+        .expect_err("solo override cannot relax tenant gate");
+        assert_eq!(
+            solo_override_denied.code,
+            rpc_error_codes::PERMISSION_DENIED
         );
     }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1684,6 +1684,12 @@ pub struct PermissionProfileListParams {
 pub struct PermissionProfileSetParams {
     pub session_id: SessionKey,
     pub update: PermissionProfileUpdate,
+    /// Optional runtime-mode override the client asserts for gating
+    /// (`"tenant"`, `"cloud"`, `"local"`, `"solo"`). When provided and
+    /// stricter than the server's deployment mode, the gate uses the
+    /// requested mode. The override can only TIGHTEN gating, never relax.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Adds optional `runtime_mode` to `PermissionProfileSetParams` (backwards-compatible via `#[serde(default)]`).
- The override can only TIGHTEN gating, never relax it: a Local server with `runtime_mode: "tenant"` in the request now rejects `danger_full_access`, while a Tenant server with `runtime_mode: "solo"` still rejects danger.
- Unblocks the M12 strict-soak negative probe which previously got `danger_full_access` applied instead of rejected when the probe ran against a locally-deployed server.

Closes #951.

## Test plan

- [x] `cargo test -p octos-cli --features api --lib permission_profile_handlers_are_server_owned_and_reject_danger_outside_local` — extended with two new override assertions (tighten + cannot-relax).
- [x] `cargo test -p octos-cli --features api --lib permission` — 9 tests green.
- [x] `cargo test -p octos-core --lib` — 211 tests green (covers the protocol struct field addition).
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)