### PR TITLE
fix(agent): validate mofa cards reported files

### DIFF
--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1468,19 +1468,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mofa_cards_contract_satisfies_when_png_files_match_recursive_glob() {
-        // P1-5: mofa_cards emits PNGs under a per-task card_dir.
+    async fn mofa_cards_contract_satisfies_when_png_files_are_reported() {
+        // octos #1041: mofa_cards emits PNGs under a per-task card_dir
+        // and reports each generated PNG through files_to_send. The
+        // contract validates those exact reported paths.
         let temp = tempfile::tempdir().unwrap();
         write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
         let card_dir = temp.path().join("cards/abc");
         std::fs::create_dir_all(&card_dir).unwrap();
-        std::fs::write(card_dir.join("a.png"), PNG_1X1).unwrap();
+        let card = card_dir.join("a.png");
+        std::fs::write(&card, PNG_1X1).unwrap();
 
         let result = enforce_spawn_task_contract_with_args(
             &ToolRegistry::with_builtins(temp.path()),
             "mofa_cards",
             "tool-call-cards",
-            &[],
+            std::slice::from_ref(&card),
             UNIX_EPOCH,
             None,
             Some(&json!({"card_dir": "cards/abc"})),
@@ -1490,6 +1493,41 @@ mod tests {
         match result {
             SpawnTaskContractResult::Satisfied { .. } => {}
             other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_cards_contract_rejects_stale_png_without_files_to_send_octos_1041() {
+        // octos #1041: a stale PNG in the workspace must not satisfy
+        // the cards contract unless the plugin reported it via
+        // files_to_send for this spawn_only invocation.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+
+        let stale = temp.path().join("cards/old/a.png");
+        std::fs::create_dir_all(stale.parent().unwrap()).unwrap();
+        std::fs::write(&stale, PNG_1X1).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_cards",
+            "tool-call-cards-stale",
+            &[],
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"card_dir": "cards/new"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert!(
+                    error.contains("files_to_send"),
+                    "expected failure to come from missing files_to_send, got: {error}"
+                );
+                assert_eq!(notify_user.as_deref(), Some("Card generation failed"));
+            }
+            other => panic!("expected failure for missing files_to_send, got {other:?}"),
         }
     }
 

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -840,12 +840,12 @@ impl WorkspacePolicy {
         // recursive `**/*.pptx` glob already used by the MagicBytes(Pptx)
         // validator on `on_completion`.
         artifacts.insert("slides_pptx".into(), "**/*.pptx".into());
-        // octos #1040 (follow-up to #1035 / #1037): `mofa_comic`,
-        // `mofa_infographic`, and `mofa_frame` all emit a single PNG via
-        // `files_to_send`. The `image_png` artifact gives those contracts
-        // a target name so `bind_explicit_files_to_artifacts` can bind the
-        // reported PNG path into `ActionContext` without erroring on "no
-        // artifact source" the same way `slides_pptx` does for slides.
+        // octos #1040/#1041 (follow-up to #1035 / #1037): image skills
+        // emit PNGs via `files_to_send`. The `image_png` artifact gives
+        // those contracts a target name so `bind_explicit_files_to_artifacts`
+        // can bind the reported PNG paths into `ActionContext` without
+        // erroring on "no artifact source" the same way `slides_pptx`
+        // does for slides.
         artifacts.insert("image_png".into(), "**/*.png".into());
 
         // fm_tts emits a single MP3 deliverable via the plugin protocol's
@@ -1055,21 +1055,21 @@ impl WorkspacePolicy {
             })],
         };
 
-        // mofa_cards writes PNGs into a `card_dir` (required input arg).
-        // The contract uses a recursive PNG glob so any layout under that
-        // directory is covered without hard-coding a single output path.
+        // mofa_cards emits every generated PNG through `files_to_send`.
+        // Validate the exact plugin-reported paths instead of accepting
+        // any stale PNG that happens to exist in the workspace.
         let mofa_cards_contract = WorkspaceSpawnTaskPolicy {
-            artifact: None,
+            artifact: Some("image_png".into()),
             artifacts: Vec::new(),
             on_verify: Vec::new(),
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:Card generation failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                glob: "**/*.png".into(),
+                glob: String::new(),
                 format: MagicByteKind::Png,
-                source: ValidatorFileSource::Glob,
-                extension: None,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("png".into()),
             })],
         };
 
