### PR TITLE
test(m12-probe): emit workspace-contract-status.json evidence (partial #906)

### DIFF
--- a/scripts/m12-solo-appui-probe.mjs
+++ b/scripts/m12-solo-appui-probe.mjs
@@ -286,6 +286,11 @@ class Recorder {
       runtimePolicy: path.join(options.outDir, "runtime-policy-stamp.json"),
       toolRegistry: path.join(options.outDir, "tool-registry-snapshot.json"),
       filesystemProbe: path.join(options.outDir, "filesystem-probe.json"),
+      // #906 — broader M12 evidence bundle. The workspace contract
+      // status is fetched via session/workspace.get and written here
+      // so soak runs without a live TUI can still prove the
+      // workspace-contract surface is reachable.
+      workspaceContract: path.join(options.outDir, "workspace-contract-status.json"),
       summary: path.join(options.outDir, "soak-summary.json"),
     };
     this.sentMethods = [];
@@ -646,6 +651,11 @@ class FixtureTransport {
         };
       case "turn/start":
         return { accepted: true };
+      // #906 — fixture transport stub so the workspace-contract probe
+      // doesn't fall over in self-test. Solo runs without tracked
+      // workspace repos return an empty contracts list.
+      case "session/workspace.get":
+        return { session_id: params.session_id, contracts: [] };
       default:
         throw new RpcError({
           code: -32601,
@@ -1108,6 +1118,53 @@ async function main() {
     snapshot: latestToolRegistry,
   });
   writeJson(recorder.paths.filesystemProbe, filesystemProbe);
+
+  // #906 — probe the workspace-contract surface and write the result
+  // to workspace-contract-status.json. Local solo runs may have no
+  // tracked repos under the workspace; the artifact still records the
+  // (possibly empty) response shape so downstream evidence consumers
+  // can rely on the file being present.
+  let workspaceContract = null;
+  const workspaceProbe = await callRpc({
+    transport,
+    recorder,
+    method: "session/workspace.get",
+    params: { session_id: options.sessionId, profile_id: options.profileId },
+    caseName: "workspace-contract-snapshot",
+  });
+  if (workspaceProbe.ok) {
+    workspaceContract = workspaceProbe.result;
+    const contracts = Array.isArray(workspaceProbe.result?.contracts)
+      ? workspaceProbe.result.contracts
+      : [];
+    summary.cases.push(caseRecord("workspace-contract-snapshot", "ok", {
+      contract_count: contracts.length,
+    }));
+  } else if (isUnsupported(workspaceProbe.error)) {
+    workspaceContract = { unavailable: true, reason: "method_not_supported" };
+    summary.cases.push(caseRecord("workspace-contract-snapshot", "blocked", {
+      reason: "session/workspace.get not negotiated",
+      error: workspaceProbe.rpcError,
+    }));
+    summary.blockers.push({
+      area: "M12-evidence",
+      reason: "session/workspace.get unavailable on this transport",
+      error: workspaceProbe.rpcError,
+    });
+  } else {
+    workspaceContract = { unavailable: true, error: workspaceProbe.rpcError };
+    summary.cases.push(caseRecord("workspace-contract-snapshot", "failed", {
+      error: workspaceProbe.rpcError,
+    }));
+  }
+  writeJson(recorder.paths.workspaceContract, {
+    schema: "octos-m12-workspace-contract-status-v1",
+    captured_at: nowIso(),
+    transport: options.transport,
+    session_id: options.sessionId,
+    profile_id: options.profileId,
+    response: workspaceContract,
+  });
 
   summary.finished_at = nowIso();
   summary.status = summary.failures.length > 0

--- a/scripts/m12-solo-appui-soak.sh
+++ b/scripts/m12-solo-appui-soak.sh
@@ -242,6 +242,7 @@ self_test() {
   [ -f "$out_dir/tool-registry-snapshot.json" ] || die "self-test missing tool-registry-snapshot.json"
   [ -f "$out_dir/approval-events.jsonl" ] || die "self-test missing approval-events.jsonl"
   [ -f "$out_dir/filesystem-probe.json" ] || die "self-test missing filesystem-probe.json"
+  [ -f "$out_dir/workspace-contract-status.json" ] || die "self-test missing workspace-contract-status.json"
   if grep -E 'auth/(send_code|verify)' "$out_dir/appui-transcript.jsonl" >/dev/null 2>&1; then
     die "self-test transcript contains OTP method traffic"
   fi


### PR DESCRIPTION
## Summary

#906 lists \`workspace-contract-status.json\` among the M12 evidence-bundle artifacts but the strict M12 soak doesn't emit it. Add a \`workspace-contract-snapshot\` probe step that calls \`session/workspace.get\` and writes the result to a new artifact file, so downstream evidence consumers (validators, milestone dashboards) can rely on the file's presence even when no repos are tracked under the workspace.

## Changes

- New probe case \`workspace-contract-snapshot\` invokes \`session/workspace.get\` via the existing \`auxiliary.rest_to_ws.v1\` bridge. Records \`ok\`/\`blocked\`/\`failed\` depending on response shape.
- New artifact \`workspace-contract-status.json\` written under each transport's artifact dir with a schema tag (\`octos-m12-workspace-contract-status-v1\`).
- Fixture transport's \`session/workspace.get\` stub keeps the offline self-test green.
- Soak self-test asserts the new artifact is present.

## Scope

This is **partial progress** on #906. The broader issue lists:

- \`workspace-contract-status.json\` ✅ (this PR)
- \`task-ledger.jsonl\` — still missing; requires the M13 task projection wiring (#966)
- \`validator-results.jsonl\` — still missing; requires the validator timeline event work
- \`tui-capture.txt\` — only relevant when a TUI client is attached

So this doesn't close #906.

## Test plan

- [x] \`bash scripts/m12-solo-appui-soak.sh self-test\` — passes; new artifact-presence assertion green.
- [x] Live strict WS soak — case \`workspace-contract-snapshot\` recorded as \`ok\` with \`contract_count: 0\`; artifact file (250B) present.
- [x] Live strict stdio soak — same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)