### PR TITLE
migrate(phase3a): close Phase 1 plumbing gaps — ui_protocol.rs + pipeline/handler.rs propagate session_scope

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15627,6 +15627,22 @@ async fn run_standalone_turn(
     if let Some(hooks) = session_runtime.profile.hook_executor.clone() {
         request_agent = request_agent.with_hooks(hooks);
     }
+    // Phase 3-A plumbing follow-up (Phase 1 gap): propagate the
+    // `SessionScope` the cached `SessionRuntime` constructed at
+    // `runtime/session.rs::bootstrap` onto this per-turn rebuilt agent.
+    // Without this, every WS turn served by `Agent::new_shared` here
+    // would observe `session_scope: None` and the Phase-2-A/B/C/D
+    // consumers (run_pipeline working dir, plugin work_dir + path
+    // validation, file tools' base_dir + path classification, shell +
+    // spawn child CWD) would silently fall through to legacy paths —
+    // re-introducing the mini5 NEW-06 contamination class on the WS
+    // chat transport. The lookup is `Option<&Arc<SessionScope>>` so
+    // legacy / channel-prefixed sessions (where Phase 1 left the
+    // field unset by design) keep their pre-Phase-1 behaviour
+    // byte-for-byte.
+    if let Some(scope) = session_runtime.agent.session_scope() {
+        request_agent = request_agent.with_session_scope(scope.clone());
+    }
     // M11-F regression fix REG-1 follow-up (codex review): wire the
     // `activate_tools` back-reference on the per-turn rebuilt agent.
     // `ProfileRuntime::bootstrap` defers non-core groups + registers

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15638,41 +15638,66 @@ async fn run_standalone_turn(
     // re-introducing the mini5 NEW-06 contamination class on the WS
     // chat transport.
     //
-    // Phase 3-A codex round-1 P1: GATE the propagation on
-    // `scope.workspace() == session_runtime.workspace_root`. When a
-    // coding-agent UI opens a session with an explicit `cwd` hint
-    // (via SessionOpenParams.cwd or appui.default_session_cwd),
-    // `resolve_workspace_root` honours the hint while
-    // `SessionRuntime::bootstrap` still builds `SessionScope` from the
-    // canonical `<data>/users/<id>/workspace` layout — so the cached
-    // scope's workspace does NOT match the runtime's. Propagating that
-    // mismatched scope would make the migrated tools (`shell`, file
-    // tools, plugins, `run_pipeline`) resolve against the empty default
-    // workspace instead of the user-selected repo. Reconciling the
-    // bootstrap-side scope-construction with `workspace_hint` is the
-    // cleaner long-term fix (codex's "construct the scope from the
-    // effective workspace") but that flips the cached scope for hint
-    // sessions which today is unread by Phase 2 consumers — i.e., a
-    // consumer-visible change. This PR stays strictly additive: when
-    // the workspaces match (default-layout sessions — the common WS
-    // chat path that mini5 NEW-06 actually surfaces on) we propagate;
-    // when they don't (hint sessions — coding-agent flow) we skip and
-    // keep the pre-Phase-3-A `session_scope: None` behaviour the hint
-    // path was on before this PR.
+    // Phase 3-A codex round-2 P1: when the cached scope's workspace
+    // does NOT match `session_runtime.workspace_root` (i.e. a
+    // coding-agent UI session opened with an explicit `cwd` hint via
+    // `SessionOpenParams.cwd` or `appui.default_session_cwd` —
+    // `resolve_workspace_root` honoured the hint while
+    // `SessionRuntime::bootstrap` still built the cached
+    // `SessionScope` from the canonical
+    // `<data>/users/<id>/workspace` layout), build a fresh
+    // **solo** scope rooted at the effective `workspace_root` and
+    // propagate THAT.
+    //
+    // Round-1 of this PR tried to fix the mismatch by SKIPPING
+    // propagation in this case, but codex correctly pointed out that
+    // leaves hint sessions on the legacy unread-scope path — which
+    // means `plugins::tool::PluginTool` falls back to its legacy
+    // absolute-path rewrite branch (no workspace-boundary validation),
+    // re-opening the path-escape class for hinted AppUI turns that
+    // invoke a plugin with `audio_path=/etc/passwd` and friends.
+    // A workspace-rooted solo scope keeps the Phase-2 consumers happy
+    // (they see a valid scope, file tools / shell / pipeline workers
+    // bind to the user-selected repo, and the plugin tool's
+    // scope-aware path validation kicks in) without depending on the
+    // pending bootstrap-side reconciliation.
     if let Some(scope) = session_runtime.agent.session_scope() {
         if scope.workspace() == session_runtime.workspace_root.as_path() {
             request_agent = request_agent.with_session_scope(scope.clone());
         } else {
-            tracing::debug!(
-                session = %session_id.0,
-                turn = %turn_id.0,
-                scope_workspace = %scope.workspace().display(),
-                runtime_workspace = %session_runtime.workspace_root.display(),
-                "skipping SessionScope propagation onto per-turn agent: \
-                 scope workspace does not match SessionRuntime.workspace_root \
-                 (likely a coding-agent hint session); falling back to \
-                 legacy unread-scope behaviour"
-            );
+            match octos_core::SessionScope::solo(session_runtime.workspace_root.clone(), Vec::new())
+            {
+                Ok(synthesized) => {
+                    tracing::debug!(
+                        session = %session_id.0,
+                        turn = %turn_id.0,
+                        scope_workspace = %scope.workspace().display(),
+                        runtime_workspace = %session_runtime.workspace_root.display(),
+                        "synthesising solo SessionScope rooted at workspace_root: \
+                         cached scope's workspace does not match \
+                         SessionRuntime.workspace_root (hint session); \
+                         a solo scope keeps Phase-2 consumers' boundary validation \
+                         active for the user-selected repo"
+                    );
+                    request_agent = request_agent.with_session_scope(Arc::new(synthesized));
+                }
+                Err(err) => {
+                    // `SessionScope::solo` only fails when the cwd is
+                    // not absolute — that should never happen here
+                    // because `resolve_workspace_root` always returns
+                    // an absolute path. Log defensively and fall back
+                    // to legacy `None` (= pre-Phase-3-A behaviour for
+                    // hint sessions).
+                    tracing::warn!(
+                        session = %session_id.0,
+                        turn = %turn_id.0,
+                        runtime_workspace = %session_runtime.workspace_root.display(),
+                        error = %err,
+                        "failed to synthesise solo SessionScope for hint session; \
+                         per-turn agent will run without scope (legacy fallback)"
+                    );
+                }
+            }
         }
     }
     // M11-F regression fix REG-1 follow-up (codex review): wire the

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15665,8 +15665,41 @@ async fn run_standalone_turn(
         if scope.workspace() == session_runtime.workspace_root.as_path() {
             request_agent = request_agent.with_session_scope(scope.clone());
         } else {
-            match octos_core::SessionScope::solo(session_runtime.workspace_root.clone(), Vec::new())
-            {
+            // Phase 3-A codex round-3 P2: the synthesized solo scope
+            // MUST grant the upload tmpdir alongside the workspace,
+            // otherwise hinted sessions lose the ability to resolve
+            // `up/...` handles and absolute paths under
+            // `octos_bus::file_handle::temp_upload_root()` through the
+            // scope-aware path resolver. Without it,
+            // `resolve_path_for_session_scope_*` would classify
+            // attachment paths as `OutOfScope` and reject them,
+            // breaking hinted coding turns that ask the agent to
+            // process an uploaded file or audio attachment.
+            //
+            // The upload root is a stable, profile-independent path
+            // (`std::env::temp_dir().join("octos-uploads")`), so
+            // granting it does not widen the boundary beyond what the
+            // legacy unscoped resolver already trusted: that resolver
+            // unconditionally allowed `canonical_path.starts_with(
+            // &upload_root)` for send_file and friends. Adding it as
+            // a `granted_dir` re-affirms that trust contract through
+            // the new scope-aware path while leaving the workspace as
+            // the primary write target.
+            let upload_root = octos_bus::file_handle::temp_upload_root();
+            let granted_dirs = if upload_root.is_absolute() {
+                vec![upload_root]
+            } else {
+                // Defensive: `temp_upload_root` returns
+                // `temp_dir().join("octos-uploads")` so it should
+                // always be absolute; bail out cleanly if a future
+                // platform tweak ever breaks the invariant rather
+                // than letting `SessionScope::solo` reject it.
+                Vec::new()
+            };
+            match octos_core::SessionScope::solo(
+                session_runtime.workspace_root.clone(),
+                granted_dirs,
+            ) {
                 Ok(synthesized) => {
                     tracing::debug!(
                         session = %session_id.0,
@@ -15677,7 +15710,7 @@ async fn run_standalone_turn(
                          cached scope's workspace does not match \
                          SessionRuntime.workspace_root (hint session); \
                          a solo scope keeps Phase-2 consumers' boundary validation \
-                         active for the user-selected repo"
+                         active for the user-selected repo + the upload tmpdir"
                     );
                     request_agent = request_agent.with_session_scope(Arc::new(synthesized));
                 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15636,12 +15636,44 @@ async fn run_standalone_turn(
     // validation, file tools' base_dir + path classification, shell +
     // spawn child CWD) would silently fall through to legacy paths —
     // re-introducing the mini5 NEW-06 contamination class on the WS
-    // chat transport. The lookup is `Option<&Arc<SessionScope>>` so
-    // legacy / channel-prefixed sessions (where Phase 1 left the
-    // field unset by design) keep their pre-Phase-1 behaviour
-    // byte-for-byte.
+    // chat transport.
+    //
+    // Phase 3-A codex round-1 P1: GATE the propagation on
+    // `scope.workspace() == session_runtime.workspace_root`. When a
+    // coding-agent UI opens a session with an explicit `cwd` hint
+    // (via SessionOpenParams.cwd or appui.default_session_cwd),
+    // `resolve_workspace_root` honours the hint while
+    // `SessionRuntime::bootstrap` still builds `SessionScope` from the
+    // canonical `<data>/users/<id>/workspace` layout — so the cached
+    // scope's workspace does NOT match the runtime's. Propagating that
+    // mismatched scope would make the migrated tools (`shell`, file
+    // tools, plugins, `run_pipeline`) resolve against the empty default
+    // workspace instead of the user-selected repo. Reconciling the
+    // bootstrap-side scope-construction with `workspace_hint` is the
+    // cleaner long-term fix (codex's "construct the scope from the
+    // effective workspace") but that flips the cached scope for hint
+    // sessions which today is unread by Phase 2 consumers — i.e., a
+    // consumer-visible change. This PR stays strictly additive: when
+    // the workspaces match (default-layout sessions — the common WS
+    // chat path that mini5 NEW-06 actually surfaces on) we propagate;
+    // when they don't (hint sessions — coding-agent flow) we skip and
+    // keep the pre-Phase-3-A `session_scope: None` behaviour the hint
+    // path was on before this PR.
     if let Some(scope) = session_runtime.agent.session_scope() {
-        request_agent = request_agent.with_session_scope(scope.clone());
+        if scope.workspace() == session_runtime.workspace_root.as_path() {
+            request_agent = request_agent.with_session_scope(scope.clone());
+        } else {
+            tracing::debug!(
+                session = %session_id.0,
+                turn = %turn_id.0,
+                scope_workspace = %scope.workspace().display(),
+                runtime_workspace = %session_runtime.workspace_root.display(),
+                "skipping SessionScope propagation onto per-turn agent: \
+                 scope workspace does not match SessionRuntime.workspace_root \
+                 (likely a coding-agent hint session); falling back to \
+                 legacy unread-scope behaviour"
+            );
+        }
     }
     // M11-F regression fix REG-1 follow-up (codex review): wire the
     // `activate_tools` back-reference on the per-turn rebuilt agent.

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15665,72 +15665,70 @@ async fn run_standalone_turn(
         if scope.workspace() == session_runtime.workspace_root.as_path() {
             request_agent = request_agent.with_session_scope(scope.clone());
         } else {
-            // Phase 3-A codex round-3 P2: the synthesized solo scope
-            // MUST grant the upload tmpdir alongside the workspace,
-            // otherwise hinted sessions lose the ability to resolve
-            // `up/...` handles and absolute paths under
-            // `octos_bus::file_handle::temp_upload_root()` through the
-            // scope-aware path resolver. Without it,
-            // `resolve_path_for_session_scope_*` would classify
-            // attachment paths as `OutOfScope` and reject them,
-            // breaking hinted coding turns that ask the agent to
-            // process an uploaded file or audio attachment.
+            // Phase 3-A codex round-4 (rolling back rounds 2/3): for
+            // hint sessions (the workspace mismatch case), do NOT
+            // propagate any SessionScope onto the per-turn agent —
+            // keep them on the pre-Phase-3-A `session_scope: None`
+            // path. Rationale + history:
             //
-            // The upload root is a stable, profile-independent path
-            // (`std::env::temp_dir().join("octos-uploads")`), so
-            // granting it does not widen the boundary beyond what the
-            // legacy unscoped resolver already trusted: that resolver
-            // unconditionally allowed `canonical_path.starts_with(
-            // &upload_root)` for send_file and friends. Adding it as
-            // a `granted_dir` re-affirms that trust contract through
-            // the new scope-aware path while leaving the workspace as
-            // the primary write target.
-            let upload_root = octos_bus::file_handle::temp_upload_root();
-            let granted_dirs = if upload_root.is_absolute() {
-                vec![upload_root]
-            } else {
-                // Defensive: `temp_upload_root` returns
-                // `temp_dir().join("octos-uploads")` so it should
-                // always be absolute; bail out cleanly if a future
-                // platform tweak ever breaks the invariant rather
-                // than letting `SessionScope::solo` reject it.
-                Vec::new()
-            };
-            match octos_core::SessionScope::solo(
-                session_runtime.workspace_root.clone(),
-                granted_dirs,
-            ) {
-                Ok(synthesized) => {
-                    tracing::debug!(
-                        session = %session_id.0,
-                        turn = %turn_id.0,
-                        scope_workspace = %scope.workspace().display(),
-                        runtime_workspace = %session_runtime.workspace_root.display(),
-                        "synthesising solo SessionScope rooted at workspace_root: \
-                         cached scope's workspace does not match \
-                         SessionRuntime.workspace_root (hint session); \
-                         a solo scope keeps Phase-2 consumers' boundary validation \
-                         active for the user-selected repo + the upload tmpdir"
-                    );
-                    request_agent = request_agent.with_session_scope(Arc::new(synthesized));
-                }
-                Err(err) => {
-                    // `SessionScope::solo` only fails when the cwd is
-                    // not absolute — that should never happen here
-                    // because `resolve_workspace_root` always returns
-                    // an absolute path. Log defensively and fall back
-                    // to legacy `None` (= pre-Phase-3-A behaviour for
-                    // hint sessions).
-                    tracing::warn!(
-                        session = %session_id.0,
-                        turn = %turn_id.0,
-                        runtime_workspace = %session_runtime.workspace_root.display(),
-                        error = %err,
-                        "failed to synthesise solo SessionScope for hint session; \
-                         per-turn agent will run without scope (legacy fallback)"
-                    );
-                }
-            }
+            // - Round-2 synthesized a workspace-rooted solo scope so
+            //   the Phase-2 consumers' boundary check would kick in,
+            //   addressing codex round-1's plugin path-escape concern.
+            //   But that introduced an upload-handle regression
+            //   (codex round-2 P2): the new scope-aware resolver
+            //   classified `up/...` and absolute upload-tmpdir paths
+            //   as OutOfScope, breaking attachment resolution.
+            // - Round-3 added `temp_upload_root()` as a granted_dir to
+            //   close the absolute-path arm, but codex round-3 P2
+            //   showed two remaining gaps the scoped resolver still
+            //   can't handle: (a) `up/...` handles are not decoded by
+            //   `resolve_path_for_session_scope_*` (they're treated as
+            //   workspace-relative `<workspace>/up/...`); (b) on macOS
+            //   the canonical upload root is `/private/var/folders/...`
+            //   while `temp_upload_root()` returns `/var/folders/...`
+            //   — the plugin tool's LEXICAL classifier doesn't follow
+            //   firmlinks, so canonical paths and decoded handles
+            //   remain OutOfScope.
+            //
+            // Both of those gaps are properly addressed in `octos-bus`
+            // (handle decoding) and `octos-agent` plugins (canonical
+            // classification) — i.e. Phase-2 consumer changes that the
+            // user explicitly bounded out of this PR ("stay in
+            // plumbing — additive scope propagation only"). Until a
+            // follow-up Phase 3-B PR closes those, the safer landing
+            // for THIS PR is to leave hint sessions on their
+            // pre-existing legacy (None) behaviour: handle resolution
+            // works through `resolve_tool_path` as before; the
+            // pre-existing plugin path-escape risk codex round-1
+            // surfaced is NEITHER introduced NOR closed by this PR
+            // (it's pre-existing — Phase-2 PRs are the right place to
+            // close it via either a bootstrap-side scope rebuild for
+            // hint sessions or scope-aware handle decoding).
+            //
+            // Default-layout sessions (the common mini5 NEW-06 path)
+            // still get full propagation through the `if` branch
+            // above. This gate ONLY skips for hint sessions whose
+            // cached scope was built under the canonical
+            // `<data>/users/<id>/workspace` layout while
+            // workspace_root tracks a caller-supplied repo path.
+            //
+            // TODO(phase3b): reconcile `SessionRuntime::bootstrap`'s
+            // SessionScope construction with `workspace_hint` (build
+            // `SessionScope::solo` from workspace_root for hint
+            // sessions, with `temp_upload_root` granted and canonical
+            // upload root pre-resolved) so this skip branch becomes
+            // unreachable and hint sessions also benefit from the
+            // Phase-2 consumer boundary checks.
+            tracing::debug!(
+                session = %session_id.0,
+                turn = %turn_id.0,
+                scope_workspace = %scope.workspace().display(),
+                runtime_workspace = %session_runtime.workspace_root.display(),
+                "skipping SessionScope propagation onto per-turn agent: \
+                 scope workspace does not match SessionRuntime.workspace_root \
+                 (likely a coding-agent hint session); falling back to \
+                 legacy unread-scope behaviour pending phase3b resolver work"
+            );
         }
     }
     // M11-F regression fix REG-1 follow-up (codex review): wire the

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -820,11 +820,17 @@ mod tests {
             .clone();
 
         // Mirror the WS turn handler's per-turn rebuild
-        // (`api/ui_protocol.rs::15608`):
+        // (`api/ui_protocol.rs::15608`), INCLUDING the codex round-1
+        // P1 gate (`scope.workspace() == workspace_root`):
         //   let request_agent = Agent::new_shared(...).with_*(...);
         //   if let Some(scope) = session_runtime.agent.session_scope() {
-        //       request_agent = request_agent.with_session_scope(scope.clone());
+        //       if scope.workspace() == session_runtime.workspace_root.as_path() {
+        //           request_agent = request_agent.with_session_scope(scope.clone());
+        //       }
         //   }
+        // For default-layout sessions (no workspace hint) the scope's
+        // workspace matches `workspace_root` so the gate passes and
+        // the scope is propagated.
         let tools = Arc::new(rt.tools.snapshot_excluding(&[]));
         let mut request_agent = Agent::new_shared(
             AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
@@ -833,7 +839,9 @@ mod tests {
             profile.memory.clone(),
         );
         if let Some(scope) = rt.agent.session_scope() {
-            request_agent = request_agent.with_session_scope(scope.clone());
+            if scope.workspace() == rt.workspace_root.as_path() {
+                request_agent = request_agent.with_session_scope(scope.clone());
+            }
         }
 
         let turn_scope = request_agent
@@ -850,6 +858,86 @@ mod tests {
         // points at the per-session workspace dir, not the profile root.
         assert_eq!(turn_scope.workspace(), runtime_scope.workspace());
         assert_eq!(turn_scope.root(), data_dir.as_path());
+    }
+
+    /// Phase 3-A codex round-1 P1 regression-pin: when a coding-agent
+    /// UI opens a session with an explicit `cwd` hint (the AppUI
+    /// `SessionOpenParams.cwd` path), the cached `SessionRuntime`
+    /// honours the hint for `workspace_root` and the rebound tool
+    /// registry, but `bootstrap` still builds the `SessionScope` from
+    /// the canonical `<data>/users/<id>/workspace` layout — so the
+    /// cached scope's workspace does NOT match the runtime's. The WS
+    /// turn handler MUST skip propagation in this case, because
+    /// propagating the mismatched scope would make migrated tools
+    /// (`shell`, file tools, plugins, `run_pipeline`) resolve against
+    /// the empty default workspace instead of the user-selected repo.
+    /// Fix-line: `if scope.workspace() == workspace_root` gate at
+    /// `api/ui_protocol.rs::15663-15664`.
+    ///
+    /// This test mirrors the gated rebuild and confirms the per-turn
+    /// agent observes `session_scope == None` for hint sessions —
+    /// keeping their pre-Phase-3-A unread-scope behaviour byte-for-byte.
+    #[tokio::test]
+    async fn ui_protocol_ws_turn_agent_skips_session_scope_on_workspace_hint() {
+        use octos_agent::Agent;
+
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        // A safe SPA-shape session id (so bootstrap DOES build a
+        // scope under the default layout) PLUS a hint pointing at a
+        // different repo path — i.e. the coding-agent UI flow.
+        let session_id = "web-1779574360681-hintsx";
+        let key = SessionKey(session_id.to_string());
+        let hint_repo = tmp.path().join("coding-agent-repo");
+        std::fs::create_dir_all(&hint_repo).unwrap();
+        let rt = SessionRuntime::bootstrap(&profile, key, Some(hint_repo.clone()))
+            .await
+            .expect("bootstrap session runtime with workspace hint");
+
+        // Pre-condition: workspace_root tracks the HINT, but the cached
+        // scope was built from the default `<data>/users/<id>/workspace`
+        // layout (Phase-1 bootstrap behaviour we deliberately leave
+        // unchanged on this PR).
+        let runtime_scope = rt
+            .agent
+            .session_scope()
+            .expect("safe session id always yields a SessionScope")
+            .clone();
+        let canonical_workspace = std::fs::canonicalize(&hint_repo).unwrap();
+        let runtime_workspace_canonical = std::fs::canonicalize(&rt.workspace_root).unwrap();
+        assert_eq!(
+            runtime_workspace_canonical, canonical_workspace,
+            "workspace_root must honour the hint"
+        );
+        assert_ne!(
+            runtime_scope.workspace(),
+            rt.workspace_root.as_path(),
+            "Phase 1 design: scope still uses default <data>/users/<id>/workspace \
+             — this is the mismatch the gate at ui_protocol.rs guards against"
+        );
+
+        // Mirror the WS turn handler's per-turn rebuild WITH the gate.
+        let tools = Arc::new(rt.tools.snapshot_excluding(&[]));
+        let mut request_agent = Agent::new_shared(
+            AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
+            profile.llm.clone(),
+            tools,
+            profile.memory.clone(),
+        );
+        if let Some(scope) = rt.agent.session_scope() {
+            if scope.workspace() == rt.workspace_root.as_path() {
+                request_agent = request_agent.with_session_scope(scope.clone());
+            }
+        }
+
+        assert!(
+            request_agent.session_scope().is_none(),
+            "per-turn agent must NOT inherit the mismatched scope when the session was \
+             opened with a workspace hint — propagating would point migrated tools at the \
+             empty default workspace instead of the user-selected repo (codex round-1 P1)",
+        );
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -860,32 +860,36 @@ mod tests {
         assert_eq!(turn_scope.root(), data_dir.as_path());
     }
 
-    /// Phase 3-A codex round-2 P1 regression-pin: when a coding-agent
-    /// UI opens a session with an explicit `cwd` hint (the AppUI
-    /// `SessionOpenParams.cwd` path), the cached `SessionRuntime`
-    /// honours the hint for `workspace_root` and the rebound tool
-    /// registry, but `bootstrap` still builds the `SessionScope` from
-    /// the canonical `<data>/users/<id>/workspace` layout — so the
-    /// cached scope's workspace does NOT match the runtime's. The WS
-    /// turn handler MUST synthesize a solo scope rooted at
-    /// `workspace_root` in this case (round-2 fix). Round-1 skipped
-    /// propagation entirely, but codex correctly flagged that this
-    /// leaves hint sessions on the legacy unread-scope path where
-    /// `PluginTool` falls back to its absolute-path rewrite branch
-    /// without workspace-boundary validation — a path-escape risk for
-    /// hinted AppUI plugin calls like `audio_path=/etc/passwd`.
-    /// Fix-line: synthesize `SessionScope::solo(workspace_root, [])`
-    /// in the mismatch branch at `api/ui_protocol.rs::15663-15689`.
+    /// Phase 3-A codex round-3 P2 regression-pin: when a coding-agent
+    /// UI opens a session with an explicit `cwd` hint, the cached
+    /// `SessionRuntime` honours the hint for `workspace_root` and the
+    /// rebound tool registry, but `bootstrap` still builds the
+    /// `SessionScope` from the canonical `<data>/users/<id>/workspace`
+    /// layout — so the cached scope's workspace does NOT match the
+    /// runtime's. The WS turn handler MUST synthesize a solo scope
+    /// rooted at `workspace_root` AND granting the upload tmpdir
+    /// (`octos_bus::file_handle::temp_upload_root()`).
     ///
-    /// This test mirrors the round-2 rebuild and confirms the per-turn
-    /// agent observes a solo scope whose `workspace() ==
-    /// workspace_root` (= user-selected repo) — so the migrated
-    /// consumers' boundary validation kicks in for the right tree
-    /// instead of the empty default workspace.
+    /// Round-2 of this fix synthesized the workspace scope but with
+    /// EMPTY granted_dirs, which made hint sessions lose `up/...`
+    /// upload-handle resolution: the file/plugin path resolvers prefer
+    /// `ctx.session_scope` when present, and the new scope-aware path
+    /// classified attachment paths under `/tmp/octos-uploads` as
+    /// `OutOfScope`, rejecting them. The legacy unscoped resolver
+    /// always allowed `canonical_path.starts_with(&upload_root)`, so
+    /// adding the upload root as a `granted_dir` reaffirms that trust
+    /// contract through the new path without widening it. Fix-line:
+    /// pass `vec![temp_upload_root()]` to `SessionScope::solo(...)`
+    /// at `api/ui_protocol.rs::15693-15703`.
+    ///
+    /// This test mirrors the round-3 rebuild and confirms the
+    /// synthesized scope's `granted_dirs` carries the upload tmpdir
+    /// (so `up/...` handles + absolute upload paths still resolve)
+    /// alongside the user-selected workspace.
     #[tokio::test]
     async fn ui_protocol_ws_turn_agent_synthesizes_workspace_scope_on_workspace_hint() {
         use octos_agent::Agent;
-        use octos_core::SessionScope;
+        use octos_core::{ScopeMode, SessionScope};
 
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
@@ -921,13 +925,19 @@ mod tests {
             runtime_scope.workspace(),
             rt.workspace_root.as_path(),
             "Phase 1 design: scope still uses default <data>/users/<id>/workspace \
-             — this is the mismatch the round-2 fix at ui_protocol.rs handles"
+             — this is the mismatch the round-3 fix at ui_protocol.rs handles"
         );
 
         // Mirror the WS turn handler's per-turn rebuild WITH the
-        // round-2 fix: when the cached scope's workspace doesn't match
+        // round-3 fix: when the cached scope's workspace doesn't match
         // the runtime's workspace_root, synthesize a solo scope rooted
-        // at workspace_root and propagate THAT.
+        // at workspace_root AND granting the upload tmpdir.
+        let upload_root = octos_bus::file_handle::temp_upload_root();
+        let granted_dirs = if upload_root.is_absolute() {
+            vec![upload_root.clone()]
+        } else {
+            Vec::new()
+        };
         let tools = Arc::new(rt.tools.snapshot_excluding(&[]));
         let mut request_agent = Agent::new_shared(
             AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
@@ -939,8 +949,8 @@ mod tests {
             if scope.workspace() == rt.workspace_root.as_path() {
                 request_agent = request_agent.with_session_scope(scope.clone());
             } else {
-                let synthesized = SessionScope::solo(rt.workspace_root.clone(), Vec::new())
-                    .expect("solo scope from absolute workspace_root");
+                let synthesized = SessionScope::solo(rt.workspace_root.clone(), granted_dirs)
+                    .expect("solo scope from absolute workspace_root + upload root grant");
                 request_agent = request_agent.with_session_scope(Arc::new(synthesized));
             }
         }
@@ -949,8 +959,8 @@ mod tests {
             .session_scope()
             .expect(
                 "per-turn agent MUST carry a synthesized scope for hint sessions \
-                     (round-2 fix — round-1 erroneously skipped propagation, leaving the \
-                     plugin tool's boundary check disabled)",
+                 (round-2 fix — round-1 erroneously skipped propagation, leaving the \
+                 plugin tool's boundary check disabled)",
             )
             .clone();
         assert_eq!(
@@ -970,6 +980,21 @@ mod tests {
             "solo scope must declare no cross-session shared zones — hint sessions own \
              their workspace boundary, not a multi-tenant layout"
         );
+        // Round-3 pin: the synthesized scope MUST grant the upload
+        // tmpdir so `up/...` handles + absolute upload paths still
+        // resolve through `resolve_path_for_session_scope_*` for
+        // hint sessions (otherwise attachments are classified
+        // `OutOfScope` and rejected).
+        match observed.mode() {
+            ScopeMode::Solo { granted_dirs } => {
+                assert!(
+                    granted_dirs.iter().any(|d| d == &upload_root),
+                    "synthesized scope MUST grant temp_upload_root() so hint sessions \
+                     can still resolve uploaded attachments; got granted_dirs = {granted_dirs:?}",
+                );
+            }
+            other => panic!("synthesized scope must be solo, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -736,6 +736,122 @@ mod tests {
         );
     }
 
+    /// Phase 3-A design-pin (Phase 1 follow-up — gap #3 from codex
+    /// review of Phase 2-C): the `else` branch at
+    /// `SessionRuntime::bootstrap` (around `is_safe_session_id` check)
+    /// deliberately leaves `session_scope` unset for channel-prefixed
+    /// legacy session ids like `api:web-1234`, `telegram:12345`,
+    /// `discord:guild#chan`. This is INTENTIONAL: the SessionScope
+    /// on-disk layout uses the raw id while gateway/legacy paths
+    /// percent-encode the `:`, so the workspace shapes are not yet
+    /// reconciled until Phase 3 routes every shape through the scope
+    /// contract. This test exists explicitly to PIN that design
+    /// decision so a future "just construct a scope for every id"
+    /// refactor cannot silently flip it without re-reading the
+    /// rationale in the comment at the unsafe-id branch.
+    #[tokio::test]
+    async fn unsafe_session_id_session_intentionally_has_none_scope() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        // Three flavours of channel-prefixed legacy ids that historically
+        // satisfied the gateway dispatcher but fail `is_safe_session_id`
+        // (the `:` character is rejected). Each must succeed at bootstrap
+        // and yield `agent.session_scope() == None`.
+        let cases = ["api:web-1234", "telegram:12345", "discord:guild#chan"];
+        for raw in cases {
+            // Split on `:` to round-trip through SessionKey::new's
+            // (channel, base) constructor.
+            let mut split = raw.splitn(2, ':');
+            let channel = split.next().expect("channel half");
+            let base = split.next().expect("base half");
+            let key = SessionKey::new(channel, base);
+            let rt = SessionRuntime::bootstrap(&profile, key.clone(), None)
+                .await
+                .expect("bootstrap must succeed for legacy channel id");
+            assert!(
+                rt.agent.session_scope().is_none(),
+                "design pin: unsafe session id {raw:?} (key={key:?}) must leave session_scope unset; \
+                 changing this requires reconciling the encoded-vs-raw workspace path mismatch first",
+            );
+        }
+    }
+
+    /// Phase 3-A plumbing follow-up (gap #1 from codex review of
+    /// Phase 2-C): the UI Protocol WS turn handler rebuilds an
+    /// `Agent` per-turn via `Agent::new_shared(...).with_*(...)` so
+    /// per-turn callbacks (reporter, prompt-context-bridge) layer in
+    /// without mutating the cached `SessionRuntime`. Before this fix
+    /// the rebuild did NOT copy `session_scope` off the runtime
+    /// session's agent, so every per-turn agent observed
+    /// `session_scope: None` and the Phase-2 consumers fell through
+    /// to legacy paths (= mini5 NEW-06 contamination on the WS
+    /// chat path).
+    ///
+    /// This test exercises the EXACT pattern the WS turn handler
+    /// uses: bootstrap a SessionRuntime, then build a fresh
+    /// per-turn Agent via the same `new_shared(...).with_session_scope(...)`
+    /// chain. It asserts the per-turn agent observes the SAME
+    /// SessionScope `Arc` the runtime session's agent carries (via
+    /// `Arc::ptr_eq`), proving the propagation is a clone of the
+    /// runtime's scope rather than an independently-built one.
+    #[tokio::test]
+    async fn ui_protocol_ws_turn_agent_inherits_session_scope() {
+        use octos_agent::Agent;
+
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile(data_dir.clone()).await;
+
+        let session_id = "web-1779574360680-ws01ab";
+        let key = SessionKey(session_id.to_string());
+        let rt = SessionRuntime::bootstrap(&profile, key, None)
+            .await
+            .expect("bootstrap session runtime");
+
+        // Pre-condition: the cached SessionRuntime's agent carries a
+        // SessionScope (Phase 1 contract — already covered by
+        // `bootstrap_attaches_session_scope_for_safe_session_id`).
+        let runtime_scope = rt
+            .agent
+            .session_scope()
+            .expect("safe session id must yield a SessionScope")
+            .clone();
+
+        // Mirror the WS turn handler's per-turn rebuild
+        // (`api/ui_protocol.rs::15608`):
+        //   let request_agent = Agent::new_shared(...).with_*(...);
+        //   if let Some(scope) = session_runtime.agent.session_scope() {
+        //       request_agent = request_agent.with_session_scope(scope.clone());
+        //   }
+        let tools = Arc::new(rt.tools.snapshot_excluding(&[]));
+        let mut request_agent = Agent::new_shared(
+            AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
+            profile.llm.clone(),
+            tools,
+            profile.memory.clone(),
+        );
+        if let Some(scope) = rt.agent.session_scope() {
+            request_agent = request_agent.with_session_scope(scope.clone());
+        }
+
+        let turn_scope = request_agent
+            .session_scope()
+            .expect("per-turn agent must inherit session_scope from runtime")
+            .clone();
+        assert!(
+            Arc::ptr_eq(&runtime_scope, &turn_scope),
+            "per-turn WS agent must point at the SAME SessionScope Arc the cached \
+             SessionRuntime holds, not a freshly-built one (proves scope is propagated, \
+             not reconstructed)",
+        );
+        // Workspace shape sanity — the per-turn agent's scope still
+        // points at the per-session workspace dir, not the profile root.
+        assert_eq!(turn_scope.workspace(), runtime_scope.workspace());
+        assert_eq!(turn_scope.root(), data_dir.as_path());
+    }
+
     #[tokio::test]
     async fn bootstrap_attaches_distinct_session_scopes_per_session() {
         // Two SPA-shape sessions on the same profile each get their

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -860,26 +860,32 @@ mod tests {
         assert_eq!(turn_scope.root(), data_dir.as_path());
     }
 
-    /// Phase 3-A codex round-1 P1 regression-pin: when a coding-agent
+    /// Phase 3-A codex round-2 P1 regression-pin: when a coding-agent
     /// UI opens a session with an explicit `cwd` hint (the AppUI
     /// `SessionOpenParams.cwd` path), the cached `SessionRuntime`
     /// honours the hint for `workspace_root` and the rebound tool
     /// registry, but `bootstrap` still builds the `SessionScope` from
     /// the canonical `<data>/users/<id>/workspace` layout — so the
     /// cached scope's workspace does NOT match the runtime's. The WS
-    /// turn handler MUST skip propagation in this case, because
-    /// propagating the mismatched scope would make migrated tools
-    /// (`shell`, file tools, plugins, `run_pipeline`) resolve against
-    /// the empty default workspace instead of the user-selected repo.
-    /// Fix-line: `if scope.workspace() == workspace_root` gate at
-    /// `api/ui_protocol.rs::15663-15664`.
+    /// turn handler MUST synthesize a solo scope rooted at
+    /// `workspace_root` in this case (round-2 fix). Round-1 skipped
+    /// propagation entirely, but codex correctly flagged that this
+    /// leaves hint sessions on the legacy unread-scope path where
+    /// `PluginTool` falls back to its absolute-path rewrite branch
+    /// without workspace-boundary validation — a path-escape risk for
+    /// hinted AppUI plugin calls like `audio_path=/etc/passwd`.
+    /// Fix-line: synthesize `SessionScope::solo(workspace_root, [])`
+    /// in the mismatch branch at `api/ui_protocol.rs::15663-15689`.
     ///
-    /// This test mirrors the gated rebuild and confirms the per-turn
-    /// agent observes `session_scope == None` for hint sessions —
-    /// keeping their pre-Phase-3-A unread-scope behaviour byte-for-byte.
+    /// This test mirrors the round-2 rebuild and confirms the per-turn
+    /// agent observes a solo scope whose `workspace() ==
+    /// workspace_root` (= user-selected repo) — so the migrated
+    /// consumers' boundary validation kicks in for the right tree
+    /// instead of the empty default workspace.
     #[tokio::test]
-    async fn ui_protocol_ws_turn_agent_skips_session_scope_on_workspace_hint() {
+    async fn ui_protocol_ws_turn_agent_synthesizes_workspace_scope_on_workspace_hint() {
         use octos_agent::Agent;
+        use octos_core::SessionScope;
 
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
@@ -915,10 +921,13 @@ mod tests {
             runtime_scope.workspace(),
             rt.workspace_root.as_path(),
             "Phase 1 design: scope still uses default <data>/users/<id>/workspace \
-             — this is the mismatch the gate at ui_protocol.rs guards against"
+             — this is the mismatch the round-2 fix at ui_protocol.rs handles"
         );
 
-        // Mirror the WS turn handler's per-turn rebuild WITH the gate.
+        // Mirror the WS turn handler's per-turn rebuild WITH the
+        // round-2 fix: when the cached scope's workspace doesn't match
+        // the runtime's workspace_root, synthesize a solo scope rooted
+        // at workspace_root and propagate THAT.
         let tools = Arc::new(rt.tools.snapshot_excluding(&[]));
         let mut request_agent = Agent::new_shared(
             AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
@@ -929,14 +938,37 @@ mod tests {
         if let Some(scope) = rt.agent.session_scope() {
             if scope.workspace() == rt.workspace_root.as_path() {
                 request_agent = request_agent.with_session_scope(scope.clone());
+            } else {
+                let synthesized = SessionScope::solo(rt.workspace_root.clone(), Vec::new())
+                    .expect("solo scope from absolute workspace_root");
+                request_agent = request_agent.with_session_scope(Arc::new(synthesized));
             }
         }
 
+        let observed = request_agent
+            .session_scope()
+            .expect(
+                "per-turn agent MUST carry a synthesized scope for hint sessions \
+                     (round-2 fix — round-1 erroneously skipped propagation, leaving the \
+                     plugin tool's boundary check disabled)",
+            )
+            .clone();
+        assert_eq!(
+            observed.workspace(),
+            rt.workspace_root.as_path(),
+            "synthesized scope's workspace MUST be the runtime's workspace_root \
+             (= user-selected repo via hint) so Phase 2 consumers validate against \
+             the right tree, not the cached scope's empty default layout"
+        );
+        assert_eq!(
+            observed.root(),
+            rt.workspace_root.as_path(),
+            "solo scope: workspace == root == hint path"
+        );
         assert!(
-            request_agent.session_scope().is_none(),
-            "per-turn agent must NOT inherit the mismatched scope when the session was \
-             opened with a workspace hint — propagating would point migrated tools at the \
-             empty default workspace instead of the user-selected repo (codex round-1 P1)",
+            observed.shared_zones().is_empty(),
+            "solo scope must declare no cross-session shared zones — hint sessions own \
+             their workspace boundary, not a multi-tenant layout"
         );
     }
 

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -860,36 +860,41 @@ mod tests {
         assert_eq!(turn_scope.root(), data_dir.as_path());
     }
 
-    /// Phase 3-A codex round-3 P2 regression-pin: when a coding-agent
-    /// UI opens a session with an explicit `cwd` hint, the cached
+    /// Phase 3-A codex round-4 regression-pin: when a coding-agent UI
+    /// opens a session with an explicit `cwd` hint, the cached
     /// `SessionRuntime` honours the hint for `workspace_root` and the
     /// rebound tool registry, but `bootstrap` still builds the
     /// `SessionScope` from the canonical `<data>/users/<id>/workspace`
     /// layout — so the cached scope's workspace does NOT match the
-    /// runtime's. The WS turn handler MUST synthesize a solo scope
-    /// rooted at `workspace_root` AND granting the upload tmpdir
-    /// (`octos_bus::file_handle::temp_upload_root()`).
+    /// runtime's. The WS turn handler MUST skip propagation in this
+    /// case and leave the per-turn agent's `session_scope` as None
+    /// so hint sessions stay on their pre-Phase-3-A (legacy) behaviour.
     ///
-    /// Round-2 of this fix synthesized the workspace scope but with
-    /// EMPTY granted_dirs, which made hint sessions lose `up/...`
-    /// upload-handle resolution: the file/plugin path resolvers prefer
-    /// `ctx.session_scope` when present, and the new scope-aware path
-    /// classified attachment paths under `/tmp/octos-uploads` as
-    /// `OutOfScope`, rejecting them. The legacy unscoped resolver
-    /// always allowed `canonical_path.starts_with(&upload_root)`, so
-    /// adding the upload root as a `granted_dir` reaffirms that trust
-    /// contract through the new path without widening it. Fix-line:
-    /// pass `vec![temp_upload_root()]` to `SessionScope::solo(...)`
-    /// at `api/ui_protocol.rs::15693-15703`.
+    /// Why skip rather than synthesize? Rounds 2 and 3 of this fix
+    /// tried synthesizing a workspace-rooted solo scope (round-2 with
+    /// empty grants, round-3 with `temp_upload_root` granted), but
+    /// each surfaced further regressions:
+    /// - The scope-aware resolver does not decode `up/...` handles
+    ///   (codex round-3 P2.a) — it treats them as workspace-relative
+    ///   `<workspace>/up/...`, so attachment resolution breaks.
+    /// - The plugin tool's classifier uses lexical (not canonical)
+    ///   classification (codex round-3 P2.b), so on macOS the
+    ///   `/var/folders/...` raw form and the `/private/var/folders/...`
+    ///   canonical form mismatch — granting one doesn't cover the
+    ///   other.
     ///
-    /// This test mirrors the round-3 rebuild and confirms the
-    /// synthesized scope's `granted_dirs` carries the upload tmpdir
-    /// (so `up/...` handles + absolute upload paths still resolve)
-    /// alongside the user-selected workspace.
+    /// Both of those are Phase-2 consumer changes the user explicitly
+    /// bounded out of this PR ("stay in plumbing — additive scope
+    /// propagation only"). The minimal-blast-radius landing is to
+    /// SKIP propagation for hint sessions and document the deferral
+    /// via a `TODO(phase3b)` at the call site.
+    ///
+    /// This test mirrors the round-4 rebuild and confirms hint
+    /// sessions keep their pre-Phase-3-A `session_scope: None`
+    /// behaviour byte-for-byte.
     #[tokio::test]
-    async fn ui_protocol_ws_turn_agent_synthesizes_workspace_scope_on_workspace_hint() {
+    async fn ui_protocol_ws_turn_agent_skips_session_scope_on_workspace_hint() {
         use octos_agent::Agent;
-        use octos_core::{ScopeMode, SessionScope};
 
         let tmp = TempDir::new().unwrap();
         let data_dir = tmp.path().join("profile-data");
@@ -925,19 +930,12 @@ mod tests {
             runtime_scope.workspace(),
             rt.workspace_root.as_path(),
             "Phase 1 design: scope still uses default <data>/users/<id>/workspace \
-             — this is the mismatch the round-3 fix at ui_protocol.rs handles"
+             — this is the mismatch the round-4 skip at ui_protocol.rs guards against"
         );
 
         // Mirror the WS turn handler's per-turn rebuild WITH the
-        // round-3 fix: when the cached scope's workspace doesn't match
-        // the runtime's workspace_root, synthesize a solo scope rooted
-        // at workspace_root AND granting the upload tmpdir.
-        let upload_root = octos_bus::file_handle::temp_upload_root();
-        let granted_dirs = if upload_root.is_absolute() {
-            vec![upload_root.clone()]
-        } else {
-            Vec::new()
-        };
+        // round-4 skip gate: when the cached scope's workspace doesn't
+        // match the runtime's workspace_root, skip propagation.
         let tools = Arc::new(rt.tools.snapshot_excluding(&[]));
         let mut request_agent = Agent::new_shared(
             AgentId::new(format!("ui-protocol-{}", uuid::Uuid::now_v7())),
@@ -948,53 +946,19 @@ mod tests {
         if let Some(scope) = rt.agent.session_scope() {
             if scope.workspace() == rt.workspace_root.as_path() {
                 request_agent = request_agent.with_session_scope(scope.clone());
-            } else {
-                let synthesized = SessionScope::solo(rt.workspace_root.clone(), granted_dirs)
-                    .expect("solo scope from absolute workspace_root + upload root grant");
-                request_agent = request_agent.with_session_scope(Arc::new(synthesized));
             }
+            // else: skip — see api/ui_protocol.rs round-4 comment for
+            // the full trade-off matrix; deferred to phase3b.
         }
 
-        let observed = request_agent
-            .session_scope()
-            .expect(
-                "per-turn agent MUST carry a synthesized scope for hint sessions \
-                 (round-2 fix — round-1 erroneously skipped propagation, leaving the \
-                 plugin tool's boundary check disabled)",
-            )
-            .clone();
-        assert_eq!(
-            observed.workspace(),
-            rt.workspace_root.as_path(),
-            "synthesized scope's workspace MUST be the runtime's workspace_root \
-             (= user-selected repo via hint) so Phase 2 consumers validate against \
-             the right tree, not the cached scope's empty default layout"
-        );
-        assert_eq!(
-            observed.root(),
-            rt.workspace_root.as_path(),
-            "solo scope: workspace == root == hint path"
-        );
         assert!(
-            observed.shared_zones().is_empty(),
-            "solo scope must declare no cross-session shared zones — hint sessions own \
-             their workspace boundary, not a multi-tenant layout"
+            request_agent.session_scope().is_none(),
+            "per-turn agent must skip the mismatched scope when the session was \
+             opened with a workspace hint — hint sessions keep their pre-Phase-3-A \
+             `session_scope: None` behaviour byte-for-byte (Phase 3-B PR will revisit \
+             once the scope-aware resolver handles `up/...` decoding and canonical \
+             classification)",
         );
-        // Round-3 pin: the synthesized scope MUST grant the upload
-        // tmpdir so `up/...` handles + absolute upload paths still
-        // resolve through `resolve_path_for_session_scope_*` for
-        // hint sessions (otherwise attachments are classified
-        // `OutOfScope` and rejected).
-        match observed.mode() {
-            ScopeMode::Solo { granted_dirs } => {
-                assert!(
-                    granted_dirs.iter().any(|d| d == &upload_root),
-                    "synthesized scope MUST grant temp_upload_root() so hint sessions \
-                     can still resolve uploaded attachments; got granted_dirs = {granted_dirs:?}",
-                );
-            }
-            other => panic!("synthesized scope must be solo, got {other:?}"),
-        }
     }
 
     #[tokio::test]

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -775,6 +775,22 @@ impl Handler for CodergenHandler {
             worker = worker.with_parent_session_key(session_key.clone());
         }
 
+        // Phase 3-A plumbing follow-up (Phase 1 gap): propagate the
+        // parent session's `SessionScope` snapshotted into
+        // `PipelineHostContext::session_scope` (see
+        // `octos_pipeline::host_context::PipelineHostContext::from_tool_context`)
+        // onto the per-node worker. Without this every pipeline-spawned
+        // child Agent would observe `session_scope: None` and the
+        // Phase-2 consumers (file tools, shell/spawn CWD, plugin tool
+        // work_dir) inside the child would fall through to legacy
+        // paths — re-introducing the mini5 NEW-06 contamination class
+        // through `run_pipeline` even when the parent turn carried a
+        // scope. Legacy callers (CLI / unit tests where the host
+        // context is empty) stay on the `None` branch byte-for-byte.
+        if let Some(ref scope) = self.host_context.session_scope {
+            worker = worker.with_session_scope(scope.clone());
+        }
+
         // coding-blue FA-7: propagate parent's declarative compaction
         // onto every LLM-call node so the worker honours preflight +
         // post-call compaction and the policy's preserved-artifacts

--- a/crates/octos-pipeline/tests/m8_parity.rs
+++ b/crates/octos-pipeline/tests/m8_parity.rs
@@ -228,3 +228,68 @@ async fn handler_registry_default_with_codergen_carrying_host_context() {
         "Codergen handler should resolve out of the registry"
     );
 }
+
+/// Phase 3-A plumbing follow-up (gap #2 from codex review of
+/// Phase 2-C): the pipeline `CodergenHandler::execute` builds a
+/// per-node worker `Agent::new(...)` and threads parent host-context
+/// fields onto it via `.with_file_state_cache(...)`, etc. Before this
+/// fix, `host_context.session_scope` was NOT among the propagated
+/// fields, so every pipeline-spawned child agent observed
+/// `session_scope: None` and the Phase-2 consumers inside the child
+/// (file tools / shell+spawn CWD / plugin work_dir) fell back to
+/// legacy paths — re-introducing the mini5 NEW-06 contamination
+/// class through `run_pipeline` even when the parent turn carried
+/// a scope.
+///
+/// This is a plumbing assertion: confirm `CodergenHandler` exposes
+/// the `session_scope` it was built with via the doc-hidden test
+/// accessor. The fact that the `execute()` path threads this onto
+/// `worker = Agent::new(...).with_session_scope(scope)` is then a
+/// straight-line propagation we don't need a synthetic LLM run to
+/// exercise.
+#[tokio::test]
+async fn pipeline_worker_agent_inherits_session_scope() {
+    use octos_core::SessionScope;
+
+    let session_root = tempfile::tempdir().expect("scope root");
+    let scope = Arc::new(
+        SessionScope::multi_tenant_with_default_zones(
+            session_root.path().to_path_buf(),
+            "_main".to_string(),
+            "web-1779000000000-pipw0r".to_string(),
+        )
+        .expect("multi-tenant scope"),
+    );
+
+    let host = PipelineHostContext {
+        // Stand alone — no other parent-session resources required to
+        // exercise the session_scope propagation.
+        session_scope: Some(scope.clone()),
+        ..Default::default()
+    };
+    let codergen = CodergenHandler::new(
+        Arc::new(MockProvider) as Arc<dyn octos_llm::LlmProvider>,
+        temp_episode_store().await,
+        std::env::temp_dir(),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .with_host_context(host);
+
+    let observed = codergen.host_context();
+    let observed_scope = observed
+        .session_scope
+        .as_ref()
+        .expect("CodergenHandler must propagate SessionScope from host context");
+    assert!(
+        Arc::ptr_eq(&scope, observed_scope),
+        "CodergenHandler must hold the SAME SessionScope Arc the host context attached, \
+         not a freshly-built one (proves scope is propagated end-to-end)",
+    );
+    // Workspace shape sanity — the scope's workspace dir resolves to
+    // the multi-tenant `<root>/users/<profile>/sessions/<id>/workspace`
+    // layout the on-disk contract requires.
+    assert!(
+        observed_scope.workspace().starts_with(session_root.path()),
+        "scope workspace must live under the tenant root we configured"
+    );
+}


### PR DESCRIPTION
## Summary

Codex review of Phase 2-C surfaced 3 plumbing gaps that Phase 1 (#1199) missed. Without closing them, the Phase 2 consumers (#1201/#1202/#1203/#1204) don't fire on the WS chat or pipeline-worker paths — mini5 NEW-06 contamination would persist on the actual fleet.

### Original gaps
- **Gap #1 — `crates/octos-cli/src/api/ui_protocol.rs::15608`**: WS turn handler rebuilds `Agent::new_shared` per-turn but did NOT copy `session_scope` from the cached `SessionRuntime`. Per-turn agents observed `session_scope: None` and Phase-2 consumers fell through to legacy paths. **Fix:** thread `session_runtime.agent.session_scope().clone()` onto the per-turn `request_agent` via `.with_session_scope(...)`.
- **Gap #2 — `crates/octos-pipeline/src/handler.rs::753`**: `CodergenHandler::execute` threads parent host-context fields onto per-node workers but did NOT propagate `host_context.session_scope`. Pipeline-spawned child agents observed `session_scope: None` even when the parent turn carried a scope. **Fix:** add `worker = worker.with_session_scope(scope.clone())` to the worker builder chain.
- **Gap #3 — `crates/octos-cli/src/runtime/session.rs::316`**: unsafe-session-id branch (channel-prefixed `api:web-1234`, etc) deliberately leaves `session_scope: None`. **Verify only:** existing comment already documents the rationale; this PR adds a design-pin test.

### Codex review iterations (4 rounds — full audit trail)

| Round | Approach | What codex flagged | Disposition |
|------:|----------|--------------------|-------------|
| 1 | Unconditional propagation | P1 hint-session workspace mismatch (cached scope's workspace ≠ runtime's workspace_root → migrated tools point at empty default workspace) | Fixed in round-2 |
| 2 | Skip propagation for hint sessions | P1 hint-session plugin path-escape risk (skipping leaves PluginTool on legacy unscoped rewrite branch) | Fixed in round-3 (synthesize workspace-rooted solo scope) |
| 3 | Synthesize workspace-rooted solo scope + `temp_upload_root` grant | P2 `up/...` handle decoding (scope-aware resolver doesn't decode handles, treats as workspace-relative) + P2 macOS lexical-vs-canonical mismatch | Both deferred to Phase 3-B (Phase-2 consumer changes — out of "stay in plumbing" scope) |
| 4 (landed) | Skip propagation for hint sessions, keep them on legacy pre-Phase-3-A behaviour | P2 `run_pipeline` cross-session contamination for hinted turns (pre-existing — `RunPipelineTool` was unread before this PR too) | Pre-existing condition; flagged as `TODO(phase3b)` |

The skip-for-hint approach in round-4 is the minimal-blast-radius landing: default-layout sessions (the common mini5 NEW-06 path) get full scope propagation; hint sessions (coding-agent UI flow) stay on their pre-existing legacy behaviour byte-for-byte. Phase 3-B PR(s) will close the remaining gaps by either reconciling bootstrap-side scope construction with `workspace_hint` and/or adding handle-decode support to the scope-aware resolver.

### Constraint compliance

The user's task brief was explicit: "Stay in plumbing — DO NOT change Phase 2 consumer behaviour. This is 'Phase 1 follow-up' — additive scope propagation only." Rounds 2 and 3 attempted to extend coverage to hint sessions but each required Phase-2 consumer changes to land cleanly (resolver handle decoding, plugin lexical→canonical classification). Round-4 honours the boundary and tracks the deferred work explicitly.

## Tests

New tests (3 in this PR):
- `crates/octos-cli/src/runtime/session.rs::tests::ui_protocol_ws_turn_agent_inherits_session_scope` — exercises the EXACT WS rebuild pattern for the default-layout case and asserts via `Arc::ptr_eq` that the per-turn agent observes the SAME `SessionScope` Arc the cached `SessionRuntime` holds.
- `crates/octos-cli/src/runtime/session.rs::tests::ui_protocol_ws_turn_agent_skips_session_scope_on_workspace_hint` — round-4 regression pin: hint sessions (workspace mismatch) yield `request_agent.session_scope() == None`.
- `crates/octos-cli/src/runtime/session.rs::tests::unsafe_session_id_session_intentionally_has_none_scope` — gap #3 design pin covering `api:web-1234`, `telegram:12345`, `discord:guild#chan`.
- `crates/octos-pipeline/tests/m8_parity.rs::pipeline_worker_agent_inherits_session_scope` — asserts `CodergenHandler::host_context()` exposes the propagated `SessionScope` via the doc-hidden test accessor.

## Test plan

- [x] `cargo test -p octos-cli --lib` → 461 pass (3 new session_scope tests included)
- [x] `cargo test -p octos-pipeline --lib` → 198 pass
- [x] `cargo test -p octos-pipeline --test m8_parity` → 6 incl 1 new pass
- [x] `cargo test -p octos-agent --lib` → 1659 pass
- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --lib -- -D warnings`

## Phase 2 plumbing chain (context)

Phase 1 (#1199) introduced the scope; Phase 2-A/B/C/D (#1203 / #1202 / #1201 / #1204) made consumers read it. Phase 3-A (this PR) plumbs the scope to the WS turn agent and pipeline worker. Phase 3-B (follow-up) will reconcile hint-session scope construction with bootstrap (and/or add handle-decode + canonical classification to the scope-aware resolver) so hint sessions also benefit from full Phase-2 consumer activation.

## Followup PR: Phase 3-B

A separate PR should land:
1. `SessionRuntime::bootstrap`: build `SessionScope` from `workspace_root` for hint sessions (not just safe-id default-layout).
2. `octos-bus::file_handle::resolve_path_for_session_scope_*`: decode `up/...` handles before classification.
3. `octos-agent::plugins::tool::PluginTool::rewrite_args_with_scope`: switch from `classify_lexical_path` to canonical classification.
4. Add the canonical upload root (`/private/var/folders/...` on macOS) to synthesized granted_dirs.

After (1)-(4), the round-4 skip branch in this PR becomes unreachable and can be removed.