### PR TITLE
fix(api): suppress synthesized spawn_only ack bubble via Background source override

### DIFF
--- a/crates/octos-agent/src/agent/budget.rs
+++ b/crates/octos-agent/src/agent/budget.rs
@@ -413,6 +413,7 @@ mod tests {
             streamed: false,
             messages: vec![],
             tool_results: vec![],
+            synthesized_from_spawn_only: false,
         };
         let cloned = resp.clone();
         assert_eq!(cloned.content, "test");

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -786,6 +786,7 @@ impl Agent {
                                 streamed: false,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
                                 tool_results: tool_structured_metadata.clone(),
+                                synthesized_from_spawn_only: false,
                             });
                         }
                     }
@@ -969,6 +970,7 @@ impl Agent {
                                 streamed,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
                                 tool_results: tool_structured_metadata.clone(),
+                                synthesized_from_spawn_only: false,
                             });
                         }
                         StopReason::ToolUse => {
@@ -1064,6 +1066,7 @@ impl Agent {
                                                 history.len(),
                                             ),
                                             tool_results: tool_structured_metadata.clone(),
+                                            synthesized_from_spawn_only: false,
                                         });
                                     }
                                     // Two-stage loop-detector recovery:
@@ -1126,6 +1129,7 @@ impl Agent {
                                                     history.len(),
                                                 ),
                                                 tool_results: tool_structured_metadata.clone(),
+                                                synthesized_from_spawn_only: false,
                                             });
                                         }
                                     }
@@ -1222,6 +1226,7 @@ impl Agent {
                                         history.len(),
                                     ),
                                     tool_results: tool_structured_metadata.clone(),
+                                    synthesized_from_spawn_only: false,
                                 });
                             }
 
@@ -1259,6 +1264,19 @@ impl Agent {
                                     streamed,
                                     messages: LoopTurnState::new_messages(&messages, history.len()),
                                     tool_results: tool_structured_metadata.clone(),
+                                    // dspfac "two bubbles per turn" fix: this
+                                    // branch synthesises `content` as the
+                                    // "Background work started for `<tool>`..."
+                                    // acknowledgement. The API persist site
+                                    // reads this flag and tags the wire
+                                    // envelope for the synthesised row with
+                                    // `MessagePersistedSource::Background`,
+                                    // which the existing capability filter
+                                    // for `event.spawn_complete.v1` clients
+                                    // suppresses. Legacy clients (without
+                                    // the capability) still see the ack as
+                                    // an assistant row — backward-compatible.
+                                    synthesized_from_spawn_only: true,
                                 });
                             }
                         }
@@ -1276,6 +1294,7 @@ impl Agent {
                                 streamed,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
                                 tool_results: tool_structured_metadata.clone(),
+                                synthesized_from_spawn_only: false,
                             });
                         }
                         StopReason::ContentFiltered => {
@@ -1299,6 +1318,7 @@ impl Agent {
                                 streamed,
                                 messages: LoopTurnState::new_messages(&messages, history.len()),
                                 tool_results: tool_structured_metadata.clone(),
+                                synthesized_from_spawn_only: false,
                             });
                         }
                     }

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -117,6 +117,17 @@ pub struct ConversationResponse {
     /// actor pulls these into the SSE `done` event so the W1.G4 cost panel
     /// can render real per-node attribution. Empty when no tool opted in.
     pub tool_results: Vec<(String, serde_json::Value)>,
+    /// Marks `content` as a synthesized acknowledgement fabricated by the
+    /// spawn_only branch in `loop_runner::process_message_inner` (the
+    /// "Background work started for `<tool>`. The final result will be
+    /// delivered automatically when it is ready." string). When `true`,
+    /// the API persist site tags the corresponding wire envelope with
+    /// `MessagePersistedSource::Background` so dual-negotiated clients
+    /// (those carrying `event.spawn_complete.v1`) suppress it via the
+    /// existing capability filter — collapsing the legacy
+    /// "two bubbles per turn" shape into a single preamble row.
+    /// Defaults to `false`; only set in the spawn_only synthesis path.
+    pub synthesized_from_spawn_only: bool,
 }
 
 /// Shared atomic counters for real-time token tracking (used by status indicators).

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15741,8 +15741,25 @@ async fn run_standalone_turn(
                         &response.content,
                         response.reasoning_content.clone(),
                     );