@@ -2523,7 +2523,7 @@ ignore = []
     #[test]
     fn session_policy_mofa_comic_infographic_frame_consume_spawn_only_files_for_octos_1040() {
         // octos #1040 (follow-up to #1035 / #1037): the MagicBytes
-        // validator on each of mofa_comic, mofa_infographic, and
+        // validator on each of mofa_cards, mofa_comic, mofa_infographic, and
         // mofa_frame must opt into `spawn_only_files` so the validator
         // consumes the plugin-reported `files_to_send` path directly
         // instead of any `**/*.png` match in the session workspace
@@ -2531,15 +2531,8 @@ ignore = []
         // `extension = "png"` filter narrows the file list if the
         // skill surfaces auxiliary files (intermediate panel PNGs,
         // layout previews, etc.) via `files_to_send`.
-        //
-        // `mofa_cards` is intentionally NOT in this sweep — the plugin
-        // does not yet emit `files_to_send` (it returns `card_dir` not
-        // `out`, and its success text `"Generated N card(s) in <dir>"`
-        // does not match the `Generated:` / `Generated PPTX:` markers
-        // that `PluginTool::detect_output_file` auto-detects). Tracked
-        // by a separate plugin-fix issue.
         let policy = WorkspacePolicy::for_session();
-        for tool in ["mofa_comic", "mofa_infographic", "mofa_frame"] {
+        for tool in ["mofa_cards", "mofa_comic", "mofa_infographic", "mofa_frame"] {
             let entry = policy
                 .spawn_tasks
                 .get(tool)
@@ -2580,18 +2573,11 @@ ignore = []
     }
 
     #[test]
-    fn session_policy_mofa_cards_keeps_glob_until_plugin_emits_files_to_send_octos_1041() {
-        // octos #1041 (audit #1040 follow-up): `mofa_cards` cannot yet
-        // sweep to `spawn_only_files` because the plugin does not emit
-        // `files_to_send` and `PluginTool::detect_output_file` does not
-        // auto-populate it (no `out` arg, success text uses an
-        // unrecognised `Generated N card(s) in <dir>` prefix).
-        //
-        // This test pins the current behaviour so a future contributor
-        // doesn't sweep `mofa_cards` without first fixing the plugin
-        // emission — that would regress to the empty-files-to-send
-        // failure mode that #1037 caught for `voice_synthesize` and
-        // tracked as #1038.
+    fn session_policy_mofa_cards_consumes_spawn_only_files_for_octos_1041() {
+        // octos #1041 (audit #1040 follow-up): mofa-skills now emits
+        // `files_to_send` for each generated card PNG, so the contract
+        // must validate those exact files instead of accepting any
+        // recursive `**/*.png` match in the workspace.
         let policy = WorkspacePolicy::for_session();
         let cards = policy
             .spawn_tasks
@@ -2609,18 +2595,23 @@ ignore = []
             _ => None,
         });
 
-        let (format, source, _extension, glob) = magic.expect(
+        let (format, source, extension, glob) = magic.expect(
             "mofa_cards contract must declare MagicBytes(Png) — see workspace_policy.rs:1043",
         );
         assert_eq!(format, MagicByteKind::Png);
         assert_eq!(
             source,
-            ValidatorFileSource::Glob,
-            "mofa_cards must keep `Glob` until octos #1041 lands the plugin-emission fix"
+            ValidatorFileSource::SpawnOnlyFiles,
+            "mofa_cards must validate the plugin-emitted files_to_send paths"
+        );
+        assert_eq!(
+            extension.as_deref(),
+            Some("png"),
+            "mofa_cards must filter files_to_send candidates to PNG outputs"
         );
         assert!(
-            glob.contains("**/*.png"),
-            "mofa_cards Glob source must keep the recursive PNG pattern; got: {glob}"
+            !glob.contains("**/*.png"),
+            "mofa_cards must not accept stale workspace PNGs via recursive glob; got: {glob}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Switch `mofa_cards` workspace MagicBytes validation from recursive PNG glob scanning to `ValidatorFileSource::SpawnOnlyFiles`.
- Bind `mofa_cards` to the existing `image_png` artifact so reported files resolve cleanly through the contract layer.
- Add contract regressions proving reported card PNGs pass and stale workspace PNGs fail when `files_to_send` is empty.

Related to #1041

## Cross-repo prerequisite
- Verified `mofa-org/mofa-skills` current `main` at `802debda80f6ec91fc5b903559e32b7bb9e763a0` emits `files_to_send` for `mofa_cards`:
  - `mofa-cli/src/main.rs:373` writes `payload["files_to_send"]` when `PluginOutput.files` is non-empty.
  - `mofa-cli/src/main.rs:625-687` builds `PluginOutput { files }` from generated card PNG paths.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p octos-agent --lib mofa_cards_contract -- --nocapture`
- `cargo test -p octos-agent workspace_policy::tests::session_policy_mofa_cards_consumes_spawn_only_files_for_octos_1041 -- --nocapture`
- `cargo test -p octos-agent workspace_policy::tests -- --nocapture`
- `cargo clippy -p octos-agent --tests --no-deps -- -D warnings`
- `git diff --check`
- `git ls-files --others --exclude-standard`
- In isolated `/private/tmp/codex-mofa-skills-1041-test`: `cargo test --manifest-path mofa-cli/Cargo.toml`

