### PR TITLE
fix(slides): hide sibling mofa_* skills in slides sessions

### DIFF
--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -165,7 +165,7 @@ pub use tools::{
     ToolResult, TurnAttachmentContext, WebFetchTool, WebSearchTool, WriteFileTool,
     admin::{AdminApiContext, register_admin_api_tools},
     build_backend_from_config, build_delegated_child_policy, build_dispatch_event_payload,
-    dispatch_with_metrics, install_robot_registry, record_dispatch,
+    dispatch_with_metrics, install_robot_registry, keep_tool_in_slides_session, record_dispatch,
 };
 pub use turn::{Turn, TurnKind, turns_to_messages};
 pub use validators::{

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -623,7 +623,7 @@ pub use registry::ToolRegistry;
 
 // Tool policy
 pub mod policy;
-pub use policy::{PolicyDecision, ToolPolicy};
+pub use policy::{PolicyDecision, ToolPolicy, keep_tool_in_slides_session};
 
 // Shared dispatch-policy gate (#714 / #713) re-exported from the
 // crate root so [`SpawnTool::with_dispatch_policy`] callers can pull

--- a/crates/octos-agent/src/tools/policy.rs
+++ b/crates/octos-agent/src/tools/policy.rs
@@ -258,6 +258,28 @@ fn expand_group(name: &str) -> Option<&'static [&'static str]> {
     tool_group_info(name).map(|g| g.tools)
 }
 
+/// Predicate that hides every `mofa_*` skill except `mofa_slides` for a
+/// slides session. Designed to be passed to [`crate::ToolRegistry::retain`]
+/// in `session_actor.rs` after `tools.activate("group:media")` so that:
+///
+/// 1. The slides system prompt's "ALWAYS use mofa_slides" rule is enforced
+///    structurally — weaker LLMs (kimi-k2.6 fallback on mini1's dspfac
+///    profile, 2026-05-24) cannot misroute the slides workflow to
+///    `mofa_site` / `mofa_youtube` even when the prompt rule is buried
+///    mid-text.
+/// 2. Non-mofa skills (fm_tts, plugin tools that don't share the prefix)
+///    pass through untouched.
+/// 3. `mofa_slides` itself is preserved.
+///
+/// Returns `true` if the tool should be kept, `false` if it should be
+/// evicted from the registry.
+pub fn keep_tool_in_slides_session(tool_name: &str) -> bool {
+    if tool_name == "mofa_slides" {
+        return true;
+    }
+    !tool_name.starts_with("mofa_")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -407,5 +429,69 @@ mod tests {
         // Tools not in the group remain allowed by default.
         assert!(policy.is_allowed("read_file"));
         assert!(policy.is_allowed("shell"));
+    }
+
+    #[test]
+    fn should_keep_mofa_slides_in_slides_session() {
+        // The canonical slides skill must survive the per-session filter
+        // — that's the one tool the system prompt instructs the LLM to
+        // call. Evicting it would break the slides workflow entirely.
+        assert!(keep_tool_in_slides_session("mofa_slides"));
+    }
+
+    #[test]
+    fn should_drop_sibling_mofa_skills_in_slides_session() {
+        // The bug originally reported (kimi-k2.6 fallback on mini1
+        // dspfac, 2026-05-24): the LLM saw `mofa_site` /
+        // `mofa_youtube` next to `mofa_slides` and misrouted to them
+        // with empty `audio_path` / `content_dir`. The filter must
+        // hide every non-slides mofa_ skill so the LLM literally
+        // cannot call them in a slides session.
+        for unwanted in [
+            "mofa_site",
+            "mofa_youtube",
+            "mofa_publish",
+            "mofa_research",
+            "mofa_pdf",
+            "mofa_xlsx",
+            "mofa_cli",
+            "mofa_fm",
+            "mofa_frame",
+            "mofa_podcast",
+            "mofa_infographic",
+            "mofa_cards",
+            "mofa_comic",
+        ] {
+            assert!(
+                !keep_tool_in_slides_session(unwanted),
+                "{unwanted} should be hidden in a slides session"
+            );
+        }
+    }
+
+    #[test]
+    fn should_preserve_non_mofa_tools_in_slides_session() {
+        // Slides sessions still need general tools: research,
+        // file ops, shell (gated by the prompt to git + PNG-cache
+        // delete), task-status checks, the auto-delivery surface.
+        // The filter only targets the `mofa_*` skill prefix.
+        for kept in [
+            "read_file",
+            "write_file",
+            "glob",
+            "shell",
+            "send_file",
+            "check_background_tasks",
+            "check_workspace_contract",
+            "web_search",
+            "web_fetch",
+            "fm_tts",
+            "fm_voice_list",
+        ] {
+            assert!(
+                keep_tool_in_slides_session(kept),
+                "{kept} must remain available in a slides session"
+            );
+        }
     }
 }

