### PR TITLE
fix(scripts): strengthen UPCR-update enforcement (#717)

### DIFF
--- a/scripts/check-ui-protocol-upcr.sh
+++ b/scripts/check-ui-protocol-upcr.sh
@@ -86,12 +86,16 @@ if [ -n "$merge_base" ] && [ -n "$head_sha" ] && [ "$merge_base" = "$head_sha" ]
 fi
 
 if [ -z "$merge_base" ] || [ "$base_equals_head" -eq 1 ]; then
-  # Probe the working tree for any protocol/spec changes via `git status`.
-  # If something is staged or untracked we can still run; otherwise reject.
+  # Probe the working tree for any uncommitted *trigger* changes only.
+  # A stray untracked UPCR / template / spec edit must NOT mask a committed
+  # protocol change here — that bypass was codex review #7. We're trying to
+  # answer "is there real protocol work in the working tree that justifies
+  # running in uncommitted-only mode?", and only protocol-code and spec-doc
+  # files (the trigger set) can answer yes.
   uncommitted_probe="$(
     git status --porcelain --untracked-files=all -- \
       "${PROTOCOL_PATHS[@]}" "${PROTOCOL_GLOBS[@]}" "$SPEC_GLOB" \
-      "$UPCR_GLOB" "$UPCR_TEMPLATE" 2>/dev/null || true
+      2>/dev/null || true
   )"
   if [ -z "$uncommitted_probe" ]; then
     if [ "${UPCR_ALLOW_NO_DOC:-0}" = "1" ]; then
@@ -106,8 +110,13 @@ override; either none resolved or the resolved ref points to HEAD itself
 state because that lets committed protocol changes slip through CI.
 
 Fix: fetch a real base (e.g. `git fetch --no-tags origin main`), or set
-UPCR_BASE_REF=<sha-or-ref> that is an ancestor of HEAD (e.g. HEAD~1 or the
-previous main SHA), or set UPCR_ALLOW_NO_DOC=1 only for a documented
+UPCR_BASE_REF=<sha-or-ref> that points to the actual target branch this
+PR/branch is built against (e.g. the merge-base SHA against origin/main,
+or the commit of the target branch tip). Do NOT use `HEAD~1` for branches
+that contain multiple commits — the gate would diff only the last commit
+and report no protocol-visible edits even when an earlier commit on the
+branch touched protocol Rust. Use `HEAD~1` only as a single-commit-only
+case. As a last resort, set UPCR_ALLOW_NO_DOC=1 for a documented
 reviewer override.
 EOF
     exit 2

--- a/scripts/check-ui-protocol-upcr.sh
+++ b/scripts/check-ui-protocol-upcr.sh
@@ -63,33 +63,64 @@ resolve_status=0
 base_ref="$(resolve_base_ref)" || resolve_status=$?
 
 merge_base=""
+head_sha=""
 if [ "$resolve_status" -eq 0 ] && [ -n "$base_ref" ]; then
   merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
+  head_sha="$(git rev-parse --verify --quiet HEAD 2>/dev/null || true)"
 fi
 
-# If we cannot establish a merge-base for the committed range, fail loud.
-# This used to silently skip the committed-range check, which was a CI
-# bypass on shallow / single-branch checkouts (#717 codex review #1).
-# The fallback for environments that legitimately have no base ref is
-# `UPCR_ALLOW_NO_DOC=1` (already documented as the reviewer override).
-if [ -z "$merge_base" ]; then
-  if [ "${UPCR_ALLOW_NO_DOC:-0}" = "1" ]; then
-    printf 'ui-protocol-upcr: no base ref available; allowed by reviewer override\n'
-    exit 0
-  fi
-  cat >&2 <<'EOF'
-ui-protocol-upcr: could not resolve a base ref for the diff (tried origin/main,
-main, origin/master, master). The gate refuses to run with only uncommitted
+# Treat merge_base == HEAD as "no committed work to inspect": HEAD..HEAD is
+# empty, so the committed-range scan would silently miss any actual diffs.
+# This is the bypass codex review #6 flagged. We distinguish two sub-cases:
+#
+#   * Uncommitted protocol changes exist in the working tree -> legitimate
+#     pre-commit case (feature branch freshly created off main); proceed
+#     with uncommitted-only checking.
+#   * No uncommitted protocol changes either -> the gate cannot tell
+#     whether the repo lacks a real base ref (shallow CI) or whether the
+#     branch is genuinely identical to main. Fail loud so a stale base
+#     ref doesn't silently bypass committed-but-not-yet-pushed work.
+base_equals_head=0
+if [ -n "$merge_base" ] && [ -n "$head_sha" ] && [ "$merge_base" = "$head_sha" ]; then
+  base_equals_head=1
+fi
+
+if [ -z "$merge_base" ] || [ "$base_equals_head" -eq 1 ]; then
+  # Probe the working tree for any protocol/spec changes via `git status`.
+  # If something is staged or untracked we can still run; otherwise reject.
+  uncommitted_probe="$(
+    git status --porcelain --untracked-files=all -- \
+      "${PROTOCOL_PATHS[@]}" "${PROTOCOL_GLOBS[@]}" "$SPEC_GLOB" \
+      "$UPCR_GLOB" "$UPCR_TEMPLATE" 2>/dev/null || true
+  )"
+  if [ -z "$uncommitted_probe" ]; then
+    if [ "${UPCR_ALLOW_NO_DOC:-0}" = "1" ]; then
+      printf 'ui-protocol-upcr: no base ref available; allowed by reviewer override\n'
+      exit 0
+    fi
+    cat >&2 <<'EOF'
+ui-protocol-upcr: could not resolve a usable base ref for the diff. The gate
+tried origin/main, main, origin/master, master, and any UPCR_BASE_REF
+override; either none resolved or the resolved ref points to HEAD itself
+(which would diff HEAD..HEAD = empty). Refusing to run with only stale
 state because that lets committed protocol changes slip through CI.
 
-Fix: fetch origin/main (e.g. `git fetch --no-tags origin main`), or set
-UPCR_BASE_REF=<sha-or-ref>, or set UPCR_ALLOW_NO_DOC=1 only for a documented
+Fix: fetch a real base (e.g. `git fetch --no-tags origin main`), or set
+UPCR_BASE_REF=<sha-or-ref> that is an ancestor of HEAD (e.g. HEAD~1 or the
+previous main SHA), or set UPCR_ALLOW_NO_DOC=1 only for a documented
 reviewer override.
 EOF
-  exit 2
+    exit 2
+  fi
+  # Uncommitted protocol/UPCR changes exist; proceed in uncommitted-only mode.
+  merge_base=""
 fi
 
-range="$merge_base..HEAD"
+if [ -n "$merge_base" ]; then
+  range="$merge_base..HEAD"
+else
+  range=""
+fi
 
 # Emit destination paths from `git diff --name-status` in the committed
 # range. The second argument selects between two filters:
@@ -273,7 +304,7 @@ fi
 cat >&2 <<EOF
 ui-protocol-upcr: protocol-visible edits require a UPCR document.
 
-Detected code-level protocol changes (range: $range):
+Detected code-level protocol changes (range: ${range:-uncommitted-only}):
 EOF
 while IFS= read -r _change; do
   [ -z "$_change" ] && continue

--- a/scripts/check-ui-protocol-upcr.sh
+++ b/scripts/check-ui-protocol-upcr.sh
@@ -92,21 +92,36 @@ fi
 range="$merge_base..HEAD"
 
 # Emit destination paths from `git diff --name-status` in the committed
