### PR TITLE
feat(appui): add task/artifact/* aliases for agent/artifact/* (#965)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -5845,6 +5845,8 @@ fn is_autonomy_method(method: &str) -> bool {
             | octos_core::ui_protocol::methods::AGENT_OUTPUT_READ
             | octos_core::ui_protocol::methods::AGENT_ARTIFACT_LIST
             | octos_core::ui_protocol::methods::AGENT_ARTIFACT_READ
+            | octos_core::ui_protocol::methods::TASK_ARTIFACT_LIST
+            | octos_core::ui_protocol::methods::TASK_ARTIFACT_READ
             | octos_core::ui_protocol::methods::AGENT_INTERRUPT
             | octos_core::ui_protocol::methods::AGENT_CLOSE
             | octos_core::ui_protocol::methods::SESSION_GOAL_GET
@@ -5866,6 +5868,8 @@ fn autonomy_method_available(method: &str, features: ConnectionUiFeatures) -> bo
         | octos_core::ui_protocol::methods::AGENT_OUTPUT_READ
         | octos_core::ui_protocol::methods::AGENT_ARTIFACT_LIST
         | octos_core::ui_protocol::methods::AGENT_ARTIFACT_READ
+        | octos_core::ui_protocol::methods::TASK_ARTIFACT_LIST
+        | octos_core::ui_protocol::methods::TASK_ARTIFACT_READ
         | octos_core::ui_protocol::methods::AGENT_INTERRUPT
         | octos_core::ui_protocol::methods::AGENT_CLOSE => features.agent_control_available(),
         octos_core::ui_protocol::methods::SESSION_GOAL_GET
@@ -5985,7 +5989,7 @@ fn raw_autonomy_rpc_with_orchestrator(
                 limit: params.limit,
             })
         }
-        methods::AGENT_ARTIFACT_LIST => {
+        methods::AGENT_ARTIFACT_LIST | methods::TASK_ARTIFACT_LIST => {
             let params: RawAgentParams = parse_raw_params(request)?;
             let profile_id = resolve_autonomy_profile_id(
                 params.session_id.as_ref(),
@@ -5998,7 +6002,7 @@ fn raw_autonomy_rpc_with_orchestrator(
                 profile_id,
             })
         }
-        methods::AGENT_ARTIFACT_READ => {
+        methods::AGENT_ARTIFACT_READ | methods::TASK_ARTIFACT_READ => {
             let params: RawAgentArtifactReadParams = parse_raw_params(request)?;
             let profile_id = resolve_autonomy_profile_id(
                 params.session_id.as_ref(),
@@ -15459,6 +15463,8 @@ mod tests {
             | methods::AGENT_OUTPUT_READ
             | methods::AGENT_ARTIFACT_LIST
             | methods::AGENT_ARTIFACT_READ
+            | methods::TASK_ARTIFACT_LIST
+            | methods::TASK_ARTIFACT_READ
             | methods::AGENT_INTERRUPT
             | methods::AGENT_CLOSE
             | methods::SESSION_GOAL_GET
@@ -19985,6 +19991,20 @@ mod tests {
                 methods::AGENT_ARTIFACT_READ,
                 json!({ "agent_id": "agent-1", "artifact_id": "artifact-1", "session_id": session_id.clone() }),
                 "read_agent_artifact:agent-1",
+            ),
+            // #965 — task/artifact/* must route through the same
+            // orchestrator handlers as agent/artifact/* so the M13
+            // contract direction (task/* canonical names) works
+            // alongside the legacy agent/* aliases.
+            (
+                methods::TASK_ARTIFACT_LIST,
+                json!({ "agent_id": "agent-2", "session_id": session_id.clone() }),
+                "list_agent_artifacts:agent-2",
+            ),
+            (
+                methods::TASK_ARTIFACT_READ,
+                json!({ "agent_id": "agent-2", "artifact_id": "artifact-2", "session_id": session_id.clone() }),
+                "read_agent_artifact:agent-2",
             ),
             (
                 methods::AGENT_INTERRUPT,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -174,6 +174,8 @@ fn method_capability_gate(method: &str) -> Option<&'static str> {
         | methods::AGENT_OUTPUT_READ
         | methods::AGENT_ARTIFACT_LIST
         | methods::AGENT_ARTIFACT_READ
+        | methods::TASK_ARTIFACT_LIST
+        | methods::TASK_ARTIFACT_READ
         | methods::AGENT_INTERRUPT
         | methods::AGENT_CLOSE => Some(UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1),
         methods::SESSION_GOAL_GET | methods::SESSION_GOAL_SET | methods::SESSION_GOAL_CLEAR => {
@@ -793,6 +795,12 @@ pub mod methods {
     pub const AGENT_OUTPUT_READ: &str = "agent/output/read";
     pub const AGENT_ARTIFACT_LIST: &str = "agent/artifact/list";
     pub const AGENT_ARTIFACT_READ: &str = "agent/artifact/read";
+    /// #965 / UPCR-2026-019 — spec-canonical names for the same payloads
+    /// served by `agent/artifact/*`. Servers dispatch both into the same
+    /// handlers; clients can use either name (the `task/*` form is the
+    /// long-term direction per the M13 contract).
+    pub const TASK_ARTIFACT_LIST: &str = "task/artifact/list";
+    pub const TASK_ARTIFACT_READ: &str = "task/artifact/read";
     pub const AGENT_INTERRUPT: &str = "agent/interrupt";
     pub const AGENT_CLOSE: &str = "agent/close";
 
@@ -961,6 +969,8 @@ pub const UI_PROTOCOL_COMMAND_METHODS: &[&str] = &[
     methods::AGENT_OUTPUT_READ,
     methods::AGENT_ARTIFACT_LIST,
     methods::AGENT_ARTIFACT_READ,
+    methods::TASK_ARTIFACT_LIST,
+    methods::TASK_ARTIFACT_READ,
     methods::AGENT_INTERRUPT,
     methods::AGENT_CLOSE,
     methods::SESSION_GOAL_GET,
@@ -1050,6 +1060,8 @@ pub const UI_PROTOCOL_FIRST_SERVER_METHODS: &[&str] = &[
     methods::AGENT_OUTPUT_READ,
     methods::AGENT_ARTIFACT_LIST,
     methods::AGENT_ARTIFACT_READ,
+    methods::TASK_ARTIFACT_LIST,
+    methods::TASK_ARTIFACT_READ,
     methods::AGENT_INTERRUPT,
     methods::AGENT_CLOSE,
     methods::SESSION_GOAL_GET,
@@ -5232,6 +5244,8 @@ mod tests {
                 "agent/output/read",
                 "agent/artifact/list",
                 "agent/artifact/read",
+                "task/artifact/list",
+                "task/artifact/read",
                 "agent/interrupt",
                 "agent/close",
                 "session/goal/get",
@@ -5323,6 +5337,8 @@ mod tests {
                 "agent/output/read",
                 "agent/artifact/list",
                 "agent/artifact/read",
+                "task/artifact/list",
+                "task/artifact/read",
                 "agent/interrupt",
                 "agent/close",
                 "session/goal/get",
@@ -5393,6 +5409,8 @@ mod tests {
                     "agent/output/read",
                     "agent/artifact/list",
                     "agent/artifact/read",
+                    "task/artifact/list",
+                    "task/artifact/read",
                     "agent/interrupt",
                     "agent/close",
                     "session/goal/get",


### PR DESCRIPTION
## Summary

UPCR-2026-019 names the artifact-projection methods \`task/artifact/list\` and \`task/artifact/read\`, but the existing M13 implementation only registered them under the legacy \`agent/artifact/*\` aliases. The previous M13 triage flagged this as the remaining contract direction blocker.

This PR adds the spec-canonical names as method constants and dispatches them through the exact same orchestrator handlers, so clients can use either name and the long-term \`task/*\` direction works end-to-end. \`agent/artifact/*\` stays in place so existing callers don't break.

## Changes

- \`TASK_ARTIFACT_LIST\` / \`TASK_ARTIFACT_READ\` declared in \`octos_core::ui_protocol::methods\`.
- Dispatch matches both \`AGENT_ARTIFACT_*\` and \`TASK_ARTIFACT_*\` to the same orchestrator entry points (\`list_agent_artifacts\`, \`read_agent_artifact\`).
- \`is_autonomy_method\`, \`autonomy_method_available\`, the negotiated-feature router, the AppUI supported-methods advertisement, and the test-fixture method dispatch all include the new names.
- Both names gate on the same \`coding.agent_control.v1\` feature so capability negotiation stays consistent.

## Test plan

- [x] \`cargo test -p octos-cli --features api --lib m15_raw_autonomy_rpc_dispatches_every_method_to_orchestrator\` — extended with two new cases proving \`task/artifact/list\` and \`task/artifact/read\` route to the same orchestrator handlers as the agent aliases.
- [x] \`cargo test -p octos-core --lib\` — golden wire-payload test updated to include the new method names; 211 tests green.
- [x] \`cargo fmt --all -- --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)