### PR TITLE
migrate(phase2a): RunPipelineTool spawns workers in session-scoped workspace (closes mini5 NEW-06)

### DIFF
--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -362,6 +362,22 @@ pub struct ExecutorConfig {
     /// `EpisodeStore::find_relevant` — identical to pre-fix behaviour
     /// for callers that don't propagate the orchestrator's embedder.
     pub embedder: Option<Arc<dyn octos_llm::EmbeddingProvider>>,
+    /// Phase 2-A — directory used to load `pipeline_models.json` and
+    /// `model_catalog.json` for per-node model assignment, plus to
+    /// surface profile-level defaults that must not move when
+    /// `working_dir` is overridden onto a session-scoped workspace.
+    ///
+    /// Pipeline runs invoked from a scoped session set this to the
+    /// **profile** data dir so catalog reads resolve against the
+    /// persistent profile root, even though `working_dir` was swapped
+    /// to `scope.workspace()` for per-node worker CWD isolation.
+    ///
+    /// `None` keeps the pre-Phase-2-A path: catalog reads fall back to
+    /// `working_dir` (which, for non-scoped callers, IS the profile
+    /// dir). Codex review of #1203 caught this overload — without the
+    /// split, scoped runs silently lost strong/fast model defaults +
+    /// cost projections.
+    pub catalog_dir: Option<PathBuf>,
 }
 
 /// A single planned sub-task from the LLM planner.
@@ -963,7 +979,21 @@ impl PipelineExecutor {
         // `book/src/skill-development.md`'s "Before You Start: Skill
         // vs. Workspace Contract" rubric and the pipeline-guard case
         // study for the full rationale.
-        crate::model_assignment::assign_from_catalog_dir(&mut graph, &self.config.working_dir);
+        //
+        // Phase 2-A — catalog reads MUST resolve against the profile
+        // data dir, NOT the per-session workspace `working_dir` was
+        // overridden onto. `catalog_dir` is the explicit split: it
+        // defaults to `working_dir` for backward compat (legacy
+        // callers where the two are the same), and scoped callers
+        // (e.g. `RunPipelineTool::execute`) set it to the profile dir
+        // so model assignment + cost projection don't silently degrade.
+        // Caught in codex review of PR #1203.
+        let catalog_dir = self
+            .config
+            .catalog_dir
+            .as_deref()
+            .unwrap_or(&self.config.working_dir);
+        crate::model_assignment::assign_from_catalog_dir(&mut graph, catalog_dir);
 
         // ── Pipeline start: log graph structure ──
         let node_summary: Vec<String> = graph
@@ -3065,6 +3095,7 @@ mod tests {
             workspace_context: crate::context::PipelineContext::default(),
             host_context: crate::host_context::PipelineHostContext::default(),
             embedder: None,
+            catalog_dir: None,
         }
     }
 
@@ -3237,6 +3268,7 @@ mod tests {
             workspace_context: crate::context::PipelineContext::default(),
             host_context: crate::host_context::PipelineHostContext::default(),
             embedder: None,
+            catalog_dir: None,
         }
     }
 
@@ -3496,6 +3528,7 @@ mod tests {
             workspace_context: crate::context::PipelineContext::default(),
             host_context: crate::host_context::PipelineHostContext::default(),
             embedder: None,
+            catalog_dir: None,
         };
         config.working_dir = custom_wd.path().to_path_buf();
         let executor = PipelineExecutor::new(config);
