### PR TITLE
feat(thinking-indicator): server-side status-word rotator for WS

### DIFF
--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -22,10 +22,19 @@ pub(super) enum BudgetStop {
     /// pipeline rejection cascaded into ~20 rounds of manual `web_fetch`
     /// until the loop hit `max_iterations` and persisted only "Reached
     /// max iterations." as the assistant reply.
-    MaxIterations { limit: u32 },
-    MaxTokens { used: u32, limit: u32 },
-    ActivityTimeout { limit: Duration },
-    IdleProgressTimeout { limit: Duration },
+    MaxIterations {
+        limit: u32,
+    },
+    MaxTokens {
+        used: u32,
+        limit: u32,
+    },
+    ActivityTimeout {
+        limit: Duration,
+    },
+    IdleProgressTimeout {
+        limit: Duration,
+    },
 }
 
 impl BudgetStop {

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -2551,8 +2551,8 @@ mod tests {
         let png = outside.path().join("host.png");
         std::fs::write(&png, PNG_MAGIC).expect("write png");
 
-        let tool = ViewImageTool::new(workspace.path())
-            .with_filesystem_scope(FilesystemScope::Host);
+        let tool =
+            ViewImageTool::new(workspace.path()).with_filesystem_scope(FilesystemScope::Host);
 
         // Absolute path: host scope must accept it even though it lives
         // outside `workspace.path()`.
@@ -2586,8 +2586,8 @@ mod tests {
         let link = outside.path().join("link.png");
         std::os::unix::fs::symlink(&target, &link).expect("create symlink");
 
-        let tool = ViewImageTool::new(workspace.path())
-            .with_filesystem_scope(FilesystemScope::Host);
+        let tool =
+            ViewImageTool::new(workspace.path()).with_filesystem_scope(FilesystemScope::Host);
 
         let result = tool
             .execute(&json!({ "path": link.to_string_lossy() }))

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -2338,6 +2338,103 @@ impl Drop for AbortOnDrop {
     }
 }
 
+/// Interval between successive status-word rotations on the in-flight
+/// thinking bubble. Mirrors the gateway `StatusIndicator::run_status_loop`
+/// (`tick % 8 == 0`) so the cadence feels identical across surfaces.
+const STATUS_WORD_INTERVAL: std::time::Duration = std::time::Duration::from_secs(8);
+
+/// CJK code-point check shared with `status_indicator::has_cjk` — kept
+/// inline here to avoid pulling the channel-aware status_indicator
+/// module into the WS turn path.
+fn prompt_has_cjk(prompt: &str) -> bool {
+    prompt.chars().any(|c| {
+        matches!(
+            c,
+            '\u{4E00}'..='\u{9FFF}'
+            | '\u{3400}'..='\u{4DBF}'
+            | '\u{F900}'..='\u{FAFF}'
+        )
+    })
+}
+
+/// Spawn a per-turn tokio task that rotates a creative status word
+/// every [`STATUS_WORD_INTERVAL`] through the progress channel for the
+/// SPA `ThinkingIndicator`. Mirrors the gateway StatusIndicator
+/// (`✦ Pondering...`, `✦ 正在炼丹...`) but for the WS surface — the
+/// frame goes through the existing `progress_tx` pipeline which the
+/// mapper at `ui_protocol_progress::map_status_word` lifts onto
+/// `progress/updated{kind:"status_word"}`.
+///
+/// The task exits when EITHER the cancel flag flips (the per-turn
+/// handler signals it via [`StatusWordRotatorGuard`] on its way out)
+/// OR the progress channel's receiver drops (function scope unwinds
+/// and the consumer is gone). Backpressure failures (`try_send` ==
+/// `Full`) just skip that rotation — a missed word is harmless.
+fn spawn_status_word_rotator(
+    progress_tx: tokio::sync::mpsc::Sender<String>,
+    prompt: &str,
+    cancel: Arc<std::sync::atomic::AtomicBool>,
+) {
+    use crate::persona_service::{DEFAULT_STATUS_WORDS, DEFAULT_STATUS_WORDS_ZH};
+
+    let is_cjk = prompt_has_cjk(prompt);
+    let pool: Vec<&'static str> = if is_cjk {
+        DEFAULT_STATUS_WORDS_ZH.to_vec()
+    } else {
+        DEFAULT_STATUS_WORDS.to_vec()
+    };
+    if pool.is_empty() {
+        return;
+    }
+
+    // Slow per-turn offset so back-to-back turns don't always start on
+    // the same word. Using `SystemTime` here is fine — the offset has
+    // no correctness role, only aesthetic spread.
+    let start_idx = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as usize)
+        .unwrap_or(0)
+        % pool.len();
+
+    tokio::spawn(async move {
+        let mut idx = start_idx;
+        loop {
+            tokio::time::sleep(STATUS_WORD_INTERVAL).await;
+            if cancel.load(std::sync::atomic::Ordering::Acquire) || progress_tx.is_closed() {
+                return;
+            }
+            let word = pool[idx % pool.len()];
+            idx = idx.wrapping_add(1);
+            let payload = serde_json::json!({
+                "type": "status_word",
+                "label": word,
+            });
+            let Ok(json) = serde_json::to_string(&payload) else {
+                continue;
+            };
+            // Backpressure failure → drop this rotation. The next
+            // tick will pick a fresh word. The SPA caches the last
+            // rendered word so a missed frame just delays the next
+            // visible swap by 8s.
+            let _ = progress_tx.try_send(json);
+        }
+    });
+}
+
+/// RAII guard that flips the rotator's cancellation flag on drop so
+/// the spawned task exits cleanly when `run_standalone_turn` returns
+/// (including on early-return / panic / interrupt paths).
+struct StatusWordRotatorGuard {
+    cancel: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Drop for StatusWordRotatorGuard {
+    fn drop(&mut self) {
+        self.cancel
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
 struct BoundedChannelReporter {
     tx: tokio::sync::mpsc::Sender<String>,
     /// Mirrors WS-layer drops: when the progress channel is full the agent
@@ -14693,6 +14790,20 @@ async fn run_standalone_turn(
             turn_id.clone(),
         ),
     );
+    // Rotator: emits `progress/updated{kind:"status_word"}` every 8s
+    // for the SPA ThinkingIndicator to swap a creative word in the
+    // in-flight bubble. The drop guard ensures the spawned task
+    // exits when this function unwinds (success, error, or interrupt).
+    let status_word_cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    spawn_status_word_rotator(
+        progress_tx.clone(),
+        &prompt,
+        Arc::clone(&status_word_cancel),
+    );
+    let _status_word_guard = StatusWordRotatorGuard {
+        cancel: Arc::clone(&status_word_cancel),
+    };
+
     let progress_tx_for_result = progress_tx.clone();
     let progress_tx_for_tasks = progress_tx.clone();
     let task_progress_dropped = progress_dropped.clone();

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -753,10 +753,7 @@ mod tests {
         );
 
         let status = mapping.status.expect("status_word status");
-        assert_eq!(
-            status.event.metadata.kind,
-            progress_kinds::STATUS_WORD
-        );
+        assert_eq!(status.event.metadata.kind, progress_kinds::STATUS_WORD);
         assert_eq!(status.event.metadata.label.as_deref(), Some("Pondering"));
         assert_eq!(mapping.warning, None);
     }

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -113,6 +113,7 @@ pub(crate) fn map_progress_json(
         "thinking" => map_simple_status(context, event, progress_kinds::THINKING),
         "response" => map_simple_status(context, event, progress_kinds::RESPONSE),
         "cost_update" => map_cost_update(context, event),
+        "status_word" => map_status_word(context, event),
         "stream_end" => map_simple_status(context, event, progress_kinds::STREAM_END),
         "retry" | "retry_backoff" => map_retry_backoff(context, event),
         "approval_requested" | "approval_request" => map_approval_requested(context, event),
@@ -419,6 +420,25 @@ fn map_cost_update(context: &ProgressMappingContext, event: &Value) -> UiProgres
     UiProgressMapping::status(context, metadata)
 }
 
+/// Map the per-turn status-word rotator's frame
+/// (`{"type":"status_word", "label":"Pondering"}`) onto a
+/// `progress/updated{kind:"status_word"}` notification. The SPA
+/// `ThinkingIndicator` subscribes via the bridge's `crew:status_word`
+/// dispatcher and swaps the word in the in-flight bubble.
+fn map_status_word(context: &ProgressMappingContext, event: &Value) -> UiProgressMapping {
+    let word = string_field(event, &["label", "word"]).filter(|s| !s.is_empty());
+    let Some(word) = word else {
+        return UiProgressMapping::warning(
+            context,
+            "invalid_progress",
+            "status_word progress event missing string field `label`".to_string(),
+        );
+    };
+    let mut metadata = UiProgressMetadata::new(progress_kinds::STATUS_WORD);
+    metadata.label = Some(word);
+    UiProgressMapping::status(context, metadata)
+}
+
 fn map_retry_backoff(context: &ProgressMappingContext, event: &Value) -> UiProgressMapping {
     let mut retry = UiRetryBackoff::new();
     retry.attempt = u32_field(event, &["attempt", "retry_round"]);
@@ -714,6 +734,47 @@ mod tests {
             assert!(mapping.notifications.is_empty());
             assert_eq!(mapping.warning, None);
         }
+    }
+
+    #[test]
+    fn ui_protocol_progress_maps_status_word_to_progress_kinds_status_word() {
+        // Lock the wire contract that the per-turn rotator
+        // (`spawn_status_word_rotator`) emits — a flat
+        // `{"type":"status_word","label":"Pondering"}` JSON frame on
+        // the progress channel — onto a
+        // `progress/updated{kind:"status_word", label:"Pondering"}`
+        // notification the SPA bridge guards/parses.
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "status_word",
+                "label": "Pondering",
+            }),
+        );
+
+        let status = mapping.status.expect("status_word status");
+        assert_eq!(
+            status.event.metadata.kind,
+            progress_kinds::STATUS_WORD
+        );
+        assert_eq!(status.event.metadata.label.as_deref(), Some("Pondering"));
+        assert_eq!(mapping.warning, None);
+    }
+
+    #[test]
+    fn ui_protocol_progress_maps_status_word_missing_label_to_warning() {
+        // Defensive: a status_word frame with no label is malformed.
+        // Surface it as a `warning` so the SPA can ignore it instead
+        // of swapping the in-flight bubble to an empty caption.
+        let mapping = map_progress_json(
+            &context(),
+            &json!({
+                "type": "status_word",
+            }),
+        );
+        assert!(mapping.status.is_none());
+        let warning = mapping.warning.expect("warning emitted for empty label");
+        assert_eq!(warning.code, "invalid_progress");
     }
 
     #[test]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -3607,6 +3607,16 @@ pub mod progress_kinds {
     pub const TOKEN_COST_UPDATE: &str = "token_cost_update";
     pub const TOOL_PROGRESS: &str = "tool_progress";
     pub const TOOL_COMPLETED: &str = "tool_completed";
