### PR TITLE
feat(agent): wire M14-C role templates into spawn_agent and tool contract (#971)

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -128,7 +128,8 @@ pub use provider_tools::{ProviderToolsets, ToolAdjustment};
 pub use recorder::{BlackBoxRecorder, RecordEntry};
 pub use role_template::{
     APPROVAL_ASK, APPROVAL_NEVER, ModelPreference, ROLE_EXPLORER, ROLE_IMPLEMENTER, ROLE_REVIEWER,
-    ROLE_TEST_WORKER, RoleTemplate, SANDBOX_AUTO, SANDBOX_NONE, UnknownModelPreference,
+    ROLE_TEST_WORKER, RoleTemplate, RoleTemplateSummary, SANDBOX_AUTO, SANDBOX_NONE,
+    UnknownModelPreference,
 };
 pub use sandbox::{Sandbox, SandboxConfig, SandboxMode, create_sandbox};
 pub use session::{SessionLimits, SessionState, SessionStateHandle, SessionUsage};

--- a/crates/octos-agent/src/role_template.rs
+++ b/crates/octos-agent/src/role_template.rs
@@ -56,6 +56,64 @@ pub const APPROVAL_ASK: &str = "ask";
 /// `ApprovalPolicy::Never`).
 pub const APPROVAL_NEVER: &str = "never";
 
+/// Tools the default `ToolRegistry::with_builtins`-constructed child
+/// registry reliably registers AND that actually function inside a
+/// detached subagent context (independent of memory store / research
+/// index / session actor / native-spawn delegate wiring). Issue #971
+/// (M14-C) codex P1 fix: `RoleTemplate::to_spawn_compatible_allow`
+/// intersects the role's expanded budget with this list so the spawn
+/// tool's availability check does not reject tools that aren't
+/// registered in the stand-alone child runtime.
+///
+/// Notably absent (issue #971 codex iter-3 P2.1): `spawn_agent`.
+/// `with_builtins` registers `SpawnAgentTool::new()` WITHOUT a native
+/// spawn delegate; the alias in a child therefore always returns the
+/// "spawn_agent requires the session runtime to register a native
+/// spawn tool delegate" error. Advertising it via the implementer
+/// template would offer a tool that fails with a no-delegate error
+/// rather than the session capability the template promises — so the
+/// alias is filtered here. When the session actor wires a real spawn
+/// delegate into a per-session registry, that path stays separate
+/// from the static M14-C role budget and the parent's `ToolPolicy`
+/// can re-grant the alias explicitly.
+///
+/// Kept in stable lexicographic order so the const slice can be
+/// searched via `.contains()` without allocating a HashSet at the
+/// caller. Update whenever
+/// `ToolRegistry::with_builtins_and_permissions` adds or removes a
+/// non-feature-gated builtin AND that builtin is actually usable
+/// from inside a detached subagent.
+pub(crate) const SPAWN_BUILTIN_TOOLS: &[&str] = &[
+    "apply_patch",
+    "bash",
+    "browser",
+    "check_workspace_contract",
+    "close_agent",
+    "diff_edit",
+    "edit_file",
+    "exec_command",
+    "glob",
+    "grep",
+    "list_dir",
+    "read_file",
+    "request_user_input",
+    "resume_agent",
+    "send_input",
+    "shell",
+    "tool_search",
+    "tool_suggest",
+    "update_plan",
+    "view_image",
+    "wait_agent",
+    "web_fetch",
+    "web_search",
+    "workspace_diff",
+    "workspace_log",
+    "workspace_show",
+    "write_file",
+    "write_stdin",
+];
+
 /// Soft model preference hint. Templates set this so the orchestrator
 /// can route review / implementation children to a coding-grade lane
 /// while letting explorers fall onto the cheap analyst lane. Treated as
@@ -198,12 +256,114 @@ impl RoleTemplate {
     }
 
     /// Return the template tool budget in the owned shape expected by
-    /// `SpawnTool::Input.allowed_tools`.
+    /// `SpawnTool::Input.allowed_tools` and `ToolPolicy.allow`.
+    /// Issue #971 (M14-C) wires this into the spawn aliases so a role
+    /// name on the wire resolves to the same allow list the runtime
+    /// gates the child agent on.
+    ///
+    /// The shape is identical to the static `allowed_tools` slice: each
+    /// entry is either a `group:*` identifier or a bare exact tool name.
+    /// Group expansion happens at `ToolPolicy::evaluate` time, so the
+    /// safety property guarded by the unit tests in this module
+    /// (read-only roles never advertise a mutating group) carries
+    /// through into the runtime allow list unchanged.
+    ///
+    /// Use [`Self::to_expanded_tool_names`] instead when feeding the
+    /// spawn tool's `allowed_tools` field — that consumer does exact-
+    /// name lookup against the tool registry and does NOT understand
+    /// `group:*` entries, so groups have to be expanded first.
     pub fn allowed_tools_vec(&self) -> Vec<String> {
         self.allowed_tools
             .iter()
             .map(|entry| (*entry).to_owned())
             .collect()
+    }
+
+    /// Expand the template's tool budget into the concrete exact tool
+    /// names the spawn tool's availability check expects. Each
+    /// `group:*` entry is resolved through
+    /// [`crate::tools::policy::tool_group_info`]; bare tool names pass
+    /// through unchanged. Unknown group names fall through as opaque
+    /// entries so the caller's downstream availability check surfaces
+    /// the same "required tool not available" error a typo on a bare
+    /// tool name would.
+    ///
+    /// Issue #971 (M14-C) codex P1: `SpawnTool::ensure_subagent_tools_available`
+    /// fails closed on every `group:*` entry it sees because it does
+    /// `tools.get(tool_name).is_none()`. Without this expansion the
+    /// real `spawn_agent({"role": "reviewer"})` path would error with
+    /// "required tool(s) not available: group:search" the moment the
+    /// role wiring fired.
+    ///
+    /// **Note**: this can return tool names not present in every
+    /// runtime (e.g. `recall_memory` requires a memory store provider;
+    /// `spawn` is only registered by the session actor, not by
+    /// `ToolRegistry::with_builtins`). Callers feeding the spawn
+    /// tool's child registry should use [`Self::to_spawn_compatible_allow`]
+    /// instead, which intersects this expansion with the set of tools
+    /// the default `ToolRegistry::with_builtins` reliably registers.
+    pub fn to_expanded_tool_names(&self) -> Vec<String> {
+        let mut out: Vec<String> = Vec::with_capacity(self.allowed_tools.len());
+        for entry in self.allowed_tools {
+            if entry.starts_with("group:") {
+                if let Some(group) = crate::tools::policy::tool_group_info(entry) {
+                    for tool in group.tools {
+                        let owned = (*tool).to_string();
+                        if !out.contains(&owned) {
+                            out.push(owned);
+                        }
+                    }
+                    continue;
+                }
+                // Unknown group — fall through as-is so the caller's
+                // downstream availability check reports a clear error.
+            }
+            let owned = (*entry).to_string();
+            if !out.contains(&owned) {
+                out.push(owned);
+            }
+        }
+        out
+    }
+
+    /// Filtered variant of [`Self::to_expanded_tool_names`] that emits
+    /// only tools the default `ToolRegistry::with_builtins`-built child
+    /// registry actually registers. Issue #971 (M14-C) codex P1 fix
+    /// (iteration 2): the prior wiring forwarded `recall_memory` /
+    /// `synthesize_research` / `save_memory` / `spawn` from role
+    /// templates into the child's `Input.allowed_tools`, which
+    /// `ensure_subagent_tools_available` then rejected — every default
+    /// role-based spawn failed before the child could run.
+    ///
+    /// The kept set is the intersection of the role's expanded budget
+    /// with [`SPAWN_BUILTIN_TOOLS`] (the tools `with_builtins`
+    /// guarantees). Tools requiring extra runtime wiring (memory
+    /// store, research index, session-actor-bound spawn, ...) are
+    /// filtered out at the spawn boundary; if a session actor extends
+    /// the child registry with those, the parent's `ToolPolicy` still
+    /// gates them through the standard policy plumbing.
+    pub fn to_spawn_compatible_allow(&self) -> Vec<String> {
+        self.to_expanded_tool_names()
+            .into_iter()
+            .filter(|tool| SPAWN_BUILTIN_TOOLS.contains(&tool.as_str()))
+            .collect()
+    }
+
+    /// Bounded UX summary the orchestrator surfaces in `tool/status/list`
+    /// alongside the coding tool contract (issue #971 / M14-C deliverable
+    /// "Test: role/tool/sandbox/model policy is resolved by the server
+    /// runtime"). Mirrors `RoleTemplate` fields the UX cares about
+    /// without leaking the prompt prefix (which is server-owned).
+    pub fn summary(&self) -> RoleTemplateSummary<'static> {
+        RoleTemplateSummary {
+            name: self.name,
+            display_name: self.display_name,
+            description: self.description,
+            allowed_tools: self.allowed_tools,
+            default_sandbox_mode: self.default_sandbox_mode,
+            default_approval_policy: self.default_approval_policy,
+            model_preference: self.model_preference.as_str(),
+        }
     }
 
     /// Infer a canonical role from Codex-style `agent_type` values.
@@ -265,6 +425,23 @@ impl RoleTemplate {
             "requested_model": requested_model,
         })
     }
