### PR TITLE
feat(dashboard): show admin bot profiles

### DIFF
--- a/dashboard/src/pages/AdminBotPage.test.tsx
+++ b/dashboard/src/pages/AdminBotPage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import AdminBotPage from './AdminBotPage'
+import type { ProfileResponse } from '../types'
+
+const mockMonitorStatus = vi.fn()
+const mockListProfiles = vi.fn()
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    api: {
+      monitorStatus: () => mockMonitorStatus(),
+      listProfiles: () => mockListProfiles(),
+      toggleWatchdog: vi.fn(),
+      toggleAlerts: vi.fn(),
+    },
+  }
+})
+
+function profile(overrides: Partial<ProfileResponse>): ProfileResponse {
+  return {
+    id: 'profile-1',
+    name: 'Profile 1',
+    enabled: true,
+    data_dir: null,
+    public_subdomain: null,
+    config: {
+      channels: [],
+      gateway: {},
+      env_vars: {},
+      admin_mode: false,
+    },
+    created_at: '2026-05-24T00:00:00Z',
+    updated_at: '2026-05-24T00:00:00Z',
+    status: {
+      running: false,
+      pid: null,
+      started_at: null,
+      uptime_secs: null,
+    },
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminBotPage />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockMonitorStatus.mockReset()
+  mockListProfiles.mockReset()
+  mockMonitorStatus.mockResolvedValue({ watchdog_enabled: false, alerts_enabled: false })
+})
+
+describe('AdminBotPage', () => {
+  it('lists admin-mode profiles with status and the active admin inline', async () => {
+    mockListProfiles.mockResolvedValue([
+      profile({
+        id: 'root-admin',
+        name: 'Root Admin',
+        config: { channels: [], gateway: {}, env_vars: {}, admin_mode: true },
+        status: { running: true, pid: 42, started_at: '2026-05-24T01:00:00Z', uptime_secs: 120 },
+      }),
+      profile({
+        id: 'backup-admin',
+        name: 'Backup Admin',
+        config: { channels: [], gateway: {}, env_vars: {}, admin_mode: true },
+      }),
+      profile({
+        id: 'normal-user',
+        name: 'Normal User',
+        config: { channels: [], gateway: {}, env_vars: {}, admin_mode: false },
+        status: { running: true, pid: 43, started_at: '2026-05-24T01:00:00Z', uptime_secs: 120 },
+      }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText(/active admin:/i)).toHaveTextContent('Root Admin'))
+    expect(screen.getAllByText('Root Admin').length).toBeGreaterThan(0)
+    expect(screen.getByText('Backup Admin')).toBeInTheDocument()
+    expect(screen.queryByText('Normal User')).not.toBeInTheDocument()
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.getByText('Stopped')).toBeInTheDocument()
+  })
+
+  it('links directly to admin-mode profile creation', async () => {
+    mockListProfiles.mockResolvedValue([])
+
+    renderPage()
+
+    const link = await screen.findByRole('link', { name: /create admin profile/i })
+    expect(link).toHaveAttribute('href', '/profiles/new?adminMode=true')
+    expect(screen.getByText('No admin bot profiles yet.')).toBeInTheDocument()
+    expect(screen.getByText(/none running/i)).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/pages/AdminBotPage.tsx
+++ b/dashboard/src/pages/AdminBotPage.tsx
@@ -1,17 +1,28 @@
 import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
 import { api } from '../api'
+import StatusBadge from '../components/StatusBadge'
 import { useToast } from '../components/Toast'
-import type { MonitorStatus } from '../types'
+import type { MonitorStatus, ProfileResponse } from '../types'
+
+function isAdminProfile(profile: ProfileResponse) {
+  return profile.config.admin_mode === true
+}
 
 export default function AdminBotPage() {
   const { toast } = useToast()
   const [loading, setLoading] = useState(true)
   const [monitorStatus, setMonitorStatus] = useState<MonitorStatus>({ watchdog_enabled: false, alerts_enabled: false })
+  const [adminProfiles, setAdminProfiles] = useState<ProfileResponse[]>([])
 
   const loadData = useCallback(async () => {
     try {
-      const monitor = await api.monitorStatus().catch(() => ({ watchdog_enabled: false, alerts_enabled: false }))
+      const [monitor, profiles] = await Promise.all([
+        api.monitorStatus().catch(() => ({ watchdog_enabled: false, alerts_enabled: false })),
+        api.listProfiles(),
+      ])
       setMonitorStatus(monitor)
+      setAdminProfiles(profiles.filter(isAdminProfile))
     } catch (e: any) {
       toast(e.message, 'error')
     } finally {
@@ -51,6 +62,8 @@ export default function AdminBotPage() {
     )
   }
 
+  const activeProfiles = adminProfiles.filter((profile) => profile.status.running)
+
   return (
     <div className="max-w-3xl">
       <div className="mb-6">
@@ -79,12 +92,55 @@ export default function AdminBotPage() {
       </div>
 
       <div className="bg-surface rounded-xl border border-gray-700/50 p-5">
-        <h2 className="text-sm font-semibold text-white mb-2">Admin Bot Profile</h2>
-        <p className="text-sm text-gray-400">
-          To set up an admin bot, create a regular profile and enable <strong className="text-white">Admin Mode</strong> in
-          its settings. Admin mode restricts the gateway to admin-only tools (profile management,
-          monitoring, logs) and uses a built-in admin system prompt.
-        </p>
+        <div className="flex items-start justify-between gap-3 mb-4">
+          <div>
+            <h2 className="text-sm font-semibold text-white">Admin Bot Profiles</h2>
+            <p className="text-xs text-gray-500 mt-1">
+              Active admin: <span className="text-gray-300">
+                {activeProfiles.length > 0
+                  ? activeProfiles.map((profile) => profile.name).join(', ')
+                  : 'None running'}
+              </span>
+            </p>
+          </div>
+          <Link
+            to="/profiles/new?adminMode=true"
+            className="shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-accent text-white hover:bg-accent-light transition"
+          >
+            Create admin profile
+          </Link>
+        </div>
+
+        {adminProfiles.length > 0 ? (
+          <div className="divide-y divide-gray-700/50">
+            {adminProfiles.map((profile) => (
+              <div key={profile.id} className="py-3 first:pt-0 last:pb-0 flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <Link
+                    to={`/profile/${profile.id}`}
+                    className="text-sm font-medium text-white hover:text-accent transition-colors truncate block"
+                  >
+                    {profile.name}
+                  </Link>
+                  <p className="text-xs text-gray-500 font-mono truncate">{profile.id}</p>
+                </div>
+                <div className="flex items-center gap-3 shrink-0">
+                  <StatusBadge running={profile.status.running} />
+                  <Link
+                    to={`/profile/${profile.id}`}
+                    className="px-3 py-1.5 text-xs font-medium rounded-lg bg-white/5 text-gray-400 hover:bg-white/10 hover:text-white border border-gray-700/50 transition"
+                  >
+                    Open
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-gray-700/70 p-4 text-sm text-gray-400">
+            No admin bot profiles yet.
+          </div>
+        )}
       </div>
     </div>
   )

--- a/dashboard/src/pages/NewProfile.test.tsx
+++ b/dashboard/src/pages/NewProfile.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import NewProfile from './NewProfile'
+
+const mockCreateProfile = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    api: {
+      createProfile: (data: unknown) => mockCreateProfile(data),
+    },
+  }
+})
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderPage(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <NewProfile />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockCreateProfile.mockReset()
+  mockCreateProfile.mockResolvedValue({})
+  mockNavigate.mockReset()
+})
+
+describe('NewProfile', () => {
+  it('preselects admin mode from the adminMode query parameter and creates an admin profile', async () => {
+    const user = userEvent.setup()
+    renderPage('/profiles/new?adminMode=true')
+
+    expect(screen.getByLabelText(/admin mode/i)).toBeChecked()
+    await user.type(screen.getByLabelText(/profile id/i), 'admin-bot')
+    await user.type(screen.getByLabelText(/display name/i), 'Admin Bot')
+    await user.click(screen.getByRole('button', { name: /create profile/i }))
+
+    await waitFor(() => expect(mockCreateProfile).toHaveBeenCalled())
+    expect(mockCreateProfile).toHaveBeenCalledWith({
+      id: 'admin-bot',
+      name: 'Admin Bot',
+      public_subdomain: null,
+      enabled: true,
+      config: {
+        channels: [],
+        gateway: {},
+        env_vars: {},
+        admin_mode: true,
+      },
+    })
+    expect(mockNavigate).toHaveBeenCalledWith('/profile/admin-bot')
+  })
+
+  it('keeps regular profile creation unchanged without the adminMode query parameter', async () => {
+    const user = userEvent.setup()
+    renderPage('/profiles/new')
+
+    expect(screen.getByLabelText(/admin mode/i)).not.toBeChecked()
+    await user.type(screen.getByLabelText(/profile id/i), 'worker-bot')
+    await user.type(screen.getByLabelText(/display name/i), 'Worker Bot')
+    await user.click(screen.getByRole('button', { name: /create profile/i }))
+
+    await waitFor(() => expect(mockCreateProfile).toHaveBeenCalled())
+    expect(mockCreateProfile).toHaveBeenCalledWith({
+      id: 'worker-bot',
+      name: 'Worker Bot',
+      public_subdomain: null,
+      enabled: true,
+    })
+  })
+})

--- a/dashboard/src/pages/NewProfile.tsx
+++ b/dashboard/src/pages/NewProfile.tsx
@@ -1,26 +1,33 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useToast } from '../components/Toast'
 import { api } from '../api'
+import type { ProfileConfig } from '../types'
 
 export default function NewProfile() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { toast } = useToast()
   const [loading, setLoading] = useState(false)
   const [id, setId] = useState('')
   const [name, setName] = useState('')
   const [publicSubdomain, setPublicSubdomain] = useState('')
   const [enabled, setEnabled] = useState(true)
+  const [adminMode, setAdminMode] = useState(searchParams.get('adminMode') === 'true')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
       setLoading(true)
+      const config: ProfileConfig | undefined = adminMode
+        ? { channels: [], gateway: {}, env_vars: {}, admin_mode: true }
+        : undefined
       await api.createProfile({
         id,
         name,
         public_subdomain: publicSubdomain.trim() || null,
         enabled,
+        ...(config ? { config } : {}),
       })
       toast('Profile created')
       navigate(`/profile/${id}`)
@@ -52,9 +59,10 @@ export default function NewProfile() {
       <div className="bg-surface rounded-xl border border-gray-700/50 p-6 max-w-lg">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">Profile ID</label>
+            <label htmlFor="profile-id" className="block text-sm font-medium text-gray-300 mb-1.5">Profile ID</label>
             <p className="text-xs text-gray-500 mb-1.5">Lowercase letters, digits, hyphens. Cannot change after creation.</p>
             <input
+              id="profile-id"
               value={id}
               onChange={(e) => setId(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
               placeholder="alice-bot"
@@ -63,8 +71,9 @@ export default function NewProfile() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">Display Name</label>
+            <label htmlFor="display-name" className="block text-sm font-medium text-gray-300 mb-1.5">Display Name</label>
             <input
+              id="display-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Alice's Bot"
@@ -73,9 +82,10 @@ export default function NewProfile() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">Public Subdomain</label>
+            <label htmlFor="public-subdomain" className="block text-sm font-medium text-gray-300 mb-1.5">Public Subdomain</label>
             <p className="text-xs text-gray-500 mb-1.5">Public URL slug. You can change this later without changing the internal profile ID.</p>
             <input
+              id="public-subdomain"
               value={publicSubdomain}
               onChange={(e) => setPublicSubdomain(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
               placeholder={id || 'alice-bot'}
@@ -91,6 +101,17 @@ export default function NewProfile() {
                 className="w-4 h-4 rounded bg-surface-dark border-gray-600 text-accent focus:ring-accent"
               />
               <span className="text-sm text-gray-400">Auto-start gateway when server starts</span>
+            </label>
+          </div>
+          <div>
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={adminMode}
+                onChange={(e) => setAdminMode(e.target.checked)}
+                className="w-4 h-4 rounded bg-surface-dark border-gray-600 text-accent focus:ring-accent"
+              />
+              <span className="text-sm text-gray-400">Admin mode (admin-only tools, no shell/file/web)</span>
             </label>
           </div>
           <div className="flex justify-end gap-3 pt-4 border-t border-gray-700/50">


### PR DESCRIPTION
## Summary
- list `admin_mode` profiles on `AdminBotPage` with running/stopped status
- show the currently active running admin profile inline
- link `Create admin profile` to `/profiles/new?adminMode=true` and create profiles with `admin_mode: true` from that shortcut

Closes #425

## Validation
- `npm --prefix dashboard test -- AdminBotPage.test.tsx NewProfile.test.tsx`
- `npm --prefix dashboard test`
- `npm --prefix dashboard run typecheck`
- `VITE_OUT_DIR=/private/tmp/octos-dashboard-build-425 npm --prefix dashboard run build`
- `git diff --check`