### PR TITLE
feat(agent): wire M13-B projection fields into BackgroundTask + AppUI (partial #966)

### DIFF
--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -236,6 +236,38 @@ pub struct BackgroundTask {
     /// still deserialize as `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub originating_client_message_id: Option<String>,
+
+    // ── #966 / M13-B projection fields ──────────────────────────────
+    // The AppUI TaskListEntry already accepts these optional fields
+    // (see octos-cli `TaskListProjection`); populating them here at
+    // register-time threads them into `task/list` and `task/updated`
+    // payloads so clients can render bounded child-task UX without
+    // probing free-form text. All five use `#[serde(default)]` so
+    // pre-M13-B persisted snapshots still deserialize as None.
+    /// Origin of this task: `"model"` (LLM scheduled via
+    /// spawn_agent/spawn/delegate), `"supervisor"` (backend), or
+    /// `"user"` (rare).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Role label assigned at spawn — mirrors M14-C role templates
+    /// (`"reviewer"`, `"implementer"`, `"test_worker"`, `"explorer"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Bounded summary capsule mirroring ChildResultSummary.summary
+    /// for terminal children.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Number of artifacts emitted so far so UX can badge tasks
+    /// without resolving task/artifact/list.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_count: Option<u32>,
+    /// Effective runtime policy stamp captured at spawn — clients
+    /// rendering reconnect hydration should display the stamp the
+    /// task originally announced, not the current session policy.
+    /// Stored as raw JSON so the agent crate doesn't depend on the
+    /// AppUI `runtime_policy_stamp` schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_policy_stamp: Option<Value>,
 }
 
 impl BackgroundTask {
@@ -1207,6 +1239,17 @@ impl TaskSupervisor {
             session_key: session_key.map(|s| s.to_string()),
             tool_input,
             originating_client_message_id,
+            // #966 / M13-B — set None at register time. Callers that
+            // know the spawn source/role (model vs supervisor, role
+            // template, runtime policy stamp) populate via the new
+            // `with_m13b_projection(...)` setter immediately after
+            // `register_*`. Future supervisor refactors can thread
+            // these through register_* directly when convenient.
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         };
         let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
         tasks.insert(id.clone(), task);
@@ -1221,6 +1264,69 @@ impl TaskSupervisor {
             },
         );
         Ok(id)
+    }
+
+    /// #966 / M13-B — attach the projection metadata (origin, role,
+    /// summary, artifact count, runtime policy stamp) to an already-
+    /// registered task. Designed for callers who already know how to
+    /// derive each piece at spawn time but want to avoid expanding
+    /// every `register_*` signature with five new optional args.
+    /// Pass `None` for any field whose value is not yet known; the
+    /// underlying [`BackgroundTask`] keeps any already-populated value
+    /// when the corresponding argument is `None`.
+    pub fn set_m13b_projection(
+        &self,
+        task_id: &str,
+        source: Option<String>,
+        role: Option<String>,
+        summary: Option<String>,
+        artifact_count: Option<u32>,
+        runtime_policy_stamp: Option<Value>,
+    ) {
+        // Codex P2 fix: also persist + notify + emit_progress so the
+        // reconnect-hydration and `task/updated` subscribers actually
+        // observe the new metadata. Without this the projection fields
+        // sit in-memory until some unrelated state change fires the
+        // callbacks. Mirror the persist/notify/emit pattern used by
+        // mark_running / mark_completed / cancel.
+        let snapshot = {
+            let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
+            let Some(task) = tasks.get_mut(task_id) else {
+                return;
+            };
+            let mut changed = false;
+            if source.is_some() {
+                task.source = source;
+                changed = true;
+            }
+            if role.is_some() {
+                task.role = role;
+                changed = true;
+            }
+            if summary.is_some() {
+                task.summary = summary;
+                changed = true;
+            }
+            if artifact_count.is_some() {
+                task.artifact_count = artifact_count;
+                changed = true;
+            }
+            if runtime_policy_stamp.is_some() {
+                task.runtime_policy_stamp = runtime_policy_stamp;
+                changed = true;
+            }
+            if !changed {
+                return;
+            }
+            // Stamp updated_at so reconnect hydration / dashboards see
+            // the projection update even when no lifecycle transition
+            // fires.
+            task.updated_at = Utc::now();
+            task.clone()
+        };
+        self.persist_snapshot(&snapshot);
+        self.notify_change(&snapshot);
+        self.emit_progress_for_state(&snapshot);
     }
 
     /// Attach (or replace) the tool input for an already-registered task.
