### PR TITLE
docs(protocol): reconcile UI protocol inventory

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -354,15 +354,18 @@ Client commands are JSON-RPC requests.
 
 Server notifications are JSON-RPC notifications.
 
-The logical command/event names are listed below. The machine-readable
-source of truth for this catalog is `UI_PROTOCOL_COMMAND_METHODS` and
-`UI_PROTOCOL_NOTIFICATION_METHODS` in
-[crates/octos-core/src/ui_protocol.rs](/Users/yuechen/home/octos/crates/octos-core/src/ui_protocol.rs:1075)
-(plus the server-handled `APPUI_EXTRA_METHODS` slice in
-[crates/octos-cli/src/api/ui_protocol.rs](/Users/yuechen/home/octos/crates/octos-cli/src/api/ui_protocol.rs:1)).
-Per `SRV-036`/M18-E, this list MUST stay in sync with those constants — a
-method that is dispatched and advertised in `supported_methods` but not
-named here is a spec defect.
+The logical command/event names below mirror the current wire inventory:
+
+- command source of truth:
+  `crates/octos-core/src/ui_protocol.rs::UI_PROTOCOL_COMMAND_METHODS`,
+  `UI_PROTOCOL_FIRST_SERVER_METHODS`, and
+  `crates/octos-cli/src/api/ui_protocol.rs::APPUI_EXTRA_METHODS`
+- notification source of truth:
+  `crates/octos-core/src/ui_protocol.rs::UI_PROTOCOL_NOTIFICATION_METHODS`
+- executable route inventory:
+  `e2e/fixtures/appui-conformance/m18-route-inventory.json`
+- human-readable wire inventory:
+  `api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md`
 
 Commands:
 