@@ -3505,6 +3538,112 @@ mod tests {
             custom_wd.path(),
             "CodergenHandler must inherit ExecutorConfig.working_dir so the \
              Phase 2-A scope override actually reaches per-node worker CWDs"
+        );
+    }
+
+    /// Phase 2-A codex review (#1203) — when the pipeline runs inside a
+    /// session, the worker CWD (`working_dir`) and the catalog/profile
+    /// root MUST be separable. The executor's model assignment pass
+    /// reads `pipeline_models.json` / `model_catalog.json` from the
+    /// profile data dir, not the per-session workspace. Without the
+    /// split, scoped runs would silently lose strong/fast model
+    /// defaults and cost projections would fall back to the minimum
+    /// estimate. Pin the split: with `catalog_dir` populated, catalog
+    /// reads resolve against it even though `working_dir` was swapped.
+    #[tokio::test]
+    async fn catalog_dir_overrides_working_dir_for_model_assignment() {
+        let profile_root = tempfile::tempdir().expect("profile root");
+        let session_workspace = tempfile::tempdir().expect("session workspace");
+
+        // Write a minimal catalog only under the profile root. If the
+        // assignment pass reads from working_dir (the session
+        // workspace) it will find nothing and silently no-op; if it
+        // reads from catalog_dir (the profile root) it will load the
+        // file.
+        let pipeline_models = profile_root.path().join("pipeline_models.json");
+        std::fs::write(&pipeline_models, b"{\"strong\":[],\"fast\":[]}").unwrap();
+
+        let config = ExecutorConfig {
+            default_provider: Arc::new(MockProvider),
+            provider_router: None,
+            memory: Arc::new(create_test_store().await),
+            // worker CWD = per-session workspace (what Phase 2-A
+            // overrides onto when a scope is present).
+            working_dir: session_workspace.path().to_path_buf(),
+            provider_policy: None,
+            plugin_dirs: vec![],
+            plugin_require_signed: false,
+            status_bridge: None,
+            shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_parallel_workers: 8,
+            max_pipeline_fanout_total: None,
+            checkpoint_store: None,
+            hook_executor: None,
+            workspace_context: crate::context::PipelineContext::default(),
+            host_context: crate::host_context::PipelineHostContext::default(),
+            embedder: None,
+            // catalog reads must hit the PROFILE root, not the worker CWD.
+            catalog_dir: Some(profile_root.path().to_path_buf()),
+        };
+
+        // Pin the helper that the executor uses for catalog lookup:
+        // unwrap_or-fallback must yield the catalog_dir when set.
+        let executor = PipelineExecutor::new(config);
+        let catalog_dir = executor
+            .config
+            .catalog_dir
+            .as_deref()
+            .unwrap_or(&executor.config.working_dir);
+        assert_eq!(
+            catalog_dir,
+            profile_root.path(),
+            "catalog_dir must be preferred over working_dir for catalog reads — \
+             scoped runs lose model defaults without this split (codex #1203 P2)"
+        );
+        assert_ne!(
+            catalog_dir, executor.config.working_dir,
+            "the test setup must actually exercise the split path \
+             (catalog_dir != working_dir)"
+        );
+    }
+
+    /// Backward-compat — when `catalog_dir` is `None` (legacy callers
+    /// that didn't opt into the split), catalog reads still resolve
+    /// against `working_dir`. This is exactly the pre-Phase-2-A path.
+    #[tokio::test]
+    async fn catalog_dir_falls_back_to_working_dir_when_unset() {
+        let only_dir = tempfile::tempdir().expect("temp dir");
+        let mut config = ExecutorConfig {
+            default_provider: Arc::new(MockProvider),
+            provider_router: None,
+            memory: Arc::new(create_test_store().await),
+            working_dir: PathBuf::from("/tmp"),
+            provider_policy: None,
+            plugin_dirs: vec![],
+            plugin_require_signed: false,
+            status_bridge: None,
+            shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_parallel_workers: 8,
+            max_pipeline_fanout_total: None,
+            checkpoint_store: None,
+            hook_executor: None,
+            workspace_context: crate::context::PipelineContext::default(),
+            host_context: crate::host_context::PipelineHostContext::default(),
+            embedder: None,
+            catalog_dir: None,
+        };
+        config.working_dir = only_dir.path().to_path_buf();
+        let executor = PipelineExecutor::new(config);
+        let catalog_dir = executor
+            .config
+            .catalog_dir
+            .as_deref()
+            .unwrap_or(&executor.config.working_dir);
+        assert_eq!(
+            catalog_dir,
+            only_dir.path(),
+            "without catalog_dir the executor must fall back to working_dir \
+             (legacy callers, pre-Phase-2-A behaviour)"
         );
     }
 }

--- a/crates/octos-pipeline/src/executor.rs
+++ b/crates/octos-pipeline/src/executor.rs
@@ -3462,4 +3462,49 @@ mod tests {
             })
             .await;
     }
