### PR TITLE
fix(core): thread M13-B projection fields through TaskUpdatedEvent (#1123)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -11521,6 +11521,14 @@ async fn run_m9_fixture_turn(
                             runtime_detail: Some(
                                 "persisted deterministic task snapshot".to_owned(),
                             ),
+                            // #1123 / M13-B — synthetic fixture path has no
+                            // BackgroundTask projection; leave all five fields
+                            // unset so the wire shape stays bare.
+                            source: None,
+                            role: None,
+                            summary: None,
+                            artifact_count: None,
+                            runtime_policy_stamp: None,
                         }),
                     );
                     let _ = send_notification_durable(
@@ -11543,6 +11551,11 @@ async fn run_m9_fixture_turn(
                             state: UiTaskRuntimeState::Completed,
                             tool_call_id: None,
                             runtime_detail: Some("fixture complete".to_owned()),
+                            source: None,
+                            role: None,
+                            summary: None,
+                            artifact_count: None,
+                            runtime_policy_stamp: None,
                         }),
                     );
                     if m9_fixture_delay_or_interrupt(
@@ -12493,6 +12506,11 @@ async fn run_native_code_review_turn(
             state: UiTaskRuntimeState::Running,
             tool_call_id: None,
             runtime_detail: Some("launching model-backed native specialists".to_owned()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }),
     );
     let _ = send_notification_durable(
@@ -12637,6 +12655,11 @@ async fn run_native_code_review_turn(
                         state: UiTaskRuntimeState::Cancelled,
                         tool_call_id: None,
                         runtime_detail: Some("interrupted by client".to_owned()),
+                        source: None,
+                        role: None,
+                        summary: None,
+                        artifact_count: None,
+                        runtime_policy_stamp: None,
                     }),
                 );
                 try_emit_terminal(
@@ -12743,6 +12766,11 @@ async fn run_native_code_review_turn(
             runtime_detail: Some(format!(
                 "{completed}/{expected_results} specialists completed"
             )),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }),
     );
     try_emit_terminal(
@@ -13219,6 +13247,11 @@ async fn run_m15_live_subagent_fixture_turn(
             state: UiTaskRuntimeState::Running,
             tool_call_id: None,
             runtime_detail: Some("octos serve launching CLI subagents".to_owned()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }),
     );
     let _ = send_notification_durable(
@@ -13348,6 +13381,11 @@ async fn run_m15_live_subagent_fixture_turn(
                         state: UiTaskRuntimeState::Cancelled,
                         tool_call_id: None,
                         runtime_detail: Some("interrupted by client".to_owned()),
+                        source: None,
+                        role: None,
+                        summary: None,
+                        artifact_count: None,
+                        runtime_policy_stamp: None,
                     }),
                 );
                 return M9FixtureOutcome::Interrupted;
@@ -13437,6 +13475,11 @@ async fn run_m15_live_subagent_fixture_turn(
             state: UiTaskRuntimeState::Completed,
             tool_call_id: None,
             runtime_detail: Some(format!("{completed} live CLI subagents completed")),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         }),
     );
     append_appui_evidence_jsonl(

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -163,7 +163,16 @@ fn map_task_started(context: &ProgressMappingContext, event: &Value) -> UiProgre
                 role: string_field(event, &["role"]),
                 summary: string_field(event, &["summary"]),
                 artifact_count: u32_field(event, &["artifact_count"]),
-                runtime_policy_stamp: event.get("runtime_policy_stamp").cloned(),
+                // Codex P2 follow-up: a `null` runtime_policy_stamp from
+                // the progress producer must be treated as ABSENT (None),
+                // not Some(Value::Null). Otherwise serde emits
+                // `"runtime_policy_stamp": null` on `task/updated` and
+                // clients that cache the stamp see it wiped on every
+                // update tick.
+                runtime_policy_stamp: event
+                    .get("runtime_policy_stamp")
+                    .cloned()
+                    .filter(|v| !v.is_null()),
             },
         )]);
     }

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -243,7 +243,15 @@ fn map_task_updated(context: &ProgressMappingContext, event: &Value) -> UiProgre
         role: string_field(event, &["role"]),
         summary: string_field(event, &["summary"]),
         artifact_count: u32_field(event, &["artifact_count"]),
-        runtime_policy_stamp: event.get("runtime_policy_stamp").cloned(),
+        // Codex P2 rev2 follow-up: same null-to-absent filtering as
+        // map_task_started above — a `null` stamp from the producer must
+        // not pass through, otherwise serde emits
+        // `"runtime_policy_stamp": null` on the regular `task/updated`
+        // tick and any client that caches the stamp sees it wiped.
+        runtime_policy_stamp: event
+            .get("runtime_policy_stamp")
+            .cloned()
+            .filter(|v| !v.is_null()),
     })])
 }
 
