### PR TITLE
fix(spawn): fork child context BEFORE background task awaits (#1125)

### DIFF
--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2559,8 +2559,34 @@ impl Tool for SpawnTool {
             let parent_file_state_cache = self.parent_file_state_cache.clone();
             let parent_subagent_output_router = self.parent_subagent_output_router.clone();
             let parent_subagent_summary_generator = self.parent_subagent_summary_generator.clone();
-            let child_prompt_context_manager_factory =
-                self.child_prompt_context_manager_factory.clone();
+            // Issue #1125: invoke the child prompt-context factory
+            // SYNCHRONOUSLY here (before any `await`) so the fork captures
+            // the parent transcript as it stood at spawn dispatch time.
+            //
+            // The previous wiring deferred this call into the detached
+            // `tokio::spawn` below, AFTER awaiting
+            // `dispatch_child_session_lifecycle`. If the parent recorded
+            // another user turn during that await window, the factory
+            // (which locks the live parent `ContextManager`) would fork a
+            // POST-spawn snapshot — leaking messages that were not part
+            // of the spawning turn into the background child's context.
+            //
+            // Fork-at-dispatch produces a `ContextManager` snapshot pinned
+            // to the pre-spawn parent generation; the detached task just
+            // installs the pre-baked manager on the child Agent without
+            // touching the parent lock.
+            let prebuilt_child_prompt_context_manager = self
+                .child_prompt_context_manager_factory
+                .as_ref()
+                .and_then(|factory| {
+                    factory(ChildPromptContextRequest {
+                        parent_session_key: self.session_key.clone(),
+                        child_session_key: tracked_child_session_key.clone(),
+                        task_id: tracked_task_id.clone(),
+                        worker_id: worker_id.to_string(),
+                        task_label: label.clone(),
+                    })
+                });
             // Guard C (issue #607): snapshot the caller's spawn depth so
             // the detached child Agent dispatched below sees
             // `parent_depth + 1` and the [`MAX_SPAWN_DEPTH`] gate fires
@@ -2724,16 +2750,15 @@ impl Tool for SpawnTool {
                 }) {
                     worker = worker.with_hook_context(ctx);
                 }
-                if let Some(factory) = child_prompt_context_manager_factory.as_ref() {
-                    if let Some(manager) = factory(ChildPromptContextRequest {
-                        parent_session_key: parent_session_key.clone(),
-                        child_session_key: tracked_child_session_key.clone(),
-                        task_id: tracked_task_id.clone(),
-                        worker_id: wid.to_string(),
-                        task_label: task_label.clone(),
-                    }) {
-                        worker = worker.with_prompt_context_manager(manager);
-                    }
+                // Issue #1125: install the pre-spawn-snapshot child
+                // prompt-context manager that we forked synchronously at
+                // dispatch time (see `prebuilt_child_prompt_context_manager`
+                // above). The factory was invoked BEFORE this `tokio::spawn`
+                // entered any await so the fork is pinned to the parent
+                // generation at SpawnTool dispatch — post-spawn user
+                // messages on the parent cannot leak into this child.
+                if let Some(manager) = prebuilt_child_prompt_context_manager {
+                    worker = worker.with_prompt_context_manager(manager);
                 }
 
                 // Review A F-004: propagate the parent's declarative

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -8316,6 +8316,207 @@ mod tests {
         );
     }
 
+    /// Regression for issue #1125. The background SpawnTool path used to
+    /// invoke the [`ChildPromptContextRequest`] factory inside the
+    /// detached `tokio::spawn` task AFTER awaiting child-session
+    /// lifecycle persistence. The factory locks the live parent
+    /// [`ContextManager`], so if the parent recorded another turn
+    /// during that await window the child fork inherited a POST-spawn
+    /// snapshot — leaking user messages that were not part of the
+    /// spawning turn into the background worker's context.
+    ///
+    /// The fix invokes the factory synchronously at the SpawnTool
+    /// dispatch site, before any `await`. This test pins that contract
+    /// by:
+    ///   1. Wiring the production-shaped factory onto a real
+    ///      [`SpawnTool`] together with a `child_session_sender` that
+    ///      sleeps to simulate slow persistence.
+    ///   2. Driving a background spawn via `execute_with_context`.
+    ///   3. Recording a "post-spawn" user message on the parent
+    ///      immediately after `execute_with_context` returns.
+    ///   4. Asserting the child manager captured by the factory does
+    ///      NOT contain the post-spawn message.
+    ///
+    /// Without the fix, the factory would still be pending while we
+    /// record the post-spawn message; the eventual fork would include
+    /// it and the test would fail.
+    #[tokio::test]
+    async fn spawn_child_context_fork_uses_pre_spawn_parent_snapshot() {
+        use crate::context_manager::TranscriptItemKind;
+        use octos_agent::tools::Tool;
+        use octos_agent::tools::spawn::{
+            ChildSessionLifecyclePayload, ChildSessionLifecycleSender,
+        };
+
+        const PRE_SPAWN_CONTENT: &str = "pre-spawn user turn that triggered spawn";
+        const POST_SPAWN_CONTENT: &str = "POST-SPAWN user message that MUST NOT leak";
+
+        let parent_session_key = SessionKey::new("cli", "parent-1125");
+        let mut parent = ContextManager::new(parent_session_key.to_string(), None);
+        parent.record_message(&test_message(MessageRole::System, "system"));
+        parent.record_message(&test_message(MessageRole::User, PRE_SPAWN_CONTENT));
+        let parent_arc = Arc::new(StdMutex::new(parent));
+        let data_dir = tempfile::TempDir::new().unwrap();
+
+        // Capture the child manager produced by the production-shaped
+        // factory so the test can introspect what the fork actually
+        // saw. The wrapping factory delegates straight to
+        // `build_forked_child_context_for_session_actor`, mirroring
+        // the production wiring at `session_actor.rs:2740` (issue
+        // #1019).
+        let captured_child: Arc<StdMutex<Option<ContextManager>>> = Arc::new(StdMutex::new(None));
+        let captured_child_for_factory = captured_child.clone();
+        let parent_arc_for_factory = parent_arc.clone();
+        let parent_session_key_for_factory = parent_session_key.clone();
+        let data_dir_for_factory = data_dir.path().to_path_buf();
+        let factory: octos_agent::tools::spawn::ChildPromptContextManagerFactory =
+            Arc::new(move |request: ChildPromptContextRequest| {
+                let (child_session_key, child_manager) =
+                    build_forked_child_context_for_session_actor(
+                        &parent_arc_for_factory,
+                        &data_dir_for_factory,
+                        &parent_session_key_for_factory,
+                        &request,
+                    );
+                // Snapshot the freshly-forked manager BEFORE handing it
+                // to the bridge so the assertions below observe exactly
+                // what the child would consume.
+                {
+                    let mut slot = captured_child_for_factory.lock().unwrap();
+                    *slot = Some(child_manager.clone());
+                }
+                Some(Arc::new(SessionActorPromptContextBridge::new(
+                    child_session_key,
+                    data_dir_for_factory.clone(),
+                    Arc::new(StdMutex::new(child_manager)),
+                )) as Arc<dyn PromptContextManager>)
+            });
+
+        // `child_session_sender` is the first `await` the background
+        // task issues after `tokio::spawn`. The pre-fix code path
+        // invoked the prompt-context factory only AFTER this future
+        // resolved; the post-spawn parent mutation would therefore
+        // race the fork. We sleep here to widen the bug window.
+        let lifecycle_sender: ChildSessionLifecycleSender =
+            Arc::new(|_payload: ChildSessionLifecyclePayload| {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    true
+                })
+            });
+
+        let work_dir = tempfile::TempDir::new().unwrap();
+        let memory = Arc::new(
+            EpisodeStore::open(work_dir.path().join(".octos"))
+                .await
+                .unwrap(),
+        );
+        let (spawn_inbound_tx, _spawn_inbound_rx) = mpsc::channel::<InboundMessage>(8);
+        let llm: Arc<dyn LlmProvider> = Arc::new(DelayedMockProvider::new(
+            "spawn-1125-llm",
+            // The detached worker will call the LLM lazily; an
+            // EndTurn response suffices because the test only cares
+            // about what the factory captured.
+            vec![(
+                Duration::from_millis(0),
+                ChatResponse {
+                    content: Some("ok".into()),
+                    reasoning_content: None,
+                    tool_calls: vec![],
+                    stop_reason: StopReason::EndTurn,
+                    usage: TokenUsage::default(),
+                    provider_index: None,
+                },
+            )],
+        ));
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let spawn_tool = SpawnTool::with_context(
+            llm,
+            memory,
+            work_dir.path().to_path_buf(),
+            spawn_inbound_tx,
+            "cli",
+            "test",
+        )
+        .with_task_supervisor(
+            supervisor.clone(),
+            parent_session_key.to_string(),
+            data_dir.path().join("task_ledger.jsonl"),
+        )
+        .with_child_session_sender(lifecycle_sender)
+        .with_child_prompt_context_manager_factory(factory);
+
+        // Dispatch a background spawn. With the fix, the factory runs
+        // synchronously inside this `execute_with_context` future
+        // BEFORE the `tokio::spawn` returns control, so by the time
+        // this `await` completes the child snapshot is already pinned
+        // to the pre-spawn parent generation.
+        let result = spawn_tool
+            .execute(&serde_json::json!({
+                "task": "background task",
+                "label": "1125-probe",
+                "mode": "background",
+            }))
+            .await
+            .expect("background spawn dispatch should succeed");
+        assert!(
+            result.success,
+            "background spawn dispatch should succeed: {}",
+            result.output
+        );
+
+        // Record a "post-spawn" user message on the parent. Before
+        // the fix, this would happen WHILE the factory was still
+        // pending inside the detached task; the fork would then
+        // observe it. After the fix, the fork has already captured
+        // the parent so this message stays parent-only.
+        {
+            let mut parent = parent_arc.lock().unwrap();
+            parent.record_message(&test_message(MessageRole::User, POST_SPAWN_CONTENT));
+        }
+
+        // Give the background task a moment to run through its
+        // lifecycle await so any pre-fix factory invocation would
+        // have fired by now (and observed the post-spawn message).
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let captured = captured_child
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("factory must have produced a child ContextManager");
+
+        // Assert the pre-spawn user turn IS in the child fork. If
+        // the fork was somehow skipped or replaced with a fresh
+        // manager, this catches it.
+        let captured_user_contents: Vec<String> = captured
+            .items()
+            .iter()
+            .filter_map(|item| match &item.kind {
+                TranscriptItemKind::UserInput { content, .. } => Some(content.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            captured_user_contents
+                .iter()
+                .any(|content| content.contains(PRE_SPAWN_CONTENT)),
+            "child fork should retain the pre-spawn user turn; observed user contents: {:?}",
+            captured_user_contents
+        );
+
+        // The critical assertion: the post-spawn user message MUST
+        // NOT appear in the child fork.
+        assert!(
+            !captured_user_contents
+                .iter()
+                .any(|content| content.contains(POST_SPAWN_CONTENT)),
+            "child fork must NOT include the post-spawn user message (issue #1125); \
+             observed user contents: {:?}",
+            captured_user_contents
+        );
+    }
+
     #[cfg(unix)]
     fn capture_hook(event: HookEvent, log_path: &std::path::Path) -> HookConfig {
         HookConfig {


### PR DESCRIPTION
## Summary

`SpawnTool`'s background dispatch path previously invoked the `ChildPromptContextRequest` factory inside the detached `tokio::spawn` task, AFTER awaiting `dispatch_child_session_lifecycle`. The factory locks the live parent `ContextManager`, so if persistence was slow and the parent recorded another user turn before the factory ran, the child fork would inherit a POST-spawn snapshot — leaking user messages that were not part of the spawning turn into the background worker's context.

This PR hoists the factory invocation to run synchronously at the SpawnTool dispatch site, before any `await`. The resulting `Option<Arc<dyn PromptContextManager>>` is moved into the detached task, which now just installs the pre-baked manager on the child Agent without touching the parent lock.

Closes #1125.

## Changes

- `crates/octos-agent/src/tools/spawn.rs` — In the background branch of `SpawnTool::execute_with_context`, invoke `child_prompt_context_manager_factory` synchronously BEFORE `tokio::spawn` and stash the result in `prebuilt_child_prompt_context_manager`. The detached task now just `worker = worker.with_prompt_context_manager(manager)` on the pre-baked value instead of calling the factory itself.
- `crates/octos-cli/src/session_actor.rs` — Adds `spawn_child_context_fork_uses_pre_spawn_parent_snapshot` (#1125 regression). The test wires the production-shaped factory onto a real `SpawnTool`, dispatches a background spawn, records a `POST-SPAWN` user message on the parent while the child-session lifecycle sender is still awaiting persistence, then asserts the captured child fork does NOT contain that post-spawn content.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p octos-cli --features api --tests` (no new warnings)
- [x] `cargo clippy -p octos-agent` (clean)
- [x] `cargo test -p octos-cli --features api --lib spawn` — 8 tests pass (including the new regression)
- [x] `cargo test -p octos-agent --lib spawn` — 82 tests pass
- [x] `cargo test -p octos-cli --features api --lib` — 1259 passed, 4 ignored
- [x] `cargo test -p octos-agent --lib` — 1490 passed, 1 ignored
- [x] **RED check**: temporarily reverted the spawn.rs change and confirmed `spawn_child_context_fork_uses_pre_spawn_parent_snapshot` fails with the exact `POST-SPAWN user message that MUST NOT leak` leak — proving the test isn't vacuous and pins the right contract.