--- a/crates/octos-agent/src/tools/registry.rs
+++ b/crates/octos-agent/src/tools/registry.rs
@@ -2539,4 +2539,98 @@ mod profile_filter_tests {
             "coding profile must preserve behaviour parity with the default path",
         );
     }
+
+    #[test]
+    fn should_retain_only_mofa_slides_when_slides_session_filter_runs() {
+        // Pins the wiring in session_actor.rs::spawn slides branch:
+        // `tools.retain(octos_agent::keep_tool_in_slides_session)` must
+        // evict every fake mofa skill except `mofa_slides`, and must NOT
+        // evict the unrelated tools (read_file, shell, etc.).
+        //
+        // Without this guardrail the kimi-k2.6 fallback on mini1 dspfac
+        // misrouted "Make a 3-slide intro deck" → mofa_site (2026-05-24
+        // soak). The structural filter makes that misroute literally
+        // impossible regardless of LLM judgement.
+        use super::policy::keep_tool_in_slides_session;
+        use async_trait::async_trait;
+        use eyre::Result;
+        use serde_json::Value;
+
+        struct FakeMofa(&'static str);
+        #[async_trait]
+        impl Tool for FakeMofa {
+            fn name(&self) -> &str {
+                self.0
+            }
+            fn description(&self) -> &str {
+                "fake mofa skill (test fixture)"
+            }
+            fn input_schema(&self) -> Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(&self, _: &Value) -> Result<ToolResult> {
+                Ok(ToolResult::default())
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut reg = ToolRegistry::with_builtins(dir.path());
+        // Simulate the fleet skill surface: every dspfac-installed mofa
+        // skill is registered as a plugin tool. (Real plugins go via
+        // PluginLoader; here we use a stub for an isolated unit test.)
+        for name in [
+            "mofa_slides",
+            "mofa_site",
+            "mofa_youtube",
+            "mofa_publish",
+            "mofa_research",
+            "mofa_pdf",
+            "mofa_xlsx",
+            "mofa_cli",
+            "mofa_fm",
+            "mofa_frame",
+            "mofa_podcast",
+            "mofa_infographic",
+            "mofa_cards",
+            "mofa_comic",
+        ] {
+            reg.register(FakeMofa(name));
+        }
+
+        reg.retain(keep_tool_in_slides_session);
+
+        let names = builtin_names(&reg);
+        assert!(
+            names.contains(&"mofa_slides".to_string()),
+            "mofa_slides MUST survive the slides-session filter",
+        );
+        for unwanted in [
+            "mofa_site",
+            "mofa_youtube",
+            "mofa_publish",
+            "mofa_research",
+            "mofa_pdf",
+            "mofa_xlsx",
+            "mofa_cli",
+            "mofa_fm",
+            "mofa_frame",
+            "mofa_podcast",
+            "mofa_infographic",
+            "mofa_cards",
+            "mofa_comic",
+        ] {
+            assert!(
+                !names.contains(&unwanted.to_string()),
+                "{unwanted} MUST be evicted from a slides session",
+            );
+        }
+        // Built-in non-mofa tools must remain — these are the tools the
+        // slides system prompt's "TOOL DISCIPLINE" block depends on.
+        for kept in ["read_file", "write_file", "glob", "shell"] {
+            assert!(
+                names.contains(&kept.to_string()),
+                "{kept} must NOT be evicted by the slides filter",
+            );
+        }
+    }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2951,6 +2951,19 @@ impl ActorFactory {
         if is_slides {
             tools.activate("group:media");
 
+            // Structural guardrail (fix/slides-session-tool-allowlist):
+            // hide every `mofa_*` plugin tool except `mofa_slides` so a
+            // weaker fallback model (e.g. kimi-k2.6 on mini1 dspfac,
+            // 2026-05-24) cannot misroute the slides workflow to
+            // `mofa_site` / `mofa_youtube` / etc. when the
+            // "ALWAYS use mofa_slides" rule buried in
+            // `prompts/slides_default.txt` is not strong enough on its
+            // own. The non-`mofa_*` tool surface (web_search, file
+            // tools, shell, send_file, contract / task checks)
+            // is unaffected — see
+            // `tools::policy::keep_tool_in_slides_session`.
+            tools.retain(octos_agent::keep_tool_in_slides_session);
+
             // Scaffold slides project INTO the workspace so file tools
             // (read_file, write_file, mofa_slides) all resolve the same paths.
             // The earlier scaffold in gateway_dispatcher writes to data_dir


### PR DESCRIPTION
## Summary

- Structural guardrail: when a session topic starts with `slides`, the registry retains `mofa_slides` and evicts every other `mofa_*` plugin tool. Non-mofa tools (read_file/shell/web_search/send_file/contract+task checks) are unaffected.
- Closes a misroute regression on mini1's dspfac soak (2026-05-24): kimi-k2.6 fallback chose `mofa_site` for short slides prompts and `mofa_youtube` (with empty `audio_path`/`url`) for long ones, despite the slides system prompt's buried "ALWAYS use mofa_slides" rule. mini3/5 (kimi-k2.5) routed correctly 5/5 — bug is model-specific instruction-following on tool selection.
- The fix moves the routing from prompt-dependent to structural: `tools.retain(octos_agent::keep_tool_in_slides_session)` runs immediately after `tools.activate("group:media")` in the slides branch of `ActorFactory::spawn`, so the misroute targets are not visible to the LLM regardless of model judgement.

## Why this layer of fix

- The prompt at `prompts/slides_default.txt` is 117 lines long and the routing rule is at line 37, surrounded by tool-discipline boilerplate.
- The prompt does NOT explicitly forbid the sibling mofa skills (mofa_site / mofa_youtube / mofa_publish / mofa_research / mofa_pdf / etc.). Weaker fallback models cannot honour an implicit constraint.
- A prompt-only fix would still leave the door open the next time we ship a weaker fallback. The structural gate is model-agnostic.

## Test plan

- [x] `cargo test -p octos-agent --lib tools::policy` (15 pass including 3 new)
- [x] `cargo test -p octos-agent --lib tools::registry` (42 pass including 1 new end-to-end)
- [x] `cargo test -p octos-agent` (full agent suite, all green)
- [x] `cargo test -p octos-cli --lib` (462 pass)
- [x] `cargo build --workspace` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] `cargo clippy --workspace --lib -- -D warnings` (clean)

## Files

- `crates/octos-agent/src/tools/policy.rs` — `keep_tool_in_slides_session(name)` predicate + 3 unit tests
- `crates/octos-agent/src/tools/registry.rs` — end-to-end retention test pinning the fleet skill surface
- `crates/octos-agent/src/tools/mod.rs`, `crates/octos-agent/src/lib.rs` — re-exports so `session_actor.rs` can name the helper
- `crates/octos-cli/src/session_actor.rs` — call site in `ActorFactory::spawn`, slides branch

## Follow-ups (out of scope)

- Layer 1 (prompt clarity): explicit "never call mofa_site / mofa_youtube in a slides session" line near the top of `prompts/slides_default.txt`. Not blocking — structural gate is sufficient to close the user-visible bug.
- Same predicate pattern could be applied to `mofa-podcast` / `mofa-site` sessions when those workflows get session topics, to mirror the structural gate.