### PR TITLE
fix(goal): render wrap-up turns as actual summarize-and-stop directive (#1131)

### DIFF
--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -1144,14 +1144,17 @@ impl InProcessAgentOrchestrator {
         let goal_snapshot = goal.clone();
         persist_goal_state(&state, session_id, &goal_snapshot, false);
         if let Some(prompt) = wrap_up {
-            // Enqueue a one-shot wrap-up turn at the top of the goal's
-            // queue. Use an explicit dedupe key so the wrap-up cannot
-            // collide with the normal-continuation key shape.
+            // #1131 — Enqueue a one-shot wrap-up turn under the
+            // dedicated `GoalWrapUp` reason so the prompt renderer
+            // emits the wrap-up directive verbatim instead of the
+            // standard "Advance the goal..." template. Use an
+            // explicit dedupe key so the wrap-up cannot collide with
+            // the normal-continuation key shape.
             let mut wrap_up_request = MasterContinuationRequest::new(
                 "coding-autonomy-goal",
                 session_id.to_string(),
                 profile_id.to_owned(),
-                MasterContinuationReason::GoalContinue,
+                MasterContinuationReason::GoalWrapUp,
                 now_system,
             )
             .with_goal_id(goal_id.clone())
@@ -3613,6 +3616,7 @@ pub(crate) fn master_continuation_reason_name(reason: &MasterContinuationReason)
         MasterContinuationReason::ScatterJoinComplete => "scatter_join_complete",
         MasterContinuationReason::LoopFire => "loop_fire",
         MasterContinuationReason::GoalContinue => "goal_continue",
+        MasterContinuationReason::GoalWrapUp => "goal_wrap_up",
         MasterContinuationReason::External(_) => "external",
     }
 }
@@ -3659,6 +3663,30 @@ pub(crate) fn master_continuation_prompt(continuation: &QueuedMasterContinuation
                 .map(|id| id.as_str())
                 .unwrap_or("unknown"),
         ),
+        // #1131 — wrap-up turns must instruct the model to summarize
+        // and stop, NOT continue work. Render the per-goal wrap-up
+        // directive (stored in metadata by `record_goal_turn`) as
+        // the actual prompt body so the LLM sees the instruction
+        // verbatim instead of the generic "Advance the goal..."
+        // template. Fall back to a safe default directive if the
+        // metadata is missing (e.g. legacy persisted continuations).
+        MasterContinuationReason::GoalWrapUp => {
+            let goal_id = continuation
+                .goal_id
+                .as_ref()
+                .map(|id| id.as_str())
+                .unwrap_or("unknown");
+            let directive = continuation
+                .metadata
+                .get("wrap_up_prompt")
+                .map(String::as_str)
+                .unwrap_or(
+                    "This goal has exhausted its continuation budget. Summarize the current state, call out remaining work, and stop starting new work.",
+                );
+            format!(
+                "[system-internal]\nThe active goal exhausted its continuation budget. This is the final wrap-up turn.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\n{directive}",
+            )
+        }
         MasterContinuationReason::External(kind) => format!(
             "[system-internal]\nAn external master continuation was requested.\n\nKind: {kind}\nGroup: {group}\nMetadata:\n{metadata}\n\nHandle the continuation conservatively and summarize the visible state for the user.",
             group = continuation.group_id.as_str(),
@@ -3672,6 +3700,7 @@ fn master_continuation_reason_wire_name(reason: &MasterContinuationReason) -> St
         MasterContinuationReason::ScatterJoinComplete => "scatter_join_complete".to_owned(),
         MasterContinuationReason::LoopFire => "loop_fire".to_owned(),
         MasterContinuationReason::GoalContinue => "goal_continue".to_owned(),
+        MasterContinuationReason::GoalWrapUp => "goal_wrap_up".to_owned(),
         MasterContinuationReason::External(kind) => format!("external:{kind}"),
     }
 }
@@ -3684,6 +3713,7 @@ fn master_continuation_reason_from_wire_name(value: &str) -> Option<MasterContin
         }
         "loop_fire" | "LoopFire" => Some(MasterContinuationReason::LoopFire),
         "goal_continue" | "GoalContinue" => Some(MasterContinuationReason::GoalContinue),
+        "goal_wrap_up" | "GoalWrapUp" => Some(MasterContinuationReason::GoalWrapUp),
         value => value
             .strip_prefix("external:")
             .map(|kind| MasterContinuationReason::External(kind.to_owned())),