-# range. `--diff-filter=AMR` keeps Added / Modified / Renamed entries; for
-# renames the trailing column is the destination, which is what we want
+# range. The second argument selects between two filters:
+#
+#   * trigger  -> AMRD: Added / Modified / Renamed / Deleted. Removal of a
+#                 protocol file is itself a protocol-visible event and must
+#                 be gated (codex review #4 / #717).
+#   * coverage -> AMR  only: a *deleted* UPCR or spec file is NOT valid
+#                 coverage for a protocol-code change (codex review #5).
+#
+# For renames the trailing column is the destination, which is what we want
 # (we care about the file that lives in the working tree at HEAD, not the
 # pre-rename path). Whitespace-only changes are filtered by re-running
 # `git diff -w --stat` on each candidate and dropping those with empty stat.
 diff_range_names() {
   local range="$1"
-  shift
+  local mode="$2"
+  shift 2
   if [ -z "$range" ]; then
     return 0
   fi
+  local filter
+  case "$mode" in
+    trigger)  filter="AMRD" ;;
+    coverage) filter="AMR"  ;;
+    *)
+      echo "diff_range_names: unknown mode '$mode'" >&2
+      return 2
+      ;;
+  esac
   local raw
-  # AMRD: Added, Modified, Renamed, Deleted. Deletions of protocol files are
-  # also protocol-visible events (codex review #4 / #717) and must be gated.
-  raw="$(git diff --name-status --diff-filter=AMRD "$range" -- "$@" 2>/dev/null || true)"
+  raw="$(git diff --name-status --diff-filter="$filter" "$range" -- "$@" 2>/dev/null || true)"
   if [ -z "$raw" ]; then
     return 0
   fi
@@ -144,7 +159,18 @@ diff_range_names() {
 }
 
 # Uncommitted change names (staged + unstaged + untracked) for matching paths.
+#
+# $1 = mode: "trigger" includes deletions, "coverage" excludes them.
 uncommitted_names() {
+  local mode="$1"
+  shift
+  case "$mode" in
+    trigger|coverage) ;;
+    *)
+      echo "uncommitted_names: unknown mode '$mode'" >&2
+      return 2
+      ;;
+  esac
   local entries
   entries="$(git status --porcelain --untracked-files=all -- "$@" 2>/dev/null || true)"
   if [ -z "$entries" ]; then
@@ -160,9 +186,15 @@ uncommitted_names() {
       path="${path##* -> }"
     fi
     case "$status_code" in
-      "??"|"A "|"AM"|" A"|R*|"D "|" D"|"DD"|"AD"|"MD")
-        # Adds, renames, and deletions are all protocol-visible events.
+      "??"|"A "|"AM"|" A"|R*)
+        # Adds and renames count for both modes.
         printf '%s\n' "$path"
+        ;;
+      "D "|" D"|"DD"|"AD"|"MD")
+        # Deletions count for trigger only — a deleted UPCR is not coverage.
+        if [ "$mode" = "trigger" ]; then
+          printf '%s\n' "$path"
+        fi
         ;;
       *)
         # Tracked modification — drop if whitespace-only.
@@ -180,25 +212,30 @@ uncommitted_names() {
 
 collect_names() {
   local range="$1"
-  shift
+  local mode="$2"
+  shift 2
   {
-    diff_range_names "$range" "$@"
-    uncommitted_names "$@"
+    diff_range_names "$range" "$mode" "$@"
+    uncommitted_names "$mode" "$@"
   } | awk 'NF && !seen[$0]++'
 }
 
 # Split changes into code-level (Rust source) and spec-doc buckets so the
 # coverage rules can treat them differently. Codex review #3 (#717): an
 # unrelated spec edit must not satisfy the gate for a code-level diff.
-code_changes="$(collect_names "$range" "${PROTOCOL_PATHS[@]}" "${PROTOCOL_GLOBS[@]}")"
-spec_changes="$(collect_names "$range" "$SPEC_GLOB")"
+# Trigger mode includes deletions so removing a protocol file is gated.
+code_changes="$(collect_names "$range" trigger "${PROTOCOL_PATHS[@]}" "${PROTOCOL_GLOBS[@]}")"
+spec_changes="$(collect_names "$range" trigger "$SPEC_GLOB")"
 
 if [ -z "$code_changes" ] && [ -z "$spec_changes" ]; then
   printf 'ui-protocol-upcr: no protocol-visible edits detected\n'
   exit 0
 fi
 
-upcr_changes="$(collect_names "$range" "$UPCR_GLOB" "$UPCR_TEMPLATE")"
+# Coverage mode for UPCR docs: only added or modified entries count. A
+# deletion of an old UPCR is NOT coverage for a fresh protocol change
+# (codex review #5 / #717).
+upcr_changes="$(collect_names "$range" coverage "$UPCR_GLOB" "$UPCR_TEMPLATE")"
 
 # Verify the matched UPCR file looks like a real UPCR-YYYY-NNN doc.
 upcr_real=""
@@ -217,10 +254,15 @@ if [ -n "$upcr_real" ]; then
   exit 0
 fi
 
-# No UPCR doc. Spec-only changes are self-coverage; otherwise fail.
+# No UPCR doc. A spec-only edit can self-cover, but only if the spec change
+# is an add/modify; a deletion-only spec change is just a protocol-visible
+# removal and still needs an explicit UPCR.
 if [ -z "$code_changes" ] && [ -n "$spec_changes" ]; then
-  printf 'ui-protocol-upcr: spec-only edit, treated as self-coverage\n'
-  exit 0
+  spec_coverage="$(collect_names "$range" coverage "$SPEC_GLOB")"
+  if [ -n "$spec_coverage" ]; then
+    printf 'ui-protocol-upcr: spec-only edit, treated as self-coverage\n'
+    exit 0
+  fi
 fi
 
 if [ "${UPCR_ALLOW_NO_DOC:-0}" = "1" ]; then

--- a/scripts/check-ui-protocol-upcr.sh
+++ b/scripts/check-ui-protocol-upcr.sh
@@ -108,17 +108,15 @@ diff_range_names() {
   if [ -z "$raw" ]; then
     return 0
   fi
-  local line code src dst name
+  local line code name
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     code="$(printf '%s' "$line" | awk '{print $1}')"
     case "$code" in
       R*)
-        # Format: "R100<TAB>old/path<TAB>new/path"
-        src="$(printf '%s' "$line" | awk '{print $2}')"
-        dst="$(printf '%s' "$line" | awk '{print $3}')"
-        # If the new path is one of the protocol paths, count it.
-        name="$dst"
+        # Format: "R<score><TAB>old/path<TAB>new/path" — destination is what
+        # lives in the working tree, so that's what consumers see.
+        name="$(printf '%s' "$line" | awk '{print $3}')"
         ;;
       *)
         name="$(printf '%s' "$line" | awk '{print $2}')"
@@ -231,7 +229,10 @@ ui-protocol-upcr: protocol-visible edits require a UPCR document.
 
 Detected code-level protocol changes (range: $range):
 EOF
-printf '  %s\n' $code_changes >&2
+while IFS= read -r _change; do
+  [ -z "$_change" ] && continue
+  printf '  %s\n' "$_change" >&2
+done <<<"$code_changes"
 if [ -n "$spec_changes" ]; then
   cat >&2 <<EOF
 

--- a/scripts/check-ui-protocol-upcr.sh
+++ b/scripts/check-ui-protocol-upcr.sh
@@ -1,12 +1,26 @@
 #!/usr/bin/env bash
 # Ensure protocol-visible edits are paired with an explicit UI Protocol change
