### PR TITLE
fix(llm,agent): classify provider HTTP errors as user-facing not 'bug'

### DIFF
--- a/crates/octos-agent/src/agent/loop_state.rs
+++ b/crates/octos-agent/src/agent/loop_state.rs
@@ -52,6 +52,9 @@ pub const OCTOS_LOOP_RETRY_TOTAL: &str = "octos_loop_retry_total";
 const DEFAULT_RATE_LIMIT_LIMIT: u32 = 5;
 const DEFAULT_CONTEXT_OVERFLOW_LIMIT: u32 = 2;
 const DEFAULT_AUTHENTICATION_LIMIT: u32 = 1;
+/// Quota errors are operator-action — auto-retry will keep failing until
+/// the operator tops up. Cap at 1 like Authentication.
+const DEFAULT_QUOTA_LIMIT: u32 = 1;
 const DEFAULT_INVALID_REQUEST_LIMIT: u32 = 2;
 const DEFAULT_CONTENT_FILTERED_LIMIT: u32 = 1;
 const DEFAULT_PROVIDER_UNAVAILABLE_LIMIT: u32 = 4;
@@ -72,6 +75,7 @@ pub struct LoopRetryLimits {
     pub rate_limited: u32,
     pub context_overflow: u32,
     pub authentication: u32,
+    pub quota: u32,
     pub invalid_request: u32,
     pub content_filtered: u32,
     pub provider_unavailable: u32,
@@ -92,6 +96,7 @@ impl Default for LoopRetryLimits {
             rate_limited: DEFAULT_RATE_LIMIT_LIMIT,
             context_overflow: DEFAULT_CONTEXT_OVERFLOW_LIMIT,
             authentication: DEFAULT_AUTHENTICATION_LIMIT,
+            quota: DEFAULT_QUOTA_LIMIT,
             invalid_request: DEFAULT_INVALID_REQUEST_LIMIT,
             content_filtered: DEFAULT_CONTENT_FILTERED_LIMIT,
             provider_unavailable: DEFAULT_PROVIDER_UNAVAILABLE_LIMIT,
@@ -172,6 +177,7 @@ pub struct LoopRetryCounters {
     pub rate_limited: u32,
     pub context_overflow: u32,
     pub authentication: u32,
+    pub quota: u32,
     pub invalid_request: u32,
     pub content_filtered: u32,
     pub provider_unavailable: u32,
@@ -355,6 +361,7 @@ impl LoopRetryState {
                 &mut self.counters.authentication,
                 self.limits.authentication,
             ),
+            HarnessError::Quota { .. } => (&mut self.counters.quota, self.limits.quota),
             HarnessError::InvalidRequest { .. } => (
                 &mut self.counters.invalid_request,
                 self.limits.invalid_request,

--- a/crates/octos-agent/src/agent/loop_state.rs
+++ b/crates/octos-agent/src/agent/loop_state.rs
@@ -55,6 +55,13 @@ const DEFAULT_AUTHENTICATION_LIMIT: u32 = 1;
 /// Quota errors are operator-action — auto-retry will keep failing until
 /// the operator tops up. Cap at 1 like Authentication.
 const DEFAULT_QUOTA_LIMIT: u32 = 1;
+
+/// `#[serde(default = "...")]` helper for `LoopRetryLimits::quota`. Lets
+/// legacy retry-state JSON (pre-quota field) deserialize cleanly with the
+/// canonical default instead of `0`, which would disable the bucket.
+fn default_quota_limit() -> u32 {
+    DEFAULT_QUOTA_LIMIT
+}
 const DEFAULT_INVALID_REQUEST_LIMIT: u32 = 2;
 const DEFAULT_CONTENT_FILTERED_LIMIT: u32 = 1;
 const DEFAULT_PROVIDER_UNAVAILABLE_LIMIT: u32 = 4;
@@ -75,6 +82,9 @@ pub struct LoopRetryLimits {
     pub rate_limited: u32,
     pub context_overflow: u32,
     pub authentication: u32,
+    /// Added in codex round-3 (Quota variant). `serde(default)` keeps
+    /// legacy retry-state sidecar JSON (pre-quota) deserializable.
+    #[serde(default = "default_quota_limit")]
     pub quota: u32,
     pub invalid_request: u32,
     pub content_filtered: u32,
@@ -177,6 +187,10 @@ pub struct LoopRetryCounters {
     pub rate_limited: u32,
     pub context_overflow: u32,
     pub authentication: u32,
+    /// Added in codex round-3 (Quota variant). `serde(default)` keeps
+    /// legacy retry-state sidecar JSON (pre-quota) deserializable; a
+    /// missing field deserializes to `0`.
+    #[serde(default)]
     pub quota: u32,
     pub invalid_request: u32,
     pub content_filtered: u32,
@@ -549,6 +563,67 @@ mod tests {
         });
         assert_eq!(state.observe_shell_spiral(), LoopDecision::Escalate);
         assert_eq!(state.observe_shell_spiral(), LoopDecision::Exhausted);
+    }
+
+    #[test]
+    fn legacy_retry_state_json_without_quota_field_deserializes() {
+        // Codex round-6: `LoopRetryLimits` and `LoopRetryCounters` gained a
+        // `quota` field in round-3. Without `#[serde(default)]`, retry-state
+        // sidecar JSON written by pre-round-3 builds would fail to
+        // deserialize, and `load_retry_state` would silently reset every
+        // counter to zero. This test pins the backward-compat behavior.
+        let legacy_json = r#"{
+            "counters": {
+                "rate_limited": 3,
+                "context_overflow": 1,
+                "authentication": 0,
+                "invalid_request": 0,
+                "content_filtered": 0,
+                "provider_unavailable": 2,
+                "network": 1,
+                "timeout": 0,
+                "tool_execution": 0,
+                "plugin_spawn": 0,
+                "plugin_timeout": 0,
+                "plugin_protocol": 0,
+                "delegate_depth_exceeded": 0,
+                "internal": 0,
+                "shell_spiral": 0
+            },
+            "limits": {
+                "rate_limited": 5,
+                "context_overflow": 2,
+                "authentication": 1,
+                "invalid_request": 2,
+                "content_filtered": 1,
+                "provider_unavailable": 4,
+                "network": 4,
+                "timeout": 3,
+                "tool_execution": 5,
+                "plugin_spawn": 2,
+                "plugin_timeout": 3,
+                "plugin_protocol": 2,
+                "delegate_depth_exceeded": 1,
+                "internal": 1,
+                "shell_spiral": 1
+            },
+            "productive_tool_calls_since_last_grace": 4,
+            "grace_calls_fired": 0
+        }"#;
+
+        let state: LoopRetryState =
+            serde_json::from_str(legacy_json).expect("legacy JSON should deserialize");
+
+        // Existing counters preserved.
+        assert_eq!(state.counters.rate_limited, 3);
+        assert_eq!(state.counters.provider_unavailable, 2);
+        // Missing quota counter defaults to 0 (a clean Default::default()).
+        assert_eq!(state.counters.quota, 0);
+        // Missing quota limit defaults to the canonical DEFAULT_QUOTA_LIMIT
+        // (1) — not 0, which would disable the bucket entirely.
+        assert_eq!(state.limits.quota, DEFAULT_QUOTA_LIMIT);
+        // Productive history preserved so grace-call gating survives.
+        assert_eq!(state.productive_tool_calls_since_last_grace, 4);
     }
 
     #[test]

--- a/crates/octos-agent/src/harness_errors.rs
+++ b/crates/octos-agent/src/harness_errors.rs
@@ -104,8 +104,15 @@ pub enum HarnessError {
         used: Option<u32>,
         message: String,
     },
-    /// Authentication failed (HTTP 401/403). Never retry — surface to operator.
+    /// Authentication failed (HTTP 401, or 403 without a quota marker).
+    /// Never retry — surface to operator with "check your API key".
     Authentication { message: String },
+    /// Provider quota / billing-tier exhausted (HTTP 403 with
+    /// `insufficient_quota` / `quota_exceeded` / `no_active_*_package`).
+    /// Distinct from `Authentication` so the operator sees "top up or
+    /// switch provider" instead of "bad API key". Never retry — auto-retry
+    /// will keep failing until the operator acts.
+    Quota { message: String },
     /// The request itself was malformed (HTTP 400, non-context) — bad
     /// parameters, invalid schema, etc.
     InvalidRequest { detail: String, message: String },
@@ -193,6 +200,7 @@ impl HarnessError {
             HarnessError::RateLimited { .. } => "rate_limited",
             HarnessError::ContextOverflow { .. } => "context_overflow",
             HarnessError::Authentication { .. } => "authentication",
+            HarnessError::Quota { .. } => "quota",
             HarnessError::InvalidRequest { .. } => "invalid_request",
             HarnessError::ContentFiltered { .. } => "content_filtered",
             HarnessError::ProviderUnavailable { .. } => "provider_unavailable",
@@ -225,6 +233,7 @@ impl HarnessError {
 
             // Non-retryable — surface to operator.
             HarnessError::Authentication { .. }
+            | HarnessError::Quota { .. }
             | HarnessError::InvalidRequest { .. }
             | HarnessError::ContentFiltered { .. }
             | HarnessError::DelegateDepthExceeded { .. }
@@ -244,6 +253,7 @@ impl HarnessError {
             HarnessError::RateLimited { message, .. }
             | HarnessError::ContextOverflow { message, .. }
             | HarnessError::Authentication { message }
+            | HarnessError::Quota { message }
             | HarnessError::InvalidRequest { message, .. }
             | HarnessError::ContentFiltered { message }
             | HarnessError::ProviderUnavailable { message, .. }
@@ -301,41 +311,63 @@ impl HarnessError {
 
     /// Classify an owned `LlmError` borrow without consuming it. Public so
     /// callers can opportunistically classify in diagnostic paths.
+    ///
+    /// The user-facing messages embedded here are what the SPA renders when
+    /// no specific variant handling exists on the client — they MUST be
+    /// actionable ("check API key", "top up provider", "switch lane") and
+    /// MUST identify the provider lane that failed so operators can pivot
+    /// without digging through daemon logs.
     pub fn from_llm_error(err: &LlmError) -> Self {
-        let message = truncate(&err.message, MAX_HARNESS_ERROR_MESSAGE_BYTES);
+        let raw = truncate(&err.message, MAX_HARNESS_ERROR_MESSAGE_BYTES);
+        // Identify the provider lane in user-facing messages. Empty label
+        // is rendered as a generic "provider" so the message still parses.
+        let lane = if err.provider.is_empty() {
+            "provider".to_string()
+        } else {
+            err.provider.clone()
+        };
         match &err.kind {
-            LlmErrorKind::Authentication => HarnessError::Authentication { message },
+            LlmErrorKind::Authentication => HarnessError::Authentication {
+                message: format!("Authentication failed for {lane} — check your API key ({raw})"),
+            },
+            LlmErrorKind::Quota => HarnessError::Quota {
+                message: format!(
+                    "Provider quota exhausted ({lane}) — top up or switch provider ({raw})"
+                ),
+            },
             LlmErrorKind::RateLimited { retry_after_secs } => HarnessError::RateLimited {
                 retry_after_secs: *retry_after_secs,
-                message,
+                message: format!("{lane} rate-limited — backing off ({raw})"),
             },
             LlmErrorKind::ContextOverflow { limit, used } => HarnessError::ContextOverflow {
                 limit: *limit,
                 used: *used,
-                message,
+                message: raw,
             },
             LlmErrorKind::ModelNotFound { model } => HarnessError::ProviderUnavailable {
                 status: Some(404),
-                message: format!("model not found: {model}"),
+                message: format!("model not found on {lane}: {model}"),
             },
             LlmErrorKind::ServerError { status } => HarnessError::ProviderUnavailable {
                 status: Some(*status),
-                message,
+                message: format!("{lane} temporarily unavailable ({raw})"),
             },
-            LlmErrorKind::Network => HarnessError::Network { message },
-            LlmErrorKind::Timeout => HarnessError::Timeout { message },
+            LlmErrorKind::Network => HarnessError::Network { message: raw },
+            LlmErrorKind::Timeout => HarnessError::Timeout { message: raw },
             LlmErrorKind::InvalidRequest { detail } => HarnessError::InvalidRequest {
                 detail: truncate(detail, MAX_HARNESS_ERROR_MESSAGE_BYTES),
-                message,
+                message: format!(
+                    "Provider rejected the request ({lane}): {raw}. This often means a model/feature mismatch."
+                ),
             },
-            LlmErrorKind::ContentFiltered => HarnessError::ContentFiltered { message },
+            LlmErrorKind::ContentFiltered => HarnessError::ContentFiltered { message: raw },
             LlmErrorKind::StreamError => HarnessError::ProviderUnavailable {
                 status: None,
-                message,
+                message: format!("{lane} stream broke ({raw})"),
             },
             LlmErrorKind::Provider { .. } => HarnessError::ProviderUnavailable {
                 status: None,
-                message,
+                message: format!("{lane} returned an error ({raw})"),
             },
         }
     }
@@ -426,6 +458,7 @@ impl HarnessError {
                 out.insert("limit".into(), Value::from(*limit));
             }
             HarnessError::Authentication { .. }
+            | HarnessError::Quota { .. }
             | HarnessError::ContentFiltered { .. }
             | HarnessError::Network { .. }
             | HarnessError::Timeout { .. }
@@ -489,6 +522,9 @@ mod tests {
                 message: "x".into(),
             },
             HarnessError::Authentication {
+                message: "x".into(),
+            },
+            HarnessError::Quota {
                 message: "x".into(),
             },
             HarnessError::InvalidRequest {
@@ -585,5 +621,61 @@ mod tests {
         let err = HarnessError::Internal { message: huge };
         let body = err.to_event_body("s", "t", None, None);
         assert!(body.message.len() <= MAX_HARNESS_ERROR_MESSAGE_BYTES + "…".len());
+    }
+
+    #[test]
+    fn quota_403_classifies_as_quota_not_internal() {
+        // Regression test for the dspfac (mini1) symptom: 403 with
+        // Wisemodel `no_active_wisemodel_package` body was surfacing as
+        // `variant=internal recovery=bug` because the eyre::bail!() report
+        // could not downcast to LlmError. With the new from_status_with_label
+        // path, providers route HTTP errors through LlmError and the
+        // harness picks the Quota variant with a user-actionable message.
+        let body = r#"{"error":{"code":"no_active_wisemodel_package","message":"没有有效的 Wisemodel 资源包，请购买后再使用","type":"insufficient_quota"}}"#;
+        let llm = LlmError::from_status_with_label(403, body, "MiniMax-M2.5-highspeed");
+        let err: HarnessError = llm.into();
+        assert_eq!(err.variant_name(), "quota");
+        assert_eq!(err.recovery_hint(), RecoveryHint::FailFast);
+        assert!(err.message().contains("MiniMax-M2.5-highspeed"));
+        assert!(err.message().contains("top up or switch provider"));
+    }
+
+    #[test]
+    fn classify_report_downcasts_quota_through_eyre() {
+        // End-to-end: a provider would do `return Err(LlmError::from_status_with_label(...).into())`,
+        // and classify_report at the loop boundary must extract Quota.
+        let body = r#"{"type":"insufficient_quota"}"#;
+        let llm = LlmError::from_status_with_label(403, body, "lane-x");
+        let report: eyre::Report = llm.into();
+        let classified = HarnessError::classify_report(&report, None);
+        assert_eq!(classified.variant_name(), "quota");
+        assert_ne!(classified.recovery_hint(), RecoveryHint::Bug);
+    }
+
+    #[test]
+    fn classify_report_downcasts_auth_403_through_eyre() {
+        // 403 without quota marker stays Authentication.
+        let llm = LlmError::from_status_with_label(403, "Forbidden", "openai");
+        let report: eyre::Report = llm.into();
+        let classified = HarnessError::classify_report(&report, None);
+        assert_eq!(classified.variant_name(), "authentication");
+        assert_eq!(classified.recovery_hint(), RecoveryHint::FailFast);
+        assert!(classified.message().contains("openai"));
+        assert!(classified.message().contains("check your API key"));
+    }
+
+    #[test]
+    fn classify_report_downcasts_invalid_request_through_eyre() {
+        let body = r#"{"error":{"type":"invalid_request_error","message":"unknown parameter"}}"#;
+        let llm = LlmError::from_status_with_label(400, body, "anthropic");
+        let report: eyre::Report = llm.into();
+        let classified = HarnessError::classify_report(&report, None);
+        assert_eq!(classified.variant_name(), "invalid_request");
+        assert!(
+            classified
+                .message()
+                .contains("Provider rejected the request")
+        );
+        assert!(classified.message().contains("anthropic"));
     }
 }

--- a/crates/octos-agent/tests/harness_errors.rs
+++ b/crates/octos-agent/tests/harness_errors.rs
@@ -219,6 +219,7 @@ fn should_count_errors_per_variant_in_metrics() {
         "rate_limited",
         "context_overflow",
         "authentication",
+        "quota",
         "invalid_request",
         "content_filtered",
         "provider_unavailable",
@@ -237,6 +238,72 @@ fn should_count_errors_per_variant_in_metrics() {
             "metric label variant '{name}' must be snake_case ASCII"
         );
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Phase 3 — Provider HTTP errors classify to user-friendly variants
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn should_classify_403_quota_as_quota_with_provider_label() {
+    // The exact dspfac symptom (mini1): MiniMax via Wisemodel returned a
+    // 403 with `no_active_wisemodel_package` / `insufficient_quota`. This
+    // used to surface as `variant=internal recovery=bug` because the
+    // provider used eyre::bail!() which loses the LlmError type — now it
+    // routes through LlmError::from_status_with_label and the harness
+    // emits a user-actionable `variant=quota recovery=fail_fast`.
+    let body = r#"{"error":{"code":"no_active_wisemodel_package","message":"没有有效的 Wisemodel 资源包，请购买后再使用","type":"insufficient_quota"}}"#;
+    let err = LlmError::from_status_with_label(403, body, "MiniMax-M2.5-highspeed");
+    let classified = HarnessError::from(err);
+    assert!(
+        matches!(classified, HarnessError::Quota { .. }),
+        "expected Quota, got {classified:?}"
+    );
+    assert_eq!(classified.variant_name(), "quota");
+    assert_eq!(classified.recovery_hint(), RecoveryHint::FailFast);
+    assert!(classified.message().contains("MiniMax-M2.5-highspeed"));
+    assert!(classified.message().contains("top up or switch provider"));
+}
+
+#[test]
+fn should_classify_403_without_quota_marker_as_auth_with_provider_label() {
+    let err = LlmError::from_status_with_label(403, "Forbidden", "openai/gpt-4");
+    let classified = HarnessError::from(err);
+    assert!(matches!(classified, HarnessError::Authentication { .. }));
+    assert!(classified.message().contains("openai/gpt-4"));
+    assert!(classified.message().contains("check your API key"));
+}
+
+#[test]
+fn should_preserve_quota_classification_when_routed_through_eyre_report() {
+    // The full provider error path: provider builds an LlmError, returns it
+    // as `Err(llm_err.into())`. The agent loop boundary calls
+    // `classify_report(&report, ...)` which must downcast and find Quota.
+    let body = r#"{"error":"quota_exceeded","detail":"out of credits"}"#;
+    let llm = LlmError::from_status_with_label(403, body, "kimi/k2");
+    let report: eyre::Report = llm.into();
+    let classified = HarnessError::classify_report(&report, None);
+    assert_eq!(classified.variant_name(), "quota");
+    assert_ne!(
+        classified.recovery_hint(),
+        RecoveryHint::Bug,
+        "quota must not surface as recovery=bug"
+    );
+}
+
+#[test]
+fn should_emit_quota_event_with_user_facing_message() {
+    let body = r#"{"type":"insufficient_quota"}"#;
+    let llm = LlmError::from_status_with_label(403, body, "lane-A");
+    let classified: HarnessError = llm.into();
+    let event = classified.to_event("s", "t", None, None);
+    let HarnessEventPayload::Error { data } = event.payload else {
+        panic!("expected Error payload");
+    };
+    assert_eq!(data.variant, "quota");
+    assert_eq!(data.recovery, "fail_fast");
+    assert!(data.message.contains("lane-A"));
+    assert!(data.message.contains("top up or switch provider"));
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -16376,7 +16376,6 @@ async fn transition_to_terminal(
     Some(TerminalTransition { reason, ack })
 }
 
-/// Atomically transition state and emit exactly one terminal event. No-op if
 /// Translate an `eyre::Report` escaping the agent loop into the
 /// user-facing string the SPA renders inside a `runtime_error` envelope.
 ///
@@ -16413,6 +16412,7 @@ fn classify_runtime_error_message(error: &eyre::Report) -> String {
     error.to_string()
 }
 
+/// Atomically transition state and emit exactly one terminal event. No-op if
 /// the state is already `Terminal(_)`. See `transition_to_terminal` for the
 /// state-machine details.
 async fn try_emit_terminal(

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15909,9 +15909,22 @@ async fn run_standalone_turn(
                 // back to the session-history scan, matching the
                 // pre-#1134 behaviour.
                 let _ = final_reply_tx.send(None);
+                // Codex round-2 MAJOR 2: prefer the typed user-actionable
+                // message over the raw LLM Display string. The agent
+                // loop's classifier (`HarnessError::classify_report` at
+                // loop_runner.rs:419) maps a raw `LlmError` to a
+                // user-friendly `HarnessError` variant whose
+                // `message()` says "top up or switch provider" /
+                // "check your API key" — but the loop currently bails
+                // with the ORIGINAL `eyre::Report` (still wrapping
+                // `LlmError`), so `error.to_string()` here would emit
+                // the raw `"API error (lane): provider quota exhausted
+                // — HTTP 403 ..."` instead. Downcast and re-classify
+                // so the SPA sees the actionable text.
+                let wire_message = classify_runtime_error_message(&error);
                 let error = json!({
                     "type": "error",
-                    "message": error.to_string(),
+                    "message": wire_message,
                 });
                 let _ = progress_tx_for_result.send(error.to_string()).await;
             }
@@ -16364,6 +16377,42 @@ async fn transition_to_terminal(
 }
 
 /// Atomically transition state and emit exactly one terminal event. No-op if
+/// Translate an `eyre::Report` escaping the agent loop into the
+/// user-facing string the SPA renders inside a `runtime_error` envelope.
+///
+/// Codex round-2 MAJOR 2: the agent loop bails with the original
+/// `eyre::Report` (still wrapping `LlmError`), so a naive
+/// `error.to_string()` here would surface the operator-grade Display
+/// string ("API error (anthropic/...): provider quota exhausted —
+/// HTTP 403 ...") instead of the user-actionable
+/// `HarnessError::message()` ("Provider quota exhausted (anthropic/...)
+/// — top up or switch provider (...)").
+///
+/// Resolution ladder:
+///   1. If a `HarnessError` is already in the chain (future-proofing
+///      for loops that bail with a typed wrapper), use its
+///      `message()` directly.
+///   2. Else if an `LlmError` is in the chain, re-classify it via
+///      `HarnessError::from_llm_error` and emit that message.
+///   3. Fall through to the raw report Display string for non-LLM
+///      failures (tool execution errors, plugin protocol errors, etc.)
+///      where the report already carries the right text.
+fn classify_runtime_error_message(error: &eyre::Report) -> String {
+    use octos_agent::HarnessError;
+    use octos_llm::LlmError;
+    for cause in error.chain() {
+        if let Some(harness) = cause.downcast_ref::<HarnessError>() {
+            return harness.message().to_string();
+        }
+    }
+    for cause in error.chain() {
+        if let Some(llm) = cause.downcast_ref::<LlmError>() {
+            return HarnessError::from_llm_error(llm).message().to_string();
+        }
+    }
+    error.to_string()
+}
+
 /// the state is already `Terminal(_)`. See `transition_to_terminal` for the
 /// state-machine details.
 async fn try_emit_terminal(
@@ -29784,5 +29833,78 @@ ignore = []
             "failover reason should describe the upstream error — got {}",
             event.reason
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Codex round-2 MAJOR 2 regression: the runtime_error wire envelope
+    // must surface `HarnessError::message()` (user-actionable) rather
+    // than the raw `LlmError::Display` operator log line.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn runtime_error_envelope_surfaces_harness_message_for_quota() {
+        let llm = octos_llm::LlmError::from_status_with_label(
+            403,
+            r#"{"error":{"type":"insufficient_quota","message":"out of credits"}}"#,
+            "MiniMax-M2.5-highspeed",
+        );
+        let report: eyre::Report = llm.into();
+        let wire = super::classify_runtime_error_message(&report);
+        // The user-facing message should mention the provider lane and
+        // direct the operator to top up or switch.
+        assert!(
+            wire.contains("quota") || wire.contains("Quota"),
+            "wire message should call out quota exhaustion — got {wire}"
+        );
+        assert!(
+            wire.contains("top up") || wire.contains("switch provider"),
+            "wire message should be actionable — got {wire}"
+        );
+        assert!(
+            wire.contains("MiniMax-M2.5-highspeed"),
+            "wire message must identify the failing lane — got {wire}"
+        );
+    }
+
+    #[test]
+    fn runtime_error_envelope_surfaces_harness_message_for_auth() {
+        let llm = octos_llm::LlmError::from_status_with_label(401, "Unauthorized", "openai/gpt-4");
+        let report: eyre::Report = llm.into();
+        let wire = super::classify_runtime_error_message(&report);
+        assert!(
+            wire.contains("Authentication") || wire.contains("API key"),
+            "wire message should call out auth failure — got {wire}"
+        );
+        assert!(
+            wire.contains("openai/gpt-4"),
+            "wire message must identify the failing lane — got {wire}"
+        );
+    }
+
+    #[test]
+    fn runtime_error_envelope_surfaces_harness_message_for_bad_request() {
+        let llm = octos_llm::LlmError::from_status_with_label(
+            400,
+            "reasoning_content missing in assistant tool call message",
+            "deepseek/v4-pro",
+        );
+        let report: eyre::Report = llm.into();
+        let wire = super::classify_runtime_error_message(&report);
+        assert!(
+            wire.contains("rejected") || wire.contains("Provider"),
+            "wire message should describe a request rejection — got {wire}"
+        );
+        assert!(
+            wire.contains("deepseek/v4-pro"),
+            "wire message must identify the failing lane — got {wire}"
+        );
+    }
+
+    #[test]
+    fn runtime_error_envelope_falls_through_for_non_llm_errors() {
+        // A tool-execution failure surfaces unchanged.
+        let report: eyre::Report = eyre::eyre!("shell tool: command not found: foo");
+        let wire = super::classify_runtime_error_message(&report);
+        assert_eq!(wire, "shell tool: command not found: foo");
     }
 }

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -145,7 +145,7 @@ impl LlmProvider for AnthropicProvider {
             return Err(crate::error::LlmError::from_status_with_label(
                 status.as_u16(),
                 &body,
-                format!("anthropic/{}", self.model),
+                format!("{}/{}", self.provider_label, self.model),
             )
             .into());
         }
@@ -228,7 +228,7 @@ impl LlmProvider for AnthropicProvider {
             return Err(crate::error::LlmError::from_status_with_label(
                 status.as_u16(),
                 &body,
-                format!("anthropic/{}", self.model),
+                format!("{}/{}", self.provider_label, self.model),
             )
             .into());
         }
@@ -767,5 +767,45 @@ mod tests {
         let provider =
             AnthropicProvider::new("key", "model").with_base_url("https://custom.api.com");
         assert_eq!(provider.base_url, "https://custom.api.com");
+    }
+
+    // Codex round-4 MAJOR: the chat() and chat_stream() error paths previously
+    // hardcoded `format!("anthropic/{}", self.model)` instead of using
+    // `self.provider_label`. Registry entries for `r9s` and `zai` lanes call
+    // `with_provider_label("r9s")` / `with_provider_label("zai")` so those
+    // lanes are distinguishable in the failover ledger — but the error label
+    // overwrote that with `"anthropic"`, so the ledger could not attribute
+    // failures to the correct lane.
+    //
+    // This test pins the label-threading contract: when a custom provider
+    // label is set, the error label produced by the chat()/chat_stream()
+    // error paths must use it, not the hardcoded "anthropic" string.
+    #[test]
+    fn should_thread_provider_label_into_error_label_when_overridden() {
+        let provider =
+            AnthropicProvider::new("test-key", "claude-3-5-sonnet").with_provider_label("r9s");
+
+        // The error label is `format!("{}/{}", self.provider_label, self.model)`
+        // — replicate that here and assert it lands on `r9s/...` not
+        // `anthropic/...`.
+        let error_label = format!("{}/{}", provider.provider_label, provider.model);
+        assert_eq!(error_label, "r9s/claude-3-5-sonnet");
+        assert!(
+            !error_label.starts_with("anthropic/"),
+            "r9s lane must NOT be misreported as anthropic/...: {error_label}"
+        );
+
+        // Feed the same label through the classifier the chat() error path
+        // calls to confirm the LlmError carries it end-to-end.
+        let err =
+            crate::error::LlmError::from_status_with_label(429, "rate_limit_error", &error_label);
+        assert_eq!(err.provider, "r9s/claude-3-5-sonnet");
+    }
+
+    #[test]
+    fn should_default_error_label_to_anthropic_when_label_not_overridden() {
+        let provider = AnthropicProvider::new("test-key", "claude-3-5-sonnet");
+        let error_label = format!("{}/{}", provider.provider_label, provider.model);
+        assert_eq!(error_label, "anthropic/claude-3-5-sonnet");
     }
 }

--- a/crates/octos-llm/src/anthropic.rs
+++ b/crates/octos-llm/src/anthropic.rs
@@ -141,10 +141,13 @@ impl LlmProvider for AnthropicProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "Anthropic API error: {status} - {}",
-                crate::provider::truncate_error_body(&body)
-            );
+            let body = crate::provider::truncate_error_body(&body);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("anthropic/{}", self.model),
+            )
+            .into());
         }
 
         let api_response: AnthropicResponse = response
@@ -221,10 +224,13 @@ impl LlmProvider for AnthropicProvider {
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "Anthropic API error: {status} - {}",
-                crate::provider::truncate_error_body(&text)
-            );
+            let body = crate::provider::truncate_error_body(&text);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("anthropic/{}", self.model),
+            )
+            .into());
         }
 
         let sse_stream = crate::sse::parse_sse_response(response);

--- a/crates/octos-llm/src/error.rs
+++ b/crates/octos-llm/src/error.rs
@@ -12,6 +12,12 @@ use tracing;
 pub enum LlmErrorKind {
     /// Authentication failure (invalid/expired API key).
     Authentication,
+    /// Provider quota exhausted / billing-tier expired / no active package
+    /// (HTTP 403 with `insufficient_quota` / `quota_exceeded` /
+    /// `no_active_*_package` markers in body). Distinct from
+    /// `Authentication` so operators see a "top up or switch provider"
+    /// message rather than "bad API key".
+    Quota,
     /// Rate limited by the provider (429).
     RateLimited {
         /// Retry-After hint in seconds, if provided.
@@ -41,10 +47,18 @@ pub enum LlmErrorKind {
 }
 
 /// A structured LLM error with kind, message, and optional source.
+///
+/// `provider` carries the operator-visible label (e.g. "anthropic",
+/// "MiniMax-M2.5-highspeed") so user-facing messages identify which lane
+/// hit the failure without leaking secrets. Default is empty when the
+/// constructor does not have a label handy.
 #[derive(Debug)]
 pub struct LlmError {
     pub kind: LlmErrorKind,
     pub message: String,
+    /// Operator-visible provider/model label (e.g. "anthropic",
+    /// "MiniMax-M2.5-highspeed"). Empty when not provided.
+    pub provider: String,
     source: Option<Box<dyn std::error::Error + Send + Sync>>,
 }
 
@@ -53,8 +67,15 @@ impl LlmError {
         Self {
             kind,
             message: message.into(),
+            provider: String::new(),
             source: None,
         }
+    }
+
+    /// Builder: attach the operator-visible provider/model label.
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = provider.into();
+        self
     }
 
     pub fn with_source(mut self, source: impl std::error::Error + Send + Sync + 'static) -> Self {
@@ -97,10 +118,43 @@ impl LlmError {
         )
     }
 
-    /// Classify an HTTP status code into an error kind.
+    /// Lowercased body markers that flag a quota / billing-tier failure.
+    /// Kept private so the classification stays the canonical contract for
+    /// `Quota` recognition.
+    fn body_signals_quota(body_lower: &str) -> bool {
+        body_lower.contains("insufficient_quota")
+            || body_lower.contains("quota_exceeded")
+            || body_lower.contains("no_active_wisemodel_package")
+            || (body_lower.contains("no_active_") && body_lower.contains("_package"))
+    }
+
+    /// Classify an HTTP status code into an error kind (legacy 2-arg form
+    /// kept for tests and downstream callers without a provider label).
     pub fn from_status(status: u16, body: &str) -> Self {
+        Self::from_status_with_label(status, body, "")
+    }
+
+    /// Classify an HTTP status code into an error kind, capturing the
+    /// operator-visible provider/model label for user-facing messages.
+    /// Primary entry point for provider HTTP error handlers — replaces the
+    /// previous `eyre::bail!("API error ({label}): ...")` pattern so the
+    /// loop-boundary classifier can downcast to `LlmError` and pick the
+    /// right `HarnessError` variant (issue: variant=internal recovery=bug
+    /// for Wisemodel 403 quota errors).
+    pub fn from_status_with_label(status: u16, body: &str, provider: impl Into<String>) -> Self {
+        let body_lower = body.to_ascii_lowercase();
         let kind = match status {
-            401 | 403 => LlmErrorKind::Authentication,
+            401 => LlmErrorKind::Authentication,
+            403 => {
+                // Disambiguate 403: quota / billing-tier failures get their
+                // own variant so the operator sees a "top up or switch
+                // provider" message instead of "bad API key".
+                if Self::body_signals_quota(&body_lower) {
+                    LlmErrorKind::Quota
+                } else {
+                    LlmErrorKind::Authentication
+                }
+            }
             429 => LlmErrorKind::RateLimited {
                 retry_after_secs: None,
             },
@@ -124,13 +178,48 @@ impl LlmError {
         };
         let truncated_body: String = body.chars().take(200).collect();
         tracing::debug!(status, body = %truncated_body, "LLM provider error response");
-        Self::new(kind, format!("HTTP {status}"))
+        let provider = provider.into();
+        // Keep the message short so the operator log line stays readable;
+        // the full body is available in the wire envelope on the SPA side.
+        let message = if truncated_body.is_empty() {
+            format!("HTTP {status}")
+        } else {
+            format!("HTTP {status} - {truncated_body}")
+        };
+        Self {
+            kind,
+            message,
+            provider,
+            source: None,
+        }
     }
 }
 
 impl fmt::Display for LlmError {
+    /// Human-readable rendering. Provider label is prefixed when non-empty
+    /// so the operator sees which lane failed (e.g.
+    /// "API error (MiniMax-M2.5-highspeed): provider quota exhausted — HTTP 403 - ...").
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}: {}", self.kind, self.message)
+        let prefix = if self.provider.is_empty() {
+            "API error".to_string()
+        } else {
+            format!("API error ({})", self.provider)
+        };
+        let summary = match &self.kind {
+            LlmErrorKind::Authentication => "authentication failed",
+            LlmErrorKind::Quota => "provider quota exhausted",
+            LlmErrorKind::RateLimited { .. } => "rate limited by provider",
+            LlmErrorKind::ContextOverflow { .. } => "context window exceeded",
+            LlmErrorKind::ModelNotFound { .. } => "model not found",
+            LlmErrorKind::ServerError { .. } => "provider server error",
+            LlmErrorKind::Network => "network error",
+            LlmErrorKind::Timeout => "request timed out",
+            LlmErrorKind::InvalidRequest { .. } => "invalid request",
+            LlmErrorKind::ContentFiltered => "content filtered by provider",
+            LlmErrorKind::StreamError => "stream error",
+            LlmErrorKind::Provider { .. } => "provider error",
+        };
+        write!(f, "{prefix}: {summary} — {}", self.message)
     }
 }
 
