### PR TITLE
fix(prompts): ACT-DIRECTLY for specialist tools; narrow menu to no-tool-match (B6 soak fix)

### DIFF
--- a/crates/octos-cli/src/commands/gateway/prompt.rs
+++ b/crates/octos-cli/src/commands/gateway/prompt.rs
@@ -125,3 +125,112 @@ pub fn settings_str(settings: &serde_json::Value, key: &str, default: &str) -> S
         .unwrap_or(default)
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for the compiled-in gateway system prompt.
+    //!
+    //! These tests assert on the *bundled* prompt string at
+    //! `crates/octos-cli/src/prompts/gateway_default.txt` (loaded via
+    //! `include_str!` in [`build_system_prompt`]). They lock in the B6
+    //! soak-bug fix where `deepseek-v4-pro` answered Chinese news prompts
+    //! (`查一下今日新闻头条`) with the 1/2/3 search menu instead of calling
+    //! the registered `news_fetch` specialist tool. The previous prompt
+    //! had a single catch-all "ALL other search/lookup requests" rule
+    //! that mandated the menu for every `查一下 / 搜一下 / 帮我查` prompt,
+    //! even when a domain-specific tool matched.
+    //!
+    //! The fix:
+    //!
+    //! 1. Adds an `ACT-DIRECTLY for registered specialist tools` rule
+    //!    BEFORE the menu, naming `news_fetch`, `get_weather`, `get_time`,
+    //!    `podcast_generate`, `voice_synthesize`, `run_pipeline`.
+    //! 2. Narrows the menu catch-all to "open-ended research/lookup
+    //!    requests WITHOUT a matching specialist tool", with an explicit
+    //!    counter-example pointing at the news case.
+    //!
+    //! These assertions are deliberately substring-based (not exact
+    //! match) so the prompt can be edited around the rule without
+    //! breaking the test — but the load-bearing phrases must stay.
+
+    const PROMPT: &str = include_str!("../../prompts/gateway_default.txt");
+
+    #[test]
+    fn should_have_act_directly_specialist_tools_section() {
+        assert!(
+            PROMPT.contains("ACT-DIRECTLY for registered specialist tools"),
+            "prompt is missing the ACT-DIRECTLY specialist-tools header; \
+             the B6 soak fix relied on this section to stop the gateway \
+             from asking 1/2/3 for queries like 查一下今日新闻头条"
+        );
+    }
+
+    #[test]
+    fn should_route_news_queries_to_news_fetch_directly() {
+        assert!(
+            PROMPT.contains("`news_fetch`"),
+            "prompt must mention `news_fetch` as the act-directly target \
+             for news-headline queries (B6 soak fix)"
+        );
+        // The Chinese trigger keywords for news must be present so the
+        // model picks `news_fetch` for prompts like "查一下今日新闻头条".
+        for keyword in ["新闻", "头条", "今日新闻"] {
+            assert!(
+                PROMPT.contains(keyword),
+                "prompt must list `{keyword}` as a news trigger keyword \
+                 so the gateway routes Chinese news queries to news_fetch \
+                 instead of the 1/2/3 menu"
+            );
+        }
+    }
+
+    #[test]
+    fn should_route_weather_and_time_queries_directly() {
+        assert!(
+            PROMPT.contains("`get_weather`"),
+            "prompt must mention `get_weather` for weather queries"
+        );
+        assert!(
+            PROMPT.contains("`get_time`"),
+            "prompt must mention `get_time` for time/date queries"
+        );
+    }
+
+    #[test]
+    fn should_route_podcast_and_tts_to_spawn_specialists() {
+        assert!(
+            PROMPT.contains("`podcast_generate`"),
+            "prompt must mention `podcast_generate` for podcast requests"
+        );
+        assert!(
+            PROMPT.contains("`voice_synthesize`"),
+            "prompt must mention `voice_synthesize` for TTS / read-aloud \
+             requests"
+        );
+    }
+
+    #[test]
+    fn should_narrow_menu_rule_to_no_specialist_tool_match() {
+        // The narrow rule must reference "WITHOUT a matching specialist
+        // tool" so the 1/2/3 menu only fires for open-ended research.
+        assert!(
+            PROMPT.contains("WITHOUT a matching specialist tool"),
+            "the menu catch-all must be narrowed to 'open-ended \
+             research/lookup requests WITHOUT a matching specialist \
+             tool' (B6 fix); the previous wording made the menu fire \
+             for ALL 查一下/搜一下 prompts"
+        );
+        // The old broken wording must NOT come back: "For ALL other
+        // search/lookup requests ... ALWAYS ask the user to pick 1/2/3"
+        // without the specialist-tool carve-out.
+        assert!(
+            !PROMPT.contains(
+                "For ALL other search/lookup requests (including \
+                 \"查一下\", \"搜一下\", \"帮我查\", \"search for\"), \
+                 ALWAYS ask the user to pick 1/2/3 first."
+            ),
+            "the unconditional 'ALL other search/lookup requests' menu \
+             rule must not be reintroduced (B6 regression guard)"
+        );
+    }
+}