--- a/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
+++ b/api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md
@@ -1,0 +1,148 @@
+# Octos UI Protocol Wire Inventory
+
+Status: current inventory for Octos issue #716
+Date: 2026-05-24
+Protocol: `octos-ui/v1alpha1`
+
+This inventory reconciles the shipped AppUI/UI Protocol wire surface with the
+spec and UPCR documents. The authoritative source remains code:
+
+- commands: `crates/octos-core/src/ui_protocol.rs::UI_PROTOCOL_COMMAND_METHODS`,
+  `UI_PROTOCOL_FIRST_SERVER_METHODS`, plus
+  `crates/octos-cli/src/api/ui_protocol.rs::APPUI_EXTRA_METHODS`
+- notifications:
+  `crates/octos-core/src/ui_protocol.rs::UI_PROTOCOL_NOTIFICATION_METHODS`
+- executable route fixture:
+  `e2e/fixtures/appui-conformance/m18-route-inventory.json`
+- parity runner:
+  `e2e/scripts/m18-appui-transport-parity-soak.mjs`
+
+## Commands
+
+| Method | Status |
+|---|---|
+| `client_hello` | shipped AppUI extra, stdio/websocket negotiation |
+| `config/capabilities/list` | shipped AppUI extra, UPCR-2026-017 |
+| `profile/local/create` | shipped, UPCR-2026-018 |
+| `session/open` | shipped base method |
+| `session/list` | shipped REST-to-WS method |
+| `session/snapshot` | shipped REST-to-WS method |
+| `session/messages_page` | shipped REST-to-WS method |
+| `session/status.get` | shipped REST-to-WS method |
+| `session/files.list` | shipped REST-to-WS method |
+| `session/tasks.list` | shipped REST-to-WS method |
+| `session/workspace.get` | shipped REST-to-WS method |
+| `session/title.set` | shipped REST-to-WS method |
+| `session/delete` | shipped REST-to-WS method |
+| `session/status/read` | shipped AppUI extra, UPCR-2026-017 |
+| `session/hydrate` | shipped, UPCR-2026-009 |
+| `thread/graph/get` | shipped, UPCR-2026-010 |
+| `turn/state/get` | shipped, UPCR-2026-011 |
+| `turn/start` | shipped base method |
+| `turn/interrupt` | shipped base method, UPCR-2026-008 typed fields |
+| `approval/respond` | shipped base method, UPCR-2026-001 optional fields |
+| `approval/scopes/list` | shipped, UPCR-2026-001 |
+| `permission/profile/list` | shipped, UPCR-2026-018 |
+| `permission/profile/set` | shipped, UPCR-2026-018 |
+| `diff/preview/get` | shipped base method |
+| `task/output/read` | shipped, UPCR-2026-006 |
+| `task/list` | shipped, UPCR-2026-005 |
+| `task/cancel` | shipped, UPCR-2026-005 |
+| `task/restart_from_node` | shipped, UPCR-2026-005 |
+| `task/artifact/list` | shipped, UPCR-2026-019 |
+| `task/artifact/read` | shipped, UPCR-2026-019 |
+| `agent/list` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/status/read` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/output/read` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/artifact/list` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/artifact/read` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/interrupt` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/close` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `session/goal/get` | shipped, UPCR-2026-021 |
+| `session/goal/set` | shipped, UPCR-2026-021 |
+| `session/goal/clear` | shipped, UPCR-2026-021 |
+| `loop/create` | shipped, UPCR-2026-021 |
+| `loop/list` | shipped, UPCR-2026-021 |
+| `loop/delete` | shipped, UPCR-2026-021 |
+| `loop/pause` | shipped, UPCR-2026-021 |
+| `loop/resume` | shipped, UPCR-2026-021 |
+| `loop/fire_now` | shipped, UPCR-2026-021 |
+| `review/start` | shipped, UPCR-2026-019 |
+| `system/status.get` | shipped REST-to-WS method |
+| `content/list` | shipped REST-to-WS method; auth-bound unavailable over unauthenticated stdio |
+| `content/delete` | shipped REST-to-WS method; auth-bound unavailable over unauthenticated stdio |
+| `content/bulk_delete` | shipped REST-to-WS method; auth-bound unavailable over unauthenticated stdio |
+| `router/set_mode` | shipped adaptive-router method |
+| `router/get_metrics` | shipped adaptive-router method |
+| `auth/status` | shipped AppUI extra, UPCR-2026-017 |
+| `auth/send_code` | shipped AppUI extra, UPCR-2026-017 |
+| `auth/verify` | shipped AppUI extra, UPCR-2026-017 |
+| `auth/me` | shipped AppUI extra; auth-bound unavailable over unauthenticated stdio |
+| `auth/logout` | shipped AppUI extra; auth-bound unavailable over unauthenticated stdio |
+| `profile/llm/catalog` | shipped AppUI extra, UPCR-2026-017 |
+| `profile/llm/list` | shipped AppUI extra, UPCR-2026-017 |
+| `profile/llm/upsert` | shipped AppUI extra, UPCR-2026-017 |
+| `profile/llm/select` | shipped AppUI extra, UPCR-2026-017 |
+| `profile/llm/delete` | shipped AppUI extra, UPCR-2026-017 |
+| `profile/llm/test` | shipped AppUI extra, UPCR-2026-017 |
+| `profile/llm/fetch_models` | shipped AppUI extra, UPCR-2026-017 |
+| `mcp/status/list` | shipped AppUI extra, UPCR-2026-017 |
+| `tool/status/list` | shipped AppUI extra, UPCR-2026-017 / UPCR-2026-020 |
+| `profile/skills/list` | shipped AppUI extra when profile store is configured |
+| `profile/skills/registry/search` | shipped AppUI extra when profile store is configured |
+| `profile/skills/install` | shipped AppUI extra when profile store is configured |
+| `profile/skills/remove` | shipped AppUI extra when profile store is configured |
+| `onboarding/workspace_probe` | shipped local-solo AppUI extra |
+
+## Notifications
+
+| Method | Status |
+|---|---|
+| `session/open` | shipped open/resume notification |
+| `turn/started` | shipped base notification |
+| `turn/completed` | shipped base notification |
+| `turn/error` | shipped base notification |
+| `message/delta` | shipped base notification |
+| `tool/started` | shipped base notification |
+| `tool/progress` | shipped base notification |
+| `tool/completed` | shipped base notification |
+| `approval/requested` | shipped base notification, UPCR-2026-001 |
+| `approval/auto_resolved` | shipped durable approval notification |
+| `approval/decided` | shipped durable approval notification |
+| `approval/cancelled` | shipped durable approval notification |
+| `task/updated` | shipped, UPCR-2026-004 |
+| `task/output/delta` | shipped task output notification |
+| `progress/updated` | shipped typed progress notification |
+| `warning` | shipped base notification |
+| `protocol/replay_lossy` | shipped backpressure/replay notification |
+| `message/persisted` | shipped, UPCR-2026-012 |
+| `turn/spawn_complete` | shipped background completion notification |
+| `file/attached` | shipped, UPCR-2026-014 |
+| `session/event` | shipped, UPCR-2026-014 |
+| `router/status` | shipped adaptive-router notification |
+| `router/failover` | shipped adaptive-router notification |
+| `queue/state` | known client-emitted queue notification |
+| `agent/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/output/delta` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `agent/artifact/updated` | shipped, UPCR-2026-019 / UPCR-2026-021 |
+| `session/goal/updated` | shipped, UPCR-2026-021 |
+| `session/goal/cleared` | shipped, UPCR-2026-021 |
+| `loop/updated` | shipped, UPCR-2026-021 |
+| `loop/fired` | shipped, UPCR-2026-021 |
+| `loop/completed` | shipped, UPCR-2026-021 |
+| `context/compaction_completed` | shipped M16 context lifecycle notification |
+| `context/normalization_reported` | shipped M16 context lifecycle notification |
+
+## Reconciliation Decisions
+
+- UPCR-2026-001, UPCR-2026-002, and UPCR-2026-003 are restored as accepted
+  documents because the spec linked them and code already ships their surfaces.
+- `approval/scopes/list`, `approval/auto_resolved`, `approval/decided`,
+  `approval/cancelled`, `progress/updated`, and `protocol/replay_lossy` are
+  documented as shipped wire-visible methods/notifications rather than
+  internal implementation details.
+- `onboarding/workspace_probe` is added to the executable route inventory
+  because `APPUI_EXTRA_METHODS` advertises it for local-solo deployments.
+- `auth/logout` and all `content/*` methods are recorded as auth-bound
+  unavailable over unauthenticated stdio, matching
+  `APPUI_STDIO_AUTH_BOUND_UNAVAILABLE_METHODS`.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_001_TYPED_APPROVAL.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_001_TYPED_APPROVAL.md
@@ -1,0 +1,130 @@
+# Octos UI Protocol Change Request: Typed Approval Payloads
+
+## Header
+
+- Request id: `UPCR-2026-001`
+- Title: Add typed approval request/response fields
+- Author: M9 protocol workstream
+- Date: 2026-04-24
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related issue: M9 protocol contract
+
+## Summary
+
+This change request codifies the approval fields that make
+`approval/requested`, `approval/respond`, and `approval/scopes/list`
+machine-readable without removing the original generic approval flow.
+
+The change is additive. Existing clients can still answer a pending approval
+with only `session_id`, `approval_id`, and `decision`. New clients can render
+typed request details, submit an advisory response scope, include a client
+note, and query the current scoped approval decisions.
+
+## Wire Contract
+
+Feature flag:
+
+- `approval.typed.v1`
+
+Methods:
+
+- `approval/respond`
+- `approval/scopes/list`
+
+Notifications:
+
+- `approval/requested`
+- `approval/auto_resolved`
+- `approval/decided`
+- `approval/cancelled`
+
+### `approval/requested`
+
+The existing notification keeps its legacy fields and may include typed
+details for command/tool approvals:
+
+- `typed_details`: structured command/tool context for rendering
+- `risk`: optional manifest or tool risk classification
+- `render_hints`: optional UI guidance
+
+Clients must tolerate missing typed fields because old servers and generic
+approval producers can still emit the legacy shape.
+
+### `approval/respond`
+
+Minimum params remain:
+
+- `session_id`
+- `approval_id`
+- `decision`
+
+Optional params:
+
+- `approval_scope`: advisory string registry. Initial accepted values are
+  `request`, `tool`, `turn`, and `session`; compatibility aliases such as
+  `approve_for_tool`, `approve_for_turn`, and `approve_for_session` normalize
+  to the same registry values.
+- `client_note`: human-readable audit/display note.
+
+The response scope must not silently create persistent allow rules beyond the
+server-owned approval policy. Unknown scopes are accepted as open-registry
+strings only when the server can preserve the literal in audit state; otherwise
+the server should reject with `invalid_params`.
+
+### `approval/scopes/list`
+
+Purpose:
+
+- return the server-recorded scoped approval decisions for a session
+
+Minimum params:
+
+- `session_id`
+
+Result:
+
+```json
+{
+  "scopes": [
+    {
+      "approval_id": "appr_...",
+      "scope": "session",
+      "decision": "approve",
+      "client_note": "looks good"
+    }
+  ]
+}
+```
+
+## Compatibility
+
+- `approval/respond` stays backwards-compatible: absent `approval_scope` and
+  `client_note` decode as `null`.
+- Old clients that ignore typed approval fields continue to receive the
+  legacy `approval/requested` information.
+- The typed approval feature does not change JSON-RPC error codes.
+- `approval/auto_resolved`, `approval/decided`, and `approval/cancelled` are
+  durable notification records used for replay and audit. Clients should treat
+  unknown fields as ignorable.
+
+## Tests
+
+Coverage lives in:
+
+- `crates/octos-core/src/ui_protocol.rs`
+  - approval response params round-trip optional `approval_scope` and
+    `client_note`
+  - `approval/scopes/list` result round-trips through `UiRpcResult`
+  - typed `approval/requested` details round-trip
+- `crates/octos-cli/src/api/ui_protocol.rs`
+  - scoped approval enforcement and scope listing
+  - durable `approval/decided` / `approval/cancelled` replay behavior
+- `e2e/tests/m9-protocol-approval-respond.spec.ts`
+  - WebSocket acceptance of optional `approval_scope` and `client_note`
+
+## Decision
+
+Accepted by the M9 protocol workstream. The approval shape was already shipped
+in code; this document restores the missing change-control record so the spec,
+source, and route inventory agree.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_002_PANE_SNAPSHOTS.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_002_PANE_SNAPSHOTS.md
@@ -1,0 +1,99 @@
+# Octos UI Protocol Change Request: Session Pane Snapshots
+
+## Header
+
+- Request id: `UPCR-2026-002`
+- Title: Add `session/open` pane snapshots
+- Author: M9 protocol workstream
+- Date: 2026-04-24
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related issue: M9 protocol contract
+
+## Summary
+
+This change request adds optional workspace, artifact, and git pane snapshots
+to the `session/open` result. The snapshots let AppUI clients bootstrap the
+right rail from server truth during open/resume without scraping local files or
+guessing the workspace state.
+
+The change is additive and capability-gated. A client that does not negotiate
+`pane.snapshots.v1` receives the legacy `session/open` result.
+
+## Wire Contract
+
+Feature flag:
+
+- `pane.snapshots.v1`
+
+Method:
+
+- `session/open`
+
+Optional result fields:
+
+- `workspace_root`: canonical server-approved workspace root when known
+- `panes`: `UiPaneSnapshot`
+
+`panes` contains:
+
+- `workspace`: optional workspace tree summary
+- `artifacts`: optional generated-artifact summary
+- `git`: optional repository status/history summary
+- `limitations`: open list of `{ code, message }` entries describing missing
+  filesystem, artifact, or git information
+- `generated_at`: server timestamp
+
+Example:
+
+```json
+{
+  "session_id": "local:demo",
+  "workspace_root": "/repo",
+  "panes": {
+    "workspace": {
+      "root": "/repo",
+      "contract": ["api octos-app-ui/v1alpha1", "feature pane.snapshots.v1"],
+      "entries": []
+    },
+    "artifacts": { "items": [] },
+    "git": {
+      "clean": true,
+      "limitations": []
+    },
+    "limitations": [],
+    "generated_at": "2026-04-24T00:00:00Z"
+  }
+}
+```
+
+## Compatibility
+
+- `panes` and `workspace_root` are additive. Old clients can ignore them.
+- Servers must emit `panes` only when `pane.snapshots.v1` is negotiated.
+- Snapshot data is best-effort. Missing workspace roots, artifact directories,
+  or git repositories are represented as `limitations`, not protocol errors.
+- This UPCR does not define live pane-update notifications. Clients that need
+  fresh state after open/resume must call the relevant AppUI methods or open a
+  later protocol change request.
+
+## Tests
+
+Coverage lives in:
+
+- `crates/octos-core/src/ui_protocol.rs`
+  - `session/open` result round-trips with `workspace_root` and `panes`
+  - feature constants advertise `pane.snapshots.v1`
+- `crates/octos-cli/src/api/ui_protocol.rs`
+  - `session/open` includes panes only when negotiated
+  - pane snapshots prefer the approved session workspace root
+  - missing git/workspace state appears in `limitations`
+- M18 AppUI parity fixtures and runner
+  - `e2e/fixtures/appui-conformance/m18-route-inventory.json`
+  - `e2e/scripts/m18-appui-transport-parity-soak.mjs`
+
+## Decision
+
+Accepted by the M9 protocol workstream. The pane snapshot payload was already
+referenced by the spec and implemented in source; this document restores the
+missing change-control record.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_003_SESSION_WORKSPACE_CWD.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_003_SESSION_WORKSPACE_CWD.md
@@ -1,0 +1,105 @@
+# Octos UI Protocol Change Request: Session Workspace CWD
+
+## Header
+
+- Request id: `UPCR-2026-003`
+- Title: Add per-session workspace `cwd` binding to `session/open`
+- Author: M9 protocol workstream
+- Date: 2026-04-24
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related issue: M9 protocol contract
+
+## Summary
+
+This change request lets an AppUI client request a workspace directory when
+opening a session. The server canonicalizes and validates the requested `cwd`,
+binds the session runtime to the approved workspace, and echoes the approved
+root as `workspace_root`.
+
+The change is additive and capability-gated. It fixes the class of bugs where
+an AppUI session visually points at one project while shell/file tools execute
+against the daemon or profile default directory.
+
+## Wire Contract
+
+Feature flag:
+
+- `session.workspace_cwd.v1`
+
+Method:
+
+- `session/open`
+
+Optional params:
+
+- `cwd`: requested workspace directory
+
+Optional result fields:
+
+- `workspace_root`: canonical server-approved workspace root
+
+Rules:
+
+- Clients may send `cwd` only when `session.workspace_cwd.v1` was negotiated.
+- Servers must expand and canonicalize `cwd`, require it to exist as a
+  directory, validate it against profile/workspace policy, and reject unsafe
+  system roots.
+- A running session's first accepted workspace is sticky until that session
+  runtime is evicted. A later `session/open` for the same session with a
+  different `cwd` must not silently rebind tools; the response should continue
+  to report the cached `workspace_root`.
+- Profile-scoped sessions require a configured profile runtime. If the server
+  cannot bind the workspace, it must return a typed error such as
+  `cwd_runtime_unavailable`, `cwd_not_accessible`, `cwd_not_directory`, or
+  `cwd_system_path_banned`.
+- When no client `cwd` is supplied, servers may use an operator configured
+  default workspace and still report it through `workspace_root`.
+
+Example:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "open-1",
+  "method": "session/open",
+  "params": {
+    "session_id": "ada:local:tui#coding",
+    "profile_id": "ada",
+    "cwd": "/Users/ada/project"
+  }
+}
+```
+
+## Compatibility
+
+- `cwd` and `workspace_root` are additive.
+- Servers that did not negotiate `session.workspace_cwd.v1` must reject a
+  non-empty `cwd` instead of ignoring it.
+- Old clients that omit `cwd` continue to open sessions through the prior
+  workspace fallback path.
+- This UPCR does not add in-session cwd mutation. Future mutation UX or
+  persistent cwd approval policy requires a separate accepted UPCR.
+
+## Tests
+
+Coverage lives in:
+
+- `crates/octos-core/src/ui_protocol.rs`
+  - `SessionOpenParams.cwd` round-trips and remains optional for legacy
+    payloads
+  - `workspace_root` round-trips in `SessionOpenResult`
+- `crates/octos-cli/src/api/ui_protocol.rs`
+  - `session/open` rejects `cwd` without the negotiated feature
+  - client-supplied `cwd` drives the session runtime workspace
+  - two sessions on one profile with different cwds stay isolated
+  - reopening the same session with a different cwd reports the cached root
+  - unregistered profiles and unsafe/system paths return typed errors
+  - operator default `appui.default_session_cwd` works when no client cwd is
+    supplied
+
+## Decision
+
+Accepted by the M9 protocol workstream. The workspace cwd surface was already
+implemented and linked from the spec; this document restores the missing
+change-control record.

--- a/e2e/fixtures/appui-conformance/m18-route-inventory.json
+++ b/e2e/fixtures/appui-conformance/m18-route-inventory.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "source": "crates/octos-core/src/ui_protocol.rs UI_PROTOCOL_COMMAND_METHODS plus crates/octos-cli/src/api/ui_protocol.rs APPUI_EXTRA_METHODS",
-  "last_reviewed": "2026-05-18",
-  "issue": "octos#1030",
+  "last_reviewed": "2026-05-24",
+  "issue": "octos#1030, octos#716",
   "transports": ["websocket", "stdio"],
   "methods": [
     { "method": "profile/local/create", "classification": "shared" },
@@ -52,7 +52,7 @@
     { "method": "system/status.get", "classification": "shared" },
     { "method": "content/list", "classification": "auth_bound_stdio_unsupported" },
     { "method": "content/delete", "classification": "auth_bound_stdio_unsupported" },
-    { "method": "content/bulk_delete", "classification": "shared" },
+    { "method": "content/bulk_delete", "classification": "auth_bound_stdio_unsupported" },
     { "method": "router/set_mode", "classification": "shared" },
     { "method": "router/get_metrics", "classification": "shared" },
     { "method": "config/capabilities/list", "classification": "shared_extra" },
@@ -65,7 +65,7 @@
     { "method": "auth/send_code", "classification": "shared_extra" },
     { "method": "auth/verify", "classification": "shared_extra" },
     { "method": "auth/me", "classification": "auth_bound_stdio_unsupported" },
-    { "method": "auth/logout", "classification": "shared_extra" },
+    { "method": "auth/logout", "classification": "auth_bound_stdio_unsupported" },
     { "method": "profile/llm/catalog", "classification": "shared_extra" },
     { "method": "profile/llm/upsert", "classification": "shared_extra" },
     { "method": "profile/llm/delete", "classification": "shared_extra" },
@@ -75,6 +75,7 @@
     { "method": "profile/skills/registry/search", "classification": "shared_extra" },
     { "method": "profile/skills/install", "classification": "shared_extra" },
     { "method": "profile/skills/remove", "classification": "shared_extra" },
+    { "method": "onboarding/workspace_probe", "classification": "local_solo_extra" },
     { "method": "client_hello", "classification": "shared_extra" }
   ]
 }

--- a/e2e/scripts/m18-appui-transport-parity-soak.mjs
+++ b/e2e/scripts/m18-appui-transport-parity-soak.mjs
@@ -1059,6 +1059,8 @@ function routeProbeParams(method) {
       return { profile_id: profileId, name: 'm18-missing-skill' };
     case 'profile/skills/remove':
       return { profile_id: profileId, name: 'm18-missing-skill' };
+    case 'onboarding/workspace_probe':
+      return { path: workspace };
     default:
       throw new Error(`missing route probe params for ${method}`);
   }


### PR DESCRIPTION
## Summary
- Restore the missing UPCR-2026-001/002/003 protocol change-request docs referenced by the UI Protocol spec.
- Update spec section 6 with the currently shipped command and notification surface, including approval scope/listing, typed approval lifecycle notifications, progress/replay-lossy, agent/loop/goal, REST-to-WS, and onboarding methods.
- Add a human-readable wire inventory and refresh the M18 route inventory/probe coverage for `onboarding/workspace_probe` plus stdio auth-bound classifications.
- Make the Unix `cli_agent_adapter` test fixtures run through `/bin/sh` instead of directly execing freshly-written shell files; this addresses the GitHub `test-octos-cli` `Text file busy (os error 26)` blocker seen on the prior branch without changing runtime adapter behavior.
- Refreshed onto current `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`; refreshed head `dcd001149d5875a4f3b7cb10c83e264342a08342`.

Closes #716

## Current-main validation
Local environment: isolated current-main clone `/private/tmp/octos-1393-f693.c8Xuzv/octos`; Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`; cargo target `/private/tmp/octos-1228-f693-target`.

