### PR TITLE
feat(admin): add durable audit log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,6 +3882,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.8.5",
+ "redb",
  "regex",
  "reqwest 0.12.28",
  "rust-embed",

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -84,6 +84,7 @@ lettre = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 teloxide = { workspace = true, optional = true }
 sysinfo = { version = "0.34", optional = true }
+redb = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 # O_NOFOLLOW for the symlink-safe preview file serve in
@@ -113,7 +114,7 @@ default = []
 # handlers and the admin dashboard's Matrix invite UI reference matrix-only
 # types (e.g. `octos_bus::MatrixInviteStore`), so the API cannot compile
 # without it.
-api = ["dep:axum", "dep:tower-http", "dep:futures", "dep:rust-embed", "dep:metrics-exporter-prometheus", "dep:lettre", "dep:rand", "dep:sysinfo", "dep:subtle", "octos-bus/api", "matrix"]
+api = ["dep:axum", "dep:tower-http", "dep:futures", "dep:rust-embed", "dep:metrics-exporter-prometheus", "dep:lettre", "dep:rand", "dep:sysinfo", "dep:subtle", "dep:redb", "octos-bus/api", "matrix"]
 admin-bot = ["dep:teloxide", "dep:futures", "api"]
 telegram = ["octos-bus/telegram"]
 discord = ["octos-bus/discord"]

--- a/crates/octos-cli/src/admin_audit_store.rs
+++ b/crates/octos-cli/src/admin_audit_store.rs
@@ -1,0 +1,270 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use eyre::{Result, WrapErr};
+use redb::{Database, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const ADMIN_AUDIT_SCHEMA_VERSION: u32 = 1;
+
+const ADMIN_AUDIT_TABLE: TableDefinition<&str, &str> = TableDefinition::new("admin_audit_v1");
+const DEFAULT_AUDIT_LIMIT: usize = 50;
+const MAX_AUDIT_LIMIT: usize = 500;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AdminAuditEntry {
+    pub schema_version: u32,
+    pub id: String,
+    pub timestamp: DateTime<Utc>,
+    pub actor: String,
+    pub action: String,
+    pub target_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_summary: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_summary: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdminAuditRecordInput {
+    pub actor: String,
+    pub action: String,
+    pub target_id: String,
+    pub before_summary: Option<Value>,
+    pub after_summary: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AdminAuditQuery {
+    pub actor: Option<String>,
+    pub action: Option<String>,
+    pub target_id: Option<String>,
+    pub from: Option<DateTime<Utc>>,
+    pub to: Option<DateTime<Utc>>,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+impl Default for AdminAuditQuery {
+    fn default() -> Self {
+        Self {
+            actor: None,
+            action: None,
+            target_id: None,
+            from: None,
+            to: None,
+            limit: DEFAULT_AUDIT_LIMIT,
+            offset: 0,
+        }
+    }
+}
+
+impl AdminAuditQuery {
+    pub fn bounded_limit(&self) -> usize {
+        self.limit.clamp(1, MAX_AUDIT_LIMIT)
+    }
+
+    fn matches(&self, entry: &AdminAuditEntry) -> bool {
+        if self
+            .actor
+            .as_deref()
+            .is_some_and(|actor| entry.actor != actor)
+        {
+            return false;
+        }
+        if self
+            .action
+            .as_deref()
+            .is_some_and(|action| entry.action != action)
+        {
+            return false;
+        }
+        if self
+            .target_id
+            .as_deref()
+            .is_some_and(|target| entry.target_id != target)
+        {
+            return false;
+        }
+        if self.from.is_some_and(|from| entry.timestamp < from) {
+            return false;
+        }
+        if self.to.is_some_and(|to| entry.timestamp > to) {
+            return false;
+        }
+        true
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AdminAuditPage {
+    pub entries: Vec<AdminAuditEntry>,
+    pub total: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+pub struct AdminAuditStore {
+    db: Arc<Database>,
+}
+
+impl AdminAuditStore {
+    pub fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
+        let data_dir = data_dir.as_ref();
+        std::fs::create_dir_all(data_dir)
+            .wrap_err_with(|| format!("failed to create data dir: {}", data_dir.display()))?;
+        let db_path = data_dir.join("admin_audit.redb");
+        let db = Database::create(&db_path)
+            .wrap_err_with(|| format!("failed to open admin audit store: {}", db_path.display()))?;
+        let write_txn = db
+            .begin_write()
+            .wrap_err("failed to initialize admin audit store")?;
+        {
+            let _table = write_txn
+                .open_table(ADMIN_AUDIT_TABLE)
+                .wrap_err("failed to initialize admin audit table")?;
+        }
+        write_txn
+            .commit()
+            .wrap_err("failed to commit admin audit table initialization")?;
+        Ok(Self { db: Arc::new(db) })
+    }
+
+    pub fn record(&self, input: AdminAuditRecordInput) -> Result<AdminAuditEntry> {
+        let timestamp = Utc::now();
+        let id = uuid::Uuid::now_v7().to_string();
+        let entry = AdminAuditEntry {
+            schema_version: ADMIN_AUDIT_SCHEMA_VERSION,
+            id,
+            timestamp,
+            actor: input.actor,
+            action: input.action,
+            target_id: input.target_id,
+            before_summary: input.before_summary,
+            after_summary: input.after_summary,
+        };
+        let key = format!("{:020}:{}", timestamp.timestamp_micros(), entry.id);
+        let value = serde_json::to_string(&entry).wrap_err("failed to serialize audit entry")?;
+
+        let write_txn = self
+            .db
+            .begin_write()
+            .wrap_err("failed to begin admin audit write")?;
+        {
+            let mut table = write_txn
+                .open_table(ADMIN_AUDIT_TABLE)
+                .wrap_err("failed to open admin audit table")?;
+            table
+                .insert(key.as_str(), value.as_str())
+                .wrap_err("failed to insert admin audit entry")?;
+        }
+        write_txn
+            .commit()
+            .wrap_err("failed to commit admin audit entry")?;
+        Ok(entry)
+    }
+
+    pub fn list(&self, query: AdminAuditQuery) -> Result<AdminAuditPage> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .wrap_err("failed to begin admin audit read")?;
+        let table = read_txn
+            .open_table(ADMIN_AUDIT_TABLE)
+            .wrap_err("failed to open admin audit table")?;
+        let mut entries = Vec::new();
+        for row in table.iter().wrap_err("failed to scan admin audit table")? {
+            let (_key, value) = row.wrap_err("failed to read admin audit row")?;
+            match serde_json::from_str::<AdminAuditEntry>(value.value()) {
+                Ok(entry) if query.matches(&entry) => entries.push(entry),
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!(error = %error, "skipping invalid admin audit entry");
+                }
+            }
+        }
+
+        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp).then_with(|| b.id.cmp(&a.id)));
+        let total = entries.len();
+        let limit = query.bounded_limit();
+        let offset = query.offset;
+        let entries = entries.into_iter().skip(offset).take(limit).collect();
+
+        Ok(AdminAuditPage {
+            entries,
+            total,
+            limit,
+            offset,
+        })
+    }
+}
+
+pub fn parse_audit_datetime(value: &str, date_end: bool) -> Result<DateTime<Utc>, String> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
+        return Ok(dt.with_timezone(&Utc));
+    }
+
+    let date = NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| format!("invalid audit timestamp '{value}'"))?;
+    let naive = if date_end {
+        date.and_hms_milli_opt(23, 59, 59, 999)
+    } else {
+        date.and_hms_opt(0, 0, 0)
+    }
+    .ok_or_else(|| format!("invalid audit date '{value}'"))?;
+    Ok(DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn records_lists_and_filters_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AdminAuditStore::open(dir.path()).unwrap();
+
+        store
+            .record(AdminAuditRecordInput {
+                actor: "admin-token".into(),
+                action: "allowlist.add".into(),
+                target_id: "ada@example.com".into(),
+                before_summary: None,
+                after_summary: Some(json!({ "email": "ada@example.com" })),
+            })
+            .unwrap();
+        store
+            .record(AdminAuditRecordInput {
+                actor: "user:root".into(),
+                action: "profile.delete".into(),
+                target_id: "demo".into(),
+                before_summary: Some(json!({ "id": "demo" })),
+                after_summary: None,
+            })
+            .unwrap();
+
+        let all = store.list(AdminAuditQuery::default()).unwrap();
+        assert_eq!(all.total, 2);
+        assert_eq!(all.entries[0].action, "profile.delete");
+
+        let filtered = store
+            .list(AdminAuditQuery {
+                action: Some("allowlist.add".into()),
+                ..AdminAuditQuery::default()
+            })
+            .unwrap();
+        assert_eq!(filtered.total, 1);
+        assert_eq!(filtered.entries[0].target_id, "ada@example.com");
+    }
+
+    #[test]
+    fn parses_rfc3339_and_date_bounds() {
+        assert!(parse_audit_datetime("2026-05-24T12:00:00Z", false).is_ok());
+        let start = parse_audit_datetime("2026-05-24", false).unwrap();
+        let end = parse_audit_datetime("2026-05-24", true).unwrap();
+        assert!(end > start);
+    }
+}