@@ -151,6 +240,43 @@ mod tests {
         let err = LlmError::from_status(401, "Unauthorized");
         assert_eq!(err.kind, LlmErrorKind::Authentication);
         assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn should_classify_403_without_quota_marker_as_auth() {
+        let err = LlmError::from_status(403, "Forbidden");
+        assert_eq!(err.kind, LlmErrorKind::Authentication);
+    }
+
+    #[test]
+    fn should_classify_403_with_quota_marker_as_quota() {
+        // The exact body that surfaced on dspfac as "variant=internal
+        // recovery=bug": Wisemodel returned 403 with an insufficient_quota
+        // payload. We now map that to LlmErrorKind::Quota so the harness
+        // taxonomy can route it to a user-friendly message.
+        let body = r#"{"error":{"code":"no_active_wisemodel_package","message":"没有有效的 Wisemodel 资源包，请购买后再使用","type":"insufficient_quota"}}"#;
+        let err = LlmError::from_status_with_label(403, body, "MiniMax-M2.5-highspeed");
+        assert_eq!(err.kind, LlmErrorKind::Quota);
+        assert_eq!(err.provider, "MiniMax-M2.5-highspeed");
+        // Display surfaces the provider label so operators see which lane
+        // is the culprit.
+        let rendered = err.to_string();
+        assert!(rendered.contains("MiniMax-M2.5-highspeed"));
+        assert!(rendered.contains("quota exhausted"));
+    }
+
+    #[test]
+    fn should_recognise_generic_quota_keyword() {
+        let body = r#"{"error":{"type":"insufficient_quota","message":"out of credits"}}"#;
+        let err = LlmError::from_status(403, body);
+        assert_eq!(err.kind, LlmErrorKind::Quota);
+    }
+
+    #[test]
+    fn should_recognise_quota_exceeded_keyword() {
+        let body = r#"{"error":"quota_exceeded"}"#;
+        let err = LlmError::from_status(403, body);
+        assert_eq!(err.kind, LlmErrorKind::Quota);
     }
 
     #[test]
@@ -183,6 +309,16 @@ mod tests {
     }
 
     #[test]
+    fn should_classify_400_invalid_request_error_payload() {
+        // OpenAI-style 400 with explicit invalid_request_error type — must
+        // map to InvalidRequest (not ContextOverflow) for the harness to
+        // surface a user-friendly "provider rejected the request" message.
+        let body = r#"{"error":{"type":"invalid_request_error","message":"unknown parameter: temperature"}}"#;
+        let err = LlmError::from_status(400, body);
+        assert!(matches!(err.kind, LlmErrorKind::InvalidRequest { .. }));
+    }
+
+    #[test]
     fn should_create_convenience_errors() {
         assert!(!LlmError::auth("bad key").is_retryable());
         assert!(LlmError::rate_limited(Some(30)).is_retryable());
@@ -194,8 +330,16 @@ mod tests {
     fn should_display_error() {
         let err = LlmError::auth("invalid API key");
         let s = err.to_string();
-        assert!(s.contains("Authentication"));
+        assert!(s.contains("authentication failed"));
         assert!(s.contains("invalid API key"));
+    }
+
+    #[test]
+    fn should_display_error_with_provider_label() {
+        let err = LlmError::from_status_with_label(403, "Forbidden", "anthropic-vertex");
+        let s = err.to_string();
+        // Operator log line should identify the provider/model lane.
+        assert!(s.contains("anthropic-vertex"));
     }
 
     #[test]

--- a/crates/octos-llm/src/error.rs
+++ b/crates/octos-llm/src/error.rs
@@ -121,9 +121,18 @@ impl LlmError {
     /// Lowercased body markers that flag a quota / billing-tier failure.
     /// Kept private so the classification stays the canonical contract for
     /// `Quota` recognition.
+    ///
+    /// Recognised markers (extended in codex round-2 MAJOR 1 to cover
+    /// the cross-provider 429-quota surface):
+    ///   * `insufficient_quota` — OpenAI billing exhausted
+    ///   * `quota_exceeded` — generic
+    ///   * `resource_exhausted` — Gemini `RESOURCE_EXHAUSTED` envelope
+    ///   * `no_active_wisemodel_package` — Wisemodel billing tier expired
+    ///   * `no_active_*_package` — generalised Wisemodel-style marker
     fn body_signals_quota(body_lower: &str) -> bool {
         body_lower.contains("insufficient_quota")
             || body_lower.contains("quota_exceeded")
+            || body_lower.contains("resource_exhausted")
             || body_lower.contains("no_active_wisemodel_package")
             || (body_lower.contains("no_active_") && body_lower.contains("_package"))
     }
@@ -145,6 +154,10 @@ impl LlmError {
         let body_lower = body.to_ascii_lowercase();
         let kind = match status {
             401 => LlmErrorKind::Authentication,
+            // Anthropic uses 402 to signal billing failure / inactive
+            // subscription. Map to Quota so the operator sees a
+            // "top up or switch provider" message rather than "bad key".
+            402 => LlmErrorKind::Quota,
             403 => {
                 // Disambiguate 403: quota / billing-tier failures get their
                 // own variant so the operator sees a "top up or switch
@@ -155,9 +168,25 @@ impl LlmError {
                     LlmErrorKind::Authentication
                 }
             }
-            429 => LlmErrorKind::RateLimited {
-                retry_after_secs: None,
-            },
+            429 => {
+                // Codex round-2 MAJOR 1: 429 is overloaded across providers.
+                // Disambiguate the same way 403 already does:
+                //   * OpenAI 429 + `insufficient_quota` → exhausted billing
+                //   * Gemini 429 + `RESOURCE_EXHAUSTED` → exhausted billing
+                //   * Wisemodel 429 + `no_active_*_package` → exhausted billing
+                //   * Anthropic 429 + `rate_limit_error` → real rate limit
+                //   * Bare 429 (no marker) → real rate limit (legacy default)
+                // Without this branch the failover ladder treats `Quota` as
+                // a retryable RateLimited and burns the next lane on
+                // identical billing failures.
+                if Self::body_signals_quota(&body_lower) {
+                    LlmErrorKind::Quota
+                } else {
+                    LlmErrorKind::RateLimited {
+                        retry_after_secs: None,
+                    }
+                }
+            }
             404 => LlmErrorKind::ModelNotFound {
                 model: String::new(),
             },
@@ -284,6 +313,59 @@ mod tests {
         let err = LlmError::from_status(429, "Too Many Requests");
         assert!(matches!(err.kind, LlmErrorKind::RateLimited { .. }));
         assert!(err.is_retryable());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Codex round-2 MAJOR 1: 429 quota disambiguation. 429 is overloaded
+    // — providers use it for both throttling and exhausted billing. The
+    // body markers tell them apart.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn should_classify_429_with_insufficient_quota_as_quota() {
+        // OpenAI billing-tier exhausted comes back as 429 +
+        // `insufficient_quota` (distinct from a transient TPM 429).
+        let body = r#"{"error":{"code":"insufficient_quota","message":"You exceeded your current quota","type":"insufficient_quota"}}"#;
+        let err = LlmError::from_status_with_label(429, body, "openai/gpt-4");
+        assert_eq!(err.kind, LlmErrorKind::Quota);
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn should_classify_429_with_resource_exhausted_as_quota() {
+        // Gemini billing-tier exhausted comes back as 429 +
+        // `RESOURCE_EXHAUSTED` envelope.
+        let body = r#"{"error":{"code":429,"message":"Quota exceeded for project","status":"RESOURCE_EXHAUSTED"}}"#;
+        let err = LlmError::from_status_with_label(429, body, "gemini-1.5-pro");
+        assert_eq!(err.kind, LlmErrorKind::Quota);
+    }
+
+    #[test]
+    fn should_classify_429_with_no_active_package_as_quota() {
+        // Wisemodel returns 429 + `no_active_*_package` when the user's
+        // resource pack is exhausted (mirroring the 403 surface).
+        let body =
+            r#"{"error":{"code":"no_active_wisemodel_package","type":"insufficient_quota"}}"#;
+        let err = LlmError::from_status_with_label(429, body, "MiniMax-M2.5-highspeed");
+        assert_eq!(err.kind, LlmErrorKind::Quota);
+    }
+
+    #[test]
+    fn should_classify_429_with_anthropic_rate_limit_error_as_rate_limited() {
+        // Anthropic uses 429 + `{"type": "rate_limit_error"}` for real
+        // transient throttling (not billing exhaustion).
+        let body = r#"{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your rate limit"}}"#;
+        let err = LlmError::from_status_with_label(429, body, "anthropic/claude-3-5-sonnet");
+        assert!(matches!(err.kind, LlmErrorKind::RateLimited { .. }));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn should_classify_402_as_quota() {
+        // Anthropic returns 402 for billing failures / inactive subscription.
+        let err = LlmError::from_status(402, "Payment Required");
+        assert_eq!(err.kind, LlmErrorKind::Quota);
+        assert!(!err.is_retryable());
     }
 
     #[test]

--- a/crates/octos-llm/src/error.rs
+++ b/crates/octos-llm/src/error.rs
@@ -12,11 +12,16 @@ use tracing;
 pub enum LlmErrorKind {
     /// Authentication failure (invalid/expired API key).
     Authentication,
-    /// Provider quota exhausted / billing-tier expired / no active package
-    /// (HTTP 403 with `insufficient_quota` / `quota_exceeded` /
-    /// `no_active_*_package` markers in body). Distinct from
-    /// `Authentication` so operators see a "top up or switch provider"
-    /// message rather than "bad API key".
+    /// Provider quota exhausted / billing-tier expired / no active package.
+    /// Sourced from HTTP 402 (Payment Required), or 403/429 bodies that
+    /// carry an explicit billing marker (`insufficient_quota`,
+    /// `quota_exceeded`, `no_active_*_package`) or a billing-class
+    /// keyword (`billing`, `monthly`, `spend`, `package`, `credit`).
+    /// Distinct from `Authentication` so operators see a "top up or
+    /// switch provider" message rather than "bad API key", and distinct
+    /// from `RateLimited` so the failover ladder skips the same-provider
+    /// backoff and tries the next configured lane (which may have a
+    /// different account/key with available billing).
     Quota,
     /// Rate limited by the provider (429).
     RateLimited {
@@ -122,19 +127,36 @@ impl LlmError {
     /// Kept private so the classification stays the canonical contract for
     /// `Quota` recognition.
     ///
-    /// Recognised markers (extended in codex round-2 MAJOR 1 to cover
-    /// the cross-provider 429-quota surface):
+    /// Codex round-3 MAJOR narrowing: bare `RESOURCE_EXHAUSTED` (Google /
+    /// Vertex) is ambiguous — it covers both billing exhaustion *and*
+    /// transient capacity. Treating it unconditionally as `Quota` blocks
+    /// retry/backoff AND (now that `Quota` triggers failover in
+    /// `RetryProvider::should_failover`) burns the next lane on what may
+    /// have been a recoverable load shed. We now require a billing-class
+    /// keyword (`billing`, `monthly`, `spend`, `package`, `credit`) to
+    /// flag `RESOURCE_EXHAUSTED` as quota; bare `RESOURCE_EXHAUSTED`
+    /// falls through to `RateLimited` so the same-provider backoff path
+    /// can drain transient capacity blips.
+    ///
+    /// Recognised explicit quota markers (no body-keyword combo needed):
     ///   * `insufficient_quota` — OpenAI billing exhausted
     ///   * `quota_exceeded` — generic
-    ///   * `resource_exhausted` — Gemini `RESOURCE_EXHAUSTED` envelope
     ///   * `no_active_wisemodel_package` — Wisemodel billing tier expired
     ///   * `no_active_*_package` — generalised Wisemodel-style marker
+    ///
+    /// Recognised billing-keyword fallbacks (any one is sufficient — these
+    /// surface across Anthropic 402, MiniMax 429, etc.):
+    ///   * `billing`, `monthly`, `spend`, `package`, `credit`
     fn body_signals_quota(body_lower: &str) -> bool {
         body_lower.contains("insufficient_quota")
             || body_lower.contains("quota_exceeded")
-            || body_lower.contains("resource_exhausted")
             || body_lower.contains("no_active_wisemodel_package")
             || (body_lower.contains("no_active_") && body_lower.contains("_package"))
+            || body_lower.contains("billing")
+            || body_lower.contains("monthly")
+            || body_lower.contains("spend")
+            || body_lower.contains("package")
+            || body_lower.contains("credit")
     }
 
     /// Classify an HTTP status code into an error kind (legacy 2-arg form
@@ -154,9 +176,11 @@ impl LlmError {
         let body_lower = body.to_ascii_lowercase();
         let kind = match status {
             401 => LlmErrorKind::Authentication,
-            // Anthropic uses 402 to signal billing failure / inactive
-            // subscription. Map to Quota so the operator sees a
-            // "top up or switch provider" message rather than "bad key".
+            // 402 Payment Required → Quota. Anthropic and other providers
+            // use this status code for billing / payment issues
+            // (inactive subscription, expired card, etc.). Map to Quota
+            // so the operator sees a "top up or switch provider" message
+            // rather than "bad key".
             402 => LlmErrorKind::Quota,
             403 => {
                 // Disambiguate 403: quota / billing-tier failures get their
@@ -172,13 +196,18 @@ impl LlmError {
                 // Codex round-2 MAJOR 1: 429 is overloaded across providers.
                 // Disambiguate the same way 403 already does:
                 //   * OpenAI 429 + `insufficient_quota` → exhausted billing
-                //   * Gemini 429 + `RESOURCE_EXHAUSTED` → exhausted billing
+                //   * Gemini 429 + `RESOURCE_EXHAUSTED` + billing keyword
+                //     → exhausted billing
+                //   * Gemini 429 + bare `RESOURCE_EXHAUSTED` (no billing
+                //     keyword) → real rate limit (capacity / transient)
                 //   * Wisemodel 429 + `no_active_*_package` → exhausted billing
                 //   * Anthropic 429 + `rate_limit_error` → real rate limit
                 //   * Bare 429 (no marker) → real rate limit (legacy default)
                 // Without this branch the failover ladder treats `Quota` as
                 // a retryable RateLimited and burns the next lane on
-                // identical billing failures.
+                // identical billing failures. Codex round-3 narrowed the
+                // `RESOURCE_EXHAUSTED` arm so transient capacity blips
+                // stay on the same provider's backoff path.
                 if Self::body_signals_quota(&body_lower) {
                     LlmErrorKind::Quota
                 } else {
@@ -332,10 +361,28 @@ mod tests {
     }
 
     #[test]
-    fn should_classify_429_with_resource_exhausted_as_quota() {
-        // Gemini billing-tier exhausted comes back as 429 +
-        // `RESOURCE_EXHAUSTED` envelope.
-        let body = r#"{"error":{"code":429,"message":"Quota exceeded for project","status":"RESOURCE_EXHAUSTED"}}"#;
+    fn should_classify_429_with_bare_resource_exhausted_as_rate_limited() {
+        // Codex round-3 MAJOR narrowing: bare `RESOURCE_EXHAUSTED`
+        // (without a billing keyword) is ambiguous between billing
+        // exhaustion and transient capacity. We now classify it as
+        // `RateLimited` so the same-provider backoff can drain capacity
+        // blips, and only escalate to `Quota` when the body explicitly
+        // names a billing/package marker.
+        let body = r#"{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota)","status":"RESOURCE_EXHAUSTED"}}"#;
+        let err = LlmError::from_status_with_label(429, body, "gemini-1.5-pro");
+        assert!(matches!(err.kind, LlmErrorKind::RateLimited { .. }));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn should_classify_429_with_resource_exhausted_plus_billing_as_quota() {
+        // Codex round-3 MAJOR narrowing companion: when
+        // `RESOURCE_EXHAUSTED` is accompanied by a billing-class keyword
+        // (`billing`, `monthly`, `spend`, `package`, `credit`), we
+        // upgrade the classification to `Quota` so the failover ladder
+        // can move to a different account/lane rather than burn cycles
+        // retrying the same exhausted billing tier.
+        let body = r#"{"error":{"code":429,"message":"Billing quota exhausted for project","status":"RESOURCE_EXHAUSTED"}}"#;
         let err = LlmError::from_status_with_label(429, body, "gemini-1.5-pro");
         assert_eq!(err.kind, LlmErrorKind::Quota);
     }

--- a/crates/octos-llm/src/gemini.rs
+++ b/crates/octos-llm/src/gemini.rs
@@ -119,10 +119,13 @@ impl LlmProvider for GeminiProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "Gemini API error: {status} - {}",
-                crate::provider::truncate_error_body(&body)
-            );
+            let body = crate::provider::truncate_error_body(&body);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("gemini/{}", self.model),
+            )
+            .into());
         }
 
         let response_text = response
@@ -261,10 +264,13 @@ impl LlmProvider for GeminiProvider {
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "Gemini API error: {status} - {}",
-                crate::provider::truncate_error_body(&text)
-            );
+            let body = crate::provider::truncate_error_body(&text);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("gemini/{}", self.model),
+            )
+            .into());
         }
 
         let sse_stream = crate::sse::parse_sse_response(response);

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -343,11 +343,19 @@ impl LlmProvider for OpenAIProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "API error ({}): {status} - {}",
-                self.model,
-                crate::provider::truncate_error_body(&body)
-            );
+            // Route through LlmError so the loop-boundary classifier
+            // (`HarnessError::classify_report`) can downcast and pick the
+            // correct user-facing variant (auth / quota / bad-request /
+            // rate-limited / server) instead of falling through to
+            // Internal/Bug. The truncated body is preserved so the
+            // operator sees the provider's actual error payload.
+            let body = crate::provider::truncate_error_body(&body);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                &self.model,
+            )
+            .into());
         }
 
         let api_response: OpenAIResponse = response
@@ -449,11 +457,13 @@ impl LlmProvider for OpenAIProvider {
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "API error ({}): {status} - {}",
-                self.model,
-                crate::provider::truncate_error_body(&text)
-            );
+            let body = crate::provider::truncate_error_body(&text);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                &self.model,
+            )
+            .into());
         }
 
         let sse_stream = crate::sse::parse_sse_response(response);

--- a/crates/octos-llm/src/openai.rs
+++ b/crates/octos-llm/src/openai.rs
@@ -349,11 +349,18 @@ impl LlmProvider for OpenAIProvider {
             // rate-limited / server) instead of falling through to
             // Internal/Bug. The truncated body is preserved so the
             // operator sees the provider's actual error payload.
+            //
+            // Codex round-2 MINOR: thread the provider_label so the
+            // operator sees e.g. "minimax/MiniMax-M2.5-highspeed"
+            // instead of just "MiniMax-M2.5-highspeed". This is the
+            // lane label the AdaptiveRouter and failover ledger use,
+            // so the wire envelope can be cross-referenced with the
+            // router events.
             let body = crate::provider::truncate_error_body(&body);
             return Err(crate::error::LlmError::from_status_with_label(
                 status.as_u16(),
                 &body,
-                &self.model,
+                format!("{}/{}", self.provider_label, self.model),
             )
             .into());
         }
@@ -458,10 +465,12 @@ impl LlmProvider for OpenAIProvider {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
             let body = crate::provider::truncate_error_body(&text);
+            // Codex round-2 MINOR: see chat() — thread provider_label so
+            // the streaming error path identifies the lane the same way.
             return Err(crate::error::LlmError::from_status_with_label(
                 status.as_u16(),
                 &body,
-                &self.model,
+                format!("{}/{}", self.provider_label, self.model),
             )
             .into());
         }

--- a/crates/octos-llm/src/openai_responses.rs
+++ b/crates/octos-llm/src/openai_responses.rs
@@ -124,10 +124,13 @@ impl LlmProvider for OpenAIResponsesProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "OpenAI Responses API error: {status} - {}",
-                crate::provider::truncate_error_body(&body)
-            );
+            let body = crate::provider::truncate_error_body(&body);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("openai-responses/{}", self.model),
+            )
+            .into());
         }
 
         let api_response: ResponsesApiResponse = response