-# request (UPCR) doc or a protocol spec revision. Compares the current branch
-# against a base ref (default: origin/main, falling back to main) using
-# `git diff --name-only --diff-filter=AM` so the check covers committed work,
-# including changes the user split across multiple commits. Uncommitted
-# changes (staged + unstaged + untracked) are folded in so the gate behaves
-# correctly when run pre-commit. Whitespace-only diffs are exempted via
-# `git diff -w --stat`.
+# request (UPCR) doc. Compares the current branch against a base ref
+# (default: origin/main, falling back to main / origin/master / master) using
+# `git diff --name-status --diff-filter=AMR <merge-base>..HEAD` so the check
+# covers committed work — including changes the user split across multiple
+# commits and rename-with-edit moves where the destination is the file we
+# care about. Uncommitted changes (staged + unstaged + untracked) are folded
+# in so the gate behaves correctly when run pre-commit. Whitespace-only diffs
+# are exempted via `git diff -w --stat`.
+#
+# Coverage rules:
+#   * Any change to a *.rs protocol file requires an added/modified
+#     `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md` in the same diff
+#     range. Editing the spec doc alone does NOT satisfy this because the
+#     spec edit may be unrelated (typo fix, broken link, etc.).
+#   * If the only protocol-visible change is the spec doc itself, the spec
+#     change is self-coverage.
+#   * `UPCR_ALLOW_NO_DOC=1` is a reviewer-override escape hatch.
+#
+# If neither a base ref nor a merge-base can be resolved, the gate refuses
+# to run rather than silently checking only uncommitted state — that
+# behaviour was the bypass closed by #717.
 
 set -euo pipefail
 
@@ -27,8 +41,14 @@ UPCR_TEMPLATE="docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_TEMPLATE.md"
 # Resolve a base ref for the merge-base diff. Allow override via UPCR_BASE_REF.
 resolve_base_ref() {
   if [ -n "${UPCR_BASE_REF:-}" ]; then
-    printf '%s\n' "$UPCR_BASE_REF"
-    return 0
+    if git rev-parse --verify --quiet "$UPCR_BASE_REF" >/dev/null; then
+      printf '%s\n' "$UPCR_BASE_REF"
+      return 0
+    fi
+    cat >&2 <<EOF
+ui-protocol-upcr: UPCR_BASE_REF='$UPCR_BASE_REF' does not resolve in this checkout.
+EOF
+    return 2
   fi
   for candidate in origin/main main origin/master master; do
     if git rev-parse --verify --quiet "$candidate" >/dev/null; then
@@ -39,44 +59,90 @@ resolve_base_ref() {
   return 1
 }
 
-base_ref=""
-if base_ref="$(resolve_base_ref)"; then
+resolve_status=0
+base_ref="$(resolve_base_ref)" || resolve_status=$?
+
+merge_base=""
+if [ "$resolve_status" -eq 0 ] && [ -n "$base_ref" ]; then
   merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
-else
-  merge_base=""
 fi
 
-# Names that changed between merge-base and HEAD (committed work),
-# restricted to Added/Modified (filters out renames/deletes whose new path
-# is what we actually care about). Whitespace-only changes are stripped via
-# `git diff -w --stat` -> empty stat means no semantic change.
+# If we cannot establish a merge-base for the committed range, fail loud.
+# This used to silently skip the committed-range check, which was a CI
+# bypass on shallow / single-branch checkouts (#717 codex review #1).
+# The fallback for environments that legitimately have no base ref is
+# `UPCR_ALLOW_NO_DOC=1` (already documented as the reviewer override).
+if [ -z "$merge_base" ]; then
+  if [ "${UPCR_ALLOW_NO_DOC:-0}" = "1" ]; then
+    printf 'ui-protocol-upcr: no base ref available; allowed by reviewer override\n'
+    exit 0
+  fi
+  cat >&2 <<'EOF'
+ui-protocol-upcr: could not resolve a base ref for the diff (tried origin/main,
+main, origin/master, master). The gate refuses to run with only uncommitted
+state because that lets committed protocol changes slip through CI.
+
+Fix: fetch origin/main (e.g. `git fetch --no-tags origin main`), or set
+UPCR_BASE_REF=<sha-or-ref>, or set UPCR_ALLOW_NO_DOC=1 only for a documented
+reviewer override.
+EOF
+  exit 2
+fi
+
+range="$merge_base..HEAD"
+
+# Emit destination paths from `git diff --name-status` in the committed
+# range. `--diff-filter=AMR` keeps Added / Modified / Renamed entries; for
+# renames the trailing column is the destination, which is what we want
+# (we care about the file that lives in the working tree at HEAD, not the
+# pre-rename path). Whitespace-only changes are filtered by re-running
+# `git diff -w --stat` on each candidate and dropping those with empty stat.
 diff_range_names() {
   local range="$1"
-  shift || true
+  shift
   if [ -z "$range" ]; then
     return 0
   fi
-  # First collect candidate names by AM filter, then re-confirm via -w --stat.
-  local candidates
-  candidates="$(git diff --name-only --diff-filter=AM "$range" -- "$@" 2>/dev/null || true)"
-  if [ -z "$candidates" ]; then
+  local raw
+  raw="$(git diff --name-status --diff-filter=AMR "$range" -- "$@" 2>/dev/null || true)"
+  if [ -z "$raw" ]; then
     return 0
   fi
-  local name
-  while IFS= read -r name; do
+  local line code src dst name
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    code="$(printf '%s' "$line" | awk '{print $1}')"
+    case "$code" in
+      R*)
+        # Format: "R100<TAB>old/path<TAB>new/path"
+        src="$(printf '%s' "$line" | awk '{print $2}')"
+        dst="$(printf '%s' "$line" | awk '{print $3}')"
+        # If the new path is one of the protocol paths, count it.
+        name="$dst"
+        ;;
+      *)
+        name="$(printf '%s' "$line" | awk '{print $2}')"
+        ;;
+    esac
     [ -z "$name" ] && continue
     local stat
+    # For renames the diff is between src and dst; only the dst path is
+    # tracked at HEAD, so diff on the dst path captures the post-rename
+    # content delta. Pure renames (no edit) will have an empty stat under
+    # `-w` because there is no in-content change.
     stat="$(git diff -w --stat "$range" -- "$name" 2>/dev/null || true)"
+    if [ -z "$stat" ] && [ "${code:0:1}" = "R" ]; then
+      # Pure rename of a protocol file is itself a protocol-visible event
+      # (consumers track file paths). Treat as a change regardless of -w.
+      stat="rename"
+    fi
     if [ -n "$stat" ]; then
       printf '%s\n' "$name"
     fi
-  done <<<"$candidates"
+  done <<<"$raw"
 }
 
 # Uncommitted change names (staged + unstaged + untracked) for matching paths.
-# Uses `git status --porcelain` so we still gate pre-commit work, but the
-# whitespace filter only applies to tracked changes (untracked files are by
-# definition new content).
 uncommitted_names() {
   local entries
   entries="$(git status --porcelain --untracked-files=all -- "$@" 2>/dev/null || true)"
@@ -93,7 +159,7 @@ uncommitted_names() {
       path="${path##* -> }"
     fi
     case "$status_code" in
-      "??"|"A "|"AM"|" A")
+      "??"|"A "|"AM"|" A"|R*)
         printf '%s\n' "$path"
         ;;
       *)
@@ -119,26 +185,20 @@ collect_names() {
   } | awk 'NF && !seen[$0]++'
 }
 
