### PR TITLE
fix(silent-failure): chat prompt run_pipeline rejection rule + surface max-iterations context

### DIFF
--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -12,7 +12,17 @@ use crate::progress::ProgressEvent;
 /// Reason why the agent loop stopped due to budget constraints.
 pub(super) enum BudgetStop {
     Shutdown,
-    MaxIterations,
+    /// The agent reached its per-turn iteration limit (`max_iterations`).
+    ///
+    /// We carry the limit so the user-facing message can name the exact
+    /// number of iterations that elapsed and the user (or downstream
+    /// tool) can recognise this as the iteration-cap path rather than
+    /// the bare "Reached max iterations." stub that pre-2026-05 builds
+    /// emitted. See the silent-failure bug where a missing `run_pipeline`
+    /// pipeline rejection cascaded into ~20 rounds of manual `web_fetch`
+    /// until the loop hit `max_iterations` and persisted only "Reached
+    /// max iterations." as the assistant reply.
+    MaxIterations { limit: u32 },
     MaxTokens { used: u32, limit: u32 },
     ActivityTimeout { limit: Duration },
     IdleProgressTimeout { limit: Duration },
@@ -22,7 +32,25 @@ impl BudgetStop {
     pub(super) fn message(&self) -> String {
         match self {
             Self::Shutdown => String::new(),
-            Self::MaxIterations => "Reached max iterations.".into(),
+            Self::MaxIterations { limit } => {
+                // Surface the iteration count and a concrete hint about
+                // what the user can do next. The previous bare "Reached
+                // max iterations." string left users with no signal
+                // about what the agent was trying to do, whether any
+                // partial work landed, or how to retry. The hint about
+                // `run_pipeline` is intentional — the common path into
+                // this stop is a manual `web_fetch` / `web_search` loop
+                // that should have been a single `run_pipeline` call.
+                format!(
+                    "The agent did not complete within {limit} iterations. \
+                     The task may be too broad for a single turn — try \
+                     breaking it into smaller steps, or, if this was a \
+                     research/multi-step task, ask the agent to use \
+                     `run_pipeline` (deep research) which delegates the \
+                     work to specialised sub-agents instead of iterating \
+                     one tool call at a time."
+                )
+            }
             Self::MaxTokens { used, limit } => {
                 format!("Token budget exceeded ({used} of {limit}).")
             }
@@ -54,7 +82,9 @@ impl Agent {
             return Some(BudgetStop::Shutdown);
         }
         if iteration >= self.config.max_iterations {
-            return Some(BudgetStop::MaxIterations);
+            return Some(BudgetStop::MaxIterations {
+                limit: self.config.max_iterations,
+            });
         }
         let idle_timeout = Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS);
         if activity.has_timed_out(idle_timeout) {
@@ -88,15 +118,10 @@ impl Agent {
                     iterations: iteration,
                 });
             }
-            BudgetStop::MaxIterations => {
-                warn!(
-                    iteration,
-                    max = self.config.max_iterations,
-                    "hit max iterations limit"
-                );
-                self.reporter().report(ProgressEvent::MaxIterationsReached {
-                    limit: self.config.max_iterations,
-                });
+            BudgetStop::MaxIterations { limit } => {
+                warn!(iteration, max = *limit, "hit max iterations limit");
+                self.reporter()
+                    .report(ProgressEvent::MaxIterationsReached { limit: *limit });
             }
             BudgetStop::MaxTokens { used, limit } => {
                 warn!(used, max = limit, "hit token budget limit");
@@ -178,10 +203,44 @@ mod tests {
     }
 
     #[test]
-    fn budget_stop_max_iterations_message() {
-        assert_eq!(
-            BudgetStop::MaxIterations.message(),
-            "Reached max iterations."
+    fn budget_stop_max_iterations_message_surfaces_iteration_count_and_hint() {
+        // Regression: prior to 2026-05 the bare "Reached max iterations."
+        // string was persisted as the assistant reply when the loop hit
+        // its iteration cap. That gave the user no signal about what the
+        // agent was attempting, no way to recognise the iteration-cap
+        // path, and no actionable next step. The fixture below pins the
+        // new message contract: (1) the iteration count is named so the
+        // user can tell whether the cap was 5 or 500, and (2) a hint
+        // about `run_pipeline` is included because the common path into
+        // this stop is an LLM that should have called `run_pipeline`
+        // once, didn't, and burned its iteration budget on manual
+        // `web_fetch` / `web_search` instead.
+        let msg = BudgetStop::MaxIterations { limit: 50 }.message();
+        assert!(
+            msg.contains("50"),
+            "expected iteration count '50' in: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("iteration"),
+            "expected the word 'iteration' in: {msg}"
+        );
+        assert!(
+            msg.contains("run_pipeline"),
+            "expected a hint about 'run_pipeline' (the canonical \
+             multi-step research path) in: {msg}"
+        );
+    }
+
+    #[test]
+    fn budget_stop_max_iterations_message_uses_actual_limit() {
+        // Different iteration caps should surface different numbers.
+        let msg = BudgetStop::MaxIterations { limit: 3 }.message();
+        assert!(msg.contains("3"), "expected '3' in: {msg}");
+        // Sanity: the 50 from the other test must NOT appear when the
+        // limit is 3 — guards against a hardcoded constant slipping in.
+        assert!(
+            !msg.contains("50 iterations") && !msg.contains("50 itr"),
+            "limit must not be hardcoded; got: {msg}"
         );
     }
 

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -494,7 +494,7 @@ impl Agent {
     ) -> bool {
         if !matches!(
             stop,
-            BudgetStop::MaxIterations | BudgetStop::MaxTokens { .. }
+            BudgetStop::MaxIterations { .. } | BudgetStop::MaxTokens { .. }
         ) {
             return false;
         }

--- a/crates/octos-agent/src/agent/turn_state.rs
+++ b/crates/octos-agent/src/agent/turn_state.rs
@@ -21,7 +21,7 @@ impl From<&BudgetStop> for LoopBudgetStopKind {
     fn from(value: &BudgetStop) -> Self {
         match value {
             BudgetStop::Shutdown => Self::Shutdown,
-            BudgetStop::MaxIterations => Self::MaxIterations,
+            BudgetStop::MaxIterations { .. } => Self::MaxIterations,
             BudgetStop::MaxTokens { .. } => Self::MaxTokens,
             BudgetStop::ActivityTimeout { .. } => Self::ActivityTimeout,
             BudgetStop::IdleProgressTimeout { .. } => Self::IdleProgressTimeout,

--- a/crates/octos-agent/tests/integration.rs
+++ b/crates/octos-agent/tests/integration.rs
@@ -177,7 +177,25 @@ async fn test_agent_max_iterations() {
         .process_message("loop forever", &[], vec![])
         .await
         .unwrap();
-    assert_eq!(resp.content, "Reached max iterations.");
+    // Regression: the bare "Reached max iterations." stub was replaced
+    // with an actionable message that names the iteration count and
+    // hints at `run_pipeline` as the canonical multi-step research path.
+    // See `crates/octos-agent/src/agent/budget.rs::BudgetStop::message`.
+    assert!(
+        resp.content.contains('3'),
+        "expected the configured iteration cap '3' in: {}",
+        resp.content
+    );
+    assert!(
+        resp.content.to_lowercase().contains("iteration"),
+        "expected 'iteration' in: {}",
+        resp.content
+    );
+    assert!(
+        resp.content.contains("run_pipeline"),
+        "expected a hint about 'run_pipeline' in: {}",
+        resp.content
+    );
 }
 
 #[tokio::test]

--- a/crates/octos-cli/src/prompts/gateway_default.txt
+++ b/crates/octos-cli/src/prompts/gateway_default.txt
@@ -33,6 +33,13 @@ In interactive chat channels, deep research is usually too slow for the foregrou
 
 For simpler single-angle searches, use `search` + `synthesize_research` manually.
 
+**run_pipeline failure discipline.** If `run_pipeline` returns a `[VALIDATION FAILED]` tool result (e.g. "pipeline 'X' not found", DOT parse error, validation error), you MUST:
+
+- Report the exact pipeline name and the validation error verbatim to the user, in their language.
+- STOP. Do not improvise a manual research workflow by activating `web_fetch` / `web_search` / `browser` and iterating round-by-round — that is a worse, more iterative version of the same work and will burn iterations until the loop hits its limit, leaving the user with no deliverable.
+- If the user originally asked for "深度研究" / "deep research" / equivalent, the canonical path is `run_pipeline`. When it fails, ask the user whether they want (a) a quick `web_search` fallback (acknowledging it will be shallower than deep research), or (b) to wait while the pipeline is fixed. Do NOT silently fall back.
+- Only retry `run_pipeline` if you can fix the input (e.g. switch from a pipeline name to a custom inline DOT digraph). Do not retry with the same arguments.
+
 ## Grounding Rules
 
 For weather queries, use the `get_weather` tool. For time/timezone queries, use the `get_time` tool. For questions about what models or providers you have, use `model_check` with action="list" — NEVER guess model names from training data. For other real-time data (stock prices, sports scores, exchange rates, news, current events, flight status, package tracking), use `web_search` or `web_fetch`. NEVER fabricate or guess real-time information — if you cannot fetch it, say so.


### PR DESCRIPTION
## Problem

User session at https://dspfac.octos.ominix.io/chat with prompt "深度研究James webb 天文望远镜的主要发现" failed silently:

1. LLM correctly called `run_pipeline(pipeline_name: "deep_research")`
2. Server rejected: `[VALIDATION FAILED] Tool 'run_pipeline' rejected input: failed to resolve pipeline DOT: pipeline 'deep_research' not found. Available: youtube, architecture, build_site, publish`
3. LLM improvised: `activate_tools(["browser", "web_fetch", "web_search"])`, then ran ~20 rounds of manual `web_fetch` / `web_search`
4. Agent hit `max_iterations` (50) and persisted **only** the literal string `"Reached max iterations."` as the assistant message
5. No partial report, no `_report.md` delivered, no signal to the user about what went wrong

The pipeline registration gap itself is being fixed separately (deploying the missing `deep_research.dot` to the fleet). These two patches are defense-in-depth so the runtime is resilient when that fix-forward isn't yet in place.

## Summary

**Fix 1 — chat default prompt (`crates/octos-cli/src/prompts/gateway_default.txt`):** adds a "run_pipeline failure discipline" rule. When `run_pipeline` returns `[VALIDATION FAILED]`, the LLM MUST report the error verbatim, STOP (no fallback through `activate_tools` to load `browser`/`web_fetch`/`web_search`), and ask the user whether they want a shallower `web_search` fallback or to wait. Rationale: a manual N-round web_fetch loop is strictly worse than the canonical `run_pipeline` path and will burn through the iteration budget without producing a deliverable.

This prompt is shared by `octos serve` web sessions via `ProfileRuntime::build_system_prompt` (see `crates/octos-cli/src/runtime/profile.rs:789`), so the rule applies to the dspfac chat path that triggered this report.

**Fix 2 — max_iterations failure path (`crates/octos-agent/src/agent/budget.rs`):** the bare string `"Reached max iterations."` was the literal assistant content persisted when the loop hit its iteration cap. It carried no signal about iteration count, what was attempted, or how to retry. Now:

- `BudgetStop::MaxIterations` carries the `limit: u32` (was a unit variant)
- The user-facing message names the iteration count and hints at `run_pipeline` as the canonical multi-step path
- `LoopBudgetStopKind::From`, `report_budget_stop`, and `try_budget_grace_call` destructure the new payload (touches `turn_state.rs`, `loop_runner.rs:497`)

## Test Plan

- [x] `cargo test -p octos-agent --lib budget` — 26 passed (includes two new regression tests pinning the three message invariants: iteration count named, the word "iteration" appears, `run_pipeline` hint present)
- [x] `cargo test -p octos-agent --test integration` — 5 passed (`test_agent_max_iterations` updated to assert the new message contract instead of the bare string)
- [x] `cargo check --workspace` — clean

## Out of scope

- Deploying `deep_research.dot` to the fleet (handled separately by the pipeline-registration fix)
- Recording attempted-tool history for the max-iterations message (no existing tracker on `Agent` to plumb through; iteration count + hint covers the actionable surface)