### PR TITLE
docs: refresh stale skill and API references

### DIFF
--- a/book-zh/src/advanced.md
+++ b/book-zh/src/advanced.md
@@ -604,15 +604,15 @@ octos cron enable <job-id> --disable
 REST API 服务器包含一个内嵌的 Web 界面：
 
 ```bash
-octos serve                              # 绑定到 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # 接受外部连接
-# 打开 http://localhost:8080
+octos serve                               # 绑定到 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # 接受外部连接
+# 打开 http://localhost:50080
 ```
 
 功能：
 - 会话侧边栏
 - 聊天界面
-- SSE 流式推送
+- UI Protocol WebSocket 流式推送
 - 暗色主题
 
 `/metrics` 端点提供 Prometheus 格式的指标：

--- a/book-zh/src/architecture.md
+++ b/book-zh/src/architecture.md
@@ -1126,7 +1126,7 @@ JSON 持久化位于 `.octos/cron.json`。
 | `clean` | 删除 .redb 文件，支持 dry-run |
 | `completions` | Shell 补全生成（bash/zsh/fish） |
 | `docs` | 生成工具 + 提供商文档 |
-| `serve` | REST API 服务器（feature：api）— axum 监听 127.0.0.1:8080（`--host` 覆盖） |
+| `serve` | REST API 服务器（feature：api）— axum 监听 127.0.0.1:50080（`--host` 覆盖） |
 
 ### 配置
 

--- a/book-zh/src/architecture.md
+++ b/book-zh/src/architecture.md
@@ -807,14 +807,16 @@ pub const BUILTIN_SKILLS: &[BuiltinSkill] = &[...];
 #### 目录布局
 
 ```
-.octos/plugins/           # 本地（项目级）
-~/.octos/plugins/         # 全局（用户级）
+<octos_home>/plugins/                 # 部署级插件
+<octos_home>/skills/                  # 部署级技能
+<octos_home>/bundled-app-skills/      # 内置应用技能
+~/.octos/profiles/<profile>/data/skills/
   └── my-plugin/
       ├── manifest.json  # 插件元数据 + 工具定义
       └── my-plugin      # 可执行文件（或 "main" 作为回退）
 ```
 
-**发现顺序**：先本地 `.octos/plugins/`，再全局 `~/.octos/plugins/`。两者均由 `Config::plugin_dirs()` 扫描。
+**发现顺序**：`Config::plugin_dirs_from_project()` 扫描部署级 `<octos_home>/plugins`、`<octos_home>/skills`、`<octos_home>/bundled-app-skills` 和 `OCTOS_SKILLS_PATH`；托管 profile gateway 再叠加平台技能和当前 profile 的 `data/skills/` 目录。旧的 HOME 全局目录（`~/.octos/plugins`、`~/.octos/skills`）不再作为常规扫描路径，只会触发一次迁移警告。
 
 #### PluginManifest
 
@@ -1163,17 +1165,17 @@ JSON 持久化位于 `.octos/cron.json`。
 
 | 路由 | 方法 | 说明 |
 |---|---|---|
-| `/api/chat` | POST | 发送消息 → 获取响应 |
-| `/api/chat/stream` | GET | ProgressEvent 的 SSE 流 |
-| `/api/sessions` | GET | 列出所有会话 |
-| `/api/sessions/{id}/messages` | GET | 分页历史（?limit=100&offset=0，最大 500） |
-| `/api/status` | GET | 版本、模型、提供商、运行时间 |
+| `/api/chat` | POST | 发送消息 → 获取响应（同步；流式内容走 WS） |
+| `/api/ui-protocol/ws` | WS | JSON-RPC 2.0 UI Protocol v1（聊天流、`session/list`、`session/messages_page`、`system/status.get` 等） |
+| `/health` | GET | 存活探针（原 `/api/status`；结构化状态已迁移到 WS `system/status.get`） |
+| `/metrics` | GET | Prometheus 文本指标（无需认证） |
+| `/*`（回退） | GET | 内嵌 Web UI（通过 rust-embed 提供静态文件） |
 | `/metrics` | GET | Prometheus 文本格式（无需认证） |
 | `/*`（回退） | GET | 嵌入式 Web UI（通过 rust-embed 的静态文件） |
 
-**认证**：可选的 bearer token，常量时间比较（仅 API 路由；`/metrics` 和静态文件为公开）。**CORS**：localhost:3000/8080。**最大消息**：1MB。
+**认证**：可选的 bearer token，常量时间比较（仅 API 路由；`/metrics` 和静态文件为公开）。**CORS**：localhost 开发源加已配置的 base domain。**最大消息**：1MB。
 
-**Web UI**：通过 `rust-embed` 嵌入的 SPA，作为回退处理器提供服务。会话侧边栏、聊天界面、SSE 流式推送、暗色主题。原生 HTML/CSS/JS（无构建工具）。
+**Web UI**：通过 `rust-embed` 嵌入的 SPA，作为回退处理器提供服务。会话侧边栏、聊天界面、UI Protocol WebSocket 流式传输以及 dashboard/admin 页面共用同一个 `octos serve` 进程。
 
 **Prometheus 指标**：`octos_tool_calls_total`（计数器，标签：tool, success）、`octos_tool_call_duration_seconds`（直方图，标签：tool）、`octos_llm_tokens_total`（计数器，标签：direction）。由 `metrics` + `metrics-exporter-prometheus` crate 驱动。
 

--- a/book-zh/src/cli-reference.md
+++ b/book-zh/src/cli-reference.md
@@ -128,11 +128,11 @@ Bootstrap Files
 
 ```bash
 cargo install --path crates/octos-cli --features api
-octos serve                              # 绑定到 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # 接受外部连接
+octos serve                               # 绑定到 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # 接受外部连接
 ```
 
-功能包括：会话侧栏、聊天界面、SSE 流式传输、暗色主题。`/metrics` 端点提供 Prometheus 格式的指标（`octos_tool_calls_total`、`octos_tool_call_duration_seconds`、`octos_llm_tokens_total`）。
+功能包括：会话侧栏、聊天界面、UI Protocol WebSocket 流式传输、暗色主题。`/metrics` 端点提供 Prometheus 格式的指标（`octos_tool_calls_total`、`octos_tool_call_duration_seconds`、`octos_llm_tokens_total`）。
 
 ---
 

--- a/book-zh/src/installation.md
+++ b/book-zh/src/installation.md
@@ -200,7 +200,7 @@ wsl --install -d Ubuntu
 # 2. 打开 Ubuntu 终端，然后按照上方 Linux (Ubuntu) 的步骤操作
 ```
 
-在 WSL2 中运行 `octos serve` 时，可以通过 Windows 浏览器访问 `http://localhost:8080`（WSL2 自动转发端口）。
+在 WSL2 中运行 `octos serve` 时，可以通过 Windows 浏览器访问 `http://localhost:50080`（WSL2 自动转发端口）。
 
 ## Docker
 
@@ -296,7 +296,7 @@ sudo systemctl restart octos-serve
 | `octos: command not found` | 将 `~/.cargo/bin` 加入 PATH：`export PATH="$HOME/.cargo/bin:$PATH"` |
 | Linux 上编译失败 | 安装 `build-essential pkg-config libssl-dev` |
 | macOS 代码签名警告 | 执行：`codesign -s - ~/.cargo/bin/octos` |
-| 无法访问仪表板 | 检查端口：`octos serve --port 8080`，打开 `http://localhost:8080` |
+| 无法访问仪表板 | 检查端口：`octos serve --port 50080`，打开 `http://localhost:50080` |
 | WSL2 端口未转发 | 重启 WSL：`wsl --shutdown`，然后重新打开终端 |
 | 服务无法启动 | 检查日志：`tail -f ~/.octos/serve.log` 或 `journalctl --user -u octos-serve` |
 | 找不到 API 密钥 | 确保环境变量在服务环境中已设置，而不仅仅在你的 Shell 中 |

--- a/book-zh/src/memory-skills.md
+++ b/book-zh/src/memory-skills.md
@@ -307,7 +307,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # 安装到指定配置文件
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 安装程序会优先从技能注册表下载预编译二进制文件（SHA-256 校验），如有 `Cargo.toml` 则回退到 `cargo build --release`，如有 `package.json` 则运行 `npm install`。
@@ -325,16 +325,14 @@ octos skills search "web scraping"   # 搜索在线注册表
 
 ### 技能解析顺序
 