@@ -879,6 +887,35 @@ mod tests {
         assert_eq!(updated.title, "search");
         assert_eq!(updated.state, UiTaskRuntimeState::Running);
         assert_eq!(updated.runtime_detail.as_deref(), Some("checking outputs"));
+    }
+
+    /// Codex P2 rev2 follow-up on #1156: a `null` runtime_policy_stamp
+    /// emitted by the producer on a `task_updated` event must NOT
+    /// pass through as `Some(Value::Null)`. Otherwise serde emits
+    /// `"runtime_policy_stamp": null` on the wire and clients that
+    /// cache the stamp see it wiped on every update tick (the same
+    /// bug the `task_started` filter already prevents).
+    #[test]
+    fn ui_protocol_progress_treats_null_stamp_as_absent_on_task_updated() {
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "task_updated",
+                "task_id": "01900000-0000-7000-8000-0000000000aa",
+                "title": "search",
+                "state": "verifying",
+                "runtime_policy_stamp": null,
+            }),
+        );
+
+        let [UiNotification::TaskUpdated(updated)] = mapping.notifications.as_slice() else {
+            panic!("expected task updated notification");
+        };
+        assert!(
+            updated.runtime_policy_stamp.is_none(),
+            "null stamp must be filtered to None, got {:?}",
+            updated.runtime_policy_stamp,
+        );
     }
 
     #[test]

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -159,6 +159,11 @@ fn map_task_started(context: &ProgressMappingContext, event: &Value) -> UiProgre
                 title: string_field(event, &["title"]).unwrap_or_else(|| "Task".into()),
                 state: UiTaskRuntimeState::Running,
                 runtime_detail: Some("task started".into()),
+                source: string_field(event, &["source"]),
+                role: string_field(event, &["role"]),
+                summary: string_field(event, &["summary"]),
+                artifact_count: u32_field(event, &["artifact_count"]),
+                runtime_policy_stamp: event.get("runtime_policy_stamp").cloned(),
             },
         )]);
     }
@@ -218,6 +223,18 @@ fn map_task_updated(context: &ProgressMappingContext, event: &Value) -> UiProgre
         title,
         state,
         runtime_detail: string_field(event, &["runtime_detail", "message", "status_message"]),
+        // #1123 codex P2 follow-up to #1113: thread the M13-B
+        // projection fields from the underlying progress JSON
+        // (produced by `background_task_to_progress_json`) onto the
+        // `task/updated` notification. Unset values stay `None`, which
+        // skip_serializing_if drops from the wire shape — so legacy
+        // emitters that don't supply the fields produce a bare
+        // payload identical to the pre-M13-B shape.
+        source: string_field(event, &["source"]),
+        role: string_field(event, &["role"]),
+        summary: string_field(event, &["summary"]),
+        artifact_count: u32_field(event, &["artifact_count"]),
+        runtime_policy_stamp: event.get("runtime_policy_stamp").cloned(),
     })])
 }
 

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -4222,6 +4222,38 @@ pub struct TaskUpdatedEvent {
     pub state: TaskRuntimeState,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_detail: Option<String>,
+    // ── #1123 / M13-B projection fields ─────────────────────────────
+    // #1113 wired these fields onto the `BackgroundTask` snapshot and
+    // `task/list` projection, but the live `task/updated` notification
+    // dropped them — clients subscribed to events saw a stale shape
+    // while clients calling `task/list` saw the new shape. Mirroring
+    // them here closes the gap. All five use
+    // `#[serde(default, skip_serializing_if = "Option::is_none")]` so
+    // legacy daemons and synthetic emitters that cannot resolve the
+    // values still round-trip.
+    /// Origin of the underlying task: `"model"`, `"supervisor"`, or
+    /// `"user"`. Mirrors `BackgroundTask::source`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    /// Role label assigned at spawn (`"reviewer"`, `"implementer"`,
+    /// `"test_worker"`, `"explorer"`). Mirrors `BackgroundTask::role`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// Bounded summary capsule mirroring `ChildResultSummary.summary`
+    /// for terminal children. Mirrors `BackgroundTask::summary`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Number of artifacts emitted so far so UX can badge tasks without
+    /// resolving `task/artifact/list`. Mirrors
+    /// `BackgroundTask::artifact_count`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_count: Option<u32>,
+    /// Effective runtime policy stamp captured at spawn. Stored as raw
+    /// JSON so the wire shape does not depend on the AppUI
+    /// `UiAutonomyRuntimePolicyStamp` schema. Mirrors
+    /// `BackgroundTask::runtime_policy_stamp`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_policy_stamp: Option<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -5791,6 +5823,11 @@ mod tests {
             title: "spawn_only_runner".into(),
             state: TaskRuntimeState::Cancelled,
             runtime_detail: Some("user cancelled".into()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         })
         .into_rpc_notification()
         .expect("serialize task/updated cancelled");
@@ -7714,6 +7751,11 @@ mod tests {
             title: "spawn_only_runner".into(),
             state: TaskRuntimeState::Cancelled,
             runtime_detail: Some("user cancelled".into()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         });
         let rpc = event
             .clone()
