### PR TITLE
fix(cli): avoid false failed status on slow background ack

### DIFF
--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -1977,13 +1977,17 @@ async fn dispatch_background_result_to_actor(
             false
         }
         Err(_) => {
+            // The actor accepted the queued BackgroundResult. A slow ack only
+            // means persistence is still pending behind current actor work; it
+            // does not prove the verified artifact failed to persist.
             record_retry("background_result_ack_timeout");
-            warn!(
+            debug!(
                 task_label,
                 timeout_ms = BACKGROUND_RESULT_ACK_TIMEOUT.as_millis(),
-                "timed out waiting for background result actor acknowledgment"
+                "timed out waiting for background result actor acknowledgment; \
+                 treating accepted actor enqueue as pending persistence"
             );
-            false
+            true
         }
     }
 }
@@ -13615,6 +13619,47 @@ mod tests {
         assert!(
             persisted,
             "producer should return the acked persistence flag"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn background_result_ack_timeout_still_counts_as_actor_accepted_for_octos_889() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let dispatch = tokio::spawn(dispatch_background_result_to_actor(
+            tx,
+            BackgroundResultPayload {
+                task_label: "fm_tts".to_string(),
+                content: String::new(),
+                kind: BackgroundResultKind::Notification,
+                media: vec!["skill-output/yangmi_1778515952.mp3".to_string()],
+                envelope_media: vec![],
+                originating_thread_id: Some("cmid-yangmi-turn".to_string()),
+                task_id: Some("task-fm-tts".to_string()),
+                tool_call_id: Some("call-fm-tts".to_string()),
+                originating_client_message_id: Some("cmid-yangmi-turn".to_string()),
+                terminal_status: None,
+            },
+        ));
+
+        let message = rx.recv().await.expect("background result enqueued");
+        let ActorMessage::BackgroundResult {
+            task_label,
+            media,
+            ack,
+            ..
+        } = message
+        else {
+            panic!("expected BackgroundResult actor message");
+        };
+        assert_eq!(task_label, "fm_tts");
+        assert_eq!(media, vec!["skill-output/yangmi_1778515952.mp3"]);
+        let _held_ack_sender = ack.expect("dispatch should request durable ack");
+
+        tokio::time::advance(BACKGROUND_RESULT_ACK_TIMEOUT + Duration::from_millis(1)).await;
+        assert!(
+            dispatch.await.expect("dispatch task should join"),
+            "a successfully enqueued background result must not be reported as \
+             persistence failure solely because the actor ack was slow"
         );
     }
 


### PR DESCRIPTION
## Summary

- Treat a successfully enqueued background-result actor message as accepted when only the durable ack times out.
- Keep actor-closed, enqueue-timeout, ack-channel-closed, and explicit ack=false paths as failures.
- Add a paused-time regression for #889 using the `fm_tts` media-delivery shape.
- Refresh from current GitHub `main`; diff remains limited to `crates/octos-cli/src/session_actor.rs`.

Closes #889

## Current-main refresh

- Base: GitHub `main` `f6936c452389c5172496ee0c3e13393956086d92`.
- Head: `c46e0efe81ed78c6b7f754497c4f16c939d23ef8`.
- Isolated checkout: `/private/tmp/octos-1393-f693.c8Xuzv/octos`.
- Cargo target: `/private/tmp/octos-1237-f693-target`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.

## Validation

- `git diff --check origin/main...HEAD` passed.
- `cargo fmt --all -- --check` passed.
- `typos crates/octos-cli/src/session_actor.rs` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1237-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api background_result_ack_timeout_still_counts_as_actor_accepted_for_octos_889 -- --nocapture` passed: 1/1 focused test.
- `CARGO_TARGET_DIR=/private/tmp/octos-1237-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api test_background_notification -- --nocapture` passed: 2/2 focused tests.
- `CARGO_TARGET_DIR=/private/tmp/octos-1237-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --all-targets -- -D warnings` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1237-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.
- `git ls-files --others --exclude-standard` was empty in the isolated checkout after validation.

## CI / merge status

- GitHub CI is green on refreshed head `c46e0efe81ed78c6b7f754497c4f16c939d23ef8`: `check`, `test-octos-cli`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `dashboard`, `swarm-app`, `check-matrix`, `typos`, and author-email all passed. Optional platform/e2e/security lanes skipped by workflow policy.
- Merge remains branch-protection blocked by required review.