### PR TITLE
feat(e2e): UX scenario manifest + ux:scenario:list (partial #1062, closes #1063)

### DIFF
--- a/e2e/lib/ux/scenarios.mjs
+++ b/e2e/lib/ux/scenarios.mjs
@@ -151,16 +151,19 @@ function normalizeScenario(row, idx, seenIds) {
   // to null when absent. But if the TOML sets them to a non-string (e.g.
   // `replay = []` or `notes = 42`), the value still slips through and
   // ends up in the --json projection — breaking the README contract
-  // that says these are string-or-null. Validate type when present.
+  // that says these are string-or-null. Validate the *type* when set,
+  // but allow empty strings: the v1 contract is "string-or-null" and
+  // tightening to "non-empty string" would be a schema-breaking change
+  // without a schema_version bump.
   for (const optField of ["replay", "notes"]) {
     if (
       Object.prototype.hasOwnProperty.call(row, optField) &&
       row[optField] !== null &&
       row[optField] !== undefined
     ) {
-      if (typeof row[optField] !== "string" || row[optField].length === 0) {
+      if (typeof row[optField] !== "string") {
         throw new ManifestSchemaError(
-          `scenario "${row.id}" field "${optField}" must be a non-empty string when set (or omitted)`,
+          `scenario "${row.id}" field "${optField}" must be a string or null`,
         );
       }
     }

--- a/e2e/lib/ux/scenarios.mjs
+++ b/e2e/lib/ux/scenarios.mjs
@@ -1,0 +1,217 @@
+// M19 UX scenario manifest loader and runnability classifier.
+//
+// Entrypoints:
+//   loadManifest({ path }) -> { schemaVersion, pack, owner, scenarios }
+//   classifyRunnability(scenario, env) -> "runnable" | "skipped" | "blocked" | "quarantined"
+//   filterByTier(scenarios, tier) -> Scenario[]
+//
+// The classifier does NOT spawn tmux, run octos, or read any process. It only
+// inspects:
+//   - the requested tier (env.tier)
+//   - whether the scenario is marked `quarantine = true` in the manifest
+//   - whether host tools exist (`env.toolExists("tmux")` etc.)
+//   - whether required env vars are set (`env.envHas("OPENAI_API_KEY")`)
+//   - whether required capabilities are declared in `env.knownCapabilities`
+//
+// All inputs are injected so the function stays pure and testable.
+
+import { readFileSync } from "node:fs";
+import { parseToml, ManifestSchemaError } from "./toml-lite.mjs";
+
+export { ManifestSchemaError } from "./toml-lite.mjs";
+
+const REQUIRED_SCENARIO_FIELDS = [
+  "id",
+  "title",
+  "description",
+  "tier",
+  "transport",
+  "provider",
+  "terminal",
+  "tui_binary",
+  "tmux_command",
+  "required_tools",
+  "required_capabilities",
+  "expected_artifacts",
+  "acceptance",
+];
+
+const VALID_TIERS = new Set(["fast", "local", "release"]);
+const VALID_TRANSPORTS = new Set(["stdio", "ws"]);
+const VALID_PROVIDERS = new Set(["fixture", "live", "none"]);
+
+export const TIER_ORDER = ["fast", "local", "release"];
+
+function tierIncludes(filter, scenarioTier) {
+  // `fast` runs in any tier; `local` runs in local/release; `release` runs
+  // only in release. Higher tiers are supersets.
+  const idxFilter = TIER_ORDER.indexOf(filter);
+  const idxScenario = TIER_ORDER.indexOf(scenarioTier);
+  return idxScenario <= idxFilter;
+}
+
+export function loadManifest({ path }) {
+  const source = readFileSync(path, "utf8");
+  let parsed;
+  try {
+    parsed = parseToml(source);
+  } catch (err) {
+    if (err instanceof ManifestSchemaError) throw err;
+    throw new ManifestSchemaError(`parse error: ${err.message}`);
+  }
+  const { top, arrays } = parsed;
+  const schemaVersion = top.schema_version;
+  if (typeof schemaVersion !== "number") {
+    throw new ManifestSchemaError(
+      `missing or non-integer top-level schema_version`,
+    );
+  }
+  if (schemaVersion !== 1) {
+    throw new ManifestSchemaError(
+      `unsupported schema_version: ${schemaVersion} (expected 1)`,
+    );
+  }
+  if (typeof top.pack !== "string" || top.pack.length === 0) {
+    throw new ManifestSchemaError(`missing top-level "pack"`);
+  }
+  if (typeof top.owner !== "string" || top.owner.length === 0) {
+    throw new ManifestSchemaError(`missing top-level "owner"`);
+  }
+  const scenarioRows = arrays.scenario ?? [];
+  if (scenarioRows.length === 0) {
+    throw new ManifestSchemaError(`manifest has no [[scenario]] entries`);
+  }
+  const seenIds = new Set();
+  const scenarios = scenarioRows.map((row, idx) => normalizeScenario(row, idx, seenIds));
+  return {
+    schemaVersion,
+    pack: top.pack,
+    owner: top.owner,
+    scenarios,
+  };
+}
+
+function normalizeScenario(row, idx, seenIds) {
+  for (const field of REQUIRED_SCENARIO_FIELDS) {
+    if (!Object.prototype.hasOwnProperty.call(row, field)) {
+      throw new ManifestSchemaError(
+        `scenario #${idx + 1} is missing required field "${field}"`,
+      );
+    }
+  }
+  if (typeof row.id !== "string" || !/^[a-z][a-z0-9-]*$/.test(row.id)) {
+    throw new ManifestSchemaError(
+      `scenario #${idx + 1} has invalid id "${row.id}" (kebab-case required)`,
+    );
+  }
+  if (seenIds.has(row.id)) {
+    throw new ManifestSchemaError(`duplicate scenario id: ${row.id}`);
+  }
+  seenIds.add(row.id);
+  if (!VALID_TIERS.has(row.tier)) {
+    throw new ManifestSchemaError(
+      `scenario "${row.id}" has invalid tier "${row.tier}"`,
+    );
+  }
+  if (!VALID_TRANSPORTS.has(row.transport)) {
+    throw new ManifestSchemaError(
+      `scenario "${row.id}" has invalid transport "${row.transport}"`,
+    );
+  }
+  if (!VALID_PROVIDERS.has(row.provider)) {
+    throw new ManifestSchemaError(
+      `scenario "${row.id}" has invalid provider "${row.provider}"`,
+    );
+  }
+  for (const arrField of [
+    "required_tools",
+    "required_capabilities",
+    "expected_artifacts",
+    "acceptance",
+  ]) {
+    if (!Array.isArray(row[arrField])) {
+      throw new ManifestSchemaError(
+        `scenario "${row.id}" field "${arrField}" must be an array`,
+      );
+    }
+    for (const item of row[arrField]) {
+      if (typeof item !== "string" || item.length === 0) {
+        throw new ManifestSchemaError(
+          `scenario "${row.id}" field "${arrField}" must contain non-empty strings`,
+        );
+      }
+    }
+  }
+  return {
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    tier: row.tier,
+    transport: row.transport,
+    provider: row.provider,
+    terminal: row.terminal,
+    tuiBinary: row.tui_binary,
+    tmuxCommand: row.tmux_command,
+    requiredTools: row.required_tools,
+    requiredCapabilities: row.required_capabilities,
+    expectedArtifacts: row.expected_artifacts,
+    acceptance: row.acceptance,
+    replay: row.replay ?? null,
+    notes: row.notes ?? null,
+    quarantine: row.quarantine === true,
+  };
+}
+
+export function filterByTier(scenarios, tier) {
+  if (!VALID_TIERS.has(tier)) {
+    throw new Error(
+      `invalid tier "${tier}" (valid: ${[...VALID_TIERS].join(", ")})`,
+    );
+  }
+  return scenarios.filter((s) => tierIncludes(tier, s.tier));
+}
+
+// Returns { status, reasons[] } where status is one of:
+//   "runnable"    - all gates green
+//   "skipped"     - host requirement missing (tool / env)
+//   "blocked"     - capability missing in current AppUI surface
+//   "quarantined" - manifest marks scenario as quarantined
+export function classifyRunnability(scenario, env) {
+  const reasons = [];
+  if (scenario.quarantine) {
+    reasons.push("scenario marked quarantine=true in manifest");
+    return { status: "quarantined", reasons };
+  }
+  for (const tool of scenario.requiredTools) {
+    if (!env.toolExists(tool)) {
+      reasons.push(`required tool not on PATH: ${tool}`);
+    }
+  }
+  if (scenario.provider === "live") {
+    // Live provider scenarios need at least one provider key. In M19-A we
+    // don't yet enumerate which one; the runner (#1065) will refine this.
+    if (
+      !env.envHas("OPENAI_API_KEY") &&
+      !env.envHas("ANTHROPIC_API_KEY") &&
+      !env.envHas("GOOGLE_API_KEY") &&
+      !env.envHas("OPENROUTER_API_KEY")
+    ) {
+      reasons.push("live provider requires at least one provider API key");
+    }
+  }
+  if (reasons.length > 0) {
+    return { status: "skipped", reasons };
+  }
+  const missingCaps = scenario.requiredCapabilities.filter(
+    (cap) => !env.knownCapabilities.has(cap),
+  );
+  if (missingCaps.length > 0) {
+    return {
+      status: "blocked",
+      reasons: missingCaps.map(
+        (cap) => `required capability not advertised by AppUI: ${cap}`,
+      ),
+    };
+  }
+  return { status: "runnable", reasons: [] };
+}

--- a/e2e/lib/ux/scenarios.mjs
+++ b/e2e/lib/ux/scenarios.mjs
@@ -91,11 +91,35 @@ export function loadManifest({ path }) {
   };
 }
 
+// Codex P2 follow-up: scalar fields that downstream code (CLI,
+// runner, table renderer, JSON consumers) assume are non-empty
+// strings. The earlier check only verified presence (i.e. that the
+// TOML key existed at all), so a value like `42` or `[]` or `""`
+// would slip through and later crash with a confusing error.
+const REQUIRED_NON_EMPTY_STRING_FIELDS = [
+  "title",
+  "description",
+  "terminal",
+  "tui_binary",
+  "tmux_command",
+];
+
 function normalizeScenario(row, idx, seenIds) {
   for (const field of REQUIRED_SCENARIO_FIELDS) {
     if (!Object.prototype.hasOwnProperty.call(row, field)) {
       throw new ManifestSchemaError(
         `scenario #${idx + 1} is missing required field "${field}"`,
+      );
+    }
+  }
+  for (const field of REQUIRED_NON_EMPTY_STRING_FIELDS) {
+    if (
+      !Object.prototype.hasOwnProperty.call(row, field) ||
+      typeof row[field] !== "string" ||
+      row[field].length === 0
+    ) {
+      throw new ManifestSchemaError(
+        `scenario #${idx + 1} has invalid "${field}": must be a non-empty string`,
       );
     }
   }

--- a/e2e/lib/ux/scenarios.mjs
+++ b/e2e/lib/ux/scenarios.mjs
@@ -147,6 +147,24 @@ function normalizeScenario(row, idx, seenIds) {
       `scenario "${row.id}" has invalid provider "${row.provider}"`,
     );
   }
+  // Codex P2 follow-up: optional scalar fields (replay, notes) default
+  // to null when absent. But if the TOML sets them to a non-string (e.g.
+  // `replay = []` or `notes = 42`), the value still slips through and
+  // ends up in the --json projection — breaking the README contract
+  // that says these are string-or-null. Validate type when present.
+  for (const optField of ["replay", "notes"]) {
+    if (
+      Object.prototype.hasOwnProperty.call(row, optField) &&
+      row[optField] !== null &&
+      row[optField] !== undefined
+    ) {
+      if (typeof row[optField] !== "string" || row[optField].length === 0) {
+        throw new ManifestSchemaError(
+          `scenario "${row.id}" field "${optField}" must be a non-empty string when set (or omitted)`,
+        );
+      }
+    }
+  }
   for (const arrField of [
     "required_tools",
     "required_capabilities",

--- a/e2e/lib/ux/toml-lite.mjs
+++ b/e2e/lib/ux/toml-lite.mjs
@@ -1,0 +1,293 @@
+// Minimal TOML reader for the M19 UX scenario manifest.
+//
+// We deliberately avoid adding a TOML dependency. The supported subset is:
+//   - line comments starting with `#`
+//   - top-level `key = value`
+//   - `[[table.array]]` array-of-tables headers
+//   - string values (single-line `"..."` with `\"` and `\\` escapes)
+//   - integer values
+//   - boolean values (`true` / `false`)
+//   - inline arrays of strings, possibly multi-line, e.g.
+//       arr = [
+//         "a",
+//         "b",
+//       ]
+//
+// Anything else throws a typed ManifestSchemaError. The manifest in
+// `e2e/matrix/octos-ux.toml` is required to stay within this subset; the
+// parser self-tests in `e2e/tests/ux/scenario-list.test.mjs` enforce it.
+
+export class ManifestSchemaError extends Error {
+  constructor(message, { line, source } = {}) {
+    super(message);
+    this.name = "ManifestSchemaError";
+    this.line = line;
+    this.source = source;
+  }
+}
+
+function stripCommentAndTrim(line) {
+  // Strip a `#` comment, but only when it's outside a string literal.
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (ch === "#" && !inString) {
+      return line.slice(0, i).trim();
+    }
+  }
+  return line.trim();
+}
+
+function parseScalar(raw, lineNo) {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    throw new ManifestSchemaError("empty value", { line: lineNo, source: raw });
+  }
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (/^-?\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10);
+  }
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return unescapeString(trimmed.slice(1, -1), lineNo);
+  }
+  throw new ManifestSchemaError(`unsupported scalar value: ${trimmed}`, {
+    line: lineNo,
+    source: raw,
+  });
+}
+
+function unescapeString(body, lineNo) {
+  let out = "";
+  let i = 0;
+  while (i < body.length) {
+    const ch = body[i];
+    if (ch === "\\") {
+      const next = body[i + 1];
+      if (next === undefined) {
+        throw new ManifestSchemaError("dangling escape in string", {
+          line: lineNo,
+          source: body,
+        });
+      }
+      switch (next) {
+        case "\\":
+          out += "\\";
+          break;
+        case '"':
+          out += '"';
+          break;
+        case "n":
+          out += "\n";
+          break;
+        case "t":
+          out += "\t";
+          break;
+        case "r":
+          out += "\r";
+          break;
+        default:
+          throw new ManifestSchemaError(
+            `unsupported escape sequence \\${next}`,
+            { line: lineNo, source: body },
+          );
+      }
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+// Parse the right-hand side of `arr = [ "a", "b" ]`, allowing the closing `]`
+// to land on a later line. Returns { value, consumed } where `consumed` is the
+// number of additional source lines consumed beyond the first.
+function parseArray(firstRhs, allLines, startIdx) {
+  let buf = firstRhs;
+  let consumed = 0;
+  while (!bracketBalanced(buf)) {
+    const nextIdx = startIdx + 1 + consumed;
+    if (nextIdx >= allLines.length) {
+      throw new ManifestSchemaError("unterminated array literal", {
+        line: startIdx + 1,
+        source: firstRhs,
+      });
+    }
+    buf += "\n" + allLines[nextIdx];
+    consumed += 1;
+  }
+  // Strip outer brackets, split on commas at depth 0 (we only support flat
+  // arrays of strings/scalars; nested arrays are out of scope).
+  const trimmed = buf.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) {
+    throw new ManifestSchemaError("malformed array literal", {
+      line: startIdx + 1,
+      source: buf,
+    });
+  }
+  const inner = trimmed.slice(1, -1);
+  const items = splitTopLevelCommas(inner)
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+  const value = items.map((item) => parseScalar(item, startIdx + 1));
+  return { value, consumed };
+}
+
+function bracketBalanced(s) {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < s.length; i += 1) {
+    const ch = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "[") depth += 1;
+    else if (ch === "]") depth -= 1;
+  }
+  return depth === 0 && !inString;
+}
+
+function splitTopLevelCommas(s) {
+  const out = [];
+  let buf = "";
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < s.length; i += 1) {
+    const ch = s[i];
+    if (escape) {
+      buf += ch;
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      buf += ch;
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      buf += ch;
+      continue;
+    }
+    if (!inString) {
+      if (ch === "[") depth += 1;
+      else if (ch === "]") depth -= 1;
+      if (ch === "," && depth === 0) {
+        out.push(buf);
+        buf = "";
+        continue;
+      }
+    }
+    buf += ch;
+  }
+  if (buf.trim().length > 0) out.push(buf);
+  return out;
+}
+
+// Parse the manifest source text into a typed structure:
+//   { top: { ... }, arrays: { "scenario": [ { ... }, ... ] } }
+export function parseToml(source) {
+  const lines = source.split(/\r?\n/);
+  const top = {};
+  const arrays = {};
+  let currentTable = null; // { kind: "array", name, obj }
+  let i = 0;
+  while (i < lines.length) {
+    const rawLine = lines[i];
+    const line = stripCommentAndTrim(rawLine);
+    if (line === "") {
+      i += 1;
+      continue;
+    }
+    if (line.startsWith("[[") && line.endsWith("]]")) {
+      const name = line.slice(2, -2).trim();
+      if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(name)) {
+        throw new ManifestSchemaError(`invalid table-array header: ${line}`, {
+          line: i + 1,
+          source: rawLine,
+        });
+      }
+      const obj = {};
+      if (!arrays[name]) arrays[name] = [];
+      arrays[name].push(obj);
+      currentTable = { kind: "array", name, obj };
+      i += 1;
+      continue;
+    }
+    if (line.startsWith("[") && line.endsWith("]")) {
+      throw new ManifestSchemaError(
+        "plain [table] headers not supported; use [[array]]",
+        { line: i + 1, source: rawLine },
+      );
+    }
+    const eq = line.indexOf("=");
+    if (eq < 0) {
+      throw new ManifestSchemaError(`expected key = value, got: ${line}`, {
+        line: i + 1,
+        source: rawLine,
+      });
+    }
+    const key = line.slice(0, eq).trim();
+    const rhs = line.slice(eq + 1).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      throw new ManifestSchemaError(`invalid key: ${key}`, {
+        line: i + 1,
+        source: rawLine,
+      });
+    }
+    let value;
+    let advance = 1;
+    if (rhs.startsWith("[")) {
+      const { value: arr, consumed } = parseArray(rhs, lines, i);
+      value = arr;
+      advance = 1 + consumed;
+    } else {
+      value = parseScalar(rhs, i + 1);
+    }
+    if (currentTable === null) {
+      if (Object.prototype.hasOwnProperty.call(top, key)) {
+        throw new ManifestSchemaError(`duplicate top-level key: ${key}`, {
+          line: i + 1,
+        });
+      }
+      top[key] = value;
+    } else {
+      if (Object.prototype.hasOwnProperty.call(currentTable.obj, key)) {
+        throw new ManifestSchemaError(
+          `duplicate key in [[${currentTable.name}]]: ${key}`,
+          { line: i + 1 },
+        );
+      }
+      currentTable.obj[key] = value;
+    }
+    i += advance;
+  }
+  return { top, arrays };
+}

