### PR TITLE
migrate(phase2c): file tools use SessionScope for base_dir + path classification (resolves #1189 asymmetry)

### DIFF
--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
-use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 use tracing::warn;
 
@@ -117,11 +116,14 @@ impl Tool for EditFileTool {
 
         // Phase 2-C of the SessionScope migration: when the host has
         // threaded a scope through `ToolContext`, use it as the single
-        // source of truth for base_dir + path classification. Same write
-        // policy as `write_file` — `InWorkspace` and `InGrantedDir`
-        // allowed; `InSharedZone` and `OutOfScope` refused.
+        // source of truth for base_dir + path classification. Same
+        // write policy as `write_file` — `InWorkspace` and
+        // `InGrantedDir` allowed; `InSharedZone` and `OutOfScope`
+        // refused. The shared helper canonicalizes the candidate before
+        // classification so ancestor symlinks can't smuggle an edit
+        // out of the workspace.
         let path = match ctx.session_scope.as_ref() {
-            Some(scope) => match resolve_with_scope_for_write(scope, &input.path) {
+            Some(scope) => match super::resolve_path_for_session_scope_write(scope, &input.path) {
                 Ok(p) => p,
                 Err(reason) => {
                     return Ok(ToolResult {
@@ -208,28 +210,6 @@ impl Tool for EditFileTool {
             file_modified: Some(path),
             ..Default::default()
         })
-    }
-}
-
-/// Resolve a user-supplied path against a [`SessionScope`] for a WRITE
-/// operation (edit_file mutates files in place, so it uses the same
-/// policy as `write_file`). Relative paths anchor at `scope.workspace()`;
-/// absolute paths must classify into `InWorkspace` or `InGrantedDir`.
-/// `InSharedZone` and `OutOfScope` are refused.
-fn resolve_with_scope_for_write(
-    scope: &SessionScope,
-    user_path: &str,
-) -> Result<PathBuf, &'static str> {
-    let candidate = PathBuf::from(user_path);
-    let absolute = if candidate.is_absolute() {
-        candidate
-    } else {
-        scope.workspace().join(candidate)
-    };
-    match scope.classify_lexical_path(&absolute) {
-        PathClassification::InWorkspace | PathClassification::InGrantedDir { .. } => Ok(absolute),
-        PathClassification::InSharedZone { .. } => Err("Writes to shared zones are not permitted"),
-        PathClassification::OutOfScope => Err("Path outside session scope"),
     }
 }
 
@@ -375,6 +355,7 @@ mod tests {
     // Phase 2-C: SessionScope integration tests for EditFileTool.
     // -----------------------------------------------------------------------
 
+    use octos_core::SessionScope;
     use std::sync::Arc;
 
     fn ctx_with_scope(scope: SessionScope) -> ToolContext {
@@ -524,6 +505,53 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(&shared_file).unwrap(),
             "untouched\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn edit_file_refuses_ancestor_symlink_escape() {
+        // Symmetric with the write_file ancestor-symlink test. Even
+        // with a real target file pre-staged at the symlink target,
+        // the scoped resolver must refuse before O_NOFOLLOW would
+        // (correctly) bail on the symlink itself.
+        use std::os::unix::fs::symlink;
+
+        let scope_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        std::fs::write(outside_dir.path().join("target.txt"), "secret\n").unwrap();
+        let link_path = scope_dir.path().join("link");
+        symlink(outside_dir.path(), &link_path).unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = EditFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": "link/target.txt",
+                    "old_string": "secret",
+                    "new_string": "owned",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.success,
+            "ancestor-symlink escape MUST be refused, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection, got: {}",
+            result.output
+        );
+        // Real file at the symlink target must remain unchanged.
+        assert_eq!(
+            std::fs::read_to_string(outside_dir.path().join("target.txt")).unwrap(),
+            "secret\n",
         );
     }
 

--- a/crates/octos-agent/src/tools/edit_file.rs
+++ b/crates/octos-agent/src/tools/edit_file.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
+use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 use tracing::warn;
 
@@ -114,20 +115,36 @@ impl Tool for EditFileTool {
             });
         }
 
-        // Resolve path (with traversal protection)
-        let path = match super::resolve_path_with_scope(
-            &self.base_dir,
-            &input.path,
-            self.filesystem_scope,
-        ) {
-            Ok(p) => p,
-            Err(_) => {
-                return Ok(ToolResult {
-                    output: format!("Path outside working directory: {}", input.path),
-                    success: false,
-                    ..Default::default()
-                });
-            }
+        // Phase 2-C of the SessionScope migration: when the host has
+        // threaded a scope through `ToolContext`, use it as the single
+        // source of truth for base_dir + path classification. Same write
+        // policy as `write_file` — `InWorkspace` and `InGrantedDir`
+        // allowed; `InSharedZone` and `OutOfScope` refused.
+        let path = match ctx.session_scope.as_ref() {
+            Some(scope) => match resolve_with_scope_for_write(scope, &input.path) {
+                Ok(p) => p,
+                Err(reason) => {
+                    return Ok(ToolResult {
+                        output: format!("{reason}: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
+            None => match super::resolve_path_with_scope(
+                &self.base_dir,
+                &input.path,
+                self.filesystem_scope,
+            ) {
+                Ok(p) => p,
+                Err(_) => {
+                    return Ok(ToolResult {
+                        output: format!("Path outside working directory: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
         };
 
         // Read current content (O_NOFOLLOW atomically rejects symlinks)
@@ -191,6 +208,28 @@ impl Tool for EditFileTool {
             file_modified: Some(path),
             ..Default::default()
         })
+    }
+}
+
+/// Resolve a user-supplied path against a [`SessionScope`] for a WRITE
+/// operation (edit_file mutates files in place, so it uses the same
+/// policy as `write_file`). Relative paths anchor at `scope.workspace()`;
+/// absolute paths must classify into `InWorkspace` or `InGrantedDir`.
+/// `InSharedZone` and `OutOfScope` are refused.
+fn resolve_with_scope_for_write(
+    scope: &SessionScope,
+    user_path: &str,
+) -> Result<PathBuf, &'static str> {
+    let candidate = PathBuf::from(user_path);
+    let absolute = if candidate.is_absolute() {
+        candidate
+    } else {
+        scope.workspace().join(candidate)
+    };
+    match scope.classify_lexical_path(&absolute) {
+        PathClassification::InWorkspace | PathClassification::InGrantedDir { .. } => Ok(absolute),
+        PathClassification::InSharedZone { .. } => Err("Writes to shared zones are not permitted"),
+        PathClassification::OutOfScope => Err("Path outside session scope"),
     }
 }
 
@@ -330,6 +369,202 @@ mod tests {
         let tool = EditFileTool::new("/tmp");
         assert_eq!(tool.name(), "edit_file");
         assert!(tool.tags().contains(&"fs"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2-C: SessionScope integration tests for EditFileTool.
+    // -----------------------------------------------------------------------
+
+    use std::sync::Arc;
+
+    fn ctx_with_scope(scope: SessionScope) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "edit-with-scope".to_string();
+        ctx.session_scope = Some(Arc::new(scope));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn edit_file_uses_scope_workspace_as_base_dir_for_relative_paths() {
+        // Relative edit path anchors at `scope.workspace()`, not the
+        // legacy `base_dir`. Pre-create the target file there.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let legacy_dir = tempfile::tempdir().unwrap();
+        std::fs::write(scope_dir.path().join("doc.md"), "before\n").unwrap();
+        std::fs::write(legacy_dir.path().join("doc.md"), "decoy\n").unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = EditFileTool::new(legacy_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": "doc.md",
+                    "old_string": "before",
+                    "new_string": "after",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+
+        // Only the scope-dir copy is mutated; the legacy decoy is
+        // untouched. (Edit even refused to look at the legacy file.)
+        assert_eq!(
+            std::fs::read_to_string(scope_dir.path().join("doc.md")).unwrap(),
+            "after\n",
+        );
+        assert_eq!(
+            std::fs::read_to_string(legacy_dir.path().join("doc.md")).unwrap(),
+            "decoy\n",
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_file_refuses_out_of_scope_path() {
+        let scope_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside_file = outside_dir.path().join("target.txt");
+        std::fs::write(&outside_file, "untouched\n").unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = EditFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": outside_file.to_string_lossy(),
+                    "old_string": "untouched",
+                    "new_string": "owned",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection, got: {}",
+            result.output
+        );
+        // File MUST remain unchanged.
+        assert_eq!(
+            std::fs::read_to_string(&outside_file).unwrap(),
+            "untouched\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_file_allows_in_workspace_path() {
+        let scope_dir = tempfile::tempdir().unwrap();
+        std::fs::write(scope_dir.path().join("inside.txt"), "alpha\n").unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = EditFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": "inside.txt",
+                    "old_string": "alpha",
+                    "new_string": "beta",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert_eq!(
+            std::fs::read_to_string(scope_dir.path().join("inside.txt")).unwrap(),
+            "beta\n",
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_file_refuses_write_to_shared_zone() {
+        // Multi-tenant shared zones are read-only for session workers
+        // — symmetric with `write_file_refuses_write_to_shared_zone`.
+        let data_dir = tempfile::tempdir().unwrap();
+        let data = data_dir.path().to_path_buf();
+        std::fs::create_dir_all(data.join("research/topic")).unwrap();
+        std::fs::create_dir_all(data.join("users/web-1/workspace")).unwrap();
+        let shared_file = data.join("research/topic/notes.md");
+        std::fs::write(&shared_file, "untouched\n").unwrap();
+
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            data.clone(),
+            "dspfac".into(),
+            "web-1".into(),
+        )
+        .unwrap();
+        let tool = EditFileTool::new(scope.workspace());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": shared_file.to_string_lossy(),
+                    "old_string": "untouched",
+                    "new_string": "owned",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("shared zone"),
+            "expected shared-zone rejection, got: {}",
+            result.output
+        );
+        assert_eq!(
+            std::fs::read_to_string(&shared_file).unwrap(),
+            "untouched\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_file_falls_back_to_legacy_when_no_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ok.txt"), "x\n").unwrap();
+        let tool = EditFileTool::new(dir.path());
+        let ctx = ToolContext::zero();
+        assert!(ctx.session_scope.is_none());
+
+        let ok = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": "ok.txt",
+                    "old_string": "x",
+                    "new_string": "y",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(ok.success);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("ok.txt")).unwrap(),
+            "y\n"
+        );
+
+        let bad = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": "../escape.txt",
+                    "old_string": "a",
+                    "new_string": "b",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(!bad.success);
+        assert!(bad.output.contains("outside working directory"));
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -38,7 +38,7 @@ use eyre::Result;
 use octos_core::TokenUsage;
 
 use crate::progress::ProgressReporter;
-use octos_core::SessionScope;
+use octos_core::{PathClassification, ScopeMode, SessionScope};
 
 /// Registry of [`AgentDefinition`]-style manifests available to tools.
 ///
@@ -819,6 +819,162 @@ pub fn resolve_path_with_scope(
         return Ok(normalize_lexical(&base_dir.join(user_path)));
     }
     resolve_path(base_dir, user_path)
+}
+
+/// Resolve and classify a user-supplied path against a [`SessionScope`]
+/// for Phase 2-C file tools. Relative paths anchor at
+/// `scope.workspace()`; absolute paths are accepted but must classify
+/// inside one of the scope's zones.
+///
+/// **Symlink containment.** [`SessionScope::classify_lexical_path`] is
+/// intentionally lexical-only — a candidate like
+/// `<workspace>/symlink/out`, where `symlink` is a symbolic link
+/// pointing outside the workspace, would classify as `InWorkspace`
+/// even though the actual on-disk location is elsewhere. `O_NOFOLLOW`
+/// (applied in [`read_no_follow`] / [`write_no_follow`]) only protects
+/// the FINAL component, not symlinked ancestors. To close that gap
+/// before classification we canonicalize both the candidate and each
+/// zone root via [`canonicalize_lossy`], matching the containment
+/// guarantee `octos_bus::file_handle::resolve_tool_path` gave the
+/// pre-Phase-2C path. See PR #1201 codex review for the precise
+/// scenario (`<workspace>/link/out`).
+///
+/// Returns the (lexically-normalised, NOT canonicalized) absolute path
+/// the file tool should open. We deliberately return the lexical form
+/// so callers can pass it back to `read_no_follow`/`write_no_follow`
+/// without re-resolving — the canonicalization here is for
+/// classification only.
+pub fn resolve_path_for_session_scope_read(
+    scope: &SessionScope,
+    user_path: &str,
+) -> Result<PathBuf, &'static str> {
+    resolve_for_scope(scope, user_path, /*for_write=*/ false)
+}
+
+/// Same as [`resolve_path_for_session_scope_read`] but with the
+/// write-side policy: `InSharedZone` is refused.
+pub fn resolve_path_for_session_scope_write(
+    scope: &SessionScope,
+    user_path: &str,
+) -> Result<PathBuf, &'static str> {
+    resolve_for_scope(scope, user_path, /*for_write=*/ true)
+}
+
+fn resolve_for_scope(
+    scope: &SessionScope,
+    user_path: &str,
+    for_write: bool,
+) -> Result<PathBuf, &'static str> {
+    let candidate = PathBuf::from(user_path);
+    let absolute = if candidate.is_absolute() {
+        candidate
+    } else {
+        scope.workspace().join(candidate)
+    };
+    // Refuse `..` lexically first so the subsequent canonicalize walk
+    // cannot accidentally surface inside a zone after climbing out.
+    let lex_normalised = match lexical_normalise_strict(&absolute) {
+        Some(p) => p,
+        None => return Err("Path outside session scope"),
+    };
+    match classify_canonical(scope, &lex_normalised) {
+        PathClassification::InWorkspace => Ok(lex_normalised),
+        PathClassification::InGrantedDir { .. } => Ok(lex_normalised),
+        PathClassification::InSharedZone { .. } => {
+            if for_write {
+                Err("Writes to shared zones are not permitted")
+            } else {
+                Ok(lex_normalised)
+            }
+        }
+        PathClassification::OutOfScope => Err("Path outside session scope"),
+    }
+}
+
+/// Classify a path against a scope after canonicalizing both sides.
+/// Closes the ancestor-symlink hole in
+/// [`SessionScope::classify_lexical_path`]. Returns the same
+/// [`PathClassification`] shape so callers can read it the same way.
+fn classify_canonical(scope: &SessionScope, lex_normalised_abs: &Path) -> PathClassification {
+    let canon = canonicalize_lossy(lex_normalised_abs);
+    let canon_ws = canonical_root_lossy(scope.workspace());
+    if canon.starts_with(&canon_ws) {
+        return PathClassification::InWorkspace;
+    }
+    match scope.mode() {
+        ScopeMode::Solo { granted_dirs } => {
+            for granted in granted_dirs {
+                let canon_grant = canonical_root_lossy(granted);
+                if canon.starts_with(&canon_grant) {
+                    return PathClassification::InGrantedDir {
+                        granted_dir: granted.clone(),
+                    };
+                }
+            }
+        }
+        ScopeMode::MultiTenant { .. } => {
+            for zone in scope.shared_zones() {
+                let canon_zone = canonical_root_lossy(zone);
+                if canon.starts_with(&canon_zone) {
+                    return PathClassification::InSharedZone { zone: zone.clone() };
+                }
+            }
+        }
+    }
+    PathClassification::OutOfScope
+}
+
+/// Lexical normalise (collapse `.`, refuse `..`). Mirrors the helper
+/// inside `octos_core::session_scope` so the canonicalize walk above
+/// can't absorb a traversal escape.
+fn lexical_normalise_strict(path: &Path) -> Option<PathBuf> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => return None,
+            Component::Normal(part) => out.push(part),
+        }
+    }
+    Some(out)
+}
+
+/// Canonicalize a path, recovering when the leaf doesn't exist yet
+/// (writes target new files). Mirrors
+/// [`octos_bus::file_handle::canonicalize_lossy`]: walks ancestors to
+/// find the longest existing prefix, canonicalizes that (resolving
+/// symlinked ancestors), and re-attaches the suffix. The input must
+/// already be lexically normalised (no `..`) so the re-attached
+/// suffix is a real would-be on-disk location.
+fn canonicalize_lossy(path: &Path) -> PathBuf {
+    if let Ok(canon) = std::fs::canonicalize(path) {
+        return canon;
+    }
+    let mut existing: &Path = path;
+    let mut suffix = PathBuf::new();
+    while let Some(parent) = existing.parent() {
+        if let Some(name) = existing.file_name() {
+            let mut next_suffix = PathBuf::from(name);
+            next_suffix.push(&suffix);
+            suffix = next_suffix;
+        }
+        existing = parent;
+        if let Ok(canon) = std::fs::canonicalize(existing) {
+            return canon.join(suffix);
+        }
+        if existing.as_os_str().is_empty() {
+            break;
+        }
+    }
+    path.to_path_buf()
+}
+
+/// Canonicalize a root, falling back to the input when the root
+/// doesn't exist (rare for `scope.workspace()` but possible in tests
+/// that pass a not-yet-created directory).
+fn canonical_root_lossy(root: &Path) -> PathBuf {
+    std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
 }
 
 /// Syntactic path normalization (no filesystem access). Collapses `.`

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
+use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 
 use super::{Tool, ToolContext, ToolResult};
@@ -104,20 +105,37 @@ impl Tool for ReadFileTool {
             });
         }
 
-        // Resolve path (with traversal protection)
-        let path = match super::resolve_path_with_scope(
-            &self.base_dir,
-            &input.path,
-            self.filesystem_scope,
-        ) {
-            Ok(p) => p,
-            Err(_) => {
-                return Ok(ToolResult {
-                    output: format!("Path outside working directory: {}", input.path),
-                    success: false,
-                    ..Default::default()
-                });
-            }
+        // Phase 2-C of the SessionScope migration: when the host has
+        // threaded a scope through `ToolContext`, use it as the single
+        // source of truth for base_dir + path classification. Reads are
+        // permitted for `InWorkspace`, `InSharedZone`, and `InGrantedDir`;
+        // `OutOfScope` is refused. When no scope is present we keep the
+        // legacy resolver (backward compat for `octos chat` etc.).
+        let path = match ctx.session_scope.as_ref() {
+            Some(scope) => match resolve_with_scope_for_read(scope, &input.path) {
+                Ok(p) => p,
+                Err(reason) => {
+                    return Ok(ToolResult {
+                        output: format!("{reason}: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
+            None => match super::resolve_path_with_scope(
+                &self.base_dir,
+                &input.path,
+                self.filesystem_scope,
+            ) {
+                Ok(p) => p,
+                Err(_) => {
+                    return Ok(ToolResult {
+                        output: format!("Path outside working directory: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
         };
 
         // Reject files larger than 10MB to prevent OOM (output is capped to 100KB
@@ -252,6 +270,30 @@ fn user_range(start: Option<usize>, end: Option<usize>) -> Option<(u64, u64)> {
         start.map(|s| s as u64).unwrap_or(0),
         end.map(|e| e as u64).unwrap_or(u64::MAX),
     ))
+}
+
+/// Resolve a user-supplied path against a [`SessionScope`] for a READ
+/// operation. Relative paths anchor at `scope.workspace()`; absolute
+/// paths are accepted but must classify into one of the read-allowed
+/// zones (`InWorkspace`, `InSharedZone`, `InGrantedDir`). `OutOfScope`
+/// — including any `..` traversal that `classify_lexical_path` refuses
+/// — is rejected.
+fn resolve_with_scope_for_read(
+    scope: &SessionScope,
+    user_path: &str,
+) -> Result<PathBuf, &'static str> {
+    let candidate = PathBuf::from(user_path);
+    let absolute = if candidate.is_absolute() {
+        candidate
+    } else {
+        scope.workspace().join(candidate)
+    };
+    match scope.classify_lexical_path(&absolute) {
+        PathClassification::InWorkspace
+        | PathClassification::InSharedZone { .. }
+        | PathClassification::InGrantedDir { .. } => Ok(absolute),
+        PathClassification::OutOfScope => Err("Path outside session scope"),
+    }
 }
 
 /// True when a cached entry can satisfy the caller's request without
@@ -509,6 +551,151 @@ mod tests {
         assert!(a.success && b.success);
         assert!(!a.output.contains("[FILE_UNCHANGED]"));
         assert!(!b.output.contains("[FILE_UNCHANGED]"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2-C: SessionScope integration tests for ReadFileTool.
+    // -----------------------------------------------------------------------
+
+    fn ctx_with_scope(scope: SessionScope) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "read-with-scope".to_string();
+        ctx.session_scope = Some(Arc::new(scope));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn read_file_uses_scope_workspace_as_base_dir_for_relative_paths() {
+        // When a scope is present, relative paths resolve against
+        // `scope.workspace()` regardless of the legacy `base_dir`.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let legacy_dir = tempfile::tempdir().unwrap();
+        std::fs::write(scope_dir.path().join("scoped.txt"), "from scope\n").unwrap();
+        std::fs::write(legacy_dir.path().join("scoped.txt"), "from legacy\n").unwrap();
+
+        // Note: legacy_dir is the tool's base_dir, but the scope's
+        // workspace is scope_dir — the latter must win.
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = ReadFileTool::new(legacy_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "scoped.txt"}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(
+            result.output.contains("from scope"),
+            "expected scope_dir content, got: {}",
+            result.output
+        );
+        assert!(!result.output.contains("from legacy"));
+    }
+
+    #[tokio::test]
+    async fn read_file_refuses_out_of_scope_path() {
+        // An absolute path outside every declared zone classifies as
+        // `OutOfScope` and must be refused.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside_file = outside_dir.path().join("secret.txt");
+        std::fs::write(&outside_file, "secret\n").unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = ReadFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": outside_file.to_string_lossy()}),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn read_file_allows_in_workspace_path() {
+        // `InWorkspace` is the obviously-allowed zone for reads.
+        let scope_dir = tempfile::tempdir().unwrap();
+        std::fs::write(scope_dir.path().join("ok.txt"), "ok\n").unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = ReadFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "ok.txt"}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(result.output.contains("ok"));
+    }
+
+    #[tokio::test]
+    async fn read_file_allows_in_shared_zone_path() {
+        // Multi-tenant scopes expose shared zones (research/, skills/).
+        // READS into those zones are allowed (writes are not — see the
+        // write_file tests). The user's intent here is explicit:
+        // they're recalling cross-session shared state.
+        let data_dir = tempfile::tempdir().unwrap();
+        let data = data_dir.path().to_path_buf();
+        std::fs::create_dir_all(data.join("research/topic")).unwrap();
+        std::fs::create_dir_all(data.join("users/web-1/workspace")).unwrap();
+        let shared_file = data.join("research/topic/notes.md");
+        std::fs::write(&shared_file, "shared notes\n").unwrap();
+
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            data.clone(),
+            "dspfac".into(),
+            "web-1".into(),
+        )
+        .unwrap();
+        let tool = ReadFileTool::new(scope.workspace());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": shared_file.to_string_lossy()}),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(result.output.contains("shared notes"));
+    }
+
+    #[tokio::test]
+    async fn read_file_falls_back_to_legacy_when_no_scope() {
+        // No scope on the context — behaviour must match the pre-Phase-2C
+        // path (relative resolved against `base_dir`, traversal blocked
+        // by the legacy resolver, etc.).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("legacy.txt"), "legacy ok\n").unwrap();
+
+        let tool = ReadFileTool::new(dir.path());
+        let ctx = ToolContext::zero();
+        assert!(ctx.session_scope.is_none());
+
+        let ok = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "legacy.txt"}))
+            .await
+            .unwrap();
+        assert!(ok.success);
+        assert!(ok.output.contains("legacy ok"));
+
+        let bad = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "../escape.txt"}))
+            .await
+            .unwrap();
+        assert!(!bad.success);
+        assert!(bad.output.contains("outside working directory"));
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/read_file.rs
+++ b/crates/octos-agent/src/tools/read_file.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
-use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 
 use super::{Tool, ToolContext, ToolResult};
@@ -109,10 +108,13 @@ impl Tool for ReadFileTool {
         // threaded a scope through `ToolContext`, use it as the single
         // source of truth for base_dir + path classification. Reads are
         // permitted for `InWorkspace`, `InSharedZone`, and `InGrantedDir`;
-        // `OutOfScope` is refused. When no scope is present we keep the
-        // legacy resolver (backward compat for `octos chat` etc.).
+        // `OutOfScope` is refused. The shared helper canonicalizes the
+        // candidate before classification so ancestor symlinks can't
+        // smuggle a path out of the workspace (`O_NOFOLLOW` only
+        // protects the final component). When no scope is present we
+        // keep the legacy resolver (backward compat for `octos chat`).
         let path = match ctx.session_scope.as_ref() {
-            Some(scope) => match resolve_with_scope_for_read(scope, &input.path) {
+            Some(scope) => match super::resolve_path_for_session_scope_read(scope, &input.path) {
                 Ok(p) => p,
                 Err(reason) => {
                     return Ok(ToolResult {
@@ -270,30 +272,6 @@ fn user_range(start: Option<usize>, end: Option<usize>) -> Option<(u64, u64)> {
         start.map(|s| s as u64).unwrap_or(0),
         end.map(|e| e as u64).unwrap_or(u64::MAX),
     ))
-}
-
-/// Resolve a user-supplied path against a [`SessionScope`] for a READ
-/// operation. Relative paths anchor at `scope.workspace()`; absolute
-/// paths are accepted but must classify into one of the read-allowed
-/// zones (`InWorkspace`, `InSharedZone`, `InGrantedDir`). `OutOfScope`
-/// — including any `..` traversal that `classify_lexical_path` refuses
-/// — is rejected.
-fn resolve_with_scope_for_read(
-    scope: &SessionScope,
-    user_path: &str,
-) -> Result<PathBuf, &'static str> {
-    let candidate = PathBuf::from(user_path);
-    let absolute = if candidate.is_absolute() {
-        candidate
-    } else {
-        scope.workspace().join(candidate)
-    };
-    match scope.classify_lexical_path(&absolute) {
-        PathClassification::InWorkspace
-        | PathClassification::InSharedZone { .. }
-        | PathClassification::InGrantedDir { .. } => Ok(absolute),
-        PathClassification::OutOfScope => Err("Path outside session scope"),
-    }
 }
 
 /// True when a cached entry can satisfy the caller's request without
@@ -557,6 +535,8 @@ mod tests {
     // Phase 2-C: SessionScope integration tests for ReadFileTool.
     // -----------------------------------------------------------------------
 
+    use octos_core::SessionScope;
+
     fn ctx_with_scope(scope: SessionScope) -> ToolContext {
         let mut ctx = ToolContext::zero();
         ctx.tool_id = "read-with-scope".to_string();
@@ -669,6 +649,46 @@ mod tests {
             .unwrap();
         assert!(result.success, "expected success, got: {}", result.output);
         assert!(result.output.contains("shared notes"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_file_refuses_ancestor_symlink_escape() {
+        // Per codex review of the Phase 2-C commit: `O_NOFOLLOW` only
+        // guards the FINAL path component, and `classify_lexical_path`
+        // is explicitly lexical. Without our canonicalization step a
+        // path like `<workspace>/link/secret.txt`, where `link` is a
+        // symlink pointing outside the workspace, would classify as
+        // `InWorkspace` and `read_no_follow` would happily open the
+        // file at the symlink's real location.
+        use std::os::unix::fs::symlink;
+
+        let scope_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        std::fs::write(outside_dir.path().join("secret.txt"), "exfiltrated\n").unwrap();
+
+        // <scope>/link -> <outside>
+        let link_path = scope_dir.path().join("link");
+        symlink(outside_dir.path(), &link_path).unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = ReadFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "link/secret.txt"}))
+            .await
+            .unwrap();
+        assert!(
+            !result.success,
+            "ancestor-symlink escape MUST be refused, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection (canonicalized leaves the workspace), got: {}",
+            result.output
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
+use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 use tracing::warn;
 
@@ -110,20 +111,39 @@ impl Tool for WriteFileTool {
             });
         }
 
-        // Resolve path (with traversal protection)
-        let path = match super::resolve_path_with_scope(
-            &self.base_dir,
-            &input.path,
-            self.filesystem_scope,
-        ) {
-            Ok(p) => p,
-            Err(_) => {
-                return Ok(ToolResult {
-                    output: format!("Path outside working directory: {}", input.path),
-                    success: false,
-                    ..Default::default()
-                });
-            }
+        // Phase 2-C of the SessionScope migration: when the host has
+        // threaded a scope through `ToolContext`, use it as the single
+        // source of truth for base_dir + path classification. WRITES are
+        // permitted only for `InWorkspace` and `InGrantedDir`;
+        // `InSharedZone` and `OutOfScope` are refused. This also fixes
+        // the path asymmetry that #1189 worked around: write_file now
+        // writes under `scope.workspace()` — the same directory that
+        // plugin tools run in — instead of the bespoke `base_dir`.
+        let path = match ctx.session_scope.as_ref() {
+            Some(scope) => match resolve_with_scope_for_write(scope, &input.path) {
+                Ok(p) => p,
+                Err(reason) => {
+                    return Ok(ToolResult {
+                        output: format!("{reason}: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
+            None => match super::resolve_path_with_scope(
+                &self.base_dir,
+                &input.path,
+                self.filesystem_scope,
+            ) {
+                Ok(p) => p,
+                Err(_) => {
+                    return Ok(ToolResult {
+                        output: format!("Path outside working directory: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
         };
 
         // Create parent directories if needed
@@ -162,6 +182,29 @@ impl Tool for WriteFileTool {
             file_modified: Some(path),
             ..Default::default()
         })
+    }
+}
+
+/// Resolve a user-supplied path against a [`SessionScope`] for a WRITE
+/// operation. Relative paths anchor at `scope.workspace()`; absolute
+/// paths are accepted but must classify into one of the write-allowed
+/// zones (`InWorkspace`, `InGrantedDir`). `InSharedZone` and
+/// `OutOfScope` are refused — shared zones are managed by maintenance
+/// paths, not session workers.
+fn resolve_with_scope_for_write(
+    scope: &SessionScope,
+    user_path: &str,
+) -> Result<PathBuf, &'static str> {
+    let candidate = PathBuf::from(user_path);
+    let absolute = if candidate.is_absolute() {
+        candidate
+    } else {
+        scope.workspace().join(candidate)
+    };
+    match scope.classify_lexical_path(&absolute) {
+        PathClassification::InWorkspace | PathClassification::InGrantedDir { .. } => Ok(absolute),
+        PathClassification::InSharedZone { .. } => Err("Writes to shared zones are not permitted"),
+        PathClassification::OutOfScope => Err("Path outside session scope"),
     }
 }
 
@@ -262,6 +305,167 @@ mod tests {
     // -----------------------------------------------------------------------
     // M8.4 integration test — write invalidates the file-state cache.
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Phase 2-C: SessionScope integration tests for WriteFileTool.
+    // -----------------------------------------------------------------------
+
+    use std::sync::Arc;
+
+    fn ctx_with_scope(scope: SessionScope) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "write-with-scope".to_string();
+        ctx.session_scope = Some(Arc::new(scope));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn write_file_uses_scope_workspace_as_base_dir_for_relative_paths() {
+        // Closes the #1189 asymmetry: when a scope is present, relative
+        // writes land under `scope.workspace()`, not the legacy
+        // `base_dir`. That's the same directory plugin tools run in,
+        // so the rescue heuristic is no longer needed.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let legacy_dir = tempfile::tempdir().unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = WriteFileTool::new(legacy_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "out.txt", "content": "hi\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        // File landed in scope.workspace(), NOT the legacy base_dir.
+        assert!(scope_dir.path().join("out.txt").exists());
+        assert!(!legacy_dir.path().join("out.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn write_file_refuses_out_of_scope_path() {
+        let scope_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside_target = outside_dir.path().join("escape.txt");
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = WriteFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": outside_target.to_string_lossy(),
+                    "content": "bad\n",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection, got: {}",
+            result.output
+        );
+        assert!(
+            !outside_target.exists(),
+            "refused write must NOT have created the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_file_allows_in_workspace_path() {
+        let scope_dir = tempfile::tempdir().unwrap();
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = WriteFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "ok.txt", "content": "ok\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        let body = std::fs::read_to_string(scope_dir.path().join("ok.txt")).unwrap();
+        assert_eq!(body, "ok\n");
+    }
+
+    #[tokio::test]
+    async fn write_file_refuses_write_to_shared_zone() {
+        // Multi-tenant shared zones (research/, skills/) are managed
+        // by maintenance paths, not session workers. write_file MUST
+        // refuse — the symmetry hole that lets a session pollute
+        // another tenant's shared data.
+        let data_dir = tempfile::tempdir().unwrap();
+        let data = data_dir.path().to_path_buf();
+        std::fs::create_dir_all(data.join("research")).unwrap();
+        std::fs::create_dir_all(data.join("users/web-1/workspace")).unwrap();
+        let shared_target = data.join("research/poisoned.md");
+
+        let scope = SessionScope::multi_tenant_with_default_zones(
+            data.clone(),
+            "dspfac".into(),
+            "web-1".into(),
+        )
+        .unwrap();
+        let tool = WriteFileTool::new(scope.workspace());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": shared_target.to_string_lossy(),
+                    "content": "bad\n",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("shared zone"),
+            "expected shared-zone rejection, got: {}",
+            result.output
+        );
+        assert!(
+            !shared_target.exists(),
+            "refused write must NOT have created the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_file_falls_back_to_legacy_when_no_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = WriteFileTool::new(dir.path());
+        let ctx = ToolContext::zero();
+        assert!(ctx.session_scope.is_none());
+
+        let ok = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "legacy.txt", "content": "legacy\n"}),
+            )
+            .await
+            .unwrap();
+        assert!(ok.success);
+        assert!(dir.path().join("legacy.txt").exists());
+
+        let bad = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": "../escape.txt", "content": "bad"}),
+            )
+            .await
+            .unwrap();
+        assert!(!bad.success);
+        assert!(bad.output.contains("outside working directory"));
+    }
 
     #[tokio::test]
     async fn should_write_file_tool_invalidate_cache_after_write() {

--- a/crates/octos-agent/src/tools/write_file.rs
+++ b/crates/octos-agent/src/tools/write_file.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
-use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 use tracing::warn;
 
@@ -113,14 +112,17 @@ impl Tool for WriteFileTool {
 
         // Phase 2-C of the SessionScope migration: when the host has
         // threaded a scope through `ToolContext`, use it as the single
-        // source of truth for base_dir + path classification. WRITES are
-        // permitted only for `InWorkspace` and `InGrantedDir`;
-        // `InSharedZone` and `OutOfScope` are refused. This also fixes
-        // the path asymmetry that #1189 worked around: write_file now
-        // writes under `scope.workspace()` — the same directory that
-        // plugin tools run in — instead of the bespoke `base_dir`.
+        // source of truth for base_dir + path classification. WRITES
+        // are permitted only for `InWorkspace` and `InGrantedDir`;
+        // `InSharedZone` and `OutOfScope` are refused. The shared
+        // helper canonicalizes the candidate before classification so
+        // ancestor symlinks can't smuggle a write out of the workspace
+        // (`O_NOFOLLOW` only protects the final component). This also
+        // fixes the path asymmetry that #1189 worked around:
+        // write_file now writes under `scope.workspace()` — the same
+        // directory plugin tools run in.
         let path = match ctx.session_scope.as_ref() {
-            Some(scope) => match resolve_with_scope_for_write(scope, &input.path) {
+            Some(scope) => match super::resolve_path_for_session_scope_write(scope, &input.path) {
                 Ok(p) => p,
                 Err(reason) => {
                     return Ok(ToolResult {
@@ -182,29 +184,6 @@ impl Tool for WriteFileTool {
             file_modified: Some(path),
             ..Default::default()
         })
-    }
-}
-
-/// Resolve a user-supplied path against a [`SessionScope`] for a WRITE
-/// operation. Relative paths anchor at `scope.workspace()`; absolute
-/// paths are accepted but must classify into one of the write-allowed
-/// zones (`InWorkspace`, `InGrantedDir`). `InSharedZone` and
-/// `OutOfScope` are refused — shared zones are managed by maintenance
-/// paths, not session workers.
-fn resolve_with_scope_for_write(
-    scope: &SessionScope,
-    user_path: &str,
-) -> Result<PathBuf, &'static str> {
-    let candidate = PathBuf::from(user_path);
-    let absolute = if candidate.is_absolute() {
-        candidate
-    } else {
-        scope.workspace().join(candidate)
-    };
-    match scope.classify_lexical_path(&absolute) {
-        PathClassification::InWorkspace | PathClassification::InGrantedDir { .. } => Ok(absolute),
-        PathClassification::InSharedZone { .. } => Err("Writes to shared zones are not permitted"),
-        PathClassification::OutOfScope => Err("Path outside session scope"),
     }
 }
 
@@ -310,6 +289,7 @@ mod tests {
     // Phase 2-C: SessionScope integration tests for WriteFileTool.
     // -----------------------------------------------------------------------
 
+    use octos_core::SessionScope;
     use std::sync::Arc;
 
     fn ctx_with_scope(scope: SessionScope) -> ToolContext {
@@ -437,6 +417,50 @@ mod tests {
             !shared_target.exists(),
             "refused write must NOT have created the file"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_file_refuses_ancestor_symlink_escape() {
+        // Per codex review of the Phase 2-C commit: without
+        // ancestor-symlink rejection, a write to `<workspace>/link/x`
+        // (where `link` is a symlink pointing outside the workspace)
+        // would land at the symlink target — `O_NOFOLLOW` only protects
+        // the final component. The shared canonicalizing classifier
+        // closes that hole.
+        use std::os::unix::fs::symlink;
+
+        let scope_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        let link_path = scope_dir.path().join("link");
+        symlink(outside_dir.path(), &link_path).unwrap();
+
+        let scope = SessionScope::solo(scope_dir.path().to_path_buf(), vec![]).unwrap();
+        let tool = WriteFileTool::new(scope_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "path": "link/leaked.txt",
+                    "content": "exfiltrated\n",
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !result.success,
+            "ancestor-symlink escape MUST be refused, got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection, got: {}",
+            result.output
+        );
+        // The escape file MUST NOT have been created at the symlink target.
+        assert!(!outside_dir.path().join("leaked.txt").exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Phase 2-C of the SessionScope migration plan (after Phase 1, PR #1199). Routes `read_file`, `write_file`, and `edit_file` through `ToolContext.session_scope` when present; falls back to the legacy per-tool resolver otherwise (backward compat for `octos chat` and any caller that hasn't been migrated yet).
- Closes the #1189 asymmetry: write_file relative paths now anchor at `scope.workspace()` — the same directory plugin tools run in — so a script the LLM writes and a plugin reads end up at the same place. No more bespoke \"probe one level up\" rescues.
- Tightens isolation in multi-tenant mode: writes to `InSharedZone` (research/, skills/) are refused. Reads into shared zones remain allowed (explicit-intent recall).

## Policy

| Tool | InWorkspace | InSharedZone | InGrantedDir | OutOfScope |
| --- | --- | --- | --- | --- |
| read_file | allow | allow | allow | refuse |
| write_file | allow | refuse | allow | refuse |
| edit_file | allow | refuse | allow | refuse |

Symlink safety is preserved: `O_NOFOLLOW` is still applied at the I/O layer (`read_no_follow` / `write_no_follow`). The new path classification is intentionally lexical-only; the OS-level fence remains the sandbox.

## Test plan

- [x] `cargo test -p octos-agent --lib tools::` — 568 pass (origin/main: 553; +15 new tests, 5 per tool)
- [x] `cargo test -p octos-agent --lib` — 1633 pass (origin/main: 1618)
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --lib -- -D warnings` — clean
- [ ] Codex review (running after PR is open; see comment to follow)

## Notes for reviewers

The scope-aware code path is gated on `ctx.session_scope.is_some()`. When `None`, the existing `resolve_path_with_scope(&base_dir, ...)` runs verbatim. So every legacy entry point (legacy `execute`, `ctx_with_cache`, etc.) keeps its existing behaviour byte-for-byte.

Phase 2-A (pipeline workers), 2-B (plugin tool), and 2-D (shell/spawn) are out of scope for this PR and continue on their own migration branches.