-技能按以下目录加载（优先级从高到低）：
+配置文件 gateway 按以下优先级加载技能：
 
-1. `.octos/plugins/`（旧版兼容）
-2. `.octos/skills/`（用户安装的自定义技能）
-3. `.octos/bundled-app-skills/`（预装应用技能）
-4. `.octos/platform-skills/`（平台技能：ASR/TTS）
-5. `~/.octos/plugins/`（全局旧版兼容）
-6. `~/.octos/skills/`（全局自定义技能）
+1. `~/.octos/profiles/<profile>/data/skills/`（配置文件作用域的自定义技能）
+2. `<octos_home>/bundled-app-skills/`（预装应用技能）
+3. `<octos_home>/platform-skills/`（管理员加载的平台技能）
 
-用户安装的技能会覆盖同名的预装技能。
+独立项目运行还可以加载 `<project>/.octos/plugins/` 和
+`<project>/.octos/skills/`。旧的 HOME 全局目录仅用于迁移，不再属于常规扫描路径。
 
 ---
 

--- a/book-zh/src/quickstart.md
+++ b/book-zh/src/quickstart.md
@@ -65,4 +65,4 @@ octos gateway
 octos serve
 ```
 
-然后在浏览器中打开 `http://localhost:8080`。
+然后在浏览器中打开 `http://localhost:50080`。

