### PR TITLE
fix(dashboard): type API errors

### DIFF
--- a/dashboard/src/api.test.ts
+++ b/dashboard/src/api.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { API_ERROR_CODES, ApiError, api } from './api'
+
+const fetchMock = vi.fn()
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  localStorage.clear()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('ApiError', () => {
+  it('preserves structured server error codes and details', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(409, {
+        code: 'email_already_allowed',
+        message: 'Email is already allowlisted',
+        details: { email: 'dev@example.com' },
+      }),
+    )
+
+    try {
+      await api.addAllowedEmail({ email: 'dev@example.com' })
+      throw new Error('expected request to fail')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiErr = err as ApiError
+      expect(apiErr.status).toBe(409)
+      expect(apiErr.code).toBe('email_already_allowed')
+      expect(apiErr.message).toBe('Email is already allowlisted')
+      expect(apiErr.details).toEqual({ email: 'dev@example.com' })
+      expect(apiErr.payload).toEqual({
+        code: 'email_already_allowed',
+        message: 'Email is already allowlisted',
+        details: { email: 'dev@example.com' },
+      })
+    }
+  })
+
+  it('derives typed codes for legacy text responses', async () => {
+    fetchMock.mockResolvedValue(new Response('forbidden', { status: 403 }))
+
+    try {
+      await api.listUsers()
+      throw new Error('expected request to fail')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiErr = err as ApiError
+      expect(apiErr.status).toBe(403)
+      expect(apiErr.code).toBe(API_ERROR_CODES.forbidden)
+      expect(apiErr.message).toBe('forbidden')
+      expect(ApiError.isAuthError(apiErr)).toBe(true)
+    }
+  })
+
+  it('uses the HTTP status code when JSON errors omit code', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(422, { message: 'Invalid email' }))
+
+    try {
+      await api.addAllowedEmail({ email: 'not-an-email' })
+      throw new Error('expected request to fail')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      const apiErr = err as ApiError
+      expect(apiErr.status).toBe(422)
+      expect(apiErr.code).toBe(API_ERROR_CODES.validation)
+      expect(apiErr.message).toBe('Invalid email')
+    }
+  })
+})

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -21,23 +21,136 @@ import type {
 
 const BASE = '/api/admin'
 
-/// Error thrown by the dashboard's request helpers when the server returns a
-/// non-2xx response. Carries the HTTP status code so callers can distinguish
-/// auth failures (401/403) from infrastructure errors (5xx) without
-/// re-parsing the message string. Use `ApiError.isAuthError(err)` for the
-/// common "auth failed, hand back to the login flow" branch.
-export class ApiError extends Error {
-  public readonly status: number
+export const API_ERROR_CODES = {
+  unauthorized: 'unauthorized',
+  forbidden: 'forbidden',
+  notFound: 'not_found',
+  conflict: 'conflict',
+  validation: 'validation_error',
+  rateLimited: 'rate_limited',
+  server: 'server_error',
+  http: 'http_error',
+} as const
 
-  constructor(status: number, message: string) {
-    super(message || `HTTP ${status}`)
+export type KnownApiErrorCode =
+  (typeof API_ERROR_CODES)[keyof typeof API_ERROR_CODES]
+
+export type ApiErrorCode = KnownApiErrorCode | (string & {})
+
+export interface ApiErrorPayload<C extends ApiErrorCode = ApiErrorCode> {
+  code: C
+  message: string
+  details?: unknown
+}
+
+interface ApiErrorOptions<C extends ApiErrorCode = ApiErrorCode> {
+  code?: C
+  details?: unknown
+  payload?: ApiErrorPayload<C>
+}
+
+/// Error thrown by the dashboard's request helpers when the server returns a
+/// non-2xx response. Carries both HTTP status and structured server error code
+/// so callers can branch on `err.code` instead of parsing message text.
+export class ApiError<C extends ApiErrorCode = ApiErrorCode> extends Error {
+  public readonly status: number
+  public readonly code: C
+  public readonly details?: unknown
+  public readonly payload: ApiErrorPayload<C>
+
+  constructor(
+    status: number,
+    message: string,
+    codeOrOptions?: C | ApiErrorOptions<C>,
+    details?: unknown,
+  ) {
+    const options: ApiErrorOptions<C> =
+      typeof codeOrOptions === 'object' && codeOrOptions !== null
+        ? codeOrOptions
+        : { code: codeOrOptions, details }
+    const code = options.code ?? (apiErrorCodeForStatus(status) as C)
+    const resolvedMessage = message || `HTTP ${status}`
+    super(resolvedMessage)
     this.name = 'ApiError'
     this.status = status
+    this.code = code
+    this.details = options.details
+    this.payload = options.payload ?? {
+      code,
+      message: resolvedMessage,
+      ...(options.details === undefined ? {} : { details: options.details }),
+    }
   }
 
   static isAuthError(err: unknown): boolean {
-    return err instanceof ApiError && (err.status === 401 || err.status === 403)
+    return (
+      err instanceof ApiError &&
+      (err.code === API_ERROR_CODES.unauthorized ||
+        err.code === API_ERROR_CODES.forbidden ||
+        err.status === 401 ||
+        err.status === 403)
+    )
   }
+}
+
+function apiErrorCodeForStatus(status: number): KnownApiErrorCode {
+  if (status === 401) return API_ERROR_CODES.unauthorized
+  if (status === 403) return API_ERROR_CODES.forbidden
+  if (status === 404) return API_ERROR_CODES.notFound
+  if (status === 409) return API_ERROR_CODES.conflict
+  if (status === 422 || status === 400) return API_ERROR_CODES.validation
+  if (status === 429) return API_ERROR_CODES.rateLimited
+  if (status >= 500) return API_ERROR_CODES.server
+  return API_ERROR_CODES.http
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeApiErrorPayload(status: number, raw: string): ApiErrorPayload {
+  const fallbackCode = apiErrorCodeForStatus(status)
+  const fallbackMessage = raw.trim() || `HTTP ${status}`
+
+  if (!raw.trim()) {
+    return { code: fallbackCode, message: fallbackMessage }
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!isRecord(parsed)) {
+      return { code: fallbackCode, message: fallbackMessage }
+    }
+    const code =
+      typeof parsed.code === 'string' && parsed.code.trim()
+        ? parsed.code
+        : fallbackCode
+    const message =
+      typeof parsed.message === 'string' && parsed.message.trim()
+        ? parsed.message
+        : typeof parsed.error === 'string' && parsed.error.trim()
+          ? parsed.error
+          : fallbackMessage
+    return {
+      code,
+      message,
+      ...(Object.prototype.hasOwnProperty.call(parsed, 'details')
+        ? { details: parsed.details }
+        : {}),
+    }
+  } catch {
+    return { code: fallbackCode, message: fallbackMessage }
+  }
+}
+
+async function apiErrorFromResponse(res: Response): Promise<ApiError> {
+  const raw = await res.text()
+  const payload = normalizeApiErrorPayload(res.status, raw)
+  return new ApiError(res.status, payload.message, {
+    code: payload.code,
+    details: payload.details,
+    payload,
+  })
 }
 
 export interface SkillRegistryPackage {
@@ -69,8 +182,7 @@ async function request<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
   return res.json()
 }
@@ -81,8 +193,7 @@ async function requestNoContent(path: string, opts?: RequestInit): Promise<void>
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
 }
 
@@ -92,8 +203,7 @@ async function publicRequest<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
   return res.json()
 }
@@ -104,8 +214,7 @@ async function authedRequest<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
   return res.json()
 }

