### PR TITLE
fix(dashboard): confirm user deletions with dialog

### DIFF
--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -21,8 +21,15 @@ export default function ConfirmDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="bg-surface rounded-xl border border-gray-700/50 shadow-2xl p-6 max-w-sm w-full mx-4">
-        <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        className="bg-surface rounded-xl border border-gray-700/50 shadow-2xl p-6 max-w-sm w-full mx-4"
+      >
+        <h3 id="confirm-dialog-title" className="text-lg font-semibold text-white mb-2">
+          {title}
+        </h3>
         <p className="text-sm text-gray-400 mb-6">{message}</p>
         <div className="flex justify-end gap-3">
           <button

--- a/dashboard/src/pages/UsersPage.test.tsx
+++ b/dashboard/src/pages/UsersPage.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import UsersPage from './UsersPage'
+import type { AllowlistEntry, User } from '../types'
+
+const mockListAllowedEmails = vi.fn()
+const mockListUsers = vi.fn()
+const mockDeleteAllowedEmail = vi.fn()
+const mockDeleteUser = vi.fn()
+const mockToast = vi.fn()
+
+vi.mock('../api', () => ({
+  api: {
+    listAllowedEmails: () => mockListAllowedEmails(),
+    listUsers: () => mockListUsers(),
+    deleteAllowedEmail: (email: string) => mockDeleteAllowedEmail(email),
+    deleteUser: (id: string) => mockDeleteUser(id),
+  },
+}))
+
+vi.mock('../components/Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+const allowlistEntries: AllowlistEntry[] = [
+  {
+    email: 'allowed@example.com',
+    note: 'pilot',
+    created_at: '2026-01-01T00:00:00Z',
+    registered: true,
+    registered_user_id: 'user-1',
+    registered_name: 'Allowed User',
+    last_login_at: '2026-01-02T00:00:00Z',
+  },
+]
+
+const users: User[] = [
+  {
+    id: 'user-1',
+    email: 'allowed@example.com',
+    name: 'Allowed User',
+    role: 'user',
+    created_at: '2026-01-01T00:00:00Z',
+    last_login_at: '2026-01-02T00:00:00Z',
+  },
+]
+
+function renderUsersPage() {
+  return render(<UsersPage />)
+}
+
+beforeEach(() => {
+  mockListAllowedEmails.mockResolvedValue({ entries: allowlistEntries })
+  mockListUsers.mockResolvedValue({ users })
+  mockDeleteAllowedEmail.mockResolvedValue({ ok: true })
+  mockDeleteUser.mockResolvedValue({ ok: true })
+  mockToast.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+describe('UsersPage destructive confirmations', () => {
+  it('uses ConfirmDialog when removing an allowlisted email', async () => {
+    const nativeConfirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const user = userEvent.setup()
+
+    renderUsersPage()
+
+    await screen.findAllByText('allowed@example.com')
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    expect(nativeConfirm).not.toHaveBeenCalled()
+
+    const dialog = screen.getByRole('dialog', {
+      name: 'Remove allowlisted email?',
+    })
+    expect(dialog).toHaveTextContent(
+      'future OTP signup will no longer be pre-authorized',
+    )
+
+    await user.click(within(dialog).getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() =>
+      expect(mockDeleteAllowedEmail).toHaveBeenCalledWith('allowed@example.com'),
+    )
+  })
+
+  it('uses ConfirmDialog when deleting a registered account', async () => {
+    const nativeConfirm = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const user = userEvent.setup()
+
+    renderUsersPage()
+
+    await screen.findAllByText('allowed@example.com')
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(nativeConfirm).not.toHaveBeenCalled()
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete account?' })
+    expect(dialog).toHaveTextContent(
+      'This will also delete the profile and stop its gateway.',
+    )
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(mockDeleteUser).toHaveBeenCalledWith('user-1'))
+  })
+})

--- a/dashboard/src/pages/UsersPage.tsx
+++ b/dashboard/src/pages/UsersPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { api } from '../api'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { useToast } from '../components/Toast'
 import type { AllowlistEntry, User } from '../types'
 
@@ -31,6 +32,22 @@ function registrationStatus(entry: AllowlistEntry): {
   }
 }
 
