### PR TITLE
migrate(phase2d): shell + spawn tools use SessionScope for child CWD

### DIFF
--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -222,18 +222,28 @@ impl Tool for ShellTool {
             serde_json::from_value(args.clone()).wrap_err("invalid shell tool input")?;
 
         // Phase 2-D of the SessionScope migration: when the host has
-        // threaded a scope through `ToolContext`, use `scope.workspace()`
-        // as the child process CWD so every tool in the session shares
-        // the single filesystem contract. Without a scope (e.g.
-        // `octos chat`, unit tests, legacy callers) we keep the
-        // construction-time `self.cwd` byte-for-byte so behaviour is
-        // unchanged. The same effective CWD also feeds the
-        // `CommandPolicy::check` call so a policy that consults the
-        // working directory sees a consistent value with what the child
-        // process will observe.
+        // threaded a scope through `ToolContext`, prefer the scope's
+        // workspace so every tool in the session shares the single
+        // filesystem contract.
+        //
+        // Codex P1 (round-1, this PR): respect a hinted workspace
+        // override. `SessionRuntime` builds `session_scope` from
+        // `<data_dir>/users/<id>/workspace` independent of any
+        // `workspace_hint` supplied by the coding-agent flow, while
+        // the registry rebinds every tool's `cwd` to the *hinted*
+        // workspace via `with_workspace_root`. If `self.cwd` differs
+        // from `scope.workspace()`, the caller deliberately pointed
+        // this tool at a different workspace — honour that and keep
+        // `self.cwd`. Otherwise the migration is a no-op for the
+        // hinted-coding-agent path until Phase 3 reconciles
+        // SessionScope construction with the hinted workspace.
+        //
+        // The same effective CWD also feeds the `CommandPolicy::check`
+        // call so a policy that consults the working directory sees a
+        // consistent value with what the child process will observe.
         let effective_cwd: &Path = match ctx.session_scope.as_ref() {
-            Some(scope) => scope.workspace(),
-            None => &self.cwd,
+            Some(scope) if scope.workspace() == self.cwd.as_path() => scope.workspace(),
+            _ => &self.cwd,
         };
 
         // Check policy first
@@ -609,17 +619,23 @@ mod tests {
 
     #[tokio::test]
     async fn shell_uses_scope_workspace_when_present() {
-        // When the host has threaded a `SessionScope` onto `ToolContext`,
-        // the child process must run with CWD == `scope.workspace()` even
-        // though the `ShellTool` was constructed with a different
-        // legacy `cwd`. Without this the scope/no-scope sessions diverge
-        // and shell-spawned subprocesses can escape the session contract.
-        let scope_dir = tempfile::tempdir().unwrap();
-        let legacy_dir = tempfile::tempdir().unwrap();
+        // When the host has threaded a `SessionScope` onto `ToolContext`
+        // AND the scope's workspace matches the tool's construction-time
+        // `cwd` (the production wiring in
+        // `octos-cli/src/runtime/session.rs`: both derive from
+        // `<data_dir>/users/<id>/workspace`), the child process runs
+        // with CWD == `scope.workspace()`. This is the load-bearing
+        // case for multi-tenant SPA sessions.
+        let workspace = tempfile::tempdir().unwrap();
+        let canonical_workspace =
+            std::fs::canonicalize(workspace.path()).expect("canonicalise workspace");
 
-        let scope = octos_core::SessionScope::solo(scope_dir.path().to_path_buf(), vec![])
+        // Both scope and ShellTool are constructed with the same
+        // workspace (the production wiring), so the migration takes
+        // effect and the child process sees the scope workspace.
+        let scope = octos_core::SessionScope::solo(canonical_workspace.clone(), vec![])
             .expect("scope construction");
-        let tool = ShellTool::new(legacy_dir.path());
+        let tool = ShellTool::new(&canonical_workspace);
         let ctx = ctx_with_scope(scope);
 
         let result = tool
@@ -628,28 +644,64 @@ mod tests {
             .unwrap();
         assert!(result.success, "expected success, got: {}", result.output);
 
-        // The child process should report the scope workspace, not the
-        // legacy `ShellTool::new` CWD. Canonicalise both sides so the
-        // assertion is robust to /var → /private/var symlinks on macOS.
-        let canonical_scope =
-            std::fs::canonicalize(scope_dir.path()).expect("canonicalise scope dir");
-        let canonical_legacy =
-            std::fs::canonicalize(legacy_dir.path()).expect("canonicalise legacy dir");
-
         assert!(
             result
                 .output
-                .contains(&canonical_scope.to_string_lossy().to_string()),
+                .contains(&canonical_workspace.to_string_lossy().to_string()),
             "expected scope workspace ({}) in shell output, got: {}",
-            canonical_scope.display(),
+            canonical_workspace.display(),
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_respects_hinted_workspace_over_session_scope_default() {
+        // Codex P1 regression: when the registry's tools were rebound
+        // to a hinted workspace (`workspace_hint` flow,
+        // `with_workspace_root` in `runtime/session.rs`) but
+        // `SessionScope` was built from the canonical
+        // `<data_dir>/users/<id>/workspace` (i.e. NOT the hint), the
+        // shell tool must honour the hinted `self.cwd` rather than
+        // silently relocating the child process into the default
+        // data-dir workspace. Without this guard, coding-agent
+        // sessions would run builds/tests in the wrong directory.
+        let hinted = tempfile::tempdir().unwrap();
+        let default_scope_workspace = tempfile::tempdir().unwrap();
+        let canonical_hinted = std::fs::canonicalize(hinted.path()).expect("canonicalise hinted");
+        let canonical_default_scope = std::fs::canonicalize(default_scope_workspace.path())
+            .expect("canonicalise default scope workspace");
+        assert_ne!(canonical_hinted, canonical_default_scope);
+
+        let scope = octos_core::SessionScope::solo(canonical_default_scope.clone(), vec![])
+            .expect("scope construction");
+        // ShellTool is rebound to the HINTED workspace, while the
+        // scope still points at the default — exactly the M11
+        // workspace_hint code path.
+        let tool = ShellTool::new(&canonical_hinted);
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"command": PWD_COMMAND}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+
+        // The hinted workspace must win — pre-fix this would have
+        // contained the default scope workspace instead.
+        assert!(
+            result
+                .output
+                .contains(&canonical_hinted.to_string_lossy().to_string()),
+            "expected hinted workspace ({}) in shell output, got: {}",
+            canonical_hinted.display(),
             result.output
         );
         assert!(
             !result
                 .output
-                .contains(&canonical_legacy.to_string_lossy().to_string()),
-            "legacy cwd ({}) leaked into shell output: {}",
-            canonical_legacy.display(),
+                .contains(&canonical_default_scope.to_string_lossy().to_string()),
+            "default scope workspace ({}) leaked into shell output: {}",
+            canonical_default_scope.display(),
             result.output
         );
     }

--- a/crates/octos-agent/src/tools/shell.rs
+++ b/crates/octos-agent/src/tools/shell.rs
@@ -12,7 +12,7 @@ use tokio::time::timeout;
 
 use super::{
     ConcurrencyClass, TOOL_APPROVAL_CTX, TOOL_CTX, Tool, ToolApprovalDecision, ToolApprovalRequest,
-    ToolResult,
+    ToolContext, ToolResult,
 };
 use crate::policy::{ApprovalPolicy, CommandPolicy, Decision, SafePolicy};
 use crate::sandbox::{NoSandbox, Sandbox};
@@ -147,11 +147,16 @@ fn apply_git_tool_env(cmd: &mut tokio::process::Command, command: &str) {
     }
 }
 
-fn apply_harness_event_sink_env(cmd: &mut tokio::process::Command) {
-    if let Ok(ctx) = TOOL_CTX.try_with(|ctx| ctx.clone()) {
-        if let Some(sink) = ctx.harness_event_sink {
-            cmd.env("OCTOS_EVENT_SINK", sink);
-        }
+fn apply_harness_event_sink_env(cmd: &mut tokio::process::Command, ctx: &ToolContext) {
+    if let Some(sink) = ctx.harness_event_sink.as_deref() {
+        cmd.env("OCTOS_EVENT_SINK", sink);
+        return;
+    }
+    // Legacy callers that route through `execute()` pass `ToolContext::zero()` —
+    // the sink isn't on the typed context but may still live on the
+    // task-local `TOOL_CTX` that older executor paths populate.
+    if let Ok(Some(sink)) = TOOL_CTX.try_with(|inner| inner.harness_event_sink.clone()) {
+        cmd.env("OCTOS_EVENT_SINK", sink);
     }
 }
 
@@ -202,11 +207,37 @@ impl Tool for ShellTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // Legacy entry point: route through the typed path with a zero-value
+        // context so out-of-band callers (tests, `ToolRegistry::execute`)
+        // exercise the same Phase 2-D scope resolution as migrated callers.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: ShellInput =
             serde_json::from_value(args.clone()).wrap_err("invalid shell tool input")?;
 
+        // Phase 2-D of the SessionScope migration: when the host has
+        // threaded a scope through `ToolContext`, use `scope.workspace()`
+        // as the child process CWD so every tool in the session shares
+        // the single filesystem contract. Without a scope (e.g.
+        // `octos chat`, unit tests, legacy callers) we keep the
+        // construction-time `self.cwd` byte-for-byte so behaviour is
+        // unchanged. The same effective CWD also feeds the
+        // `CommandPolicy::check` call so a policy that consults the
+        // working directory sees a consistent value with what the child
+        // process will observe.
+        let effective_cwd: &Path = match ctx.session_scope.as_ref() {
+            Some(scope) => scope.workspace(),
+            None => &self.cwd,
+        };
+
         // Check policy first
-        let decision = self.policy.check(&input.command, &self.cwd);
+        let decision = self.policy.check(&input.command, effective_cwd);
         match decision {
             Decision::Deny => {
                 tracing::warn!(command = %input.command, "command denied by policy");
@@ -248,9 +279,13 @@ impl Tool for ShellTool {
                     });
                 };
 
-                let tool_id = TOOL_CTX
-                    .try_with(|ctx| ctx.tool_id.clone())
-                    .unwrap_or_default();
+                let tool_id = if ctx.tool_id.is_empty() {
+                    TOOL_CTX
+                        .try_with(|inner| inner.tool_id.clone())
+                        .unwrap_or_default()
+                } else {
+                    ctx.tool_id.clone()
+                };
                 let decision = requester
                     .request_approval(ToolApprovalRequest {
                         tool_id,
@@ -258,7 +293,7 @@ impl Tool for ShellTool {
                         title: "Approve shell command".to_owned(),
                         body: format!("Run command: {}", input.command),
                         command: Some(input.command.clone()),
-                        cwd: Some(self.cwd.to_string_lossy().into_owned()),
+                        cwd: Some(effective_cwd.to_string_lossy().into_owned()),
                     })
                     .await;
                 if matches!(decision, ToolApprovalDecision::Deny) {
@@ -285,12 +320,12 @@ impl Tool for ShellTool {
         // Spawn the child, grab its PID, then timeout on wait_with_output().
         // If timeout fires, kill by PID to prevent orphaned processes.
         // (wait_with_output() takes ownership of child, so we save the PID first.)
-        let mut cmd = self.sandbox.wrap_command(&input.command, &self.cwd);
+        let mut cmd = self.sandbox.wrap_command(&input.command, effective_cwd);
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-        apply_frontend_tool_env(&mut cmd, &self.cwd);
+        apply_frontend_tool_env(&mut cmd, effective_cwd);
         apply_git_tool_env(&mut cmd, &input.command);
         sanitize_command_env(&mut cmd, &EnvAllowlist::empty());
-        apply_harness_event_sink_env(&mut cmd);
+        apply_harness_event_sink_env(&mut cmd, ctx);
 
         let child = match cmd.spawn() {
             Ok(c) => c,
@@ -548,5 +583,128 @@ mod tests {
         assert!(contains_git_invocation("GIT_DIR=.git git status --short"));
         assert!(contains_git_invocation("env GIT_DIR=.git git status"));
         assert!(!contains_git_invocation("printf 'git diff -- notes.txt'"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2-D: SessionScope integration tests for ShellTool.
+    //
+    // The child process CWD is the load-bearing observable here — a shell
+    // command that runs `pwd` (or the `cd` cmd-builtin equivalent on
+    // Windows) must see `scope.workspace()` when the host has threaded a
+    // scope through `ToolContext`, and must see `self.cwd` (legacy
+    // behaviour) when the host has not.
+    // -----------------------------------------------------------------------
+
+    fn ctx_with_scope(scope: octos_core::SessionScope) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "shell-with-scope".to_string();
+        ctx.session_scope = Some(Arc::new(scope));
+        ctx
+    }
+
+    #[cfg(not(windows))]
+    const PWD_COMMAND: &str = "pwd";
+    #[cfg(windows)]
+    const PWD_COMMAND: &str = "cd";
+
+    #[tokio::test]
+    async fn shell_uses_scope_workspace_when_present() {
+        // When the host has threaded a `SessionScope` onto `ToolContext`,
+        // the child process must run with CWD == `scope.workspace()` even
+        // though the `ShellTool` was constructed with a different
+        // legacy `cwd`. Without this the scope/no-scope sessions diverge
+        // and shell-spawned subprocesses can escape the session contract.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let legacy_dir = tempfile::tempdir().unwrap();
+
+        let scope = octos_core::SessionScope::solo(scope_dir.path().to_path_buf(), vec![])
+            .expect("scope construction");
+        let tool = ShellTool::new(legacy_dir.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"command": PWD_COMMAND}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+
+        // The child process should report the scope workspace, not the
+        // legacy `ShellTool::new` CWD. Canonicalise both sides so the
+        // assertion is robust to /var → /private/var symlinks on macOS.
+        let canonical_scope =
+            std::fs::canonicalize(scope_dir.path()).expect("canonicalise scope dir");
+        let canonical_legacy =
+            std::fs::canonicalize(legacy_dir.path()).expect("canonicalise legacy dir");
+
+        assert!(
+            result
+                .output
+                .contains(&canonical_scope.to_string_lossy().to_string()),
+            "expected scope workspace ({}) in shell output, got: {}",
+            canonical_scope.display(),
+            result.output
+        );
+        assert!(
+            !result
+                .output
+                .contains(&canonical_legacy.to_string_lossy().to_string()),
+            "legacy cwd ({}) leaked into shell output: {}",
+            canonical_legacy.display(),
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_falls_back_to_self_cwd_when_no_scope() {
+        // No scope on the context — behaviour must match the pre-Phase-2D
+        // path (child process runs with CWD == construction-time
+        // `self.cwd`). Guards the legacy `octos chat` / test-harness
+        // codepath that never plumbs a `SessionScope`.
+        let legacy_dir = tempfile::tempdir().unwrap();
+        let tool = ShellTool::new(legacy_dir.path());
+        let ctx = ToolContext::zero();
+        assert!(ctx.session_scope.is_none());
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"command": PWD_COMMAND}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+
+        let canonical_legacy =
+            std::fs::canonicalize(legacy_dir.path()).expect("canonicalise legacy dir");
+        assert!(
+            result
+                .output
+                .contains(&canonical_legacy.to_string_lossy().to_string()),
+            "expected legacy cwd ({}) in shell output, got: {}",
+            canonical_legacy.display(),
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_safe_policy_still_denies_with_scope_present() {
+        // Codex-anticipated regression: a scope on the context must NOT
+        // weaken the `SafePolicy` denylist — `rm -rf /` is refused
+        // whether or not a scope is set. The CWD that the policy sees
+        // changes (it now sees the scope workspace), but the denylist is
+        // command-string only so the verdict is unchanged.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let scope = octos_core::SessionScope::solo(scope_dir.path().to_path_buf(), vec![])
+            .expect("scope construction");
+        let tool = ShellTool::new(std::env::temp_dir());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"command": "rm -rf /"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("denied"),
+            "expected deny, got: {}",
+            result.output
+        );
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2484,6 +2484,16 @@ impl Tool for SpawnTool {
                 // own spawn tool calls see the higher value and the
                 // [`MAX_SPAWN_DEPTH`] gate fires at the bounded limit.
                 .with_spawn_depth(ctx.spawn_depth.saturating_add(1));
+            // Phase 2-D of the SessionScope migration: propagate the
+            // parent's scope into the child Agent so the child's tools
+            // (shell, read_file, write_file, edit_file, plugin tool,
+            // pipeline workers) all see the same filesystem contract.
+            // The child runs in a sub-session of the same parent — for
+            // now it shares the parent's workspace; a future enhancement
+            // can carve out per-child subdirs if isolation is required.
+            if let Some(scope) = ctx.session_scope.as_ref() {
+                worker = worker.with_session_scope(scope.clone());
+            }
             // Keep an Arc handle to the child's tool registry so we can run
             // declared validators against it after `run_task` returns.
             let child_tools_handle = worker.tool_registry().clone();
@@ -2776,6 +2786,13 @@ impl Tool for SpawnTool {
             // `parent_depth + 1` and the [`MAX_SPAWN_DEPTH`] gate fires
             // after a bounded number of nests.
             let child_spawn_depth = ctx.spawn_depth.saturating_add(1);
+            // Phase 2-D of the SessionScope migration: snapshot the
+            // parent's scope before crossing into the detached
+            // `tokio::spawn` task. The background child shares the
+            // parent workspace — same contract as the sync branch above
+            // — so subprocesses spawned by the child's shell tool see
+            // the same CWD the foreground would.
+            let child_session_scope = ctx.session_scope.clone();
 
             tokio::spawn(async move {
                 if let (Some(supervisor), Some(task_id)) =
@@ -2899,6 +2916,13 @@ impl Tool for SpawnTool {
                     // nesting depth + 1 so the detached child sees the
                     // higher value when its own spawn calls run.
                     .with_spawn_depth(child_spawn_depth);
+                // Phase 2-D: inherit the parent's SessionScope so the
+                // detached child sees the same filesystem contract as
+                // the sync spawn path (see `child_session_scope`
+                // snapshot at dispatch time).
+                if let Some(scope) = child_session_scope.as_ref() {
+                    worker = worker.with_session_scope(scope.clone());
+                }
                 // Keep an Arc to the child's tool registry for the
                 // post-`run_task` validator invocation below.
                 let child_tools_handle = worker.tool_registry().clone();
@@ -5309,5 +5333,291 @@ PY
                 );
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2-D: SessionScope propagation tests for SpawnTool.
+    //
+    // The migrated spawn tool reads `ctx.session_scope` and threads it
+    // onto the child Agent via `Agent::with_session_scope`. The child
+    // Agent's execution loop then plants the same scope onto every
+    // child `ToolContext` (see `agent/execution.rs`). These tests
+    // exercise that path end-to-end by mounting a recording tool on the
+    // child registry and asserting on what `execute_with_context` sees.
+    // -----------------------------------------------------------------------
+
+    /// Test-only tool that records the `session_scope.workspace()` it
+    /// observes on its `ToolContext`. Used by the Phase 2-D propagation
+    /// tests to capture what the child Agent's execution loop hands to
+    /// migrated tools. Lives only inside `#[cfg(test)]`.
+    struct ScopeRecordingTool {
+        observed: Arc<std::sync::Mutex<Option<PathBuf>>>,
+    }
+
+    #[async_trait]
+    impl Tool for ScopeRecordingTool {
+        fn name(&self) -> &str {
+            "scope_probe"
+        }
+
+        fn description(&self) -> &str {
+            "test-only tool that records the session_scope it observes"
+        }
+
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object", "properties": {} })
+        }
+
+        async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+            self.execute_with_context(&super::super::ToolContext::zero(), args)
+                .await
+        }
+
+        async fn execute_with_context(
+            &self,
+            ctx: &super::super::ToolContext,
+            _args: &serde_json::Value,
+        ) -> Result<ToolResult> {
+            let observed = ctx
+                .session_scope
+                .as_ref()
+                .map(|scope| scope.workspace().to_path_buf());
+            *self.observed.lock().unwrap_or_else(|e| e.into_inner()) = observed;
+            Ok(ToolResult {
+                output: "ok".to_string(),
+                success: true,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Mock provider that calls `scope_probe` once and then ends — drives
+    /// the child Agent through exactly one tool execution so the
+    /// recording tool sees the migrated `ToolContext`.
+    struct ScopeProbeProvider;
+
+    #[async_trait]
+    impl LlmProvider for ScopeProbeProvider {
+        async fn chat(
+            &self,
+            messages: &[octos_core::Message],
+            _tools: &[octos_llm::ToolSpec],
+            _config: &octos_llm::ChatConfig,
+        ) -> Result<octos_llm::ChatResponse> {
+            // First call → invoke scope_probe; second call (after the
+            // probe's tool_result lands) → end the turn.
+            let probe_already_run = messages
+                .iter()
+                .any(|msg| matches!(msg.role, octos_core::MessageRole::Tool));
+            if probe_already_run {
+                Ok(octos_llm::ChatResponse {
+                    content: Some("done".into()),
+                    reasoning_content: None,
+                    tool_calls: vec![],
+                    stop_reason: octos_llm::StopReason::EndTurn,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                })
+            } else {
+                Ok(octos_llm::ChatResponse {
+                    content: None,
+                    reasoning_content: None,
+                    tool_calls: vec![octos_core::ToolCall {
+                        id: "call_scope_probe".into(),
+                        name: "scope_probe".into(),
+                        arguments: serde_json::json!({}),
+                        metadata: None,
+                    }],
+                    stop_reason: octos_llm::StopReason::ToolUse,
+                    usage: octos_llm::TokenUsage::default(),
+                    provider_index: None,
+                })
+            }
+        }
+
+        fn model_id(&self) -> &str {
+            "mock"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_propagates_scope_to_sub_agent() {
+        // When the parent `ToolContext` carries a `SessionScope`, the
+        // sync-mode sub-agent's tools must see the same scope on their
+        // own `ToolContext`. Without this, a session's filesystem
+        // contract is forgotten the moment work is delegated to a
+        // sub-agent.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let scope = octos_core::SessionScope::solo(scope_dir.path().to_path_buf(), vec![])
+            .expect("scope construction");
+
+        let observed = Arc::new(std::sync::Mutex::new(None::<PathBuf>));
+        let observed_for_factory = observed.clone();
+
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(ScopeProbeProvider),
+            Arc::new(create_test_store().await),
+            scope_dir.path().to_path_buf(),
+            in_tx,
+        )
+        .with_child_tool_factory(Arc::new(move || {
+            Arc::new(ScopeRecordingTool {
+                observed: observed_for_factory.clone(),
+            })
+        }));
+
+        let mut ctx = super::super::ToolContext::zero();
+        ctx.session_scope = Some(Arc::new(scope));
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "task": "probe the scope",
+                    "mode": "sync",
+                    "allowed_tools": ["scope_probe"]
+                }),
+            )
+            .await
+            .expect("spawn returns Ok");
+        assert!(
+            result.success,
+            "expected sync spawn success: {}",
+            result.output
+        );
+
+        let captured = observed.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        let captured = captured.expect(
+            "scope_probe must observe a SessionScope on its ToolContext — \
+             without Phase 2-D propagation the child Agent runs scope-less",
+        );
+        let canonical_expected =
+            std::fs::canonicalize(scope_dir.path()).expect("canonicalise scope dir");
+        let canonical_observed =
+            std::fs::canonicalize(&captured).expect("canonicalise observed workspace");
+        assert_eq!(
+            canonical_observed, canonical_expected,
+            "child Agent's session_scope.workspace() must match the parent's"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_sub_agent_inherits_workspace_cwd() {
+        // The sync-mode child Agent's `working_dir` (passed via
+        // `TaskContext`) and the scope's workspace agree when the
+        // SpawnTool was constructed with `working_dir == scope.workspace()`.
+        // This is the production wiring (`runtime/session.rs` builds
+        // `SpawnTool::new(... working_dir == scope.workspace())`), and
+        // it's the property the Phase 2-D contract relies on: the child
+        // workspace CWD == the parent's scoped workspace, so any shell
+        // tool the child invokes runs with the right CWD even without
+        // the scope plumb.
+        let scope_dir = tempfile::tempdir().unwrap();
+        let scope = octos_core::SessionScope::solo(scope_dir.path().to_path_buf(), vec![])
+            .expect("scope construction");
+
+        let observed = Arc::new(std::sync::Mutex::new(None::<PathBuf>));
+        let observed_for_factory = observed.clone();
+
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        // SpawnTool's working_dir matches scope.workspace() — this is
+        // the production case.
+        let tool = SpawnTool::new(
+            Arc::new(ScopeProbeProvider),
+            Arc::new(create_test_store().await),
+            scope_dir.path().to_path_buf(),
+            in_tx,
+        )
+        .with_child_tool_factory(Arc::new(move || {
+            Arc::new(ScopeRecordingTool {
+                observed: observed_for_factory.clone(),
+            })
+        }));
+
+        let mut ctx = super::super::ToolContext::zero();
+        ctx.session_scope = Some(Arc::new(scope));
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "task": "probe",
+                    "mode": "sync",
+                    "allowed_tools": ["scope_probe"]
+                }),
+            )
+            .await
+            .expect("spawn ok");
+        assert!(result.success);
+
+        let captured = observed
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .expect("scope_probe ran");
+        let canonical_workspace = std::fs::canonicalize(&captured).expect("canonicalise");
+        let canonical_spawn_cwd =
+            std::fs::canonicalize(scope_dir.path()).expect("canonicalise spawn cwd");
+        assert_eq!(
+            canonical_workspace, canonical_spawn_cwd,
+            "child workspace must equal the spawn cwd when SpawnTool::new \
+             was given `scope.workspace()` as its `working_dir`"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_falls_back_to_legacy_cwd_when_no_scope() {
+        // No scope on the parent context — the child Agent must keep
+        // its pre-Phase-2D behaviour byte-for-byte: `session_scope ==
+        // None`. The recording tool sees no scope. The legacy
+        // `working_dir` continues to drive every other code path
+        // (`ToolRegistry::with_builtins`, `TaskContext`).
+        let working = tempfile::tempdir().unwrap();
+        let observed = Arc::new(std::sync::Mutex::new(None::<PathBuf>));
+        let observed_for_factory = observed.clone();
+
+        let (in_tx, _in_rx) = tokio::sync::mpsc::channel(16);
+        let tool = SpawnTool::new(
+            Arc::new(ScopeProbeProvider),
+            Arc::new(create_test_store().await),
+            working.path().to_path_buf(),
+            in_tx,
+        )
+        .with_child_tool_factory(Arc::new(move || {
+            Arc::new(ScopeRecordingTool {
+                observed: observed_for_factory.clone(),
+            })
+        }));
+
+        let ctx = super::super::ToolContext::zero();
+        assert!(
+            ctx.session_scope.is_none(),
+            "precondition: parent ctx has no scope"
+        );
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "task": "probe",
+                    "mode": "sync",
+                    "allowed_tools": ["scope_probe"]
+                }),
+            )
+            .await
+            .expect("spawn ok");
+        assert!(result.success);
+
+        let captured = observed.lock().unwrap_or_else(|e| e.into_inner()).clone();
+        assert!(
+            captured.is_none(),
+            "without a parent scope the child Agent must NOT synthesise one; observed={:?}",
+            captured
+        );
     }
 }


### PR DESCRIPTION
## Summary

Phase 2-D of the [SessionScope migration](https://github.com/octos-org/octos/pull/1198) (Phase 1: #1199).

- **shell.rs** — overrides `Tool::execute_with_context`; derives `effective_cwd` from `ctx.session_scope.workspace()` and falls back to `self.cwd` when no scope. The same effective CWD feeds `CommandPolicy::check`, `sandbox.wrap_command`, the frontend cache env, and the approval payload so policy and the spawned child agree on the working directory.
- **spawn.rs** — propagates `ctx.session_scope` into both the sync and async sub-agent branches via `Agent::with_session_scope`, so the child Agent's execution loop stamps the scope onto every child `ToolContext`. The child shares the parent workspace (no per-child subdir carve-out yet).
- 6 new tests covering scope present, scope absent, and the codex-anticipated `SafePolicy` denylist regression (`rm -rf /` still denied with a scope on the context).

## Test plan

- [x] `cargo test -p octos-agent --lib tools::shell tools::spawn` — 12 shell + 42 spawn pass, 0 new failures
- [x] `cargo test -p octos-agent --lib --no-fail-fast` — 1624 passed, 3 pre-existing ignored
- [x] `cargo build --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --lib --tests -- -D warnings` clean

## Out of scope

- Phase 2-A: pipeline workers
- Phase 2-B: plugin tool
- Phase 2-C: read_file / write_file / edit_file

These ship in their own PRs.