### PR TITLE
test(m12-probe): assert M14 coding tool contract reaches ready (#969)

### DIFF
--- a/scripts/m12-solo-appui-probe.mjs
+++ b/scripts/m12-solo-appui-probe.mjs
@@ -631,6 +631,18 @@ class FixtureTransport {
             { name: "shell", enabled: true, approval_policy: this.permission.approval_policy },
             { name: "filesystem", enabled: true, scope: this.permission.mode },
           ],
+          // #969 — the fixture transport must also include a minimal
+          // `coding_tool_contract` so the probe's `coding-tool-contract-
+          // ready` assertion stays satisfied in self-test mode. The
+          // real backend builds this in `coding_tool_contract_payload`.
+          coding_tool_contract: {
+            id: "codex-compatible-coding-v1",
+            version: "1",
+            feature: "coding.tool_contract.v1",
+            status: "ready",
+            missing_required_tools: [],
+            deferred_model_tools: [],
+          },
         };
       case "turn/start":
         return { accepted: true };
@@ -968,6 +980,48 @@ async function main() {
       policy_id: tools.result?.policy_id,
       tool_count: Array.isArray(tools.result?.tools) ? tools.result.tools.length : undefined,
     }));
+
+    // #969 / M14-E — the M14 coding tool contract must reach `ready`
+    // status with no `missing_required_tools` on live runs, otherwise
+    // P0 tool parity has regressed (either a tool was de-registered or
+    // the deferred-aware resolver introduced in #1092 stopped seeing
+    // the deferred set). Pin the property as a strict-soak invariant.
+    const contract = tools.result?.coding_tool_contract;
+    if (contract) {
+      const contractStatus = contract.status;
+      const missing = Array.isArray(contract.missing_required_tools)
+        ? contract.missing_required_tools
+        : [];
+      if (contractStatus === "ready" && missing.length === 0) {
+        summary.cases.push(caseRecord("coding-tool-contract-ready", "ok", {
+          contract_status: contractStatus,
+          missing_required_tools: missing,
+          deferred_model_tools: Array.isArray(contract.deferred_model_tools)
+            ? contract.deferred_model_tools
+            : undefined,
+        }));
+      } else {
+        summary.failures.push({
+          area: "M14-E",
+          reason:
+            "coding_tool_contract reports incomplete P0 coverage — either a required tool was de-registered or the deferred-aware path regressed",
+          contract_status: contractStatus,
+          missing_required_tools: missing,
+        });
+        summary.cases.push(caseRecord("coding-tool-contract-ready", "failed", {
+          contract_status: contractStatus,
+          missing_required_tools: missing,
+        }));
+      }
+    } else {
+      summary.blockers.push({
+        area: "M14-E",
+        reason: "tool/status/list response is missing coding_tool_contract — M14 contract not advertised",
+      });
+      summary.cases.push(caseRecord("coding-tool-contract-ready", "blocked", {
+        reason: "no coding_tool_contract field on tool/status/list result",
+      }));
+    }
   } else {
     latestToolRegistry = {
       unavailable: true,


### PR DESCRIPTION
## Summary

After #1092 (#970) the live M12 soak's \`tool-registry-snapshot.json\` shows the M14 coding tool contract at \`status: ready\` with empty \`missing_required_tools\`. But the M12 probe doesn't yet *assert* this — a future regression that re-introduces missing P0 entries would only surface as a buried snapshot field, not as a strict-soak failure.

Add a typed \`coding-tool-contract-ready\` case to the probe that fails the run when:
- \`tool/status/list\` returns no \`coding_tool_contract\` field at all (M14 contract not advertised).
- \`coding_tool_contract.status\` is anything other than \`"ready"\`.
- \`coding_tool_contract.missing_required_tools\` is non-empty.

The fixture transport's \`tool/status/list\` stub also emits a minimal \`coding_tool_contract\` so the offline self-test continues to pass.

## Test plan

- [x] \`bash scripts/m12-solo-appui-soak.sh self-test\` — passes.
- [x] Live strict WS soak — new case \`coding-tool-contract-ready\` recorded with \`contract_status: ready\`, \`missing_required_tools: []\`, and the 12 currently-deferred tool names.
- [x] Live strict stdio soak — same.

## Notes

This is a guard test, not a feature. The actual P0 tool invocation evidence (\`apply_patch\` / \`exec_command\` / \`update_plan\` / \`request_user_input\` running real commands) is the broader M14-E (#969) scope and not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)