### PR TITLE
feat(e2e): add UX gate reporting summaries

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -180,6 +180,50 @@ The focused fixture test is:
 npm --prefix e2e run test -- --workers=1 tests/m12-solo-soak-artifacts.spec.ts
 ```
 
+### M19 UX Gate Reporting
+
+Use this gate for the real-tmux UX matrix from `e2e/matrix/octos-ux.toml`.
+The list command is provider-free and backend-free, so it is safe for PR CI:
+
+```bash
+# List the CI-safe local scenarios without requiring live provider keys.
+npm --prefix e2e run ux:scenario:list:ci
+npm --prefix e2e run ux:scenario:list -- --tier local --provider-free --json
+
+# Run the artifact/validator self-test without launching tmux.
+OCTOS_UX_TMUX_OUT_ROOT=/tmp/octos-ux \
+  npm --prefix e2e run ux:tmux:run -- --self-test stdio-happy-path
+
+# Write a blocked dry-run artifact skeleton for a scenario.
+OCTOS_UX_TMUX_OUT_ROOT=/tmp/octos-ux \
+  npm --prefix e2e run ux:tmux:run -- stdio-happy-path --dry-run
+
+# Re-run validators against a scenario artifact directory.
+npm --prefix e2e run ux:tmux:validate -- \
+  /tmp/octos-ux/<run-id>/<scenario-id>
+```
+
+Per-scenario artifacts live under
+`e2e/test-results-ux/<run-id>/<scenario-id>/` unless
+`OCTOS_UX_TMUX_OUT_ROOT` or `OCTOS_UX_TMUX_OUT_DIR` overrides the path.
+Every run directory also contains:
+
+- `ux-summary.json`
+- `ux-summary.md`
+
+The run summary reports `passed`, `failed`, `skipped`, `blocked`, and
+`quarantined` separately. Each scenario entry includes the scenario id,
+launch command, duration, status, mode, validator ids, artifact directory, and
+first actionable validator failure. Release-facing summaries must not treat
+skipped, blocked, dry-run, self-test, or placeholder scenarios as passed.
+
+Recommended lanes:
+
+- PR local: `ux:scenario:list:ci` plus `ux:tmux:run -- --self-test stdio-happy-path`.
+- Nightly: local-tier provider-free real tmux runs on hosts with `octos` and `octos-tui`.
+- Soak: release-tier provider-free real tmux runs with retained artifacts.
+- Release: full release matrix; fail on `failed`, `blocked`, or `skipped`, and review any `quarantined` scenarios explicitly.
+
 ### M22 TUI Solo Onboarding Gate
 
 Use this gate for first-run TUI onboarding product-surface evidence. The full

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -28,6 +28,7 @@
     "soak:m18:appui-transport-parity": "node scripts/m18-appui-transport-parity-soak.mjs",
     "matrix": "node matrix/run.mjs",
     "ux:scenario:list": "node scripts/ux-scenario-list.mjs",
+    "ux:scenario:list:ci": "node scripts/ux-scenario-list.mjs --tier local --provider-free --json",
     "ux:scenario:list:test": "node --test tests/ux/scenario-list.test.mjs",
     "soak:m17:live-proof": "bash scripts/m17-live-proof-soak.sh run",
     "soak:m17:live-proof:validate": "bash scripts/m17-live-proof-soak.sh validate",

--- a/e2e/scripts/ux-scenario-list.mjs
+++ b/e2e/scripts/ux-scenario-list.mjs
@@ -9,6 +9,7 @@
 //   npm --prefix e2e run ux:scenario:list                # full release tier
 //   npm --prefix e2e run ux:scenario:list -- --tier fast
 //   npm --prefix e2e run ux:scenario:list -- --tier local
+//   npm --prefix e2e run ux:scenario:list -- --tier local --provider-free
 //   npm --prefix e2e run ux:scenario:list -- --json
 //
 // Exit codes:
@@ -34,7 +35,12 @@ const REPO_ROOT = resolve(__dirname, "..", "..");
 const DEFAULT_MANIFEST = resolve(REPO_ROOT, "e2e", "matrix", "octos-ux.toml");
 
 function parseArgs(argv) {
-  const opts = { tier: "release", json: false, manifest: DEFAULT_MANIFEST };
+  const opts = {
+    tier: "release",
+    json: false,
+    manifest: DEFAULT_MANIFEST,
+    providerFree: false,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--tier") {
@@ -49,6 +55,8 @@ function parseArgs(argv) {
       i += 1;
     } else if (arg.startsWith("--manifest=")) {
       opts.manifest = resolve(arg.slice("--manifest=".length));
+    } else if (arg === "--provider-free") {
+      opts.providerFree = true;
     } else if (arg === "--help" || arg === "-h") {
       opts.help = true;
     } else {
@@ -67,7 +75,7 @@ class UsageError extends Error {}
 
 function usage() {
   return [
-    "Usage: ux:scenario:list [--tier fast|local|release] [--json] [--manifest path]",
+    "Usage: ux:scenario:list [--tier fast|local|release] [--provider-free] [--json] [--manifest path]",
     "",
     "Lists UX scenarios declared in e2e/matrix/octos-ux.toml without launching",
     "tmux or any backend. See e2e/ux/README.md for the manifest schema.",
@@ -171,7 +179,10 @@ function main() {
     throw err;
   }
   const env = makeEnv();
-  const filtered = filterByTier(manifest.scenarios, opts.tier);
+  const tierFiltered = filterByTier(manifest.scenarios, opts.tier);
+  const filtered = opts.providerFree
+    ? tierFiltered.filter((scenario) => scenario.provider !== "live")
+    : tierFiltered;
   // Sort by id for deterministic output.
   const sorted = [...filtered].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const rows = sorted.map((s) => {
@@ -213,6 +224,7 @@ function main() {
           pack: manifest.pack,
           owner: manifest.owner,
           tier_filter: opts.tier,
+          provider_filter: opts.providerFree ? "provider-free" : "all",
           summary,
           scenarios: rows,
         },
@@ -222,7 +234,7 @@ function main() {
     );
   } else {
     process.stdout.write(
-      `Pack: ${manifest.pack}  Owner: ${manifest.owner}  Tier filter: ${opts.tier}\n`,
+      `Pack: ${manifest.pack}  Owner: ${manifest.owner}  Tier filter: ${opts.tier}  Provider filter: ${opts.providerFree ? "provider-free" : "all"}\n`,
     );
     process.stdout.write(
       formatTable(rows, [

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -5,9 +5,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { loadManifest } from '../lib/ux/scenarios.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
+const defaultManifest = path.resolve(repoRoot, 'e2e', 'matrix', 'octos-ux.toml');
 const defaultScenarioId = 'stdio-happy-path';
 const requiredArtifacts = [
   'scenario.json',
@@ -21,6 +23,8 @@ const requiredArtifacts = [
   'runtime-policy-stamp.json',
   'appui-transcript.jsonl',
 ];
+const terminalSummaryStatuses = new Set(['passed', 'failed', 'blocked', 'skipped', 'quarantined']);
+const runSummaryStatuses = ['passed', 'failed', 'skipped', 'blocked', 'quarantined', 'running', 'unknown'];
 
 const scenarios = new Map([
   [
@@ -314,6 +318,31 @@ function artifactInfo(outDir, name) {
   };
 }
 
+function readJsonFile(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function durationMillis(startedAt, finishedAt) {
+  if (!startedAt || !finishedAt) return null;
+  const start = Date.parse(startedAt);
+  const finish = Date.parse(finishedAt);
+  if (!Number.isFinite(start) || !Number.isFinite(finish)) return null;
+  return Math.max(0, finish - start);
+}
+
+function loadManifestScenario(scenarioId) {
+  try {
+    const manifest = loadManifest({ path: defaultManifest });
+    return manifest.scenarios.find((scenario) => scenario.id === scenarioId) || null;
+  } catch {
+    return null;
+  }
+}
+
 function resolveContext({ scenarioId, selfTest }) {
   const scenario = scenarios.get(scenarioId);
   if (!scenario) {
@@ -321,6 +350,7 @@ function resolveContext({ scenarioId, selfTest }) {
       `unsupported scenario: ${scenarioId}. Supported scenarios: ${[...scenarios.keys()].join(', ')}`,
     );
   }
+  const manifestScenario = loadManifestScenario(scenarioId);
 
   const stamp = compactTimestamp();
   const runId =
@@ -332,6 +362,7 @@ function resolveContext({ scenarioId, selfTest }) {
   const scenarioDir = path.resolve(
     process.env.OCTOS_UX_TMUX_OUT_DIR || path.join(outRoot, runId, scenario.id),
   );
+  const runDir = path.dirname(scenarioDir);
   const runtimeRoot = path.resolve(
     process.env.OCTOS_UX_TMUX_RUNTIME_ROOT || path.join(os.tmpdir(), `octos-ux-tmux-${runKey}`),
   );
@@ -386,6 +417,7 @@ function resolveContext({ scenarioId, selfTest }) {
     runId,
     runKey,
     outRoot,
+    runDir,
     scenarioDir,
     runtimeRoot,
     dataDir,
@@ -407,6 +439,8 @@ function resolveContext({ scenarioId, selfTest }) {
     backendEnv,
     backendCommand,
     launchCommand,
+    manifestScenario,
+    validators: manifestScenario?.acceptance || [],
   };
 }
 
@@ -488,8 +522,177 @@ function collectArtifactNames(outDir) {
   });
 }
 
+function normalizedRunStatus(status) {
+  if (terminalSummaryStatuses.has(status)) return status;
+  if (status === 'starting') return 'running';
+  return 'unknown';
+}
+
+function firstFailureFrom(summary, validation) {
+  const validationFailure = Array.isArray(validation?.failures)
+    ? validation.failures[0]
+    : null;
+  if (validationFailure) {
+    return {
+      validator: validationFailure.id || null,
+      detail: validationFailure.detail || 'validator failed',
+      evidence: Array.isArray(validationFailure.evidence) ? validationFailure.evidence : [],
+    };
+  }
+
+  const failedCheck = Array.isArray(validation?.checks)
+    ? validation.checks.find((check) => check?.status === 'failed')
+    : null;
+  if (failedCheck) {
+    return {
+      validator: failedCheck.id || null,
+      detail: failedCheck.detail || 'validator failed',
+      evidence: Array.isArray(failedCheck.evidence) ? failedCheck.evidence : [],
+    };
+  }
+
+  if (Array.isArray(summary.blockers) && summary.blockers.length > 0) {
+    return {
+      validator: null,
+      detail: String(summary.blockers[0]),
+      evidence: [],
+    };
+  }
+
+  if (summary.status === 'failed' && typeof summary.message === 'string' && summary.message.length > 0) {
+    return {
+      validator: null,
+      detail: summary.message,
+      evidence: [],
+    };
+  }
+
+  return null;
+}
+
+function runScenarioSummaryRecord(summary, scenarioDir) {
+  const validation = readJsonFile(path.join(scenarioDir, 'validation.json'));
+  return {
+    scenario_id: summary.scenario_id || path.basename(scenarioDir),
+    command: summary.command || null,
+    duration_ms: Number.isInteger(summary.duration_ms) ? summary.duration_ms : null,
+    status: normalizedRunStatus(summary.status),
+    raw_status: summary.status || null,
+    mode: summary.mode || null,
+    real_tmux_launched: summary.real_tmux_launched === true,
+    placeholder_artifacts: summary.placeholder_artifacts !== false,
+    validators: Array.isArray(summary.validators) ? summary.validators : [],
+    artifact_dir: summary.artifact_dir || summary.output_dir || scenarioDir,
+    first_failure: firstFailureFrom(summary, validation),
+  };
+}
+
+function collectRunScenarioSummaries(runDir) {
+  if (!fs.existsSync(runDir) || !fs.statSync(runDir).isDirectory()) return [];
+  const records = [];
+  for (const entry of fs.readdirSync(runDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const scenarioDir = path.join(runDir, entry.name);
+    const summary = readJsonFile(path.join(scenarioDir, 'summary.json'));
+    if (!summary || typeof summary !== 'object') continue;
+    records.push(runScenarioSummaryRecord(summary, scenarioDir));
+  }
+  return records.sort((left, right) => left.scenario_id.localeCompare(right.scenario_id));
+}
+
+function buildRunSummary(ctx) {
+  const scenariosForRun = collectRunScenarioSummaries(ctx.runDir);
+  const counts = Object.fromEntries(runSummaryStatuses.map((status) => [status, 0]));
+  for (const scenario of scenariosForRun) {
+    counts[scenario.status] = (counts[scenario.status] || 0) + 1;
+  }
+  counts.total = scenariosForRun.length;
+  const notReleaseEvidence = scenariosForRun.filter((scenario) => (
+    scenario.status === 'passed'
+      && (scenario.mode !== 'run' || !scenario.real_tmux_launched || scenario.placeholder_artifacts)
+  )).length;
+  const releaseBlocking =
+    counts.failed + counts.skipped + counts.blocked + counts.running + counts.unknown + notReleaseEvidence;
+  return {
+    schema: 'octos.ux.run_summary.v1',
+    generated_at: utcNow(),
+    run_id: ctx.runId,
+    run_dir: ctx.runDir,
+    counts,
+    release_gate: {
+      passed: releaseBlocking === 0,
+      blocking_status_counts: {
+        failed: counts.failed,
+        skipped: counts.skipped,
+        blocked: counts.blocked,
+        running: counts.running,
+        unknown: counts.unknown,
+        not_release_evidence: notReleaseEvidence,
+      },
+      quarantined: counts.quarantined,
+      note: 'Skipped, blocked, failed, running, unknown, and placeholder/self-test scenarios are never counted as release-passed.',
+    },
+    scenarios: scenariosForRun,
+  };
+}
+
+function markdownStatusLabel(status) {
+  return status[0].toUpperCase() + status.slice(1);
+}
+
+function renderRunSummaryMarkdown(summary) {
+  const lines = [
+    '# Octos UX Run Summary',
+    '',
+    `Run: ${summary.run_id}`,
+    `Generated: ${summary.generated_at}`,
+    `Run directory: ${summary.run_dir}`,
+    '',
+    `Counts: passed=${summary.counts.passed} failed=${summary.counts.failed} skipped=${summary.counts.skipped} blocked=${summary.counts.blocked} quarantined=${summary.counts.quarantined} running=${summary.counts.running} unknown=${summary.counts.unknown}`,
+    `Release gate: ${summary.release_gate.passed ? 'passed' : 'not passed'}`,
+    '',
+  ];
+
+  for (const status of ['passed', 'failed', 'skipped', 'blocked', 'quarantined']) {
+    lines.push(`## ${markdownStatusLabel(status)}`, '');
+    const scenariosForStatus = summary.scenarios.filter((scenario) => scenario.status === status);
+    if (scenariosForStatus.length === 0) {
+      lines.push('- None', '');
+      continue;
+    }
+    for (const scenario of scenariosForStatus) {
+      lines.push(`- ${scenario.scenario_id}`);
+      lines.push(`  Status: ${scenario.raw_status || scenario.status}`);
+      lines.push(`  Mode: ${scenario.mode || '<unknown>'}`);
+      lines.push(`  Command: ${scenario.command || '<none>'}`);
+      lines.push(`  Duration: ${scenario.duration_ms === null ? '<unknown>' : `${scenario.duration_ms} ms`}`);
+      lines.push(`  Validators: ${scenario.validators.length === 0 ? '<none>' : scenario.validators.join(', ')}`);
+      lines.push(`  Artifact directory: ${scenario.artifact_dir}`);
+      if (scenario.first_failure) {
+        lines.push(`  First failure: ${scenario.first_failure.validator || '<runner>'}: ${scenario.first_failure.detail}`);
+      }
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function refreshRunSummary(ctx) {
+  const summary = buildRunSummary(ctx);
+  writeJson(path.join(ctx.runDir, 'ux-summary.json'), summary);
+  writeText(path.join(ctx.runDir, 'ux-summary.md'), renderRunSummaryMarkdown(summary));
+}
+
 function writeArtifactSkeleton(ctx, options) {
   const generatedAt = utcNow();
+  const summaryPath = path.join(ctx.scenarioDir, 'summary.json');
+  const previousSummary = readJsonFile(summaryPath);
+  const startedAt = options.startedAt || previousSummary?.started_at || generatedAt;
+  const finishedAt = options.finishedAt !== undefined
+    ? options.finishedAt
+    : (terminalSummaryStatuses.has(options.status) ? generatedAt : null);
+  const durationMs = durationMillis(startedAt, finishedAt);
   const placeholder = options.placeholderArtifacts !== false;
   fs.mkdirSync(ctx.scenarioDir, { recursive: true });
   fs.mkdirSync(ctx.dataDir, { recursive: true });
@@ -507,6 +710,7 @@ function writeArtifactSkeleton(ctx, options) {
     transport: ctx.scenario.transport,
     run_id: ctx.runId,
     output_dir: ctx.scenarioDir,
+    run_dir: ctx.runDir,
     runtime_root: ctx.runtimeRoot,
     data_dir: ctx.dataDir,
     workspace: ctx.workdir,
@@ -517,6 +721,7 @@ function writeArtifactSkeleton(ctx, options) {
     lower_runner: ctx.lowerRunner,
     fixture_env: ctx.fixtureEnv,
     required_artifacts: requiredArtifacts,
+    validators: ctx.validators,
   });
 
   writeText(path.join(ctx.scenarioDir, 'launch-command.txt'), `${ctx.launchCommand}\n`);
@@ -583,10 +788,12 @@ function writeArtifactSkeleton(ctx, options) {
     }
   }
 
-  const summaryPath = path.join(ctx.scenarioDir, 'summary.json');
   const summary = {
     schema: 'octos.ux.summary.v1',
     generated_at: generatedAt,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    duration_ms: durationMs,
     ok: Boolean(options.ok),
     status: options.status,
     mode: options.mode,
@@ -594,7 +801,11 @@ function writeArtifactSkeleton(ctx, options) {
     blockers: options.blockers || [],
     scenario_id: ctx.scenario.id,
     run_id: ctx.runId,
+    command: ctx.launchCommand,
+    validators: ctx.validators,
+    artifact_dir: ctx.scenarioDir,
     output_dir: ctx.scenarioDir,
+    run_dir: ctx.runDir,
     placeholder_artifacts: placeholder,
     real_tmux_launched: Boolean(options.realTmuxLaunched),
     lower_runner: {
@@ -609,6 +820,7 @@ function writeArtifactSkeleton(ctx, options) {
     collectArtifactNames(ctx.scenarioDir).map((name) => [name, artifactInfo(ctx.scenarioDir, name)]),
   );
   writeJson(summaryPath, summary);
+  refreshRunSummary(ctx);
 }
 
 function validateArtifactSkeleton(ctx) {
@@ -631,12 +843,15 @@ function refreshSummaryArtifacts(ctx, validationStatus = null) {
       summary.ok = false;
       summary.status = 'failed';
       summary.message = `${summary.message}; validation failed; see validation.json`;
+      summary.finished_at = utcNow();
+      summary.duration_ms = durationMillis(summary.started_at, summary.finished_at);
     }
   }
   summary.artifacts = Object.fromEntries(
     collectArtifactNames(ctx.scenarioDir).map((name) => [name, artifactInfo(ctx.scenarioDir, name)]),
   );
   writeJson(summaryPath, summary);
+  refreshRunSummary(ctx);
 }
 
 function missingRunnerBlocker(ctx) {

--- a/e2e/tests/ux/scenario-list.test.mjs
+++ b/e2e/tests/ux/scenario-list.test.mjs
@@ -53,6 +53,26 @@ const REQUIRED_ARTIFACTS = [
   "validation.json",
 ];
 
+function scenarioToml({ id, provider, tier = "local" }) {
+  return [
+    "[[scenario]]",
+    `id = "${id}"`,
+    `title = "${id}"`,
+    `description = "${id}"`,
+    `tier = "${tier}"`,
+    'transport = "stdio"',
+    `provider = "${provider}"`,
+    'terminal = "80x24"',
+    'tui_binary = "octos-tui"',
+    'tmux_command = "x"',
+    'required_tools = []',
+    'required_capabilities = []',
+    'expected_artifacts = ["scenario.json"]',
+    'acceptance = ["validator.example"]',
+    "",
+  ].join("\n");
+}
+
 function makeEnv({
   tools = new Set(["tmux", "octos", "octos-tui"]),
   envVars = new Set(),
@@ -237,6 +257,35 @@ test("CLI exits 0 on a valid manifest and JSON output round-trips", () => {
   for (const s of parsed.scenarios) {
     assert.ok(["runnable", "skipped", "blocked", "quarantined"].includes(s.status));
   }
+});
+
+test("CLI provider-free mode excludes live provider scenarios", () => {
+  const dir = mkdtempSync(join(tmpdir(), "ux-provider-free-"));
+  const manifest = join(dir, "octos-ux.toml");
+  writeFileSync(
+    manifest,
+    [
+      'schema_version = 1',
+      'pack = "octos-ux"',
+      'owner = "test"',
+      scenarioToml({ id: "fixture-case", provider: "fixture" }),
+      scenarioToml({ id: "none-case", provider: "none" }),
+      scenarioToml({ id: "live-case", provider: "live" }),
+    ].join("\n"),
+  );
+
+  const out = execFileSync(
+    process.execPath,
+    [CLI, "--manifest", manifest, "--tier", "release", "--provider-free", "--json"],
+    { encoding: "utf8" },
+  );
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.provider_filter, "provider-free");
+  assert.deepEqual(
+    parsed.scenarios.map((scenario) => scenario.id).sort(),
+    ["fixture-case", "none-case"],
+  );
+  assert.ok(parsed.scenarios.every((scenario) => scenario.provider !== "live"));
 });
 
 test("CLI exits 2 on usage error", () => {

--- a/e2e/ux/README.md
+++ b/e2e/ux/README.md
@@ -112,6 +112,10 @@ npm --prefix e2e run ux:scenario:list -- --tier fast
 npm --prefix e2e run ux:scenario:list -- --tier local
 npm --prefix e2e run ux:scenario:list -- --tier release
 
+# CI-safe local selection: excludes live-provider scenarios.
+npm --prefix e2e run ux:scenario:list:ci
+npm --prefix e2e run ux:scenario:list -- --tier local --provider-free --json
+
 # Machine-readable output for CI. Use --silent so npm's lifecycle
 # banner ("> ux:scenario:list", "> node …") doesn't pollute stdout
 # before the JSON document. Alternatively, invoke node directly:
@@ -128,7 +132,26 @@ The command:
 - Validates the schema and reports a typed `manifest schema error` on bad input (exit code 3).
 - Classifies each scenario as `runnable`, `skipped`, `blocked`, or `quarantined` without launching tmux or any backend.
 - Prints a deterministic table sorted by scenario id.
-- With `--json`, prints a JSON document with `schema_version`, `pack`, `owner`, `tier_filter`, `summary`, and the full scenario records.
+- With `--provider-free`, excludes `provider = "live"` scenarios so PR CI can choose local, provider-free work without requiring production keys.
+- With `--json`, prints a JSON document with `schema_version`, `pack`, `owner`, `tier_filter`, `provider_filter`, `summary`, and the full scenario records.
+
+## Run summaries
+
+`npm --prefix e2e run ux:tmux:run -- <scenario-id>` writes per-scenario
+artifacts under `e2e/test-results-ux/<run-id>/<scenario-id>/` by default.
+The runner also refreshes run-level summaries in the parent run directory:
+
+- `ux-summary.json` - machine-readable `octos.ux.run_summary.v1` output with
+  separate counts for `passed`, `failed`, `skipped`, `blocked`,
+  `quarantined`, `running`, and `unknown`.
+- `ux-summary.md` - Markdown summary for PR, nightly, soak, and release
+  triage.
+
+Each scenario entry includes the scenario id, command, duration, status,
+mode, validators, artifact directory, and first validator failure when one is
+available. Release-facing summaries never count skipped, blocked, failed,
+running, unknown, self-test, dry-run, or placeholder scenarios as passed;
+quarantined scenarios are counted separately.
 
 ### Classification rules
 


### PR DESCRIPTION
## Summary
- Add `--provider-free` scenario listing plus `ux:scenario:list:ci` for local/provider-free UX CI selection.
- Refresh per-scenario UX summaries with command, duration, mode, validators, and artifact directory, and emit run-level `ux-summary.json` / `ux-summary.md` with separated passed/failed/skipped/blocked/quarantined counts.
- Document M19 UX gate commands, artifact paths, PR/nightly/soak/release recommendations, and release-gate counting rules.

Related to #1068

## Validation
- `node --check e2e/scripts/ux-scenario-list.mjs`
- `node --check e2e/scripts/ux-tmux-run.mjs`
- `node --check e2e/scripts/ux-tmux-validate.mjs`
- `npm --prefix e2e run ux:scenario:list:test`
- `npm --prefix e2e run ux:scenario:list:ci`
- `OCTOS_UX_TMUX_OUT_ROOT=/private/tmp/octos-ux-1068-final OCTOS_UX_TMUX_RUN_ID=ux-reporting-self-test npm --prefix e2e run ux:tmux:run -- --self-test stdio-happy-path`
- `OCTOS_UX_TMUX_OUT_ROOT=/private/tmp/octos-ux-1068-final OCTOS_UX_TMUX_RUN_ID=ux-reporting-dry-run npm --prefix e2e run ux:tmux:run -- router-status-failover --dry-run`
- `npm --prefix e2e run ux:tmux:validate -- /private/tmp/octos-ux-1068-final/ux-reporting-self-test/stdio-happy-path`
- `jq` assertions for self-test `summary.json`, run-level `ux-summary.json`, blocked dry-run counts, release-gate behavior, and Markdown artifact presence
- `git diff --check`
- `git ls-files --others --exclude-standard`

