### PR TITLE
fix(agent): fail closed on compaction preservation

### DIFF
--- a/crates/octos-agent/src/agent/compaction.rs
+++ b/crates/octos-agent/src/agent/compaction.rs
@@ -93,15 +93,18 @@ impl Agent {
     /// legacy declarative runner must not mutate the same prompt vector first.
     /// Also no-op when no [`crate::compaction::CompactionRunner`] is attached,
     /// preserving legacy extractive behaviour for every existing caller.
-    pub(super) fn maybe_run_preflight_compaction(&self, messages: &mut Vec<Message>) {
+    pub(super) fn maybe_run_preflight_compaction(
+        &self,
+        messages: &mut Vec<Message>,
+    ) -> eyre::Result<()> {
         if self.prompt_context_manager.is_some() {
-            return;
+            return Ok(());
         }
         let Some(runner) = self.compaction_runner.as_ref() else {
-            return;
+            return Ok(());
         };
         if runner.needs_preflight(messages).is_none() {
-            return;
+            return Ok(());
         }
         let outcome = runner.run(messages, CompactionPhase::Preflight);
         info!(
@@ -114,7 +117,7 @@ impl Agent {
             summarizer = outcome.summarizer_kind,
             "harness M6.3 compaction preflight fired"
         );
-        self.enforce_preservation(messages, CompactionPhase::Preflight);
+        self.enforce_preservation(messages, CompactionPhase::Preflight)
     }
 
     /// M8.5 tier 1: cheap per-turn micro-compaction.  Runs the
@@ -172,17 +175,21 @@ impl Agent {
     /// active when a [`crate::compaction::CompactionRunner`] is wired; a
     /// no-op otherwise so every caller that does not wire the contract keeps
     /// the existing behaviour byte-for-byte.
-    pub(super) fn maybe_run_turn_compaction(&self, messages: &mut Vec<Message>, iteration: u32) {
+    pub(super) fn maybe_run_turn_compaction(
+        &self,
+        messages: &mut Vec<Message>,
+        iteration: u32,
+    ) -> eyre::Result<()> {
         if self.prompt_context_manager.is_some() {
-            return;
+            return Ok(());
         }
         let Some(runner) = self.compaction_runner.as_ref() else {
-            return;
+            return Ok(());
         };
         // Skip the very first iteration when the preflight path already ran
         // — preflight emits its own events and enforces preservation.
         if iteration == 1 {
-            return;
+            return Ok(());
         }
         let outcome = runner.run(messages, CompactionPhase::TurnEnd);
         if outcome.performed {
@@ -196,8 +203,9 @@ impl Agent {
                 summarizer = outcome.summarizer_kind,
                 "harness M6.3 compaction per-turn pass"
             );
-            self.enforce_preservation(messages, CompactionPhase::TurnEnd);
+            self.enforce_preservation(messages, CompactionPhase::TurnEnd)?;
         }
+        Ok(())
     }
 
     /// Ask the caller-owned context bridge to prepare the final model prompt.
@@ -250,16 +258,21 @@ impl Agent {
     }
 
     /// Run the post-compaction validator rail against the declared
-    /// `preserved_artifacts` + `preserved_invariants`. Failures emit a warning
-    /// so operators can surface a typed block upstream; the current loop does
-    /// not abort mid-turn because M0 guarantees the legacy extractive path
-    /// would have been a no-op for the same inputs.
-    fn enforce_preservation(&self, messages: &[Message], phase: CompactionPhase) {
+    /// `preserved_artifacts` + `preserved_invariants`.
+    ///
+    /// Missing required preservation entries are fail-closed: the caller
+    /// aborts the turn instead of sending a prompt that already lost a declared
+    /// invariant.
+    fn enforce_preservation(
+        &self,
+        messages: &[Message],
+        phase: CompactionPhase,
+    ) -> eyre::Result<()> {
         let Some(runner) = self.compaction_runner.as_ref() else {
-            return;
+            return Ok(());
         };
         let Some(workspace) = self.compaction_workspace.as_ref() else {
-            return;
+            return Ok(());
         };
         match runner.check_preserved(messages, workspace) {
             Ok(ledger) => {
@@ -276,10 +289,17 @@ impl Agent {
                         "phase" => phase.as_str().to_string(),
                     )
                     .increment(missing.len() as u64);
+                    eyre::bail!(
+                        "compaction preservation validator failed during {}: missing declared artifacts/invariants: {}",
+                        phase.as_str(),
+                        missing.join(",")
+                    );
                 }
+                Ok(())
             }
             Err(err) => {
                 warn!(error = %err, "harness M6.3 compaction validator failed");
+                Err(err.wrap_err("compaction preservation validator failed"))
             }
         }
     }

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -433,7 +433,13 @@ impl Agent {
                     iteration,
                     "loop retry: compacting context before retry"
                 );
-                self.maybe_run_turn_compaction(messages, iteration);
+                if let Err(error) = self.maybe_run_turn_compaction(messages, iteration) {
+                    tracing::warn!(
+                        error = %error,
+                        "loop retry: compaction preservation failed; bailing"
+                    );
+                    return LoopErrorAction::Bail;
+                }
                 self.prepare_prompt_with_context_manager(
                     messages,
                     PromptContextPhase::Retry,
@@ -816,7 +822,7 @@ impl Agent {
                     // LLM call when a compaction policy is wired and the
                     // context already exceeds the declared threshold.
                     if iteration == 1 {
-                        self.maybe_run_preflight_compaction(&mut messages);
+                        self.maybe_run_preflight_compaction(&mut messages)?;
                     }
                     // Harness M8.5 tier 1: cheap in-place stale/oversized
                     // tool-result pruning. Runs every iteration (including
@@ -829,7 +835,7 @@ impl Agent {
                     // runner sees the final shape of the conversation (after
                     // tool-pair repair + system-message normalization). This
                     // also feeds the validator rail on subsequent iterations.
-                    self.maybe_run_turn_compaction(&mut messages, iteration);
+                    self.maybe_run_turn_compaction(&mut messages, iteration)?;
                     self.prepare_prompt_with_context_manager(
                         &mut messages,
                         if iteration == 1 {

--- a/crates/octos-agent/tests/compaction_policy.rs
+++ b/crates/octos-agent/tests/compaction_policy.rs
@@ -7,7 +7,10 @@
 //! Run with `cargo test -p octos-agent --test compaction_policy`.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
+use async_trait::async_trait;
 use octos_agent::compaction::{
     CompactionPhase, CompactionPolicy, CompactionRunner, ExtractiveSummarizer, PreservedArtifact,
     Summarizer, TOOL_RESULT_PLACEHOLDER_SCHEMA_VERSION, ToolResultPlaceholder,
@@ -18,8 +21,43 @@ use octos_agent::workspace_policy::{
     WorkspaceSnapshotTrigger, WorkspaceTrackingPolicy, WorkspaceVersionControlPolicy,
     WorkspaceVersionControlProvider,
 };
+use octos_agent::{Agent, ToolRegistry};
 use octos_agent::{COMPACTION_POLICY_SCHEMA_VERSION, WORKSPACE_POLICY_SCHEMA_VERSION};
-use octos_core::{Message, MessageRole, ToolCall};
+use octos_core::{AgentId, Message, MessageRole, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+
+struct CountingProvider {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl LlmProvider for CountingProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        self.calls.fetch_add(1, AtomicOrdering::SeqCst);
+        Ok(ChatResponse {
+            content: Some("should not be reached".to_string()),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    fn model_id(&self) -> &str {
+        "counting"
+    }
+
+    fn provider_name(&self) -> &str {
+        "counting"
+    }
+}
 
 fn user_msg(content: &str) -> Message {
     Message {
@@ -252,6 +290,55 @@ fn should_gate_on_validator_failure_when_invariants_not_preserved() {
     assert!(
         !ledger.missing.is_empty(),
         "ledger should list missing invariants"
+    );
+}
+
+#[tokio::test]
+async fn agent_preflight_compaction_fails_closed_when_invariant_is_missing() {
+    let policy = CompactionPolicy {
+        schema_version: COMPACTION_POLICY_SCHEMA_VERSION,
+        token_budget: 10_000,
+        preflight_threshold: Some(1),
+        prune_tool_results_after_turns: None,
+        preserved_artifacts: vec![],
+        preserved_invariants: vec!["NEVER_MENTIONED_STRING".into()],
+        summarizer: Default::default(),
+    };
+    let workspace = policy_with_compaction(policy.clone());
+    let runner = CompactionRunner::new(policy).with_workspace_policy(&workspace);
+    let dir = tempfile::tempdir().unwrap();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let provider: Arc<dyn LlmProvider> = Arc::new(CountingProvider {
+        calls: calls.clone(),
+    });
+    let memory = Arc::new(EpisodeStore::open(dir.path().join("memory")).await.unwrap());
+    let agent = Agent::new(
+        AgentId::new("preservation-fail-closed"),
+        provider,
+        ToolRegistry::new(),
+        memory,
+    )
+    .with_compaction_runner(Arc::new(runner))
+    .with_compaction_workspace(workspace);
+
+    let err = agent
+        .process_message("hello", &[], vec![])
+        .await
+        .expect_err("missing preserved invariant must abort the turn");
+    let err = err.to_string();
+
+    assert!(
+        err.contains("compaction preservation validator failed"),
+        "expected preservation failure, got: {err}"
+    );
+    assert!(
+        err.contains("invariant:NEVER_MENTIONED_STRING"),
+        "error must name the missing invariant, got: {err}"
+    );
+    assert_eq!(
+        calls.load(AtomicOrdering::SeqCst),
+        0,
+        "fail-closed preflight must stop before the LLM call"
     );
 }
 


### PR DESCRIPTION
## Summary
- make declarative compaction preservation checks return hard errors instead of warning-only metrics when required artifacts or invariants are missing
- propagate preflight and turn-end preservation failures through the agent loop so the turn aborts before sending a prompt with lost contract state
- add an integration test proving a missing preserved invariant stops before the LLM call

Closes #706

## Validation
- `cargo fmt --all`
- `cargo test -p octos-agent --test compaction_policy -- --nocapture`
- `cargo test -p octos-agent --lib agent::loop_runner -- --nocapture`
- `cargo clippy -p octos-agent --tests --no-deps -- -D warnings`
- `git diff --check`
- `git ls-files --others --exclude-standard` (empty)


## CI / merge status
- GitHub CI is green on head `b24be0658ecbe951b475c81f0ddd62faedf1fae6`: required checks in the current status rollup passed; optional platform/e2e/security expansion jobs were skipped by workflow conditions.
- Current GitHub state remains `MERGEABLE` but branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
- #706 should close through this PR after review and merge; no manual closure was performed.
