### PR TITLE
feat(deploy): add Windows server deploy script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,52 @@ jobs:
       - uses: actions/checkout@v6
       - uses: crate-ci/typos@v1.33.1
 
+  windows-deploy-script:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Windows deploy dry run
+        shell: pwsh
+        run: |
+          $deploy = & .\scripts\deploy.ps1 `
+            -HostName win.example.invalid `
+            -User deploy `
+            -Port 2222 `
+            -Version v0.0.0-test `
+            -RemoteRoot 'C:\octos-ci' `
+            -ServiceName OctosServeTest `
+            -ServePort 50080 `
+            -AuthToken test-token `
+            -DryRun 2>&1
+          $deployText = $deploy | Out-String
+          Write-Host $deployText
+          if ($deployText -notmatch '\$nssmExe install') {
+            throw 'deploy dry run did not include NSSM service registration'
+          }
+          if ($deployText -notmatch 'C:\\octos-ci') {
+            throw 'deploy dry run did not include the requested remote root'
+          }
+          if ($deployText -notmatch 'ssh -p 2222') {
+            throw 'deploy dry run did not include SSH port handling'
+          }
+
+          $uninstall = & .\scripts\deploy.ps1 `
+            -HostName win.example.invalid `
+            -RemoteRoot 'C:\octos-ci' `
+            -ServiceName OctosServeTest `
+            -Uninstall `
+            -Purge `
+            -DryRun 2>&1
+          $uninstallText = $uninstall | Out-String
+          Write-Host $uninstallText
+          if ($uninstallText -notmatch 'sc\.exe delete') {
+            throw 'uninstall dry run did not include sc.exe fallback'
+          }
+          if ($uninstallText -notmatch 'Remove-Item -Recurse -Force') {
+            throw 'uninstall dry run did not include purge behavior'
+          }
+
   check:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
           # Copy whichever platform bundles were built
           find artifacts -name 'octos-bundle-*' -exec cp {} release-assets/ \;
           # Always include install scripts
-          cp scripts/install.sh scripts/install.ps1 scripts/octos-doctor.sh release-assets/
+          cp scripts/install.sh scripts/install.ps1 scripts/deploy.ps1 scripts/octos-doctor.sh release-assets/
           echo "Assets to upload:"
           ls -la release-assets/
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,26 @@ This wraps three host-side steps:
 - `scripts/frp/setup-frps.sh` — installs and configures `frps`
 - `scripts/frp/setup-caddy.sh` — configures public routing and wildcard HTTPS
 
+Windows Server targets use the PowerShell deploy script from an operator machine
+with OpenSSH access to the server:
+
+```powershell
+.\scripts\deploy.ps1 `
+    -HostName win.example.com `
+    -User Administrator `
+    -Version latest `
+    -RemoteRoot 'C:\octos' `
+    -ServiceName OctosServe
+```
+
+Run the same command with `-DryRun` first to print the remote commands without
+connecting. The script deploys the `octos-bundle-x86_64-pc-windows-msvc.zip`
+release bundle, installs `octos.exe` under `C:\octos\bin`, stores runtime data in
+`C:\octos\data`, writes logs under `C:\octos\logs`, and registers `OctosServe` as
+an auto-start Windows service through NSSM. Use `-LocalBundle <zip>` to deploy a
+locally built bundle over `scp`, and `-Uninstall [-Purge]` to remove the service
+and optionally delete the remote install root.
+
 Recommended DNS split:
 
 - `octos.example.com` and `*.octos.example.com` for the portal and tenant dashboards

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,415 @@
+# deploy.ps1 - Deploy Octos to a remote Windows server over OpenSSH.
+#
+# This is the Windows counterpart to the shell deploy flows. It runs from an
+# operator machine with PowerShell and OpenSSH, connects to a Windows target via
+# ssh/scp, installs the release bundle under C:\octos by default, and registers
+# octos serve as an auto-start Windows service through NSSM.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$HostName,
+
+    [string]$User = "",
+    [int]$Port = 22,
+    [string]$IdentityFile = "",
+    [string]$Version = "latest",
+    [string]$RemoteRoot = "C:\octos",
+    [string]$ServiceName = "OctosServe",
+    [int]$ServePort = 8080,
+    [string]$AuthToken = "",
+    [string]$DownloadBase = "",
+    [string]$LocalBundle = "",
+    [switch]$InstallDeps,
+    [switch]$Restart,
+    [switch]$Uninstall,
+    [switch]$Purge,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+$GithubRepo = "octos-org/octos"
+$BundleName = "octos-bundle-x86_64-pc-windows-msvc.zip"
+$NssmVersion = "2.24"
+
+function Section([string]$Message) {
+    Write-Host ""
+    Write-Host "==> $Message"
+}
+
+function Ok([string]$Message) {
+    Write-Host "    OK: $Message"
+}
+
+function Fail([string]$Message) {
+    throw $Message
+}
+
+function Assert-Command([string]$Name) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Fail "required command not found: $Name"
+    }
+}
+
+function ConvertTo-PSLiteral([string]$Value) {
+    return "'" + ($Value -replace "'", "''") + "'"
+}
+
+function ConvertTo-EncodedPowerShellCommand([string]$ScriptText) {
+    $bytes = [System.Text.Encoding]::Unicode.GetBytes($ScriptText)
+    return [Convert]::ToBase64String($bytes)
+}
+
+function Get-ReleaseBase {
+    if ($DownloadBase) {
+        return $DownloadBase.TrimEnd("/")
+    }
+    if ($Version -eq "latest") {
+        return "https://github.com/$GithubRepo/releases/latest/download"
+    }
+    return "https://github.com/$GithubRepo/releases/download/$Version"
+}
+
+function Get-Target {
+    if ($User) {
+        return "${User}@${HostName}"
+    }
+    return $HostName
+}
+
+function Get-SshArgs {
+    $cmdArgs = @()
+    if ($Port -ne 22) {
+        $cmdArgs += @("-p", "$Port")
+    }
+    if ($IdentityFile) {
+        $cmdArgs += @("-i", $IdentityFile)
+    }
+    return $cmdArgs
+}
+
+function Get-ScpArgs {
+    $cmdArgs = @()
+    if ($Port -ne 22) {
+        $cmdArgs += @("-P", "$Port")
+    }
+    if ($IdentityFile) {
+        $cmdArgs += @("-i", $IdentityFile)
+    }
+    return $cmdArgs
+}
+
+function Format-Command([string]$Exe, [string[]]$CommandArgs) {
+    $parts = @($Exe)
+    foreach ($arg in $CommandArgs) {
+        if ($arg -match '^[A-Za-z0-9_./:@=+,-]+$') {
+            $parts += $arg
+        } else {
+            $parts += '"' + ($arg -replace '"', '\"') + '"'
+        }
+    }
+    return ($parts -join " ")
+}
+
+function Invoke-Native([string]$Exe, [string[]]$CommandArgs) {
+    if ($DryRun) {
+        Write-Output "    [dry-run] $(Format-Command $Exe $CommandArgs)"
+        return
+    }
+
+    & $Exe @CommandArgs
+    if ($LASTEXITCODE -ne 0) {
+        Fail "$Exe exited with code $LASTEXITCODE"
+    }
+}
+
+function ConvertTo-ScpRemotePath([string]$Path) {
+    return ($Path -replace "\\", "/")
+}
+
+function Copy-ToRemote([string]$LocalPath, [string]$RemotePath) {
+    $target = Get-Target
+    $remote = "$(ConvertTo-ScpRemotePath $RemotePath)"
+    $cmdArgs = (Get-ScpArgs) + @($LocalPath, "${target}:$remote")
+    Invoke-Native "scp" $cmdArgs
+}
+
+function Invoke-RemoteScript([string]$ScriptText) {
+    $target = Get-Target
+    $encoded = ConvertTo-EncodedPowerShellCommand $ScriptText
+    $remoteCommand = "powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded"
+
+    if ($DryRun) {
+        Write-Output "    [dry-run] remote PowerShell script:"
+        foreach ($line in ($ScriptText -split "`r?`n")) {
+            if ($line.Trim().Length -gt 0) {
+                Write-Output "      $line"
+            }
+        }
+    }
+
+    $cmdArgs = (Get-SshArgs) + @($target, $remoteCommand)
+    Invoke-Native "ssh" $cmdArgs
+}
+
+function New-RemoteDeployScript([string]$UploadedBundlePath) {
+    $releaseBase = Get-ReleaseBase
+    $bundleUrl = "$releaseBase/$BundleName"
+    $nssmUrl = "https://nssm.cc/release/nssm-$NssmVersion.zip"
+
+    $template = @'
+$ErrorActionPreference = "Stop"
+
+$remoteRoot = __REMOTE_ROOT__
+$serviceName = __SERVICE_NAME__
+$servePort = __SERVE_PORT__
+$authToken = __AUTH_TOKEN__
+$bundleUrl = __BUNDLE_URL__
+$uploadedBundle = __UPLOADED_BUNDLE__
+$bundleName = __BUNDLE_NAME__
+$nssmUrl = __NSSM_URL__
+$installDeps = __INSTALL_DEPS__
+$restartOnly = __RESTART_ONLY__
+
+function Section([string]$Message) {
+    Write-Host ""
+    Write-Host "==> $Message"
+}
+
+function Ok([string]$Message) {
+    Write-Host "    OK: $Message"
+}
+
+function Ensure-Directory([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    }
+}
+
+function Write-Utf8NoBom([string]$Path, [string]$Content) {
+    [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
+}
+
+function New-AuthToken {
+    $bytes = New-Object byte[] 32
+    ([System.Security.Cryptography.RandomNumberGenerator]::Create()).GetBytes($bytes)
+    return ($bytes | ForEach-Object { $_.ToString("x2") }) -join ""
+}
+
+$binDir = Join-Path $remoteRoot "bin"
+$dataDir = Join-Path $remoteRoot "data"
+$logDir = Join-Path $remoteRoot "logs"
+$tmpDir = Join-Path $remoteRoot "tmp"
+
+Ensure-Directory $binDir
+Ensure-Directory $dataDir
+Ensure-Directory $logDir
+Ensure-Directory $tmpDir
+
+if (-not $authToken) {
+    $authToken = New-AuthToken
+}
+
+$octosExe = Join-Path $binDir "octos.exe"
+$nssmExe = Join-Path $binDir "nssm.exe"
+
+if ($installDeps) {
+    Section "Installing runtime dependencies"
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        Write-Host "    WARN: winget not found; install Git, Node.js, Python, and FFmpeg manually if this host needs them"
+    } else {
+        foreach ($pkg in @("Git.Git", "OpenJS.NodeJS.LTS", "Python.Python.3.12", "Gyan.FFmpeg")) {
+            winget install --id $pkg --exact --silent --accept-package-agreements --accept-source-agreements
+        }
+        Ok "runtime dependency install attempted through winget"
+    }
+}
+
+if (-not $restartOnly) {
+    Section "Installing Octos bundle"
+    $bundleZip = Join-Path $tmpDir $bundleName
+    if ($uploadedBundle) {
+        Copy-Item -LiteralPath $uploadedBundle -Destination $bundleZip -Force
+    } else {
+        Invoke-WebRequest -Uri $bundleUrl -OutFile $bundleZip -UseBasicParsing
+    }
+
+    $extractDir = Join-Path $tmpDir "bundle"
+    if (Test-Path -LiteralPath $extractDir) {
+        Remove-Item -Recurse -Force $extractDir
+    }
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+    Expand-Archive -Path $bundleZip -DestinationPath $extractDir -Force
+
+    $octosSource = Get-ChildItem -Path $extractDir -Recurse -Filter "octos.exe" | Select-Object -First 1
+    if (-not $octosSource) {
+        throw "octos.exe not found in $bundleZip"
+    }
+    Copy-Item $octosSource.FullName -Destination $octosExe -Force
+    Ok "installed $octosExe"
+}
+
+$configPath = Join-Path $dataDir "config.json"
+if (-not (Test-Path -LiteralPath $configPath)) {
+    $config = [ordered]@{
+        provider = "openai"
+        model = "gpt-4.1-mini"
+        api_key_env = "OPENAI_API_KEY"
+        mode = "local"
+        auth_token = $authToken
+    }
+    Write-Utf8NoBom $configPath ($config | ConvertTo-Json -Depth 8)
+    Ok "created $configPath"
+} else {
+    Ok "preserving existing $configPath"
+}
+
+if (-not (Test-Path -LiteralPath $nssmExe)) {
+    Section "Installing NSSM service wrapper"
+    $nssmZip = Join-Path $tmpDir "nssm.zip"
+    $nssmExtract = Join-Path $tmpDir "nssm"
+    Invoke-WebRequest -Uri $nssmUrl -OutFile $nssmZip -UseBasicParsing
+    if (Test-Path -LiteralPath $nssmExtract) {
+        Remove-Item -Recurse -Force $nssmExtract
+    }
+    Expand-Archive -Path $nssmZip -DestinationPath $nssmExtract -Force
+    $nssmSource = Get-ChildItem -Path $nssmExtract -Recurse -Filter "nssm.exe" |
+        Where-Object { $_.FullName -match "\\win64\\" } |
+        Select-Object -First 1
+    if (-not $nssmSource) {
+        throw "win64 nssm.exe not found in $nssmZip"
+    }
+    Copy-Item $nssmSource.FullName -Destination $nssmExe -Force
+    Ok "installed $nssmExe"
+}
+
+Section "Registering Windows service"
+& $nssmExe stop $serviceName 2>$null | Out-Null
+& $nssmExe remove $serviceName confirm 2>$null | Out-Null
+
+& $nssmExe install $serviceName $octosExe "serve" "--host" "0.0.0.0" "--port" "$servePort" "--data-dir" $dataDir "--auth-token" $authToken
+if ($LASTEXITCODE -ne 0) {
+    throw "nssm.exe install failed"
+}
+
+& $nssmExe set $serviceName AppDirectory $remoteRoot | Out-Null
+& $nssmExe set $serviceName AppStdout (Join-Path $logDir "serve.log") | Out-Null
+& $nssmExe set $serviceName AppStderr (Join-Path $logDir "serve.err.log") | Out-Null
+& $nssmExe set $serviceName AppRotateFiles 1 | Out-Null
+& $nssmExe set $serviceName Start SERVICE_AUTO_START | Out-Null
+& $nssmExe set $serviceName AppEnvironmentExtra "OCTOS_HOME=$dataDir" "OCTOS_DATA_DIR=$dataDir" "OCTOS_AUTH_TOKEN=$authToken" | Out-Null
+
+& $nssmExe start $serviceName
+if ($LASTEXITCODE -ne 0) {
+    throw "nssm.exe start failed"
+}
+
+Ok "$serviceName service started"
+Write-Host ""
+Write-Host "    Remote root: $remoteRoot"
+Write-Host "    Binary:      $octosExe"
+Write-Host "    Data dir:    $dataDir"
+Write-Host "    Logs:        $logDir"
+Write-Host "    Dashboard:   http://$env:COMPUTERNAME`:$servePort/admin/"
+'@
+
+    $scriptText = $template
+    $scriptText = $scriptText.Replace("__REMOTE_ROOT__", (ConvertTo-PSLiteral $RemoteRoot))
+    $scriptText = $scriptText.Replace("__SERVICE_NAME__", (ConvertTo-PSLiteral $ServiceName))
+    $scriptText = $scriptText.Replace("__SERVE_PORT__", "$ServePort")
+    $scriptText = $scriptText.Replace("__AUTH_TOKEN__", (ConvertTo-PSLiteral $AuthToken))
+    $scriptText = $scriptText.Replace("__BUNDLE_URL__", (ConvertTo-PSLiteral $bundleUrl))
+    $scriptText = $scriptText.Replace("__UPLOADED_BUNDLE__", (ConvertTo-PSLiteral $UploadedBundlePath))
+    $scriptText = $scriptText.Replace("__BUNDLE_NAME__", (ConvertTo-PSLiteral $BundleName))
+    $scriptText = $scriptText.Replace("__NSSM_URL__", (ConvertTo-PSLiteral $nssmUrl))
+    $scriptText = $scriptText.Replace("__INSTALL_DEPS__", ($(if ($InstallDeps) { '$true' } else { '$false' })))
+    $scriptText = $scriptText.Replace("__RESTART_ONLY__", ($(if ($Restart) { '$true' } else { '$false' })))
+    return $scriptText
+}
+
+function New-RemoteUninstallScript {
+    $template = @'
+$ErrorActionPreference = "Stop"
+
+$remoteRoot = __REMOTE_ROOT__
+$serviceName = __SERVICE_NAME__
+$purge = __PURGE__
+
+function Ok([string]$Message) {
+    Write-Host "    OK: $Message"
+}
+
+$nssmExe = Join-Path (Join-Path $remoteRoot "bin") "nssm.exe"
+if (Test-Path -LiteralPath $nssmExe) {
+    & $nssmExe stop $serviceName 2>$null | Out-Null
+    & $nssmExe remove $serviceName confirm 2>$null | Out-Null
+    Ok "removed $serviceName through NSSM"
+} else {
+    sc.exe stop $serviceName 2>$null | Out-Null
+    sc.exe delete $serviceName 2>$null | Out-Null
+    Ok "requested $serviceName removal through sc.exe"
+}
+
+if ($purge) {
+    Remove-Item -Recurse -Force $remoteRoot -ErrorAction SilentlyContinue
+    Ok "removed $remoteRoot"
+}
+'@
+
+    $scriptText = $template
+    $scriptText = $scriptText.Replace("__REMOTE_ROOT__", (ConvertTo-PSLiteral $RemoteRoot))
+    $scriptText = $scriptText.Replace("__SERVICE_NAME__", (ConvertTo-PSLiteral $ServiceName))
+    $scriptText = $scriptText.Replace("__PURGE__", ($(if ($Purge) { '$true' } else { '$false' })))
+    return $scriptText
+}
+
+function Validate-Inputs {
+    if ($Port -lt 1 -or $Port -gt 65535) {
+        Fail "Port must be between 1 and 65535"
+    }
+    if ($ServePort -lt 1 -or $ServePort -gt 65535) {
+        Fail "ServePort must be between 1 and 65535"
+    }
+    if ($ServiceName -notmatch '^[A-Za-z0-9_.-]+$') {
+        Fail "ServiceName must contain only letters, numbers, dots, underscores, and dashes"
+    }
+    if ($LocalBundle -and -not (Test-Path -LiteralPath $LocalBundle)) {
+        Fail "LocalBundle not found: $LocalBundle"
+    }
+}
+
+Validate-Inputs
+
+if (-not $DryRun) {
+    Assert-Command "ssh"
+    if ($LocalBundle) {
+        Assert-Command "scp"
+    }
+}
+
+Section "Windows deploy target"
+Ok "target: $(Get-Target)"
+Ok "remote root: $RemoteRoot"
+Ok "service: $ServiceName"
+
+$uploadedBundlePath = ""
+if ($LocalBundle -and -not $Uninstall) {
+    Section "Uploading local bundle"
+    $incomingDir = Join-Path $RemoteRoot "incoming"
+    $createIncoming = "New-Item -ItemType Directory -Path $(ConvertTo-PSLiteral $incomingDir) -Force | Out-Null"
+    Invoke-RemoteScript $createIncoming
+
+    $uploadedBundlePath = Join-Path $incomingDir $BundleName
+    Copy-ToRemote $LocalBundle $uploadedBundlePath
+}
+
+if ($Uninstall) {
+    Section "Uninstalling remote Windows service"
+    Invoke-RemoteScript (New-RemoteUninstallScript)
+} else {
+    Section "Deploying remote Windows service"
+    Invoke-RemoteScript (New-RemoteDeployScript $uploadedBundlePath)
+}
+
+Ok "deploy.ps1 completed"

