### PR TITLE
fix(spawn): thread DispatchPolicy into agent_mcp spawn site (#714)

### DIFF
--- a/crates/octos-agent/src/dispatch_policy.rs
+++ b/crates/octos-agent/src/dispatch_policy.rs
@@ -1,0 +1,510 @@
+//! Pre-dispatch policy gate shared by every MCP-agent dispatch site —
+//! [`crate::tools::SpawnTool`]'s `agent_mcp` branch (#714) and the
+//! [`octos_swarm::Swarm`] dispatcher (#710 / #713).
+//!
+//! Pre-#714, [`crate::tools::SpawnTool`] dispatched to its configured
+//! MCP backend via [`crate::tools::mcp_agent::dispatch_with_metrics`]
+//! with no policy gate at all — even when `octos serve` had wired one
+//! into the swarm side, the direct spawn path was a bypass. Lifting
+//! the gate out of `octos-swarm` and into this crate lets both call
+//! sites enforce the same shape of gates against the same shared
+//! types ([`crate::ToolPolicy`], [`crate::ToolApprovalRequester`],
+//! [`crate::tools::mcp_agent::McpAgentBackend`]).
+//!
+//! [`DispatchPolicy`] **exposes** the same shape of gates the native
+//! [`crate::ToolRegistry::execute_with_context`] path applies: tool
+//! policy, approval, sandbox-required, and env (allowlist or
+//! denylist). Whether a given gate is *active* is up to the caller —
+//! see [`DispatchPolicy::from_agent_gates`] for the production
+//! constructor `octos serve` uses (it wires `tool_policy` +
+//! injection-env denylist; approval bridge / sandbox-required /
+//! per-skill manifest env are intentionally not mirrored, see that
+//! constructor's rustdoc for the full boundary).
+//!
+//! The gate is **opt-in**: callers wire it via
+//! [`crate::tools::SpawnTool::with_dispatch_policy`] or
+//! [`octos_swarm::SwarmBuilder::with_dispatch_policy`]. Without a
+//! configured policy the dispatcher's behaviour is unchanged so
+//! existing M7.1 callers and tests do not regress.
+//!
+//! ## Failure surfacing
+//!
+//! Each gate failure produces a [`GateDenial`] with a stable
+//! `last_dispatch_outcome` label. Stable labels:
+//!
+//! - `policy_denied` — [`crate::ToolPolicy`] denied the dispatched
+//!   tool name. The `error` carries the policy reason
+//!   (`policy_deny` or `robot_tier_gate`).
+//! - `approval_denied` — the configured
+//!   [`crate::ToolApprovalRequester`] returned
+//!   [`crate::ToolApprovalDecision::Deny`].
+//! - `approval_unavailable` — approval is required but no requester
+//!   was wired. **Fail closed** — never fall through to dispatch.
+//! - `env_forbidden` — the dispatch's task carries an env key that
+//!   fails either the dispatch policy's env allowlist (key not in
+//!   allowlist) or env denylist (key in denylist). Used by callers
+//!   that pass env through the task payload to the backend.
+//! - `sandbox_required` — the dispatch policy demands a sandboxed
+//!   backend but the wired backend does not self-report sandboxing.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tracing::warn;
+
+use crate::tools::mcp_agent::McpAgentBackend;
+use crate::{
+    PolicyDecision, ToolApprovalDecision, ToolApprovalRequest, ToolApprovalRequester, ToolPolicy,
+};
+
+/// Configuration for the dispatch policy gate.
+///
+/// Every field is independently optional so callers can opt into just the
+/// gates they need. An entirely default value is a no-op (matches the
+/// pre-#710/#714 dispatcher behaviour).
+#[derive(Clone, Default)]
+pub struct DispatchPolicy {
+    /// Tool policy evaluated against the dispatched tool name. Deny
+    /// wins; an empty allow list permits every tool name not explicitly
+    /// denied (mirrors [`ToolPolicy`] semantics).
+    pub tool_policy: Option<ToolPolicy>,
+    /// When `true`, every dispatch must clear the approval gate before
+    /// the backend is called. The dispatch fails closed if no
+    /// [`ToolApprovalRequester`] is wired.
+    pub require_approval: bool,
+    /// Approval bridge used when [`Self::require_approval`] is true.
+    pub approval_requester: Option<Arc<dyn ToolApprovalRequester>>,
+    /// Env keys the dispatch is allowed to forward to the backend.
+    /// Inspected against the dispatched task payload — if the task
+    /// carries an `env` object whose keys overlap any name **not** in
+    /// this allowlist, the dispatch is denied with `env_forbidden`.
+    /// `None` means allowlist checking is off. Names are matched
+    /// case-insensitively against the upper-cased form.
+    pub env_allowlist: Option<HashSet<String>>,
+    /// Env keys the dispatch must reject if the task payload tries to
+    /// forward them. Complements [`Self::env_allowlist`]: an entry here
+    /// is denied unconditionally (matches the agent's
+    /// `subprocess_env::BLOCKED_ENV_VARS` denylist semantics, e.g.
+    /// `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`). Both
+    /// fields can be wired together — the denylist runs first so a
+    /// permissive allowlist cannot accidentally let a known-bad key
+    /// through. Names are matched case-insensitively. `None` means the
+    /// denylist gate is off.
+    pub env_denylist: Option<HashSet<String>>,
+    /// When `true`, the wired backend must self-report as sandboxed. No
+    /// [`McpAgentBackend`] does today, so this field is provided for
+    /// forward compatibility — setting it true on a non-sandboxed
+    /// backend fails closed every time.
+    pub require_sandboxed: bool,
+}
+
+impl std::fmt::Debug for DispatchPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DispatchPolicy")
+            .field("tool_policy", &self.tool_policy)
+            .field("require_approval", &self.require_approval)
+            .field(
+                "approval_requester",
+                &self.approval_requester.as_ref().map(|_| "<requester>"),
+            )
+            .field("env_allowlist", &self.env_allowlist)
+            .field("env_denylist", &self.env_denylist)
+            .field("require_sandboxed", &self.require_sandboxed)
+            .finish()
+    }
+}
+
+impl DispatchPolicy {
+    /// True if every gate is unset — the dispatcher can skip the
+    /// gate entirely.
+    pub fn is_noop(&self) -> bool {
+        self.tool_policy
+            .as_ref()
+            .is_none_or(|policy| policy.is_empty())
+            && !self.require_approval
+            && self.env_allowlist.is_none()
+            && self
+                .env_denylist
+                .as_ref()
+                .is_none_or(|denylist| denylist.is_empty())
+            && !self.require_sandboxed
+    }
+
+    /// M7 req 7 production wiring (#713 / #714): build a
+    /// [`DispatchPolicy`] that inherits the **two operator-configured
+    /// gates** the audit's #701 finding called out — the workspace-wide
+    /// tool-name policy (`config.tool_policy`) and the shared
+    /// `BLOCKED_ENV_VARS` injection-env denylist — so MCP and CLI
+    /// swarm backends fail closed on the same names native execution
+    /// rejects, without requiring operators to wire a separate config
+    /// file.
+    ///
+    /// **Not mirrored by this constructor** (intentional, scope of
+    /// #713 / #701):
+    ///
+    /// - `require_approval` / `approval_requester` — the native
+    ///   approval bridge is `TOOL_APPROVAL_CTX`, a per-turn
+    ///   task-local; there is no global requester to clone at server
+    ///   startup. Operators that want dispatch-level approval can
+    ///   layer it on by mutating the public fields after construction.
+    /// - `require_sandboxed` — no [`McpAgentBackend`] self-reports as
+    ///   sandboxed today; the field is forward-compat.
+    /// - `env_allowlist` — the native side uses denylist semantics
+    ///   (drop blocked names) plus secret-detection, not an allowlist.
+    ///   This constructor populates the parallel `env_denylist` field
+    ///   so the gate semantics match.
+    /// - Per-skill manifest env allowlists — those live on the
+    ///   plugin tool, not the workspace config; they are out of scope
+    ///   for a workspace-level dispatch gate.
+    ///
+    /// `tool_policy: None` keeps the tool-name gate off (matches the
+    /// native side: an absent config means no policy is applied).
+    /// `block_injection_env_vars: true` populates the env denylist
+    /// with the workspace-wide [`crate::sandbox::BLOCKED_ENV_VARS`]
+    /// set so dispatches fail closed if the contract carries
+    /// `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, etc.
+    /// Use `false` only for tests that explicitly need to drive an
+    /// injection-style env through the gate.
+    pub fn from_agent_gates(
+        tool_policy: Option<ToolPolicy>,
+        block_injection_env_vars: bool,
+    ) -> Self {
+        let env_denylist = if block_injection_env_vars {
+            Some(
+                crate::sandbox::BLOCKED_ENV_VARS
+                    .iter()
+                    .map(|name| name.to_ascii_uppercase())
+                    .collect::<HashSet<String>>(),
+            )
+        } else {
+            None
+        };
+        Self {
+            tool_policy,
+            require_approval: false,
+            approval_requester: None,
+            env_allowlist: None,
+            env_denylist,
+            require_sandboxed: false,
+        }
+    }
+}
+
+/// Outcome produced when a gate denies a dispatch. Callers fold this
+/// into their crate-local outcome shape (swarm `SubtaskOutcome`,
+/// spawn `ToolResult`, etc.) so the surface area on this crate's API
+/// is the gate semantics, not the failure type.
+#[derive(Debug, Clone)]
+pub struct GateDenial {
+    /// Stable label for the dispatch metric / harness event. One of:
+    /// `policy_denied`, `approval_denied`, `approval_unavailable`,
+    /// `env_forbidden`, `sandbox_required`.
+    pub last_dispatch_outcome: &'static str,
+    /// Human-readable reason for the failure. Safe to expose to the
+    /// caller — does not embed sensitive payload values.
+    pub reason: String,
+}
+
+/// Minimal shape of the dispatch a caller wants to gate. The native
+/// swarm dispatcher passes its `ContractSpec`; the spawn `agent_mcp`
+/// path passes the constructed dispatch payload. Holding only the
+/// fields the gate actually inspects keeps this crate free of the
+/// swarm-only `ContractSpec` type.
+pub struct DispatchTarget<'a> {
+    /// Stable identifier for log / metric correlation. The swarm side
+    /// uses the contract id; the spawn side uses the child task id.
+    pub dispatch_id: &'a str,
+    /// Tool name evaluated against [`DispatchPolicy::tool_policy`].
+    pub tool_name: &'a str,
+    /// Task payload inspected for forbidden env keys when an
+    /// allowlist / denylist is configured.
+    pub task: &'a serde_json::Value,
+}
+
+/// Run every configured gate against `target`. Returns `Ok(())` if the
+/// dispatch may proceed, otherwise the first failing gate's denial.
+///
+/// Gates run in this fixed order, so the surfaced failure matches the
+/// most-deterministic check first:
+///
+/// 1. Sandbox requirement (cheapest, config-only).
+/// 2. Tool policy (synchronous evaluator, no I/O).
+/// 3. Env denylist (synchronous, inspects the task payload — runs
+///    before the allowlist so a permissive allowlist cannot let a
+///    known-bad key through).
+/// 4. Env allowlist (synchronous, inspects the task payload).
+/// 5. Approval (last; may block on user interaction).
+pub async fn enforce_dispatch_gates(
+    policy: &DispatchPolicy,
+    backend: &dyn McpAgentBackend,
+    target: DispatchTarget<'_>,
+) -> Result<(), GateDenial> {
+    if policy.is_noop() {
+        return Ok(());
+    }
+
+    if policy.require_sandboxed && !backend_is_sandboxed(backend) {
+        return Err(GateDenial {
+            last_dispatch_outcome: "sandbox_required",
+            reason: format!(
+                "dispatch requires a sandboxed backend; backend '{}' (endpoint '{}') is not sandboxed",
+                backend.backend_label(),
+                backend.endpoint_label()
+            ),
+        });
+    }
+
+    if let Some(ref tool_policy) = policy.tool_policy {
+        if let PolicyDecision::Deny { reason } = tool_policy.evaluate(target.tool_name) {
+            warn!(
+                dispatch_id = %target.dispatch_id,
+                tool_name = %target.tool_name,
+                deny_reason = reason,
+                "dispatch denied by tool policy"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "policy_denied",
+                reason: format!(
+                    "tool '{}' denied by dispatch policy ({})",
+                    target.tool_name, reason
+                ),
+            });
+        }
+    }
+
+    if let Some(ref denylist) = policy.env_denylist {
+        if let Some(forbidden) = first_denied_env_key(target.task, denylist) {
+            warn!(
+                dispatch_id = %target.dispatch_id,
+                forbidden_key = %forbidden,
+                "dispatch denied by env denylist"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "env_forbidden",
+                reason: format!(
+                    "env variable '{forbidden}' is denied by the dispatch denylist (injection-class env vars are blocked)"
+                ),
+            });
+        }
+    }
+
+    if let Some(ref allowlist) = policy.env_allowlist {
+        if let Some(forbidden) = first_forbidden_env_key(target.task, allowlist) {
+            warn!(
+                dispatch_id = %target.dispatch_id,
+                forbidden_key = %forbidden,
+                "dispatch denied by env allowlist"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "env_forbidden",
+                reason: format!("env variable '{forbidden}' is not in the dispatch allowlist"),
+            });
+        }
+    }
+
+    if policy.require_approval {
+        let Some(ref requester) = policy.approval_requester else {
+            warn!(
+                dispatch_id = %target.dispatch_id,
+                "dispatch requires approval but no approver is wired"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "approval_unavailable",
+                reason: format!(
+                    "dispatch policy requires approval but no requester is wired (dispatch '{}')",
+                    target.dispatch_id
+                ),
+            });
+        };
+        let request = ToolApprovalRequest {
+            tool_id: target.dispatch_id.to_string(),
+            tool_name: target.tool_name.to_string(),
+            title: format!("Approve dispatch for {}", target.tool_name),
+            body: format!(
+                "Backend '{}' (endpoint '{}') will receive dispatch '{}'.",
+                backend.backend_label(),
+                backend.endpoint_label(),
+                target.dispatch_id
+            ),
+            command: None,
+            cwd: None,
+        };
+        let decision = requester.request_approval(request).await;
+        if matches!(decision, ToolApprovalDecision::Deny) {
+            warn!(
+                dispatch_id = %target.dispatch_id,
+                tool_name = %target.tool_name,
+                "dispatch denied by approval requester"
+            );
+            return Err(GateDenial {
+                last_dispatch_outcome: "approval_denied",
+                reason: format!(
+                    "dispatch for tool '{}' denied by approval requester",
+                    target.tool_name
+                ),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn backend_is_sandboxed(_backend: &dyn McpAgentBackend) -> bool {
+    // No `McpAgentBackend` implementation reports as sandboxed today.
+    // The trait does not expose an `is_sandboxed()` method, so callers
+    // that demand sandboxing must wire a backend that wraps the dispatch
+    // call site in their own isolation surface (Bubblewrap subprocess,
+    // Docker container, etc.). When the trait grows an `is_sandboxed()`
+    // method, this helper becomes the single switch-point.
+    false
+}
+
+fn first_forbidden_env_key(
+    task: &serde_json::Value,
+    allowlist: &HashSet<String>,
+) -> Option<String> {
+    let env = task.get("env")?.as_object()?;
+    for key in env.keys() {
+        let normalized = key.to_ascii_uppercase();
+        if !allowlist.contains(&normalized) {
+            return Some(key.clone());
+        }
+    }
+    None
+}
+
+fn first_denied_env_key(task: &serde_json::Value, denylist: &HashSet<String>) -> Option<String> {
+    let env = task.get("env")?.as_object()?;
+    for key in env.keys() {
+        let normalized = key.to_ascii_uppercase();
+        if denylist.contains(&normalized) {
+            return Some(key.clone());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use serde_json::json;
+
+    use crate::tools::mcp_agent::{DispatchOutcome, DispatchRequest, DispatchResponse};
+
+    struct StubBackend;
+
+    #[async_trait]
+    impl McpAgentBackend for StubBackend {
+        fn backend_label(&self) -> &'static str {
+            "local"
+        }
+        fn endpoint_label(&self) -> String {
+            "stub".into()
+        }
+        async fn dispatch(&self, _request: DispatchRequest) -> DispatchResponse {
+            DispatchResponse {
+                outcome: DispatchOutcome::Success,
+                output: String::new(),
+                files_to_send: Vec::new(),
+                error: None,
+                context_contract: None,
+            }
+        }
+    }
+
+    fn target<'a>(id: &'a str, tool: &'a str, task: &'a serde_json::Value) -> DispatchTarget<'a> {
+        DispatchTarget {
+            dispatch_id: id,
+            tool_name: tool,
+            task,
+        }
+    }
+
+    #[tokio::test]
+    async fn noop_policy_passes_every_dispatch() {
+        let policy = DispatchPolicy::default();
+        let backend = StubBackend;
+        let task = json!({});
+        assert!(
+            enforce_dispatch_gates(&policy, &backend, target("c1", "any_tool", &task))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_policy_deny_blocks_dispatch() {
+        let tool_policy = ToolPolicy {
+            deny: vec!["forbidden".into()],
+            ..Default::default()
+        };
+        let policy = DispatchPolicy {
+            tool_policy: Some(tool_policy),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let task = json!({});
+        let denial = enforce_dispatch_gates(&policy, &backend, target("c1", "forbidden", &task))
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "policy_denied");
+        assert!(denial.reason.contains("forbidden"));
+    }
+
+    #[tokio::test]
+    async fn approval_required_without_requester_fails_closed() {
+        let policy = DispatchPolicy {
+            require_approval: true,
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let task = json!({});
+        let denial = enforce_dispatch_gates(&policy, &backend, target("c1", "any_tool", &task))
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "approval_unavailable");
+    }
+
+    #[tokio::test]
+    async fn env_denylist_blocks_known_injection_keys() {
+        let mut denylist = HashSet::new();
+        denylist.insert("LD_PRELOAD".to_string());
+
+        let policy = DispatchPolicy {
+            env_denylist: Some(denylist),
+            ..Default::default()
+        };
+        let backend = StubBackend;
+        let task = json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}});
+        let denial = enforce_dispatch_gates(&policy, &backend, target("c1", "any", &task))
+            .await
+            .expect_err("denied");
+        assert_eq!(denial.last_dispatch_outcome, "env_forbidden");
+        assert!(denial.reason.contains("LD_PRELOAD"));
+    }
+
+    #[test]
+    fn is_noop_handles_default_and_empty_policy() {
+        assert!(DispatchPolicy::default().is_noop());
+        assert!(
+            DispatchPolicy {
+                tool_policy: Some(ToolPolicy::default()),
+                ..Default::default()
+            }
+            .is_noop()
+        );
+    }
+
+    /// #713/#714: with no operator tool policy and the env denylist on,
+    /// the policy is **not** a no-op — it still gates against
+    /// injection env vars.
+    #[tokio::test]
+    async fn from_agent_gates_with_only_denylist_is_not_noop() {
+        let policy = DispatchPolicy::from_agent_gates(None, true);
+        assert!(
+            !policy.is_noop(),
+            "a denylist-only policy must run the gate"
+        );
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -17,6 +17,7 @@ pub mod bundled_app_skills;
 pub mod compaction;
 pub mod compaction_tiered;
 pub mod cost_ledger;
+pub mod dispatch_policy;
 pub mod event_bus;
 pub mod exec_env;
 pub mod file_state_cache;
@@ -86,6 +87,7 @@ pub use cost_ledger::{
     COST_USD_HISTOGRAM, ContractCostRollup, CostAccountant, CostAttributionEvent, CostBudgetPolicy,
     CostLedger, PersistentCostLedger, project_cost_usd,
 };
+pub use dispatch_policy::{DispatchPolicy, DispatchTarget, GateDenial, enforce_dispatch_gates};
 pub use event_bus::{EventBus, EventSubscriber};
 pub use exec_env::{DockerEnvironment, ExecEnvironment, ExecOutput, LocalEnvironment};
 pub use file_state_cache::{

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -608,6 +608,13 @@ pub use registry::ToolRegistry;
 pub mod policy;
 pub use policy::{PolicyDecision, ToolPolicy};
 
+// Shared dispatch-policy gate (#714 / #713) re-exported from the
+// crate root so [`SpawnTool::with_dispatch_policy`] callers can pull
+// the type alongside the other `tools::*` re-exports.
+pub use crate::dispatch_policy::{
+    DispatchPolicy, DispatchTarget, GateDenial, enforce_dispatch_gates,
+};
+
 // Robot safety-tier groups consulted by ToolPolicy evaluation.
 pub mod robot_groups;
 pub use robot_groups::{RobotToolRegistry, install_registry as install_robot_registry};

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -15,8 +15,9 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use super::mcp_agent::{
-    DispatchContextContract, DispatchRequest, DispatchResponse, McpAgentBackendConfig,
-    SharedBackend, build_backend_from_config, build_dispatch_event_payload, dispatch_with_metrics,
+    DispatchContextContract, DispatchOutcome, DispatchRequest, DispatchResponse,
+    McpAgentBackendConfig, SharedBackend, build_backend_from_config, build_dispatch_event_payload,
+    dispatch_with_metrics,
 };
 use super::{Tool, ToolPolicy, ToolRegistry, ToolResult};
 use crate::file_state_cache::FileStateCache;
@@ -782,6 +783,63 @@ impl SpawnTool {
             .mcp_agent_tool_name
             .clone()
             .unwrap_or_else(|| DEFAULT_MCP_AGENT_TOOL_NAME.to_string());
+
+        // #714: the public `dispatch_to_mcp_agent` helper is a thin
+        // wrapper around `dispatch_with_metrics`. Apply the same policy
+        // gate the main `execute` agent_mcp branch uses so a configured
+        // policy cannot be bypassed by routing through this helper. The
+        // gate inspects the dispatch payload (tool_name + task) before
+        // any backend round-trip, so denials never touch the network
+        // and never increment the dispatch metric. On denial we
+        // synthesise a `RemoteError` response carrying the gate reason
+        // so the existing harness-event + dispatch-event pipeline
+        // surfaces the failure with the same shape as a backend error.
+        if let Some(policy) = self.dispatch_policy.as_ref() {
+            if let Err(denial) = crate::dispatch_policy::enforce_dispatch_gates(
+                policy,
+                backend.as_ref(),
+                crate::dispatch_policy::DispatchTarget {
+                    dispatch_id: task_id,
+                    tool_name: &tool_name,
+                    task: &task,
+                },
+            )
+            .await
+            {
+                warn!(
+                    task_id = %task_id,
+                    outcome = %denial.last_dispatch_outcome,
+                    reason = %denial.reason,
+                    "rejecting direct MCP dispatch by DispatchPolicy gate"
+                );
+                let denied_response = DispatchResponse {
+                    outcome: DispatchOutcome::RemoteError,
+                    output: String::new(),
+                    files_to_send: Vec::new(),
+                    error: Some(format!(
+                        "dispatch rejected by policy ({}): {}",
+                        denial.last_dispatch_outcome, denial.reason
+                    )),
+                    context_contract: None,
+                };
+                let payload = build_dispatch_event_payload(
+                    session_id,
+                    task_id,
+                    workflow,
+                    phase,
+                    backend.as_ref(),
+                    &denied_response,
+                );
+                let event = HarnessEvent {
+                    schema: crate::harness_events::HARNESS_EVENT_SCHEMA_V1.to_string(),
+                    payload,
+                };
+                event.validate().map_err(|error| {
+                    eyre::eyre!("policy-denied dispatch event failed validation: {error}")
+                })?;
+                return Ok((denied_response, event));
+            }
+        }
 
         let request = DispatchRequest::new(tool_name, task).with_context_contract(
             // #1021 / M17-C — populate backend_kind/agent_id/risk so the

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -476,6 +476,13 @@ pub struct SpawnTool {
     /// starts, so child prompts are compacted and normalized by the same
     /// durable context path as top-level turns.
     child_prompt_context_manager_factory: Option<ChildPromptContextManagerFactory>,
+    /// #714: pre-dispatch policy gate for the `agent_mcp` spawn branch.
+    /// Without one, `dispatch_with_metrics` is reached unconditionally —
+    /// the same bypass the swarm side closed via
+    /// `octos_swarm::SwarmBuilder::with_dispatch_policy` in #710 / #713.
+    /// `None` keeps the pre-fix behaviour for callers that opted out
+    /// (e.g. legacy tests not exercising the gate).
+    dispatch_policy: Option<crate::dispatch_policy::DispatchPolicy>,
 }
 
 impl SpawnTool {
@@ -514,6 +521,7 @@ impl SpawnTool {
             parent_subagent_output_router: None,
             parent_subagent_summary_generator: None,
             child_prompt_context_manager_factory: None,
+            dispatch_policy: None,
         }
     }
 
@@ -555,6 +563,7 @@ impl SpawnTool {
             parent_subagent_output_router: None,
             parent_subagent_summary_generator: None,
             child_prompt_context_manager_factory: None,
+            dispatch_policy: None,
         }
     }
 
@@ -671,6 +680,19 @@ impl SpawnTool {
     ) -> Result<Self> {
         let backend = build_backend_from_config(config, Some(self.working_dir.as_path()))?;
         Ok(self.with_mcp_agent_backend(backend, tool_name))
+    }
+
+    /// #714: wire a pre-dispatch policy gate for the `agent_mcp` spawn
+    /// branch. Mirrors
+    /// [`octos_swarm::SwarmBuilder::with_dispatch_policy`] so both
+    /// dispatch surfaces fail closed on the same shape of gates
+    /// ([`ToolPolicy`], env denylist / allowlist, approval,
+    /// `require_sandboxed`). Without one, the agent_mcp branch reaches
+    /// [`crate::tools::mcp_agent::dispatch_with_metrics`] directly —
+    /// the bypass #714 closes.
+    pub fn with_dispatch_policy(mut self, policy: crate::dispatch_policy::DispatchPolicy) -> Self {
+        self.dispatch_policy = Some(policy);
+        self
     }
 
     /// Attach a cost / provenance accountant (M7.4). Every successful
@@ -1916,6 +1938,48 @@ impl Tool for SpawnTool {
                 "workflow": workflow.clone(),
                 "additional_instructions": input.additional_instructions,
             });
+
+            // #714: pre-dispatch policy gate. Runs **before** any
+            // budget reservation or backend dispatch so a denial
+            // short-circuits the whole pipeline (no reservation taken,
+            // no backend touched) — the same ordering the swarm
+            // dispatcher uses in `octos_swarm::dispatch_with_budget`.
+            // Without a configured policy this is a noop and the
+            // existing path is unchanged. With one, the gate enforces
+            // `tool_policy`, env denylist / allowlist, `require_approval`,
+            // and `require_sandboxed` so the agent_mcp branch can no
+            // longer bypass the constraints the operator wired into
+            // `octos serve`.
+            if let Some(policy) = self.dispatch_policy.as_ref() {
+                if let Err(denial) = crate::dispatch_policy::enforce_dispatch_gates(
+                    policy,
+                    backend.as_ref(),
+                    crate::dispatch_policy::DispatchTarget {
+                        dispatch_id: &task_id_for_event,
+                        tool_name: &tool_name,
+                        task: &dispatch_payload,
+                    },
+                )
+                .await
+                {
+                    warn!(
+                        task_id = %task_id_for_event,
+                        outcome = %denial.last_dispatch_outcome,
+                        reason = %denial.reason,
+                        "rejecting MCP sub-agent dispatch by DispatchPolicy gate"
+                    );
+                    let message = format!(
+                        "Status: FAILED\nDispatch rejected by policy ({outcome}): {reason}",
+                        outcome = denial.last_dispatch_outcome,
+                        reason = denial.reason,
+                    );
+                    return Ok(ToolResult {
+                        output: message,
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            }
 
             // Pre-dispatch budget reservation (F-003). Absent a
             // configured accountant the reservation short-circuits to
@@ -3399,6 +3463,7 @@ mod tests {
             parent_subagent_output_router: None,
             parent_subagent_summary_generator: None,
             child_prompt_context_manager_factory: None,
+            dispatch_policy: None,
         };
 
         assert_eq!(tool.worker_count.load(Ordering::SeqCst), 0);

--- a/crates/octos-agent/tests/agent_mcp_dispatch_policy.rs
+++ b/crates/octos-agent/tests/agent_mcp_dispatch_policy.rs
@@ -1,0 +1,203 @@
+//! Regression test for #714 — the `agent_mcp` spawn variant must
+//! honour [`DispatchPolicy`] gates the same way the native swarm
+//! dispatcher does.
+//!
+//! Pre-fix, [`SpawnTool::execute`] dispatched via
+//! [`octos_agent::tools::mcp_agent::dispatch_with_metrics`] without
+//! consulting any policy, so rate-limit / fan-out / denylist
+//! constraints were trivially bypassed by a malicious or buggy MCP
+//! server. Companion gap to the supervisor fan-out cap shipped via
+//! #607 / #610 — the agent_mcp path slipped through.
+//!
+//! The test models the "fan-out cap" the bug report calls out by
+//! wiring a stateful approval requester that approves the first N
+//! dispatches and denies the rest. Without the fix, the spawn site
+//! never consults the requester so every dispatch succeeds; with the
+//! fix, the (N+1)-th dispatch is rejected by the policy gate before
+//! the backend is touched.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use async_trait::async_trait;
+use octos_agent::tools::mcp_agent::{
+    DispatchOutcome, DispatchRequest, DispatchResponse, McpAgentBackend,
+};
+use octos_agent::tools::{DispatchPolicy, SharedBackend, SpawnTool, Tool};
+use octos_agent::{ToolApprovalDecision, ToolApprovalRequest, ToolApprovalRequester};
+use octos_core::InboundMessage;
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+/// MCP backend that always reports success. Counts the dispatches it
+/// served so the test can assert the policy gate fired before this
+/// backend was touched.
+struct CountingBackend {
+    served: AtomicU32,
+}
+
+#[async_trait]
+impl McpAgentBackend for CountingBackend {
+    fn backend_label(&self) -> &'static str {
+        "local"
+    }
+
+    fn endpoint_label(&self) -> String {
+        "counting".to_string()
+    }
+
+    async fn dispatch(&self, _request: DispatchRequest) -> DispatchResponse {
+        self.served.fetch_add(1, Ordering::SeqCst);
+        DispatchResponse {
+            outcome: DispatchOutcome::Success,
+            output: "ok".to_string(),
+            files_to_send: Vec::new(),
+            error: None,
+            context_contract: None,
+        }
+    }
+}
+
+/// Stateful approval requester that approves the first `cap` requests
+/// and denies the rest. Models the "fan-out cap" semantics the bug
+/// report describes — the underlying constraint enforced via
+/// [`DispatchPolicy::require_approval`] + a stateful requester.
+struct CappedApprover {
+    cap: u32,
+    seen: AtomicU32,
+}
+
+#[async_trait]
+impl ToolApprovalRequester for CappedApprover {
+    async fn request_approval(&self, _: ToolApprovalRequest) -> ToolApprovalDecision {
+        let n = self.seen.fetch_add(1, Ordering::SeqCst);
+        if n < self.cap {
+            ToolApprovalDecision::Approve
+        } else {
+            ToolApprovalDecision::Deny
+        }
+    }
+}
+
+struct NullLlm;
+
+#[async_trait]
+impl LlmProvider for NullLlm {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        Ok(ChatResponse {
+            content: Some("ok".to_string()),
+            reasoning_content: None,
+            tool_calls: Vec::new(),
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "null"
+    }
+
+    fn provider_name(&self) -> &str {
+        "null"
+    }
+}
+
+async fn memory(dir: &TempDir) -> Arc<EpisodeStore> {
+    Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap())
+}
+
+#[tokio::test]
+async fn agent_mcp_spawn_respects_dispatch_policy_fanout_cap_per_714() {
+    let dir = TempDir::new().unwrap();
+    let memory = memory(&dir).await;
+    let (tx, _rx) = tokio::sync::mpsc::channel::<InboundMessage>(8);
+
+    let backend_inner = Arc::new(CountingBackend {
+        served: AtomicU32::new(0),
+    });
+    let backend: SharedBackend = backend_inner.clone();
+
+    let approver = Arc::new(CappedApprover {
+        cap: 2,
+        seen: AtomicU32::new(0),
+    });
+    let policy = DispatchPolicy {
+        require_approval: true,
+        approval_requester: Some(approver.clone() as Arc<dyn ToolApprovalRequester>),
+        ..Default::default()
+    };
+
+    let llm: Arc<dyn LlmProvider> = Arc::new(NullLlm);
+    let spawn = SpawnTool::new(llm, memory, PathBuf::from(dir.path()), tx)
+        .with_mcp_agent_backend(backend, Some("run_task".to_string()))
+        .with_dispatch_policy(policy);
+
+    // Dispatch three sub-agents through the agent_mcp path. The first
+    // two MUST be approved by the policy; the third MUST be rejected
+    // before the backend is touched.
+    let r1 = spawn
+        .execute(&serde_json::json!({
+            "task": "first",
+            "mode": "sync",
+            "backend": "agent_mcp",
+            "label": "fanout-1",
+        }))
+        .await
+        .unwrap();
+    let r2 = spawn
+        .execute(&serde_json::json!({
+            "task": "second",
+            "mode": "sync",
+            "backend": "agent_mcp",
+            "label": "fanout-2",
+        }))
+        .await
+        .unwrap();
+    let r3 = spawn
+        .execute(&serde_json::json!({
+            "task": "third",
+            "mode": "sync",
+            "backend": "agent_mcp",
+            "label": "fanout-3",
+        }))
+        .await
+        .unwrap();
+
+    assert!(r1.success, "first dispatch under cap must succeed");
+    assert!(r2.success, "second dispatch at cap must succeed");
+    assert!(
+        !r3.success,
+        "third dispatch over fan-out cap must be rejected by DispatchPolicy; got success=true, output=`{}`",
+        r3.output
+    );
+    assert!(
+        r3.output.contains("approval") || r3.output.contains("denied"),
+        "rejection output must mention the policy denial; got `{}`",
+        r3.output
+    );
+
+    // The backend MUST only have served the two approved dispatches;
+    // if the policy gate is skipped, this count would be 3.
+    let served = backend_inner.served.load(Ordering::SeqCst);
+    assert_eq!(
+        served, 2,
+        "backend served {served} dispatches; expected 2 (third must be blocked by DispatchPolicy before backend is touched)"
+    );
+
+    // The approver MUST have been consulted at least three times — the
+    // gate must fail closed, not silently bypass when no requester is
+    // available.
+    let consults = approver.seen.load(Ordering::SeqCst);
+    assert_eq!(
+        consults, 3,
+        "approver consulted {consults} times; expected 3 (one per spawn)"
+    );
+}

--- a/crates/octos-agent/tests/agent_mcp_dispatch_policy.rs
+++ b/crates/octos-agent/tests/agent_mcp_dispatch_policy.rs
@@ -201,3 +201,63 @@ async fn agent_mcp_spawn_respects_dispatch_policy_fanout_cap_per_714() {
         "approver consulted {consults} times; expected 3 (one per spawn)"
     );
 }
+
+/// #714 follow-up (codex review): the public `dispatch_to_mcp_agent`
+/// helper is a thin wrapper around `dispatch_with_metrics`. A
+/// configured [`DispatchPolicy`] must gate this entry point too —
+/// callers that route through the helper cannot be allowed to bypass
+/// the gate the main spawn execute path enforces.
+#[tokio::test]
+async fn dispatch_to_mcp_agent_helper_respects_dispatch_policy_per_714() {
+    let dir = TempDir::new().unwrap();
+    let memory = memory(&dir).await;
+    let (tx, _rx) = tokio::sync::mpsc::channel::<InboundMessage>(8);
+
+    let backend_inner = Arc::new(CountingBackend {
+        served: AtomicU32::new(0),
+    });
+    let backend: SharedBackend = backend_inner.clone();
+
+    // Tool policy that denies the default MCP dispatch tool name. The
+    // gate must reject the helper invocation before the backend is
+    // touched.
+    let policy = DispatchPolicy {
+        tool_policy: Some(octos_agent::ToolPolicy {
+            deny: vec!["run_task".into()],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let llm: Arc<dyn LlmProvider> = Arc::new(NullLlm);
+    let spawn = SpawnTool::new(llm, memory, PathBuf::from(dir.path()), tx)
+        .with_mcp_agent_backend(backend, Some("run_task".to_string()))
+        .with_dispatch_policy(policy);
+
+    let (response, _event) = spawn
+        .dispatch_to_mcp_agent(
+            serde_json::json!({"task": "helper bypass attempt"}),
+            "session-helper",
+            "task-helper",
+            None,
+            None,
+        )
+        .await
+        .expect("helper returns a synthesized response on denial, not an error");
+
+    assert_eq!(
+        response.outcome,
+        DispatchOutcome::RemoteError,
+        "policy-denied helper dispatch must surface RemoteError, not Success"
+    );
+    let error = response.error.expect("denied response carries error");
+    assert!(
+        error.contains("policy") || error.contains("denied"),
+        "error must mention the policy gate; got `{error}`"
+    );
+    assert_eq!(
+        backend_inner.served.load(Ordering::SeqCst),
+        0,
+        "backend must NOT be touched when the policy gate denies the helper dispatch"
+    );
+}

--- a/crates/octos-swarm/src/dispatcher.rs
+++ b/crates/octos-swarm/src/dispatcher.rs
@@ -44,13 +44,14 @@ use tracing::{debug, warn};
 
 use octos_agent::cost_ledger::{CostAccountant, CostAttributionEvent, project_cost_usd};
 
-use crate::gate::{DispatchPolicy, enforce_or_outcome};
+use crate::gate::enforce_or_outcome;
 use crate::ledger::{CostLedger, NoopCostLedger, SwarmCostAttribution};
 use crate::persistence::{DispatchRecord, DispatchStore};
 use crate::result::{
     AggregateArtifact, SubtaskOutcome, SubtaskStatus, SwarmOutcomeKind, SwarmResult,
 };
 use crate::topology::{ContractSpec, MAX_CONTRACTS_PER_DISPATCH, SwarmTopology};
+use octos_agent::DispatchPolicy;
 
 /// Maximum number of retry rounds the primitive performs before
 /// surfacing a partial result. Bounded per invariant 5 so a flaky

--- a/crates/octos-swarm/src/gate.rs
+++ b/crates/octos-swarm/src/gate.rs
@@ -1,365 +1,22 @@
-//! Pre-dispatch policy gate for [`Swarm::dispatch`](crate::Swarm::dispatch).
+//! Swarm-local glue around the shared dispatch-policy gate.
 //!
-//! Addresses M7 requirement 7 (policy enforcement parity): every backend
-//! the swarm dispatches to — local stdio MCP, remote HTTP MCP, native
-//! sub-agent via [`octos_agent::tools::SpawnTool`] — is funnelled through
-//! [`crate::dispatcher::Swarm::dispatch_once`], so a single gate point
-//! covers all transports.
+//! The gate type and enforcement logic live in
+//! [`octos_agent::dispatch_policy`] — both
+//! [`crate::dispatcher::Swarm::dispatch_once`] and the
+//! [`octos_agent::tools::SpawnTool`] `agent_mcp` branch route through
+//! the same checks so a single bypass cannot reopen the audit's #701
+//! / #714 finding.
 //!
-//! [`DispatchPolicy`] **exposes** the same shape of gates the native
-//! [`octos_agent::tools::ToolRegistry::execute_with_context`] path
-//! applies: tool policy, approval, sandbox-required, and env (allowlist
-//! or denylist). Whether a given gate is *active* is up to the caller —
-//! see [`DispatchPolicy::from_agent_gates`] for the production
-//! constructor `octos serve` uses (it wires `tool_policy` +
-//! injection-env denylist; approval bridge / sandbox-required /
-//! per-skill manifest env are intentionally not mirrored, see that
-//! constructor's rustdoc for the full boundary).
-//!
-//! The gate is **opt-in**: callers wire it via
-//! [`crate::SwarmBuilder::with_dispatch_policy`]. Without a configured
-//! policy the dispatcher's behaviour is unchanged so existing M7.1 callers
-//! and tests do not regress.
-//!
-//! ## Failure surfacing
-//!
-//! Each gate failure synthesises a [`crate::SubtaskOutcome`] with status
-//! `TerminalFailed` and a stable `last_dispatch_outcome` label. The label
-//! flows through the existing `octos_swarm_dispatch_total{topology,outcome}`
-//! counter and the typed
-//! [`octos_agent::HarnessEventPayload::SwarmDispatch`] event the harness
-//! observability channel consumes (M7 requirement 8 stays satisfied).
-//!
-//! Stable labels:
-//!
-//! - `policy_denied` — [`octos_agent::ToolPolicy`] denied the contract's
-//!   tool name. The `error` carries the policy reason
-//!   (`policy_deny` or `robot_tier_gate`).
-//! - `approval_denied` — the configured
-//!   [`octos_agent::ToolApprovalRequester`] returned
-//!   [`octos_agent::ToolApprovalDecision::Deny`].
-//! - `approval_unavailable` — approval is required but no requester was
-//!   wired. **Fail closed** — never fall through to dispatch.
-//! - `env_forbidden` — the contract's task carries an env key that fails
-//!   either the dispatch policy's env allowlist (key not in allowlist)
-//!   or env denylist (key in denylist). Used by callers that pass env
-//!   through the task payload to the backend.
-//! - `sandbox_required` — the dispatch policy demands a sandboxed
-//!   backend but the wired backend does not self-report sandboxing.
-
-use std::collections::HashSet;
-use std::sync::Arc;
+//! This module keeps a swarm-side adapter ([`enforce_or_outcome`])
+//! that folds a [`octos_agent::GateDenial`] into a swarm-local
+//! [`crate::SubtaskOutcome`] so the existing event / metrics path
+//! does not have to learn the agent crate's failure type.
 
 use octos_agent::tools::mcp_agent::McpAgentBackend;
-use octos_agent::{
-    PolicyDecision, ToolApprovalDecision, ToolApprovalRequest, ToolApprovalRequester, ToolPolicy,
-};
-use tracing::warn;
+use octos_agent::{DispatchPolicy, DispatchTarget, enforce_dispatch_gates};
 
 use crate::result::{SubtaskOutcome, SubtaskStatus};
 use crate::topology::ContractSpec;
-
-/// Configuration for the swarm dispatch policy gate.
-///
-/// Every field is independently optional so callers can opt into just the
-/// gates they need. An entirely default value is a no-op (matches the
-/// pre-fix dispatcher behaviour).
-#[derive(Clone, Default)]
-pub struct DispatchPolicy {
-    /// Tool policy evaluated against [`ContractSpec::tool_name`]. Deny
-    /// wins; an empty allow list permits every tool name not explicitly
-    /// denied (mirrors [`ToolPolicy`] semantics).
-    pub tool_policy: Option<ToolPolicy>,
-    /// When `true`, every dispatch must clear the approval gate before
-    /// the backend is called. The dispatch fails closed if no
-    /// [`ToolApprovalRequester`] is wired.
-    pub require_approval: bool,
-    /// Approval bridge used when [`Self::require_approval`] is true.
-    pub approval_requester: Option<Arc<dyn ToolApprovalRequester>>,
-    /// Env keys the dispatch is allowed to forward to the backend.
-    /// Inspected against the contract's task payload — if the task
-    /// carries an `env` object whose keys overlap any name **not** in
-    /// this allowlist, the dispatch is denied with `env_forbidden`.
-    /// `None` means allowlist checking is off (existing
-    /// [`octos_agent::tools::mcp_agent::StdioMcpAgent`] env handling
-    /// remains the only barrier). Names are matched case-insensitively
-    /// against the upper-cased form (mirrors
-    /// `subprocess_env::EnvAllowlist`).
-    pub env_allowlist: Option<HashSet<String>>,
-    /// Env keys the dispatch must reject if the task payload tries to
-    /// forward them. Complements [`Self::env_allowlist`]: an entry here
-    /// is denied unconditionally (matches the agent's
-    /// `subprocess_env::BLOCKED_ENV_VARS` denylist semantics, e.g.
-    /// `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`). Both
-    /// fields can be wired together — the denylist runs first so a
-    /// permissive allowlist cannot accidentally let a known-bad key
-    /// through. Names are matched case-insensitively. `None` means the
-    /// denylist gate is off.
-    pub env_denylist: Option<HashSet<String>>,
-    /// When `true`, the wired backend must self-report as sandboxed. No
-    /// [`McpAgentBackend`] does today, so this field is provided for
-    /// forward compatibility — setting it true on a non-sandboxed
-    /// backend fails closed every time.
-    pub require_sandboxed: bool,
-}
-
-impl std::fmt::Debug for DispatchPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DispatchPolicy")
-            .field("tool_policy", &self.tool_policy)
-            .field("require_approval", &self.require_approval)
-            .field(
-                "approval_requester",
-                &self.approval_requester.as_ref().map(|_| "<requester>"),
-            )
-            .field("env_allowlist", &self.env_allowlist)
-            .field("env_denylist", &self.env_denylist)
-            .field("require_sandboxed", &self.require_sandboxed)
-            .finish()
-    }
-}
-
-impl DispatchPolicy {
-    /// True if every gate is unset — the dispatcher can skip the
-    /// gate entirely.
-    pub fn is_noop(&self) -> bool {
-        self.tool_policy
-            .as_ref()
-            .is_none_or(|policy| policy.is_empty())
-            && !self.require_approval
-            && self.env_allowlist.is_none()
-            && self
-                .env_denylist
-                .as_ref()
-                .is_none_or(|denylist| denylist.is_empty())
-            && !self.require_sandboxed
-    }
-
-    /// M7 req 7 production wiring (#713): build a [`DispatchPolicy`]
-    /// that inherits the **two operator-configured gates** the audit's
-    /// #701 finding called out — the workspace-wide tool-name policy
-    /// (`config.tool_policy`) and the shared `BLOCKED_ENV_VARS`
-    /// injection-env denylist — so MCP and CLI swarm backends fail
-    /// closed on the same names native execution rejects, without
-    /// requiring operators to wire a separate config file.
-    ///
-    /// `octos serve` builds this from `config.tool_policy` + the
-    /// shared denylist and passes it to
-    /// [`crate::SwarmBuilder::with_dispatch_policy`]. The resulting
-    /// policy is **deny-on-parity**, not deny-all — it fires only
-    /// when the operator-configured tool policy fires, or the contract
-    /// payload tries to forward a known-bad env key.
-    ///
-    /// **Not mirrored by this constructor** (intentional, scope of
-    /// #713 / #701):
-    ///
-    /// - `require_approval` / `approval_requester` — the native
-    ///   approval bridge is `TOOL_APPROVAL_CTX`, a per-turn
-    ///   task-local; there is no global requester to clone at server
-    ///   startup. Operators that want swarm-level approval can layer
-    ///   it on with [`crate::SwarmBuilder::with_dispatch_policy`].
-    /// - `require_sandboxed` — no [`octos_agent::tools::mcp_agent::McpAgentBackend`]
-    ///   self-reports as sandboxed today; the field is forward-compat.
-    /// - `env_allowlist` — the native side uses denylist semantics
-    ///   (drop blocked names) plus secret-detection, not an allowlist.
-    ///   This constructor populates the parallel `env_denylist` field
-    ///   so the gate semantics match.
-    /// - Per-skill manifest env allowlists — those live on the
-    ///   plugin tool, not the workspace config; they are out of scope
-    ///   for a workspace-level dispatch gate.
-    ///
-    /// Operators that want any of the above can layer them on top via
-    /// [`crate::SwarmBuilder::with_dispatch_policy`] — the public
-    /// fields on [`DispatchPolicy`] remain mutable for that reason.
-    ///
-    /// `tool_policy: None` keeps the tool-name gate off (matches the
-    /// native side: an absent config means no policy is applied).
-    /// `block_injection_env_vars: true` populates the env denylist
-    /// with the workspace-wide
-    /// [`octos_agent::sandbox::BLOCKED_ENV_VARS`] set so swarm
-    /// dispatches fail closed if the contract carries `LD_PRELOAD`,
-    /// `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, etc. — even if the
-    /// underlying backend's own env handling forgets to strip them.
-    /// Use `false` only for tests that explicitly need to drive an
-    /// injection-style env through the gate.
-    pub fn from_agent_gates(
-        tool_policy: Option<octos_agent::ToolPolicy>,
-        block_injection_env_vars: bool,
-    ) -> Self {
-        let env_denylist = if block_injection_env_vars {
-            Some(
-                octos_agent::sandbox::BLOCKED_ENV_VARS
-                    .iter()
-                    .map(|name| name.to_ascii_uppercase())
-                    .collect::<HashSet<String>>(),
-            )
-        } else {
-            None
-        };
-        Self {
-            tool_policy,
-            require_approval: false,
-            approval_requester: None,
-            env_allowlist: None,
-            env_denylist,
-            require_sandboxed: false,
-        }
-    }
-}
-
-/// Outcome produced when a gate denies a dispatch. Folded directly into
-/// a [`SubtaskOutcome`] so the swarm result and harness event surface
-/// the failure with the same shape as backend failures.
-#[derive(Debug, Clone)]
-pub(crate) struct GateDenial {
-    pub last_dispatch_outcome: &'static str,
-    pub reason: String,
-}
-
-impl GateDenial {
-    fn into_outcome(self, contract: &ContractSpec, prior_attempts: u32) -> SubtaskOutcome {
-        SubtaskOutcome {
-            contract_id: contract.contract_id.clone(),
-            label: contract.label.clone(),
-            status: SubtaskStatus::TerminalFailed,
-            attempts: prior_attempts.saturating_add(1),
-            last_dispatch_outcome: self.last_dispatch_outcome.to_string(),
-            output: self.reason.clone(),
-            files_to_send: Vec::new(),
-            error: Some(self.reason),
-        }
-    }
-}
-
-/// Run every configured gate against `contract`. Returns `Ok(())` if the
-/// dispatch may proceed, otherwise the first failing gate's denial.
-///
-/// Gates run in this fixed order, so the surfaced failure matches the
-/// most-deterministic check first:
-///
-/// 1. Sandbox requirement (cheapest, config-only).
-/// 2. Tool policy (synchronous evaluator, no I/O).
-/// 3. Env denylist (synchronous, inspects the task payload — runs
-///    before the allowlist so a permissive allowlist cannot let a
-///    known-bad key through).
-/// 4. Env allowlist (synchronous, inspects the task payload).
-/// 5. Approval (last; may block on user interaction).
-pub(crate) async fn enforce_dispatch_gates(
-    policy: &DispatchPolicy,
-    backend: &dyn McpAgentBackend,
-    contract: &ContractSpec,
-) -> std::result::Result<(), GateDenial> {
-    if policy.is_noop() {
-        return Ok(());
-    }
-
-    if policy.require_sandboxed && !backend_is_sandboxed(backend) {
-        return Err(GateDenial {
-            last_dispatch_outcome: "sandbox_required",
-            reason: format!(
-                "swarm dispatch requires a sandboxed backend; backend '{}' (endpoint '{}') is not sandboxed",
-                backend.backend_label(),
-                backend.endpoint_label()
-            ),
-        });
-    }
-
-    if let Some(ref tool_policy) = policy.tool_policy {
-        if let PolicyDecision::Deny { reason } = tool_policy.evaluate(&contract.tool_name) {
-            warn!(
-                contract_id = %contract.contract_id,
-                tool_name = %contract.tool_name,
-                deny_reason = reason,
-                "swarm dispatch denied by tool policy"
-            );
-            return Err(GateDenial {
-                last_dispatch_outcome: "policy_denied",
-                reason: format!(
-                    "tool '{}' denied by swarm dispatch policy ({})",
-                    contract.tool_name, reason
-                ),
-            });
-        }
-    }
-
-    if let Some(ref denylist) = policy.env_denylist {
-        if let Some(forbidden) = first_denied_env_key(&contract.task, denylist) {
-            warn!(
-                contract_id = %contract.contract_id,
-                forbidden_key = %forbidden,
-                "swarm dispatch denied by env denylist"
-            );
-            return Err(GateDenial {
-                last_dispatch_outcome: "env_forbidden",
-                reason: format!(
-                    "env variable '{forbidden}' is denied by the swarm dispatch denylist (injection-class env vars are blocked)"
-                ),
-            });
-        }
-    }
-
-    if let Some(ref allowlist) = policy.env_allowlist {
-        if let Some(forbidden) = first_forbidden_env_key(&contract.task, allowlist) {
-            warn!(
-                contract_id = %contract.contract_id,
-                forbidden_key = %forbidden,
-                "swarm dispatch denied by env allowlist"
-            );
-            return Err(GateDenial {
-                last_dispatch_outcome: "env_forbidden",
-                reason: format!(
-                    "env variable '{forbidden}' is not in the swarm dispatch allowlist"
-                ),
-            });
-        }
-    }
-
-    if policy.require_approval {
-        let Some(ref requester) = policy.approval_requester else {
-            warn!(
-                contract_id = %contract.contract_id,
-                "swarm dispatch requires approval but no approver is wired"
-            );
-            return Err(GateDenial {
-                last_dispatch_outcome: "approval_unavailable",
-                reason: format!(
-                    "swarm dispatch policy requires approval but no requester is wired (contract '{}')",
-                    contract.contract_id
-                ),
-            });
-        };
-        let request = ToolApprovalRequest {
-            tool_id: contract.contract_id.clone(),
-            tool_name: contract.tool_name.clone(),
-            title: format!("Approve swarm dispatch for {}", contract.tool_name),
-            body: format!(
-                "Backend '{}' (endpoint '{}') will receive contract '{}'.",
-                backend.backend_label(),
-                backend.endpoint_label(),
-                contract.contract_id
-            ),
-            command: None,
-            cwd: None,
-        };
-        let decision = requester.request_approval(request).await;
-        if matches!(decision, ToolApprovalDecision::Deny) {
-            warn!(
-                contract_id = %contract.contract_id,
-                tool_name = %contract.tool_name,
-                "swarm dispatch denied by approval requester"
-            );
-            return Err(GateDenial {
-                last_dispatch_outcome: "approval_denied",
-                reason: format!(
-                    "swarm dispatch for tool '{}' denied by approval requester",
-                    contract.tool_name
-                ),
-            });
-        }
-    }
-
-    Ok(())
-}
 
 /// Helper for the dispatcher: enforce gates and synthesise a
 /// [`SubtaskOutcome`] on denial. Returns `Ok(())` if dispatch may
@@ -371,51 +28,31 @@ pub(crate) async fn enforce_or_outcome(
     contract: &ContractSpec,
     prior_attempts: u32,
 ) -> std::result::Result<(), SubtaskOutcome> {
-    match enforce_dispatch_gates(policy, backend, contract).await {
+    let target = DispatchTarget {
+        dispatch_id: &contract.contract_id,
+        tool_name: &contract.tool_name,
+        task: &contract.task,
+    };
+    match enforce_dispatch_gates(policy, backend, target).await {
         Ok(()) => Ok(()),
-        Err(denial) => Err(denial.into_outcome(contract, prior_attempts)),
+        Err(denial) => Err(SubtaskOutcome {
+            contract_id: contract.contract_id.clone(),
+            label: contract.label.clone(),
+            status: SubtaskStatus::TerminalFailed,
+            attempts: prior_attempts.saturating_add(1),
+            last_dispatch_outcome: denial.last_dispatch_outcome.to_string(),
+            output: denial.reason.clone(),
+            files_to_send: Vec::new(),
+            error: Some(denial.reason),
+        }),
     }
-}
-
-fn backend_is_sandboxed(_backend: &dyn McpAgentBackend) -> bool {
-    // No `McpAgentBackend` implementation reports as sandboxed today.
-    // The trait does not expose an `is_sandboxed()` method, so callers
-    // that demand sandboxing must wire a backend that wraps the dispatch
-    // call site in their own isolation surface (Bubblewrap subprocess,
-    // Docker container, etc.). When the trait grows an `is_sandboxed()`
-    // method, this helper becomes the single switch-point.
-    false
-}
-
-fn first_forbidden_env_key(
-    task: &serde_json::Value,
-    allowlist: &HashSet<String>,
-) -> Option<String> {
-    let env = task.get("env")?.as_object()?;
-    for key in env.keys() {
-        let normalized = key.to_ascii_uppercase();
-        if !allowlist.contains(&normalized) {
-            return Some(key.clone());
-        }
-    }
-    None
-}
-
-fn first_denied_env_key(task: &serde_json::Value, denylist: &HashSet<String>) -> Option<String> {
-    let env = task.get("env")?.as_object()?;
-    for key in env.keys() {
-        let normalized = key.to_ascii_uppercase();
-        if denylist.contains(&normalized) {
-            return Some(key.clone());
-        }
-    }
-    None
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use octos_agent::ToolPolicy;
     use octos_agent::tools::mcp_agent::{DispatchOutcome, DispatchRequest, DispatchResponse};
 
     struct StubBackend;
@@ -449,305 +86,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn noop_policy_passes_every_dispatch() {
+    async fn enforce_or_outcome_passes_when_policy_is_noop() {
         let policy = DispatchPolicy::default();
         let backend = StubBackend;
         let contract = contract("c1", "any_tool");
         assert!(
-            enforce_dispatch_gates(&policy, &backend, &contract)
+            enforce_or_outcome(&policy, &backend, &contract, 0)
                 .await
                 .is_ok()
         );
     }
 
     #[tokio::test]
-    async fn tool_policy_deny_blocks_dispatch() {
-        let tool_policy = ToolPolicy {
-            deny: vec!["forbidden".into()],
-            ..Default::default()
-        };
-        let policy = DispatchPolicy {
-            tool_policy: Some(tool_policy),
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = contract("c1", "forbidden");
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("denied");
-        assert_eq!(denial.last_dispatch_outcome, "policy_denied");
-        assert!(denial.reason.contains("forbidden"));
-    }
-
-    #[tokio::test]
-    async fn tool_policy_allowlist_misses_block_dispatch() {
+    async fn enforce_or_outcome_folds_tool_policy_denial_into_subtask_outcome() {
         let policy = DispatchPolicy {
             tool_policy: Some(ToolPolicy {
-                allow: vec!["allowed_tool".into()],
+                deny: vec!["forbidden".into()],
                 ..Default::default()
             }),
             ..Default::default()
         };
         let backend = StubBackend;
-        let contract = contract("c1", "another_tool");
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
+        let contract = contract("c1", "forbidden");
+        let outcome = enforce_or_outcome(&policy, &backend, &contract, 0)
             .await
             .expect_err("denied");
-        assert_eq!(denial.last_dispatch_outcome, "policy_denied");
-    }
-
-    #[tokio::test]
-    async fn approval_required_without_requester_fails_closed() {
-        let policy = DispatchPolicy {
-            require_approval: true,
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = contract("c1", "any_tool");
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("denied");
-        assert_eq!(denial.last_dispatch_outcome, "approval_unavailable");
-    }
-
-    #[tokio::test]
-    async fn approval_deny_blocks_dispatch() {
-        struct DenyRequester;
-
-        #[async_trait]
-        impl ToolApprovalRequester for DenyRequester {
-            async fn request_approval(&self, _: ToolApprovalRequest) -> ToolApprovalDecision {
-                ToolApprovalDecision::Deny
-            }
-        }
-
-        let policy = DispatchPolicy {
-            require_approval: true,
-            approval_requester: Some(Arc::new(DenyRequester)),
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = contract("c1", "any_tool");
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("denied");
-        assert_eq!(denial.last_dispatch_outcome, "approval_denied");
-    }
-
-    #[tokio::test]
-    async fn approval_approve_passes_through() {
-        struct ApproveRequester;
-
-        #[async_trait]
-        impl ToolApprovalRequester for ApproveRequester {
-            async fn request_approval(&self, _: ToolApprovalRequest) -> ToolApprovalDecision {
-                ToolApprovalDecision::Approve
-            }
-        }
-
-        let policy = DispatchPolicy {
-            require_approval: true,
-            approval_requester: Some(Arc::new(ApproveRequester)),
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = contract("c1", "any_tool");
-        assert!(
-            enforce_dispatch_gates(&policy, &backend, &contract)
-                .await
-                .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn env_allowlist_rejects_forbidden_keys() {
-        let mut allowlist = HashSet::new();
-        allowlist.insert("OPENAI_API_KEY".to_string());
-
-        let policy = DispatchPolicy {
-            env_allowlist: Some(allowlist),
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = ContractSpec {
-            contract_id: "c1".into(),
-            tool_name: "any".into(),
-            task: serde_json::json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}}),
-            label: None,
-        };
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("denied");
-        assert_eq!(denial.last_dispatch_outcome, "env_forbidden");
-        assert!(denial.reason.contains("LD_PRELOAD"));
-    }
-
-    #[tokio::test]
-    async fn env_allowlist_passes_allowed_keys() {
-        let mut allowlist = HashSet::new();
-        allowlist.insert("OPENAI_API_KEY".to_string());
-
-        let policy = DispatchPolicy {
-            env_allowlist: Some(allowlist),
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = ContractSpec {
-            contract_id: "c1".into(),
-            tool_name: "any".into(),
-            task: serde_json::json!({"env": {"OPENAI_API_KEY": "sk-test"}}),
-            label: None,
-        };
-        assert!(
-            enforce_dispatch_gates(&policy, &backend, &contract)
-                .await
-                .is_ok()
-        );
-    }
-
-    #[tokio::test]
-    async fn require_sandboxed_blocks_unsandboxed_backend() {
-        let policy = DispatchPolicy {
-            require_sandboxed: true,
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = contract("c1", "any_tool");
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("denied");
-        assert_eq!(denial.last_dispatch_outcome, "sandbox_required");
-    }
-
-    #[test]
-    fn is_noop_handles_default_and_empty_policy() {
-        assert!(DispatchPolicy::default().is_noop());
-        assert!(
-            DispatchPolicy {
-                tool_policy: Some(ToolPolicy::default()),
-                ..Default::default()
-            }
-            .is_noop()
-        );
-    }
-
-    #[tokio::test]
-    async fn env_denylist_blocks_known_injection_keys() {
-        let mut denylist = HashSet::new();
-        denylist.insert("LD_PRELOAD".to_string());
-        denylist.insert("DYLD_INSERT_LIBRARIES".to_string());
-
-        let policy = DispatchPolicy {
-            env_denylist: Some(denylist),
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = ContractSpec {
-            contract_id: "c1".into(),
-            tool_name: "any".into(),
-            task: serde_json::json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}}),
-            label: None,
-        };
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("denied");
-        assert_eq!(denial.last_dispatch_outcome, "env_forbidden");
-        assert!(denial.reason.contains("LD_PRELOAD"));
-        assert!(denial.reason.contains("denylist"));
-    }
-
-    #[tokio::test]
-    async fn env_denylist_passes_unrelated_keys() {
-        let mut denylist = HashSet::new();
-        denylist.insert("LD_PRELOAD".to_string());
-
-        let policy = DispatchPolicy {
-            env_denylist: Some(denylist),
-            ..Default::default()
-        };
-        let backend = StubBackend;
-        let contract = ContractSpec {
-            contract_id: "c1".into(),
-            tool_name: "any".into(),
-            task: serde_json::json!({"env": {"OPENAI_API_KEY": "sk-test"}}),
-            label: None,
-        };
-        assert!(
-            enforce_dispatch_gates(&policy, &backend, &contract)
-                .await
-                .is_ok()
-        );
-    }
-
-    /// #713: `from_agent_gates` populates the env denylist from the
-    /// shared `BLOCKED_ENV_VARS`, so MCP swarm dispatch refuses to
-    /// forward injection-class keys without the operator wiring a
-    /// separate denylist.
-    #[tokio::test]
-    async fn from_agent_gates_denies_injection_env_by_default() {
-        let policy = DispatchPolicy::from_agent_gates(None, true);
-        // The constructor's denylist must contain at least `LD_PRELOAD`
-        // (sanity check on `BLOCKED_ENV_VARS` content).
-        let denylist = policy.env_denylist.as_ref().expect("denylist set");
-        assert!(denylist.contains("LD_PRELOAD"));
-        assert!(denylist.contains("DYLD_INSERT_LIBRARIES"));
-        assert!(denylist.contains("NODE_OPTIONS"));
-
-        let backend = StubBackend;
-        let contract = ContractSpec {
-            contract_id: "c1".into(),
-            tool_name: "any".into(),
-            task: serde_json::json!({"env": {"LD_PRELOAD": "/tmp/evil.so"}}),
-            label: None,
-        };
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("dispatch with LD_PRELOAD must be denied");
-        assert_eq!(denial.last_dispatch_outcome, "env_forbidden");
-    }
-
-    /// #713: `from_agent_gates` mirrors the operator's tool policy so
-    /// MCP swarm dispatch denies the same names native execution
-    /// denies.
-    #[tokio::test]
-    async fn from_agent_gates_inherits_tool_policy_deny() {
-        let tool_policy = ToolPolicy {
-            deny: vec!["dangerous_tool".into()],
-            ..Default::default()
-        };
-        let policy = DispatchPolicy::from_agent_gates(Some(tool_policy), true);
-        let backend = StubBackend;
-        let contract = contract("c1", "dangerous_tool");
-        let denial = enforce_dispatch_gates(&policy, &backend, &contract)
-            .await
-            .expect_err("dispatch of dangerous_tool must be denied");
-        assert_eq!(denial.last_dispatch_outcome, "policy_denied");
-    }
-
-    /// #713: `from_agent_gates` with `block_injection_env_vars: false`
-    /// leaves the denylist off, used by tests that need to drive an
-    /// injection-style env through the gate.
-    #[tokio::test]
-    async fn from_agent_gates_can_disable_env_denylist() {
-        let policy = DispatchPolicy::from_agent_gates(None, false);
-        assert!(policy.env_denylist.is_none());
-        // With nothing configured + injection denylist off, the policy
-        // must be a no-op so the dispatcher's hot path is unchanged for
-        // tests that explicitly opt out.
-        assert!(policy.is_noop());
-    }
-
-    /// #713: with no operator tool policy and the env denylist on, the
-    /// policy is **not** a no-op — it still gates against injection
-    /// env vars. This guards the dispatcher's `is_noop()` short-circuit
-    /// against accidentally bypassing the gate when only the denylist
-    /// is configured.
-    #[tokio::test]
-    async fn from_agent_gates_with_only_denylist_is_not_noop() {
-        let policy = DispatchPolicy::from_agent_gates(None, true);
-        assert!(
-            !policy.is_noop(),
-            "a denylist-only policy must run the gate"
-        );
+        assert_eq!(outcome.status, SubtaskStatus::TerminalFailed);
+        assert_eq!(outcome.last_dispatch_outcome, "policy_denied");
+        assert_eq!(outcome.attempts, 1);
+        assert!(outcome.error.unwrap().contains("forbidden"));
     }
 }

--- a/crates/octos-swarm/src/lib.rs
+++ b/crates/octos-swarm/src/lib.rs
@@ -89,8 +89,12 @@ pub use dispatcher::{
     AggregateValidator, MAX_RETRY_ROUNDS, NoopSwarmEventSink, Swarm, SwarmBudget, SwarmBuilder,
     SwarmContext, SwarmCostBudget, SwarmEventSink, flatten_aggregate,
 };
-pub use gate::DispatchPolicy;
+// #714: the gate type now lives in `octos-agent` so both swarm and
+// spawn agent_mcp dispatch share a single source of truth. Re-export
+// here so existing `octos_swarm::DispatchPolicy` callers (CLI / tests
+// / harness) keep compiling without changes.
 pub use ledger::{CostLedger, NoopCostLedger, SwarmCostAttribution};
+pub use octos_agent::DispatchPolicy;
 pub use persistence::{DISPATCH_RECORD_SCHEMA_VERSION, DispatchRecord, DispatchStore};
 pub use result::{AggregateArtifact, SubtaskOutcome, SubtaskStatus, SwarmOutcomeKind, SwarmResult};
 pub use topology::{ContractSpec, FanoutPattern, MAX_CONTRACTS_PER_DISPATCH, SwarmTopology};


### PR DESCRIPTION
## Summary

- Closes #714 — the `agent_mcp` spawn branch in `tools/spawn.rs` dispatched via `dispatch_with_metrics()` with no `DispatchPolicy`, bypassing the same `tool_policy` / env-denylist / approval / sandbox-required gates the swarm side enforces.
- Companion gap to `#607` / `#610` — the supervisor fan-out cap closed the native bypass but the `agent_mcp` variant slipped through. A malicious or buggy MCP server could spawn unbounded agents.
- Moves `DispatchPolicy` + the enforce helpers out of `octos-swarm/gate.rs` and into `octos-agent::dispatch_policy` so both call sites share a single source of truth. `octos-swarm::DispatchPolicy` becomes a re-export, the swarm `gate.rs` keeps only the `SubtaskOutcome`-folding adapter.
- Adds `SpawnTool::with_dispatch_policy()` and applies `enforce_dispatch_gates` before the budget reservation and `dispatch_with_metrics` call in the agent_mcp branch (matching swarm `dispatch_with_budget` ordering).

## Test plan

- [x] RED test on main: `agent_mcp_spawn_respects_dispatch_policy_fanout_cap_per_714` — three `agent_mcp` spawns through a `CappedApprover` (cap=2). Without the fix, all three succeed and the counting backend serves 3. With the fix, the 3rd is rejected by `DispatchPolicy` (`approval_denied`), backend serves exactly 2.
- [x] `cargo test -p octos-agent --test agent_mcp_dispatch_policy` — green.
- [x] `cargo test -p octos-agent` — 1508 + sibling-suite tests all pass.
- [x] `cargo test -p octos-swarm` — 4+10+9 + unit tests all pass (gate.rs adapter, `swarm_dispatch_policy`, `subtask_contracts`).
- [x] `cargo clippy --workspace --no-deps --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo build -p octos-cli --features "api,telegram,discord,whatsapp,feishu,twilio,wecom,wecom-bot,audio_mp3"` — clean (verifies the re-export keeps `octos serve`'s `from_agent_gates` wiring working).