### PR TITLE
test(e2e): add UX validator registry checks

### DIFF
--- a/e2e/fixtures/ux-artifact-self-test/appui-transcript.jsonl
+++ b/e2e/fixtures/ux-artifact-self-test/appui-transcript.jsonl
@@ -1,5 +1,5 @@
 {"ts":"2026-05-18T00:00:00.000Z","direction":"client_to_server","frame":{"jsonrpc":"2.0","id":"self-1","method":"client_hello","params":{"client":"ux-artifact-self-test"}}}
-{"ts":"2026-05-18T00:00:00.010Z","direction":"server_to_client","frame":{"jsonrpc":"2.0","id":"self-1","result":{"server":"octos","capabilities":["runtime.policy_stamp.v1"]}}}
+{"ts":"2026-05-18T00:00:00.010Z","direction":"server_to_client","frame":{"jsonrpc":"2.0","id":"self-1","result":{"server":"octos","capabilities":["runtime.policy_stamp.v1"],"supported_methods":["session/open"]}}}
 {"ts":"2026-05-18T00:00:00.020Z","direction":"client_to_server","frame":{"jsonrpc":"2.0","id":"self-2","method":"session/open","params":{"session_id":"ux-artifact-self-test","profile_id":"local"}}}
 {"ts":"2026-05-18T00:00:00.030Z","direction":"server_to_client","frame":{"jsonrpc":"2.0","id":"self-2","result":{"opened":{"session_id":"ux-artifact-self-test"},"runtime_policy_stamp":{"profile_id":"local","sandbox_mode":"danger-full-access","approval_policy":"never"}}}}
 {"ts":"2026-05-18T00:00:00.040Z","direction":"server_to_client","frame":{"jsonrpc":"2.0","method":"turn/completed","params":{"session_id":"ux-artifact-self-test","turn_id":"turn-self-test","status":"completed"}}}

--- a/e2e/fixtures/ux-artifact-self-test/validation.json
+++ b/e2e/fixtures/ux-artifact-self-test/validation.json
@@ -28,6 +28,22 @@
       ]
     },
     {
+      "id": "capabilities_before_followups",
+      "status": "passed",
+      "detail": "capability advertisement precedes follow-up requests at line 2",
+      "evidence": [
+        "appui-transcript.jsonl"
+      ]
+    },
+    {
+      "id": "no_unadvertised_methods_called",
+      "status": "passed",
+      "detail": "all 3 advertised method gate(s) respected",
+      "evidence": [
+        "appui-transcript.jsonl"
+      ]
+    },
+    {
       "id": "real_tmux_evidence",
       "status": "passed",
       "detail": "real tmux evidence is not required for mode=self-test status=passed",
@@ -62,6 +78,77 @@
         "terminal-size.json",
         "tui-capture.txt"
       ]
