### PR TITLE
feat(dashboard): add user bulk actions

### DIFF
--- a/dashboard/src/pages/UsersPage.test.tsx
+++ b/dashboard/src/pages/UsersPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import UsersPage from './UsersPage'
+import type { AllowlistEntry, User } from '../types'
 
 const mockApi = vi.hoisted(() => ({
   listAllowedEmails: vi.fn(),
@@ -124,5 +125,123 @@ describe('UsersPage destructive confirmations', () => {
 
     expect(screen.queryByRole('dialog', { name: 'Delete Account' })).not.toBeInTheDocument()
     expect(mockApi.deleteUser).not.toHaveBeenCalled()
+  })
+})
+
+describe('UsersPage bulk account management', () => {
+  const bulkUsers: User[] = [
+    {
+      id: 'admin-1',
+      email: 'admin@example.com',
+      name: 'Ada Admin',
+      role: 'admin',
+      created_at: '2026-05-01T00:00:00Z',
+      last_login_at: null,
+    },
+    {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'Uma User',
+      role: 'user',
+      created_at: '2026-05-02T00:00:00Z',
+      last_login_at: null,
+    },
+    {
+      id: 'ops-1',
+      email: 'ops@example.com',
+      name: 'Omar Ops',
+      role: 'user',
+      created_at: '2026-05-03T00:00:00Z',
+      last_login_at: null,
+    },
+  ]
+
+  const bulkAllowlist: AllowlistEntry[] = [
+    {
+      email: 'admin@example.com',
+      note: null,
+      created_at: '2026-05-01T00:00:00Z',
+      claimed_user_id: null,
+      registered_user_id: 'admin-1',
+      registered_name: 'Ada Admin',
+      registered: true,
+      last_login_at: null,
+    },
+  ]
+
+  async function waitForUsers() {
+    expect(await screen.findByLabelText(/select user admin@example\.com/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/select user user@example\.com/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/select user ops@example\.com/i)).toBeInTheDocument()
+  }
+
+  beforeEach(() => {
+    mockApi.listAllowedEmails.mockResolvedValue({ entries: bulkAllowlist })
+    mockApi.listUsers.mockResolvedValue({ users: bulkUsers })
+  })
+
+  it('filters registered accounts by search text and role', async () => {
+    const user = userEvent.setup()
+    render(<UsersPage />)
+    await waitForUsers()
+
+    await user.selectOptions(screen.getByLabelText(/role/i), 'admin')
+    expect(screen.getByLabelText(/select user admin@example\.com/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/select user user@example\.com/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/select user ops@example\.com/i)).not.toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText(/role/i), 'all')
+    await user.type(screen.getByLabelText(/search users/i), 'ops')
+    expect(screen.getByLabelText(/select user ops@example\.com/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/select user admin@example\.com/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/select user user@example\.com/i)).not.toBeInTheDocument()
+  })
+
+  it('selects all visible accounts and bulk deletes only that filtered set', async () => {
+    const user = userEvent.setup()
+    mockApi.deleteUser.mockResolvedValue({ ok: true })
+    render(<UsersPage />)
+    await waitForUsers()
+
+    await user.type(screen.getByLabelText(/search users/i), 'ops')
+    await user.click(screen.getByLabelText(/select all visible users/i))
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /delete selected/i }))
+    const dialog = screen.getByText(/delete selected accounts/i).closest('div')
+    expect(dialog).not.toBeNull()
+    await user.click(within(dialog as HTMLElement).getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => expect(mockApi.deleteUser).toHaveBeenCalledTimes(1))
+    expect(mockApi.deleteUser).toHaveBeenCalledWith('ops-1')
+    expect(mockToast).toHaveBeenCalledWith('Deleted 1 account')
+    expect(screen.getByText('0 selected')).toBeInTheDocument()
+  })
+
+  it('reports per-account bulk delete failures and keeps failed accounts selected', async () => {
+    const user = userEvent.setup()
+    mockApi.deleteUser.mockImplementation(async (id: string) => {
+      if (id === 'user-1') {
+        throw new Error('gateway still stopping')
+      }
+      return { ok: true }
+    })
+    render(<UsersPage />)
+    await waitForUsers()
+
+    await user.click(screen.getByLabelText(/select user admin@example\.com/i))
+    await user.click(screen.getByLabelText(/select user user@example\.com/i))
+    await user.click(screen.getByRole('button', { name: /delete selected/i }))
+    const dialog = screen.getByText(/delete selected accounts/i).closest('div')
+    expect(dialog).not.toBeNull()
+    await user.click(within(dialog as HTMLElement).getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => expect(mockApi.deleteUser).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'user@example.com: gateway still stopping',
+    )
+    expect(mockToast).toHaveBeenCalledWith('1 deleted, 1 failed', 'error')
+    expect(screen.getByLabelText(/select user admin@example\.com/i)).not.toBeChecked()
+    expect(screen.getByLabelText(/select user user@example\.com/i)).toBeChecked()
   })
 })

