### PR TITLE
fix(agent): persist from append-only per-turn log instead of mutated prompt buffer (NEW-16)

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -732,7 +732,7 @@ impl Agent {
                     base_content
                 };
 
-                messages.push(Message {
+                let current_user = Message {
                     role: MessageRole::User,
                     content,
                     media,
@@ -742,7 +742,30 @@ impl Agent {
                     client_message_id: None,
                     thread_id: None,
                     timestamp: chrono::Utc::now(),
-                });
+                };
+                messages.push(current_user.clone());
+
+                // NEW-16 (codex design): append-only per-turn output log.
+                //
+                // The persisted `ConversationResponse.messages` MUST NOT be
+                // derived from the LLM prompt buffer (`messages`) by slicing
+                // at `1 + history.len()`. That buffer is mutated during the
+                // loop by `prepare_conversation_messages` (which calls
+                // `repair_message_order`) and by the AppUI context-window
+                // bridge in `ui_protocol.rs`. After mutation, OLD rows from
+                // prior turns can end up past the stale boundary and get
+                // returned as "new", which causes re-persistence and the
+                // 7x duplicate-content drag-forward seen in soak captures
+                // (mini3 Yuan-dynasty content, 2026-05-23).
+                //
+                // Instead, we build an append-only log of just the rows we
+                // genuinely produce in THIS turn (current User, assistant
+                // replies + tool results from `handle_tool_use`, synthetic
+                // loop-detector rows, and any terminal/synthesised assistant
+                // row a return site adds). The log is never read back from
+                // — only pushed to — so no mutation pass can shift OLD rows
+                // into it.
+                let mut turn_output_log: Vec<Message> = vec![current_user];
 
                 let config = self.chat_config();
                 let mut files_modified = Vec::new();
@@ -784,7 +807,7 @@ impl Agent {
                                 files_modified,
                                 files_to_send,
                                 streamed: false,
-                                messages: LoopTurnState::new_messages(&messages, history.len()),
+                                messages: turn_output_log.clone(),
                                 tool_results: tool_structured_metadata.clone(),
                                 synthesized_from_spawn_only: false,
                             });
@@ -968,7 +991,7 @@ impl Agent {
                                 files_modified,
                                 files_to_send,
                                 streamed,
-                                messages: LoopTurnState::new_messages(&messages, history.len()),
+                                messages: turn_output_log.clone(),
                                 tool_results: tool_structured_metadata.clone(),
                                 synthesized_from_spawn_only: false,
                             });
@@ -1061,10 +1084,7 @@ impl Agent {
                                             files_modified,
                                             files_to_send,
                                             streamed,
-                                            messages: LoopTurnState::new_messages(
-                                                &messages,
-                                                history.len(),
-                                            ),
+                                            messages: turn_output_log.clone(),
                                             tool_results: tool_structured_metadata.clone(),
                                             synthesized_from_spawn_only: false,
                                         });
