### PR TITLE
test(install): make path smoke self-contained

### DIFF
--- a/scripts/test-install-paths.sh
+++ b/scripts/test-install-paths.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 INSTALLER="$ROOT_DIR/scripts/install.sh"
-DOWNLOAD_BASE="file://$ROOT_DIR"
+DOWNLOAD_BASE=""
 
 fail() {
     echo "FAIL: $1" >&2
@@ -16,14 +16,15 @@ run_installer() {
     local home_dir="$2"
     local prefix="$3"
     local output_file="$4"
+    local mock_bin="$5"
 
     mkdir -p "$home_dir"
 
     set +e
     (
         cd "$workdir"
-        HOME="$home_dir" OCTOS_DOWNLOAD_URL="$DOWNLOAD_BASE" \
-            bash "$INSTALLER" --prefix "$prefix" --version test --no-tunnel
+        HOME="$home_dir" OCTOS_DOWNLOAD_URL="$DOWNLOAD_BASE" PATH="$mock_bin:$PATH" \
+            bash "$INSTALLER" --prefix "$prefix" --version test
     ) >"$output_file" 2>&1
     local status=$?
     set -e
@@ -34,14 +35,60 @@ run_installer() {
     fi
 }
 
+host_triple() {
+    local os arch platform
+    os="$(uname -s)"
+    arch="$(uname -m)"
+    case "$os" in
+        Darwin) platform="apple-darwin" ;;
+        Linux) platform="unknown-linux-gnu" ;;
+        *) fail "unsupported test OS: $os" ;;
+    esac
+    case "$arch" in
+        x86_64) echo "x86_64-$platform" ;;
+        aarch64|arm64) echo "aarch64-$platform" ;;
+        *) fail "unsupported test architecture: $arch" ;;
+    esac
+}
+
+create_fake_bundle() {
+    local bundle_dir="$1"
+    local triple
+    triple="$(host_triple)"
+    mkdir -p "$bundle_dir/payload"
+    cat >"$bundle_dir/payload/octos" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$bundle_dir/payload/octos"
+    tar -czf "$bundle_dir/octos-bundle-$triple.tar.gz" -C "$bundle_dir/payload" octos
+}
+
+create_mock_sudo() {
+    local mock_bin="$1"
+    mkdir -p "$mock_bin"
+    cat >"$mock_bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+echo "sudo: Operation not permitted" >&2
+exit 1
+EOF
+    chmod +x "$mock_bin/sudo"
+}
+
 main() {
     local test_root
     test_root="$(mktemp -d /tmp/octos-install-paths.XXXXXX)"
     trap 'rm -rf "${test_root:-}"' EXIT
+    local bundle_dir="$test_root/download"
+    local mock_bin="$test_root/mock-bin"
+    mkdir -p "$bundle_dir"
+    create_fake_bundle "$bundle_dir"
+    create_mock_sudo "$mock_bin"
+    DOWNLOAD_BASE="file://$bundle_dir"
 
     local rel_workdir="$test_root/relative"
     mkdir -p "$rel_workdir"
-    run_installer "$rel_workdir" "$test_root/home-rel" "./relative-bin" "$test_root/relative.out"
+    run_installer "$rel_workdir" "$test_root/home-rel" "./relative-bin" "$test_root/relative.out" "$mock_bin"
     if grep -q "invalid prefix" "$test_root/relative.out"; then
         fail "relative prefix was rejected"
     fi
@@ -50,7 +97,7 @@ main() {
     local tilde_workdir="$test_root/tilde"
     local tilde_home="$test_root/home-tilde"
     mkdir -p "$tilde_workdir"
-    run_installer "$tilde_workdir" "$tilde_home" "~/tilde-bin" "$test_root/tilde.out"
+    run_installer "$tilde_workdir" "$tilde_home" "~/tilde-bin" "$test_root/tilde.out" "$mock_bin"
     if grep -q "invalid prefix" "$test_root/tilde.out"; then
         fail "tilde prefix was rejected"
     fi


### PR DESCRIPTION
## Summary
- remove the stale `--no-tunnel` flag from `scripts/test-install-paths.sh`
- generate a minimal local octos bundle inside the test temp dir instead of depending on release artifacts in the repo root
- mock privileged `sudo` service setup so the path smoke can validate install destinations without mutating host services

Related issue: #237

## Validation
- `bash -n scripts/test-install-paths.sh scripts/install.sh`
- `bash -n scripts/install.sh scripts/cloud-host-deploy.sh scripts/octos-doctor.sh scripts/build-local-bundle.sh`
- `bash scripts/test-install-paths.sh`
- `git diff --check`
- `git ls-files --others --exclude-standard`

## Closure note
This PR is validation-enabling only. Issue #237 still needs Linux bare-metal validation with command transcript and target OS matrix before resolution.

## CI / merge status
- GitHub CI is green on head `336736a378013f85711b5ef5eb206f5acd9301a4`: `check`, `test-octos-cli`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `dashboard`, `swarm-app`, `check-matrix`, `typos`, and author-email passed. Optional platform/e2e/security expansion jobs were skipped by workflow conditions.
- Current GitHub state remains `MERGEABLE` but branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
- This PR is validation-enabling only for #237; Linux bare-metal/VM transcript evidence and target OS matrix are still required before issue closure.
