### PR TITLE
fix(admin): return structured email conflict errors

### DIFF
--- a/crates/octos-cli/src/api/user_admin.rs
+++ b/crates/octos-cli/src/api/user_admin.rs
@@ -55,29 +55,67 @@ pub struct ActionResponse {
     pub message: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    pub code: &'static str,
+    pub message: String,
+}
+
+type ApiResult<T> = Result<T, (StatusCode, Json<ErrorBody>)>;
+
+fn api_error(
+    status: StatusCode,
+    code: &'static str,
+    message: impl Into<String>,
+) -> (StatusCode, Json<ErrorBody>) {
+    (
+        status,
+        Json(ErrorBody {
+            code,
+            message: message.into(),
+        }),
+    )
+}
+
 /// GET /api/admin/users
-pub async fn list_users(
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<UsersListResponse>, StatusCode> {
-    let us = state
-        .user_store
-        .as_ref()
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let users = us.list().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+pub async fn list_users(State(state): State<Arc<AppState>>) -> ApiResult<Json<UsersListResponse>> {
+    let us = state.user_store.as_ref().ok_or_else(|| {
+        api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "user_store_unavailable",
+            "user store is unavailable",
+        )
+    })?;
+    let users = us.list().map_err(|e| {
+        tracing::error!(error = %e, "failed to list users");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "users_list_failed",
+            "failed to list users",
+        )
+    })?;
     Ok(Json(UsersListResponse { users }))
 }
 
 /// GET /api/admin/allowed-emails
 pub async fn list_allowed_emails(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<AllowlistResponse>, StatusCode> {
-    let allowlist = state
-        .allowlist_store
-        .as_ref()
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    let entries = allowlist
-        .list()
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+) -> ApiResult<Json<AllowlistResponse>> {
+    let allowlist = state.allowlist_store.as_ref().ok_or_else(|| {
+        api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "allowlist_store_unavailable",
+            "login allowlist store is unavailable",
+        )
+    })?;
+    let entries = allowlist.list().map_err(|e| {
+        tracing::error!(error = %e, "failed to list allowed emails");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "allowlist_list_failed",
+            "failed to list allowed emails",
+        )
+    })?;
     let user_store = state.user_store.as_ref();
     let mapped = entries
         .into_iter()
@@ -104,28 +142,51 @@ pub async fn list_allowed_emails(
 pub async fn add_allowed_email(
     State(state): State<Arc<AppState>>,
     Json(req): Json<AllowlistRequest>,
-) -> Result<(StatusCode, Json<AllowlistEntryResponse>), StatusCode> {
-    let allowlist = state
-        .allowlist_store
-        .as_ref()
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+) -> ApiResult<(StatusCode, Json<AllowlistEntryResponse>)> {
+    let allowlist = state.allowlist_store.as_ref().ok_or_else(|| {
+        api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "allowlist_store_unavailable",
+            "login allowlist store is unavailable",
+        )
+    })?;
     let email = crate::login_allowlist::normalize_email(&req.email);
-    super::admin::validate_email(&email).map_err(|_| StatusCode::BAD_REQUEST)?;
+    super::admin::validate_email(&email)
+        .map_err(|message| api_error(StatusCode::BAD_REQUEST, "invalid_email", message))?;
 
-    if allowlist
-        .contains(&email)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    {
-        return Err(StatusCode::CONFLICT);
+    if allowlist.contains(&email).map_err(|e| {
+        tracing::error!(email = %email, error = %e, "failed to check login allowlist");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "allowlist_read_failed",
+            "failed to read login allowlist",
+        )
+    })? {
+        return Err(api_error(
+            StatusCode::CONFLICT,
+            "email_already_allowed",
+            format!("Email \"{email}\" is already allowlisted"),
+        ));
     }
 
     if let Some(user_store) = state.user_store.as_ref() {
         if user_store
             .get_by_email(&email)
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .map_err(|e| {
+                tracing::error!(email = %email, error = %e, "failed to check registered users");
+                api_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "users_read_failed",
+                    "failed to read registered users",
+                )
+            })?
             .is_some()
         {
-            return Err(StatusCode::CONFLICT);
+            return Err(api_error(
+                StatusCode::CONFLICT,
+                "email_already_registered",
+                format!("Email \"{email}\" is already registered to an account"),
+            ));
         }
     }
 
@@ -143,9 +204,14 @@ pub async fn add_allowed_email(
         claimed_user_id: None,
         claimed_at: None,
     };
