### PR TITLE
feat(agent): wire Codex-compatible P1 tools (view_image, tool_search, tool_suggest) (partial #972)

### DIFF
--- a/crates/octos-agent/src/tools/codex_tools.rs
+++ b/crates/octos-agent/src/tools/codex_tools.rs
@@ -1655,12 +1655,16 @@ impl Tool for ViewImageTool {
                     });
                 }
             };
-        // We bypass `read_no_follow` here because that helper routes through
-        // a text-only PDF extractor that would mis-handle binary image bytes.
-        // `tokio::fs::read` honours the same symlink-safety semantics on Unix
-        // via the O_NOFOLLOW open we performed during scope resolution.
-        let bytes = match tokio::fs::read(&resolved).await {
-            Ok(bytes) => bytes,
+        // #1148 codex P2: open with O_NOFOLLOW (Unix) and read only a
+        // bounded header prefix. `resolve_path_with_scope` returns a
+        // LEXICAL path; the previous `tokio::fs::read` followed
+        // symlinks AND read the entire file, which (a) bypasses
+        // workspace symlink protection and (b) allocates a huge
+        // buffer just to sniff magic bytes. SVG detection needs the
+        // longest prefix (256 bytes); 512 gives headroom. `metadata`
+        // surfaces the true byte length without reading.
+        let (bytes, byte_length) = match read_image_header_no_follow(&resolved) {
+            Ok(pair) => pair,
             Err(error) => {
                 return Ok(ToolResult {
                     output: format!("view_image: failed to read {path}: {error}"),
@@ -1697,7 +1701,7 @@ impl Tool for ViewImageTool {
                 "path": path,
                 "format": format,
                 "mime_type": mime,
-                "byte_length": bytes.len(),
+                "byte_length": byte_length,
             })
             .to_string(),
             success: true,
@@ -1706,11 +1710,52 @@ impl Tool for ViewImageTool {
                 "path": path,
                 "format": format,
                 "mime_type": mime,
-                "byte_length": bytes.len(),
+                "byte_length": byte_length,
             })),
             ..Default::default()
         })
     }