+                    // dspfac "two bubbles per turn" fix: when the loop
+                    // returned a synthesised spawn_only ack
+                    // (`response.synthesized_from_spawn_only = true`),
+                    // the row carrying that ack content is the one
+                    // returned from `final_assistant_message`. The
+                    // capability filter at
+                    // `live_event_passes_capability_filter` suppresses
+                    // `message/persisted` events whose
+                    // `source: background` so dual-negotiated clients
+                    // (those carrying `event.spawn_complete.v1`) drop
+                    // the duplicate of the iter-1 preamble row,
+                    // collapsing the visible chat shape from two
+                    // bubbles to one. Legacy clients without that
+                    // capability still receive the ack as an
+                    // assistant row — backward-compatible.
+                    let final_assistant_uses_background_source =
+                        response.synthesized_from_spawn_only && final_assistant.is_some();
                     let mut skipped_internal_user = false;
-                    for message in response.messages.iter().cloned().chain(final_assistant) {
+                    for message in response.messages.iter().cloned() {
                         if skip_internal_user_persist
                             && !skipped_internal_user
                             && message.role == MessageRole::User
@@ -15779,6 +15796,45 @@ async fn run_standalone_turn(
                             if is_final_assistant_carrier {
                                 final_assistant_persisted = true;
                             }
+                        }
+                    }
+                    if let Some(message) = final_assistant {
+                        // The `final_assistant` row is the synthesised
+                        // carrier of `response.content`. By
+                        // construction this is an Assistant row (so
+                        // the skip_internal_user_persist branch does
+                        // not apply) and its content equals
+                        // `response.content` (so it is the
+                        // final-assistant carrier).
+                        let to_save =
+                            pre_stamp_turn_thread_id(message, &turn_thread_id_for_persist);
+                        let saved_for_context = to_save.clone();
+                        let session_id_for_persist = agent_session_id.clone();
+                        let persist = async {
+                            sessions
+                                .add_message_with_seq(&session_id_for_persist, to_save)
+                                .await
+                        };
+                        let commit = if final_assistant_uses_background_source {
+                            MESSAGE_PERSISTED_SOURCE_OVERRIDE
+                                .scope(Some(MessagePersistedSource::Background), persist)
+                                .await
+                        } else {
+                            persist.await
+                        };
+                        if let Ok(seq) = commit {
+                            record_appui_context_manager_message(
+                                &context_data_dir_for_result,
+                                &context_manager_for_result,
+                                &agent_session_id,
+                                &saved_for_context,
+                                seq,
+                            );
+                            cursor = Some(UiCursor {
+                                stream: agent_session_id.0.clone(),
+                                seq: seq as u64,
+                            });
+                            final_assistant_persisted = true;
                         }
                     }
                 }
@@ -27782,6 +27838,162 @@ ignore = []
         // After the scope ends, the default behaviour is restored.
         let after = current_message_persisted_source(MessageRole::Assistant);
         assert_eq!(after, MessagePersistedSource::Assistant);
