### PR TITLE
fix(ux): complete tmux runner validation controls

### DIFF
--- a/crates/octos-cli/src/api/coding_tool_contract.rs
+++ b/crates/octos-cli/src/api/coding_tool_contract.rs
@@ -781,6 +781,23 @@ fn required_tool_status_entry(
     entry.insert("capability".into(), json!(spec.capability));
     entry.insert("policy".into(), json!(spec.policy));
 
+    // #970: a tool registered but currently in the deferred set is
+    // recoverable through `activate_tools`. Surface it as `deferred` so
+    // clients can render "available, currently inactive" UX; it counts
+    // as available for the contract's `missing_required_tools` filter.
+    // This check intentionally precedes disabled-by-policy: deferred
+    // tools are registered but hidden from the model surface until
+    // activation, so they can appear in both sets.
+    if deferred_model_tools.contains(spec.name) {
+        entry.insert("status".into(), json!(TOOL_STATUS_DEFERRED));
+        entry.insert("backend_tool".into(), json!(spec.name));
+        entry.insert(
+            "detail".into(),
+            json!("registered but currently auto-deferred; recoverable via activate_tools"),
+        );
+        return Value::Object(entry);
+    }
+
     if disabled_model_tools.contains(spec.name) {
         entry.insert("status".into(), json!(TOOL_STATUS_DISABLED_BY_POLICY));
         entry.insert("backend_tool".into(), json!(spec.name));
@@ -791,20 +808,6 @@ fn required_tool_status_entry(
     if available_model_tools.contains(spec.name) {
         entry.insert("status".into(), json!(TOOL_STATUS_AVAILABLE));
         entry.insert("backend_tool".into(), json!(spec.name));
-        return Value::Object(entry);
-    }
-
-    // #970: a tool registered but currently in the deferred set is
-    // recoverable through `activate_tools`. Surface it as `deferred` so
-    // clients can render "available, currently inactive" UX; it counts
-    // as available for the contract's `missing_required_tools` filter.
-    if deferred_model_tools.contains(spec.name) {
-        entry.insert("status".into(), json!(TOOL_STATUS_DEFERRED));
-        entry.insert("backend_tool".into(), json!(spec.name));
-        entry.insert(
-            "detail".into(),
-            json!("registered but currently auto-deferred; recoverable via activate_tools"),
-        );
         return Value::Object(entry);
     }
 
@@ -1169,6 +1172,38 @@ mod tests {
 
         let apply_patch = required_tool(contract, "apply_patch");
         assert_eq!(apply_patch["status"], json!(TOOL_STATUS_AVAILABLE));
+    }
+
+    #[test]
+    fn deferred_canonical_tool_wins_over_disabled_policy_status() {
+        // The runtime derives `disabled_model_tools` as registered-but-not-
+        // visible. Auto-deferred tools are therefore present in both the
+        // disabled and deferred sets; deferred must win so the contract stays
+        // ready and points clients at `activate_tools`.
+        let deferred = &[
+            "exec_command",
+            "write_stdin",
+            "spawn_agent",
+            "send_input",
+            "resume_agent",
+            "wait_agent",
+            "close_agent",
+        ];
+        let context = ToolStatusListContext {
+            available_model_tools: &["apply_patch", "update_plan", "request_user_input"],
+            disabled_model_tools: deferred,
+            deferred_model_tools: deferred,
+            ..ToolStatusListContext::default_for_session("coding:test")
+        };
+        let payload = tool_status_list_payload(context);
+        let contract = &payload["coding_tool_contract"];
+
+        assert_eq!(contract["status"], json!("ready"));
+        assert_eq!(contract["missing_required_tools"], json!([]));
+        assert_eq!(
+            required_tool(contract, "exec_command")["status"],
+            json!(TOOL_STATUS_DEFERRED)
+        );
     }
 
     #[test]

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -29,6 +29,7 @@
     "matrix": "node matrix/run.mjs",
     "ux:scenario:list": "node scripts/ux-scenario-list.mjs",
     "ux:scenario:list:test": "node --test tests/ux/scenario-list.test.mjs",
+    "ux:tmux:run:test": "node --test tests/ux/tmux-run.test.mjs",
     "soak:m17:live-proof": "bash scripts/m17-live-proof-soak.sh run",
     "soak:m17:live-proof:validate": "bash scripts/m17-live-proof-soak.sh validate",
     "soak:m17:live-proof:self-test": "bash scripts/m17-live-proof-soak.sh self-test"

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -157,13 +157,15 @@ const scenarios = new Map([
 
 function usage() {
   return `Usage:
-  node e2e/scripts/ux-tmux-run.mjs <scenario-id> [--dry-run]
+  node e2e/scripts/ux-tmux-run.mjs <scenario-id> [--dry-run] [--keep-session] [--no-validate]
   node e2e/scripts/ux-tmux-run.mjs --self-test [${defaultScenarioId}]
 
 Options:
-  --dry-run      Write the artifact skeleton without launching tmux.
-  --self-test    Write and validate the artifact skeleton without launching tmux.
-  --help         Show this help.
+  --dry-run       Write the artifact skeleton without launching tmux.
+  --keep-session  Leave tmux sessions running after a real run.
+  --no-validate   Skip automatic ux:tmux:validate after a dry or real run.
+  --self-test     Write and validate the artifact skeleton without launching tmux.
+  --help          Show this help.
 
 Scenarios:
   ${[...scenarios.keys()].join(', ')}
@@ -180,6 +182,8 @@ Environment:
 function parseArgs(argv) {
   let scenarioId = null;
   let dryRun = false;
+  let keepSession = false;
+  let noValidate = false;
   let selfTest = false;
   let help = false;
 
@@ -187,6 +191,10 @@ function parseArgs(argv) {
     const arg = argv[i];
     if (arg === '--dry-run') {
       dryRun = true;
+    } else if (arg === '--keep-session') {
+      keepSession = true;
+    } else if (arg === '--no-validate') {
+      noValidate = true;
     } else if (arg === '--self-test' || arg === 'self-test') {
       selfTest = true;
     } else if (arg === '--scenario') {
@@ -211,6 +219,8 @@ function parseArgs(argv) {
   return {
     scenarioId: scenarioId || defaultScenarioId,
     dryRun,
+    keepSession,
+    noValidate,
     selfTest,
     help,
   };
@@ -353,6 +363,7 @@ function resolveContext({ scenarioId, selfTest }) {
   const cols = positiveIntegerEnv('OCTOS_UX_TMUX_COLS', scenario.id === 'narrow-layout' ? 80 : 120);
   const rows = positiveIntegerEnv('OCTOS_UX_TMUX_ROWS', scenario.id === 'narrow-layout' ? 24 : 40);
   const port = positiveIntegerEnv('OCTOS_UX_TMUX_PORT', stablePortForRunId(runKey));
+  const fakeOpenAiPort = positiveIntegerEnv('OCTOS_UX_TMUX_FAKE_OPENAI_PORT', port + 1);
   const profileId = process.env.OCTOS_UX_TMUX_PROFILE || 'coding';
   const sessionId =
     process.env.OCTOS_UX_TMUX_SESSION_ID || `${profileId}:local:ux:${scenario.id}:${runId}`;
@@ -398,6 +409,7 @@ function resolveContext({ scenarioId, selfTest }) {
     cols,
     rows,
     port,
+    fakeOpenAiPort,
     websocketEndpoint,
     authToken,
     profileId,
@@ -639,6 +651,24 @@ function refreshSummaryArtifacts(ctx, validationStatus = null) {
   writeJson(summaryPath, summary);
 }
 
+function skipValidation(ctx) {
+  const summaryPath = path.join(ctx.scenarioDir, 'summary.json');
+  if (fs.existsSync(summaryPath)) {
+    const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+    summary.validation_status = 'skipped';
+    summary.validation_skipped = true;
+    summary.artifacts = Object.fromEntries(
+      collectArtifactNames(ctx.scenarioDir).map((name) => [
+        name,
+        artifactInfo(ctx.scenarioDir, name),
+      ]),
+    );
+    writeJson(summaryPath, summary);
+  }
+  console.log(`Validation skipped (--no-validate): ${ctx.scenarioDir}`);
+  return 0;
+}
+
 function missingRunnerBlocker(ctx) {
   if (!fs.existsSync(ctx.lowerRunner)) {
     return `octos-tui tmux runner is missing: ${ctx.lowerRunner}`;
@@ -866,11 +896,107 @@ function runnerSteps(ctx) {
   if (ctx.scenario.runner === 'task-subagent-tree') {
     return ['start', 'drive-task-subagent-tree', 'drive-solo'];
   }
+  if (ctx.scenario.runner === 'onboarding-solo') {
+    return ['start', 'drive-solo', 'send-turn'];
+  }
   return ['start', 'drive-solo'];
 }
 
-function runLowerRunner(ctx) {
+function sleep(seconds) {
+  spawnSync('sleep', [String(seconds)]);
+}
+
+function waitForTcp(host, port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const script = [
+    'import socket, sys',
+    `host=${JSON.stringify(host)}`,
+    `port=${Number(port)}`,
+    's=socket.socket()',
+    's.settimeout(0.2)',
+    'try:',
+    '    s.connect((host, port))',
+    'except OSError:',
+    '    sys.exit(1)',
+    'finally:',
+    '    s.close()',
+  ].join('\n');
+  while (Date.now() < deadline) {
+    const probe = spawnSync('python3', ['-c', script], { stdio: 'ignore' });
+    if (probe.status === 0) return true;
+    sleep(0.1);
+  }
+  return false;
+}
+
+function startScenarioFakeOpenAi(ctx) {
+  if (ctx.scenario.runner !== 'onboarding-solo' || !ctx.scenario.finalMarker) {
+    return null;
+  }
+  const fakeServer = path.join(ctx.tuiRepo, 'scripts', 'fake-openai-server.py');
+  if (!fs.existsSync(fakeServer)) {
+    throw new Error(`fake OpenAI server is missing: ${fakeServer}`);
+  }
+  fs.mkdirSync(ctx.scenarioDir, { recursive: true });
+  const logPath = path.join(ctx.scenarioDir, 'fake-openai.log');
+  const logFd = fs.openSync(logPath, 'a');
+  const child = spawn('python3', [
+    fakeServer,
+    '--host',
+    '127.0.0.1',
+    '--port',
+    String(ctx.fakeOpenAiPort),
+    '--content',
+    `\`${ctx.scenario.finalMarker}\``,
+  ], {
+    cwd: ctx.tuiRepo,
+    stdio: ['ignore', logFd, logFd],
+  });
+  if (!waitForTcp('127.0.0.1', ctx.fakeOpenAiPort, 5_000)) {
+    child.kill('SIGTERM');
+    fs.closeSync(logFd);
+    throw new Error(`fake OpenAI server did not become ready on port ${ctx.fakeOpenAiPort}`);
+  }
+  return {
+    stop() {
+      child.kill('SIGTERM');
+      fs.closeSync(logFd);
+    },
+  };
+}
+
+function captureContainsFinalAnswerMarker(text, marker) {
+  const normalizedMarker = marker.replaceAll('_', '');
+  return text.split('\n').some((line) => {
+    const normalizedLine = line.replaceAll('_', '');
+    if (!line.includes(marker) && !normalizedLine.includes(normalizedMarker)) return false;
+    return !/^\s*[›>]/.test(line) && !/finish with|send one short prompt/i.test(line);
+  });
+}
+
+function waitForFinalMarker(ctx, action) {
+  if (!ctx.scenario.finalMarker) return 0;
+  const deadline = Date.now() + Number(process.env.OCTOS_UX_TMUX_FINAL_MARKER_WAIT_MS || 20_000);
+  const capturePath = path.join(ctx.scenarioDir, 'tui-capture.txt');
+  while (Date.now() < deadline) {
+    const capture = action('capture', false);
+    if (capture.error) throw capture.error;
+    if (capture.status !== 0) return capture.status || 1;
+    if (fs.existsSync(capturePath)) {
+      const text = fs.readFileSync(capturePath, 'utf8');
+      if (captureContainsFinalAnswerMarker(text, ctx.scenario.finalMarker)) {
+        return 0;
+      }
+    }
+    sleep(1);
+  }
+  console.error(`final marker was not visible in tui-capture.txt: ${ctx.scenario.finalMarker}`);
+  return 1;
+}
+
+function runLowerRunner(ctx, options = {}) {
   const shouldInitProfileLlm = ctx.scenario.runner === 'provider-missing' ? '0' : '1';
+  const fakeOpenAiBaseUrl = `http://127.0.0.1:${ctx.fakeOpenAiPort}/v1`;
   const env = {
     ...process.env,
     OCTOS_REPO: repoRoot,
@@ -890,6 +1016,14 @@ function runLowerRunner(ctx) {
     OCTOS_TUI_SOAK_LOCAL_USERNAME: process.env.OCTOS_TUI_SOAK_LOCAL_USERNAME || ctx.profileId,
     OCTOS_TUI_SOAK_LOCAL_EMAIL: process.env.OCTOS_TUI_SOAK_LOCAL_EMAIL || `${ctx.profileId}@example.invalid`,
     OCTOS_TUI_SOAK_API_KEY: process.env.OCTOS_TUI_SOAK_API_KEY || 'octos-m19-placeholder-key',
+    OCTOS_TUI_SOAK_PROMPT: process.env.OCTOS_TUI_SOAK_PROMPT || ctx.scenario.prompt || '',
+    OCTOS_TUI_SOAK_TURN_WAIT_SECS: process.env.OCTOS_TUI_SOAK_TURN_WAIT_SECS || '12',
+    OCTOS_TUI_SOAK_EXPECT_BASE_URL: process.env.OCTOS_TUI_SOAK_EXPECT_BASE_URL || fakeOpenAiBaseUrl,
+    OCTOS_TUI_SOAK_EXPECT_ROUTE: process.env.OCTOS_TUI_SOAK_EXPECT_ROUTE || 'm19-fake-openai',
+    OCTOS_TUI_SOAK_EXPECT_MODEL: process.env.OCTOS_TUI_SOAK_EXPECT_MODEL || 'gpt-4o-mini',
+    OCTOS_TUI_SOAK_EXPECT_FAMILY: process.env.OCTOS_TUI_SOAK_EXPECT_FAMILY || 'openai',
+    OCTOS_TUI_SOAK_EXPECT_API_KEY_ENV:
+      process.env.OCTOS_TUI_SOAK_EXPECT_API_KEY_ENV || 'OCTOS_M19_FAKE_OPENAI_KEY',
     OCTOS_TUI_SOAK_INIT_PROFILE_LLM:
       process.env.OCTOS_TUI_SOAK_INIT_PROFILE_LLM || shouldInitProfileLlm,
     OCTOS_TUI_SOAK_PORT: String(ctx.port),
@@ -902,7 +1036,9 @@ function runLowerRunner(ctx) {
       || (ctx.scenario.transport === 'websocket' ? '4' : '1'),
     OCTOS_TUI_SOAK_TUI_WAIT_SECS: process.env.OCTOS_TUI_SOAK_TUI_WAIT_SECS || '2',
     OCTOS_TUI_SOAK_EXIT_HOLD_SECS: process.env.OCTOS_TUI_SOAK_EXIT_HOLD_SECS || '30',
-    OCTOS_M9_PROTOCOL_FIXTURES: '1',
+    OCTOS_M9_PROTOCOL_FIXTURES:
+      process.env.OCTOS_M9_PROTOCOL_FIXTURES
+      || (ctx.scenario.runner === 'onboarding-solo' ? '0' : '1'),
     ...ctx.fixtureEnv,
   };
 
@@ -913,39 +1049,47 @@ function runLowerRunner(ctx) {
   });
 
   let status = 0;
-  if (ctx.scenario.runner === 'restart-reconnect') {
-    status = runRestartReconnectScenario(ctx, action, env);
-  } else if (ctx.scenario.runner === 'dropped-completion-backpressure') {
-    status = runDroppedCompletionBackpressureScenario(ctx, action, env);
-  } else {
-    for (const step of runnerSteps(ctx)) {
-      if (status !== 0) break;
-      const stepEnv = ctx.scenario.runner === 'provider-missing' && step === 'drive-solo'
-        ? { OCTOS_TUI_SOAK_INIT_PROFILE_LLM: '1' }
-        : {};
-      const result = action(step, true, stepEnv);
-      if (result.error) throw result.error;
-      if (result.status !== 0) status = result.status || 1;
-      if (step === 'start' && status === 0) {
-        if (ctx.scenario.transport === 'websocket' && !tmuxHasSession(ctx.sessionName)) {
-          console.error(`TUI session ${ctx.sessionName} was missing after lower runner start; relaunching real websocket TUI`);
-          const fallbackStatus = launchWebsocketTuiFallback(ctx, env);
-          if (fallbackStatus !== 0) status = fallbackStatus;
+  let fakeServer = null;
+  try {
+    fakeServer = startScenarioFakeOpenAi(ctx);
+    if (ctx.scenario.runner === 'restart-reconnect') {
+      status = runRestartReconnectScenario(ctx, action, env);
+    } else if (ctx.scenario.runner === 'dropped-completion-backpressure') {
+      status = runDroppedCompletionBackpressureScenario(ctx, action, env);
+    } else {
+      for (const step of runnerSteps(ctx)) {
+        if (status !== 0) break;
+        const stepEnv = ctx.scenario.runner === 'provider-missing' && step === 'drive-solo'
+          ? { OCTOS_TUI_SOAK_INIT_PROFILE_LLM: '1' }
+          : {};
+        const result = action(step, true, stepEnv);
+        if (result.error) throw result.error;
+        if (result.status !== 0) status = result.status || 1;
+        if (step === 'start' && status === 0) {
+          if (ctx.scenario.transport === 'websocket' && !tmuxHasSession(ctx.sessionName)) {
+            console.error(`TUI session ${ctx.sessionName} was missing after lower runner start; relaunching real websocket TUI`);
+            const fallbackStatus = launchWebsocketTuiFallback(ctx, env);
+            if (fallbackStatus !== 0) status = fallbackStatus;
+          }
+          resizeTmuxWindow(ctx);
         }
-        resizeTmuxWindow(ctx);
+        if (step === 'send-turn' && status === 0) {
+          status = waitForFinalMarker(ctx, action);
+        }
       }
     }
+
+    const capture = action('capture');
+    if (capture.error && status === 0) throw capture.error;
+    if (capture.status !== 0 && status === 0) status = capture.status || 1;
+
+    return status;
+  } finally {
+    if (!options.keepSession && process.env.OCTOS_UX_TMUX_KEEP_SESSION !== '1') {
+      action('stop', false);
+    }
+    if (fakeServer) fakeServer.stop();
   }
-
-  const capture = action('capture');
-  if (capture.error && status === 0) throw capture.error;
-  if (capture.status !== 0 && status === 0) status = capture.status || 1;
-
-  if (process.env.OCTOS_UX_TMUX_KEEP_SESSION !== '1') {
-    action('stop', false);
-  }
-
-  return status;
 }
 
 function runValidation(ctx) {
@@ -959,7 +1103,7 @@ function runValidation(ctx) {
   return status;
 }
 
-function realMode(ctx) {
+function realMode(ctx, options = {}) {
   if (!ctx.scenario.runner) {
     const blocker = ctx.scenario.blockedMessage || `scenario ${ctx.scenario.id} has no real tmux runner yet`;
     writeArtifactSkeleton(ctx, {
@@ -971,7 +1115,7 @@ function realMode(ctx) {
       placeholderArtifacts: true,
       realTmuxLaunched: false,
     });
-    const validationStatus = runValidation(ctx);
+    const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
     console.error(`${blocker}\nArtifacts: ${ctx.scenarioDir}`);
     return validationStatus === 0 ? 2 : validationStatus;
   }
@@ -987,7 +1131,7 @@ function realMode(ctx) {
       placeholderArtifacts: true,
       realTmuxLaunched: false,
     });
-    const validationStatus = runValidation(ctx);
+    const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
     console.error(`${runnerBlocker}\nArtifacts: ${ctx.scenarioDir}`);
     return validationStatus === 0 ? 2 : validationStatus;
   }
@@ -1003,7 +1147,7 @@ function realMode(ctx) {
       placeholderArtifacts: true,
       realTmuxLaunched: false,
     });
-    const validationStatus = runValidation(ctx);
+    const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
     console.error(`${blocker}\nArtifacts: ${ctx.scenarioDir}`);
     return validationStatus === 0 ? 2 : validationStatus;
   }
@@ -1019,7 +1163,7 @@ function realMode(ctx) {
 
   let status = 1;
   try {
-    status = runLowerRunner(ctx);
+    status = runLowerRunner(ctx, { keepSession: options.keepSession });
   } finally {
     writeArtifactSkeleton(ctx, {
       mode: 'run',
@@ -1030,12 +1174,12 @@ function realMode(ctx) {
       realTmuxLaunched: true,
     });
   }
-  const validationStatus = runValidation(ctx);
+  const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
   console.log(`UX tmux artifacts: ${ctx.scenarioDir}`);
   return status === 0 ? validationStatus : status;
 }
 
-function dryRun(ctx) {
+function dryRun(ctx, options = {}) {
   writeArtifactSkeleton(ctx, {
     mode: 'dry-run',
     status: 'blocked',
@@ -1044,7 +1188,7 @@ function dryRun(ctx) {
     placeholderArtifacts: true,
     realTmuxLaunched: false,
   });
-  const validationStatus = runValidation(ctx);
+  const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
   console.log(`Dry run wrote UX tmux artifact skeleton: ${ctx.scenarioDir}`);
   return validationStatus;
 }
@@ -1076,8 +1220,8 @@ function main() {
 
   const ctx = resolveContext(args);
   if (args.selfTest) return selfTest(ctx);
-  if (args.dryRun) return dryRun(ctx);
-  return realMode(ctx);
+  if (args.dryRun) return dryRun(ctx, { noValidate: args.noValidate });
+  return realMode(ctx, { keepSession: args.keepSession, noValidate: args.noValidate });
 }
 
 try {

--- a/e2e/tests/ux/tmux-run.test.mjs
+++ b/e2e/tests/ux/tmux-run.test.mjs
@@ -1,0 +1,66 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const RUNNER = resolve(REPO_ROOT, "e2e", "scripts", "ux-tmux-run.mjs");
+
+function makeEnv(runId) {
+  const root = mkdtempSync(join(tmpdir(), "octos-ux-tmux-run-test-"));
+  return {
+    env: {
+      ...process.env,
+      OCTOS_UX_TMUX_RUN_ID: runId,
+      OCTOS_UX_TMUX_OUT_ROOT: join(root, "out"),
+      OCTOS_UX_TMUX_RUNTIME_ROOT: join(root, "runtime"),
+    },
+    outDir: join(root, "out", runId, "stdio-happy-path"),
+  };
+}
+
+function run(args, env = process.env) {
+  return execFileSync(process.execPath, [RUNNER, ...args], {
+    cwd: REPO_ROOT,
+    env,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+test("help documents keep-session and no-validate flags", () => {
+  const out = run(["--help"]);
+  assert.match(out, /--keep-session/);
+  assert.match(out, /--no-validate/);
+});
+
+test("self-test writes and validates the artifact skeleton", () => {
+  const { env, outDir } = makeEnv("ux-run-test-self");
+  const out = run(["--self-test", "stdio-happy-path"], env);
+  assert.match(out, /Self-test passed:/);
+
+  const summary = readJson(join(outDir, "summary.json"));
+  const validation = readJson(join(outDir, "validation.json"));
+  assert.equal(summary.validation_status, "passed");
+  assert.equal(validation.status, "passed");
+});
+
+test("dry-run can skip automatic validation", () => {
+  const { env, outDir } = makeEnv("ux-run-test-no-validate");
+  const out = run(["stdio-happy-path", "--dry-run", "--no-validate"], env);
+  assert.match(out, /Validation skipped/);
+
+  const summary = readJson(join(outDir, "summary.json"));
+  assert.equal(summary.validation_status, "skipped");
+  assert.equal(summary.validation_skipped, true);
+  assert.equal(existsSync(join(outDir, "validation.json")), false);
+});


### PR DESCRIPTION
## Summary
- Add `--keep-session` and `--no-validate` support to `ux:tmux:run`, including skipped-validation summary metadata.
- Add a dedicated `ux:tmux:run:test` script covering help output, self-test artifacts, and `--no-validate` dry runs.
- Treat canonical deferred Codex tools as deferred before disabled-by-policy so the real tmux lower soak reports the coding tool contract ready.
- Drive the stdio happy path through a local fake OpenAI-compatible provider and verify the final answer marker is visible in the captured TUI pane.

Refs #1065 — superseded as the closure path by PR #1307, which carries the passing real stdio UX gate evidence.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p octos-cli --features api --lib api::coding_tool_contract::tests::`
- `npm --prefix e2e run ux:tmux:run:test`
- `node --test e2e/tests/ux/tmux-run.test.mjs`
- `npm --prefix e2e run ux:scenario:list:test`
- `npm --prefix e2e run ux:tmux:run -- --self-test stdio-happy-path`
- `npm --prefix e2e run ux:tmux:run -- stdio-happy-path --dry-run --no-validate`
- `cargo build -p octos-cli --features api --bin octos`
- `OCTOS_TUI_REPO=/Users/yuechen/home/octos-tui npm --prefix e2e run ux:tmux:run -- stdio-happy-path`
- `rg -n "M19_STDIO_HAPPY_PATH_FINAL_LINE" e2e/test-results-ux/ux-tmux-20260524T064652Z/stdio-happy-path/tui-capture.txt`
- `cargo clippy -p octos-cli --features api --lib --no-deps` (passes; existing warnings remain outside this slice)

Real tmux artifact: `/Users/yuechen/home/octos/target/codex-ux-tmux-run-1065/e2e/test-results-ux/ux-tmux-20260524T064652Z/stdio-happy-path`

The real lane validation status was `passed`, including artifact ABI, AppUI transcript parse/semantic checks, real tmux evidence, screen geometry, lower soak summary semantic checks, and the final marker visible in `tui-capture.txt` line 7.