### PR TITLE
feat(appui): advertise UPCR-2026-019 canonical M13-A capability flags (#965)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1172,6 +1172,21 @@ impl ConnectionUiFeatures {
                 APPUI_FEATURE_CONTEXT_LIFECYCLE_V1,
             );
         }
+        // #965 / UPCR-2026-019 — advertise the M13-A canonical capability
+        // names alongside the consolidated `coding.agent_control.v1` so
+        // clients that look for the spec strings find them. The methods
+        // themselves still gate on `coding.agent_control.v1`, so older
+        // clients negotiating only that flag keep working unchanged.
+        if self.agent_control_available() {
+            push_capability_feature(
+                &mut capabilities.supported_features,
+                octos_core::ui_protocol::UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1,
+            );
+            push_capability_feature(
+                &mut capabilities.supported_features,
+                octos_core::ui_protocol::UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+            );
+        }
         if supports_local_solo_profile_create(state) {
             push_capability_feature(
                 &mut capabilities.supported_features,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -113,6 +113,24 @@ pub const UI_PROTOCOL_FEATURE_REVIEW_START_V1: &str = "review.start.v1";
 /// compaction lifecycle inspection.
 pub const UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1: &str = "context.lifecycle.v1";
 
+/// #965 / UPCR-2026-019 — spec-canonical feature name for the
+/// supervised-task inspection surface (`task/list`, `task/updated`,
+/// `task/output/read`, `agent/list`, `agent/status/read`, `agent/output/read`,
+/// `agent/interrupt`, `agent/close`). The methods themselves stay gated on
+/// [`UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1`] so older clients keep
+/// working; this constant is advertised in parallel so the protocol
+/// vocabulary matches the M13-A spec strings.
+pub const UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1: &str =
+    "harness.task_supervision_inspection.v1";
+
+/// #965 / UPCR-2026-019 — spec-canonical feature name for the
+/// supervised-task artifact surface (`task/artifact/list`, `task/artifact/read`,
+/// `agent/artifact/list`, `agent/artifact/read`, `agent/artifact/updated`).
+/// Advertised alongside [`UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1`] so
+/// clients that look for the M13-A name find it; method gating stays on the
+/// existing consolidated flag.
+pub const UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1: &str = "harness.task_artifacts.v1";
+
 /// Server-known feature registry. Used by
 /// [`UiProtocolCapabilities::for_negotiated_features`] (UPCR-2026-007) to
 /// intersect a client's `X-Octos-Ui-Features` request with the names the
@@ -136,6 +154,8 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1,
     UI_PROTOCOL_FEATURE_REVIEW_START_V1,
     UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
+    UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1,
+    UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
 ];
 
 /// Returns the feature flag that gates `method` per spec § 7 capability
@@ -5288,6 +5308,14 @@ mod tests {
             UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
             "context.lifecycle.v1"
         );
+        assert_eq!(
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1,
+            "harness.task_supervision_inspection.v1"
+        );
+        assert_eq!(
+            UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
+            "harness.task_artifacts.v1"
+        );
 
         assert_eq!(
             UI_PROTOCOL_COMMAND_METHODS,
@@ -5561,7 +5589,9 @@ mod tests {
                     "coding.goal_runtime.v1",
                     "coding.loop_runtime.v1",
                     "review.start.v1",
-                    "context.lifecycle.v1"
+                    "context.lifecycle.v1",
+                    "harness.task_supervision_inspection.v1",
+                    "harness.task_artifacts.v1"
                 ]
             })
         );


### PR DESCRIPTION
## Summary

UPCR-2026-019 specifies separate capability flags \`harness.task_supervision_inspection.v1\` and \`harness.task_artifacts.v1\` for the supervised-task inspection / artifact surfaces. The implementation has been reusing the consolidated \`coding.agent_control.v1\` flag to gate every method on both surfaces, so the protocol vocabulary diverged from the spec.

Resolution: **advertise both names**. Method gating stays on \`coding.agent_control.v1\` so older clients keep working unchanged, but the canonical M13-A names now appear in \`supported_features\` so new clients can find them and negotiate against either name.

## Changes

- New \`UI_PROTOCOL_FEATURE_HARNESS_TASK_SUPERVISION_INSPECTION_V1\` and \`UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1\` constants in \`octos-core::ui_protocol\`.
- Registered in \`UI_PROTOCOL_KNOWN_FEATURES\` so negotiation rejects neither.
- Advertised in \`advertised_capabilities\` whenever \`agent_control_available()\` is true, paired with \`coding.agent_control.v1\` so the matrix stays internally consistent.
- Golden \`client_hello\` capabilities-payload fixture updated to include both names; \`ui_protocol_v1_alpha1_constants_match_specification\` pins the wire strings.

## Why advertise instead of replace

Spec says **distinct** flags; implementation uses **consolidated** flag. A hard replacement would break every existing client that negotiated against \`coding.agent_control.v1\`. Advertising in parallel lets:

- Older clients continue with the consolidated flag.
- New clients (e.g. octos-tui PR #61 in the sibling repo, which already references \`harness.task_supervision_inspection.v1\` / \`harness.task_artifacts.v1\` constants) negotiate against either name and get the same methods.

A future cleanup could narrow method-level gating onto the canonical names, but that is a deprecation-cycle decision.

## Test plan

- [x] \`cargo test -p octos-core --lib\` — 213 tests green; \`ui_protocol_v1_alpha1_constants_match_specification\` covers the new wire strings; \`ui_protocol_v1_representative_wire_payloads_are_golden\` updated to include both names in the client_hello golden.
- [x] \`cargo test -p octos-cli --features api --lib\` — 1207 tests green (one pre-existing flake in \`master_continuation_tick_reenters_actor_loop\` passes in isolation).
- [x] \`cargo fmt --all -- --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)