@@ -5802,7 +5832,9 @@ mod tests {
         );
 
         // The wrap-up turn must be queued separately from any prior
-        // GoalContinue.
+        // GoalContinue, and rides the new dedicated `GoalWrapUp`
+        // reason (#1131) so the prompt renderer treats it as a
+        // "summarize and stop" turn instead of a regular advance.
         let drained = orchestrator.drain_ready_continuations_for_session(
             &session_id,
             "tenant-a",
@@ -5810,7 +5842,7 @@ mod tests {
             usize::MAX,
         );
         assert_eq!(drained.len(), 1);
-        assert_eq!(drained[0].reason, MasterContinuationReason::GoalContinue);
+        assert_eq!(drained[0].reason, MasterContinuationReason::GoalWrapUp);
         assert_eq!(
             drained[0].metadata.get("wrap_up").map(String::as_str),
             Some("true")
@@ -5827,6 +5859,67 @@ mod tests {
         // emit a duplicate wrap-up.
         orchestrator.record_goal_turn(&session_id, "tenant-a", 100, 1);
         assert_eq!(orchestrator.pending_continuation_count_for_test(), 0);
+    }
+
+    /// #1131 — when the budget-exhaustion wrap-up turn is dispatched,
+    /// the rendered prompt must contain the wrap-up directive
+    /// verbatim (i.e. "Summarize the current state..."), NOT the
+    /// regular "Advance the goal by one bounded step" template that
+    /// the GoalContinue path emits. Otherwise the model keeps
+    /// working instead of summarizing and stopping.
+    #[test]
+    fn goal_wrap_up_turn_uses_wrap_up_text_as_directive() {
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "goal-wrap-prompt");
+        orchestrator
+            .set_goal(GoalSetRequest {
+                session_id: session_id.clone(),
+                profile_id: "tenant-a".into(),
+                objective: "exhaust then summarize".into(),
+                status: Some("active".into()),
+                token_budget: Some(1_000),
+                transition_actor: None,
+            })
+            .expect("set active goal");
+        // Drain any goal continuation that the `set_goal` lifecycle
+        // may have queued so we only observe the wrap-up turn below.
+        let _ = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+
+        orchestrator.force_goal_tokens_used_for_test(&session_id, 900);
+        orchestrator.record_goal_turn(&session_id, "tenant-a", 200, 5);
+
+        let drained = orchestrator.drain_ready_continuations_for_session(
+            &session_id,
+            "tenant-a",
+            MasterContinuationRuntimeState::idle(),
+            usize::MAX,
+        );
+        assert_eq!(drained.len(), 1, "wrap-up must be the only queued turn");
+        assert_eq!(drained[0].reason, MasterContinuationReason::GoalWrapUp);
+
+        let rendered = master_continuation_prompt(&drained[0]);
+        let wrap_up_directive = drained[0]
+            .metadata
+            .get("wrap_up_prompt")
+            .cloned()
+            .expect("wrap_up_prompt metadata must be present");
+        assert!(
+            rendered.contains(&wrap_up_directive),
+            "rendered prompt must contain the wrap-up directive verbatim; rendered=\n{rendered}",
+        );
+        assert!(
+            rendered.contains("Summarize the current state"),
+            "rendered prompt must instruct the model to summarize; rendered=\n{rendered}",
+        );
+        assert!(
+            !rendered.contains("Advance the goal by one bounded step"),
+            "rendered prompt must NOT use the GoalContinue 'advance' template; rendered=\n{rendered}",
+        );
     }
 
     /// Bullet 3: a goal in `budget_limited` no longer fires the

--- a/crates/octos-cli/src/api/agent_orchestrator.rs
+++ b/crates/octos-cli/src/api/agent_orchestrator.rs
@@ -3655,14 +3655,30 @@ pub(crate) fn master_continuation_prompt(continuation: &QueuedMasterContinuation
                 .map(|id| id.as_str())
                 .unwrap_or("unknown"),
         ),
-        MasterContinuationReason::GoalContinue => format!(
-            "[system-internal]\nAn active goal continuation is ready.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\nAdvance the goal by one bounded step. If the goal needs user input, ask a numbered choice question and recommend one option.",
-            goal_id = continuation
+        MasterContinuationReason::GoalContinue => {
+            // #1139 codex P2 follow-up: legacy promotion — wrap-up
+            // continuations queued by the pre-#1131 wire shape (which
+            // used `GoalContinue` + `wrap_up_prompt` metadata) survive
+            // a restart with the old reason. Detect that legacy shape
+            // here and render it as a wrap-up turn so the in-flight
+            // final turn instructs the model to summarize-and-stop
+            // instead of "Advance the goal...". New continuations
+            // queued post-#1131 use `GoalWrapUp` directly; this
+            // promotion is a one-way restore-time fixup.
+            let goal_id = continuation
                 .goal_id
                 .as_ref()
                 .map(|id| id.as_str())
-                .unwrap_or("unknown"),
-        ),
+                .unwrap_or("unknown");
+            if let Some(directive) = continuation.metadata.get("wrap_up_prompt") {
+                return format!(
+                    "[system-internal]\nThe active goal exhausted its continuation budget. This is the final wrap-up turn.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\n{directive}",
+                );
+            }
+            format!(
+                "[system-internal]\nAn active goal continuation is ready.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\nAdvance the goal by one bounded step. If the goal needs user input, ask a numbered choice question and recommend one option.",
+            )
+        }
         // #1131 — wrap-up turns must instruct the model to summarize
         // and stop, NOT continue work. Render the per-goal wrap-up
         // directive (stored in metadata by `record_goal_turn`) as
@@ -5919,6 +5935,54 @@ mod tests {
         assert!(
             !rendered.contains("Advance the goal by one bounded step"),
             "rendered prompt must NOT use the GoalContinue 'advance' template; rendered=\n{rendered}",
+        );
+    }
+
+    /// #1139 codex P2 acceptance: a legacy wrap-up continuation
+    /// (queued before #1131 with `GoalContinue` + `wrap_up_prompt`
+    /// metadata, then restored after an upgrade/restart) MUST render
+    /// as a wrap-up directive — NOT as the regular "Advance the goal"
+    /// template. This pins the restore-time promotion in
+    /// `master_continuation_prompt`.
+    ///
+    /// We can't ergonomically hand-build a `QueuedMasterContinuation`
+    /// (private fields), so we drive the legacy-shaped enqueue
+    /// directly: `MasterContinuationRequest::new(GoalContinue, …)`
+    /// with a `wrap_up_prompt` metadata key — exactly what
+    /// pre-#1131 code emitted on budget exhaustion.
+    #[test]
+    fn legacy_goal_continue_with_wrap_up_metadata_promotes_to_wrap_up() {
+        use crate::api::master_continuation_scheduler::MasterContinuationRequest;
+
+        let orchestrator = InProcessAgentOrchestrator::default();
+        let session_id = SessionKey::with_profile("tenant-a", "api", "legacy-wrap-up");
+        let mut state = orchestrator.state();
+        // Hand-enqueue the legacy shape.
+        let legacy = MasterContinuationRequest::new(
+            "coding-autonomy-goal",
+            session_id.to_string(),
+            "tenant-a".to_owned(),
+            MasterContinuationReason::GoalContinue,
+            SystemTime::now(),
+        )
+        .with_goal_id("legacy-goal-id")
+        .with_metadata(
+            "wrap_up_prompt",
+            "LEGACY DIRECTIVE: summarize what you've done and stop.",
+        );
+        let outcome = enqueue_and_persist_continuation(&mut state, legacy);
+        let queued = outcome.queued().expect("legacy enqueue must succeed");
+        let legacy_continuation = queued.clone();
+        drop(state);
+
+        let rendered = master_continuation_prompt(&legacy_continuation);
+        assert!(
+            rendered.contains("LEGACY DIRECTIVE: summarize what you've done and stop."),
+            "legacy promotion must render the persisted wrap-up directive verbatim; rendered=\n{rendered}",
+        );
+        assert!(
+            !rendered.contains("Advance the goal by one bounded step"),
+            "legacy promotion must NOT fall through to the regular GoalContinue template; rendered=\n{rendered}",
         );
     }
 

--- a/crates/octos-cli/src/api/master_continuation_scheduler.rs
+++ b/crates/octos-cli/src/api/master_continuation_scheduler.rs
@@ -87,6 +87,12 @@ pub(crate) enum MasterContinuationReason {
     ScatterJoinComplete,
     LoopFire,
     GoalContinue,
+    /// #1131 — terminal "summarize and stop" turn enqueued when a
+    /// goal exhausts its token budget. Carries the wrap-up directive
+    /// in `wrap_up_prompt` metadata; the prompt renderer must use
+    /// that text verbatim instead of the standard "Advance the
+    /// goal..." template.
+    GoalWrapUp,
     External(String),
 }
 
@@ -97,7 +103,10 @@ impl MasterContinuationReason {
             Self::ChildCompleted | Self::ScatterJoinComplete => {
                 MasterContinuationPriority::ChildOrScatterJoinComplete
             }
-            Self::GoalContinue => MasterContinuationPriority::GoalContinue,
+            // #1131 — wrap-up rides the same priority lane as a
+            // regular goal continuation. It is the LAST goal turn
+            // before the session pauses, not a privileged one.
+            Self::GoalContinue | Self::GoalWrapUp => MasterContinuationPriority::GoalContinue,
             Self::External(_) => MasterContinuationPriority::External,
         }
     }
