### PR TITLE
feat(cli): add custom init provider

### DIFF
--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -1115,6 +1115,10 @@ pub(crate) fn create_provider_with_api_type(
     base_url: Option<String>,
     api_type: Option<&str>,
 ) -> Result<Arc<dyn LlmProvider>> {
+    if name == "custom" {
+        return create_custom_provider(config, model, base_url, api_type);
+    }
+
     let entry = octos_llm::registry::lookup(name).ok_or_else(|| {
         eyre::eyre!(
             "unknown provider: {name}. Valid: {}",
@@ -1195,4 +1199,113 @@ pub(crate) fn create_provider_with_api_type(
 
     let provider = (entry.create)(params)?;
     Ok(provider)
+}
+
+fn create_custom_provider(
+    config: &Config,
+    model: Option<String>,
+    base_url: Option<String>,
+    api_type: Option<&str>,
+) -> Result<Arc<dyn LlmProvider>> {
+    let key = config.get_api_key("custom")?;
+    let model = model.ok_or_else(|| eyre::eyre!("custom provider requires model"))?;
+    let base_url = base_url.ok_or_else(|| eyre::eyre!("custom provider requires base_url"))?;
+
+    // Extract timeout overrides from gateway config (if any).
+    let llm_timeout_secs = config.gateway.as_ref().and_then(|g| g.llm_timeout_secs);
+    let llm_connect_timeout_secs = config
+        .gateway
+        .as_ref()
+        .and_then(|g| g.llm_connect_timeout_secs);
+
+    match api_type.unwrap_or("openai") {
+        "openai" => {
+            let mut provider = octos_llm::openai::OpenAIProvider::new(key, model)
+                .with_base_url(&base_url)
+                .with_provider_label("custom");
+            if let Some(t) = llm_timeout_secs {
+                let c =
+                    llm_connect_timeout_secs.unwrap_or(octos_llm::DEFAULT_LLM_CONNECT_TIMEOUT_SECS);
+                provider = provider.with_http_timeout(t, c);
+            }
+            Ok(Arc::new(provider))
+        }
+        "anthropic" => {
+            let mut provider = octos_llm::anthropic::AnthropicProvider::new(key, model)
+                .with_base_url(&base_url)
+                .with_provider_label("custom");
+            if let Some(t) = llm_timeout_secs {
+                let c =
+                    llm_connect_timeout_secs.unwrap_or(octos_llm::DEFAULT_LLM_CONNECT_TIMEOUT_SECS);
+                provider = provider.with_http_timeout(t, c);
+            }
+            Ok(Arc::new(provider))
+        }
+        other => eyre::bail!("unsupported custom api_type '{other}'; use openai or anthropic"),
+    }
+}
+
+#[cfg(test)]
+mod custom_provider_tests {
+    use super::*;
+
+    fn custom_config() -> Config {
+        let mut config = Config {
+            api_key_env: Some("CUSTOM_API_KEY".to_string()),
+            ..Default::default()
+        };
+        config
+            .env_vars
+            .insert("CUSTOM_API_KEY".to_string(), "test-key".to_string());
+        config
+    }
+
+    #[test]
+    fn creates_custom_openai_compatible_provider() {
+        let provider = create_provider_with_api_type(
+            "custom",
+            &custom_config(),
+            Some("llama-3.1-70b-instruct".to_string()),
+            Some("http://127.0.0.1:11434/v1".to_string()),
+            Some("openai"),
+        )
+        .unwrap();
+
+        assert_eq!(provider.provider_name(), "custom");
+        assert_eq!(provider.model_id(), "llama-3.1-70b-instruct");
+    }
+
+    #[test]
+    fn creates_custom_anthropic_compatible_provider() {
+        let provider = create_provider_with_api_type(
+            "custom",
+            &custom_config(),
+            Some("claude-compatible".to_string()),
+            Some("https://proxy.example.com/anthropic".to_string()),
+            Some("anthropic"),
+        )
+        .unwrap();
+
+        assert_eq!(provider.provider_name(), "custom");
+        assert_eq!(provider.model_id(), "claude-compatible");
+    }
+
+    #[test]
+    fn rejects_custom_provider_without_base_url() {
+        let result = create_provider_with_api_type(
+            "custom",
+            &custom_config(),
+            Some("llama".to_string()),
+            None,
+            Some("openai"),
+        );
+
+        match result {
+            Ok(provider) => panic!(
+                "expected missing base_url error, got provider {}",
+                provider.provider_name()
+            ),
+            Err(err) => assert!(err.to_string().contains("requires base_url")),
+        }
+    }
 }

--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -3,11 +3,12 @@
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use clap::Args;
 use colored::Colorize;
 use eyre::{Result, WrapErr, eyre};
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::Executable;
 
@@ -21,6 +22,10 @@ struct ProviderInfo {
     api_type: Option<&'static str>,
     api_types: &'static [ApiTypeOption],
 }
+
+const CUSTOM_PROVIDER_NAME: &str = "custom";
+const CUSTOM_API_KEY_ENV: &str = "CUSTOM_API_KEY";
+const MODEL_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct ApiTypeOption {
@@ -168,6 +173,316 @@ fn build_config(
     config
 }
 
+/// A fully-resolved custom (self-hosted / proxy) provider selection.
+///
+/// The preset providers in `PROVIDERS` are written via [`build_config`] which
+/// keys off a [`ProviderInfo`]; the custom path has no static `ProviderInfo`,
+/// so it carries its own owned fields here and serializes via [`Self::to_json`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectedProvider {
+    provider: String,
+    model: String,
+    api_key_env: String,
+    base_url: Option<String>,
+    api_type: Option<String>,
+}
+
+impl SelectedProvider {
+    fn to_json(&self) -> Value {
+        let mut config = json!({
+            "provider": self.provider,
+            "model": self.model,
+            "api_key_env": self.api_key_env
+        });
+        if let Some(base_url) = &self.base_url {
+            config["base_url"] = json!(base_url);
+        }
+        if let Some(api_type) = &self.api_type {
+            config["api_type"] = json!(api_type);
+        }
+        config
+    }
+}
+
+fn validate_base_url(input: &str) -> Result<String> {
+    let trimmed = input.trim().trim_end_matches('/').to_string();
+    let parsed = reqwest::Url::parse(&trimmed)
+        .wrap_err_with(|| format!("base_url '{trimmed}' is not a valid URL"))?;
+    match parsed.scheme() {
+        "http" | "https" => Ok(trimmed),
+        other => eyre::bail!("base_url scheme '{other}' is not supported; use http or https"),
+    }
+}
+
+fn models_endpoint(base_url: &str) -> String {
+    format!("{}/models", base_url.trim_end_matches('/'))
+}
+
+fn parse_model_ids(value: &Value) -> Vec<String> {
+    if let Some(data) = value.get("data").and_then(Value::as_array) {
+        return data
+            .iter()
+            .filter_map(|item| item.get("id").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect();
+    }
+
+    value
+        .get("models")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            item.as_str()
+                .or_else(|| item.get("id").and_then(Value::as_str))
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+fn fetch_custom_models(base_url: &str, api_key_env: &str) -> Result<Vec<String>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(MODEL_FETCH_TIMEOUT)
+        .build()?;
+    let mut request = client
+        .get(models_endpoint(base_url))
+        .header(reqwest::header::ACCEPT, "application/json");
+
+    if let Ok(api_key) = std::env::var(api_key_env) {
+        let api_key = api_key.trim();
+        if !api_key.is_empty() {
+            request = request.bearer_auth(api_key);
+        }
+    }
+
+    let response = request.send()?.error_for_status()?;
+    let body: Value = response.json()?;
+    Ok(parse_model_ids(&body))
+}
+
+fn prompt_api_type() -> Result<String> {
+    println!();
+    println!("Available API types:");
+    println!("  1. OpenAI (Chat Completions API)");
+    println!("  2. Anthropic (Messages API)");
+    print!("Select API type [1]: ");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    Ok(match input.trim() {
+        "" | "1" | "openai" | "OpenAI" => "openai".to_string(),
+        "2" | "anthropic" | "Anthropic" => "anthropic".to_string(),
+        _ => {
+            println!("{}", "Invalid API type, using OpenAI".yellow());
+            "openai".to_string()
+        }
+    })
+}
+
+fn prompt_model(default_model: &str, fetched_models: &[String]) -> Result<String> {
+    println!();
+    if fetched_models.is_empty() {
+        print!("Custom Model Name [{default_model}]: ");
+    } else {
+        println!("Available models:");
+        for (i, model) in fetched_models.iter().enumerate() {
+            let rec = if i == 0 { " (default)" } else { "" };
+            println!("  {}. {}{}", i + 1, model, rec);
+        }
+        print!("Select model or enter custom name [1]: ");
+    }
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Ok(fetched_models
+            .first()
+            .cloned()
+            .unwrap_or_else(|| default_model.to_string()));
+    }
+    if let Ok(choice) = trimmed.parse::<usize>() {
+        if choice >= 1 && choice <= fetched_models.len() {
+            return Ok(fetched_models[choice - 1].clone());
+        }
+    }
+    Ok(trimmed.to_string())
+}
+
+fn prompt_custom_provider() -> Result<SelectedProvider> {
+    println!();
+    println!("{}", "Custom provider configuration".green());
+
+    let base_url = loop {
+        print!("Custom API Base URL: ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        match validate_base_url(&input) {
+            Ok(url) => break url,
+            Err(err) => println!("{} {err:#}", "Invalid base URL:".yellow()),
+        }
+    };
+
+    let api_type = prompt_api_type()?;
+
+    println!();
+    print!("Environment variable containing the API Key [{CUSTOM_API_KEY_ENV}]: ");
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    let api_key_env = if input.trim().is_empty() {
+        CUSTOM_API_KEY_ENV.to_string()
+    } else {
+        input.trim().to_string()
+    };
+
+    println!();
+    print!(
+        "Fetching available models from {} ... ",
+        models_endpoint(&base_url)
+    );
+    io::stdout().flush()?;
+    let fetched_models = match fetch_custom_models(&base_url, &api_key_env) {
+        Ok(models) if !models.is_empty() => {
+            println!("{}", "✓".green());
+            models
+        }
+        Ok(_) => {
+            println!("{}", "no models returned".yellow());
+            Vec::new()
+        }
+        Err(err) => {
+            println!("{}", "unavailable".yellow());
+            println!("  {}", format!("{err:#}").dimmed());
+            Vec::new()
+        }
+    };
+
+    let model = prompt_model("auto", &fetched_models)?;
+
+    Ok(SelectedProvider {
+        provider: CUSTOM_PROVIDER_NAME.to_string(),
+        model,
+        api_key_env,
+        base_url: Some(base_url),
+        api_type: Some(api_type),
+    })
+}
+
+/// Write the resolved config plus the bootstrap scaffolding (gitignore,
+/// AGENTS.md/SOUL.md/USER.md templates, subdirectories, final hints).
+///
+/// Shared by the preset path (config built via [`build_config`]) and the
+/// custom path (config built via [`SelectedProvider::to_json`]) so both flows
+/// produce an identical, fully-bootstrapped octos home.
+fn write_init_files(
+    config_dir: PathBuf,
+    config_path: PathBuf,
+    config: Value,
+    api_key_env: String,
+) -> Result<()> {
+    // Create directory
+    std::fs::create_dir_all(&config_dir)
+        .wrap_err_with(|| format!("failed to create directory: {}", config_dir.display()))?;
+
+    // Write config
+    let config_str = serde_json::to_string_pretty(&config)?;
+    std::fs::write(&config_path, &config_str)
+        .wrap_err_with(|| format!("failed to write config: {}", config_path.display()))?;
+
+    println!();
+    println!("{}", "─".repeat(50).dimmed());
+    println!();
+    println!("{} {}", "Created:".green(), config_path.display());
+    println!();
+    println!("{}", "Config:".cyan());
+    println!("{}", config_str);
+    println!();
+
+    // Check if API key is set
+    if std::env::var(&api_key_env).is_err() {
+        println!("{} {} is not set", "Warning:".yellow(), api_key_env);
+        println!();
+        println!("Set it with:");
+        println!("  export {}=your-api-key", api_key_env);
+        println!();
+    } else {
+        println!("{} {} is set", "✓".green(), api_key_env);
+    }
+
+    // Create .gitignore if it doesn't exist
+    let gitignore_path = config_dir.join(".gitignore");
+    if !gitignore_path.exists() {
+        std::fs::write(
+            &gitignore_path,
+            "# Ignore task state and database files\ntasks/\nsessions/\n*.redb\n",
+        )?;
+        println!("{} {}", "Created:".green(), gitignore_path.display());
+    }
+
+    // Create bootstrap template files (skip existing)
+    let templates: &[(&str, &str)] = &[
+        (
+            "AGENTS.md",
+            "# Agent Instructions\n\nCustomize agent behavior and guidelines here.\n",
+        ),
+        (
+            "SOUL.md",
+            "# Soul — Who You Are\n\n\
+             ## Core Principles\n\n\
+             - **Help, don't perform.** Skip filler phrases. No \"Great question!\" or \"I'd be happy to help!\" — just do the thing.\n\
+             - **Be resourceful.** Read the file. Check context. Search for it. Come back with answers, not questions.\n\
+             - **Have a voice.** You can disagree, suggest alternatives, flag bad ideas. A useful assistant has opinions.\n\
+             - **Match the medium.** Telegram gets concise replies. CLI gets detail. Email gets structure. Read the room.\n\n\
+             ## Trust & Safety\n\n\
+             - You're a guest in someone's digital life. Act like it.\n\
+             - Private things stay private. No leaking context across sessions or users.\n\
+             - **External actions need care.** Sending messages, emails, or making API calls — double-check before acting.\n\
+             - **Internal actions are yours.** Reading files, searching, organizing, running sandboxed commands — be bold.\n\
+             - Never send half-finished replies to messaging channels.\n\n\
+             ## Working Style\n\n\
+             - Prefer doing over explaining what you'll do.\n\
+             - When a task is ambiguous, make a reasonable choice and state your assumption.\n\
+             - Use tools. You have them for a reason.\n\
+             - If something fails, diagnose before retrying.\n\
+             - Keep responses proportional to the question.\n\n\
+             ## Continuity\n\n\
+             Your memory persists through episodes and MEMORY.md.\n\
+             Bootstrap files (this one included) are loaded every session.\n\
+             If you update this file, tell the user — it defines who you are.\n",
+        ),
+        (
+            "USER.md",
+            "# User Info\n\nAdd your information and preferences here.\n",
+        ),
+    ];
+
+    for (name, content) in templates {
+        let path = config_dir.join(name);
+        if !path.exists() {
+            std::fs::write(&path, content)?;
+            println!("{} {}", "Created:".green(), path.display());
+        }
+    }
+
+    // Create subdirectories
+    for dir in &["memory", "sessions", "skills"] {
+        let path = config_dir.join(dir);
+        if !path.exists() {
+            std::fs::create_dir_all(&path)?;
+            println!("{} {}/", "Created:".green(), path.display());
+        }
+    }
+
+    println!();
+    println!("{}", "Ready! Run 'octos chat' to start.".green().bold());
+
+    Ok(())
+}
+
 /// Load models from model_catalog.json, grouped by provider.
 fn load_catalog_models() -> BTreeMap<String, Vec<String>> {
     let mut result = BTreeMap::new();
@@ -239,12 +554,32 @@ pub struct InitCommand {
     /// Overwrite an existing config without prompting.
     #[arg(long)]
     pub force: bool,
+
+    /// Configure a custom/self-hosted OpenAI- or Anthropic-compatible API base URL.
+    #[arg(long)]
+    pub custom_base_url: Option<String>,
+
+    /// Model name to write with --custom-base-url.
+    #[arg(long)]
+    pub custom_model: Option<String>,
+
+    /// API protocol to write with --custom-base-url: openai or anthropic.
+    #[arg(long, value_parser = ["openai", "anthropic"])]
+    pub custom_api_type: Option<String>,
+
+    /// Environment variable containing the API key for --custom-base-url.
+    #[arg(long)]
+    pub custom_api_key_env: Option<String>,
 }
 
 impl Executable for InitCommand {
     fn execute(self) -> Result<()> {
         println!("{}", "octos init".cyan().bold());
         println!();
+
+        // Resolve a flag-driven custom provider up front so an invalid
+        // --custom-* combination fails before we touch the filesystem.
+        let custom_flag_selection = self.custom_selection_from_flags()?;
 
         // Where to write the starter config:
         //   --cwd C        → C/.octos (explicit project-local request)
@@ -291,6 +626,13 @@ impl Executable for InitCommand {
                     "Overwriting existing config because --force was set.".yellow()
                 );
             }
+        }
+
+        // Flag-driven custom provider: write it directly and skip the preset
+        // selection flow entirely.
+        if let Some(custom) = custom_flag_selection {
+            let api_key_env = custom.api_key_env.clone();
+            return write_init_files(config_dir, config_path, custom.to_json(), api_key_env);
         }
 
         // Load model catalog for hints
@@ -341,6 +683,7 @@ impl Executable for InitCommand {
                 };
                 println!("  {marker} {}. {}", i + 1, p.display);
             }
+            println!("    {}. Custom (self-hosted or proxy)", PROVIDERS.len() + 1);
             println!();
 
             let default_idx = detect_from_env().unwrap_or(0);
@@ -354,6 +697,16 @@ impl Executable for InitCommand {
             } else {
                 match input.trim().parse::<usize>() {
                     Ok(n) if n >= 1 && n <= PROVIDERS.len() => n - 1,
+                    Ok(n) if n == PROVIDERS.len() + 1 => {
+                        let custom = prompt_custom_provider()?;
+                        let api_key_env = custom.api_key_env.clone();
+                        return write_init_files(
+                            config_dir,
+                            config_path,
+                            custom.to_json(),
+                            api_key_env,
+                        );
+                    }
                     _ => {
                         println!("{}", "Invalid selection, using detected/default".yellow());
                         default_idx
@@ -453,103 +806,44 @@ impl Executable for InitCommand {
 
         let config = build_config(info, &model, &api_key_env, api_selection);
 
-        // Create directory
-        std::fs::create_dir_all(&config_dir)
-            .wrap_err_with(|| format!("failed to create directory: {}", config_dir.display()))?;
+        write_init_files(config_dir, config_path, config, api_key_env)
+    }
+}
 
-        // Write config
-        let config_str = serde_json::to_string_pretty(&config)?;
-        std::fs::write(&config_path, &config_str)
-            .wrap_err_with(|| format!("failed to write config: {}", config_path.display()))?;
-
-        println!();
-        println!("{}", "─".repeat(50).dimmed());
-        println!();
-        println!("{} {}", "Created:".green(), config_path.display());
-        println!();
-        println!("{}", "Config:".cyan());
-        println!("{}", config_str);
-        println!();
-
-        // Check if API key is set
-        if std::env::var(&api_key_env).is_err() {
-            println!("{} {} is not set", "Warning:".yellow(), api_key_env);
-            println!();
-            println!("Set it with:");
-            println!("  export {}=your-api-key", api_key_env);
-            println!();
-        } else {
-            println!("{} {} is set", "✓".green(), api_key_env);
+impl InitCommand {
+    /// Build a [`SelectedProvider`] from the `--custom-*` flags, or `None` when
+    /// no custom flag was passed. `--custom-base-url` is required whenever any
+    /// custom flag is present.
+    fn custom_selection_from_flags(&self) -> Result<Option<SelectedProvider>> {
+        let has_custom_flag = self.custom_base_url.is_some()
+            || self.custom_model.is_some()
+            || self.custom_api_type.is_some()
+            || self.custom_api_key_env.is_some();
+        if !has_custom_flag {
+            return Ok(None);
         }
 
-        // Create .gitignore if it doesn't exist
-        let gitignore_path = config_dir.join(".gitignore");
-        if !gitignore_path.exists() {
-            std::fs::write(
-                &gitignore_path,
-                "# Ignore task state and database files\ntasks/\nsessions/\n*.redb\n",
-            )?;
-            println!("{} {}", "Created:".green(), gitignore_path.display());
-        }
+        let Some(base_url) = &self.custom_base_url else {
+            eyre::bail!("--custom-base-url is required when using custom init flags");
+        };
 
-        // Create bootstrap template files (skip existing)
-        let templates: &[(&str, &str)] = &[
-            (
-                "AGENTS.md",
-                "# Agent Instructions\n\nCustomize agent behavior and guidelines here.\n",
+        Ok(Some(SelectedProvider {
+            provider: CUSTOM_PROVIDER_NAME.to_string(),
+            model: self
+                .custom_model
+                .clone()
+                .unwrap_or_else(|| "auto".to_string()),
+            api_key_env: self
+                .custom_api_key_env
+                .clone()
+                .unwrap_or_else(|| CUSTOM_API_KEY_ENV.to_string()),
+            base_url: Some(validate_base_url(base_url)?),
+            api_type: Some(
+                self.custom_api_type
+                    .clone()
+                    .unwrap_or_else(|| "openai".to_string()),
             ),
-            (
-                "SOUL.md",
-                "# Soul — Who You Are\n\n\
-                 ## Core Principles\n\n\
-                 - **Help, don't perform.** Skip filler phrases. No \"Great question!\" or \"I'd be happy to help!\" — just do the thing.\n\
-                 - **Be resourceful.** Read the file. Check context. Search for it. Come back with answers, not questions.\n\
-                 - **Have a voice.** You can disagree, suggest alternatives, flag bad ideas. A useful assistant has opinions.\n\
-                 - **Match the medium.** Telegram gets concise replies. CLI gets detail. Email gets structure. Read the room.\n\n\
-                 ## Trust & Safety\n\n\
-                 - You're a guest in someone's digital life. Act like it.\n\
-                 - Private things stay private. No leaking context across sessions or users.\n\
-                 - **External actions need care.** Sending messages, emails, or making API calls — double-check before acting.\n\
-                 - **Internal actions are yours.** Reading files, searching, organizing, running sandboxed commands — be bold.\n\
-                 - Never send half-finished replies to messaging channels.\n\n\
-                 ## Working Style\n\n\
-                 - Prefer doing over explaining what you'll do.\n\
-                 - When a task is ambiguous, make a reasonable choice and state your assumption.\n\
-                 - Use tools. You have them for a reason.\n\
-                 - If something fails, diagnose before retrying.\n\
-                 - Keep responses proportional to the question.\n\n\
-                 ## Continuity\n\n\
-                 Your memory persists through episodes and MEMORY.md.\n\
-                 Bootstrap files (this one included) are loaded every session.\n\
-                 If you update this file, tell the user — it defines who you are.\n",
-            ),
-            (
-                "USER.md",
-                "# User Info\n\nAdd your information and preferences here.\n",
-            ),
-        ];
-
-        for (name, content) in templates {
-            let path = config_dir.join(name);
-            if !path.exists() {
-                std::fs::write(&path, content)?;
-                println!("{} {}", "Created:".green(), path.display());
-            }
-        }
-
-        // Create subdirectories
-        for dir in &["memory", "sessions", "skills"] {
-            let path = config_dir.join(dir);
-            if !path.exists() {
-                std::fs::create_dir_all(&path)?;
-                println!("{} {}/", "Created:".green(), path.display());
-            }
-        }
-
-        println!();
-        println!("{}", "Ready! Run 'octos chat' to start.".green().bold());
-
-        Ok(())
+        }))
     }
 }
 
@@ -621,5 +915,106 @@ mod tests {
         assert_eq!(config["provider"], "minimax");
         assert_eq!(config["base_url"], "https://api.minimax.io/v1");
         assert!(config.get("api_type").is_none());
+    }
+
+    #[test]
+    fn custom_provider_config_writes_required_fields() {
+        let selected = SelectedProvider {
+            provider: CUSTOM_PROVIDER_NAME.to_string(),
+            model: "llama-3.1-70b-instruct".to_string(),
+            api_key_env: CUSTOM_API_KEY_ENV.to_string(),
+            base_url: Some("https://api.example.com/v1".to_string()),
+            api_type: Some("openai".to_string()),
+        };
+
+        let config = selected.to_json();
+
+        assert_eq!(config["provider"], json!("custom"));
+        assert_eq!(config["model"], json!("llama-3.1-70b-instruct"));
+        assert_eq!(config["base_url"], json!("https://api.example.com/v1"));
+        assert_eq!(config["api_type"], json!("openai"));
+        assert_eq!(config["api_key_env"], json!("CUSTOM_API_KEY"));
+    }
+
+    #[test]
+    fn custom_flags_build_custom_selection() {
+        let cmd = InitCommand {
+            cwd: None,
+            defaults: false,
+            force: false,
+            custom_base_url: Some("https://api.example.com/v1/".to_string()),
+            custom_model: Some("qwen-2.5-14b".to_string()),
+            custom_api_type: Some("anthropic".to_string()),
+            custom_api_key_env: Some("EXAMPLE_KEY".to_string()),
+        };
+
+        let selected = cmd.custom_selection_from_flags().unwrap().unwrap();
+
+        assert_eq!(selected.provider, "custom");
+        assert_eq!(selected.model, "qwen-2.5-14b");
+        assert_eq!(selected.api_key_env, "EXAMPLE_KEY");
+        assert_eq!(
+            selected.base_url.as_deref(),
+            Some("https://api.example.com/v1")
+        );
+        assert_eq!(selected.api_type.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn custom_flags_require_base_url() {
+        let cmd = InitCommand {
+            cwd: None,
+            defaults: false,
+            force: false,
+            custom_base_url: None,
+            custom_model: Some("qwen-2.5-14b".to_string()),
+            custom_api_type: None,
+            custom_api_key_env: None,
+        };
+
+        let err = cmd.custom_selection_from_flags().unwrap_err();
+
+        assert!(err.to_string().contains("--custom-base-url is required"));
+    }
+
+    #[test]
+    fn custom_models_endpoint_trims_trailing_slashes() {
+        assert_eq!(
+            models_endpoint("https://api.example.com/v1/"),
+            "https://api.example.com/v1/models"
+        );
+    }
+
+    #[test]
+    fn parses_openai_models_response() {
+        let body = json!({
+            "data": [
+                {"id": "llama-3.1-70b-instruct"},
+                {"id": "qwen-2.5-14b"}
+            ]
+        });
+
+        assert_eq!(
+            parse_model_ids(&body),
+            vec![
+                "llama-3.1-70b-instruct".to_string(),
+                "qwen-2.5-14b".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_plain_models_array_response() {
+        let body = json!({
+            "models": [
+                "mistral-large",
+                {"id": "codestral"}
+            ]
+        });
+
+        assert_eq!(
+            parse_model_ids(&body),
+            vec!["mistral-large".to_string(), "codestral".to_string()]
+        );
     }
 }

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -1407,7 +1407,7 @@ impl Config {
 
         // Check provider is valid
         if let Some(ref provider) = self.provider {
-            if octos_llm::registry::lookup(provider).is_none() {
+            if provider != "custom" && octos_llm::registry::lookup(provider).is_none() {
                 let valid = octos_llm::registry::all_names();
                 warnings.push(format!(
                     "Unknown provider '{}'. Valid options: {}",
@@ -1715,6 +1715,23 @@ mod tests {
         };
         let warnings = config.validate();
         assert!(warnings.iter().any(|w| w.contains("Unknown provider")));
+    }
+
+    #[test]
+    fn test_validate_allows_custom_provider_with_base_url() {
+        let config = Config {
+            provider: Some("custom".to_string()),
+            model: Some("llama-3.1-70b-instruct".to_string()),
+            base_url: Some("http://127.0.0.1:11434/v1".to_string()),
+            api_type: Some("openai".to_string()),
+            api_key_env: Some("CUSTOM_API_KEY".to_string()),
+            ..Default::default()
+        };
+        let warnings = config.validate();
+        assert!(
+            !warnings.iter().any(|w| w.contains("Unknown provider")),
+            "custom provider config should not warn as unknown: {warnings:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a custom/self-hosted provider path to `octos init`, including base URL, API protocol, API key env var, model prompt, and best-effort `/models` discovery.
- Add scoped `--custom-*` init flags for non-interactive custom provider setup.
- Allow `provider: "custom"` configs through validation and map custom OpenAI/Anthropic API types to runtime providers.
- Add config serialization, flag parsing, model-list parsing, and provider factory tests.

Closes #289

## Current-main refresh
- Refreshed onto `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Previous PR head: `4a273e789139370ed40f844d6139240d7b2718ca`.
- Refreshed head: `18bddb5c2546aa851fe4f5f6ed760d99787005e1`.
- Tree: `f4887effe77485844e7b4b9f043609732ac33db7`.
- Force-pushed with exact `--force-with-lease` after rechecking the remote branch.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1247-refresh-current.UCAxbU/octos`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.
- Diff is limited to `crates/octos-cli/src/commands/chat.rs`, `crates/octos-cli/src/commands/init.rs`, and `crates/octos-cli/src/config.rs`.

## Validation
- `git diff --check origin/main...HEAD` passed.
- `rustfmt --check crates/octos-cli/src/commands/chat.rs crates/octos-cli/src/commands/init.rs crates/octos-cli/src/config.rs` passed.
- `cargo fmt --all -- --check` passed.
- `typos crates/octos-cli/src/commands/chat.rs crates/octos-cli/src/commands/init.rs crates/octos-cli/src/config.rs` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli commands::init::tests -- --nocapture` passed: 6/6 focused init tests.
- `CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli commands::chat::custom_provider_tests -- --nocapture` passed: 3/3 custom provider tests.
- `CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli config::tests::test_validate_allows_custom_provider_with_base_url -- --nocapture` passed: 1/1 config validation test.
- Interactive custom provider smoke passed: `printf '9\nhttp://127.0.0.1:1/v1\n1\n\nllama-3.1-70b-instruct\n' | CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo run -p octos-cli -- init --cwd /private/tmp/octos-1247-current-interactive.xH4EtQ`.
- Interactive smoke wrote `provider=custom`, `base_url=http://127.0.0.1:1/v1`, `api_type=openai`, `api_key_env=CUSTOM_API_KEY`, and `model=llama-3.1-70b-instruct`; `/models` fetch failed closed to manual model input as expected.
- Flag smoke passed: `CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo run -p octos-cli -- init --cwd /private/tmp/octos-1247-current-flags.zkdtdw --custom-base-url https://proxy.example.com/v1/ --custom-model qwen-2.5-14b --custom-api-type anthropic --custom-api-key-env EXAMPLE_KEY`.
- Flag smoke wrote normalized `provider=custom`, `base_url=https://proxy.example.com/v1`, `api_type=anthropic`, `api_key_env=EXAMPLE_KEY`, and `model=qwen-2.5-14b`.
- `CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --tests --no-deps -- -D warnings` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --features api --all-targets` passed with pre-existing API warnings in `api/swarm.rs`, `api/ui_protocol.rs`, `api/ui_protocol_ledger.rs`, and `api/admin.rs`.
- `CARGO_TARGET_DIR=/private/tmp/octos-1247-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api commands::init::tests -- --nocapture` passed: 6/6 focused init tests, with the same pre-existing API warnings.
- Final `git status --short --branch` showed only the refreshed branch ahead of `origin/main`.
- Final `git ls-files --others --exclude-standard` was empty in the isolated checkout.

## Artifacts
- Cargo target: `/private/tmp/octos-1247-current-4adbe-target`
- Interactive smoke config: `/private/tmp/octos-1247-current-interactive.xH4EtQ/.octos/config.json`
- Flag smoke config: `/private/tmp/octos-1247-current-flags.zkdtdw/.octos/config.json`
- No generated artifacts are included in the PR diff.

## CI / merge status
- GitHub CI is green on head `18bddb5c2546aa851fe4f5f6ed760d99787005e1`: https://github.com/octos-org/octos/actions/runs/26792789033
- Merge remains branch-protection blocked by required review: `mergeStateStatus=BLOCKED`, `reviewDecision=REVIEW_REQUIRED`.