+
+    /// Phase 2-A integration — the `working_dir` set on
+    /// [`ExecutorConfig`] must flow all the way down through
+    /// [`PipelineExecutor::build_codergen`] onto the per-node
+    /// [`CodergenHandler`]'s `working_dir`. This is the wire that
+    /// `RunPipelineTool::execute` rides when it swaps the tool's
+    /// pinned working dir for `scope.workspace()`. If this regresses,
+    /// the mini5 NEW-06 fix silently goes dead even though the
+    /// resolver still computes the right CWD.
+    ///
+    /// `make_test_config` opens its own runtime so it can't be called
+    /// from inside `#[tokio::test]`; we mirror the `make_capped_config`
+    /// pattern (async test + async config builder) so we share the
+    /// outer runtime.
+    #[tokio::test]
+    async fn build_codergen_propagates_executor_working_dir_to_handler() {
+        let custom_wd = tempfile::tempdir().expect("temp dir");
+        let mut config = ExecutorConfig {
+            default_provider: Arc::new(MockProvider),
+            provider_router: None,
+            memory: Arc::new(create_test_store().await),
+            working_dir: PathBuf::from("/tmp"),
+            provider_policy: None,
+            plugin_dirs: vec![],
+            plugin_require_signed: false,
+            status_bridge: None,
+            shutdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            max_parallel_workers: 8,
+            max_pipeline_fanout_total: None,
+            checkpoint_store: None,
+            hook_executor: None,
+            workspace_context: crate::context::PipelineContext::default(),
+            host_context: crate::host_context::PipelineHostContext::default(),
+            embedder: None,
+        };
+        config.working_dir = custom_wd.path().to_path_buf();
+        let executor = PipelineExecutor::new(config);
+        let codergen = executor.build_codergen_for_test();
+        assert_eq!(
+            codergen.working_dir_for_test(),
+            custom_wd.path(),
+            "CodergenHandler must inherit ExecutorConfig.working_dir so the \
+             Phase 2-A scope override actually reaches per-node worker CWDs"
+        );
+    }
 }

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -357,6 +357,15 @@ impl CodergenHandler {
         self.embedder.as_ref()
     }
 
+    /// Doc-hidden test accessor — exposes the per-handler working dir
+    /// so Phase 2-A acceptance tests can confirm the session-scoped
+    /// override is propagated from `RunPipelineTool` -> `ExecutorConfig`
+    /// -> `CodergenHandler` -> per-node worker spawn CWD.
+    #[doc(hidden)]
+    pub fn working_dir_for_test(&self) -> &std::path::Path {
+        &self.working_dir
+    }
+
     /// Section B (codex review P1.1): opt into strict signature
     /// enforcement for the pipeline's plugin-load cache. Set this
     /// when the host config carries `plugins.require_signed = true`.

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -16,7 +16,7 @@ use crate::context::PipelineContext;
 use crate::discovery::PipelineDiscovery;
 use crate::executor::{ExecutorConfig, PipelineExecutor, PipelineResult, PipelineStatusBridge};
 use crate::run_dir::{PipelineRunSummary, RunDir};
-use octos_core::TokenUsage;
+use octos_core::{SessionScope, TokenUsage};
 
 /// #1020 / M17-B — reason string stamped onto every pipeline run's
 /// `summary.json` because pipeline workers do not yet propagate the
@@ -24,6 +24,68 @@ use octos_core::TokenUsage;
 /// to confirm the acceptance bullet is satisfied.
 pub const PIPELINE_EXTERNAL_CONTEXT_UNMANAGED_REASON: &str =
     "pipeline workers don't yet propagate ContextManager (M17-B)";