--- a/crates/octos-cli/src/api/admin.rs
+++ b/crates/octos-cli/src/api/admin.rs
@@ -12,6 +12,7 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
+use super::router::AuthIdentity;
 use crate::profiles::{ProfileConfig, UserProfile, mask_secrets};
 
 /// Basic email format validation.
@@ -260,6 +261,7 @@ pub(crate) fn relocate_keychain_backed_secrets(
 
 /// POST /api/admin/profiles
 pub async fn create_profile(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateProfileRequest>,
 ) -> Result<(StatusCode, Json<ProfileResponse>), (StatusCode, String)> {
@@ -313,18 +315,26 @@ pub async fn create_profile(
 
     tracing::info!(profile = %profile.id, name = %profile.name, "profile created");
     let status = pm.status(&profile.id).await;
-    Ok((
-        StatusCode::CREATED,
-        Json(ProfileResponse {
-            email: None,
-            profile: mask_secrets(&profile),
-            status,
-        }),
-    ))
+    let response = ProfileResponse {
+        email: None,
+        profile: mask_secrets(&profile),
+        status,
+    };
+    super::admin_audit::record_admin_action(
+        &state,
+        identity.as_ref().map(|identity| &identity.0),
+        "profile.create",
+        profile.id.clone(),
+        None,
+        super::admin_audit::summary_value(&response.profile),
+    )
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// PUT /api/admin/profiles/:id
 pub async fn update_profile(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     body: String,
@@ -346,6 +356,7 @@ pub async fn update_profile(
         .get(&id)
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, format!("profile '{id}' not found")))?;
+    let before_profile = profile.clone();
 
     if let Some(name) = req.name {
         profile.name = name;
@@ -425,15 +436,28 @@ pub async fn update_profile(
 
     tracing::info!(profile = %id, "profile updated");
     let status = pm.status(&id).await;
-    Ok(Json(ProfileResponse {
+    let response = ProfileResponse {
         email: None,
         profile: mask_secrets(&profile),
         status,
-    }))
+    };
+    let before_summary = super::admin_audit::summary_value(&mask_secrets(&before_profile));
+    let after_summary = super::admin_audit::summary_value(&response.profile);
+    super::admin_audit::record_admin_action(
+        &state,
+        identity.as_ref().map(|identity| &identity.0),
+        "profile.update",
+        id,
+        before_summary,
+        after_summary,
+    )
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(response))
 }
 
 /// DELETE /api/admin/profiles/:id
 pub async fn delete_profile(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
@@ -477,6 +501,10 @@ pub async fn delete_profile(
         return Err((StatusCode::NOT_FOUND, format!("profile '{id}' not found")));
     }
 
+    let before_summary = profile
+        .as_ref()
+        .and_then(|profile| super::admin_audit::summary_value(&mask_secrets(profile)));
+
     // Clean up data directory
     if let Some(profile) = profile {
         let data_dir = store.resolve_data_dir(&profile);
@@ -488,6 +516,15 @@ pub async fn delete_profile(
     }
 
     tracing::info!(profile = %id, "profile deleted");
+    super::admin_audit::record_admin_action(
+        &state,
+        identity.as_ref().map(|identity| &identity.0),
+        "profile.delete",
+        id.clone(),
+        before_summary,
+        None,
+    )
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(Json(ActionResponse {
         ok: true,
         message: Some(format!("profile '{id}' deleted")),
@@ -1958,12 +1995,27 @@ pub struct ProfileMonitorUpdateRequest {
 
 /// POST /api/admin/monitor/watchdog — toggle watchdog.
 pub async fn toggle_watchdog(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Json(req): Json<MonitorToggleRequest>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
+    let before = state
+        .watchdog_enabled
+        .as_ref()
+        .map(|flag| flag.load(std::sync::atomic::Ordering::Relaxed))
+        .unwrap_or(false);
     if let Some(ref flag) = state.watchdog_enabled {
         flag.store(req.enabled, std::sync::atomic::Ordering::Relaxed);
     }
+    super::admin_audit::record_admin_action(
+        &state,
+        identity.as_ref().map(|identity| &identity.0),
+        "monitor.watchdog.toggle",
+        "monitor.watchdog",
+        Some(serde_json::json!({ "enabled": before })),
+        Some(serde_json::json!({ "enabled": req.enabled })),
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Json(
         serde_json::json!({ "ok": true, "watchdog_enabled": req.enabled }),
     ))
@@ -1971,12 +2023,27 @@ pub async fn toggle_watchdog(
 
 /// POST /api/admin/monitor/alerts — toggle alerts.
 pub async fn toggle_alerts(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Json(req): Json<MonitorToggleRequest>,
 ) -> Result<Json<serde_json::Value>, StatusCode> {
+    let before = state
+        .alerts_enabled
+        .as_ref()
+        .map(|flag| flag.load(std::sync::atomic::Ordering::Relaxed))
+        .unwrap_or(false);
     if let Some(ref flag) = state.alerts_enabled {
         flag.store(req.enabled, std::sync::atomic::Ordering::Relaxed);
     }
+    super::admin_audit::record_admin_action(
+        &state,
+        identity.as_ref().map(|identity| &identity.0),
+        "monitor.alerts.toggle",
+        "monitor.alerts",
+        Some(serde_json::json!({ "enabled": before })),
+        Some(serde_json::json!({ "enabled": req.enabled })),
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(Json(
         serde_json::json!({ "ok": true, "alerts_enabled": req.enabled }),
     ))

--- a/crates/octos-cli/src/api/admin_audit.rs
+++ b/crates/octos-cli/src/api/admin_audit.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+
+use super::AppState;
+use super::router::AuthIdentity;
+use crate::admin_audit_store::{
+    AdminAuditPage, AdminAuditQuery, AdminAuditRecordInput, parse_audit_datetime,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct AdminAuditListParams {
+    #[serde(default)]
+    pub actor: Option<String>,
+    #[serde(default)]
+    pub action: Option<String>,
+    #[serde(default)]
+    pub target_id: Option<String>,
+    #[serde(default)]
+    pub from: Option<String>,
+    #[serde(default)]
+    pub to: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+    #[serde(default)]
+    pub offset: Option<usize>,
+}
+
+impl AdminAuditListParams {
+    fn into_query(self) -> Result<AdminAuditQuery, String> {
+        Ok(AdminAuditQuery {
+            actor: non_empty(self.actor),
+            action: non_empty(self.action),
+            target_id: non_empty(self.target_id),
+            from: self
+                .from
+                .as_deref()
+                .map(|value| parse_audit_datetime(value, false))
+                .transpose()?,
+            to: self
+                .to
+                .as_deref()
+                .map(|value| parse_audit_datetime(value, true))
+                .transpose()?,
+            limit: self
+                .limit
+                .unwrap_or_else(|| AdminAuditQuery::default().limit),
+            offset: self.offset.unwrap_or_default(),
+        })
+    }
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub async fn list_audit(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<AdminAuditListParams>,
+) -> Result<Json<AdminAuditPage>, (StatusCode, String)> {
+    let store = state.admin_audit_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admin audit store not configured".to_string(),
+    ))?;
+    let query = params
+        .into_query()
+        .map_err(|message| (StatusCode::BAD_REQUEST, message))?;
+    let page = store
+        .list(query)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    Ok(Json(page))
+}
+
+pub(crate) fn actor_from_identity(identity: Option<&AuthIdentity>) -> String {
+    match identity {
+        Some(AuthIdentity::Admin) => "admin-token".to_string(),
+        Some(AuthIdentity::User { id, role }) => {
+            let role = match role {
+                crate::user_store::UserRole::Admin => "admin",
+                crate::user_store::UserRole::User => "user",
+            };
+            format!("user:{id}:{role}")
+        }
+        None => "admin-unauthenticated".to_string(),
+    }
+}
+
+pub(crate) fn summary_value<T: Serialize>(value: &T) -> Option<Value> {
+    serde_json::to_value(value).ok()
+}
+
+pub(crate) fn record_admin_action(
+    state: &AppState,
+    identity: Option<&AuthIdentity>,
+    action: &str,
+    target_id: impl Into<String>,
+    before_summary: Option<Value>,
+    after_summary: Option<Value>,
+) -> eyre::Result<()> {
+    let Some(store) = state.admin_audit_store.as_ref() else {
+        return Ok(());
+    };
+    store.record(AdminAuditRecordInput {
+        actor: actor_from_identity(identity),
+        action: action.to_string(),
+        target_id: target_id.into(),
+        before_summary,
+        after_summary,
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admin_audit_store::AdminAuditStore;
+
+    #[test]
+    fn list_params_parse_filters_and_dates() {
+        let query = AdminAuditListParams {
+            actor: Some(" admin-token ".into()),
+            action: Some("profile.update".into()),
+            target_id: None,
+            from: Some("2026-05-24".into()),
+            to: Some("2026-05-25T00:00:00Z".into()),
+            limit: Some(10),
+            offset: Some(5),
+        }
+        .into_query()
+        .unwrap();
+
+        assert_eq!(query.actor.as_deref(), Some("admin-token"));
+        assert_eq!(query.action.as_deref(), Some("profile.update"));
+        assert_eq!(query.limit, 10);
+        assert_eq!(query.offset, 5);
+        assert!(query.from.is_some());
+        assert!(query.to.is_some());
+    }
+
+    #[tokio::test]
+    async fn list_audit_returns_store_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(AdminAuditStore::open(dir.path()).unwrap());
+        store
+            .record(crate::admin_audit_store::AdminAuditRecordInput {
+                actor: "admin-token".into(),
+                action: "profile.create".into(),
+                target_id: "demo".into(),
+                before_summary: None,
+                after_summary: Some(serde_json::json!({ "id": "demo" })),
+            })
+            .unwrap();
+        let state = Arc::new(AppState {
+            admin_audit_store: Some(store),
+            ..AppState::empty_for_tests()
+        });
+
+        let Json(page) = list_audit(
+            State(state),
+            Query(AdminAuditListParams {
+                actor: Some("admin-token".into()),
+                action: None,
+                target_id: None,
+                from: None,
+                to: None,
+                limit: None,
+                offset: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].target_id, "demo");
+    }
+}

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -8,6 +8,7 @@
 //! process-wide [`EventBroadcaster`] over SSE (admin-only).
 
 pub mod admin;
+pub mod admin_audit;
 pub mod admin_setup;
 pub(crate) mod agent_orchestrator;
 pub mod auth_handlers;
@@ -108,6 +109,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
+use crate::admin_audit_store::AdminAuditStore;
 use crate::admin_token_store::AdminTokenStore;
 use crate::content_catalog::ContentCatalogManager;
 use crate::login_allowlist::LoginAllowlistStore;
@@ -220,6 +222,8 @@ pub struct AppState {
     pub user_store: Option<Arc<UserStore>>,
     /// Allowlist for pre-authorized email-based signup.
     pub allowlist_store: Option<Arc<LoginAllowlistStore>>,
+    /// Persistent audit log for state-changing admin actions.
+    pub admin_audit_store: Option<Arc<AdminAuditStore>>,
     /// Auth manager for email OTP and sessions.
     pub auth_manager: Option<Arc<AuthManager>>,
     /// Shared HTTP client for webhook proxying.
@@ -357,6 +361,7 @@ impl AppState {
             process_manager: None,
             user_store: None,
             allowlist_store: None,
+            admin_audit_store: None,
             auth_manager: None,
             http_client: reqwest::Client::new(),
             config_path: None,

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -12,6 +12,7 @@ use tower_http::trace::TraceLayer;
 
 use super::AppState;
 use super::admin;
+use super::admin_audit;
 use super::admin_setup;
 use super::auth_handlers;
 use super::bilibili;
@@ -346,6 +347,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
     let admin_api = Router::new()
         .layer(DefaultBodyLimit::max(1024 * 1024))
         .route("/api/admin/overview", get(admin::overview))
+        .route("/api/admin/audit", get(admin_audit::list_audit))
         .route("/api/admin/profiles", get(admin::list_profiles))
         .route("/api/admin/profiles", post(admin::create_profile))
         .route("/api/admin/profiles/{id}", get(admin::get_profile))

--- a/crates/octos-cli/src/api/user_admin.rs
+++ b/crates/octos-cli/src/api/user_admin.rs
@@ -9,6 +9,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
+use super::router::AuthIdentity;
 use crate::login_allowlist::AllowedLogin;
 use crate::user_store::User;
 
@@ -122,6 +123,7 @@ pub async fn list_allowed_emails(
 
 /// POST /api/admin/allowed-emails
 pub async fn add_allowed_email(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Json(req): Json<AllowlistRequest>,
 ) -> Result<(StatusCode, Json<AllowlistEntryResponse>), (StatusCode, Json<ErrorBody>)> {
@@ -195,24 +197,39 @@ pub async fn add_allowed_email(
         )
     })?;
 
-    Ok((
-        StatusCode::CREATED,
-        Json(AllowlistEntryResponse {
-            email,
-            note: entry.note,
-            created_at: entry.created_at,
-            claimed_user_id: None,
-            claimed_at: None,
-            registered: false,
-            registered_user_id: None,
-            registered_name: None,
-            last_login_at: None,
-        }),
-    ))
+    let response = AllowlistEntryResponse {
+        email,
+        note: entry.note,
+        created_at: entry.created_at,
+        claimed_user_id: None,
+        claimed_at: None,
+        registered: false,
+        registered_user_id: None,
+        registered_name: None,
+        last_login_at: None,
+    };
+    super::admin_audit::record_admin_action(
+        &state,
+        identity.as_ref().map(|identity| &identity.0),
+        "allowlist.add",
+        response.email.clone(),
+        None,
+        super::admin_audit::summary_value(&response),
+    )
+    .map_err(|error| {
+        tracing::error!(error = %error, "failed to record admin audit entry");
+        error_body(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "admin_audit_failed",
+            "failed to record admin audit entry",
+        )
+    })?;
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// DELETE /api/admin/allowed-emails/{email}
 pub async fn delete_allowed_email(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Path(email): Path<String>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
@@ -220,20 +237,36 @@ pub async fn delete_allowed_email(
         .allowlist_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let before = allowlist
+        .get(&email)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     match allowlist
         .delete(&email)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     {
-        true => Ok(Json(ActionResponse {
-            ok: true,
-            message: None,
-        })),
+        true => {
+            let normalized = crate::login_allowlist::normalize_email(&email);
+            super::admin_audit::record_admin_action(
+                &state,
+                identity.as_ref().map(|identity| &identity.0),
+                "allowlist.delete",
+                normalized,
+                before.as_ref().and_then(super::admin_audit::summary_value),
+                None,
+            )
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            Ok(Json(ActionResponse {
+                ok: true,
+                message: None,
+            }))
+        }
         false => Err(StatusCode::NOT_FOUND),
     }
 }
 
 /// DELETE /api/admin/users/{id}
 pub async fn delete_user(
+    identity: Option<axum::Extension<AuthIdentity>>,
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
@@ -241,6 +274,7 @@ pub async fn delete_user(
         .user_store
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let before_user = us.get(&id).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     if let Some(ref pm) = state.process_manager {
         let _ = pm.stop(&id).await;
@@ -253,6 +287,17 @@ pub async fn delete_user(
     match us.delete(&id) {
         Ok(true) => {
             tracing::info!(user_id = %id, "delete_user: user deleted");
+            super::admin_audit::record_admin_action(
+                &state,
+                identity.as_ref().map(|identity| &identity.0),
+                "user.delete",
+                id.clone(),
+                before_user
+                    .as_ref()
+                    .and_then(super::admin_audit::summary_value),
+                None,
+            )
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
             Ok(Json(ActionResponse {
                 ok: true,
                 message: None,
@@ -349,6 +394,7 @@ mod tests {
         let state = state_with_stores(allowlist, None);
 
         let result = add_allowed_email(
+            None,
             State(state),
             Json(AllowlistRequest {
                 email: "ALICE@example.com".into(),
@@ -386,6 +432,7 @@ mod tests {
         let state = state_with_stores(allowlist, Some(user_store));
 
         let result = add_allowed_email(
+            None,
             State(state),
             Json(AllowlistRequest {
                 email: "alice@example.com".into(),
@@ -403,5 +450,38 @@ mod tests {
             body.message,
             "email 'alice@example.com' is already registered"
         );
+    }
+
+    #[tokio::test]
+    async fn add_allowed_email_records_admin_audit_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let allowlist =
+            Arc::new(crate::login_allowlist::LoginAllowlistStore::open(dir.path()).unwrap());
+        let audit = Arc::new(crate::admin_audit_store::AdminAuditStore::open(dir.path()).unwrap());
+        let state = Arc::new(AppState {
+            allowlist_store: Some(allowlist),
+            admin_audit_store: Some(audit.clone()),
+            ..AppState::empty_for_tests()
+        });
+
+        let (status, Json(response)) = add_allowed_email(
+            Some(axum::Extension(AuthIdentity::Admin)),
+            State(state),
+            Json(AllowlistRequest {
+                email: "Ada@Example.com".into(),
+                note: Some("Pilot".into()),
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(response.email, "ada@example.com");
+        let page = audit
+            .list(crate::admin_audit_store::AdminAuditQuery::default())
+            .unwrap();
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].action, "allowlist.add");
+        assert_eq!(page.entries[0].target_id, "ada@example.com");
     }
 }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -507,6 +507,10 @@ impl ServeCommand {
             crate::login_allowlist::LoginAllowlistStore::open(&data_dir)
                 .wrap_err("failed to open login allowlist store")?,
         );
+        let admin_audit_store = Arc::new(
+            crate::admin_audit_store::AdminAuditStore::open(&data_dir)
+                .wrap_err("failed to open admin audit store")?,
+        );
         let auth_manager = {
             let (auth_config, derived_profile_password) = match config.dashboard_auth.clone() {
                 Some(auth) => (Some(auth), None),
@@ -638,6 +642,7 @@ impl ServeCommand {
             process_manager: Some(process_manager.clone()),
             user_store: Some(user_store),
             allowlist_store: Some(allowlist_store),
+            admin_audit_store: Some(admin_audit_store),
             auth_manager,
             http_client: reqwest::Client::new(),
             // If a config file was loaded, admin edits target that exact file.

--- a/crates/octos-cli/src/lib.rs
+++ b/crates/octos-cli/src/lib.rs
@@ -5,6 +5,8 @@
 //! the MCP server dispatch in [`commands::mcp_serve`]). Keep the public API
 //! narrow — only items that integration tests or sibling crates consume.
 
+#[cfg(feature = "api")]
+pub mod admin_audit_store;
 pub mod admin_token_store;
 #[cfg(feature = "api")]
 pub mod api;

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import Dashboard from './pages/Dashboard'
 import NewProfile from './pages/NewProfile'
 import LoginPage from './pages/LoginPage'
 import UsersPage from './pages/UsersPage'
+import AdminAuditPage from './pages/AdminAuditPage'
 import AdminBotPage from './pages/AdminBotPage'
 import ServerMetricsPage from './pages/ServerMetricsPage'
 import SetupRotateToken from './pages/SetupRotateToken'
@@ -35,6 +36,7 @@ export default function App() {
               {/* Global admin pages */}
               <Route index element={<Dashboard />} />
               <Route path="users" element={<AdminGuard><UsersPage /></AdminGuard>} />
+              <Route path="audit" element={<AdminGuard><AdminAuditPage /></AdminGuard>} />
               <Route path="admin-bot" element={<AdminGuard><AdminBotPage /></AdminGuard>} />
               <Route path="server" element={<AdminGuard><ServerMetricsPage /></AdminGuard>} />
               <Route path="harness" element={<AdminGuard><HarnessPage /></AdminGuard>} />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -18,6 +18,7 @@ import type {
   MonitorProfileStatus,
   SystemMetrics,
   PurgeReport,
+  AdminAuditResponse,
 } from './types'
 
 const BASE = '/api/admin'
@@ -139,10 +140,31 @@ async function authedRequest<T>(path: string, opts?: RequestInit): Promise<T> {
   return res.json()
 }
 
+function queryPath(path: string, params: Record<string, string | number | undefined | null>): string {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && `${value}`.trim() !== '') {
+      query.set(key, `${value}`)
+    }
+  }
+  const suffix = query.toString()
+  return suffix ? `${path}?${suffix}` : path
+}
+
 // ── Admin API (existing) ────────────────────────────────────────────
 
 export const api = {
   overview: () => request<OverviewResponse>('/overview'),
+
+  listAudit: (params?: {
+    actor?: string
+    action?: string
+    target_id?: string
+    from?: string
+    to?: string
+    limit?: number
+    offset?: number
+  }) => request<AdminAuditResponse>(queryPath('/audit', params ?? {})),
 
   listProfiles: () => request<ProfileResponse[]>('/profiles'),
 

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -68,6 +68,7 @@ export default function Sidebar() {
                 <div className="border-t border-gray-700/30 my-3" />
                 <SidebarLink to="/" end icon={<GridIcon />} label="All Profiles" />
                 <SidebarLink to="/users" icon={<UsersIcon />} label="Access" />
+                <SidebarLink to="/audit" icon={<AuditIcon />} label="Audit" />
                 <SidebarLink to="/admin-bot" icon={<BotIcon />} label="Admin Bot" />
                 <SidebarLink to="/harness" icon={<ShieldIcon />} label="Harness" />
                 <SidebarLink to="/server" icon={<PulseIcon />} label="Server" />
@@ -213,6 +214,14 @@ function UsersIcon() {
   return (
     <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+    </svg>
+  )
+}
+
+function AuditIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 7h6M9 11h6M9 15h3M5 4h14a1 1 0 011 1v14l-3-2-3 2-3-2-3 2-3-2-3 2V5a1 1 0 011-1z" />
     </svg>
   )
 }

--- a/dashboard/src/pages/AdminAuditPage.test.tsx
+++ b/dashboard/src/pages/AdminAuditPage.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AdminAuditPage from './AdminAuditPage'
+
+const mockListAudit = vi.hoisted(() => vi.fn())
+const mockToast = vi.hoisted(() => vi.fn())
+
+vi.mock('../api', () => ({
+  api: {
+    listAudit: mockListAudit,
+  },
+}))
+
+vi.mock('../components/Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+beforeEach(() => {
+  mockListAudit.mockReset()
+  mockToast.mockReset()
+  mockListAudit.mockResolvedValue({
+    total: 1,
+    limit: 50,
+    offset: 0,
+    entries: [
+      {
+        schema_version: 1,
+        id: 'entry-1',
+        timestamp: '2026-05-24T10:15:00Z',
+        actor: 'admin-token',
+        action: 'profile.update',
+        target_id: 'demo',
+        before_summary: { enabled: false },
+        after_summary: { enabled: true },
+      },
+    ],
+  })
+})
+
+describe('AdminAuditPage', () => {
+  it('renders audit entries from the admin audit API', async () => {
+    render(<AdminAuditPage />)
+
+    await waitFor(() => expect(mockListAudit).toHaveBeenCalledWith({
+      actor: '',
+      action: '',
+      from: '',
+      to: '',
+      limit: 50,
+      offset: 0,
+    }))
+    expect(await screen.findByText('admin-token')).toBeInTheDocument()
+    expect(screen.getByText('profile.update')).toBeInTheDocument()
+    expect(screen.getByText('demo')).toBeInTheDocument()
+  })
+
+  it('submits actor action and date filters', async () => {
+    const user = userEvent.setup()
+    render(<AdminAuditPage />)
+    await screen.findByText('profile.update')
+
+    await user.type(screen.getByPlaceholderText('Actor'), 'admin-token')
+    await user.type(screen.getByPlaceholderText('Action'), 'allowlist.add')
+    await user.type(screen.getByLabelText('From date'), '2026-05-20')
+    await user.type(screen.getByLabelText('To date'), '2026-05-24')
+    await user.click(screen.getByRole('button', { name: /^apply$/i }))
+
+    await waitFor(() => expect(mockListAudit).toHaveBeenLastCalledWith({
+      actor: 'admin-token',
+      action: 'allowlist.add',
+      from: '2026-05-20',
+      to: '2026-05-24',
+      limit: 50,
+      offset: 0,
+    }))
+  })
+})

--- a/dashboard/src/pages/AdminAuditPage.tsx
+++ b/dashboard/src/pages/AdminAuditPage.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { api } from '../api'
+import { useToast } from '../components/Toast'
+import type { AdminAuditEntry } from '../types'
+
+const DEFAULT_LIMIT = 50
+
+type AuditFilters = {
+  actor: string
+  action: string
+  from: string
+  to: string
+}
+
+function formatDateTime(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleString()
+}
+
+function compactJson(value: unknown): string {
+  if (value === undefined || value === null) return '-'
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function actionTone(action: string): string {
+  if (action.includes('delete')) return 'bg-red-500/15 text-red-300'
+  if (action.includes('toggle')) return 'bg-amber-500/15 text-amber-300'
+  if (action.includes('create') || action.includes('add')) return 'bg-green-500/15 text-green-300'
+  return 'bg-blue-500/15 text-blue-300'
+}
+
+export default function AdminAuditPage() {
+  const { toast } = useToast()
+  const [entries, setEntries] = useState<AdminAuditEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [actor, setActor] = useState('')
+  const [action, setAction] = useState('')
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+
+  const pageLabel = useMemo(() => {
+    if (total === 0) return '0'
+    const start = offset + 1
+    const end = Math.min(offset + DEFAULT_LIMIT, total)
+    return `${start}-${end} of ${total}`
+  }, [offset, total])
+
+  const loadAudit = useCallback(async (
+    nextOffset = offset,
+    filterOverride?: Partial<AuditFilters>,
+  ) => {
+    const filters = {
+      actor,
+      action,
+      from,
+      to,
+      ...filterOverride,
+    }
+    try {
+      setLoading(true)
+      const page = await api.listAudit({
+        actor: filters.actor,
+        action: filters.action,
+        from: filters.from,
+        to: filters.to,
+        limit: DEFAULT_LIMIT,
+        offset: nextOffset,
+      })
+      setEntries(page.entries)
+      setTotal(page.total)
+      setOffset(page.offset)
+    } catch (e: any) {
+      toast(e.message, 'error')
+    } finally {
+      setLoading(false)
+    }
+  }, [action, actor, from, offset, to, toast])
+
+  useEffect(() => {
+    loadAudit(0)
+  }, [])
+
+  const applyFilters = (event: React.FormEvent) => {
+    event.preventDefault()
+    loadAudit(0)
+  }
+
+  const clearFilters = () => {
+    setActor('')
+    setAction('')
+    setFrom('')
+    setTo('')
+    loadAudit(0, { actor: '', action: '', from: '', to: '' })
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Audit</h1>
+          <p className="text-sm text-gray-500 mt-1">{pageLabel}</p>
+        </div>
+        <button
+          onClick={() => loadAudit(offset)}
+          className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-700 text-gray-300 hover:bg-white/5 transition"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <form onSubmit={applyFilters} className="grid grid-cols-1 md:grid-cols-5 gap-3">
+        <input
+          value={actor}
+          onChange={(event) => setActor(event.target.value)}
+          aria-label="Actor"
+          placeholder="Actor"
+          className="input text-sm"
+        />
+        <input
+          value={action}
+          onChange={(event) => setAction(event.target.value)}
+          aria-label="Action"
+          placeholder="Action"
+          className="input text-sm"
+        />
+        <input
+          type="date"
+          value={from}
+          onChange={(event) => setFrom(event.target.value)}
+          aria-label="From date"
+          className="input text-sm"
+        />
+        <input
+          type="date"
+          value={to}
+          onChange={(event) => setTo(event.target.value)}
+          aria-label="To date"
+          className="input text-sm"
+        />
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className="flex-1 px-3 py-2 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent-light transition"
+          >
+            Apply
+          </button>
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-700 text-gray-400 hover:text-white hover:bg-white/5 transition"
+          >
+            Clear
+          </button>
+        </div>
+      </form>
+
+      <div className="bg-surface rounded-xl border border-gray-700/50 overflow-hidden">
+        {loading ? (
+          <div className="flex items-center justify-center h-64">
+            <div className="animate-spin w-6 h-6 border-2 border-accent border-t-transparent rounded-full" />
+          </div>
+        ) : entries.length === 0 ? (
+          <div className="px-4 py-12 text-center text-sm text-gray-500">No audit entries</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[980px]">
+              <thead>
+                <tr className="border-b border-gray-700/50">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Time</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Actor</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Action</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Target</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">Before</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">After</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((entry) => (
+                  <tr key={entry.id} className="border-b border-gray-700/30 last:border-0 align-top">
+                    <td className="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">{formatDateTime(entry.timestamp)}</td>
+                    <td className="px-4 py-3 text-sm text-gray-300 font-mono">{entry.actor}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex px-2 py-0.5 text-[10px] font-medium rounded-full ${actionTone(entry.action)}`}>
+                        {entry.action}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-white font-mono">{entry.target_id}</td>
+                    <td className="px-4 py-3 text-xs text-gray-400 font-mono max-w-xs truncate" title={compactJson(entry.before_summary)}>
+                      {compactJson(entry.before_summary)}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-400 font-mono max-w-xs truncate" title={compactJson(entry.after_summary)}>
+                      {compactJson(entry.after_summary)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <button
+          onClick={() => loadAudit(Math.max(0, offset - DEFAULT_LIMIT))}
+          disabled={offset === 0 || loading}
+          className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-700 text-gray-300 hover:bg-white/5 transition disabled:opacity-40"
+        >
+          Previous
+        </button>
+        <button
+          onClick={() => loadAudit(offset + DEFAULT_LIMIT)}
+          disabled={offset + DEFAULT_LIMIT >= total || loading}
+          className="px-3 py-2 text-sm font-medium rounded-lg border border-gray-700 text-gray-300 hover:bg-white/5 transition disabled:opacity-40"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -252,6 +252,24 @@ export interface AllowlistEntry {
   last_login_at?: string | null
 }
 
+export interface AdminAuditEntry {
+  schema_version: number
+  id: string
+  timestamp: string
+  actor: string
+  action: string
+  target_id: string
+  before_summary?: unknown
+  after_summary?: unknown
+}
+
+export interface AdminAuditResponse {
+  entries: AdminAuditEntry[]
+  total: number
+  limit: number
+  offset: number
+}
+
 /// The active tenant scope derived from the request `Host` /
 /// `X-Forwarded-Host` header. Populated by the server's
 /// `host_scoped_profile_id` resolver. `null` when no tenant subdomain


### PR DESCRIPTION
## Summary
- Add a redb-backed admin audit store with timestamp, actor, action, target id, and before/after summaries.
- Expose `GET /api/admin/audit` with limit/offset pagination plus actor/action/target/date filters.
- Record audit entries for profile create/update/delete, user deletion, allowlist add/remove, and watchdog/alert toggles.
- Add an Admin Audit dashboard page with filters, pagination controls, sidebar route, and focused tests.

Closes #424

## Current refresh
- Base: `origin/main` 1df02bd3975a66b232ae1a5c62ddf48297f88317
- Head: 7eb3628a7cf508976ac6be94e27a93e051d5ec1a
- Refreshed from a clean isolated clone; no generated artifacts or untracked files included.

## Validation
- `git diff --check origin/main...HEAD`
- `rustfmt --check crates/octos-cli/src/admin_audit_store.rs crates/octos-cli/src/api/admin.rs crates/octos-cli/src/api/admin_audit.rs crates/octos-cli/src/api/mod.rs crates/octos-cli/src/api/router.rs crates/octos-cli/src/api/user_admin.rs crates/octos-cli/src/commands/serve.rs crates/octos-cli/src/lib.rs`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/octos-1249-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api admin_audit -- --nocapture` (5 passed)
- `CARGO_TARGET_DIR=/private/tmp/octos-1249-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api user_admin -- --nocapture` (4 passed)
- `CARGO_TARGET_DIR=/private/tmp/octos-1249-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --all-targets`
- `CARGO_TARGET_DIR=/private/tmp/octos-1249-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --features api --all-targets` (passes with existing unrelated warning noise)
- `CARGO_TARGET_DIR=/private/tmp/octos-1249-refresh-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --features api --all-targets --no-deps` (exits 0 with existing unrelated clippy warning noise)
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1249-refresh npm --prefix dashboard ci` (repo reports existing 3 npm audit findings: 1 moderate, 2 high)
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1249-refresh npm --prefix dashboard test -- AdminAuditPage` (2 passed)
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1249-refresh npm --prefix dashboard test` (34 passed)
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1249-refresh npm --prefix dashboard run typecheck`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1249-refresh VITE_OUT_DIR=/private/tmp/octos-1249-dashboard-dist-refresh npm --prefix dashboard run build`
- `git status --short --branch` and `git ls-files --others --exclude-standard` in the isolated clone show no untracked/generated files.

## Notes
- Full clippy with `-D warnings` is still blocked by pre-existing warnings outside this slice, so this refresh records the clean exit of the repository-standard clippy invocation without widening the PR.


## CI / merge status
- GitHub CI is green on head `7eb3628a7cf508976ac6be94e27a93e051d5ec1a`: required checks in the current status rollup passed; optional platform/e2e/security expansion jobs were skipped by workflow conditions.
- Current GitHub state remains `MERGEABLE` but branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
- #424 should close through this PR after review and merge; no manual closure was performed.
