### PR TITLE
migrate(phase1): plumb SessionScope through host contexts (additive, no consumer yet)

### DIFF
--- a/crates/octos-agent/src/agent/execution.rs
+++ b/crates/octos-agent/src/agent/execution.rs
@@ -238,6 +238,13 @@ impl Agent {
         // both stamp it onto every tool call. The spawn tool reads
         // `ctx.spawn_depth` and refuses further nesting at the cap.
         let spawn_depth = self.spawn_depth;
+        // Phase 1 of the SessionScope migration (PR #1198 follow-up):
+        // snapshot the agent's `session_scope` so the foreground and
+        // spawn_only `ToolContext` builders below thread it onto every
+        // tool call. `None` keeps pre-Phase-1 behaviour; downstream
+        // consumers (pipeline workers, file tools, plugins) come online
+        // in Phase 2.
+        let session_scope = self.session_scope.clone();
 
         tokio::spawn(async move {
             let tool_start = Instant::now();
@@ -470,6 +477,12 @@ impl Agent {
                 // Guard C (issue #607): clone the agent's spawn nesting
                 // depth into the spawn_only TOOL_CTX builder.
                 let bg_spawn_depth = spawn_depth;
+                // Phase 1 of the SessionScope migration: clone the
+                // agent's session scope into the spawn_only TOOL_CTX
+                // builder so background sub-agents see the same
+                // filesystem contract as the parent session. None
+                // keeps pre-Phase-1 behaviour.
+                let bg_session_scope = session_scope.clone();
                 let bg_session_id_for_watcher = format!("agent:{}", tc_id);
                 // M10 Phase 4: keep a copy of the task_id so the synthesized
                 // tool-result message returned to the LLM (built after this
@@ -524,6 +537,11 @@ impl Agent {
                         // sub-agents (e.g. fm_tts → spawn) see the
                         // higher value when their TOOL_CTX is read.
                         spawn_depth: bg_spawn_depth,
+                        // Phase 1 SessionScope migration: thread the
+                        // shared scope onto the spawn_only TOOL_CTX so
+                        // every background sub-agent sees the same
+                        // filesystem contract as the parent.
+                        session_scope: bg_session_scope.clone(),
                         ..ToolContext::zero()
                     };
 
@@ -1399,6 +1417,10 @@ impl Agent {
                 // when deciding whether the next nested spawn is
                 // allowed.
                 spawn_depth,
+                // Phase 1 SessionScope migration: thread the shared
+                // scope onto the foreground TOOL_CTX so tools and the
+                // pipeline host context snapshot the same handle.
+                session_scope: session_scope.clone(),
                 ..ToolContext::zero()
             };
             // Thread the typed context into execute_with_context. Legacy tools

--- a/crates/octos-agent/src/agent/mod.rs
+++ b/crates/octos-agent/src/agent/mod.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 
-use octos_core::{AgentId, Message, TokenUsage};
+use octos_core::{AgentId, Message, SessionScope, TokenUsage};
 use octos_llm::{EmbeddingProvider, LlmProvider, ProviderMetadata};
 use octos_memory::EpisodeStore;
 
@@ -273,6 +273,19 @@ pub struct Agent {
     /// through their durable context ledger without making `octos-agent`
     /// depend on the CLI crate.
     pub(super) prompt_context_manager: Option<Arc<dyn PromptContextManager>>,
+    /// Phase 1 of the [`SessionScope`] migration (PR #1198 follow-up):
+    /// the single filesystem contract for this session, constructed at
+    /// the host entry point (`chat.rs` solo, `runtime/session.rs`
+    /// multi-tenant). Threaded onto every per-tool
+    /// [`crate::tools::ToolContext`] so the same scope is visible to
+    /// tools and to pipeline workers via
+    /// [`octos_pipeline::PipelineHostContext::from_tool_context`].
+    ///
+    /// `None` keeps pre-Phase-1 behaviour byte-for-byte — no consumer
+    /// reads the field yet. Phase 2 PRs will migrate file tools,
+    /// pipeline workers, plugins, and shell to derive their CWD and
+    /// path validation from this scope.
+    pub(super) session_scope: Option<Arc<SessionScope>>,
 }
 
 impl Agent {
@@ -316,6 +329,7 @@ impl Agent {
             spawn_depth: 0,
             sandbox_config: None,
             prompt_context_manager: None,
+            session_scope: None,
         }
     }
 
@@ -360,6 +374,7 @@ impl Agent {
             spawn_depth: 0,
             sandbox_config: None,
             prompt_context_manager: None,
+            session_scope: None,
         }
     }
 
@@ -552,6 +567,27 @@ impl Agent {
     /// Access the recorded parent session key, if any.
     pub fn parent_session_key(&self) -> Option<&str> {
         self.parent_session_key.as_deref()
+    }
+
+    /// Attach the session's [`SessionScope`] (Phase 1 of the migration
+    /// landed by PR #1198). Threaded into every per-tool
+    /// [`crate::tools::ToolContext`] so the same scope is visible to
+    /// the foreground branch, the spawn_only background branch, and —
+    /// via [`octos_pipeline::PipelineHostContext::from_tool_context`] —
+    /// to pipeline workers.
+    ///
+    /// Phase 1 is additive: no consumer reads the field yet. Setting
+    /// `None` (the default) preserves pre-Phase-1 behaviour byte-for-
+    /// byte; setting `Some(scope)` makes the value visible to the
+    /// downstream consumers that will come online in Phase 2.
+    pub fn with_session_scope(mut self, scope: Arc<SessionScope>) -> Self {
+        self.session_scope = Some(scope);
+        self
+    }
+
+    /// Access the configured session scope, if any.
+    pub fn session_scope(&self) -> Option<&Arc<SessionScope>> {
+        self.session_scope.as_ref()
     }
 
     /// Guard C (issue #607): record this agent's spawn nesting depth so
@@ -1004,5 +1040,36 @@ mod profile_integration_tests {
             agent.profile().is_none(),
             "agents built without a profile envelope return None",
         );
+    }
+
+    #[tokio::test]
+    async fn agent_without_session_scope_returns_none_by_default() {
+        // Phase 1 of the SessionScope migration: agents built without
+        // an explicit scope keep the legacy pre-Phase-1 behaviour. The
+        // accessor reports `None`; downstream consumers (Phase 2) must
+        // treat that as "no contract, fall back to today's path".
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = agent_default(tmp.path()).await;
+        assert!(
+            agent.session_scope().is_none(),
+            "agents built without a SessionScope return None for the accessor",
+        );
+    }
+
+    #[tokio::test]
+    async fn with_session_scope_populates_field_for_solo_cwd() {
+        // Phase 1 wiring contract: once the host entry point calls
+        // `with_session_scope(...)`, the field is present and the
+        // accessor returns the scope's `workspace()` == the user's cwd
+        // for solo mode. No downstream consumer reads it yet — the test
+        // exists so a regression in the plumbing fails loudly.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path().to_path_buf();
+        let scope = Arc::new(SessionScope::solo(cwd.clone(), vec![]).expect("solo scope"));
+        let agent = agent_default(tmp.path()).await.with_session_scope(scope);
+        let recorded = agent
+            .session_scope()
+            .expect("scope is wired into the agent");
+        assert_eq!(recorded.workspace(), cwd.as_path());
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -38,6 +38,7 @@ use eyre::Result;
 use octos_core::TokenUsage;
 
 use crate::progress::ProgressReporter;
+use octos_core::SessionScope;
 
 /// Registry of [`AgentDefinition`]-style manifests available to tools.
 ///
@@ -273,6 +274,21 @@ pub struct ToolContext {
     /// Beyond [`crate::tools::spawn::MAX_SPAWN_DEPTH`] the spawn tool
     /// refuses further nesting to bound mutual-recursion blowups.
     pub spawn_depth: u8,
+    /// Phase 1 of the [`SessionScope`] migration (PR #1198 follow-up):
+    /// the single filesystem contract for this session. Constructed at
+    /// the host entry point (`chat.rs` for solo, `serve.rs` /
+    /// `runtime/session.rs` for multi-tenant) and threaded through
+    /// `TOOL_CTX` so any tool can derive its CWD and validate paths
+    /// against the same scope.
+    ///
+    /// `Optional` because Phase 1 is additive — no consumer reads this
+    /// yet. Phase 2 PRs will migrate `RunPipelineTool.working_dir`,
+    /// plugin tool `work_dir`, file tools, shell, etc. to read from
+    /// this field; Phase 3 will retire bespoke validators like
+    /// `api_session_workspace_dirs` in favour of
+    /// [`SessionScope::workspace`]. See `octos_core::session_scope`
+    /// for the contract and migration notes.
+    pub session_scope: Option<Arc<SessionScope>>,
 }
 
 impl ToolContext {
@@ -298,6 +314,7 @@ impl ToolContext {
             cost_accountant: None,
             parent_session_key: None,
             spawn_depth: 0,
+            session_scope: None,
         }
     }
 }

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -437,12 +437,19 @@ impl ChatCommand {
         // `SessionScope::solo` invariant holds without panicking on
         // user input. Phase 2 PRs will start reading this from tools,
         // pipelines, and plugins; today it is wired through but unused.
+        //
+        // Codex review note (Phase-1 LOW): surface a hard error when
+        // `cwd` is relative AND `current_dir()` fails so the
+        // `SessionScope::solo` `expect` below can never fire on a
+        // relative path. Mirroring `current_dir()` failures up as
+        // `wrap_err` is consistent with the existing fallback at the
+        // top of `run_async` that constructed `cwd` the same way.
         let absolute_cwd: PathBuf = if cwd.is_absolute() {
             cwd.clone()
         } else {
             std::env::current_dir()
-                .map(|base| base.join(&cwd))
-                .unwrap_or_else(|_| cwd.clone())
+                .wrap_err("failed to absolutize --cwd: current_dir() unavailable")?
+                .join(&cwd)
         };
         let session_scope = Arc::new(SessionScope::solo(absolute_cwd, Vec::new()).expect(
             "solo CWD absolutized just above; SessionScope::solo's only invariant is absolute",
@@ -847,13 +854,17 @@ mod tests {
         // before it ships to fleet.
         let tmp = tempfile::tempdir().expect("tempdir");
         let cwd = tmp.path().to_path_buf();
-        // Mirror chat.rs's absolutize-then-build pattern.
+        // Mirror chat.rs's absolutize-then-build pattern. The entry
+        // point propagates `current_dir()` failures via `wrap_err?`;
+        // here in the test the cwd is already absolute (`tempdir`
+        // returns an absolute path) so the relative branch is never
+        // taken.
         let absolute_cwd: PathBuf = if cwd.is_absolute() {
             cwd.clone()
         } else {
             std::env::current_dir()
-                .map(|base| base.join(&cwd))
-                .unwrap_or_else(|_| cwd.clone())
+                .expect("current_dir() in tests")
+                .join(&cwd)
         };
         let scope = SessionScope::solo(absolute_cwd, Vec::new())
             .expect("solo SessionScope construction must succeed for an absolute cwd");
@@ -867,28 +878,23 @@ mod tests {
         // Defensive cover for chat.rs's absolutize branch — the
         // `--cwd relative` case must not propagate a relative path
         // into `SessionScope::solo`, which would `expect` on the
-        // `RootNotAbsolute` invariant. The branch resolves against
-        // `current_dir()` first so the SessionScope ctor always sees
-        // an absolute path.
+        // `RootNotAbsolute` invariant. The chat entry point now
+        // bubbles `current_dir()` errors up via `wrap_err?` so the
+        // branch only ever produces an absolute path or returns Err
+        // before reaching the `SessionScope::solo` call site.
         let relative = PathBuf::from("some-subdir");
+        let base = std::env::current_dir().expect("current_dir() in tests");
         let absolute_cwd: PathBuf = if relative.is_absolute() {
             relative.clone()
         } else {
-            std::env::current_dir()
-                .map(|base| base.join(&relative))
-                .unwrap_or_else(|_| relative.clone())
+            base.join(&relative)
         };
         assert!(
-            absolute_cwd.is_absolute() || std::env::current_dir().is_err(),
-            "absolutize branch must produce an absolute path when current_dir() succeeds"
+            absolute_cwd.is_absolute(),
+            "current_dir().join(relative) must produce an absolute path"
         );
-        // We can't always guarantee `current_dir()` succeeds in CI
-        // sandboxes, but when it does we should be able to call
-        // SessionScope::solo without panicking.
-        if absolute_cwd.is_absolute() {
-            SessionScope::solo(absolute_cwd, Vec::new())
-                .expect("SessionScope::solo accepts the absolutized path");
-        }
+        SessionScope::solo(absolute_cwd, Vec::new())
+            .expect("SessionScope::solo accepts the absolutized path");
     }
 
     /// NEW-06 codex follow-up — when [`build_run_pipeline_tool`] is

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -12,7 +12,7 @@ use octos_agent::{
     Agent, AgentConfig, CompactionSummarizerKind, ConsoleReporter, HookExecutor, ToolRegistry,
     read_workspace_policy,
 };
-use octos_core::{AgentId, Message, MessageRole};
+use octos_core::{AgentId, Message, MessageRole, SessionScope};
 use octos_llm::{
     AdaptiveConfig, AdaptiveRouter, EmbeddingProvider, LlmProvider, OpenAIEmbedder, ProviderChain,
     RetryProvider,
@@ -429,6 +429,25 @@ impl ChatCommand {
             supervisor_for_summary,
         ));
 
+        // Phase 1 of the SessionScope migration (PR #1198 follow-up):
+        // construct the single filesystem contract for this solo
+        // session and stash it on the agent. `cwd` may have come from
+        // `--cwd` (potentially relative) or from `current_dir()`
+        // (always absolute). Absolutize defensively so the
+        // `SessionScope::solo` invariant holds without panicking on
+        // user input. Phase 2 PRs will start reading this from tools,
+        // pipelines, and plugins; today it is wired through but unused.
+        let absolute_cwd: PathBuf = if cwd.is_absolute() {
+            cwd.clone()
+        } else {
+            std::env::current_dir()
+                .map(|base| base.join(&cwd))
+                .unwrap_or_else(|_| cwd.clone())
+        };
+        let session_scope = Arc::new(SessionScope::solo(absolute_cwd, Vec::new()).expect(
+            "solo CWD absolutized just above; SessionScope::solo's only invariant is absolute",
+        ));
+
         let mut agent = Agent::new(AgentId::new("chat"), llm, tools, memory)
             .with_config(agent_config)
             .with_reporter(reporter)
@@ -437,7 +456,8 @@ impl ChatCommand {
             .with_profile(profile_arc.clone())
             .with_file_state_cache(file_state_cache)
             .with_subagent_output_router(subagent_output_router)
-            .with_subagent_summary_generator(subagent_summary_generator);
+            .with_subagent_summary_generator(subagent_summary_generator)
+            .with_session_scope(session_scope);
 
         // M8.3: if the profile declares a system_prompt_template, try to
         // read it relative to `~/.octos/profiles/<name>/`. The path is a
@@ -812,6 +832,63 @@ mod tests {
         assert!(
             resolve_provider_policy(&config, "anthropic", "claude-sonnet-4-20250514").is_none()
         );
+    }
+
+    #[test]
+    fn chat_constructs_solo_session_scope_with_user_cwd() {
+        // Phase 1 SessionScope migration (PR #1198 follow-up): the
+        // chat entry point constructs a solo [`SessionScope`] from the
+        // user-finalized `cwd` (or `current_dir()` fallback) and
+        // attaches it to the per-session agent via
+        // [`Agent::with_session_scope`]. This test mirrors the exact
+        // construction the entry point performs so a regression that
+        // drops the wiring (or accidentally rejects valid input by
+        // mistakenly making the constructor fail) fails the suite
+        // before it ships to fleet.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cwd = tmp.path().to_path_buf();
+        // Mirror chat.rs's absolutize-then-build pattern.
+        let absolute_cwd: PathBuf = if cwd.is_absolute() {
+            cwd.clone()
+        } else {
+            std::env::current_dir()
+                .map(|base| base.join(&cwd))
+                .unwrap_or_else(|_| cwd.clone())
+        };
+        let scope = SessionScope::solo(absolute_cwd, Vec::new())
+            .expect("solo SessionScope construction must succeed for an absolute cwd");
+        assert_eq!(scope.workspace(), cwd.as_path());
+        assert_eq!(scope.root(), cwd.as_path());
+        assert!(scope.shared_zones().is_empty());
+    }
+
+    #[test]
+    fn chat_solo_session_scope_does_not_panic_on_relative_cwd_input() {
+        // Defensive cover for chat.rs's absolutize branch — the
+        // `--cwd relative` case must not propagate a relative path
+        // into `SessionScope::solo`, which would `expect` on the
+        // `RootNotAbsolute` invariant. The branch resolves against
+        // `current_dir()` first so the SessionScope ctor always sees
+        // an absolute path.
+        let relative = PathBuf::from("some-subdir");
+        let absolute_cwd: PathBuf = if relative.is_absolute() {
+            relative.clone()
+        } else {
+            std::env::current_dir()
+                .map(|base| base.join(&relative))
+                .unwrap_or_else(|_| relative.clone())
+        };
+        assert!(
+            absolute_cwd.is_absolute() || std::env::current_dir().is_err(),
+            "absolutize branch must produce an absolute path when current_dir() succeeds"
+        );
+        // We can't always guarantee `current_dir()` succeeds in CI
+        // sandboxes, but when it does we should be able to call
+        // SessionScope::solo without panicking.
+        if absolute_cwd.is_absolute() {
+            SessionScope::solo(absolute_cwd, Vec::new())
+                .expect("SessionScope::solo accepts the absolutized path");
+        }
     }
 
     /// NEW-06 codex follow-up — when [`build_run_pipeline_tool`] is

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -16,7 +16,7 @@ use octos_agent::{
     SubAgentOutputRouter, ToolRegistry,
 };
 use octos_bus::SessionManager;
-use octos_core::{AgentId, SessionKey};
+use octos_core::{AgentId, SessionKey, SessionScope, is_safe_session_id};
 
 use super::ProfileRuntime;
 
@@ -299,6 +299,41 @@ impl SessionRuntime {
         ));
         let file_state_cache = Arc::new(FileStateCache::new());
 
+        // Phase 1 of the SessionScope migration (PR #1198 follow-up):
+        // construct the multi-tenant filesystem contract for this
+        // session and stash it on the agent. The session id must
+        // satisfy [`is_safe_session_id`] (SPA `web-/slides-/site-`
+        // shapes pass; channel-prefixed `api:...` shapes do not). For
+        // unsafe shapes we leave the scope unset — Phase 1 is
+        // additive, no consumer reads the field yet. Phase 3 will
+        // migrate `api_session_workspace_dirs` and the related
+        // bespoke validators onto this contract; that's when the
+        // workspace shape mismatch between `SessionScope.workspace`
+        // (`<data>/users/<id>/workspace`) and the legacy encoded path
+        // (`<data>/users/<encoded id>/workspace` when the id has
+        // chars `is_safe_session_id` rejects) gets reconciled.
+        let session_id_raw = session_key.base_key().to_string();
+        let session_scope = if is_safe_session_id(&session_id_raw) {
+            match SessionScope::multi_tenant_with_default_zones(
+                profile.data_dir.clone(),
+                profile.profile_id.clone(),
+                session_id_raw.clone(),
+            ) {
+                Ok(scope) => Some(Arc::new(scope)),
+                Err(err) => {
+                    tracing::warn!(
+                        profile_id = %profile.profile_id,
+                        session = %session_key,
+                        error = %err,
+                        "SessionScope construction failed; bootstrap continues without scope (Phase 1 additive)",
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let mut agent = Agent::new_shared(
             AgentId::new("api"),
             profile.llm.clone(),
@@ -326,6 +361,13 @@ impl SessionRuntime {
         .with_subagent_summary_generator(subagent_summary_generator)
         .with_sandbox_config(sandbox.clone())
         .with_workspace_root(workspace_root.clone());
+
+        // Phase 1 of the SessionScope migration: attach the constructed
+        // scope to the per-session agent. `None` keeps pre-Phase-1
+        // behaviour byte-for-byte (no consumer reads the field yet).
+        if let Some(scope) = session_scope {
+            agent = agent.with_session_scope(scope);
+        }
 
         // M11-F regression fix REG-3: propagate the profile-scope
         // [`octos_agent::HookExecutor`] onto the per-session agent.
@@ -624,6 +666,87 @@ mod tests {
         // Plugin work dir is created and lives under workspace root.
         assert!(rt.plugin_work_dir.is_dir());
         assert!(rt.plugin_work_dir.starts_with(&rt.workspace_root));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_attaches_session_scope_for_safe_session_id() {
+        // Phase 1 of the SessionScope migration (PR #1198 follow-up):
+        // bootstrap a SPA-shape session_id (alphanumeric + `-` + `_` +
+        // `#`) and confirm the per-session agent carries a
+        // multi-tenant SessionScope. Phase 1 only asserts the field
+        // is present + the workspace shape matches
+        // `<data>/users/<id>/workspace`; no consumer reads it yet.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        let session_id = "web-1779574360679-o8x9kv";
+        let key = SessionKey(session_id.to_string());
+
+        let rt = SessionRuntime::bootstrap(&profile, key, None)
+            .await
+            .expect("bootstrap with safe SPA id");
+
+        let scope = rt
+            .agent
+            .session_scope()
+            .expect("safe session id yields a SessionScope")
+            .clone();
+        let expected_workspace = data_dir.join("users").join(session_id).join("workspace");
+        assert_eq!(scope.workspace(), expected_workspace.as_path());
+        assert_eq!(scope.root(), data_dir.as_path());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_leaves_session_scope_unset_for_unsafe_session_id() {
+        // Phase 1 contract: when the session_id contains characters
+        // outside the `is_safe_session_id` alphabet (e.g. the legacy
+        // `channel:chat_id` shape with `:`), bootstrap MUST NOT panic
+        // — it leaves the scope unset and the agent keeps pre-Phase-1
+        // behaviour. Phase 3 reconciles the encoded-path-vs-bare-id
+        // mismatch by routing every legitimate id through the scope
+        // contract.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        // SessionKey with a `:` channel prefix — fails is_safe_session_id.
+        let key = SessionKey::new("api", "web-1234");
+        let rt = SessionRuntime::bootstrap(&profile, key, None)
+            .await
+            .expect("bootstrap must succeed even when scope can't be built");
+
+        assert!(
+            rt.agent.session_scope().is_none(),
+            "channel-prefixed session ids must not produce a scope in Phase 1",
+        );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_attaches_distinct_session_scopes_per_session() {
+        // Two SPA-shape sessions on the same profile each get their
+        // own SessionScope pointing at their own per-session workspace
+        // directory. Verifies the scope tracks `session_id`, not just
+        // the parent profile.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        let key_a = SessionKey("web-1779000000000-aaa".to_string());
+        let key_b = SessionKey("web-1779000000000-bbb".to_string());
+
+        let rt_a = SessionRuntime::bootstrap(&profile, key_a.clone(), None)
+            .await
+            .expect("bootstrap A");
+        let rt_b = SessionRuntime::bootstrap(&profile, key_b.clone(), None)
+            .await
+            .expect("bootstrap B");
+
+        let scope_a = rt_a.agent.session_scope().expect("scope A").clone();
+        let scope_b = rt_b.agent.session_scope().expect("scope B").clone();
+        assert_ne!(scope_a.workspace(), scope_b.workspace());
+        // Both still share the same tenant root.
+        assert_eq!(scope_a.root(), scope_b.root());
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -331,6 +331,20 @@ impl SessionRuntime {
                 }
             }
         } else {
+            // Codex review note (Phase-1 LOW): channel-prefixed legacy
+            // session ids (`api:web-1234`, `telegram:12345`, etc.) fail
+            // `is_safe_session_id` by design — the SessionScope on-disk
+            // layout uses the raw id, while gateway/legacy paths
+            // percent-encode the `:` before joining. Phase 3 will route
+            // every shape through the scope contract; until then, log
+            // the skip at `debug!` (not `warn!`) since this is the
+            // expected path for non-SPA channels and we don't want
+            // gateway sessions to spam warn lines.
+            tracing::debug!(
+                profile_id = %profile.profile_id,
+                session = %session_key,
+                "skipping SessionScope construction: session id outside is_safe_session_id alphabet (Phase 1 expected for channel-prefixed shapes)",
+            );
             None
         };
 

--- a/crates/octos-pipeline/src/host_context.rs
+++ b/crates/octos-pipeline/src/host_context.rs
@@ -25,6 +25,7 @@ use octos_agent::subagent_output::SubAgentOutputRouter;
 use octos_agent::subagent_summary::AgentSummaryGenerator;
 use octos_agent::task_supervisor::TaskSupervisor;
 use octos_agent::tools::ToolContext;
+use octos_core::SessionScope;
 
 /// Shared resources inherited from the parent session by a pipeline
 /// run. Each field is independently optional so legacy callers stay on
@@ -62,6 +63,13 @@ pub struct PipelineHostContext {
     /// registrations so the supervisor links the child task to the
     /// owning session.
     pub parent_session_key: Option<String>,
+    /// Phase 1 of the [`SessionScope`] migration (PR #1198 follow-up):
+    /// the single filesystem contract for the parent session. Snapshotted
+    /// from the active [`ToolContext::session_scope`] when a `run_pipeline`
+    /// tool call enters the executor; threaded down to per-node workers
+    /// so they inherit the same scope. `None` keeps the legacy pre-Phase-1
+    /// behaviour where each worker computed its own CWD.
+    pub session_scope: Option<Arc<SessionScope>>,
 }
 
 impl PipelineHostContext {
@@ -80,6 +88,7 @@ impl PipelineHostContext {
                 Some(ctx.tool_id.clone())
             },
             parent_session_key: ctx.parent_session_key.clone(),
+            session_scope: ctx.session_scope.clone(),
         }
     }
 
@@ -94,6 +103,7 @@ impl PipelineHostContext {
             && self.cost_accountant.is_none()
             && self.parent_tool_call_id.is_none()
             && self.parent_session_key.is_none()
+            && self.session_scope.is_none()
     }
 }
 
@@ -113,6 +123,7 @@ impl std::fmt::Debug for PipelineHostContext {
             .field("cost_accountant", &self.cost_accountant.is_some())
             .field("parent_tool_call_id", &self.parent_tool_call_id)
             .field("parent_session_key", &self.parent_session_key)
+            .field("session_scope", &self.session_scope.is_some())
             .finish()
     }
 }
@@ -149,6 +160,28 @@ mod tests {
         tool_ctx.file_state_cache = Some(Arc::new(FileStateCache::new()));
         let host = PipelineHostContext::from_tool_context(&tool_ctx);
         assert!(host.file_state_cache.is_some());
+        assert!(!host.is_empty());
+    }
+
+    #[test]
+    fn from_tool_context_picks_up_session_scope() {
+        // Phase 1 of the SessionScope migration: when the parent
+        // session has constructed a [`SessionScope`] at the host entry
+        // point, the pipeline host context snapshots the same handle so
+        // pipeline workers will (in Phase 2) inherit the scope instead
+        // of computing CWD from raw inputs. Today the field is wired
+        // through but unused — this test exists to prevent regressions
+        // as the consumers come online.
+        let cwd = if cfg!(windows) {
+            std::path::PathBuf::from("C:/home/yc/project")
+        } else {
+            std::path::PathBuf::from("/home/yc/project")
+        };
+        let scope = Arc::new(SessionScope::solo(cwd, vec![]).unwrap());
+        let mut tool_ctx = ToolContext::zero();
+        tool_ctx.session_scope = Some(scope);
+        let host = PipelineHostContext::from_tool_context(&tool_ctx);
+        assert!(host.session_scope.is_some());
         assert!(!host.is_empty());
     }
 }

--- a/crates/octos-pipeline/tests/m8_parity.rs
+++ b/crates/octos-pipeline/tests/m8_parity.rs
@@ -76,6 +76,10 @@ async fn host_context_with_cache_and_supervisor() -> (
         cost_accountant: Some(accountant.clone()),
         parent_tool_call_id: Some("tool-call-w1-test".into()),
         parent_session_key: Some("session-w1".into()),
+        // Phase 1 of the SessionScope migration (PR #1198 follow-up):
+        // existing M8 parity tests stay on the legacy None path since
+        // no consumer reads the field yet.
+        session_scope: None,
     };
     (host, cache, supervisor, accountant, ledger_dir)
 }


### PR DESCRIPTION
## Summary

Phase 1 of the [SessionScope migration](https://github.com/octos-org/octos/pull/1198) spec'd by #1198. **Additive only — no consumer reads the field yet.** Behaviour is byte-identical to pre-Phase-1.

- Add `session_scope: Option<Arc<SessionScope>>` to `ToolContext`, `PipelineHostContext`, and `Agent` (with builder + accessor).
- Construct the scope at the host entry points:
  - **`chat.rs`** (solo): absolutize the user-supplied `--cwd` then call `SessionScope::solo`.
  - **`runtime/session.rs`** (multi-tenant): call `SessionScope::multi_tenant_with_default_zones` from `(profile.data_dir, profile.profile_id, session_key.base_key())` **only when** the session id passes `is_safe_session_id`. Channel-prefixed legacy ids silently fall through to `None`.
- Thread the scope onto every `TOOL_CTX` (foreground + spawn_only) and snapshot it into `PipelineHostContext::from_tool_context`.

Phase 2 will migrate `RunPipelineTool.working_dir`, plugin tool `work_dir`, file tools, shell, etc. to read from this field. Phase 3 will retire `api_session_workspace_dirs` and the related bespoke validators in favour of `SessionScope::workspace()`.

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo test -p octos-pipeline` lib + m8_parity — green (the pre-existing `test_06_send_file_sandbox_escape` failure in `ux_pipeline.rs` is reproducible on origin/main and unrelated to this PR)
- [x] `cargo test -p octos-agent --lib` — 1618 passed
- [x] `cargo test -p octos-cli --lib` — 458 passed (including 5 new SessionScope tests in this PR)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean

New regression tests:

| Test | Crate | Asserts |
|------|-------|---------|
| `from_tool_context_picks_up_session_scope` | `octos-pipeline` | scope flows from TOOL_CTX into PipelineHostContext |
| `agent_without_session_scope_returns_none_by_default` | `octos-agent` | accessor returns None pre-Phase-1 |
| `with_session_scope_populates_field_for_solo_cwd` | `octos-agent` | `Agent::with_session_scope` wires the field |
| `chat_constructs_solo_session_scope_with_user_cwd` | `octos-cli` | solo construction matches chat entry-point pattern |
| `chat_solo_session_scope_does_not_panic_on_relative_cwd_input` | `octos-cli` | absolutize branch prevents the `expect` from firing |
| `bootstrap_attaches_session_scope_for_safe_session_id` | `octos-cli` | multi-tenant scope wired with correct workspace path |
| `bootstrap_leaves_session_scope_unset_for_unsafe_session_id` | `octos-cli` | channel-prefixed ids silently skip scope, no panic |
| `bootstrap_attaches_distinct_session_scopes_per_session` | `octos-cli` | two SPA sessions get distinct workspaces, shared root |