-range=""
-if [ -n "$merge_base" ]; then
-  range="$merge_base..HEAD"
-fi
+# Split changes into code-level (Rust source) and spec-doc buckets so the
+# coverage rules can treat them differently. Codex review #3 (#717): an
+# unrelated spec edit must not satisfy the gate for a code-level diff.
+code_changes="$(collect_names "$range" "${PROTOCOL_PATHS[@]}" "${PROTOCOL_GLOBS[@]}")"
+spec_changes="$(collect_names "$range" "$SPEC_GLOB")"
 
-protocol_changes="$(collect_names "$range" "${PROTOCOL_PATHS[@]}" "${PROTOCOL_GLOBS[@]}" "$SPEC_GLOB")"
-
-if [ -z "$protocol_changes" ]; then
+if [ -z "$code_changes" ] && [ -z "$spec_changes" ]; then
   printf 'ui-protocol-upcr: no protocol-visible edits detected\n'
   exit 0
 fi
 
 upcr_changes="$(collect_names "$range" "$UPCR_GLOB" "$UPCR_TEMPLATE")"
-spec_changes="$(collect_names "$range" "$SPEC_GLOB")"
 
-# Sanity-check: at least one UPCR file looks like a real UPCR-YYYY-NNN doc
-# (i.e. matches docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md). The collect
-# step already restricts to that glob, but we re-verify the name pattern here
-# so a stray match (e.g. someone renaming the template) can't satisfy the
-# gate by accident.
+# Verify the matched UPCR file looks like a real UPCR-YYYY-NNN doc.
 upcr_real=""
 while IFS= read -r name; do
   [ -z "$name" ] && continue
@@ -155,8 +215,9 @@ if [ -n "$upcr_real" ]; then
   exit 0
 fi
 
-if [ -n "$spec_changes" ]; then
-  printf 'ui-protocol-upcr: protocol edits have protocol spec coverage\n'
+# No UPCR doc. Spec-only changes are self-coverage; otherwise fail.
+if [ -z "$code_changes" ] && [ -n "$spec_changes" ]; then
+  printf 'ui-protocol-upcr: spec-only edit, treated as self-coverage\n'
   exit 0
 fi
 
@@ -168,13 +229,20 @@ fi
 cat >&2 <<EOF
 ui-protocol-upcr: protocol-visible edits require a UPCR document.
 
-Detected protocol changes (range: ${range:-uncommitted only}):
+Detected code-level protocol changes (range: $range):
 EOF
-printf '  %s\n' $protocol_changes >&2
+printf '  %s\n' $code_changes >&2
+if [ -n "$spec_changes" ]; then
+  cat >&2 <<EOF
+
+Spec-doc changes are also present, but a spec edit alone does NOT satisfy the
+gate when Rust protocol surfaces have changed — it could be an unrelated fix.
+Add an explicit UPCR doc that references this change.
+EOF
+fi
 cat >&2 <<'EOF'
 
-Add or update docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md (or revise the
-api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md spec) in the same branch, or set
-UPCR_ALLOW_NO_DOC=1 only for a documented reviewer override.
+Add or update docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md in the same
+branch, or set UPCR_ALLOW_NO_DOC=1 only for a documented reviewer override.
 EOF
 exit 1

--- a/scripts/check-ui-protocol-upcr.sh
+++ b/scripts/check-ui-protocol-upcr.sh
@@ -104,7 +104,9 @@ diff_range_names() {
     return 0
   fi
   local raw
-  raw="$(git diff --name-status --diff-filter=AMR "$range" -- "$@" 2>/dev/null || true)"
+  # AMRD: Added, Modified, Renamed, Deleted. Deletions of protocol files are
+  # also protocol-visible events (codex review #4 / #717) and must be gated.
+  raw="$(git diff --name-status --diff-filter=AMRD "$range" -- "$@" 2>/dev/null || true)"
   if [ -z "$raw" ]; then
     return 0
   fi
@@ -123,20 +125,21 @@ diff_range_names() {
         ;;
     esac
     [ -z "$name" ] && continue
-    local stat
-    # For renames the diff is between src and dst; only the dst path is
-    # tracked at HEAD, so diff on the dst path captures the post-rename
-    # content delta. Pure renames (no edit) will have an empty stat under
-    # `-w` because there is no in-content change.
-    stat="$(git diff -w --stat "$range" -- "$name" 2>/dev/null || true)"
-    if [ -z "$stat" ] && [ "${code:0:1}" = "R" ]; then
-      # Pure rename of a protocol file is itself a protocol-visible event
-      # (consumers track file paths). Treat as a change regardless of -w.
-      stat="rename"
-    fi
-    if [ -n "$stat" ]; then
-      printf '%s\n' "$name"
-    fi
+    case "${code:0:1}" in
+      R|D)
+        # Pure rename or deletion is itself a protocol-visible event;
+        # `git diff -w --stat` on a deleted path is meaningless and a
+        # rename-only delta can come back empty under `-w`. Short-circuit.
+        printf '%s\n' "$name"
+        ;;
+      *)
+        local stat
+        stat="$(git diff -w --stat "$range" -- "$name" 2>/dev/null || true)"
+        if [ -n "$stat" ]; then
+          printf '%s\n' "$name"
+        fi
+        ;;
+    esac
   done <<<"$raw"
 }
 
@@ -157,7 +160,8 @@ uncommitted_names() {
       path="${path##* -> }"
     fi
     case "$status_code" in
-      "??"|"A "|"AM"|" A"|R*)
+      "??"|"A "|"AM"|" A"|R*|"D "|" D"|"DD"|"AD"|"MD")
+        # Adds, renames, and deletions are all protocol-visible events.
         printf '%s\n' "$path"
         ;;
       *)

--- a/scripts/check-ui-protocol-upcr.sh
+++ b/scripts/check-ui-protocol-upcr.sh
@@ -1,40 +1,157 @@
 #!/usr/bin/env bash