-    allowlist
-        .save(&entry)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    allowlist.save(&entry).map_err(|e| {
+        tracing::error!(email = %email, error = %e, "failed to save allowed email");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "allowlist_save_failed",
+            "failed to save allowed email",
+        )
+    })?;
 
     Ok((
         StatusCode::CREATED,
@@ -167,20 +233,31 @@ pub async fn add_allowed_email(
 pub async fn delete_allowed_email(
     State(state): State<Arc<AppState>>,
     Path(email): Path<String>,
-) -> Result<Json<ActionResponse>, StatusCode> {
-    let allowlist = state
-        .allowlist_store
-        .as_ref()
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
-    match allowlist
-        .delete(&email)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    {
+) -> ApiResult<Json<ActionResponse>> {
+    let allowlist = state.allowlist_store.as_ref().ok_or_else(|| {
+        api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "allowlist_store_unavailable",
+            "login allowlist store is unavailable",
+        )
+    })?;
+    match allowlist.delete(&email).map_err(|e| {
+        tracing::error!(email = %email, error = %e, "failed to delete allowed email");
+        api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "allowlist_delete_failed",
+            "failed to delete allowed email",
+        )
+    })? {
         true => Ok(Json(ActionResponse {
             ok: true,
             message: None,
         })),
-        false => Err(StatusCode::NOT_FOUND),
+        false => Err(api_error(
+            StatusCode::NOT_FOUND,
+            "allowed_email_not_found",
+            format!("Allowlisted email \"{email}\" was not found"),
+        )),
     }
 }
 
@@ -188,11 +265,14 @@ pub async fn delete_allowed_email(
 pub async fn delete_user(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
-) -> Result<Json<ActionResponse>, StatusCode> {
-    let us = state
-        .user_store
-        .as_ref()
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+) -> ApiResult<Json<ActionResponse>> {
+    let us = state.user_store.as_ref().ok_or_else(|| {
+        api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "user_store_unavailable",
+            "user store is unavailable",
+        )
+    })?;
 
     if let Some(ref pm) = state.process_manager {
         let _ = pm.stop(&id).await;
@@ -212,11 +292,19 @@ pub async fn delete_user(
         }
         Ok(false) => {
             tracing::warn!(user_id = %id, "delete_user: user not found");
-            Err(StatusCode::NOT_FOUND)
+            Err(api_error(
+                StatusCode::NOT_FOUND,
+                "user_not_found",
+                format!("User \"{id}\" was not found"),
+            ))
         }
         Err(e) => {
             tracing::error!(user_id = %id, error = %e, "delete_user: failed to delete");
-            Err(StatusCode::INTERNAL_SERVER_ERROR)
+            Err(api_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "user_delete_failed",
+                "failed to delete user",
+            ))
         }
     }
 }
@@ -224,6 +312,25 @@ pub async fn delete_user(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::login_allowlist::LoginAllowlistStore;
+    use crate::user_store::{UserRole, UserStore};
+
+    fn temp_user_admin_state() -> (
+        tempfile::TempDir,
+        Arc<AppState>,
+        Arc<UserStore>,
+        Arc<LoginAllowlistStore>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        let allowlist_store = Arc::new(LoginAllowlistStore::open(dir.path()).unwrap());
+        let state = Arc::new(AppState {
+            user_store: Some(user_store.clone()),
+            allowlist_store: Some(allowlist_store.clone()),
+            ..AppState::empty_for_tests()
+        });
+        (dir, state, user_store, allowlist_store)
+    }
 
     #[test]
     fn users_list_response_serialize() {
@@ -252,5 +359,85 @@ mod tests {
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["ok"], false);
         assert_eq!(json["message"], "not found");
+    }
+
+    #[test]
+    fn error_body_serialize() {
+        let resp = ErrorBody {
+            code: "email_already_allowed",
+            message: "Email is already allowlisted".into(),
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["code"], "email_already_allowed");
+        assert_eq!(json["message"], "Email is already allowlisted");
+    }
+
+    #[tokio::test]
+    async fn add_allowed_email_conflict_reports_allowlist_reason() {
+        let (_dir, state, _user_store, allowlist_store) = temp_user_admin_state();
+        allowlist_store
+            .save(&AllowedLogin {
+                email: "taken@example.com".into(),
+                note: None,
+                created_at: Utc::now(),
+                claimed_user_id: None,
+                claimed_at: None,
+            })
+            .unwrap();
+
+        let err = match add_allowed_email(
+            State(state),
+            Json(AllowlistRequest {
+                email: "taken@example.com".into(),
+                note: None,
+            }),
+        )
+        .await
+        {
+            Ok(_) => panic!("allowlist conflict should return a structured error"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.0, StatusCode::CONFLICT);
+        assert_eq!(err.1.0.code, "email_already_allowed");
+        assert_eq!(
+            err.1.0.message,
+            "Email \"taken@example.com\" is already allowlisted"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_allowed_email_conflict_reports_registered_user_reason() {
+        let (_dir, state, user_store, _allowlist_store) = temp_user_admin_state();
+        user_store
+            .save(&User {
+                id: "taken".into(),
+                email: "taken@example.com".into(),
+                name: "Taken User".into(),
+                role: UserRole::User,
+                created_at: Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+
+        let err = match add_allowed_email(
+            State(state),
+            Json(AllowlistRequest {
+                email: "taken@example.com".into(),
+                note: None,
+            }),
+        )
+        .await
+        {
+            Ok(_) => panic!("registered email conflict should return a structured error"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.0, StatusCode::CONFLICT);
+        assert_eq!(err.1.0.code, "email_already_registered");
+        assert_eq!(
+            err.1.0.message,
+            "Email \"taken@example.com\" is already registered to an account"
+        );
     }
 }

--- a/dashboard/src/api.test.ts
+++ b/dashboard/src/api.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, api } from './api'
+
+describe('api error handling', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('preserves structured error code, message, and details', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          code: 'email_already_allowed',
+          message: 'Email "user@example.com" is already allowlisted',
+          details: { email: 'user@example.com' },
+        }),
+        {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+
+    await expect(
+      api.addAllowedEmail({ email: 'user@example.com' }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'email_already_allowed',
+      message: 'Email "user@example.com" is already allowlisted',
+      details: { email: 'user@example.com' },
+    })
+  })
+
+  it('falls back to plain text response bodies', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('legacy conflict', { status: 409 }),
+    )
+
+    await expect(
+      api.addAllowedEmail({ email: 'user@example.com' }),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: 'http_error',
+      message: 'legacy conflict',
+    })
+  })
+
+  it('keeps ApiError auth detection backward compatible', () => {
+    expect(ApiError.isAuthError(new ApiError(401, 'unauthorized'))).toBe(true)
+    expect(ApiError.isAuthError(new ApiError(500, 'server error'))).toBe(false)
+  })
+})

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -18,6 +18,18 @@ import type {
 
 const BASE = '/api/admin'
 
+export type ApiErrorCode =
+  | 'email_already_allowed'
+  | 'email_already_registered'
+  | 'http_error'
+  | (string & {})
+
+interface StructuredErrorBody {
+  code?: unknown
+  message?: unknown
+  details?: unknown
+}
+
 /// Error thrown by the dashboard's request helpers when the server returns a
 /// non-2xx response. Carries the HTTP status code so callers can distinguish
 /// auth failures (401/403) from infrastructure errors (5xx) without
@@ -25,16 +37,52 @@ const BASE = '/api/admin'
 /// common "auth failed, hand back to the login flow" branch.
 export class ApiError extends Error {
   public readonly status: number
+  public readonly code: ApiErrorCode
+  public readonly details: unknown
 
-  constructor(status: number, message: string) {
+  constructor(
+    status: number,
+    message: string,
+    code: ApiErrorCode = 'http_error',
+    details?: unknown,
+  ) {
     super(message || `HTTP ${status}`)
     this.name = 'ApiError'
     this.status = status
+    this.code = code
+    this.details = details
   }
 
   static isAuthError(err: unknown): boolean {
     return err instanceof ApiError && (err.status === 401 || err.status === 403)
   }
+}
+
+function parseStructuredErrorBody(text: string): StructuredErrorBody | null {
+  if (!text.trim()) return null
+
+  try {
+    const value = JSON.parse(text) as StructuredErrorBody
+    if (value && typeof value === 'object') {
+      return value
+    }
+  } catch {
+    // Non-JSON error bodies are still valid legacy responses.
+  }
+
+  return null
+}
+
+async function errorFromResponse(res: Response): Promise<ApiError> {
+  const text = await res.text()
+  const body = parseStructuredErrorBody(text)
+  if (body) {
+    const code = typeof body.code === 'string' ? body.code : 'http_error'
+    const message = typeof body.message === 'string' ? body.message : text
+    return new ApiError(res.status, message, code, body.details)
+  }
+
+  return new ApiError(res.status, text)
 }
 
 export interface SkillRegistryPackage {
@@ -66,8 +114,7 @@ async function request<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await errorFromResponse(res)
   }
   return res.json()
 }
@@ -78,8 +125,7 @@ async function requestNoContent(path: string, opts?: RequestInit): Promise<void>
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await errorFromResponse(res)
   }
 }
 
@@ -89,8 +135,7 @@ async function publicRequest<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await errorFromResponse(res)
   }
   return res.json()
 }
@@ -101,8 +146,7 @@ async function authedRequest<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await errorFromResponse(res)
   }
   return res.json()
 }


### PR DESCRIPTION
## Summary
- return structured `{ code, message }` JSON errors from user-admin endpoints, including distinct 409 codes for already-allowlisted and already-registered emails
- parse structured backend errors in `dashboard/src/api.ts` and preserve `ApiError.code` / `ApiError.details` while keeping plain-text fallback behavior
- add Rust and dashboard tests for the new conflict/error parsing behavior

Closes #429
Refs #431

## Validation
- cargo fmt --all -- --check
- cargo test -p octos-cli --features api user_admin::tests
- cargo clippy -p octos-cli --features api --lib --no-deps (exit 0; reports pre-existing warnings outside `user_admin.rs`)
- npm run test -- api
- npm run test
- npm run typecheck
- npm run build
- ./scripts/milestone-ci.sh dashboard
- git diff --check

## Notes
- This does not claim #431 because the dashboard now preserves typed error fields, but the whole API surface has not yet adopted a single exhaustive error-code contract.
- No generated artifacts are included.