+    }
+
+    /// dspfac "two bubbles per turn" fix: a spawn_only loop turn emits
+    /// TWO persisted assistant rows — the iter-1 LLM reply carrying the
+    /// preamble TEXT + `tool_calls`, and the synthesised ack
+    /// ("Background work started for `<tool>`. ...") fabricated in
+    /// `loop_runner::process_message_inner`. Pre-fix both landed with
+    /// `source: assistant`, so SPAs negotiating
+    /// `event.spawn_complete.v1` (which suppress `source: background`
+    /// rows via `live_event_passes_capability_filter`) rendered both as
+    /// chat bubbles.
+    ///
+    /// Post-fix the API persist site wraps ONLY the synthesised ack row
+    /// in `MESSAGE_PERSISTED_SOURCE_OVERRIDE.scope(Background, _)` —
+    /// gated on `ConversationResponse.synthesized_from_spawn_only`. This
+    /// test mirrors that wire shape and asserts the ledger emits the
+    /// preamble as `Assistant` and the ack as `Background`. The
+    /// downstream capability filter (already covered by the
+    /// background-persist suppression tests above) then collapses the
+    /// observable chat shape to one bubble for upgraded clients while
+    /// remaining backward-compatible for legacy clients.
+    #[tokio::test(flavor = "current_thread")]
+    async fn spawn_only_synthesized_ack_emits_as_background_source() {
+        use octos_core::ui_protocol::MessagePersistedSource;
+
+        let _guard = message_commit_observer_test_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        // Wire a fresh ledger + observer the same way the live server
+        // wires them on first `event_ledger` call.
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        install_message_commit_observer(ledger.clone());
+
+        let session_id = SessionKey("local:spawn-only-synth-ack".into());
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut manager =
+            octos_bus::SessionManager::open(tmp.path()).expect("session manager open");
+
+        // The iter-1 LLM reply that drove the spawn_only branch:
+        // non-empty preamble TEXT plus the tool_calls that selected
+        // `run_pipeline`. This is `response.messages` — persisted with
+        // the role-derived default `source: Assistant`.
+        let preamble_text = "Sure, I'll kick off the pipeline now.".to_string();
+        let preamble = Message {
+            role: MessageRole::Assistant,
+            content: preamble_text.clone(),
+            media: vec![],
+            tool_calls: Some(vec![octos_core::ToolCall {
+                id: "tc-run_pipeline-1".into(),
+                name: "run_pipeline".into(),
+                arguments: serde_json::json!({}),
+                metadata: None,
+            }]),
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("thread-spawn-only-synth".into()),
+            timestamp: Utc::now(),
+        };
+        manager
+            .add_message_with_seq(&session_id, preamble)
+            .await
+            .expect("commit preamble assistant row");
+
+        // The synthesised ack fabricated by the spawn_only branch in
+        // `loop_runner::process_message_inner`. Persisted INSIDE the
+        // `MESSAGE_PERSISTED_SOURCE_OVERRIDE.scope(Background, _)`
+        // because `ConversationResponse.synthesized_from_spawn_only`
+        // was true — exactly what the production persist site does.
+        let ack_text = "Background work started for `run_pipeline`. \
+             The final result will be delivered automatically when it is ready."
+            .to_string();
+        let ack = Message {
+            role: MessageRole::Assistant,
+            content: ack_text.clone(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("thread-spawn-only-synth".into()),
+            timestamp: Utc::now(),
+        };
+        let session_id_for_persist = session_id.clone();
+        let persist = async {
+            manager
+                .add_message_with_seq(&session_id_for_persist, ack)
+                .await
+        };
+        let commit = MESSAGE_PERSISTED_SOURCE_OVERRIDE
+            .scope(Some(MessagePersistedSource::Background), persist)
+            .await;
+        commit.expect("commit synthesised ack row");
+
+        // Drain the broadcast and bucket every assistant
+        // `MessagePersisted` envelope by source.
+        let mut assistant_envelopes: Vec<MessagePersistedEvent> = Vec::new();
+        while let Ok(event) = subscriber.try_recv() {
+            if let UiProtocolLedgerEvent::Notification(UiNotification::MessagePersisted(ev)) =
+                &event.event
+            {
+                if ev.role == octos_core::MessageRole::Assistant.as_str() {
+                    assistant_envelopes.push(ev.clone());
+                }
+            }
+        }
+
+        assert_eq!(
+            assistant_envelopes.len(),
+            2,
+            "spawn_only turn must commit BOTH the preamble and the ack — \
+             pre-fix both were `source: assistant` (the two-bubble bug); \
+             post-fix the preamble is Assistant and the ack is Background; \
+             got {} envelopes",
+            assistant_envelopes.len(),
+        );
+
+        // Preamble (carries `tool_calls` + preamble TEXT): default
+        // role-derived source `Assistant`. The capability filter at
+        // `live_event_passes_capability_filter` leaves Assistant rows
+        // alone, so dual-negotiated SPAs still render this row — that
+        // is the surviving "single bubble" of the turn.
+        let preamble_env = &assistant_envelopes[0];
+        assert_eq!(
+            preamble_env.source,
+            MessagePersistedSource::Assistant,
+            "iter-1 preamble row (carrying tool_calls + preamble text) must keep source=Assistant",
+        );
+
+        // Synthesised ack: tagged `Background` via the override scope.
+        // The capability filter then suppresses this row for SPAs that
+        // negotiated `event.spawn_complete.v1`, collapsing the chat
+        // shape to a single bubble per turn.
+        let ack_env = &assistant_envelopes[1];
+        assert_eq!(
+            ack_env.source,
+            MessagePersistedSource::Background,
+            "synthesised spawn_only ack row must carry source=Background so \
+             `live_event_passes_capability_filter` suppresses the second bubble",
+        );
+
+        // Sanity: the override scope is correctly scoped — after the
+        // ack persist returns, the task-local is back to its default.
+        let after = current_message_persisted_source(MessageRole::Assistant);
+        assert_eq!(
+            after,
+            MessagePersistedSource::Assistant,
+            "override is scoped to the ack persist call only — must not leak",
+        );
+
+        // Restore the global observer slot to None so subsequent tests
+        // see a clean state.
+        octos_bus::set_message_commit_observer(None);
     }
 
     /// Codex P2 follow-up: the `turn/spawn_complete` envelope's flat


### PR DESCRIPTION
## Bug

A `spawn_only` loop turn (e.g. the LLM picks `run_pipeline`, emits a preamble TEXT + `tool_calls`, then stops) was committing TWO `message/persisted` assistant rows under one turn, both tagged `source: assistant`:

1. **Iter-1 LLM reply** — built at `streaming.rs:281`, persisted at `ui_protocol.rs:15745`. Carries the preamble TEXT + `tool_calls: [run_pipeline]`. Renders as **"Bubble with details"** (preamble + tool card).
2. **Synthesised ack** — fabricated at `loop_runner.rs:1238` (`"Background work started for `run_pipeline`. The final result will be delivered automatically when it is ready."`). Built by `final_assistant_message`, persisted in the same loop. Renders as **"Bubble without details"** (text only).

Both reached the SPA as `source: Assistant`, so the dual-suppression filter at `live_event_passes_capability_filter` (`ui_protocol.rs:7600` — which today suppresses `source: Background` rows for clients negotiating `event.spawn_complete.v1`) never fired, and dspfac saw two bubbles per spawn_only turn.

### Ledger evidence shape (pre-fix)

```
turn/started
message/delta(preamble)
message/persisted { role: assistant, source: assistant, content: "<preamble>" }  <-- bubble 1 (kept)
message/persisted { role: assistant, source: assistant, content: "Background work started for `run_pipeline`. ..." }  <-- bubble 2 (unwanted)
turn/completed
```

## Fix

* Thread a `synthesized_from_spawn_only: bool` flag through `ConversationResponse` so the API persist site can identify the synthesised row without a sentinel-text match. Set to `true` only at the spawn_only branch in `loop_runner.rs`; every other return site ships `false`.
* In the persist site (`ui_protocol.rs:15737-15783`) hoist the `final_assistant` row out of the response-messages loop. When the flag is set, wrap its `add_message_with_seq` call in `MESSAGE_PERSISTED_SOURCE_OVERRIDE.scope(Some(Background), _)` — the exact pattern the `BackgroundResultSender` already uses for spawn_complete-companion rows. The durable JSONL row is unchanged; only the live-broadcast envelope's `source` flips to `Background`.

`live_event_passes_capability_filter` then suppresses the synthesised ack for clients with `event.spawn_complete.v1` (today's SPA), so the visible chat shape collapses to a single preamble bubble per turn. **Legacy clients without the capability still receive the ack** — the pre-fix behaviour is preserved for them, so this is backward-compatible.

### Ledger evidence shape (post-fix, for `event.spawn_complete.v1` clients)

```
turn/started
message/delta(preamble)
message/persisted { role: assistant, source: assistant, content: "<preamble>" }  <-- bubble 1 (only one)
message/persisted { role: assistant, source: background, content: "Background work started..." }  <-- server suppressed
turn/completed
```

## Test plan

- [x] **Server unit test** added at `api::ui_protocol::tests::spawn_only_synthesized_ack_emits_as_background_source` — drives the exact persist pattern (preamble row directly, ack row inside the override scope), drains the ledger broadcast, and asserts the preamble carries `source: Assistant` while the synthesised ack carries `source: Background`. Mirrors the `gamma_7_dedup_one_assistant_persisted_per_turn` / `message_persisted_source_override_routes_through_task_local` harness already used in the same module.
- [x] `cargo build --workspace` — passes.
- [x] `cargo test -p octos-cli --features api --lib spawn_only_synthesized_ack` — passes.
- [x] `cargo test -p octos-cli --features api --lib -- --test-threads=1` — 1318 passed; 0 failed; 4 ignored (parallel runs surface known unrelated test-interference; single-threaded is clean).
- [x] `cargo test -p octos-agent --lib` — 1583 passed; 0 failed; 3 ignored.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p octos-agent -p octos-cli --features api -- -D warnings` — no new lints introduced by this PR (baseline = 49 errors all pre-existing; this PR fixes one of them as a side effect of refactoring the persist loop).
- [x] **SPA matching test** added in `octos-web` at `src/runtime/ui-protocol-event-router.test.ts` — `"spawn_only turn collapses to ONE bubble when server suppresses the synthesised ack (dspfac fix)"`. Mirrors the wire shape upgraded clients see (delta preamble -> persisted preamble -> turn/completed; persisted ack is server-suppressed), asserts `responses.length === 1`. Will land in a parallel `octos-web` PR.