### PR TITLE
feat(admin): scope monitor settings per profile

### DIFF
--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -1795,7 +1795,25 @@ fn task_row_to_input(
 
 // ── Monitor control endpoints ────────────────────────────────────────
 
-/// GET /api/admin/monitor/status — returns watchdog/alerts status.
+fn profile_monitor_status_json(
+    profile: UserProfile,
+    system_watchdog: bool,
+    system_alerts: bool,
+) -> serde_json::Value {
+    let watchdog_override = profile.config.gateway.watchdog_enabled;
+    let alerts_override = profile.config.gateway.alerts_enabled;
+    serde_json::json!({
+        "id": profile.id,
+        "name": profile.name,
+        "enabled": profile.enabled,
+        "watchdog_enabled": watchdog_override.unwrap_or(system_watchdog),
+        "watchdog_override": watchdog_override,
+        "alerts_enabled": alerts_override.unwrap_or(system_alerts),
+        "alerts_override": alerts_override,
+    })
+}
+
+/// GET /api/admin/monitor/status — returns system defaults plus profile overrides.
 pub async fn monitor_status(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
@@ -1809,16 +1827,53 @@ pub async fn monitor_status(
         .as_ref()
         .map(|a| a.load(std::sync::atomic::Ordering::Relaxed))
         .unwrap_or(false);
+    let profiles = if let Some(store) = state.profile_store.as_ref() {
+        store
+            .list()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .into_iter()
+            .map(|profile| profile_monitor_status_json(profile, watchdog, alerts))
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
 
     Ok(Json(serde_json::json!({
         "watchdog_enabled": watchdog,
         "alerts_enabled": alerts,
+        "profiles": profiles,
     })))
 }
 
 #[derive(Deserialize)]
 pub struct MonitorToggleRequest {
     pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProfileMonitorOverrideRequest {
+    Inherit,
+    Enabled,
+    Disabled,
+}
+
+impl ProfileMonitorOverrideRequest {
+    fn as_option_bool(self) -> Option<bool> {
+        match self {
+            Self::Inherit => None,
+            Self::Enabled => Some(true),
+            Self::Disabled => Some(false),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ProfileMonitorUpdateRequest {
+    #[serde(default)]
+    pub watchdog: Option<ProfileMonitorOverrideRequest>,
+    #[serde(default)]
+    pub alerts: Option<ProfileMonitorOverrideRequest>,
 }
 
 /// POST /api/admin/monitor/watchdog — toggle watchdog.
@@ -1845,6 +1900,47 @@ pub async fn toggle_alerts(
     Ok(Json(
         serde_json::json!({ "ok": true, "alerts_enabled": req.enabled }),
     ))
+}
+
+/// POST /api/admin/monitor/profiles/:id — set per-profile monitor overrides.
+pub async fn update_profile_monitor(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<ProfileMonitorUpdateRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = state.profile_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admin not configured".into(),
+    ))?;
+
+    let mut profile = store
+        .get(&id)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, format!("profile '{id}' not found")))?;
+
+    if let Some(watchdog) = req.watchdog {
+        profile.config.gateway.watchdog_enabled = watchdog.as_option_bool();
+    }
+    if let Some(alerts) = req.alerts {
+        profile.config.gateway.alerts_enabled = alerts.as_option_bool();
+    }
+    profile.updated_at = Utc::now();
+    store
+        .save(&profile)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let watchdog = state
+        .watchdog_enabled
+        .as_ref()
+        .map(|a| a.load(std::sync::atomic::Ordering::Relaxed))
+        .unwrap_or(false);
+    let alerts = state
+        .alerts_enabled
+        .as_ref()
+        .map(|a| a.load(std::sync::atomic::Ordering::Relaxed))
+        .unwrap_or(false);
+
+    Ok(Json(profile_monitor_status_json(profile, watchdog, alerts)))
 }
 
 // ── Skill management ─────────────────────────────────────────────────

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -446,6 +446,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/admin/monitor/status", get(admin::monitor_status))
         .route("/api/admin/monitor/watchdog", post(admin::toggle_watchdog))
         .route("/api/admin/monitor/alerts", post(admin::toggle_alerts))
+        .route(
+            "/api/admin/monitor/profiles/{id}",
+            post(admin::update_profile_monitor),
+        )
         // Platform skills management
         .route(
             "/api/admin/platform-skills",

--- a/crates/octos-cli/src/monitor.rs
+++ b/crates/octos-cli/src/monitor.rs
@@ -38,6 +38,15 @@ pub enum AdminAlert {
 }
 
 impl AdminAlert {
+    pub fn profile_id(&self) -> &str {
+        match self {
+            Self::GatewayExited { profile_id, .. }
+            | Self::ProfileDown { profile_id, .. }
+            | Self::WatchdogRestarted { profile_id, .. }
+            | Self::WatchdogGaveUp { profile_id, .. } => profile_id,
+        }
+    }
+
     /// Human-readable alert message.
     pub fn message(&self) -> String {
         match self {
@@ -68,6 +77,32 @@ impl AdminAlert {
             }
         }
     }
+}
+
+fn profile_watchdog_enabled(
+    profile_store: &ProfileStore,
+    profile_id: &str,
+    system_default: bool,
+) -> bool {
+    profile_store
+        .get(profile_id)
+        .ok()
+        .flatten()
+        .and_then(|profile| profile.config.gateway.watchdog_enabled)
+        .unwrap_or(system_default)
+}
+
+fn profile_alerts_enabled(
+    profile_store: &ProfileStore,
+    profile_id: &str,
+    system_default: bool,
+) -> bool {
+    profile_store
+        .get(profile_id)
+        .ok()
+        .flatten()
+        .and_then(|profile| profile.config.gateway.alerts_enabled)
+        .unwrap_or(system_default)
 }
 
 /// Trait for sending alerts to messaging channels.
@@ -150,8 +185,11 @@ impl Monitor {
                     break;
                 }
 
+                let profile_alerts_enabled =
+                    profile_alerts_enabled(&ps1, alert.profile_id(), al1.load(Ordering::Relaxed));
+
                 // Send alert to all channels
-                if al1.load(Ordering::Relaxed) {
+                if profile_alerts_enabled {
                     let msg = alert.message();
                     for sender in senders1.iter() {
                         sender.send_alert(&msg).await;
@@ -160,7 +198,7 @@ impl Monitor {
 
                 // Watchdog: auto-restart on GatewayExited
                 if let AdminAlert::GatewayExited { ref profile_id, .. } = alert {
-                    if wd1.load(Ordering::Relaxed) {
+                    if profile_watchdog_enabled(&ps1, profile_id, wd1.load(Ordering::Relaxed)) {
                         let mut counts = rc1.lock().await;
                         let (count, _) =
                             counts.entry(profile_id.clone()).or_insert((0, Utc::now()));
@@ -175,7 +213,7 @@ impl Monitor {
                             );
 
                             // Send restart notification
-                            if al1.load(Ordering::Relaxed) {
+                            if profile_alerts_enabled {
                                 let restart_msg = AdminAlert::WatchdogRestarted {
                                     profile_id: profile_id.clone(),
                                     attempt,
@@ -210,7 +248,7 @@ impl Monitor {
                                 attempts = attempt,
                                 "watchdog giving up"
                             );
-                            if al1.load(Ordering::Relaxed) {
+                            if profile_alerts_enabled {
                                 let giveup_msg = AdminAlert::WatchdogGaveUp {
                                     profile_id: profile_id.clone(),
                                     attempts: attempt,
@@ -251,7 +289,12 @@ impl Monitor {
                         let already_tracked = counts.get(&p.id).is_some_and(|(c, _)| *c > 0);
                         drop(counts);
 
-                        if !already_tracked && al.load(Ordering::Relaxed) {
+                        if !already_tracked
+                            && p.config
+                                .gateway
+                                .alerts_enabled
+                                .unwrap_or_else(|| al.load(Ordering::Relaxed))
+                        {
                             let msg = AdminAlert::ProfileDown {
                                 profile_id: p.id.clone(),
                                 profile_name: p.name.clone(),
@@ -403,5 +446,53 @@ impl AlertSender for FeishuAlertSender {
                 tracing::warn!(user_id = %user_id, error = %e, "failed to send Feishu alert");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profiles::{GatewaySettings, ProfileConfig, UserProfile};
+
+    fn profile(
+        id: &str,
+        watchdog_enabled: Option<bool>,
+        alerts_enabled: Option<bool>,
+    ) -> UserProfile {
+        let now = Utc::now();
+        UserProfile {
+            id: id.to_string(),
+            name: id.to_string(),
+            public_subdomain: None,
+            enabled: true,
+            data_dir: None,
+            parent_id: None,
+            config: ProfileConfig {
+                gateway: GatewaySettings {
+                    watchdog_enabled,
+                    alerts_enabled,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn profile_monitor_overrides_fall_back_to_system_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ProfileStore::open(dir.path()).unwrap();
+        store
+            .save(&profile("alpha", Some(false), Some(true)))
+            .unwrap();
+        store.save(&profile("beta", None, None)).unwrap();
+
+        assert!(!profile_watchdog_enabled(&store, "alpha", true));
+        assert!(profile_alerts_enabled(&store, "alpha", false));
+        assert!(profile_watchdog_enabled(&store, "beta", true));
+        assert!(!profile_alerts_enabled(&store, "beta", false));
+        assert!(profile_watchdog_enabled(&store, "missing", true));
     }
 }

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -479,6 +479,10 @@ pub struct GatewaySettingsPatch {
     pub browser_timeout_secs: PatchField<u64>,
     #[serde(default)]
     pub max_output_tokens: PatchField<u32>,
+    #[serde(default)]
+    pub watchdog_enabled: PatchField<bool>,
+    #[serde(default)]
+    pub alerts_enabled: PatchField<bool>,
 }
 
 /// Structured LLM contract for a profile.
@@ -786,6 +790,20 @@ impl GatewaySettingsPatch {
                 gateway.max_output_tokens = Some(max_output_tokens);
             }
         }
+        match self.watchdog_enabled {
+            PatchField::Absent => {}
+            PatchField::Clear => gateway.watchdog_enabled = None,
+            PatchField::Value(watchdog_enabled) => {
+                gateway.watchdog_enabled = Some(watchdog_enabled);
+            }
+        }
+        match self.alerts_enabled {
+            PatchField::Absent => {}
+            PatchField::Clear => gateway.alerts_enabled = None,
+            PatchField::Value(alerts_enabled) => {
+                gateway.alerts_enabled = Some(alerts_enabled);
+            }
+        }
     }
 }
 
@@ -1020,6 +1038,12 @@ pub struct GatewaySettings {
     /// Overrides the built-in default from model_limits.json.
     #[serde(default)]
     pub max_output_tokens: Option<u32>,
+    /// Per-profile watchdog override. `None` inherits the system monitor default.
+    #[serde(default)]
+    pub watchdog_enabled: Option<bool>,
+    /// Per-profile alert override. `None` inherits the system monitor default.
+    #[serde(default)]
+    pub alerts_enabled: Option<bool>,
 }
 
 /// Manages profile storage as individual JSON files.

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -15,6 +15,7 @@ import type {
   AllowlistEntry,
   SharedMetrics,
   MonitorStatus,
+  MonitorProfileStatus,
   SystemMetrics,
   PurgeReport,
 } from './types'
@@ -214,6 +215,15 @@ export const api = {
     request<{ ok: boolean; alerts_enabled: boolean }>('/monitor/alerts', {
       method: 'POST',
       body: JSON.stringify({ enabled }),
+    }),
+
+  updateProfileMonitor: (
+    id: string,
+    data: { watchdog?: 'inherit' | 'enabled' | 'disabled'; alerts?: 'inherit' | 'enabled' | 'disabled' },
+  ) =>
+    request<MonitorProfileStatus>(`/monitor/profiles/${encodeURIComponent(id)}`, {
+      method: 'POST',
+      body: JSON.stringify(data),
     }),
 
   gatewayStatus: (id: string) =>

--- a/dashboard/src/pages/AdminBotPage.test.tsx
+++ b/dashboard/src/pages/AdminBotPage.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AdminBotPage from './AdminBotPage'
+
+const mockMonitorStatus = vi.fn()
+const mockToggleWatchdog = vi.fn()
+const mockToggleAlerts = vi.fn()
+const mockUpdateProfileMonitor = vi.fn()
+const mockToast = vi.fn()
+
+vi.mock('../api', () => ({
+  api: {
+    monitorStatus: () => mockMonitorStatus(),
+    toggleWatchdog: (enabled: boolean) => mockToggleWatchdog(enabled),
+    toggleAlerts: (enabled: boolean) => mockToggleAlerts(enabled),
+    updateProfileMonitor: (
+      id: string,
+      data: { watchdog?: string; alerts?: string },
+    ) => mockUpdateProfileMonitor(id, data),
+  },
+}))
+
+vi.mock('../components/Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+const alpha = {
+  id: 'alpha',
+  name: 'Alpha',
+  enabled: true,
+  watchdog_enabled: true,
+  watchdog_override: null,
+  alerts_enabled: false,
+  alerts_override: false,
+}
+
+beforeEach(() => {
+  mockMonitorStatus.mockReset()
+  mockToggleWatchdog.mockReset()
+  mockToggleAlerts.mockReset()
+  mockUpdateProfileMonitor.mockReset()
+  mockToast.mockReset()
+})
+
+describe('AdminBotPage', () => {
+  it('renders profile monitor override rows with inherited effective state', async () => {
+    mockMonitorStatus.mockResolvedValue({
+      watchdog_enabled: true,
+      alerts_enabled: true,
+      profiles: [alpha],
+    })
+
+    render(<AdminBotPage />)
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getAllByText('Effective: enabled')).toHaveLength(1)
+    expect(screen.getByText('Effective: disabled')).toBeInTheDocument()
+  })
+
+  it('persists a per-profile watchdog override without changing the system default', async () => {
+    const user = userEvent.setup()
+    mockMonitorStatus.mockResolvedValue({
+      watchdog_enabled: true,
+      alerts_enabled: true,
+      profiles: [alpha],
+    })
+    mockUpdateProfileMonitor.mockResolvedValue({
+      ...alpha,
+      watchdog_enabled: false,
+      watchdog_override: false,
+    })
+
+    render(<AdminBotPage />)
+
+    const watchdogSelect = (await screen.findAllByRole('combobox'))[0]
+    await user.selectOptions(watchdogSelect, 'disabled')
+
+    expect(mockUpdateProfileMonitor).toHaveBeenCalledWith('alpha', {
+      watchdog: 'disabled',
+    })
+    await waitFor(() => {
+      expect(screen.getAllByText('Effective: disabled')).toHaveLength(2)
+    })
+    expect(mockToggleWatchdog).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/pages/AdminBotPage.tsx
+++ b/dashboard/src/pages/AdminBotPage.tsx
@@ -1,17 +1,26 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../api'
 import { useToast } from '../components/Toast'
-import type { MonitorStatus } from '../types'
+import type { MonitorProfileStatus, MonitorStatus } from '../types'
+
+type MonitorOverride = 'inherit' | 'enabled' | 'disabled'
+
+const EMPTY_MONITOR_STATUS: MonitorStatus = {
+  watchdog_enabled: false,
+  alerts_enabled: false,
+  profiles: [],
+}
 
 export default function AdminBotPage() {
   const { toast } = useToast()
   const [loading, setLoading] = useState(true)
-  const [monitorStatus, setMonitorStatus] = useState<MonitorStatus>({ watchdog_enabled: false, alerts_enabled: false })
+  const [savingProfileId, setSavingProfileId] = useState<string | null>(null)
+  const [monitorStatus, setMonitorStatus] = useState<MonitorStatus>(EMPTY_MONITOR_STATUS)
 
   const loadData = useCallback(async () => {
     try {
-      const monitor = await api.monitorStatus().catch(() => ({ watchdog_enabled: false, alerts_enabled: false }))
-      setMonitorStatus(monitor)
+      const monitor = await api.monitorStatus().catch(() => EMPTY_MONITOR_STATUS)
+      setMonitorStatus({ ...EMPTY_MONITOR_STATUS, ...monitor, profiles: monitor.profiles ?? [] })
     } catch (e: any) {
       toast(e.message, 'error')
     } finally {
@@ -43,6 +52,26 @@ export default function AdminBotPage() {
     }
   }
 
+  const handleProfileMonitorChange = async (
+    profile: MonitorProfileStatus,
+    field: 'watchdog' | 'alerts',
+    value: MonitorOverride,
+  ) => {
+    setSavingProfileId(profile.id)
+    try {
+      const updated = await api.updateProfileMonitor(profile.id, { [field]: value })
+      setMonitorStatus((prev) => ({
+        ...prev,
+        profiles: prev.profiles.map((item) => (item.id === updated.id ? updated : item)),
+      }))
+      toast(`${profile.name} ${field} set to ${labelOverride(value).toLowerCase()}`)
+    } catch (e: any) {
+      toast(e.message, 'error')
+    } finally {
+      setSavingProfileId(null)
+    }
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -52,30 +81,81 @@ export default function AdminBotPage() {
   }
 
   return (
-    <div className="max-w-3xl">
+    <div className="max-w-5xl">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-white">Monitor & Watchdog</h1>
         <p className="text-sm text-gray-500 mt-1">
-          Controls for the system-wide watchdog and alerting. These apply to all gateway profiles.
+          Set the system default, then override watchdog and alerts for individual profiles.
         </p>
       </div>
 
       <div className="bg-surface rounded-xl border border-gray-700/50 p-5 mb-5">
-        <h2 className="text-sm font-semibold text-white mb-4">Watchdog & Alerts</h2>
+        <h2 className="text-sm font-semibold text-white mb-4">System Default</h2>
         <div className="space-y-4">
           <Toggle
             label="Watchdog enabled"
-            description="Automatically restart crashed gateways"
+            description="Fallback restart behavior for profiles without an override"
             checked={monitorStatus.watchdog_enabled}
             onChange={handleToggleWatchdog}
           />
           <Toggle
             label="Alerts enabled"
-            description="Send proactive alerts when gateways crash or become unhealthy"
+            description="Fallback alert behavior for profiles without an override"
             checked={monitorStatus.alerts_enabled}
             onChange={handleToggleAlerts}
           />
         </div>
+      </div>
+
+      <div className="bg-surface rounded-xl border border-gray-700/50 p-5 mb-5">
+        <h2 className="text-sm font-semibold text-white mb-4">Profile Overrides</h2>
+        {monitorStatus.profiles.length === 0 ? (
+          <p className="text-sm text-gray-500">No profiles found.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="text-xs uppercase text-gray-500">
+                <tr className="border-b border-gray-700/50">
+                  <th className="pb-2 font-medium">Profile</th>
+                  <th className="pb-2 font-medium">Status</th>
+                  <th className="pb-2 font-medium">Watchdog</th>
+                  <th className="pb-2 font-medium">Alerts</th>
+                </tr>
+              </thead>
+              <tbody>
+                {monitorStatus.profiles.map((profile) => (
+                  <tr key={profile.id} className="border-b border-gray-800/80 last:border-0">
+                    <td className="py-3 pr-4">
+                      <div className="font-medium text-white">{profile.name}</div>
+                      <div className="font-mono text-xs text-gray-500">{profile.id}</div>
+                    </td>
+                    <td className="py-3 pr-4">
+                      <span className={profile.enabled ? 'text-emerald-300' : 'text-gray-500'}>
+                        {profile.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </td>
+                    <td className="py-3 pr-4">
+                      <MonitorOverrideSelect
+                        value={overrideValue(profile.watchdog_override)}
+                        effective={profile.watchdog_enabled}
+                        disabled={savingProfileId === profile.id}
+                        onChange={(value) => handleProfileMonitorChange(profile, 'watchdog', value)}
+                      />
+                    </td>
+                    <td className="py-3">
+                      <MonitorOverrideSelect
+                        value={overrideValue(profile.alerts_override)}
+                        effective={profile.alerts_enabled}
+                        disabled={savingProfileId === profile.id}
+                        onChange={(value) => handleProfileMonitorChange(profile, 'alerts', value)}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
 
       <div className="bg-surface rounded-xl border border-gray-700/50 p-5">
@@ -86,6 +166,52 @@ export default function AdminBotPage() {
           monitoring, logs) and uses a built-in admin system prompt.
         </p>
       </div>
+    </div>
+  )
+}
+
+function overrideValue(value: boolean | null | undefined): MonitorOverride {
+  if (value == null) return 'inherit'
+  return value ? 'enabled' : 'disabled'
+}
+
+function labelOverride(value: MonitorOverride) {
+  switch (value) {
+    case 'enabled':
+      return 'Enabled'
+    case 'disabled':
+      return 'Disabled'
+    case 'inherit':
+      return 'Inherit'
+  }
+}
+
+function MonitorOverrideSelect({
+  value,
+  effective,
+  disabled,
+  onChange,
+}: {
+  value: MonitorOverride
+  effective: boolean
+  disabled: boolean
+  onChange: (value: MonitorOverride) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value as MonitorOverride)}
+        className="w-36 rounded-lg border border-gray-700 bg-background px-2 py-1.5 text-sm text-white focus:border-accent focus:outline-none disabled:opacity-50"
+      >
+        <option value="inherit">Inherit</option>
+        <option value="enabled">Enabled</option>
+        <option value="disabled">Disabled</option>
+      </select>
+      <span className="text-xs text-gray-500">
+        Effective: {effective ? 'enabled' : 'disabled'}
+      </span>
     </div>
   )
 }

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -12,6 +12,8 @@ export interface GatewaySettings {
   max_concurrent_sessions?: number | null
   browser_timeout_secs?: number | null
   max_output_tokens?: number | null
+  watchdog_enabled?: boolean | null
+  alerts_enabled?: boolean | null
 }
 
 export interface ChannelCredentials {
@@ -371,6 +373,17 @@ export interface AdminBotConfig {
 export interface MonitorStatus {
   watchdog_enabled: boolean
   alerts_enabled: boolean
+  profiles: MonitorProfileStatus[]
+}
+
+export interface MonitorProfileStatus {
+  id: string
+  name: string
+  enabled: boolean
+  watchdog_enabled: boolean
+  watchdog_override: boolean | null
+  alerts_enabled: boolean
+  alerts_override: boolean | null
 }
 
 // ── System Metrics ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add optional per-profile watchdog and alert overrides to gateway profile config while preserving system defaults as fallback.
- Teach the monitor runtime to consult profile overrides before alerting or restarting gateways.
- Extend the admin monitor API and dashboard with per-profile inherit/enabled/disabled controls.

Closes #426

## Current refresh
- Base: `origin/main` 1df02bd3975a66b232ae1a5c62ddf48297f88317
- Head: 9b3d5389613e9fa5d8f233d1d731fff17993d25f
- Refreshed from a clean isolated clone; no generated artifacts or untracked files included.

## Validation
- `git diff --check origin/main...HEAD`
- `rustfmt --check crates/octos-cli/src/api/admin.rs crates/octos-cli/src/api/router.rs crates/octos-cli/src/monitor.rs crates/octos-cli/src/profiles.rs`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/octos-1241-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api monitor::tests::profile_monitor_overrides_fall_back_to_system_defaults -- --exact --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1241-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --features api --all-targets`
- `CARGO_TARGET_DIR=/private/tmp/octos-1241-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --features api --all-targets --no-deps` (passes with existing unrelated warning noise)
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1241-refresh npm --prefix dashboard ci` (repo reports existing 3 npm audit findings: 1 moderate, 2 high)
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1241-refresh npm --prefix dashboard test -- AdminBotPage`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1241-refresh npm --prefix dashboard test`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1241-refresh npm --prefix dashboard run typecheck`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1241-refresh VITE_OUT_DIR=/private/tmp/octos-1241-dashboard-dist-refresh npm --prefix dashboard run build`
- `git status --short --branch` and `git ls-files --others --exclude-standard` in the isolated clone show no untracked/generated files.


## CI / merge status
- GitHub CI is green on head `9b3d5389613e9fa5d8f233d1d731fff17993d25f`: required checks in the current status rollup passed; optional platform/e2e/security expansion jobs were skipped by workflow conditions.
- Current GitHub state remains `MERGEABLE` but branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
- #426 should close through this PR after review and merge; no manual closure was performed.
