### PR TITLE
fix(admin): use current operator summary URL

### DIFF
--- a/crates/octos-cli/src/commands/admin.rs
+++ b/crates/octos-cli/src/commands/admin.rs
@@ -15,6 +15,8 @@ use crate::admin_token_store::AdminTokenStore;
 use crate::smtp_secret_store::SmtpSecretStore;
 use crate::tenant::{TenantConfig, TenantStatus, TenantStore, render_frpc_config};
 
+const DEFAULT_ADMIN_BASE_URL: &str = "http://127.0.0.1:50080";
+
 /// Admin commands for tenant and tunnel management.
 #[derive(Debug, Args)]
 pub struct AdminCommand {
@@ -341,7 +343,7 @@ fn resolve_base_url(cli_value: Option<String>) -> String {
     cli_value
         .or_else(|| std::env::var("OCTOS_BASE_URL").ok())
         .or_else(|| std::env::var("OCTOS_TEST_URL").ok())
-        .unwrap_or_else(|| "http://127.0.0.1:3000".to_string())
+        .unwrap_or_else(|| DEFAULT_ADMIN_BASE_URL.to_string())
 }
 
 fn resolve_auth_token(cli_value: Option<String>) -> Option<String> {
@@ -632,7 +634,7 @@ mod tests {
             resolve_base_url(Some("https://example.com".into())),
             "https://example.com"
         );
-        assert_eq!(resolve_base_url(None), "http://127.0.0.1:3000");
+        assert_eq!(resolve_base_url(None), DEFAULT_ADMIN_BASE_URL);
     }
 
     #[test]
@@ -723,7 +725,7 @@ mod tests {
             }
         });
 
-        let rendered = render_operator_summary("http://127.0.0.1:3000", &summary);
+        let rendered = render_operator_summary(DEFAULT_ADMIN_BASE_URL, &summary);
 
         assert!(rendered.contains("Coverage"));
         assert!(rendered.contains("Runtime Sources"));


### PR DESCRIPTION
## Summary

- Replace the stale admin/operator summary fallback URL from `http://127.0.0.1:3000` with the current `octos serve` default dashboard URL `http://127.0.0.1:50080`.
- Centralize that fallback in `DEFAULT_ADMIN_BASE_URL` and update the focused admin tests.
- Rebuilt from current `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`; refreshed head `6f4e47545e703d7a61b286944c67e7219d4ae60b`; kept the diff to `crates/octos-cli/src/commands/admin.rs`.

Related to #121

## Current-main validation

Environment: isolated clone `/private/tmp/octos-1245-f693.4HPec4/octos`; root dirty checkout left untouched; cargo target `/private/tmp/octos-1245-f693-target`; Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`.

Passed locally:

- `git diff --check origin/main...HEAD`
- `rustfmt --check crates/octos-cli/src/commands/admin.rs`
- `cargo fmt --all -- --check`
- `typos crates/octos-cli/src/commands/admin.rs`
- `rg -n "127\\.0\\.0\\.1:3000|http://localhost:3000|localhost:3000|:3000" crates/octos-cli/src/commands/admin.rs crates/octos-cli/src/commands/serve.rs` -> no matches
- `CARGO_TARGET_DIR=/private/tmp/octos-1245-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli commands::admin::tests -- --nocapture` -> 7 admin tests passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1245-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --lib --no-deps -- -D warnings`
- `git ls-files --others --exclude-standard` -> empty in the isolated checkout

Scope note: this remains related-only to #121. It removes the stale admin fallback URL, but the full stale-message closure audit is broader and should not be claimed by this narrow PR alone.

## CI / merge status

GitHub CI is green on refreshed head `6f4e47545e703d7a61b286944c67e7219d4ae60b`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, `typos`, and blocked-email passed. Optional expansion jobs were skipped as expected.

Merge remains branch-protection blocked by required review.