--- a/dashboard/src/pages/UsersPage.tsx
+++ b/dashboard/src/pages/UsersPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { api } from '../api'
 import ConfirmDialog from '../components/ConfirmDialog'
 import { useToast } from '../components/Toast'
-import type { AllowlistEntry, User } from '../types'
+import type { AllowlistEntry, User, UserRole } from '../types'
 
 function formatDate(value: string | null | undefined): string {
   if (!value) return 'Never'
@@ -48,6 +48,12 @@ export default function UsersPage() {
   const [removingEmail, setRemovingEmail] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null)
+  const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(() => new Set())
+  const [userSearch, setUserSearch] = useState('')
+  const [roleFilter, setRoleFilter] = useState<UserRole | 'all'>('all')
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
+  const [bulkDeleting, setBulkDeleting] = useState(false)
+  const [bulkErrors, setBulkErrors] = useState<string[]>([])
 
   const loadData = useCallback(async () => {
     try {
@@ -70,6 +76,11 @@ export default function UsersPage() {
     loadData()
   }, [loadData])
 
+  useEffect(() => {
+    const liveIds = new Set(users.map((user) => user.id))
+    setSelectedUserIds((prev) => new Set([...prev].filter((id) => liveIds.has(id))))
+  }, [users])
+
   const registeredIds = useMemo(
     () => new Set(allowedEmails.map((entry) => entry.registered_user_id).filter(Boolean)),
     [allowedEmails],
@@ -84,6 +95,29 @@ export default function UsersPage() {
     () => users.filter((user) => !registeredIds.has(user.id)),
     [registeredIds, users],
   )
+
+  const accountRows = useMemo(() => [...registeredUsers, ...otherUsers], [otherUsers, registeredUsers])
+
+  const filteredAccountRows = useMemo(() => {
+    const query = userSearch.trim().toLowerCase()
+    return accountRows.filter((user) => {
+      const matchesRole = roleFilter === 'all' || user.role === roleFilter
+      if (!matchesRole) return false
+      if (!query) return true
+      return (
+        user.email.toLowerCase().includes(query)
+        || user.name.toLowerCase().includes(query)
+      )
+    })
+  }, [accountRows, roleFilter, userSearch])
+
+  const selectedUsers = useMemo(
+    () => accountRows.filter((user) => selectedUserIds.has(user.id)),
+    [accountRows, selectedUserIds],
+  )
+
+  const visibleSelectedCount = filteredAccountRows.filter((user) => selectedUserIds.has(user.id)).length
+  const allVisibleSelected = filteredAccountRows.length > 0 && visibleSelectedCount === filteredAccountRows.length
 
   const handleAllowEmail = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -153,6 +187,76 @@ export default function UsersPage() {
         ? `Remove "${pendingConfirm.entry.email}" from the allowlist?`
         : ''
   const confirmLabel = pendingConfirm?.kind === 'user' ? 'Delete' : 'Remove'
+
+  const toggleSelectedUser = (userId: string) => {
+    setSelectedUserIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(userId)) {
+        next.delete(userId)
+      } else {
+        next.add(userId)
+      }
+      return next
+    })
+  }
+
+  const toggleAllVisibleUsers = () => {
+    setSelectedUserIds((prev) => {
+      const next = new Set(prev)
+      if (allVisibleSelected) {
+        filteredAccountRows.forEach((user) => next.delete(user.id))
+      } else {
+        filteredAccountRows.forEach((user) => next.add(user.id))
+      }
+      return next
+    })
+  }
+
+  const handleBulkDeleteUsers = async () => {
+    const targets = selectedUsers
+    if (targets.length === 0) return
+
+    setBulkDeleting(true)
+    setBulkErrors([])
+    try {
+      const results = await Promise.allSettled(
+        targets.map(async (user) => {
+          await api.deleteUser(user.id)
+          return user
+        }),
+      )
+
+      const failures: { user: User; message: string }[] = []
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          failures.push({
+            user: targets[index],
+            message: result.reason instanceof Error ? result.reason.message : String(result.reason),
+          })
+        }
+      })
+
+      const deletedCount = targets.length - failures.length
+      if (failures.length > 0) {
+        setBulkErrors(
+          failures.map(({ user, message }) => `${user.email}: ${message}`),
+        )
+        setSelectedUserIds(new Set(failures.map(({ user }) => user.id)))
+        toast(`${deletedCount} deleted, ${failures.length} failed`, 'error')
+      } else {
+        setSelectedUserIds(new Set())
+        toast(`Deleted ${deletedCount} account${deletedCount === 1 ? '' : 's'}`)
+      }
+
+      await loadData()
+    } catch (e: any) {
+      setBulkErrors([e.message])
+      toast(e.message, 'error')
+    } finally {
+      setBulkDeleting(false)
+      setBulkDeleteOpen(false)
+    }
+  }
 
   if (loading) {
     return (
@@ -297,16 +401,76 @@ export default function UsersPage() {
       </div>
 
       <div className="bg-surface rounded-xl border border-gray-700/50 overflow-hidden">
-        <div className="px-4 py-3 border-b border-gray-700/50">
-          <h2 className="text-sm font-medium text-white">Registered accounts</h2>
-          <p className="text-xs text-gray-500 mt-1">
-            Real accounts that already exist. These are shown for visibility; allowlist management above is the primary signup workflow.
-          </p>
+        <div className="px-4 py-3 border-b border-gray-700/50 space-y-3">
+          <div>
+            <h2 className="text-sm font-medium text-white">Registered accounts</h2>
+            <p className="text-xs text-gray-500 mt-1">
+              Real accounts that already exist. These are shown for visibility; allowlist management above is the primary signup workflow.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px] lg:w-[520px]">
+              <label className="block">
+                <span className="block text-xs text-gray-500 mb-1">Search users</span>
+                <input
+                  value={userSearch}
+                  onChange={(e) => setUserSearch(e.target.value)}
+                  placeholder="Email or name"
+                  className="input text-sm"
+                />
+              </label>
+              <label className="block">
+                <span className="block text-xs text-gray-500 mb-1">Role</span>
+                <select
+                  value={roleFilter}
+                  onChange={(e) => setRoleFilter(e.target.value as UserRole | 'all')}
+                  className="input text-sm"
+                >
+                  <option value="all">All roles</option>
+                  <option value="admin">Admins</option>
+                  <option value="user">Users</option>
+                </select>
+              </label>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="text-xs text-gray-500">
+                {selectedUsers.length} selected
+              </span>
+              <button
+                type="button"
+                onClick={() => setBulkDeleteOpen(true)}
+                disabled={selectedUsers.length === 0 || bulkDeleting}
+                className="px-3 py-2 text-xs font-medium rounded-lg border border-red-500/30 text-red-300 bg-red-500/10 hover:bg-red-500/20 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {bulkDeleting ? 'Deleting...' : 'Delete Selected'}
+              </button>
+            </div>
+          </div>
+          {bulkErrors.length > 0 && (
+            <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 p-3">
+              <h3 className="text-xs font-medium text-red-300 mb-2">Bulk delete errors</h3>
+              <ul className="space-y-1">
+                {bulkErrors.map((error) => (
+                  <li key={error} className="text-xs text-red-200">{error}</li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
-        {users.length > 0 ? (
+        {filteredAccountRows.length > 0 ? (
           <table className="w-full">
             <thead>
               <tr className="border-b border-gray-700/50">
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase w-10">
+                  <input
+                    type="checkbox"
+                    aria-label="Select all visible users"
+                    checked={allVisibleSelected}
+                    onChange={toggleAllVisibleUsers}
+                    disabled={filteredAccountRows.length === 0}
+                    className="h-4 w-4 rounded border-gray-600 bg-gray-900 text-accent focus:ring-accent"
+                  />
+                </th>
                 <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Email</th>
                 <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Name</th>
                 <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Role</th>
@@ -316,8 +480,17 @@ export default function UsersPage() {
               </tr>
             </thead>
             <tbody>
-              {[...registeredUsers, ...otherUsers].map((user) => (
+              {filteredAccountRows.map((user) => (
                 <tr key={user.id} className="border-b border-gray-700/30 last:border-0">
+                  <td className="px-4 py-3">
+                    <input
+                      type="checkbox"
+                      aria-label={`Select user ${user.email}`}
+                      checked={selectedUserIds.has(user.id)}
+                      onChange={() => toggleSelectedUser(user.id)}
+                      className="h-4 w-4 rounded border-gray-600 bg-gray-900 text-accent focus:ring-accent"
+                    />
+                  </td>
                   <td className="px-4 py-3 text-sm text-white font-mono">{user.email}</td>
                   <td className="px-4 py-3 text-sm text-gray-300">{user.name}</td>
                   <td className="px-4 py-3">
@@ -350,6 +523,13 @@ export default function UsersPage() {
               ))}
             </tbody>
           </table>
+        ) : users.length > 0 ? (
+          <div className="px-4 py-10 text-center">
+            <h3 className="text-lg font-medium text-gray-400 mb-2">No accounts match the filters</h3>
+            <p className="text-sm text-gray-500">
+              Adjust the search text or role filter to show more registered accounts.
+            </p>
+          </div>
         ) : (
           <div className="px-4 py-10 text-center">
             <h3 className="text-lg font-medium text-gray-400 mb-2">No registered accounts yet</h3>
@@ -367,6 +547,15 @@ export default function UsersPage() {
         danger
         onConfirm={handleConfirm}
         onCancel={() => setPendingConfirm(null)}
+      />
+      <ConfirmDialog
+        open={bulkDeleteOpen}
+        title="Delete selected accounts?"
+        message={`Delete ${selectedUsers.length} selected account${selectedUsers.length === 1 ? '' : 's'}? This will also delete their profiles and stop their gateways.`}
+        confirmLabel="Delete"
+        danger
+        onCancel={() => setBulkDeleteOpen(false)}
+        onConfirm={handleBulkDeleteUsers}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- add registered-account search, role filtering, row checkboxes, and select-all-visible controls on UsersPage
- add a bulk delete flow using the existing authenticated delete endpoint for each selected account
- show per-account bulk delete errors and keep failed accounts selected for retry
- add UsersPage component coverage for filtering, bulk delete success, and partial failures

Closes #428

## Refresh
- Refreshed onto current GitHub `main` base `1df02bd3975a66b232ae1a5c62ddf48297f88317`.
- New head after refresh: `64d2f97d246335e3b0c2035fd9ac72f67819ce31`.
- Diff remains limited to `dashboard/src/pages/UsersPage.tsx` and `dashboard/src/pages/UsersPage.test.tsx`.

## Validation
- `git diff --check origin/main...HEAD`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1246-refresh npm --prefix dashboard ci`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1246-refresh npm --prefix dashboard test -- UsersPage`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1246-refresh npm --prefix dashboard test`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1246-refresh npm --prefix dashboard run typecheck`
- `rm -rf /private/tmp/octos-1246-dashboard-dist-refresh && NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1246-refresh VITE_OUT_DIR=/private/tmp/octos-1246-dashboard-dist-refresh npm --prefix dashboard run build`
- `git status --short --branch && git ls-files --others --exclude-standard`


## CI / merge status
- GitHub CI is green on refreshed head `64d2f97d246335e3b0c2035fd9ac72f67819ce31`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `test-octos-cli`, `typos`, and author-email passed. Optional expansion jobs were skipped by workflow policy.
- Merge remains branch-protection blocked by required review (`BLOCKED`, `REVIEW_REQUIRED`).
