### PR TITLE
fix(pipeline): bound codergen worker stalls

### DIFF
--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -183,6 +183,26 @@ impl ProgressReporter for PipelineNodeReporter {
                     self.node_id, self.model, iteration
                 )
             }
+            ProgressEvent::LlmStatus { message, iteration } => {
+                format!(
+                    "{} [{}]: {} (iteration {})",
+                    self.node_id, self.model, message, iteration
+                )
+            }
+            ProgressEvent::ActivityTimeoutReached { limit, .. } => {
+                format!(
+                    "{} [{}]: activity timeout after {}s",
+                    self.node_id,
+                    self.model,
+                    limit.as_secs()
+                )
+            }
+            ProgressEvent::TaskInterrupted { iterations } => {
+                format!(
+                    "{} [{}]: interrupted after {} iteration(s)",
+                    self.node_id, self.model, iterations
+                )
+            }
             // Bug 3 / Gap 3.3 — per-node cost updates from inner agents must
             // reach the parent SSE stream. The legacy `_ => return` arm
             // swallowed these silently, leaving the W1.G4 CostBreakdown
@@ -839,7 +859,39 @@ impl Handler for CodergenHandler {
             "executing codergen node"
         );
 
-        match worker.run_task(&task).await {
+        let run_task = worker.run_task(&task);
+        let result = if let Some(timeout_secs) = node.timeout_secs.filter(|secs| *secs > 0) {
+            match tokio::time::timeout(Duration::from_secs(timeout_secs), run_task).await {
+                Ok(result) => result,
+                Err(_) => {
+                    let message = format!(
+                        "Node '{}' timed out after {timeout_secs}s while waiting for worker '{}'",
+                        node.id, worker_id
+                    );
+                    warn!(
+                        node = %node.id,
+                        worker = %worker_id,
+                        timeout_secs,
+                        "pipeline codergen worker hard timeout"
+                    );
+                    crate::executor::report_progress(&format!(
+                        "{} [{}]: timed out after {}s; cancelling stalled worker",
+                        node.id, resolved_model, timeout_secs
+                    ));
+                    return Ok(NodeOutcome {
+                        node_id: node.id.clone(),
+                        status: OutcomeStatus::Error,
+                        content: message,
+                        token_usage: TokenUsage::default(),
+                        files_modified: vec![],
+                    });
+                }
+            }
+        } else {
+            run_task.await
+        };
+
+        match result {
             Ok(result) => {
                 if !result.files_modified.is_empty() {
                     info!(

--- a/crates/octos-pipeline/tests/codergen_worker_timeout.rs
+++ b/crates/octos-pipeline/tests/codergen_worker_timeout.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_core::Message;
+use octos_llm::{ChatConfig, ChatResponse, ChatStream, LlmProvider, StopReason, ToolSpec};
+use octos_memory::EpisodeStore;
+use octos_pipeline::handler::HandlerContext;
+use octos_pipeline::{CodergenHandler, Handler, HandlerKind, OutcomeStatus, PipelineNode};
+
+struct HangingProvider;
+
+#[async_trait]
+impl LlmProvider for HangingProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        tokio::time::sleep(Duration::from_secs(3_600)).await;
+        Ok(ChatResponse {
+            content: Some("unexpected".to_string()),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+            usage: Default::default(),
+            provider_index: None,
+        })
+    }
+
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatStream> {
+        tokio::time::sleep(Duration::from_secs(3_600)).await;
+        Ok(Box::pin(futures::stream::empty()))
+    }
+
+    fn model_id(&self) -> &str {
+        "hanging"
+    }
+
+    fn provider_name(&self) -> &str {
+        "test"
+    }
+}
+
+async fn episode_store(path: &Path) -> Arc<EpisodeStore> {
+    Arc::new(EpisodeStore::open(path).await.expect("open episode store"))
+}
+
+#[tokio::test]
+async fn codergen_timeout_secs_cancels_stalled_worker() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let handler = CodergenHandler::new(
+        Arc::new(HangingProvider),
+        episode_store(dir.path()).await,
+        dir.path().to_path_buf(),
+        Arc::new(AtomicBool::new(false)),
+    );
+    let node = PipelineNode {
+        id: "synthesize".to_string(),
+        handler: HandlerKind::Codergen,
+        prompt: Some("write the final report".to_string()),
+        timeout_secs: Some(1),
+        ..Default::default()
+    };
+    let ctx = HandlerContext {
+        input: "research notes".to_string(),
+        completed: HashMap::new(),
+        predecessor_outcomes: vec![],
+        working_dir: dir.path().to_path_buf(),
+    };
+
+    let started = Instant::now();
+    let outcome = handler.execute(&node, &ctx).await.expect("node outcome");
+    let elapsed = started.elapsed();
+
+    assert_eq!(outcome.status, OutcomeStatus::Error);
+    assert!(
+        outcome.content.contains("timed out after 1s"),
+        "unexpected outcome: {}",
+        outcome.content
+    );
+    assert!(
+        elapsed < Duration::from_millis(1_750),
+        "worker timeout should trip promptly, got {elapsed:?}"
+    );
+}


### PR DESCRIPTION
Summary:
- enforce codergen node timeout_secs as a hard wall-clock guard around worker run_task
- return an Error node outcome with actionable timeout telemetry so M8.9 recovery can retry instead of silently waiting
- forward LLM status, activity timeout, and interruption progress from pipeline workers to parent progress
- add a regression test with a provider whose stream never starts

Validation:
- cargo fmt --all
- git diff --check
- cargo test -p octos-pipeline --test codergen_worker_timeout -- --nocapture
- cargo test -p octos-pipeline --test deadline_enforcement -- --nocapture
- cargo test -p octos-pipeline --lib --tests
- cargo clippy -p octos-pipeline --tests -- -D warnings

Closes #964

## CI / merge status
- GitHub CI is green on head `719a88c0282dd864daa652afa9111374239ffd65`: required checks in the current status rollup passed; optional platform/e2e/security expansion jobs were skipped by workflow conditions.
- Current GitHub state remains `MERGEABLE` but branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
- #964 should close through this PR after review and merge; no manual closure was performed.
