### PR TITLE
fix(pipeline): extend run_pipeline timeout ceiling 1800→3600 + DOT default_timeout_secs metadata (NEW-15)

### DIFF
--- a/crates/octos-pipeline/src/graph.rs
+++ b/crates/octos-pipeline/src/graph.rs
@@ -18,6 +18,18 @@ pub struct PipelineGraph {
     /// cumulative input + output tokens reaches this cap.
     #[serde(default)]
     pub max_total_tokens: Option<u32>,
+    /// Optional per-pipeline default wall-clock timeout in seconds (NEW-15).
+    /// Set via the DOT graph attribute `default_timeout_secs`. Used by
+    /// `RunPipelineTool::execute()` as the fallback when the LLM does not
+    /// pass `timeout_secs`. Always clamped to [60, 3600] downstream.
+    ///
+    /// Rationale: the historical 1800s default starves slow-LLM-lane
+    /// pipelines (e.g. wisemodel kimi/MiniMax) where plan_and_search
+    /// consumes >60% of the budget, leaving the synthesize node with no
+    /// room. Skill authors should set this to a realistic per-pipeline
+    /// upper bound rather than rely on the LLM to estimate correctly.
+    #[serde(default)]
+    pub default_timeout_secs: Option<u64>,
     /// Nodes keyed by their ID.
     pub nodes: HashMap<String, PipelineNode>,
     /// Directed edges.

--- a/crates/octos-pipeline/src/model_assignment.rs
+++ b/crates/octos-pipeline/src/model_assignment.rs
@@ -397,6 +397,7 @@ mod tests {
             label: None,
             default_model: None,
             max_total_tokens: None,
+            default_timeout_secs: None,
             nodes: nodes.into_iter().collect::<HashMap<_, _>>(),
             edges: Vec::new(),
             subgraphs: Vec::new(),

--- a/crates/octos-pipeline/src/parser.rs
+++ b/crates/octos-pipeline/src/parser.rs
@@ -59,6 +59,7 @@ impl<'a> DotParser<'a> {
             label: None,
             default_model: None,
             max_total_tokens: None,
+            default_timeout_secs: None,
             nodes: HashMap::new(),
             edges: Vec::new(),
             subgraphs: Vec::new(),
@@ -497,6 +498,11 @@ fn apply_graph_attrs(graph: &mut PipelineGraph, attrs: &HashMap<String, String>)
     }
     if let Some(max_total_tokens) = attrs.get("max_total_tokens") {
         graph.max_total_tokens = max_total_tokens.parse().ok();
+    }
+    // NEW-15: per-pipeline wall-clock default. Accepts a plain integer
+    // ("2400") or a suffixed duration ("40m", "2400s", "1h").
+    if let Some(timeout) = attrs.get("default_timeout_secs") {
+        graph.default_timeout_secs = parse_duration_secs(timeout);
     }
 }
 
@@ -1120,6 +1126,51 @@ mod tests {
         "#;
         let graph = parse_dot(dot).unwrap();
         assert_eq!(graph.max_total_tokens, Some(1234));
+    }
+
+    /// NEW-15: the DOT graph attribute `default_timeout_secs` is parsed
+    /// into `PipelineGraph::default_timeout_secs` so `RunPipelineTool`
+    /// can use it as the per-pipeline fallback wall-clock cap when the
+    /// LLM does not supply `timeout_secs`.
+    #[test]
+    fn should_parse_graph_default_timeout_secs_plain_integer() {
+        let dot = r#"
+            digraph test {
+                graph [default_timeout_secs="2400"]
+                n1 [prompt="a"]
+            }
+        "#;
+        let graph = parse_dot(dot).unwrap();
+        assert_eq!(graph.default_timeout_secs, Some(2400));
+    }
+
+    /// `default_timeout_secs` accepts suffixed durations (parity with
+    /// other duration attributes elsewhere in the parser).
+    #[test]
+    fn should_parse_graph_default_timeout_secs_suffixed_duration() {
+        let dot = r#"
+            digraph test {
+                graph [default_timeout_secs="40m"]
+                n1 [prompt="a"]
+            }
+        "#;
+        let graph = parse_dot(dot).unwrap();
+        assert_eq!(graph.default_timeout_secs, Some(2400));
+    }
+
+    /// Backward-compat: when the DOT graph omits `default_timeout_secs`,
+    /// the field stays `None` so callers fall through to the hard-coded
+    /// 1800s default.
+    #[test]
+    fn should_leave_default_timeout_secs_none_when_attribute_absent() {
+        let dot = r#"
+            digraph test {
+                graph [label="no timeout here"]
+                n1 [prompt="a"]
+            }
+        "#;
+        let graph = parse_dot(dot).unwrap();
+        assert!(graph.default_timeout_secs.is_none());
     }
 
     #[test]

--- a/crates/octos-pipeline/src/tool.rs
+++ b/crates/octos-pipeline/src/tool.rs
@@ -379,9 +379,48 @@ struct Input {
     input: String,
     #[serde(default)]
     variables: serde_json::Map<String, serde_json::Value>,
-    /// Pipeline-level timeout in seconds. Default: 1800 (30 min). Max: 1800.
+    /// Pipeline-level timeout in seconds. Default: 1800 (30 min),
+    /// optionally overridden per-pipeline via the DOT graph attribute
+    /// `default_timeout_secs`. Clamped to [60, 3600].
     #[serde(default)]
     timeout_secs: Option<u64>,
+}
+
+/// Hard wall-clock floor on `run_pipeline` (seconds).
+///
+/// Below this value the pipeline cannot complete even the smallest
+/// 2-node graph reliably; we clamp up so a careless caller never disarms
+/// the timeout entirely.
+const PIPELINE_TIMEOUT_MIN_SECS: u64 = 60;
+
+/// Hard wall-clock ceiling on `run_pipeline` (seconds, NEW-15).
+///
+/// Raised from 1800 → 3600 to give honest deep research with crawl +
+/// synthesize on slow production LLM lanes (e.g. wisemodel
+/// kimi/MiniMax) room to finish without synthesize-node starvation.
+/// Anything above this is treated as a runaway and clamped — operators
+/// can still observe the original requested value in the bridge logs,
+/// they just don't get more than an hour per spawn_only invocation.
+const PIPELINE_TIMEOUT_MAX_SECS: u64 = 3600;
+
+/// Hard-coded fallback when neither the LLM nor the DOT graph specify
+/// a timeout. Kept at 1800s for byte-identical backward-compat with
+/// pre-NEW-15 callers.
+const PIPELINE_TIMEOUT_DEFAULT_SECS: u64 = 1800;
+
+/// Resolve the effective wall-clock timeout for a `run_pipeline` run.
+///
+/// Precedence: LLM-supplied > DOT-graph default > hard-coded 1800s.
+/// Always clamped to [`PIPELINE_TIMEOUT_MIN_SECS`,
+/// `PIPELINE_TIMEOUT_MAX_SECS`].
+///
+/// Extracted so the resolution policy can be unit-tested without
+/// constructing a full `RunPipelineTool` + `TOOL_CTX`.
+fn resolve_pipeline_timeout(llm_value: Option<u64>, dot_default: Option<u64>) -> u64 {
+    llm_value
+        .or(dot_default)
+        .unwrap_or(PIPELINE_TIMEOUT_DEFAULT_SECS)
+        .clamp(PIPELINE_TIMEOUT_MIN_SECS, PIPELINE_TIMEOUT_MAX_SECS)
 }
 
 #[async_trait]
@@ -438,7 +477,7 @@ impl Tool for RunPipelineTool {
                 },
                 "timeout_secs": {
                     "type": "integer",
-                    "description": "Timeout in seconds. Estimate based on real execution times: simple 2-node pipeline ~3min → 300s; standard 3-node research pipeline ~8min → 600s; 5-7 topic deep research with crawl+synthesize ~15-20min → 1200s; complex multi-source analysis with many nodes ~25min → 1500s. Max: 1800. Default: 1800"
+                    "description": "Timeout in seconds. Estimate from real production execution times (kimi/MiniMax on wisemodel — frontier models may be 2-3x faster):\n- simple 2-node pipeline ~3min → 300s\n- standard 3-node research pipeline ~10min → 800s\n- 5-7 topic deep research with crawl+synthesize ~25-30min → 1800s\n- complex multi-source analysis with many nodes ~40-50min → 3000s\n- exhaustive deep research with broad fan-out ~60min → 3600s\nMax: 3600. Default: 1800 (per-pipeline DOT may override via the `default_timeout_secs` graph attribute). Prefer higher estimates on production LLM lanes — under-estimating causes synthesize-node starvation when plan_and_search consumes >60% of the wall-clock budget."
                 }
             },
             "required": ["pipeline", "input"]
