### PR TITLE
Fix live tool catalog and pipeline budget controls

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1601,11 +1601,21 @@ impl Agent {
         files_modified: Vec<std::path::PathBuf>,
         files_to_send: Vec<std::path::PathBuf>,
     ) -> TaskResult {
-        let success = response.stop_reason != StopReason::MaxTokens;
+        let truncated = response.stop_reason == StopReason::MaxTokens;
+        let success = !truncated;
+        let mut output = response.content.clone().unwrap_or_default();
+        if truncated {
+            let marker = "[partial output: max_output_tokens reached before a final answer]";
+            output = if output.trim().is_empty() {
+                marker.to_string()
+            } else {
+                format!("{marker}\n\n{output}")
+            };
+        }
         TaskResult {
             schema_version: octos_core::TASK_RESULT_SCHEMA_VERSION,
             success,
-            output: response.content.clone().unwrap_or_default(),
+            output,
             files_modified,
             files_to_send,
             subtasks: Vec::new(),

--- a/crates/octos-agent/src/tools/coding_tools.rs
+++ b/crates/octos-agent/src/tools/coding_tools.rs
@@ -5213,6 +5213,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_search_live_catalog_respects_visibility_filters() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+
+        let search_tool = registry
+            .get_tool("tool_search")
+            .expect("tool_search registered by with_builtins");
+
+        registry.defer(["bash".to_string()]);
+        let result = search_tool
+            .execute(&serde_json::json!({ "query": "bash" }))
+            .await
+            .expect("tool_search ok");
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        let names: Vec<_> = payload["matches"]
+            .as_array()
+            .expect("matches")
+            .iter()
+            .filter_map(|m| m["name"].as_str())
+            .collect();
+        assert!(
+            !names.contains(&"bash"),
+            "deferred tools must stay out of tool_search: {names:?}"
+        );
+
+        registry.activate("bash");
+        registry.set_provider_policy(crate::tools::ToolPolicy {
+            deny: vec!["bash".to_string()],
+            ..Default::default()
+        });
+        let result = search_tool
+            .execute(&serde_json::json!({ "query": "bash" }))
+            .await
+            .expect("tool_search ok");
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        let names: Vec<_> = payload["matches"]
+            .as_array()
+            .expect("matches")
+            .iter()
+            .filter_map(|m| m["name"].as_str())
+            .collect();
+        assert!(
+            !names.contains(&"bash"),
+            "provider-denied tools must stay out of tool_search: {names:?}"
+        );
+
+        let mut registry = ToolRegistry::with_builtins(temp.path());
+        let search_tool = registry
+            .get_tool("tool_search")
+            .expect("tool_search registered by with_builtins");
+        registry.set_context_filter(vec!["web".to_string()]);
+        let result = search_tool
+            .execute(&serde_json::json!({ "query": "apply_patch" }))
+            .await
+            .expect("tool_search ok");
+        let payload: Value = serde_json::from_str(&result.output).expect("payload");
+        let names: Vec<_> = payload["matches"]
+            .as_array()
+            .expect("matches")
+            .iter()
+            .filter_map(|m| m["name"].as_str())
+            .collect();
+        assert!(
+            !names.contains(&"apply_patch"),
+            "context-hidden tools must stay out of tool_search: {names:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn builtins_expose_p1_codex_tool_names() {
         let temp = tempfile::tempdir().expect("tempdir");
         let registry = ToolRegistry::with_builtins(temp.path());

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -895,6 +895,7 @@ impl ToolRegistry {
         }
 
         if !activated.is_empty() {
+            drop(deferred);
             self.invalidate_cache_shared();
         }
         activated
@@ -1278,12 +1279,26 @@ impl ToolRegistry {
         registry
     }
 
-    /// Snapshot of every currently-registered tool as a [`ToolCatalogEntry`]
+    /// Snapshot of every currently model-visible tool as a [`ToolCatalogEntry`]
     /// list. Used by `with_builtins` to wire `tool_search` / `tool_suggest`
     /// against the effective coding tool contract.
     pub fn catalog_snapshot(&self) -> Vec<ToolCatalogEntry> {
+        let deferred = self.deferred.lock().unwrap_or_else(|e| e.into_inner());
         self.tools
             .values()
+            .filter(|tool| !deferred.contains(tool.name()))
+            .filter(|tool| {
+                self.provider_policy.as_ref().is_none_or(|policy| {
+                    provider_policy_allows_equivalent_with_tags(policy, tool.name(), tool.tags())
+                })
+            })
+            .filter(|tool| {
+                self.context_filter.as_ref().is_none_or(|tags| {
+                    let tool_tags = tool.tags();
+                    tool_tags.is_empty()
+                        || tool_tags.iter().any(|tag| tags.contains(&tag.to_string()))
+                })
+            })
             .map(|tool| {
                 ToolCatalogEntry::new(
                     tool.name(),

--- a/crates/octos-cli/src/status_layers.rs
+++ b/crates/octos-cli/src/status_layers.rs
@@ -252,6 +252,7 @@ mod default_priority {
 
 /// Minimum interval between message edits (rate limit protection).
 const EDIT_THROTTLE: Duration = Duration::from_millis(1000);
+const MAX_VISIBLE_STATUS_LAYERS: usize = 3;
 
 /// Composable status message system for messaging channels.
 ///
@@ -783,6 +784,9 @@ fn compose_message(
     let mut lines: Vec<String> = Vec::new();
 
     for layer in layers {
+        if lines.len() >= MAX_VISIBLE_STATUS_LAYERS {
+            break;
+        }
         // Skip disabled layers
         if layer.id == layer_id::PROVIDER && !provider_visible {
             continue;
@@ -1006,7 +1010,7 @@ mod tests {
     }
 
     #[test]
-    fn should_include_all_layers_in_order() {
+    fn should_cap_default_layers_in_priority_order() {
         let config = UserStatusConfig::default();
         let layers = build_layers(&config);
 
@@ -1028,12 +1032,14 @@ mod tests {
 
         let composed = compose_message(&layers, true, true, None);
         let lines: Vec<&str> = composed.lines().collect();
-        // Priority order: greeting(10), operation(20), retry(25), provider(30), metrics(40)
-        assert_eq!(lines[0], "👋 Hey!");
-        assert_eq!(lines[1], "✦ Pondering...");
-        assert_eq!(lines[2], "⟳ Switching to deepseek...");
-        assert_eq!(lines[3], "via moonshot");
-        assert_eq!(lines[4], "5s");
+        // Priority order: greeting(10), operation(20), retry(25).
+        // Provider and metrics stay suppressed once the default cap is reached.
+        assert_eq!(
+            lines,
+            vec!["👋 Hey!", "✦ Pondering...", "⟳ Switching to deepseek..."]
+        );
+        assert!(!composed.contains("via moonshot"));
+        assert!(!composed.contains("5s"));
     }
 
     #[test]

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -2553,7 +2553,7 @@ impl PipelineExecutor {
             }
 
             // Handle errors
-            if outcome.status == OutcomeStatus::Error {
+            if outcome.status == OutcomeStatus::Error && !node.continue_on_error {
                 warn!(
                     node = %node.id,
                     "node returned error, stopping pipeline"
@@ -2566,6 +2566,37 @@ impl PipelineExecutor {
                     files_modified: vec![],
                     node_costs: node_costs.clone(),
                 });
+            }
+            if outcome.status == OutcomeStatus::Error && node.continue_on_error {
+                warn!(
+                    node = %node.id,
+                    "node returned error, continuing because continue_on_error=true"
+                );
+            }
+
+            if let Some(max_total_tokens) = graph.max_total_tokens {
+                let spent = total_tokens
+                    .input_tokens
+                    .saturating_add(total_tokens.output_tokens);
+                if spent >= max_total_tokens {
+                    warn!(
+                        pipeline = %graph.id,
+                        spent,
+                        max_total_tokens,
+                        "pipeline token budget exhausted"
+                    );
+                    return Ok(PipelineResult {
+                        output: format!(
+                            "Pipeline token budget exhausted after node '{}': spent {spent}/{max_total_tokens} tokens",
+                            node.id
+                        ),
+                        success: false,
+                        token_usage: total_tokens,
+                        node_summaries: summaries,
+                        files_modified: vec![],
+                        node_costs: node_costs.clone(),
+                    });
+                }
             }
 
             // Select next edge

--- a/crates/octos-pipeline/src/graph.rs
+++ b/crates/octos-pipeline/src/graph.rs
@@ -14,6 +14,10 @@ pub struct PipelineGraph {
     pub label: Option<String>,
     /// Default model key for nodes that don't specify one.
     pub default_model: Option<String>,
+    /// Optional run-level token budget. The executor stops between nodes once
+    /// cumulative input + output tokens reaches this cap.
+    #[serde(default)]
+    pub max_total_tokens: Option<u32>,
     /// Nodes keyed by their ID.
     pub nodes: HashMap<String, PipelineNode>,
     /// Directed edges.
@@ -134,6 +138,10 @@ pub struct PipelineNode {
     /// deadline is set but no action is specified.
     #[serde(default)]
     pub deadline_action: Option<DeadlineAction>,
+    /// When true, preserve an Error outcome and continue edge routing instead
+    /// of aborting the whole pipeline immediately.
+    #[serde(default)]
+    pub continue_on_error: bool,
     /// Mission-level checkpoints to persist after this node completes.
     /// An empty list means no checkpoint is written for this node.
     #[serde(default)]
@@ -161,6 +169,7 @@ impl Default for PipelineNode {
             max_tasks: None,
             deadline_secs: None,
             deadline_action: None,
+            continue_on_error: false,
             checkpoints: Vec::new(),
         }
     }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -18,6 +18,9 @@ use octos_agent::tools::{TOOL_CTX, Tool, ToolRegistry};
 use crate::condition;
 use crate::graph::{HandlerKind, NodeOutcome, OutcomeStatus, PipelineNode};
 
+const DEFAULT_PIPELINE_MAX_OUTPUT_TOKENS: u32 = 4096;
+const PIPELINE_INPUT_COMPACTION_RESERVE_TOKENS: u32 = 1024;
+
 /// Cached snapshot of plugin tools loaded from `plugin_dirs`.
 ///
 /// Computed once per `CodergenHandler` instance and shared across every
@@ -747,9 +750,10 @@ impl Handler for CodergenHandler {
             }
         }
 
+        let instruction = compact_pipeline_instruction(&ctx.input, node.context_window, max_tokens);
         let task = Task::new(
             TaskKind::Code {
-                instruction: ctx.input.clone(),
+                instruction,
                 files: vec![],
             },
             TaskContext {
@@ -995,6 +999,41 @@ impl Handler for NoopHandler {
     }
 }
 
+fn compact_pipeline_instruction(
+    input: &str,
+    context_window: Option<u32>,
+    max_output_tokens: Option<u32>,
+) -> String {
+    let Some(context_window) = context_window else {
+        return input.to_string();
+    };
+    let reserved = max_output_tokens
+        .unwrap_or(DEFAULT_PIPELINE_MAX_OUTPUT_TOKENS)
+        .saturating_add(PIPELINE_INPUT_COMPACTION_RESERVE_TOKENS);
+    let budget = context_window.saturating_sub(reserved).max(512);
+    if octos_llm::context::estimate_tokens(input) <= budget {
+        return input.to_string();
+    }
+
+    let max_chars = (budget as usize).saturating_mul(4).max(256);
+    let char_count = input.chars().count();
+    if char_count <= max_chars {
+        return input.to_string();
+    }
+
+    let head_chars = max_chars / 2;
+    let tail_chars = max_chars.saturating_sub(head_chars);
+    let head: String = input.chars().take(head_chars).collect();
+    let tail: String = input
+        .chars()
+        .skip(char_count.saturating_sub(tail_chars))
+        .collect();
+    format!(
+        "{head}\n\n[... pipeline input compacted: omitted approximately {} tokens ...]\n\n{tail}",
+        octos_llm::context::estimate_tokens(input).saturating_sub(budget)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1136,6 +1175,7 @@ mod tests {
             max_tasks: None,
             deadline_secs: None,
             deadline_action: None,
+            continue_on_error: false,
             checkpoints: vec![],
         };
 
@@ -1204,6 +1244,7 @@ mod tests {
             max_tasks: None,
             deadline_secs: None,
             deadline_action: None,
+            continue_on_error: false,
             checkpoints: vec![],
         };
 
@@ -1256,6 +1297,7 @@ mod tests {
             max_tasks: None,
             deadline_secs: None,
             deadline_action: None,
+            continue_on_error: false,
             checkpoints: vec![],
         };
 
@@ -1318,6 +1360,7 @@ mod tests {
             max_tasks: None,
             deadline_secs: None,
             deadline_action: None,
+            continue_on_error: false,
             checkpoints: vec![],
         };
 
@@ -1380,6 +1423,7 @@ mod tests {
             max_tasks: None,
             deadline_secs: None,
             deadline_action: None,
+            continue_on_error: false,
             checkpoints: vec![],
         };
 
@@ -1440,6 +1484,7 @@ mod tests {
             max_tasks: None,
             deadline_secs: None,
             deadline_action: None,
+            continue_on_error: false,
             checkpoints: vec![],
         };
 
@@ -1480,5 +1525,16 @@ mod tests {
             e,
             ProgressEvent::ToolProgress { name, .. } if name == "run_pipeline"
         )));
+    }
+
+    #[test]
+    fn compact_pipeline_instruction_keeps_head_and_tail() {
+        let input = format!("HEAD:{}:TAIL", " middle".repeat(2_000));
+        let compacted = super::compact_pipeline_instruction(&input, Some(1_024), Some(256));
+
+        assert!(compacted.starts_with("HEAD:"));
+        assert!(compacted.ends_with(":TAIL"));
+        assert!(compacted.contains("pipeline input compacted"));
+        assert!(compacted.len() < input.len());
     }
 }

--- a/crates/octos-pipeline/src/model_assignment.rs
+++ b/crates/octos-pipeline/src/model_assignment.rs
@@ -396,6 +396,7 @@ mod tests {
             id: "test".into(),
             label: None,
             default_model: None,
+            max_total_tokens: None,
             nodes: nodes.into_iter().collect::<HashMap<_, _>>(),
             edges: Vec::new(),
             subgraphs: Vec::new(),

--- a/crates/octos-pipeline/src/parser.rs
+++ b/crates/octos-pipeline/src/parser.rs
@@ -58,6 +58,7 @@ impl<'a> DotParser<'a> {
             id,
             label: None,
             default_model: None,
+            max_total_tokens: None,
             nodes: HashMap::new(),
             edges: Vec::new(),
             subgraphs: Vec::new(),
@@ -494,6 +495,9 @@ fn apply_graph_attrs(graph: &mut PipelineGraph, attrs: &HashMap<String, String>)
     if let Some(model) = attrs.get("default_model") {
         graph.default_model = Some(model.clone());
     }
+    if let Some(max_total_tokens) = attrs.get("max_total_tokens") {
+        graph.max_total_tokens = max_total_tokens.parse().ok();
+    }
 }
 
 /// Parse a duration string like "900s", "15m", "2h" into seconds.
@@ -572,6 +576,10 @@ fn build_node(id: &str, attrs: &HashMap<String, String>) -> PipelineNode {
         max_tasks: attrs.get("max_tasks").and_then(|s| s.parse().ok()),
         deadline_secs,
         deadline_action,
+        continue_on_error: attrs
+            .get("continue_on_error")
+            .and_then(|s| parse_bool(s))
+            .unwrap_or(false),
         checkpoints,
     }
 }
@@ -1100,6 +1108,29 @@ mod tests {
         "#;
         let graph = parse_dot(dot).unwrap();
         assert!(graph.nodes["n3"].checkpoints.is_empty());
+    }
+
+    #[test]
+    fn should_parse_run_level_token_budget() {
+        let dot = r#"
+            digraph test {
+                graph [max_total_tokens="1234"]
+                n1 [prompt="a"]
+            }
+        "#;
+        let graph = parse_dot(dot).unwrap();
+        assert_eq!(graph.max_total_tokens, Some(1234));
+    }
+
+    #[test]
+    fn should_parse_continue_on_error() {
+        let dot = r#"
+            digraph test {
+                n1 [prompt="a", continue_on_error="true"]
+            }
+        "#;
+        let graph = parse_dot(dot).unwrap();
+        assert!(graph.nodes["n1"].continue_on_error);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Filter live `tool_search` / `tool_suggest` catalog entries through deferred, provider-policy, and context-filter visibility.
- Add pipeline `continue_on_error` routing and graph-level `max_total_tokens` budget stopping.
- Add deterministic head/tail compaction for oversized pipeline codergen input when a context window is configured.
- Mark max-token task results as explicit partial output instead of returning an unlabelled truncated body.
- Cap composed status layers to avoid speculative/status-message explosion.

## Issue coverage

Closes #1152
Closes #223
Closes #7
Refs #225
Refs #222
Refs #226

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p octos-pipeline -p octos-agent -p octos-cli`
- `cargo clippy -p octos-agent -p octos-pipeline -p octos-cli --all-targets -- -D warnings`
- `cargo test -p octos-pipeline --lib`
- `cargo test -p octos-agent --lib tool_search_live_catalog_respects_visibility_filters -- --nocapture`
- `cargo test -p octos-cli --lib should_cap_default_layers_in_priority_order -- --nocapture`