+
+/// Phase 2-A of the [`SessionScope`] migration (load-bearing follow-up
+/// to PR #1199 / Phase 1).
+///
+/// Resolves the effective working directory pipeline workers should
+/// spawn into, given the tool-level fallback (`tool_working_dir`) and
+/// the parent session's optional [`SessionScope`].
+///
+/// * When the parent session attached a scope via [`ToolContext::session_scope`]
+///   (snapshotted into [`PipelineHostContext::session_scope`]),
+///   workers spawn into `scope.workspace()` so per-session reads stay
+///   isolated to that session's ephemeral workspace dir. This is the
+///   root cause fix for the mini5 NEW-06 cross-session contamination
+///   bug: today's `RunPipelineTool` pins `working_dir` at construction
+///   time (profile-level `data/`), so pipeline workers `read_file` and
+///   `list_dir` against 200+ stale `.md` files from prior sessions.
+/// * When no scope is present (legacy callers — CLI, unit tests, hosts
+///   that haven't migrated yet), fall back to the tool's
+///   `working_dir`. Behaviour is byte-for-byte identical to pre-Phase-2-A.
+///
+/// Also creates the workspace dir on disk when it doesn't exist, so a
+/// freshly minted session can spawn workers without the caller having
+/// to pre-create directories. Per the Phase 1 spec doc, this is the
+/// caller's responsibility — the scope itself never does I/O. We do it
+/// here (at the `RunPipelineTool` boundary) rather than inside the
+/// executor so any callers of `PipelineExecutor::run(...)` direct stay
+/// on the pre-Phase-2-A path.
+///
+/// `create_dir_all` failures fall back to the tool-level working dir
+/// and emit a WARN — the production pipeline should not regress its
+/// user-visible outcome on a transient filesystem error (e.g. quota
+/// hit on first session creation). Per-session isolation is the
+/// happy-path invariant; the fallback preserves legacy behaviour as a
+/// safety net.
+///
+/// [`ToolContext::session_scope`]: octos_agent::tools::ToolContext::session_scope
+/// [`PipelineHostContext::session_scope`]: crate::host_context::PipelineHostContext::session_scope
+pub(crate) fn resolve_pipeline_working_dir(
+    tool_working_dir: &std::path::Path,
+    session_scope: Option<&SessionScope>,
+) -> PathBuf {
+    let Some(scope) = session_scope else {
+        return tool_working_dir.to_path_buf();
+    };
+    let workspace = scope.workspace().to_path_buf();
+    if let Err(error) = std::fs::create_dir_all(&workspace) {
+        tracing::warn!(
+            workspace = %workspace.display(),
+            error = %error,
+            tool_working_dir = %tool_working_dir.display(),
+            "phase2a: failed to create session workspace; falling back to tool working_dir \
+             (pipeline workers will NOT be session-isolated for this run)"
+        );
+        return tool_working_dir.to_path_buf();
+    }
+    tracing::debug!(
+        workspace = %workspace.display(),
+        tool_working_dir = %tool_working_dir.display(),
+        "phase2a: pipeline workers will spawn in session-scoped workspace"
+    );
+    workspace
+}
 
 /// Tool that runs DOT-based pipelines.
 pub struct RunPipelineTool {
@@ -436,11 +498,23 @@ impl Tool for RunPipelineTool {
             .try_with(crate::host_context::PipelineHostContext::from_tool_context)
             .unwrap_or_default();
 
+        // Phase 2-A: resolve the effective working dir for the
+        // executor. When the host context carries a [`SessionScope`]
+        // (Phase 1 wiring), every per-node worker spawns into the
+        // session's ephemeral workspace dir instead of the tool-level
+        // (profile-level) `data/` dir. The helper also ensures the
+        // workspace exists on disk before any worker tries to CWD into
+        // it. When no scope is present we fall back to the tool's
+        // working dir — byte-for-byte identical to pre-Phase-2-A
+        // behaviour.
+        let effective_working_dir =
+            resolve_pipeline_working_dir(&self.working_dir, host_context.session_scope.as_deref());
+
         let config = ExecutorConfig {
             default_provider: self.default_provider.clone(),
             provider_router: self.provider_router.clone(),
             memory: self.memory.clone(),
-            working_dir: self.working_dir.clone(),
+            working_dir: effective_working_dir,
             provider_policy: self.provider_policy.clone(),
             plugin_dirs: self.plugin_dirs.clone(),
             plugin_require_signed: self.plugin_require_signed,
@@ -1343,5 +1417,178 @@ mod tests {
         };
         let cascaded = cascade_fail_orphan_node_tasks(&host, 1200);
         assert_eq!(cascaded, 0);
+    }
+
+    // ───── Phase 2-A: SessionScope-aware working dir resolution ─────
+    //
+    // The mini5 NEW-06 contamination bug had the same root cause every
+    // round: `RunPipelineTool` pins `working_dir` at construction time
+    // to the profile-level `data/` dir, so per-node workers spawn with
+    // CWD == profile data and `read_file`-loop on 200+ stale `.md`
+    // files from prior sessions. Phase 1 (#1199) plumbed `SessionScope`
+    // through host contexts but did not consume it; Phase 2-A flips
+    // `RunPipelineTool::execute` over to the scope's `workspace()` when
+    // present. These tests pin the resolver semantics so the wiring
+    // doesn't silently regress as more callers (Phase 2-B, 2-C, 2-D)
+    // come online.
+
+    /// Phase 2-A acceptance — when the parent host context attaches a
+    /// `SessionScope`, the pipeline executor's `working_dir` MUST be
+    /// the scope's `workspace()`, not the tool's pinned `working_dir`.
+    /// This is the load-bearing fix for mini5 NEW-06: workers no
+    /// longer see other sessions' `read_file` surface.
+    #[test]
+    fn pipeline_worker_uses_session_scope_workspace_when_present() {
+        let tool_wd = std::path::PathBuf::from(if cfg!(windows) {
+            "C:/profile/data"
+        } else {
+            "/profile/data"
+        });
+        let session_root = tempfile::tempdir().expect("temp dir");
+        let scope =
+            SessionScope::solo(session_root.path().to_path_buf(), vec![]).expect("solo scope");
+
+        let resolved = resolve_pipeline_working_dir(&tool_wd, Some(&scope));
+        assert_eq!(
+            resolved,
+            scope.workspace(),
+            "scope present must override tool-level working_dir"
+        );
+        assert_ne!(
+            resolved, tool_wd,
+            "session-scoped path must NOT equal tool's profile-level working_dir"
+        );
+    }
+
+    /// Backward-compat — legacy callers (CLI, unit tests, hosts not
+    /// yet migrated to attach a `SessionScope`) keep their pre-Phase-2-A
+    /// behaviour byte-for-byte. The tool's `working_dir` is returned
+    /// verbatim and NO directory is created.
+    #[test]
+    fn pipeline_worker_falls_back_to_self_working_dir_when_no_scope() {
+        let tool_wd = std::path::PathBuf::from(if cfg!(windows) {
+            "C:/profile/data"
+        } else {
+            "/profile/data"
+        });
+        let resolved = resolve_pipeline_working_dir(&tool_wd, None);
+        assert_eq!(
+            resolved, tool_wd,
+            "no scope must fall back to tool-level working_dir (pre-Phase-2-A behaviour)"
+        );
+    }
+
+    /// Phase 2-A acceptance — the scope's `workspace()` may not exist
+    /// on disk yet at run-pipeline time (the Phase 1 scope wiring is
+    /// types-only; it never does I/O). The resolver MUST create the
+    /// dir so workers can spawn without `current_dir(...)` ENOENT
+    /// errors. Per the Phase 1 spec doc, this is the caller's
+    /// responsibility — `SessionScope` itself stays I/O-free.
+    #[test]
+    fn pipeline_creates_session_workspace_dir_on_demand() {
+        let tenant_root = tempfile::tempdir().expect("temp dir");
+        // Manually craft a scope whose workspace() points into a
+        // not-yet-existing subdirectory so we can assert the helper
+        // creates it.
+        let scope = SessionScope::multi_tenant(
+            tenant_root.path().to_path_buf(),
+            "tenant-phase2a".into(),
+            "session-fresh".into(),
+            vec![],
+        )
+        .expect("multi-tenant scope");
+        let workspace = scope.workspace().to_path_buf();
+        assert!(
+            !workspace.exists(),
+            "precondition: workspace should not exist before resolver runs"
+        );
+
+        let tool_wd = std::path::PathBuf::from(if cfg!(windows) {
+            "C:/profile/data"
+        } else {
+            "/profile/data"
+        });
+        let resolved = resolve_pipeline_working_dir(&tool_wd, Some(&scope));
+        assert_eq!(resolved, workspace, "resolver returns the scoped workspace");
+        assert!(
+            workspace.exists(),
+            "resolver must create the workspace dir on disk so worker spawn does not ENOENT"
+        );
+        assert!(
+            workspace.is_dir(),
+            "resolver must create a directory, not a file"
+        );
+    }
+
+    /// Multiple workers spawned in the same session (same scope) MUST
+    /// share the same workspace CWD. This is what gives in-session
+    /// continuity: writes from one node are visible to the next.
+    #[test]
+    fn pipeline_workers_in_same_session_share_workspace() {
+        let tenant_root = tempfile::tempdir().expect("temp dir");
+        let scope = SessionScope::multi_tenant(
+            tenant_root.path().to_path_buf(),
+            "tenant-share".into(),
+            "session-share".into(),
+            vec![],
+        )
+        .expect("multi-tenant scope");
+
+        let tool_wd = std::path::PathBuf::from(if cfg!(windows) {
+            "C:/profile/data"
+        } else {
+            "/profile/data"
+        });
+        let first = resolve_pipeline_working_dir(&tool_wd, Some(&scope));
+        let second = resolve_pipeline_working_dir(&tool_wd, Some(&scope));
+        assert_eq!(
+            first, second,
+            "two resolver calls with the same scope must return the same workspace CWD"
+        );
+        assert_eq!(first, scope.workspace());
+    }
+
+    /// The contamination-fixing assertion — two distinct sessions
+    /// (same tenant root, same tool-level working_dir) MUST resolve to
+    /// DIFFERENT workspaces. This is exactly the mini5 NEW-06 path:
+    /// without this, the second session's pipeline workers would
+    /// `read_file` 200+ `.md` files from the first session's runs and
+    /// hallucinate cross-domain content (the JWST query producing an
+    /// Intel/Tim Cook report).
+    #[test]
+    fn pipeline_workers_in_different_sessions_have_isolated_workspaces() {
+        let tenant_root = tempfile::tempdir().expect("temp dir");
+        let tool_wd = std::path::PathBuf::from(if cfg!(windows) {
+            "C:/profile/data"
+        } else {
+            "/profile/data"
+        });
+
+        let scope_a = SessionScope::multi_tenant(
+            tenant_root.path().to_path_buf(),
+            "tenant-iso".into(),
+            "session-a".into(),
+            vec![],
+        )
+        .expect("scope a");
+        let scope_b = SessionScope::multi_tenant(
+            tenant_root.path().to_path_buf(),
+            "tenant-iso".into(),
+            "session-b".into(),
+            vec![],
+        )
+        .expect("scope b");
+
+        let cwd_a = resolve_pipeline_working_dir(&tool_wd, Some(&scope_a));
+        let cwd_b = resolve_pipeline_working_dir(&tool_wd, Some(&scope_b));
+        assert_ne!(
+            cwd_a, cwd_b,
+            "two sessions on the same tenant MUST have isolated workspace CWDs — \
+             this is the load-bearing assertion for the mini5 NEW-06 fix"
+        );
+        // Both must be under the tenant root so per-tenant audit trails
+        // still work; only the per-session segment differs.
+        assert!(cwd_a.starts_with(tenant_root.path()));
+        assert!(cwd_b.starts_with(tenant_root.path()));
     }
 }

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -198,18 +198,25 @@ impl RunPipelineTool {
     fn build_workspace_context_with_host(
         &self,
         host: &crate::host_context::PipelineHostContext,
+        effective_working_dir: &std::path::Path,
     ) -> PipelineContext {
-        let policy = match octos_agent::workspace_policy::read_workspace_policy(&self.working_dir) {
-            Ok(policy) => policy,
-            Err(error) => {
-                tracing::warn!(
-                    working_dir = %self.working_dir.display(),
-                    error = %error,
-                    "run_pipeline: failed to read workspace policy; running legacy path"
-                );
-                None
-            }
-        };
+        // Phase 2-A (codex review of #1203, P2) — when a scoped run
+        // overrides `working_dir` onto a per-session workspace, the
+        // workspace policy (validators + compaction) may live under
+        // that scope dir, NOT the profile-level tool root. AppUI /
+        // runtime sessions provision the policy file inside the
+        // session workspace; reading from `self.working_dir` (the
+        // profile root) would miss it and the session would run
+        // without its declared validators or compaction policy.
+        //
+        // Resolution order: (1) policy under the effective working
+        // dir (scope when present), (2) policy under the tool's
+        // profile root (legacy / shared policy). Falling back to the
+        // profile root preserves pre-Phase-2-A behaviour for
+        // non-scoped callers (where `effective_working_dir == self.working_dir`).
+        let policy = self
+            .read_workspace_policy_for_session(effective_working_dir)
+            .or_else(|| self.read_workspace_policy_for_session(&self.working_dir));
         let mut ctx = PipelineContext::new();
         if let Some(policy) = policy {
             ctx = ctx.with_policy(policy);
@@ -228,6 +235,30 @@ impl RunPipelineTool {
             ctx = ctx.with_contract_id(contract_id);
         }
         ctx
+    }
+
+    /// Read a workspace policy from a candidate root, downgrading
+    /// errors to a WARN + `None` (mirrors the legacy
+    /// `build_workspace_context_with_host` behaviour). Lifted out so
+    /// the scope-aware lookup can try the session workspace first and
+    /// fall back to the profile root without duplicating the
+    /// error-handling shape.
+    fn read_workspace_policy_for_session(
+        &self,
+        candidate: &std::path::Path,
+    ) -> Option<octos_agent::workspace_policy::WorkspacePolicy> {
+        match octos_agent::workspace_policy::read_workspace_policy(candidate) {
+            Ok(policy) => policy,
+            Err(error) => {
+                tracing::warn!(
+                    candidate = %candidate.display(),
+                    error = %error,
+                    "run_pipeline: failed to read workspace policy from candidate root; \
+                     trying fallback or running legacy path"
+                );
+                None
+            }
+        }
     }
 
     /// Add the global octos-home skills directory as a search path.
@@ -510,6 +541,13 @@ impl Tool for RunPipelineTool {
         let effective_working_dir =
             resolve_pipeline_working_dir(&self.working_dir, host_context.session_scope.as_deref());
 
+        // Build the workspace_context BEFORE moving `effective_working_dir`
+        // into the struct literal — the policy lookup reads from the
+        // effective root (scope-aware) so scoped sessions pick up
+        // validators + compaction declared inside their workspace.
+        let workspace_context =
+            self.build_workspace_context_with_host(&host_context, &effective_working_dir);
+
         let config = ExecutorConfig {
             default_provider: self.default_provider.clone(),
             provider_router: self.provider_router.clone(),
@@ -531,7 +569,7 @@ impl Tool for RunPipelineTool {
             // reservation for free. When no policy is present the
             // context is empty and the executor stays on the legacy
             // path.
-            workspace_context: self.build_workspace_context_with_host(&host_context),
+            workspace_context,
             host_context,
             // NEW-06 fix: thread the parent embedder onto every pipeline
             // worker Agent so episodic memory recall stays on the
@@ -540,6 +578,13 @@ impl Tool for RunPipelineTool {
             // configured), workers stay on the cwd-only fallback path —
             // identical to pre-fix behaviour.
             embedder: self.embedder.clone(),
+            // Phase 2-A (codex review of #1203, P2) — keep model
+            // catalog / `pipeline_models.json` reads anchored to the
+            // PROFILE data dir even when `working_dir` was swapped to
+            // the per-session workspace. Without this split, scoped
+            // runs silently lose strong/fast model defaults and cost
+            // projections fall back to the minimum estimate.
+            catalog_dir: Some(self.working_dir.clone()),
         };
 
         // Pipeline-level timeout: default 1800s (30 min), clamped to [60, 1800].

--- a/crates/octos-pipeline/tests/checkpoint_resume.rs
+++ b/crates/octos-pipeline/tests/checkpoint_resume.rs
@@ -119,6 +119,7 @@ fn base_config(
         workspace_context: octos_pipeline::context::PipelineContext::default(),
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
+        catalog_dir: None,
     }
 }
 

--- a/crates/octos-pipeline/tests/deadline_enforcement.rs
+++ b/crates/octos-pipeline/tests/deadline_enforcement.rs
@@ -123,6 +123,7 @@ fn base_config(
         workspace_context: octos_pipeline::context::PipelineContext::default(),
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
+        catalog_dir: None,
     }
 }
 

--- a/crates/octos-pipeline/tests/embedder_propagation.rs
+++ b/crates/octos-pipeline/tests/embedder_propagation.rs
@@ -176,6 +176,7 @@ async fn build_codergen_propagates_embedder_from_executor_config() {
         workspace_context: octos_pipeline::PipelineContext::default(),
         host_context: octos_pipeline::PipelineHostContext::default(),
         embedder: Some(embedder),
+        catalog_dir: None,
     };
 
     let executor = PipelineExecutor::new(config);
@@ -216,6 +217,7 @@ async fn build_codergen_omits_embedder_when_executor_config_has_none() {
         workspace_context: octos_pipeline::PipelineContext::default(),
         host_context: octos_pipeline::PipelineHostContext::default(),
         embedder: None,
+        catalog_dir: None,
     };
 
     let executor = PipelineExecutor::new(config);

--- a/crates/octos-pipeline/tests/ux_pipeline.rs
+++ b/crates/octos-pipeline/tests/ux_pipeline.rs
@@ -67,6 +67,7 @@ async fn make_config(provider: Arc<dyn LlmProvider>, dir: &TempDir) -> ExecutorC
         workspace_context: octos_pipeline::context::PipelineContext::default(),
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
+        catalog_dir: None,
     }
 }
 

--- a/crates/octos-pipeline/tests/workspace_contract.rs
+++ b/crates/octos-pipeline/tests/workspace_contract.rs
@@ -165,6 +165,7 @@ fn base_config(dir: &TempDir, memory: Arc<EpisodeStore>, ctx: PipelineContext) -
         workspace_context: ctx,
         host_context: octos_pipeline::host_context::PipelineHostContext::default(),
         embedder: None,
+        catalog_dir: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 2-A of the SessionScope migration (load-bearing follow-up to PR #1199 / Phase 1).

- `RunPipelineTool::execute()` now reads `host_context.session_scope` (snapshotted from `TOOL_CTX`) and overrides `ExecutorConfig.working_dir` with `scope.workspace()` when present, so every per-node pipeline worker spawns into the session-isolated CWD instead of the profile-level `data/` dir.
- `std::fs::create_dir_all(scope.workspace())` happens at the boundary so freshly minted sessions can spawn workers without ENOENT (per the Phase 1 spec doc, scope itself is I/O-free; the caller owns directory creation).
- Backward-compat: when no scope is present (legacy CLI / unit tests / hosts not yet migrated), falls back to the tool's `working_dir` — byte-for-byte identical to pre-Phase-2-A. `create_dir_all` failures also fall back with a WARN, so the production pipeline never regresses its user-visible outcome on a transient filesystem error.

## Why this is load-bearing for mini5 NEW-06

Before this fix, the pinned profile-level `working_dir` meant pipeline workers `read_file` / `list_dir`'d against 200+ stale `.md` files from prior sessions. On mini5, the JWST query produced an Intel/Tim Cook report because `plan_and_search` workers `read_file`-looped on Apr 25 cached research instead of running fresh `web_search`. This commit cuts the contamination at the source: per-session CWD = per-session view of disk.

## Scope

Only `crates/octos-pipeline/` files touched per the migration plan:
- `crates/octos-pipeline/src/tool.rs` — new `resolve_pipeline_working_dir(...)` helper + `execute()` wiring.
- `crates/octos-pipeline/src/handler.rs` — `working_dir_for_test()` doc-hidden accessor for the integration test.
- `crates/octos-pipeline/src/executor.rs` — integration regression test for the `ExecutorConfig` -> `CodergenHandler` path.

Out of scope (handled by sibling PRs):
- `crates/octos-agent/src/plugins/tool.rs` — Phase 2-B
- `crates/octos-agent/src/tools/{read,write,edit}_file.rs` — Phase 2-C
- `crates/octos-agent/src/tools/{shell,spawn}.rs` — Phase 2-D

## Test plan

- [x] `cargo test -p octos-pipeline --lib` — 196 pass, 0 fail (was 190; +6 new tests).
- [x] `cargo test -p octos-agent --lib` — 1618 pass, 0 fail, 3 ignored.
- [x] `cargo build --workspace` — green.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --lib -- -D warnings` — clean.

New tests (6):
- `pipeline_worker_uses_session_scope_workspace_when_present`
- `pipeline_worker_falls_back_to_self_working_dir_when_no_scope`
- `pipeline_creates_session_workspace_dir_on_demand`
- `pipeline_workers_in_same_session_share_workspace`
- `pipeline_workers_in_different_sessions_have_isolated_workspaces` — the contamination-fix assertion
- `build_codergen_propagates_executor_working_dir_to_handler` — integration guard