### PR TITLE
test: add thread binding property coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,7 @@ Thumbs.db
 node_modules/
 
 # Playwright/tmux test artifacts
-e2e/test-results/
-e2e/test-results-tmux/
-e2e/test-results-ux/
+e2e/test-results*/
 
 # Dashboard build output.
 #
@@ -130,4 +128,3 @@ scripts/deploy.sh
 !e2e/fixtures/compat-test-skill/manifest.json
 !e2e/fixtures/compat-test-skill/main
 tsconfig.tsbuildinfo
-e2e/test-results-matrix/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,6 +3757,7 @@ dependencies = [
  "mailparse",
  "metrics",
  "octos-core",
+ "proptest",
  "reqwest 0.12.28",
  "rustls 0.23.36",
  "rustls-native-certs",
@@ -4326,6 +4342,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4358,6 +4393,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -4511,6 +4552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4897,6 +4947,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustyline"
@@ -6299,6 +6361,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6424,6 +6492,15 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ tower = { version = "0.5", features = ["util"] }
 # Testing
 tokio-test = "0.4"
 tempfile = "3"
+proptest = "1.11"
 
 # -- Release configuration --------------------------------------------------
 [workspace.metadata.release]

--- a/crates/octos-bus/Cargo.toml
+++ b/crates/octos-bus/Cargo.toml
@@ -68,3 +68,4 @@ workspace = true
 tokio-test = { workspace = true }
 tempfile = { workspace = true }
 tower = { workspace = true }
+proptest = { workspace = true }

--- a/crates/octos-bus/tests/api_channel_property.rs
+++ b/crates/octos-bus/tests/api_channel_property.rs
@@ -1,0 +1,459 @@
+#![cfg(feature = "api")]
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+use chrono::{TimeZone, Utc};
+use eyre::{Result, ensure, eyre};
+use octos_bus::{ApiChannel, Channel, SessionManager};
+use octos_core::OutboundMessage;
+use proptest::prelude::*;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+const CHAT_ID: &str = "property-thread-binding";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CompletionKind {
+    Assistant,
+    Tool,
+}
+
+impl CompletionKind {
+    fn role(self) -> &'static str {
+        match self {
+            Self::Assistant => "assistant",
+            Self::Tool => "tool",
+        }
+    }
+
+    fn sort_rank(self) -> u8 {
+        match self {
+            Self::Assistant => 0,
+            Self::Tool => 1,
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+struct TurnCase {
+    cmid: String,
+    send_at_ms: u64,
+    prompt: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+struct CompletionCase {
+    turn_index: usize,
+    kind: CompletionKind,
+    complete_at_ms: u64,
+    content: String,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+struct ThreadBindingScenario {
+    schema: &'static str,
+    turns: Vec<TurnCase>,
+    completions: Vec<CompletionCase>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+struct TranscriptRecord {
+    role: &'static str,
+    content: String,
+    at_ms: u64,
+    thread_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_message_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_to_client_message_id: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ThreadBindingViolation {
+    record_index: usize,
+    role: String,
+    expected_thread_id: String,
+    actual_thread_id: String,
+    response_to_client_message_id: Option<String>,
+    content_preview: String,
+}
+
+impl ThreadBindingScenario {
+    fn from_specs(specs: Vec<(u16, u16, Option<u16>)>) -> Self {
+        let mut send_at_ms = 0_u64;
+        let mut turns = Vec::with_capacity(specs.len());
+
+        for (index, (gap_ms, _, _)) in specs.iter().enumerate() {
+            if index > 0 {
+                send_at_ms += u64::from(*gap_ms);
+            }
+            turns.push(TurnCase {
+                cmid: format!("cmid-prop-{}", index + 1),
+                send_at_ms,
+                prompt: format!("property prompt {}", index + 1),
+            });
+        }
+
+        let last_send_at_ms = turns.last().map(|turn| turn.send_at_ms).unwrap_or(0);
+        let mut completions = Vec::with_capacity(specs.len() * 2);
+        for (index, (_, assistant_delay_ms, maybe_tool_delay_ms)) in specs.iter().enumerate() {
+            let turn = &turns[index];
+            let mut complete_at_ms = turn.send_at_ms + u64::from(*assistant_delay_ms);
+            if index == 0 {
+                complete_at_ms = complete_at_ms.max(last_send_at_ms + 1);
+            }
+            completions.push(CompletionCase {
+                turn_index: index,
+                kind: CompletionKind::Assistant,
+                complete_at_ms,
+                content: format!("assistant result for {}", turn.cmid),
+            });
+
+            if let Some(tool_delay_ms) = maybe_tool_delay_ms {
+                completions.push(CompletionCase {
+                    turn_index: index,
+                    kind: CompletionKind::Tool,
+                    complete_at_ms: turn.send_at_ms + u64::from(*tool_delay_ms),
+                    content: format!("tool result for {}", turn.cmid),
+                });
+            }
+        }
+
+        completions.sort_by_key(|completion| {
+            (
+                completion.complete_at_ms,
+                completion.turn_index,
+                completion.kind.sort_rank(),
+            )
+        });
+
+        Self {
+            schema: "octos.thread-binding.property.v1",
+            turns,
+            completions,
+        }
+    }
+
+    fn origin_cmid(&self, completion: &CompletionCase) -> &str {
+        &self.turns[completion.turn_index].cmid
+    }
+
+    fn latest_user_at(&self, at_ms: u64) -> &TurnCase {
+        self.turns
+            .iter()
+            .rfind(|turn| turn.send_at_ms <= at_ms)
+            .unwrap_or(&self.turns[0])
+    }
+
+    fn has_sticky_pressure(&self) -> bool {
+        self.completions.iter().any(|completion| {
+            self.latest_user_at(completion.complete_at_ms).cmid != self.origin_cmid(completion)
+        })
+    }
+
+    fn transcript(&self, mode: BindingMode) -> Vec<TranscriptRecord> {
+        let mut records = Vec::with_capacity(self.turns.len() + self.completions.len());
+
+        for turn in &self.turns {
+            records.push(TranscriptRecord {
+                role: "user",
+                content: turn.prompt.clone(),
+                at_ms: turn.send_at_ms,
+                thread_id: turn.cmid.clone(),
+                client_message_id: Some(turn.cmid.clone()),
+                response_to_client_message_id: None,
+            });
+        }
+
+        for completion in &self.completions {
+            let origin = self.origin_cmid(completion);
+            let sticky = self.latest_user_at(completion.complete_at_ms).cmid.as_str();
+            let thread_id = match mode {
+                BindingMode::BoundAtSpawn => origin,
+                BindingMode::StickyLatestUser => sticky,
+            };
+            records.push(TranscriptRecord {
+                role: completion.kind.role(),
+                content: completion.content.clone(),
+                at_ms: completion.complete_at_ms,
+                thread_id: thread_id.to_string(),
+                client_message_id: None,
+                response_to_client_message_id: Some(origin.to_string()),
+            });
+        }
+
+        records.sort_by_key(|record| {
+            let role_rank = if record.role == "user" { 0 } else { 1 };
+            (record.at_ms, role_rank, record.content.clone())
+        });
+        records
+    }
+
+    fn to_promotable_fixture_json(&self) -> String {
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema": self.schema,
+            "turns": self.turns,
+            "completions": self.completions,
+            "records": self.transcript(BindingMode::BoundAtSpawn),
+            "sticky_latest_user_records": self.transcript(BindingMode::StickyLatestUser),
+        }))
+        .expect("scenario should serialize")
+    }
+}
+
+#[derive(Clone, Copy)]
+enum BindingMode {
+    BoundAtSpawn,
+    StickyLatestUser,
+}
+
+fn scenario_strategy() -> impl Strategy<Value = ThreadBindingScenario> {
+    proptest::collection::vec(
+        (
+            0_u16..=2_500,
+            0_u16..=35_000,
+            prop::option::of(0_u16..=35_000),
+        ),
+        3..=8,
+    )
+    .prop_map(ThreadBindingScenario::from_specs)
+}
+
+fn check_transcript(records: &[TranscriptRecord]) -> Vec<ThreadBindingViolation> {
+    let known_user_cmids: HashSet<String> = records
+        .iter()
+        .filter(|record| record.role == "user")
+        .filter_map(|record| record.client_message_id.clone())
+        .collect();
+    let mut current_user_cmid = None;
+    let mut violations = Vec::new();
+
+    for (index, record) in records.iter().enumerate() {
+        match record.role {
+            "user" => {
+                current_user_cmid = record.client_message_id.clone();
+                if let Some(cmid) = &record.client_message_id {
+                    if record.thread_id != *cmid {
+                        violations.push(ThreadBindingViolation {
+                            record_index: index,
+                            role: record.role.to_string(),
+                            expected_thread_id: cmid.clone(),
+                            actual_thread_id: record.thread_id.clone(),
+                            response_to_client_message_id: None,
+                            content_preview: record.content.chars().take(80).collect(),
+                        });
+                    }
+                }
+            }
+            "assistant" | "tool" => {
+                let expected = record
+                    .response_to_client_message_id
+                    .clone()
+                    .filter(|cmid| known_user_cmids.contains(cmid))
+                    .or_else(|| current_user_cmid.clone());
+                if let Some(expected) = expected {
+                    if record.thread_id != expected {
+                        violations.push(ThreadBindingViolation {
+                            record_index: index,
+                            role: record.role.to_string(),
+                            expected_thread_id: expected,
+                            actual_thread_id: record.thread_id.clone(),
+                            response_to_client_message_id: record
+                                .response_to_client_message_id
+                                .clone(),
+                            content_preview: record.content.chars().take(80).collect(),
+                        });
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    violations
+}
+
+fn make_channel() -> Result<ApiChannel> {
+    let temp = tempfile::tempdir()?;
+    let sessions = Arc::new(Mutex::new(SessionManager::open(temp.path())?));
+    Ok(ApiChannel::new(
+        0,
+        None,
+        Arc::new(AtomicBool::new(false)),
+        sessions,
+        None,
+    ))
+}
+
+fn completion_result_json(scenario: &ThreadBindingScenario, completion: &CompletionCase) -> Value {
+    let cmid = scenario.origin_cmid(completion);
+    serde_json::json!({
+        "role": completion.kind.role(),
+        "content": completion.content.clone(),
+        "thread_id": cmid,
+        "response_to_client_message_id": cmid,
+        "timestamp": Utc.timestamp_millis_opt(completion.complete_at_ms as i64)
+            .single()
+            .unwrap_or_else(Utc::now)
+            .to_rfc3339(),
+    })
+}
+
+async fn next_watcher_event(rx: &mut tokio::sync::broadcast::Receiver<String>) -> Result<Value> {
+    let payload = tokio::time::timeout(Duration::from_millis(250), rx.recv())
+        .await
+        .map_err(|_| eyre!("timed out waiting for watcher event"))?
+        .map_err(|error| eyre!("watcher closed before event: {error}"))?;
+    Ok(serde_json::from_str(&payload)?)
+}
+
+fn assert_event_bound_to_origin(
+    value: &Value,
+    expected_thread_id: &str,
+    expected_role: &str,
+    seq_by_thread: &mut HashMap<String, u64>,
+) -> Result<()> {
+    ensure!(
+        value.get("event_type").and_then(Value::as_str) == Some("session_result"),
+        "unexpected event_type in {value}"
+    );
+    ensure!(
+        value.get("thread_id").and_then(Value::as_str) == Some(expected_thread_id),
+        "envelope thread_id drifted in {value}"
+    );
+    ensure!(
+        value.pointer("/payload/thread_id").and_then(Value::as_str) == Some(expected_thread_id),
+        "payload thread_id drifted in {value}"
+    );
+
+    let next_seq = seq_by_thread
+        .entry(expected_thread_id.to_string())
+        .and_modify(|seq| *seq += 1)
+        .or_insert(1);
+    ensure!(
+        value.get("event_seq").and_then(Value::as_u64) == Some(*next_seq),
+        "event_seq should be per-thread and monotonic in {value}"
+    );
+
+    let message = value
+        .get("message")
+        .or_else(|| value.pointer("/payload/message"))
+        .ok_or_else(|| eyre!("session_result event missing message: {value}"))?;
+    ensure!(
+        message.get("role").and_then(Value::as_str) == Some(expected_role),
+        "message role drifted in {value}"
+    );
+    ensure!(
+        message.get("thread_id").and_then(Value::as_str) == Some(expected_thread_id),
+        "nested message thread_id drifted in {value}"
+    );
+    ensure!(
+        message
+            .get("response_to_client_message_id")
+            .and_then(Value::as_str)
+            == Some(expected_thread_id),
+        "nested message response_to_client_message_id drifted in {value}"
+    );
+
+    Ok(())
+}
+
+async fn run_api_channel_scenario(scenario: &ThreadBindingScenario) -> Result<()> {
+    let channel = make_channel()?;
+    let mut watcher = channel.subscribe_watcher_for_tests(CHAT_ID, None).await;
+    let mut seq_by_thread = HashMap::new();
+
+    for completion in &scenario.completions {
+        let cmid = scenario.origin_cmid(completion);
+        let result = completion_result_json(scenario, completion);
+        let msg = OutboundMessage {
+            channel: "api".to_string(),
+            chat_id: CHAT_ID.to_string(),
+            content: completion.content.clone(),
+            reply_to: None,
+            media: vec![],
+            metadata: serde_json::json!({
+                "thread_id": cmid,
+                "_session_result": result,
+            }),
+        };
+
+        channel.send(&msg).await?;
+        let event = next_watcher_event(&mut watcher).await?;
+        assert_event_bound_to_origin(&event, cmid, completion.kind.role(), &mut seq_by_thread)?;
+    }
+
+    let first = scenario
+        .completions
+        .first()
+        .ok_or_else(|| eyre!("scenario should contain at least one completion"))?;
+    let unbound = OutboundMessage {
+        channel: "api".to_string(),
+        chat_id: CHAT_ID.to_string(),
+        content: first.content.clone(),
+        reply_to: None,
+        media: vec![],
+        metadata: serde_json::json!({
+            "_session_result": completion_result_json(scenario, first),
+        }),
+    };
+    let err = channel
+        .send(&unbound)
+        .await
+        .expect_err("session_result emission without thread_id must fail closed");
+    ensure!(
+        err.to_string().contains("required thread_id"),
+        "unexpected missing-thread error: {err}"
+    );
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn api_channel_preserves_thread_binding_under_generated_completion_orders(
+        scenario in scenario_strategy()
+    ) {
+        prop_assert!(
+            scenario.has_sticky_pressure(),
+            "generator did not exercise sticky-map pressure:\n{}",
+            scenario.to_promotable_fixture_json()
+        );
+
+        let baseline_violations = check_transcript(&scenario.transcript(BindingMode::BoundAtSpawn));
+        prop_assert!(
+            baseline_violations.is_empty(),
+            "bound-at-spawn baseline violated invariant: {:?}\n{}",
+            baseline_violations,
+            scenario.to_promotable_fixture_json()
+        );
+
+        let sticky_violations = check_transcript(&scenario.transcript(BindingMode::StickyLatestUser));
+        prop_assert!(
+            !sticky_violations.is_empty(),
+            "sticky latest-user model unexpectedly satisfied invariant:\n{}",
+            scenario.to_promotable_fixture_json()
+        );
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        if let Err(error) = runtime.block_on(run_api_channel_scenario(&scenario)) {
+            prop_assert!(
+                false,
+                "api_channel event invariant failed: {error:?}\n{}",
+                scenario.to_promotable_fixture_json()
+            );
+        }
+    }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
+    "test:property:thread-binding": "npx playwright test --workers=1 tests/property/thread-binding.property.ts",
     "test:m9-protocol": "npx playwright test --workers=1 tests/m9-protocol-*.spec.ts",
     "test:m9-protocol:list": "npx playwright test --list tests/m9-protocol-*.spec.ts",
     "test:tmux:m9-protocol": "cd .. && bash e2e/tmux/run.sh m9-protocol",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -12,6 +12,12 @@ import { defineConfig } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
+  testMatch: [
+    '**/*.spec.ts',
+    '**/*.test.ts',
+    '**/*.test.mjs',
+    '**/*.property.ts',
+  ],
   timeout: 60_000,
   retries: 0,
   use: {

--- a/e2e/test-fixtures/regressions/README.md
+++ b/e2e/test-fixtures/regressions/README.md
@@ -1,0 +1,5 @@
+# Regression Fixtures
+
+`thread-binding.property.ts` writes a promotable JSON payload here as
+`*.fixture.json` when a generated case fails. Keep `expected_violations`
+with promoted cases so future runs catch the same binding regression.

--- a/e2e/test-fixtures/regressions/thread-binding-sticky-overflow.fixture.json
+++ b/e2e/test-fixtures/regressions/thread-binding-sticky-overflow.fixture.json
@@ -1,0 +1,78 @@
+{
+  "schema": "octos.thread-binding-regression.v1",
+  "name": "sticky-map-three-user-overflow",
+  "records": [
+    {
+      "role": "user",
+      "content": "slow research",
+      "at_ms": 0,
+      "client_message_id": "cmid-1",
+      "thread_id": "cmid-1"
+    },
+    {
+      "role": "user",
+      "content": "stock query",
+      "at_ms": 1500,
+      "client_message_id": "cmid-2",
+      "thread_id": "cmid-2"
+    },
+    {
+      "role": "user",
+      "content": "voice list",
+      "at_ms": 3000,
+      "client_message_id": "cmid-3",
+      "thread_id": "cmid-3"
+    },
+    {
+      "role": "assistant",
+      "content": "voice answer",
+      "at_ms": 4200,
+      "response_to_client_message_id": "cmid-3",
+      "thread_id": "cmid-3"
+    },
+    {
+      "role": "tool",
+      "content": "deep research stock result",
+      "at_ms": 9000,
+      "response_to_client_message_id": "cmid-2",
+      "thread_id": "cmid-3"
+    },
+    {
+      "role": "assistant",
+      "content": "stock answer",
+      "at_ms": 11000,
+      "response_to_client_message_id": "cmid-2",
+      "thread_id": "cmid-3"
+    },
+    {
+      "role": "assistant",
+      "content": "slow research final",
+      "at_ms": 20000,
+      "response_to_client_message_id": "cmid-1",
+      "thread_id": "cmid-3"
+    }
+  ],
+  "expected_violations": [
+    {
+      "record_index": 4,
+      "role": "tool",
+      "expected_thread_id": "cmid-2",
+      "actual_thread_id": "cmid-3",
+      "response_to_client_message_id": "cmid-2"
+    },
+    {
+      "record_index": 5,
+      "role": "assistant",
+      "expected_thread_id": "cmid-2",
+      "actual_thread_id": "cmid-3",
+      "response_to_client_message_id": "cmid-2"
+    },
+    {
+      "record_index": 6,
+      "role": "assistant",
+      "expected_thread_id": "cmid-1",
+      "actual_thread_id": "cmid-3",
+      "response_to_client_message_id": "cmid-1"
+    }
+  ]
+}

--- a/e2e/tests/property/thread-binding.property.ts
+++ b/e2e/tests/property/thread-binding.property.ts
@@ -1,0 +1,309 @@
+import { expect, test } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ITERATIONS = 50;
+const REGRESSION_DIR = path.resolve(
+  __dirname,
+  '../../test-fixtures/regressions',
+);
+const REGRESSION_FIXTURE_SCHEMA = 'octos.thread-binding-regression.v1';
+
+type Role = 'user' | 'assistant' | 'tool';
+
+interface TranscriptRecord {
+  role: Role;
+  content: string;
+  at_ms: number;
+  thread_id: string;
+  client_message_id?: string;
+  response_to_client_message_id?: string;
+}
+
+interface TurnCase {
+  cmid: string;
+  prompt: string;
+  send_at_ms: number;
+}
+
+interface CompletionCase {
+  turn_index: number;
+  role: Exclude<Role, 'user'>;
+  complete_at_ms: number;
+  content: string;
+}
+
+interface ScenarioCase {
+  schema: 'octos.thread-binding.property.v1';
+  seed: number;
+  turns: TurnCase[];
+  completions: CompletionCase[];
+}
+
+interface BindingViolation {
+  record_index: number;
+  role: Role;
+  expected_thread_id: string;
+  actual_thread_id: string;
+  response_to_client_message_id?: string;
+  content_preview: string;
+}
+
+interface RegressionFixture {
+  schema: string;
+  name: string;
+  records: TranscriptRecord[];
+  expected_violations: Array<Partial<BindingViolation>>;
+}
+
+function mulberry32(seed: number) {
+  return () => {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function intBetween(rand: () => number, min: number, max: number) {
+  return Math.floor(rand() * (max - min + 1)) + min;
+}
+
+function roleRank(role: Role) {
+  return role === 'user' ? 0 : 1;
+}
+
+function generateScenario(seed: number): ScenarioCase {
+  const rand = mulberry32(seed);
+  const turnCount = intBetween(rand, 3, 8);
+  const turns: TurnCase[] = [];
+  let sendAtMs = 0;
+
+  for (let i = 0; i < turnCount; i++) {
+    sendAtMs += i === 0 ? 0 : intBetween(rand, 0, 2500);
+    turns.push({
+      cmid: `cmid-${seed}-${i + 1}`,
+      prompt: `property prompt ${seed}.${i + 1}`,
+      send_at_ms: sendAtMs,
+    });
+  }
+
+  const lastSendAtMs = turns[turns.length - 1].send_at_ms;
+  const completions: CompletionCase[] = [];
+  for (const [i, turn] of turns.entries()) {
+    let completeAtMs = turn.send_at_ms + intBetween(rand, 0, 35_000);
+    if (i === 0) {
+      completeAtMs = Math.max(completeAtMs, lastSendAtMs + 1);
+    }
+    completions.push({
+      turn_index: i,
+      role: 'assistant',
+      complete_at_ms: completeAtMs,
+      content: `assistant result for ${turn.cmid}`,
+    });
+
+    if (rand() < 0.55) {
+      completions.push({
+        turn_index: i,
+        role: 'tool',
+        complete_at_ms: turn.send_at_ms + intBetween(rand, 0, 35_000),
+        content: `tool result for ${turn.cmid}`,
+      });
+    }
+  }
+
+  completions.sort(
+    (a, b) =>
+      a.complete_at_ms - b.complete_at_ms ||
+      a.turn_index - b.turn_index ||
+      a.role.localeCompare(b.role),
+  );
+
+  return {
+    schema: 'octos.thread-binding.property.v1',
+    seed,
+    turns,
+    completions,
+  };
+}
+
+function latestTurnAt(scenario: ScenarioCase, atMs: number) {
+  let latest = scenario.turns[0];
+  for (const turn of scenario.turns) {
+    if (turn.send_at_ms <= atMs) latest = turn;
+  }
+  return latest;
+}
+
+function materializeScenario(
+  scenario: ScenarioCase,
+  mode: 'bound-at-spawn' | 'sticky-latest-user',
+): TranscriptRecord[] {
+  const records: TranscriptRecord[] = [];
+
+  for (const turn of scenario.turns) {
+    records.push({
+      role: 'user',
+      content: turn.prompt,
+      at_ms: turn.send_at_ms,
+      client_message_id: turn.cmid,
+      thread_id: turn.cmid,
+    });
+  }
+
+  for (const completion of scenario.completions) {
+    const origin = scenario.turns[completion.turn_index];
+    const sticky = latestTurnAt(scenario, completion.complete_at_ms);
+    records.push({
+      role: completion.role,
+      content: completion.content,
+      at_ms: completion.complete_at_ms,
+      response_to_client_message_id: origin.cmid,
+      thread_id: mode === 'bound-at-spawn' ? origin.cmid : sticky.cmid,
+    });
+  }
+
+  records.sort(
+    (a, b) =>
+      a.at_ms - b.at_ms ||
+      roleRank(a.role) - roleRank(b.role) ||
+      a.content.localeCompare(b.content),
+  );
+  return records;
+}
+
+function checkThreadBinding(records: TranscriptRecord[]): BindingViolation[] {
+  const knownUserCmids = new Set(
+    records
+      .filter((record) => record.role === 'user')
+      .map((record) => record.client_message_id)
+      .filter((cmid): cmid is string => Boolean(cmid)),
+  );
+  const violations: BindingViolation[] = [];
+  let currentUserCmid: string | undefined;
+
+  for (const [index, record] of records.entries()) {
+    if (record.role === 'user') {
+      currentUserCmid = record.client_message_id;
+      if (record.client_message_id && record.thread_id !== record.client_message_id) {
+        violations.push({
+          record_index: index,
+          role: record.role,
+          expected_thread_id: record.client_message_id,
+          actual_thread_id: record.thread_id,
+          content_preview: record.content.slice(0, 80),
+        });
+      }
+      continue;
+    }
+
+    const responseTo = record.response_to_client_message_id;
+    const expected =
+      responseTo && knownUserCmids.has(responseTo) ? responseTo : currentUserCmid;
+    if (expected && record.thread_id !== expected) {
+      violations.push({
+        record_index: index,
+        role: record.role,
+        expected_thread_id: expected,
+        actual_thread_id: record.thread_id,
+        response_to_client_message_id: responseTo,
+        content_preview: record.content.slice(0, 80),
+      });
+    }
+  }
+
+  return violations;
+}
+
+function serializePromotableFixture(scenario: ScenarioCase) {
+  return JSON.stringify(
+    {
+      ...scenario,
+      records: materializeScenario(scenario, 'bound-at-spawn'),
+      sticky_latest_user_records: materializeScenario(
+        scenario,
+        'sticky-latest-user',
+      ),
+    },
+    null,
+    2,
+  );
+}
+
+function writePromotableFixture(
+  scenario: ScenarioCase,
+  records: TranscriptRecord[],
+  violations: BindingViolation[],
+  reason: string,
+) {
+  fs.mkdirSync(REGRESSION_DIR, { recursive: true });
+  const fileName = `thread-binding-${reason}-seed-${scenario.seed}.fixture.json`;
+  const fixturePath = path.join(REGRESSION_DIR, fileName);
+  const fixture = {
+    schema: REGRESSION_FIXTURE_SCHEMA,
+    name: `generated-${reason}-seed-${scenario.seed}`,
+    source_schema: scenario.schema,
+    seed: scenario.seed,
+    reason,
+    turns: scenario.turns,
+    completions: scenario.completions,
+    records,
+    expected_violations: violations,
+  };
+  fs.writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`);
+  return fixturePath;
+}
+
+test.describe('thread_id binding property', () => {
+  test(`generated speculative-overflow transcripts preserve binding across ${ITERATIONS} cases`, () => {
+    let stickyFailuresDetected = 0;
+
+    for (let seed = 1; seed <= ITERATIONS; seed++) {
+      const scenario = generateScenario(seed);
+      const records = materializeScenario(scenario, 'bound-at-spawn');
+      const violations = checkThreadBinding(records);
+      const fixturePath =
+        violations.length > 0
+          ? writePromotableFixture(
+              scenario,
+              records,
+              violations,
+              'bound-at-spawn-violation',
+            )
+          : undefined;
+      expect(
+        violations,
+        `generated bound-at-spawn transcript violated thread binding; wrote fixture: ${fixturePath}\npromote with:\n${serializePromotableFixture(scenario)}`,
+      ).toEqual([]);
+
+      const stickyRecords = materializeScenario(scenario, 'sticky-latest-user');
+      const stickyViolations = checkThreadBinding(stickyRecords);
+      if (stickyViolations.length > 0) {
+        stickyFailuresDetected += 1;
+      }
+    }
+
+    expect(stickyFailuresDetected).toBeGreaterThan(0);
+  });
+
+  test('promoted sticky-map regression fixtures are detected by the invariant checker', () => {
+    const files = fs
+      .readdirSync(REGRESSION_DIR)
+      .filter((file) => file.endsWith('.fixture.json'));
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const fixture = JSON.parse(
+        fs.readFileSync(path.join(REGRESSION_DIR, file), 'utf8'),
+      ) as RegressionFixture;
+      const violations = checkThreadBinding(fixture.records);
+
+      for (const expected of fixture.expected_violations) {
+        expect(
+          violations,
+          `${fixture.name} should include violation ${JSON.stringify(expected)}`,
+        ).toContainEqual(expect.objectContaining(expected));
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `octos-bus` proptest coverage for generated thread-binding/speculative-overflow completion orders, including runtime `ApiChannel` session_result emission checks and missing-thread fail-closed behavior.
- Add Playwright property coverage for 50 generated replay cases plus a checked-in sticky-map regression fixture and fixture-promotion writer for failing generated cases.
- Add a dedicated `npm run test:property:thread-binding` script, include `*.property.ts` in Playwright discovery, and ignore all `e2e/test-results*` artifact directories.

Closes #654

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p octos-bus --features api --test api_channel_property --no-deps`
- [x] `cargo test -p octos-bus --features api --test api_channel_property`
- [x] `cd e2e && npm run test:property:thread-binding -- --list`
- [x] `cd e2e && npm run test:property:thread-binding`

Note: a full `npx playwright test --list` still stops on the pre-existing live `mini5-history-timing-probe.spec.ts` `OCTOS_USER_TOKEN` guard. The #654 property lane is validated through the dedicated script above.