+    },
+    {
+      "id": "final_answer_visible",
+      "status": "passed",
+      "detail": "final answer/completion evidence is visible",
+      "evidence": [
+        "scenario.json",
+        "summary.json",
+        "tui-capture.txt",
+        "appui-transcript.jsonl"
+      ]
+    },
+    {
+      "id": "composer_usable",
+      "status": "passed",
+      "detail": "composer label and input row are visible inside the declared terminal",
+      "evidence": [
+        "terminal-size.json",
+        "tui-capture.txt"
+      ]
+    },
+    {
+      "id": "secret_redaction",
+      "status": "passed",
+      "detail": "scanned 9 retained text artifact(s) for secret leaks",
+      "evidence": [
+        "appui-transcript.jsonl",
+        "input-replay.log",
+        "launch-command.txt",
+        "runtime-policy-stamp.json",
+        "scenario.json",
+        "server.log",
+        "summary.json",
+        "terminal-size.json",
+        "tui-capture.txt"
+      ]
+    },
+    {
+      "id": "terminal_layout_snapshot",
+      "status": "passed",
+      "detail": "embedded layout snapshot with 2 detected region(s) and 0 cursor sample(s)",
+      "evidence": [
+        "terminal-size.json",
+        "tui-capture.txt"
+      ],
+      "layout_snapshot": {
+        "schema": "octos.ux.terminal_layout_snapshot.v1",
+        "terminal": {
+          "cols": 120,
+          "rows": 40
+        },
+        "cursor_samples": {
+          "present": false,
+          "count": 0,
+          "samples": []
+        },
+        "regions": [
+          {
+            "name": "history",
+            "start_row": 3,
+            "end_row": 3,
+            "detected": true
+          },
+          {
+            "name": "composer",
+            "start_row": 7,
+            "end_row": 7,
+            "detected": true
+          }
+        ]
+      }
     },
     {
       "id": "permission_selection_visible_contract",

--- a/e2e/fixtures/ux-artifact-self-test/validation.json
+++ b/e2e/fixtures/ux-artifact-self-test/validation.json
@@ -1,6 +1,53 @@
 {
   "schema": "octos.ux.validation.v1",
   "status": "passed",
+  "validators": [
+    "artifact_abi",
+    "appui_transcript_parseable",
+    "capabilities_before_followups",
+    "no_unadvertised_methods_called",
+    "real_tmux_evidence",
+    "appui_transcript_semantic",
+    "rendered_screen_no_known_bug_patterns",
+    "screen_geometry_consistent",
+    "final_answer_visible",
+    "composer_usable",
+    "secret_redaction",
+    "terminal_layout_snapshot",
+    "permission_selection_visible_contract",
+    "provider_missing_visible_contract",
+    "approval_denial_visible_contract",
+    "task_subagent_tree_visible_contract",
+    "restart_reconnect_visible_contract",
+    "dropped_completion_backpressure_contract",
+    "lower_soak_summary_semantic"
+  ],
+  "layout_snapshot": {
+    "schema": "octos.ux.terminal_layout_snapshot.v1",
+    "terminal": {
+      "cols": 120,
+      "rows": 40
+    },
+    "cursor_samples": {
+      "present": false,
+      "count": 0,
+      "samples": []
+    },
+    "regions": [
+      {
+        "name": "history",
+        "start_row": 3,
+        "end_row": 3,
+        "detected": true
+      },
+      {
+        "name": "composer",
+        "start_row": 7,
+        "end_row": 7,
+        "detected": true
+      }
+    ]
+  },
   "checks": [
     {
       "id": "artifact_abi",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -27,6 +27,7 @@
     "ux:tmux:run": "node scripts/ux-tmux-run.mjs",
     "ux:tmux:validate": "node scripts/ux-tmux-validate.mjs",
     "ux:tmux:validate:backpressure-test": "node --test tests/ux/backpressure-validate.test.mjs",
+    "ux:tmux:validate:test": "node --test tests/ux/validate.test.mjs",
     "soak:m14:codex-tool-parity": "node scripts/m14-codex-tool-parity-soak.mjs",
     "soak:m11:session-sandbox": "cd .. && bash scripts/validate-session-policy-local.sh",
     "soak:m18:appui-transport-parity": "node scripts/m18-appui-transport-parity-soak.mjs",

--- a/e2e/scripts/ux-tmux-validate.mjs
+++ b/e2e/scripts/ux-tmux-validate.mjs
@@ -1802,9 +1802,12 @@ function buildValidation(artifactDir) {
       detail: check.detail,
       evidence: check.evidence,
     }));
+  const layoutCheck = checks.find((check) => check.id === 'terminal_layout_snapshot');
   return {
     schema: VALIDATION_SCHEMA,
     status: failures.length === 0 ? 'passed' : 'failed',
+    validators: checks.map((check) => check.id),
+    layout_snapshot: layoutCheck?.layout_snapshot ?? null,
     checks,
     failures,
   };

--- a/e2e/scripts/ux-tmux-validate.mjs
+++ b/e2e/scripts/ux-tmux-validate.mjs
@@ -203,6 +203,10 @@ function codepointLength(text) {
   return [...text].length;
 }
 
+function firstInteger(...values) {
+  return values.find((value) => Number.isInteger(value)) ?? null;
+}
+
 function sortedStrings(values) {
   return [...new Set(values)].sort();
 }
@@ -213,6 +217,13 @@ function makeCheck(id, passed, detail, evidence) {
     status: passed ? 'passed' : 'failed',
     detail,
     evidence,
+  };
+}
+
+function makeCheckWithData(id, passed, detail, evidence, data) {
+  return {
+    ...makeCheck(id, passed, detail, evidence),
+    ...data,
   };
 }
 
@@ -450,13 +461,84 @@ function normalizeTranscriptFrame(value) {
   return null;
 }
 
-function checkAppuiTranscriptParseable(artifactDir) {
+function transcriptFrameRows(artifactDir) {
   const parsed = parseJsonl(artifactPath(artifactDir, 'appui-transcript.jsonl'));
+  return {
+    parsed,
+    frameRows: parsed.rows
+      .map((row) => ({ row, frame: normalizeTranscriptFrame(row.value) }))
+      .filter((entry) => isPlainObject(entry.frame)),
+  };
+}
+
+function isRequestFrame(frame) {
+  return isPlainObject(frame)
+    && typeof frame.method === 'string'
+    && Object.prototype.hasOwnProperty.call(frame, 'id');
+}
+
+function isResponseFrame(frame) {
+  return isPlainObject(frame)
+    && (Object.prototype.hasOwnProperty.call(frame, 'result')
+      || Object.prototype.hasOwnProperty.call(frame, 'error'));
+}
+
+function extractAdvertisedMethodSet(result) {
+  const methods = new Set(['client_hello', 'config/capabilities/list']);
+  const visit = (value, key = '') => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, key);
+      return;
+    }
+    if (!isPlainObject(value)) {
+      if (
+        typeof value === 'string'
+        && value.includes('/')
+        && /methods?|commands?|routes?|capabilities/i.test(key)
+      ) {
+        methods.add(value);
+      }
+      return;
+    }
+    for (const [childKey, childValue] of Object.entries(value)) {
+      visit(childValue, childKey);
+    }
+  };
+  visit(result);
+  return methods;
+}
+
+function findCapabilityAdvertisement(frameRows) {
+  const requestsById = new Map();
+  for (const entry of frameRows) {
+    if (isRequestFrame(entry.frame)) {
+      requestsById.set(String(entry.frame.id), entry.frame.method);
+    }
+    if (!isResponseFrame(entry.frame) || !isPlainObject(entry.frame.result)) continue;
+    const responseTo = requestsById.get(String(entry.frame.id));
+    const result = entry.frame.result;
+    if (
+      responseTo === 'client_hello'
+      || responseTo === 'config/capabilities/list'
+      || Array.isArray(result.capabilities)
+      || Array.isArray(result.methods)
+      || Array.isArray(result.supported_methods)
+      || Array.isArray(result.commands)
+    ) {
+      return {
+        row: entry.row,
+        result,
+        methods: extractAdvertisedMethodSet(result),
+      };
+    }
+  }
+  return null;
+}
+
+function checkAppuiTranscriptParseable(artifactDir) {
+  const { parsed, frameRows } = transcriptFrameRows(artifactDir);
   const shapeErrors = parsed.rows.flatMap((row) => validateFrameShape(row));
   const jsonErrors = parsed.errors.map((entry) => `line ${entry.line}: ${entry.error}`);
-  const frameRows = parsed.rows
-    .map((row) => ({ row, frame: normalizeTranscriptFrame(row.value) }))
-    .filter((entry) => isPlainObject(entry.frame));
   const methodNames = sortedStrings(
     frameRows
       .map((entry) => entry.frame.method)
@@ -485,6 +567,63 @@ function checkAppuiTranscriptParseable(artifactDir) {
     problems.length === 0
       ? `parsed ${parsed.rows.length} JSONL entries; methods=${methodNames.join(', ')}; responses=${responseCount}`
       : `transcript parse problems: ${problems.join('; ')}`,
+    ['appui-transcript.jsonl'],
+  );
+}
+
+function checkCapabilitiesBeforeFollowups(artifactDir) {
+  const { parsed, frameRows } = transcriptFrameRows(artifactDir);
+  const problems = parsed.errors.map((entry) => `line ${entry.line}: ${entry.error}`);
+  const advertisement = findCapabilityAdvertisement(frameRows);
+  if (!advertisement) {
+    problems.push('no client_hello or config/capabilities/list capability advertisement response found');
+  }
+  for (const entry of frameRows) {
+    if (!isRequestFrame(entry.frame)) continue;
+    const method = entry.frame.method;
+    if (method === 'client_hello' || method === 'config/capabilities/list') continue;
+    if (!advertisement || entry.row.line < advertisement.row.line) {
+      problems.push(`line ${entry.row.line}: ${method} was sent before capability advertisement`);
+      break;
+    }
+  }
+  return makeCheck(
+    'capabilities_before_followups',
+    problems.length === 0,
+    problems.length === 0
+      ? `capability advertisement precedes follow-up requests at line ${advertisement.row.line}`
+      : `capability ordering problems: ${problems.join('; ')}`,
+    ['appui-transcript.jsonl'],
+  );
+}
+
+function checkNoUnadvertisedMethodsCalled(artifactDir) {
+  const { parsed, frameRows } = transcriptFrameRows(artifactDir);
+  const problems = parsed.errors.map((entry) => `line ${entry.line}: ${entry.error}`);
+  const advertisement = findCapabilityAdvertisement(frameRows);
+  if (!advertisement) {
+    return makeCheck(
+      'no_unadvertised_methods_called',
+      false,
+      'no method advertisement found before checking AppUI request methods',
+      ['appui-transcript.jsonl'],
+    );
+  }
+  const advertised = advertisement.methods;
+  for (const entry of frameRows) {
+    if (!isRequestFrame(entry.frame)) continue;
+    const method = entry.frame.method;
+    if (entry.row.line <= advertisement.row.line) continue;
+    if (!advertised.has(method)) {
+      problems.push(`line ${entry.row.line}: ${method} was not advertised`);
+    }
+  }
+  return makeCheck(
+    'no_unadvertised_methods_called',
+    problems.length === 0,
+    problems.length === 0
+      ? `all ${advertised.size} advertised method gate(s) respected`
+      : `unadvertised AppUI method problems: ${problems.join('; ')}`,
     ['appui-transcript.jsonl'],
   );
 }
@@ -528,6 +667,249 @@ function checkRealTmuxEvidence(artifactDir) {
       ? 'summary confirms this artifact set came from a completed real tmux run'
       : `real tmux evidence problems: ${problems.join('; ')}`,
     ['summary.json'],
+  );
+}
+
+function checkFinalAnswerVisible(artifactDir) {
+  const scenario = readJson(artifactPath(artifactDir, 'scenario.json'));
+  const summary = readJson(artifactPath(artifactDir, 'summary.json'));
+  const capture = readText(artifactPath(artifactDir, 'tui-capture.txt'));
+  const transcript = readText(artifactPath(artifactDir, 'appui-transcript.jsonl'));
+  const problems = [];
+  const marker = scenario.ok && typeof scenario.value.final_marker === 'string'
+    ? scenario.value.final_marker
+    : null;
+  if (!summary.ok) {
+    problems.push(`summary.json is not parseable JSON: ${summary.error}`);
+  }
+  if (!capture.ok) {
+    problems.push(`tui-capture.txt could not be read: ${capture.error}`);
+  }
+  if (!transcript.ok) {
+    problems.push(`appui-transcript.jsonl could not be read: ${transcript.error}`);
+  }
+  if (problems.length === 0) {
+    const combined = `${capture.text}\n${transcript.text}`;
+    if (marker) {
+      const compactMarker = marker.replace(/_/g, '');
+      const compactCombined = combined.replace(/[_\s]/g, '');
+      if (!combined.includes(marker) && !compactCombined.includes(compactMarker)) {
+        problems.push(`final marker ${marker} is missing from capture/transcript`);
+      }
+    } else if (
+      summary.value.status === 'passed'
+      && !/(Assistant:|turn\/completed|final answer|completed)/i.test(combined)
+    ) {
+      problems.push('passed scenario has no visible assistant/final-completion evidence');
+    }
+  }
+  return makeCheck(
+    'final_answer_visible',
+    problems.length === 0,
+    problems.length === 0
+      ? (marker ? `final marker ${marker} is visible` : 'final answer/completion evidence is visible')
+      : `final answer visibility problems: ${problems.join('; ')}`,
+    ['scenario.json', 'summary.json', 'tui-capture.txt', 'appui-transcript.jsonl'],
+  );
+}
+
+function checkComposerUsable(artifactDir) {
+  const capture = readText(artifactPath(artifactDir, 'tui-capture.txt'));
+  const terminal = readJson(artifactPath(artifactDir, 'terminal-size.json'));
+  const problems = [];
+  if (!capture.ok) {
+    problems.push(`tui-capture.txt could not be read: ${capture.error}`);
+  }
+  if (!terminal.ok) {
+    problems.push(`terminal-size.json is not parseable JSON: ${terminal.error}`);
+  }
+  if (problems.length === 0) {
+    if (!/\bComposer\b/i.test(capture.text)) {
+      problems.push('capture is missing Composer label');
+    }
+    if (!/(^|\n)\s*(>|›|Input:|Prompt:)/.test(capture.text)) {
+      problems.push('capture is missing an input prompt/cursor row');
+    }
+    const lines = captureLines(capture.text);
+    const composerIndex = lines.findIndex((line) => /\bComposer\b/i.test(line));
+    if (composerIndex === -1) {
+      problems.push('composer row could not be located');
+    } else if (terminal.ok && composerIndex >= terminal.value.rows) {
+      problems.push(`composer row ${composerIndex + 1} is outside declared terminal height ${terminal.value.rows}`);
+    }
+  }
+  return makeCheck(
+    'composer_usable',
+    problems.length === 0,
+    problems.length === 0
+      ? 'composer label and input row are visible inside the declared terminal'
+      : `composer usability problems: ${problems.join('; ')}`,
+    ['terminal-size.json', 'tui-capture.txt'],
+  );
+}
+
+const SECRET_PATTERNS = [
+  /\b(?:OPENAI|ANTHROPIC|GOOGLE|OPENROUTER|DEEPSEEK|KIMI|AUTODL)_API_KEY\s*=\s*sk-[A-Za-z0-9_-]{8,}/,
+  /\bBearer\s+sk-[A-Za-z0-9_-]{8,}/,
+  /"api[_-]?key"\s*:\s*"sk-[A-Za-z0-9_-]{8,}"/i,
+  /OCTOS_UX_SECRET_SHOULD_BE_REDACTED/,
+];
+
+function shouldScanForSecrets(name) {
+  return /\.(json|jsonl|txt|log|md|env)$/.test(name) && name !== 'validation.json';
+}
+
+function checkSecretRedaction(artifactDir) {
+  const problems = [];
+  const evidence = [];
+  const visit = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const file = path.join(dir, entry.name);
+      const relative = path.relative(artifactDir, file);
+      if (entry.isDirectory()) {
+        visit(file);
+      } else if (entry.isFile() && shouldScanForSecrets(relative)) {
+        evidence.push(relative);
+        const text = readText(file);
+        if (!text.ok) {
+          problems.push(`${relative} could not be read: ${text.error}`);
+          continue;
+        }
+        for (const pattern of SECRET_PATTERNS) {
+          const match = lineMatches(text.text, pattern);
+          if (match) {
+            problems.push(`${relative}:${match.line} contains unredacted secret-like text`);
+            break;
+          }
+        }
+      }
+    }
+  };
+  visit(artifactDir);
+  return makeCheck(
+    'secret_redaction',
+    problems.length === 0,
+    problems.length === 0
+      ? `scanned ${evidence.length} retained text artifact(s) for secret leaks`
+      : `secret redaction problems: ${problems.join('; ')}`,
+    evidence,
+  );
+}
+
+function readCursorSamples(artifactDir) {
+  const name = 'tmux-cursor-samples.jsonl';
+  const file = artifactPath(artifactDir, name);
+  if (!fs.existsSync(file)) {
+    return {
+      present: false,
+      samples: [],
+      errors: [],
+      evidence: [],
+    };
+  }
+
+  const parsed = parseJsonl(file);
+  const samples = parsed.rows.map((row) => {
+    const value = row.value;
+    const source = isPlainObject(value.cursor)
+      ? value.cursor
+      : isPlainObject(value.position)
+        ? value.position
+        : value;
+    return {
+      line: row.line,
+      row: firstInteger(
+        source.row,
+        source.y,
+        source.cursor_row,
+        source.cursor_y,
+        value.row,
+        value.y,
+        value.cursor_row,
+        value.cursor_y,
+      ),
+      col: firstInteger(
+        source.col,
+        source.column,
+        source.x,
+        source.cursor_col,
+        source.cursor_x,
+        value.col,
+        value.column,
+        value.x,
+        value.cursor_col,
+        value.cursor_x,
+      ),
+    };
+  });
+  const errors = [
+    ...parsed.errors.map((entry) => `line ${entry.line}: ${entry.error}`),
+    ...samples
+      .filter((sample) => sample.row === null || sample.col === null)
+      .map((sample) => `line ${sample.line}: cursor sample must include row/col coordinates`),
+  ];
+  return {
+    present: true,
+    samples,
+    errors,
+    evidence: [name],
+  };
+}
+
+function checkTerminalLayoutSnapshot(artifactDir) {
+  const capture = readText(artifactPath(artifactDir, 'tui-capture.txt'));
+  const terminal = readJson(artifactPath(artifactDir, 'terminal-size.json'));
+  const cursorSamples = readCursorSamples(artifactDir);
+  const problems = [];
+  if (!capture.ok) problems.push(`tui-capture.txt could not be read: ${capture.error}`);
+  if (!terminal.ok) problems.push(`terminal-size.json is not parseable JSON: ${terminal.error}`);
+  problems.push(...cursorSamples.errors);
+  const snapshot = {
+    schema: 'octos.ux.terminal_layout_snapshot.v1',
+    terminal: terminal.ok
+      ? { cols: terminal.value.cols, rows: terminal.value.rows }
+      : null,
+    cursor_samples: {
+      present: cursorSamples.present,
+      count: cursorSamples.samples.length,
+      samples: cursorSamples.samples.slice(0, 20),
+    },
+    regions: [],
+  };
+  if (problems.length === 0) {
+    const lines = captureLines(capture.text);
+    const regionPatterns = [
+      ['history', /Messages|Assistant:|User:/i],
+      ['composer', /\bComposer\b|(^|\n)\s*(>|›|Input:|Prompt:)/i],
+      ['status', /^ state |Status:/i],
+      ['menu', /\bMenu\b|Permissions|Model/i],
+      ['approval_prompt', /Approve|Deny|approval/i],
+      ['task_output', /Task|Subagent|Progress/i],
+    ];
+    for (const [name, regex] of regionPatterns) {
+      const line = lines.findIndex((value) => regex.test(value));
+      if (line !== -1) {
+        snapshot.regions.push({
+          name,
+          start_row: line + 1,
+          end_row: line + 1,
+          detected: true,
+        });
+      }
+    }
+    if (snapshot.regions.length === 0) {
+      problems.push('no terminal layout regions detected in capture');
+    }
+  }
+  return makeCheckWithData(
+    'terminal_layout_snapshot',
+    problems.length === 0,
+    problems.length === 0
+      ? `embedded layout snapshot with ${snapshot.regions.length} detected region(s) and ${cursorSamples.samples.length} cursor sample(s)`
+      : `terminal layout snapshot problems: ${problems.join('; ')}`,
+    ['terminal-size.json', 'tui-capture.txt', ...cursorSamples.evidence],
+    { layout_snapshot: snapshot },
   );
 }
 