-# Ensure protocol-visible edits are paired with an explicit UI Protocol change request.
+# Ensure protocol-visible edits are paired with an explicit UI Protocol change
+# request (UPCR) doc or a protocol spec revision. Compares the current branch
+# against a base ref (default: origin/main, falling back to main) using
+# `git diff --name-only --diff-filter=AM` so the check covers committed work,
+# including changes the user split across multiple commits. Uncommitted
+# changes (staged + unstaged + untracked) are folded in so the gate behaves
+# correctly when run pre-commit. Whitespace-only diffs are exempted via
+# `git diff -w --stat`.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-protocol_changes="$(
-  git status --porcelain --untracked-files=all -- \
-    crates/octos-core/src/ui_protocol.rs \
-    crates/octos-cli/src/api/ui_protocol.rs \
-    crates/octos-cli/src/api/ui_protocol_*.rs \
-    api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md \
-    2>/dev/null || true
-)"
+PROTOCOL_PATHS=(
+  "crates/octos-core/src/ui_protocol.rs"
+  "crates/octos-cli/src/api/ui_protocol.rs"
+)
+PROTOCOL_GLOBS=(
+  "crates/octos-cli/src/api/ui_protocol_*.rs"
+)
+SPEC_GLOB="api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md"
+UPCR_GLOB="docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md"
+UPCR_TEMPLATE="docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_TEMPLATE.md"
+
+# Resolve a base ref for the merge-base diff. Allow override via UPCR_BASE_REF.
+resolve_base_ref() {
+  if [ -n "${UPCR_BASE_REF:-}" ]; then
+    printf '%s\n' "$UPCR_BASE_REF"
+    return 0
+  fi
+  for candidate in origin/main main origin/master master; do
+    if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+base_ref=""
+if base_ref="$(resolve_base_ref)"; then
+  merge_base="$(git merge-base "$base_ref" HEAD 2>/dev/null || true)"
+else
+  merge_base=""
+fi
+
+# Names that changed between merge-base and HEAD (committed work),
+# restricted to Added/Modified (filters out renames/deletes whose new path
+# is what we actually care about). Whitespace-only changes are stripped via
+# `git diff -w --stat` -> empty stat means no semantic change.
+diff_range_names() {
+  local range="$1"
+  shift || true
+  if [ -z "$range" ]; then
+    return 0
+  fi
+  # First collect candidate names by AM filter, then re-confirm via -w --stat.
+  local candidates
+  candidates="$(git diff --name-only --diff-filter=AM "$range" -- "$@" 2>/dev/null || true)"
+  if [ -z "$candidates" ]; then
+    return 0
+  fi
+  local name
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    local stat
+    stat="$(git diff -w --stat "$range" -- "$name" 2>/dev/null || true)"
+    if [ -n "$stat" ]; then
+      printf '%s\n' "$name"
+    fi
+  done <<<"$candidates"
+}
+
+# Uncommitted change names (staged + unstaged + untracked) for matching paths.
+# Uses `git status --porcelain` so we still gate pre-commit work, but the
+# whitespace filter only applies to tracked changes (untracked files are by
+# definition new content).
+uncommitted_names() {
+  local entries
+  entries="$(git status --porcelain --untracked-files=all -- "$@" 2>/dev/null || true)"
+  if [ -z "$entries" ]; then
+    return 0
+  fi
+  local line status_code path
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    status_code="${line:0:2}"
+    path="${line:3}"
+    # Handle renames: "R  old -> new" — take the new path.
+    if [[ "$status_code" == R* ]]; then
+      path="${path##* -> }"
+    fi
+    case "$status_code" in
+      "??"|"A "|"AM"|" A")
+        printf '%s\n' "$path"
+        ;;
+      *)
+        # Tracked modification — drop if whitespace-only.
+        local stat
+        stat="$(git diff -w --stat HEAD -- "$path" 2>/dev/null || true)"
+        local stat_cached
+        stat_cached="$(git diff -w --cached --stat -- "$path" 2>/dev/null || true)"
+        if [ -n "$stat" ] || [ -n "$stat_cached" ]; then
+          printf '%s\n' "$path"
+        fi
+        ;;
+    esac
+  done <<<"$entries"
+}
+
+collect_names() {
+  local range="$1"
+  shift
+  {
+    diff_range_names "$range" "$@"
+    uncommitted_names "$@"
+  } | awk 'NF && !seen[$0]++'
+}
+
+range=""
+if [ -n "$merge_base" ]; then
+  range="$merge_base..HEAD"
+fi
+
+protocol_changes="$(collect_names "$range" "${PROTOCOL_PATHS[@]}" "${PROTOCOL_GLOBS[@]}" "$SPEC_GLOB")"
 
 if [ -z "$protocol_changes" ]; then
   printf 'ui-protocol-upcr: no protocol-visible edits detected\n'
   exit 0
 fi
 
-upcr_changes="$(
-  git status --porcelain --untracked-files=all -- \
-    docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md \
-    docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_TEMPLATE.md \
-    2>/dev/null || true
-)"
+upcr_changes="$(collect_names "$range" "$UPCR_GLOB" "$UPCR_TEMPLATE")"
+spec_changes="$(collect_names "$range" "$SPEC_GLOB")"
 
-spec_changes="$(
-  git status --porcelain --untracked-files=all -- \
-    api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md \
-    2>/dev/null || true
-)"
+# Sanity-check: at least one UPCR file looks like a real UPCR-YYYY-NNN doc
+# (i.e. matches docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md). The collect
+# step already restricts to that glob, but we re-verify the name pattern here
+# so a stray match (e.g. someone renaming the template) can't satisfy the
+# gate by accident.
+upcr_real=""
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  case "$name" in
+    docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md)
+      upcr_real="$name"
+      break
+      ;;
+  esac
+done <<<"$upcr_changes"
 
-if [ -n "$upcr_changes" ]; then
-  printf 'ui-protocol-upcr: protocol edits have UPCR coverage\n'
+if [ -n "$upcr_real" ]; then
+  printf 'ui-protocol-upcr: protocol edits have UPCR coverage (%s)\n' "$upcr_real"
   exit 0
 fi
 
@@ -48,11 +165,16 @@ if [ "${UPCR_ALLOW_NO_DOC:-0}" = "1" ]; then
   exit 0
 fi
 
-cat >&2 <<'EOF'
+cat >&2 <<EOF
 ui-protocol-upcr: protocol-visible edits require a UPCR document.
 
-Add or update docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md, or set
+Detected protocol changes (range: ${range:-uncommitted only}):
+EOF
+printf '  %s\n' $protocol_changes >&2
+cat >&2 <<'EOF'
+
+Add or update docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md (or revise the
+api/OCTOS_UI_PROTOCOL_V1_SPEC_*.md spec) in the same branch, or set
 UPCR_ALLOW_NO_DOC=1 only for a documented reviewer override.
 EOF
-printf '%s\n' "$protocol_changes" >&2
 exit 1

--- a/scripts/tests/test-check-ui-protocol-upcr.sh
+++ b/scripts/tests/test-check-ui-protocol-upcr.sh
@@ -22,6 +22,8 @@
 #      deletions are protocol-visible too).
 #  13. Code change + deletion of an existing UPCR (no add/modify of any
 #      UPCR) -> exit non-zero (codex #5 — deleted UPCR is not coverage).
+#  14. Resolved base ref equals HEAD (single-branch CI) -> exit non-zero
+#      (codex #6 — closes HEAD..HEAD silent-empty-diff bypass).
 #
 # Runs entirely offline. Each scenario uses an isolated temp repo so state
 # does not leak between cases.
@@ -337,7 +339,7 @@ scenario_no_base_ref_fails() {
   )
   local out status=0
   out="$(run_gate "$dir" 2>&1)" || status=$?
-  if [ "$status" -ne 0 ] && grep -q "could not resolve a base ref" <<<"$out"; then
+  if [ "$status" -ne 0 ] && grep -q "could not resolve a usable base ref" <<<"$out"; then
     pass "missing base ref fails loud (no silent CI bypass)"
   else
     fail "missing base ref: status=$status output=$out"
@@ -404,6 +406,34 @@ scenario_deleted_upcr_is_not_coverage() {
 }
 
 scenario_deleted_upcr_is_not_coverage
+
+# Scenario 14: resolved base ref equals HEAD (e.g. single-branch CI checkout
+# where origin/main and the feature branch are the same commit). HEAD..HEAD
+# is empty by construction; the script must refuse to run instead of silently
+# reporting "no protocol-visible edits detected". Codex review #6.
+scenario_base_equals_head_fails() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    # Commit a protocol change directly onto feature, then point
+    # origin/main at HEAD so merge-base(origin/main, HEAD) == HEAD.
+    printf '// changed\n' > crates/octos-core/src/ui_protocol.rs
+    git add -A
+    git commit --quiet -m "feat: extend"
+    git update-ref refs/remotes/origin/main HEAD
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "could not resolve a usable base ref" <<<"$out"; then
+    pass "merge_base == HEAD fails loud (no empty-diff bypass)"
+  else
+    fail "merge_base == HEAD: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+scenario_base_equals_head_fails
 
 echo
 echo "==> Summary: $PASS passed, $FAIL failed"

