### PR TITLE
fix(agent): validate mofa_cards from reported files

### DIFF
--- a/crates/octos-agent/src/workspace_contract.rs
+++ b/crates/octos-agent/src/workspace_contract.rs
@@ -1468,18 +1468,55 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mofa_cards_contract_satisfies_when_png_files_match_recursive_glob() {
-        // P1-5: mofa_cards emits PNGs under a per-task card_dir.
+    async fn mofa_cards_contract_satisfies_reported_pngs_at_arbitrary_depth_octos_1041() {
+        // octos #1041: mofa_cards emits PNGs under a caller-supplied
+        // card_dir and reports every generated image via files_to_send.
+        // The contract must accept those exact reported paths even when
+        // they live under an arbitrary nested card_dir.
         let temp = tempfile::tempdir().unwrap();
         write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
-        let card_dir = temp.path().join("cards/abc");
+        let card_dir = temp.path().join("skill-output/cards/abc/deep/layout");
         std::fs::create_dir_all(&card_dir).unwrap();
-        std::fs::write(card_dir.join("a.png"), PNG_1X1).unwrap();
+        let card = card_dir.join("a.png");
+        std::fs::write(&card, PNG_1X1).unwrap();
 
         let result = enforce_spawn_task_contract_with_args(
             &ToolRegistry::with_builtins(temp.path()),
             "mofa_cards",
             "tool-call-cards",
+            std::slice::from_ref(&card),
+            UNIX_EPOCH,
+            None,
+            Some(&json!({"card_dir": "skill-output/cards/abc/deep/layout"})),
+        )
+        .await;
+
+        match result {
+            SpawnTaskContractResult::Satisfied { output_files } => {
+                assert!(
+                    output_files.iter().any(|p| p.ends_with("a.png")),
+                    "satisfied result must surface the reported card PNG, got {output_files:?}"
+                );
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mofa_cards_contract_does_not_pass_on_stale_unrelated_png_octos_1041() {
+        // octos #1041: mofa_cards must consume files_to_send, not a
+        // workspace `**/*.png` glob. A stale valid PNG in the workspace
+        // must not satisfy a run where the plugin reported no files.
+        let temp = tempfile::tempdir().unwrap();
+        write_workspace_policy(temp.path(), &WorkspacePolicy::for_session()).unwrap();
+
+        let stale = temp.path().join("stale-card.png");
+        std::fs::write(&stale, PNG_1X1).unwrap();
+
+        let result = enforce_spawn_task_contract_with_args(
+            &ToolRegistry::with_builtins(temp.path()),
+            "mofa_cards",
+            "tool-call-cards-stale",
             &[],
             UNIX_EPOCH,
             None,
@@ -1488,8 +1525,14 @@ mod tests {
         .await;
 
         match result {
-            SpawnTaskContractResult::Satisfied { .. } => {}
-            other => panic!("expected success, got {other:?}"),
+            SpawnTaskContractResult::Failed { error, notify_user } => {
+                assert_eq!(notify_user.as_deref(), Some("Card generation failed"));
+                assert!(
+                    error.contains("files_to_send") || error.contains("spawn_only_files"),
+                    "expected missing files_to_send/spawn_only_files failure, got: {error}"
+                );
+            }
+            other => panic!("expected failure for missing card files_to_send, got {other:?}"),
         }
     }
 

--- a/crates/octos-agent/src/workspace_policy.rs
+++ b/crates/octos-agent/src/workspace_policy.rs
@@ -1055,21 +1055,22 @@ impl WorkspacePolicy {
             })],
         };
 
-        // mofa_cards writes PNGs into a `card_dir` (required input arg).
-        // The contract uses a recursive PNG glob so any layout under that
-        // directory is covered without hard-coding a single output path.
+        // mofa_cards writes one PNG per card into a `card_dir` and now
+        // reports every generated PNG via `files_to_send` (octos #1041).
+        // Consume that explicit list so stale PNGs elsewhere in the
+        // workspace cannot satisfy a failed card run.
         let mofa_cards_contract = WorkspaceSpawnTaskPolicy {
-            artifact: None,
+            artifact: Some("image_png".into()),
             artifacts: Vec::new(),
             on_verify: Vec::new(),
             on_complete: vec![],
             on_deliver: vec![],
             on_failure: vec!["notify_user:Card generation failed".into()],
             on_completion: vec![SpawnTaskValidatorSpec::Bare(ValidatorSpec::MagicBytes {
-                glob: "**/*.png".into(),
+                glob: String::new(),
                 format: MagicByteKind::Png,
-                source: ValidatorFileSource::Glob,
-                extension: None,
+                source: ValidatorFileSource::SpawnOnlyFiles,
+                extension: Some("png".into()),
             })],
         };
 
@@ -2532,14 +2533,8 @@ ignore = []
         // skill surfaces auxiliary files (intermediate panel PNGs,
         // layout previews, etc.) via `files_to_send`.
         //
-        // `mofa_cards` is intentionally NOT in this sweep — the plugin
-        // does not yet emit `files_to_send` (it returns `card_dir` not
-        // `out`, and its success text `"Generated N card(s) in <dir>"`
-        // does not match the `Generated:` / `Generated PPTX:` markers
-        // that `PluginTool::detect_output_file` auto-detects). Tracked
-        // by a separate plugin-fix issue.
         let policy = WorkspacePolicy::for_session();
-        for tool in ["mofa_comic", "mofa_infographic", "mofa_frame"] {
+        for tool in ["mofa_cards", "mofa_comic", "mofa_infographic", "mofa_frame"] {
             let entry = policy
                 .spawn_tasks
                 .get(tool)
@@ -2580,18 +2575,11 @@ ignore = []
     }
 
     #[test]
-    fn session_policy_mofa_cards_keeps_glob_until_plugin_emits_files_to_send_octos_1041() {
-        // octos #1041 (audit #1040 follow-up): `mofa_cards` cannot yet
-        // sweep to `spawn_only_files` because the plugin does not emit
-        // `files_to_send` and `PluginTool::detect_output_file` does not
-        // auto-populate it (no `out` arg, success text uses an
-        // unrecognised `Generated N card(s) in <dir>` prefix).
-        //
-        // This test pins the current behaviour so a future contributor
-        // doesn't sweep `mofa_cards` without first fixing the plugin
-        // emission — that would regress to the empty-files-to-send
-        // failure mode that #1037 caught for `voice_synthesize` and
-        // tracked as #1038.
+    fn session_policy_mofa_cards_consumes_spawn_only_files_for_octos_1041() {
+        // octos #1041: the deployed mofa_cards plugin emits all generated
+        // PNGs via files_to_send, so the contract must consume that list
+        // instead of a recursive workspace glob that could match stale
+        // PNGs from a previous turn.
         let policy = WorkspacePolicy::for_session();
         let cards = policy
             .spawn_tasks
@@ -2609,18 +2597,23 @@ ignore = []
             _ => None,
         });
 
-        let (format, source, _extension, glob) = magic.expect(
+        let (format, source, extension, glob) = magic.expect(
             "mofa_cards contract must declare MagicBytes(Png) — see workspace_policy.rs:1043",
         );
         assert_eq!(format, MagicByteKind::Png);
         assert_eq!(
             source,
-            ValidatorFileSource::Glob,
-            "mofa_cards must keep `Glob` until octos #1041 lands the plugin-emission fix"
+            ValidatorFileSource::SpawnOnlyFiles,
+            "mofa_cards MagicBytes must opt into spawn_only_files (octos #1041)"
+        );
+        assert_eq!(
+            extension.as_deref(),
+            Some("png"),
+            "mofa_cards MagicBytes must filter to png outputs"
         );
         assert!(
-            glob.contains("**/*.png"),
-            "mofa_cards Glob source must keep the recursive PNG pattern; got: {glob}"
+            !glob.contains("**/*.png"),
+            "mofa_cards must not pin a recursive PNG glob; got: {glob}"
         );
     }
 


### PR DESCRIPTION
## Summary

- switch the `mofa_cards` workspace contract from recursive `**/*.png` glob validation to explicit `files_to_send` PNG validation
- add regression coverage proving reported card PNGs at arbitrary nested `card_dir` paths satisfy the contract
- add regression coverage proving stale workspace PNGs cannot satisfy a card run when the plugin reports no files
- refresh from current `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`

## Context

Current `mofa-org/mofa-skills` main already emits generated `mofa_cards` PNG paths through `files_to_send`; this Octos change consumes that explicit plugin output and removes the stale-glob fallback tracked by #1041.

Closes #1041

## Current-main refresh

- Base: `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Head: `07b20baf69b4c3f7b9ccd5ae90ddfa4dd8a48540`.
- Isolated checkout: `/private/tmp/octos-1257-current.gwlYa6/octos`.
- Cargo target: `/private/tmp/octos-1257-current-4adbe-target`.
- Root dirty checkout was not used or modified.

## Validation

Passed locally on refreshed head `07b20baf69b4c3f7b9ccd5ae90ddfa4dd8a48540`:

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `typos crates/octos-agent/src/workspace_contract.rs crates/octos-agent/src/workspace_policy.rs`
- `CARGO_TARGET_DIR=/private/tmp/octos-1257-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent mofa_cards_contract -- --nocapture` -> 2/2 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1257-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent session_policy_mofa_cards -- --nocapture` -> passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1257-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent session_policy_mofa_comic_infographic_frame_consume_spawn_only_files_for_octos_1040 -- --nocapture` -> passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1257-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-agent --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/octos-1257-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git ls-files --others --exclude-standard` -> empty

GitHub CI is green on refreshed head `07b20baf69b4c3f7b9ccd5ae90ddfa4dd8a48540`:

- CI run `26794666182` passed `dashboard`, `swarm-app`, `typos`, `check`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `test-octos-cli`, and `check-matrix`.
- Author-email run `26794666245` passed.

## Merge status

- No generated artifacts are included.
- Merge remains branch-protection blocked by required review.
