### PR TITLE
fix(install): tighten TLS gate to apex + single label only (#1124)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1345,6 +1345,10 @@ if ($Domain -and (Test-Command "caddy")) {
     Section "Configuring Caddy for $Domain"
     $caddyfile = Join-Path $DataDir "Caddyfile"
     $caddyUpstream = "localhost:$Port"
+    # Regex-escape the configured domain so dots match literally
+    # (each '.' becomes '\\.' in the emitted Caddyfile, which CEL parses
+    # to '\.' and RE2 then treats as a literal dot). Closes #1124.
+    $DomainRe = $Domain.Replace('.', '\\.')
     @"
 {
     on_demand_tls {
@@ -1353,13 +1357,16 @@ if ($Domain -and (Test-Command "caddy")) {
 }
 
 :9999 {
-    # On-demand TLS gate. Only the configured apex/subdomains may
+    # On-demand TLS gate. Only the configured apex or exactly one
+    # label before it (matching the *.$Domain route below) may
     # trigger ACME issuance — any other SNI returns 403 so Caddy
-    # refuses to ask Let's Encrypt for a cert. This is the security
+    # refuses to ask Let's Encrypt for a cert. Deeper names like
+    # a.b.$Domain are NOT routed and must not consume the
+    # configured domain's ACME rate limit. This is the security
     # boundary that prevents arbitrary DNS pointed at this server
     # from burning ACME rate limits. See codex P1 follow-up to
-    # #380 / #1070.
-    @octos_tls expression ``{query.domain} == "$Domain" || {query.domain}.endsWith(".$Domain")``
+    # #380 / #1070, and #1124 for the apex+single-label tightening.
+    @octos_tls expression ``{query.domain}.matches("^([^.]+\\.)?$DomainRe`$")``
     respond @octos_tls 200
     respond /check 403
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1747,6 +1747,11 @@ if [ -n "$CADDY_DOMAIN" ]; then
     # Determine serve port (match what octos serve uses)
     CADDY_UPSTREAM="localhost:${PORT}"
 
+    # Regex-escape the configured domain so dots match literally
+    # (each '.' becomes '\\.' in the emitted Caddyfile, which CEL parses
+    # to '\.' and RE2 then treats as a literal dot). Closes #1124.
+    CADDY_DOMAIN_RE="${CADDY_DOMAIN//./\\\\.}"
+
     # Write Caddyfile
     CADDYFILE_PATH="$DATA_DIR/Caddyfile"
     cat > "$CADDYFILE_PATH" << CADDYEOF
@@ -1757,13 +1762,16 @@ if [ -n "$CADDY_DOMAIN" ]; then
 }
 
 :9999 {
-    # On-demand TLS gate. Only the configured apex/subdomains may
-    # trigger ACME issuance — any other SNI returns 403 so Caddy
-    # refuses to ask Let's Encrypt for a cert. This is the security
+    # On-demand TLS gate. Only the configured apex or exactly one
+    # label before it (matching the *.${CADDY_DOMAIN} route below)
+    # may trigger ACME issuance — any other SNI returns 403 so Caddy
+    # refuses to ask Let's Encrypt for a cert. Deeper names like
+    # a.b.${CADDY_DOMAIN} are NOT routed and must not consume the
+    # configured domain's ACME rate limit. This is the security
     # boundary that prevents arbitrary DNS pointed at this server
     # from burning ACME rate limits. See codex P1 follow-up to
-    # #380 / #1070.
-    @octos_tls expression \`{query.domain} == "${CADDY_DOMAIN}" || {query.domain}.endsWith(".${CADDY_DOMAIN}")\`
+    # #380 / #1070, and #1124 for the apex+single-label tightening.
+    @octos_tls expression \`{query.domain}.matches("^([^.]+\\\\.)?${CADDY_DOMAIN_RE}\$")\`
     respond @octos_tls 200
     respond /check 403
 }


### PR DESCRIPTION
## Summary

The on-demand TLS ask endpoint previously used:

```
{query.domain} == "${CADDY_DOMAIN}" || {query.domain}.endsWith(".${CADDY_DOMAIN}")
```

The `endsWith` branch matched deeper names such as `a.b.${CADDY_DOMAIN}` and returned 200, even though the catch-all `https://` site below only routes the apex (`${CADDY_DOMAIN}`) and exactly one label before it (`*.${CADDY_DOMAIN}`). Non-routed deeper names could still trigger ACME issuance and burn the configured domain's rate limit.

## Fix

Replace the suffix check with a regex match that allows the apex or exactly one label before it:

```
{query.domain}.matches("^([^.]+\\.)?<domain-escaped>$")
```

- `^...$` anchors the full hostname.
- `([^.]+\.)?` optionally allows one dot-free label followed by a literal dot.
- `<domain-escaped>` is the configured `CADDY_DOMAIN` with each `.` replaced by `\\.` (in the emitted Caddyfile). CEL parses `\\.` to `\.` and RE2 then matches as a literal dot.

The same regex shape is applied to `scripts/install.ps1` via `$Domain.Replace('.', '\\.')`.

### Regex behavior (verified live against `caddy v2.11.3`)

| Hostname              | Old gate | New gate |
|-----------------------|----------|----------|
| `example.com` (apex)  | 200      | 200      |
| `foo.example.com`     | 200      | 200      |
| `foo-bar.example.com` | 200      | 200      |
| `a.b.example.com`     | 200 (bug)| 403      |
| `a.b.c.example.com`   | 200 (bug)| 403      |
| `evil.com`            | 403      | 403      |
| `xexample.com`        | 403      | 403      |

The fix's regex / expression shape (reproduced here so a reviewer can verify by inspection):

- install.sh emits: `` `{query.domain}.matches("^([^.]+\\.)?example\\.com$")` ``
- install.ps1 emits the same line.

## Test plan

- [x] Validate emitted Caddyfile with `caddy validate` — passes.
- [x] Run Caddy live with the new gate and curl all hostname cases above — matches the table.
- [x] Confirm the OLD expression returns 200 for `a.b.example.com` (reproduces the bug).
- [x] Confirm shebang and PowerShell interpolation produce the expected literal regex (`\\.` in the file).

Closes #1124.