### PR TITLE
feat(agent): register image_generation Codex stub (#1149)

### DIFF
--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -2798,6 +2798,162 @@ impl Tool for ToolSuggestTool {
     }
 }
 
+// ---------------------------------------------------------------------------
+// #1149 / M14-B P2 tool: `image_generation`.
+//
+// Codex's optional image-generation surface. Octos doesn't ship a native
+// image-generation backend yet (no MoFA media skill is bundled and the
+// `octos-llm` providers — Anthropic / Gemini / OpenRouter — don't expose
+// an image-generation endpoint; OpenAI does via DALL-E but isn't wired
+// through `LlmProvider` either). Rather than leave the canonical Codex
+// name unregistered (which would surface to the model as "tool not
+// found"), we register a stub that returns a typed
+// `coding_tool_unsupported` envelope. This keeps the wire-level contract
+// complete: model-visible name advertised, structured error returned,
+// follow-up work tracked in #1149 for a real backend (OpenAI image API
+// or a bundled skill).
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ImageGenerationInput {
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    size: Option<String>,
+    #[serde(default)]
+    n: Option<u32>,
+}
+
+/// Codex-compatible `image_generation` tool.
+///
+/// Stub: always returns a structured `coding_tool_unsupported` envelope. The
+/// canonical Codex input shape (`prompt`, optional `size`, optional `n`) is
+/// accepted and validated so a future backend-bound implementation can
+/// upgrade in place without breaking the model-visible schema. See #1149
+/// for the follow-up wiring (OpenAI image API or bundled skill).
+pub struct ImageGenerationTool {
+    backend_bound: bool,
+}
+
+impl Default for ImageGenerationTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ImageGenerationTool {
+    /// Construct the stub variant. Always returns `coding_tool_unsupported`
+    /// because no native or skill backend is bound. The constructor is kept
+    /// `pub` so the `with_builtins` path and tests both reach it through one
+    /// entrypoint; a future #1149 follow-up will add `with_backend(...)` here
+    /// and flip `backend_bound`.
+    pub fn new() -> Self {
+        Self {
+            backend_bound: false,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ImageGenerationTool {
+    fn name(&self) -> &str {
+        "image_generation"
+    }
+
+    fn description(&self) -> &str {
+        "Generate an image from a text prompt. STUB: no native or skill backend is bound yet (#1149 follow-up); calls return a typed `coding_tool_unsupported` error envelope."
+    }
+
+    fn tags(&self) -> &[&str] {
+        &["media", "code"]
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Free-form text prompt describing the image to generate"
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Optional output size hint (e.g. `1024x1024`). Provider-specific; reserved for the backend-bound variant."
+                },
+                "n": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 4,
+                    "description": "Optional number of images to generate (1-4). Reserved for the backend-bound variant."
+                }
+            },
+            "required": ["prompt"]
+        })
+    }
+
+    async fn execute(&self, args: &Value) -> Result<ToolResult> {
+        let input: ImageGenerationInput =
+            serde_json::from_value(args.clone()).wrap_err("invalid image_generation input")?;
+        let prompt = input
+            .prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|p| !p.is_empty());
+        if prompt.is_none() {
+            return Ok(ToolResult {
+                output: "image_generation requires a non-empty `prompt`".to_string(),
+                success: false,
+                structured_metadata: Some(json!({
+                    "codex_tool": "image_generation",
+                    "error_kind": "coding_tool_denied",
+                    "reason": "missing_prompt",
+                })),
+                ..Default::default()
+            });
+        }
+        // `backend_bound` is reserved for the #1149 follow-up. Until a real
+        // backend is wired, every call returns the typed unsupported
+        // envelope; we keep the field on the struct so the future upgrade
+        // is a behaviour change, not an API break.
+        if self.backend_bound {
+            // Unreachable until #1149 follow-up; the stub constructor
+            // always sets `backend_bound = false`.
+            return Ok(ToolResult {
+                output: "image_generation: backend bound but no implementation available"
+                    .to_string(),
+                success: false,
+                structured_metadata: Some(json!({
+                    "codex_tool": "image_generation",
+                    "error_kind": "coding_tool_missing",
+                })),
+                ..Default::default()
+            });
+        }
+        let prompt = prompt.unwrap_or("");
+        Ok(ToolResult {
+            output: json!({
+                "error": "image_generation has no native or skill backend bound on this profile",
+                "follow_up": "https://github.com/octos-org/octos/issues/1149",
+                "prompt": prompt,
+            })
+            .to_string(),
+            success: false,
+            structured_metadata: Some(json!({
+                "codex_tool": "image_generation",
+                "error_kind": "coding_tool_unsupported",
+                "reason": "no_backend_bound",
+                "follow_up_issue": "https://github.com/octos-org/octos/issues/1149",
+                "accepted_input": {
+                    "prompt": prompt,
+                    "size": input.size,
+                    "n": input.n,
+                },
+            })),
+            ..Default::default()
+        })
+    }
+}
+
 /// Tokenise a query into lowercase words, dropping anything shorter than two
 /// characters. Used by both `tool_search` (fallback when no exact substring
 /// match exists) and `tool_suggest`.