@@ -7722,6 +7764,85 @@ mod tests {
         let decoded =
             UiNotification::from_rpc_notification(rpc).expect("deserialize task/updated cancelled");
         assert_eq!(decoded, event);
+    }
+
+    /// #1123 codex P2 follow-up to #1113: pin that the new M13-B
+    /// projection fields (source / role / summary / artifact_count /
+    /// runtime_policy_stamp) round-trip through serde on
+    /// `TaskUpdatedEvent` AND that absent fields stay absent on the
+    /// wire (no `null` leakage that would clobber a prior value cached
+    /// by a stale subscriber).
+    #[test]
+    fn task_updated_event_round_trips_m13b_projection_fields() {
+        // Populated path: every projection field set, all five must
+        // appear on the wire and decode back unchanged.
+        let event = TaskUpdatedEvent {
+            session_id: SessionKey("local:demo".into()),
+            task_id: TaskId(Uuid::from_u128(0xBEEF)),
+            tool_call_id: Some("call-r".into()),
+            title: "review".into(),
+            state: TaskRuntimeState::Running,
+            runtime_detail: None,
+            source: Some("model".into()),
+            role: Some("reviewer".into()),
+            summary: Some("found 1 issue".into()),
+            artifact_count: Some(2),
+            runtime_policy_stamp: Some(json!({ "approval_policy": "on-request" })),
+        };
+        let value = serde_json::to_value(&event).expect("serialize task/updated");
+        assert_eq!(value.get("source"), Some(&json!("model")));
+        assert_eq!(value.get("role"), Some(&json!("reviewer")));
+        assert_eq!(value.get("summary"), Some(&json!("found 1 issue")));
+        assert_eq!(value.get("artifact_count"), Some(&json!(2)));
+        assert_eq!(
+            value.get("runtime_policy_stamp"),
+            Some(&json!({ "approval_policy": "on-request" })),
+        );
+        let parsed: TaskUpdatedEvent =
+            serde_json::from_value(value).expect("deserialize task/updated");
+        assert_eq!(parsed, event);
+
+        // Absent path: no field set, no field on the wire. A legacy
+        // payload that pre-dates the fields still parses thanks to
+        // `#[serde(default)]`.
+        let bare = TaskUpdatedEvent {
+            session_id: SessionKey("local:demo".into()),
+            task_id: TaskId(Uuid::from_u128(0xBEE0)),
+            tool_call_id: None,
+            title: "review".into(),
+            state: TaskRuntimeState::Running,
+            runtime_detail: None,
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
+        };
+        let bare_value = serde_json::to_value(&bare).expect("serialize bare task/updated");
+        assert!(bare_value.get("source").is_none(), "absent source omits");
+        assert!(bare_value.get("role").is_none(), "absent role omits");
+        assert!(bare_value.get("summary").is_none(), "absent summary omits");
+        assert!(
+            bare_value.get("artifact_count").is_none(),
+            "absent artifact_count omits",
+        );
+        assert!(
+            bare_value.get("runtime_policy_stamp").is_none(),
+            "absent runtime_policy_stamp omits",
+        );
+        let legacy_json = json!({
+            "session_id": "local:demo",
+            "task_id": TaskId(Uuid::from_u128(0xBEE0)),
+            "title": "review",
+            "state": "running",
+        });
+        let parsed_legacy: TaskUpdatedEvent =
+            serde_json::from_value(legacy_json).expect("deserialize legacy bare");
+        assert_eq!(parsed_legacy.source, None);
+        assert_eq!(parsed_legacy.role, None);
+        assert_eq!(parsed_legacy.summary, None);
+        assert_eq!(parsed_legacy.artifact_count, None);
+        assert_eq!(parsed_legacy.runtime_policy_stamp, None);
     }
 
     // ===== UPCR-2026-009 / -010 / -011 / -012 golden tests (PR G) =====
@@ -8112,6 +8233,11 @@ mod tests {
             title: "podcast_generate".into(),
             state: TaskRuntimeState::Completed,
             runtime_detail: Some("rendered output.mp3".into()),
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         };
         let task_value = serde_json::to_value(&task_event).expect("serialize task_updated");
         assert_eq!(
@@ -8132,6 +8258,11 @@ mod tests {
             title: "legacy".into(),
             state: TaskRuntimeState::Running,
             runtime_detail: None,
+            source: None,
+            role: None,
+            summary: None,
+            artifact_count: None,
+            runtime_policy_stamp: None,
         };
         let legacy_value = serde_json::to_value(&task_legacy).expect("serialize legacy");
         assert!(


### PR DESCRIPTION
## Summary
Closes #1123 — codex P2 follow-up to #1113.

Threads the M13-B `BackgroundTask` projection fields (`source`, `role`, `summary`, `artifact_count`, `runtime_policy_stamp`) through the live `task/updated` AppUI notification so clients subscribed to updates see the same shape as those polling `task/list`.

## Test plan
- [x] `task_updated_event_round_trips_m13b_projection_fields` (octos-core)
- [x] `ui_protocol_progress_maps_task_updated_to_notification` (octos-cli)
- [x] cargo build -p octos-cli --features api clean

Salvaged from a worktree agent that had finished the implementation when force-stopped.