### PR TITLE
feat(admin): manage user roles

### DIFF
--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -447,7 +447,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         )
         // User management
         .route("/api/admin/users", get(user_admin::list_users))
-        .route("/api/admin/users/{id}", delete(user_admin::delete_user))
+        .route(
+            "/api/admin/users/{id}",
+            delete(user_admin::delete_user).patch(user_admin::update_user),
+        )
         .route(
             "/api/admin/allowed-emails",
             get(user_admin::list_allowed_emails),

--- a/crates/octos-cli/src/api/user_admin.rs
+++ b/crates/octos-cli/src/api/user_admin.rs
@@ -2,16 +2,16 @@
 
 use std::sync::Arc;
 
-use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
+use axum::{Extension, Json};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
 use super::router::AuthIdentity;
 use crate::login_allowlist::AllowedLogin;
-use crate::user_store::User;
+use crate::user_store::{User, UserRole};
 
 #[derive(Serialize)]
 pub struct UsersListResponse {
@@ -23,6 +23,11 @@ pub struct AllowlistRequest {
     pub email: String,
     #[serde(default)]
     pub note: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateUserRequest {
+    pub role: UserRole,
 }
 
 #[derive(Serialize)]
@@ -86,6 +91,42 @@ pub async fn list_users(
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     let users = us.list().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Json(UsersListResponse { users }))
+}
+
+/// PATCH /api/admin/users/{id}
+pub async fn update_user(
+    State(state): State<Arc<AppState>>,
+    Extension(identity): Extension<AuthIdentity>,
+    Path(id): Path<String>,
+    Json(req): Json<UpdateUserRequest>,
+) -> Result<Json<User>, StatusCode> {
+    if !matches!(identity, AuthIdentity::Admin) {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    let us = state
+        .user_store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let mut user = us
+        .get(&id)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    let old_role = user.role.clone();
+    if old_role == req.role {
+        return Ok(Json(user));
+    }
+
+    user.role = req.role;
+    us.save(&user)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    tracing::info!(
+        user_id = %id,
+        old_role = ?old_role,
+        new_role = ?user.role,
+        "update_user: role changed"
+    );
+    Ok(Json(user))
 }
 
 /// GET /api/admin/allowed-emails
@@ -333,6 +374,28 @@ mod tests {
         })
     }
 
+    fn test_user(id: &str, role: UserRole) -> User {
+        User {
+            id: id.to_string(),
+            email: format!("{id}@example.com"),
+            name: id.to_string(),
+            role,
+            created_at: Utc::now(),
+            last_login_at: None,
+        }
+    }
+
+    fn state_with_user(user: User) -> (Arc<AppState>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(crate::user_store::UserStore::open(dir.path()).unwrap());
+        store.save(&user).unwrap();
+        let state = Arc::new(AppState {
+            user_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+        (state, dir)
+    }
+
     #[test]
     fn users_list_response_serialize() {
         let resp = UsersListResponse { users: vec![] };
@@ -483,5 +546,78 @@ mod tests {
         assert_eq!(page.total, 1);
         assert_eq!(page.entries[0].action, "allowlist.add");
         assert_eq!(page.entries[0].target_id, "ada@example.com");
+    }
+
+    #[tokio::test]
+    async fn update_user_role_promotes_with_global_admin_token() {
+        let (state, _dir) = state_with_user(test_user("alice", UserRole::User));
+
+        let Json(updated) = update_user(
+            State(state.clone()),
+            Extension(AuthIdentity::Admin),
+            Path("alice".to_string()),
+            Json(UpdateUserRequest {
+                role: UserRole::Admin,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated.role, UserRole::Admin);
+        let persisted = state
+            .user_store
+            .as_ref()
+            .unwrap()
+            .get("alice")
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.role, UserRole::Admin);
+    }
+
+    #[tokio::test]
+    async fn update_user_role_rejects_user_session_admins() {
+        let (state, _dir) = state_with_user(test_user("alice", UserRole::User));
+
+        let err = update_user(
+            State(state.clone()),
+            Extension(AuthIdentity::User {
+                id: "operator".to_string(),
+                role: UserRole::Admin,
+            }),
+            Path("alice".to_string()),
+            Json(UpdateUserRequest {
+                role: UserRole::Admin,
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err, StatusCode::FORBIDDEN);
+        let persisted = state
+            .user_store
+            .as_ref()
+            .unwrap()
+            .get("alice")
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.role, UserRole::User);
+    }
+
+    #[tokio::test]
+    async fn update_user_role_returns_not_found_for_missing_user() {
+        let (state, _dir) = state_with_user(test_user("alice", UserRole::User));
+
+        let err = update_user(
+            State(state),
+            Extension(AuthIdentity::Admin),
+            Path("bob".to_string()),
+            Json(UpdateUserRequest {
+                role: UserRole::Admin,
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err, StatusCode::NOT_FOUND);
     }
 }

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -12,6 +12,7 @@ import type {
   SoloLoginResult,
   SoloCreateResult,
   User,
+  UserRole,
   AllowlistEntry,
   SharedMetrics,
   MonitorStatus,
@@ -235,6 +236,12 @@ export const api = {
 
   // User management (admin)
   listUsers: () => request<{ users: User[] }>('/users'),
+
+  updateUserRole: (id: string, role: UserRole) =>
+    request<User>(`/users/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ role }),
+    }),
 
   listAllowedEmails: () => request<{ entries: AllowlistEntry[] }>('/allowed-emails'),
 

--- a/dashboard/src/pages/UsersPage.test.tsx
+++ b/dashboard/src/pages/UsersPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import UsersPage from './UsersPage'
-import type { AllowlistEntry, User } from '../types'
+import type { AllowlistEntry, User, UserRole } from '../types'
 
 const mockApi = vi.hoisted(() => ({
   listAllowedEmails: vi.fn(),
@@ -10,6 +10,7 @@ const mockApi = vi.hoisted(() => ({
   addAllowedEmail: vi.fn(),
   deleteAllowedEmail: vi.fn(),
   deleteUser: vi.fn(),
+  updateUserRole: vi.fn(),
 }))
 
 const mockToast = vi.hoisted(() => vi.fn())
@@ -243,5 +244,57 @@ describe('UsersPage bulk account management', () => {
     expect(mockToast).toHaveBeenCalledWith('1 deleted, 1 failed', 'error')
     expect(screen.getByLabelText(/select user admin@example\.com/i)).not.toBeChecked()
     expect(screen.getByLabelText(/select user user@example\.com/i)).toBeChecked()
+  })
+})
+
+describe('UsersPage role management', () => {
+  function userWithRole(role: UserRole): User {
+    return {
+      id: 'alice',
+      email: 'alice@example.com',
+      name: 'Alice',
+      role,
+      created_at: '2026-05-24T00:00:00Z',
+      last_login_at: null,
+    }
+  }
+
+  function renderPage(users: User[]) {
+    mockApi.listAllowedEmails.mockResolvedValue({ entries: [] })
+    mockApi.listUsers.mockResolvedValue({ users })
+    return render(<UsersPage />)
+  }
+
+  beforeEach(() => {
+    mockApi.updateUserRole.mockResolvedValue(userWithRole('admin'))
+    vi.stubGlobal('confirm', vi.fn(() => true))
+  })
+
+  it.each([
+    ['Promote', 'user', 'admin', 'Promote account "alice@example.com" to admin?'],
+    ['Demote', 'admin', 'user', 'Demote account "alice@example.com" to regular user?'],
+  ] as const)(
+    'confirms and sends %s role changes',
+    async (buttonLabel, currentRole, nextRole, confirmMessage) => {
+      const actor = userEvent.setup()
+      renderPage([userWithRole(currentRole)])
+
+      await actor.click(await screen.findByRole('button', { name: buttonLabel }))
+
+      await waitFor(() => {
+        expect(window.confirm).toHaveBeenCalledWith(confirmMessage)
+        expect(mockApi.updateUserRole).toHaveBeenCalledWith('alice', nextRole)
+      })
+    },
+  )
+
+  it('does not update a role when confirmation is declined', async () => {
+    vi.stubGlobal('confirm', vi.fn(() => false))
+    const actor = userEvent.setup()
+    renderPage([userWithRole('user')])
+
+    await actor.click(await screen.findByRole('button', { name: 'Promote' }))
+
+    expect(mockApi.updateUserRole).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/pages/UsersPage.tsx
+++ b/dashboard/src/pages/UsersPage.tsx
@@ -54,6 +54,7 @@ export default function UsersPage() {
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
   const [bulkDeleting, setBulkDeleting] = useState(false)
   const [bulkErrors, setBulkErrors] = useState<string[]>([])
+  const [updatingRoleId, setUpdatingRoleId] = useState<string | null>(null)
 
   const loadData = useCallback(async () => {
     try {
@@ -255,6 +256,25 @@ export default function UsersPage() {
     } finally {
       setBulkDeleting(false)
       setBulkDeleteOpen(false)
+    }
+  }
+
+  const handleChangeRole = async (user: User) => {
+    const nextRole: UserRole = user.role === 'admin' ? 'user' : 'admin'
+    const action = nextRole === 'admin' ? 'Promote' : 'Demote'
+    const target = nextRole === 'admin' ? 'admin' : 'regular user'
+    if (!confirm(`${action} account "${user.email}" to ${target}?`)) {
+      return
+    }
+    try {
+      setUpdatingRoleId(user.id)
+      await api.updateUserRole(user.id, nextRole)
+      toast(`${action}d account "${user.email}"`)
+      await loadData()
+    } catch (e: any) {
+      toast(e.message, 'error')
+    } finally {
+      setUpdatingRoleId(null)
     }
   }
 
@@ -511,13 +531,26 @@ export default function UsersPage() {
                     {formatDate(user.last_login_at)}
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <button
-                      onClick={() => setPendingConfirm({ kind: 'user', user })}
-                      disabled={deletingId === user.id}
-                      className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
-                    >
-                      {deletingId === user.id ? 'Deleting...' : 'Delete'}
-                    </button>
+                    <div className="flex justify-end gap-3">
+                      <button
+                        onClick={() => handleChangeRole(user)}
+                        disabled={updatingRoleId === user.id}
+                        className="text-xs text-amber-300 hover:text-amber-200 disabled:opacity-50"
+                      >
+                        {updatingRoleId === user.id
+                          ? 'Updating...'
+                          : user.role === 'admin'
+                            ? 'Demote'
+                            : 'Promote'}
+                      </button>
+                      <button
+                        onClick={() => setPendingConfirm({ kind: 'user', user })}
+                        disabled={deletingId === user.id}
+                        className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
+                      >
+                        {deletingId === user.id ? 'Deleting...' : 'Delete'}
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary
- Add `PATCH /api/admin/users/{id}` for role updates with a global-admin-token-only guard.
- Add promote/demote actions with confirmation to the dashboard Users page.
- Cover backend role update behavior and frontend confirmation/API dispatch with focused tests.

Closes #423

## Refresh
- Refreshed onto current GitHub `main` base `1df02bd3975a66b232ae1a5c62ddf48297f88317`.
- New head after refresh: `39b473f6d3f68ec2302d85240213857080812a32`.
- Diff remains limited to `crates/octos-cli/src/api/router.rs`, `crates/octos-cli/src/api/user_admin.rs`, `dashboard/src/api.ts`, `dashboard/src/pages/UsersPage.tsx`, and `dashboard/src/pages/UsersPage.test.tsx`.

## Validation
- `git diff --check origin/main...HEAD`
- `rustfmt --check crates/octos-cli/src/api/router.rs crates/octos-cli/src/api/user_admin.rs`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/octos-1244-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api api::user_admin::tests -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-1244-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --features api --all-targets`
- `CARGO_TARGET_DIR=/private/tmp/octos-1244-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --features api --all-targets --no-deps` (exits 0 with pre-existing warnings outside this slice)
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1244-refresh npm --prefix dashboard ci`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1244-refresh npm --prefix dashboard test -- UsersPage`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1244-refresh npm --prefix dashboard test`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1244-refresh npm --prefix dashboard run typecheck`
- `rm -rf /private/tmp/octos-1244-dashboard-dist-refresh && NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1244-refresh VITE_OUT_DIR=/private/tmp/octos-1244-dashboard-dist-refresh npm --prefix dashboard run build`
- `git status --short --branch && git ls-files --others --exclude-standard`

## Notes
- Audit logging is limited to a structured `tracing::info!` entry here because durable audit-log storage is tracked separately in #424.
- The focused API-feature check/clippy commands still emit current-main warnings in unrelated files; no warnings are introduced in the new role-update path.


## CI / merge status
- GitHub CI is green on refreshed head `39b473f6d3f68ec2302d85240213857080812a32`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `test-octos-cli`, `typos`, and author-email passed. Optional expansion jobs were skipped by workflow policy.
- Merge remains branch-protection blocked by required review (`BLOCKED`, `REVIEW_REQUIRED`).