--- a/e2e/matrix/octos-ux.toml
+++ b/e2e/matrix/octos-ux.toml
@@ -1,0 +1,309 @@
+# M19 Octos UX Scenario Manifest
+#
+# Schema version is the contract between `ux:scenario:list` (M19-A, #1063),
+# the artifact ABI (#1064), the tmux wrapper (#1065), and the validator
+# registry (#1066). When the schema changes, bump `schema_version`.
+#
+# Each `[[scenario]]` table declares one UX scenario the gate can list, plan,
+# and (in follow-up PRs) actually run through real tmux against a real
+# `octos` plus real `octos-tui`.
+#
+# Mandatory fields per scenario:
+#   id                 - kebab-case identifier, unique
+#   title              - one-line human label
+#   description        - why this scenario exists; what it proves
+#   tier               - "fast" | "local" | "release"
+#   transport          - "stdio" | "ws"
+#   provider           - "fixture" | "live" | "none"
+#   terminal           - "80x24" | "100x30" | "120x40" | "narrow"
+#   tui_binary         - logical name; resolved by the runner (#1065)
+#   tmux_command       - logical command label; the runner picks the script
+#   required_tools     - host binaries that must be on PATH
+#   required_capabilities - AppUI capability flags (see UPCR-2026-019)
+#   expected_artifacts - filenames the runner MUST emit under
+#                        e2e/test-results-ux/<run-id>/<scenario-id>/
+#   acceptance         - validator IDs (implementations land in #1066)
+#
+# Optional:
+#   replay             - path to a replay script (driver input)
+#   notes              - free-form
+
+schema_version = 1
+pack = "octos-ux"
+owner = "M19 UX gate"
+
+[[scenario]]
+id = "tui-solo-onboarding"
+title = "Solo onboarding first-run"
+description = "Fresh profile boots into Solo mode, capability gate reports no-OTP path, runtime policy stamp lands in artifacts."
+tier = "fast"
+transport = "stdio"
+provider = "fixture"
+terminal = "80x24"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-solo-onboarding"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["onboarding/workspace_probe", "runtime/policy_stamp"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+]
+acceptance = [
+  "appui.no_otp_calls",
+  "appui.profile_id_consistent",
+  "tui.first_frame_not_blank",
+  "runtime.policy_stamp_present",
+]
+replay = "e2e/ux/replays/tui-solo-onboarding.replay"
+notes = "Mirrors M22-H onboarding pack but focused on the UX gate plumbing."
+
+[[scenario]]
+id = "provider-missing-recoverable"
+title = "Provider missing, recoverable"
+description = "Boot without a configured provider; UX should surface a recoverable banner, not crash, and validators should see a typed error in appui-transcript."
+tier = "fast"
+transport = "stdio"
+provider = "none"
+terminal = "80x24"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-provider-missing"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["onboarding/workspace_probe"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+]
+acceptance = [
+  "appui.provider_missing_banner_present",
+  "appui.no_panic",
+  "tui.first_frame_not_blank",
+]
+
+[[scenario]]
+id = "permission-selection"
+title = "Permission profile selection"
+description = "User toggles between Solo and Dangerous permission profiles; selection persists and policy stamp updates accordingly."
+tier = "local"
+transport = "stdio"
+provider = "fixture"
+terminal = "80x24"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-permission-selection"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["runtime/policy_stamp", "permission/profile_select"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+]
+acceptance = [
+  "runtime.policy_stamp_present",
+  "runtime.policy_stamp_matches_selection",
+  "appui.no_otp_calls",
+]
+
+[[scenario]]
+id = "stdio-happy-path"
+title = "stdio coding-session happy path"
+description = "Send a prompt over stdio transport, receive a response, capture the final TUI frame. The canonical M19 happy-path scenario."
+tier = "local"
+transport = "stdio"
+provider = "fixture"
+terminal = "100x30"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-stdio-happy"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["chat/send_prompt", "chat/receive_response"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+]
+acceptance = [
+  "tui.first_frame_not_blank",
+  "appui.assistant_response_present",
+  "appui.no_unsupported_method",
+]
+replay = "e2e/ux/replays/stdio-happy-path.replay"
+
+[[scenario]]
+id = "websocket-happy-path"
+title = "WebSocket coding-session happy path"
+description = "Same happy-path shape as stdio-happy-path but via the WS transport. Required to keep both transports green."
+tier = "local"
+transport = "ws"
+provider = "fixture"
+terminal = "100x30"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-ws-happy"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["chat/send_prompt", "chat/receive_response"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+]
+acceptance = [
+  "tui.first_frame_not_blank",
+  "appui.assistant_response_present",
+  "appui.no_unsupported_method",
+]
+replay = "e2e/ux/replays/websocket-happy-path.replay"
+
+[[scenario]]
+id = "approval-denial"
+title = "Approval denial flow"
+description = "Tool call requires approval; user denies; subsequent agent loop respects the denial and surfaces a typed denial event in the transcript."
+tier = "local"
+transport = "stdio"
+provider = "fixture"
+terminal = "100x30"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-approval-denial"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["approval/request", "approval/deny"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+  "approval-events.jsonl",
+]
+acceptance = [
+  "appui.approval_denied_event_present",
+  "appui.no_tool_call_after_denial",
+]
+
+[[scenario]]
+id = "task-subagent-tree"
+title = "Task / subagent tree visibility"
+description = "Spawn a subagent task; the TUI shows the supervisor/child tree, the artifact index lists child outputs, and the AppUI ledger has parent/child wiring."
+tier = "local"
+transport = "stdio"
+provider = "fixture"
+terminal = "120x40"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-task-subagent-tree"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["task/spawn", "task/observe"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+  "task-ledger.jsonl",
+  "artifact-index.json",
+]
+acceptance = [
+  "appui.child_parent_wiring_consistent",
+  "tui.task_tree_rendered",
+]
+
+[[scenario]]
+id = "restart-reconnect"
+title = "Restart + reconnect"
+description = "Backend restarts mid-session; the TUI reconnects, prior session state is preserved, no duplicate prompts are issued."
+tier = "release"
+transport = "ws"
+provider = "fixture"
+terminal = "100x30"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-restart-reconnect"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["session/resume", "transport/reconnect"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+  "reconnect-events.jsonl",
+]
+acceptance = [
+  "appui.no_duplicate_prompt_after_reconnect",
+  "appui.session_state_preserved",
+]
+
+[[scenario]]
+id = "narrow-layout"
+title = "Narrow terminal layout"
+description = "Run the happy-path scenario in a narrow terminal (60x20). Layout must reflow, not truncate-and-hide control lines."
+tier = "release"
+transport = "stdio"
+provider = "fixture"
+terminal = "narrow"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-narrow-layout"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["chat/send_prompt"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+]
+acceptance = [
+  "tui.no_truncated_control_lines",
+  "tui.first_frame_not_blank",
+]
+
+[[scenario]]
+id = "dropped-completion-backpressure"
+title = "Dropped completion under backpressure"
+description = "Provider stalls mid-stream; backpressure handling MUST surface a typed warning, MUST NOT silently drop tokens, and the next prompt MUST still succeed."
+tier = "release"
+transport = "ws"
+provider = "fixture"
+terminal = "100x30"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-dropped-completion"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["chat/send_prompt", "chat/stream"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+  "stream-events.jsonl",
+]
+acceptance = [
+  "appui.backpressure_warning_present",
+  "appui.no_silent_token_drop",
+  "appui.next_prompt_succeeds",
+]

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -22,6 +22,8 @@
     "test:live:acceptance": "npx playwright test --workers=1 tests/live-browser.spec.ts tests/refactor-capabilities.spec.ts tests/session-recovery.spec.ts",
     "test:live:coding": "npx playwright test tests/coding-hardcases.spec.ts",
     "soak:m14:codex-tool-parity": "node scripts/m14-codex-tool-parity-soak.mjs",
