### PR TITLE
feat(appui): add TaskListEntry M13-B projection fields (partial #966)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -10536,6 +10536,18 @@ struct TaskListProjection {
     lifecycle_state: String,
     #[serde(default)]
     runtime_state: String,
+    // #966 / M13-B — extended projection fields. Optional so legacy
+    // snapshots from older TaskSupervisor query JSON deserialize cleanly.
+    #[serde(default)]
+    source: Option<String>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    artifact_count: Option<u32>,
+    #[serde(default)]
+    runtime_policy_stamp: Option<Value>,
     #[serde(default)]
     child_terminal_state: Option<String>,
     #[serde(default)]
@@ -10578,6 +10590,15 @@ fn task_list_entry_from_value(value: Value) -> Result<TaskListEntry, RpcError> {
         status: projected.status,
         lifecycle_state: projected.lifecycle_state,
         runtime_state: projected.runtime_state,
+        // #966 / M13-B — extended projection fields. Backed by
+        // additional optional fields in the TaskSupervisor query
+        // JSON; when absent (legacy snapshots), these stay None and
+        // are omitted from the wire.
+        source: projected.source,
+        role: projected.role,
+        summary: projected.summary,
+        artifact_count: projected.artifact_count,
+        runtime_policy_stamp: projected.runtime_policy_stamp,
         parent_session_key: projected.parent_session_key,
         child_session_key: projected.child_session_key,
         child_terminal_state: projected.child_terminal_state,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -1798,6 +1798,37 @@ pub struct TaskListEntry {
     pub status: String,
     pub lifecycle_state: String,
     pub runtime_state: String,
+    /// #966 / M13-B — origin of this child task. One of `"model"` (the
+    /// LLM scheduled it via spawn_agent / spawn / delegate), `"supervisor"`
+    /// (a backend supervisor created it, e.g. review/start), or `"user"`
+    /// (explicit user-driven schedule, rare). Lets clients tell apart
+    /// LLM-owned children from user-initiated tasks without parsing
+    /// free-form fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// #966 / M13-B — role label assigned at spawn (e.g.
+    /// `"reviewer"`, `"implementer"`, `"test_worker"`, `"explorer"`).
+    /// Pairs with the M14-C role templates and lets the UX render
+    /// "Reviewer running" instead of "task-xxx running".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// #966 / M13-B — bounded summary capsule for the task (mirrors
+    /// `ChildResultSummary.summary` for terminal children). Short text
+    /// that clients can render inline without fetching the full
+    /// artifact list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// #966 / M13-B — number of artifacts the child has emitted so
+    /// far. Lets the UX badge tasks with their artifact count without
+    /// resolving `task/artifact/list`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_count: Option<u32>,
+    /// #966 / M13-B — runtime policy stamp captured at spawn time
+    /// (model, sandbox, approval policy, …). Lets reconnect hydration
+    /// surface the same effective state the original task/updated
+    /// notifications announced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_policy_stamp: Option<Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_session_key: Option<SessionKey>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -6404,6 +6435,11 @@ mod tests {
                 status: "running".into(),
                 lifecycle_state: "running".into(),
                 runtime_state: "executing_tool".into(),
+                source: None,
+                role: None,
+                summary: None,
+                artifact_count: None,
+                runtime_policy_stamp: None,
                 parent_session_key: Some(SessionKey("local:demo".into())),
                 child_session_key: Some(SessionKey("local:demo#child-1".into())),
                 child_terminal_state: None,


### PR DESCRIPTION
## Summary

UPCR-2026-019 / M13-B requires \`task/list\` and \`task/updated\` payloads to carry the LLM-owned subagent metadata clients need to render bounded child-task UX without reaching for free-form fields. The existing \`TaskListEntry\` already exposed parent/child session keys, lifecycle state, terminal/join state, and workflow kind, but lacked five fields the spec calls out.

This PR adds them, all optional + \`skip_serializing_if = "Option::is_none"\` so the wire stays backwards-compatible:

| Field | Purpose |
|---|---|
| \`source\` | Origin of the task (\`"model"\` / \`"supervisor"\` / \`"user"\`) so clients can tell LLM-owned children from user-initiated tasks. |
| \`role\` | Role label assigned at spawn time (mirrors the M14-C templates: reviewer / implementer / test_worker / explorer). Lets UX render "Reviewer running" instead of "task-xxx running". |
| \`summary\` | Bounded summary capsule, mirrors \`ChildResultSummary.summary\` for terminal children. |
| \`artifact_count\` | Number of artifacts emitted so far so UX can badge tasks without resolving \`task/artifact/list\`. |
| \`runtime_policy_stamp\` | Effective server policy captured at spawn so reconnect hydration matches the original \`task/updated\` emit. |

\`TaskListProjection\` (the cli-side decoder of the TaskSupervisor query JSON) gets matching optional fields so a future supervisor that populates them is read end-to-end. Until the supervisor wires it, every value comes through as None and the wire shape is unchanged.

## Scope

Closes the **protocol-shape** acceptance bullet of #966 / M13-B. The remaining bullets need the \`TaskSupervisor\` to actually populate the new query-JSON fields — that wiring lives in the spawn path being added under #971 / #991.

## Test plan

- [x] \`cargo test -p octos-core --lib\` — 211 tests green; the existing \`ui_protocol_v1_representative_wire_payloads_are_golden\` covers the new field shape (None ⇒ omitted ⇒ identical golden).
- [x] \`cargo test -p octos-cli --features api --lib\` — 1201 tests green (one flaky session_actor test passes in isolation, same flake we've seen before).
- [x] \`cargo fmt --all -- --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)