@@ -587,8 +626,23 @@ impl Tool for RunPipelineTool {
             catalog_dir: Some(self.working_dir.clone()),
         };
 
-        // Pipeline-level timeout: default 1800s (30 min), clamped to [60, 1800].
-        let timeout_secs = input.timeout_secs.unwrap_or(1800).clamp(60, 1800);
+        // Pipeline-level timeout resolution (NEW-15):
+        // 1. LLM-supplied `timeout_secs` always wins (so an operator can
+        //    override a pipeline's baked-in default per-call).
+        // 2. Otherwise, fall back to the DOT graph's `default_timeout_secs`
+        //    attribute (set by skill authors per-pipeline — e.g.
+        //    `deep_research` ships with 2400s because its fan-out shape
+        //    consistently exceeds the historical 1800s default on
+        //    production LLM lanes).
+        // 3. Otherwise, fall back to the hard-coded 1800s.
+        // Final value is clamped to [60, 3600] — the upper bound was
+        // raised from 1800 → 3600 so honest deep research with crawl +
+        // synthesize on slow LLM lanes has room to finish without
+        // synthesize-node starvation.
+        let dot_default_timeout = crate::parser::parse_dot(&dot_content)
+            .ok()
+            .and_then(|g| g.default_timeout_secs);
+        let timeout_secs = resolve_pipeline_timeout(input.timeout_secs, dot_default_timeout);
 
         let executor = PipelineExecutor::new(config);
         let result = tokio::time::timeout(
@@ -1211,6 +1265,62 @@ mod tests {
     #[test]
     fn node_costs_metadata_returns_none_for_empty_rows() {
         assert!(node_costs_metadata(&[]).is_none());
+    }
+
+    /// NEW-15 (1): the 30-min historical default is preserved when
+    /// neither the LLM nor the DOT supply a timeout — backward-compat
+    /// guard.
+    #[test]
+    fn resolve_pipeline_timeout_defaults_to_1800_when_unspecified() {
+        assert_eq!(resolve_pipeline_timeout(None, None), 1800);
+    }
+
+    /// NEW-15 (2): an LLM-supplied value within [60, 3600] passes
+    /// through unmodified — the new ceiling no longer truncates honest
+    /// deep-research estimates at 1800s.
+    #[test]
+    fn resolve_pipeline_timeout_passes_llm_value_in_range() {
+        assert_eq!(resolve_pipeline_timeout(Some(3000), None), 3000);
+    }
+
+    /// NEW-15 (3): an LLM value above the new 3600s ceiling clamps
+    /// down — a runaway pipeline still cannot lock the session past
+    /// an hour per spawn_only invocation.
+    #[test]
+    fn resolve_pipeline_timeout_clamps_llm_value_above_ceiling() {
+        assert_eq!(resolve_pipeline_timeout(Some(5000), None), 3600);
+    }
+
+    /// NEW-15 (4): an LLM value below the 60s floor clamps up — a
+    /// careless caller cannot disarm the timeout entirely.
+    #[test]
+    fn resolve_pipeline_timeout_clamps_llm_value_below_floor() {
+        assert_eq!(resolve_pipeline_timeout(Some(10), None), 60);
+    }
+
+    /// NEW-15 (5): when the LLM does NOT supply `timeout_secs`, the
+    /// DOT graph's `default_timeout_secs` attribute wins over the
+    /// hard-coded 1800s default. This is the path that lets skill
+    /// authors ship per-pipeline realistic caps.
+    #[test]
+    fn resolve_pipeline_timeout_uses_dot_default_when_llm_omits() {
+        assert_eq!(resolve_pipeline_timeout(None, Some(2400)), 2400);
+    }
+
+    /// NEW-15 (6): the LLM's explicit `timeout_secs` always wins over
+    /// the DOT default — operators can override per-call without
+    /// editing the shipped pipeline.
+    #[test]
+    fn resolve_pipeline_timeout_llm_overrides_dot_default() {
+        assert_eq!(resolve_pipeline_timeout(Some(1500), Some(2400)), 1500);
+    }
+
+    /// NEW-15 (7): clamping applies to the DOT default too — a skill
+    /// author cannot ship a pipeline whose baked-in fallback exceeds
+    /// the new 3600s ceiling.
+    #[test]
+    fn resolve_pipeline_timeout_clamps_dot_default_above_ceiling() {
+        assert_eq!(resolve_pipeline_timeout(None, Some(7200)), 3600);
     }
 
     /// #1020 / M17-B — `build_pipeline_run_summary` MUST stamp the


### PR DESCRIPTION
## Summary

Soak round-9 deep_research on wisemodel kimi-k2.5 timed out at 1200s — synthesize node had only 113s of wall-clock left after plan_and_search consumed 980s. Root cause was layered; this PR fixes it end-to-end.

### Inner ceiling + DOT metadata (commit 1)

- **Raise wall-clock clamp ceiling 1800s → 3600s** inside `RunPipelineTool::execute()` (default stays 1800s). Honest deep research with crawl+synthesize on slow production LLM lanes (wisemodel kimi/MiniMax) routinely takes 25–30min; the prior 1800s ceiling capped every call.
- **Rewrite the `timeout_secs` JSON Schema description** with production-tier (kimi/MiniMax) estimates and a caller-facing rule: prefer higher estimates because *synthesize starvation*, not overestimation, is the failure mode.
- **Add DOT graph attribute `default_timeout_secs`** parsed into `PipelineGraph::default_timeout_secs`. Resolution order: `LLM-supplied > DOT-default > 1800s`, all clamped to `[60, 3600]`. Skill authors should ship per-pipeline realistic caps (e.g. `mofa-research`'s `deep_research.dot` should set `default_timeout_secs="2400"`). Note: DOT files ship via the skill repo, not octos — only the parser support + tool wiring land here.

Extracted `resolve_pipeline_timeout(llm, dot) -> u64` as a unit-testable helper.

### Outer dispatcher fixes (commits 2-4, driven by codex iterative review)

- **Codex round-1 finding (P1)**: the inner extension is ineffective on the `spawn(allowed_tools=["run_pipeline"])` path because the subagent calls `tools.clear_spawn_only()`, making `run_pipeline` a regular synchronous tool, and the outer dispatcher clamps at `MAX_TOOL_TIMEOUT_SECS = 1800`. **Fix**: raise `MAX_TOOL_TIMEOUT_SECS` to 3600.
- **Codex round-2 finding (P2)**: raising `DEFAULT_TOOL_TIMEOUT_SECS` globally would let wedged non-pipeline tools (hung `bash` / `web_fetch` / `browser`) tie up a worker for an hour. **Fix**: keep `DEFAULT_TOOL_TIMEOUT_SECS` at 1800, add narrow per-tool floor lift (`TOOLS_NEEDING_EXTENDED_TIMEOUT = ["run_pipeline"]`) that bumps to 3600 only when `run_pipeline` is in the batch.
- **Codex round-3 finding (P1)**: the LLM's documented path is `spawn(mode:"sync", allowed_tools:["run_pipeline"])` — top-level batch only contains `spawn`, so name-only check missed it. **Fix**: walk into spawn's `allowed_tools` for sync mode.
- **Codex round-4 finding (P2)**: `spawn_agent` is a Codex-compatible alias auto-bound by `ToolRegistry::register`; the round-3 fix didn't recognize it. **Fix**: promote to `SYNC_SPAWN_ALIASES = ["spawn", "spawn_agent"]` const.
- **Codex round-5**: no further issues. Clean.

## Files changed

- `crates/octos-pipeline/src/tool.rs` — clamp ceiling, schema description rewrite, `resolve_pipeline_timeout` helper, 7 tests.
- `crates/octos-pipeline/src/graph.rs` — `default_timeout_secs: Option<u64>` field.
- `crates/octos-pipeline/src/parser.rs` — read `default_timeout_secs` graph attribute, 3 tests.
- `crates/octos-pipeline/src/model_assignment.rs` — keep test helper compiling.
- `crates/octos-agent/src/agent/mod.rs` — bump `MAX_TOOL_TIMEOUT_SECS` to 3600, keep `DEFAULT_TOOL_TIMEOUT_SECS` at 1800.
- `crates/octos-agent/src/agent/budget.rs` — update timeout-constant assertions.
- `crates/octos-agent/src/agent/execution.rs` — `TOOLS_NEEDING_EXTENDED_TIMEOUT` allowlist, `SYNC_SPAWN_ALIASES` const, `tool_call_needs_extended_timeout` + `extended_timeout_floor_for_batch` helpers, 9 tests.

## Test plan

- [x] `cargo test -p octos-pipeline --lib` — **210 passed** (was 200; +10).
- [x] `cargo test -p octos-agent --lib` — **1669 passed** (was 1660; +9).
- [x] `cargo build --workspace` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --lib -- -D warnings` — clean.
- [x] `codex review --commit <each>` — round-5 returns no issues.
- [ ] Skill author follow-up: update `mofa-research/deep_research.dot` to set `default_timeout_secs="2400"`. Done outside this PR (skill repo).
- [ ] Soak: deep_research run on mini3/kimi-k2.5 completes synthesize without wall-clock timeout.

## Effective timeout matrix

| Path | Before | After |
|---|---|---|
| Direct `run_pipeline`, LLM passes `timeout_secs: 2400` | clamped to 1800 | 2400 |
| Direct `run_pipeline`, LLM omits, DOT sets `default_timeout_secs="2400"` | falls back to 1800 (DOT ignored) | 2400 |
| `spawn(mode:"sync", allowed_tools:["run_pipeline"])`, child needs 2400s | parent dispatcher kills at 1800 | parent waits up to 3600, child uses DOT/LLM value |
| `spawn_agent(mode:"sync", ...)` same shape | parent dispatcher kills at 1800 | parent waits up to 3600 |
| `spawn(mode:"background", ...)` | parent returns immediately | parent returns immediately (no lift) |
| Wedged `bash` / `web_fetch` in any path | reaped at 1800 | reaped at 1800 (unchanged) |