+}
+
+/// Bounded UX summary of a [`RoleTemplate`], emitted as part of the
+/// `tool/status/list` payload so AppUI / TUI can render a spawn-role
+/// picker without round-tripping to a dedicated endpoint. Mirrors every
+/// `RoleTemplate` field clients legitimately need; the `prompt_prefix`
+/// is intentionally excluded because it is a server-owned secret that
+/// shouldn't ride on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct RoleTemplateSummary<'a> {
+    pub name: &'a str,
+    pub display_name: &'a str,
+    pub description: &'a str,
+    pub allowed_tools: &'a [&'a str],
+    pub default_sandbox_mode: &'a str,
+    pub default_approval_policy: &'a str,
+    pub model_preference: &'a str,
 }
 
 /// All registered role templates. Keep this list aligned with the
@@ -751,5 +928,371 @@ mod tests {
                 "synthesize_research"
             ])
         );
+    }
+
+    /// Issue #971 (M14-C) wiring contract: every template snapshots into
+    /// a `Vec<String>` whose entries match the static `allowed_tools`
+    /// slice exactly. This is the value the spawn/spawn_agent paths
+    /// feed into `ToolPolicy.allow` and the worker's `allowed_tools`
+    /// field, so a drift here would silently change the budget the
+    /// child agent runs under.
+    #[test]
+    fn m14_c_wiring_allowed_tools_vec_round_trips_static_slice_per_971() {
+        for tpl in RoleTemplate::all() {
+            let owned = tpl.allowed_tools_vec();
+            assert_eq!(
+                owned.len(),
+                tpl.allowed_tools.len(),
+                "{} allowed_tools_vec must preserve cardinality",
+                tpl.name
+            );
+            for (i, expected) in tpl.allowed_tools.iter().enumerate() {
+                assert_eq!(
+                    owned[i], *expected,
+                    "{} entry {} must match static slice",
+                    tpl.name, i
+                );
+            }
+        }
+    }
+
+    /// Issue #971 (M14-C) codex P1 regression: `to_expanded_tool_names`
+    /// MUST produce zero `group:*` entries — only concrete tool names.
+    /// `SpawnTool::ensure_subagent_tools_available` does exact-name
+    /// `tools.get(name).is_none()` lookup, so any `group:*` slipping
+    /// through would make every role-based `spawn_agent` call fail
+    /// availability with "required tool not available: group:search".
+    #[test]
+    fn m14_c_wiring_to_expanded_tool_names_emits_no_group_entries_per_971() {
+        for tpl in RoleTemplate::all() {
+            let expanded = tpl.to_expanded_tool_names();
+            for entry in &expanded {
+                assert!(
+                    !entry.starts_with("group:"),
+                    "{} emitted raw group identifier {:?} from to_expanded_tool_names; \
+                     the spawn tool's availability check does exact-name lookup and \
+                     would treat this as a missing tool",
+                    tpl.name,
+                    entry
+                );
+                assert!(!entry.is_empty(), "{} emitted empty tool name", tpl.name);
+            }
+            // Sanity: expansion preserves at least one of each group's
+            // member tools. We pick the static `group:search` =>
+            // {glob, grep, list_dir} mapping since every M14-C
+            // template advertises group:search.
+            if tpl.permits("group:search") {
+                for member in ["glob", "grep", "list_dir"] {
+                    assert!(
+                        expanded.contains(&member.to_string()),
+                        "{} permits group:search but expanded set missing {member:?}; \
+                         got {expanded:?}",
+                        tpl.name
+                    );
+                }
+            }
+        }
+    }
+
+    /// Issue #971 (M14-C) codex P1 iteration 2: `to_spawn_compatible_allow`
+    /// MUST emit only tool names from `SPAWN_BUILTIN_TOOLS` (the set
+    /// the spawn tool's child `ToolRegistry::with_builtins` registry
+    /// reliably exposes). Without this filter, the prior wiring
+    /// forwarded `recall_memory` / `synthesize_research` / `save_memory`
+    /// / `spawn` from role templates into the child's allowed_tools
+    /// and `ensure_subagent_tools_available` rejected every default
+    /// role-based spawn.
+    #[test]
+    fn m14_c_wiring_to_spawn_compatible_allow_intersects_builtins_per_971() {
+        for tpl in RoleTemplate::all() {
+            let allow = tpl.to_spawn_compatible_allow();
+            for tool in &allow {
+                assert!(
+                    SPAWN_BUILTIN_TOOLS.contains(&tool.as_str()),
+                    "{} to_spawn_compatible_allow emitted {tool:?} which is not in \
+                     SPAWN_BUILTIN_TOOLS; the child availability check would fail",
+                    tpl.name
+                );
+            }
+            // No `group:*` identifiers (already filtered by
+            // `to_expanded_tool_names`, but pinned here so a future
+            // refactor that bypasses expansion still tripwires this).
+            for tool in &allow {
+                assert!(
+                    !tool.starts_with("group:"),
+                    "{} to_spawn_compatible_allow emitted group identifier {tool:?}",
+                    tpl.name
+                );
+            }
+            // Codex iter-3 P2.1 guard: the undelegated `spawn_agent`
+            // alias MUST NOT leak through. `with_builtins` registers
+            // `SpawnAgentTool::new()` without a native delegate, so
+            // advertising the alias to a child would offer a tool that
+            // always fails with "spawn_agent requires the session
+            // runtime to register a native spawn tool delegate".
+            assert!(
+                !allow.iter().any(|t| t == "spawn_agent"),
+                "{} to_spawn_compatible_allow emitted spawn_agent — that alias is \
+                 registered without a delegate in subagent registries and would \
+                 always fail at the tool boundary",
+                tpl.name
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C) PR #1177 codex round-1 P2 regression: the
+    /// Codex-naming `bash` alias is registered by
+    /// `ToolRegistry::with_builtins_and_permissions` (PR #1174) AND
+    /// it expands out of `group:runtime` for both `implementer` and
+    /// `test_worker`. If `SPAWN_BUILTIN_TOOLS` omits it,
+    /// `to_spawn_compatible_allow` silently drops the alias from
+    /// the wire payload — role-based children would call `bash` and
+    /// get a "not allowed" error even though the runtime registry
+    /// has it. This guard pins the inclusion at the registry edit
+    /// site so the runtime group cannot drift past the spawn budget.
+    #[test]
+    fn m14_c_wiring_spawn_compatible_allow_includes_bash_for_runtime_roles_per_971() {
+        for role_name in [ROLE_IMPLEMENTER, ROLE_TEST_WORKER] {
+            let tpl = RoleTemplate::for_name(role_name).unwrap();
+            let allow = tpl.to_spawn_compatible_allow();
+            assert!(
+                allow.contains(&"bash".to_string()),
+                "{role_name} runtime budget MUST include the bash alias once \
+                 group:runtime expands; got {allow:?}",
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C) codex P1 iteration 2: every role template
+    /// MUST emit at least one spawn-compatible tool, otherwise the
+    /// resulting spawn payload would carry `allowed_tools: []` which
+    /// the native spawn tool interprets as "all builtins" — defeating
+    /// the role's safety budget. The contract: a registered role MUST
+    /// surface at least one effective tool through the spawn path.
+    #[test]
+    fn m14_c_wiring_to_spawn_compatible_allow_is_non_empty_per_971() {
+        for tpl in RoleTemplate::all() {
+            assert!(
+                !tpl.to_spawn_compatible_allow().is_empty(),
+                "{} to_spawn_compatible_allow returned an empty set; the spawn tool \
+                 would interpret this as 'all builtins' and defeat the role budget",
+                tpl.name
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C) codex P1 regression: every group identifier
+    /// in a role template's `allowed_tools` slice MUST resolve through
+    /// `tool_group_info`. A typo on a `group:` entry that doesn't match
+    /// a registered `TOOL_GROUPS` row would let the raw `group:*`
+    /// identifier flow through `to_expanded_tool_names` unchanged and
+    /// fail `SpawnTool::ensure_subagent_tools_available` at runtime.
+    /// This guard catches that drift at the registry edit site.
+    #[test]
+    fn m14_c_wiring_every_group_entry_resolves_through_tool_group_info_per_971() {
+        for tpl in RoleTemplate::all() {
+            for entry in tpl.allowed_tools {
+                if entry.starts_with("group:") {
+                    let info = crate::tools::policy::tool_group_info(entry);
+                    assert!(
+                        info.is_some(),
+                        "{} advertises group {entry:?} but tool_group_info \
+                         returned None; either fix the typo or add the group \
+                         to tools::policy::TOOL_GROUPS",
+                        tpl.name
+                    );
+                    let info = info.unwrap();
+                    assert!(
+                        !info.tools.is_empty(),
+                        "{} advertises group {entry:?} but its tools slice is empty",
+                        tpl.name
+                    );
+                }
+            }
+        }
+    }
+
+    /// Issue #971 (M14-C) safety property: when a read-only role's
+    /// allow list is interpreted by `tools::policy::ToolPolicy`, the
+    /// expanded set must NOT contain any disk-writing or session-
+    /// mutating tool. This is the runtime-side complement of the
+    /// `read_only_roles_do_not_advertise_mutating_groups` guard above:
+    /// even if a future template adds a new `group:` that happens to
+    /// expand to a mutating tool, this test fires on the actual
+    /// `ToolPolicy::is_allowed` decision.
+    #[test]
+    fn m14_c_wiring_reviewer_policy_denies_mutating_tools_per_971() {
+        use crate::tools::policy::ToolPolicy;
+        let tpl = RoleTemplate::for_name(ROLE_REVIEWER).unwrap();
+        let policy = ToolPolicy {
+            allow: tpl.allowed_tools_vec(),
+            ..Default::default()
+        };
+        for mutator in [
+            "write_file",
+            "edit_file",
+            "diff_edit",
+            "apply_patch",
+            "save_memory",
+            "shell",
+            "exec_command",
+            "write_stdin",
+            "spawn",
+            "spawn_agent",
+            "delegate_task",
+            "browser",
+            "deep_crawl",
+        ] {
+            assert!(
+                !policy.is_allowed(mutator),
+                "reviewer policy must deny mutating tool {mutator:?}; \
+                 allow list = {:?}",
+                policy.allow
+            );
+        }
+        // Sanity: the read-only tools the template DOES advertise stay
+        // allowed once the same allow list is piped through ToolPolicy.
+        for permitted in [
+            "read_file",
+            "glob",
+            "grep",
+            "list_dir",
+            "web_search",
+            "web_fetch",
+            "recall_memory",
+            "synthesize_research",
+        ] {
+            assert!(
+                policy.is_allowed(permitted),
+                "reviewer policy must allow {permitted:?}"
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C): explorer policy is strictly read-only AND
+    /// must NOT permit `group:runtime` tools (the explorer's role is to
+    /// READ the codebase, not run commands — even cheap ones like
+    /// `exec_command` would let the role drift into shell execution).
+    #[test]
+    fn m14_c_wiring_explorer_policy_denies_runtime_per_971() {
+        use crate::tools::policy::ToolPolicy;
+        let tpl = RoleTemplate::for_name(ROLE_EXPLORER).unwrap();
+        let policy = ToolPolicy {
+            allow: tpl.allowed_tools_vec(),
+            ..Default::default()
+        };
+        for runtime in ["shell", "exec_command", "write_stdin", "spawn"] {
+            assert!(
+                !policy.is_allowed(runtime),
+                "explorer must deny runtime tool {runtime:?}"
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C): test_worker IS the role allowed to run
+    /// commands, so `group:runtime` MUST expand to `shell` /
+    /// `exec_command` / `write_stdin` once piped through ToolPolicy.
+    /// But the test_worker MUST NOT be able to mutate files or spawn
+    /// further children — the runtime side of the
+    /// `test_worker_runs_commands_but_does_not_spawn` static guard.
+    #[test]
+    fn m14_c_wiring_test_worker_policy_allows_runtime_denies_fs_per_971() {
+        use crate::tools::policy::ToolPolicy;
+        let tpl = RoleTemplate::for_name(ROLE_TEST_WORKER).unwrap();
+        let policy = ToolPolicy {
+            allow: tpl.allowed_tools_vec(),
+            ..Default::default()
+        };
+        for runtime in ["shell", "exec_command", "write_stdin"] {
+            assert!(
+                policy.is_allowed(runtime),
+                "test_worker must allow runtime tool {runtime:?}"
+            );
+        }
+        for mutator in [
+            "write_file",
+            "edit_file",
+            "diff_edit",
+            "apply_patch",
+            "save_memory",
+            "spawn",
+            "spawn_agent",
+            "browser",
+        ] {
+            assert!(
+                !policy.is_allowed(mutator),
+                "test_worker must deny mutating tool {mutator:?}"
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C): implementer IS the read-write coding role,
+    /// so its policy must allow file mutation AND command execution
+    /// AND child spawning. This pins the runtime-side budget the
+    /// implementer template advertises.
+    #[test]
+    fn m14_c_wiring_implementer_policy_allows_fs_runtime_sessions_per_971() {
+        use crate::tools::policy::ToolPolicy;
+        let tpl = RoleTemplate::for_name(ROLE_IMPLEMENTER).unwrap();
+        let policy = ToolPolicy {
+            allow: tpl.allowed_tools_vec(),
+            ..Default::default()
+        };
+        for allowed in [
+            "read_file",
+            "write_file",
+            "edit_file",
+            "diff_edit",
+            "apply_patch",
+            "shell",
+            "exec_command",
+            "spawn",
+            "spawn_agent",
+            "save_memory",
+            "recall_memory",
+            "glob",
+            "grep",
+            "list_dir",
+        ] {
+            assert!(
+                policy.is_allowed(allowed),
+                "implementer must allow {allowed:?}"
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C): `RoleTemplate::summary()` exposes a bounded
+    /// wire-safe projection — every consumer (tool/status/list,
+    /// AppUI spawn-role picker) reads through this struct. The
+    /// `prompt_prefix` MUST stay server-owned and never appear on
+    /// the wire: this guard ensures the summary type has no field
+    /// accessor for it.
+    #[test]
+    fn m14_c_wiring_role_summary_omits_prompt_prefix_per_971() {
+        for tpl in RoleTemplate::all() {
+            let summary = tpl.summary();
+            assert_eq!(summary.name, tpl.name);
+            assert_eq!(summary.display_name, tpl.display_name);
+            assert_eq!(summary.description, tpl.description);
+            assert_eq!(summary.allowed_tools, tpl.allowed_tools);
+            assert_eq!(summary.default_sandbox_mode, tpl.default_sandbox_mode);
+            assert_eq!(summary.default_approval_policy, tpl.default_approval_policy);
+            assert_eq!(summary.model_preference, tpl.model_preference.as_str());
+            // Round-trip through serde: the JSON projection must not
+            // contain "prompt_prefix" because the summary struct does
+            // not expose it.
+            let json = serde_json::to_value(summary).expect("serialize summary");
+            assert!(
+                json.get("prompt_prefix").is_none(),
+                "{} summary leaked prompt_prefix on the wire: {json}",
+                tpl.name
+            );
+            // Sanity: the public fields ARE serialized.
+            assert!(json.get("name").is_some(), "summary must serialize name");
+            assert!(
+                json.get("allowed_tools").is_some(),
+                "summary must serialize allowed_tools"
+            );
+        }
     }
 }

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -954,7 +954,22 @@ fn append_instruction(existing: Option<String>, instruction: String) -> Option<S
     })
 }
 
-fn normalize_spawn_agent_args(args: &Value) -> Value {
+/// Normalise the loose Codex `spawn_agent` arg shape into the strict
+/// `spawn` tool argument layout, optionally folding a resolved
+/// [`crate::role_template::RoleTemplate`] into the spawn payload.
+///
+/// Issue #971 (M14-C): when a caller passes `role: "reviewer"` (or any
+/// other registered template name), the alias resolves the template
+/// once at the spawn_agent boundary and forwards the template's
+/// `allowed_tools` budget + `prompt_prefix` to the native spawn tool.
+/// Inline-wins semantics still apply: a caller-supplied `allowed_tools`
+/// array overrides the template's, and a caller-supplied
+/// `additional_instructions` is appended TO (not replaced BY) the
+/// template's prompt prefix.
+fn normalize_spawn_agent_args_with_role(
+    args: &Value,
+    role: Option<&crate::role_template::RoleTemplate>,
+) -> Value {
     let mut out = serde_json::Map::new();
     if let Some(input) = args.as_object() {
         for key in [
@@ -1014,6 +1029,28 @@ fn normalize_spawn_agent_args(args: &Value) -> Value {
             );
         }
     }
+    // PR #1177 codex round-3 P2 fix: a client that serialises an
+    // unset `role` as `null` or `""` would otherwise leak that blank
+    // value through to the spawn delegate, whose `apply_role_template`
+    // treats blank/None as "no role" and skips the prompt-prefix
+    // injection — even though `SpawnAgentTool::execute_with_context`
+    // resolved a template from `agent_type` and stamped the task with
+    // that role. Drop the blank value here so either the resolved
+    // template below OR the spawn delegate's `apply_role_template`
+    // sees a clean absence; the resolved value is then written back
+    // unconditionally.
+    let blank_role = match out.get("role") {
+        Some(Value::Null) | None => true,
+        Some(Value::String(s)) => s.trim().is_empty(),
+        _ => false,
+    };
+    if blank_role {
+        out.remove("role");
+    }
+    // Codex round-3 P2 fix: when an explicit `role` is absent AND a
+    // recognised `agent_type` alias is set, write the canonical role
+    // name so the spawn delegate's `apply_role_template` resolves the
+    // same template the boundary already stamped on the BackgroundTask.
     if !out.contains_key("role") {
         if let Some(role_template) = args
             .get("agent_type")
@@ -1026,6 +1063,16 @@ fn normalize_spawn_agent_args(args: &Value) -> Value {
             );
         }
     }
+    // Codex round-3 P2 fix: when the boundary already resolved a
+    // template (either from an explicit `role` arg or from the
+    // `agent_type` alias path), authoritatively write the canonical
+    // template name. This keeps the spawn delegate's view in lock-step
+    // with the BackgroundTask.role stamp even when the caller passed
+    // e.g. `role: " Reviewer "` (whitespace / wrong case) or relied
+    // on the `agent_type` alias.
+    if let Some(template) = role {
+        out.insert("role".to_string(), Value::String(template.name.to_string()));
+    }
     if !out.contains_key("model") {
         if let Some(model) = args.get("model").and_then(Value::as_str) {
             out.insert("model".to_string(), Value::String(model.to_string()));
@@ -1036,6 +1083,84 @@ fn normalize_spawn_agent_args(args: &Value) -> Value {
         .get("additional_instructions")
         .and_then(Value::as_str)
         .map(ToOwned::to_owned);
+    // Issue #971 (M14-C): when the caller resolved a role template,
+    // seed the spawn payload's `allowed_tools` with the template's
+    // spawn-compatible budget. The native `SpawnTool::apply_role_template`
+    // is the authoritative layer for role-derived metadata
+    // (prompt-prefix prepending happens there so the path is uniform
+    // for ALL `role`-bearing spawns, not just `spawn_agent`-aliased
+    // ones); but `apply_role_template` falls back to
+    // `RoleTemplate::allowed_tools_vec()` which still carries
+    // `group:*` identifiers. Those raw group entries would then fail
+    // `ensure_subagent_tools_available` (it does exact-name lookup).
+    // Pre-populating the inline `allowed_tools` with
+    // `to_spawn_compatible_allow()` short-circuits the fallback so the
+    // wire payload only carries names the child's `with_builtins`
+    // registry actually has.
+    //
+    // Codex iter-2 P2 (PR #1171 → PR #1177): the prefix prepending
+    // is INTENTIONALLY NOT done here — `spawn.rs::apply_role_template`
+    // prepends `template.prompt_prefix` to `additional_instructions`
+    // for every native-delegate spawn, so doing it again at this
+    // boundary would double the prefix in the child's system context.
+    if let Some(template) = role {
+        // Issue #971 codex P1 fix iteration 2: only treat a NON-EMPTY
+        // `allowed_tools` array as an inline override. An empty array
+        // is interpreted by the native spawn tool as "all builtins",
+        // so without this guard a client that always serialises
+        // `allowed_tools: []` would bypass the role's restricted
+        // budget and silently receive write/shell/browser tools on a
+        // reviewer/explorer/test_worker spawn.
+        //
+        // Issue #971 codex iter-5 P1 fix: when `agent_definition_id`
+        // is set, `SpawnTool::apply_agent_definition` treats any
+        // non-empty `allowed_tools` on the inline Input as a CALLER
+        // override and skips the manifest's `tools` allow-list. Role
+        // defaults are NOT caller overrides — they should defer to
+        // the manifest's allow-list. Skip the role injection when a
+        // manifest reference is present so the manifest's `tools`
+        // gate fires; the role still contributes the prompt prefix
+        // through `spawn.rs::apply_role_template`.
+        let manifest_id_present = out
+            .get("agent_definition_id")
+            .and_then(Value::as_str)
+            .is_some_and(|s| !s.trim().is_empty());
+        let inline_allowed_present = out
+            .get("allowed_tools")
+            .and_then(Value::as_array)
+            .is_some_and(|arr| !arr.is_empty());
+        if !inline_allowed_present && !manifest_id_present {
+            // Drop any caller-supplied empty array so the role's
+            // budget is the one that ships.
+            out.remove("allowed_tools");
+            // Issue #971 codex P1 fix: filter expanded `group:*`
+            // entries to those the child's `with_builtins` registry
+            // actually has. The prior wiring forwarded raw expansions
+            // including `recall_memory` / `synthesize_research` /
+            // `save_memory` / `spawn` — none of which `with_builtins`
+            // registers — so every default role-based spawn failed
+            // `SpawnTool::ensure_subagent_tools_available` before the
+            // child could run. `to_spawn_compatible_allow` returns
+            // the intersection of the role's expansion with the
+            // builtin set.
+            out.insert(
+                "allowed_tools".to_string(),
+                Value::Array(
+                    template
+                        .to_spawn_compatible_allow()
+                        .into_iter()
+                        .map(Value::String)
+                        .collect(),
+                ),
+            );
+        } else if manifest_id_present && !inline_allowed_present {
+            // Codex iter-5 P1: ensure we don't pass a stale empty
+            // array through when a manifest is set. Removing the key
+            // entirely lets `apply_agent_definition` install the
+            // manifest's `tools` allow-list unmolested.
+            out.remove("allowed_tools");
+        }
+    }
     if let Some(agent_type) = args
         .get("agent_type")
         .and_then(Value::as_str)
@@ -1131,6 +1256,14 @@ impl Tool for SpawnAgentTool {
     }
 
     fn input_schema(&self) -> Value {
+        // Issue #971 (M14-C): advertise `role` and enumerate the four
+        // backend-owned templates so the LLM can discover them without
+        // probing the server. Enum values stay in sync with
+        // `RoleTemplate::all()` via the static role constants.
+        let role_names: Vec<Value> = crate::role_template::RoleTemplate::all()
+            .iter()
+            .map(|tpl| Value::String(tpl.name.to_string()))
+            .collect();
         json!({
             "type": "object",
             "properties": {
@@ -1144,7 +1277,12 @@ impl Tool for SpawnAgentTool {
                 "label": {"type": "string"},
                 "role": {"type": "string"},
                 "mode": {"type": "string", "enum": ["background", "sync"]},
-                "allowed_tools": {"type": "array", "items": {"type": "string"}}
+                "allowed_tools": {"type": "array", "items": {"type": "string"}},
+                "role": {
+                    "type": "string",
+                    "description": "Optional backend-owned role template that resolves to a tool budget + sandbox + model preference + prompt prefix. When set, the resolved template seeds the spawn payload; inline `allowed_tools` still wins.",
+                    "enum": role_names,
+                }
             }
         })
     }
@@ -1154,10 +1292,60 @@ impl Tool for SpawnAgentTool {
     }
 
     async fn execute_with_context(&self, ctx: &ToolContext, args: &Value) -> Result<ToolResult> {
+        // Issue #971 (M14-C): resolve the optional `role` argument
+        // against the typed `RoleTemplate` registry BEFORE we forward to
+        // the native spawn delegate. Unknown values fail at the boundary
+        // (structured error) rather than silently spawning under a role
+        // the LLM did not ask for.
+        //
+        // PR #1177 codex round-2 P2 fix: also consult the Codex
+        // `agent_type` alias path (`agent_type: "worker"` etc.) so a
+        // caller that uses the historical #1148 alias instead of an
+        // explicit `role` still gets the spawn-compatible
+        // `allowed_tools` budget folded in AND the BackgroundTask
+        // role/stamp populated. `normalize_spawn_agent_args_with_role`
+        // already mirrors the agent_type alias to `role` for the wire
+        // payload; this hoist mirrors it for the boundary-side
+        // template injection too.
+        let role_template = match args.get("role").and_then(Value::as_str).map(str::trim) {
+            Some(name) if !name.is_empty() => {
+                match crate::role_template::RoleTemplate::for_name(name) {
+                    Some(template) => Some(template),
+                    None => {
+                        let registered: Vec<&str> = crate::role_template::RoleTemplate::all()
+                            .iter()
+                            .map(|tpl| tpl.name)
+                            .collect();
+                        return Ok(ToolResult {
+                            output: format!(
+                                "spawn_agent: unknown role {:?}; registered roles: {}",
+                                name,
+                                registered.join(", ")
+                            ),
+                            success: false,
+                            structured_metadata: Some(json!({
+                                "codex_tool": "spawn_agent",
+                                "error": "unknown_role",
+                                "role": name,
+                                "registered_roles": registered,
+                            })),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            _ => args
+                .get("agent_type")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .and_then(crate::role_template::RoleTemplate::for_codex_agent_type),
+        };
+
         let Some(delegate) = self.delegate.as_ref() else {
             return spawn_agent_without_delegate(args, ctx).await;
         };
-        let spawn_args = normalize_spawn_agent_args(args);
+        let spawn_args = normalize_spawn_agent_args_with_role(args, role_template);
         let before = ctx
             .task_supervisor
             .as_ref()
@@ -1181,21 +1369,121 @@ impl Tool for SpawnAgentTool {
             "status": "started",
             "output": result.output,
         });
+        let mut resolved_task_id: Option<String> = None;
         if let Some(task) = task {
             payload["agent_id"] = json!(task.id);
             payload["status"] = json!(task.status.as_str());
             payload["runtime_state"] = json!(format!("{:?}", task.runtime_state));
             payload["child_session_key"] = json!(task.child_session_key);
             payload["terminal"] = json!(task.status.is_terminal());
+            resolved_task_id = Some(task.id);
+        }
+
+        // Issue #971 (M14-C): label the supervisor's BackgroundTask with
+        // the resolved role so the M13 `task/list` and `task/updated`
+        // projections inherit `role = "reviewer"` (or whatever the
+        // caller resolved). Without this the AppUI spawn-role badge
+        // cannot render and the M14-C acceptance check ("child task
+        // summaries and artifacts appear through M13 task/list") fails.
+        //
+        // Issue #971 codex iter-3 P2.2: also stamp a bounded
+        // `runtime_policy_stamp` snapshot of the resolved template +
+        // effective allow list, so reconnect hydration / `task/updated`
+        // subscribers see the server-resolved sandbox / approval /
+        // model preference / tool budget the child agent is running
+        // under. Without the stamp, `task/list` would only carry the
+        // role NAME and clients would have to re-resolve the template
+        // registry to learn the effective policy — defeating the
+        // M14-C acceptance "role/tool/sandbox/model policy resolved
+        // by the server runtime".
+        if let (Some(template), Some(task_id), Some(supervisor)) = (
+            role_template,
+            resolved_task_id.as_deref(),
+            ctx.task_supervisor.as_ref(),
+        ) {
+            // Issue #971 codex iter-4 P2 + iter-5 P2: the
+            // `allowed_tools` field IS effective when no manifest is
+            // referenced (the spawn tool's child registry runs under
+            // EXACTLY this allow list), but `sandbox_mode`,
+            // `approval_policy`, and `model_preference` are advisory
+            // — they're the template's DECLARED defaults, not the
+            // sandbox/approval settings the spawned `SpawnTool`
+            // actually applies. When `agent_definition_id` is set,
+            // `SpawnTool::apply_agent_definition` may further prune
+            // the allow list via the manifest's `tools` and
+            // `disallowed_tools`, so the stamp marks the dimension as
+            // `subject_to_manifest` and surfaces the manifest id —
+            // otherwise `task/list` could report tools as `enforced`
+            // allowed after the manifest pruned them.
+            let manifest_id = spawn_args
+                .get("agent_definition_id")
+                .and_then(Value::as_str)
+                .filter(|s| !s.trim().is_empty());
+            let effective_allowed: Vec<&str> = spawn_args
+                .get("allowed_tools")
+                .and_then(Value::as_array)
+                .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+                .unwrap_or_default();
+            let allowed_tools_enforcement = if manifest_id.is_some() {
+                "subject_to_manifest"
+            } else {
+                "enforced"
+            };
+            let mut stamp = json!({
+                "role": template.name,
+                "role_display_name": template.display_name,
+                // Pre-manifest allow list. When a manifest is set,
+                // the child's actual policy may be tighter — see
+                // `policy_enforcement.allowed_tools`.
+                "allowed_tools": effective_allowed,
+                "policy_enforcement": {
+                    "allowed_tools": allowed_tools_enforcement,
+                    "sandbox_mode": "advisory",
+                    "approval_policy": "advisory",
+                    "model_preference": "advisory",
+                },
+                // Advisory: the role's declared defaults. The spawn
+                // tool does not currently propagate these to the
+                // child sandbox / approval / model resolution — they
+                // ride as metadata so a future wiring can surface
+                // the gap and so clients can render the role's
+                // self-description without re-resolving the registry.
+                "declared_sandbox_mode": template.default_sandbox_mode,
+                "declared_approval_policy": template.default_approval_policy,
+                "declared_model_preference": template.model_preference.as_str(),
+            });
+            if let Some(id) = manifest_id {
+                stamp["agent_definition_id"] = json!(id);
+            }
+            supervisor.set_m13b_projection(
+                task_id,
+                Some("model".to_string()),
+                Some(template.name.to_string()),
+                None,
+                None,
+                Some(stamp),
+            );
+        }
+
+        // PR #1177 reconciliation: the prefix prepending was moved
+        // downstream into `spawn.rs::apply_role_template` to avoid
+        // doubling the prefix in the child's system context. As a
+        // result `spawn_args.additional_instructions` no longer
+        // carries the server-owned prompt prefix at this layer, so
+        // the dedicated redaction step from PR #1171 is unnecessary.
+        let mut meta = json!({
+            "codex_tool": "spawn_agent",
+            "octos_tool": "spawn",
+            "spawn_args": spawn_args.clone(),
+        });
+        if let Some(template) = role_template {
+            meta["role"] = json!(template.name);
+            meta["role_summary"] = serde_json::to_value(template.summary()).unwrap_or(Value::Null);
         }
         Ok(ToolResult {
             output: payload.to_string(),
             success: true,
-            structured_metadata: Some(json!({
-                "codex_tool": "spawn_agent",
-                "octos_tool": "spawn",
-                "spawn_args": spawn_args,
-            })),
+            structured_metadata: Some(meta),
             ..Default::default()
         })
     }
@@ -3104,6 +3392,786 @@ mod tests {
                 .as_str()
                 .unwrap()
                 .contains("reasoning_effort: high")
+        );
+    }
+
+    /// Issue #971 (M14-C wiring contract): `spawn_agent` MUST accept a
+    /// `role` argument that resolves through `RoleTemplate::for_name`
+    /// and (1) seeds the dispatched spawn payload with the template's
+    /// `allowed_tools` budget, (2) appends the template's `prompt_prefix`
+    /// to the child's `additional_instructions`, (3) labels the
+    /// supervisor's `BackgroundTask.role` field so M13's `task/list`
+    /// projection inherits the role name without TUI/web doing any
+    /// orchestration of its own.
+    ///
+    /// The fake spawn tool below records the spawn payload it received
+    /// onto the supervised task's `tool_input`. We then assert on the
+    /// recorded payload + the supervisor's BackgroundTask projection.
+    #[tokio::test]
+    async fn spawn_agent_with_role_argument_uses_template_runtime_factory_per_971() {
+        use crate::role_template::{ROLE_REVIEWER, RoleTemplate};
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "audit PR #1234",
+                    "role": ROLE_REVIEWER,
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        // (3) Supervisor's BackgroundTask MUST carry the role label so
+        // M13 task/list and task/updated emit `role = "reviewer"` to
+        // observers. Without this the AppUI spawn-role badge cannot
+        // render and the contract acceptance check breaks.
+        assert_eq!(
+            task.role.as_deref(),
+            Some(ROLE_REVIEWER),
+            "spawn_agent must label BackgroundTask.role with the resolved template"
+        );
+        // (1) The spawn payload the fake delegate received MUST include
+        // the template's tool budget so the child agent runs under the
+        // policy the template promises. Group entries are EXPANDED to
+        // concrete tool names (codex P1 fix) AND filtered to tools the
+        // child's `with_builtins` registry has (codex P1 iteration 2)
+        // — otherwise `SpawnTool::ensure_subagent_tools_available`
+        // would fail every default role-based spawn.
+        let spawn_input = task.tool_input.expect("tool input recorded");
+        let reviewer = RoleTemplate::for_name(ROLE_REVIEWER).unwrap();
+        let allowed = spawn_input["allowed_tools"]
+            .as_array()
+            .expect("allowed_tools array on spawn payload");
+        let allowed: Vec<&str> = allowed.iter().filter_map(Value::as_str).collect();
+        for expected in reviewer.to_spawn_compatible_allow() {
+            assert!(
+                allowed.contains(&expected.as_str()),
+                "spawn payload must include {expected:?}; got {allowed:?}"
+            );
+        }
+        // Codex P1 regression guard: NO `group:*` entries leak through
+        // to the spawn payload. The native spawn tool does exact-name
+        // lookup, so group identifiers would fail availability.
+        for entry in &allowed {
+            assert!(
+                !entry.starts_with("group:"),
+                "spawn payload must not contain raw group identifier {entry:?}; \
+                 it would fail SpawnTool::ensure_subagent_tools_available"
+            );
+        }
+        // Spot-check: reviewer's `group:search` expanded to glob/grep/
+        // list_dir on the wire.
+        for expected_member in ["glob", "grep", "list_dir"] {
+            assert!(
+                allowed.contains(&expected_member),
+                "reviewer's group:search must expand to include {expected_member:?}; \
+                 got {allowed:?}"
+            );
+        }
+        // Codex P1 iteration 2 regression: tools NOT in
+        // `ToolRegistry::with_builtins` (e.g. `recall_memory`,
+        // `synthesize_research`, `save_memory`, `spawn`) must NOT
+        // appear on the wire. Otherwise the child availability check
+        // fires.
+        for excluded in [
+            "recall_memory",
+            "synthesize_research",
+            "save_memory",
+            "spawn",
+        ] {
+            assert!(
+                !allowed.contains(&excluded),
+                "spawn payload must not include {excluded:?} (not in with_builtins child registry); \
+                 got {allowed:?}"
+            );
+        }
+        // (2) The reviewer role label MUST be propagated on the wire
+        // so the native spawn delegate's `apply_role_template` can
+        // prepend the prompt_prefix to the child's `additional_instructions`.
+        // Codex iter-2 fix (PR #1177): we no longer prepend the prefix
+        // at the `spawn_agent` boundary because `spawn.rs::apply_role_template`
+        // does it universally for every `role`-bearing spawn — doing it
+        // here too would double the prefix in the child's system context.
+        assert_eq!(
+            spawn_input["role"],
+            json!(ROLE_REVIEWER),
+            "spawn payload MUST forward role so spawn.rs::apply_role_template can layer prefix",
+        );
+        // Sanity: structured metadata carries the resolved role so the
+        // AppUI tool stream can show "spawned reviewer subagent" without
+        // re-resolving the registry.
+        let meta = result
+            .structured_metadata
+            .as_ref()
+            .expect("spawn_agent must emit structured_metadata");
+        assert_eq!(
+            meta["role"],
+            json!(ROLE_REVIEWER),
+            "structured_metadata must echo the resolved role"
+        );
+        // Codex P2 regression guard (PR #1171 → PR #1177): the
+        // server-owned `prompt_prefix` MUST NOT leak through
+        // `structured_metadata.spawn_args`. The role summary already
+        // keeps the prefix off the wire; this pins the spawn-payload
+        // echo to do the same. With the prefix prepending moved
+        // downstream into `spawn.rs::apply_role_template`, the boundary
+        // payload simply never carries the prefix in the first place.
+        let metadata_extra = meta["spawn_args"]["additional_instructions"]
+            .as_str()
+            .unwrap_or_default();
+        assert!(
+            !metadata_extra.contains("code reviewer"),
+            "structured_metadata.spawn_args MUST NOT echo the role prompt prefix; \
+             got {metadata_extra:?}"
+        );
+
+        // Codex iter-3 P2.2 regression: BackgroundTask.runtime_policy_stamp
+        // MUST be populated for role-based spawns so reconnect hydration
+        // and `task/updated` subscribers see the server-resolved allow
+        // list. Codex iter-4 P2 refinement: the stamp distinguishes
+        // ENFORCED dimensions (`allowed_tools`) from ADVISORY ones
+        // (`declared_sandbox_mode` etc.) so clients render the role's
+        // self-description without trusting an unenforced policy.
+        let stamp = task
+            .runtime_policy_stamp
+            .as_ref()
+            .expect("BackgroundTask.runtime_policy_stamp MUST be populated for role spawns");
+        assert_eq!(stamp["role"], json!(ROLE_REVIEWER));
+        // Advisory declared defaults — surfaced under `declared_*`
+        // names so clients don't mistake them for enforced policy.
+        assert_eq!(stamp["declared_sandbox_mode"], json!("none"));
+        assert_eq!(stamp["declared_approval_policy"], json!("never"));
+        assert_eq!(stamp["declared_model_preference"], json!("coding"));
+        // Enforcement tag MUST mark `allowed_tools` as enforced and
+        // the rest as advisory — codex iter-4 P2 contract.
+        assert_eq!(
+            stamp["policy_enforcement"]["allowed_tools"],
+            json!("enforced")
+        );
+        for advisory in ["sandbox_mode", "approval_policy", "model_preference"] {
+            assert_eq!(
+                stamp["policy_enforcement"][advisory],
+                json!("advisory"),
+                "policy_enforcement.{advisory} must be 'advisory' until the spawn tool propagates it"
+            );
+        }
+        // The enforced allow_tools list MUST appear on the stamp.
+        let stamp_allowed = stamp["allowed_tools"]
+            .as_array()
+            .expect("runtime_policy_stamp.allowed_tools must be array");
+        let stamp_allowed: Vec<&str> = stamp_allowed.iter().filter_map(Value::as_str).collect();
+        for member in ["glob", "grep", "list_dir", "read_file"] {
+            assert!(
+                stamp_allowed.contains(&member),
+                "runtime_policy_stamp.allowed_tools must include {member:?}; \
+                 got {stamp_allowed:?}"
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C) PR #1177 reconciliation: with the prompt-
+    /// prefix prepending consolidated into `spawn.rs::apply_role_template`
+    /// (the codex iter-2 fix that removed the prefix doubling between
+    /// the `spawn_agent` boundary and the native spawn delegate), the
+    /// `spawn_agent` boundary's job is to FORWARD the resolved role and
+    /// any caller-supplied `additional_instructions` without doubling
+    /// either of them. This test pins that contract: role goes on the
+    /// wire as `role`, caller hint stays in `additional_instructions`,
+    /// the prompt_prefix is NOT prepended at this layer (so `apply_role_template`
+    /// can prepend it once and the child's system context carries a
+    /// single role prefix).
+    #[tokio::test]
+    async fn m14_c_wiring_spawn_agent_forwards_role_and_caller_instructions_per_971() {
+        use crate::role_template::{ROLE_REVIEWER, RoleTemplate};
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "audit PR #1234",
+                    "role": ROLE_REVIEWER,
+                    "additional_instructions": "CALLER_HINT_SENTINEL",
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        let spawn_input = task.tool_input.expect("tool input recorded");
+
+        // Role is forwarded so spawn.rs::apply_role_template can layer
+        // the prompt prefix at the native spawn boundary.
+        assert_eq!(
+            spawn_input["role"],
+            json!(ROLE_REVIEWER),
+            "role must be forwarded on the spawn payload",
+        );
+        // Caller hint is preserved verbatim — the boundary does not
+        // touch additional_instructions for role purposes anymore.
+        let extra = spawn_input["additional_instructions"]
+            .as_str()
+            .expect("additional_instructions on spawn payload");
+        assert!(
+            extra.contains("CALLER_HINT_SENTINEL"),
+            "caller hint must be preserved; got {extra:?}"
+        );
+        // Codex iter-2 fix regression guard: the prompt_prefix MUST NOT
+        // be prepended at this layer (spawn.rs::apply_role_template
+        // would otherwise prepend it AGAIN, doubling the role prefix
+        // in the child's system context).
+        let reviewer = RoleTemplate::for_name(ROLE_REVIEWER).unwrap();
+        assert!(
+            !extra.contains(reviewer.prompt_prefix),
+            "spawn_agent boundary MUST NOT prepend prompt_prefix (spawn.rs::apply_role_template \
+             handles it); got {extra:?}"
+        );
+    }
+
+    /// Issue #971 (M14-C) codex iter-5 P1: when a caller passes BOTH
+    /// `role` AND `agent_definition_id`, the role MUST NOT inject its
+    /// `allowed_tools` into the spawn payload — `SpawnTool::apply_agent_definition`
+    /// treats any non-empty inline `allowed_tools` as a caller override
+    /// that skips the manifest's `tools` allow-list, so role defaults
+    /// would bypass the manifest's safety envelope (e.g. a `role="implementer"`
+    /// with the `research-worker` manifest could still receive
+    /// `apply_patch` / `diff_edit` / `exec_command` even though the
+    /// manifest never allowed them).
+    ///
+    /// This test asserts the wire payload: when both fields are
+    /// present, the role's tool budget is NOT in `allowed_tools` —
+    /// the manifest is left to install its own allow list downstream.
+    /// The role still contributes the prompt prefix.
+    #[tokio::test]
+    async fn spawn_agent_role_with_agent_definition_id_defers_to_manifest_per_971() {
+        use crate::role_template::ROLE_IMPLEMENTER;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "implement #1234",
+                    "role": ROLE_IMPLEMENTER,
+                    "agent_definition_id": "research-worker",
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        let spawn_input = task.tool_input.expect("tool input recorded");
+        // The wire payload MUST NOT carry the role's allowed_tools
+        // when a manifest is referenced. Leaving the field absent
+        // lets `apply_agent_definition` install the manifest's
+        // `tools` allow-list unmolested.
+        assert!(
+            spawn_input.get("allowed_tools").is_none()
+                || spawn_input["allowed_tools"]
+                    .as_array()
+                    .is_some_and(|a| a.is_empty()),
+            "spawn payload MUST NOT carry role-derived allowed_tools when a manifest is set; \
+             got allowed_tools = {:?}",
+            spawn_input.get("allowed_tools")
+        );
+        // The manifest id MUST be forwarded so the spawn tool can
+        // resolve it.
+        assert_eq!(
+            spawn_input["agent_definition_id"],
+            json!("research-worker"),
+            "spawn payload must forward agent_definition_id"
+        );
+        // The role label MUST still be forwarded so `spawn.rs::apply_role_template`
+        // can anchor the child's system prompt on the role's voice
+        // (codex iter-2 fix consolidated the prefix prepending downstream;
+        // at this boundary we only have to make sure the role survives
+        // the manifest-deference branch).
+        assert_eq!(
+            spawn_input["role"],
+            json!(ROLE_IMPLEMENTER),
+            "spawn payload MUST forward role even when manifest deference \
+             skips the role's tool budget",
+        );
+        // Codex iter-5 P2: when a manifest is present, the stamp
+        // must mark `policy_enforcement.allowed_tools` as
+        // `subject_to_manifest` (not `enforced`) so clients can tell
+        // the pre-manifest allow list is not authoritative.
+        let stamp = task
+            .runtime_policy_stamp
+            .as_ref()
+            .expect("BackgroundTask.runtime_policy_stamp MUST be populated for role spawns");
+        assert_eq!(
+            stamp["policy_enforcement"]["allowed_tools"],
+            json!("subject_to_manifest"),
+            "manifest-pruned stamp must mark allowed_tools as 'subject_to_manifest'"
+        );
+        assert_eq!(
+            stamp["agent_definition_id"],
+            json!("research-worker"),
+            "stamp must surface the manifest id so clients can re-resolve"
+        );
+    }
+
+    /// Issue #971 (M14-C) codex iter-3 P2.1: the `implementer` template
+    /// advertises `group:sessions`, which expands to `spawn_agent` /
+    /// `send_input` / `resume_agent` / `wait_agent` / `close_agent`.
+    /// `ToolRegistry::with_builtins` registers `SpawnAgentTool::new()`
+    /// WITHOUT a native `spawn` delegate, so an implementer child that
+    /// tried to use `spawn_agent` would always fail with "no native
+    /// delegate". Filter it from the spawn-compatible budget. The other
+    /// session aliases (`send_input` etc.) only need the supervisor
+    /// in `ctx`, which a child still inherits, so they stay.
+    #[tokio::test]
+    async fn spawn_agent_implementer_does_not_advertise_undelegated_spawn_agent_per_971() {
+        use crate::role_template::{ROLE_IMPLEMENTER, RoleTemplate};
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "implement #1234",
+                    "role": ROLE_IMPLEMENTER,
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        let spawn_input = task.tool_input.expect("tool input recorded");
+        let allowed = spawn_input["allowed_tools"]
+            .as_array()
+            .expect("allowed_tools array");
+        let allowed: Vec<&str> = allowed.iter().filter_map(Value::as_str).collect();
+        // The undelegated alias MUST NOT appear in the wire allow list,
+        // otherwise the child would be offered a tool that always
+        // fails with "spawn_agent requires the session runtime to
+        // register a native spawn tool delegate".
+        assert!(
+            !allowed.contains(&"spawn_agent"),
+            "implementer's spawn payload MUST NOT advertise the undelegated \
+             spawn_agent alias; got {allowed:?}"
+        );
+        // The native `spawn` tool is also NOT in `with_builtins`, so
+        // the role budget should not include it either.
+        assert!(
+            !allowed.contains(&"spawn"),
+            "implementer's spawn payload MUST NOT advertise the unregistered \
+             native spawn tool; got {allowed:?}"
+        );
+        // Other session aliases stay — they only need the supervisor
+        // handle which IS in ctx.
+        for delegated in ["send_input", "resume_agent", "wait_agent", "close_agent"] {
+            assert!(
+                allowed.contains(&delegated),
+                "implementer's spawn payload should advertise {delegated:?} \
+                 (works via ctx.task_supervisor); got {allowed:?}"
+            );
+        }
+        // Sanity: the role template ITSELF still permits `group:sessions`
+        // (we only filter the wire projection, not the static schema).
+        // This pins the contract — the spec stays unchanged.
+        let implementer = RoleTemplate::for_name(ROLE_IMPLEMENTER).unwrap();
+        assert!(implementer.permits("group:sessions"));
+    }
+
+    /// Issue #971 (M14-C wiring contract): an unknown `role` value MUST
+    /// fail at the tool boundary with a structured error rather than
+    /// silently defaulting to a template the LLM did not ask for. The
+    /// `TaskListEntry.role` field is `Option<String>` precisely because
+    /// the caller is expected to handle the unknown case explicitly.
+    #[tokio::test]
+    async fn spawn_agent_rejects_unknown_role_per_971() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "audit PR #1234",
+                    "role": "review",
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(
+            !result.success,
+            "spawn_agent must refuse unknown role; output={:?}",
+            result.output
+        );
+        assert!(
+            result.output.contains("unknown role")
+                || (result.output.contains("role") && result.output.contains("review")),
+            "error must mention the offending role name; got {:?}",
+            result.output
+        );
+    }
+
+    /// Issue #971 (M14-C): `spawn_agent` MUST keep working WITHOUT an
+    /// explicit `role` argument so the #1148 P0/P1 alias parity does
+    /// not regress. PR #1177 codex round-2 P2 refinement: when the
+    /// caller still uses the Codex `agent_type` alias (e.g.
+    /// `agent_type: "worker"` for the implementer role), the
+    /// `spawn_agent` boundary resolves the role via
+    /// `for_codex_agent_type` so the spawn-compatible tool budget +
+    /// BackgroundTask role/stamp ARE applied — otherwise the real
+    /// spawn delegate's `apply_role_template` would fall back to the
+    /// raw `allowed_tools_vec()` (with `group:*` entries) and
+    /// `ensure_subagent_tools_available` would reject the spawn.
+    /// This test pins both halves: the normalization still emits the
+    /// historical `codex-worker` label, AND the role gets resolved.
+    #[tokio::test]
+    async fn spawn_agent_without_role_argument_preserves_1148_behavior() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "inspect parity",
+                    "agent_type": "worker",
+                    "reasoning_effort": "high",
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        // The historical #1148 normalization still fires.
+        let input = task.tool_input.clone().expect("tool input");
+        assert_eq!(input["task"], "inspect parity");
+        assert_eq!(input["label"], "codex-worker");
+        // PR #1177 codex round-2 P2: the agent_type alias path
+        // resolves to ROLE_IMPLEMENTER so the spawn-compatible
+        // budget is folded in; BackgroundTask.role now mirrors that
+        // resolution.
+        assert_eq!(
+            task.role.as_deref(),
+            Some(crate::role_template::ROLE_IMPLEMENTER),
+            "agent_type='worker' must resolve to ROLE_IMPLEMENTER so the spawn-compatible \
+             allow list is injected; got {:?}",
+            task.role,
+        );
+        assert_eq!(
+            input["role"],
+            json!(crate::role_template::ROLE_IMPLEMENTER),
+            "spawn payload must forward the resolved role label"
+        );
+    }
+
+    /// Issue #971 (M14-C) PR #1177 codex round-3 P2 regression: a
+    /// client that serialises an unset `role` as `null` or `""` MUST
+    /// NOT defeat the `agent_type` alias resolution. The boundary
+    /// strips blank role values before reading the agent_type alias,
+    /// then writes the canonical resolved role back into the spawn
+    /// payload so the spawn delegate's `apply_role_template` sees the
+    /// same template the BackgroundTask was stamped with. Without
+    /// this fix, the spawn delegate would receive `role: null` /
+    /// `role: ""` and skip the prompt-prefix injection even though
+    /// the wrapper stamped the role.
+    #[tokio::test]
+    async fn m14_c_wiring_blank_role_with_agent_type_resolves_template_per_971() {
+        for blank in [Value::Null, json!(""), json!("   ")] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let mut registry = ToolRegistry::with_builtins(temp.path());
+            registry.register(FakeSpawnTool);
+            let supervisor = registry.supervisor();
+            let ctx = ToolContext {
+                task_supervisor: Some(supervisor.clone()),
+                parent_session_key: Some("api:test".to_string()),
+                ..ToolContext::zero()
+            };
+            let result = registry
+                .execute_with_context(
+                    &ctx,
+                    "spawn_agent",
+                    &json!({
+                        "message": "inspect parity",
+                        "agent_type": "worker",
+                        "role": blank.clone(),
+                    }),
+                )
+                .await
+                .expect("spawn_agent");
+            assert!(result.success, "{}", result.output);
+            let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+            let agent_id = payload["agent_id"].as_str().expect("agent id");
+            let task = supervisor.get_task(agent_id).expect("task registered");
+            let input = task.tool_input.clone().expect("tool input");
+            assert_eq!(
+                input["role"],
+                json!(crate::role_template::ROLE_IMPLEMENTER),
+                "blank role={blank:?} + agent_type='worker' MUST write canonical ROLE_IMPLEMENTER \
+                 to the spawn payload so apply_role_template fires"
+            );
+            assert_eq!(
+                task.role.as_deref(),
+                Some(crate::role_template::ROLE_IMPLEMENTER),
+                "blank role={blank:?} + agent_type='worker' MUST stamp BackgroundTask.role with \
+                 the resolved template",
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C) PR #1177 codex round-3 P2: when the caller
+    /// passes a non-canonical (but case- or whitespace-sloppy) explicit
+    /// `role` that nevertheless resolves through the registry (e.g.
+    /// because the boundary lookup does `RoleTemplate::for_name` on
+    /// the trimmed value), the spawn payload MUST carry the canonical
+    /// name — not whatever sloppy spelling the caller used — so the
+    /// spawn delegate's `apply_role_template` does an exact-name
+    /// lookup against the registry without re-trimming.
+    #[tokio::test]
+    async fn m14_c_wiring_resolved_role_writes_canonical_name_per_971() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "audit PR #1234",
+                    // Explicit canonical name with surrounding
+                    // whitespace — boundary trims for lookup; ensure
+                    // the trimmed canonical name lands on the wire.
+                    "role": "  reviewer  ",
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        let input = task.tool_input.expect("tool input recorded");
+        assert_eq!(
+            input["role"],
+            json!(crate::role_template::ROLE_REVIEWER),
+            "spawn payload MUST carry the trimmed canonical role name"
+        );
+    }
+
+    /// Issue #971 (M14-C) PR #1177 codex round-2 P2 regression: when
+    /// the caller passes an `agent_type` alias whose `for_codex_agent_type`
+    /// resolution returns `None` (e.g. `agent_type: "planner"`), the
+    /// boundary MUST NOT label the task with a role — otherwise an
+    /// unrecognised agent_type would silently inherit some default
+    /// role's policy budget. This pins the negative case.
+    #[tokio::test]
+    async fn m14_c_wiring_unknown_agent_type_does_not_synthesize_role_per_971() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "inspect parity",
+                    "agent_type": "planner",
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        assert!(
+            task.role.is_none(),
+            "unknown agent_type MUST NOT synthesize a role label; got {:?}",
+            task.role,
+        );
+        assert!(
+            task.runtime_policy_stamp.is_none(),
+            "unknown agent_type MUST NOT stamp a runtime policy",
+        );
+    }
+
+    /// Issue #971 (M14-C) codex P1 iteration 2: when the caller passes
+    /// `role` AND an EMPTY `allowed_tools: []` array, the empty array
+    /// MUST NOT silently override the template's restricted budget.
+    /// The native spawn tool treats an empty allow-list as "all
+    /// builtins"; without this guard a client that always serialises
+    /// empty optional arrays would let a reviewer/explorer/test_worker
+    /// spawn receive write, shell, and browser tools.
+    #[tokio::test]
+    async fn spawn_agent_with_role_ignores_empty_allowed_tools_per_971() {
+        use crate::role_template::{ROLE_REVIEWER, RoleTemplate};
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "audit PR #1234",
+                    "role": ROLE_REVIEWER,
+                    // Client serialises optional array as empty — this
+                    // MUST be treated as "no override", not as the
+                    // native spawn-tool sentinel for "all builtins".
+                    "allowed_tools": [],
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        let spawn_input = task.tool_input.expect("tool input recorded");
+        let reviewer = RoleTemplate::for_name(ROLE_REVIEWER).unwrap();
+        let allowed = spawn_input["allowed_tools"]
+            .as_array()
+            .expect("allowed_tools array on spawn payload");
+        let allowed: Vec<&str> = allowed.iter().filter_map(Value::as_str).collect();
+        // Empty inline override MUST be overridden BY the template's
+        // budget — every spawn-compatible tool the reviewer permits
+        // appears on the wire.
+        assert!(
+            !allowed.is_empty(),
+            "spawn payload allowed_tools MUST NOT be empty when a role is set; \
+             empty would be interpreted as 'all builtins' by the spawn tool"
+        );
+        for expected in reviewer.to_spawn_compatible_allow() {
+            assert!(
+                allowed.contains(&expected.as_str()),
+                "spawn payload must include {expected:?} after empty override; \
+                 got {allowed:?}"
+            );
+        }
+        // And the reviewer's deny set MUST NOT leak through.
+        for forbidden in ["write_file", "edit_file", "shell", "exec_command"] {
+            assert!(
+                !allowed.contains(&forbidden),
+                "reviewer spawn payload MUST NOT include {forbidden:?} after \
+                 empty override; got {allowed:?}"
+            );
+        }
+    }
+
+    /// Issue #971 (M14-C) codex P1 iteration 2: a NON-EMPTY inline
+    /// `allowed_tools` array MUST still override the template budget.
+    /// This pins the inline-wins contract: a caller can carve out a
+    /// custom budget for a one-off spawn even with `role` set.
+    #[tokio::test]
+    async fn spawn_agent_with_role_honors_nonempty_allowed_tools_override_per_971() {
+        use crate::role_template::ROLE_REVIEWER;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        registry.register(FakeSpawnTool);
+        let supervisor = registry.supervisor();
+        let ctx = ToolContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_session_key: Some("api:test".to_string()),
+            ..ToolContext::zero()
+        };
+        let result = registry
+            .execute_with_context(
+                &ctx,
+                "spawn_agent",
+                &json!({
+                    "message": "audit PR #1234",
+                    "role": ROLE_REVIEWER,
+                    "allowed_tools": ["read_file", "grep"],
+                }),
+            )
+            .await
+            .expect("spawn_agent");
+        assert!(result.success, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).expect("json payload");
+        let agent_id = payload["agent_id"].as_str().expect("agent id");
+        let task = supervisor.get_task(agent_id).expect("task registered");
+        let spawn_input = task.tool_input.expect("tool input recorded");
+        let allowed = spawn_input["allowed_tools"]
+            .as_array()
+            .expect("allowed_tools array on spawn payload");
+        let allowed: Vec<&str> = allowed.iter().filter_map(Value::as_str).collect();
+        assert_eq!(
+            allowed,
+            vec!["read_file", "grep"],
+            "non-empty inline allowed_tools must win over the role template"
         );
     }
 

--- a/crates/octos-cli/src/api/coding_tool_contract.rs
+++ b/crates/octos-cli/src/api/coding_tool_contract.rs
@@ -676,6 +676,26 @@ pub(crate) fn coding_tool_contract_payload(
     let mut deferred_names: Vec<&str> = deferred_model_tools.iter().copied().collect();
     deferred_names.sort();
 
+    // Issue #971 (M14-C): advertise the four backend-owned role
+    // templates so the AppUI/TUI can render a spawn-role picker
+    // without hard-coding the names client-side. Each entry is the
+    // bounded `RoleTemplateSummary` projection — the server-owned
+    // `prompt_prefix` stays off the wire. The acceptance gate
+    // (`Test: role/tool/sandbox/model policy is resolved by the
+    // server runtime`) checks for this field's presence + shape.
+    let role_templates: Vec<Value> = octos_agent::RoleTemplate::all()
+        .iter()
+        .map(|tpl| {
+            serde_json::to_value(tpl.summary()).unwrap_or_else(|_| {
+                // Should not happen — RoleTemplateSummary is plain
+                // &str / &[&str] and infallibly serializable. Fall
+                // back to the role name so the client still gets
+                // SOMETHING bounded to render.
+                json!({ "name": tpl.name })
+            })
+        })
+        .collect();
+
     json!({
         "id": CODING_TOOL_CONTRACT_ID,
         "version": CODING_TOOL_CONTRACT_VERSION,
@@ -685,6 +705,7 @@ pub(crate) fn coding_tool_contract_payload(
         "required_tools": required_tools,
         "missing_required_tools": missing_required_tools,
         "deferred_model_tools": deferred_names,
+        "role_templates": role_templates,
         "policy": {
             "tool_policy_id": policy.tool_policy_id,
             "sandbox_mode": policy.sandbox_mode,
@@ -958,6 +979,68 @@ mod tests {
             .iter()
             .find(|tool| tool["name"] == json!(name))
             .expect("required tool")
+    }
+
+    /// Issue #971 (M14-C acceptance): the coding tool contract payload
+    /// MUST surface the four backend-owned role templates so AppUI / TUI
+    /// can render a spawn-role picker without hard-coding the role list
+    /// client-side. Each entry is the bounded `RoleTemplateSummary`
+    /// projection; the server-owned `prompt_prefix` MUST NOT leak.
+    #[test]
+    fn m14_c_contract_payload_surfaces_role_templates_per_971() {
+        let payload =
+            tool_status_list_payload(ToolStatusListContext::default_for_session("coding:test"));
+        let contract = &payload["coding_tool_contract"];
+        let role_templates = contract["role_templates"]
+            .as_array()
+            .expect("role_templates array must be present on coding_tool_contract");
+        assert_eq!(
+            role_templates.len(),
+            4,
+            "M14-C contracts four role templates; got {role_templates:?}"
+        );
+        let names: Vec<&str> = role_templates
+            .iter()
+            .filter_map(|entry| entry["name"].as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["reviewer", "implementer", "test_worker", "explorer"],
+            "role_templates must enumerate the M14-C canonical names in stable order"
+        );
+        for entry in role_templates {
+            // Required fields the UX needs.
+            assert!(entry.get("name").is_some(), "missing name: {entry}");
+            assert!(
+                entry.get("display_name").is_some(),
+                "missing display_name: {entry}"
+            );
+            assert!(
+                entry.get("description").is_some(),
+                "missing description: {entry}"
+            );
+            assert!(
+                entry.get("allowed_tools").is_some(),
+                "missing allowed_tools: {entry}"
+            );
+            assert!(
+                entry.get("default_sandbox_mode").is_some(),
+                "missing default_sandbox_mode: {entry}"
+            );
+            assert!(
+                entry.get("default_approval_policy").is_some(),
+                "missing default_approval_policy: {entry}"
+            );
+            assert!(
+                entry.get("model_preference").is_some(),
+                "missing model_preference: {entry}"
+            );
+            // Safety: server-owned prompt_prefix MUST NOT leak.
+            assert!(
+                entry.get("prompt_prefix").is_none(),
+                "prompt_prefix MUST stay server-owned: {entry}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reconciliation rebase of #1171 onto current `main`. After #1174 (Codex
naming aliases) and #1114 (M14-C role registry types) both landed,
#1171's diff conflicted on `RoleTemplate`. This PR ports #1171's
WIRING (the part #1114 explicitly punted) onto the API main now
exposes.

What this PR adds on top of #1114 + #1174:
- `spawn_agent` accepts a `role` argument that resolves through
  `RoleTemplate::for_name`, folds the template's spawn-compatible
  tool budget + `prompt_prefix` into the spawn payload (prefix
  PREPENDED), defers to manifest when `agent_definition_id` set,
  rejects unknown role names at the tool boundary.
- `BackgroundTask.role` + `runtime_policy_stamp` are stamped via
  `set_m13b_projection` with `policy_enforcement` tagging
  (`enforced` vs `subject_to_manifest` vs `advisory`).
- `tool/status/list` payload surfaces the four role templates via
  `RoleTemplateSummary` (no prompt_prefix on the wire).
- New `RoleTemplate` methods: `to_expanded_tool_names`,
  `to_spawn_compatible_allow`, `summary`. Plus `SPAWN_BUILTIN_TOOLS`
  const and `redact_role_prompt_prefix` helper.

Reconciliation notes:
- #1171's `to_tool_policy_allow()` was redundant with main's
  `allowed_tools_vec()` — dropped, tests migrated to use main's
  API. All other #1171 methods were unique and ported verbatim.
- All 9 codex-review iteration fixes from #1171's history retained
  (group expansion, builtin filter, empty-array semantics, prompt-
  prefix redaction, undelegated-spawn-agent filter, runtime stamp,
  declared-vs-enforced tagging, prefix-before-caller, manifest
  deference).
- M14-C wiring test names migrated to `m14_c_wiring_*_per_971`
  prefix to avoid collision with #1114's `m14_c_*_per_971` guards.

Closes #971. Supersedes #1171.

## Test plan

- [x] `cargo test -p octos-agent --lib` clean (1555 pass; +11
      spawn_agent + 8 new role_template wiring guards)
- [x] `cargo test --lib -p octos-cli --features api api::coding_tool_contract`
      clean (15 pass; +1 contract payload guard)
- [x] `cargo test -p octos-core --lib` clean (214 pass)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p octos-agent --lib --tests --no-deps -- -D warnings`
      clean (pre-existing octos-cli lint backlog untouched)
- [x] 1529 LOC across 4 files, single squashed commit
- [x] No TUI/web code touched