--- a/scripts/tests/test-check-ui-protocol-upcr.sh
+++ b/scripts/tests/test-check-ui-protocol-upcr.sh
@@ -24,6 +24,9 @@
 #      UPCR) -> exit non-zero (codex #5 — deleted UPCR is not coverage).
 #  14. Resolved base ref equals HEAD (single-branch CI) -> exit non-zero
 #      (codex #6 — closes HEAD..HEAD silent-empty-diff bypass).
+#  15. Missing base ref + committed protocol change + untracked UPCR
+#      template (no uncommitted protocol/spec trigger) -> exit non-zero
+#      (codex #7 — coverage docs must not unblock the missing-base probe).
 #
 # Runs entirely offline. Each scenario uses an isolated temp repo so state
 # does not leak between cases.
@@ -434,6 +437,35 @@ scenario_base_equals_head_fails() {
 }
 
 scenario_base_equals_head_fails
+
+# Scenario 15: shallow checkout with no base ref AND a committed protocol
+# change AND a stray untracked UPCR-template. The recovery probe must look
+# only at trigger files (protocol code + spec), not coverage docs, or a
+# stale UPCR/template would mask the committed protocol bypass. Codex
+# review #7.
+scenario_missing_base_with_untracked_template_fails() {
+  local dir
+  dir="$(make_repo 0)"
+  (
+    cd "$dir"
+    printf '// changed\n' > crates/octos-core/src/ui_protocol.rs
+    git add -A
+    git commit --quiet -m "feat: extend"
+    # Drop a stray untracked UPCR template into the working tree.
+    printf '# template stub\n' \
+      > docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_TEMPLATE.md
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "could not resolve a usable base ref" <<<"$out"; then
+    pass "stray untracked template does not unblock missing-base probe"
+  else
+    fail "stray template bypass: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+scenario_missing_base_with_untracked_template_fails
 
 echo
 echo "==> Summary: $PASS passed, $FAIL failed"

--- a/scripts/tests/test-check-ui-protocol-upcr.sh
+++ b/scripts/tests/test-check-ui-protocol-upcr.sh
@@ -12,8 +12,12 @@
 #      HEAD~1) -> still gated because diff-range covers merge-base..HEAD.
 #   5. Whitespace-only protocol diff -> exempt (exit 0).
 #   6. Untracked UPCR file with staged protocol change -> exit 0.
-#   7. Spec revision instead of UPCR doc -> exit 0.
+#   7. Spec-only edit (no Rust protocol diff) -> exit 0 (self-coverage).
 #   8. UPCR_ALLOW_NO_DOC=1 override -> exit 0 even without a UPCR doc.
+#   9. Renamed protocol file with edits -> still gated (codex #2).
+#  10. Rust protocol change + unrelated spec edit + no UPCR -> exit non-zero
+#      (codex #3 — spec-as-coverage bypass closed for code-level changes).
+#  11. No base ref resolvable -> exit non-zero (codex #1 — closes CI bypass).
 #
 # Runs entirely offline. Each scenario uses an isolated temp repo so state
 # does not leak between cases.
@@ -37,7 +41,10 @@ fail() { echo "  FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 
 # Make a throwaway git repo seeded with the placeholder protocol + spec
 # files that the gate inspects, so "no change" is a sane baseline.
+# Optional first argument disables the origin/main pointer so the
+# missing-base-ref scenarios can exercise that failure path.
 make_repo() {
+  local set_origin="${1:-1}"
   local dir
   dir="$(mktemp -d /tmp/upcr-gate-test.XXXXXX)"
   (
@@ -53,17 +60,23 @@ make_repo() {
 
     printf '// baseline\n' > crates/octos-core/src/ui_protocol.rs
     printf '// baseline\n' > crates/octos-cli/src/api/ui_protocol.rs
+    printf 'pub fn old() {}\n' > crates/octos-cli/src/api/ui_protocol_alpha.rs
     printf '# spec baseline\n' > api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
     printf '# placeholder\n' > docs/.keep
 
     git add -A
     git commit --quiet -m "baseline"
 
-    # Pretend main is also our upstream so resolve_base_ref picks it up.
-    git update-ref refs/remotes/origin/main HEAD
-
-    # Create a feature branch for the case under test.
-    git checkout --quiet -b feature
+    if [ "$set_origin" = "1" ]; then
+      # Pretend main is also our upstream so resolve_base_ref picks it up.
+      git update-ref refs/remotes/origin/main HEAD
+      git checkout --quiet -b feature
+    else
+      # Move HEAD off main so the script can't find a base ref via
+      # main/origin/main and there is nowhere to merge-base against.
+      git checkout --quiet -b orphan
+      git branch --quiet -D main
+    fi
   )
   printf '%s\n' "$dir"
 }
@@ -90,9 +103,8 @@ scenario_protocol_plus_upcr() {
     git add -A
     git commit --quiet -m "feat: extend protocol + upcr"
   )
-  local out status
-  out="$(run_gate "$dir" 2>&1)"
-  status=$?
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
   if [ "$status" -eq 0 ] && grep -q "UPCR coverage" <<<"$out"; then
     pass "protocol + UPCR -> exit 0 with coverage line"
   else
@@ -217,23 +229,23 @@ scenario_uncommitted_upcr() {
   rm -rf "$dir"
 }
 
-# Scenario 7: protocol spec revision satisfies gate when no UPCR doc exists.
-scenario_spec_change() {
+# Scenario 7: spec-only edit (no Rust protocol diff) -> exit 0 (self-coverage).
+scenario_spec_only_self_coverage() {
   local dir
   dir="$(make_repo)"
   (
     cd "$dir"
-    printf '// extend\n' > crates/octos-core/src/ui_protocol.rs
-    printf '# spec v2\n' > api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+    printf '# spec v2 (text update)\nfoo bar baz\n' \
+      > api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
     git add -A
-    git commit --quiet -m "spec: extend"
+    git commit --quiet -m "spec: clarify wording"
   )
   local out status=0
   out="$(run_gate "$dir" 2>&1)" || status=$?
-  if [ "$status" -eq 0 ] && grep -q "protocol spec coverage" <<<"$out"; then
-    pass "spec revision satisfies gate"
+  if [ "$status" -eq 0 ] && grep -q "self-coverage" <<<"$out"; then
+    pass "spec-only edit -> exit 0 (self-coverage)"
   else
-    fail "spec revision: status=$status output=$out"
+    fail "spec-only: status=$status output=$out"
   fi
   rm -rf "$dir"
 }
@@ -258,6 +270,75 @@ scenario_reviewer_override() {
   rm -rf "$dir"
 }
 
+# Scenario 9: renamed protocol file with edits -> still gated (codex #2).
+# A rename with content edits in the new path is a protocol-visible change.
+scenario_renamed_protocol_file() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    git mv crates/octos-cli/src/api/ui_protocol_alpha.rs \
+           crates/octos-cli/src/api/ui_protocol_beta.rs
+    # Add content so it's a rename-with-edit (R<100).
+    printf 'pub fn old() {}\npub fn new_wire() {}\n' \
+      > crates/octos-cli/src/api/ui_protocol_beta.rs
+    git add -A
+    git commit --quiet -m "refactor: rename alpha -> beta"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "require a UPCR document" <<<"$out"; then
+    pass "renamed protocol file is gated (rename detection)"
+  else
+    fail "renamed protocol file: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 10: Rust protocol change + unrelated spec edit + no UPCR -> fail
+# (codex #3 — spec-as-coverage must NOT satisfy the gate when code changed).
+scenario_unrelated_spec_does_not_cover_code() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// added v2 field\n' > crates/octos-core/src/ui_protocol.rs
+    printf '# spec baseline\n\nTypo fix.\n' \
+      > api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+    git add -A
+    git commit --quiet -m "feat: extend + spec typo"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "require a UPCR document" <<<"$out" \
+       && grep -q "spec edit alone does NOT" <<<"$out"; then
+    pass "unrelated spec edit does not satisfy gate for code-level diff"
+  else
+    fail "unrelated spec coverage bypass: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 11: no base ref resolvable -> exit non-zero (codex #1).
+scenario_no_base_ref_fails() {
+  local dir
+  dir="$(make_repo 0)"
+  (
+    cd "$dir"
+    printf '// extend\n' > crates/octos-core/src/ui_protocol.rs
+    git add -A
+    git commit --quiet -m "feat: extend"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "could not resolve a base ref" <<<"$out"; then
+    pass "missing base ref fails loud (no silent CI bypass)"
+  else
+    fail "missing base ref: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
 echo "==> check-ui-protocol-upcr.sh scenario tests"
 echo "  target: $TARGET"
 
@@ -267,8 +348,11 @@ scenario_no_protocol
 scenario_split_commits_bypass
 scenario_whitespace_only
 scenario_uncommitted_upcr
-scenario_spec_change
+scenario_spec_only_self_coverage
 scenario_reviewer_override
+scenario_renamed_protocol_file
+scenario_unrelated_spec_does_not_cover_code
+scenario_no_base_ref_fails
 
 echo
 echo "==> Summary: $PASS passed, $FAIL failed"

--- a/scripts/tests/test-check-ui-protocol-upcr.sh
+++ b/scripts/tests/test-check-ui-protocol-upcr.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# test-check-ui-protocol-upcr.sh — regression tests for
+# scripts/check-ui-protocol-upcr.sh (#717).
+#
+# Builds throwaway git repos, copies the gate script into them, then
+# exercises the scenarios documented in #717:
+#
+#   1. Protocol changed + UPCR added in same diff range -> exit 0.
+#   2. Protocol changed + no UPCR change -> exit non-zero with clear msg.
+#   3. No protocol change -> exit 0 regardless of UPCR state.
+#   4. Protocol change split across two commits (not in HEAD's diff vs
+#      HEAD~1) -> still gated because diff-range covers merge-base..HEAD.
+#   5. Whitespace-only protocol diff -> exempt (exit 0).
+#   6. Untracked UPCR file with staged protocol change -> exit 0.
+#   7. Spec revision instead of UPCR doc -> exit 0.
+#   8. UPCR_ALLOW_NO_DOC=1 override -> exit 0 even without a UPCR doc.
+#
+# Runs entirely offline. Each scenario uses an isolated temp repo so state
+# does not leak between cases.
+
+set -eEuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET="$REPO_ROOT/scripts/check-ui-protocol-upcr.sh"
+
+if [ ! -x "$TARGET" ] && [ ! -r "$TARGET" ]; then
+  echo "FAIL: cannot read $TARGET" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+pass() { echo "  OK:   $*"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+
+# Make a throwaway git repo seeded with the placeholder protocol + spec
+# files that the gate inspects, so "no change" is a sane baseline.
+make_repo() {
+  local dir
+  dir="$(mktemp -d /tmp/upcr-gate-test.XXXXXX)"
+  (
+    cd "$dir"
+    git init --quiet --initial-branch=main
+    git config user.email "test@example.com"
+    git config user.name "test"
+    git config commit.gpgsign false
+
+    mkdir -p scripts crates/octos-core/src crates/octos-cli/src/api api docs
+    cp "$TARGET" scripts/check-ui-protocol-upcr.sh
+    chmod +x scripts/check-ui-protocol-upcr.sh
+
+    printf '// baseline\n' > crates/octos-core/src/ui_protocol.rs
+    printf '// baseline\n' > crates/octos-cli/src/api/ui_protocol.rs
+    printf '# spec baseline\n' > api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+    printf '# placeholder\n' > docs/.keep
+
+    git add -A
+    git commit --quiet -m "baseline"
+
+    # Pretend main is also our upstream so resolve_base_ref picks it up.
+    git update-ref refs/remotes/origin/main HEAD
+
+    # Create a feature branch for the case under test.
+    git checkout --quiet -b feature
+  )
+  printf '%s\n' "$dir"
+}
+
+run_gate() {
+  local dir="$1"
+  shift
+  (
+    cd "$dir"
+    "$@" bash scripts/check-ui-protocol-upcr.sh
+  )
+}
+
+# Scenario 1: protocol changed + UPCR added -> exit 0.
+scenario_protocol_plus_upcr() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// added v2 field\nstruct Foo { bar: u32 }\n' \
+      > crates/octos-core/src/ui_protocol.rs
+    printf '# UPCR-2026-099 Test\n\nChange description.\n' \
+      > docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_099_TEST.md
+    git add -A
+    git commit --quiet -m "feat: extend protocol + upcr"
+  )
+  local out status
+  out="$(run_gate "$dir" 2>&1)"
+  status=$?
+  if [ "$status" -eq 0 ] && grep -q "UPCR coverage" <<<"$out"; then
+    pass "protocol + UPCR -> exit 0 with coverage line"
+  else
+    fail "protocol + UPCR: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 2: protocol changed without UPCR -> exit non-zero.
+scenario_protocol_without_upcr() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// added v2 field\nstruct Foo { bar: u32 }\n' \
+      > crates/octos-core/src/ui_protocol.rs
+    git add -A
+    git commit --quiet -m "feat: extend protocol no upcr"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "require a UPCR document" <<<"$out"; then
+    pass "protocol without UPCR -> exit non-zero with clear msg"
+  else
+    fail "protocol without UPCR: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 3: no protocol change -> exit 0 regardless of UPCR state.
+scenario_no_protocol() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    mkdir -p src
+    printf 'fn main() {}\n' > src/main.rs
+    git add -A
+    git commit --quiet -m "feat: unrelated change"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -eq 0 ] && grep -q "no protocol-visible edits" <<<"$out"; then
+    pass "no protocol change -> exit 0"
+  else
+    fail "no protocol change: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 4: protocol change in a parent commit that does not also touch the
+# UPCR; the bypass the legacy script allowed. With diff-range covering
+# merge-base..HEAD the gate must still fail.
+scenario_split_commits_bypass() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// added v2 field\n' > crates/octos-core/src/ui_protocol.rs
+    git add -A
+    git commit --quiet -m "feat: protocol diff only"
+
+    # A second commit that touches something unrelated. HEAD's diff vs HEAD~1
+    # contains no protocol file, but merge-base..HEAD does.
+    printf 'note\n' > NOTES.md
+    git add NOTES.md
+    git commit --quiet -m "docs: notes"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "require a UPCR document" <<<"$out"; then
+    pass "split-commit bypass is closed (merge-base..HEAD diff)"
+  else
+    fail "split-commit bypass: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 5: whitespace-only protocol diff -> exempt.
+scenario_whitespace_only() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    # Append trailing spaces only — `git diff -w --stat` must report empty,
+    # which is how the gate detects whitespace-only diffs.
+    printf '// baseline   \n' > crates/octos-core/src/ui_protocol.rs
+    git add -A
+    git commit --quiet -m "style: whitespace"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -eq 0 ] && grep -q "no protocol-visible edits" <<<"$out"; then
+    pass "whitespace-only protocol diff is exempt"
+  else
+    fail "whitespace-only: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 6: untracked UPCR file alongside staged protocol change -> exit 0.
+# This is the pre-commit case: the original script's `git status` already
+# handled it, and the new script must keep parity.
+scenario_uncommitted_upcr() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// staged change\n' > crates/octos-core/src/ui_protocol.rs
+    printf '# UPCR-2026-100 Untracked\n' \
+      > docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_100_UNTRACKED.md
+    git add crates/octos-core/src/ui_protocol.rs
+    # UPCR doc stays untracked on purpose.
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -eq 0 ] && grep -q "UPCR coverage" <<<"$out"; then
+    pass "untracked UPCR satisfies the gate (pre-commit parity)"
+  else
+    fail "untracked UPCR: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 7: protocol spec revision satisfies gate when no UPCR doc exists.
+scenario_spec_change() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// extend\n' > crates/octos-core/src/ui_protocol.rs
+    printf '# spec v2\n' > api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+    git add -A
+    git commit --quiet -m "spec: extend"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -eq 0 ] && grep -q "protocol spec coverage" <<<"$out"; then
+    pass "spec revision satisfies gate"
+  else
+    fail "spec revision: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+# Scenario 8: UPCR_ALLOW_NO_DOC=1 override.
+scenario_reviewer_override() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// extend\n' > crates/octos-core/src/ui_protocol.rs
+    git add -A
+    git commit --quiet -m "feat: extend"
+  )
+  local out status=0
+  out="$(run_gate "$dir" env UPCR_ALLOW_NO_DOC=1 2>&1)" || status=$?
+  if [ "$status" -eq 0 ] && grep -q "reviewer override" <<<"$out"; then
+    pass "reviewer override flag still works"
+  else
+    fail "reviewer override: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+echo "==> check-ui-protocol-upcr.sh scenario tests"
+echo "  target: $TARGET"
+
+scenario_protocol_plus_upcr
+scenario_protocol_without_upcr
+scenario_no_protocol
+scenario_split_commits_bypass
+scenario_whitespace_only
+scenario_uncommitted_upcr
+scenario_spec_change
+scenario_reviewer_override
+
+echo
+echo "==> Summary: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/scripts/tests/test-check-ui-protocol-upcr.sh
+++ b/scripts/tests/test-check-ui-protocol-upcr.sh
@@ -20,6 +20,8 @@
 #  11. No base ref resolvable -> exit non-zero (codex #1 — closes CI bypass).
 #  12. Protocol file deletion (no UPCR) -> exit non-zero (codex #4 —
 #      deletions are protocol-visible too).
+#  13. Code change + deletion of an existing UPCR (no add/modify of any
+#      UPCR) -> exit non-zero (codex #5 — deleted UPCR is not coverage).
 #
 # Runs entirely offline. Each scenario uses an isolated temp repo so state
 # does not leak between cases.
@@ -64,6 +66,8 @@ make_repo() {
     printf '// baseline\n' > crates/octos-cli/src/api/ui_protocol.rs
     printf 'pub fn old() {}\n' > crates/octos-cli/src/api/ui_protocol_alpha.rs
     printf '# spec baseline\n' > api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+    printf '# UPCR-2026-001 seed baseline\n' \
+      > docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_001_SEED.md
     printf '# placeholder\n' > docs/.keep
 
     git add -A
@@ -376,6 +380,30 @@ scenario_renamed_protocol_file
 scenario_unrelated_spec_does_not_cover_code
 scenario_no_base_ref_fails
 scenario_deleted_protocol_file
+
+# Scenario 13: deleting an existing UPCR while editing protocol code must
+# NOT satisfy coverage. Closes the bypass codex caught in review #5.
+scenario_deleted_upcr_is_not_coverage() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    printf '// extend\n' > crates/octos-core/src/ui_protocol.rs
+    git rm --quiet docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_001_SEED.md
+    git add -A
+    git commit --quiet -m "feat: extend + drop old upcr"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "require a UPCR document" <<<"$out"; then
+    pass "deleted UPCR does not satisfy coverage"
+  else
+    fail "deleted UPCR coverage bypass: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
+scenario_deleted_upcr_is_not_coverage
 
 echo
 echo "==> Summary: $PASS passed, $FAIL failed"

--- a/scripts/tests/test-check-ui-protocol-upcr.sh
+++ b/scripts/tests/test-check-ui-protocol-upcr.sh
@@ -18,6 +18,8 @@
 #  10. Rust protocol change + unrelated spec edit + no UPCR -> exit non-zero
 #      (codex #3 — spec-as-coverage bypass closed for code-level changes).
 #  11. No base ref resolvable -> exit non-zero (codex #1 — closes CI bypass).
+#  12. Protocol file deletion (no UPCR) -> exit non-zero (codex #4 —
+#      deletions are protocol-visible too).
 #
 # Runs entirely offline. Each scenario uses an isolated temp repo so state
 # does not leak between cases.
@@ -339,6 +341,26 @@ scenario_no_base_ref_fails() {
   rm -rf "$dir"
 }
 
+# Scenario 12: deleting a protocol file without a UPCR is itself a
+# protocol-visible event and must be gated (codex review #4).
+scenario_deleted_protocol_file() {
+  local dir
+  dir="$(make_repo)"
+  (
+    cd "$dir"
+    git rm --quiet crates/octos-cli/src/api/ui_protocol_alpha.rs
+    git commit --quiet -m "chore: drop alpha"
+  )
+  local out status=0
+  out="$(run_gate "$dir" 2>&1)" || status=$?
+  if [ "$status" -ne 0 ] && grep -q "require a UPCR document" <<<"$out"; then
+    pass "deleted protocol file is gated (no UPCR)"
+  else
+    fail "deleted protocol file: status=$status output=$out"
+  fi
+  rm -rf "$dir"
+}
+
 echo "==> check-ui-protocol-upcr.sh scenario tests"
 echo "  target: $TARGET"
 
@@ -353,6 +375,7 @@ scenario_reviewer_override
 scenario_renamed_protocol_file
 scenario_unrelated_spec_does_not_cover_code
 scenario_no_base_ref_fails
+scenario_deleted_protocol_file
 
 echo
 echo "==> Summary: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- `scripts/check-ui-protocol-upcr.sh` previously relied on `git status --porcelain`, which silently misses staging gaps, ignores the actual diff range, can be bypassed by splitting protocol edits across commits, and treats unrelated spec touch-ups as coverage.
- The gate now diffs `merge-base(origin/main, HEAD)..HEAD` with `--name-status --diff-filter=AMR` so committed work (including rename-with-edit moves) is captured, folds in uncommitted state for the pre-commit case, and exempts whitespace-only edits via `git diff -w --stat`.
- Coverage rules: any Rust protocol diff requires an added/modified `docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_*.md` in the same range. A spec-only edit self-covers, but a spec edit alongside a code change does NOT — that bypass is closed.
- If no base ref can be resolved (single-branch / shallow CI), the gate now fails loudly instead of silently skipping the committed-range check.
- `scripts/tests/test-check-ui-protocol-upcr.sh` exercises 11 scenarios end-to-end in throwaway repos.

Closes #717

## Test plan
- [x] `bash scripts/tests/test-check-ui-protocol-upcr.sh` (11/11)
- [x] `bash scripts/check-ui-protocol-upcr.sh` on this branch (no protocol-visible edits -> exit 0)
- [ ] CI green