### PR TITLE
docs: refresh stale skill and serve references

### DIFF
--- a/book-zh/src/advanced.md
+++ b/book-zh/src/advanced.md
@@ -604,9 +604,9 @@ octos cron enable <job-id> --disable
 REST API 服务器包含一个内嵌的 Web 界面：
 
 ```bash
-octos serve                              # 绑定到 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # 接受外部连接
-# 打开 http://localhost:8080
+octos serve                               # 绑定到 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # 接受外部连接
+# 打开 http://localhost:50080
 ```
 
 功能：

--- a/book-zh/src/cli-reference.md
+++ b/book-zh/src/cli-reference.md
@@ -128,8 +128,8 @@ Bootstrap Files
 
 ```bash
 cargo install --path crates/octos-cli --features api
-octos serve                              # 绑定到 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # 接受外部连接
+octos serve                               # 绑定到 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # 接受外部连接
 ```
 
 功能包括：会话侧栏、聊天界面、SSE 流式传输、暗色主题。`/metrics` 端点提供 Prometheus 格式的指标（`octos_tool_calls_total`、`octos_tool_call_duration_seconds`、`octos_llm_tokens_total`）。

--- a/book-zh/src/memory-skills.md
+++ b/book-zh/src/memory-skills.md
@@ -307,7 +307,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # 安装到指定配置文件
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 安装程序会优先从技能注册表下载预编译二进制文件（SHA-256 校验），如有 `Cargo.toml` 则回退到 `cargo build --release`，如有 `package.json` 则运行 `npm install`。
@@ -325,16 +325,14 @@ octos skills search "web scraping"   # 搜索在线注册表
 
 ### 技能解析顺序
 
-技能按以下目录加载（优先级从高到低）：
+配置文件 gateway 按以下优先级加载技能：
 
-1. `.octos/plugins/`（旧版兼容）
-2. `.octos/skills/`（用户安装的自定义技能）
-3. `.octos/bundled-app-skills/`（预装应用技能）
-4. `.octos/platform-skills/`（平台技能：ASR/TTS）
-5. `~/.octos/plugins/`（全局旧版兼容）
-6. `~/.octos/skills/`（全局自定义技能）
+1. `~/.octos/profiles/<profile>/data/skills/`（配置文件作用域的自定义技能）
+2. `<octos_home>/bundled-app-skills/`（预装应用技能）
+3. `<octos_home>/platform-skills/`（管理员加载的平台技能）
 
-用户安装的技能会覆盖同名的预装技能。
+独立项目运行还可以加载 `<project>/.octos/plugins/` 和
+`<project>/.octos/skills/`。旧的 HOME 全局目录仅用于迁移，不再属于常规扫描路径。
 
 ---
 