Passed locally:
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `jq empty e2e/fixtures/appui-conformance/m18-route-inventory.json e2e/fixtures/appui-conformance/m18-conformance-allowlist.json`
- `node --check e2e/scripts/m18-appui-transport-parity-soak.mjs`
- `bash scripts/check-ui-protocol-upcr.sh`
- Route inventory verifier -> `72 inventory methods validated`
- `typos api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md api/OCTOS_UI_PROTOCOL_WIRE_INVENTORY_2026-05-24.md docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_001_TYPED_APPROVAL.md docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_002_PANE_SNAPSHOTS.md docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_003_SESSION_WORKSPACE_CWD.md e2e/fixtures/appui-conformance/m18-route-inventory.json e2e/scripts/m18-appui-transport-parity-soak.mjs crates/octos-cli/src/cli_agent_adapter.rs`
- `CARGO_TARGET_DIR=/private/tmp/octos-1228-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-core ui_protocol --lib -- --nocapture` -> 111 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1228-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api server_supported_methods_are_route_complete -- --nocapture` -> 1 passed; existing warning-level test warnings only
- `CARGO_TARGET_DIR=/private/tmp/octos-1228-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --lib cli_agent_adapter::tests:: -- --nocapture` -> 8 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1228-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git ls-files --others --exclude-standard` -> empty in the isolated checkout

## CI / merge status
- GitHub CI is green on refreshed head `dcd001149d5875a4f3b7cb10c83e264342a08342`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, `typos`, and blocked-email passed. Optional platform/e2e/security expansion jobs were skipped by workflow policy.
- No generated artifacts are included.
- Merge remains branch-protection blocked by required review (`MERGEABLE` / `BLOCKED` / `REVIEW_REQUIRED`).