@@ -163,10 +166,13 @@ impl LlmProvider for OpenAIResponsesProvider {
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "OpenAI Responses API error: {status} - {}",
-                crate::provider::truncate_error_body(&text)
-            );
+            let body = crate::provider::truncate_error_body(&text);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("openai-responses/{}", self.model),
+            )
+            .into());
         }
 
         let sse_stream = crate::sse::parse_sse_response(response);

--- a/crates/octos-llm/src/openrouter.rs
+++ b/crates/octos-llm/src/openrouter.rs
@@ -113,10 +113,15 @@ impl LlmProvider for OpenRouterProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "OpenRouter API error: {status} - {}",
-                crate::provider::truncate_error_body(&body)
-            );
+            let body = crate::provider::truncate_error_body(&body);
+            // Route through LlmError so the harness classifier can pick the
+            // user-facing variant rather than falling through to Internal/Bug.
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("openrouter/{}", self.model),
+            )
+            .into());
         }
 
         let api_response: ApiResponse = response
@@ -228,10 +233,13 @@ impl LlmProvider for OpenRouterProvider {
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
-            eyre::bail!(
-                "OpenRouter API error: {status} - {}",
-                crate::provider::truncate_error_body(&text)
-            );
+            let body = crate::provider::truncate_error_body(&text);
+            return Err(crate::error::LlmError::from_status_with_label(
+                status.as_u16(),
+                &body,
+                format!("openrouter/{}", self.model),
+            )
+            .into());
         }
 
         let sse_stream = crate::sse::parse_sse_response(response);

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -81,10 +81,15 @@ impl RetryProvider {
         for cause in error.chain() {
             if let Some(llm) = cause.downcast_ref::<LlmError>() {
                 return match &llm.kind {
-                    // Fail-fast — operator must top up billing or switch
-                    // provider manually. Auto-failover would just burn
-                    // the next lane's quota too.
-                    LlmErrorKind::Quota => false,
+                    // Quota is a per-lane/provider credential failure
+                    // (like Auth): the *same* provider won't recover on
+                    // retry (won't be `is_retryable`), but another
+                    // configured lane may have a different key/account
+                    // with available quota. Codex round-3 BLOCKER fix:
+                    // previous version returned `false` here which
+                    // collapsed the entire chain when the primary lane
+                    // ran out of billing.
+                    LlmErrorKind::Quota => true,
                     // The current provider's credentials are bad — try
                     // the next lane which may have a valid key.
                     LlmErrorKind::Authentication => true,
@@ -419,12 +424,17 @@ mod tests {
     // ──────────────────────────────────────────────────────────────────────
 
     #[test]
-    fn test_should_not_failover_typed_quota() {
-        // Quota = fail-fast: top up or switch lane manually.
+    fn test_should_failover_typed_quota() {
+        // Codex round-3 BLOCKER: Quota is a per-lane credential failure.
+        // Same-provider retry stays false (quota won't reset on retry),
+        // but failover to the next provider must be true — another
+        // configured lane may have a different key/account with quota.
         let llm = LlmError::new(LlmErrorKind::Quota, "out of credits")
             .with_provider("MiniMax-M2.5-highspeed");
         let err: eyre::Report = llm.into();
-        assert!(!RetryProvider::should_failover(&err));
+        assert!(RetryProvider::should_failover(&err));
+        // But the same provider must NOT auto-retry the request.
+        assert!(!RetryProvider::is_retryable_error(&err));
     }
 
     #[test]

--- a/crates/octos-llm/src/retry.rs
+++ b/crates/octos-llm/src/retry.rs
@@ -9,6 +9,7 @@ use octos_core::Message;
 use tracing::{debug, warn};
 
 use crate::config::ChatConfig;
+use crate::error::{LlmError, LlmErrorKind};
 use crate::provider::LlmProvider;
 use crate::types::{ChatResponse, ChatStream, ToolSpec};
 
@@ -62,7 +63,53 @@ impl RetryProvider {
     /// This is broader than `is_retryable_error`: auth failures (401/403)
     /// should not be retried on the *same* provider but should failover to
     /// a different provider which may have valid credentials.
+    ///
+    /// Codex round-2 BLOCKER fix: prior versions only string-matched the
+    /// legacy `"API error: <code>"` shape. The typed `LlmError::Display`
+    /// renders as `"API error (<provider>): <summary> — HTTP <code> ..."`
+    /// which the legacy match misses, so `FallbackProvider` and
+    /// `ProviderChain` failed to failover for Quota / Auth / Rate-Limited /
+    /// Server-Error classifications. We now downcast to `LlmError` first
+    /// and switch on `LlmErrorKind` directly; the legacy string-match
+    /// branch is preserved for non-typed callers and bare `eyre::eyre!`
+    /// reports.
     pub(crate) fn should_failover(error: &eyre::Report) -> bool {
+        // Typed-error path: walk the cause chain and switch on the
+        // structured kind. This is the canonical entry point — once a
+        // provider emits `LlmError::from_status_with_label`, this branch
+        // wins.
+        for cause in error.chain() {
+            if let Some(llm) = cause.downcast_ref::<LlmError>() {
+                return match &llm.kind {
+                    // Fail-fast — operator must top up billing or switch
+                    // provider manually. Auto-failover would just burn
+                    // the next lane's quota too.
+                    LlmErrorKind::Quota => false,
+                    // The current provider's credentials are bad — try
+                    // the next lane which may have a valid key.
+                    LlmErrorKind::Authentication => true,
+                    LlmErrorKind::RateLimited { .. } => true,
+                    // BadRequest / InvalidRequest is failover-worthy:
+                    // e.g. deepseek's `reasoning_content` 400 may pass
+                    // through openai-compat lanes with different
+                    // validation rules.
+                    LlmErrorKind::InvalidRequest { .. } => true,
+                    LlmErrorKind::ServerError { status } => (500..600).contains(status),
+                    // Transient — failover gives us a chance to swap to
+                    // a healthy lane while the primary recovers.
+                    LlmErrorKind::Network
+                    | LlmErrorKind::Timeout
+                    | LlmErrorKind::StreamError
+                    | LlmErrorKind::ContextOverflow { .. } => true,
+                    // 4xx other / generic provider error — keep current
+                    // provider, the next one will hit the same wall.
+                    LlmErrorKind::ContentFiltered
+                    | LlmErrorKind::ModelNotFound { .. }
+                    | LlmErrorKind::Provider { .. } => false,
+                };
+            }
+        }
+
         // Auth errors and timeouts: don't retry same provider, but do failover
         for cause in error.chain() {
             if let Some(reqwest_err) = cause.downcast_ref::<reqwest::Error>() {
@@ -105,6 +152,15 @@ impl RetryProvider {
     /// (reqwest errors carry status). Falls back to keyword matching for
     /// non-HTTP errors like connection failures.
     pub(crate) fn is_retryable_error(error: &eyre::Report) -> bool {
+        // Typed-error path: the new provider error path constructs
+        // `LlmError` directly. Honor `is_retryable()` so RateLimited /
+        // ServerError / Network / Timeout / StreamError get the same
+        // backoff treatment they had under the legacy string match.
+        for cause in error.chain() {
+            if let Some(llm) = cause.downcast_ref::<LlmError>() {
+                return llm.is_retryable();
+            }
+        }
         // Check for reqwest errors with status codes (most reliable)
         for cause in error.chain() {
             if let Some(reqwest_err) = cause.downcast_ref::<reqwest::Error>() {
@@ -351,6 +407,96 @@ mod tests {
     fn test_should_not_failover_400() {
         let err = eyre::eyre!("API error: 400 - bad request");
         assert!(!RetryProvider::should_failover(&err));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Codex round-2 BLOCKER regression: pin each `LlmErrorKind` branch so
+    // the typed-error path stays in sync with `should_failover`. These
+    // tests would have caught the original bug where the typed Display
+    // string (`"API error (<provider>): … — HTTP 403 …"`) didn't match
+    // the legacy `"API error: 403"` string-match, so 403/quota/auth/etc.
+    // silently bypassed failover.
+    // ──────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_should_not_failover_typed_quota() {
+        // Quota = fail-fast: top up or switch lane manually.
+        let llm = LlmError::new(LlmErrorKind::Quota, "out of credits")
+            .with_provider("MiniMax-M2.5-highspeed");
+        let err: eyre::Report = llm.into();
+        assert!(!RetryProvider::should_failover(&err));
+    }
+
+    #[test]
+    fn test_should_failover_typed_authentication() {
+        // Auth = next lane may have a valid key.
+        let llm = LlmError::new(LlmErrorKind::Authentication, "bad key");
+        let err: eyre::Report = llm.into();
+        assert!(RetryProvider::should_failover(&err));
+    }
+
+    #[test]
+    fn test_should_failover_typed_rate_limited() {
+        let llm = LlmError::rate_limited(Some(30));
+        let err: eyre::Report = llm.into();
+        assert!(RetryProvider::should_failover(&err));
+    }
+
+    #[test]
+    fn test_should_failover_typed_bad_request() {
+        // Provider rejected the request body — try a different provider
+        // whose validation rules may be looser (e.g. deepseek
+        // `reasoning_content` 400 → kimi works).
+        let llm = LlmError::new(
+            LlmErrorKind::InvalidRequest {
+                detail: "reasoning_content missing".into(),
+            },
+            "HTTP 400",
+        );
+        let err: eyre::Report = llm.into();
+        assert!(RetryProvider::should_failover(&err));
+    }
+
+    #[test]
+    fn test_should_failover_typed_server_error_5xx() {
+        let llm = LlmError::new(LlmErrorKind::ServerError { status: 503 }, "service down");
+        let err: eyre::Report = llm.into();
+        assert!(RetryProvider::should_failover(&err));
+    }
+
+    #[test]
+    fn test_should_not_failover_typed_content_filtered() {
+        let llm = LlmError::new(LlmErrorKind::ContentFiltered, "blocked");
+        let err: eyre::Report = llm.into();
+        assert!(!RetryProvider::should_failover(&err));
+    }
+
+    #[test]
+    fn test_is_retryable_typed_rate_limited() {
+        let llm = LlmError::rate_limited(None);
+        let err: eyre::Report = llm.into();
+        assert!(RetryProvider::is_retryable_error(&err));
+    }
+
+    #[test]
+    fn test_is_retryable_typed_server_error() {
+        let llm = LlmError::new(LlmErrorKind::ServerError { status: 502 }, "bad gateway");
+        let err: eyre::Report = llm.into();
+        assert!(RetryProvider::is_retryable_error(&err));
+    }
+
+    #[test]
+    fn test_not_retryable_typed_auth() {
+        let llm = LlmError::auth("bad key");
+        let err: eyre::Report = llm.into();
+        assert!(!RetryProvider::is_retryable_error(&err));
+    }
+
+    #[test]
+    fn test_not_retryable_typed_quota() {
+        let llm = LlmError::new(LlmErrorKind::Quota, "out of credits");
+        let err: eyre::Report = llm.into();
+        assert!(!RetryProvider::is_retryable_error(&err));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Provider HTTP errors used to surface as `variant=internal recovery=bug` on the daemon log line and SPA because `eyre::bail!()` in the 5 provider modules produced an `eyre::Report` whose downcast to `LlmError` always failed inside `HarnessError::classify_report`. The result: a Wisemodel 403 quota error on dspfac (mini1) — clearly an operator-fixable billing-tier issue — looked like an unknown "stuck" daemon bug.

Concrete evidence from the dspfac daemon log:

```
WARN harness error classified variant="internal" recovery=bug error=API error (MiniMax-M2.5-highspeed): 403 Forbidden - {"error":{"code":"no_active_wisemodel_package","message":"没有有效的 Wisemodel 资源包，请购买后再使用","type":"insufficient_quota"}}
```

## Fix in three layers

**Phase 1 — `LlmError` taxonomy (`crates/octos-llm/src/error.rs`):**
- New `LlmErrorKind::Quota` variant.
- New `from_status_with_label(status, body, provider)` constructor that captures the operator-visible provider/model label and disambiguates 403 by body content (`insufficient_quota` / `quota_exceeded` / `no_active_*_package` -> `Quota`, else `Authentication`).
- New `provider: String` field on `LlmError`; `Display` renders `API error (<provider>): <summary> — HTTP <status> - <body>` so operators see which lane failed.

**Phase 2 — Provider plumbing (5 files):**
- `crates/octos-llm/src/anthropic.rs`, `gemini.rs`, `openai.rs`, `openai_responses.rs`, `openrouter.rs`
- All `chat()` + `chat_stream()` HTTP-error paths now do `return Err(LlmError::from_status_with_label(...).into())` instead of `eyre::bail!(...)`. The eyre::Report downcasts cleanly at the loop boundary.

**Phase 3 — Harness taxonomy (`crates/octos-agent/src/harness_errors.rs` + `agent/loop_state.rs`):**
- New `HarnessError::Quota { message }` variant with `RecoveryHint::FailFast` ("top up or switch provider — top up or switch provider").
- `from_llm_error` enriches every variant's message with the lane label so the SPA's `runtime_error` envelope shows actionable text.
- `LoopRetryLimits` / `LoopRetryCounters` gain a `quota` bucket (cap=1) for the per-variant retry state machine.

## Test plan
- [x] `cargo test -p octos-llm` — 21 error.rs tests including 5 new (Quota detection from 3 body shapes, invalid_request_error payload, provider-label Display)
- [x] `cargo test -p octos-agent --lib harness_errors` — 10 unit tests including 5 new (eyre::Report -> LlmError -> HarnessError downcast for Quota / Auth-403 / InvalidRequest)
- [x] `cargo test -p octos-agent --test harness_errors` — 18 integration tests including 4 new pinning the dspfac log-symptom regression
- [x] `cargo test -p octos-llm -p octos-agent --lib` — 1875 lib tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)