### PR TITLE
fix(cli): protect init defaults config

### DIFF
--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -167,7 +167,13 @@ impl Executable for InitCommand {
                 "Config already exists:".yellow(),
                 config_path.display()
             );
-            if !self.defaults {
+            if self.defaults {
+                return Err(eyre::eyre!(
+                    "octos init --defaults will not overwrite existing config at {}. \
+Run `octos init` interactively to confirm replacement.",
+                    config_path.display()
+                ));
+            } else {
                 print!("Overwrite? [y/N] ");
                 io::stdout().flush()?;
 

--- a/crates/octos-cli/tests/cli_tests.rs
+++ b/crates/octos-cli/tests/cli_tests.rs
@@ -174,6 +174,38 @@ fn test_init_defaults_in_temp_dir() {
 }
 
 #[test]
+fn test_init_defaults_refuses_to_overwrite_existing_config() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".octos");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_path = config_dir.join("config.json");
+    let original = r#"{"provider":"sentinel","model":"keep-me"}"#;
+    std::fs::write(&config_path, original).unwrap();
+
+    let mut cmd = Command::new(octos_binary());
+    clear_provider_env(&mut cmd);
+    let output = cmd
+        .env("ANTHROPIC_API_KEY", "test-ant-key")
+        .args(["init", "--defaults", "--cwd"])
+        .arg(temp_dir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "init --defaults should fail instead of overwriting existing config"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.contains("Config already exists:"));
+    assert!(
+        stderr.contains("will not overwrite existing config"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(std::fs::read_to_string(&config_path).unwrap(), original);
+}
+
+#[test]
 fn test_init_defaults_uses_octos_home_when_cwd_not_provided() {
     let temp_dir = tempfile::tempdir().unwrap();
     let octos_home = temp_dir.path().join("custom-home");


### PR DESCRIPTION
## Summary
- make `octos init --defaults` fail closed when `config.json` already exists
- keep the interactive overwrite prompt behavior unchanged for `octos init`
- add a CLI regression test proving the existing config remains untouched

Closes #290

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p octos-cli --test cli_tests test_init_defaults -- --nocapture`
- `cargo test -p octos-cli --test cli_tests -- --nocapture`
- `cargo clippy -p octos-cli --test cli_tests --no-deps`
- `git diff --check`