### PR TITLE
fix(cli): make auth store path configurable

### DIFF
--- a/crates/octos-cli/src/auth/mod.rs
+++ b/crates/octos-cli/src/auth/mod.rs
@@ -6,4 +6,4 @@ pub mod store;
 pub mod token;
 
 pub use keychain::KEYCHAIN_MARKER;
-pub use store::{AuthCredential, AuthStore};
+pub use store::{AUTH_STORE_PATH_ENV, AuthCredential, AuthStore};

--- a/crates/octos-cli/src/auth/store.rs
+++ b/crates/octos-cli/src/auth/store.rs
@@ -1,4 +1,7 @@
-//! Auth credential storage at ~/.octos/auth.json (mode 0600).
+//! Auth credential storage.
+//!
+//! Defaults to `~/.octos/auth.json` and can be overridden with
+//! `OCTOS_AUTH_STORE_PATH` or `auth_store_path` in config.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -6,6 +9,9 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use eyre::{Result, WrapErr};
 use serde::{Deserialize, Serialize};
+
+/// Environment override for the auth store file path.
+pub const AUTH_STORE_PATH_ENV: &str = "OCTOS_AUTH_STORE_PATH";
 
 /// A stored authentication credential.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -41,7 +47,17 @@ pub struct AuthStore {
 impl AuthStore {
     /// Load the auth store from disk (or create empty).
     pub fn load() -> Result<Self> {
-        let path = Self::store_path()?;
+        Self::load_from_path(Self::store_path()?)
+    }
+
+    /// Load the auth store using config/env path resolution.
+    pub fn load_for_config(config: &crate::config::Config) -> Result<Self> {
+        Self::load_from_path(Self::store_path_for_config(Some(config))?)
+    }
+
+    /// Load the auth store from an explicit path.
+    pub fn load_from_path(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
         let data = if path.exists() {
             let content = std::fs::read_to_string(&path).wrap_err("failed to read auth store")?;
             serde_json::from_str(&content).wrap_err("failed to parse auth store")?
@@ -108,8 +124,31 @@ impl AuthStore {
         Ok(())
     }
 
-    /// Path: ~/.octos/auth.json
+    /// Resolve the auth store path.
+    ///
+    /// Precedence: `OCTOS_AUTH_STORE_PATH` > `auth_store_path` in config >
+    /// `~/.octos/auth.json`.
     fn store_path() -> Result<PathBuf> {
+        Self::store_path_for_config(None)
+    }
+
+    fn store_path_for_config(config: Option<&crate::config::Config>) -> Result<PathBuf> {
+        if let Some(path) = std::env::var_os(AUTH_STORE_PATH_ENV) {
+            if !path.as_os_str().is_empty() {
+                return Ok(PathBuf::from(path));
+            }
+        }
+
+        if let Some(path) = config.and_then(|config| config.auth_store_path.as_ref()) {
+            if !path.as_os_str().is_empty() {
+                return Ok(path.clone());
+            }
+        }
+
+        Self::default_store_path()
+    }
+
+    fn default_store_path() -> Result<PathBuf> {
         let home =
             dirs::home_dir().ok_or_else(|| eyre::eyre!("cannot determine home directory"))?;
         Ok(home.join(".octos").join("auth.json"))
@@ -120,6 +159,12 @@ impl AuthStore {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn auth_store_env_lock() -> &'static std::sync::Mutex<()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn test_store(dir: &TempDir) -> AuthStore {
         let path = dir.path().join("auth.json");
@@ -146,6 +191,55 @@ mod tests {
         let got = store.get("anthropic").unwrap();
         assert_eq!(got.access_token, "sk-test-123");
         assert_eq!(got.auth_method, "paste_token");
+    }
+
+    #[test]
+    fn load_from_path_reads_explicit_store_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("custom-auth.json");
+
+        let mut store = AuthStore::load_from_path(&path).unwrap();
+        store
+            .set(
+                "openai",
+                AuthCredential {
+                    access_token: "sk-custom-store".to_string(),
+                    refresh_token: None,
+                    expires_at: None,
+                    provider: "openai".to_string(),
+                    auth_method: "paste_token".to_string(),
+                },
+            )
+            .unwrap();
+
+        let reloaded = AuthStore::load_from_path(&path).unwrap();
+        assert_eq!(
+            reloaded
+                .get("openai")
+                .map(|cred| cred.access_token.as_str()),
+            Some("sk-custom-store")
+        );
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn store_path_prefers_env_override() {
+        let _guard = auth_store_env_lock().lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let expected = tmp.path().join("env-auth.json");
+        let previous = std::env::var_os(AUTH_STORE_PATH_ENV);
+
+        // SAFETY: serialized by `auth_store_env_lock` and restored below.
+        unsafe { std::env::set_var(AUTH_STORE_PATH_ENV, &expected) };
+        let resolved = AuthStore::store_path().unwrap();
+
+        // SAFETY: serialized by `auth_store_env_lock`.
+        match previous {
+            Some(value) => unsafe { std::env::set_var(AUTH_STORE_PATH_ENV, value) },
+            None => unsafe { std::env::remove_var(AUTH_STORE_PATH_ENV) },
+        }
+
+        assert_eq!(resolved, expected);
     }
 
     #[test]

--- a/crates/octos-cli/src/commands/auth.rs
+++ b/crates/octos-cli/src/commands/auth.rs
@@ -1,13 +1,15 @@
 //! Auth command: login, logout, status, and keychain management.
 
 use std::io::Write as _;
+use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 use colored::Colorize;
-use eyre::Result;
+use eyre::{Result, WrapErr};
 
 use super::Executable;
 use crate::auth::{AuthStore, keychain, oauth, token};
+use crate::config::Config;
 use crate::profiles::ProfileStore;
 
 /// Manage authentication for LLM providers.
@@ -121,7 +123,7 @@ async fn login(provider: &str, device_code: bool) -> Result<()> {
         _ => token::paste_token_flow(provider)?,
     };
 
-    let mut store = AuthStore::load()?;
+    let mut store = load_auth_store()?;
     store.set(provider, cred)?;
 
     println!(
@@ -133,7 +135,7 @@ async fn login(provider: &str, device_code: bool) -> Result<()> {
 }
 
 fn logout(provider: &str) -> Result<()> {
-    let mut store = AuthStore::load()?;
+    let mut store = load_auth_store()?;
     if store.remove(provider)? {
         println!("{} Logged out from {}", "OK".green().bold(), provider);
     } else {
@@ -143,7 +145,7 @@ fn logout(provider: &str) -> Result<()> {
 }
 
 fn status() -> Result<()> {
-    let store = AuthStore::load()?;
+    let store = load_auth_store()?;
     let creds: Vec<_> = store.list().collect();
 
     if creds.is_empty() {
@@ -169,6 +171,23 @@ fn status() -> Result<()> {
         println!("  {name}: {status} [{method}]{expiry}");
     }
     Ok(())
+}
+
+fn auth_config_data_dir() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("OCTOS_HOME") {
+        Ok(PathBuf::from(path))
+    } else {
+        dirs::home_dir()
+            .map(|home| home.join(".octos"))
+            .ok_or_else(|| eyre::eyre!("cannot determine home directory"))
+    }
+}
+
+fn load_auth_store() -> Result<AuthStore> {
+    let cwd = std::env::current_dir().wrap_err("failed to get current directory")?;
+    let data_dir = auth_config_data_dir()?;
+    let config = Config::load(&cwd, &data_dir)?;
+    AuthStore::load_for_config(&config)
 }
 
 // ── Keychain subcommands ───────────────────────────────────────────────────

--- a/crates/octos-cli/src/config.rs
+++ b/crates/octos-cli/src/config.rs
@@ -44,6 +44,11 @@ pub struct Config {
     #[serde(default)]
     pub api_key_env: Option<String>,
 
+    /// Auth credential store path. Defaults to `~/.octos/auth.json`;
+    /// overridden by `OCTOS_AUTH_STORE_PATH` when that env var is set.
+    #[serde(default)]
+    pub auth_store_path: Option<PathBuf>,
+
     /// Profile-scoped environment values, including API keys persisted by the dashboard/AppUI.
     #[serde(default)]
     pub env_vars: std::collections::HashMap<String, String>,
@@ -1104,6 +1109,10 @@ impl Config {
         if let Some(ref mut provider) = self.provider {
             *provider = Self::expand_env_var(provider);
         }
+        if let Some(ref mut auth_store_path) = self.auth_store_path {
+            *auth_store_path =
+                PathBuf::from(Self::expand_env_var(&auth_store_path.to_string_lossy()));
+        }
     }
 
     /// Expand ${VAR_NAME} patterns in a string.
@@ -1132,7 +1141,7 @@ impl Config {
     /// Get the API key: auth store first, then environment variable.
     pub fn get_api_key(&self, provider: &str) -> Result<String> {
         // Check auth store first.
-        if let Ok(store) = crate::auth::AuthStore::load() {
+        if let Ok(store) = crate::auth::AuthStore::load_for_config(self) {
             if let Some(cred) = store.get(provider) {
                 if !cred.is_expired() {
                     return Ok(cred.access_token.clone());
@@ -1410,6 +1419,17 @@ mod tests {
     }
 
     #[test]
+    fn auth_store_path_deserializes_from_config_json() {
+        let config: Config =
+            serde_json::from_str(r#"{"auth_store_path":"/tmp/octos-auth.json"}"#).unwrap();
+
+        assert_eq!(
+            config.auth_store_path.as_deref(),
+            Some(Path::new("/tmp/octos-auth.json"))
+        );
+    }
+
+    #[test]
     fn test_gateway_max_history_default() {
         let json = r#"{"channels": [{"type": "cli"}]}"#;
         let gw: GatewayConfig = serde_json::from_str(json).unwrap();
@@ -1494,6 +1514,48 @@ mod tests {
         };
         let warnings = config.validate();
         assert!(warnings.iter().any(|w| w.contains("Unknown channel type")));
+    }
+
+    #[test]
+    #[allow(unsafe_code)]
+    fn get_api_key_uses_configured_auth_store_path() {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let previous = std::env::var_os(crate::auth::store::AUTH_STORE_PATH_ENV);
+        // SAFETY: serialized by `LOCK` and restored before returning.
+        unsafe { std::env::remove_var(crate::auth::store::AUTH_STORE_PATH_ENV) };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("configured-auth.json");
+        let mut store = crate::auth::AuthStore::load_from_path(&path).unwrap();
+        store
+            .set(
+                "openai",
+                crate::auth::AuthCredential {
+                    access_token: "sk-configured-store".to_string(),
+                    refresh_token: None,
+                    expires_at: None,
+                    provider: "openai".to_string(),
+                    auth_method: "paste_token".to_string(),
+                },
+            )
+            .unwrap();
+
+        let config = Config {
+            auth_store_path: Some(path),
+            ..Default::default()
+        };
+        let resolved = config.get_api_key("openai").unwrap();
+
+        // SAFETY: serialized by `LOCK`.
+        match previous {
+            Some(value) => unsafe {
+                std::env::set_var(crate::auth::store::AUTH_STORE_PATH_ENV, value)
+            },
+            None => unsafe { std::env::remove_var(crate::auth::store::AUTH_STORE_PATH_ENV) },
+        }
+
+        assert_eq!(resolved, "sk-configured-store");
     }
 
     #[test]

--- a/crates/octos-cli/src/config_watcher.rs
+++ b/crates/octos-cli/src/config_watcher.rs
@@ -166,6 +166,9 @@ impl ConfigWatcher {
         if old.api_key_env != new.api_key_env {
             restart_fields.push("api_key_env".into());
         }
+        if old.auth_store_path != new.auth_store_path {
+            restart_fields.push("auth_store_path".into());
+        }
         if old.sandbox != new.sandbox {
             restart_fields.push("sandbox".into());
         }
@@ -368,6 +371,28 @@ mod tests {
                 "provider change should not require restart, got fields: {:?}",
                 fields
             );
+        }
+    }
+
+    #[test]
+    fn auth_store_path_change_requires_restart() {
+        let dir = TempDir::new().unwrap();
+        let path = write_config(&dir, r#"{"auth_store_path": "/tmp/old-auth.json"}"#);
+        let old_config = Config::from_file(&path).unwrap();
+
+        std::fs::write(&path, r#"{"auth_store_path": "/tmp/new-auth.json"}"#).unwrap();
+        let new_config = Config::from_file(&path).unwrap();
+
+        let (tx, rx) = watch::channel(None);
+        let watcher = ConfigWatcher::new(vec![path], old_config, tx);
+        watcher.diff_and_emit(&new_config);
+
+        let change = rx.borrow().clone();
+        match change {
+            Some(ConfigChange::RestartRequired(fields)) => {
+                assert!(fields.contains(&"auth_store_path".to_string()));
+            }
+            other => panic!("expected RestartRequired, got {other:?}"),
         }
     }
 }

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -1519,6 +1519,7 @@ pub(crate) fn config_from_profile(
                 .as_ref()
                 .and_then(|route| route.api_key_env.clone())
         }),
+        auth_store_path: None,
         env_vars: profile.config.env_vars.clone(),
         api_type: primary.and_then(|selection| {
             selection


### PR DESCRIPTION
## Summary

- add `auth_store_path` config support and the `OCTOS_AUTH_STORE_PATH` env override for auth credential storage
- route config API-key resolution and `octos auth` login/logout/status through the configured auth store path
- treat auth store path changes as restart-required in the config watcher
- refresh from current `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`

Closes #120

## Current-main refresh

- Base: `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Head: `1f198bb9f5ea59b840a0b7821caba50818557d90`.
- Isolated checkout: `/private/tmp/octos-1262-current.Xg32qD/octos`.
- Cargo target: `/private/tmp/octos-1262-current-4adbe-target`.
- Root dirty checkout was not used or modified.

## Validation

Passed locally on refreshed head `1f198bb9f5ea59b840a0b7821caba50818557d90`:

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `typos crates/octos-cli/src/auth/mod.rs crates/octos-cli/src/auth/store.rs crates/octos-cli/src/commands/auth.rs crates/octos-cli/src/config.rs crates/octos-cli/src/config_watcher.rs crates/octos-cli/src/profiles.rs`
- `CARGO_TARGET_DIR=/private/tmp/octos-1262-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli auth::store::tests -- --nocapture` -> 6/6 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1262-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli get_api_key_uses_configured_auth_store_path -- --nocapture` -> passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1262-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli auth_store_path_deserializes_from_config_json -- --nocapture` -> passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1262-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli auth_store_path_change_requires_restart -- --nocapture` -> passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1262-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --features api`
- `CARGO_TARGET_DIR=/private/tmp/octos-1262-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --lib` -> 487 passed, 2 ignored
- `CARGO_TARGET_DIR=/private/tmp/octos-1262-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git ls-files --others --exclude-standard` -> empty

GitHub CI is green on refreshed head `1f198bb9f5ea59b840a0b7821caba50818557d90`:

- CI run `26794146082` passed `dashboard`, `swarm-app`, `typos`, `check`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `test-octos-cli`, and `check-matrix`.
- Author-email run `26794146076` passed.

## Merge status

- No generated artifacts are included.
- Merge remains branch-protection blocked by required review.