--- a/crates/octos-cli/src/commands/gateway/prompt.rs
+++ b/crates/octos-cli/src/commands/gateway/prompt.rs
@@ -210,6 +210,32 @@ mod tests {
     }
 
     #[test]
+    fn should_reconcile_grounding_rule_with_news_fetch_preference() {
+        // The Grounding Rules historically listed "news" alongside other
+        // real-time data routed to `web_search` / `web_fetch`. That
+        // contradicted the ACT-DIRECTLY specialist-tools rule (codex
+        // review on d8eebec9, P2). The reconciled wording must prefer
+        // `news_fetch` when it is registered.
+        assert!(
+            PROMPT.contains(
+                "prefer the `news_fetch` specialist tool when it is registered"
+            ),
+            "Grounding Rules must explicitly prefer news_fetch over \
+             web_search/web_fetch when news_fetch is registered (codex \
+             P2 follow-up to B6 fix)"
+        );
+        // The old conflicting phrasing — "news, current events" lumped
+        // into the web_search bucket — must not return.
+        assert!(
+            !PROMPT.contains(
+                "(stock prices, sports scores, exchange rates, news, current events"
+            ),
+            "the unqualified 'news' entry in the web_search list must \
+             not be reintroduced (codex P2 regression guard)"
+        );
+    }
+
+    #[test]
     fn should_narrow_menu_rule_to_no_specialist_tool_match() {
         // The narrow rule must reference "WITHOUT a matching specialist
         // tool" so the 1/2/3 menu only fires for open-ended research.

--- a/crates/octos-cli/src/prompts/gateway_default.txt
+++ b/crates/octos-cli/src/prompts/gateway_default.txt
@@ -53,7 +53,7 @@ For simpler single-angle searches, use `search` + `synthesize_research` manually
 
 ## Grounding Rules
 
-For weather queries, use the `get_weather` tool. For time/timezone queries, use the `get_time` tool. For questions about what models or providers you have, use `model_check` with action="list" — NEVER guess model names from training data. For other real-time data (stock prices, sports scores, exchange rates, news, current events, flight status, package tracking), use `web_search` or `web_fetch`. NEVER fabricate or guess real-time information — if you cannot fetch it, say so.
+For weather queries, use the `get_weather` tool. For time/timezone queries, use the `get_time` tool. For news headlines / current news, prefer the `news_fetch` specialist tool when it is registered (see the ACT-DIRECTLY specialist-tools rule above) — fall back to `web_search` / `web_fetch` only when `news_fetch` is unavailable. For questions about what models or providers you have, use `model_check` with action="list" — NEVER guess model names from training data. For other real-time data (stock prices, sports scores, exchange rates, current events, flight status, package tracking), use `web_search` or `web_fetch`. NEVER fabricate or guess real-time information — if you cannot fetch it, say so.
 
 ## Coding And Shell Rules
 

--- a/crates/octos-cli/src/prompts/gateway_default.txt
+++ b/crates/octos-cli/src/prompts/gateway_default.txt
@@ -14,6 +14,17 @@ You are Octos, an AI assistant. Reply directly — never say "Thinking" or narra
 - If the user message contains "爬取这个网站" or names a specific URL to crawl → call `deep_crawl` **immediately**.
 - If the user replies with "1", "2", or "3" after a prior menu → execute the corresponding tool **immediately**.
 
+**ACT-DIRECTLY for registered specialist tools (check BEFORE the search menu).** When the user's request matches a domain that a registered specialist tool already covers, call that tool directly with the user's query. Do NOT show the 1/2/3 search menu — the menu is only for open-ended research where no specialist tool fits.
+
+- News headlines / current news (`新闻`, `news`, `headline`, `头条`, `速递`, `今日新闻`, `今天新闻`) → call `news_fetch` directly with the query.
+- Weather (`天气`, `weather`, `气温`, `温度`, `forecast`) → call `get_weather` directly.
+- Time / date (`时间`, `日期`, `time`, `date`, `几点`, `星期`) → call `get_time` directly.
+- Podcast (`播客`, `podcast`, `播客介绍`, `做一期播客`) → spawn `podcast_generate` with defaults. Only ask the user to confirm choices if they explicitly say "ask me first" / "让我选".
+- TTS / read aloud (`朗读`, `念一下`, `read aloud`, `配音`, `TTS`) → spawn `voice_synthesize` with the default voice.
+- Deep research (`深度研究`, `深度调查`, `深入研究`) → spawn `run_pipeline` with an inline `deep_research`-style digraph (see ACT-DIRECTLY rules above).
+
+If a specialist tool is named in the rule but is NOT actually registered in this session, fall back to the menu rule below. Do not invent or guess a tool name — only call tools that appear in the tool catalog.
+
 Only when NONE of the act-directly rules above match, AND the user asked to research/search/investigate something:
 
 FIRST confirm which approach:
@@ -24,7 +35,7 @@ FIRST confirm which approach:
 
 Match the user's language (Chinese question → Chinese options).
 
-For ALL other search/lookup requests (including "查一下", "搜一下", "帮我查", "search for"), ALWAYS ask the user to pick 1/2/3 first. Do NOT assume web_search is enough.
+For open-ended research/lookup requests WITHOUT a matching specialist tool (including bare "查一下", "搜一下", "帮我查", "search for" when no specialist domain like news/weather/time/podcast/TTS/deep-research applies), ask the user to pick 1/2/3 first. Do NOT assume web_search is enough. If a specialist tool DOES match (e.g. "查一下今日新闻头条" → news), follow the ACT-DIRECTLY rule above instead — do not show the menu.
 
 After choosing, you MUST actually call the tool. NEVER just reply with text like "I'm starting research" — invoke the tool.
 


### PR DESCRIPTION
## Summary

- **B6 soak bug:** `deepseek-v4-pro` answered Chinese news prompts like `查一下今日新闻头条` with the 1/2/3 search menu instead of calling the registered `news_fetch` specialist tool.
- **Root cause:** `gateway_default.txt` had a catch-all "For ALL other search/lookup requests (including '查一下', '搜一下', '帮我查', 'search for'), ALWAYS ask the user to pick 1/2/3 first" — overriding every specialist-tool route. Plus the Grounding Rules section lumped "news, current events" into `web_search`/`web_fetch` — contradictory.
- **Fix (2 commits):**
  1. **d8eebec9** — Added an `ACT-DIRECTLY for registered specialist tools` block *before* the menu, naming `news_fetch`, `get_weather`, `get_time`, `podcast_generate`, `voice_synthesize`, and `run_pipeline` with their trigger keywords (Chinese + English). Narrowed the menu catch-all to "open-ended research/lookup requests WITHOUT a matching specialist tool" with an explicit inline counter-example: `"查一下今日新闻头条" → news_fetch`. Added 5 regression tests in `commands::gateway::prompt::tests` that assert on the compiled-in prompt via `include_str!`.
  2. **24860c6e** (codex P2 follow-up) — Codex review on d8eebec9 flagged that the Grounding Rules section still listed "news" as a `web_search`/`web_fetch` target, contradicting the new ACT-DIRECTLY rule. Added an explicit "prefer the `news_fetch` specialist tool when it is registered" carve-out and dropped "news" from the unqualified web_search list. Added a 6th regression test.

## Codex review

- Pass 1 on d8eebec9: P2 — Reconcile news tool routing (Grounding Rules ⇄ ACT-DIRECTLY). Addressed in 24860c6e.
- Pass 2 on 24860c6e: clean — "I did not find a discrete introduced bug that would break existing behavior or tests."

## Test plan

- [x] `cargo build --workspace` (clean)
- [x] `cargo test -p octos-cli --lib commands::gateway::prompt::tests` — 6/6 pass
- [x] `cargo clippy -p octos-cli --lib` — clean
- [x] Codex review on both commits
- [ ] Soak retry of `查一下今日新闻头条` against deepseek-v4-pro and other models to confirm `news_fetch` is now called directly