### PR TITLE
test(appui): pin task/artifact/* capability gating (partial #965)

### DIFF
--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -5196,6 +5196,44 @@ mod tests {
     }
 
     #[test]
+    fn negotiated_capabilities_hide_task_and_agent_artifact_methods_without_feature() {
+        // #965 — UPCR-2026-019 capability gating: `task/artifact/list`
+        // and `task/artifact/read` (plus the legacy `agent/artifact/*`
+        // aliases that route through the same handlers) must not appear
+        // in `supported_methods` unless the negotiated capability set
+        // includes `coding.agent_control.v1`. Without the gate the
+        // server would advertise an RPC that immediately returns
+        // `agent_control_unavailable` for every caller.
+        let capabilities = UiProtocolCapabilities::for_negotiated_features(Vec::<String>::new());
+        assert!(!capabilities.supports_feature(UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1));
+        assert!(!capabilities.supports_method(methods::TASK_ARTIFACT_LIST));
+        assert!(!capabilities.supports_method(methods::TASK_ARTIFACT_READ));
+        assert!(!capabilities.supports_method(methods::AGENT_ARTIFACT_LIST));
+        assert!(!capabilities.supports_method(methods::AGENT_ARTIFACT_READ));
+    }
+
+    #[test]
+    fn negotiated_capabilities_advertise_task_and_agent_artifact_methods_when_feature_requested() {
+        // #965 — counterpart to the gate-off test above. When the
+        // client requests `coding.agent_control.v1` (paired with the
+        // `coding.autonomy.v1` base, since `agent_control` is an
+        // autonomy-optional add-on), both the canonical `task/artifact/*`
+        // names and the legacy `agent/artifact/*` aliases appear in
+        // the negotiated method set so the dispatcher
+        // (`task/artifact/* | agent/artifact/* => handler`) is reachable
+        // by name in either direction.
+        let capabilities = UiProtocolCapabilities::for_negotiated_features([
+            UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1,
+            UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
+        ]);
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1));
+        assert!(capabilities.supports_method(methods::TASK_ARTIFACT_LIST));
+        assert!(capabilities.supports_method(methods::TASK_ARTIFACT_READ));
+        assert!(capabilities.supports_method(methods::AGENT_ARTIFACT_LIST));
+        assert!(capabilities.supports_method(methods::AGENT_ARTIFACT_READ));
+    }
+
+    #[test]
     fn ui_protocol_v1_wire_contract_is_golden() {
         assert_eq!(UI_PROTOCOL_V1, "octos-ui/v1alpha1");
         assert_eq!(UI_PROTOCOL_SCHEMA_VERSION, 1);


### PR DESCRIPTION
## Summary

UPCR-2026-019 / #965 capability-gating acceptance bullet:
> Capability gating hides new fields/methods unless negotiated.

PR #1094 wired the `task/artifact/list` and `task/artifact/read` dispatch (and kept the legacy `agent/artifact/*` aliases routing through the same handlers, both sharing `coding.agent_control.v1` per the autonomy-runtime grouping). What was missing was an explicit unit-level guard that the gate is both **on** when the feature isn't negotiated and **off** when it is — without one, a future regression that drops the gate (or drops the feature from `method_capability_gate`) would only surface in live soak transcripts.

This PR adds two paired tests in `octos-core::ui_protocol`:

- `negotiated_capabilities_hide_task_and_agent_artifact_methods_without_feature` asserts both pairs are absent from `supported_methods` when no feature is negotiated.
- `negotiated_capabilities_advertise_task_and_agent_artifact_methods_when_feature_requested` asserts both pairs are present when the client negotiates `coding.autonomy.v1 + coding.agent_control.v1` (autonomy is the required base for the autonomy-optional `agent_control` add-on).

## Scope

Partial progress on #965. Closes the **capability-gating** acceptance bullet at the unit level. The remaining acceptance bullets either match construction (the dispatcher routes both names through the same handler, and existing M12 soaks already capture `agent/artifact/*` over both stdio + WS) or require an architectural decision (#1094's design call to reuse `coding.agent_control.v1` rather than minting separate `harness.task_supervision_inspection.v1` / `harness.task_artifacts.v1` feature names).

## Test plan

- [x] `cargo test -p octos-core --lib` — 213 tests green (2 new).
- [x] `cargo fmt --all -- --check` clean.