--- a/book-zh/src/skill-development.md
+++ b/book-zh/src/skill-development.md
@@ -127,7 +127,7 @@ pub enum ValidatorSpec {
 ```
 User message → LLM → tool_use("get_weather", {"city": "Paris"})
                          ↓
-              Gateway spawns: ~/.octos/skills/weather/main get_weather
+              Gateway spawns: ~/.octos/profiles/<profile>/data/skills/weather/main get_weather
                          ↓
               Stdin:  {"city": "Paris"}
               Stdout: {"output": "Paris, France\nClear sky\n...", "success": true}
@@ -153,7 +153,7 @@ crates/app-skills/my-skill/
 启动引导后，技能安装在：
 
 ```
-~/.octos/skills/my-skill/
+~/.octos/profiles/alice/data/skills/my-skill/
 ├── main                # 可执行二进制文件（从 target/ 复制）
 ├── manifest.json       # 工具定义
 └── SKILL.md            # 文档
@@ -392,7 +392,7 @@ pub const BUNDLED_APP_SKILLS: &[(&str, &str, &str, &str)] = &[
 
 **元组格式：** `(dir_name, binary_name, skill_md, manifest_json)`
 
-- `dir_name`：`~/.octos/skills/` 下的目录名
+- `dir_name`：引导写入 `<octos_home>/bundled-app-skills/` 时使用的目录名
 - `binary_name`：`target/release/` 中的二进制文件名（必须与 Cargo.toml 中的 `[[bin]] name` 匹配）
 - `skill_md`：嵌入的 SKILL.md 内容
 - `manifest_json`：嵌入的 manifest.json 内容
@@ -431,12 +431,15 @@ echo '{"param1": "test"}' | ./target/debug/my_skill unknown_tool
 # 构建 release 版本并安装
 cargo build --release --workspace
 
-# 启动网关（技能自动引导加载）
-octos gateway
+# 安装到要测试的配置文件
+octos skills --profile alice install ./my-skill
 
 # 检查技能是否已加载
-ls ~/.octos/skills/my-skill/
+ls ~/.octos/profiles/alice/data/skills/my-skill/
 # main  manifest.json  SKILL.md
+
+# 启动网关
+octos gateway
 
 # 让 Agent 使用你的技能
 ```
@@ -672,7 +675,7 @@ fn get_smtp_config() -> SmtpConfig {
 **示例：技能目录布局**
 
 ```
-~/.octos/skills/my-style-guide/
+~/.octos/profiles/alice/data/skills/my-style-guide/
 ├── manifest.json
 ├── SKILL.md
 └── prompts/
@@ -878,8 +881,8 @@ requires_env: MY_API_KEY
 # 只构建该技能
 cargo build --release -p weather
 
-# 复制到远程服务器
-scp target/release/weather remote:~/.octos/skills/weather/main
+# 复制到远程服务器上的目标配置文件
+scp target/release/weather remote:~/.octos/profiles/alice/data/skills/weather/main
 
 # 无需重启网关 — 下次工具调用时使用新二进制文件
 ```
@@ -952,8 +955,8 @@ manage_skills(action="search", query="comic")
 
 1. `<profile-data>/skills/` — 按配置文件（最高优先级）
 2. `<project-dir>/skills/` — 项目本地
-3. `<project-dir>/bundled-skills/` — 内置应用技能
-4. `~/.octos/skills/` — 全局（最低优先级）
+3. `<project-dir>/bundled-app-skills/` — 内置应用技能
+4. `~/.octos/skills/` — 旧版全局目录，仅用于迁移
 
 ### 发布到注册表
 
@@ -1062,7 +1065,7 @@ let styles_dir = skill_dir.join("styles");
 - [ ] 添加到 `bundled_app_skills.rs` 中的 `BUNDLED_APP_SKILLS`
 - [ ] `cargo build --workspace` 成功
 - [ ] 独立测试：`echo '{"param": "value"}' | ./target/debug/my_skill my_tool`
-- [ ] 网关测试：技能出现在 `~/.octos/skills/` 中且 Agent 可以使用
+- [ ] 网关测试：技能出现在目标配置文件的 `data/skills/` 中且 Agent 可以使用
 
 ### 扩展（MCP 服务器、钩子、提示片段）
 

--- a/book-zh/src/troubleshooting.md
+++ b/book-zh/src/troubleshooting.md
@@ -93,7 +93,7 @@ export WECOM_BOT_SECRET="your_secret"
 
 | 问题 | 解决方案 |
 |---------|----------|
-| 仪表板无法访问 | 检查端口：`octos serve --port 8080`，打开 `http://localhost:8080/admin/` |
+| 仪表板无法访问 | 检查端口：`octos serve --port 50080`，打开 `http://localhost:50080/admin/` |
 | WSL2 端口未转发 | 重启 WSL：`wsl --shutdown` 然后重新打开终端 |
 | 服务无法启动 | 查看日志：`tail -f ~/.octos/serve.log`（macOS）或 `journalctl --user -u octos-serve`（Linux） |
 | Windows: 找不到 `octos` | 确保 `%USERPROFILE%\.cargo\bin` 在 PATH 中 |

--- a/book/src/advanced.md
+++ b/book/src/advanced.md
@@ -604,15 +604,15 @@ octos cron enable <job-id> --disable
 The REST API server includes an embedded web UI:
 
 ```bash
-octos serve                              # Binds to 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # Accept external connections
-# Open http://localhost:8080
+octos serve                               # Binds to 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # Accept external connections
+# Open http://localhost:50080
 ```
 
 Features:
 - Session sidebar
 - Chat interface
-- SSE streaming
+- UI Protocol WebSocket streaming
 - Dark theme
 
 A `/metrics` endpoint provides Prometheus-format metrics:

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -807,14 +807,16 @@ Plugins extend the agent with external tools via standalone executables. Each pl
 #### Directory Layout
 
 ```
-.octos/plugins/           # local (project-level)
-~/.octos/plugins/         # global (user-level)
+<octos_home>/plugins/                 # deployment-scoped plugins
+<octos_home>/skills/                  # deployment-scoped skills
+<octos_home>/bundled-app-skills/      # bundled app skills
+~/.octos/profiles/<profile>/data/skills/
   └── my-plugin/
       ├── manifest.json  # plugin metadata + tool definitions
       └── my-plugin      # executable (or "main" as fallback)
 ```
 
-**Discovery order**: local `.octos/plugins/` first, then global `~/.octos/plugins/`. Both are scanned by `Config::plugin_dirs()`.
+**Discovery order**: `Config::plugin_dirs_from_project()` scans deployment-scoped `<octos_home>/plugins`, `<octos_home>/skills`, `<octos_home>/bundled-app-skills`, and `OCTOS_SKILLS_PATH`; managed profile gateways then layer platform skills and the active profile's `data/skills/` directory on top. Legacy HOME-rooted globals (`~/.octos/plugins`, `~/.octos/skills`) are no longer scanned except for a one-shot migration warning.
 
 #### PluginManifest
 
@@ -1169,9 +1171,9 @@ Polls every 5 seconds. SHA-256 hash comparison of file contents.
 | `/metrics` | GET | Prometheus text exposition format (unauthenticated) |
 | `/*` (fallback) | GET | Embedded web UI (static files via rust-embed) |
 
-**Auth**: Optional bearer token with constant-time comparison (API routes only; `/metrics` and static files are public). **CORS**: localhost:3000/8080. **Max message**: 1MB.
+**Auth**: Optional bearer token with constant-time comparison (API routes only; `/metrics` and static files are public). **CORS**: localhost development origins plus the configured base domain. **Max message**: 1MB.
 
-**Web UI**: Embedded SPA via `rust-embed` served as the fallback handler. Session sidebar, chat interface, SSE streaming, dark theme. Vanilla HTML/CSS/JS (no build tools).
+**Web UI**: Embedded SPA via `rust-embed` served as the fallback handler. Session sidebar, chat interface, UI Protocol WebSocket streaming, and dashboard/admin surfaces share the same `octos serve` process.
 
 **Prometheus Metrics**: `octos_tool_calls_total` (counter, labels: tool, success), `octos_tool_call_duration_seconds` (histogram, label: tool), `octos_llm_tokens_total` (counter, label: direction). Powered by `metrics` + `metrics-exporter-prometheus` crates.
 

--- a/book/src/architecture.md
+++ b/book/src/architecture.md
@@ -1126,7 +1126,7 @@ Periodic check of `HEARTBEAT.md` (default: 30 min interval). Sends content to ag
 | `clean` | Remove .redb files with dry-run support |
 | `completions` | Shell completion generation (bash/zsh/fish) |
 | `docs` | Generate tool + provider documentation |
-| `serve` | REST API server (feature: api) — axum on 127.0.0.1:8080 (`--host` to override) |
+| `serve` | REST API server (feature: api) — axum on 127.0.0.1:50080 (`--host` to override) |
 
 ### Configuration
 

--- a/book/src/cli-reference.md
+++ b/book/src/cli-reference.md
@@ -128,11 +128,11 @@ Launch the web UI and REST API server. Requires the `api` feature flag.
 
 ```bash
 cargo install --path crates/octos-cli --features api
-octos serve                              # Binds to 127.0.0.1:8080
-octos serve --host 0.0.0.0 --port 3000  # Accept external connections
+octos serve                               # Binds to 127.0.0.1:50080
+octos serve --host 0.0.0.0 --port 50080  # Accept external connections
 ```
 
-Features: session sidebar, chat interface, SSE streaming, dark theme. A `/metrics` endpoint provides Prometheus-format metrics (`octos_tool_calls_total`, `octos_tool_call_duration_seconds`, `octos_llm_tokens_total`).
+Features: session sidebar, chat interface, UI Protocol WebSocket streaming, dark theme. A `/metrics` endpoint provides Prometheus-format metrics (`octos_tool_calls_total`, `octos_tool_call_duration_seconds`, `octos_llm_tokens_total`).
 
 ---
 

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -216,7 +216,7 @@ wsl --install -d Ubuntu
 # 2. Open Ubuntu terminal, then follow Linux (Ubuntu) steps above
 ```
 
-When running `octos serve` inside WSL2, the dashboard is accessible from your Windows browser at `http://localhost:8080` (WSL2 auto-forwards ports).
+When running `octos serve` inside WSL2, the dashboard is accessible from your Windows browser at `http://localhost:50080` (WSL2 auto-forwards ports).
 
 ## Docker
 
@@ -318,7 +318,7 @@ sudo systemctl restart octos-serve
 | `octos: command not found` | Add `~/.cargo/bin` to PATH: `export PATH="$HOME/.cargo/bin:$PATH"` |
 | Build fails on Linux | Install `build-essential pkg-config libssl-dev` |
 | macOS codesign warning | Run: `codesign -s - ~/.cargo/bin/octos` |
-| Dashboard not accessible | Check port: `octos serve --port 8080`, open `http://localhost:8080` |
+| Dashboard not accessible | Check port: `octos serve --port 50080`, open `http://localhost:50080` |
 | WSL2 port not forwarded | Restart WSL: `wsl --shutdown` then reopen terminal |
 | Service won't start | Check logs: `tail -f ~/.octos/serve.log` or `journalctl --user -u octos-serve` |
 | API key not found | Ensure env var is set in the service environment, not just your shell |

--- a/book/src/memory-skills.md
+++ b/book/src/memory-skills.md
@@ -307,7 +307,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # Install into a specific profile
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 The installer tries to download a pre-built binary from the skill registry (SHA-256 verified), falls back to `cargo build --release` if a `Cargo.toml` is present, or runs `npm install` if a `package.json` is present.
@@ -325,16 +325,15 @@ octos skills search "web scraping"   # Search the online registry
 
 ### Skill Resolution Order
 
-Skills are loaded from these directories (highest priority first):
+Profile gateways load skills from these directories (highest priority first):
 
-1. `.octos/plugins/` (legacy)
-2. `.octos/skills/` (user-installed custom skills)
-3. `.octos/bundled-app-skills/` (bundled app skills)
-4. `.octos/platform-skills/` (platform: ASR/TTS)
-5. `~/.octos/plugins/` (global legacy)
-6. `~/.octos/skills/` (global custom)
+1. `~/.octos/profiles/<profile>/data/skills/` (profile-scoped custom skills)
+2. `<octos_home>/bundled-app-skills/` (bundled app skills)
+3. `<octos_home>/platform-skills/` (admin-loaded platform skills)
 
-User-installed skills override bundled skills with the same name.
+Standalone project runs can also load `<project>/.octos/plugins/` and
+`<project>/.octos/skills/`. The old HOME-rooted global directories are
+migration-only and are no longer part of the normal scan path.
 
 ---
 

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -65,4 +65,4 @@ If you built with the `api` feature, start the web dashboard:
 octos serve
 ```
 
-Then open `http://localhost:8080` in your browser.
+Then open `http://localhost:50080` in your browser.

--- a/book/src/skill-development.md
+++ b/book/src/skill-development.md
@@ -21,7 +21,7 @@ This guide covers the full lifecycle of an Octos skill — from development to p
 | **App Store** | Apple App Store | [octos-hub](https://github.com/octos-org/octos-hub) registry |
 | **Distribution** | App Store binary delivery | Pre-built binaries in GitHub Releases |
 | **Install** | Tap "Get" | `octos skills install user/repo` |
-| **Sideload** | Ad-hoc / TestFlight | Copy to `~/.octos/skills/` directly |
+| **Sideload** | Ad-hoc / TestFlight | `octos skills --profile <profile> install ./my-skill` |
 
 ---
 
@@ -148,7 +148,7 @@ A skill is a **standalone executable** that communicates via **stdin/stdout JSON
 ```
 User message → LLM → tool_use("get_weather", {"city": "Paris"})
                         ↓
-             Gateway spawns: ~/.octos/skills/weather/main get_weather
+             Gateway spawns: ~/.octos/profiles/<profile>/data/skills/weather/main get_weather
                         ↓
              Stdin:  {"city": "Paris"}
              Stdout: {"output": "25°C, sunny", "success": true}
@@ -441,12 +441,15 @@ echo '{"param1": "hello"}' | ./my-skill/main my_tool
 # Build everything
 cargo build --release --workspace
 
-# Start the gateway
-octos gateway
+# Install into the profile you want to test
+octos skills --profile alice install ./my-skill
 
 # Verify skill loaded
-ls ~/.octos/skills/my-skill/
+ls ~/.octos/profiles/alice/data/skills/my-skill/
 # main  manifest.json  SKILL.md
+
+# Start the gateway
+octos gateway
 
 # Ask the agent to use your skill in conversation
 ```
@@ -688,21 +691,26 @@ DELETE /api/admin/profiles/alice/skills/my-skill
 
 ### Sideloading (Manual Install)
 
-Copy a skill directory directly — like sideloading an app:
+Install a local skill directory into the profile that should be allowed to use
+it:
 
 ```bash
-# Copy to global skills directory
-cp -r my-skill/ ~/.octos/skills/my-skill/
-chmod +x ~/.octos/skills/my-skill/main
+octos skills --profile alice install ./my-skill --force
+```
 
-# Or to a profile-specific directory
+For one-off debugging you can copy the directory yourself, but keep the target
+profile-scoped:
+
+```bash
+# Canonical: per-profile install
 cp -r my-skill/ ~/.octos/profiles/alice/data/skills/my-skill/
+chmod +x ~/.octos/profiles/alice/data/skills/my-skill/main
 ```
 
 ### Installed Skill Layout
 
 ```
-~/.octos/skills/my-skill/
+~/.octos/profiles/alice/data/skills/my-skill/
 ├── main                # Executable binary
 ├── manifest.json       # Tool definitions
 ├── SKILL.md            # Documentation
@@ -729,8 +737,8 @@ When multiple directories contain a skill with the same name, first match wins:
 |----------|----------|--------|
 | 1 (highest) | `<profile-data>/skills/` | Per-profile install |
 | 2 | `<project-dir>/skills/` | Project-local |
-| 3 | `<project-dir>/bundled-skills/` | Bundled app-skills |
-| 4 (lowest) | `~/.octos/skills/` | Global install |
+| 3 | `<project-dir>/bundled-app-skills/` | Bundled app-skills |
+| 4 (lowest, deprecated) | `~/.octos/skills/` | Legacy global install, migration only |
 
 ---
 
@@ -758,7 +766,7 @@ Skill binaries can be updated without restarting the gateway:
 cargo build --release -p my-skill
 
 # Replace the binary
-cp target/release/my_skill ~/.octos/skills/my-skill/main
+cp target/release/my_skill ~/.octos/profiles/alice/data/skills/my-skill/main
 
 # Next tool call automatically uses the new binary
 ```

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -93,7 +93,7 @@ Messages over 4096 characters are automatically split into multiple chunks by oc
 
 | Problem | Solution |
 |---------|----------|
-| Dashboard not accessible | Check port: `octos serve --port 8080`, open `http://localhost:8080/admin/` |
+| Dashboard not accessible | Check port: `octos serve --port 50080`, open `http://localhost:50080/admin/` |
 | WSL2 port not forwarded | Restart WSL: `wsl --shutdown` then reopen terminal |
 | Service will not start | Check logs: `tail -f ~/.octos/serve.log` (macOS) or `journalctl --user -u octos-serve` (Linux) |
 | Windows: `octos` not found | Ensure `%USERPROFILE%\.cargo\bin` is in your PATH |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1218,7 +1218,7 @@ Periodic check of `HEARTBEAT.md` (default: 30 min interval). Sends content to ag
 | `clean` | Remove .redb files with dry-run support |
 | `completions` | Shell completion generation (bash/zsh/fish) |
 | `docs` | Generate tool + provider documentation |
-| `serve` | REST API server (feature: api) — axum on 127.0.0.1:8080 (`--host` to override). On first launch with no admin profile, the embedded dashboard runs the **setup wizard** (deployment-mode → SMTP → LLM provider → admin profile). Setup endpoints under `/api/admin/setup/{state,step,complete,skip}`. |
+| `serve` | REST API server (feature: api) — axum on 127.0.0.1:50080 (`--host` to override). On first launch with no admin profile, the embedded dashboard runs the **setup wizard** (deployment-mode → SMTP → LLM provider → admin profile). Setup endpoints under `/api/admin/setup/{state,step,complete,skip}`. |
 
 ### Configuration
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -611,7 +611,7 @@ The other workspace `app-skills/*` crates (`harness-starter-{audio,coding,generi
 
 ### Bootstrap (`bootstrap.rs`)
 
-`bootstrap.rs` writes the contents of each `BUNDLED_APP_SKILLS` entry into `~/.octos/bundled-app-skills/<dir>/` (constant: `BUNDLED_APP_SKILLS_DIR = "bundled-app-skills"`) at gateway startup, then drops the matching binary alongside it. The runtime resolves these in addition to user-installed skills under `~/.octos/skills/` and per-profile `~/.octos/profiles/<id>/data/skills/`. Operators or sideloaded user skills go into `~/.octos/skills/` so they aren't overwritten on next bootstrap.
+`bootstrap.rs` writes the contents of each `BUNDLED_APP_SKILLS` entry into `<octos_home>/bundled-app-skills/<dir>/` (constant: `BUNDLED_APP_SKILLS_DIR = "bundled-app-skills"`) at gateway startup, then drops the matching binary alongside it. Platform skills live under `<octos_home>/platform-skills/`, while operator or sideloaded custom skills are installed per profile under `~/.octos/profiles/<id>/data/skills/`. Legacy HOME-rooted globals such as `~/.octos/skills/` are migration-only; current profile gateways no longer scan them as a normal install location.
 
 ### Sub-Agent Output Router (M8.7)
 
@@ -873,14 +873,16 @@ Plugins extend the agent with external tools via standalone executables. Each pl
 #### Directory Layout
 
 ```
-.octos/plugins/           # local (project-level)
-~/.octos/plugins/         # global (user-level)
+<octos_home>/plugins/                 # deployment-scoped plugins
+<octos_home>/skills/                  # deployment-scoped skills
+<octos_home>/bundled-app-skills/      # bundled app skills
+~/.octos/profiles/<profile>/data/skills/
   └── my-plugin/
       ├── manifest.json  # plugin metadata + tool definitions
       └── my-plugin      # executable (or "main" as fallback)
 ```
 
-**Discovery order**: local `.octos/plugins/` first, then global `~/.octos/plugins/`. Both are scanned by `Config::plugin_dirs()`.
+**Discovery order**: `Config::plugin_dirs_from_project()` scans deployment-scoped `<octos_home>/plugins`, `<octos_home>/skills`, `<octos_home>/bundled-app-skills`, and `OCTOS_SKILLS_PATH`; managed profile gateways then layer platform skills and the active profile's `data/skills/` directory on top. Legacy HOME-rooted globals (`~/.octos/plugins`, `~/.octos/skills`) are no longer scanned except for a one-shot migration warning.
 
 #### PluginManifest
 
@@ -1261,9 +1263,9 @@ Polls every 5 seconds. SHA-256 hash comparison of file contents.
 | `/metrics` | GET | Prometheus text exposition format (unauthenticated) |
 | `/*` (fallback) | GET | Embedded web UI (static files via rust-embed) |
 
-**Auth**: Optional bearer token with constant-time comparison (API routes only; `/metrics` and static files are public). **CORS**: localhost:3000/8080. **Max message**: 1MB.
+**Auth**: Optional bearer token with constant-time comparison (API routes only; `/metrics` and static files are public). **CORS**: localhost development origins plus the configured base domain. **Max message**: 1MB.
 
-**Web UI**: Embedded SPA via `rust-embed` served as the fallback handler. Session sidebar, chat interface, SSE streaming, dark theme. Vanilla HTML/CSS/JS (no build tools).
+**Web UI**: Embedded SPA via `rust-embed` served as the fallback handler. Session sidebar, chat interface, UI Protocol WebSocket streaming, and dashboard/admin surfaces share the same `octos serve` process.
 
 **Prometheus Metrics**: `octos_tool_calls_total` (counter, labels: tool, success), `octos_tool_call_duration_seconds` (histogram, label: tool), `octos_llm_tokens_total` (counter, label: direction). Powered by `metrics` + `metrics-exporter-prometheus` crates.
 
@@ -1344,7 +1346,7 @@ crates/octos-plugin/src/
 
 **InstallSpec**: Declarative install steps with `kind` (brew, apt, cargo, url), platform-specific formulas/packages, and provided binary names.
 
-**Discovery** (`discovery.rs`): Scans plugin directories with precedence (local `.octos/plugins/` before global `~/.octos/plugins/`).
+**Discovery** (`discovery.rs`): Loads the directories supplied by `Config::plugin_dirs_from_project()` plus the profile/platform layers added by the serving runtime; HOME-rooted global plugin directories are deprecated migration remnants, not part of normal discovery.
 
 **Plugin Protocol v2** (`protocol_v2.rs`): Skills can opt in to a richer reporting protocol by setting `protocol_version: 2` in the manifest. In addition to the v1 stdin/stdout JSON contract, v2 plugins emit structured **events on stderr**, one JSON object per line:
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -712,7 +712,7 @@ Profile containers need selective network access:
 Run a domain-allowlist HTTP proxy on the host. Profile containers route all traffic through it.
 
 ```
-octos serve (host, port 3000)
+octos serve (host, port 50080)
 ├── allowlist proxy (host, port 8888)
 │   ├── sales profile: allow api.moonshot.ai, api.telegram.org
 │   ├── support profile: allow api.deepseek.com, api.telegram.org

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -363,7 +363,7 @@ This restricts shell command reads at the kernel level to the profile's data, sh
 
 #### project_dir decoupled from cwd
 
-Shared resources -- installed skills (`~/.octos/skills/`), global config (`~/.octos/config.json`), bundled app-skills -- are loaded from `--octos-home` (the `project_dir`), not from `cwd`. This decoupling means narrowing `cwd` to the profile's data directory does not break access to shared pipelines and configurations.
+Shared resources such as deployment-scoped skills, platform skills, global config (`~/.octos/config.json`), and bundled app-skills are loaded from `--octos-home` (the `project_dir`) plus the active profile's `data/skills/` directory, not from `cwd`. This decoupling means narrowing `cwd` to the profile's data directory does not break access to shared pipelines and configurations.
 
 #### Remaining gaps
 

--- a/docs/SKILL_DEPLOYMENT.md
+++ b/docs/SKILL_DEPLOYMENT.md
@@ -28,7 +28,7 @@ pushing mofa-skills onto the fleet. Differences from the old script:
 
 | Concern                | `deploy-mini.sh` (legacy)            | `fleet-install-skills.sh` (new)                              |
 |------------------------|--------------------------------------|---------------------------------------------------------------|
-| Transport              | raw `scp` of each file               | `rsync` to staging + `octos skills install <staging-path>`    |
+| Transport              | raw `scp` of each file               | `rsync` to staging + `octos skills --profile <id> install <staging-path>` |
 | sha256 verification    | none                                 | yes, via `manage_skills::download_binary` when manifest binaries are declared |
 | Install path           | hard-coded `~/.octos/profiles/dspfac/data/skills/` | resolved server-side by `--profile <id>`                      |
 | Multi-profile          | one profile per run                  | iterates every profile on the host (or explicit `--profile`)  |

--- a/docs/app-skill-dev-guide-zh.md
+++ b/docs/app-skill-dev-guide-zh.md
@@ -206,7 +206,7 @@ console.log(JSON.stringify({ output: result, success: true }));
 | `CostEvent` | `{step, provider, model, input_tokens, output_tokens, usd}` | 单步 LLM 成本，由 `cost_ledger.rs` 汇总 |
 | `ArtifactEvent` | `{name, path, mime}` | 产出物指针（文件路径或 URL） |
 
-宿主把 phase/progress 事件以 `tool_progress` SSE 形式转发给仪表盘/客户端，把 `CostEvent` 累加到父级单轮成本汇总；解析失败的行视为普通日志（按 `info` 级别记入 `LogEvent`）。
+宿主通过 UI Protocol 的任务/进度事件流把 phase/progress 事件转发给仪表盘/客户端，把 `CostEvent` 累加到父级单轮成本汇总；解析失败的行视为普通日志（按 `info` 级别记入 `LogEvent`）。
 
 合成式技能（`deep-search`、`deep-crawl`）在 `manifest.json` 声明 `synthesis_config` 与 `x-octos-host-config-keys`，宿主据此为合成调用注入正确的 LLM provider/model 并转发 API key 等环境变量。合同测试位于 `crates/octos-plugin/tests/lifecycle_sandbox.rs`。
 
@@ -281,7 +281,7 @@ manage_skills(action="search", query="comic")
 1. `<profile-data>/skills/` — 配置文件级（最高优先级）
 2. `<project-dir>/skills/` — 项目本地
 3. `<project-dir>/bundled-app-skills/` — 内置应用技能（常量 `BUNDLED_APP_SKILLS_DIR`，位于 `octos-agent/src/bootstrap.rs`，由 `Config::plugin_dirs_from_project` 扫描）
-4. `~/.octos/skills/` — 全局（最低优先级）
+4. `~/.octos/skills/` — 旧版全局目录，仅用于迁移
 
 ### 发布到注册中心
 

--- a/docs/app-skill-dev-guide.md
+++ b/docs/app-skill-dev-guide.md
@@ -21,7 +21,7 @@ This guide covers the full lifecycle of an Octos skill — from development to p
 | **App Store** | Apple App Store | [octos-hub](https://github.com/octos-org/octos-hub) registry |
 | **Distribution** | App Store binary delivery | Pre-built binaries in GitHub Releases |
 | **Install** | Tap "Get" | `octos skills install user/repo` |
-| **Sideload** | Ad-hoc / TestFlight | Copy to `~/.octos/skills/` directly |
+| **Sideload** | Ad-hoc / TestFlight | `octos skills --profile <profile> install ./my-skill` |
 
 ---
 
@@ -34,7 +34,7 @@ A skill is a **standalone executable** that communicates via **stdin/stdout JSON
 ```
 User message → LLM → tool_use("get_weather", {"city": "Paris"})
                         ↓
-             Gateway spawns: ~/.octos/skills/weather/main get_weather
+             Gateway spawns: ~/.octos/profiles/<profile>/data/skills/weather/main get_weather
                         ↓
              Stdin:  {"city": "Paris"}
              Stdout: {"output": "25°C, sunny", "success": true}
@@ -332,12 +332,15 @@ echo '{"param1": "hello"}' | ./my-skill/main my_tool
 # Build everything
 cargo build --release --workspace
 
-# Start the gateway
-octos gateway
+# Install into the profile you want to test
+octos skills --profile alice install ./my-skill
 
 # Verify skill loaded
-ls ~/.octos/skills/my-skill/
+ls ~/.octos/profiles/alice/data/skills/my-skill/
 # main  manifest.json  SKILL.md
+
+# Start the gateway
+octos gateway
 
 # Ask the agent to use your skill in conversation
 ```
@@ -579,13 +582,21 @@ DELETE /api/admin/profiles/alice/skills/my-skill
 
 ### Fleet Deploy
 
-For multi-host fleets, use `scripts/fleet-install-skills.sh` (PR #939) — it replaces the legacy `mofa-skills/scripts/deploy-mini.sh` `scp` flow. The new script rsyncs each skill to a staging path on every host and then runs `octos skills install <staging-path>` server-side so the manifest's sha256 verification runs inside the same code path the runtime uses.
+For multi-host fleets, use `scripts/fleet-install-skills.sh` (PR #939) — it replaces the legacy `mofa-skills/scripts/deploy-mini.sh` `scp` flow. The new script rsyncs each skill to a staging path on every host and then runs `octos skills --profile <profile> install <staging-path>` server-side so the manifest's sha256 verification runs inside the same code path the runtime uses.
 
 See [`docs/SKILL_DEPLOYMENT.md`](./SKILL_DEPLOYMENT.md) for the operator-side runbook (CLI flags, env overrides, migration from legacy `~/.octos/skills/`, verification commands).
 
 ### Sideloading (Manual Install)
 
-Copy a skill directory directly — like sideloading an app:
+Install a local skill directory into the profile that should be allowed to use
+it:
+
+```bash
+octos skills --profile alice install ./my-skill --force
+```
+
+For one-off debugging you can copy the directory yourself, but keep the target
+profile-scoped:
 
 ```bash
 # Canonical: per-profile install
@@ -597,12 +608,14 @@ cp -r my-skill/ ~/.octos/skills/my-skill/
 chmod +x ~/.octos/skills/my-skill/main
 ```
 
-The global `~/.octos/skills/` directory is being retired (PR #944). New deployments should write directly to the per-profile path.
+The global `~/.octos/skills/` directory is retired for new installs. It is kept
+only as a legacy migration source; new deployments should write directly to the
+per-profile path or use `octos skills --profile <profile> install`.
 
 ### Installed Skill Layout
 
 ```
-~/.octos/skills/my-skill/
+~/.octos/profiles/alice/data/skills/my-skill/
 ├── main                # Executable binary
 ├── manifest.json       # Tool definitions
 ├── SKILL.md            # Documentation
@@ -627,12 +640,18 @@ Loading dedupes by `manifest.id` — the **first** directory scanned that contai
 
 | Priority | Location | Source |
 |----------|----------|--------|
-| 1 (highest) | `~/.octos/profiles/<profile>/data/skills/` | **Canonical** per-profile install (`octos skills install --profile <p>`; `fleet-install-skills.sh`) |
+| 1 (highest) | `~/.octos/profiles/<profile>/data/skills/` | **Canonical** per-profile install (`octos skills --profile <p> install`; `fleet-install-skills.sh`) |
 | 2 | `<project-dir>/skills/` | Project-local (development checkouts) |
 | 3 | `<project-dir>/bundled-app-skills/` | Bundled app-skills (constant `BUNDLED_APP_SKILLS_DIR` in `octos-agent/src/bootstrap.rs`; scanned by `Config::plugin_dirs_from_project`) |
 | 4 (lowest, **deprecated**) | `~/.octos/skills/` | Legacy global install — the loader emits a deprecation warning on every startup that sees this directory. See [Part 5: Install](#part-5-install) and [`docs/SKILL_DEPLOYMENT.md`](./SKILL_DEPLOYMENT.md) for the per-profile-only migration (PR #944). |
 
-**Lesson from the fleet (2026):** before PR #936 the loader registered duplicate ids twice and `ToolRegistry::register` overwrote by tool name — so a stale per-profile install could silently shadow a freshly-deployed global skill, and vice versa. Two production regressions (yangmi, douwentao) traced back to this trap before the dedup landed. On fleet upgrades, update **both** `~/.octos/skills/<x>/` *and* `<profile>/data/skills/<x>/` in lock-step until the global directory is removed.
+**Lesson from the fleet (2026):** before PR #936 the loader registered duplicate
+ids twice and `ToolRegistry::register` overwrote by tool name — so a stale
+per-profile install could silently shadow a freshly-deployed global skill, and
+vice versa. Two production regressions (yangmi, douwentao) traced back to this
+trap before the dedup landed. On fleet upgrades, migrate legacy global skills
+into the intended per-profile directories and then stop refreshing
+`~/.octos/skills/`; do not keep the two locations in lock-step.
 
 ---
 
@@ -660,7 +679,7 @@ Skill binaries can be updated without restarting the gateway:
 cargo build --release -p my-skill
 
 # Replace the binary
-cp target/release/my_skill ~/.octos/skills/my-skill/main
+cp target/release/my_skill ~/.octos/profiles/alice/data/skills/my-skill/main
 
 # Next tool call automatically uses the new binary
 ```
@@ -929,7 +948,7 @@ For skill authors with existing skills, here's what to align with as of 2026-05-
   - `has_meaningful_tts_audio` / `parse_wav_metadata` (mofa-podcast) → replace with `ValidatorSpec::AudioNonSilent` + `ValidatorSpec::MagicBytes`.
   - `poll_training_status` (mofa-fm) → replace with `ValidatorSpec::HttpProbeUntil`.
 - [ ] **For spawn-only artifact-producers, emit `named_outputs` where the harness needs to validate the output.** e.g. a `mofa_publish`-style skill must emit `{ "deploy_url": "..." }` so the harness's `HttpProbe { url_template = "${output.deploy_url}" }` can probe the live URL.
-- [ ] **Move to per-profile install.** Stop writing to `~/.octos/skills/`; use `octos skills install --profile <p>` or the fleet script.
+- [ ] **Move to per-profile install.** Stop writing to `~/.octos/skills/`; use `octos skills --profile <p> install` or the fleet script.
 - [ ] **Ship `manifest.json` `binaries.<platform>.sha256` if you publish pre-built binaries.** The installer verifies before copy.
 
 ### Backward compatibility
@@ -976,7 +995,7 @@ Long-running skills (research, crawls, voice training, multi-step pipelines) nee
 | `CostEvent` | `{step, provider, model, input_tokens, output_tokens, usd}` | Per-step LLM cost — rolls up via `cost_ledger.rs` |
 | `ArtifactEvent` | `{name, path, mime}` | Pointer to a produced artifact (file path or URL) |
 
-The host parses each line, surfaces phase/progress events as `tool_progress` SSE events to the dashboard/clients, and aggregates `CostEvent` lines into the parent's per-turn cost rollup. Lines that don't parse as events are treated as plain log lines (downgraded to `LogEvent` with `level=info`).
+The host parses each line, surfaces phase/progress events through the UI Protocol task/progress event stream to the dashboard/clients, and aggregates `CostEvent` lines into the parent's per-turn cost rollup. Lines that don't parse as events are treated as plain log lines (downgraded to `LogEvent` with `level=info`).
 
 **Stdout** still carries the final v1-shaped JSON: `{"output": "<final result>", "success": true, "files_to_send": [...]}`.
 

--- a/docs/user-guide-zh.md
+++ b/docs/user-guide-zh.md
@@ -78,10 +78,10 @@ octos serve（控制面板 + 仪表盘，约 140 个 REST 端点）
 
 ```bash
 # 启动控制面板
-octos serve --host 0.0.0.0 --port 3000
+octos serve --host 0.0.0.0
 
 # 仪表盘地址：
-# http://localhost:3000
+# http://localhost:50080
 ```
 
 如果在反向代理（如 Caddy 或 Nginx）后运行，请配置转发到 serve 端口。
@@ -622,7 +622,7 @@ export PERPLEXITY_API_KEY="pplx-your-key"
 #### 通过管理 API
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/profiles \
+curl -X POST http://localhost:50080/api/admin/profiles \
   -H "Content-Type: application/json" \
   -d '{
     "id": "my-bot",
@@ -652,16 +652,16 @@ curl -X POST http://localhost:3000/api/admin/profiles \
 
 ```bash
 # 启动配置文件的 gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/start
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/start
 
 # 停止配置文件的 gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/stop
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/stop
 
 # 重启（停止 + 启动）
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/restart
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/restart
 
 # 检查状态
-curl http://localhost:3000/api/admin/profiles/my-bot/status
+curl http://localhost:50080/api/admin/profiles/my-bot/status
 ```
 
 **启动验证：** 启动端点会在启动 gateway 之前验证 LLM 提供商是否已配置。如果提供商或 API 密钥缺失，将返回错误。
@@ -671,7 +671,7 @@ curl http://localhost:3000/api/admin/profiles/my-bot/status
 更新使用 **JSON 合并** — 只有你包含的字段会被修改。所有其他字段保持不变。
 
 ```bash
-curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
+curl -X PUT http://localhost:50080/api/admin/profiles/my-bot \
   -H "Content-Type: application/json" \
   -d '{
     "name": "更新后的机器人名称",
@@ -687,7 +687,7 @@ curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
 ### 8.4 删除配置文件
 
 ```bash
-curl -X DELETE http://localhost:3000/api/admin/profiles/my-bot
+curl -X DELETE http://localhost:50080/api/admin/profiles/my-bot
 ```
 
 这将停止 gateway 进程（如果正在运行）并级联删除所有子账户。
@@ -696,17 +696,17 @@ curl -X DELETE http://localhost:3000/api/admin/profiles/my-bot
 
 ```bash
 # SSE 日志流（实时）
-curl http://localhost:3000/api/admin/profiles/my-bot/logs
+curl http://localhost:50080/api/admin/profiles/my-bot/logs
 
 # 提供商指标
-curl http://localhost:3000/api/admin/profiles/my-bot/metrics
+curl http://localhost:50080/api/admin/profiles/my-bot/metrics
 ```
 
 ### 8.6 API 总览端点
 
 ```bash
 # 获取所有配置文件的摘要
-curl http://localhost:3000/api/admin/overview
+curl http://localhost:50080/api/admin/overview
 ```
 
 返回总数、运行中/已停止数量以及每个配置文件的状态。
@@ -716,7 +716,7 @@ curl http://localhost:3000/api/admin/overview
 部署前测试提供商配置：
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/test-provider \
+curl -X POST http://localhost:50080/api/admin/test-provider \
   -H "Content-Type: application/json" \
   -d '{
     "provider": "moonshot",
@@ -896,7 +896,7 @@ curl -X POST http://localhost:3000/api/admin/test-provider \
 - **最大历史记录：** 通过 `gateway.max_history` 配置（默认：50 条消息）
 - **会话分叉：** `/new` 创建带有 parent_key 追踪的分支对话
 - **三层上下文压缩（M8.5）：** 工作层 / 冷层 / 归档层。当对话超过 LLM 的上下文窗口时，较旧的消息按首行摘要（工具参数被剥离），最早的消息被推入实体库作为长期记忆。
-- **Sticky `thread_id` 与 `committed_seq`（M8.10）：** 每个会话拥有稳定的 `thread_id`，在首次 SSE 发送之前完成绑定，并在后续每个事件（`token`、`tool_progress`、`task_status`、`session_result`）上携带。`done` 事件还携带 `committed_seq`（终态写入的持久序号），客户端因此能够通过 `GET /sessions/:id/events/stream` 在断线重连后做确定性回放。详情见 [SESSION_EVENT_ARCHITECTURE.md](./SESSION_EVENT_ARCHITECTURE.md)。
+- **Sticky `thread_id` 与 `committed_seq`（M8.10）：** 每个会话拥有稳定的 `thread_id`，在首次流式事件之前完成绑定，并在后续 UI Protocol 更新中携带。终态事件还携带 `committed_seq`（最终写入的持久序号），客户端因此能够在断线重连后做确定性回放。详情见 [SESSION_EVENT_ARCHITECTURE.md](./SESSION_EVENT_ARCHITECTURE.md)。
 - **结构化恢复（M8.6）：** 当工作树缺失或子 Agent 失败时，监督者拒绝静默丢弃当前轮次，而是用一个描述失败原因的结构化恢复负载重新驱动 LLM。
 
 ### 11.3 记忆系统
@@ -1066,9 +1066,9 @@ octos cron enable <job-id> --disable
 
 `spawn_only` 技能工具（长时间研究、深度爬取、音色训练等）作为后台任务在每个配置文件的 `task_supervisor` 下运行。用户可以：
 
-- 通过插件协议 v2 事件（以 `tool_progress` SSE 形式）接收周期性进度
+- 通过插件协议 v2 事件（经 UI Protocol 任务/进度更新转发）接收周期性进度
 - 使用 `check_background_tasks` 工具查看待处理后台任务
-- 通过专用会话事件流接收终态：监督者在持久化完成后提交带 `committed_seq` 的 `session_result` 事件（#629），仪表盘据此确定性更新
+- 通过 UI Protocol 会话/任务事件流接收终态：监督者在持久化完成后提交带 `committed_seq` 的终态事件（#629），仪表盘据此确定性更新
 
 **Fleet 稳定性（#610）**：`spawn`、Pipeline 扇出与 swarm 调度共用全局并发上限，避免单个失控 Agent 耗尽运行资源。归属会话已结束的孤立任务由 `task_supervisor` 清理。
 
@@ -1078,7 +1078,7 @@ octos cron enable <job-id> --disable
 
 ## 12. 内置应用技能
 
-内置应用技能作为编译好的二进制文件随 `octos` 一起发布。Gateway 启动时会写入 `~/.octos/bundled-app-skills/<name>/`（与用户自定义的 `~/.octos/skills/` 分开，重新部署不会覆盖运维/用户的修改）。完整列表见 `BUNDLED_APP_SKILLS`（`crates/octos-agent/src/bundled_app_skills.rs`）：
+内置应用技能作为编译好的二进制文件随 `octos` 一起发布。Gateway 启动时会写入 `<octos_home>/bundled-app-skills/<name>/`，运维或用户自定义技能安装到当前 profile 的 `~/.octos/profiles/<profile>/data/skills/`，因此重新部署不会覆盖自定义内容。完整列表见 `BUNDLED_APP_SKILLS`（`crates/octos-agent/src/bundled_app_skills.rs`）：
 
 > **自动安装的内置技能：** news、deep-search、deep-crawl、send-email、account-manager、time（二进制名 `clock`）、weather、pipeline-guard、skill-evolve。加上平台技能 `voice`。
 
@@ -1515,18 +1515,18 @@ export LARK_FROM_ADDRESS="your-feishu-email@company.com"
 
 ```bash
 # 启动 OminiX
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/start
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/start
 
 # 检查健康状态
-curl http://localhost:3000/api/admin/platform-skills/asr/health
+curl http://localhost:50080/api/admin/platform-skills/asr/health
 
 # 下载模型
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/models/download \
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/models/download \
   -H "Content-Type: application/json" \
   -d '{"model_id": "Qwen3-ASR-1.7B-8bit"}'
 
 # 查看日志
-curl http://localhost:3000/api/admin/platform-skills/ominix-api/logs?lines=100
+curl http://localhost:50080/api/admin/platform-skills/ominix-api/logs?lines=100
 ```
 
 ### 13.3 语音转录 (`voice_transcribe`)
@@ -1656,7 +1656,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # 安装到特定配置文件
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 **安装过程：**
@@ -1785,16 +1785,15 @@ requires_env: MY_API_KEY
 
 ### 14.6 技能解析顺序
 
-技能从以下目录加载（按优先级排序）：
+配置文件 gateway 按以下优先级加载技能：
 
-1. `.octos/plugins/`（旧版）
-2. `.octos/skills/`（用户安装的自定义技能）
-3. `.octos/bundled-app-skills/`（内置：news、deep-search 等）
-4. `.octos/platform-skills/`（平台：asr/tts）
-5. `~/.octos/plugins/`（全局旧版）
-6. `~/.octos/skills/`（全局自定义）
+1. `~/.octos/profiles/<profile>/data/skills/`（配置文件作用域的自定义技能）
+2. `<octos_home>/bundled-app-skills/`（内置：news、deep-search 等）
+3. `<octos_home>/platform-skills/`（管理员加载的平台技能，如 ASR/TTS）
 
-用户安装的技能覆盖同名的内置技能。
+独立项目运行还可以加载 `<project>/.octos/plugins/` 和
+`<project>/.octos/skills/`。旧的 HOME 全局目录 `~/.octos/plugins/` 和
+`~/.octos/skills/` 仅用于迁移，不再属于常规扫描路径。
 
 ### 14.7 创建自定义技能
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -78,10 +78,10 @@ The admin dashboard is a React web application embedded in the `octos serve` bin
 
 ```bash
 # Start the control plane
-octos serve --host 0.0.0.0 --port 3000
+octos serve --host 0.0.0.0
 
 # Dashboard is available at:
-# http://localhost:3000
+# http://localhost:50080
 ```
 
 If you're running behind a reverse proxy (e.g., Caddy or Nginx), configure it to forward to the serve port.
@@ -692,7 +692,7 @@ Profiles are bot instances managed through the admin dashboard or API. Each prof
 #### Via Admin API
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/profiles \
+curl -X POST http://localhost:50080/api/admin/profiles \
   -H "Content-Type: application/json" \
   -d '{
     "id": "my-bot",
@@ -722,16 +722,16 @@ Use the Start / Stop / Restart buttons on each profile card.
 
 ```bash
 # Start a profile's gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/start
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/start
 
 # Stop a profile's gateway
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/stop
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/stop
 
 # Restart (stop + start)
-curl -X POST http://localhost:3000/api/admin/profiles/my-bot/restart
+curl -X POST http://localhost:50080/api/admin/profiles/my-bot/restart
 
 # Check status
-curl http://localhost:3000/api/admin/profiles/my-bot/status
+curl http://localhost:50080/api/admin/profiles/my-bot/status
 ```
 
 **Start validation:** The start endpoint validates that an LLM provider is configured before launching the gateway. If the provider or API key is missing, it returns an error.
@@ -741,7 +741,7 @@ curl http://localhost:3000/api/admin/profiles/my-bot/status
 Updates use **JSON merge** — only the fields you include are modified. All other fields are preserved.
 
 ```bash
-curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
+curl -X PUT http://localhost:50080/api/admin/profiles/my-bot \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Updated Bot Name",
@@ -757,7 +757,7 @@ curl -X PUT http://localhost:3000/api/admin/profiles/my-bot \
 ### 8.4 Deleting a Profile
 
 ```bash
-curl -X DELETE http://localhost:3000/api/admin/profiles/my-bot
+curl -X DELETE http://localhost:50080/api/admin/profiles/my-bot
 ```
 
 This stops the gateway process (if running) and cascades to all sub-accounts.
@@ -766,17 +766,17 @@ This stops the gateway process (if running) and cascades to all sub-accounts.
 
 ```bash
 # SSE log stream (real-time)
-curl http://localhost:3000/api/admin/profiles/my-bot/logs
+curl http://localhost:50080/api/admin/profiles/my-bot/logs
 
 # Provider metrics
-curl http://localhost:3000/api/admin/profiles/my-bot/metrics
+curl http://localhost:50080/api/admin/profiles/my-bot/metrics
 ```
 
 ### 8.6 API Overview Endpoint
 
 ```bash
 # Get summary of all profiles
-curl http://localhost:3000/api/admin/overview
+curl http://localhost:50080/api/admin/overview
 ```
 
 Returns total count, running/stopped counts, and status of each profile.
@@ -786,7 +786,7 @@ Returns total count, running/stopped counts, and status of each profile.
 Before deploying, test a provider configuration:
 
 ```bash
-curl -X POST http://localhost:3000/api/admin/test-provider \
+curl -X POST http://localhost:50080/api/admin/test-provider \
   -H "Content-Type: application/json" \
   -d '{
     "provider": "moonshot",
@@ -967,7 +967,7 @@ Each channel:chat_id pair maintains its own session (conversation history).
 - **Max history:** Configurable via `gateway.max_history` (default: 50 messages)
 - **Session forking:** `/new` creates a branched conversation with parent_key tracking
 - **Context compaction:** Three-tier (M8.5) — working / cold / archived. When the conversation exceeds the LLM's context window, older messages are summarized to first lines (tool arguments stripped) and the oldest are pushed into the entity bank as long-term memory.
-- **Sticky `thread_id` and `committed_seq` (M8.10)** — every session has a stable `thread_id` that is bound before the first SSE emission and carried on every subsequent event (`token`, `tool_progress`, `task_status`, `session_result`). The `done` event additionally carries `committed_seq` — the durable history sequence number of the terminal write — so a web client can replay deterministically after reconnect via `GET /sessions/:id/events/stream`. See [SESSION_EVENT_ARCHITECTURE.md](./SESSION_EVENT_ARCHITECTURE.md).
+- **Sticky `thread_id` and `committed_seq` (M8.10)** — every session has a stable `thread_id` that is bound before the first streamed event and carried on subsequent UI Protocol updates. Terminal events include `committed_seq` — the durable history sequence number of the final write — so a web client can replay deterministically after reconnect. See [SESSION_EVENT_ARCHITECTURE.md](./SESSION_EVENT_ARCHITECTURE.md).
 - **Structured resume (M8.6)** — when a worktree is missing or a sub-agent fails, the supervisor refuses to silently drop the turn and re-engages the LLM with a structured-resume payload describing the failure.
 
 ### 11.3 Memory System
@@ -1128,9 +1128,9 @@ When a user sends messages while the agent is processing:
 
 `spawn_only` skill tools (long-running research, deep crawls, voice-clone training, etc.) run as background tasks under the per-profile `task_supervisor`. Users can:
 
-- Receive progress as periodic plugin protocol v2 events surfaced as `tool_progress` SSE events
+- Receive progress as periodic plugin protocol v2 events surfaced through UI Protocol task/progress updates
 - Inspect outstanding background work with the `check_background_tasks` tool
-- Get terminal status via the dedicated session events stream — the supervisor commits a `session_result` event with `committed_seq` (#629) so the dashboard updates deterministically once the work is durable
+- Get terminal status via the UI Protocol session/task event stream — the supervisor commits a terminal event with `committed_seq` (#629) so the dashboard updates deterministically once the work is durable
 
 **Fleet stability** (#610): `spawn`, pipeline fan-out, and swarm dispatch share a global concurrency cap so a runaway agent cannot exhaust runner CPU/memory. Orphan tasks (whose owning session has terminated) are reaped by `task_supervisor`.
 
@@ -1149,7 +1149,7 @@ Check for new issues in the GitHub repo and summarize any urgent ones.
 
 ## 12. Bundled App Skills
 
-Bundled app skills ship as compiled binaries alongside the `octos` binary. On gateway startup they are written into `~/.octos/bundled-app-skills/<name>/` (a separate directory from user-installed skills under `~/.octos/skills/`, so a re-deploy never overwrites operator/user customizations). The full list lives in `BUNDLED_APP_SKILLS` (`crates/octos-agent/src/bundled_app_skills.rs`):
+Bundled app skills ship as compiled binaries alongside the `octos` binary. On gateway startup they are written into `<octos_home>/bundled-app-skills/<name>/`, while operator or user customizations are installed into the active profile's `~/.octos/profiles/<profile>/data/skills/` directory so a re-deploy never overwrites them. The full list lives in `BUNDLED_APP_SKILLS` (`crates/octos-agent/src/bundled_app_skills.rs`):
 
 > **Bundled (auto-installed):** news, deep-search, deep-crawl, send-email, account-manager, time (binary `clock`), weather, pipeline-guard, skill-evolve. Plus the platform-skill `voice`.
 
@@ -1594,18 +1594,18 @@ Or via admin API:
 
 ```bash
 # Start OminiX
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/start
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/start
 
 # Check health
-curl http://localhost:3000/api/admin/platform-skills/asr/health
+curl http://localhost:50080/api/admin/platform-skills/asr/health
 
 # Download a model
-curl -X POST http://localhost:3000/api/admin/platform-skills/ominix-api/models/download \
+curl -X POST http://localhost:50080/api/admin/platform-skills/ominix-api/models/download \
   -H "Content-Type: application/json" \
   -d '{"model_id": "Qwen3-ASR-1.7B-8bit"}'
 
 # View logs
-curl http://localhost:3000/api/admin/platform-skills/ominix-api/logs?lines=100
+curl http://localhost:50080/api/admin/platform-skills/ominix-api/logs?lines=100
 ```
 
 ### 13.3 Voice Transcription (`voice_transcribe`)
@@ -1735,7 +1735,7 @@ octos skills install user/repo --branch develop
 octos skills install user/repo --force
 
 # Install into a specific profile
-octos skills install user/repo --profile my-bot
+octos skills --profile my-bot install user/repo
 ```
 
 **Installation process:**
@@ -1864,16 +1864,16 @@ The tool binary receives JSON input on stdin and outputs JSON on stdout:
 
 ### 14.6 Skill Resolution Order
 
-Skills are loaded from these directories (in priority order):
+Profile gateways load skills from these directories, in priority order:
 
-1. `.octos/plugins/` (legacy)
-2. `.octos/skills/` (user-installed custom skills)
-3. `.octos/bundled-app-skills/` (bundled: news, deep-search, etc.)
-4. `.octos/platform-skills/` (platform: asr/tts)
-5. `~/.octos/plugins/` (global legacy)
-6. `~/.octos/skills/` (global custom)
+1. `~/.octos/profiles/<profile>/data/skills/` (profile-scoped custom skills)
+2. `<octos_home>/bundled-app-skills/` (bundled: news, deep-search, etc.)
+3. `<octos_home>/platform-skills/` (admin-loaded platform skills, such as ASR/TTS)
 
-User-installed skills override bundled skills with the same name.
+Standalone project runs can also load `<project>/.octos/plugins/` and
+`<project>/.octos/skills/`. The old HOME-rooted global directories
+`~/.octos/plugins/` and `~/.octos/skills/` are migration-only and are no longer
+part of the normal scan path.
 
 ### 14.7 Creating a Custom Skill
 


### PR DESCRIPTION
## Summary

- Refresh stale skills/config/API documentation to match the current UI Protocol and profile-scoped skill layout.
- Update remaining bare `octos serve` documentation to the current default dashboard port `50080`, while leaving explicit test-only, OminiX, and legacy-migration examples unchanged.
- Rebuilt the branch from current GitHub `main` `f6936c452389c5172496ee0c3e13393956086d92`; refreshed head `34747ce5a976e168e5b4dc11f933893b0ae4873d`; docs-only diff retained.

Closes #117

## Current-main validation

Environment: isolated clone `/private/tmp/octos-1259-f693.jZE8dA/octos`; root dirty checkout left untouched; Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; `mdbook v0.5.2`.

Diff shape: docs-only across `docs`, `book`, and `book-zh`.

Passed locally:

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `typos docs book book-zh`
- `rg -n "octos serve.*(8080|3000)|--port 3000|/api/chat/stream|SSE stream|SSE streaming|SSE 流式推送|~/.octos/skills/(my-skill|my-style-guide|weather|.*/main)" docs book book-zh -S -g '!book/public/**' -g '!book-zh/public/**' -g '!docs/TESTING.md'` -> no matches
- `mdbook build book` (passes; existing unclosed `<f32>` warning remains)
- `mdbook build book-zh` (passes; existing unclosed `<f32>` warning remains)
- `git ls-files --others --exclude-standard` -> empty in the isolated checkout

Notes:

- mdBook output is ignored under `book/public` and `book-zh/public`.
- `docs/TESTING.md` still contains an explicit local live-test server command using `--port 3000`; that is intentionally a test-only example, not stale user/config guidance.
- No generated artifacts are included.

## CI / merge status

GitHub CI is green on refreshed head `34747ce5a976e168e5b4dc11f933893b0ae4873d`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, `typos`, and blocked-email passed. Optional expansion jobs were skipped as expected.

Current merge gate: `BLOCKED` / `REVIEW_REQUIRED`.