@@ -4079,5 +4235,104 @@ mod tests {
             "child process must be killed on timeout — sentinel file at {} should NOT exist",
             sentinel.display(),
         );
+    }
+
+    // #1149 / M14-B P2 tests — `image_generation` stub.
+    // -----------------------------------------------------------------------
+
+    /// The stub MUST surface `image_generation` as model-visible so
+    /// the canonical Codex tool surface is wire-complete.
+    #[tokio::test]
+    async fn builtins_expose_image_generation_tool_name() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let registry = ToolRegistry::with_builtins(temp.path());
+        let names: std::collections::HashSet<_> =
+            registry.specs().into_iter().map(|spec| spec.name).collect();
+        assert!(
+            names.contains("image_generation"),
+            "image_generation must be model-visible: {names:?}"
+        );
+    }
+
+    /// Happy stub path: a valid prompt returns a structured
+    /// `coding_tool_unsupported` envelope (no backend bound). The
+    /// model must NOT receive a generic "tool not found" — instead it
+    /// gets a typed error it can react to (UPCR-2026-020 §8).
+    #[tokio::test]
+    async fn image_generation_returns_typed_unsupported_envelope() {
+        let tool = ImageGenerationTool::new();
+        let result = tool
+            .execute(&json!({
+                "prompt": "a snowy cabin at dusk, watercolour",
+                "size": "1024x1024",
+                "n": 1
+            }))
+            .await
+            .expect("image_generation runs");
+        assert!(
+            !result.success,
+            "stub must not claim success while no backend is bound"
+        );
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["codex_tool"], json!("image_generation"));
+        assert_eq!(meta["error_kind"], json!("coding_tool_unsupported"));
+        assert_eq!(meta["reason"], json!("no_backend_bound"));
+        // The accepted input is echoed so AppUI clients can render
+        // "tool was called with X" UX while waiting for the follow-up.
+        assert_eq!(
+            meta["accepted_input"]["prompt"],
+            json!("a snowy cabin at dusk, watercolour")
+        );
+        assert_eq!(meta["accepted_input"]["size"], json!("1024x1024"));
+        assert_eq!(meta["accepted_input"]["n"], json!(1));
+    }
+
+    /// Error path: a missing / blank prompt returns
+    /// `coding_tool_denied` (input validation), not
+    /// `coding_tool_unsupported` (backend missing). Distinguishing
+    /// these is important so AppUI clients render the right UX.
+    #[tokio::test]
+    async fn image_generation_rejects_missing_prompt() {
+        let tool = ImageGenerationTool::new();
+        let result = tool
+            .execute(&json!({}))
+            .await
+            .expect("image_generation runs");
+        assert!(!result.success);
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["error_kind"], json!("coding_tool_denied"));
+        assert_eq!(meta["reason"], json!("missing_prompt"));
+    }
+
+    /// The stub's spec / schema must accept the canonical Codex
+    /// input shape (`prompt` required, `size` + `n` optional) so a
+    /// future backend swap-in is wire-compatible.
+    #[test]
+    fn image_generation_schema_pins_canonical_input_shape() {
+        let tool = ImageGenerationTool::new();
+        assert_eq!(tool.name(), "image_generation");
+        let schema = tool.input_schema();
+        assert_eq!(schema["type"], json!("object"));
+        assert_eq!(schema["required"], json!(["prompt"]));
+        let props = schema["properties"].as_object().expect("properties");
+        assert!(props.contains_key("prompt"));
+        assert!(props.contains_key("size"));
+        assert!(props.contains_key("n"));
+    }
+
+    /// Blank-string prompt still triggers the missing-prompt
+    /// validation path (trimmed). Pinned so a future refactor of
+    /// the trim/empty filter doesn't quietly drop the check.
+    #[tokio::test]
+    async fn image_generation_rejects_whitespace_only_prompt() {
+        let tool = ImageGenerationTool::new();
+        let result = tool
+            .execute(&json!({ "prompt": "   \n\t  " }))
+            .await
+            .expect("image_generation runs");
+        assert!(!result.success);
+        let meta = result.structured_metadata.expect("structured metadata");
+        assert_eq!(meta["error_kind"], json!("coding_tool_denied"));
+        assert_eq!(meta["reason"], json!("missing_prompt"));
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -666,8 +666,9 @@ pub mod code_structure;
 
 pub use coding_tools::{
     ApplyPatchTool, BashTool, CloseAgentTool, DelegateAliasTool, ExecCommandTool,
-    RequestUserInputTool, ResumeAgentTool, SendInputTool, SpawnAgentTool, ToolCatalogEntry,
-    ToolSearchTool, ToolSuggestTool, UpdatePlanTool, ViewImageTool, WaitAgentTool, WriteStdinTool,
+    ImageGenerationTool, RequestUserInputTool, ResumeAgentTool, SendInputTool, SpawnAgentTool,
+    ToolCatalogEntry, ToolSearchTool, ToolSuggestTool, UpdatePlanTool, ViewImageTool,
+    WaitAgentTool, WriteStdinTool,
 };
 pub use deep_search::DeepSearchTool;
 pub use delegate::{

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -16,11 +16,12 @@ use super::CodeStructureTool;
 use super::policy::{self, ToolPolicy};
 use super::{
     ApplyPatchTool, BrowserTool, CheckWorkspaceContractTool, CloseAgentTool, ConfigureToolTool,
-    DiffEditTool, EditFileTool, ExecCommandTool, GlobTool, GrepTool, ListDirTool, ReadFileTool,
-    RequestUserInputTool, ResumeAgentTool, SendInputTool, ShellTool, SpawnAgentTool, Tool,
-    ToolCatalogEntry, ToolConfigStore, ToolLifecycle, ToolResult, ToolSearchTool, ToolSuggestTool,
-    UpdatePlanTool, ViewImageTool, WaitAgentTool, WebFetchTool, WebSearchTool, WorkspaceDiffTool,
-    WorkspaceLogTool, WorkspaceShowTool, WriteFileTool, WriteStdinTool,
+    DiffEditTool, EditFileTool, ExecCommandTool, GlobTool, GrepTool, ImageGenerationTool,
+    ListDirTool, ReadFileTool, RequestUserInputTool, ResumeAgentTool, SendInputTool, ShellTool,
+    SpawnAgentTool, Tool, ToolCatalogEntry, ToolConfigStore, ToolLifecycle, ToolResult,
+    ToolSearchTool, ToolSuggestTool, UpdatePlanTool, ViewImageTool, WaitAgentTool, WebFetchTool,
+    WebSearchTool, WorkspaceDiffTool, WorkspaceLogTool, WorkspaceShowTool, WriteFileTool,
+    WriteStdinTool,
 };
 use crate::sandbox::{NoSandbox, Sandbox};
 
@@ -1262,6 +1263,14 @@ impl ToolRegistry {
         let catalog_cell = registry.live_catalog_handle();
         registry.register(ToolSearchTool::new(catalog_cell.clone()));
         registry.register(ToolSuggestTool::new(catalog_cell));
+        // #1149 / M14-B P2: register the canonical Codex
+        // `image_generation` entry. It currently returns a typed
+        // `coding_tool_unsupported` envelope because no native or
+        // skill backend is bound; the wire-level contract is complete
+        // so the model gets a clean error instead of a "tool not
+        // found" miss. Follow-up to wire a real backend lives on
+        // issue #1149.
+        registry.register(ImageGenerationTool::new());
         // Final refresh so the catalog reflects the just-registered
         // search/suggest tools too (cosmetic — they show up in their
         // own search results).

--- a/crates/octos-cli/src/api/coding_tool_contract.rs
+++ b/crates/octos-cli/src/api/coding_tool_contract.rs
@@ -72,6 +72,15 @@ pub(crate) const ERROR_KIND_CODING_TOOL_DENIED: &str = "coding_tool_denied";
 pub(crate) const ERROR_KIND_CODING_TOOL_MISSING: &str = "coding_tool_missing";
 #[allow(dead_code)]
 pub(crate) const ERROR_KIND_EXEC_SESSION_UNKNOWN: &str = "exec_session_unknown";
+/// #1149 — typed error kind returned by `image_generation` when the tool
+/// is registered but no native or skill backend is bound for the active
+/// profile. Distinguishes "the contract advertises this name, but no
+/// implementation is available right now" from `coding_tool_missing`
+/// (path/resource not found) and `coding_tool_denied` (policy refusal),
+/// so AppUI clients can surface the right next step (install a skill,
+/// switch provider) instead of generic "tool error".
+#[allow(dead_code)]
+pub(crate) const ERROR_KIND_CODING_TOOL_UNSUPPORTED: &str = "coding_tool_unsupported";
 
 pub(crate) const CODING_P0_REQUIRED_TOOL_NAMES: &[&str] = &[
     "apply_patch",
@@ -129,6 +138,14 @@ pub(crate) const OCTOS_KNOWN_MODEL_VISIBLE_TOOLS: &[&str] = &[
     // alongside the canonical primitives.
     "bash",
     "delegate",
+    // #1149 / M14-B P2 — Codex-compatible `image_generation` entry. The
+    // tool is registered so the wire-level contract is complete and the
+    // model gets a typed `coding_tool_unsupported` response instead of a
+    // generic "tool not found", but no native or skill backend is bound
+    // yet. See `crates/octos-agent/src/tools/coding_tools.rs`
+    // (`ImageGenerationTool`) and #1149 for the follow-up to wire a
+    // real backend (OpenAI image API or a bundled skill).
+    "image_generation",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -532,6 +549,25 @@ const OCTOS_TOOL_SPECS: &[OctosToolSpec] = &[
         policy: "allowed",
         detail: Some(
             "Canonical Codex view_image entry. Returns format / MIME / byte length for a workspace image.",
+        ),
+    },
+    // #1149 / M14-B P2: canonical Codex image-generation surface.
+    //
+    // Registered as a model-visible stub so the wire-level contract is
+    // complete; the tool currently returns `coding_tool_unsupported` for
+    // every call because no native or skill backend is bound yet. The
+    // `coding.image_generation.v1` capability is intentionally NOT
+    // advertised in `ui_protocol::advertised_capabilities` so clients
+    // don't render it as usable (UPCR-2026-020 §5: capability-gated
+    // fields are omitted when the implementation isn't bound). Follow-up
+    // to wire a real backend tracked in #1149.
+    OctosToolSpec {
+        name: "image_generation",
+        category: "media",
+        aliases: &[],
+        policy: "allowed",
+        detail: Some(
+            "Canonical Codex image_generation entry. Stub: no native or skill backend bound yet; calls return a typed coding_tool_unsupported response (#1149 follow-up).",
         ),
     },
     OctosToolSpec {
@@ -949,6 +985,14 @@ mod tests {
         assert_eq!(ERROR_KIND_CODING_TOOL_DENIED, "coding_tool_denied");
         assert_eq!(ERROR_KIND_CODING_TOOL_MISSING, "coding_tool_missing");
         assert_eq!(ERROR_KIND_EXEC_SESSION_UNKNOWN, "exec_session_unknown");
+        // #1149 — typed error kind for the registered-but-unimplemented
+        // `image_generation` stub. Pinned so a future spec rename
+        // (`coding_tool_unsupported` -> `tool_unsupported`, etc.) becomes a
+        // compile-time diff.
+        assert_eq!(
+            ERROR_KIND_CODING_TOOL_UNSUPPORTED,
+            "coding_tool_unsupported"
+        );
     }
 
     fn required_tool<'a>(contract: &'a Value, name: &str) -> &'a Value {
@@ -1192,6 +1236,7 @@ mod tests {
         };
         let payload = tool_status_list_payload(context);
         let tools = payload["tools"].as_array().expect("tools array");
+
         for name in available {
             let entry = tools
                 .iter()
@@ -1203,6 +1248,47 @@ mod tests {
                 "alias {name} must report `available` when registered",
             );
         }
+    }
+
+    /// #1149 / M14-B P2 — `image_generation` must be registered by
+    /// `ToolRegistry::with_builtins_and_sandbox` as a stub so the
+    /// canonical Codex tool surface is wire-complete. Real backend
+    /// wiring (OpenAI image API / bundled skill) is tracked in #1149.
+    #[test]
+    fn p2_image_generation_is_registered_by_session_builtins() {
+        use octos_agent::ToolRegistry;
+        use octos_agent::sandbox::NoSandbox;
+
+        let cwd = std::path::Path::new("/tmp");
+        let registry = ToolRegistry::with_builtins_and_sandbox(cwd, Box::new(NoSandbox));
+        let names: std::collections::HashSet<String> = registry.tool_names().into_iter().collect();
+
+        assert!(
+            names.contains("image_generation"),
+            "P2 canonical tool image_generation must be registered by \
+             ToolRegistry::with_builtins_and_sandbox so the M14 coding \
+             tool contract can advertise it. Registered tool names: {names:?}"
+        );
+    }
+
+    /// #1149 / M14-B P2 — when the runtime reports `image_generation` as
+    /// available, the contract's `tools` array must surface it through the
+    /// OCTOS_TOOL_SPECS entry (status `available`, category `media`).
+    #[test]
+    fn p2_image_generation_appears_in_contract_tools_array() {
+        let available = &["image_generation"];
+        let context = ToolStatusListContext {
+            available_model_tools: available,
+            ..ToolStatusListContext::default_for_session("coding:test")
+        };
+        let payload = tool_status_list_payload(context);
+        let tools = payload["tools"].as_array().expect("tools array");
+        let entry = tools
+            .iter()
+            .find(|tool| tool["name"] == json!("image_generation"))
+            .expect("image_generation must appear in contract tools array");
+        assert_eq!(entry["status"], json!(TOOL_STATUS_AVAILABLE));
+        assert_eq!(entry["category"], json!("media"));
     }
 
     /// #972 / M14-B P1 — the contract's `tools` array (driven by


### PR DESCRIPTION
## Summary
Codex P2 follow-up to #1148 (M14-B P1 tools).

`image_generation` was the only outstanding Codex-parity entry from UPCR-2026-020 (optional P2). Octos has no native image-generation backend bound (the LLM providers don't expose one, and no bundled skill covers it), so this registers the canonical tool surface as a typed `coding_tool_unsupported` stub. The wire-level contract is complete; the LLM gets a clean typed error instead of "tool not found".

Real backend wiring tracked separately as a follow-up.

Closes #1149.