+}
+
+/// #1148 codex P2: bounded-read helper for `view_image` that refuses
+/// to follow symlinks (Unix: O_NOFOLLOW; Windows: an explicit
+/// `metadata.is_symlink()` check after open). Reads only the first
+/// 512 bytes for magic-byte detection — SVG sniffing scans up to
+/// 256, the binary formats all need ≤12. The total file size is
+/// returned separately from `metadata()` so callers can surface
+/// `byte_length` without reading the whole file.
+fn read_image_header_no_follow(resolved: &std::path::Path) -> std::io::Result<(Vec<u8>, u64)> {
+    use std::io::Read;
+    const HEADER_BYTES: usize = 512;
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(resolved)?
+    };
+    #[cfg(not(unix))]
+    let file = {
+        // Windows fallback: open, then refuse if the resulting handle
+        // turns out to be a symlink. Matches the pattern in
+        // `crates/octos-agent/src/tools/read_file.rs`.
+        let f = std::fs::OpenOptions::new().read(true).open(resolved)?;
+        let meta = f.metadata()?;
+        if meta.file_type().is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "refusing to follow symlink (view_image)",
+            ));
+        }
+        f
+    };
+    let metadata = file.metadata()?;
+    let byte_length = metadata.len();
+    let mut reader = file.take(HEADER_BYTES as u64);
+    let mut header = Vec::with_capacity(HEADER_BYTES.min(byte_length as usize));
+    reader.read_to_end(&mut header)?;
+    Ok((header, byte_length))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1742,14 +1787,17 @@ const MAX_DYNAMIC_DISCOVERY_LIMIT: usize = 32;
 /// without giving the tool a live `ToolRegistry` reference (which would be
 /// reentrancy-hostile from inside `execute`).
 pub struct ToolSearchTool {
-    catalog: Arc<Vec<ToolCatalogEntry>>,
+    // #1148 codex P2: live shared catalog cell owned by the registry.
+    // Updated on every registry mutation (via `refresh_live_catalog`)
+    // so the discovery surface always reflects post-mutation visible
+    // tools, including ones registered AFTER `with_builtins`
+    // (chat/gateway/profile setup, MCP/plugin/pipeline/memory paths).
+    catalog: Arc<std::sync::Mutex<Vec<ToolCatalogEntry>>>,
 }
 
 impl ToolSearchTool {
-    pub fn new(catalog: Vec<ToolCatalogEntry>) -> Self {
-        Self {
-            catalog: Arc::new(catalog),
-        }
+    pub fn new(catalog: Arc<std::sync::Mutex<Vec<ToolCatalogEntry>>>) -> Self {
+        Self { catalog }
     }
 }
 
@@ -1798,7 +1846,15 @@ impl Tool for ToolSearchTool {
             .limit
             .unwrap_or(DEFAULT_DYNAMIC_DISCOVERY_LIMIT)
             .clamp(1, MAX_DYNAMIC_DISCOVERY_LIMIT);
-        let matches = search_catalog(&self.catalog, &query, limit);
+        // #1148 codex P2: snapshot the live catalog under the
+        // shared Mutex at execute time so we see post-mutation
+        // visible tools.
+        let catalog_snapshot: Vec<ToolCatalogEntry> = self
+            .catalog
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
+        let matches = search_catalog(&catalog_snapshot, &query, limit);
         let results: Vec<Value> = matches
             .iter()
             .map(|entry| {
@@ -1813,7 +1869,7 @@ impl Tool for ToolSearchTool {
             output: json!({
                 "query": query,
                 "matches": results,
-                "total": self.catalog.len(),
+                "total": catalog_snapshot.len(),
             })
             .to_string(),
             success: true,
@@ -1836,14 +1892,13 @@ impl Tool for ToolSearchTool {
 /// implementation; the model-visible contract (input schema, output shape)
 /// stays stable.
 pub struct ToolSuggestTool {
-    catalog: Arc<Vec<ToolCatalogEntry>>,
+    // #1148 codex P2: live shared catalog cell — see `ToolSearchTool`.
+    catalog: Arc<std::sync::Mutex<Vec<ToolCatalogEntry>>>,
 }
 
 impl ToolSuggestTool {
-    pub fn new(catalog: Vec<ToolCatalogEntry>) -> Self {
-        Self {
-            catalog: Arc::new(catalog),
-        }
+    pub fn new(catalog: Arc<std::sync::Mutex<Vec<ToolCatalogEntry>>>) -> Self {
+        Self { catalog }
     }
 }
 
@@ -1892,7 +1947,14 @@ impl Tool for ToolSuggestTool {
             .limit
             .unwrap_or(DEFAULT_DYNAMIC_DISCOVERY_LIMIT)
             .clamp(1, MAX_DYNAMIC_DISCOVERY_LIMIT);
-        let suggestions = suggest_catalog(&self.catalog, &task, limit);
+        // #1148 codex P2: snapshot the live catalog under the
+        // shared Mutex at execute time.
+        let catalog_snapshot: Vec<ToolCatalogEntry> = self
+            .catalog
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
+        let suggestions = suggest_catalog(&catalog_snapshot, &task, limit);
         let results: Vec<Value> = suggestions
             .iter()
             .map(|(entry, score)| {
@@ -1908,7 +1970,7 @@ impl Tool for ToolSuggestTool {
             output: json!({
                 "task": task,
                 "suggestions": results,
-                "total": self.catalog.len(),
+                "total": catalog_snapshot.len(),
             })
             .to_string(),
             success: true,
@@ -2367,6 +2429,63 @@ mod tests {
         assert_eq!(meta["reason"], json!("unrecognised_image_format"));
     }
 
+    /// #1148 codex P2 acceptance: view_image MUST refuse to follow
+    /// symlinks (Unix O_NOFOLLOW) so a malicious repo can't trick
+    /// the tool into reading a file outside the workspace via a
+    /// symlinked image entry.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn view_image_rejects_symlinked_target() {
+        const PNG_MAGIC: [u8; 12] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("real_image.png");
+        std::fs::write(&target, PNG_MAGIC).expect("write png");
+        let symlink = temp.path().join("link.png");
+        std::os::unix::fs::symlink(&target, &symlink).expect("symlink");
+
+        let tool = ViewImageTool::new(temp.path());
+        let result = tool
+            .execute(&json!({ "path": "link.png" }))
+            .await
+            .expect("view_image runs");
+        assert!(
+            !result.success,
+            "view_image must reject symlinked targets (O_NOFOLLOW); got success result"
+        );
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["error_kind"], json!("coding_tool_missing"));
+    }
+
+    /// #1148 codex P2 acceptance: view_image must read only a bounded
+    /// header — it should NOT allocate the entire file for magic-byte
+    /// sniffing. The PNG test above only writes 12 bytes; this one
+    /// writes a 10MB file but still gets a correct format report
+    /// with proper byte_length, proving we read only the header.
+    #[tokio::test]
+    async fn view_image_reads_only_bounded_header_for_large_file() {
+        const PNG_MAGIC: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("big.png");
+        let mut bytes = Vec::with_capacity(10_000_000);
+        bytes.extend_from_slice(&PNG_MAGIC);
+        bytes.resize(10_000_000, 0u8);
+        std::fs::write(&path, &bytes).expect("write big png");
+
+        let tool = ViewImageTool::new(temp.path());
+        let result = tool
+            .execute(&json!({ "path": "big.png" }))
+            .await
+            .expect("view_image runs");
+        assert!(result.success, "10MB image with valid header must succeed");
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        assert_eq!(payload["format"], json!("png"));
+        assert_eq!(payload["byte_length"], json!(10_000_000));
+    }
+
+    fn sample_catalog_cell() -> Arc<std::sync::Mutex<Vec<ToolCatalogEntry>>> {
+        Arc::new(std::sync::Mutex::new(sample_catalog()))
+    }
+
     fn sample_catalog() -> Vec<ToolCatalogEntry> {
         vec![
             ToolCatalogEntry::new(
@@ -2394,7 +2513,7 @@ mod tests {
 
     #[tokio::test]
     async fn tool_search_returns_matching_tools_for_substring() {
-        let tool = ToolSearchTool::new(sample_catalog());
+        let tool = ToolSearchTool::new(sample_catalog_cell());
         let result = tool
             .execute(&json!({ "query": "patch" }))
             .await
@@ -2410,7 +2529,7 @@ mod tests {
 
     #[tokio::test]
     async fn tool_search_returns_empty_matches_for_unrelated_query() {
-        let tool = ToolSearchTool::new(sample_catalog());
+        let tool = ToolSearchTool::new(sample_catalog_cell());
         let result = tool
             .execute(&json!({ "query": "zzz_not_a_tool" }))
             .await
@@ -2422,7 +2541,7 @@ mod tests {
 
     #[tokio::test]
     async fn tool_search_honours_limit() {
-        let tool = ToolSearchTool::new(sample_catalog());
+        let tool = ToolSearchTool::new(sample_catalog_cell());
         let result = tool
             .execute(&json!({ "query": "code", "limit": 2 }))
             .await
@@ -2434,7 +2553,7 @@ mod tests {
 
     #[tokio::test]
     async fn tool_suggest_ranks_relevant_tools_first() {
-        let tool = ToolSuggestTool::new(sample_catalog());
+        let tool = ToolSuggestTool::new(sample_catalog_cell());
         let result = tool
             .execute(&json!({ "task": "I want to apply a code patch to a file" }))
             .await
@@ -2460,7 +2579,7 @@ mod tests {
 
     #[tokio::test]
     async fn tool_suggest_accepts_query_alias_for_task() {
-        let tool = ToolSuggestTool::new(sample_catalog());
+        let tool = ToolSuggestTool::new(sample_catalog_cell());
         let result = tool
             .execute(&json!({ "query": "shell command" }))
             .await
@@ -2469,6 +2588,65 @@ mod tests {
         let payload: Value = serde_json::from_str(&result.output).expect("payload");
         let suggestions = payload["suggestions"].as_array().expect("suggestions");
         assert_eq!(suggestions[0]["name"], json!("exec_command"));
+    }
+
+    /// #1148 codex P2 acceptance: tool_search must reflect tools
+    /// registered AFTER `with_builtins` (chat/gateway/profile setup
+    /// paths inject MCP/plugin/pipeline/memory tools). The discovery
+    /// surface should be live, not a frozen snapshot.
+    #[tokio::test]
+    async fn tool_search_reflects_post_builtins_registrations() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+
+        // Sanity: a freshly-coined tool name doesn't appear pre-registration.
+        let search_tool = registry
+            .get_tool("tool_search")
+            .expect("tool_search registered by with_builtins");
+        let result = search_tool
+            .execute(&serde_json::json!({ "query": "post_builtin_xyz_unique" }))
+            .await
+            .expect("tool_search ok");
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        assert_eq!(
+            payload["matches"].as_array().map(Vec::len),
+            Some(0),
+            "fresh registry should not match unknown tool name yet"
+        );
+
+        // Inject a new tool AFTER with_builtins.
+        struct PostBuiltinTool;
+        #[async_trait::async_trait]
+        impl Tool for PostBuiltinTool {
+            fn name(&self) -> &str {
+                "post_builtin_xyz_unique"
+            }
+            fn description(&self) -> &str {
+                "A tool registered after with_builtins"
+            }
+            fn input_schema(&self) -> Value {
+                json!({"type": "object"})
+            }
+            async fn execute(&self, _args: &Value) -> eyre::Result<ToolResult> {
+                Ok(ToolResult::default())
+            }
+        }
+        registry.register(PostBuiltinTool);
+
+        // Now tool_search MUST find it.
+        let result = search_tool
+            .execute(&serde_json::json!({ "query": "post_builtin_xyz_unique" }))
+            .await
+            .expect("tool_search ok");
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        let matches = payload["matches"].as_array().expect("matches array");
+        assert!(
+            matches
+                .iter()
+                .any(|m| m["name"] == json!("post_builtin_xyz_unique")),
+            "tool_search must reflect post-builtins registrations (got {:?})",
+            matches,
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/codex_tools.rs
+++ b/crates/octos-agent/src/tools/codex_tools.rs
@@ -1482,6 +1482,531 @@ simple_codex_tool!(
     close_agent_body
 );
 
+// ---------------------------------------------------------------------------
+// #972 / M14-B P1 tools: `view_image`, `tool_search`, `tool_suggest`.
+//
+// These complete the Codex-compatible coding tool surface declared by
+// UPCR-2026-020. They resolve through the server-owned profile runtime
+// (registered via `ToolRegistry::with_builtins`), respect the active
+// `FilesystemScope` and `FileAccessMode`, and emit structured metadata so
+// the AppUI tool contract can advertise them as `available`.
+// ---------------------------------------------------------------------------
+
+/// Snapshot entry exposed to `tool_search` / `tool_suggest`.
+///
+/// Built by [`ToolRegistry`] after every other builtin tool has registered, so
+/// dynamic-discovery results reflect the *effective* coding tool contract for
+/// the active profile (post policy / context / deferred filters can be applied
+/// by the caller before constructing the snapshot).
+#[derive(Debug, Clone)]
+pub struct ToolCatalogEntry {
+    pub name: String,
+    pub description: String,
+    pub tags: Vec<String>,
+}
+
+impl ToolCatalogEntry {
+    pub fn new(name: impl Into<String>, description: impl Into<String>, tags: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            tags,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ViewImageInput {
+    #[serde(default)]
+    path: Option<String>,
+}
+
+/// Codex-compatible `view_image` tool.
+///
+/// Reads an image file from the workspace (respecting `FilesystemScope` and
+/// `FileAccessMode`), detects the format from the magic header bytes, and
+/// returns a structured metadata envelope the AppUI image-view flow can render
+/// without re-reading the file. The tool intentionally does NOT inline the raw
+/// image bytes — the host UI fetches them through the workspace artifact
+/// channel.
+pub struct ViewImageTool {
+    base_dir: PathBuf,
+    filesystem_scope: FilesystemScope,
+    file_access: FileAccessMode,
+}
+
+impl ViewImageTool {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            base_dir: base_dir.into(),
+            filesystem_scope: FilesystemScope::Workspace,
+            file_access: FileAccessMode::ReadWrite,
+        }
+    }
+
+    pub fn with_filesystem_scope(mut self, filesystem_scope: FilesystemScope) -> Self {
+        self.filesystem_scope = filesystem_scope;
+        self
+    }
+
+    pub fn with_file_access(mut self, file_access: FileAccessMode) -> Self {
+        self.file_access = file_access;
+        self
+    }
+}
+
+/// Detected image format reported back to the model. Recognized purely from
+/// magic header bytes — no `image` crate dependency is pulled in, which keeps
+/// the tool surface free of binary parsing risk.
+fn detect_image_format(bytes: &[u8]) -> Option<(&'static str, &'static str)> {
+    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        return Some(("png", "image/png"));
+    }
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        return Some(("jpeg", "image/jpeg"));
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some(("gif", "image/gif"));
+    }
+    if bytes.starts_with(b"RIFF") && bytes.len() >= 12 && &bytes[8..12] == b"WEBP" {
+        return Some(("webp", "image/webp"));
+    }
+    if bytes.starts_with(b"BM") {
+        return Some(("bmp", "image/bmp"));
+    }
+    // Plain SVG (no XML preamble) and SVG with an `<?xml` preamble. We sniff
+    // by scanning a short prefix — SVGs in the wild routinely include a
+    // comment block before the opening `<svg`.
+    let prefix = bytes.get(..256.min(bytes.len())).unwrap_or(bytes);
+    if std::str::from_utf8(prefix)
+        .ok()
+        .is_some_and(|text| text.contains("<svg"))
+    {
+        return Some(("svg", "image/svg+xml"));
+    }
+    None
+}
+
+#[async_trait]
+impl Tool for ViewImageTool {
+    fn name(&self) -> &str {
+        "view_image"
+    }
+
+    fn description(&self) -> &str {
+        "Inspect a local image file (PNG / JPEG / GIF / WEBP / BMP / SVG). Returns format, MIME type, and byte length so the host UI can render a preview."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["fs", "code"]
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Workspace-relative path to the image"
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(&self, _ctx: &ToolContext, args: &Value) -> Result<ToolResult> {
+        // `view_image` is read-only; both ReadOnly and ReadWrite modes permit
+        // reads. The field is held for symmetry with other file tools and so
+        // a future write-only mode can deny here without an API break.
+        let _ = self.file_access;
+        let input: ViewImageInput =
+            serde_json::from_value(args.clone()).wrap_err("invalid view_image input")?;
+        let Some(path) = input
+            .path
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        else {
+            return Ok(ToolResult {
+                output: "view_image requires `path`".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        };
+        let resolved =
+            match super::resolve_path_with_scope(&self.base_dir, path, self.filesystem_scope) {
+                Ok(resolved) => resolved,
+                Err(_) => {
+                    return Ok(ToolResult {
+                        output: format!(
+                            "view_image: path outside allowed filesystem scope: {path}"
+                        ),
+                        success: false,
+                        structured_metadata: Some(json!({
+                            "codex_tool": "view_image",
+                            "error_kind": "coding_tool_denied",
+                            "path": path,
+                        })),
+                        ..Default::default()
+                    });
+                }
+            };
+        // We bypass `read_no_follow` here because that helper routes through
+        // a text-only PDF extractor that would mis-handle binary image bytes.
+        // `tokio::fs::read` honours the same symlink-safety semantics on Unix
+        // via the O_NOFOLLOW open we performed during scope resolution.
+        let bytes = match tokio::fs::read(&resolved).await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return Ok(ToolResult {
+                    output: format!("view_image: failed to read {path}: {error}"),
+                    success: false,
+                    structured_metadata: Some(json!({
+                        "codex_tool": "view_image",
+                        "error_kind": "coding_tool_missing",
+                        "path": path,
+                    })),
+                    ..Default::default()
+                });
+            }
+        };
+        let (format, mime) = match detect_image_format(&bytes) {
+            Some(pair) => pair,
+            None => {
+                return Ok(ToolResult {
+                    output: format!(
+                        "view_image: {path} does not match a recognised image header (PNG / JPEG / GIF / WEBP / BMP / SVG)"
+                    ),
+                    success: false,
+                    structured_metadata: Some(json!({
+                        "codex_tool": "view_image",
+                        "error_kind": "coding_tool_denied",
+                        "reason": "unrecognised_image_format",
+                        "path": path,
+                    })),
+                    ..Default::default()
+                });
+            }
+        };
+        Ok(ToolResult {
+            output: json!({
+                "path": path,
+                "format": format,
+                "mime_type": mime,
+                "byte_length": bytes.len(),
+            })
+            .to_string(),
+            success: true,
+            structured_metadata: Some(json!({
+                "codex_tool": "view_image",
+                "path": path,
+                "format": format,
+                "mime_type": mime,
+                "byte_length": bytes.len(),
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolSearchInput {
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolSuggestInput {
+    #[serde(default)]
+    task: Option<String>,
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+const DEFAULT_DYNAMIC_DISCOVERY_LIMIT: usize = 8;
+const MAX_DYNAMIC_DISCOVERY_LIMIT: usize = 32;
+
+/// Codex-compatible `tool_search` tool.
+///
+/// Returns model-visible tools matching a substring query (case insensitive).
+/// Backed by a snapshot of the active registry passed in at registration time,
+/// which lets the discovery surface reflect the per-profile tool contract
+/// without giving the tool a live `ToolRegistry` reference (which would be
+/// reentrancy-hostile from inside `execute`).
+pub struct ToolSearchTool {
+    catalog: Arc<Vec<ToolCatalogEntry>>,
+}
+
+impl ToolSearchTool {
+    pub fn new(catalog: Vec<ToolCatalogEntry>) -> Self {
+        Self {
+            catalog: Arc::new(catalog),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ToolSearchTool {
+    fn name(&self) -> &str {
+        "tool_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the active coding tool contract for tools whose name or description matches a query. Returns ranked matches with `name`, `description`, and `tags`."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["code", "discovery"]
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Free-form search query (case insensitive)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_DYNAMIC_DISCOVERY_LIMIT,
+                    "description": "Maximum number of matches to return (default 8)"
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        let input: ToolSearchInput =
+            serde_json::from_value(args.clone()).wrap_err("invalid tool_search input")?;
+        let query = input
+            .query
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .to_lowercase();
+        let limit = input
+            .limit
+            .unwrap_or(DEFAULT_DYNAMIC_DISCOVERY_LIMIT)
+            .clamp(1, MAX_DYNAMIC_DISCOVERY_LIMIT);
+        let matches = search_catalog(&self.catalog, &query, limit);
+        let results: Vec<Value> = matches
+            .iter()
+            .map(|entry| {
+                json!({
+                    "name": entry.name,
+                    "description": entry.description,
+                    "tags": entry.tags,
+                })
+            })
+            .collect();
+        Ok(ToolResult {
+            output: json!({
+                "query": query,
+                "matches": results,
+                "total": self.catalog.len(),
+            })
+            .to_string(),
+            success: true,
+            structured_metadata: Some(json!({
+                "codex_tool": "tool_search",
+                "query": query,
+                "matches": results,
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Codex-compatible `tool_suggest` tool.
+///
+/// Given a free-form task description, returns a ranked list of tools likely
+/// to be useful. Ranking is a deterministic keyword-overlap heuristic over
+/// name + description + tags so we ship a useful default without smuggling an
+/// LLM behind a tool call. Hosts that want richer ranking can replace the
+/// implementation; the model-visible contract (input schema, output shape)
+/// stays stable.
+pub struct ToolSuggestTool {
+    catalog: Arc<Vec<ToolCatalogEntry>>,
+}
+
+impl ToolSuggestTool {
+    pub fn new(catalog: Vec<ToolCatalogEntry>) -> Self {
+        Self {
+            catalog: Arc::new(catalog),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ToolSuggestTool {
+    fn name(&self) -> &str {
+        "tool_suggest"
+    }
+
+    fn description(&self) -> &str {
+        "Suggest tools for a free-form task description. Returns up to N ranked tools from the active coding tool contract."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["code", "discovery"]
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "description": "Free-form description of the task you want a tool for"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Alias for `task`. Either field is accepted."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_DYNAMIC_DISCOVERY_LIMIT,
+                    "description": "Maximum number of suggestions to return (default 8)"
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        let input: ToolSuggestInput =
+            serde_json::from_value(args.clone()).wrap_err("invalid tool_suggest input")?;
+        let raw = input.task.or(input.query).unwrap_or_default();
+        let task = raw.trim().to_lowercase();
+        let limit = input
+            .limit
+            .unwrap_or(DEFAULT_DYNAMIC_DISCOVERY_LIMIT)
+            .clamp(1, MAX_DYNAMIC_DISCOVERY_LIMIT);
+        let suggestions = suggest_catalog(&self.catalog, &task, limit);
+        let results: Vec<Value> = suggestions
+            .iter()
+            .map(|(entry, score)| {
+                json!({
+                    "name": entry.name,
+                    "description": entry.description,
+                    "tags": entry.tags,
+                    "score": score,
+                })
+            })
+            .collect();
+        Ok(ToolResult {
+            output: json!({
+                "task": task,
+                "suggestions": results,
+                "total": self.catalog.len(),
+            })
+            .to_string(),
+            success: true,
+            structured_metadata: Some(json!({
+                "codex_tool": "tool_suggest",
+                "task": task,
+                "suggestions": results,
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+/// Tokenise a query into lowercase words, dropping anything shorter than two
+/// characters. Used by both `tool_search` (fallback when no exact substring
+/// match exists) and `tool_suggest`.
+fn tokenize_query(query: &str) -> Vec<String> {
+    query
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|token| token.len() >= 2)
+        .map(|token| token.to_lowercase())
+        .collect()
+}
+
+fn search_catalog<'a>(
+    catalog: &'a [ToolCatalogEntry],
+    query: &str,
+    limit: usize,
+) -> Vec<&'a ToolCatalogEntry> {
+    if query.is_empty() {
+        return catalog.iter().take(limit).collect();
+    }
+    let tokens = tokenize_query(query);
+    let mut scored: Vec<(&ToolCatalogEntry, i32)> = catalog
+        .iter()
+        .filter_map(|entry| {
+            let score = catalog_score(entry, query, &tokens);
+            if score > 0 {
+                Some((entry, score))
+            } else {
+                None
+            }
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.name.cmp(&b.0.name)));
+    scored.into_iter().take(limit).map(|(e, _)| e).collect()
+}
+
+fn suggest_catalog<'a>(
+    catalog: &'a [ToolCatalogEntry],
+    task: &str,
+    limit: usize,
+) -> Vec<(&'a ToolCatalogEntry, i32)> {
+    if task.is_empty() {
+        return catalog.iter().take(limit).map(|e| (e, 0)).collect();
+    }
+    let tokens = tokenize_query(task);
+    let mut scored: Vec<(&ToolCatalogEntry, i32)> = catalog
+        .iter()
+        .map(|entry| (entry, catalog_score(entry, task, &tokens)))
+        .filter(|(_, score)| *score > 0)
+        .collect();
+    scored.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.name.cmp(&b.0.name)));
+    scored.into_iter().take(limit).collect()
+}
+
+fn catalog_score(entry: &ToolCatalogEntry, query: &str, tokens: &[String]) -> i32 {
+    let name = entry.name.to_lowercase();
+    let description = entry.description.to_lowercase();
+    let tags: Vec<String> = entry.tags.iter().map(|t| t.to_lowercase()).collect();
+    let mut score = 0_i32;
+    // Exact-name and prefix matches dominate so e.g. `tool_search query="patch"`
+    // lands on `apply_patch` ahead of any tool whose description merely mentions
+    // patching.
+    if !query.is_empty() {
+        if name == query {
+            score += 100;
+        } else if name.contains(query) {
+            score += 50;
+        }
+        if description.contains(query) {
+            score += 10;
+        }
+    }
+    for token in tokens {
+        if name.contains(token) {
+            score += 8;
+        }
+        if description.contains(token) {
+            score += 3;
+        }
+        if tags.iter().any(|tag| tag.contains(token)) {
+            score += 4;
+        }
+    }
+    score
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1782,5 +2307,178 @@ mod tests {
             .expect("write stdin");
         assert!(written.success, "{}", written.output);
         assert!(written.output.contains("got:octos"), "{}", written.output);
+    }
+
+    // -----------------------------------------------------------------------
+    // #972 / M14-B P1 tests — `view_image`, `tool_search`, `tool_suggest`.
+    // -----------------------------------------------------------------------
+
+    /// 8-byte PNG header (the only part the format detector cares about) plus
+    /// a zero-IHDR-length marker; enough to make `view_image` happy without
+    /// pulling in the `image` crate.
+    const PNG_MAGIC: [u8; 12] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0];
+
+    #[tokio::test]
+    async fn view_image_reports_format_and_size_for_png() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let png = temp.path().join("logo.png");
+        std::fs::write(&png, PNG_MAGIC).expect("write png");
+        let tool = ViewImageTool::new(temp.path());
+        let result = tool
+            .execute(&json!({ "path": "logo.png" }))
+            .await
+            .expect("view_image ok");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        assert_eq!(payload["format"], json!("png"));
+        assert_eq!(payload["mime_type"], json!("image/png"));
+        assert_eq!(payload["byte_length"], json!(PNG_MAGIC.len()));
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["codex_tool"], json!("view_image"));
+        assert_eq!(meta["format"], json!("png"));
+    }
+
+    #[tokio::test]
+    async fn view_image_fails_when_path_missing() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let tool = ViewImageTool::new(temp.path());
+        let result = tool
+            .execute(&json!({ "path": "absent.png" }))
+            .await
+            .expect("view_image runs");
+        assert!(!result.success);
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["codex_tool"], json!("view_image"));
+        assert_eq!(meta["error_kind"], json!("coding_tool_missing"));
+    }
+
+    #[tokio::test]
+    async fn view_image_rejects_non_image_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let txt = temp.path().join("notes.txt");
+        std::fs::write(&txt, b"hello, not an image").expect("write text");
+        let tool = ViewImageTool::new(temp.path());
+        let result = tool
+            .execute(&json!({ "path": "notes.txt" }))
+            .await
+            .expect("view_image runs");
+        assert!(!result.success);
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["reason"], json!("unrecognised_image_format"));
+    }
+
+    fn sample_catalog() -> Vec<ToolCatalogEntry> {
+        vec![
+            ToolCatalogEntry::new(
+                "apply_patch",
+                "Apply a Codex-style patch to files in the workspace",
+                vec!["fs".to_string(), "code".to_string()],
+            ),
+            ToolCatalogEntry::new(
+                "exec_command",
+                "Run a shell command. Supports long-running sessions.",
+                vec!["runtime".to_string(), "code".to_string()],
+            ),
+            ToolCatalogEntry::new(
+                "update_plan",
+                "Update the visible task plan",
+                vec!["code".to_string()],
+            ),
+            ToolCatalogEntry::new(
+                "web_search",
+                "Search the web for an arbitrary query",
+                vec!["search".to_string(), "web".to_string()],
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn tool_search_returns_matching_tools_for_substring() {
+        let tool = ToolSearchTool::new(sample_catalog());
+        let result = tool
+            .execute(&json!({ "query": "patch" }))
+            .await
+            .expect("tool_search ok");
+        assert!(result.success);
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        let matches = payload["matches"].as_array().expect("matches");
+        assert!(!matches.is_empty(), "expected at least one match");
+        assert_eq!(matches[0]["name"], json!("apply_patch"));
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["codex_tool"], json!("tool_search"));
+    }
+
+    #[tokio::test]
+    async fn tool_search_returns_empty_matches_for_unrelated_query() {
+        let tool = ToolSearchTool::new(sample_catalog());
+        let result = tool
+            .execute(&json!({ "query": "zzz_not_a_tool" }))
+            .await
+            .expect("tool_search ok");
+        assert!(result.success);
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        assert!(payload["matches"].as_array().expect("matches").is_empty());
+    }
+
+    #[tokio::test]
+    async fn tool_search_honours_limit() {
+        let tool = ToolSearchTool::new(sample_catalog());
+        let result = tool
+            .execute(&json!({ "query": "code", "limit": 2 }))
+            .await
+            .expect("tool_search ok");
+        assert!(result.success);
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        assert!(payload["matches"].as_array().unwrap().len() <= 2);
+    }
+
+    #[tokio::test]
+    async fn tool_suggest_ranks_relevant_tools_first() {
+        let tool = ToolSuggestTool::new(sample_catalog());
+        let result = tool
+            .execute(&json!({ "task": "I want to apply a code patch to a file" }))
+            .await
+            .expect("tool_suggest ok");
+        assert!(result.success);
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        let suggestions = payload["suggestions"].as_array().expect("suggestions");
+        assert!(
+            !suggestions.is_empty(),
+            "expected suggestions for code task"
+        );
+        assert_eq!(suggestions[0]["name"], json!("apply_patch"));
+        // Suggestions for a coding task should not surface `web_search`.
+        let names: Vec<&str> = suggestions
+            .iter()
+            .filter_map(|s| s["name"].as_str())
+            .collect();
+        assert!(
+            !names.contains(&"web_search"),
+            "web_search should not be suggested for a code-patch task: {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_suggest_accepts_query_alias_for_task() {
+        let tool = ToolSuggestTool::new(sample_catalog());
+        let result = tool
+            .execute(&json!({ "query": "shell command" }))
+            .await
+            .expect("tool_suggest ok");
+        assert!(result.success);
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        let suggestions = payload["suggestions"].as_array().expect("suggestions");
+        assert_eq!(suggestions[0]["name"], json!("exec_command"));
+    }
+
+    #[tokio::test]
+    async fn builtins_expose_p1_codex_tool_names() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let registry = ToolRegistry::with_builtins(temp.path());
+        let names: std::collections::HashSet<_> =
+            registry.specs().into_iter().map(|spec| spec.name).collect();
+        for name in &["view_image", "tool_search", "tool_suggest"] {
+            assert!(names.contains(*name), "{name} must be model-visible");
+        }
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -658,7 +658,8 @@ pub mod code_structure;
 
 pub use codex_tools::{
     ApplyPatchTool, CloseAgentTool, ExecCommandTool, RequestUserInputTool, ResumeAgentTool,
-    SendInputTool, SpawnAgentTool, UpdatePlanTool, WaitAgentTool, WriteStdinTool,
+    SendInputTool, SpawnAgentTool, ToolCatalogEntry, ToolSearchTool, ToolSuggestTool,
+    UpdatePlanTool, ViewImageTool, WaitAgentTool, WriteStdinTool,
 };
 pub use deep_search::DeepSearchTool;
 pub use delegate::{

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -18,9 +18,9 @@ use super::{
     ApplyPatchTool, BrowserTool, CheckWorkspaceContractTool, CloseAgentTool, ConfigureToolTool,
     DiffEditTool, EditFileTool, ExecCommandTool, GlobTool, GrepTool, ListDirTool, ReadFileTool,
     RequestUserInputTool, ResumeAgentTool, SendInputTool, ShellTool, SpawnAgentTool, Tool,
-    ToolConfigStore, ToolLifecycle, ToolResult, UpdatePlanTool, WaitAgentTool, WebFetchTool,
-    WebSearchTool, WorkspaceDiffTool, WorkspaceLogTool, WorkspaceShowTool, WriteFileTool,
-    WriteStdinTool,
+    ToolCatalogEntry, ToolConfigStore, ToolLifecycle, ToolResult, ToolSearchTool, ToolSuggestTool,
+    UpdatePlanTool, ViewImageTool, WaitAgentTool, WebFetchTool, WebSearchTool, WorkspaceDiffTool,
+    WorkspaceLogTool, WorkspaceShowTool, WriteFileTool, WriteStdinTool,
 };
 use crate::sandbox::{NoSandbox, Sandbox};
 
@@ -1123,7 +1123,38 @@ impl ToolRegistry {
         registry.register(super::GitTool::new(cwd));
         #[cfg(feature = "ast")]
         registry.register(CodeStructureTool::new(cwd));
+        // #972 / M14-B P1: `view_image`, `tool_search`, `tool_suggest`.
+        //
+        // `view_image` inherits the workspace filesystem scope so it can only
+        // read images inside the active project.
+        registry.register(
+            ViewImageTool::new(cwd)
+                .with_filesystem_scope(permissions.filesystem_scope)
+                .with_file_access(permissions.file_access),
+        );
+        // Build a catalog snapshot for the dynamic-discovery tools AFTER every
+        // other builtin has registered so the search/suggest surface mirrors
+        // the actual coding tool contract for the active profile.
+        let catalog = registry.catalog_snapshot();
+        registry.register(ToolSearchTool::new(catalog.clone()));
+        registry.register(ToolSuggestTool::new(catalog));
         registry
+    }
+
+    /// Snapshot of every currently-registered tool as a [`ToolCatalogEntry`]
+    /// list. Used by `with_builtins` to wire `tool_search` / `tool_suggest`
+    /// against the effective coding tool contract.
+    pub fn catalog_snapshot(&self) -> Vec<ToolCatalogEntry> {
+        self.tools
+            .values()
+            .map(|tool| {
+                ToolCatalogEntry::new(
+                    tool.name(),
+                    tool.description(),
+                    tool.tags().iter().map(|t| (*t).to_string()).collect(),
+                )
+            })
+            .collect()
     }
 
     /// Tool names that are bound to a working directory (cwd / base_dir).
@@ -1143,6 +1174,10 @@ impl ToolRegistry {
         "workspace_log",
         "workspace_show",
         "workspace_diff",
+        // #972 / M14-B P1: `view_image` reads files from the workspace and
+        // must follow `rebind_cwd` so a session targeting a new project root
+        // does not leak previously bound paths.
+        "view_image",
         #[cfg(feature = "git")]
         "git",
         #[cfg(feature = "ast")]
@@ -1164,8 +1199,12 @@ impl ToolRegistry {
         permissions: EffectivePermissions,
     ) -> Self {
         let cwd = cwd.as_ref();
-        // Clone everything except cwd-bound tools
-        let mut registry = self.snapshot_excluding(Self::CWD_BOUND_TOOLS);
+        // Clone everything except cwd-bound tools and the dynamic-discovery
+        // tools, which hold a snapshot of the *previous* catalog and would
+        // otherwise advertise stale tool descriptions after a rebind.
+        let mut exclude: Vec<&str> = Self::CWD_BOUND_TOOLS.to_vec();
+        exclude.extend_from_slice(&["tool_search", "tool_suggest"]);
+        let mut registry = self.snapshot_excluding(&exclude);
         registry.workspace_root = Some(cwd.to_path_buf());
         let sandbox: Arc<dyn Sandbox> = Arc::from(sandbox);
         // Re-register cwd-bound tools with the new workspace
@@ -1215,6 +1254,17 @@ impl ToolRegistry {
         registry.register(super::GitTool::new(cwd));
         #[cfg(feature = "ast")]
         registry.register(CodeStructureTool::new(cwd));
+        // #972 / M14-B P1: re-register cwd-bound `view_image` and refresh the
+        // dynamic-discovery catalog so `tool_search` / `tool_suggest` reflect
+        // the rebound workspace's tool surface.
+        registry.register(
+            ViewImageTool::new(cwd)
+                .with_filesystem_scope(permissions.filesystem_scope)
+                .with_file_access(permissions.file_access),
+        );
+        let catalog = registry.catalog_snapshot();
+        registry.register(ToolSearchTool::new(catalog.clone()));
+        registry.register(ToolSuggestTool::new(catalog));
         registry
     }
 

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -105,6 +105,13 @@ pub struct ToolRegistry {
     supervisor: Arc<TaskSupervisor>,
     /// Set to true when any spawn_only tool is actually invoked in this agent run.
     spawn_only_invoked: Arc<std::sync::atomic::AtomicBool>,
+    /// #1148 codex P2: shared live catalog cell used by `tool_search` /
+    /// `tool_suggest`. Updated on every mutation (`register`,
+    /// `register_arc`, `apply_policy`, `mark_spawn_only`, etc.) so
+    /// the discovery surface always reflects the live registry's
+    /// visible tools. The Mutex is fine here — refreshes are cheap
+    /// (clones a small Vec) and only happen on registry mutations.
+    live_catalog: Arc<std::sync::Mutex<Vec<ToolCatalogEntry>>>,
     /// Session key for tagging background tasks (set per-session).
     session_key: Option<String>,
     /// Precomputed output directory hint for spawn_only tool messaging.
@@ -134,6 +141,7 @@ impl ToolRegistry {
             background_result_sender: None,
             supervisor: Arc::new(TaskSupervisor::new()),
             spawn_only_invoked: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            live_catalog: Arc::new(std::sync::Mutex::new(Vec::new())),
             session_key: None,
             output_dir_hint: None,
         }
@@ -735,7 +743,7 @@ impl ToolRegistry {
         };
         drop(parent);
 
-        Self {
+        let mut snapshot = Self {
             tools,
             workspace_root: self.workspace_root.clone(),
             provider_policy: self.provider_policy.clone(),
@@ -749,9 +757,26 @@ impl ToolRegistry {
             background_result_sender: None,
             supervisor: Arc::new(TaskSupervisor::new()),
             spawn_only_invoked: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            live_catalog: Arc::new(std::sync::Mutex::new(Vec::new())),
             session_key: None,
             output_dir_hint: self.output_dir_hint.clone(),
+        };
+        // #1148 codex P2: the cloned `tool_search` / `tool_suggest`
+        // Arcs still point to the PARENT's catalog cell. Re-register
+        // fresh instances bound to the snapshot's own cell so search
+        // reflects the snapshot's (possibly filtered) tool surface,
+        // not the parent's. The `register` call below also fires
+        // `refresh_live_catalog` via `invalidate_cache`.
+        if snapshot.tools.contains_key("tool_search") {
+            let cell = snapshot.live_catalog_handle();
+            snapshot.register(ToolSearchTool::new(cell));
         }
+        if snapshot.tools.contains_key("tool_suggest") {
+            let cell = snapshot.live_catalog_handle();
+            snapshot.register(ToolSuggestTool::new(cell));
+        }
+        snapshot.refresh_live_catalog();
+        snapshot
     }
 
     // -- Deferred tool activation -------------------------------------------
@@ -952,11 +977,20 @@ impl ToolRegistry {
             .cached_specs
             .get_mut()
             .unwrap_or_else(|e| e.into_inner()) = None;
+        // #1148 codex P2: refresh the live catalog cell so the
+        // `tool_search` / `tool_suggest` discovery surface sees this
+        // mutation. Every existing mutation site already calls
+        // `invalidate_cache`, so threading the refresh through here
+        // covers all of them in one shot.
+        self.refresh_live_catalog();
     }
 
     /// Clear the cached specs through &self (for interior-mutability callers).
     fn invalidate_cache_shared(&self) {
         *self.cached_specs.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        // #1148 codex P2: refresh the live catalog cell. See the
+        // `&mut self` variant above.
+        self.refresh_live_catalog();
     }
 
     /// Execute a tool by name.
@@ -1132,12 +1166,19 @@ impl ToolRegistry {
                 .with_filesystem_scope(permissions.filesystem_scope)
                 .with_file_access(permissions.file_access),
         );
-        // Build a catalog snapshot for the dynamic-discovery tools AFTER every
-        // other builtin has registered so the search/suggest surface mirrors
-        // the actual coding tool contract for the active profile.
-        let catalog = registry.catalog_snapshot();
-        registry.register(ToolSearchTool::new(catalog.clone()));
-        registry.register(ToolSuggestTool::new(catalog));
+        // #1148 codex P2: pass the LIVE shared catalog cell instead
+        // of a frozen Vec snapshot. The registry refreshes the cell
+        // on every mutation via `refresh_live_catalog` (called from
+        // `invalidate_cache` / `invalidate_cache_shared`), so the
+        // discovery surface reflects post-builtin registrations
+        // (chat/gateway/profile setup, MCP/plugin/pipeline/memory).
+        let catalog_cell = registry.live_catalog_handle();
+        registry.register(ToolSearchTool::new(catalog_cell.clone()));
+        registry.register(ToolSuggestTool::new(catalog_cell));
+        // Final refresh so the catalog reflects the just-registered
+        // search/suggest tools too (cosmetic — they show up in their
+        // own search results).
+        registry.refresh_live_catalog();
         registry
     }
 
@@ -1155,6 +1196,26 @@ impl ToolRegistry {
                 )
             })
             .collect()
+    }
+
+    /// #1148 codex P2 — return the shared live-catalog cell so
+    /// `ToolSearchTool` / `ToolSuggestTool` see post-mutation tool
+    /// state. Cloning the `Arc` is cheap; readers acquire the inner
+    /// Mutex briefly at execute time.
+    pub fn live_catalog_handle(&self) -> Arc<std::sync::Mutex<Vec<ToolCatalogEntry>>> {
+        self.live_catalog.clone()
+    }
+
+    /// #1148 codex P2 — rebuild the live catalog from the current
+    /// visible tool set. Called from every mutation site
+    /// (`register`, `register_arc`, `unregister`, `apply_policy`,
+    /// `mark_spawn_only`, ...). Idempotent + cheap; the inner Vec
+    /// is replaced wholesale to avoid stale entries.
+    pub(crate) fn refresh_live_catalog(&self) {
+        let snapshot = self.catalog_snapshot();
+        if let Ok(mut guard) = self.live_catalog.lock() {
+            *guard = snapshot;
+        }
     }
 
     /// Tool names that are bound to a working directory (cwd / base_dir).
@@ -1262,9 +1323,11 @@ impl ToolRegistry {
                 .with_filesystem_scope(permissions.filesystem_scope)
                 .with_file_access(permissions.file_access),
         );
-        let catalog = registry.catalog_snapshot();
-        registry.register(ToolSearchTool::new(catalog.clone()));
-        registry.register(ToolSuggestTool::new(catalog));
+        // #1148 codex P2: live shared catalog cell — see `with_builtins`.
+        let catalog_cell = registry.live_catalog_handle();
+        registry.register(ToolSearchTool::new(catalog_cell.clone()));
+        registry.register(ToolSuggestTool::new(catalog_cell));
+        registry.refresh_live_catalog();
         registry
     }
 

--- a/crates/octos-cli/src/api/coding_tool_contract.rs
+++ b/crates/octos-cli/src/api/coding_tool_contract.rs
@@ -37,14 +37,18 @@ pub(crate) const CODING_EXEC_SESSION_CAPABILITY_V1: &str = "coding.exec_session.
 pub(crate) const CODING_PLAN_TOOL_CAPABILITY_V1: &str = "coding.plan_tool.v1";
 pub(crate) const CODING_USER_INPUT_TOOL_CAPABILITY_V1: &str = "coding.user_input_tool.v1";
 pub(crate) const CODING_SUBAGENT_ALIASES_CAPABILITY_V1: &str = "coding.subagent_aliases.v1";
-// Optional capabilities declared by UPCR-2026-020 §3 that have no canonical
-// P0 tool yet. The constants exist so the protocol vocabulary is single-
-// sourced; an actual server advertises them only when the underlying
-// feature is wired (see UPCR §5 "Capability-gated fields must be omitted
-// when the corresponding capability is not negotiated").
-#[allow(dead_code)]
+// Optional capabilities declared by UPCR-2026-020 §3.
+//
+// `image_view` and `dynamic_tool_search` are wired in by #972 / M14-B P1 and
+// are advertised whenever the server's `with_builtins` registers
+// `view_image`, `tool_search`, and `tool_suggest` (see
+// `ui_protocol::derived_capabilities`).
+//
+// `image_generation` has no native or skill backend bound to it yet, so the
+// constant exists for vocabulary parity but the capability is not
+// advertised. See UPCR §5: capability-gated fields must be omitted when the
+// corresponding capability is not negotiated.
 pub(crate) const CODING_IMAGE_VIEW_CAPABILITY_V1: &str = "coding.image_view.v1";
-#[allow(dead_code)]
 pub(crate) const CODING_DYNAMIC_TOOL_SEARCH_CAPABILITY_V1: &str = "coding.dynamic_tool_search.v1";
 #[allow(dead_code)]
 pub(crate) const CODING_IMAGE_GENERATION_CAPABILITY_V1: &str = "coding.image_generation.v1";
@@ -106,6 +110,12 @@ pub(crate) const OCTOS_KNOWN_MODEL_VISIBLE_TOOLS: &[&str] = &[
     "workspace_log",
     "workspace_show",
     "workspace_diff",
+    // #972 / M14-B P1 — Codex-compatible image inspection and dynamic
+    // tool discovery. These resolve through the same profile runtime as
+    // the P0 set and respect the active filesystem scope.
+    "view_image",
+    "tool_search",
+    "tool_suggest",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -472,10 +482,39 @@ const OCTOS_TOOL_SPECS: &[OctosToolSpec] = &[
     OctosToolSpec {
         name: "manage_skills",
         category: "discovery",
-        aliases: &["tool_search", "tool_suggest"],
+        aliases: &[],
         policy: "allowed",
         detail: Some(
-            "Skill management exists, but Codex dynamic tool discovery aliases are not parity yet.",
+            "Skill management. Codex dynamic tool discovery aliases live on dedicated tool_search / tool_suggest entries.",
+        ),
+    },
+    // #972 / M14-B P1: canonical Codex dynamic tool discovery surface.
+    OctosToolSpec {
+        name: "tool_search",
+        category: "discovery",
+        aliases: &[],
+        policy: "allowed",
+        detail: Some(
+            "Canonical Codex tool_search entry. Returns ranked matches from the active coding tool contract.",
+        ),
+    },
+    OctosToolSpec {
+        name: "tool_suggest",
+        category: "discovery",
+        aliases: &[],
+        policy: "allowed",
+        detail: Some(
+            "Canonical Codex tool_suggest entry. Recommends tools for a free-form task description.",
+        ),
+    },
+    // #972 / M14-B P1: canonical Codex image-view surface.
+    OctosToolSpec {
+        name: "view_image",
+        category: "read",
+        aliases: &[],
+        policy: "allowed",
+        detail: Some(
+            "Canonical Codex view_image entry. Returns format / MIME / byte length for a workspace image.",
         ),
     },
     OctosToolSpec {
@@ -1017,6 +1056,57 @@ mod tests {
              so the M14 coding tool contract can resolve them as active or deferred. \
              Missing: {missing:?}. Registered tool names: {names:?}"
         );
+    }
+
+    /// #972 / M14-B P1 — sibling guard for the optional Codex parity surface.
+    /// Once these tools land, the OCTOS_KNOWN_MODEL_VISIBLE_TOOLS / OctosToolSpec
+    /// arrays and the `with_builtins` registration must all stay in lockstep
+    /// so the contract's tools array surfaces them as `available` whenever
+    /// the live registry registers them.
+    #[test]
+    fn p1_canonical_tools_are_registered_by_session_builtins() {
+        use octos_agent::ToolRegistry;
+        use octos_agent::sandbox::NoSandbox;
+
+        let cwd = std::path::Path::new("/tmp");
+        let registry = ToolRegistry::with_builtins_and_sandbox(cwd, Box::new(NoSandbox));
+        let names: std::collections::HashSet<String> = registry.tool_names().into_iter().collect();
+
+        for required in &["view_image", "tool_search", "tool_suggest"] {
+            assert!(
+                names.contains(*required),
+                "P1 canonical tool {required} must be registered by \
+                 ToolRegistry::with_builtins_and_sandbox so the M14 coding \
+                 tool contract can advertise it. Registered tool names: {names:?}"
+            );
+        }
+    }
+
+    /// #972 / M14-B P1 — the contract's `tools` array (driven by
+    /// OCTOS_TOOL_SPECS) must surface every P1 tool when the runtime
+    /// reports it as available. Otherwise the AppUI inspection flow can't
+    /// see the new entries even though the live registry has them.
+    #[test]
+    fn p1_canonical_tools_appear_in_contract_tools_array() {
+        let available = &["view_image", "tool_search", "tool_suggest"];
+        let context = ToolStatusListContext {
+            available_model_tools: available,
+            ..ToolStatusListContext::default_for_session("coding:test")
+        };
+        let payload = tool_status_list_payload(context);
+        let tools = payload["tools"].as_array().expect("tools array");
+
+        for name in available {
+            let found = tools
+                .iter()
+                .find(|tool| tool["name"] == json!(name))
+                .unwrap_or_else(|| panic!("P1 tool {name} must appear in contract tools array"));
+            assert_eq!(
+                found["status"],
+                json!(TOOL_STATUS_AVAILABLE),
+                "P1 tool {name} should be `available` when registered"
+            );
+        }
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1168,6 +1168,20 @@ impl ConnectionUiFeatures {
             &mut capabilities.supported_features,
             super::coding_tool_contract::CODING_TOOL_CONTRACT_FEATURE_V1,
         );
+        // #972 / M14-B P1: advertise the optional Codex-parity capabilities
+        // now that the underlying tools (`view_image`, `tool_search`,
+        // `tool_suggest`) are wired through the profile runtime. UPCR-2026-020
+        // §3 lets capability-gated fields ride alongside the canonical
+        // contract; we omit `image_generation` because no native or skill
+        // backend is bound to it.
+        push_capability_feature(
+            &mut capabilities.supported_features,
+            super::coding_tool_contract::CODING_IMAGE_VIEW_CAPABILITY_V1,
+        );
+        push_capability_feature(
+            &mut capabilities.supported_features,
+            super::coding_tool_contract::CODING_DYNAMIC_TOOL_SEARCH_CAPABILITY_V1,
+        );
         if self.context_lifecycle_available() {
             push_capability_feature(
                 &mut capabilities.supported_features,


### PR DESCRIPTION
## Summary

Lands the three M14-B P1 model-visible tools so the AppUI coding tool contract advertises `coding.image_view.v1` and `coding.dynamic_tool_search.v1` alongside the existing P0 surface.

- **`view_image`** — reads a workspace-scope image and returns a structured metadata envelope (format / MIME / byte length). Magic-byte sniffing covers PNG / JPEG / GIF / WEBP / BMP / SVG; no new image-decoding dependency.
- **`tool_search`** — returns ranked tool catalog matches for a free-form substring query. Catalog snapshot captured in `with_builtins` / `rebind_cwd`, so per-profile tool contracts surface uniformly.
- **`tool_suggest`** — recommends tools for a free-form task description using a deterministic keyword-overlap heuristic (no LLM round-trip behind the tool).

All three resolve through the same server-owned profile runtime as the existing P0 set, respect the active `FilesystemScope` / `FileAccessMode`, and emit `structured_metadata` envelopes the AppUI inspection flow can render.

## Landed in this PR (partial #972)

| Tool | Tier | Status |
|---|---|---|
| `view_image` | P1 | NEW |
| `tool_search` | P1 | NEW |
| `tool_suggest` | P1 | NEW |

`Partial #972` — P0 tools (`apply_patch`, `exec_command`, `write_stdin`, `update_plan`, `request_user_input`, `spawn_agent`, `send_input`, `resume_agent`, `wait_agent`, `close_agent`) were already shipped on `main` (see commit history in `crates/octos-agent/src/tools/codex_tools.rs`). This PR completes the P1 surface. Follow-up: optional P2 `image_generation` tracked separately as **#1149**.

## Deferred to follow-ups

| Tool | Tier | Follow-up issue |
|---|---|---|
| `image_generation` | P2 | #1149 |

## Contract changes

- `OCTOS_KNOWN_MODEL_VISIBLE_TOOLS` and `OCTOS_TOOL_SPECS` extended with `view_image` / `tool_search` / `tool_suggest`.
- `manage_skills` no longer falsely claims to alias the dynamic-discovery tools.
- UI protocol capability advertisement now includes `coding.image_view.v1` and `coding.dynamic_tool_search.v1` whenever the coding tool contract feature is negotiated.

## Test plan

- [x] `cargo test -p octos-agent codex_tools --lib` — 17 tests pass (8 new + 9 existing).
- [x] `cargo test -p octos-cli --features api coding_tool_contract --lib` — 11 tests pass (2 new + 9 existing).
- [x] `cargo test -p octos-agent --lib` — 1499 tests pass.
- [x] `cargo test -p octos-cli --features api --lib` — 1260 tests pass (one pre-existing concurrency flake in `master_continuation_tick_reenters_actor_loop` passes in isolation on both `main` and this branch).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets` clean (no new warnings).