@@ -1101,11 +1121,12 @@ impl Agent {
                                     self.emit_cost_update(turn.total_usage(), &response);
                                     match self.dedup_loop_warning(warning) {
                                         Ok(warning_content) => {
-                                            inject_loop_detected_synthetic_results(
+                                            inject_loop_detected_synthetic_results_with_log(
                                                 &mut messages,
                                                 &response,
                                                 &warning_content,
                                                 self,
+                                                Some(&mut turn_output_log),
                                             );
                                             warn!(
                                                 "loop detected — injected synthetic tool results with warning and continuing for ONE more iteration"
@@ -1124,10 +1145,7 @@ impl Agent {
                                                 files_modified,
                                                 files_to_send,
                                                 streamed,
-                                                messages: LoopTurnState::new_messages(
-                                                    &messages,
-                                                    history.len(),
-                                                ),
+                                                messages: turn_output_log.clone(),
                                                 tool_results: tool_structured_metadata.clone(),
                                                 synthesized_from_spawn_only: false,
                                             });
@@ -1164,6 +1182,7 @@ impl Agent {
                                     tracker,
                                     Some(&mut tool_structured_metadata),
                                     Some(&mut iter_tool_success),
+                                    Some(&mut turn_output_log),
                                 )
                                 .await
                             {
@@ -1243,10 +1262,7 @@ impl Agent {
                                     files_modified,
                                     files_to_send,
                                     streamed,
-                                    messages: LoopTurnState::new_messages(
-                                        &messages,
-                                        history.len(),
-                                    ),
+                                    messages: turn_output_log.clone(),
                                     tool_results: tool_structured_metadata.clone(),
                                     synthesized_from_spawn_only: false,
                                 });
@@ -1352,7 +1368,7 @@ impl Agent {
                                         files_modified,
                                         files_to_send,
                                         streamed,
-                                        messages: LoopTurnState::new_messages(&messages, history.len()),
+                                        messages: turn_output_log.clone(),
                                         tool_results: tool_structured_metadata.clone(),
                                         // dspfac "two bubbles per turn" fix: this
                                         // branch synthesises `content` as the
@@ -1383,7 +1399,7 @@ impl Agent {
                                 files_modified,
                                 files_to_send,
                                 streamed,
-                                messages: LoopTurnState::new_messages(&messages, history.len()),
+                                messages: turn_output_log.clone(),
                                 tool_results: tool_structured_metadata.clone(),
                                 synthesized_from_spawn_only: false,
                             });
@@ -1407,7 +1423,7 @@ impl Agent {
                                 files_modified,
                                 files_to_send,
                                 streamed,
-                                messages: LoopTurnState::new_messages(&messages, history.len()),
+                                messages: turn_output_log.clone(),
                                 tool_results: tool_structured_metadata.clone(),
                                 synthesized_from_spawn_only: false,
                             });
@@ -1704,6 +1720,7 @@ impl Agent {
                                 None,
                                 None,
                                 None,
+                                None,
                             )
                             .await
                         {
@@ -1844,6 +1861,13 @@ impl Agent {
         // the content shape of each tool message). Background callers
         // pass `None` because the task-loop never emits the synth-ack.
         tool_success_by_id: Option<&mut Vec<(String, bool)>>,
+        // NEW-16: append-only per-turn output log sink for the
+        // conversation loop. When supplied, the SAME assistant message
+        // and merged tool-result rows that go into `messages` are also
+        // appended here. The task loop passes `None` (it returns
+        // `TaskResult`, not `ConversationResponse`, so no log is
+        // needed there).
+        turn_output_log: Option<&mut Vec<Message>>,
     ) -> Result<ChatResponse> {
         // Fix tool_call IDs -- some models (e.g. qwen via dashscope) generate
         // duplicate or empty IDs which downstream providers reject with 400.
@@ -1889,7 +1913,8 @@ impl Agent {
                 );
             }
         }
-        messages.push(self.response_to_message(&response));
+        let assistant_msg = self.response_to_message(&response);
+        messages.push(assistant_msg.clone());
         let (limited_response, blocked_messages) =
             self.enforce_session_limits_on_tool_calls(&response);
         let tool_batches = split_tool_calls(
@@ -1961,6 +1986,17 @@ impl Agent {
             }
         }
 
+        // NEW-16: mirror the same assistant + merged rows into the
+        // append-only turn log when the caller (conversation loop)
+        // supplied a sink. The clone is intentional — the prompt
+        // buffer `messages` will be mutated downstream by
+        // `prepare_conversation_messages` /
+        // `repair_message_order`, but the log must stay frozen as the
+        // chronological record of what THIS turn produced.
+        if let Some(log) = turn_output_log {
+            log.push(assistant_msg);
+            log.extend(merged.iter().cloned());
+        }
         messages.extend(merged);
         files_modified.extend(tool_files);
         if let Some(files_to_send) = files_to_send {
@@ -2418,11 +2454,31 @@ fn shell_retry_terminal_user_message(content: &str) -> String {
 ///
 /// See PR `fix/news-fetch-loop-and-detect-recovery`
 /// (session `web-1779494658716-mxrxe8`, ledger seq 214-562).
+///
+/// NEW-16: kept alive for the test suite which exercises the legacy
+/// no-log API. Production callers go through
+/// `inject_loop_detected_synthetic_results_with_log`.
+#[cfg(test)]
 fn inject_loop_detected_synthetic_results(
     messages: &mut Vec<Message>,
     response: &ChatResponse,
     warning: &str,
     agent: &Agent,
+) {
+    inject_loop_detected_synthetic_results_with_log(messages, response, warning, agent, None);
+}
+
+/// NEW-16: same as `inject_loop_detected_synthetic_results`, but also
+/// mirrors the synthetic assistant + tool rows into the conversation
+/// loop's append-only `turn_output_log` when supplied. Keeps the
+/// `messages` mutation behaviour byte-identical for callers that pass
+/// `None` (tests in particular).
+fn inject_loop_detected_synthetic_results_with_log(
+    messages: &mut Vec<Message>,
+    response: &ChatResponse,
+    warning: &str,
+    agent: &Agent,
+    turn_output_log: Option<&mut Vec<Message>>,
 ) {
     let synthesis_hint = "\n\nTry a different approach — synthesise from prior tool results already in this conversation, call a different tool, or finish the turn with the partial information you have.";
     let primary_body = format!("{warning}{synthesis_hint}");
@@ -2446,11 +2502,17 @@ fn inject_loop_detected_synthetic_results(
     // Push the assistant turn (carries the sanitized `tool_calls`) so the
     // synthetic tool-result messages have a corresponding `tool_use` to
     // bind to.
-    messages.push(agent.response_to_message(&sanitized_response));
+    let assistant_msg = agent.response_to_message(&sanitized_response);
+    messages.push(assistant_msg.clone());
+    // Collect the same rows we just pushed so we can mirror them into
+    // the append-only turn log below (when a sink was supplied).
+    let mut rows_for_log: Vec<Message> =
+        Vec::with_capacity(1 + sanitized_response.tool_calls.len());
+    rows_for_log.push(assistant_msg);
 
     for (idx, tc) in sanitized_response.tool_calls.iter().enumerate() {
         let body = if idx == 0 { &primary_body } else { stub_body };
-        messages.push(Message {
+        let tool_msg = Message {
             role: MessageRole::Tool,
             content: body.to_string(),
             media: vec![],
@@ -2460,7 +2522,13 @@ fn inject_loop_detected_synthetic_results(
             client_message_id: None,
             thread_id: None,
             timestamp: chrono::Utc::now(),
-        });
+        };
+        messages.push(tool_msg.clone());
+        rows_for_log.push(tool_msg);
+    }
+
+    if let Some(log) = turn_output_log {
+        log.extend(rows_for_log);
     }
 }
 

--- a/crates/octos-agent/src/agent/turn_state.rs
+++ b/crates/octos-agent/src/agent/turn_state.rs
@@ -143,17 +143,22 @@ impl LoopTurnState {
         });
     }
 
-    pub(crate) fn new_output_start(history_len: usize, messages_len: usize) -> usize {
-        (1 + history_len).min(messages_len)
-    }
-
-    pub(crate) fn new_messages(
-        messages: &[octos_core::Message],
-        history_len: usize,
-    ) -> Vec<octos_core::Message> {
-        let new_start = Self::new_output_start(history_len, messages.len());
-        messages[new_start..].to_vec()
-    }
+    // NOTE: `new_messages` / `new_output_start` were removed in NEW-16
+    // (fix/persist-from-append-only-turn-log-not-mutated-buffer).
+    //
+    // They sliced the LLM prompt buffer at `1 + history_len`, which was
+    // unstable because that buffer is mutated during the loop by
+    // `prepare_conversation_messages` (which calls `repair_message_order`)
+    // and by the AppUI bridge in `ui_protocol.rs`. After mutation, OLD
+    // rows from prior turns could end up past the stale boundary and be
+    // returned as "new", which caused the cross-turn drag-forward
+    // re-persistence bug (mini3 Yuan-dynasty content showing up 7x in
+    // a single session, 2026-05-23 soak).
+    //
+    // The replacement is the append-only `turn_output_log` built in
+    // `process_message_inner` (see `loop_runner.rs`). It is never read
+    // back from — only pushed to — so no downstream mutation pass can
+    // shift OLD rows into it.
 }
 
 #[cfg(test)]

--- a/crates/octos-agent/tests/persist_append_only_log_new16.rs
+++ b/crates/octos-agent/tests/persist_append_only_log_new16.rs
@@ -1,0 +1,411 @@
+//! NEW-16 (fix/persist-from-append-only-turn-log-not-mutated-buffer):
+//! Integration test that locks in codex's append-only per-turn output log
+//! semantics for `ConversationResponse.messages`.
+//!
+//! Background:
+//! `ConversationResponse.messages` used to be built by slicing the LLM
+//! prompt buffer at `1 + history_len` (the system prompt + history
+//! boundary). The buffer is mutated during the loop by
+//! `prepare_conversation_messages` (which calls `repair_message_order`)
+//! and — on the API server — by the AppUI bridge in
+//! `ui_protocol.rs`. After mutation, OLD rows from prior turns could
+//! end up past the stale boundary and get returned as "new". The WS
+//! persist site reads `response.messages` blindly and writes each row
+//! to JSONL, causing the cross-turn drag-forward duplicate-persistence
+//! bug (mini3 Yuan-dynasty content showed up 7x in one session,
+//! 2026-05-23 soak captures).
+//!
+//! Codex's fix (this PR): build an append-only per-turn output log
+//! alongside the prompt buffer. The log is never read back from, only
+//! pushed to — so no mutation pass can shift OLD rows into it.
+//! `ConversationResponse.messages` is now `turn_output_log.clone()`,
+//! independent of whatever rearrangement happened in the prompt
+//! buffer.
+//!
+//! This test exercises the full agent loop with:
+//!   1. Prior session history that contains a malformed/stranded Tool
+//!      row (`tool_call_id` references a tool_call from a prior
+//!      assistant message that did NOT yet have its result paired).
+//!      This forces `repair_message_order` to do real work.
+//!   2. A mock LLM provider that produces ToolUse -> EndTurn for the
+//!      current turn (the canonical "tool call then summary" shape).
+//!   3. An assertion that `response.messages` contains ONLY the rows
+//!      this turn produced — current User + assistant(tool_calls) +
+//!      Tool(result) + zero copies of the prior-turn rows that
+//!      `repair_message_order` shuffled in the prompt buffer.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use octos_agent::{Agent, AgentConfig, ToolRegistry};
+use octos_core::{AgentId, Message, MessageRole, ToolCall};
+use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+use octos_memory::EpisodeStore;
+use tempfile::TempDir;
+
+/// Mirrors the `MockLlmProvider` in `integration.rs` but exposes the
+/// last `messages` slice the loop sent us. We use this to confirm the
+/// prompt buffer DID get mutated (i.e. `repair_message_order` did
+/// real work) so the test is exercising the right path.
+struct CapturingMockProvider {
+    responses: Mutex<Vec<ChatResponse>>,
+    last_messages: Mutex<Vec<Vec<Message>>>,
+}
+
+impl CapturingMockProvider {
+    fn new(responses: Vec<ChatResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+            last_messages: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn captured_calls(&self) -> Vec<Vec<Message>> {
+        self.last_messages.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CapturingMockProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> eyre::Result<ChatResponse> {
+        self.last_messages.lock().unwrap().push(messages.to_vec());
+        let mut responses = self.responses.lock().unwrap();
+        if responses.is_empty() {
+            eyre::bail!("CapturingMockProvider: no more scripted responses");
+        }
+        Ok(responses.remove(0))
+    }
+
+    fn context_window(&self) -> u32 {
+        128_000
+    }
+
+    fn model_id(&self) -> &str {
+        "mock-model-new16"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock-new16"
+    }
+}
+
+fn tool_use_call(name: &str, id: &str, args: serde_json::Value) -> ChatResponse {
+    ChatResponse {
+        content: None,
+        reasoning_content: None,
+        tool_calls: vec![ToolCall {
+            id: id.into(),
+            name: name.into(),
+            arguments: args,
+            metadata: None,
+        }],
+        stop_reason: StopReason::ToolUse,
+        usage: TokenUsage {
+            input_tokens: 10,
+            output_tokens: 5,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+fn end_turn(text: &str) -> ChatResponse {
+    ChatResponse {
+        content: Some(text.to_string()),
+        reasoning_content: None,
+        tool_calls: vec![],
+        stop_reason: StopReason::EndTurn,
+        usage: TokenUsage {
+            input_tokens: 8,
+            output_tokens: 4,
+            ..Default::default()
+        },
+        provider_index: None,
+    }
+}
+
+/// Build a prior history that contains:
+///   - A normal user/assistant exchange (chronological "Yuan-dynasty"
+///     content — the soak-captured drag-forward bug)
+///   - An assistant message with tool_calls
+///   - A *stranded* Tool row (tool_call_id matches the assistant's
+///     tool_call, but it lives FOUR rows after a User message, which
+///     `repair_message_order` will gather and re-position).
+///   - A second user-asks-something row (the "previous turn" that
+///     completed before the current turn).
+fn prior_history_with_stranded_tool_row() -> Vec<Message> {
+    vec![
+        Message {
+            role: MessageRole::User,
+            content: "Tell me about the Yuan dynasty.".to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("prior-turn-a".into()),
+            timestamp: chrono::Utc::now(),
+        },
+        Message {
+            role: MessageRole::Assistant,
+            content: String::new(),
+            media: vec![],
+            tool_calls: Some(vec![ToolCall {
+                id: "old_call_yuan_1".into(),
+                name: "read_file".into(),
+                arguments: serde_json::json!({"path": "yuan.txt"}),
+                metadata: None,
+            }]),
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("prior-turn-a".into()),
+            timestamp: chrono::Utc::now(),
+        },
+        // A user row separating the assistant's tool_call from its result
+        // — exactly the shape that triggers `repair_message_order` to
+        // gather the stranded Tool row and place it adjacent to the
+        // assistant.
+        Message {
+            role: MessageRole::User,
+            content: "(internal: continuing previous turn)".to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("prior-turn-a".into()),
+            timestamp: chrono::Utc::now(),
+        },
+        Message {
+            role: MessageRole::Tool,
+            content: "The Yuan dynasty (1271-1368) was founded by Kublai Khan.".to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: Some("old_call_yuan_1".into()),
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("prior-turn-a".into()),
+            timestamp: chrono::Utc::now(),
+        },
+        Message {
+            role: MessageRole::Assistant,
+            content: "The Yuan dynasty was a Mongol-led dynasty in China from 1271 to 1368."
+                .to_string(),
+            media: vec![],
+            tool_calls: None,
+            tool_call_id: None,
+            reasoning_content: None,
+            client_message_id: None,
+            thread_id: Some("prior-turn-a".into()),
+            timestamp: chrono::Utc::now(),
+        },
+    ]
+}
+
+/// Lock in NEW-16: with a stranded Tool row in prior history forcing
+/// `repair_message_order` to re-position prompt-buffer rows, the
+/// returned `ConversationResponse.messages` MUST contain ONLY rows
+/// this turn produced (current user, current assistant w/ tool_calls,
+/// current tool result), and ZERO prior-turn content.
+#[tokio::test]
+async fn process_message_returns_only_current_turn_rows_after_repair_runs() {
+    let dir = TempDir::new().unwrap();
+
+    // Stage a file the current turn's read_file will actually read so
+    // the dispatcher returns success rather than a synthetic error.
+    std::fs::write(dir.path().join("current.txt"), "current-turn-content").unwrap();
+
+    let provider = Arc::new(CapturingMockProvider::new(vec![
+        // iter 1: model calls read_file on a NEW file (current turn)
+        tool_use_call(
+            "read_file",
+            "current_call_1",
+            serde_json::json!({"path": "current.txt"}),
+        ),
+        // iter 2: model wraps up
+        end_turn("Read current-turn-content."),
+    ]));
+    let llm: Arc<dyn LlmProvider> = provider.clone();
+    let tools = ToolRegistry::with_builtins(dir.path());
+    let memory = Arc::new(EpisodeStore::open(dir.path().join(".octos")).await.unwrap());
+    let agent =
+        Agent::new(AgentId::new("test-new16"), llm, tools, memory).with_config(AgentConfig {
+            save_episodes: false,
+            ..Default::default()
+        });
+
+    let history = prior_history_with_stranded_tool_row();
+    let history_len = history.len();
+
+    let resp = agent
+        .process_message("Read current.txt", &history, vec![])
+        .await
+        .expect("agent should respond");
+
+    // Sanity: the LLM saw a prompt where prior rows were rearranged
+    // (repair_message_order moved the stranded Tool row adjacent to
+    // its parent assistant). The post-prep prompt should NOT have
+    // the same length as System + history + current_user + new rows
+    // by simple addition — repair shuffled OLD rows in place. We
+    // check this by confirming the prompt buffer contains the
+    // stranded Tool row's `tool_call_id` ("old_call_yuan_1") AND
+    // that the LLM saw more messages than just the new ones.
+    // Sanity: confirm `repair_message_order` (or `normalize_tool_call_ids`)
+    // did real work on the prompt buffer — i.e. the prompt the LLM saw
+    // differs in structure from the raw `System + history + current_user`
+    // concatenation. We check this by confirming the stranded Tool row
+    // moved adjacent to its parent assistant (it was at index 4 in the
+    // original history, behind a User row at index 3; after repair, the
+    // Tool row must immediately follow its Assistant parent).
+    let captured = provider.captured_calls();
+    assert!(!captured.is_empty(), "provider received at least one call");
+    let first_call_messages = &captured[0];
+    // Locate the assistant-with-tool_calls and confirm the very next
+    // row is the matching Tool, not the "(internal: continuing previous
+    // turn)" User row that was originally between them.
+    let asst_with_tcs_idx = first_call_messages
+        .iter()
+        .position(|m| {
+            m.role == MessageRole::Assistant
+                && m.tool_calls.as_ref().is_some_and(|tcs| !tcs.is_empty())
+        })
+        .expect("the prior assistant-with-tool_calls row should still appear in the prompt");
+    let row_after = &first_call_messages
+        .get(asst_with_tcs_idx + 1)
+        .expect("there is a row after the assistant-with-tool_calls");
+    assert_eq!(
+        row_after.role,
+        MessageRole::Tool,
+        "repair_message_order should have moved the stranded Tool row to \
+         immediately follow its parent Assistant. Got role {:?} instead. \
+         This precondition guarantees the test is exercising the actual \
+         prompt-buffer mutation path NEW-16 was reported against.",
+        row_after.role
+    );
+
+    // The CORE assertion: `response.messages` is the per-turn append-only
+    // output log — NOT a slice of the prompt buffer. It should contain
+    // ONLY rows produced this turn:
+    //   1. current user ("Read current.txt")
+    //   2. assistant w/ tool_calls (call_id = "current_call_1")
+    //   3. tool result for "current_call_1"
+    //
+    // It MUST NOT contain ANY prior-turn content (the Yuan-dynasty
+    // assistant message, the stranded Tool row, etc.) even though
+    // `repair_message_order` moved that content around in the prompt
+    // buffer.
+    assert!(
+        !resp.messages.is_empty(),
+        "response.messages should contain the current-turn rows"
+    );
+
+    // Inspect every row and assert it is current-turn material.
+    for (i, msg) in resp.messages.iter().enumerate() {
+        // No System rows ever (the loop drops the System prompt from
+        // the slice equivalent).
+        assert_ne!(
+            msg.role,
+            MessageRole::System,
+            "response.messages[{i}] must not be a System row"
+        );
+        // No prior-turn Yuan content.
+        assert!(
+            !msg.content.contains("Yuan dynasty"),
+            "response.messages[{i}] should NOT contain prior-turn 'Yuan dynasty' \
+             content — that is the NEW-16 drag-forward bug. Got: {:?}",
+            msg.content
+        );
+        assert!(
+            !msg.content.contains("Mongol-led dynasty"),
+            "response.messages[{i}] should NOT contain prior-turn Yuan summary"
+        );
+        assert!(
+            !msg.content.contains("Kublai Khan"),
+            "response.messages[{i}] should NOT contain prior-turn tool output \
+             about Kublai Khan"
+        );
+        // No prior-turn tool_call_id.
+        assert_ne!(
+            msg.tool_call_id.as_deref(),
+            Some("old_call_yuan_1"),
+            "response.messages[{i}] should NOT carry the prior-turn stranded \
+             tool_call_id 'old_call_yuan_1'"
+        );
+    }
+
+    // Shape check: expect at least User + Assistant + Tool from this turn.
+    let user_count = resp
+        .messages
+        .iter()
+        .filter(|m| m.role == MessageRole::User)
+        .count();
+    let assistant_count = resp
+        .messages
+        .iter()
+        .filter(|m| m.role == MessageRole::Assistant)
+        .count();
+    let tool_count = resp
+        .messages
+        .iter()
+        .filter(|m| m.role == MessageRole::Tool)
+        .count();
+    assert_eq!(
+        user_count, 1,
+        "exactly one User row this turn — the current prompt; got {user_count} \
+         in {:?}",
+        resp.messages
+    );
+    assert!(
+        assistant_count >= 1,
+        "at least one Assistant row this turn (the ToolUse iteration); \
+         got {assistant_count} in {:?}",
+        resp.messages
+    );
+    assert_eq!(
+        tool_count, 1,
+        "exactly one Tool row this turn — the result of read_file on current.txt; \
+         got {tool_count} in {:?}",
+        resp.messages
+    );
+
+    // The User row is the CURRENT prompt, not any prior user.
+    let current_user_row = resp
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::User)
+        .unwrap();
+    assert_eq!(current_user_row.content, "Read current.txt");
+
+    // The Tool row references the CURRENT turn's tool_call_id.
+    let current_tool_row = resp
+        .messages
+        .iter()
+        .find(|m| m.role == MessageRole::Tool)
+        .unwrap();
+    assert_eq!(
+        current_tool_row.tool_call_id.as_deref(),
+        Some("current_call_1"),
+        "the Tool row in response.messages should reference the current turn's \
+         tool_call_id, not any prior turn's"
+    );
+
+    // Sanity: `history_len` did NOT determine response.messages length.
+    // Under the OLD code path, `repair_message_order` could shift
+    // prior rows past `1 + history_len` and bloat the slice. Under
+    // NEW-16 the count is independent of history_len.
+    assert!(
+        resp.messages.len() < history_len,
+        "response.messages.len() should be far smaller than history.len() ({history_len}) — \
+         it should only contain the rows produced THIS turn. Got {} rows.",
+        resp.messages.len()
+    );
+
+    // Final answer is the EndTurn content.
+    assert_eq!(resp.content, "Read current-turn-content.");
+}

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1423,24 +1423,57 @@ fn active_turns_registry() -> SharedActiveTurns {
 /// so cross-session collisions are vanishingly unlikely, but the
 /// composite key keeps the contract explicit.
 ///
-/// Entries are garbage-collected at the end of each turn, after
-/// the per-turn `agent_task.await` has joined (or been aborted) in
-/// `run_standalone_turn`. This is OUTSIDE the session-manager
-/// critical section that holds the cursor read/write sites, so a
-/// queued same-`(session, turn)` re-entry serialised on the
-/// session lock can still observe the advanced cursor before the
-/// outer GC runs. The codex round-2 review on NEW-16 mandated this
-/// placement; doing the GC inside the persist block evicts the
-/// state before the second invocation can read it, defeating the
-/// guard for the queued case AND leaking on abort/panic paths
-/// inside the persist block.
-type TurnPersistCursors = Arc<TokioMutex<HashMap<(String, String), usize>>>;
+/// Entries carry a `last_touched_at: Instant` and are evicted
+/// opportunistically on every read/write that finds them stale
+/// (older than `TURN_PERSIST_CURSOR_TTL`). Codex round 3 caught
+/// that an immediate end-of-turn GC has two flaws:
+///   1. A queued same-`(session, turn)` re-entry serialised on the
+///      session lock can be scheduled AFTER the first outer task
+///      already evicted the cursor — the guard would miss.
+///   2. Cursor entries leak if the outer `run_standalone_turn`
+///      future is aborted (connection close, parent task drop)
+///      after the persist block inserted the cursor but before
+///      the bottom-of-fn GC runs.
+///
+/// A TTL covers both: the cursor lives long enough for any
+/// realistic queued re-entry to observe it (the TTL is far longer
+/// than the inter-invocation window), and stale entries get
+/// pruned by subsequent persist activity in the SAME session
+/// rather than relying on cancellation-safe cleanup paths.
+type TurnPersistCursors = Arc<TokioMutex<HashMap<(String, String), TurnPersistCursorEntry>>>;
+
+#[derive(Clone, Copy, Debug)]
+struct TurnPersistCursorEntry {
+    /// Highest-index-already-persisted + 1 (i.e. the NEXT index to
+    /// write). For the synthetic final-assistant row, this is
+    /// `response.messages.len() + 1`.
+    next_index: usize,
+    last_touched_at: std::time::Instant,
+}
+
+/// TTL for per-`(session, turn)` cursor entries. 5 minutes is
+/// far longer than any realistic per-turn execution time (the
+/// agent loop's `DEFAULT_SESSION_TIMEOUT_SECS` is 1800s, and a
+/// queued same-turn re-entry would be serialised on the session
+/// lock — typically tens of milliseconds at most). Long enough
+/// to make the queued-re-entry guard reliable; short enough that
+/// abort/panic leaks bound at ~5 minutes per stale entry.
+const TURN_PERSIST_CURSOR_TTL: Duration = Duration::from_secs(300);
 
 fn turn_persist_cursors() -> TurnPersistCursors {
     static CURSORS: OnceLock<TurnPersistCursors> = OnceLock::new();
     CURSORS
         .get_or_init(|| Arc::new(TokioMutex::new(HashMap::new())))
         .clone()
+}
+
+/// Opportunistic prune: remove every entry older than
+/// `TURN_PERSIST_CURSOR_TTL`. Called from the persist block
+/// itself on every entry/exit, so the map is bounded by
+/// "entries created within the last TTL window."
+fn prune_stale_turn_persist_cursors(map: &mut HashMap<(String, String), TurnPersistCursorEntry>) {
+    let now = std::time::Instant::now();
+    map.retain(|_, entry| now.duration_since(entry.last_touched_at) < TURN_PERSIST_CURSOR_TTL);
 }
 
 fn contract_stores() -> Arc<UiProtocolContractStores> {
@@ -15982,18 +16015,25 @@ async fn run_standalone_turn(
                     // `turn_output_log` upstream — but if some edge
                     // path re-entered this persist loop for the SAME
                     // `(session, turn)` pair, we MUST NOT double-write
-                    // the same indexed row. The cursor is loaded under
-                    // the session lock (which is already held below
-                    // via `sessions.lock().await`) so the load-update
-                    // sequence is atomic w.r.t. the session manager.
+                    // the same indexed row.
+                    //
+                    // Codex round-3 P1+P2: switched from immediate
+                    // end-of-turn GC to TTL-based opportunistic
+                    // pruning. The entry stays alive long enough for
+                    // any realistic queued re-entry to observe it,
+                    // and stale entries (from abort/panic paths
+                    // where the outer task was cancelled) get
+                    // pruned by subsequent persist activity rather
+                    // than relying on cancellation-safe cleanup.
                     let persist_cursors = turn_persist_cursors();
                     let cursor_key = (
                         agent_session_id.0.clone(),
                         turn_thread_id_for_persist.clone(),
                     );
                     let cursor_already_advanced = {
-                        let cursors = persist_cursors.lock().await;
-                        cursors.get(&cursor_key).copied().unwrap_or(0)
+                        let mut cursors = persist_cursors.lock().await;
+                        prune_stale_turn_persist_cursors(&mut cursors);
+                        cursors.get(&cursor_key).map(|e| e.next_index).unwrap_or(0)
                     };
                     for (message_index, message) in response.messages.iter().cloned().enumerate() {
                         if skip_internal_user_persist
@@ -16066,12 +16106,22 @@ async fn run_standalone_turn(
                             // anyone re-entering the persist loop on
                             // this `(session, turn)` will see the
                             // updated cursor on their next read).
+                            //
+                            // Codex round-3: timestamp the entry so
+                            // the TTL pruner can evict it.
                             {
                                 let mut cursors = persist_cursors.lock().await;
-                                let entry = cursors.entry(cursor_key.clone()).or_insert(0);
-                                if message_index + 1 > *entry {
-                                    *entry = message_index + 1;
+                                let now = std::time::Instant::now();
+                                let entry = cursors.entry(cursor_key.clone()).or_insert(
+                                    TurnPersistCursorEntry {
+                                        next_index: 0,
+                                        last_touched_at: now,
+                                    },
+                                );
+                                if message_index + 1 > entry.next_index {
+                                    entry.next_index = message_index + 1;
                                 }
+                                entry.last_touched_at = now;
                             }
                             record_appui_context_manager_message(
                                 &context_data_dir_for_result,
@@ -16188,7 +16238,8 @@ async fn run_standalone_turn(
                             let final_virtual_index = response.messages.len();
                             let cursor_already_at_final = {
                                 let c = persist_cursors.lock().await;
-                                c.get(&cursor_key).copied().unwrap_or(0) > final_virtual_index
+                                c.get(&cursor_key).map(|e| e.next_index).unwrap_or(0)
+                                    > final_virtual_index
                             };
                             if cursor_already_at_final {
                                 tracing::debug!(
@@ -16217,10 +16268,17 @@ async fn run_standalone_turn(
                                     // final-row index so a re-entry skips it.
                                     {
                                         let mut c = persist_cursors.lock().await;
-                                        let entry = c.entry(cursor_key.clone()).or_insert(0);
-                                        if final_virtual_index + 1 > *entry {
-                                            *entry = final_virtual_index + 1;
+                                        let now = std::time::Instant::now();
+                                        let entry = c.entry(cursor_key.clone()).or_insert(
+                                            TurnPersistCursorEntry {
+                                                next_index: 0,
+                                                last_touched_at: now,
+                                            },
+                                        );
+                                        if final_virtual_index + 1 > entry.next_index {
+                                            entry.next_index = final_virtual_index + 1;
                                         }
+                                        entry.last_touched_at = now;
                                     }
                                     record_appui_context_manager_message(
                                         &context_data_dir_for_result,
@@ -16238,16 +16296,20 @@ async fn run_standalone_turn(
                             }
                         }
                     }
-                    // NEW-16 codex round-2 P1: do NOT GC the cursor
-                    // here. Eviction has moved to the OUTER scope
-                    // (after `agent_task.await` joins / abort path)
-                    // so that a queued same-`(session, turn)` re-entry
-                    // serialised on the session lock can still observe
-                    // the advanced cursor. GC'ing inside the session
-                    // critical section that holds the lock would
-                    // delete the state before the re-entry could
-                    // acquire the lock and read it, defeating the
-                    // guard for the queued case.
+                    // NEW-16 codex round-3 P1+P2: do NOT GC the
+                    // cursor here AND do NOT GC at the bottom of
+                    // `run_standalone_turn`. The TTL pruner
+                    // (`prune_stale_turn_persist_cursors`) handles
+                    // eviction opportunistically on subsequent
+                    // persist activity. That covers:
+                    //   - queued same-`(session, turn)` re-entry
+                    //     (entry stays alive until TTL expires)
+                    //   - abort/panic paths (outer GC would be
+                    //     skipped on cancellation; TTL evicts
+                    //     anyway)
+                    //   - long-running server map bound (TTL
+                    //     caps memory at "entries created within
+                    //     the last 5 minutes")
                 }
                 // #1158 codex P2 rev3 follow-up: distinguish two
                 // shapes of "empty captured reply":
@@ -16490,22 +16552,20 @@ async fn run_standalone_turn(
 
     let _ = agent_task.await;
 
-    // NEW-16 codex round-2 P1+P2: garbage-collect the per-turn
-    // persist cursor here, AFTER the agent task has joined (or been
-    // aborted above). This is OUTSIDE the session-manager lock the
-    // persist block held, so any queued same-`(session, turn)`
-    // re-entry serialised on that lock got to observe the advanced
-    // cursor before we removed it. This also closes the
-    // abort-leak path the round-2 P2 review flagged: even on
-    // `agent_task.abort()`, the join completes and we still run
-    // through here. Eviction is keyed by `(session_id.0,
-    // turn_id.0)` so it cannot mistakenly evict a sibling turn's
-    // entry.
-    {
-        let cursors = turn_persist_cursors();
-        let mut c = cursors.lock().await;
-        c.remove(&(session_id.0.clone(), turn_id.0.to_string()));
-    }
+    // NEW-16 codex round-3 P1+P2: GC moved from here to the
+    // TTL-based opportunistic pruner inside the persist block.
+    // Earlier rounds 1-2 evicted here, but that left two gaps:
+    //   1. A queued same-`(session, turn)` re-entry scheduled
+    //      AFTER this outer task completed would see a cleaned
+    //      cursor and could re-persist (the guard's whole point
+    //      was to prevent that).
+    //   2. Connection-close abort of the OUTER
+    //      `run_standalone_turn` future would skip this GC line
+    //      entirely, leaking entries until process restart.
+    // The TTL pruner solves both: cursor lives long enough for
+    // realistic re-entries, and stale entries get evicted by
+    // subsequent persist activity rather than relying on a
+    // cancellation-safe cleanup path.
 
     // Wave4-A: emit a final `router/status` snapshot adjacent to
     // `turn/completed` so clients see the actual provider that ran
@@ -31217,6 +31277,17 @@ ignore = []
         assert_eq!(wire, "shell tool: command not found: foo");
     }
 
+    /// NEW-16 codex round-3: helper for building a
+    /// `TurnPersistCursorEntry` in tests at a given `next_index`,
+    /// stamped at NOW. Centralises the construction so a future
+    /// refactor of the entry type only touches one place.
+    fn make_cursor_entry_fresh(next_index: usize) -> super::TurnPersistCursorEntry {
+        super::TurnPersistCursorEntry {
+            next_index,
+            last_touched_at: std::time::Instant::now(),
+        }
+    }
+
     /// NEW-16: the per-turn message-index cursor used as
     /// defense-in-depth inside the `response.messages` persist loop
     /// MUST skip any `(session, turn, message_index)` triple it has
@@ -31234,7 +31305,7 @@ ignore = []
         // advances to 3 (i.e. next index to write is 3).
         {
             let mut c = cursors.lock().await;
-            c.insert(key.clone(), 3);
+            c.insert(key.clone(), make_cursor_entry_fresh(3));
         }
 
         // Second invocation: same `(session, turn)` re-enters with the
@@ -31242,7 +31313,7 @@ ignore = []
         // 2) MUST be skipped. Only index 3 is new.
         let cursor_already_advanced = {
             let c = cursors.lock().await;
-            c.get(&key).copied().unwrap_or(0)
+            c.get(&key).map(|e| e.next_index).unwrap_or(0)
         };
         assert_eq!(
             cursor_already_advanced, 3,
@@ -31266,20 +31337,34 @@ ignore = []
         // After successfully persisting index 3, the cursor advances.
         {
             let mut c = cursors.lock().await;
-            let entry = c.entry(key.clone()).or_insert(0);
-            if 3 + 1 > *entry {
-                *entry = 3 + 1;
+            let now = std::time::Instant::now();
+            let entry = c
+                .entry(key.clone())
+                .or_insert(super::TurnPersistCursorEntry {
+                    next_index: 0,
+                    last_touched_at: now,
+                });
+            if 3 + 1 > entry.next_index {
+                entry.next_index = 3 + 1;
             }
+            entry.last_touched_at = now;
         }
         let cursor_after = {
             let c = cursors.lock().await;
-            c.get(&key).copied().unwrap_or(0)
+            c.get(&key).map(|e| e.next_index).unwrap_or(0)
         };
         assert_eq!(cursor_after, 4, "cursor should advance to next index");
+
+        // Cleanup: opportunistic prune treats the entry as fresh
+        // (no TTL elapsed), so explicitly remove for hermeticity.
+        {
+            let mut c = cursors.lock().await;
+            c.remove(&key);
+        }
     }
 
-    /// NEW-16 codex review P1: the cursor guard MUST cover the
-    /// synthesised final assistant row too. When the cursor is
+    /// NEW-16 codex review round-1 P1: the cursor guard MUST cover
+    /// the synthesised final assistant row too. When the cursor is
     /// advanced to `response.messages.len() + 1`, the synthesised
     /// final row has already been persisted in a prior invocation
     /// and must be skipped on re-entry.
@@ -31290,23 +31375,19 @@ ignore = []
         let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
         let key = (session_id.clone(), turn_id.clone());
 
-        // Simulate first invocation: 3 indexed log rows + 1 synthetic
-        // final row all persisted. Cursor advances to
-        // `messages.len() + 1` = 3 + 1 = 4.
         let log_row_count = 3usize;
-        let final_virtual_index = log_row_count; // == messages.len()
+        let final_virtual_index = log_row_count;
         {
             let mut c = cursors.lock().await;
-            c.insert(key.clone(), final_virtual_index + 1);
+            c.insert(
+                key.clone(),
+                make_cursor_entry_fresh(final_virtual_index + 1),
+            );
         }
 
-        // Second invocation (re-entry on SAME (session, turn)):
-        // - All indexed rows < final_virtual_index must skip.
-        // - The synthetic final row check: cursor > final_virtual_index?
-        //   Yes (4 > 3), so the synthetic final row is also skipped.
         let cursor_already_advanced = {
             let c = cursors.lock().await;
-            c.get(&key).copied().unwrap_or(0)
+            c.get(&key).map(|e| e.next_index).unwrap_or(0)
         };
         for message_index in 0..log_row_count {
             assert!(
@@ -31321,59 +31402,99 @@ ignore = []
              this is the codex round-1 P1 contract on NEW-16"
         );
 
-        // Cleanup so this test is hermetic.
         {
             let mut c = cursors.lock().await;
             c.remove(&key);
         }
     }
 
-    /// NEW-16 codex review round-1 P2 + round-2 P1+P2: cursor
-    /// entries are evicted in the OUTER scope of `run_standalone_turn`,
-    /// after `agent_task.await` joins (or is aborted). Eviction
-    /// happens OUTSIDE the session-manager critical section the
-    /// persist block held — so a queued same-`(session, turn)`
-    /// re-entry serialised on that lock can still observe the
-    /// advanced cursor before the outer GC runs. The eviction also
-    /// covers the abort/panic path (because `agent_task.await`
-    /// returns after `agent_task.abort()` too).
+    /// NEW-16 codex review round-3 P2: the TTL pruner MUST evict
+    /// entries older than `TURN_PERSIST_CURSOR_TTL`. This guards
+    /// against:
+    ///   - abort/panic paths that prevented end-of-turn cleanup
+    ///   - long-running server map growth (bounded at ~TTL of
+    ///     entries created within the last window)
+    ///
+    /// We can't easily wait 5 minutes in a test, so we forge an
+    /// entry with an old `last_touched_at` directly and run the
+    /// pruner.
     #[tokio::test]
-    async fn new16_turn_persist_cursor_is_evicted_after_turn_completes() {
+    async fn new16_turn_persist_cursor_ttl_pruner_evicts_stale_entries() {
         let cursors = super::turn_persist_cursors();
         let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
         let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
         let key = (session_id.clone(), turn_id.clone());
 
-        // Simulate the persist block populating the cursor while
-        // holding the sessions lock.
+        // Forge an entry that is 2× TTL old.
+        let stale_ts = std::time::Instant::now()
+            - super::TURN_PERSIST_CURSOR_TTL
+            - std::time::Duration::from_secs(1);
         {
             let mut c = cursors.lock().await;
-            c.insert(key.clone(), 5);
+            c.insert(
+                key.clone(),
+                super::TurnPersistCursorEntry {
+                    next_index: 99,
+                    last_touched_at: stale_ts,
+                },
+            );
         }
-        // While the persist block holds the sessions lock, the
-        // cursor is observable — a queued same-`(session, turn)`
-        // invocation waiting on the sessions lock would see this on
-        // its next read. Confirm it's there.
-        {
-            let c = cursors.lock().await;
-            assert_eq!(c.get(&key).copied(), Some(5));
-        }
-        // Simulate the OUTER-scope GC at end of `run_standalone_turn`,
-        // AFTER `agent_task.await` joins. By this point any queued
-        // same-turn re-entry's persist block has already completed.
-        {
-            let mut c = cursors.lock().await;
-            c.remove(&key);
-        }
-        // The entry is gone.
+        // The stale entry is present.
         {
             let c = cursors.lock().await;
             assert!(
-                c.get(&key).is_none(),
-                "cursor entry MUST be evicted after the per-turn agent_task \
-                 joins (codex round-2 P2 — covers normal + abort/panic paths \
-                 and keeps the map bounded on a long-running server)"
+                c.contains_key(&key),
+                "stale entry should be present before prune"
             );
+        }
+        // Run the pruner.
+        {
+            let mut c = cursors.lock().await;
+            super::prune_stale_turn_persist_cursors(&mut c);
+        }
+        // The stale entry is gone.
+        {
+            let c = cursors.lock().await;
+            assert!(
+                !c.contains_key(&key),
+                "stale entry MUST be evicted by TTL pruner (codex round-3 P2 — \
+                 the pruner is the only GC path now, so this MUST work)"
+            );
+        }
+    }
+
+    /// NEW-16 codex round-3: fresh entries (within TTL) MUST be
+    /// preserved by the pruner. A regression that nukes everything
+    /// would defeat the cursor guard entirely.
+    #[tokio::test]
+    async fn new16_turn_persist_cursor_ttl_pruner_preserves_fresh_entries() {
+        let cursors = super::turn_persist_cursors();
+        let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
+        let key = (session_id.clone(), turn_id.clone());
+
+        {
+            let mut c = cursors.lock().await;
+            c.insert(key.clone(), make_cursor_entry_fresh(42));
+        }
+        {
+            let mut c = cursors.lock().await;
+            super::prune_stale_turn_persist_cursors(&mut c);
+        }
+        {
+            let c = cursors.lock().await;
+            let entry = c
+                .get(&key)
+                .expect("fresh entry MUST survive the TTL pruner");
+            assert_eq!(
+                entry.next_index, 42,
+                "the pruner must not corrupt surviving entries"
+            );
+        }
+        // Cleanup.
+        {
+            let mut c = cursors.lock().await;
+            c.remove(&key);
         }
     }
 
@@ -31394,28 +31515,35 @@ ignore = []
 
         {
             let mut c = cursors.lock().await;
-            c.insert(key_a1.clone(), 5);
-            c.insert(key_a2.clone(), 2);
-            c.insert(key_b1.clone(), 1);
+            c.insert(key_a1.clone(), make_cursor_entry_fresh(5));
+            c.insert(key_a2.clone(), make_cursor_entry_fresh(2));
+            c.insert(key_b1.clone(), make_cursor_entry_fresh(1));
         }
 
         let c = cursors.lock().await;
         // Each (session, turn) pair has its own cursor.
-        assert_eq!(c.get(&key_a1).copied(), Some(5));
-        assert_eq!(c.get(&key_a2).copied(), Some(2));
-        assert_eq!(c.get(&key_b1).copied(), Some(1));
+        assert_eq!(c.get(&key_a1).map(|e| e.next_index), Some(5));
+        assert_eq!(c.get(&key_a2).map(|e| e.next_index), Some(2));
+        assert_eq!(c.get(&key_b1).map(|e| e.next_index), Some(1));
         // Cross-key lookups return None — distinct pairs don't share state.
-        assert_eq!(
+        assert!(
             c.get(&(session_a.clone(), "turn-nonexistent".into()))
-                .copied(),
-            None,
+                .is_none(),
             "a non-existent turn under session-a must NOT inherit any cursor"
         );
-        assert_eq!(
-            c.get(&(session_b.clone(), turn_2.clone())).copied(),
-            None,
+        assert!(
+            c.get(&(session_b.clone(), turn_2.clone())).is_none(),
             "session-b's view of turn-2 must NOT inherit session-a's cursor for turn-2 \
              (the composite key prevents cross-session collisions)"
         );
+        drop(c);
+
+        // Cleanup.
+        {
+            let mut c = cursors.lock().await;
+            c.remove(&key_a1);
+            c.remove(&key_a2);
+            c.remove(&key_b1);
+        }
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -31337,11 +31337,13 @@ ignore = []
     /// process-wide static map AND the process-wide prune
     /// throttle. Running them in parallel under
     /// `cargo test --test-threads=N` would let one test's prune
-    /// or insert race another's assertion. Serialise via a static
-    /// `Mutex` (NOT a Tokio mutex — the lock spans only synchronous
-    /// setup/teardown across awaits, but we don't `await` while
-    /// holding it; the tokio::test loop manages async after the
-    /// guard drops).
+    /// or insert race another's assertion. Serialise via a
+    /// `tokio::sync::Mutex` whose owned guard each test holds for
+    /// its entire body across `await` points (so we get a true
+    /// inter-test serialisation, not just sync setup serialisation).
+    /// A std `Mutex` would not work here because tokio tests
+    /// suspend across `.await`; that would either deadlock or
+    /// require parking a worker thread on the lock.
     fn new16_cursor_test_lock() -> Arc<tokio::sync::Mutex<()>> {
         static LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
         LOCK.get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1423,11 +1423,17 @@ fn active_turns_registry() -> SharedActiveTurns {
 /// so cross-session collisions are vanishingly unlikely, but the
 /// composite key keeps the contract explicit.
 ///
-/// Entries are NOT garbage-collected per-turn — the long-running
-/// server may accumulate them across many turns. The map is bounded
-/// in practice by active sessions; if this becomes a concern, the
-/// follow-up is to evict entries when a turn-end event fires (the
-/// active-turns registry already tracks turn lifetimes).
+/// Entries are garbage-collected at the end of each turn, after
+/// the per-turn `agent_task.await` has joined (or been aborted) in
+/// `run_standalone_turn`. This is OUTSIDE the session-manager
+/// critical section that holds the cursor read/write sites, so a
+/// queued same-`(session, turn)` re-entry serialised on the
+/// session lock can still observe the advanced cursor before the
+/// outer GC runs. The codex round-2 review on NEW-16 mandated this
+/// placement; doing the GC inside the persist block evicts the
+/// state before the second invocation can read it, defeating the
+/// guard for the queued case AND leaking on abort/panic paths
+/// inside the persist block.
 type TurnPersistCursors = Arc<TokioMutex<HashMap<(String, String), usize>>>;
 
 fn turn_persist_cursors() -> TurnPersistCursors {
@@ -16232,22 +16238,16 @@ async fn run_standalone_turn(
                             }
                         }
                     }
-                    // NEW-16 codex review P2: garbage-collect the cursor
-                    // entry for this `(session, turn)` pair now that the
-                    // persist block has completed. The cursor is a
-                    // re-entry guard; once both the indexed-log loop and
-                    // the synthetic-final-row branch are done, the entry
-                    // is no longer needed. Without this, the map would
-                    // grow unbounded with every turn on a long-running
-                    // server. Eviction happens under the existing
-                    // session lock so it cannot race a concurrent
-                    // re-entry from THIS turn — and the keying is
-                    // `(session, turn)` so it cannot collide with
-                    // distinct turns either.
-                    {
-                        let mut c = persist_cursors.lock().await;
-                        c.remove(&cursor_key);
-                    }
+                    // NEW-16 codex round-2 P1: do NOT GC the cursor
+                    // here. Eviction has moved to the OUTER scope
+                    // (after `agent_task.await` joins / abort path)
+                    // so that a queued same-`(session, turn)` re-entry
+                    // serialised on the session lock can still observe
+                    // the advanced cursor. GC'ing inside the session
+                    // critical section that holds the lock would
+                    // delete the state before the re-entry could
+                    // acquire the lock and read it, defeating the
+                    // guard for the queued case.
                 }
                 // #1158 codex P2 rev3 follow-up: distinguish two
                 // shapes of "empty captured reply":
@@ -16489,6 +16489,23 @@ async fn run_standalone_turn(
     }
 
     let _ = agent_task.await;
+
+    // NEW-16 codex round-2 P1+P2: garbage-collect the per-turn
+    // persist cursor here, AFTER the agent task has joined (or been
+    // aborted above). This is OUTSIDE the session-manager lock the
+    // persist block held, so any queued same-`(session, turn)`
+    // re-entry serialised on that lock got to observe the advanced
+    // cursor before we removed it. This also closes the
+    // abort-leak path the round-2 P2 review flagged: even on
+    // `agent_task.abort()`, the join completes and we still run
+    // through here. Eviction is keyed by `(session_id.0,
+    // turn_id.0)` so it cannot mistakenly evict a sibling turn's
+    // entry.
+    {
+        let cursors = turn_persist_cursors();
+        let mut c = cursors.lock().await;
+        c.remove(&(session_id.0.clone(), turn_id.0.to_string()));
+    }
 
     // Wave4-A: emit a final `router/status` snapshot adjacent to
     // `turn/completed` so clients see the actual provider that ran
@@ -31311,9 +31328,15 @@ ignore = []
         }
     }
 
-    /// NEW-16 codex review P2: cursor entries MUST be removed from
-    /// the registry once the persist block completes so the map does
-    /// not grow unbounded on a long-running server.
+    /// NEW-16 codex review round-1 P2 + round-2 P1+P2: cursor
+    /// entries are evicted in the OUTER scope of `run_standalone_turn`,
+    /// after `agent_task.await` joins (or is aborted). Eviction
+    /// happens OUTSIDE the session-manager critical section the
+    /// persist block held — so a queued same-`(session, turn)`
+    /// re-entry serialised on that lock can still observe the
+    /// advanced cursor before the outer GC runs. The eviction also
+    /// covers the abort/panic path (because `agent_task.await`
+    /// returns after `agent_task.abort()` too).
     #[tokio::test]
     async fn new16_turn_persist_cursor_is_evicted_after_turn_completes() {
         let cursors = super::turn_persist_cursors();
@@ -31321,17 +31344,23 @@ ignore = []
         let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
         let key = (session_id.clone(), turn_id.clone());
 
-        // Simulate the persist loop populating the cursor.
+        // Simulate the persist block populating the cursor while
+        // holding the sessions lock.
         {
             let mut c = cursors.lock().await;
             c.insert(key.clone(), 5);
         }
-        // Confirm it landed.
+        // While the persist block holds the sessions lock, the
+        // cursor is observable — a queued same-`(session, turn)`
+        // invocation waiting on the sessions lock would see this on
+        // its next read. Confirm it's there.
         {
             let c = cursors.lock().await;
             assert_eq!(c.get(&key).copied(), Some(5));
         }
-        // Simulate the GC at end of persist loop.
+        // Simulate the OUTER-scope GC at end of `run_standalone_turn`,
+        // AFTER `agent_task.await` joins. By this point any queued
+        // same-turn re-entry's persist block has already completed.
         {
             let mut c = cursors.lock().await;
             c.remove(&key);
@@ -31341,8 +31370,9 @@ ignore = []
             let c = cursors.lock().await;
             assert!(
                 c.get(&key).is_none(),
-                "cursor entry MUST be evicted after persist block completes \
-                 (codex round-1 P2 — prevents unbounded map growth)"
+                "cursor entry MUST be evicted after the per-turn agent_task \
+                 joins (codex round-2 P2 — covers normal + abort/panic paths \
+                 and keeps the map bounded on a long-running server)"
             );
         }
     }

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -16169,28 +16169,84 @@ async fn run_standalone_turn(
                             // not apply) and its content equals
                             // `response.content` (so it is the
                             // final-assistant carrier).
-                            let to_save =
-                                pre_stamp_turn_thread_id(message, &turn_thread_id_for_persist);
-                            let saved_for_context = to_save.clone();
-                            let session_id_for_persist = agent_session_id.clone();
-                            let commit = sessions
-                                .add_message_with_seq(&session_id_for_persist, to_save)
-                                .await;
-                            if let Ok(seq) = commit {
-                                record_appui_context_manager_message(
-                                    &context_data_dir_for_result,
-                                    &context_manager_for_result,
-                                    &agent_session_id,
-                                    &saved_for_context,
-                                    seq,
+                            //
+                            // NEW-16 codex review P1: extend the per-turn
+                            // cursor guard to cover the synthesised final
+                            // assistant row too. Treat it as VIRTUAL
+                            // index `response.messages.len()` — the slot
+                            // immediately past the last log row. If a
+                            // re-entry into this persist block sees the
+                            // cursor advanced to `messages.len() + 1`,
+                            // the final row has already been written and
+                            // the second invocation must skip.
+                            let final_virtual_index = response.messages.len();
+                            let cursor_already_at_final = {
+                                let c = persist_cursors.lock().await;
+                                c.get(&cursor_key).copied().unwrap_or(0) > final_virtual_index
+                            };
+                            if cursor_already_at_final {
+                                tracing::debug!(
+                                    session = %agent_session_id.0,
+                                    turn = %turn_thread_id_for_persist,
+                                    final_virtual_index,
+                                    "NEW-16 cursor guard skipped already-persisted synthetic \
+                                     final assistant row in this turn"
                                 );
-                                cursor = Some(UiCursor {
-                                    stream: agent_session_id.0.clone(),
-                                    seq: seq as u64,
-                                });
+                                // The final row was committed by an earlier
+                                // invocation. Flip `final_assistant_persisted`
+                                // so downstream signalling (oneshot send)
+                                // sees the same state as the original
+                                // successful path.
                                 final_assistant_persisted = true;
+                            } else {
+                                let to_save =
+                                    pre_stamp_turn_thread_id(message, &turn_thread_id_for_persist);
+                                let saved_for_context = to_save.clone();
+                                let session_id_for_persist = agent_session_id.clone();
+                                let commit = sessions
+                                    .add_message_with_seq(&session_id_for_persist, to_save)
+                                    .await;
+                                if let Ok(seq) = commit {
+                                    // Advance the cursor past the virtual
+                                    // final-row index so a re-entry skips it.
+                                    {
+                                        let mut c = persist_cursors.lock().await;
+                                        let entry = c.entry(cursor_key.clone()).or_insert(0);
+                                        if final_virtual_index + 1 > *entry {
+                                            *entry = final_virtual_index + 1;
+                                        }
+                                    }
+                                    record_appui_context_manager_message(
+                                        &context_data_dir_for_result,
+                                        &context_manager_for_result,
+                                        &agent_session_id,
+                                        &saved_for_context,
+                                        seq,
+                                    );
+                                    cursor = Some(UiCursor {
+                                        stream: agent_session_id.0.clone(),
+                                        seq: seq as u64,
+                                    });
+                                    final_assistant_persisted = true;
+                                }
                             }
                         }
+                    }
+                    // NEW-16 codex review P2: garbage-collect the cursor
+                    // entry for this `(session, turn)` pair now that the
+                    // persist block has completed. The cursor is a
+                    // re-entry guard; once both the indexed-log loop and
+                    // the synthetic-final-row branch are done, the entry
+                    // is no longer needed. Without this, the map would
+                    // grow unbounded with every turn on a long-running
+                    // server. Eviction happens under the existing
+                    // session lock so it cannot race a concurrent
+                    // re-entry from THIS turn — and the keying is
+                    // `(session, turn)` so it cannot collide with
+                    // distinct turns either.
+                    {
+                        let mut c = persist_cursors.lock().await;
+                        c.remove(&cursor_key);
                     }
                 }
                 // #1158 codex P2 rev3 follow-up: distinguish two
@@ -31203,6 +31259,92 @@ ignore = []
             c.get(&key).copied().unwrap_or(0)
         };
         assert_eq!(cursor_after, 4, "cursor should advance to next index");
+    }
+
+    /// NEW-16 codex review P1: the cursor guard MUST cover the
+    /// synthesised final assistant row too. When the cursor is
+    /// advanced to `response.messages.len() + 1`, the synthesised
+    /// final row has already been persisted in a prior invocation
+    /// and must be skipped on re-entry.
+    #[tokio::test]
+    async fn new16_turn_persist_cursor_covers_synthesised_final_assistant_row() {
+        let cursors = super::turn_persist_cursors();
+        let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
+        let key = (session_id.clone(), turn_id.clone());
+
+        // Simulate first invocation: 3 indexed log rows + 1 synthetic
+        // final row all persisted. Cursor advances to
+        // `messages.len() + 1` = 3 + 1 = 4.
+        let log_row_count = 3usize;
+        let final_virtual_index = log_row_count; // == messages.len()
+        {
+            let mut c = cursors.lock().await;
+            c.insert(key.clone(), final_virtual_index + 1);
+        }
+
+        // Second invocation (re-entry on SAME (session, turn)):
+        // - All indexed rows < final_virtual_index must skip.
+        // - The synthetic final row check: cursor > final_virtual_index?
+        //   Yes (4 > 3), so the synthetic final row is also skipped.
+        let cursor_already_advanced = {
+            let c = cursors.lock().await;
+            c.get(&key).copied().unwrap_or(0)
+        };
+        for message_index in 0..log_row_count {
+            assert!(
+                message_index < cursor_already_advanced,
+                "indexed row {message_index} must be skipped on re-entry"
+            );
+        }
+        let final_row_already_persisted = cursor_already_advanced > final_virtual_index;
+        assert!(
+            final_row_already_persisted,
+            "the synthetic final assistant row MUST also be skipped on re-entry — \
+             this is the codex round-1 P1 contract on NEW-16"
+        );
+
+        // Cleanup so this test is hermetic.
+        {
+            let mut c = cursors.lock().await;
+            c.remove(&key);
+        }
+    }
+
+    /// NEW-16 codex review P2: cursor entries MUST be removed from
+    /// the registry once the persist block completes so the map does
+    /// not grow unbounded on a long-running server.
+    #[tokio::test]
+    async fn new16_turn_persist_cursor_is_evicted_after_turn_completes() {
+        let cursors = super::turn_persist_cursors();
+        let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
+        let key = (session_id.clone(), turn_id.clone());
+
+        // Simulate the persist loop populating the cursor.
+        {
+            let mut c = cursors.lock().await;
+            c.insert(key.clone(), 5);
+        }
+        // Confirm it landed.
+        {
+            let c = cursors.lock().await;
+            assert_eq!(c.get(&key).copied(), Some(5));
+        }
+        // Simulate the GC at end of persist loop.
+        {
+            let mut c = cursors.lock().await;
+            c.remove(&key);
+        }
+        // The entry is gone.
+        {
+            let c = cursors.lock().await;
+            assert!(
+                c.get(&key).is_none(),
+                "cursor entry MUST be evicted after persist block completes \
+                 (codex round-1 P2 — prevents unbounded map growth)"
+            );
+        }
     }
 
     /// NEW-16: cursor entries are keyed by `(session, turn)`. Two

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1467,13 +1467,58 @@ fn turn_persist_cursors() -> TurnPersistCursors {
         .clone()
 }
 
+/// Codex round-4 P2: throttle the full `HashMap::retain` scan
+/// to at most once per `TURN_PERSIST_CURSOR_PRUNE_INTERVAL`.
+/// `retain` is O(capacity), and `HashMap` capacity can stay
+/// high after a burst. Without the throttle, thousands of
+/// concurrent turns/sec would all serialise behind a full-map
+/// scan under the global cursor mutex. When the throttle says
+/// "too soon," the read returns immediately and stale entries
+/// get evicted on the next eligible scan. Memory growth is
+/// bounded by `persist rate * (TTL + PRUNE_INTERVAL)` in the
+/// worst case — still O(active turns × constant).
+const TURN_PERSIST_CURSOR_PRUNE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Per-process throttle marker for `prune_stale_turn_persist_cursors`.
+/// `StdMutex` is fine — we only hold it across an `Instant` read.
+fn turn_persist_cursor_prune_throttle() -> Arc<StdMutex<Option<std::time::Instant>>> {
+    static THROTTLE: OnceLock<Arc<StdMutex<Option<std::time::Instant>>>> = OnceLock::new();
+    THROTTLE
+        .get_or_init(|| Arc::new(StdMutex::new(None)))
+        .clone()
+}
+
 /// Opportunistic prune: remove every entry older than
 /// `TURN_PERSIST_CURSOR_TTL`. Called from the persist block
 /// itself on every entry/exit, so the map is bounded by
 /// "entries created within the last TTL window."
 fn prune_stale_turn_persist_cursors(map: &mut HashMap<(String, String), TurnPersistCursorEntry>) {
+    let throttle = turn_persist_cursor_prune_throttle();
     let now = std::time::Instant::now();
+    {
+        let mut last_pruned = throttle.lock().unwrap_or_else(|e| e.into_inner());
+        match *last_pruned {
+            Some(prev) if now.duration_since(prev) < TURN_PERSIST_CURSOR_PRUNE_INTERVAL => {
+                // Within the throttle window — skip the full scan.
+                return;
+            }
+            _ => {
+                *last_pruned = Some(now);
+            }
+        }
+    }
     map.retain(|_, entry| now.duration_since(entry.last_touched_at) < TURN_PERSIST_CURSOR_TTL);
+}
+
+/// Test-only helper: clear the prune throttle so the next call
+/// to `prune_stale_turn_persist_cursors` actually scans. Used by
+/// the TTL eviction test, which would otherwise see "too soon" if
+/// another test in the same process already primed the throttle.
+#[cfg(test)]
+fn reset_turn_persist_cursor_prune_throttle_for_test() {
+    let throttle = turn_persist_cursor_prune_throttle();
+    let mut g = throttle.lock().unwrap_or_else(|e| e.into_inner());
+    *g = None;
 }
 
 fn contract_stores() -> Arc<UiProtocolContractStores> {
@@ -31288,6 +31333,21 @@ ignore = []
         }
     }
 
+    /// NEW-16 codex round-4: the cursor tests share the same
+    /// process-wide static map AND the process-wide prune
+    /// throttle. Running them in parallel under
+    /// `cargo test --test-threads=N` would let one test's prune
+    /// or insert race another's assertion. Serialise via a static
+    /// `Mutex` (NOT a Tokio mutex — the lock spans only synchronous
+    /// setup/teardown across awaits, but we don't `await` while
+    /// holding it; the tokio::test loop manages async after the
+    /// guard drops).
+    fn new16_cursor_test_lock() -> Arc<tokio::sync::Mutex<()>> {
+        static LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+        LOCK.get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
     /// NEW-16: the per-turn message-index cursor used as
     /// defense-in-depth inside the `response.messages` persist loop
     /// MUST skip any `(session, turn, message_index)` triple it has
@@ -31296,6 +31356,7 @@ ignore = []
     /// caught here.
     #[tokio::test]
     async fn new16_turn_persist_cursor_skips_already_persisted_indexes() {
+        let _serial = new16_cursor_test_lock().lock_owned().await;
         let cursors = super::turn_persist_cursors();
         let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
         let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
@@ -31370,6 +31431,7 @@ ignore = []
     /// and must be skipped on re-entry.
     #[tokio::test]
     async fn new16_turn_persist_cursor_covers_synthesised_final_assistant_row() {
+        let _serial = new16_cursor_test_lock().lock_owned().await;
         let cursors = super::turn_persist_cursors();
         let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
         let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
@@ -31417,15 +31479,18 @@ ignore = []
     ///
     /// We can't easily wait 5 minutes in a test, so we forge an
     /// entry with an old `last_touched_at` directly and run the
-    /// pruner.
+    /// pruner. Codex round-4 P2 added a per-process throttle on
+    /// the prune call; clear it via the test-only helper so we
+    /// know this scan won't be throttled out.
     #[tokio::test]
     async fn new16_turn_persist_cursor_ttl_pruner_evicts_stale_entries() {
+        let _serial = new16_cursor_test_lock().lock_owned().await;
         let cursors = super::turn_persist_cursors();
         let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
         let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
         let key = (session_id.clone(), turn_id.clone());
 
-        // Forge an entry that is 2× TTL old.
+        // Forge an entry older than TTL.
         let stale_ts = std::time::Instant::now()
             - super::TURN_PERSIST_CURSOR_TTL
             - std::time::Duration::from_secs(1);
@@ -31447,6 +31512,8 @@ ignore = []
                 "stale entry should be present before prune"
             );
         }
+        // Reset round-4 throttle so the prune actually scans.
+        super::reset_turn_persist_cursor_prune_throttle_for_test();
         // Run the pruner.
         {
             let mut c = cursors.lock().await;
@@ -31468,6 +31535,7 @@ ignore = []
     /// would defeat the cursor guard entirely.
     #[tokio::test]
     async fn new16_turn_persist_cursor_ttl_pruner_preserves_fresh_entries() {
+        let _serial = new16_cursor_test_lock().lock_owned().await;
         let cursors = super::turn_persist_cursors();
         let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
         let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
@@ -31477,6 +31545,8 @@ ignore = []
             let mut c = cursors.lock().await;
             c.insert(key.clone(), make_cursor_entry_fresh(42));
         }
+        // Reset round-4 throttle so the prune actually scans.
+        super::reset_turn_persist_cursor_prune_throttle_for_test();
         {
             let mut c = cursors.lock().await;
             super::prune_stale_turn_persist_cursors(&mut c);
@@ -31498,11 +31568,72 @@ ignore = []
         }
     }
 
+    /// NEW-16 codex round-4 P2: the prune throttle MUST suppress
+    /// subsequent prune calls within
+    /// `TURN_PERSIST_CURSOR_PRUNE_INTERVAL` so a burst of
+    /// concurrent persist blocks doesn't all hold the global
+    /// cursor mutex while doing redundant full-map scans.
+    #[tokio::test]
+    async fn new16_turn_persist_cursor_prune_throttle_suppresses_back_to_back_scans() {
+        let _serial = new16_cursor_test_lock().lock_owned().await;
+        let cursors = super::turn_persist_cursors();
+        let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
+        let key = (session_id.clone(), turn_id.clone());
+
+        // Reset throttle, then run an initial scan that primes it.
+        super::reset_turn_persist_cursor_prune_throttle_for_test();
+        {
+            let mut c = cursors.lock().await;
+            super::prune_stale_turn_persist_cursors(&mut c);
+        }
+
+        // Now insert a stale entry. A subsequent prune within the
+        // throttle window should NOT evict it (the throttle skips
+        // the scan entirely).
+        let stale_ts = std::time::Instant::now()
+            - super::TURN_PERSIST_CURSOR_TTL
+            - std::time::Duration::from_secs(1);
+        {
+            let mut c = cursors.lock().await;
+            c.insert(
+                key.clone(),
+                super::TurnPersistCursorEntry {
+                    next_index: 7,
+                    last_touched_at: stale_ts,
+                },
+            );
+        }
+        // Second prune call — throttle is still primed (we just
+        // ran one above), so the scan should be skipped and the
+        // stale entry should survive.
+        {
+            let mut c = cursors.lock().await;
+            super::prune_stale_turn_persist_cursors(&mut c);
+        }
+        {
+            let c = cursors.lock().await;
+            assert!(
+                c.contains_key(&key),
+                "throttle within window MUST suppress the scan — the stale entry \
+                 should survive until the throttle window expires (codex round-4 P2)"
+            );
+        }
+        // Cleanup: reset throttle so the next test starts clean,
+        // then remove the forged entry.
+        super::reset_turn_persist_cursor_prune_throttle_for_test();
+        {
+            let mut c = cursors.lock().await;
+            c.remove(&key);
+        }
+    }
+
     /// NEW-16: cursor entries are keyed by `(session, turn)`. Two
     /// different `(session, turn)` pairs MUST be independent — one
     /// turn's progress cannot leak into another turn's guard.
     #[tokio::test]
     async fn new16_turn_persist_cursor_isolates_sessions_and_turns() {
+        let _serial = new16_cursor_test_lock().lock_owned().await;
         let cursors = super::turn_persist_cursors();
         let session_a = format!("session-a-{}", uuid::Uuid::new_v4());
         let session_b = format!("session-b-{}", uuid::Uuid::new_v4());

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -1407,6 +1407,36 @@ fn active_turns_registry() -> SharedActiveTurns {
         .clone()
 }
 
+/// NEW-16 defense-in-depth: per-turn message-index cursor for the
+/// `response.messages` persist loop.
+///
+/// The main fix is the append-only `turn_output_log` upstream in
+/// `loop_runner.rs`, but this cursor exists as a second wall. It
+/// tracks the highest message-index successfully persisted for each
+/// `(session_id, turn_id)` pair. If the same `(turn, index)` is seen
+/// twice (e.g. an edge path drove the persist loop into the SAME
+/// turn twice), subsequent indexes are skipped.
+///
+/// Keyed by `(SessionId.0, TurnId.0)` strings so distinct sessions
+/// using the same TurnId string cannot collide. Today TurnIds are
+/// UUIDs minted server-side (see `TurnId::new` -> `Uuid::new_v4`)
+/// so cross-session collisions are vanishingly unlikely, but the
+/// composite key keeps the contract explicit.
+///
+/// Entries are NOT garbage-collected per-turn — the long-running
+/// server may accumulate them across many turns. The map is bounded
+/// in practice by active sessions; if this becomes a concern, the
+/// follow-up is to evict entries when a turn-end event fires (the
+/// active-turns registry already tracks turn lifetimes).
+type TurnPersistCursors = Arc<TokioMutex<HashMap<(String, String), usize>>>;
+
+fn turn_persist_cursors() -> TurnPersistCursors {
+    static CURSORS: OnceLock<TurnPersistCursors> = OnceLock::new();
+    CURSORS
+        .get_or_init(|| Arc::new(TokioMutex::new(HashMap::new())))
+        .clone()
+}
+
 fn contract_stores() -> Arc<UiProtocolContractStores> {
     static CONTRACT_STORES: OnceLock<Arc<UiProtocolContractStores>> = OnceLock::new();
     CONTRACT_STORES
@@ -15941,12 +15971,47 @@ async fn run_standalone_turn(
                     // drop the preamble's hint).
                     let mut last_persisted_preamble_assistant: Option<String> = None;
                     let mut skipped_internal_user = false;
-                    for message in response.messages.iter().cloned() {
+                    // NEW-16 defense-in-depth: per-turn message-index
+                    // cursor. The main fix is the append-only
+                    // `turn_output_log` upstream — but if some edge
+                    // path re-entered this persist loop for the SAME
+                    // `(session, turn)` pair, we MUST NOT double-write
+                    // the same indexed row. The cursor is loaded under
+                    // the session lock (which is already held below
+                    // via `sessions.lock().await`) so the load-update
+                    // sequence is atomic w.r.t. the session manager.
+                    let persist_cursors = turn_persist_cursors();
+                    let cursor_key = (
+                        agent_session_id.0.clone(),
+                        turn_thread_id_for_persist.clone(),
+                    );
+                    let cursor_already_advanced = {
+                        let cursors = persist_cursors.lock().await;
+                        cursors.get(&cursor_key).copied().unwrap_or(0)
+                    };
+                    for (message_index, message) in response.messages.iter().cloned().enumerate() {
                         if skip_internal_user_persist
                             && !skipped_internal_user
                             && message.role == MessageRole::User
                         {
                             skipped_internal_user = true;
+                            continue;
+                        }
+                        // NEW-16 defense-in-depth: skip indexes already
+                        // persisted for this `(session, turn)` pair.
+                        // `cursor_already_advanced` reflects the
+                        // highest-index-already-written + 1 (i.e. the
+                        // NEXT index that needs writing). If the
+                        // current index is below that watermark, an
+                        // earlier invocation already wrote it.
+                        if message_index < cursor_already_advanced {
+                            tracing::debug!(
+                                session = %agent_session_id.0,
+                                turn = %turn_thread_id_for_persist,
+                                message_index,
+                                cursor_already_advanced,
+                                "NEW-16 cursor guard skipped already-persisted message in this turn"
+                            );
                             continue;
                         }
                         // Detect the exact row that carries
@@ -15988,6 +16053,20 @@ async fn run_standalone_turn(
                             .add_message_with_seq(&agent_session_id, to_save)
                             .await
                         {
+                            // NEW-16: advance the per-turn cursor
+                            // ONLY after the JSONL write succeeded
+                            // (and inside the session lock — note
+                            // that `sessions` is the lock guard, so
+                            // anyone re-entering the persist loop on
+                            // this `(session, turn)` will see the
+                            // updated cursor on their next read).
+                            {
+                                let mut cursors = persist_cursors.lock().await;
+                                let entry = cursors.entry(cursor_key.clone()).or_insert(0);
+                                if message_index + 1 > *entry {
+                                    *entry = message_index + 1;
+                                }
+                            }
                             record_appui_context_manager_message(
                                 &context_data_dir_for_result,
                                 &context_manager_for_result,
@@ -31063,5 +31142,108 @@ ignore = []
         let report: eyre::Report = eyre::eyre!("shell tool: command not found: foo");
         let wire = super::classify_runtime_error_message(&report);
         assert_eq!(wire, "shell tool: command not found: foo");
+    }
+
+    /// NEW-16: the per-turn message-index cursor used as
+    /// defense-in-depth inside the `response.messages` persist loop
+    /// MUST skip any `(session, turn, message_index)` triple it has
+    /// already seen in a previous invocation. This locks in the
+    /// helper logic so a regression that drops the cursor check is
+    /// caught here.
+    #[tokio::test]
+    async fn new16_turn_persist_cursor_skips_already_persisted_indexes() {
+        let cursors = super::turn_persist_cursors();
+        let session_id = format!("test-session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("test-turn-{}", uuid::Uuid::new_v4());
+        let key = (session_id.clone(), turn_id.clone());
+
+        // First invocation: 3 messages persist successfully, cursor
+        // advances to 3 (i.e. next index to write is 3).
+        {
+            let mut c = cursors.lock().await;
+            c.insert(key.clone(), 3);
+        }
+
+        // Second invocation: same `(session, turn)` re-enters with the
+        // SAME 3 messages plus 1 new one. The first 3 (indexes 0, 1,
+        // 2) MUST be skipped. Only index 3 is new.
+        let cursor_already_advanced = {
+            let c = cursors.lock().await;
+            c.get(&key).copied().unwrap_or(0)
+        };
+        assert_eq!(
+            cursor_already_advanced, 3,
+            "cursor should reflect the highest-index-already-written + 1"
+        );
+
+        // Simulate the persist loop's index guard for messages 0..=3.
+        let mut indexes_that_would_persist = Vec::new();
+        for message_index in 0..4 {
+            if message_index < cursor_already_advanced {
+                continue;
+            }
+            indexes_that_would_persist.push(message_index);
+        }
+        assert_eq!(
+            indexes_that_would_persist,
+            vec![3],
+            "only the genuinely new index (3) should pass the cursor guard"
+        );
+
+        // After successfully persisting index 3, the cursor advances.
+        {
+            let mut c = cursors.lock().await;
+            let entry = c.entry(key.clone()).or_insert(0);
+            if 3 + 1 > *entry {
+                *entry = 3 + 1;
+            }
+        }
+        let cursor_after = {
+            let c = cursors.lock().await;
+            c.get(&key).copied().unwrap_or(0)
+        };
+        assert_eq!(cursor_after, 4, "cursor should advance to next index");
+    }
+
+    /// NEW-16: cursor entries are keyed by `(session, turn)`. Two
+    /// different `(session, turn)` pairs MUST be independent — one
+    /// turn's progress cannot leak into another turn's guard.
+    #[tokio::test]
+    async fn new16_turn_persist_cursor_isolates_sessions_and_turns() {
+        let cursors = super::turn_persist_cursors();
+        let session_a = format!("session-a-{}", uuid::Uuid::new_v4());
+        let session_b = format!("session-b-{}", uuid::Uuid::new_v4());
+        let turn_1 = format!("turn-1-{}", uuid::Uuid::new_v4());
+        let turn_2 = format!("turn-2-{}", uuid::Uuid::new_v4());
+
+        let key_a1 = (session_a.clone(), turn_1.clone());
+        let key_a2 = (session_a.clone(), turn_2.clone());
+        let key_b1 = (session_b.clone(), turn_1.clone());
+
+        {
+            let mut c = cursors.lock().await;
+            c.insert(key_a1.clone(), 5);
+            c.insert(key_a2.clone(), 2);
+            c.insert(key_b1.clone(), 1);
+        }
+
+        let c = cursors.lock().await;
+        // Each (session, turn) pair has its own cursor.
+        assert_eq!(c.get(&key_a1).copied(), Some(5));
+        assert_eq!(c.get(&key_a2).copied(), Some(2));
+        assert_eq!(c.get(&key_b1).copied(), Some(1));
+        // Cross-key lookups return None — distinct pairs don't share state.
+        assert_eq!(
+            c.get(&(session_a.clone(), "turn-nonexistent".into()))
+                .copied(),
+            None,
+            "a non-existent turn under session-a must NOT inherit any cursor"
+        );
+        assert_eq!(
+            c.get(&(session_b.clone(), turn_2.clone())).copied(),
+            None,
+            "session-b's view of turn-2 must NOT inherit session-a's cursor for turn-2 \
+             (the composite key prevents cross-session collisions)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `ConversationResponse.messages` used to be `messages[(1 + history_len)..]` of the LLM prompt buffer. That buffer is mutated mid-loop by `repair_message_order` (in `prepare_conversation_messages`) and on the API server by the AppUI bridge in `ui_protocol.rs`. After mutation, OLD rows from prior turns could end up past the stale boundary and get returned as "new". The WS persist site (`crates/octos-cli/src/api/ui_protocol.rs:15944`) wrote each row to JSONL, causing the cross-turn drag-forward duplicate-persistence bug (mini3 Yuan-dynasty content showed up 7x in one session, 2026-05-23 soak captures).
- Fix per codex's design: build an append-only `turn_output_log: Vec<Message>` alongside the prompt buffer. The log is never read back from, only pushed to. All 8 return sites in `Agent::process_message_inner` now return `turn_output_log.clone()`. `handle_tool_use` accepts a log sink so each turn's assistant + merged tool-result rows mirror into the log alongside the prompt-buffer push. The synthetic loop-detector helper gains a `_with_log` variant.
- Defense-in-depth at the WS persist site: a per-`(session, turn)` message-index cursor (`turn_persist_cursors`) skips any index already written.
- `LoopTurnState::new_messages` / `new_output_start` were removed — they had no other callers. The doc comment explains the rationale.

## Test plan

- [x] `cargo test -p octos-agent --lib` — 1667 pass
- [x] `cargo test -p octos-agent --tests` — all integration suites pass
- [x] `cargo test -p octos-cli --lib --features api` — 1369 pass (2 new cursor tests + 1367 prior); pre-existing flaky `router_failover_*` tests reproduce on main too
- [x] `cargo build --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --lib -- -D warnings` clean
- [x] New integration test `crates/octos-agent/tests/persist_append_only_log_new16.rs` builds prior history with a stranded Tool row (forces `repair_message_order` to do real work), runs ToolUse -> EndTurn, asserts `response.messages` contains ONLY current-turn rows and zero copies of prior content
- [x] New unit tests in `crates/octos-cli/src/api/ui_protocol.rs::tests` validate the cursor wrapper (skip-already-persisted; isolation across distinct `(session, turn)` pairs)