--- a/scripts/test-windows-deploy.sh
+++ b/scripts/test-windows-deploy.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/deploy.ps1"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+require_grep() {
+    local pattern="$1"
+    local path="$2"
+    local message="$3"
+    grep -qE "$pattern" "$path" || fail "$message"
+}
+
+[ -f "$SCRIPT" ] || fail "scripts/deploy.ps1 is missing"
+
+require_grep 'param\(' "$SCRIPT" "deploy.ps1 must expose parameters"
+require_grep '\[string\]\$HostName' "$SCRIPT" "deploy.ps1 must accept a target host"
+require_grep '\[switch\]\$DryRun' "$SCRIPT" "deploy.ps1 must support dry-run mode"
+require_grep '\[switch\]\$Uninstall' "$SCRIPT" "deploy.ps1 must support uninstall mode"
+require_grep 'octos-bundle-x86_64-pc-windows-msvc\.zip' "$SCRIPT" "deploy.ps1 must target the Windows release bundle"
+require_grep 'ssh' "$SCRIPT" "deploy.ps1 must use OpenSSH for remote execution"
+require_grep 'scp' "$SCRIPT" "deploy.ps1 must use SCP for local bundle uploads"
+require_grep 'EncodedCommand' "$SCRIPT" "deploy.ps1 must send encoded PowerShell to the remote host"
+require_grep '\$nssmExe install' "$SCRIPT" "deploy.ps1 must register OctosServe through NSSM"
+require_grep 'SERVICE_AUTO_START' "$SCRIPT" "deploy.ps1 must configure auto-start service behavior"
+require_grep 'OCTOS_HOME=' "$SCRIPT" "deploy.ps1 must set the remote Octos data path"
+require_grep 'C:\\octos' "$SCRIPT" "deploy.ps1 must document the default Windows install root"
+
+if command -v pwsh >/dev/null 2>&1; then
+    out="$(pwsh -NoProfile -ExecutionPolicy Bypass -File "$SCRIPT" \
+        -HostName win.example.invalid \
+        -User deploy \
+        -Port 2222 \
+        -IdentityFile "$ROOT_DIR/.ssh/test-key" \
+        -Version v0.0.0-test \
+        -RemoteRoot 'C:\octos-ci' \
+        -ServiceName OctosServeTest \
+        -ServePort 50080 \
+        -AuthToken test-token \
+        -DryRun 2>&1)"
+
+    grep -q '\[dry-run\] remote PowerShell script' <<<"$out" \
+        || fail "dry run should print the remote script"
+    grep -q '\$nssmExe install' <<<"$out" \
+        || fail "dry run should show service registration"
+    grep -q 'C:\\octos-ci' <<<"$out" \
+        || fail "dry run should include the requested remote root"
+    grep -q 'OctosServeTest' <<<"$out" \
+        || fail "dry run should include the requested service name"
+    grep -q -- '--auth-token' <<<"$out" \
+        || fail "dry run should include auth-token serve argument"
+    grep -q 'test-token' <<<"$out" \
+        || fail "dry run should include the requested auth token"
+    grep -q 'ssh -p 2222' <<<"$out" \
+        || fail "dry run should show SSH port handling"
+
+    uninstall_out="$(pwsh -NoProfile -ExecutionPolicy Bypass -File "$SCRIPT" \
+        -HostName win.example.invalid \
+        -RemoteRoot 'C:\octos-ci' \
+        -ServiceName OctosServeTest \
+        -Uninstall \
+        -Purge \
+        -DryRun 2>&1)"
+    grep -q 'nssm.exe' <<<"$uninstall_out" \
+        || fail "uninstall dry run should prefer NSSM removal"
+    grep -q 'sc.exe delete' <<<"$uninstall_out" \
+        || fail "uninstall dry run should include sc.exe fallback"
+    grep -q 'Remove-Item -Recurse -Force' <<<"$uninstall_out" \
+        || fail "purge dry run should include remote root removal"
+else
+    echo "pwsh not found; static deploy.ps1 checks only"
+fi
+
+echo "windows deploy tests passed"


### PR DESCRIPTION
## Summary
- add `scripts/deploy.ps1` for remote Windows Server deployment over OpenSSH/SCP
- install the Windows release bundle under `C:\octos` by default and register `OctosServe` as an auto-start NSSM-managed Windows service
- document path/service behavior, ship the deploy script in release assets, and add dry-run coverage including a Windows CI job

Closes #239

## Validation
- `bash -n scripts/test-windows-deploy.sh scripts/test-cloud-host-deploy.sh`
- `bash scripts/test-windows-deploy.sh` (static checks here because local `pwsh` is unavailable)
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml"); puts "workflow yaml parsed"'`\n- `git diff --cached --check` before commit\n\n## Notes\n- The new `windows-deploy-script` Actions job runs the PowerShell dry-run path on `windows-latest`, covering the parser/runtime that is unavailable on this macOS host.\n

## CI / merge status
- GitHub CI is green on head `561c8d9cccce1002f82ed749acf1ded20131c016`: required checks in the current status rollup passed; optional platform/e2e/security expansion jobs were skipped by workflow conditions.
- Current GitHub state remains `MERGEABLE` but branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
- #239 should close through this PR after review and merge; no manual closure was performed.