@@ -1786,6 +1892,132 @@ mod tests {
         assert!(tasks[0].child_failure_action.is_none());
         assert!(tasks[0].completed_at.is_none());
         assert!(tasks[0].updated_at >= tasks[0].started_at);
+    }
+
+    /// #966 / M13-B — the projection setter populates the new
+    /// optional fields. Verifies that:
+    /// - Newly-registered tasks start with all five fields None.
+    /// - `set_m13b_projection` overwrites the fields that were
+    ///   supplied as Some and leaves the rest untouched.
+    /// - The persisted JSON round-trips through serde and the
+    ///   default-omitted fields stay invisible until populated.
+    #[test]
+    fn set_m13b_projection_populates_optional_fields() {
+        use serde_json::json;
+        let supervisor = TaskSupervisor::new();
+        let id = supervisor.register("tts", "call-m13b", None);
+
+        let initial = supervisor.get_task(&id).expect("task");
+        assert!(initial.source.is_none());
+        assert!(initial.role.is_none());
+        assert!(initial.summary.is_none());
+        assert!(initial.artifact_count.is_none());
+        assert!(initial.runtime_policy_stamp.is_none());
+
+        supervisor.set_m13b_projection(
+            &id,
+            Some("model".into()),
+            Some("reviewer".into()),
+            Some("found 1 issue".into()),
+            Some(2),
+            Some(json!({ "approval_policy": "on-request" })),
+        );
+
+        let updated = supervisor.get_task(&id).expect("task");
+        assert_eq!(updated.source.as_deref(), Some("model"));
+        assert_eq!(updated.role.as_deref(), Some("reviewer"));
+        assert_eq!(updated.summary.as_deref(), Some("found 1 issue"));
+        assert_eq!(updated.artifact_count, Some(2));
+        assert_eq!(
+            updated.runtime_policy_stamp,
+            Some(json!({ "approval_policy": "on-request" }))
+        );
+
+        // Partial update — only the artifact_count moves; the rest stay.
+        supervisor.set_m13b_projection(&id, None, None, None, Some(5), None);
+        let after_partial = supervisor.get_task(&id).expect("task");
+        assert_eq!(after_partial.source.as_deref(), Some("model"));
+        assert_eq!(after_partial.role.as_deref(), Some("reviewer"));
+        assert_eq!(after_partial.artifact_count, Some(5));
+
+        // Wire-shape: legacy snapshots without the fields round-trip
+        // cleanly thanks to `#[serde(default)]`, AND newly-populated
+        // ones surface every field.
+        let json_form = serde_json::to_value(&after_partial).unwrap();
+        assert_eq!(json_form["source"], "model");
+        assert_eq!(json_form["role"], "reviewer");
+        assert_eq!(json_form["summary"], "found 1 issue");
+        assert_eq!(json_form["artifact_count"], 5);
+
+        let bare = supervisor.register("podcast_generate", "call-bare", None);
+        let bare_json = serde_json::to_value(supervisor.get_task(&bare).unwrap()).unwrap();
+        assert!(bare_json.as_object().unwrap().get("source").is_none());
+        assert!(
+            bare_json
+                .as_object()
+                .unwrap()
+                .get("artifact_count")
+                .is_none()
+        );
+    }
+
+    /// Codex P2 fix: `set_m13b_projection` must persist + notify so
+    /// reconnect hydration and `task/updated` subscribers observe the
+    /// new metadata without waiting for an unrelated lifecycle event.
+    /// Pins the on_change callback firing AND `updated_at` advancing.
+    #[test]
+    fn set_m13b_projection_fires_on_change_and_bumps_updated_at() {
+        use std::sync::{Arc, Mutex};
+
+        let supervisor = TaskSupervisor::new();
+        let id = supervisor.register("tts", "call-m13b-notify", None);
+        let before = supervisor.get_task(&id).expect("task").updated_at;
+
+        let notifications: Arc<Mutex<Vec<BackgroundTask>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&notifications);
+        supervisor.set_on_change(move |task: &BackgroundTask| {
+            sink.lock().unwrap().push(task.clone());
+        });
+
+        // Sleep so updated_at is observably greater than registered_at.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        supervisor.set_m13b_projection(
+            &id,
+            Some("model".into()),
+            Some("reviewer".into()),
+            None,
+            None,
+            None,
+        );
+
+        let updated = supervisor.get_task(&id).expect("task");
+        assert!(
+            updated.updated_at > before,
+            "set_m13b_projection must bump updated_at; before={before:?} after={:?}",
+            updated.updated_at
+        );
+
+        let observed_len = notifications.lock().unwrap().len();
+        assert_eq!(observed_len, 1, "on_change should fire exactly once");
+        let event = notifications.lock().unwrap()[0].clone();
+        assert_eq!(event.source.as_deref(), Some("model"));
+        assert_eq!(event.role.as_deref(), Some("reviewer"));
+
+        // No-op call (every arg None) must NOT fire the callback or
+        // bump updated_at — defensive, avoids spurious update spam.
+        let after_change = updated.updated_at;
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        supervisor.set_m13b_projection(&id, None, None, None, None, None);
+        let after_noop = supervisor.get_task(&id).expect("task");
+        assert_eq!(
+            after_noop.updated_at, after_change,
+            "no-op call must NOT bump updated_at"
+        );
+        assert_eq!(
+            notifications.lock().unwrap().len(),
+            1,
+            "no-op call must NOT fire on_change"
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3986,6 +3986,11 @@ mod tests {
             session_key: Some(session_id.to_string()),
             tool_input: Some(json!({"task": "review"})),
             originating_client_message_id: None,
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         };
 
         let (mirrored_session, agent) =

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -22572,6 +22572,11 @@ mod tests {
             session_key: Some("local:test".into()),
             tool_input: None,
             originating_client_message_id: None,
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }
     }
 

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -495,14 +495,39 @@ pub(crate) fn background_task_to_progress_json(task: &octos_agent::BackgroundTas
     // mapper below threads it onto `TaskUpdatedEvent`. The client uses
     // the wire-side mapping instead of racing a `task/updated` watcher
     // to build `task_id → tool_call_id` post-hoc.
-    json!({
+    //
+    // Codex P2 follow-up (#1113): the M13-B projection fields
+    // (source/role/summary/artifact_count/runtime_policy_stamp) live
+    // on `BackgroundTask` after `set_m13b_projection` runs, but the
+    // live `task/updated` JSON used to drop them, so connected
+    // subscribers had to refresh `task/list` to see the metadata.
+    // Include them here so the live wire matches the snapshot view.
+    let mut payload = json!({
         "type": "task_updated",
         "task_id": task.id,
         "tool_call_id": task.tool_call_id,
         "title": task.tool_name,
         "state": task.lifecycle_state(),
         "runtime_detail": stable_task_runtime_detail(task),
-    })
+    });
+    if let Value::Object(obj) = &mut payload {
+        if let Some(source) = task.source.as_ref() {
+            obj.insert("source".into(), json!(source));
+        }
+        if let Some(role) = task.role.as_ref() {
+            obj.insert("role".into(), json!(role));
+        }
+        if let Some(summary) = task.summary.as_ref() {
+            obj.insert("summary".into(), json!(summary));
+        }
+        if let Some(count) = task.artifact_count {
+            obj.insert("artifact_count".into(), json!(count));
+        }
+        if let Some(stamp) = task.runtime_policy_stamp.as_ref() {
+            obj.insert("runtime_policy_stamp".into(), stamp.clone());
+        }
+    }
+    payload
 }
 
 fn stable_task_runtime_detail(task: &octos_agent::BackgroundTask) -> Option<String> {
@@ -983,6 +1008,11 @@ mod tests {
             session_key: Some("local:demo".into()),
             tool_input: None,
             originating_client_message_id: None,
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         };
 
         let event = background_task_to_progress_json(&task);
@@ -991,5 +1021,94 @@ mod tests {
         assert_eq!(event["title"], "search");
         assert_eq!(event["state"], "verifying");
         assert_eq!(event["runtime_detail"], "Writing report");
+    }
+
+    /// #1113 codex P2 follow-up: when `set_m13b_projection` populates
+    /// the source/role/summary/artifact_count/runtime_policy_stamp
+    /// fields, the live `task/updated` JSON used to drop them, leaving
+    /// connected subscribers to refresh `task/list` to see the
+    /// metadata. Pin that the live JSON now carries the projection
+    /// fields when they're populated, AND that unset fields stay
+    /// absent (no `null` leakage that would clobber a prior value).
+    #[test]
+    fn background_task_progress_json_carries_m13b_projection_fields() {
+        let task = octos_agent::BackgroundTask {
+            id: "01900000-0000-7000-8000-000000000004".into(),
+            tool_name: "review".into(),
+            tool_call_id: "call-r".into(),
+            parent_session_key: Some("local:demo".into()),
+            child_session_key: Some("local:demo#child-r".into()),
+            child_terminal_state: None,
+            child_join_state: None,
+            child_joined_at: None,
+            child_failure_action: None,
+            task_ledger_path: None,
+            status: octos_agent::TaskStatus::Running,
+            runtime_state: octos_agent::TaskRuntimeState::ExecutingTool,
+            runtime_detail: None,
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+            completed_at: None,
+            output_files: Vec::new(),
+            error: None,
+            session_key: Some("local:demo".into()),
+            tool_input: None,
+            originating_client_message_id: None,
+            source: Some("model".into()),
+            role: Some("reviewer".into()),
+            summary: Some("found 1 issue".into()),
+            artifact_count: Some(2),
+            runtime_policy_stamp: Some(json!({ "approval_policy": "on-request" })),
+        };
+
+        let event = background_task_to_progress_json(&task);
+        assert_eq!(event["source"], "model");
+        assert_eq!(event["role"], "reviewer");
+        assert_eq!(event["summary"], "found 1 issue");
+        assert_eq!(event["artifact_count"], 2);
+        assert_eq!(
+            event["runtime_policy_stamp"]["approval_policy"],
+            "on-request"
+        );
+
+        // Now exercise the absent-field path — unset fields must NOT
+        // appear (no `null`) so a stale subscriber doesn't observe a
+        // spurious "reset" of fields it had already cached.
+        let bare = octos_agent::BackgroundTask {
+            id: "01900000-0000-7000-8000-000000000005".into(),
+            tool_name: "search".into(),
+            tool_call_id: "call-s".into(),
+            parent_session_key: None,
+            child_session_key: None,
+            child_terminal_state: None,
+            child_join_state: None,
+            child_joined_at: None,
+            child_failure_action: None,
+            task_ledger_path: None,
+            status: octos_agent::TaskStatus::Running,
+            runtime_state: octos_agent::TaskRuntimeState::ExecutingTool,
+            runtime_detail: None,
+            started_at: Utc::now(),
+            updated_at: Utc::now(),
+            completed_at: None,
+            output_files: Vec::new(),
+            error: None,
+            session_key: None,
+            tool_input: None,
+            originating_client_message_id: None,
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
+        };
+
+        let bare_event = background_task_to_progress_json(&bare);
+        let obj = bare_event.as_object().expect("object");
+        assert!(!obj.contains_key("source"));
+        assert!(!obj.contains_key("role"));
+        assert!(!obj.contains_key("summary"));
+        assert!(!obj.contains_key("artifact_count"));
+        assert!(!obj.contains_key("runtime_policy_stamp"));
     }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1289,6 +1289,17 @@ fn sanitize_task_for_response(
         "child_join_state": task.child_join_state,
         "child_joined_at": task.child_joined_at,
         "child_failure_action": task.child_failure_action,
+        // #966 / M13-B — surface the new BackgroundTask projection
+        // fields. Each is Option-typed; absent values serialize as
+        // null, which the AppUI TaskListProjection treats as None
+        // (its fields use `#[serde(default)]`). Existing snapshots
+        // without these fields surface as null/None, so the wire
+        // shape stays backwards-compatible.
+        "source": task.source,
+        "role": task.role,
+        "summary": task.summary,
+        "artifact_count": task.artifact_count,
+        "runtime_policy_stamp": task.runtime_policy_stamp,
         "output_files": task.output_files.iter().map(|path| task_response_path(data_dir, path)).collect::<Vec<_>>(),
         "error": task.error,
         "session_key": task.session_key,
@@ -13053,6 +13064,11 @@ mod tests {
             session_key: Some("local:test".into()),
             tool_input: None,
             originating_client_message_id: None,
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }
     }
 


### PR DESCRIPTION
## Summary

#1103 + #1109 added \`TaskListEntry.source/role/summary/artifact_count/runtime_policy_stamp\` on the AppUI wire and the corresponding decoder guard tests. The remaining gap: the production \`TaskSupervisor\` never populated them, so live \`task/list\` / \`task/updated\` payloads always emitted None.

This PR closes the supervisor-side production gap.

## Changes

| Layer | Change |
|---|---|
| \`octos_agent::task_supervisor::BackgroundTask\` | Adds five optional fields (\`source\`, \`role\`, \`summary\`, \`artifact_count\`, \`runtime_policy_stamp\`). All \`#[serde(default)]\` for backwards-compatible deserialization of pre-M13-B persisted snapshots. |
| \`TaskSupervisor::set_m13b_projection(...)\` | New setter — populates the fields after \`register_*\` without expanding every register signature. Partial updates preserve unsupplied fields. |
| \`sanitize_task_for_response\` (octos-cli session_actor) | Surfaces all five fields on the \`task/list\` and \`task/updated\` wire so the \`TaskListProjection\` decoder sees them. |
| Test-fixture constructors | 5 sites across cli + agent updated to initialise the new fields to None. |

## Tests

- \`set_m13b_projection_populates_optional_fields\` — full happy-path coverage in \`task_supervisor::tests\`:
  - register with None defaults.
  - full populate via setter overwrites every field.
  - partial update only modifies the \`Some(_)\` fields.
  - JSON wire shape matches expectation (populated fields appear, unset stays absent).
- 1476 octos-agent lib tests green.
- 1207 octos-cli lib tests green (1 pre-existing flake passes in isolation).

## Scope

This PR ships the **supervisor-side population infrastructure + AppUI wire surfacing**. Each individual spawn path (SpawnTool, DelegateTool, review/start, pipeline-driven workers) still needs to call \`set_m13b_projection(...)\` at the right moment with the right values — that wiring follows in #991 (AgentOrchestrator) and #1019/#1020 (context propagation) as those specs require knowing the spawn kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)