### PR TITLE
fix(soak): include `.` in OAuth-token redaction patterns (codex P1 follow-up to #1089)

### DIFF
--- a/e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh
+++ b/e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh
@@ -169,8 +169,8 @@ const roots = process.argv.slice(2);
 
 const patterns = [
   { regex: /dummy-key-for-m15-task-supervisor-fixture/g, label: '<fixture-key>' },
-  { regex: /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9_\-]{20,}/g, label: '<redacted>' },
-  { regex: /sk-ant-oat01-[A-Za-z0-9_\-]{20,}/g, label: '<redacted>' },
+  { regex: /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9._\-]{20,}/g, label: '<redacted>' },
+  { regex: /sk-ant-oat01-[A-Za-z0-9._\-]{20,}/g, label: '<redacted>' },
   { regex: /AIza[0-9A-Za-z_\-]{30,}/g, label: '<redacted>' },
   { regex: /AC[0-9a-f]{32}/g, label: '<redacted>' },
   { regex: /Bearer [A-Za-z0-9._\-]{32,}/g, label: 'Bearer <redacted>' },

--- a/e2e/scripts/m16-live-tui-tmux-soak.sh
+++ b/e2e/scripts/m16-live-tui-tmux-soak.sh
@@ -496,16 +496,19 @@ google: AIzaSyA-1234567890abcdefghijklmnopqrstuv
 TXT
   cat > "$out_dir/anthropic.env" <<TXT
 ANTHROPIC_API_KEY=sk-ant-oat01-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
-# codex P1 follow-up to #1089: dotted JWT-shaped OAuth tokens must be
-# scrubbed in full, not just up to the first \`.\` separator. The token
-# below uses three JWT-style segments and is included in the residual
-# grep so a regression that drops \`.\` from the char class fails here.
-ANTHROPIC_OAUTH_JWT=sk-ant-oat01-abcdefghijklmnopqr.stuvwxyz0123456789.ABCDEFGHIJKLMNOPQR
+# codex P1+P3 follow-up to #1089: dotted JWT-shaped OAuth tokens must
+# be scrubbed in full, not just up to the first \`.\` separator. The
+# first JWT segment below is intentionally short so the old (no-\`.\`)
+# regex cannot match the prefix-with-segment as a 20+ char run either;
+# without dot-aware redaction the entire token survives. The residual
+# grep then matches distinctive payload and signature markers so any
+# regression that drops \`.\` from the char class fails this self-test.
+ANTHROPIC_OAUTH_JWT=sk-ant-oat01-jwthdr.octosjwtpayloadABCDEFGH.octosjwtsignatureIJKLMNOP
 TXT
   scrub_secrets
-  if grep -RIEq -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij' "$fixture_root"; then
+  if grep -RIEq -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij|octosjwtpayload|octosjwtsignature' "$fixture_root"; then
     echo "scrub_secrets self-test FAIL: residual secrets in $fixture_root" >&2
-    grep -RIEn -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij' "$fixture_root" || true
+    grep -RIEn -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij|octosjwtpayload|octosjwtsignature' "$fixture_root" || true
     out_dir="$old_out_dir"; data_dir="$old_data_dir"; runtime_root="$old_runtime_root"
     return 1
   fi

--- a/e2e/scripts/m16-live-tui-tmux-soak.sh
+++ b/e2e/scripts/m16-live-tui-tmux-soak.sh
@@ -331,9 +331,9 @@ const roots = process.argv.slice(2);
 
 const patterns = [
   // OpenAI / DeepSeek / generic OpenAI-compatible
-  /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9_\-]{20,}/g,
+  /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9._\-]{20,}/g,
   // Anthropic OAuth bearer tokens (sk-ant-oat01-...)
-  /sk-ant-oat01-[A-Za-z0-9_\-]{20,}/g,
+  /sk-ant-oat01-[A-Za-z0-9._\-]{20,}/g,
   // Google Gemini AIza... keys
   /AIza[0-9A-Za-z_\-]{30,}/g,
   // Twilio account/auth pairs
@@ -496,6 +496,11 @@ google: AIzaSyA-1234567890abcdefghijklmnopqrstuv
 TXT
   cat > "$out_dir/anthropic.env" <<TXT
 ANTHROPIC_API_KEY=sk-ant-oat01-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+# codex P1 follow-up to #1089: dotted JWT-shaped OAuth tokens must be
+# scrubbed in full, not just up to the first \`.\` separator. The token
+# below uses three JWT-style segments and is included in the residual
+# grep so a regression that drops \`.\` from the char class fails here.
+ANTHROPIC_OAUTH_JWT=sk-ant-oat01-abcdefghijklmnopqr.stuvwxyz0123456789.ABCDEFGHIJKLMNOPQR
 TXT
   scrub_secrets
   if grep -RIEq -- 'sk-test|sk-ant-oat01|AIzaSy|Bearer abcdefghij' "$fixture_root"; then

--- a/scripts/m12-solo-appui-soak.sh
+++ b/scripts/m12-solo-appui-soak.sh
@@ -61,8 +61,8 @@ const path = require('path');
 const roots = process.argv.slice(2);
 
 const patterns = [
-  /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9_\-]{20,}/g,
-  /sk-ant-oat01-[A-Za-z0-9_\-]{20,}/g,
+  /sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?[A-Za-z0-9._\-]{20,}/g,
+  /sk-ant-oat01-[A-Za-z0-9._\-]{20,}/g,
   /AIza[0-9A-Za-z_\-]{30,}/g,
   /AC[0-9a-f]{32}/g,
   /Bearer [A-Za-z0-9._\-]{32,}/g,


### PR DESCRIPTION
## Summary

- Codex flagged on #1089 that the soak `scrub_secrets` Anthropic OAuth pattern `sk-ant-oat01-[A-Za-z0-9_\-]{20,}` excludes `.`, so a JWT-shaped token written as `sk-ant-oat01-<header>.<payload>.<sig>` matches only the first segment and the remaining payload+signature survive into the evidence tree.
- Broaden the char class to `[A-Za-z0-9._\-]{20,}` on both the generic `sk-(?:proj-|ant-|svcacct-|admin-|or-v1-)?` and the dedicated `sk-ant-oat01-` regex.
- Apply the same fix to the sibling soak scripts hardened in #1099 / #1100 (`e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh`, `scripts/m12-solo-appui-soak.sh`); they were forked from the same template and share the gap.
- Extend the m16 `self-test` fixture with a three-segment JWT-shaped token (`sk-ant-oat01-<a>.<b>.<c>`); the existing residual `grep` already matches `sk-ant-oat01`, so any regression that drops `.` from the char class will fail the self-test.

## Test plan

- [x] `bash e2e/scripts/m16-live-tui-tmux-soak.sh self-test`
- [x] `bash e2e/scripts/m15-task-supervisor-mirror-tmux-soak.sh self-test`
- [x] `bash scripts/m12-solo-appui-soak.sh self-test`