@@ -1394,10 +1776,16 @@ function buildValidation(artifactDir) {
   const checks = [
     checkArtifactAbi(artifactDir),
     checkAppuiTranscriptParseable(artifactDir),
+    checkCapabilitiesBeforeFollowups(artifactDir),
+    checkNoUnadvertisedMethodsCalled(artifactDir),
     checkRealTmuxEvidence(artifactDir),
     checkAppuiTranscriptSemantic(artifactDir),
     checkRenderedScreenNoKnownBugPatterns(artifactDir),
     checkScreenGeometryConsistent(artifactDir),
+    checkFinalAnswerVisible(artifactDir),
+    checkComposerUsable(artifactDir),
+    checkSecretRedaction(artifactDir),
+    checkTerminalLayoutSnapshot(artifactDir),
     checkPermissionSelectionScenario(artifactDir),
     checkProviderMissingScenario(artifactDir),
     checkApprovalDenialScenario(artifactDir),

--- a/e2e/tests/ux/validate.test.mjs
+++ b/e2e/tests/ux/validate.test.mjs
@@ -211,6 +211,8 @@ test("validator registry emits required M19 checks and layout snapshot", () => {
   }
   const layout = checkById(result, "terminal_layout_snapshot").layout_snapshot;
   assert.equal(layout.schema, "octos.ux.terminal_layout_snapshot.v1");
+  assert.ok(result.validators.includes("terminal_layout_snapshot"));
+  assert.equal(result.layout_snapshot.schema, "octos.ux.terminal_layout_snapshot.v1");
   assert.ok(layout.regions.some((region) => region.name === "composer"));
 });
 

--- a/e2e/tests/ux/validate.test.mjs
+++ b/e2e/tests/ux/validate.test.mjs
@@ -1,0 +1,334 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const VALIDATOR = resolve(REPO_ROOT, "e2e", "scripts", "ux-tmux-validate.mjs");
+
+const REQUIRED_ARTIFACTS = [
+  "scenario.json",
+  "summary.json",
+  "launch-command.txt",
+  "terminal-size.json",
+  "input-replay.log",
+  "appui-transcript.jsonl",
+  "server.log",
+  "tui-capture.txt",
+  "runtime-policy-stamp.json",
+  "validation.json",
+];
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function baseTranscript({
+  advertiseBeforeFollowups = true,
+  includeUnadvertised = false,
+} = {}) {
+  const rows = [];
+  const helloTx = {
+    direction: "client_to_server",
+    frame: {
+      jsonrpc: "2.0",
+      id: "hello-1",
+      method: "client_hello",
+      params: { client: "validator-test" },
+    },
+  };
+  const helloRx = {
+    direction: "server_to_client",
+    frame: {
+      jsonrpc: "2.0",
+      id: "hello-1",
+      result: {
+        capabilities: ["runtime.policy_stamp.v1"],
+        supported_methods: ["session/open", "turn/start"],
+      },
+    },
+  };
+  const openTx = {
+    direction: "client_to_server",
+    frame: {
+      jsonrpc: "2.0",
+      id: "open-1",
+      method: "session/open",
+      params: { session_id: "ux-validator-test" },
+    },
+  };
+  if (advertiseBeforeFollowups) {
+    rows.push(helloTx, helloRx, openTx);
+  } else {
+    rows.push(helloTx, openTx, helloRx);
+  }
+  rows.push({
+    direction: "server_to_client",
+    frame: {
+      jsonrpc: "2.0",
+      id: "open-1",
+      result: { opened: { session_id: "ux-validator-test" } },
+    },
+  });
+  rows.push({
+    direction: "client_to_server",
+    frame: {
+      jsonrpc: "2.0",
+      id: "turn-1",
+      method: includeUnadvertised ? "tool/status/list" : "turn/start",
+      params: { session_id: "ux-validator-test" },
+    },
+  });
+  rows.push({
+    direction: "server_to_client",
+    frame: {
+      jsonrpc: "2.0",
+      id: "turn-1",
+      result: { ok: true },
+    },
+  });
+  rows.push({
+    direction: "server_to_client",
+    frame: {
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        session_id: "ux-validator-test",
+        turn_id: "turn-1",
+        status: "completed",
+      },
+    },
+  });
+  return rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+}
+
+function makeArtifactDir(overrides = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "octos-ux-validate-"));
+  mkdirSync(dir, { recursive: true });
+  writeJson(join(dir, "scenario.json"), {
+    schema: "octos.ux.scenario.v1",
+    id: "validator-test",
+    artifact_abi: "octos.ux.artifacts.v1",
+    final_marker: "M19_VALIDATOR_FINAL_LINE",
+    required_artifacts: REQUIRED_ARTIFACTS,
+    ...(overrides.scenario || {}),
+  });
+  writeJson(join(dir, "summary.json"), {
+    schema: "octos.ux.summary.v1",
+    status: "passed",
+    mode: "self-test",
+    scenario_id: "validator-test",
+    artifacts: Object.fromEntries(REQUIRED_ARTIFACTS.map((name) => [name, name])),
+    ...(overrides.summary || {}),
+  });
+  writeJson(join(dir, "terminal-size.json"), {
+    schema: "octos.ux.terminal_size.v1",
+    cols: 120,
+    rows: 40,
+    ...(overrides.terminal || {}),
+  });
+  writeJson(join(dir, "runtime-policy-stamp.json"), {
+    schema: "octos.runtime_policy_stamp.v1",
+    stamp: { sandbox_mode: "workspace-write", approval_policy: "never" },
+  });
+  writeFileSync(
+    join(dir, "appui-transcript.jsonl"),
+    overrides.transcript || baseTranscript(),
+    "utf8",
+  );
+  writeFileSync(
+    join(dir, "tui-capture.txt"),
+    overrides.capture ||
+      [
+        "Octos TUI",
+        "",
+        "Messages",
+        "User: validate the UX gate",
+        "Assistant: completed M19_VALIDATOR_FINAL_LINE",
+        "",
+        "Composer",
+        ">",
+        "",
+        "state Ready",
+        "",
+      ].join("\n"),
+    "utf8",
+  );
+  writeFileSync(join(dir, "launch-command.txt"), "octos-tui --mode protocol\n", "utf8");
+  writeFileSync(join(dir, "input-replay.log"), "line validate\n", "utf8");
+  writeFileSync(join(dir, "server.log"), overrides.serverLog || "server ready\n", "utf8");
+  if (overrides.cursorSamples !== undefined) {
+    writeFileSync(join(dir, "tmux-cursor-samples.jsonl"), overrides.cursorSamples, "utf8");
+  }
+  writeJson(join(dir, "validation.json"), {
+    schema: "octos.ux.validation.v1",
+    status: "passed",
+    checks: [],
+  });
+  return dir;
+}
+
+function runValidator(dir) {
+  try {
+    const stdout = execFileSync(process.execPath, [VALIDATOR, dir], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { status: 0, result: JSON.parse(stdout) };
+  } catch (error) {
+    const stdout = error.stdout?.toString() || readFileSync(join(dir, "validation.json"), "utf8");
+    return { status: error.status, result: JSON.parse(stdout) };
+  }
+}
+
+function checkById(result, id) {
+  const check = result.checks.find((entry) => entry.id === id);
+  assert.ok(check, `missing check ${id}`);
+  return check;
+}
+
+test("validator registry emits required M19 checks and layout snapshot", () => {
+  const dir = makeArtifactDir();
+  const { status, result } = runValidator(dir);
+  assert.equal(status, 0);
+  for (const id of [
+    "artifact_abi",
+    "appui_transcript_parseable",
+    "capabilities_before_followups",
+    "no_unadvertised_methods_called",
+    "rendered_screen_no_known_bug_patterns",
+    "final_answer_visible",
+    "composer_usable",
+    "secret_redaction",
+    "terminal_layout_snapshot",
+  ]) {
+    assert.equal(checkById(result, id).status, "passed");
+  }
+  const layout = checkById(result, "terminal_layout_snapshot").layout_snapshot;
+  assert.equal(layout.schema, "octos.ux.terminal_layout_snapshot.v1");
+  assert.ok(layout.regions.some((region) => region.name === "composer"));
+});
+
+test("layout snapshot parses tmux cursor samples", () => {
+  const dir = makeArtifactDir({
+    cursorSamples: JSON.stringify({ ts: "2026-05-24T00:00:00.000Z", cursor: { row: 8, col: 2 } }) + "\n",
+  });
+  const { status, result } = runValidator(dir);
+  assert.equal(status, 0);
+  const layout = checkById(result, "terminal_layout_snapshot").layout_snapshot;
+  assert.equal(layout.cursor_samples.present, true);
+  assert.equal(layout.cursor_samples.count, 1);
+  assert.deepEqual(layout.cursor_samples.samples[0], { line: 1, row: 8, col: 2 });
+});
+
+test("known rendered capture bug patterns fail", () => {
+  const cases = [
+    {
+      name: "overlap",
+      capture: [
+        "Octos TUI",
+        "Messages",
+        "Assistant: completed M19_VALIDATOR_FINAL_LINE",
+        "┌Work › overlapped input",
+        "Composer",
+        ">",
+        "state Ready",
+      ].join("\n"),
+    },
+    {
+      name: "spinner",
+      capture: [
+        "Octos TUI",
+        "Messages",
+        "Assistant: completed M19_VALIDATOR_FINAL_LINE",
+        "Composer",
+        ">",
+        " state ◐",
+        " state ◑",
+      ].join("\n"),
+    },
+    {
+      name: "stuck-working",
+      capture: [
+        "Octos TUI",
+        "Messages",
+        "Assistant: completed M19_VALIDATOR_FINAL_LINE",
+        "Composer",
+        ">",
+        "state Working",
+      ].join("\n"),
+      serverLog: "writer channel full for lifecycle frame\n",
+    },
+    {
+      name: "raw-markdown",
+      capture: [
+        "Octos TUI",
+        "Messages",
+        "Assistant: completed M19_VALIDATOR_FINAL_LINE",
+        "• #### leaked markdown control",
+        "Composer",
+        ">",
+        "state Ready",
+      ].join("\n"),
+    },
+  ];
+
+  for (const renderedCase of cases) {
+    const dir = makeArtifactDir({
+      capture: renderedCase.capture,
+      serverLog: renderedCase.serverLog,
+    });
+    const { status, result } = runValidator(dir);
+    assert.equal(status, 1, renderedCase.name);
+    assert.equal(
+      checkById(result, "rendered_screen_no_known_bug_patterns").status,
+      "failed",
+      renderedCase.name,
+    );
+  }
+});
+
+test("hidden final answer fails final_answer_visible", () => {
+  const dir = makeArtifactDir({
+    capture: ["Octos TUI", "Messages", "Assistant: still working", "Composer", ">", "state Ready"].join("\n"),
+  });
+  const { status, result } = runValidator(dir);
+  assert.equal(status, 1);
+  assert.equal(checkById(result, "final_answer_visible").status, "failed");
+});
+
+test("missing composer fails composer_usable", () => {
+  const dir = makeArtifactDir({
+    capture: ["Octos TUI", "Messages", "Assistant: completed M19_VALIDATOR_FINAL_LINE", "state Ready"].join("\n"),
+  });
+  const { status, result } = runValidator(dir);
+  assert.equal(status, 1);
+  assert.equal(checkById(result, "composer_usable").status, "failed");
+});
+
+test("unredacted retained secrets fail secret_redaction", () => {
+  const dir = makeArtifactDir({
+    serverLog: "OPENAI_API_KEY=sk-live-secret-1234567890 leaked\n",
+  });
+  const { status, result } = runValidator(dir);
+  assert.equal(status, 1);
+  assert.equal(checkById(result, "secret_redaction").status, "failed");
+});
+
+test("capability ordering and unadvertised method calls fail", () => {
+  const dir = makeArtifactDir({
+    transcript: baseTranscript({
+      advertiseBeforeFollowups: false,
+      includeUnadvertised: true,
+    }),
+  });
+  const { status, result } = runValidator(dir);
+  assert.equal(status, 1);
+  assert.equal(checkById(result, "capabilities_before_followups").status, "failed");
+  assert.equal(checkById(result, "no_unadvertised_methods_called").status, "failed");
+});


### PR DESCRIPTION
## Summary
- Add deterministic M19 UX validator checks for capability ordering, advertised method use, final-answer visibility, composer usability, retained-secret scanning, and embedded terminal layout snapshots.
- Parse optional `tmux-cursor-samples.jsonl` into the layout snapshot and refresh the checked-in self-test validation fixture.
- Add a focused offline `ux:tmux:validate:test` suite covering known-good fixtures, bad rendered captures, hidden final answers, missing composer rows, secret leaks, cursor samples, and capability/method failures.
- Current-main refresh: rebuilt the PR branch from `origin/main` `f6936c452389c5172496ee0c3e13393956086d92` and replayed only the existing #1066 PR commits.

Closes #1066

## Validation
Base: `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`.
Head: `e03bac9e6a35f68ed98edfeb41572e2c1eebc652`.
Environment: isolated clone `/private/tmp/octos-1232-f693.W7zLYN/octos`; npm cache `/private/tmp/octos-npm-cache-1232-f693`; cargo targets under `/private/tmp`; `CARGO_INCREMENTAL=0`; `CARGO_PROFILE_DEV_DEBUG=0`; root dirty checkout untouched.

Passed locally:
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `node --check e2e/scripts/ux-tmux-validate.mjs`
- `node --check e2e/tests/ux/validate.test.mjs`
- `rg -n "capabilities_before_followups|no_unadvertised_methods_called|rendered_screen_no_known_bug_patterns|final_answer_visible|composer_usable|secret_redaction|terminal_layout_snapshot|tmux-cursor-samples" e2e/scripts/ux-tmux-validate.mjs e2e/tests/ux/validate.test.mjs e2e/fixtures/ux-artifact-self-test/validation.json`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1232-f693 npm --prefix e2e ci` completed; existing moderate npm audit warning remains
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1232-f693 npm --prefix e2e run ux:tmux:validate:test` -> 7/7 passed
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1232-f693 node e2e/scripts/ux-tmux-validate.mjs e2e/fixtures/ux-artifact-self-test` -> `status=passed`, `failures=[]`, 19 validators, `layout_snapshot.schema=octos.ux.terminal_layout_snapshot.v1`, regions include `history` and `composer`
- `CARGO_TARGET_DIR=/private/tmp/octos-1232-f693-target-agent CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib idle_timeout_constant -- --nocapture` -> 2/2 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1232-f693-target-cli CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --lib cli_agent_adapter::tests -- --nocapture` -> 8/8 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1232-f693-target-cli CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --lib session_actor::tests::test_cancel_matches_profile_scoped_actor_by_session_key -- --exact --nocapture` -> passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1232-f693-target-clippy CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git ls-files --others --exclude-standard` -> no untracked commit candidates

No generated artifacts are included.

## CI / merge status
GitHub CI is green on `e03bac9e6a35f68ed98edfeb41572e2c1eebc652`: check, check-matrix, dashboard, swarm-app, test-octos-agent integration/lib, test-octos-cli, typos, and blocked-email all passed. Optional platform/e2e/security lanes were skipped by workflow rules.

Current merge gate: `BLOCKED` / `REVIEW_REQUIRED`.
