### PR TITLE
fix(pipeline): cascade-fail child node tasks on pipeline timeout (closes the dspfac "pipeline:analyze running" forever bug)

### DIFF
--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1551,6 +1551,48 @@ impl TaskSupervisor {
         }
     }
 
+    /// Cascade-fail every still-active child of `parent_tool_call_id`.
+    ///
+    /// Used by the `run_pipeline` timeout arm to flush orphan
+    /// `pipeline:<node>` child tasks when the parent future is dropped
+    /// before per-node `mark_completed` / `mark_failed` can fire. Without
+    /// this cascade the children stay forever as `state: "running"` in
+    /// the supervisor, and the SessionTaskIndicator on the dashboard
+    /// shows e.g. `pipeline:analyze running` indefinitely.
+    ///
+    /// Snapshots the matching active task ids under the `tasks` mutex
+    /// first, then drops the lock and calls `mark_failed` per id so the
+    /// per-task lock acquisition inside `mark_failed` does not deadlock
+    /// on the snapshot. Returns the number of children that were
+    /// transitioned to `Failed`. Already-terminal tasks are skipped by
+    /// `is_active()` and the deadlock-safe `mark_failed` guard.
+    pub fn mark_descendants_failed(&self, parent_tool_call_id: &str, reason: &str) -> usize {
+        if parent_tool_call_id.is_empty() {
+            return 0;
+        }
+        let active_children: Vec<String> = self
+            .tasks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .filter(|task| task.tool_call_id == parent_tool_call_id && task.status.is_active())
+            .map(|task| task.id.clone())
+            .collect();
+        let count = active_children.len();
+        for child_id in active_children {
+            self.mark_failed(&child_id, reason.to_string());
+        }
+        if count > 0 {
+            tracing::info!(
+                parent_tool_call_id = %parent_tool_call_id,
+                cascaded = count,
+                reason = %reason,
+                "cascade-failed child tasks under parent tool_call_id"
+            );
+        }
+        count
+    }
+
     /// Emit a `SpawnOnlyFailureSignal` for a freshly-failed task, if a
     /// failure callback has been registered. The error_message is taken
     /// from the task's `error` field (set immediately before this call).