--- a/dashboard/src/components/BootstrapGate.tsx
+++ b/dashboard/src/components/BootstrapGate.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
-import { ApiError, api, authApi } from '../api'
+import { API_ERROR_CODES, ApiError, api, authApi } from '../api'
 import { useAuth } from '../contexts/AuthContext'
 
 // Result of the bootstrap check.
@@ -14,6 +14,17 @@ import { useAuth } from '../contexts/AuthContext'
 type GateDecision = { redirectTo: string | null; path: string }
 
 const SETUP_PATHS = new Set(['/setup/welcome', '/setup/rotate-token'])
+
+function isAuthApiError(reason: unknown): boolean {
+  if (!(reason instanceof ApiError)) return false
+  switch (reason.code) {
+    case API_ERROR_CODES.unauthorized:
+    case API_ERROR_CODES.forbidden:
+      return true
+    default:
+      return ApiError.isAuthError(reason)
+  }
+}
 
 export default function BootstrapGate({ children }: { children: React.ReactNode }) {
   const { isAdmin } = useAuth()
@@ -41,8 +52,8 @@ export default function BootstrapGate({ children }: { children: React.ReactNode 
       if (cancelled) return
 
       const authFailed =
-        (statusRes.status === 'rejected' && ApiError.isAuthError(statusRes.reason)) ||
-        (stateRes.status === 'rejected' && ApiError.isAuthError(stateRes.reason))
+        (statusRes.status === 'rejected' && isAuthApiError(statusRes.reason)) ||
+        (stateRes.status === 'rejected' && isAuthApiError(stateRes.reason))
       if (authFailed) {
         // Let AuthGuard handle the redirect. Render children so the
         // unauthenticated path is invisible (no setup chrome flashes).


### PR DESCRIPTION
## Summary

- Extend dashboard `ApiError` with typed `code`, optional `details`, and original structured payload.
- Parse non-2xx JSON error bodies shaped as `{ code, message, details? }`, while deriving stable fallback codes for legacy text responses.
- Update `BootstrapGate` to branch on typed auth codes while preserving current main's no-password solo-login probe.
- Add API client tests for structured errors, legacy text fallback codes, and JSON errors without an explicit code.
- Refreshed from current GitHub `main` `1df02bd3975a66b232ae1a5c62ddf48297f88317`; refreshed head `e6bb01a4927d3bcb2b34624a3c47ec65c20d7433`.

Closes #431

## Validation

Environment: isolated clone `/Users/yuechen/home/octos/target/octos-431-refresh.xUNFhp/octos`; root checkout left untouched; npm cache `/private/tmp/octos-npm-cache-431-refresh-current`; dashboard build output `/private/tmp/octos-431-dashboard-build-current-1df02`.

Passed locally:
- `git diff --check origin/main...HEAD`
- `git ls-files --others --exclude-standard` -> empty
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-431-refresh-current npm --prefix dashboard ci` -> completed with existing npm audit findings only
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-431-refresh-current npm --prefix dashboard test -- api.test.ts` -> 1 file / 3 tests passed
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-431-refresh-current npm --prefix dashboard test` -> 7 files / 35 tests passed
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-431-refresh-current npm --prefix dashboard run typecheck`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-431-refresh-current VITE_OUT_DIR=/private/tmp/octos-431-dashboard-build-current-1df02 npm --prefix dashboard run build`

GitHub checks passed:
- CI run `26734475681`: `dashboard`, `swarm-app`, `typos`, `check`, `check-matrix`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, and `test-octos-cli` passed; platform/security/e2e expansion jobs skipped by workflow matrix.
- Author-email run `26734475701`: `reject blocked author/committer emails` passed.

No generated artifacts are included. Remaining merge gate: branch protection requires review (`REVIEW_REQUIRED`).