@@ -108,6 +117,7 @@ impl MasterContinuationReason {
             Self::ScatterJoinComplete => "scatter_join_complete",
             Self::LoopFire => "loop_fire",
             Self::GoalContinue => "goal_continue",
+            Self::GoalWrapUp => "goal_wrap_up",
             Self::External(_) => "external",
         }
     }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -8469,7 +8469,16 @@ async fn maybe_spawn_appui_master_continuation_runner(
         // dispatch-only updater touches only the timestamp, so the
         // budget remains aligned with real token spend. Full token
         // accounting + sentinel detection wiring tracked in #1133.
-        if matches!(continuation.reason, MasterContinuationReason::GoalContinue) {
+        // #1131 — `GoalWrapUp` is also a goal-driven dispatch, so
+        // touch the goal's `last_continued_at_ms` here too. The goal
+        // is already in `budget_limited` and the scheduler will not
+        // re-fire it, but keeping the dispatch path symmetric with
+        // `GoalContinue` avoids drift in any future caller that
+        // inspects the timestamp.
+        if matches!(
+            continuation.reason,
+            MasterContinuationReason::GoalContinue | MasterContinuationReason::GoalWrapUp,
+        ) {
             default_agent_orchestrator().record_goal_dispatch_only(
                 &SessionKey(continuation.session_id.as_str().to_owned()),
                 continuation.profile_id.as_str(),

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3463,14 +3463,27 @@ fn master_continuation_prompt(continuation: &QueuedMasterContinuation) -> String
                 .map(|id| id.as_str())
                 .unwrap_or("unknown"),
         ),
-        MasterContinuationReason::GoalContinue => format!(
-            "[system-internal]\nAn active goal continuation is ready.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\nAdvance the goal by one bounded step. If the goal needs user input, ask a numbered choice question and recommend one option.",
-            goal_id = continuation
+        MasterContinuationReason::GoalContinue => {
+            // #1139 codex P2 follow-up: legacy wrap-up promotion —
+            // mirrors `agent_orchestrator::master_continuation_prompt`.
+            // A continuation queued by the pre-#1131 wire shape used
+            // `GoalContinue` + `wrap_up_prompt` metadata; promote it
+            // at render time so the in-flight final turn instructs
+            // the model to summarize-and-stop.
+            let goal_id = continuation
                 .goal_id
                 .as_ref()
                 .map(|id| id.as_str())
-                .unwrap_or("unknown"),
-        ),
+                .unwrap_or("unknown");
+            if let Some(directive) = continuation.metadata.get("wrap_up_prompt") {
+                return format!(
+                    "[system-internal]\nThe active goal exhausted its continuation budget. This is the final wrap-up turn.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\n{directive}",
+                );
+            }
+            format!(
+                "[system-internal]\nAn active goal continuation is ready.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\nAdvance the goal by one bounded step. If the goal needs user input, ask a numbered choice question and recommend one option.",
+            )
+        }
         // #1131 — wrap-up turns must instruct the model to summarize
         // and stop, NOT continue work. Render the per-goal wrap-up
         // directive (stored in metadata by `record_goal_turn`) as

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -3423,6 +3423,7 @@ fn master_continuation_reason_name(reason: &MasterContinuationReason) -> &str {
         MasterContinuationReason::ScatterJoinComplete => "scatter_join_complete",
         MasterContinuationReason::LoopFire => "loop_fire",
         MasterContinuationReason::GoalContinue => "goal_continue",
+        MasterContinuationReason::GoalWrapUp => "goal_wrap_up",
         MasterContinuationReason::External(_) => "external",
     }
 }
@@ -3470,6 +3471,30 @@ fn master_continuation_prompt(continuation: &QueuedMasterContinuation) -> String
                 .map(|id| id.as_str())
                 .unwrap_or("unknown"),
         ),
+        // #1131 — wrap-up turns must instruct the model to summarize
+        // and stop, NOT continue work. Render the per-goal wrap-up
+        // directive (stored in metadata by `record_goal_turn`) as
+        // the actual prompt body so the LLM sees the instruction
+        // verbatim instead of the generic "Advance the goal..."
+        // template. Mirrors the canonical renderer in
+        // `agent_orchestrator::master_continuation_prompt`.
+        MasterContinuationReason::GoalWrapUp => {
+            let goal_id = continuation
+                .goal_id
+                .as_ref()
+                .map(|id| id.as_str())
+                .unwrap_or("unknown");
+            let directive = continuation
+                .metadata
+                .get("wrap_up_prompt")
+                .map(String::as_str)
+                .unwrap_or(
+                    "This goal has exhausted its continuation budget. Summarize the current state, call out remaining work, and stop starting new work.",
+                );
+            format!(
+                "[system-internal]\nThe active goal exhausted its continuation budget. This is the final wrap-up turn.\n\nGoal: {goal_id}\nMetadata:\n{metadata}\n\n{directive}",
+            )
+        }
         MasterContinuationReason::External(kind) => format!(
             "[system-internal]\nAn external master continuation was requested.\n\nKind: {kind}\nGroup: {group}\nMetadata:\n{metadata}\n\nHandle the continuation conservatively and summarize the visible state for the user.",
             group = continuation.group_id.as_str(),
@@ -3843,8 +3868,16 @@ impl SessionActor {
                 reason = master_continuation_reason_name(&continuation.reason),
                 "draining queued master continuation into session actor"
             );
-            let is_goal_turn =
-                matches!(continuation.reason, MasterContinuationReason::GoalContinue);
+            // #1131 — `GoalWrapUp` is the final goal turn under
+            // budget exhaustion. Treat it as a goal turn for runtime
+            // accounting so per-turn elapsed time is still recorded;
+            // `record_goal_turn_internal` is idempotent against the
+            // already-set `wrap_up_emitted` flag and will NOT
+            // re-enqueue a second wrap-up.
+            let is_goal_turn = matches!(
+                continuation.reason,
+                MasterContinuationReason::GoalContinue | MasterContinuationReason::GoalWrapUp,
+            );
             let goal_turn_start = Instant::now();
             default_agent_orchestrator().mark_continuation_started(&continuation);
             // #977 bullet 4 — capture the loop id (if any) BEFORE we


### PR DESCRIPTION
Closes #1131. Goal wrap-up now actually instructs the model to summarize.

## Summary

- Budget-exhaustion wrap-up turns previously rode the `GoalContinue` continuation reason, so the production prompt renderer kept ending them with "Advance the goal by one bounded step." The wrap-up text sat in metadata while the LLM was told to continue working.
- Added `MasterContinuationReason::GoalWrapUp`. `record_goal_turn` now enqueues the wrap-up under this dedicated reason.
- `master_continuation_prompt` (both the canonical copy in `agent_orchestrator.rs` and the duplicate in `session_actor.rs`) renders the metadata `wrap_up_prompt` verbatim as the prompt body for `GoalWrapUp`, so the model actually summarizes and stops.
- All wire-level surfaces updated: `master_continuation_reason_name`, `master_continuation_reason_wire_name`, the reverse `master_continuation_reason_from_wire_name` deserializer, the `is_goal_turn` predicate in `session_actor`, and the `record_goal_dispatch_only` predicate in `ui_protocol`. New variant round-trips through the persisted continuation record.
- Took **Option A** (preferred): the new enum variant gives cleaner separation of concerns, and the exhaustiveness churn was contained to four files.

## Test plan

- [x] `cargo build -p octos-cli --features api` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-cli --features api` — no new warnings introduced
- [x] `cargo test -p octos-cli --features api --lib goal` — 27 passed including:
  - new `goal_wrap_up_turn_uses_wrap_up_text_as_directive`
  - existing `record_goal_turn_emits_wrap_up_on_budget_exhaustion` (updated to expect the new reason)

## Notes

- Wrap-up turns still ride the same `GoalContinue` priority lane — this is the LAST goal turn before the session pauses, not a privileged one.
- `record_goal_turn_internal` already guards against double wrap-up via `wrap_up_emitted`, so dispatching a `GoalWrapUp` and then re-entering the runtime won't enqueue a second wrap-up.