@@ -2298,6 +2340,89 @@ mod tests {
         let active = supervisor.get_active_tasks();
         assert_eq!(active.len(), 1);
         assert_eq!(active[0].tool_call_id, "call-2");
+    }
+
+    /// Cascade-fail every active child of a parent's `tool_call_id`.
+    /// Regression pin for the `run_pipeline` timeout orphan bug —
+    /// without `mark_descendants_failed` child `pipeline:<node>` tasks
+    /// registered before the timeout future was dropped stayed in
+    /// `state: "running"` forever (visible to dashboard users as e.g.
+    /// `pipeline:analyze running` indefinitely).
+    #[test]
+    fn mark_descendants_failed_cascades_active_children_under_parent_tcid() {
+        let supervisor = TaskSupervisor::new();
+        let parent_tcid = "call-run_pipeline-parent";
+        // Three children share the parent's tool_call_id. The first is
+        // pre-completed (should stay completed), the other two are
+        // running (should both transition to Failed with the timeout
+        // reason).
+        let child1 = supervisor.register("pipeline:setup", parent_tcid, Some("sess-1"));
+        let child2 = supervisor.register("pipeline:analyze", parent_tcid, Some("sess-1"));
+        let child3 = supervisor.register("pipeline:plan_and_search", parent_tcid, Some("sess-1"));
+        // A sibling task NOT under the timing-out parent: must be
+        // untouched by the cascade.
+        let unrelated = supervisor.register("tts", "call-other-parent", Some("sess-1"));
+
+        supervisor.mark_running(&child2);
+        supervisor.mark_running(&child3);
+        supervisor.mark_running(&unrelated);
+        supervisor.mark_completed(&child1, vec![]);
+
+        let cascaded =
+            supervisor.mark_descendants_failed(parent_tcid, "pipeline timed out after 1200s");
+        assert_eq!(
+            cascaded, 2,
+            "exactly two children were active and should cascade-fail"
+        );
+
+        // child1 was completed before the cascade — must stay completed
+        // (mark_failed's terminal-state guard preserves it).
+        let t1 = supervisor.get_task(&child1).expect("child1");
+        assert_eq!(t1.status, TaskStatus::Completed);
+
+        // child2 and child3 were running — must now be Failed with the
+        // pipeline-timeout reason carried in the error field.
+        for cid in [&child2, &child3] {
+            let task = supervisor.get_task(cid).expect("child task");
+            assert_eq!(
+                task.status,
+                TaskStatus::Failed,
+                "child {cid} must be Failed after cascade"
+            );
+            assert_eq!(task.runtime_state, TaskRuntimeState::Failed);
+            assert!(task.completed_at.is_some());
+            let err = task.error.clone().unwrap_or_default();
+            assert!(
+                err.contains("pipeline timed out after 1200s"),
+                "child {cid} error must carry the timeout reason, got: {err}"
+            );
+        }
+
+        // The unrelated sibling under a different parent tool_call_id
+        // must remain Running.
+        let other = supervisor.get_task(&unrelated).expect("unrelated");
+        assert_eq!(
+            other.status,
+            TaskStatus::Running,
+            "task under a different parent tool_call_id must not be cascaded"
+        );
+    }
+
+    /// `mark_descendants_failed` with an empty parent tool_call_id is
+    /// a no-op (defensive guard — empty strings never match a real
+    /// registered task, and we don't want to mass-fail tasks that
+    /// happened to register with no parent context).
+    #[test]
+    fn mark_descendants_failed_with_empty_parent_is_noop() {
+        let supervisor = TaskSupervisor::new();
+        let id = supervisor.register("pipeline:work", "", Some("sess"));
+        supervisor.mark_running(&id);
+
+        let cascaded = supervisor.mark_descendants_failed("", "timeout");
+        assert_eq!(cascaded, 0, "empty parent tcid must short-circuit");
+
+        let task = supervisor.get_task(&id).expect("task survives");
+        assert_eq!(task.status, TaskStatus::Running);
     }
 
     #[test]

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -1560,6 +1560,16 @@ impl TaskSupervisor {
     /// the supervisor, and the SessionTaskIndicator on the dashboard
     /// shows e.g. `pipeline:analyze running` indefinitely.
     ///
+    /// IMPORTANT: filters to NODE children only via the `pipeline:`
+    /// `tool_name` prefix. The parent `run_pipeline` task is itself
+    /// registered with the same `tool_call_id` (see
+    /// `execution.rs::register_task_with_input_and_cmid`), and pipeline
+    /// node tasks reuse that id via `executor.rs::register_node_task`.
+    /// Without the prefix filter the cascade would also mark the parent
+    /// failed, racing with the parent runner's own `mark_failed` path.
+    /// `pipeline:` is the only prefix `register_node_task` ever emits,
+    /// so this is a precise filter for "node tasks under this run".
+    ///
     /// Snapshots the matching active task ids under the `tasks` mutex
     /// first, then drops the lock and calls `mark_failed` per id so the
     /// per-task lock acquisition inside `mark_failed` does not deadlock
@@ -1575,7 +1585,11 @@ impl TaskSupervisor {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .values()
-            .filter(|task| task.tool_call_id == parent_tool_call_id && task.status.is_active())
+            .filter(|task| {
+                task.tool_call_id == parent_tool_call_id
+                    && task.status.is_active()
+                    && task.tool_name.starts_with("pipeline:")
+            })
             .map(|task| task.id.clone())
             .collect();
         let count = active_children.len();
@@ -2352,10 +2366,16 @@ mod tests {
     fn mark_descendants_failed_cascades_active_children_under_parent_tcid() {
         let supervisor = TaskSupervisor::new();
         let parent_tcid = "call-run_pipeline-parent";
-        // Three children share the parent's tool_call_id. The first is
-        // pre-completed (should stay completed), the other two are
-        // running (should both transition to Failed with the timeout
-        // reason).
+        // The parent `run_pipeline` task is registered with the same
+        // tool_call_id its node children reuse via
+        // `executor.rs::register_node_task`. The cascade MUST NOT
+        // touch the parent (it has its own `mark_failed` path in the
+        // timeout arm of `RunPipelineTool::execute`).
+        let parent = supervisor.register("run_pipeline", parent_tcid, Some("sess-1"));
+        // Three node children share the parent's tool_call_id. The
+        // first is pre-completed (should stay completed), the other
+        // two are running (should both transition to Failed with the
+        // timeout reason).
         let child1 = supervisor.register("pipeline:setup", parent_tcid, Some("sess-1"));
         let child2 = supervisor.register("pipeline:analyze", parent_tcid, Some("sess-1"));
         let child3 = supervisor.register("pipeline:plan_and_search", parent_tcid, Some("sess-1"));
@@ -2363,6 +2383,7 @@ mod tests {
         // untouched by the cascade.
         let unrelated = supervisor.register("tts", "call-other-parent", Some("sess-1"));
 
+        supervisor.mark_running(&parent);
         supervisor.mark_running(&child2);
         supervisor.mark_running(&child3);
         supervisor.mark_running(&unrelated);
@@ -2372,7 +2393,7 @@ mod tests {
             supervisor.mark_descendants_failed(parent_tcid, "pipeline timed out after 1200s");
         assert_eq!(
             cascaded, 2,
-            "exactly two children were active and should cascade-fail"
+            "exactly two pipeline:<node> children were active and should cascade-fail"
         );
 
         // child1 was completed before the cascade — must stay completed
@@ -2398,6 +2419,17 @@ mod tests {
             );
         }
 
+        // The parent `run_pipeline` task itself must remain Running —
+        // its own `mark_failed` path in the timeout arm of
+        // `RunPipelineTool::execute` is responsible for transitioning
+        // it (the cascade must not race with that).
+        let parent_task = supervisor.get_task(&parent).expect("parent");
+        assert_eq!(
+            parent_task.status,
+            TaskStatus::Running,
+            "parent run_pipeline task must NOT be cascaded — it has its own mark_failed path"
+        );
+
         // The unrelated sibling under a different parent tool_call_id
         // must remain Running.
         let other = supervisor.get_task(&unrelated).expect("unrelated");
@@ -2405,6 +2437,41 @@ mod tests {
             other.status,
             TaskStatus::Running,
             "task under a different parent tool_call_id must not be cascaded"
+        );
+    }
+
+    /// Explicit regression pin for the codex MAJOR on #1180: the
+    /// cascade MUST filter to `pipeline:<node>` children and skip the
+    /// parent `run_pipeline` task even though both share the same
+    /// `tool_call_id`. Without the prefix filter, the cascade would
+    /// race with `RunPipelineTool::execute`'s own `mark_failed` path
+    /// for the parent.
+    #[test]
+    fn mark_descendants_failed_does_not_touch_parent_run_pipeline_task() {
+        let supervisor = TaskSupervisor::new();
+        let parent_tcid = "call-run_pipeline-only-parent";
+        // Register ONLY the parent (no node children yet — pipeline
+        // timed out before any node was dispatched, or all nodes
+        // already completed). Cascade must be a no-op for the parent.
+        let parent = supervisor.register("run_pipeline", parent_tcid, Some("sess-only"));
+        supervisor.mark_running(&parent);
+
+        let cascaded =
+            supervisor.mark_descendants_failed(parent_tcid, "pipeline timed out after 1200s");
+        assert_eq!(
+            cascaded, 0,
+            "no pipeline:<node> children registered, so cascade must be a no-op"
+        );
+
+        let parent_task = supervisor.get_task(&parent).expect("parent survives");
+        assert_eq!(
+            parent_task.status,
+            TaskStatus::Running,
+            "parent run_pipeline task must remain Running — cascade only targets pipeline:<node>"
+        );
+        assert!(
+            parent_task.error.is_none(),
+            "cascade must not write an error to the parent task"
         );
     }
 

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -458,6 +458,17 @@ impl Tool for RunPipelineTool {
                     &run_start_rfc3339,
                     timeout_secs,
                 );
+                // Cascade-fail every still-active `pipeline:<node>` child
+                // task registered under this `run_pipeline` invocation.
+                // The pipeline's executor calls `supervisor.mark_running`
+                // for each node task but only `mark_completed`/`mark_failed`
+                // *after* the dispatch returns; on timeout the awaiting
+                // future is dropped before either fires and the children
+                // stay as `state: "running"` forever.
+                let host_context = octos_agent::tools::TOOL_CTX
+                    .try_with(crate::host_context::PipelineHostContext::from_tool_context)
+                    .unwrap_or_default();
+                cascade_fail_orphan_node_tasks(&host_context, timeout_secs);
                 return Err(eyre::eyre!(
                     "pipeline timed out after {}s (timeout_secs={})",
                     timeout_secs,
@@ -610,6 +621,40 @@ pub(crate) fn build_pipeline_run_summary(
 
 /// #1126 codex P2 follow-up to #1020 / M17-B — write a `summary.json`
 /// for the timeout failure path. Without this, runs that hit the
+/// Cascade-fail every still-active `pipeline:<node>` child task
+/// registered in the supervisor under the `run_pipeline` parent's
+/// `tool_call_id`. Invoked from the `RunPipelineTool::execute` timeout
+/// arm so dropped child futures don't leave orphan `state: "running"`
+/// entries in the supervisor (the bug that surfaced as
+/// `pipeline:analyze running` indefinitely on the dashboard).
+///
+/// No-op when the host context didn't snapshot a supervisor (legacy
+/// callers / unit tests) or didn't carry a parent_tool_call_id. The
+/// underlying [`TaskSupervisor::mark_descendants_failed`] is itself
+/// idempotent on already-terminal tasks, so re-invocation is safe.
+fn cascade_fail_orphan_node_tasks(
+    host_context: &crate::host_context::PipelineHostContext,
+    timeout_secs: u64,
+) -> usize {
+    let Some(supervisor) = host_context.task_supervisor.as_ref() else {
+        return 0;
+    };
+    let Some(parent_tcid) = host_context.parent_tool_call_id.as_deref() else {
+        return 0;
+    };
+    let reason = format!("pipeline timed out after {timeout_secs}s");
+    let cascaded = supervisor.mark_descendants_failed(parent_tcid, &reason);
+    if cascaded > 0 {
+        tracing::warn!(
+            parent_tool_call_id = %parent_tcid,
+            cascaded,
+            timeout_secs,
+            "run_pipeline timeout cascade-failed orphan child node tasks",
+        );
+    }
+    cascaded
+}
+
 /// pipeline-level timeout had no audit-trail marker at all, even
 /// though pipeline workers had been launched and consumed budget.
 /// Records `success: false`, a `duration_ms` equal to the elapsed
@@ -1121,5 +1166,101 @@ mod tests {
                 .contains("1800"),
             "context_reason must include the timeout in seconds",
         );
+    }
+
+    /// Regression pin for the `run_pipeline` timeout orphan bug:
+    /// when a pipeline times out, every still-active
+    /// `pipeline:<node>` child task registered under the parent's
+    /// `tool_call_id` must be cascade-failed in the supervisor with
+    /// the timeout reason. Previously the future was dropped before
+    /// `mark_completed`/`mark_failed` could fire, so children stayed
+    /// in `state: "running"` forever. The ledger evidence from mini3
+    /// showed parent task hitting `task_updated:failed` while
+    /// `pipeline:analyze` had exactly ONE `state:running` event and
+    /// never a terminal mark.
+    #[test]
+    fn cascade_fail_orphan_node_tasks_marks_all_active_children_failed() {
+        use octos_agent::task_supervisor::TaskSupervisor;
+        use std::sync::Arc;
+
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let parent_tcid = "tool-call-run_pipeline-timeout";
+
+        // Two pipeline-node child tasks registered under the parent
+        // tool_call_id, both moved to running (matching what the
+        // executor does at node dispatch time).
+        let child_analyze = supervisor.register(
+            "pipeline:analyze",
+            parent_tcid,
+            Some("session-timeout-test"),
+        );
+        let child_plan_and_search = supervisor.register(
+            "pipeline:plan_and_search",
+            parent_tcid,
+            Some("session-timeout-test"),
+        );
+        supervisor.mark_running(&child_analyze);
+        supervisor.mark_running(&child_plan_and_search);
+
+        // Build the host context the way TOOL_CTX would expose it
+        // when run_pipeline dispatches inside a real session.
+        let host = crate::host_context::PipelineHostContext {
+            task_supervisor: Some(supervisor.clone()),
+            parent_tool_call_id: Some(parent_tcid.to_string()),
+            parent_session_key: Some("session-timeout-test".to_string()),
+            ..Default::default()
+        };
+
+        // Drive the timeout cascade with timeout_secs = 1200 to match
+        // the ledger evidence.
+        let cascaded = cascade_fail_orphan_node_tasks(&host, 1200);
+        assert_eq!(
+            cascaded, 2,
+            "both active pipeline:<node> children must cascade-fail"
+        );
+
+        for cid in [&child_analyze, &child_plan_and_search] {
+            let task = supervisor.get_task(cid).expect("child task survives");
+            assert_eq!(
+                task.status.as_str(),
+                "failed",
+                "child task {} must be Failed after pipeline timeout cascade",
+                task.tool_name
+            );
+            let err = task.error.clone().unwrap_or_default();
+            assert!(
+                err.contains("pipeline timed out after 1200s"),
+                "error must carry the canonical timeout reason, got: {err}",
+            );
+        }
+    }
+
+    /// `cascade_fail_orphan_node_tasks` is a no-op when the host
+    /// context didn't snapshot a supervisor — preserves the legacy
+    /// pre-M8 path (pipelines invoked from CLI / unit tests where
+    /// TOOL_CTX is empty).
+    #[test]
+    fn cascade_fail_orphan_node_tasks_noop_without_supervisor() {
+        let host = crate::host_context::PipelineHostContext::default();
+        let cascaded = cascade_fail_orphan_node_tasks(&host, 1200);
+        assert_eq!(cascaded, 0);
+    }
+
+    /// `cascade_fail_orphan_node_tasks` is a no-op when the host
+    /// context didn't capture a parent_tool_call_id. Defensive guard
+    /// so we never mass-fail unrelated tasks.
+    #[test]
+    fn cascade_fail_orphan_node_tasks_noop_without_parent_tcid() {
+        use octos_agent::task_supervisor::TaskSupervisor;
+        use std::sync::Arc;
+
+        let supervisor = Arc::new(TaskSupervisor::new());
+        let host = crate::host_context::PipelineHostContext {
+            task_supervisor: Some(supervisor),
+            parent_tool_call_id: None,
+            ..Default::default()
+        };
+        let cascaded = cascade_fail_orphan_node_tasks(&host, 1200);
+        assert_eq!(cascaded, 0);
     }
 }

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -621,40 +621,6 @@ pub(crate) fn build_pipeline_run_summary(
 
 /// #1126 codex P2 follow-up to #1020 / M17-B — write a `summary.json`
 /// for the timeout failure path. Without this, runs that hit the
-/// Cascade-fail every still-active `pipeline:<node>` child task
-/// registered in the supervisor under the `run_pipeline` parent's
-/// `tool_call_id`. Invoked from the `RunPipelineTool::execute` timeout
-/// arm so dropped child futures don't leave orphan `state: "running"`
-/// entries in the supervisor (the bug that surfaced as
-/// `pipeline:analyze running` indefinitely on the dashboard).
-///
-/// No-op when the host context didn't snapshot a supervisor (legacy
-/// callers / unit tests) or didn't carry a parent_tool_call_id. The
-/// underlying [`TaskSupervisor::mark_descendants_failed`] is itself
-/// idempotent on already-terminal tasks, so re-invocation is safe.
-fn cascade_fail_orphan_node_tasks(
-    host_context: &crate::host_context::PipelineHostContext,
-    timeout_secs: u64,
-) -> usize {
-    let Some(supervisor) = host_context.task_supervisor.as_ref() else {
-        return 0;
-    };
-    let Some(parent_tcid) = host_context.parent_tool_call_id.as_deref() else {
-        return 0;
-    };
-    let reason = format!("pipeline timed out after {timeout_secs}s");
-    let cascaded = supervisor.mark_descendants_failed(parent_tcid, &reason);
-    if cascaded > 0 {
-        tracing::warn!(
-            parent_tool_call_id = %parent_tcid,
-            cascaded,
-            timeout_secs,
-            "run_pipeline timeout cascade-failed orphan child node tasks",
-        );
-    }
-    cascaded
-}
-
 /// pipeline-level timeout had no audit-trail marker at all, even
 /// though pipeline workers had been launched and consumed budget.
 /// Records `success: false`, a `duration_ms` equal to the elapsed
@@ -701,6 +667,45 @@ fn emit_external_context_unmanaged_timeout_summary(
             "failed to write M17-B timeout summary; downstream evidence validators may flag this run"
         );
     }
+}
+
+/// Cascade-fail every still-active `pipeline:<node>` child task
+/// registered in the supervisor under the `run_pipeline` parent's
+/// `tool_call_id`. Invoked from the `RunPipelineTool::execute` timeout
+/// arm so dropped child futures don't leave orphan `state: "running"`
+/// entries in the supervisor (the bug that surfaced as
+/// `pipeline:analyze running` indefinitely on the dashboard).
+///
+/// No-op when the host context didn't snapshot a supervisor (legacy
+/// callers / unit tests) or didn't carry a parent_tool_call_id. The
+/// underlying [`TaskSupervisor::mark_descendants_failed`] filters to
+/// the `pipeline:` `tool_name` prefix so the parent `run_pipeline`
+/// task (which shares the same `tool_call_id` as its node children)
+/// is never touched by the cascade — its own `mark_failed` path in
+/// the timeout arm handles parent-level transition. The supervisor
+/// method is also idempotent on already-terminal tasks, so
+/// re-invocation is safe.
+fn cascade_fail_orphan_node_tasks(
+    host_context: &crate::host_context::PipelineHostContext,
+    timeout_secs: u64,
+) -> usize {
+    let Some(supervisor) = host_context.task_supervisor.as_ref() else {
+        return 0;
+    };
+    let Some(parent_tcid) = host_context.parent_tool_call_id.as_deref() else {
+        return 0;
+    };
+    let reason = format!("pipeline timed out after {timeout_secs}s");
+    let cascaded = supervisor.mark_descendants_failed(parent_tcid, &reason);
+    if cascaded > 0 {
+        tracing::warn!(
+            parent_tool_call_id = %parent_tcid,
+            cascaded,
+            timeout_secs,
+            "run_pipeline timeout cascade-failed orphan child node tasks",
+        );
+    }
+    cascaded
 }
 
 /// #1020 / M17-B — write a `summary.json` carrying the
@@ -1178,6 +1183,11 @@ mod tests {
     /// showed parent task hitting `task_updated:failed` while
     /// `pipeline:analyze` had exactly ONE `state:running` event and
     /// never a terminal mark.
+    ///
+    /// Codex MAJOR follow-up on #1180: the cascade MUST NOT touch the
+    /// parent `run_pipeline` task even though it shares the same
+    /// `tool_call_id` as its node children — the parent's own
+    /// `mark_failed` path handles parent-level transition.
     #[test]
     fn cascade_fail_orphan_node_tasks_marks_all_active_children_failed() {
         use octos_agent::task_supervisor::TaskSupervisor;
@@ -1185,6 +1195,15 @@ mod tests {
 
         let supervisor = Arc::new(TaskSupervisor::new());
         let parent_tcid = "tool-call-run_pipeline-timeout";
+
+        // The parent run_pipeline task is registered with the SAME
+        // tool_call_id its node children reuse (see
+        // execution.rs::register_task_with_input_and_cmid +
+        // executor.rs::register_node_task). The cascade must filter
+        // by `pipeline:` prefix and skip this parent.
+        let parent_task =
+            supervisor.register("run_pipeline", parent_tcid, Some("session-timeout-test"));
+        supervisor.mark_running(&parent_task);
 
         // Two pipeline-node child tasks registered under the parent
         // tool_call_id, both moved to running (matching what the
@@ -1233,6 +1252,23 @@ mod tests {
                 "error must carry the canonical timeout reason, got: {err}",
             );
         }
+
+        // Parent task must remain Running — the cascade filters by
+        // `pipeline:` prefix so the parent run_pipeline task is
+        // never touched even though it shares the same tool_call_id.
+        let parent_after = supervisor
+            .get_task(&parent_task)
+            .expect("parent run_pipeline task survives");
+        assert_eq!(
+            parent_after.status.as_str(),
+            "running",
+            "parent run_pipeline task must NOT be touched by the cascade — \
+             its own mark_failed path in the timeout arm handles parent-level transition"
+        );
+        assert!(
+            parent_after.error.is_none(),
+            "cascade must not write an error to the parent task"
+        );
     }
 
     /// `cascade_fail_orphan_node_tasks` is a no-op when the host


### PR DESCRIPTION
## Summary

When `run_pipeline` hits its `tokio::time::timeout` budget, the inner executor future is dropped before per-node `mark_completed`/`mark_failed` cleanup at `executor.rs:2456-2478` can fire. The parent task transitions to `Failed`, but every `pipeline:<node>` child task registered via `register_node_task` stays in `state: "running"` in the supervisor — visible on the dashboard as e.g. `pipeline:analyze running` indefinitely.

This PR adds `TaskSupervisor::mark_descendants_failed(parent_tool_call_id, reason)` that snapshots active tasks under the supervisor mutex matching the parent's `tool_call_id`, then iterates and calls `mark_failed` on each (deadlock-safe, mirrors the fanout-cap cascade at `task_supervisor.rs:1350-1368`). In `RunPipelineTool::execute`'s timeout arm we now re-snapshot the host context from `TOOL_CTX` and call the new method via a small `cascade_fail_orphan_node_tasks` helper.

The fix is server-only — orphan child tasks now never reach the wire in `state: "running"` once the parent has timed out.

## Ledger evidence

On mini3 (`/Users/cloud/.octos/ui-protocol/.../ledger-...39922.log`):
- Parent task `019e5210-...` (`run_pipeline`) hit `task_updated:failed` at seq 1158 with reason `"pipeline timed out after 1200s"`.
- Child `019e5222-...` (`pipeline:analyze`) had exactly ONE event — `state:running` at seq 1142 — and never a terminal mark.

After this fix the timeout arm cascades the timeout reason onto every still-active child registered under the parent's `tool_call_id`, so the next ledger event for `019e5222-...` would be `task_updated:failed` with reason `"pipeline timed out after 1200s"`.

## Test plan

- [x] `cargo test -p octos-agent --lib mark_descendants` — 2 new supervisor tests cover the cascade in isolation
- [x] `cargo test -p octos-pipeline --lib cascade` — 3 new tool tests pin the helper end-to-end with the same parent_tcid + child task shape the ledger evidence showed (cascade fires; no-op without supervisor; no-op without parent_tool_call_id)
- [x] `cargo test -p octos-pipeline` — 184 lib + 48 integration tests, no regressions
- [x] `cargo test --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

## Files

- `crates/octos-agent/src/task_supervisor.rs` — new `mark_descendants_failed` + 2 unit tests
- `crates/octos-pipeline/src/tool.rs` — timeout arm cascade + new `cascade_fail_orphan_node_tasks` helper + 3 unit tests

## DO NOTs honored

- Did NOT touch SPA / TaskStore client paths — supervisor's authoritative state is now correct, no client-side workaround required.
- Did NOT emit a synthetic `task/updated` event from the client side.
- Added a regression test (per the user-visible bug report).