+    /// Creative status-word rotation matching the gateway's
+    /// `StatusIndicator` (`✦ Pondering...`, `✦ Brewing...`, etc.) for
+    /// the web ThinkingIndicator surface. The server emits
+    /// `progress/updated{kind:"status_word", label:"<word>"}` every
+    /// ~8s during an in-flight agent turn; the SPA bridge
+    /// (`ui-protocol-event-router.ts`) lifts these onto a
+    /// `crew:status_word` DOM event the `ThinkingIndicator` listens
+    /// for. CJK-aware: the rotator picks Chinese words for Chinese
+    /// input, English for English.
+    pub const STATUS_WORD: &str = "status_word";
     pub const UNKNOWN: &str = "unknown";
 }
 


### PR DESCRIPTION
## Summary

Per-turn tokio task that rotates a creative status word every ~8s through the existing progress channel, mirroring the gateway `StatusIndicator` (`✦ Pondering...`, `✦ Brewing...`, `✦ 正在炼丹...`) on the WS surface for the SPA `ThinkingIndicator` (octos-org/octos-web#146) to swap in.

Closes the deferred Part B from the thinking-indicator stack — supersedes (and self-contains) the constant-only PR octos-org/octos#1170.

## Wire shape

```
progress/updated {
  kind: "status_word",
  label: "<rotating word>"
}
```

## Changes (3 files, +182)

| File | What |
|---|---|
| `octos-core/src/ui_protocol.rs` | Reserve `progress_kinds::STATUS_WORD` constant |
| `octos-cli/src/api/ui_protocol_progress.rs` | `map_status_word` mapper + dispatch case in `map_progress_json`; defensive warning on empty/missing label |
| `octos-cli/src/api/ui_protocol.rs` | `spawn_status_word_rotator` helper + `StatusWordRotatorGuard` (RAII Drop cancellation); wired into `run_standalone_turn` right after `BoundedChannelReporter` |

## Lifecycle

- **Spawn**: at turn start, right after the progress channel is created
- **Tick**: every 8s (matches gateway `run_status_loop` cadence)
- **Stop**: either the cancel flag flips (guard fires on `run_standalone_turn` unwind — success, error, or interrupt) OR the progress channel's receiver drops
- **Backpressure**: `try_send` failure drops that rotation silently; the SPA caches the last word so a miss only delays the next visible swap by 8s
- **CJK-aware**: picks `DEFAULT_STATUS_WORDS_ZH` for Chinese input, `DEFAULT_STATUS_WORDS` for English; word index starts at a time-based offset so back-to-back turns don't always begin on the same word

## Test plan
- [x] `cargo test -p octos-cli --features api --lib status_word` — 2/2 new tests pass
- [x] `cargo check -p octos-cli --tests` clean
- [x] `cargo clippy -p octos-core --all-targets -- -D warnings` clean
- [ ] Live: trigger an agent turn on mini3 dspfac and confirm the SPA ThinkingIndicator rotates words ~every 8s

## Follow-up
- Plumb the per-persona LLM-generated word pool from `PersonaService` into the WS turn path so the rotator picks from a richer per-persona set instead of the fallback constants. (The defaults are the same ones `PersonaService` uses when no LLM pool is available — shippable as-is.)