### PR TITLE
Enforce pipeline token and continuation budgets

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -27,6 +27,8 @@ use crate::session::SessionLimits;
 use crate::tools::{TURN_ATTACHMENT_CTX, TurnAttachmentContext};
 
 const MAX_PARALLEL_TOOL_CALLS_PER_BATCH: usize = 8;
+const MAX_TOKENS_CONTINUATION_LIMIT: usize = 2;
+const MAX_TOKENS_CONTINUATION_PROMPT: &str = "Your output was truncated at the token limit. Continue directly from where you stopped. Do not repeat or summarize what you already wrote.";
 const SHELL_RETRY_RECOVERY_THRESHOLD: usize = 4;
 
 /// Audit Gap-8 helper: consult the workspace-contract layer at EndTurn time
@@ -1331,6 +1333,8 @@ impl Agent {
             let mut files_modified = Vec::new();
             let mut files_to_send = Vec::new();
             let mut turn = LoopTurnState::new(task_start);
+            let mut max_token_continuations = 0usize;
+            let mut max_token_fragments = Vec::new();
             // M6.2: per-run retry-bucket state machine. Same instance lives
             // across all iterations of the task loop so bucket counters
             // accumulate the way operators expect.
@@ -1447,8 +1451,10 @@ impl Agent {
 
                 match response.stop_reason {
                     StopReason::EndTurn | StopReason::StopSequence => {
+                        let final_response =
+                            response_with_max_token_fragments(&response, &max_token_fragments);
                         if self.config.save_episodes {
-                            let summary = response.content.clone().unwrap_or_default();
+                            let summary = final_response.content.clone().unwrap_or_default();
                             let summary_truncated =
                                 octos_core::truncated_utf8(&summary, 500, "...");
 
@@ -1495,7 +1501,7 @@ impl Agent {
                             }
                         }
 
-                        self.emit_cost_update(turn.total_usage(), &response);
+                        self.emit_cost_update(turn.total_usage(), &final_response);
 
                         // Audit Gap-8: auto-fire `check_workspace_contract`
                         // on Completion. The LLM-callable wrapper stays for
@@ -1550,7 +1556,7 @@ impl Agent {
                             "task completed"
                         );
                         let mut result = self.build_result(
-                            &response,
+                            &final_response,
                             turn.total_usage().clone(),
                             files_modified,
                             files_to_send,
@@ -1595,14 +1601,33 @@ impl Agent {
                         }
                     }
                     StopReason::MaxTokens => {
-                        self.emit_cost_update(turn.total_usage(), &response);
+                        if max_token_continuations < MAX_TOKENS_CONTINUATION_LIMIT {
+                            if let Some(content) = response.content.clone() {
+                                if !content.trim().is_empty() {
+                                    max_token_fragments.push(content);
+                                }
+                            }
+                            push_max_tokens_continuation(&mut messages, &response);
+                            max_token_continuations += 1;
+                            warn!(
+                                iteration,
+                                continuation = max_token_continuations,
+                                max = MAX_TOKENS_CONTINUATION_LIMIT,
+                                "task output hit max_tokens; continuing in the same agent loop"
+                            );
+                            continue;
+                        }
+
+                        let final_response =
+                            response_with_max_token_fragments(&response, &max_token_fragments);
+                        self.emit_cost_update(turn.total_usage(), &final_response);
                         self.reporter().report(ProgressEvent::TaskCompleted {
                             success: false,
                             iterations: iteration,
                             duration: task_start.elapsed(),
                         });
                         return Ok(self.build_result(
-                            &response,
+                            &final_response,
                             turn.total_usage().clone(),
                             files_modified,
                             files_to_send,
@@ -2231,6 +2256,36 @@ fn strip_success_exit_suffix(content: &str) -> String {
         .to_string()
 }
 
+fn push_max_tokens_continuation(messages: &mut Vec<Message>, response: &ChatResponse) {
+    let mut assistant = Message::assistant(response.content.clone().unwrap_or_default());
+    assistant.reasoning_content = response.reasoning_content.clone();
+    messages.push(assistant);
+    messages.push(Message::user(MAX_TOKENS_CONTINUATION_PROMPT));
+}
+
+fn response_with_max_token_fragments(
+    response: &ChatResponse,
+    fragments: &[String],
+) -> ChatResponse {
+    if fragments.is_empty() {
+        return response.clone();
+    }
+
+    let mut combined_parts: Vec<&str> = fragments
+        .iter()
+        .map(String::as_str)
+        .filter(|part| !part.trim().is_empty())
+        .collect();
+    let final_content = response.content.as_deref().unwrap_or_default();
+    if !final_content.trim().is_empty() {
+        combined_parts.push(final_content);
+    }
+
+    let mut combined = response.clone();
+    combined.content = Some(combined_parts.join("\n"));
+    combined
+}
+
 fn shell_retry_limit_message(content: &str) -> String {
     let latest_output =
         octos_core::truncated_utf8(content.trim(), 1200, "\n... (shell output truncated)");
@@ -2344,6 +2399,67 @@ mod tests {
     struct RecordingToolThenEndProvider {
         calls: AtomicUsize,
         observed_prompts: Arc<StdMutex<Vec<Vec<String>>>>,
+    }
+
+    struct MaxTokensThenEndProvider {
+        calls: AtomicUsize,
+        observed_prompts: Arc<StdMutex<Vec<Vec<String>>>>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for MaxTokensThenEndProvider {
+        async fn chat(
+            &self,
+            messages: &[Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<ChatResponse> {
+            self.observed_prompts
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .push(
+                    messages
+                        .iter()
+                        .map(|message| message.content.clone())
+                        .collect(),
+                );
+            let call = self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(if call == 0 {
+                ChatResponse {
+                    content: Some("part one".to_string()),
+                    reasoning_content: None,
+                    tool_calls: vec![],
+                    stop_reason: StopReason::MaxTokens,
+                    usage: LlmTokenUsage {
+                        input_tokens: 3,
+                        output_tokens: 10,
+                        ..Default::default()
+                    },
+                    provider_index: None,
+                }
+            } else {
+                ChatResponse {
+                    content: Some("part two".to_string()),
+                    reasoning_content: None,
+                    tool_calls: vec![],
+                    stop_reason: StopReason::EndTurn,
+                    usage: LlmTokenUsage {
+                        input_tokens: 4,
+                        output_tokens: 11,
+                        ..Default::default()
+                    },
+                    provider_index: None,
+                }
+            })
+        }
+
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
     }
 
     #[async_trait]
@@ -2749,6 +2865,57 @@ mod tests {
         assert!(result.success);
         assert!(result.files_modified.is_empty());
         assert_eq!(result.files_to_send, vec![file_path]);
+    }
+
+    #[tokio::test]
+    async fn run_task_continues_after_max_tokens_in_same_loop() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = ToolRegistry::with_builtins(dir.path());
+        let observed_prompts = Arc::new(StdMutex::new(Vec::new()));
+        let provider = Arc::new(MaxTokensThenEndProvider {
+            calls: AtomicUsize::new(0),
+            observed_prompts: Arc::clone(&observed_prompts),
+        });
+        let provider_for_agent: Arc<dyn LlmProvider> = provider.clone();
+        let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+        let agent = Agent::new(
+            AgentId::new("max-tokens-test"),
+            provider_for_agent,
+            tools,
+            memory,
+        );
+        let task = Task::new(
+            TaskKind::Code {
+                instruction: "Write a long report".to_string(),
+                files: vec![],
+            },
+            TaskContext {
+                working_dir: dir.path().to_path_buf(),
+                ..Default::default()
+            },
+        );
+
+        let result = agent.run_task(&task).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(
+            result.output,
+            "part one
+part two"
+        );
+        assert_eq!(provider.calls.load(AtomicOrdering::SeqCst), 2);
+        assert_eq!(result.token_usage.input_tokens, 7);
+        assert_eq!(result.token_usage.output_tokens, 21);
+        let prompts = observed_prompts
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        assert_eq!(prompts.len(), 2);
+        assert!(prompts[1].iter().any(|content| content == "part one"));
+        assert!(
+            prompts[1]
+                .iter()
+                .any(|content| content.contains("Continue directly from where you stopped"))
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -645,6 +645,31 @@ fn extract_json_array(text: &str) -> Option<&str> {
     None
 }
 
+fn total_pipeline_tokens(usage: &TokenUsage) -> u32 {
+    usage.input_tokens.saturating_add(usage.output_tokens)
+}
+
+fn remaining_pipeline_tokens(max_total_tokens: Option<u32>, usage: &TokenUsage) -> Option<u32> {
+    let max_total_tokens = max_total_tokens?;
+    Some(max_total_tokens.saturating_sub(total_pipeline_tokens(usage)))
+}
+
+fn cap_node_output_tokens_for_remaining_budget(
+    node: &mut PipelineNode,
+    remaining_tokens: u32,
+    peer_count: usize,
+) {
+    if !matches!(node.handler, HandlerKind::Codergen) || remaining_tokens == 0 {
+        return;
+    }
+    let divisor = u32::try_from(peer_count.max(1)).unwrap_or(u32::MAX).max(1);
+    let per_node_cap = remaining_tokens.saturating_div(divisor).max(1);
+    node.max_output_tokens = Some(
+        node.max_output_tokens
+            .map_or(per_node_cap, |existing| existing.min(per_node_cap).max(1)),
+    );
+}
+
 /// Process results from parallel worker execution, producing merged content and summaries.
 fn process_worker_results(
     results: Vec<(String, PipelineNode, Duration, Result<NodeOutcome>)>,
@@ -1643,6 +1668,29 @@ impl PipelineExecutor {
                     return Err(eyre::eyre!(err));
                 }
 
+                let llm_target_count = targets
+                    .iter()
+                    .filter_map(|target_id| graph.nodes.get(target_id))
+                    .filter(|target| matches!(target.handler, HandlerKind::Codergen))
+                    .count()
+                    .max(1);
+                let parallel_remaining_tokens =
+                    remaining_pipeline_tokens(graph.max_total_tokens, &total_tokens);
+                if matches!(parallel_remaining_tokens, Some(0)) {
+                    return Ok(PipelineResult {
+                        output: format!(
+                            "Pipeline token budget exhausted before parallel node '{}': spent {} tokens",
+                            node.id,
+                            total_pipeline_tokens(&total_tokens)
+                        ),
+                        success: false,
+                        token_usage: total_tokens,
+                        node_summaries: summaries,
+                        files_modified: vec![],
+                        node_costs: node_costs.clone(),
+                    });
+                }
+
                 let fan_start = Instant::now();
 
                 // Prepare and execute all targets concurrently, capped by semaphore
@@ -1681,6 +1729,13 @@ impl PipelineExecutor {
                     }
                     if target_with_prompt.model.is_none() {
                         target_with_prompt.model = graph.default_model.clone();
+                    }
+                    if let Some(remaining_tokens) = parallel_remaining_tokens {
+                        cap_node_output_tokens_for_remaining_budget(
+                            &mut target_with_prompt,
+                            remaining_tokens,
+                            llm_target_count,
+                        );
                     }
 
                     // Reserve budget for each LLM-call branch before
@@ -1917,6 +1972,22 @@ impl PipelineExecutor {
                 if let Some(ref bridge) = self.config.status_bridge {
                     bridge.add_tokens(&plan_usage);
                 }
+                let dynamic_remaining_tokens =
+                    remaining_pipeline_tokens(graph.max_total_tokens, &total_tokens);
+                if matches!(dynamic_remaining_tokens, Some(0)) {
+                    return Ok(PipelineResult {
+                        output: format!(
+                            "Pipeline token budget exhausted after dynamic_parallel planner '{}': spent {} tokens",
+                            node.id,
+                            total_pipeline_tokens(&total_tokens)
+                        ),
+                        success: false,
+                        token_usage: total_tokens,
+                        node_summaries: summaries,
+                        files_modified: vec![],
+                        node_costs: node_costs.clone(),
+                    });
+                }
 
                 // Build synthetic PipelineNodes for each dynamic task
                 let worker_prompt_template = node.worker_prompt.as_deref().unwrap_or(
@@ -2052,6 +2123,13 @@ impl PipelineExecutor {
                             resolved = resolved.replace(&placeholder, value);
                         }
                         synth_node.prompt = Some(resolved.trim_end().to_string());
+                    }
+                    if let Some(remaining_tokens) = dynamic_remaining_tokens {
+                        cap_node_output_tokens_for_remaining_budget(
+                            &mut synth_node,
+                            remaining_tokens,
+                            total_workers,
+                        );
                     }
 
                     if let Some(handle) = self.reserve_node_budget(&graph.id, &synth_node).await? {
@@ -2212,6 +2290,30 @@ impl PipelineExecutor {
             // Resolve model from graph default if node doesn't specify one
             if node_with_prompt.model.is_none() {
                 node_with_prompt.model = graph.default_model.clone();
+            }
+
+            if let Some(remaining_tokens) =
+                remaining_pipeline_tokens(graph.max_total_tokens, &total_tokens)
+            {
+                if remaining_tokens == 0 {
+                    return Ok(PipelineResult {
+                        output: format!(
+                            "Pipeline token budget exhausted before node '{}': spent {} tokens",
+                            node.id,
+                            total_pipeline_tokens(&total_tokens)
+                        ),
+                        success: false,
+                        token_usage: total_tokens,
+                        node_summaries: summaries,
+                        files_modified: vec![],
+                        node_costs: node_costs.clone(),
+                    });
+                }
+                cap_node_output_tokens_for_remaining_budget(
+                    &mut node_with_prompt,
+                    remaining_tokens,
+                    1,
+                );
             }
 
             let input_bytes = input_text.len();
@@ -2985,6 +3087,31 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let dir = Box::leak(Box::new(dir));
         EpisodeStore::open(dir.path()).await.unwrap()
+    }
+
+    #[test]
+    fn caps_codergen_output_tokens_by_remaining_pipeline_budget() {
+        let mut node = PipelineNode {
+            handler: HandlerKind::Codergen,
+            ..Default::default()
+        };
+        cap_node_output_tokens_for_remaining_budget(&mut node, 900, 3);
+        assert_eq!(node.max_output_tokens, Some(300));
+
+        node.max_output_tokens = Some(100);
+        cap_node_output_tokens_for_remaining_budget(&mut node, 900, 3);
+        assert_eq!(node.max_output_tokens, Some(100));
+    }
+
+    #[test]
+    fn leaves_non_llm_nodes_uncapped_by_pipeline_budget() {
+        let mut node = PipelineNode {
+            handler: HandlerKind::Shell,
+            max_output_tokens: Some(500),
+            ..Default::default()
+        };
+        cap_node_output_tokens_for_remaining_budget(&mut node, 900, 3);
+        assert_eq!(node.max_output_tokens, Some(500));
     }
 
     // --- extract_json_array tests ---

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -734,7 +734,10 @@ impl Handler for CodergenHandler {
         // policy must be present — the workspace is how the runner
         // resolves declared artifact names to glob patterns.
         if let Some(compaction_policy) = self.compaction_policy.clone() {
-            let compaction_provider = self.compaction_llm_provider.clone().unwrap_or(provider);
+            let compaction_provider = self
+                .compaction_llm_provider
+                .clone()
+                .unwrap_or_else(|| provider.clone());
             let runner = octos_agent::compaction::CompactionRunner::with_provider(
                 compaction_policy,
                 compaction_provider,
@@ -750,7 +753,8 @@ impl Handler for CodergenHandler {
             }
         }
 
-        let instruction = compact_pipeline_instruction(&ctx.input, node.context_window, max_tokens);
+        let instruction =
+            compact_pipeline_instruction(&ctx.input, Some(provider.context_window()), max_tokens);
         let task = Task::new(
             TaskKind::Code {
                 instruction,
@@ -1010,7 +1014,10 @@ fn compact_pipeline_instruction(
     let reserved = max_output_tokens
         .unwrap_or(DEFAULT_PIPELINE_MAX_OUTPUT_TOKENS)
         .saturating_add(PIPELINE_INPUT_COMPACTION_RESERVE_TOKENS);
-    let budget = context_window.saturating_sub(reserved).max(512);
+    let half_context = context_window / 2;
+    let budget = half_context
+        .min(context_window.saturating_sub(reserved))
+        .max(512);
     if octos_llm::context::estimate_tokens(input) <= budget {
         return input.to_string();
     }
@@ -1021,7 +1028,7 @@ fn compact_pipeline_instruction(
         return input.to_string();
     }
 
-    let head_chars = max_chars / 2;
+    let head_chars = max_chars.saturating_mul(7) / 10;
     let tail_chars = max_chars.saturating_sub(head_chars);
     let head: String = input.chars().take(head_chars).collect();
     let tail: String = input


### PR DESCRIPTION
## Summary
- cap codergen node max output by remaining `max_total_tokens` before sequential, static parallel, and dynamic parallel dispatch
- account dynamic planner usage before worker allocation and abort before convergence when the run budget is exhausted
- compact pipeline node input using the resolved provider context window by default, with deterministic 70/30 head/tail preservation
- continue task-mode agent runs up to two times on `StopReason::MaxTokens`, preserving the partial output in the same loop history

Closes #225
Closes #222
Closes #226

## Verification
- `cargo fmt --all -- --check`
- `cargo check -p octos-pipeline -p octos-agent`
- `cargo clippy -p octos-agent -p octos-pipeline --all-targets -- -D warnings`
- `cargo test -p octos-pipeline --lib`
- `cargo test -p octos-agent --lib run_task_continues_after_max_tokens_in_same_loop -- --nocapture`
