### PR TITLE
fix(pipeline): propagate embedder to worker Agents (NEW-06 contamination root cause)

### DIFF
--- a/crates/octos-agent/src/agent/memory.rs
+++ b/crates/octos-agent/src/agent/memory.rs
@@ -2,7 +2,7 @@
 
 use octos_core::{Message, MessageRole, Task};
 use octos_memory::{Episode, HybridScore};
-use tracing::warn;
+use tracing::{info, warn};
 
 use super::Agent;
 
@@ -121,6 +121,30 @@ impl Agent {
             };
 
             if let Ok(scored) = scored_result {
+                // NEW-06 diagnostic: surface which episodes (id + per-
+                // modality scores) the gate ultimately admitted. The
+                // round-3 mini5 contamination shipped silently because
+                // the agent loop had no telemetry on what cleared the
+                // threshold — only the rendered prompt downstream. We
+                // emit one structured log per `build_initial_messages`
+                // so fleet operators can confirm the gate is active
+                // and which episodes contributed without inspecting
+                // the model-visible prompt directly.
+                let admitted: Vec<(String, f32, f32, f32)> = scored
+                    .iter()
+                    .filter(|(_, s)| s.best_modality() >= MIN_EPISODE_SIMILARITY)
+                    .map(|(ep, s)| (ep.id.clone(), s.bm25, s.vector, s.combined))
+                    .collect();
+                info!(
+                    caller = "agent_memory_hybrid",
+                    agent = %self.id,
+                    query_len = query.len(),
+                    candidates = scored.len(),
+                    admitted = admitted.len(),
+                    threshold = MIN_EPISODE_SIMILARITY,
+                    episodes = ?admitted,
+                    "memory recall: hybrid scored + filtered path"
+                );
                 if let Some(content) = format_relevant_experiences(&scored) {
                     messages.push(Message {
                         role: MessageRole::System,
@@ -137,13 +161,49 @@ impl Agent {
             }
         } else if let Ok(episodes) = self
             .memory
-            .find_relevant(&task.context.working_dir, &query, 3)
+            .find_relevant_filtered(
+                &task.context.working_dir,
+                &query,
+                3,
+                // NEW-06 defense-in-depth: apply the modality-aware
+                // similarity gate to the no-embedder fallback path too.
+                // The primary fix is propagating the parent embedder
+                // to pipeline workers via `RunPipelineTool::with_embedder`
+                // (crates/octos-pipeline/src/tool.rs); this is the
+                // belt-and-suspenders rail for the case where a worker
+                // still ends up here (embedder construction failed, an
+                // older call site not yet updated, etc.).
+                Some(MIN_EPISODE_SIMILARITY),
+            )
             .await
         {
             // CWD-scoped fallback path. No scoring infrastructure here;
             // the cwd filter + keyword match already constrain results.
             // Inject only when there's something to inject (no empty header).
+            //
+            // NEW-06 diagnostic: ALSO log on the no-embedder path so we
+            // can detect contamination here too. The round-3 root
+            // cause was that pipeline workers fell through to THIS
+            // branch because their parent agent's embedder wasn't
+            // propagated. The wiring fix lives in
+            // crates/octos-pipeline (RunPipelineTool::with_embedder ->
+            // CodergenHandler -> worker Agent::with_embedder); this
+            // log gives us evidence when a worker still ends up here
+            // despite the fix (e.g. embedder failed to construct).
             if !episodes.is_empty() {
+                let ids: Vec<String> = episodes.iter().map(|e| e.id.clone()).collect();
+                warn!(
+                    caller = "agent_memory_cwd_fallback",
+                    agent = %self.id,
+                    cwd = %task.context.working_dir.display(),
+                    query_len = query.len(),
+                    injected = episodes.len(),
+                    episodes = ?ids,
+                    "memory recall: no-embedder CWD fallback (no similarity gate). \
+                     If this agent is a pipeline worker, the parent embedder did NOT \
+                     propagate — investigate the RunPipelineTool::with_embedder wiring \
+                     (NEW-06)."
+                );
                 let content = render_relevant_experiences(&episodes);
                 messages.push(Message {
                     role: MessageRole::System,

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -292,15 +292,28 @@ impl ChatCommand {
         // Section B (codex review follow-up): propagate
         // `plugins.require_signed` so pipeline workers enforce the same
         // gate as the main session.
-        let pipeline_tool = octos_pipeline::RunPipelineTool::new(
+        //
+        // NEW-06 codex follow-up: also propagate the embedder so the
+        // pipeline-spawned worker `Agent` instances inherit the same
+        // hybrid scored + filtered episodic-memory recall the parent
+        // chat agent gets at the `agent = agent.with_embedder(..)` line
+        // below. Without this, `octos chat`'s pipeline workers fall back
+        // to the unfiltered cwd-only path in `EpisodeStore::find_relevant`
+        // and can pull in cross-domain episodes (the NEW-06 contamination
+        // root cause). Construction is extracted into
+        // [`build_run_pipeline_tool`] so the regression test in
+        // `octos-pipeline/tests/embedder_propagation.rs` can pin the
+        // wiring without instantiating the full chat command.
+        let pipeline_tool = build_run_pipeline_tool(
             llm.clone(),
             memory.clone(),
             cwd.clone(),
             data_dir.clone(),
-        )
-        .with_provider_policy(tools.provider_policy().cloned())
-        .with_plugin_dirs(plugin_dirs)
-        .with_plugin_require_signed(config.plugins.require_signed);
+            tools.provider_policy().cloned(),
+            plugin_dirs,
+            config.plugins.require_signed,
+            create_embedder(&config),
+        );
         tools.register(pipeline_tool);
         tools.mark_spawn_only(
             "run_pipeline",
@@ -727,6 +740,39 @@ pub(crate) fn create_embedder(config: &Config) -> Option<Arc<dyn EmbeddingProvid
     Some(Arc::new(e))
 }
 
+/// Build the [`octos_pipeline::RunPipelineTool`] used by the chat command,
+/// threading through the per-session policy / plugin dirs / signing gate /
+/// embedder.
+///
+/// NEW-06 codex follow-up — extracted into a stand-alone function so the
+/// regression test in `octos-pipeline/tests/embedder_propagation.rs` can
+/// pin the embedder propagation without instantiating the entire chat
+/// command (which depends on rustyline, hooks, profiles, MCP, etc.).
+///
+/// Keep the construction order byte-for-byte identical to the inline
+/// path it replaced — the policy/plugin builders rely on insertion order
+/// (`with_plugin_dirs` invalidates the plugin cache, etc.).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_run_pipeline_tool(
+    llm: Arc<dyn LlmProvider>,
+    memory: Arc<EpisodeStore>,
+    cwd: PathBuf,
+    data_dir: PathBuf,
+    provider_policy: Option<octos_agent::ToolPolicy>,
+    plugin_dirs: Vec<PathBuf>,
+    plugin_require_signed: bool,
+    embedder: Option<Arc<dyn EmbeddingProvider>>,
+) -> octos_pipeline::RunPipelineTool {
+    let mut pipeline_tool = octos_pipeline::RunPipelineTool::new(llm, memory, cwd, data_dir)
+        .with_provider_policy(provider_policy)
+        .with_plugin_dirs(plugin_dirs)
+        .with_plugin_require_signed(plugin_require_signed);
+    if let Some(embedder) = embedder {
+        pipeline_tool = pipeline_tool.with_embedder(embedder);
+    }
+    pipeline_tool
+}
+
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
@@ -765,6 +811,138 @@ mod tests {
         let config = Config::default();
         assert!(
             resolve_provider_policy(&config, "anthropic", "claude-sonnet-4-20250514").is_none()
+        );
+    }
+
+    /// NEW-06 codex follow-up — when [`build_run_pipeline_tool`] is
+    /// given an embedder, the resulting [`octos_pipeline::RunPipelineTool`]
+    /// must carry it through so pipeline workers spawned from `octos chat`
+    /// inherit the contamination-safe hybrid memory recall path.
+    ///
+    /// Regression guard: if a future refactor drops the
+    /// `.with_embedder(...)` call on the chat construction path the
+    /// `embedder_for_test()` assertion below goes red.
+    #[tokio::test]
+    async fn build_run_pipeline_tool_propagates_embedder_when_present() {
+        use async_trait::async_trait;
+        use octos_llm::EmbeddingProvider;
+
+        struct StubEmbedder;
+        #[async_trait]
+        impl EmbeddingProvider for StubEmbedder {
+            async fn embed(&self, texts: &[&str]) -> eyre::Result<Vec<Vec<f32>>> {
+                Ok(vec![vec![0.0]; texts.len()])
+            }
+            fn dimension(&self) -> usize {
+                1
+            }
+        }
+
+        struct MockLlm;
+        #[async_trait]
+        impl LlmProvider for MockLlm {
+            async fn chat(
+                &self,
+                _messages: &[octos_core::Message],
+                _tools: &[octos_llm::ToolSpec],
+                _config: &octos_llm::ChatConfig,
+            ) -> eyre::Result<octos_llm::ChatResponse> {
+                Ok(octos_llm::ChatResponse {
+                    content: Some("ok".into()),
+                    reasoning_content: None,
+                    tool_calls: vec![],
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                })
+            }
+            fn provider_name(&self) -> &str {
+                "mock"
+            }
+            fn model_id(&self) -> &str {
+                "mock-1"
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let memory = Arc::new(EpisodeStore::open(dir.path()).await.unwrap());
+        let llm = Arc::new(MockLlm) as Arc<dyn LlmProvider>;
+        let embedder = Arc::new(StubEmbedder) as Arc<dyn EmbeddingProvider>;
+
+        let tool = build_run_pipeline_tool(
+            llm,
+            memory,
+            std::env::temp_dir(),
+            std::env::temp_dir(),
+            None,
+            vec![],
+            false,
+            Some(embedder),
+        );
+
+        assert!(
+            tool.embedder_for_test().is_some(),
+            "build_run_pipeline_tool must call `.with_embedder(..)` when \
+             the caller supplies one — otherwise `octos chat` pipeline \
+             workers fall back to the unfiltered cwd-only memory recall \
+             path and re-introduce the NEW-06 contamination."
+        );
+    }
+
+    /// NEW-06 codex follow-up — without an embedder argument the helper
+    /// produces a tool that matches pre-fix behaviour byte-for-byte
+    /// (`embedder_for_test()` returns `None`). Locks the legacy fall-through
+    /// for callers that don't have an embedder configured.
+    #[tokio::test]
+    async fn build_run_pipeline_tool_defaults_to_no_embedder() {
+        use async_trait::async_trait;
+
+        struct MockLlm;
+        #[async_trait]
+        impl LlmProvider for MockLlm {
+            async fn chat(
+                &self,
+                _messages: &[octos_core::Message],
+                _tools: &[octos_llm::ToolSpec],
+                _config: &octos_llm::ChatConfig,
+            ) -> eyre::Result<octos_llm::ChatResponse> {
+                Ok(octos_llm::ChatResponse {
+                    content: Some("ok".into()),
+                    reasoning_content: None,
+                    tool_calls: vec![],
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                })
+            }
+            fn provider_name(&self) -> &str {
+                "mock"
+            }
+            fn model_id(&self) -> &str {
+                "mock-1"
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let memory = Arc::new(EpisodeStore::open(dir.path()).await.unwrap());
+        let llm = Arc::new(MockLlm) as Arc<dyn LlmProvider>;
+
+        let tool = build_run_pipeline_tool(
+            llm,
+            memory,
+            std::env::temp_dir(),
+            std::env::temp_dir(),
+            None,
+            vec![],
+            false,
+            None,
+        );
+
+        assert!(
+            tool.embedder_for_test().is_none(),
+            "build_run_pipeline_tool with `embedder = None` must not \
+             attach one — otherwise legacy callers that never configured \
+             an embedder would observe a behaviour change."
         );
     }
 }

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -938,6 +938,12 @@ impl GatewayRuntime {
                     router: Option<Arc<ProviderRouter>>,
                     octos_home: Option<PathBuf>,
                     plugin_require_signed: bool,
+                    /// NEW-06 fix: forwarded to every worker `Agent`
+                    /// via `RunPipelineTool::with_embedder` so
+                    /// pipeline-spawned agents inherit hybrid scored +
+                    /// filtered memory recall instead of the cwd-only
+                    /// unfiltered fallback.
+                    embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
                 }
 
                 impl crate::session_actor::PipelineToolFactory for DefaultPipelineToolFactory {
@@ -957,9 +963,20 @@ impl GatewayRuntime {
                         if let Some(ref octos_home) = self.octos_home {
                             pt = pt.with_octos_home(octos_home.clone());
                         }
+                        if let Some(ref embedder) = self.embedder {
+                            pt = pt.with_embedder(embedder.clone());
+                        }
                         Arc::new(pt)
                     }
                 }
+
+                // NEW-06 fix: capture the gateway's embedder so pipeline
+                // workers inherit the same contamination-safe memory
+                // recall the gateway's own session agent gets via
+                // `ActorFactory::embedder` -> `with_embedder` (see
+                // session_actor.rs).
+                let embedder_c =
+                    create_embedder(&config).map(|e| e as Arc<dyn octos_llm::EmbeddingProvider>);
 
                 pipeline_factory = Some(Arc::new(DefaultPipelineToolFactory {
                     llm: llm_c,
@@ -971,6 +988,7 @@ impl GatewayRuntime {
                     router: router_c,
                     octos_home: octos_home_c,
                     plugin_require_signed: plugin_require_signed_c,
+                    embedder: embedder_c,
                 })
                     as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
             }

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -808,6 +808,11 @@ impl ProfileActorFactoryBuilder {
                 router: Option<Arc<ProviderRouter>>,
                 octos_home: PathBuf,
                 plugin_require_signed: bool,
+                /// NEW-06 fix: forwarded to every worker `Agent` via
+                /// `RunPipelineTool::with_embedder` so pipeline-spawned
+                /// agents inherit hybrid scored + filtered memory
+                /// recall instead of the cwd-only unfiltered fallback.
+                embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
             }
 
             impl crate::session_actor::PipelineToolFactory for ChildPipelineToolFactory {
@@ -825,9 +830,19 @@ impl ProfileActorFactoryBuilder {
                     if let Some(ref router) = self.router {
                         pt = pt.with_provider_router(router.clone());
                     }
+                    if let Some(ref embedder) = self.embedder {
+                        pt = pt.with_embedder(embedder.clone());
+                    }
                     Arc::new(pt)
                 }
             }
+
+            // NEW-06 fix: the parent ActorFactory's session agent gets
+            // its embedder from `create_embedder(profile_config)`; mirror
+            // that here so child-profile pipeline workers run on the
+            // same contamination-safe hybrid memory path.
+            let child_pipeline_embedder = create_embedder(&profile_config)
+                .map(|e| e as Arc<dyn octos_llm::EmbeddingProvider>);
 
             pipeline_factory = Some(Arc::new(ChildPipelineToolFactory {
                 llm: llm.clone(),
@@ -840,6 +855,7 @@ impl ProfileActorFactoryBuilder {
                 // Section B (codex review follow-up): propagate the
                 // profile's strict-signing policy.
                 plugin_require_signed: profile_config.plugins.require_signed,
+                embedder: child_pipeline_embedder,
             })
                 as Arc<dyn crate::session_actor::PipelineToolFactory + Send + Sync>);
 

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -669,7 +669,7 @@ impl ProfileRuntime {
             // by `RetryProvider` → `ProviderChain` → `AdaptiveRouter`
             // when adaptive is configured, so per-node calls still
             // fan out through the adaptive layer.
-            let pt = octos_pipeline::RunPipelineTool::new(
+            let mut pt = octos_pipeline::RunPipelineTool::new(
                 llm.clone(),
                 memory.clone(),
                 data_dir.to_path_buf(),
@@ -678,6 +678,20 @@ impl ProfileRuntime {
             .with_provider_policy(config.tool_policy.clone())
             .with_plugin_dirs(plugin_dirs.clone())
             .with_octos_home(effective_octos_home.clone());
+            // NEW-06 fix: propagate the embedder down to pipeline
+            // worker `Agent` instances so episodic memory recall stays
+            // on the contamination-safe hybrid scored + filtered path
+            // (`MIN_EPISODE_SIMILARITY`). Without this, deep_research
+            // pipeline workers (mini5 / round-3 soak) hit the
+            // unfiltered cwd-only fallback in
+            // `EpisodeStore::find_relevant` and pulled cross-domain
+            // episodes (Apple CEO / GPT-5.5 podcast) into a JWST
+            // research worker's prompt.
+            if let Some(embedder) =
+                chat::create_embedder(&config).map(|e| e as Arc<dyn octos_llm::EmbeddingProvider>)
+            {
+                pt = pt.with_embedder(embedder);
+            }
             tools.register(pt);
             tools.mark_spawn_only(
                 "run_pipeline",

--- a/crates/octos-memory/src/hybrid_search.rs
+++ b/crates/octos-memory/src/hybrid_search.rs
@@ -154,6 +154,20 @@ impl HybridIndex {
         self.ids.is_empty()
     }
 
+    /// Total number of documents inserted into the index (including
+    /// tombstoned ones — the BM25 inverted index still has them).
+    ///
+    /// Returned to callers like
+    /// [`crate::store::EpisodeStore::find_relevant_filtered`] that need
+    /// to size an inner-fetch pool exhaustively. Because BM25-only
+    /// inserts continue beyond `HNSW_CAPACITY` (HNSW gracefully
+    /// degrades to BM25-only insertion), the BM25 inverted index can
+    /// outgrow the HNSW graph; callers MUST NOT assume the corpus
+    /// size is capped at `HNSW_CAPACITY`.
+    pub fn len(&self) -> usize {
+        self.ids.len()
+    }
+
     /// Set custom hybrid scoring weights. Weights should sum to 1.0.
     pub fn with_weights(mut self, vector_weight: f32, bm25_weight: f32) -> Self {
         self.vector_weight = vector_weight;

--- a/crates/octos-memory/src/hybrid_search.rs
+++ b/crates/octos-memory/src/hybrid_search.rs
@@ -100,7 +100,7 @@ const HNSW_MAX_LAYER: usize = 16;
 /// `search(..., 10_000, ...)` call per query, which is bounded by the
 /// real document count (HNSW caps at HNSW_CAPACITY anyway) and only
 /// runs when a caller explicitly asks for the floor.
-const FLOOR_PREFILTER_POOL: usize = HNSW_CAPACITY;
+pub(crate) const FLOOR_PREFILTER_POOL: usize = HNSW_CAPACITY;
 
 /// Compute the BM25 per-modality candidate pool size for a single
 /// `search_scored_filtered` call.

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -341,13 +341,43 @@ impl EpisodeStore {
             .unwrap_or(false);
 
         if index_populated {
-            // Over-fetch to account for CWD filtering, then filter.
-            // We use the `_scored_filtered` variant so the floor is
-            // applied INSIDE the index BEFORE the combined-rank
-            // truncation — same dead-band-safe contract as the
-            // hybrid path documented in agent::memory.
+            // Inner-fetch sizing — codex P2 round 4 follow-up:
+            //
+            // The hybrid index is global (not cwd-scoped). After we
+            // ask for the top-N candidates, we apply the cwd filter
+            // locally. If we used the standard `limit * 4` pool, a
+            // shared episode store with many foreign-cwd matches that
+            // clear the same floor could truncate a current-cwd
+            // match out BEFORE the cwd filter ever sees it — flipping
+            // the "return empty when floor set" branch into a false-
+            // negative for legitimately relevant local memories.
+            //
+            // Two regimes:
+            // * No floor → keep the legacy `limit * 4` over-fetch.
+            //   Without a floor there is no natural cap on the
+            //   candidate set; growing the pool unboundedly would be
+            //   wasted work and the legacy fall-through to
+            //   `find_relevant_db_scan` already handles the no-cwd-
+            //   match case.
+            // * Floor supplied → request the full floor-prefilter
+            //   pool (`FLOOR_PREFILTER_POOL = HNSW_CAPACITY = 10_000`,
+            //   the structural ceiling of the in-memory index). The
+            //   floor itself bounds the candidate set, so this is the
+            //   tightest pool that guarantees a current-cwd match
+            //   clearing the floor reaches the cwd filter regardless
+            //   of how many foreign-cwd matches share the floor pass.
+            //
+            // `usize::MAX` would also work but is dishonest: the index
+            // can't hold more than HNSW_CAPACITY documents, so asking
+            // for it is wasted intent. The constant is re-exported
+            // from `hybrid_search` for this exact reuse.
+            let inner_limit = if min_best_modality.is_some() {
+                crate::hybrid_search::FLOOR_PREFILTER_POOL
+            } else {
+                limit * 4
+            };
             let candidates = self
-                .find_relevant_hybrid_scored_filtered(query, None, limit * 4, min_best_modality)
+                .find_relevant_hybrid_scored_filtered(query, None, inner_limit, min_best_modality)
                 .await?;
             let filtered: Vec<Episode> = candidates
                 .into_iter()
@@ -361,13 +391,13 @@ impl EpisodeStore {
             }
             // NEW-06 codex follow-up: when a caller passed a
             // `min_best_modality` floor and the scored+CWD-filtered set
-            // came back empty, returning empty is the correct answer —
-            // nothing in the index cleared the contamination floor for
-            // this cwd. Falling through to the unscored
-            // `find_relevant_db_scan` would silently bypass the floor
-            // (the scan is keyword-substring only with no scoring
-            // infrastructure), which is exactly the contamination
-            // pattern this filter exists to prevent.
+            // came back empty (with an exhaustive `inner_limit`), the
+            // correct answer is empty — nothing in the index cleared
+            // the contamination floor for this cwd. Falling through to
+            // the unscored `find_relevant_db_scan` would silently
+            // bypass the floor (the scan is keyword-substring only
+            // with no scoring infrastructure), which is exactly the
+            // contamination pattern this filter exists to prevent.
             //
             // Only fall through to the unscored DB scan when no floor
             // was requested (legacy `find_relevant` semantics).
@@ -883,6 +913,79 @@ mod tests {
              to unscored DB scan when the scored+cwd set is empty; \
              returned {} contaminated episodes: {results:?}",
             results.len()
+        );
+    }
+
+    /// NEW-06 codex P2 round 4 — when a floor is supplied AND the
+    /// hybrid index holds many foreign-cwd matches that all clear the
+    /// floor with stronger scores, a current-cwd match that ALSO
+    /// clears the floor must not be truncated out by the inner
+    /// `limit * 4` pool before the cwd filter sees it.
+    ///
+    /// Pre-fix-round-4: with `limit=1` and ~10 stronger foreign-cwd
+    /// exact matches sharing the same query token, the inner fetch
+    /// pool (`limit * 4 = 4`) returned only foreign episodes; the
+    /// cwd filter dropped them all; the floor-set early-return then
+    /// returned empty even though a local episode clearing the floor
+    /// existed in the store. Functional regression in local memory
+    /// recall.
+    ///
+    /// Post-fix-round-4: when a floor is supplied, the inner fetch
+    /// exhausts the floor-prefilter pool (`FLOOR_PREFILTER_POOL =
+    /// HNSW_CAPACITY = 10_000`) so the cwd filter sees every
+    /// floor-clearing candidate regardless of how many foreign-cwd
+    /// matches share the floor pass.
+    #[tokio::test]
+    async fn find_relevant_filtered_returns_local_match_through_many_foreign_with_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EpisodeStore::open(dir.path()).await.unwrap();
+
+        // 20 foreign-cwd episodes that all match the query token —
+        // these will all clear the floor and crowd the inner pool.
+        // `limit * 4 = 4` (with the caller's `limit = 1`) is far
+        // below 20, so without round-4 the local episode below would
+        // be truncated out.
+        for i in 0..20 {
+            store
+                .store(make_episode(
+                    "deep_research gravitational lensing JWST",
+                    &format!("/foreign-cwd-{i}"),
+                ))
+                .await
+                .unwrap();
+        }
+        // Single local episode that also clears the floor.
+        store
+            .store(make_episode(
+                "deep_research gravitational lensing JWST",
+                "/proj",
+            ))
+            .await
+            .unwrap();
+
+        let results = store
+            .find_relevant_filtered(
+                Path::new("/proj"),
+                "deep_research gravitational lensing JWST",
+                1,
+                Some(0.5),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "find_relevant_filtered must return the local floor-clearing \
+             episode even when many foreign-cwd matches share the floor \
+             pass (codex P2 round 4); returned {} episodes",
+            results.len()
+        );
+        assert_eq!(
+            results[0].working_dir,
+            PathBuf::from("/proj"),
+            "local match must be the one returned, not a foreign-cwd \
+             leak: got {:?}",
+            results[0].working_dir
         );
     }
 

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -309,6 +309,30 @@ impl EpisodeStore {
         query: &str,
         limit: usize,
     ) -> Result<Vec<Episode>> {
+        self.find_relevant_filtered(cwd, query, limit, None).await
+    }
+
+    /// NEW-06 defense-in-depth: CWD-scoped relevance search with an
+    /// optional `min_best_modality` floor applied to the BM25 score
+    /// (the only modality available on the no-embedder fallback path).
+    ///
+    /// The agent loop calls this when no embedder is configured so
+    /// pipeline workers spawned without the parent embedder still
+    /// drop sub-threshold matches BEFORE injection — even though the
+    /// `find_relevant_hybrid` path inside this fallback only has BM25
+    /// scores. A score of `1.0` on BM25 still passes; loose
+    /// cross-domain "shared token" matches (the NEW-06 contamination
+    /// pattern) do not.
+    ///
+    /// `min_best_modality == None` matches [`Self::find_relevant`]
+    /// semantics exactly.
+    pub async fn find_relevant_filtered(
+        &self,
+        cwd: &Path,
+        query: &str,
+        limit: usize,
+        min_best_modality: Option<f32>,
+    ) -> Result<Vec<Episode>> {
         // Check if hybrid index has documents
         let index_populated = self
             .index
@@ -317,11 +341,18 @@ impl EpisodeStore {
             .unwrap_or(false);
 
         if index_populated {
-            // Over-fetch to account for CWD filtering, then filter
-            let candidates = self.find_relevant_hybrid(query, None, limit * 4).await?;
+            // Over-fetch to account for CWD filtering, then filter.
+            // We use the `_scored_filtered` variant so the floor is
+            // applied INSIDE the index BEFORE the combined-rank
+            // truncation — same dead-band-safe contract as the
+            // hybrid path documented in agent::memory.
+            let candidates = self
+                .find_relevant_hybrid_scored_filtered(query, None, limit * 4, min_best_modality)
+                .await?;
             let filtered: Vec<Episode> = candidates
                 .into_iter()
-                .filter(|ep| ep.working_dir == cwd)
+                .filter(|(ep, _)| ep.working_dir == cwd)
+                .map(|(ep, _)| ep)
                 .take(limit)
                 .collect();
 
@@ -331,7 +362,11 @@ impl EpisodeStore {
             // Fall through to DB scan if hybrid returned no CWD matches
         }
 
-        // Fallback: direct DB scan (for empty index or no CWD matches)
+        // Fallback: direct DB scan (for empty index or no CWD matches).
+        // The DB scan path is keyword-substring based with no scoring
+        // infrastructure, so we can't apply `min_best_modality` here
+        // without rewriting it. Keep legacy behaviour — the index path
+        // is the contamination vector callers actually care about.
         self.find_relevant_db_scan(cwd, query, limit).await
     }
 

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -359,14 +359,32 @@ impl EpisodeStore {
             if !filtered.is_empty() {
                 return Ok(filtered);
             }
+            // NEW-06 codex follow-up: when a caller passed a
+            // `min_best_modality` floor and the scored+CWD-filtered set
+            // came back empty, returning empty is the correct answer —
+            // nothing in the index cleared the contamination floor for
+            // this cwd. Falling through to the unscored
+            // `find_relevant_db_scan` would silently bypass the floor
+            // (the scan is keyword-substring only with no scoring
+            // infrastructure), which is exactly the contamination
+            // pattern this filter exists to prevent.
+            //
+            // Only fall through to the unscored DB scan when no floor
+            // was requested (legacy `find_relevant` semantics).
+            if min_best_modality.is_some() {
+                return Ok(Vec::new());
+            }
             // Fall through to DB scan if hybrid returned no CWD matches
+            // AND no contamination floor was requested.
         }
 
         // Fallback: direct DB scan (for empty index or no CWD matches).
         // The DB scan path is keyword-substring based with no scoring
         // infrastructure, so we can't apply `min_best_modality` here
-        // without rewriting it. Keep legacy behaviour — the index path
-        // is the contamination vector callers actually care about.
+        // without rewriting it. We only reach this path when the caller
+        // did not request a floor (see early-return above), so legacy
+        // unscored behaviour is preserved without bypassing the
+        // contamination filter when one was asked for.
         self.find_relevant_db_scan(cwd, query, limit).await
     }
 
@@ -801,6 +819,100 @@ mod tests {
             .await
             .unwrap();
         assert!(results.is_empty());
+    }
+
+    /// NEW-06 codex follow-up — when `min_best_modality` is supplied
+    /// and the scored+cwd-filtered set comes back empty, the function
+    /// MUST return empty instead of falling through to the unscored
+    /// `find_relevant_db_scan` (which has no scoring infrastructure
+    /// and would silently bypass the contamination floor).
+    ///
+    /// Reproduces the codex follow-up bug at lines 365-370. The
+    /// scenario engineered below:
+    /// * one episode at cwd `/proj` with a deliberately weak BM25
+    ///   match for the query (so it does NOT clear the 0.99 floor);
+    /// * one episode at a foreign cwd with a strong BM25 match (so
+    ///   its score normalises high but it gets dropped by the cwd
+    ///   filter).
+    ///
+    /// Pre-fix, `find_relevant_hybrid_scored_filtered` would return
+    /// the foreign-cwd episode, the cwd filter would drop it, the
+    /// `!filtered.is_empty()` short-circuit would fail, and execution
+    /// would fall through to the DB scan — which IS cwd-scoped and
+    /// matches by substring, so the weak `/proj` episode would be
+    /// returned despite never having cleared the floor.
+    ///
+    /// Post-fix, when the caller supplies a floor, the fallthrough is
+    /// gated off and the function returns empty.
+    #[tokio::test]
+    async fn find_relevant_filtered_returns_empty_when_floor_set_and_no_cwd_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EpisodeStore::open(dir.path()).await.unwrap();
+
+        // Foreign-cwd episode with a strong BM25 match (verbatim query
+        // tokens). Normalises to BM25=1.0 in the result set so it
+        // clears any reasonable floor — but the cwd filter drops it.
+        store
+            .store(make_episode(
+                "gravitational lensing observations of distant galaxies",
+                "/foreign-cwd",
+            ))
+            .await
+            .unwrap();
+        // Target-cwd episode whose summary shares only the noise-token
+        // "podcast" with the query. Its BM25 score is positive but
+        // far below the foreign-cwd episode's score after normalisation,
+        // so it does NOT clear the floor.
+        store
+            .store(make_episode("Apple CEO podcast", "/proj"))
+            .await
+            .unwrap();
+
+        let results = store
+            .find_relevant_filtered(
+                Path::new("/proj"),
+                "gravitational lensing observations",
+                10,
+                Some(0.5), // floor — foreign-cwd clears it, /proj does not
+            )
+            .await
+            .unwrap();
+        assert!(
+            results.is_empty(),
+            "find_relevant_filtered with a floor must NOT fall through \
+             to unscored DB scan when the scored+cwd set is empty; \
+             returned {} contaminated episodes: {results:?}",
+            results.len()
+        );
+    }
+
+    /// NEW-06 codex follow-up companion — when `min_best_modality` is
+    /// `None`, the legacy fall-through to the unscored DB scan stays in
+    /// place. Locks the "no behaviour change for legacy callers" half
+    /// of the fix.
+    #[tokio::test]
+    async fn find_relevant_filtered_falls_through_to_db_scan_when_no_floor() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = EpisodeStore::open(dir.path()).await.unwrap();
+
+        store
+            .store(make_episode("Fixed parser bug in tokenizer", "/proj"))
+            .await
+            .unwrap();
+
+        // No floor → legacy behaviour: keyword-substring matching via
+        // the index OR the DB scan returns the episode.
+        let results = store
+            .find_relevant_filtered(Path::new("/proj"), "parser", 10, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            results.len(),
+            1,
+            "find_relevant_filtered with no floor must keep legacy \
+             behaviour byte-for-byte — got {} episodes",
+            results.len()
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-memory/src/store.rs
+++ b/crates/octos-memory/src/store.rs
@@ -341,7 +341,7 @@ impl EpisodeStore {
             .unwrap_or(false);
 
         if index_populated {
-            // Inner-fetch sizing — codex P2 round 4 follow-up:
+            // Inner-fetch sizing — codex P2 rounds 4 and 5 follow-up:
             //
             // The hybrid index is global (not cwd-scoped). After we
             // ask for the top-N candidates, we apply the cwd filter
@@ -359,20 +359,22 @@ impl EpisodeStore {
             //   wasted work and the legacy fall-through to
             //   `find_relevant_db_scan` already handles the no-cwd-
             //   match case.
-            // * Floor supplied → request the full floor-prefilter
-            //   pool (`FLOOR_PREFILTER_POOL = HNSW_CAPACITY = 10_000`,
-            //   the structural ceiling of the in-memory index). The
-            //   floor itself bounds the candidate set, so this is the
-            //   tightest pool that guarantees a current-cwd match
-            //   clearing the floor reaches the cwd filter regardless
-            //   of how many foreign-cwd matches share the floor pass.
-            //
-            // `usize::MAX` would also work but is dishonest: the index
-            // can't hold more than HNSW_CAPACITY documents, so asking
-            // for it is wasted intent. The constant is re-exported
-            // from `hybrid_search` for this exact reuse.
+            // * Floor supplied → size the inner fetch from the actual
+            //   corpus (`HybridIndex::len`). Round 4 used
+            //   `FLOOR_PREFILTER_POOL = HNSW_CAPACITY = 10_000`, but
+            //   codex round 5 flagged that the BM25 inverted index
+            //   keeps inserting documents AFTER HNSW saturates, so a
+            //   corpus larger than 10K BM25-only docs could still
+            //   truncate a local floor-clearing match. Reading the
+            //   corpus size directly closes that gap without
+            //   over-allocating for small stores.
+            let corpus_size = self
+                .index
+                .read()
+                .map(|idx| idx.len())
+                .unwrap_or(crate::hybrid_search::FLOOR_PREFILTER_POOL);
             let inner_limit = if min_best_modality.is_some() {
-                crate::hybrid_search::FLOOR_PREFILTER_POOL
+                corpus_size
             } else {
                 limit * 4
             };
@@ -916,25 +918,29 @@ mod tests {
         );
     }
 
-    /// NEW-06 codex P2 round 4 — when a floor is supplied AND the
+    /// NEW-06 codex P2 rounds 4 + 5 — when a floor is supplied AND the
     /// hybrid index holds many foreign-cwd matches that all clear the
     /// floor with stronger scores, a current-cwd match that ALSO
-    /// clears the floor must not be truncated out by the inner
-    /// `limit * 4` pool before the cwd filter sees it.
+    /// clears the floor must not be truncated out before the cwd
+    /// filter sees it.
     ///
     /// Pre-fix-round-4: with `limit=1` and ~10 stronger foreign-cwd
     /// exact matches sharing the same query token, the inner fetch
     /// pool (`limit * 4 = 4`) returned only foreign episodes; the
     /// cwd filter dropped them all; the floor-set early-return then
     /// returned empty even though a local episode clearing the floor
-    /// existed in the store. Functional regression in local memory
-    /// recall.
+    /// existed in the store.
     ///
-    /// Post-fix-round-4: when a floor is supplied, the inner fetch
-    /// exhausts the floor-prefilter pool (`FLOOR_PREFILTER_POOL =
-    /// HNSW_CAPACITY = 10_000`) so the cwd filter sees every
-    /// floor-clearing candidate regardless of how many foreign-cwd
-    /// matches share the floor pass.
+    /// Round 4 raised the inner pool to `FLOOR_PREFILTER_POOL = 10_000`
+    /// (the HNSW capacity), but codex round 5 flagged that the BM25
+    /// inverted index keeps inserting beyond `HNSW_CAPACITY` (HNSW
+    /// gracefully degrades to BM25-only), so a corpus with >10K
+    /// foreign-cwd BM25 matches could still truncate out a local hit.
+    ///
+    /// Post-fix-round-5: the inner pool is sized from the actual
+    /// corpus (`HybridIndex::len`), so no truncation happens before
+    /// the cwd filter regardless of how large the BM25-only index
+    /// grows.
     #[tokio::test]
     async fn find_relevant_filtered_returns_local_match_through_many_foreign_with_floor() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -354,6 +354,14 @@ pub struct ExecutorConfig {
     /// at run_pipeline dispatch. Default = empty, which keeps every
     /// pre-M8 invocation site bitwise identical.
     pub host_context: crate::host_context::PipelineHostContext,
+    /// NEW-06 fix: parent-session embedder forwarded onto every per-
+    /// node worker [`octos_agent::Agent`] so episodic memory recall
+    /// stays on the contamination-safe hybrid scored + filtered path.
+    ///
+    /// `None` keeps the legacy unfiltered cwd-only fallback in
+    /// `EpisodeStore::find_relevant` — identical to pre-fix behaviour
+    /// for callers that don't propagate the orchestrator's embedder.
+    pub embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
 }
 
 /// A single planned sub-task from the LLM planner.
@@ -1415,6 +1423,15 @@ impl PipelineExecutor {
         // SubAgentOutputRouter / AgentSummaryGenerator. Empty context
         // keeps pre-M8 behaviour bitwise identical.
         .with_host_context(self.config.host_context.clone());
+
+        // NEW-06 fix: thread the parent embedder through to the
+        // handler so every per-node worker Agent runs the
+        // contamination-safe hybrid memory recall path. When unset
+        // (legacy callers without an embedder configured) workers stay
+        // on the cwd-only fallback — identical to pre-fix behaviour.
+        if let Some(ref embedder) = self.config.embedder {
+            codergen = codergen.with_embedder(embedder.clone());
+        }
 
         if let Some(ref router) = self.config.provider_router {
             codergen = codergen.with_provider_router(router.clone());
@@ -3047,6 +3064,7 @@ mod tests {
             hook_executor: None,
             workspace_context: crate::context::PipelineContext::default(),
             host_context: crate::host_context::PipelineHostContext::default(),
+            embedder: None,
         }
     }
 
@@ -3218,6 +3236,7 @@ mod tests {
             hook_executor: None,
             workspace_context: crate::context::PipelineContext::default(),
             host_context: crate::host_context::PipelineHostContext::default(),
+            embedder: None,
         }
     }
 

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use eyre::Result;
 use octos_core::{AgentId, Task, TaskContext, TaskKind, TokenUsage};
-use octos_llm::{ContextWindowOverride, LlmProvider, ProviderRouter};
+use octos_llm::{ContextWindowOverride, EmbeddingProvider, LlmProvider, ProviderRouter};
 use octos_memory::EpisodeStore;
 use tracing::{info, warn};
 
@@ -304,6 +304,15 @@ pub struct CodergenHandler {
     /// the SHA-256 verification + 100 MB executable read that would
     /// otherwise re-run on every node and starve the SSE window.
     plugin_cache: Arc<OnceLock<Arc<CachedPluginRegistration>>>,
+    /// NEW-06 fix: optional embedder propagated onto every worker
+    /// `Agent` built by this handler so episodic memory recall stays
+    /// on the contamination-safe hybrid scored + filtered path
+    /// (`MIN_EPISODE_SIMILARITY`). Without it, workers fall back to
+    /// the unfiltered cwd-only path in `EpisodeStore::find_relevant`
+    /// — the round-3 fleet soak (mini5 / deep_research) proved this
+    /// is the missing wiring that lets cross-domain episodes
+    /// contaminate worker prompts.
+    embedder: Option<Arc<dyn EmbeddingProvider>>,
 }
 
 impl CodergenHandler {
@@ -327,7 +336,25 @@ impl CodergenHandler {
             compaction_llm_provider: None,
             host_context: crate::host_context::PipelineHostContext::default(),
             plugin_cache: Arc::new(OnceLock::new()),
+            embedder: None,
         }
+    }
+
+    /// NEW-06 fix: attach the parent embedder. Each per-node worker
+    /// [`Agent`] built by this handler will receive a `.with_embedder`
+    /// call so episodic memory recall runs the modality-aware hybrid
+    /// scored + filtered path (`MIN_EPISODE_SIMILARITY`) instead of
+    /// the unfiltered cwd-only fallback.
+    pub fn with_embedder(mut self, embedder: Arc<dyn EmbeddingProvider>) -> Self {
+        self.embedder = Some(embedder);
+        self
+    }
+
+    /// Doc-hidden test accessor — confirms the embedder propagation
+    /// path is wired (NEW-06 regression guard).
+    #[doc(hidden)]
+    pub fn embedder_for_test(&self) -> Option<&Arc<dyn EmbeddingProvider>> {
+        self.embedder.as_ref()
     }
 
     /// Section B (codex review P1.1): opt into strict signature
@@ -702,6 +729,18 @@ impl Handler for CodergenHandler {
         .with_reporter(reporter);
         if let Some(sink) = inherited_harness_sink {
             worker = worker.with_harness_event_sink(sink);
+        }
+
+        // NEW-06 fix: thread the parent embedder onto the worker so
+        // `build_initial_messages` runs the hybrid scored + filtered
+        // memory recall path (`MIN_EPISODE_SIMILARITY` gate). Without
+        // this the worker falls back to the cwd-only unfiltered path
+        // in `EpisodeStore::find_relevant` and pulls cross-domain
+        // episodes into its prompt (e.g. round-3 mini5/deep_research:
+        // JWST research contaminated by an Apple CEO / GPT-5.5 podcast
+        // episode).
+        if let Some(ref embedder) = self.embedder {
+            worker = worker.with_embedder(embedder.clone());
         }
 
         // M8 parity (W1.A1): wire the parent session's shared

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use octos_agent::cost_ledger::CostAccountant;
 use octos_agent::{Tool, ToolPolicy, ToolResult};
-use octos_llm::{LlmProvider, ProviderRouter};
+use octos_llm::{EmbeddingProvider, LlmProvider, ProviderRouter};
 use octos_memory::EpisodeStore;
 use serde::Deserialize;
 
@@ -50,6 +50,17 @@ pub struct RunPipelineTool {
     /// auto-populates from the workspace policy. Defaults to the
     /// graph id + `"pipeline"` fallback when empty.
     contract_id: Option<String>,
+    /// NEW-06 fix: optional embedder for hybrid memory search.
+    ///
+    /// Without this set, worker `Agent` instances spawned per pipeline
+    /// node fall through to the unfiltered cwd-only fallback path in
+    /// `EpisodeStore::find_relevant` — which only does keyword overlap
+    /// plus CWD filtering, NOT the modality-aware similarity gate in
+    /// [`octos_agent::agent::memory::MIN_EPISODE_SIMILARITY`]. The
+    /// gateway / serve runtimes own the embedder; this lets the
+    /// orchestrator propagate it down to pipeline workers so episodic
+    /// memory recall is contamination-safe end-to-end.
+    embedder: Option<Arc<dyn EmbeddingProvider>>,
 }
 
 impl RunPipelineTool {
@@ -72,7 +83,24 @@ impl RunPipelineTool {
             status_bridge: std::sync::Mutex::new(None),
             cost_accountant: None,
             contract_id: None,
+            embedder: None,
         }
+    }
+
+    /// NEW-06 fix: attach an embedder that the pipeline executor will
+    /// propagate onto every per-node worker [`octos_agent::Agent`].
+    ///
+    /// When set, the worker's "Relevant Past Experiences" memory recall
+    /// runs the modality-aware hybrid path that applies
+    /// [`octos_agent::agent::memory::MIN_EPISODE_SIMILARITY`] BEFORE
+    /// injecting episodes into the worker's prompt. Without it, workers
+    /// fell back to the unfiltered cwd-only path in
+    /// `EpisodeStore::find_relevant` and pulled in cross-domain
+    /// episodes (e.g. a JWST research prompt rendered with an Apple
+    /// CEO / GPT-5.5 podcast episode on mini5).
+    pub fn with_embedder(mut self, embedder: Arc<dyn EmbeddingProvider>) -> Self {
+        self.embedder = Some(embedder);
+        self
     }
 
     /// Attach a [`CostAccountant`] (coding-blue FA-7). When set, pipeline
@@ -239,6 +267,16 @@ impl RunPipelineTool {
     /// StatusIndicator (status words + token tracker).
     pub fn set_status_bridge(&self, bridge: PipelineStatusBridge) {
         *self.status_bridge.lock().unwrap_or_else(|e| e.into_inner()) = Some(bridge);
+    }
+
+    /// Doc-hidden test accessor — confirms the embedder propagation
+    /// path is wired (NEW-06 regression guard). The pipeline worker
+    /// memory-recall threshold gate only runs when an embedder is
+    /// present; this lets tests assert the constructor + builder paths
+    /// keep it threaded through.
+    #[doc(hidden)]
+    pub fn embedder_for_test(&self) -> Option<&Arc<dyn EmbeddingProvider>> {
+        self.embedder.as_ref()
     }
 }
 
@@ -421,6 +459,13 @@ impl Tool for RunPipelineTool {
             // path.
             workspace_context: self.build_workspace_context_with_host(&host_context),
             host_context,
+            // NEW-06 fix: thread the parent embedder onto every pipeline
+            // worker Agent so episodic memory recall stays on the
+            // contamination-safe hybrid scored + filtered path. When
+            // unset (legacy callers or hosts without an embedder
+            // configured), workers stay on the cwd-only fallback path —
+            // identical to pre-fix behaviour.
+            embedder: self.embedder.clone(),
         };
 
         // Pipeline-level timeout: default 1800s (30 min), clamped to [60, 1800].

--- a/crates/octos-pipeline/tests/checkpoint_resume.rs
+++ b/crates/octos-pipeline/tests/checkpoint_resume.rs
@@ -118,6 +118,7 @@ fn base_config(
         hook_executor: None,
         workspace_context: octos_pipeline::context::PipelineContext::default(),
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
+        embedder: None,
     }
 }
 

--- a/crates/octos-pipeline/tests/deadline_enforcement.rs
+++ b/crates/octos-pipeline/tests/deadline_enforcement.rs
@@ -122,6 +122,7 @@ fn base_config(
         hook_executor,
         workspace_context: octos_pipeline::context::PipelineContext::default(),
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
+        embedder: None,
     }
 }
 

--- a/crates/octos-pipeline/tests/embedder_propagation.rs
+++ b/crates/octos-pipeline/tests/embedder_propagation.rs
@@ -1,0 +1,146 @@
+//! NEW-06 regression: pipeline workers must inherit the parent
+//! orchestrator's embedder so episodic memory recall stays on the
+//! contamination-safe hybrid scored + filtered path
+//! (`MIN_EPISODE_SIMILARITY`) instead of the unfiltered cwd-only
+//! fallback in `EpisodeStore::find_relevant`.
+//!
+//! Root cause (round-3 fleet soak, mini5 / deep_research): the pipeline
+//! call chain `RunPipelineTool::execute` -> `ExecutorConfig` ->
+//! `CodergenHandler` -> worker `Agent::new()` did NOT plumb the
+//! parent's embedder, so workers fell through to the unfiltered path
+//! and pulled cross-domain episodes (Apple CEO / GPT-5.5 podcast) into
+//! a JWST research worker's prompt.
+//!
+//! These tests pin the wiring at every hop in the chain. If a future
+//! refactor forgets to forward the embedder, one of them goes red.
+
+#![cfg(unix)]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_llm::EmbeddingProvider;
+use octos_pipeline::{CodergenHandler, RunPipelineTool};
+
+async fn temp_episode_store() -> Arc<octos_memory::EpisodeStore> {
+    let dir = tempfile::tempdir().unwrap();
+    Arc::new(octos_memory::EpisodeStore::open(dir.path()).await.unwrap())
+}
+
+/// Stub embedder — never actually invoked by these tests; we only
+/// assert that the `Arc` was threaded through. Using a no-op
+/// implementation avoids pulling in network / API-key state.
+struct StubEmbedder;
+
+#[async_trait]
+impl EmbeddingProvider for StubEmbedder {
+    async fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        Ok(vec![vec![0.0_f32; 1]; texts.len()])
+    }
+
+    fn dimension(&self) -> usize {
+        1
+    }
+}
+
+#[allow(dead_code)]
+struct MockProvider;
+
+#[async_trait]
+impl octos_llm::LlmProvider for MockProvider {
+    async fn chat(
+        &self,
+        _messages: &[octos_core::Message],
+        _tools: &[octos_llm::ToolSpec],
+        _config: &octos_llm::ChatConfig,
+    ) -> eyre::Result<octos_llm::ChatResponse> {
+        Ok(octos_llm::ChatResponse {
+            content: Some("ok".into()),
+            tool_calls: vec![],
+            stop_reason: octos_llm::StopReason::EndTurn,
+            usage: octos_llm::TokenUsage::default(),
+            reasoning_content: None,
+            provider_index: None,
+        })
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+    fn model_id(&self) -> &str {
+        "mock-1"
+    }
+}
+
+/// NEW-06 hop 1 — the parent's `with_embedder` must store the handle
+/// on the `RunPipelineTool` so `execute` can copy it into
+/// `ExecutorConfig`.
+#[tokio::test]
+async fn run_pipeline_tool_stores_embedder_from_builder() {
+    let memory = temp_episode_store().await;
+    let llm = Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>;
+    let embedder = Arc::new(StubEmbedder) as Arc<dyn EmbeddingProvider>;
+    let tool = RunPipelineTool::new(llm, memory, std::env::temp_dir(), std::env::temp_dir())
+        .with_embedder(embedder.clone());
+
+    assert!(
+        tool.embedder_for_test().is_some(),
+        "RunPipelineTool::with_embedder must persist the handle so \
+         `execute` can forward it onto worker Agents (NEW-06)"
+    );
+}
+
+/// NEW-06 hop 2 — `CodergenHandler::with_embedder` is the inner-loop
+/// builder the executor calls. If this drops the handle, every worker
+/// `Agent` will be born without it.
+#[tokio::test]
+async fn codergen_handler_stores_embedder_from_builder() {
+    let embedder = Arc::new(StubEmbedder) as Arc<dyn EmbeddingProvider>;
+    let codergen = CodergenHandler::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        std::env::temp_dir(),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .with_embedder(embedder.clone());
+
+    assert!(
+        codergen.embedder_for_test().is_some(),
+        "CodergenHandler::with_embedder must persist the handle so \
+         every per-node worker Agent inherits hybrid memory recall (NEW-06)"
+    );
+}
+
+/// NEW-06 default — the constructors must produce instances with no
+/// embedder set (matches pre-fix behaviour for legacy callers that
+/// don't propagate one yet).
+#[tokio::test]
+async fn run_pipeline_tool_defaults_to_no_embedder() {
+    let tool = RunPipelineTool::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        std::env::temp_dir(),
+        std::env::temp_dir(),
+    );
+    assert!(
+        tool.embedder_for_test().is_none(),
+        "RunPipelineTool::new must default to no embedder so legacy \
+         callers stay byte-for-byte identical"
+    );
+}
+
+/// NEW-06 default — same for `CodergenHandler`.
+#[tokio::test]
+async fn codergen_handler_defaults_to_no_embedder() {
+    let codergen = CodergenHandler::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        std::env::temp_dir(),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    );
+    assert!(
+        codergen.embedder_for_test().is_none(),
+        "CodergenHandler::new must default to no embedder so legacy \
+         callers stay byte-for-byte identical"
+    );
+}

--- a/crates/octos-pipeline/tests/embedder_propagation.rs
+++ b/crates/octos-pipeline/tests/embedder_propagation.rs
@@ -144,3 +144,125 @@ async fn codergen_handler_defaults_to_no_embedder() {
          callers stay byte-for-byte identical"
     );
 }
+
+/// NEW-06 codex follow-up — the executor->handler hop is the load-
+/// bearing wiring point that the earlier builder tests do NOT cover.
+/// If a future refactor breaks `PipelineExecutor::build_codergen` (the
+/// internal seam that copies `ExecutorConfig.embedder` onto the per-node
+/// `CodergenHandler`), the four pre-existing builder tests above would
+/// still all pass — so this test drives the full `PipelineExecutor::new`
+/// -> `build_codergen_for_test()` chain and asserts the embedder
+/// survives.
+#[tokio::test]
+async fn build_codergen_propagates_embedder_from_executor_config() {
+    use octos_pipeline::PipelineExecutor;
+    use octos_pipeline::executor::ExecutorConfig;
+
+    let embedder = Arc::new(StubEmbedder) as Arc<dyn EmbeddingProvider>;
+    let config = ExecutorConfig {
+        default_provider: Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        provider_router: None,
+        memory: temp_episode_store().await,
+        working_dir: std::env::temp_dir(),
+        provider_policy: None,
+        plugin_dirs: vec![],
+        plugin_require_signed: false,
+        status_bridge: None,
+        shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        max_parallel_workers: 8,
+        max_pipeline_fanout_total: None,
+        checkpoint_store: None,
+        hook_executor: None,
+        workspace_context: octos_pipeline::PipelineContext::default(),
+        host_context: octos_pipeline::PipelineHostContext::default(),
+        embedder: Some(embedder),
+    };
+
+    let executor = PipelineExecutor::new(config);
+    let codergen = executor.build_codergen_for_test();
+
+    assert!(
+        codergen.embedder_for_test().is_some(),
+        "PipelineExecutor::build_codergen must copy `ExecutorConfig.embedder` \
+         onto the per-node CodergenHandler — otherwise worker Agents built \
+         by the handler never see the embedder and fall back to the \
+         unfiltered cwd-only memory recall path (NEW-06 contamination)."
+    );
+}
+
+/// NEW-06 codex follow-up — the executor->handler hop must also leave
+/// `embedder = None` alone when no embedder was attached on the
+/// `ExecutorConfig`. Guards against a future refactor accidentally
+/// fabricating one from defaults / lazily-cached state.
+#[tokio::test]
+async fn build_codergen_omits_embedder_when_executor_config_has_none() {
+    use octos_pipeline::PipelineExecutor;
+    use octos_pipeline::executor::ExecutorConfig;
+
+    let config = ExecutorConfig {
+        default_provider: Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        provider_router: None,
+        memory: temp_episode_store().await,
+        working_dir: std::env::temp_dir(),
+        provider_policy: None,
+        plugin_dirs: vec![],
+        plugin_require_signed: false,
+        status_bridge: None,
+        shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        max_parallel_workers: 8,
+        max_pipeline_fanout_total: None,
+        checkpoint_store: None,
+        hook_executor: None,
+        workspace_context: octos_pipeline::PipelineContext::default(),
+        host_context: octos_pipeline::PipelineHostContext::default(),
+        embedder: None,
+    };
+
+    let executor = PipelineExecutor::new(config);
+    let codergen = executor.build_codergen_for_test();
+
+    assert!(
+        codergen.embedder_for_test().is_none(),
+        "build_codergen must not synthesise an embedder when none was \
+         configured — that would silently change the legacy path."
+    );
+}
+
+/// NEW-06 codex follow-up — `RunPipelineTool::execute` is the user-
+/// facing entrypoint. The earlier builder test pins
+/// `RunPipelineTool::with_embedder` but does NOT cover the `execute`
+/// path's `ExecutorConfig` build. The integration-level assertion below
+/// drives `RunPipelineTool::with_embedder` and inspects the stored
+/// handle via `embedder_for_test`, which is the same field `execute`
+/// reads when constructing the `ExecutorConfig`. The pairing
+/// (`with_embedder` -> stored field -> `ExecutorConfig` read site -> the
+/// `build_codergen` propagation test above) closes the chain end to end
+/// without needing to spin up an LLM-driven pipeline run.
+#[tokio::test]
+async fn run_pipeline_tool_with_embedder_chain_pin() {
+    let memory = temp_episode_store().await;
+    let llm = Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>;
+    let embedder = Arc::new(StubEmbedder) as Arc<dyn EmbeddingProvider>;
+
+    // 1) RunPipelineTool::with_embedder stores the handle.
+    let tool = RunPipelineTool::new(
+        llm.clone(),
+        memory.clone(),
+        std::env::temp_dir(),
+        std::env::temp_dir(),
+    )
+    .with_embedder(embedder.clone());
+    assert!(tool.embedder_for_test().is_some());
+
+    // 2) The handle Arc-points at the same provider instance — guards
+    //    against a future refactor that re-wraps the embedder in a
+    //    different `Arc` (legal at the type level but breaks any
+    //    identity-based downstream wiring).
+    let stored = tool.embedder_for_test().cloned().unwrap();
+    assert!(
+        Arc::ptr_eq(&stored, &embedder),
+        "RunPipelineTool::with_embedder must not re-wrap the supplied Arc — \
+         the executor and worker Agents rely on the handle identity to \
+         share scoring state."
+    );
+}

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -66,6 +66,7 @@ async fn make_config(provider: Arc<dyn LlmProvider>, dir: &TempDir) -> ExecutorC
         hook_executor: None,
         workspace_context: octos_pipeline::context::PipelineContext::default(),
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
+        embedder: None,
     }
 }
 

--- a/crates/octos-pipeline/tests/workspace_contract.rs
+++ b/crates/octos-pipeline/tests/workspace_contract.rs
@@ -164,6 +164,7 @@ fn base_config(dir: &TempDir, memory: Arc<EpisodeStore>, ctx: PipelineContext) -
         hook_executor: None,
         workspace_context: ctx,
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
+        embedder: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- **Root cause for NEW-06 (round-3 fleet soak, mini5/deep_research):** pipeline worker `Agent` instances spawned by `CodergenHandler` were constructed **without** the parent orchestrator's embedder, so episodic memory recall fell through to the unfiltered CWD-only fallback path in `EpisodeStore::find_relevant` — which has no `MIN_EPISODE_SIMILARITY` gate. Even after raising the threshold to 0.55 (#1195), JWST research workers still pulled in Apple CEO / GPT-5.5 podcast episodes because the gate never ran for them.
- **Wiring fix:** plumb `Option<Arc<dyn EmbeddingProvider>>` through `RunPipelineTool::with_embedder` → `ExecutorConfig::embedder` → `CodergenHandler::with_embedder` → worker `Agent::new(...).with_embedder(...)`. All 3 call sites (`runtime/profile.rs`, `gateway_runtime.rs::DefaultPipelineToolFactory`, `profile_factory.rs::ChildPipelineToolFactory`) now call `create_embedder(&config)` and forward the handle.
- **Defense-in-depth:** `EpisodeStore::find_relevant_filtered` (new) applies the `min_best_modality` floor inside the hybrid index BEFORE truncation on the no-embedder path too. The agent loop calls it with `MIN_EPISODE_SIMILARITY` so a worker still ending up here also drops sub-threshold matches.
- **Diagnostics:** structured `info!`/`warn!` logs on both memory-recall branches with episode IDs + per-modality scores + caller path, so fleet operators can verify the gate without reading the model-visible prompt.

## Test plan

- [x] `cargo test -p octos-agent --lib agent::memory` — 8 tests pass
- [x] `cargo test -p octos-pipeline` — 241 tests pass (4 new in `tests/embedder_propagation.rs`)
- [x] `cargo build --workspace` — green
- [x] `cargo clippy -p octos-pipeline -p octos-memory -p octos-agent` — clean
- [x] `cargo fmt --all` applied
- [ ] codex review pre-merge per `feedback_codex_review_before_merge`

## Files touched

- `crates/octos-pipeline/src/tool.rs` — `RunPipelineTool::with_embedder` + accessor, `execute()` threads embedder into ExecutorConfig
- `crates/octos-pipeline/src/executor.rs` — `ExecutorConfig::embedder` field, `build_codergen` forwards it
- `crates/octos-pipeline/src/handler.rs` — `CodergenHandler::with_embedder` + accessor, worker spawn calls `.with_embedder` before existing M8-parity wiring
- `crates/octos-cli/src/runtime/profile.rs` — serve-path `RunPipelineTool::new(...).with_embedder(create_embedder(&config))`
- `crates/octos-cli/src/commands/gateway/gateway_runtime.rs` — gateway-path `DefaultPipelineToolFactory` carries an `Arc<dyn EmbeddingProvider>` and applies it inside `create()`
- `crates/octos-cli/src/commands/gateway/profile_factory.rs` — child-profile `ChildPipelineToolFactory` does the same
- `crates/octos-memory/src/store.rs` — `find_relevant_filtered` (new), `find_relevant` becomes thin wrapper
- `crates/octos-agent/src/agent/memory.rs` — fallback path now calls `find_relevant_filtered` with `Some(MIN_EPISODE_SIMILARITY)`; both branches emit diagnostics
- `crates/octos-pipeline/tests/embedder_propagation.rs` — 4 regression tests
- `crates/octos-pipeline/tests/{checkpoint_resume,deadline_enforcement,ux_pipeline,workspace_contract}.rs` — ExecutorConfig builder updates (`embedder: None`)