+type PendingConfirmation =
+  | {
+      kind: 'allowlist'
+      entry: AllowlistEntry
+      title: string
+      message: string
+      confirmLabel: string
+    }
+  | {
+      kind: 'user'
+      user: User
+      title: string
+      message: string
+      confirmLabel: string
+    }
+
 export default function UsersPage() {
   const { toast } = useToast()
   const [allowedEmails, setAllowedEmails] = useState<AllowlistEntry[]>([])
@@ -42,6 +59,8 @@ export default function UsersPage() {
   const [newNote, setNewNote] = useState('')
   const [removingEmail, setRemovingEmail] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [pendingConfirmation, setPendingConfirmation] =
+    useState<PendingConfirmation | null>(null)
 
   const loadData = useCallback(async () => {
     try {
@@ -99,14 +118,19 @@ export default function UsersPage() {
     }
   }
 
-  const handleRemoveAllowlist = async (entry: AllowlistEntry) => {
-    const confirmed = confirm(
-      entry.registered
+  const requestRemoveAllowlist = (entry: AllowlistEntry) => {
+    setPendingConfirmation({
+      kind: 'allowlist',
+      entry,
+      title: 'Remove allowlisted email?',
+      message: entry.registered
         ? `Remove "${entry.email}" from the allowlist? The already-registered account will remain, but future OTP signup will no longer be pre-authorized.`
         : `Remove "${entry.email}" from the allowlist?`,
-    )
-    if (!confirmed) return
+      confirmLabel: 'Remove',
+    })
+  }
 
+  const removeAllowlist = async (entry: AllowlistEntry) => {
     try {
       setRemovingEmail(entry.email)
       await api.deleteAllowedEmail(entry.email)
@@ -119,10 +143,17 @@ export default function UsersPage() {
     }
   }
 
-  const handleDeleteUser = async (user: User) => {
-    if (!confirm(`Delete account "${user.email}"? This will also delete the profile and stop its gateway.`)) {
-      return
-    }
+  const requestDeleteUser = (user: User) => {
+    setPendingConfirmation({
+      kind: 'user',
+      user,
+      title: 'Delete account?',
+      message: `Delete account "${user.email}"? This will also delete the profile and stop its gateway.`,
+      confirmLabel: 'Delete',
+    })
+  }
+
+  const deleteUser = async (user: User) => {
     try {
       setDeletingId(user.id)
       await api.deleteUser(user.id)
@@ -133,6 +164,20 @@ export default function UsersPage() {
     } finally {
       setDeletingId(null)
     }
+  }
+
+  const handleConfirmAction = async () => {
+    const confirmation = pendingConfirmation
+    if (!confirmation) return
+
+    setPendingConfirmation(null)
+
+    if (confirmation.kind === 'allowlist') {
+      await removeAllowlist(confirmation.entry)
+      return
+    }
+
+    await deleteUser(confirmation.user)
   }
 
   if (loading) {
@@ -255,7 +300,7 @@ export default function UsersPage() {
                     </td>
                     <td className="px-4 py-3 text-right">
                       <button
-                        onClick={() => handleRemoveAllowlist(entry)}
+                        onClick={() => requestRemoveAllowlist(entry)}
                         disabled={removingEmail === entry.email}
                         className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
                       >
@@ -320,7 +365,7 @@ export default function UsersPage() {
                   </td>
                   <td className="px-4 py-3 text-right">
                     <button
-                      onClick={() => handleDeleteUser(user)}
+                      onClick={() => requestDeleteUser(user)}
                       disabled={deletingId === user.id}
                       className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
                     >
@@ -340,6 +385,16 @@ export default function UsersPage() {
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        open={pendingConfirmation !== null}
+        title={pendingConfirmation?.title ?? ''}
+        message={pendingConfirmation?.message ?? ''}
+        confirmLabel={pendingConfirmation?.confirmLabel}
+        danger
+        onConfirm={handleConfirmAction}
+        onCancel={() => setPendingConfirmation(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replace native `confirm()` usage on UsersPage allowlist removal and account deletion with the shared `ConfirmDialog` component.
- Preserve the destructive-action warning text, including the account-delete profile/gateway impact.
- Add accessibility role wiring to `ConfirmDialog` and regression coverage proving UsersPage no longer calls `window.confirm` for these actions.

Closes #420

## Validation
- `cd dashboard && npm ci`
- `cd dashboard && npm run test -- UsersPage`
- `cd dashboard && npm run test`
- `cd dashboard && npm run typecheck`
- `cd dashboard && npm run build`
- `git diff --check`
- `git ls-files --others --exclude-standard`