### PR TITLE
fix(dashboard): use ConfirmDialog on UsersPage deletes

### DIFF
--- a/dashboard/src/pages/UsersPage.test.tsx
+++ b/dashboard/src/pages/UsersPage.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import UsersPage from './UsersPage'
+import type { AllowlistEntry, User } from '../types'
+
+const mockListAllowedEmails = vi.fn()
+const mockListUsers = vi.fn()
+const mockAddAllowedEmail = vi.fn()
+const mockDeleteAllowedEmail = vi.fn()
+const mockDeleteUser = vi.fn()
+
+vi.mock('../api', () => ({
+  api: {
+    listAllowedEmails: () => mockListAllowedEmails(),
+    listUsers: () => mockListUsers(),
+    addAllowedEmail: (data: { email: string; note?: string }) => mockAddAllowedEmail(data),
+    deleteAllowedEmail: (email: string) => mockDeleteAllowedEmail(email),
+    deleteUser: (id: string) => mockDeleteUser(id),
+  },
+}))
+
+const allowlisted: AllowlistEntry[] = [
+  {
+    email: 'registered@example.com',
+    note: 'pilot',
+    created_at: '2026-05-01T00:00:00Z',
+    registered: true,
+    registered_user_id: 'user-1',
+    registered_name: 'Registered User',
+    last_login_at: '2026-05-02T00:00:00Z',
+  },
+]
+
+const users: User[] = [
+  {
+    id: 'user-1',
+    email: 'registered@example.com',
+    name: 'Registered User',
+    role: 'user',
+    created_at: '2026-05-01T00:00:00Z',
+    last_login_at: '2026-05-02T00:00:00Z',
+  },
+]
+
+function mockLoadedState() {
+  mockListAllowedEmails.mockResolvedValue({ entries: allowlisted })
+  mockListUsers.mockResolvedValue({ users })
+  mockAddAllowedEmail.mockResolvedValue({})
+  mockDeleteAllowedEmail.mockResolvedValue({})
+  mockDeleteUser.mockResolvedValue({})
+}
+
+describe('UsersPage confirmation dialogs', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    mockLoadedState()
+  })
+
+  it('removes allowlist entries through ConfirmDialog without native confirm', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    const user = userEvent.setup()
+
+    render(<UsersPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Remove' }))
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(/future OTP signup will no longer be pre-authorized/i),
+    ).toBeInTheDocument()
+    expect(mockDeleteAllowedEmail).not.toHaveBeenCalled()
+
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' })
+    await user.click(removeButtons[removeButtons.length - 1])
+
+    await waitFor(() => {
+      expect(mockDeleteAllowedEmail).toHaveBeenCalledWith('registered@example.com')
+    })
+  })
+
+  it('deletes users through ConfirmDialog and respects cancel', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    const user = userEvent.setup()
+
+    render(<UsersPage />)
+
+    await user.click(await screen.findByRole('button', { name: 'Delete' }))
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(/will also delete the profile and stop its gateway/i),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(mockDeleteUser).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' })
+    await user.click(deleteButtons[deleteButtons.length - 1])
+
+    await waitFor(() => {
+      expect(mockDeleteUser).toHaveBeenCalledWith('user-1')
+    })
+  })
+})

--- a/dashboard/src/pages/UsersPage.tsx
+++ b/dashboard/src/pages/UsersPage.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { api } from '../api'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { useToast } from '../components/Toast'
 import type { AllowlistEntry, User } from '../types'
+
+interface PendingConfirm {
+  title: string
+  message: string
+  confirmLabel: string
+  onConfirm: () => Promise<void>
+}
 
 function formatDate(value: string | null | undefined): string {
   if (!value) return 'Never'
@@ -42,6 +50,7 @@ export default function UsersPage() {
   const [newNote, setNewNote] = useState('')
   const [removingEmail, setRemovingEmail] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null)
 
   const loadData = useCallback(async () => {
     try {
@@ -99,14 +108,7 @@ export default function UsersPage() {
     }
   }
 
-  const handleRemoveAllowlist = async (entry: AllowlistEntry) => {
-    const confirmed = confirm(
-      entry.registered
-        ? `Remove "${entry.email}" from the allowlist? The already-registered account will remain, but future OTP signup will no longer be pre-authorized.`
-        : `Remove "${entry.email}" from the allowlist?`,
-    )
-    if (!confirmed) return
-
+  const removeAllowlist = async (entry: AllowlistEntry) => {
     try {
       setRemovingEmail(entry.email)
       await api.deleteAllowedEmail(entry.email)
@@ -119,10 +121,18 @@ export default function UsersPage() {
     }
   }
 
-  const handleDeleteUser = async (user: User) => {
-    if (!confirm(`Delete account "${user.email}"? This will also delete the profile and stop its gateway.`)) {
-      return
-    }
+  const handleRemoveAllowlist = (entry: AllowlistEntry) => {
+    setPendingConfirm({
+      title: 'Remove Allowlisted Email',
+      message: entry.registered
+        ? `Remove "${entry.email}" from the allowlist? The already-registered account will remain, but future OTP signup will no longer be pre-authorized.`
+        : `Remove "${entry.email}" from the allowlist?`,
+      confirmLabel: 'Remove',
+      onConfirm: () => removeAllowlist(entry),
+    })
+  }
+
+  const deleteUser = async (user: User) => {
     try {
       setDeletingId(user.id)
       await api.deleteUser(user.id)
@@ -133,6 +143,22 @@ export default function UsersPage() {
     } finally {
       setDeletingId(null)
     }
+  }
+
+  const handleDeleteUser = (user: User) => {
+    setPendingConfirm({
+      title: 'Delete Account',
+      message: `Delete account "${user.email}"? This will also delete the profile and stop its gateway.`,
+      confirmLabel: 'Delete',
+      onConfirm: () => deleteUser(user),
+    })
+  }
+
+  const handleConfirmAction = async () => {
+    const action = pendingConfirm
+    if (!action) return
+    setPendingConfirm(null)
+    await action.onConfirm()
   }
 
   if (loading) {
@@ -340,6 +366,18 @@ export default function UsersPage() {
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={pendingConfirm !== null}
+        title={pendingConfirm?.title ?? ''}
+        message={pendingConfirm?.message ?? ''}
+        confirmLabel={pendingConfirm?.confirmLabel}
+        danger
+        onConfirm={() => {
+          void handleConfirmAction()
+        }}
+        onCancel={() => setPendingConfirm(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace UsersPage native confirm() calls for allowlist removal and account deletion with the shared ConfirmDialog component
- keep context-specific destructive warnings, including the existing registered-allowlist and profile/gateway deletion warnings
- add UsersPage tests proving destructive API calls wait for modal confirmation and do not call window.confirm()

Closes #420

## Validation
- npm run test -- UsersPage
- npm run test
- npm run typecheck
- npm run build
- ./scripts/milestone-ci.sh dashboard
- rg -n "window\.confirm|[^A-Za-z]confirm\(" dashboard/src/pages/UsersPage.tsx (no matches)
- git diff --check

## Notes
- The current /users API response does not include sub-account cascade counts; this dialog surfaces the cascade information already available in UsersPage.
- No generated artifacts are included.