### PR TITLE
fix(harness): recognize Working/Progress states + idle soft-wait (#854)

### DIFF
--- a/scripts/compare-tui-coding-ux-tmux.sh
+++ b/scripts/compare-tui-coding-ux-tmux.sh
@@ -481,9 +481,14 @@ tui_capture_has_ready_state() {
 }
 
 tui_capture_has_active_state() {
+  # Match the visible "active" footer / status vocabulary the current TUI
+  # emits. Includes the legacy `running|blocked` words as well as the new
+  # `Working|Progress|Streaming` footer states (#854 — deepseek-v4-pro
+  # live soak transcripts showed `state ◒ Working (...)` which the
+  # legacy regex missed and caused inline-diff detection to stall).
   local capture="$1"
   printf '%s\n' "$capture" | grep -E -q -- \
-    '>_ Octos TUI[[:space:]]+.*Thinking|state[[:space:]]+[^[:space:]]+[[:space:]]+(running|blocked)|status[[:space:]]+(Turn started|Tool started|Approval requested|Approval denied|Thinking)|model[[:space:]]+Waiting for model|Approval Requested|live assistant'
+    '>_ Octos TUI[[:space:]]+.*Thinking|state[[:space:]]+[^[:space:]]+[[:space:]]+(running|blocked|Working|Progress|Streaming)|status[[:space:]]+(Turn started|Tool started|Approval requested|Approval denied|Thinking|Working|Progress)|model[[:space:]]+Waiting for model|Approval Requested|live assistant'
 }
 
 tui_capture_has_blocking_approval() {
@@ -646,6 +651,34 @@ wait_for_regex_soft() {
     capture="$(printf '%s\n' "$capture" | strip_prompt_echoes)"
     if printf '%s\n' "$capture" | grep -E -q -- "$regex"; then
       return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+# Soft wait that also exits early if the TUI returns to a ready/idle
+# state while the requested regex remains absent. #854 — without the
+# fast-exit branch, soak runs spend the full MAX_WAIT_TURN budget when
+# the model lands back at Done/Idle without producing the expected
+# soft signal, slowing CI and masking detector drift as timeouts.
+wait_for_tui_regex_or_idle() {
+  local session="$1"
+  local regex="$2"
+  local timeout="$3"
+  local deadline=$((SECONDS + timeout))
+  local capture
+
+  while [ "$SECONDS" -le "$deadline" ]; do
+    capture="$(capture_visible_clean "$session" || true)"
+    capture="$(printf '%s\n' "$capture" | strip_prompt_echoes)"
+    if printf '%s\n' "$capture" | grep -E -q -- "$regex"; then
+      return 0
+    fi
+    if tui_capture_has_ready_state "$capture" \
+      && ! tui_capture_has_active_state "$capture" \
+      && ! tui_capture_has_blocking_approval "$capture"; then
+      return 1
     fi
     sleep 0.5
   done
@@ -1124,7 +1157,7 @@ EOF
   if ! send_tui_prompt "$tui_session" "$PROMPT_QUESTION" "question turn"; then
     append_capture_clean_to_file "$tui_session" "$transcript" "octos-tui question submit failure"
   fi
-  if wait_for_regex_soft "$tui_session" "$QUESTION_REGEX" "$MAX_WAIT_TURN"; then
+  if wait_for_tui_regex_or_idle "$tui_session" "$QUESTION_REGEX" "$MAX_WAIT_TURN"; then
     question_seen=1
   fi
   wait_for_tui_turn_cycle "$tui_session" 240 || wait_for_tui_first_turn_complete "$tui_session" 60 || true
@@ -1842,4 +1875,9 @@ main() {
   fi
 }
 
-main "$@"
+# Only run the soak when this script is invoked directly. Sourcing
+# (e.g. from scripts/tests/test-compare-tui-coding-ux-detectors.sh) is
+# expected to load helpers without running the long-running flow.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/scripts/tests/test-compare-tui-coding-ux-detectors.sh
+++ b/scripts/tests/test-compare-tui-coding-ux-detectors.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# test-compare-tui-coding-ux-detectors.sh — Deterministic detector
+# regression tests for scripts/compare-tui-coding-ux-tmux.sh.
+#
+# Pins the active/ready-state vocabulary the harness must recognize so
+# detector drift (#854 — deepseek-v4-pro-live transcripts showed
+# `state ◒ Working (...)` which the legacy `running|blocked` regex
+# missed) does not slip back in unnoticed.
+#
+# Runs entirely offline. No tmux, no octos-tui process. The script is
+# sourced so the detector helpers are loaded as bash functions; the
+# soak `main` invocation is guarded by `BASH_SOURCE` so sourcing does
+# not start the long-running flow.
+
+set -eEuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET="$ROOT_DIR/scripts/compare-tui-coding-ux-tmux.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  OK:   $*"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $*" >&2
+  FAIL=$((FAIL + 1))
+}
+
+assert_active() {
+  local label="$1"
+  local capture="$2"
+  if tui_capture_has_active_state "$capture"; then
+    pass "$label"
+  else
+    fail "$label — capture not recognized as active"
+  fi
+}
+
+assert_not_active() {
+  local label="$1"
+  local capture="$2"
+  if tui_capture_has_active_state "$capture"; then
+    fail "$label — capture wrongly recognized as active"
+  else
+    pass "$label"
+  fi
+}
+
+assert_ready() {
+  local label="$1"
+  local capture="$2"
+  if tui_capture_has_ready_state "$capture"; then
+    pass "$label"
+  else
+    fail "$label — capture not recognized as ready"
+  fi
+}
+
+echo "==> compare-tui-coding-ux-tmux.sh detector tests"
+echo "  target: $TARGET"
+
+# Source the script. The `main` invocation is guarded by BASH_SOURCE so
+# only helpers are loaded.
+# shellcheck source=/dev/null
+source "$TARGET"
+
+# #854: deepseek-v4-pro-live footer vocabulary.
+assert_active "Working state (deepseek-v4-pro-live transcript)" "$(cat <<'EOF'
+some pane content
+state ◒ Working (foo bar)
+> _ Octos TUI
+EOF
+)"
+
+assert_active "Progress state" "$(cat <<'EOF'
+state ◐ Progress (compiling)
+EOF
+)"
+
+assert_active "Streaming state" "$(cat <<'EOF'
+state ◑ Streaming (responding)
+EOF
+)"
+
+# Legacy active states must still match so the regression is one-way.
+assert_active "running state (legacy)" "$(cat <<'EOF'
+state ◒ running (foo)
+EOF
+)"
+
+assert_active "blocked state (legacy)" "$(cat <<'EOF'
+state ◒ blocked (approval)
+EOF
+)"
+
+assert_active "Approval Requested banner" "$(cat <<'EOF'
+Approval Requested: please confirm
+EOF
+)"
+
+# Idle/done snapshots must NOT be considered active.
+assert_not_active "done state" "$(cat <<'EOF'
+state ◒ done (turn completed)
+>_ Octos TUI  idle
+EOF
+)"
+
+assert_not_active "idle composer" "$(cat <<'EOF'
+>_ Octos TUI  idle
+Ask Octos to change code
+EOF
+)"
+
+# Ready-state detector recognizes the same idle/done capture.
+assert_ready "ready-state idle composer" "$(cat <<'EOF'
+>_ Octos TUI  idle
+Ask Octos to change code
+EOF
+)"
+
+assert_ready "ready-state done footer" "$(cat <<'EOF'
+state ◒ done (turn completed)
+Composer
+EOF
+)"
+
+echo
+echo "==> Detector test summary: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Extends `tui_capture_has_active_state` to recognize the current TUI footer vocabulary (`Working`, `Progress`, `Streaming`) so inline-diff detection no longer stalls on `state ◒ Working (...)`.
- Adds `wait_for_tui_regex_or_idle` that exits fast when the TUI returns to a ready/idle state without producing the requested soft regex — replaces the question-soft-wait call so a clean Done/Idle does not burn the full `MAX_WAIT_TURN` budget.
- Guards `main "$@"` with `BASH_SOURCE` so detector tests can source the script.
- Adds deterministic detector tests under `scripts/tests/` covering the deepseek-v4-pro-live transcript snippets (10 assertions).

Closes #854.

## Test plan

- [x] `bash scripts/tests/test-compare-tui-coding-ux-detectors.sh` — 10 assertions pass.
- [x] `bash -n scripts/compare-tui-coding-ux-tmux.sh` — syntax clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)