### PR TITLE
fix(delegate): forward TaskSupervisor child_session_key to context factory (#1132)

### DIFF
--- a/crates/octos-agent/src/tools/delegate.rs
+++ b/crates/octos-agent/src/tools/delegate.rs
@@ -634,19 +634,27 @@ impl Tool for DelegateTool {
             worker = worker.with_system_prompt(prompt.clone());
         }
         if let Some(factory) = self.child_prompt_context_manager_factory.as_ref() {
-            // #1126 codex P1: pass `None` so the factory derives a
-            // unique child session key per delegated worker (e.g.
-            // `parent#spawn-<worker>` in the session_actor factory).
-            // Previously this forwarded `self.session_key.clone()`
-            // (the PARENT key), which the factory honours verbatim —
-            // every delegated child then persisted its forked context
-            // back onto the parent's `context_ledgers/<session>.json`,
-            // letting resume/audit observe a child's truncated fork
-            // in place of the parent transcript. Mirrors the SpawnTool
-            // path which already passes `None` (see spawn.rs).
+            // #1132: forward the supervisor-derived `child_session_key`
+            // (`parent#child-<task_id>`) so the persisted context
+            // ledger matches the key recorded in the task ledger.
+            // Audit/resume paths follow `BackgroundTask.child_session_key`,
+            // so synthesising a different key here (PR #1126 passed
+            // `None`, which made the session_actor factory mint a
+            // `parent#spawn-delegate-N` key) silently divorced the
+            // child's forked context from the task it backed.
+            //
+            // Fallback: when no TaskSupervisor is wired (standalone /
+            // legacy tests), keep `None` so the factory mints its own
+            // unique key — there's no registered BackgroundTask to
+            // read a key from.
+            let supervisor_child_session_key = self
+                .task_supervisor
+                .as_ref()
+                .and_then(|supervisor| supervisor.get_task(&child_task_id))
+                .and_then(|task| task.child_session_key);
             if let Some(manager) = factory(ChildPromptContextRequest {
                 parent_session_key: self.session_key.clone(),
-                child_session_key: None,
+                child_session_key: supervisor_child_session_key,
                 task_id: Some(child_task_id.clone()),
                 worker_id: worker_id_for_context,
                 task_label: label.clone(),

--- a/crates/octos-agent/tests/delegate_tool.rs
+++ b/crates/octos-agent/tests/delegate_tool.rs
@@ -140,7 +140,7 @@ async fn should_wire_prompt_context_manager_into_delegated_child() {
     let factory_requests = requests.clone();
 
     let tool = DelegateTool::new(llm("done"), memory, PathBuf::from(dir.path()))
-        .with_task_supervisor(supervisor, "api:test-session")
+        .with_task_supervisor(supervisor.clone(), "api:test-session")
         .with_child_prompt_context_manager_factory(Arc::new(move |request| {
             factory_requests
                 .lock()
@@ -172,20 +172,84 @@ async fn should_wire_prompt_context_manager_into_delegated_child() {
         request.parent_session_key.as_deref(),
         Some("api:test-session")
     );
-    // #1126 codex P1: DelegateTool MUST pass `None` so the factory
-    // derives a unique child session key (mirrors SpawnTool). The
-    // previous shape forwarded the parent key, which made the child
-    // bridge persist its forked context onto the parent's ledger and
-    // let resume/audit observe a truncated child fork in place of the
-    // parent transcript.
+    // #1132: when a TaskSupervisor is wired, DelegateTool MUST forward
+    // the supervisor-registered `child_session_key` so the persisted
+    // context ledger and the supervisor's task ledger share the same
+    // key. Synthesising a separate `parent#spawn-delegate-N` key
+    // (PR #1126) caused audit/resume paths that follow
+    // `child_session_key` to miss the delegated worker's forked context.
+    let registered_tasks = supervisor.get_tasks_for_session("api:test-session");
+    assert_eq!(registered_tasks.len(), 1, "register must record one task");
+    let registered = &registered_tasks[0];
+    let expected_child_key = format!("api:test-session#child-{}", registered.id);
+    assert_eq!(
+        request.child_session_key.as_deref(),
+        Some(expected_child_key.as_str()),
+        "child_session_key must match the supervisor-derived key (got {:?}, expected {:?})",
+        request.child_session_key,
+        expected_child_key,
+    );
+    assert_eq!(
+        registered.child_session_key.as_deref(),
+        Some(expected_child_key.as_str()),
+        "supervisor must persist the same child_session_key it forwarded to the factory"
+    );
+    assert_eq!(request.task_id.as_deref(), Some(registered.id.as_str()));
+    assert_eq!(request.worker_id, "delegate-0");
+    assert_eq!(request.task_label, "managed-delegate");
+}
+
+#[tokio::test]
+async fn should_pass_none_child_session_key_when_supervisor_absent() {
+    // #1132: legacy / standalone path — when no TaskSupervisor is wired
+    // there is no registered BackgroundTask to read a key from, so
+    // DelegateTool must fall back to `None` and let the factory mint a
+    // unique key (mirrors the SpawnTool path).
+    let dir = TempDir::new().unwrap();
+    let memory = memory(&dir).await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let requests: Arc<std::sync::Mutex<Vec<ChildPromptContextRequest>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let factory_calls = calls.clone();
+    let factory_requests = requests.clone();
+
+    let tool = DelegateTool::new(llm("done"), memory, PathBuf::from(dir.path()))
+        .with_child_prompt_context_manager_factory(Arc::new(move |request| {
+            factory_requests
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(request);
+            Some(Arc::new(RecordingPromptContextManager {
+                calls: factory_calls.clone(),
+            }))
+        }));
+
+    let result = tool
+        .execute(&serde_json::json!({
+            "task": "delegate without supervisor",
+            "label": "standalone-delegate"
+        }))
+        .await
+        .unwrap();
+
+    assert!(result.success, "child should succeed: {}", result.output);
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    let captured = requests.lock().unwrap_or_else(|error| error.into_inner());
+    assert_eq!(captured.len(), 1);
+    let request = &captured[0];
+    assert!(
+        request.parent_session_key.is_none(),
+        "no supervisor means no parent session key (got {:?})",
+        request.parent_session_key,
+    );
     assert!(
         request.child_session_key.is_none(),
-        "child_session_key must be None so the factory mints a unique child key (got {:?})",
+        "without a supervisor the fallback must keep child_session_key=None (got {:?})",
         request.child_session_key,
     );
     assert!(request.task_id.is_some());
     assert_eq!(request.worker_id, "delegate-0");
-    assert_eq!(request.task_label, "managed-delegate");
+    assert_eq!(request.task_label, "standalone-delegate");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- DelegateTool now forwards the TaskSupervisor-registered `BackgroundTask.child_session_key` (`parent#child-<task_id>`) into `ChildPromptContextRequest`, so the persisted context ledger matches the key exposed on the task ledger.
- The legacy / standalone path (no supervisor wired) keeps the `None` fallback so the factory still mints its own unique key, mirroring `SpawnTool`.

## Why

PR #1126 made DelegateTool pass `None`, which let the session_actor factory synthesise a separate `parent#spawn-delegate-N` key for the persisted context ledger. That divorced the persisted context from the supervisor's task ledger, so any audit/resume path that follows `BackgroundTask.child_session_key` could not locate the delegated worker's forked context.

## Test plan

- [x] `cargo test -p octos-agent --test delegate_tool` (10/10 passing, incl. updated `should_wire_prompt_context_manager_into_delegated_child` + new `should_pass_none_child_session_key_when_supervisor_absent`).
- [x] `cargo test -p octos-agent` (full crate suite green).
- [x] `cargo fmt --all -- --check`.
- [x] `cargo clippy -p octos-agent --all-targets -- -D warnings`.

Closes #1132.