--- a/book-zh/src/skill-development.md
+++ b/book-zh/src/skill-development.md
@@ -127,7 +127,7 @@ pub enum ValidatorSpec {
 ```
 User message → LLM → tool_use("get_weather", {"city": "Paris"})
                          ↓
-              Gateway spawns: ~/.octos/skills/weather/main get_weather
+              Gateway spawns: ~/.octos/profiles/<profile>/data/skills/weather/main get_weather
                          ↓
               Stdin:  {"city": "Paris"}
               Stdout: {"output": "Paris, France\nClear sky\n...", "success": true}
@@ -153,7 +153,7 @@ crates/app-skills/my-skill/
 启动引导后，技能安装在：
 
 ```
-~/.octos/skills/my-skill/
+~/.octos/profiles/alice/data/skills/my-skill/
 ├── main                # 可执行二进制文件（从 target/ 复制）
 ├── manifest.json       # 工具定义
 └── SKILL.md            # 文档
@@ -392,7 +392,7 @@ pub const BUNDLED_APP_SKILLS: &[(&str, &str, &str, &str)] = &[
 
 **元组格式：** `(dir_name, binary_name, skill_md, manifest_json)`
 
-- `dir_name`：`~/.octos/skills/` 下的目录名
+- `dir_name`：引导写入 `<octos_home>/bundled-app-skills/` 时使用的目录名
 - `binary_name`：`target/release/` 中的二进制文件名（必须与 Cargo.toml 中的 `[[bin]] name` 匹配）
 - `skill_md`：嵌入的 SKILL.md 内容
 - `manifest_json`：嵌入的 manifest.json 内容
@@ -431,12 +431,15 @@ echo '{"param1": "test"}' | ./target/debug/my_skill unknown_tool
 # 构建 release 版本并安装
 cargo build --release --workspace
 
-# 启动网关（技能自动引导加载）
-octos gateway
+# 安装到要测试的配置文件
+octos skills --profile alice install ./my-skill
 
 # 检查技能是否已加载
-ls ~/.octos/skills/my-skill/
+ls ~/.octos/profiles/alice/data/skills/my-skill/
 # main  manifest.json  SKILL.md
+
+# 启动网关
+octos gateway
 
 # 让 Agent 使用你的技能
 ```
@@ -672,7 +675,7 @@ fn get_smtp_config() -> SmtpConfig {
 **示例：技能目录布局**
 
 ```
-~/.octos/skills/my-style-guide/
+~/.octos/profiles/alice/data/skills/my-style-guide/
 ├── manifest.json
 ├── SKILL.md
 └── prompts/
@@ -878,8 +881,8 @@ requires_env: MY_API_KEY
 # 只构建该技能
 cargo build --release -p weather
 
-# 复制到远程服务器
-scp target/release/weather remote:~/.octos/skills/weather/main
+# 复制到远程服务器上的目标配置文件
+scp target/release/weather remote:~/.octos/profiles/alice/data/skills/weather/main
 
 # 无需重启网关 — 下次工具调用时使用新二进制文件
 ```
@@ -952,8 +955,8 @@ manage_skills(action="search", query="comic")
 
 1. `<profile-data>/skills/` — 按配置文件（最高优先级）
 2. `<project-dir>/skills/` — 项目本地
-3. `<project-dir>/bundled-skills/` — 内置应用技能
-4. `~/.octos/skills/` — 全局（最低优先级）
+3. `<project-dir>/bundled-app-skills/` — 内置应用技能
+4. `~/.octos/skills/` — 旧版全局目录，仅用于迁移
 
 ### 发布到注册表
 
@@ -1062,7 +1065,7 @@ let styles_dir = skill_dir.join("styles");
 - [ ] 添加到 `bundled_app_skills.rs` 中的 `BUNDLED_APP_SKILLS`
 - [ ] `cargo build --workspace` 成功
 - [ ] 独立测试：`echo '{"param": "value"}' | ./target/debug/my_skill my_tool`
-- [ ] 网关测试：技能出现在 `~/.octos/skills/` 中且 Agent 可以使用
+- [ ] 网关测试：技能出现在目标配置文件的 `data/skills/` 中且 Agent 可以使用
 
 ### 扩展（MCP 服务器、钩子、提示片段）
 

--- a/book/src/advanced.md
+++ b/book/src/advanced.md
@@ -604,9 +604,9 @@ octos cron enable <job-id> --disable
 The REST API server includes an embedded web UI:
 
 ```bash
-octos serve                              # Binds to 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # Accept external connections
-# Open http://localhost:8080
+octos serve                               # Binds to 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # Accept external connections
+# Open http://localhost:50080
 ```
 
 Features:

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -128,8 +128,8 @@ Launch the web UI and REST API server. Requires the `api` feature flag.
 
 ```bash
 cargo install --path crates/octos-cli --features api
-octos serve                              # Binds to 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # Accept external connections
+octos serve                               # Binds to 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # Accept external connections
 ```
 
 Features: session sidebar, chat interface, SSE streaming, dark theme. A `/metrics` endpoint provides Prometheus-format metrics (`octos_tool_calls_total`, `octos_tool_call_duration_seconds`, `octos_llm_tokens_total`).

--- a/book/src/memory-skills.md
+++ b/book/src/memory-skills.md
@@ -307,7 +307,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # Install into a specific profile
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 The installer tries to download a pre-built binary from the skill registry (SHA-256 verified), falls back to `cargo build --release` if a `Cargo.toml` is present, or runs `npm install` if a `package.json` is present.
@@ -325,16 +325,15 @@ octos skills search "web scraping"   # Search the online registry
 
 ### Skill Resolution Order
 
-Skills are loaded from these directories (highest priority first):
+Profile gateways load skills from these directories (highest priority first):
 
-1. `.octos/plugins/` (legacy)
-2. `.octos/skills/` (user-installed custom skills)
-3. `.octos/bundled-app-skills/` (bundled app skills)
-4. `.octos/platform-skills/` (platform: ASR/TTS)
-5. `~/.octos/plugins/` (global legacy)
-6. `~/.octos/skills/` (global custom)
+1. `~/.octos/profiles/<profile>/data/skills/` (profile-scoped custom skills)
+2. `<octos_home>/bundled-app-skills/` (bundled app skills)
+3. `<octos_home>/platform-skills/` (admin-loaded platform skills)
 
-User-installed skills override bundled skills with the same name.
+Standalone project runs can also load `<project>/.octos/plugins/` and
+`<project>/.octos/skills/`. The old HOME-rooted global directories are
+migration-only and are no longer part of the normal scan path.
 
 ---
 

--- a/book/src/skill-development.md
+++ b/book/src/skill-development.md
@@ -21,7 +21,7 @@ This guide covers the full lifecycle of an Octos skill — from development to p
 | **App Store** | Apple App Store | [octos-hub](https://github.com/octos-org/octos-hub) registry |
 | **Distribution** | App Store binary delivery | Pre-built binaries in GitHub Releases |
 | **Install** | Tap "Get" | `octos skills install user/repo` |
-| **Sideload** | Ad-hoc / TestFlight | Copy to `~/.octos/skills/` directly |
+| **Sideload** | Ad-hoc / TestFlight | `octos skills --profile <profile> install ./my-skill` |
 
 ---
 
@@ -148,7 +148,7 @@ A skill is a **standalone executable** that communicates via **stdin/stdout JSON
 ```
 User message → LLM → tool_use("get_weather", {"city": "Paris"})
                         ↓
-             Gateway spawns: ~/.octos/skills/weather/main get_weather
+             Gateway spawns: ~/.octos/profiles/<profile>/data/skills/weather/main get_weather
                         ↓
              Stdin:  {"city": "Paris"}
              Stdout: {"output": "25°C, sunny", "success": true}
@@ -441,12 +441,15 @@ echo '{"param1": "hello"}' | ./my-skill/main my_tool
 # Build everything
 cargo build --release --workspace
 
-# Start the gateway
-octos gateway
+# Install into the profile you want to test
+octos skills --profile alice install ./my-skill
 
 # Verify skill loaded
-ls ~/.octos/skills/my-skill/
+ls ~/.octos/profiles/alice/data/skills/my-skill/
 # main  manifest.json  SKILL.md
+
+# Start the gateway
+octos gateway
 
 # Ask the agent to use your skill in conversation
 ```
@@ -688,21 +691,26 @@ DELETE /api/admin/profiles/alice/skills/my-skill
 
 ### Sideloading (Manual Install)
 
-Copy a skill directory directly — like sideloading an app:
+Install a local skill directory into the profile that should be allowed to use
+it:
 
 ```bash
-# Copy to global skills directory
-cp -r my-skill/ ~/.octos/skills/my-skill/
-chmod +x ~/.octos/skills/my-skill/main
+octos skills --profile alice install ./my-skill --force
+```
 
-# Or to a profile-specific directory
+For one-off debugging you can copy the directory yourself, but keep the target
+profile-scoped:
+
+```bash
+# Canonical: per-profile install
 cp -r my-skill/ ~/.octos/profiles/alice/data/skills/my-skill/
+chmod +x ~/.octos/profiles/alice/data/skills/my-skill/main
 ```
 
 ### Installed Skill Layout
 
 ```
-~/.octos/skills/my-skill/
+~/.octos/profiles/alice/data/skills/my-skill/
 ├── main                # Executable binary
 ├── manifest.json       # Tool definitions
 ├── SKILL.md            # Documentation
@@ -729,8 +737,8 @@ When multiple directories contain a skill with the same name, first match wins:
 |----------|----------|--------|
 | 1 (highest) | `<profile-data>/skills/` | Per-profile install |
 | 2 | `<project-dir>/skills/` | Project-local |
-| 3 | `<project-dir>/bundled-skills/` | Bundled app-skills |
-| 4 (lowest) | `~/.octos/skills/` | Global install |
+| 3 | `<project-dir>/bundled-app-skills/` | Bundled app-skills |
+| 4 (lowest, deprecated) | `~/.octos/skills/` | Legacy global install, migration only |
 
 ---
 
@@ -758,7 +766,7 @@ Skill binaries can be updated without restarting the gateway:
 cargo build --release -p my-skill
 
 # Replace the binary
-cp target/release/my_skill ~/.octos/skills/my-skill/main
+cp target/release/my_skill ~/.octos/profiles/alice/data/skills/my-skill/main
 
 # Next tool call automatically uses the new binary
 ```

--- a/docs/app-skill-dev-guide-zh.md
+++ b/docs/app-skill-dev-guide-zh.md
@@ -281,7 +281,7 @@ manage_skills(action="search", query="comic")
 1. `<profile-data>/skills/` — 配置文件级（最高优先级）
 2. `<project-dir>/skills/` — 项目本地
 3. `<project-dir>/bundled-app-skills/` — 内置应用技能（常量 `BUNDLED_APP_SKILLS_DIR`，位于 `octos-agent/src/bootstrap.rs`，由 `Config::plugin_dirs_from_project` 扫描）
-4. `~/.octos/skills/` — 全局（最低优先级）
+4. `~/.octos/skills/` — 旧版全局目录，仅用于迁移
 
 ### 发布到注册中心
 

--- a/docs/app-skill-dev-guide.md
+++ b/docs/app-skill-dev-guide.md
@@ -21,7 +21,7 @@ This guide covers the full lifecycle of an Octos skill — from development to p
 | **App Store** | Apple App Store | [octos-hub](https://github.com/octos-org/octos-hub) registry |
 | **Distribution** | App Store binary delivery | Pre-built binaries in GitHub Releases |
 | **Install** | Tap "Get" | `octos skills install user/repo` |
-| **Sideload** | Ad-hoc / TestFlight | Copy to `~/.octos/skills/` directly |
+| **Sideload** | Ad-hoc / TestFlight | `octos skills --profile <profile> install ./my-skill` |
 
 ---
 
@@ -34,7 +34,7 @@ A skill is a **standalone executable** that communicates via **stdin/stdout JSON
 ```
 User message → LLM → tool_use("get_weather", {"city": "Paris"})
                         ↓
-             Gateway spawns: ~/.octos/skills/weather/main get_weather
+             Gateway spawns: ~/.octos/profiles/<profile>/data/skills/weather/main get_weather
                         ↓
              Stdin:  {"city": "Paris"}
              Stdout: {"output": "25°C, sunny", "success": true}
@@ -332,12 +332,15 @@ echo '{"param1": "hello"}' | ./my-skill/main my_tool
 # Build everything
 cargo build --release --workspace
 
-# Start the gateway
-octos gateway
+# Install into the profile you want to test
+octos skills --profile alice install ./my-skill
 
 # Verify skill loaded
-ls ~/.octos/skills/my-skill/
+ls ~/.octos/profiles/alice/data/skills/my-skill/
 # main  manifest.json  SKILL.md
+
+# Start the gateway
+octos gateway
 
 # Ask the agent to use your skill in conversation
 ```
@@ -585,7 +588,15 @@ See [`docs/SKILL_DEPLOYMENT.md`](./SKILL_DEPLOYMENT.md) for the operator-side ru
 
 ### Sideloading (Manual Install)
 
-Copy a skill directory directly — like sideloading an app:
+Install a local skill directory into the profile that should be allowed to use
+it:
+
+```bash
+octos skills --profile alice install ./my-skill --force
+```
+
+For one-off debugging you can copy the directory yourself, but keep the target
+profile-scoped:
 
 ```bash
 # Canonical: per-profile install
@@ -597,12 +608,14 @@ cp -r my-skill/ ~/.octos/skills/my-skill/
 chmod +x ~/.octos/skills/my-skill/main
 ```
 
-The global `~/.octos/skills/` directory is being retired (PR #944). New deployments should write directly to the per-profile path.
+The global `~/.octos/skills/` directory is retired for new installs. It is kept
+only as a legacy migration source; new deployments should write directly to the
+per-profile path or use `octos skills --profile <profile> install`.
 
 ### Installed Skill Layout
 
 ```
-~/.octos/skills/my-skill/
+~/.octos/profiles/alice/data/skills/my-skill/
 ├── main                # Executable binary
 ├── manifest.json       # Tool definitions
 ├── SKILL.md            # Documentation
@@ -627,12 +640,18 @@ Loading dedupes by `manifest.id` — the **first** directory scanned that contai
 
 | Priority | Location | Source |
 |----------|----------|--------|
-| 1 (highest) | `~/.octos/profiles/<profile>/data/skills/` | **Canonical** per-profile install (`octos skills install --profile <p>`; `fleet-install-skills.sh`) |
+| 1 (highest) | `~/.octos/profiles/<profile>/data/skills/` | **Canonical** per-profile install (`octos skills --profile <p> install`; `fleet-install-skills.sh`) |
 | 2 | `<project-dir>/skills/` | Project-local (development checkouts) |
 | 3 | `<project-dir>/bundled-app-skills/` | Bundled app-skills (constant `BUNDLED_APP_SKILLS_DIR` in `octos-agent/src/bootstrap.rs`; scanned by `Config::plugin_dirs_from_project`) |
 | 4 (lowest, **deprecated**) | `~/.octos/skills/` | Legacy global install — the loader emits a deprecation warning on every startup that sees this directory. See [Part 5: Install](#part-5-install) and [`docs/SKILL_DEPLOYMENT.md`](./SKILL_DEPLOYMENT.md) for the per-profile-only migration (PR #944). |
 
-**Lesson from the fleet (2026):** before PR #936 the loader registered duplicate ids twice and `ToolRegistry::register` overwrote by tool name — so a stale per-profile install could silently shadow a freshly-deployed global skill, and vice versa. Two production regressions (yangmi, douwentao) traced back to this trap before the dedup landed. On fleet upgrades, update **both** `~/.octos/skills/<x>/` *and* `<profile>/data/skills/<x>/` in lock-step until the global directory is removed.
+**Lesson from the fleet (2026):** before PR #936 the loader registered duplicate
+ids twice and `ToolRegistry::register` overwrote by tool name — so a stale
+per-profile install could silently shadow a freshly-deployed global skill, and
+vice versa. Two production regressions (yangmi, douwentao) traced back to this
+trap before the dedup landed. On fleet upgrades, migrate legacy global skills
+into the intended per-profile directories and then stop refreshing
+`~/.octos/skills/`; do not keep the two locations in lock-step.
 
 ---
 
@@ -660,7 +679,7 @@ Skill binaries can be updated without restarting the gateway:
 cargo build --release -p my-skill
 
 # Replace the binary
-cp target/release/my_skill ~/.octos/skills/my-skill/main
+cp target/release/my_skill ~/.octos/profiles/alice/data/skills/my-skill/main
 
 # Next tool call automatically uses the new binary
 ```
@@ -929,7 +948,7 @@ For skill authors with existing skills, here's what to align with as of 2026-05-
   - `has_meaningful_tts_audio` / `parse_wav_metadata` (mofa-podcast) → replace with `ValidatorSpec::AudioNonSilent` + `ValidatorSpec::MagicBytes`.
   - `poll_training_status` (mofa-fm) → replace with `ValidatorSpec::HttpProbeUntil`.
 - [ ] **For spawn-only artifact-producers, emit `named_outputs` where the harness needs to validate the output.** e.g. a `mofa_publish`-style skill must emit `{ "deploy_url": "..." }` so the harness's `HttpProbe { url_template = "${output.deploy_url}" }` can probe the live URL.
-- [ ] **Move to per-profile install.** Stop writing to `~/.octos/skills/`; use `octos skills install --profile <p>` or the fleet script.
+- [ ] **Move to per-profile install.** Stop writing to `~/.octos/skills/`; use `octos skills --profile <p> install` or the fleet script.
 - [ ] **Ship `manifest.json` `binaries.<platform>.sha256` if you publish pre-built binaries.** The installer verifies before copy.
 
 ### Backward compatibility

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -78,10 +78,10 @@ octos serve（控制面板 + 仪表盘，约 140 个 REST 端点）
 
 ```bash
 # 启动控制面板
-octos serve --host 0.0.0.0 --port 3000
+octos serve --host 0.0.0.0
 
 # 仪表盘地址：
-# http://localhost:3000
+# http://localhost:50080
 ```
 
 如果在反向代理（如 Caddy 或 Nginx）后运行，请配置转发到 serve 端口。
@@ -622,7 +622,7 @@ export PERPLEXITY_API_KEY="pplx-your-key"
 #### 通过管理 API
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/profiles \
+curl -X POST http://localhost:50080/api/admin/profiles \
   -H "Content-Type: application/json" \
   -d '{
     "id": "my-bot",
@@ -652,16 +652,16 @@ curl -X POST http://localhost:3000/api/admin/profiles \
 
 ```bash
 # 启动配置文件的 gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/start
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/start
 
 # 停止配置文件的 gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/stop
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/stop
 
 # 重启（停止 + 启动）
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/restart
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/restart
 
 # 检查状态
-curl http://localhost:3000/api/admin/profiles/my-bot/status
+curl http://localhost:50080/api/admin/profiles/my-bot/status
 ```
 
 **启动验证：** 启动端点会在启动 gateway 之前验证 LLM 提供商是否已配置。如果提供商或 API 密钥缺失，将返回错误。
@@ -671,7 +671,7 @@ curl http://localhost:3000/api/admin/profiles/my-bot/status
 更新使用 **JSON 合并** — 只有你包含的字段会被修改。所有其他字段保持不变。
 
 ```bash
-curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
+curl -X PUT http://localhost:50080/api/admin/profiles/my-bot \
   -H "Content-Type: application/json" \
   -d '{
     "name": "更新后的机器人名称",
@@ -687,7 +687,7 @@ curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
 ### 8.4 删除配置文件
 
 ```bash
-curl -X DELETE http://localhost:3000/api/admin/profiles/my-bot
+curl -X DELETE http://localhost:50080/api/admin/profiles/my-bot
 ```
 
 这将停止 gateway 进程（如果正在运行）并级联删除所有子账户。
@@ -696,17 +696,17 @@ curl -X DELETE http://localhost:3000/api/admin/profiles/my-bot
 
 ```bash
 # SSE 日志流（实时）
-curl http://localhost:3000/api/admin/profiles/my-bot/logs
+curl http://localhost:50080/api/admin/profiles/my-bot/logs
 
 # 提供商指标
-curl http://localhost:3000/api/admin/profiles/my-bot/metrics
+curl http://localhost:50080/api/admin/profiles/my-bot/metrics
 ```
 
 ### 8.6 API 总览端点
 
 ```bash
 # 获取所有配置文件的摘要
-curl http://localhost:3000/api/admin/overview
+curl http://localhost:50080/api/admin/overview
 ```
 
 返回总数、运行中/已停止数量以及每个配置文件的状态。
@@ -716,7 +716,7 @@ curl http://localhost:3000/api/admin/overview
 部署前测试提供商配置：
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/test-provider \
+curl -X POST http://localhost:50080/api/admin/test-provider \
   -H "Content-Type: application/json" \
   -d '{
     "provider": "moonshot",
@@ -1515,18 +1515,18 @@ export LARK_FROM_ADDRESS="your-feishu-email@company.com"
 
 ```bash
 # 启动 OminiX
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/start
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/start
 
 # 检查健康状态
-curl http://localhost:3000/api/admin/platform-skills/asr/health
+curl http://localhost:50080/api/admin/platform-skills/asr/health
 
 # 下载模型
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/models/download \
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/models/download \
   -H "Content-Type: application/json" \
   -d '{"model_id": "Qwen3-ASR-1.7B-8bit"}'
 
 # 查看日志
-curl http://localhost:3000/api/admin/platform-skills/ominix-api/logs?lines=100
+curl http://localhost:50080/api/admin/platform-skills/ominix-api/logs?lines=100
 ```
 
 ### 13.3 语音转录 (`voice_transcribe`)
@@ -1656,7 +1656,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # 安装到特定配置文件
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 **安装过程：**
@@ -1785,16 +1785,15 @@ requires_env: MY_API_KEY
 
 ### 14.6 技能解析顺序
 
-技能从以下目录加载（按优先级排序）：
+配置文件 gateway 按以下优先级加载技能：
 
-1. `.octos/plugins/`（旧版）
-2. `.octos/skills/`（用户安装的自定义技能）
-3. `.octos/bundled-app-skills/`（内置：news、deep-search 等）
-4. `.octos/platform-skills/`（平台：asr/tts）
-5. `~/.octos/plugins/`（全局旧版）
-6. `~/.octos/skills/`（全局自定义）
+1. `~/.octos/profiles/<profile>/data/skills/`（配置文件作用域的自定义技能）
+2. `<octos_home>/bundled-app-skills/`（内置：news、deep-search 等）
+3. `<octos_home>/platform-skills/`（管理员加载的平台技能，如 ASR/TTS）
 
-用户安装的技能覆盖同名的内置技能。
+独立项目运行还可以加载 `<project>/.octos/plugins/` 和
+`<project>/.octos/skills/`。旧的 HOME 全局目录 `~/.octos/plugins/` 和
+`~/.octos/skills/` 仅用于迁移，不再属于常规扫描路径。
 
 ### 14.7 创建自定义技能
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -78,10 +78,10 @@ The admin dashboard is a React web application embedded in the `octos serve` bin
 
 ```bash
 # Start the control plane
-octos serve --host 0.0.0.0 --port 3000
+octos serve --host 0.0.0.0
 
 # Dashboard is available at:
-# http://localhost:3000
+# http://localhost:50080
 ```
 
 If you're running behind a reverse proxy (e.g., Caddy or Nginx), configure it to forward to the serve port.
@@ -692,7 +692,7 @@ Profiles are bot instances managed through the admin dashboard or API. Each prof
 #### Via Admin API
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/profiles \
+curl -X POST http://localhost:50080/api/admin/profiles \
   -H "Content-Type: application/json" \
   -d '{
     "id": "my-bot",
@@ -722,16 +722,16 @@ Use the Start / Stop / Restart buttons on each profile card.
 
 ```bash
 # Start a profile's gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/start
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/start
 
 # Stop a profile's gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/stop
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/stop
 
 # Restart (stop + start)
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/restart
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/restart
 
 # Check status
-curl http://localhost:3000/api/admin/profiles/my-bot/status
+curl http://localhost:50080/api/admin/profiles/my-bot/status
 ```
 
 **Start validation:** The start endpoint validates that an LLM provider is configured before launching the gateway. If the provider or API key is missing, it returns an error.
@@ -741,7 +741,7 @@ curl http://localhost:3000/api/admin/profiles/my-bot/status
 Updates use **JSON merge** — only the fields you include are modified. All other fields are preserved.
 
 ```bash
-curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
+curl -X PUT http://localhost:50080/api/admin/profiles/my-bot \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Updated Bot Name",
@@ -757,7 +757,7 @@ curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
 ### 8.4 Deleting a Profile
 
 ```bash
-curl -X DELETE http://localhost:3000/api/admin/profiles/my-bot
+curl -X DELETE http://localhost:50080/api/admin/profiles/my-bot
 ```
 
 This stops the gateway process (if running) and cascades to all sub-accounts.
@@ -766,17 +766,17 @@ This stops the gateway process (if running) and cascades to all sub-accounts.
 
 ```bash
 # SSE log stream (real-time)
-curl http://localhost:3000/api/admin/profiles/my-bot/logs
+curl http://localhost:50080/api/admin/profiles/my-bot/logs
 
 # Provider metrics
-curl http://localhost:3000/api/admin/profiles/my-bot/metrics
+curl http://localhost:50080/api/admin/profiles/my-bot/metrics
 ```
 
 ### 8.6 API Overview Endpoint
 
 ```bash
 # Get summary of all profiles
-curl http://localhost:3000/api/admin/overview
+curl http://localhost:50080/api/admin/overview
 ```
 
 Returns total count, running/stopped counts, and status of each profile.
@@ -786,7 +786,7 @@ Returns total count, running/stopped counts, and status of each profile.
 Before deploying, test a provider configuration:
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/test-provider \
+curl -X POST http://localhost:50080/api/admin/test-provider \
   -H "Content-Type: application/json" \
   -d '{
     "provider": "moonshot",
@@ -1594,18 +1594,18 @@ Or via admin API:
 
 ```bash
 # Start OminiX
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/start
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/start
 
 # Check health
-curl http://localhost:3000/api/admin/platform-skills/asr/health
+curl http://localhost:50080/api/admin/platform-skills/asr/health
 
 # Download a model
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/models/download \
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/models/download \
   -H "Content-Type: application/json" \
   -d '{"model_id": "Qwen3-ASR-1.7B-8bit"}'
 
 # View logs
-curl http://localhost:3000/api/admin/platform-skills/ominix-api/logs?lines=100
+curl http://localhost:50080/api/admin/platform-skills/ominix-api/logs?lines=100
 ```
 
 ### 13.3 Voice Transcription (`voice_transcribe`)
@@ -1735,7 +1735,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # Install into a specific profile
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 **Installation process:**
@@ -1864,16 +1864,16 @@ The tool binary receives JSON input on stdin and outputs JSON on stdout:
 
 ### 14.6 Skill Resolution Order
 
-Skills are loaded from these directories (in priority order):
+Profile gateways load skills from these directories, in priority order:
 
-1. `.octos/plugins/` (legacy)
-2. `.octos/skills/` (user-installed custom skills)
-3. `.octos/bundled-app-skills/` (bundled: news, deep-search, etc.)
-4. `.octos/platform-skills/` (platform: asr/tts)
-5. `~/.octos/plugins/` (global legacy)
-6. `~/.octos/skills/` (global custom)
+1. `~/.octos/profiles/<profile>/data/skills/` (profile-scoped custom skills)
+2. `<octos_home>/bundled-app-skills/` (bundled: news, deep-search, etc.)
+3. `<octos_home>/platform-skills/` (admin-loaded platform skills, such as ASR/TTS)
 
-User-installed skills override bundled skills with the same name.
+Standalone project runs can also load `<project>/.octos/plugins/` and
+`<project>/.octos/skills/`. The old HOME-rooted global directories
+`~/.octos/plugins/` and `~/.octos/skills/` are migration-only and are no longer
+part of the normal scan path.
 
 ### 14.7 Creating a Custom Skill
 


### PR DESCRIPTION
## Summary
- Update user-guide and mdBook serve examples to use the current `octos serve` default port `50080` instead of stale `3000`/`8080` examples.
- Refresh skill installation docs to use profile-scoped `octos skills --profile <id> install ...` commands and per-profile `data/skills` paths.
- Update skill resolution order docs to reflect current per-profile loading and legacy HOME-global directories as migration-only.

Related to #117

## Validation
- `git diff --check`
- `mdbook build book` (passes; existing unrelated warning: unclosed HTML tag `<f32>` in `architecture.md`)
- `mdbook build book-zh` (passes; existing unrelated warning: unclosed HTML tag `<f32>` in `architecture.md`)
- stale-pattern grep over docs/books excluding intentional CORS/testing references (no matches)
- `git ls-files --others --exclude-standard` (empty)