-    "soak:m18:appui-transport-parity": "node scripts/m18-appui-transport-parity-soak.mjs"
+    "soak:m18:appui-transport-parity": "node scripts/m18-appui-transport-parity-soak.mjs",
+    "ux:scenario:list": "node scripts/ux-scenario-list.mjs",
+    "ux:scenario:list:test": "node --test tests/ux/scenario-list.test.mjs"
   }
 }

--- a/e2e/scripts/ux-scenario-list.mjs
+++ b/e2e/scripts/ux-scenario-list.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// M19-A: ux:scenario:list
+//
+// Reads e2e/matrix/octos-ux.toml and prints the declared UX scenarios.
+// Does NOT launch tmux, octos, or any backend. The list command must work
+// even when the host has no octos binary installed.
+//
+// Usage:
+//   npm --prefix e2e run ux:scenario:list                # full release tier
+//   npm --prefix e2e run ux:scenario:list -- --tier fast
+//   npm --prefix e2e run ux:scenario:list -- --tier local
+//   npm --prefix e2e run ux:scenario:list -- --json
+//
+// Exit codes:
+//   0  - manifest parsed and printed successfully
+//   2  - usage error (unknown flag, bad tier)
+//   3  - manifest schema error
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  classifyRunnability,
+  filterByTier,
+  loadManifest,
+  ManifestSchemaError,
+  TIER_ORDER,
+} from "../lib/ux/scenarios.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const DEFAULT_MANIFEST = resolve(REPO_ROOT, "e2e", "matrix", "octos-ux.toml");
+
+function parseArgs(argv) {
+  const opts = { tier: "release", json: false, manifest: DEFAULT_MANIFEST };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--tier") {
+      opts.tier = argv[i + 1];
+      i += 1;
+    } else if (arg.startsWith("--tier=")) {
+      opts.tier = arg.slice("--tier=".length);
+    } else if (arg === "--json") {
+      opts.json = true;
+    } else if (arg === "--manifest") {
+      opts.manifest = resolve(argv[i + 1]);
+      i += 1;
+    } else if (arg.startsWith("--manifest=")) {
+      opts.manifest = resolve(arg.slice("--manifest=".length));
+    } else if (arg === "--help" || arg === "-h") {
+      opts.help = true;
+    } else {
+      throw new UsageError(`unknown argument: ${arg}`);
+    }
+  }
+  if (!TIER_ORDER.includes(opts.tier)) {
+    throw new UsageError(
+      `--tier must be one of ${TIER_ORDER.join(", ")} (got "${opts.tier}")`,
+    );
+  }
+  return opts;
+}
+
+class UsageError extends Error {}
+
+function usage() {
+  return [
+    "Usage: ux:scenario:list [--tier fast|local|release] [--json] [--manifest path]",
+    "",
+    "Lists UX scenarios declared in e2e/matrix/octos-ux.toml without launching",
+    "tmux or any backend. See e2e/ux/README.md for the manifest schema.",
+  ].join("\n");
+}
+
+function makeEnv() {
+  const knownCapabilities = new Set();
+  const capsPath = resolve(REPO_ROOT, "e2e", "matrix", "ux-capabilities.json");
+  if (existsSync(capsPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(capsPath, "utf8"));
+      if (Array.isArray(parsed.capabilities)) {
+        for (const cap of parsed.capabilities) {
+          if (typeof cap === "string") knownCapabilities.add(cap);
+        }
+      }
+    } catch {
+      // Best-effort; fall back to empty capability set.
+    }
+  }
+  return {
+    toolExists(name) {
+      try {
+        execSync(`command -v ${shellEscape(name)}`, { stdio: "ignore" });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    envHas(name) {
+      return typeof process.env[name] === "string" && process.env[name].length > 0;
+    },
+    knownCapabilities,
+  };
+}
+
+function shellEscape(s) {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+function padRight(s, width) {
+  if (s.length >= width) return s;
+  return s + " ".repeat(width - s.length);
+}
+
+function formatTable(rows, columns) {
+  const widths = columns.map((col) =>
+    Math.max(col.header.length, ...rows.map((r) => String(r[col.key] ?? "").length)),
+  );
+  const lines = [];
+  const headerLine = columns
+    .map((col, i) => padRight(col.header, widths[i]))
+    .join("  ");
+  lines.push(headerLine);
+  lines.push(columns.map((_, i) => "-".repeat(widths[i])).join("  "));
+  for (const r of rows) {
+    lines.push(
+      columns
+        .map((col, i) => padRight(String(r[col.key] ?? ""), widths[i]))
+        .join("  "),
+    );
+  }
+  return lines.join("\n");
+}
+
+function summarize(rows) {
+  const counts = { runnable: 0, skipped: 0, blocked: 0, quarantined: 0 };
+  for (const r of rows) {
+    counts[r.status] = (counts[r.status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    if (err instanceof UsageError) {
+      process.stderr.write(`error: ${err.message}\n\n${usage()}\n`);
+      process.exit(2);
+    }
+    throw err;
+  }
+  if (opts.help) {
+    process.stdout.write(usage() + "\n");
+    process.exit(0);
+  }
+  let manifest;
+  try {
+    manifest = loadManifest({ path: opts.manifest });
+  } catch (err) {
+    if (err instanceof ManifestSchemaError) {
+      process.stderr.write(`manifest schema error: ${err.message}\n`);
+      if (err.line) {
+        process.stderr.write(`  at line ${err.line}\n`);
+      }
+      process.exit(3);
+    }
+    throw err;
+  }
+  const env = makeEnv();
+  const filtered = filterByTier(manifest.scenarios, opts.tier);
+  // Sort by id for deterministic output.
+  const sorted = [...filtered].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  const rows = sorted.map((s) => {
+    const { status, reasons } = classifyRunnability(s, env);
+    return {
+      id: s.id,
+      tier: s.tier,
+      transport: s.transport,
+      provider: s.provider,
+      terminal: s.terminal,
+      title: s.title,
+      status,
+      reasons,
+      requiredTools: s.requiredTools,
+      requiredCapabilities: s.requiredCapabilities,
+      acceptance: s.acceptance,
+      expectedArtifacts: s.expectedArtifacts,
+    };
+  });
+  const summary = summarize(rows);
+  if (opts.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          schema_version: manifest.schemaVersion,
+          pack: manifest.pack,
+          owner: manifest.owner,
+          tier_filter: opts.tier,
+          summary,
+          scenarios: rows,
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+  } else {
+    process.stdout.write(
+      `Pack: ${manifest.pack}  Owner: ${manifest.owner}  Tier filter: ${opts.tier}\n`,
+    );
+    process.stdout.write(
+      formatTable(rows, [
+        { key: "id", header: "id" },
+        { key: "transport", header: "transport" },
+        { key: "tier", header: "tier" },
+        { key: "status", header: "status" },
+        { key: "title", header: "title" },
+      ]) + "\n",
+    );
+    process.stdout.write(
+      `\nSummary: runnable=${summary.runnable ?? 0} skipped=${summary.skipped ?? 0} blocked=${summary.blocked ?? 0} quarantined=${summary.quarantined ?? 0}\n`,
+    );
+    const withReasons = rows.filter((r) => r.reasons && r.reasons.length > 0);
+    if (withReasons.length > 0) {
+      process.stdout.write(`\nReasons:\n`);
+      for (const r of withReasons) {
+        for (const reason of r.reasons) {
+          process.stdout.write(`  [${r.status}] ${r.id}: ${reason}\n`);
+        }
+      }
+    }
+  }
+}
+
+main();

--- a/e2e/scripts/ux-scenario-list.mjs
+++ b/e2e/scripts/ux-scenario-list.mjs
@@ -176,6 +176,13 @@ function main() {
   const sorted = [...filtered].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const rows = sorted.map((s) => {
     const { status, reasons } = classifyRunnability(s, env);
+    // Codex P2 follow-up: emit the FULL normalized scenario record in
+    // each row so JSON consumers (CI, the future runner in #1064-#1067)
+    // can decide which TUI binary / tmux command / replay payload /
+    // notes to use without reparsing the TOML. Previously the JSON
+    // output was just the table-column projection (id/tier/transport/
+    // provider/terminal/title), missing description/tuiBinary/
+    // tmuxCommand/replay/notes/quarantine.
     return {
       id: s.id,
       tier: s.tier,
@@ -183,12 +190,18 @@ function main() {
       provider: s.provider,
       terminal: s.terminal,
       title: s.title,
+      description: s.description,
+      tuiBinary: s.tuiBinary,
+      tmuxCommand: s.tmuxCommand,
       status,
       reasons,
       requiredTools: s.requiredTools,
       requiredCapabilities: s.requiredCapabilities,
       acceptance: s.acceptance,
       expectedArtifacts: s.expectedArtifacts,
+      replay: s.replay,
+      notes: s.notes,
+      quarantine: s.quarantine,
     };
   });
   const summary = summarize(rows);

--- a/e2e/tests/ux/scenario-list.test.mjs
+++ b/e2e/tests/ux/scenario-list.test.mjs
@@ -1,0 +1,278 @@
+// Unit tests for the M19-A UX scenario list pipeline.
+// Run with: `npm --prefix e2e run ux:scenario:list:test`
+//
+// Tests:
+//   1. The real manifest at e2e/matrix/octos-ux.toml parses cleanly and
+//      declares all ten scenarios the umbrella issue requires.
+//   2. A malformed manifest raises a typed ManifestSchemaError.
+//   3. Tier filtering: fast subset is contained in local, local in release.
+//   4. Runnability classifier reports skip / block / runnable correctly
+//      against an injected fake host env.
+//   5. The CLI exits 0 on a valid manifest and 3 on a schema error.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  classifyRunnability,
+  filterByTier,
+  loadManifest,
+  ManifestSchemaError,
+} from "../../lib/ux/scenarios.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const MANIFEST = resolve(REPO_ROOT, "e2e", "matrix", "octos-ux.toml");
+const CLI = resolve(REPO_ROOT, "e2e", "scripts", "ux-scenario-list.mjs");
+
+const EXPECTED_IDS = [
+  "tui-solo-onboarding",
+  "provider-missing-recoverable",
+  "permission-selection",
+  "stdio-happy-path",
+  "websocket-happy-path",
+  "approval-denial",
+  "task-subagent-tree",
+  "restart-reconnect",
+  "narrow-layout",
+  "dropped-completion-backpressure",
+];
+
+const REQUIRED_ARTIFACTS = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+];
+
+function makeEnv({
+  tools = new Set(["tmux", "octos", "octos-tui"]),
+  envVars = new Set(),
+  capabilities = new Set(),
+} = {}) {
+  return {
+    toolExists: (t) => tools.has(t),
+    envHas: (k) => envVars.has(k),
+    knownCapabilities: capabilities,
+  };
+}
+
+test("manifest parses and declares all umbrella-required scenarios", () => {
+  const manifest = loadManifest({ path: MANIFEST });
+  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.pack, "octos-ux");
+  const ids = manifest.scenarios.map((s) => s.id).sort();
+  assert.deepEqual(ids, [...EXPECTED_IDS].sort());
+  for (const s of manifest.scenarios) {
+    for (const required of REQUIRED_ARTIFACTS) {
+      assert.ok(
+        s.expectedArtifacts.includes(required),
+        `scenario ${s.id} missing required artifact ${required}`,
+      );
+    }
+    assert.ok(s.acceptance.length > 0, `scenario ${s.id} declares no validators`);
+  }
+});
+
+test("manifest has at least one stdio and one ws transport scenario", () => {
+  const manifest = loadManifest({ path: MANIFEST });
+  const stdio = manifest.scenarios.filter((s) => s.transport === "stdio");
+  const ws = manifest.scenarios.filter((s) => s.transport === "ws");
+  assert.ok(stdio.length >= 1, "expected at least one stdio scenario");
+  assert.ok(ws.length >= 1, "expected at least one ws scenario");
+});
+
+test("malformed manifest raises a typed ManifestSchemaError", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ux-manifest-"));
+  const bad = join(dir, "octos-ux.toml");
+  writeFileSync(
+    bad,
+    [
+      'schema_version = 1',
+      'pack = "octos-ux"',
+      'owner = "test"',
+      "[[scenario]]",
+      'id = "missing-fields"',
+      "",
+    ].join("\n"),
+  );
+  assert.throws(() => loadManifest({ path: bad }), (err) => {
+    assert.ok(err instanceof ManifestSchemaError);
+    assert.match(err.message, /missing required field/);
+    return true;
+  });
+});
+
+test("unsupported schema_version raises typed error", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ux-manifest-"));
+  const bad = join(dir, "octos-ux.toml");
+  writeFileSync(
+    bad,
+    ['schema_version = 999', 'pack = "p"', 'owner = "o"', ""].join("\n"),
+  );
+  assert.throws(() => loadManifest({ path: bad }), (err) => {
+    assert.ok(err instanceof ManifestSchemaError);
+    assert.match(err.message, /unsupported schema_version/);
+    return true;
+  });
+});
+
+test("duplicate scenario id raises typed error", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ux-manifest-"));
+  const bad = join(dir, "octos-ux.toml");
+  const body = readFileSync(MANIFEST, "utf8");
+  // Append a duplicate of the first scenario id to trigger duplicate detection.
+  writeFileSync(
+    bad,
+    body +
+      "\n[[scenario]]\n" +
+      'id = "tui-solo-onboarding"\n' +
+      'title = "dup"\n' +
+      'description = "dup"\n' +
+      'tier = "fast"\n' +
+      'transport = "stdio"\n' +
+      'provider = "fixture"\n' +
+      'terminal = "80x24"\n' +
+      'tui_binary = "octos-tui"\n' +
+      'tmux_command = "x"\n' +
+      "required_tools = []\n" +
+      "required_capabilities = []\n" +
+      "expected_artifacts = []\n" +
+      "acceptance = []\n",
+  );
+  assert.throws(() => loadManifest({ path: bad }), (err) => {
+    assert.ok(err instanceof ManifestSchemaError);
+    assert.match(err.message, /duplicate scenario id/);
+    return true;
+  });
+});
+
+test("filterByTier honors fast / local / release ordering", () => {
+  const manifest = loadManifest({ path: MANIFEST });
+  const fast = filterByTier(manifest.scenarios, "fast");
+  const local = filterByTier(manifest.scenarios, "local");
+  const release = filterByTier(manifest.scenarios, "release");
+  assert.ok(fast.length >= 1, "expected at least one fast-tier scenario");
+  assert.ok(local.length >= fast.length, "local must be a superset of fast");
+  assert.equal(
+    release.length,
+    manifest.scenarios.length,
+    "release tier must include every scenario",
+  );
+  // Every fast scenario id must appear in local; every local id in release.
+  const fastIds = new Set(fast.map((s) => s.id));
+  const localIds = new Set(local.map((s) => s.id));
+  const releaseIds = new Set(release.map((s) => s.id));
+  for (const id of fastIds) assert.ok(localIds.has(id));
+  for (const id of localIds) assert.ok(releaseIds.has(id));
+});
+
+test("filterByTier rejects an unknown tier", () => {
+  const manifest = loadManifest({ path: MANIFEST });
+  assert.throws(() => filterByTier(manifest.scenarios, "experimental"));
+});
+
+test("classifyRunnability reports runnable when all gates are green", () => {
+  const manifest = loadManifest({ path: MANIFEST });
+  const scenario = manifest.scenarios.find((s) => s.id === "stdio-happy-path");
+  const env = makeEnv({
+    capabilities: new Set(scenario.requiredCapabilities),
+  });
+  const r = classifyRunnability(scenario, env);
+  assert.equal(r.status, "runnable");
+  assert.deepEqual(r.reasons, []);
+});
+
+test("classifyRunnability reports skipped when host tool missing", () => {
+  const manifest = loadManifest({ path: MANIFEST });
+  const scenario = manifest.scenarios.find((s) => s.id === "stdio-happy-path");
+  const env = makeEnv({
+    tools: new Set(["octos", "octos-tui"]), // tmux missing
+    capabilities: new Set(scenario.requiredCapabilities),
+  });
+  const r = classifyRunnability(scenario, env);
+  assert.equal(r.status, "skipped");
+  assert.ok(r.reasons.some((reason) => reason.includes("tmux")));
+});
+
+test("classifyRunnability reports blocked when capability missing", () => {
+  const manifest = loadManifest({ path: MANIFEST });
+  const scenario = manifest.scenarios.find((s) => s.id === "stdio-happy-path");
+  const env = makeEnv({
+    capabilities: new Set(), // no capabilities advertised
+  });
+  const r = classifyRunnability(scenario, env);
+  assert.equal(r.status, "blocked");
+  assert.ok(r.reasons.length > 0);
+});
+
+test("classifyRunnability honors quarantine flag", () => {
+  const fakeScenario = {
+    id: "q",
+    requiredTools: [],
+    requiredCapabilities: [],
+    provider: "fixture",
+    quarantine: true,
+  };
+  const r = classifyRunnability(fakeScenario, makeEnv());
+  assert.equal(r.status, "quarantined");
+});
+
+test("CLI exits 0 on a valid manifest and JSON output round-trips", () => {
+  const out = execFileSync(process.execPath, [CLI, "--tier", "fast", "--json"], {
+    encoding: "utf8",
+  });
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.tier_filter, "fast");
+  assert.equal(parsed.pack, "octos-ux");
+  assert.ok(parsed.scenarios.length >= 1);
+  for (const s of parsed.scenarios) {
+    assert.ok(["runnable", "skipped", "blocked", "quarantined"].includes(s.status));
+  }
+});
+
+test("CLI exits 2 on usage error", () => {
+  try {
+    execFileSync(process.execPath, [CLI, "--tier", "no-such-tier"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    assert.fail("expected non-zero exit");
+  } catch (err) {
+    assert.equal(err.status, 2);
+  }
+});
+
+test("CLI exits 3 on a malformed manifest", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ux-cli-"));
+  const bad = join(dir, "octos-ux.toml");
+  writeFileSync(bad, 'schema_version = "not-an-int"\n');
+  try {
+    execFileSync(
+      process.execPath,
+      [CLI, "--manifest", bad, "--tier", "fast"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    assert.fail("expected non-zero exit");
+  } catch (err) {
+    assert.equal(err.status, 3);
+  }
+});
+
+test("CLI plain output is deterministic for a fixed tier", () => {
+  const first = execFileSync(process.execPath, [CLI, "--tier", "local"], {
+    encoding: "utf8",
+  });
+  const second = execFileSync(process.execPath, [CLI, "--tier", "local"], {
+    encoding: "utf8",
+  });
+  assert.equal(first, second);
+});

--- a/e2e/ux/README.md
+++ b/e2e/ux/README.md
@@ -1,0 +1,158 @@
+# M19 UX Scenario Manifest
+
+This directory documents the shared scenario format used by the M19 real-tmux
+UX gate. The manifest itself lives at `e2e/matrix/octos-ux.toml`. The list
+command is wired through `npm --prefix e2e run ux:scenario:list` and runs
+without launching tmux, octos, or any backend.
+
+This is the first cut of the gate (umbrella issue #1062, sub-issue #1063).
+Subsequent PRs add:
+
+- `#1064` artifact ABI and validation self-test
+- `#1065` tmux runner wrapper and `stdio-happy-path` execution
+- `#1066` validator registry and terminal layout snapshot checks
+- `#1067` initial scenario migration from existing tmux soak scripts
+- `#1068` CI, reports, and testing docs
+
+The manifest format below is the contract those PRs build on. Bump
+`schema_version` when the contract changes.
+
+## Manifest layout
+
+The manifest is a single TOML file with a small top-level header and a
+sequence of `[[scenario]]` tables:
+
+```toml
+schema_version = 1
+pack = "octos-ux"
+owner = "M19 UX gate"
+
+[[scenario]]
+id = "stdio-happy-path"
+title = "stdio coding-session happy path"
+description = "..."
+tier = "local"
+transport = "stdio"
+provider = "fixture"
+terminal = "100x30"
+tui_binary = "octos-tui"
+tmux_command = "ux-tui-stdio-happy"
+required_tools = ["tmux", "octos", "octos-tui"]
+required_capabilities = ["chat/send_prompt", "chat/receive_response"]
+expected_artifacts = [
+  "scenario.json",
+  "summary.json",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+]
+acceptance = [
+  "tui.first_frame_not_blank",
+  "appui.assistant_response_present",
+]
+replay = "e2e/ux/replays/stdio-happy-path.replay"
+```
+
+### Top-level fields
+
+| Field            | Type    | Required | Notes                                                |
+|------------------|---------|----------|------------------------------------------------------|
+| `schema_version` | integer | yes      | Currently `1`. Bump on breaking changes.             |
+| `pack`           | string  | yes      | Logical pack name; `octos-ux` for the M19 gate.      |
+| `owner`          | string  | yes      | Free-form ownership label for reviewers.             |
+
+### Scenario fields
+
+| Field                   | Type           | Required | Notes |
+|-------------------------|----------------|----------|-------|
+| `id`                    | string (kebab) | yes      | Unique. `[a-z][a-z0-9-]*`. |
+| `title`                 | string         | yes      | One-line human label. |
+| `description`           | string         | yes      | Why this scenario exists. |
+| `tier`                  | enum           | yes      | `fast` ⊆ `local` ⊆ `release`. |
+| `transport`             | enum           | yes      | `stdio` or `ws`. |
+| `provider`              | enum           | yes      | `fixture`, `live`, or `none`. |
+| `terminal`              | string         | yes      | e.g. `80x24`, `100x30`, `120x40`, `narrow`. |
+| `tui_binary`            | string         | yes      | Logical binary name; resolved by the runner (#1065). |
+| `tmux_command`          | string         | yes      | Logical command label; runner picks the script. |
+| `required_tools`        | string[]       | yes      | Host binaries that MUST be on PATH. |
+| `required_capabilities` | string[]       | yes      | AppUI capability flags (see UPCR-2026-019). |
+| `expected_artifacts`    | string[]       | yes      | Filenames written under the artifact dir. |
+| `acceptance`            | string[]       | yes      | Validator IDs (impl lands in #1066). |
+| `replay`                | string         | no       | Path to a replay script (driver input). |
+| `notes`                 | string         | no       | Free-form. |
+| `quarantine`            | bool           | no       | Default `false`. Set `true` to mark the scenario as known-broken; the gate reports `quarantined`, not `failed`. |
+
+### Required artifact ABI
+
+Every scenario MUST declare these artifacts in `expected_artifacts`. The
+shared ABI is defined by the umbrella issue and locked down by `#1064`:
+
+- `scenario.json`            — the scenario record as listed by `ux:scenario:list`
+- `summary.json`             — pass/fail/skip per validator + overall verdict
+- `appui-transcript.jsonl`   — AppUI events captured for the run
+- `server.log`               — backend stdout/stderr
+- `tui-capture.txt`          — final tmux pane capture
+- `runtime-policy-stamp.json`— RuntimePolicyStamp emitted by the backend
+- `validation.json`          — validator outputs (paths + reasons)
+
+Scenario-specific artifacts (e.g. `approval-events.jsonl`,
+`reconnect-events.jsonl`, `task-ledger.jsonl`, `artifact-index.json`,
+`stream-events.jsonl`) can be added on top.
+
+## The list command
+
+```sh
+# Print every scenario the manifest knows about.
+npm --prefix e2e run ux:scenario:list
+
+# Filter by tier. Tiers nest: fast ⊆ local ⊆ release.
+npm --prefix e2e run ux:scenario:list -- --tier fast
+npm --prefix e2e run ux:scenario:list -- --tier local
+npm --prefix e2e run ux:scenario:list -- --tier release
+
+# Machine-readable output for CI.
+npm --prefix e2e run ux:scenario:list -- --tier release --json
+
+# Point at a different manifest (for testing).
+npm --prefix e2e run ux:scenario:list -- --manifest /tmp/alt.toml
+```
+
+The command:
+
+- Reads `e2e/matrix/octos-ux.toml`.
+- Validates the schema and reports a typed `manifest schema error` on bad input (exit code 3).
+- Classifies each scenario as `runnable`, `skipped`, `blocked`, or `quarantined` without launching tmux or any backend.
+- Prints a deterministic table sorted by scenario id.
+- With `--json`, prints a JSON document with `schema_version`, `pack`, `owner`, `tier_filter`, `summary`, and the full scenario records.
+
+### Classification rules
+
+| Status         | When                                                       |
+|----------------|------------------------------------------------------------|
+| `quarantined`  | `quarantine = true` in the manifest                       |
+| `skipped`      | A required host tool is missing, or a `live` provider scenario has no provider API key |
+| `blocked`      | A required capability is not advertised in `e2e/matrix/ux-capabilities.json` |
+| `runnable`     | All gates green                                            |
+
+The capability gate file `e2e/matrix/ux-capabilities.json` is optional in
+M19-A — if absent, every scenario with capability requirements is `blocked`.
+That file is populated by `#1066` once the validator registry can derive the
+real AppUI capability advertisement.
+
+## Adding a new scenario
+
+1. Append a `[[scenario]]` table to `e2e/matrix/octos-ux.toml`.
+2. Make sure every required field is present and arrays are non-empty.
+3. Run `npm --prefix e2e run ux:scenario:list:test` to check schema and parser.
+4. Run `npm --prefix e2e run ux:scenario:list -- --tier release` and confirm the new id appears.
+5. Land the validator implementation under `acceptance` in a follow-up PR (`#1066`).
+
+## Relationship to M22
+
+M22 (`#1056`) ships a separate manifest at `e2e/matrix/onboarding.toml`.
+M22 and M19 share the same scenario schema and artifact ABI, but live in
+different packs so the gates can move independently. Cross-cutting validators
+(no-OTP, runtime policy stamp present, blank-tmux-capture-fails) should be
+implemented once in the validator registry (`#1066`) and reused by both packs.

--- a/e2e/ux/README.md
+++ b/e2e/ux/README.md
@@ -112,8 +112,11 @@ npm --prefix e2e run ux:scenario:list -- --tier fast
 npm --prefix e2e run ux:scenario:list -- --tier local
 npm --prefix e2e run ux:scenario:list -- --tier release
 
-# Machine-readable output for CI.
-npm --prefix e2e run ux:scenario:list -- --tier release --json
+# Machine-readable output for CI. Use --silent so npm's lifecycle
+# banner ("> ux:scenario:list", "> node …") doesn't pollute stdout
+# before the JSON document. Alternatively, invoke node directly:
+#   node e2e/scripts/ux-scenario-list.mjs --tier release --json
+npm --silent --prefix e2e run ux:scenario:list -- --tier release --json
 
 # Point at a different manifest (for testing).
 npm --prefix e2e run ux:scenario:list -- --manifest /tmp/alt.toml


### PR DESCRIPTION
## Summary
First-PR slice of M19 (real tmux UX gate, umbrella #1062). Lands #1063 (M19-A: UX scenario manifest + `ux:scenario:list` tool).

Provides the scenario-manifest foundation that subsequent M19 sub-issues (#1064 ABI, #1065 wrapper, #1066 validators, #1067 scenarios, #1068 CI/docs) will build on.

## Test plan
- [x] `scripts/ux-scenario-list.sh` lists declared scenarios
- [x] `--tier <fast|local|release>` filter works
- [x] `--json` flag emits machine-parseable output

Closes #1063. Subsequent M19 sub-issues deferred to follow-ups.

🤖 Salvaged from a worktree agent that was force-stopped mid-push; original work intact.