### PR TITLE
test(appui): guard P0 canonical tools are registered (#972)

### DIFF
--- a/crates/octos-cli/src/api/coding_tool_contract.rs
+++ b/crates/octos-cli/src/api/coding_tool_contract.rs
@@ -988,6 +988,37 @@ mod tests {
         assert_eq!(write_stdin["status"], json!(TOOL_STATUS_MISSING));
     }
 
+    /// #972 — guard against accidental removal of any P0 canonical tool
+    /// from the per-session tool registry. The M14 contract relies on
+    /// every name in `CODING_P0_REQUIRED_TOOL_NAMES` being registered
+    /// (whether active or deferred). If a future change drops one of
+    /// the registrations in `with_builtins_and_permissions`, this test
+    /// fails loudly instead of letting the live contract silently
+    /// regress to `status: incomplete` only when the strict M12 soak
+    /// runs in CI.
+    #[test]
+    fn p0_canonical_tools_are_registered_by_session_builtins() {
+        use octos_agent::ToolRegistry;
+        use octos_agent::sandbox::NoSandbox;
+
+        let cwd = std::path::Path::new("/tmp");
+        let registry = ToolRegistry::with_builtins_and_sandbox(cwd, Box::new(NoSandbox));
+        let names: std::collections::HashSet<String> = registry.tool_names().into_iter().collect();
+
+        let mut missing: Vec<&str> = Vec::new();
+        for required in CODING_P0_REQUIRED_TOOL_NAMES {
+            if !names.contains(*required) {
+                missing.push(*required);
+            }
+        }
+        assert!(
+            missing.is_empty(),
+            "P0 canonical tools must be registered by ToolRegistry::with_builtins_and_sandbox \
+             so the M14 coding tool contract can resolve them as active or deferred. \
+             Missing: {missing:?}. Registered tool names: {names:?}"
+        );
+    }
+
     #[test]
     fn disabled_canonical_tool_is_reported_as_policy_gap() {
         let context = ToolStatusListContext {


### PR DESCRIPTION
## Summary

Add a unit test that fails immediately if a future change drops one of the Codex P0 canonical tool names from \`ToolRegistry::with_builtins_and_sandbox\`. Currently a silent removal would leave the M14 coding tool contract permanently reporting \`status: incomplete\` and only surface in live strict M12 soaks running in CI.

The test exercises the same registry-construction path that \`ProfileRuntime::bootstrap\` and \`SessionRuntime::bootstrap\` use, so the guard sits at the right layer.

## Scope

This is **partial progress** on #972 — it covers acceptance bullet 1 ("coding profile advertises all P0 tools when policy allows them") at the unit level. The remaining acceptance bullets need a live invocation soak (apply_patch + exec_command + write_stdin + update_plan + request_user_input actually running). That's the same scope as #969.

## Test plan

- [x] \`cargo test -p octos-cli --features api --lib p0_canonical_tools_are_registered_by_session_builtins\` — green.
- [x] \`cargo fmt --all -- --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)