### PR TITLE
fix(agent): populate M17-C DispatchContextContract fields at MCP dispatch sites (#1021)

### DIFF
--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -762,11 +762,19 @@ impl SpawnTool {
             .unwrap_or_else(|| DEFAULT_MCP_AGENT_TOOL_NAME.to_string());
 
         let request = DispatchRequest::new(tool_name, task).with_context_contract(
+            // #1021 / M17-C — populate backend_kind/agent_id/risk so the
+            // evidence ledger can identify this unmanaged dispatch
+            // without parsing free-form text. Direct MCP dispatch never
+            // forks the Octos prompt context manager, so we tag it
+            // `risk: medium` (external transport, no managed context).
             DispatchContextContract::external_unmanaged(
                 "direct_mcp_dispatch_has_no_octos_context_manager_payload",
             )
             .with_parent_session_key(Some(session_id.to_string()))
-            .with_child_session_key(Some(task_id.to_string())),
+            .with_child_session_key(Some(task_id.to_string()))
+            .with_backend_kind("mcp")
+            .with_agent_id(task_id.to_string())
+            .with_risk("medium"),
         );
         let (response, _summary) = dispatch_with_metrics(backend.as_ref(), request).await;
         let payload = build_dispatch_event_payload(
@@ -1969,11 +1977,20 @@ impl Tool for SpawnTool {
             let (response, event) = {
                 let request = DispatchRequest::new(tool_name, dispatch_payload)
                     .with_context_contract(
+                        // #1021 / M17-C — backend_kind/agent_id/risk
+                        // identify this unmanaged dispatch in the
+                        // evidence ledger. Same medium-risk tagging as
+                        // the direct dispatch path: external MCP
+                        // transport that never forks the Octos prompt
+                        // context manager.
                         DispatchContextContract::external_unmanaged(
                             "mcp_agent_backend_does_not_consume_octos_prompt_context_manager",
                         )
                         .with_parent_session_key(self.session_key.clone())
-                        .with_child_session_key(Some(task_id_for_event.clone())),
+                        .with_child_session_key(Some(task_id_for_event.clone()))
+                        .with_backend_kind("mcp")
+                        .with_agent_id(task_id_for_event.clone())
+                        .with_risk("medium"),
                     );
                 let (response, _summary) = dispatch_with_metrics(backend.as_ref(), request).await;
                 let payload = build_dispatch_event_payload(

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -842,9 +842,18 @@ async fn dispatch_once(
     contract: &ContractSpec,
     prior_attempts: u32,
 ) -> SubtaskOutcome {
+    // #1021 / M17-C — swarm dispatches go through external MCP backends
+    // that don't consume the Octos prompt context manager. Tag the
+    // contract with backend_kind/agent_id/risk so the evidence ledger
+    // can identify each unmanaged dispatch without parsing free-form
+    // text. The contract_id doubles as the agent_id here — swarm
+    // subtasks don't have a separate Octos task supervisor handle.
     let context_contract =
         DispatchContextContract::external_unmanaged("swarm_mcp_backend_context_payload_not_wired")
-            .with_child_session_key(Some(contract.contract_id.clone()));
+            .with_child_session_key(Some(contract.contract_id.clone()))
+            .with_backend_kind("mcp")
+            .with_agent_id(contract.contract_id.clone())
+            .with_risk("medium");
     let request = DispatchRequest::new(contract.tool_name.clone(), contract.task.clone())
         .with_context_contract(context_contract.clone());
     let response = backend
@@ -970,5 +979,70 @@ mod tests {
             max_retry_rounds: None,
         };
         assert_eq!(budget.effective_max_contracts(), MAX_CONTRACTS_PER_DISPATCH);
+    }
+
+    /// #1021 / M17-C — when the swarm dispatches a subtask through an
+    /// external MCP backend, the request's context contract must carry
+    /// the new diagnostic fields (`backend_kind: "mcp"`, an `agent_id`
+    /// matching the contract_id, and `risk: "medium"`). Without this
+    /// the evidence ledger could not identify each unmanaged dispatch
+    /// from a single line.
+    #[tokio::test]
+    async fn dispatch_once_populates_m17c_context_contract_fields() {
+        use crate::topology::ContractSpec;
+        use async_trait::async_trait;
+        use octos_agent::tools::mcp_agent::{DispatchOutcome, DispatchResponse};
+        use std::sync::Mutex;
+
+        #[derive(Default)]
+        struct CapturingBackend {
+            last_request: Mutex<Option<DispatchRequest>>,
+        }
+
+        #[async_trait]
+        impl McpAgentBackend for CapturingBackend {
+            fn backend_label(&self) -> &'static str {
+                "local"
+            }
+            fn endpoint_label(&self) -> String {
+                "capture".to_string()
+            }
+            async fn dispatch(&self, request: DispatchRequest) -> DispatchResponse {
+                *self.last_request.lock().unwrap() = Some(request);
+                DispatchResponse {
+                    outcome: DispatchOutcome::Success,
+                    output: "ok".into(),
+                    files_to_send: Vec::new(),
+                    error: None,
+                    context_contract: None,
+                }
+            }
+        }
+
+        let backend = CapturingBackend::default();
+        let contract = ContractSpec {
+            contract_id: "swarm-subtask-42".into(),
+            tool_name: "run_task".into(),
+            task: serde_json::json!({ "contract_id": "swarm-subtask-42" }),
+            label: Some("c-42".into()),
+        };
+
+        let _ = dispatch_once(&backend, &contract, 0).await;
+
+        let captured = backend
+            .last_request
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("backend must have recorded a request");
+        let cc = captured
+            .context_contract
+            .as_ref()
+            .expect("dispatch must attach a context contract");
+        assert_eq!(cc.mode, "external_context_unmanaged");
+        assert_eq!(cc.backend_kind.as_deref(), Some("mcp"));
+        assert_eq!(cc.agent_id.as_deref(), Some("swarm-subtask-42"));
+        assert_eq!(cc.risk.as_deref(), Some("medium"));
+        assert_eq!(cc.child_session_key.as_deref(), Some("swarm-subtask-42"));
     }
 }


### PR DESCRIPTION
## Summary

PR #1102 added \`backend_kind\`, \`agent_id\`, and \`risk\` to \`DispatchContextContract\`, but no production call site populated them — the fields existed on the type but stayed \`None\` on every emission. This PR wires all three external-unmanaged MCP dispatch paths so the new diagnostic fields appear on the wire.

| Site | backend_kind | agent_id | risk |
|---|---|---|---|
| \`spawn.rs\` direct MCP dispatch helper | \`"mcp"\` | \`task_id\` | \`"medium"\` |
| \`spawn.rs\` MCP fan-out | \`"mcp"\` | \`task_id_for_event\` | \`"medium"\` |
| \`dispatcher.rs\` (swarm) \`dispatch_once\` | \`"mcp"\` | \`contract_id\` | \`"medium"\` |

The \`"medium"\` risk default matches the existing contract semantics: external MCP transport that never forks the Octos prompt context manager. Future managed-payload paths (when M17-B/M17-A propagation ships) will populate \`risk: "low"\` with a managed \`context_ref\`.

## Test plan

- [x] New unit test in \`dispatcher::tests::dispatch_once_populates_m17c_context_contract_fields\` exercises a \`CapturingBackend\` through \`dispatch_once\` and asserts the new fields land on the wire.
- [x] \`cargo test -p octos-swarm --lib\` — 35 tests green.
- [x] \`cargo test -p octos-agent --lib mcp_agent\` — 12 tests green.
- [x] \`cargo fmt --all -- --check\` clean.

## Scope

Closes the MCP-side emission half of #1021. Native + CLI specialist paths are scoped under #991 (AgentOrchestrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)