### PR TITLE
Add per-session sandbox narrowing

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -53,13 +53,14 @@ use octos_core::ui_protocol::{
     UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1, UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
     UI_PROTOCOL_FEATURE_MESSAGE_PERSISTED_V1, UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
     UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1, UI_PROTOCOL_FEATURE_REVIEW_START_V1,
-    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
-    UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1, UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
-    UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1, UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UiAgentRecord,
-    UiArtifactPaneItem, UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord,
-    UiContextNormalizationReport, UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem,
-    UiGitPaneSnapshot, UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation,
-    UiProgressEvent, UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
+    UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1, UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1,
+    UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1, UI_PROTOCOL_FEATURE_SPAWN_COMPLETE_V1,
+    UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1, UI_PROTOCOL_FEATURE_TURN_STATE_GET_V1,
+    UI_PROTOCOL_FEATURE_USER_QUESTION_V1, UiAgentRecord, UiArtifactPaneItem,
+    UiArtifactPaneSnapshot, UiCommand, UiContextCompactionRecord, UiContextNormalizationReport,
+    UiContextState, UiCursor, UiFileMutationNotice, UiGitHistoryItem, UiGitPaneSnapshot,
+    UiGitStatusItem, UiNotification, UiPaneSnapshot, UiPaneSnapshotLimitation, UiProgressEvent,
+    UiProgressMetadata, UiProtocolCapabilities, UiRpcResult, UiWorkspacePaneEntry,
     UiWorkspacePaneSnapshot, UnsupportedCapabilityReport, UserQuestionRequestedEvent,
     UserQuestionRespondParams, approval_cancelled_reasons, approval_kinds, hydrate_sections,
     progress_kinds, thread_status,
@@ -981,6 +982,7 @@ struct ConnectionUiFeatures {
     typed_approvals: bool,
     pane_snapshots: bool,
     session_workspace_cwd: bool,
+    session_sandbox: bool,
     harness_task_control: bool,
     harness_task_artifacts: bool,
     /// UPCR-2026-009 `state.session_hydrate.v1` negotiated.
@@ -1077,6 +1079,7 @@ impl ConnectionUiFeatures {
                 query,
                 UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
             ),
+            session_sandbox: has_ui_feature(headers, query, UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1),
             harness_task_control: has_ui_feature(
                 headers,
                 query,
@@ -1144,6 +1147,7 @@ impl ConnectionUiFeatures {
             typed_approvals: true,
             pane_snapshots: true,
             session_workspace_cwd: true,
+            session_sandbox: true,
             harness_task_control: true,
             harness_task_artifacts: true,
             session_hydrate: true,
@@ -1195,6 +1199,7 @@ impl ConnectionUiFeatures {
             typed_approvals: has(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1),
             pane_snapshots: has(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1),
             session_workspace_cwd: has(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1),
+            session_sandbox: has(UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1),
             harness_task_control: has(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1),
             harness_task_artifacts: has(UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1),
             session_hydrate: has(UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1),
@@ -1239,6 +1244,9 @@ impl ConnectionUiFeatures {
         }
         if self.session_workspace_cwd {
             requested.push(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1);
+        }
+        if self.session_sandbox {
+            requested.push(UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1);
         }
         if self.harness_task_control {
             requested.push(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1);
@@ -8656,6 +8664,7 @@ async fn open_session_result(
     ensure_session_profile_runtime(state, active_profile_id.as_deref()).await?;
     let requested_workspace =
         validate_requested_session_cwd(state, features, active_profile_id.as_deref(), &params)?;
+    validate_session_sandbox_feature_gate(features, &params)?;
     // M11-F deliverable D: re-introduce the
     // `appui.default_session_cwd` Tier-2 fallback that M11-E's
     // `clone_session_tools` deletion took out. Pre-resolution order:
@@ -8708,13 +8717,19 @@ async fn open_session_result(
     {
         let hint = effective_workspace_hint.clone();
         let permissions = effective_permissions_for_session(state, &params.session_id)?;
+        let sandbox_override = validate_requested_session_sandbox(
+            features,
+            &params,
+            &permissions.apply_to_sandbox(&profile_runtime.default_sandbox),
+        )?;
         match state
             .session_cache
-            .get_or_init_with_permissions(
+            .get_or_init_with_permissions_and_sandbox(
                 &profile_runtime,
                 params.session_id.clone(),
                 hint,
                 permissions,
+                sandbox_override,
             )
             .await
         {
@@ -8733,6 +8748,14 @@ async fn open_session_result(
                 )));
             }
         }
+    } else if params.sandbox.is_some() {
+        return Err(RpcError::invalid_params(
+            "session/open sandbox requires a configured profile runtime",
+        )
+        .with_data(json!({
+            "kind": "sandbox_runtime_unavailable",
+            "active_profile_id": active_profile_id,
+        })));
     } else if let Some(workspace_root) = effective_workspace_hint.as_ref() {
         // No profile registered (legacy single-agent serve). Stash the
         // effective hint in the read-through map so the legacy
@@ -8901,6 +8924,140 @@ fn validate_requested_session_cwd(
     let workspace_root = canonical_existing_dir(cwd)?;
     validate_session_workspace_allowed(state, active_profile_id, &workspace_root)?;
     Ok(Some(workspace_root))
+}
+
+fn validate_session_sandbox_feature_gate(
+    features: ConnectionUiFeatures,
+    params: &SessionOpenParams,
+) -> Result<(), RpcError> {
+    if params.sandbox.is_some() && !features.session_sandbox {
+        return Err(RpcError::invalid_params(
+            "session/open sandbox requires feature session.sandbox.v1",
+        )
+        .with_data(json!({
+            "kind": "feature_required",
+            "feature": UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1,
+        })));
+    }
+    Ok(())
+}
+
+fn validate_requested_session_sandbox(
+    features: ConnectionUiFeatures,
+    params: &SessionOpenParams,
+    inherited: &octos_agent::SandboxConfig,
+) -> Result<Option<octos_agent::SandboxConfig>, RpcError> {
+    validate_session_sandbox_feature_gate(features, params)?;
+    let Some(requested) = params.sandbox.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut narrowed = inherited.clone();
+    if let Some(enabled) = requested.enabled {
+        if !enabled && inherited.enabled {
+            return Err(session_sandbox_widening_error(
+                "enabled",
+                json!(enabled),
+                json!(inherited.enabled),
+                "session sandbox cannot disable profile-level sandbox isolation",
+            ));
+        }
+        narrowed.enabled = enabled;
+    }
+
+    if let Some(network_access) = requested.network_access {
+        if network_access && !inherited.allow_network {
+            return Err(session_sandbox_widening_error(
+                "network_access",
+                json!(network_access),
+                json!(inherited.allow_network),
+                "session sandbox cannot enable network access denied by the profile",
+            ));
+        }
+        narrowed.allow_network = network_access;
+    }
+
+    if !requested.read_allow_paths.is_empty() {
+        let requested_paths =
+            canonical_session_sandbox_paths("read_allow_paths", &requested.read_allow_paths)?;
+        if !inherited.read_allow_paths.is_empty() {
+            let inherited_paths = canonical_session_sandbox_paths(
+                "inherited_read_allow_paths",
+                &inherited.read_allow_paths,
+            )?;
+            for requested_path in &requested_paths {
+                if !inherited_paths
+                    .iter()
+                    .any(|allowed| requested_path == allowed || requested_path.starts_with(allowed))
+                {
+                    return Err(session_sandbox_widening_error(
+                        "read_allow_paths",
+                        json!(requested_path.to_string_lossy()),
+                        json!(
+                            inherited_paths
+                                .iter()
+                                .map(|path| path.to_string_lossy().to_string())
+                                .collect::<Vec<_>>()
+                        ),
+                        "session sandbox read paths must stay within the profile allowlist",
+                    ));
+                }
+            }
+        }
+        narrowed.read_allow_paths = requested_paths
+            .into_iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect();
+    }
+
+    Ok(Some(narrowed))
+}
+
+fn canonical_session_sandbox_paths(
+    field: &str,
+    paths: &[String],
+) -> Result<Vec<PathBuf>, RpcError> {
+    paths
+        .iter()
+        .map(|path| {
+            let trimmed = path.trim();
+            if trimmed.is_empty() {
+                return Err(RpcError::invalid_params(format!(
+                    "session/open sandbox {field} path must not be empty"
+                ))
+                .with_data(json!({
+                    "kind": "session_sandbox_path_empty",
+                    "field": field,
+                })));
+            }
+            let expanded = expand_home_path(trimmed);
+            std::fs::canonicalize(&expanded).map_err(|error| {
+                RpcError::invalid_params(format!(
+                    "session/open sandbox {field} path is not accessible: {path}"
+                ))
+                .with_data(json!({
+                    "kind": "session_sandbox_path_not_accessible",
+                    "field": field,
+                    "path": path,
+                    "error": error.to_string(),
+                }))
+            })
+        })
+        .collect()
+}
+
+fn session_sandbox_widening_error(
+    field: &'static str,
+    requested: Value,
+    inherited: Value,
+    message: &'static str,
+) -> RpcError {
+    RpcError::permission_denied(message).with_data(json!({
+        "kind": "session_sandbox_would_widen_profile",
+        "field": field,
+        "requested": requested,
+        "inherited": inherited,
+    }))
 }
 
 fn canonical_existing_dir(path: &str) -> Result<PathBuf, RpcError> {
@@ -22138,7 +22295,7 @@ mod tests {
         ApprovalDecision, ApprovalId, ApprovalRespondParams, ApprovalRespondStatus, DiffPreview,
         DiffPreviewFile, DiffPreviewFileStatus, DiffPreviewGetParams, DiffPreviewGetStatus,
         DiffPreviewHunk, DiffPreviewLine, DiffPreviewLineKind, DiffPreviewSource, PreviewId,
-        QuestionId, approval_scopes, methods, rpc_error_codes,
+        QuestionId, SessionSandboxParams, approval_scopes, methods, rpc_error_codes,
     };
 
     fn local_profile_state(dir: &Path) -> AppState {
@@ -22728,6 +22885,7 @@ mod tests {
             topic: None,
             profile_id: None,
             cwd: None,
+            sandbox: None,
             after: None,
         };
         assert_eq!(
@@ -22740,6 +22898,7 @@ mod tests {
             topic: None,
             profile_id: Some("explicit".into()),
             cwd: None,
+            sandbox: None,
             after: None,
         };
         assert_eq!(
@@ -22752,6 +22911,7 @@ mod tests {
             topic: None,
             profile_id: None,
             cwd: None,
+            sandbox: None,
             after: None,
         };
         assert_eq!(
@@ -24406,6 +24566,7 @@ ignore = []
             topic: None,
             profile_id: Some("missing".into()),
             cwd: None,
+            sandbox: None,
             after: None,
         };
         let candidate = stdio_session_open_candidate_profile(&missing_params, binding.as_deref());
@@ -24459,6 +24620,7 @@ ignore = []
             topic: None,
             profile_id: Some("grace".into()),
             cwd: None,
+            sandbox: None,
             after: None,
         };
         let candidate = stdio_session_open_candidate_profile(&grace_params, binding.as_deref());
@@ -24627,6 +24789,7 @@ ignore = []
                     topic: None,
                     profile_id: None,
                     cwd: None,
+                    sandbox: None,
                     after: None,
                 },
             )
@@ -25103,6 +25266,7 @@ ignore = []
             topic: None,
             profile_id: Some("ada".into()),
             cwd: Some(workspace.path().to_string_lossy().into_owned()),
+            sandbox: None,
             after: None,
         };
 
@@ -26457,6 +26621,7 @@ ignore = []
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                session_sandbox: false,
                 harness_task_control: false,
                 harness_task_artifacts: false,
                 session_hydrate: false,
@@ -26519,6 +26684,7 @@ ignore = []
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                session_sandbox: false,
                 harness_task_control: false,
                 harness_task_artifacts: false,
                 session_hydrate: false,
@@ -26626,6 +26792,7 @@ ignore = []
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                session_sandbox: false,
                 harness_task_control: false,
                 harness_task_artifacts: false,
                 session_hydrate: false,
@@ -26688,6 +26855,7 @@ ignore = []
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                session_sandbox: false,
                 harness_task_control: false,
                 harness_task_artifacts: false,
                 session_hydrate: false,
@@ -26743,6 +26911,7 @@ ignore = []
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                session_sandbox: false,
                 harness_task_control: false,
                 harness_task_artifacts: false,
                 session_hydrate: false,
@@ -26841,6 +27010,7 @@ ignore = []
                 typed_approvals: true,
                 pane_snapshots: false,
                 session_workspace_cwd: false,
+                session_sandbox: false,
                 harness_task_control: false,
                 harness_task_artifacts: false,
                 session_hydrate: false,
@@ -28296,6 +28466,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(first.cursor),
             },
         )
@@ -28358,6 +28529,7 @@ ignore = []
                 topic: Some("alpha".into()),
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(UiCursor {
                     stream: alpha_session.0.clone(),
                     seq: 0,
@@ -28388,6 +28560,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(UiCursor {
                     stream: base_session.0.clone(),
                     seq: 0,
@@ -28427,6 +28600,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(UiCursor {
                     stream: "local:other".into(),
                     seq: 0,
@@ -28487,6 +28661,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(UiCursor {
                     stream: session_id.0.clone(),
                     seq: 0,
@@ -28543,6 +28718,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: None,
             },
         )
@@ -28935,6 +29111,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(UiCursor {
                     stream: session_id.0.clone(),
                     seq: 1,
@@ -28979,6 +29156,7 @@ ignore = []
                 typed_approvals: false,
                 pane_snapshots: true,
                 session_workspace_cwd: false,
+                session_sandbox: false,
                 harness_task_control: false,
                 harness_task_artifacts: false,
                 session_hydrate: false,
@@ -29004,6 +29182,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: None,
             },
         )
@@ -29055,6 +29234,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: Some(temp.path().to_string_lossy().to_string()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -29093,6 +29273,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: None,
             },
         )
@@ -29165,6 +29346,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: None,
             },
         )
@@ -31631,6 +31813,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: None,
             },
         )
@@ -31656,6 +31839,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(UiCursor {
                     stream: session_id.0.clone(),
                     seq: 0,
@@ -33572,6 +33756,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: None,
+                sandbox: None,
                 after: Some(warmup.cursor.clone()),
             },
         )
@@ -37831,17 +38016,11 @@ ignore = []
         }
     }
 
-    async fn make_m11e_profile(
-        profile_id: &str,
-        data_dir: &std::path::Path,
-    ) -> Arc<crate::runtime::ProfileRuntime> {
-        make_m11e_profile_with_llm(profile_id, data_dir, Arc::new(M11EStubLlm)).await
-    }
-
-    async fn make_m11e_profile_with_llm(
+    async fn make_m11e_profile_with_llm_and_sandbox(
         profile_id: &str,
         data_dir: &std::path::Path,
         llm: Arc<dyn octos_llm::LlmProvider>,
+        sandbox: octos_agent::SandboxConfig,
     ) -> Arc<crate::runtime::ProfileRuntime> {
         std::fs::create_dir_all(data_dir).expect("profile data dir");
         let memory = Arc::new(
@@ -37859,7 +38038,6 @@ ignore = []
                 .await
                 .expect("tool config store"),
         );
-        let sandbox = octos_agent::SandboxConfig::default();
         let base_tools = octos_agent::ToolRegistry::with_builtins_and_sandbox(
             data_dir,
             octos_agent::create_sandbox(&sandbox),
@@ -37915,6 +38093,21 @@ ignore = []
         profile_id: &str,
         llm: Arc<dyn octos_llm::LlmProvider>,
     ) -> (Arc<AppState>, Arc<crate::runtime::ProfileRuntime>) {
+        state_with_profile_llm_and_sandbox(
+            data_dir,
+            profile_id,
+            llm,
+            octos_agent::SandboxConfig::default(),
+        )
+        .await
+    }
+
+    async fn state_with_profile_llm_and_sandbox(
+        data_dir: &std::path::Path,
+        profile_id: &str,
+        llm: Arc<dyn octos_llm::LlmProvider>,
+        sandbox: octos_agent::SandboxConfig,
+    ) -> (Arc<AppState>, Arc<crate::runtime::ProfileRuntime>) {
         std::fs::create_dir_all(data_dir).expect("data dir");
 
         let sessions = Arc::new(tokio::sync::Mutex::new(
@@ -37922,7 +38115,9 @@ ignore = []
         ));
 
         let profile_data_dir = data_dir.join("profiles").join(profile_id).join("data");
-        let profile_runtime = make_m11e_profile_with_llm(profile_id, &profile_data_dir, llm).await;
+        let profile_runtime =
+            make_m11e_profile_with_llm_and_sandbox(profile_id, &profile_data_dir, llm, sandbox)
+                .await;
 
         let mut profiles = HashMap::new();
         profiles.insert(profile_id.to_string(), profile_runtime.clone());
@@ -38175,6 +38370,7 @@ ignore = []
         let session_id = SessionKey::with_profile("m11e-custom-cwd", "api", "custom-cwd-session");
         let features = ConnectionUiFeatures {
             session_workspace_cwd: true,
+            session_sandbox: false,
             header_present: true,
             ..ConnectionUiFeatures::default()
         };
@@ -38192,6 +38388,7 @@ ignore = []
                 topic: None,
                 profile_id: Some("m11e-custom-cwd".into()),
                 cwd: Some(supplied_cwd.to_string_lossy().into_owned()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -38239,6 +38436,235 @@ ignore = []
         );
     }
 
+    #[test]
+    fn session_sandbox_requires_negotiated_feature() {
+        let params = SessionOpenParams {
+            session_id: SessionKey::new("api", "sandbox-feature-required"),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: Some(SessionSandboxParams {
+                enabled: None,
+                network_access: Some(false),
+                read_allow_paths: Vec::new(),
+            }),
+            after: None,
+        };
+
+        let err = validate_requested_session_sandbox(
+            ConnectionUiFeatures::default(),
+            &params,
+            &octos_agent::SandboxConfig::default(),
+        )
+        .expect_err("sandbox override must require feature negotiation");
+        assert_eq!(
+            err.data.as_ref().and_then(|data| data.get("kind")),
+            Some(&json!("feature_required"))
+        );
+        assert_eq!(
+            err.data.as_ref().and_then(|data| data.get("feature")),
+            Some(&json!(UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1))
+        );
+    }
+
+    #[test]
+    fn session_sandbox_can_narrow_network_but_not_widen() {
+        let features = ConnectionUiFeatures {
+            session_sandbox: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        };
+        let params = SessionOpenParams {
+            session_id: SessionKey::new("api", "sandbox-network-narrow"),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: Some(SessionSandboxParams {
+                enabled: None,
+                network_access: Some(false),
+                read_allow_paths: Vec::new(),
+            }),
+            after: None,
+        };
+        let inherited = octos_agent::SandboxConfig {
+            allow_network: true,
+            ..octos_agent::SandboxConfig::default()
+        };
+
+        let narrowed = validate_requested_session_sandbox(features, &params, &inherited)
+            .expect("network:false narrows network-enabled profile")
+            .expect("override present");
+        assert!(!narrowed.allow_network);
+
+        let widening = SessionOpenParams {
+            session_id: SessionKey::new("api", "sandbox-network-widen"),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: Some(SessionSandboxParams {
+                enabled: None,
+                network_access: Some(true),
+                read_allow_paths: Vec::new(),
+            }),
+            after: None,
+        };
+        let err = validate_requested_session_sandbox(
+            features,
+            &widening,
+            &octos_agent::SandboxConfig::default(),
+        )
+        .expect_err("network:true widens a network-denied profile");
+        assert_eq!(
+            err.data.as_ref().and_then(|data| data.get("kind")),
+            Some(&json!("session_sandbox_would_widen_profile"))
+        );
+        assert_eq!(
+            err.data.as_ref().and_then(|data| data.get("field")),
+            Some(&json!("network_access"))
+        );
+    }
+
+    #[test]
+    fn session_sandbox_read_paths_must_stay_within_profile_allowlist() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let allowed = temp.path().join("allowed");
+        let nested = allowed.join("nested");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&nested).expect("nested dir");
+        std::fs::create_dir_all(&outside).expect("outside dir");
+        let features = ConnectionUiFeatures {
+            session_sandbox: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        };
+        let inherited = octos_agent::SandboxConfig {
+            read_allow_paths: vec![allowed.to_string_lossy().into_owned()],
+            ..octos_agent::SandboxConfig::default()
+        };
+
+        let narrowed = SessionOpenParams {
+            session_id: SessionKey::new("api", "sandbox-read-narrow"),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: Some(SessionSandboxParams {
+                enabled: None,
+                network_access: None,
+                read_allow_paths: vec![nested.to_string_lossy().into_owned()],
+            }),
+            after: None,
+        };
+        let sandbox = validate_requested_session_sandbox(features, &narrowed, &inherited)
+            .expect("nested read path narrows profile allowlist")
+            .expect("override present");
+        assert_eq!(sandbox.read_allow_paths.len(), 1);
+        assert!(Path::new(&sandbox.read_allow_paths[0]).ends_with("nested"));
+
+        let widening = SessionOpenParams {
+            session_id: SessionKey::new("api", "sandbox-read-widen"),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            sandbox: Some(SessionSandboxParams {
+                enabled: None,
+                network_access: None,
+                read_allow_paths: vec![outside.to_string_lossy().into_owned()],
+            }),
+            after: None,
+        };
+        let err = validate_requested_session_sandbox(features, &widening, &inherited)
+            .expect_err("outside read path widens profile allowlist");
+        assert_eq!(
+            err.data.as_ref().and_then(|data| data.get("kind")),
+            Some(&json!("session_sandbox_would_widen_profile"))
+        );
+        assert_eq!(
+            err.data.as_ref().and_then(|data| data.get("field")),
+            Some(&json!("read_allow_paths"))
+        );
+    }
+
+    #[tokio::test]
+    async fn session_sandbox_open_override_materializes_distinct_session_policies() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (state, profile_runtime) = state_with_profile_llm_and_sandbox(
+            temp.path(),
+            "m11-session-sandbox",
+            Arc::new(M11EStubLlm),
+            octos_agent::SandboxConfig {
+                allow_network: true,
+                ..octos_agent::SandboxConfig::default()
+            },
+        )
+        .await;
+        let ledger = UiProtocolLedger::new(16);
+        let approvals = PendingApprovalStore::default();
+        let features = ConnectionUiFeatures {
+            session_sandbox: true,
+            header_present: true,
+            ..ConnectionUiFeatures::default()
+        };
+        let gamma = SessionKey::with_profile("m11-session-sandbox", "api", "gamma");
+        let delta = SessionKey::with_profile("m11-session-sandbox", "api", "delta");
+
+        let _ = open_session_result(
+            &state,
+            &ledger,
+            &approvals,
+            ConnectionId::next(),
+            Some("m11-session-sandbox"),
+            features,
+            SessionOpenParams {
+                session_id: gamma.clone(),
+                topic: None,
+                profile_id: Some("m11-session-sandbox".into()),
+                cwd: None,
+                sandbox: Some(SessionSandboxParams {
+                    enabled: None,
+                    network_access: Some(false),
+                    read_allow_paths: Vec::new(),
+                }),
+                after: None,
+            },
+        )
+        .await
+        .expect("gamma session/open with network false sandbox override");
+        let _ = open_session_result(
+            &state,
+            &ledger,
+            &approvals,
+            ConnectionId::next(),
+            Some("m11-session-sandbox"),
+            features,
+            SessionOpenParams {
+                session_id: delta.clone(),
+                topic: None,
+                profile_id: Some("m11-session-sandbox".into()),
+                cwd: None,
+                sandbox: None,
+                after: None,
+            },
+        )
+        .await
+        .expect("delta session/open with default sandbox");
+
+        let gamma_runtime = state
+            .session_cache
+            .get_or_init(&profile_runtime, gamma, None)
+            .await
+            .expect("gamma runtime");
+        let delta_runtime = state
+            .session_cache
+            .get_or_init(&profile_runtime, delta, None)
+            .await
+            .expect("delta runtime");
+
+        assert!(profile_runtime.default_sandbox.allow_network);
+        assert!(!gamma_runtime.sandbox.allow_network);
+        assert!(delta_runtime.sandbox.allow_network);
+        assert_ne!(gamma_runtime.workspace_root, delta_runtime.workspace_root);
+    }
+
     /// M11-E acceptance §2: two AppUI sessions opened on the SAME profile
     /// with DIFFERENT cwds must not see each other's files. This is the
     /// multi-tenant scope invariant codex flagged on PR #868 — pre-M11
@@ -38265,6 +38691,7 @@ ignore = []
 
         let features = ConnectionUiFeatures {
             session_workspace_cwd: true,
+            session_sandbox: false,
             header_present: true,
             ..ConnectionUiFeatures::default()
         };
@@ -38283,6 +38710,7 @@ ignore = []
                 topic: None,
                 profile_id: Some("m11e-multi-cwd".into()),
                 cwd: Some(cwd_a.to_string_lossy().into_owned()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -38303,6 +38731,7 @@ ignore = []
                 topic: None,
                 profile_id: Some("m11e-multi-cwd".into()),
                 cwd: Some(cwd_b.to_string_lossy().into_owned()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -38435,6 +38864,7 @@ ignore = []
         let session_id = SessionKey::with_profile("m11e-rebind-attempt", "api", "single-key");
         let features = ConnectionUiFeatures {
             session_workspace_cwd: true,
+            session_sandbox: false,
             header_present: true,
             ..ConnectionUiFeatures::default()
         };
@@ -38452,6 +38882,7 @@ ignore = []
                 topic: None,
                 profile_id: Some("m11e-rebind-attempt".into()),
                 cwd: Some(first_cwd.to_string_lossy().into_owned()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -38472,6 +38903,7 @@ ignore = []
                 profile_id: Some("m11e-rebind-attempt".into()),
                 // Different cwd — must NOT take effect; cache is sticky.
                 cwd: Some(second_cwd.to_string_lossy().into_owned()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -38526,6 +38958,7 @@ ignore = []
         let session_id = SessionKey::with_profile("m11e-not-registered", "api", "x");
         let features = ConnectionUiFeatures {
             session_workspace_cwd: true,
+            session_sandbox: false,
             header_present: true,
             ..ConnectionUiFeatures::default()
         };
@@ -38545,6 +38978,7 @@ ignore = []
                 topic: None,
                 profile_id: None,
                 cwd: Some(cwd.to_string_lossy().into_owned()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -38595,6 +39029,7 @@ ignore = []
         let session_a = SessionKey::with_profile("m11e-symlink", "api", "session-a");
         let features = ConnectionUiFeatures {
             session_workspace_cwd: true,
+            session_sandbox: false,
             header_present: true,
             ..ConnectionUiFeatures::default()
         };
@@ -38612,6 +39047,7 @@ ignore = []
                 topic: None,
                 profile_id: Some("m11e-symlink".into()),
                 cwd: Some(cwd_a.to_string_lossy().into_owned()),
+                sandbox: None,
                 after: None,
             },
         )
@@ -38720,6 +39156,7 @@ ignore = []
         // that the M11-E deletion of `clone_session_tools` broke.
         let features = ConnectionUiFeatures {
             session_workspace_cwd: false,
+            session_sandbox: false,
             header_present: true,
             ..ConnectionUiFeatures::default()
         };
@@ -38737,6 +39174,7 @@ ignore = []
                 topic: None,
                 profile_id: Some("m11f-tier2-default".into()),
                 cwd: None,
+                sandbox: None,
                 after: None,
             },
         )

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use eyre::Result;
-use octos_agent::EffectivePermissions;
+use octos_agent::{EffectivePermissions, SandboxConfig};
 use octos_core::SessionKey;
 use tokio::sync::{Notify, Semaphore};
 use tokio::task::JoinHandle;
@@ -277,6 +277,28 @@ impl SessionRuntimeCache {
         workspace_hint: Option<PathBuf>,
         permissions: EffectivePermissions,
     ) -> Result<Arc<SessionRuntime>> {
+        self.get_or_init_with_permissions_and_sandbox(
+            profile,
+            session_key,
+            workspace_hint,
+            permissions,
+            None,
+        )
+        .await
+    }
+
+    /// Look up or build a session runtime using explicit effective
+    /// permissions plus an optional, already-validated sandbox override.
+    /// Cache hits intentionally keep the first bootstrapped runtime for a
+    /// session key, including its sandbox policy.
+    pub async fn get_or_init_with_permissions_and_sandbox(
+        &self,
+        profile: &Arc<ProfileRuntime>,
+        session_key: SessionKey,
+        workspace_hint: Option<PathBuf>,
+        permissions: EffectivePermissions,
+        sandbox_override: Option<SandboxConfig>,
+    ) -> Result<Arc<SessionRuntime>> {
         let key = (profile.profile_id.clone(), session_key.clone());
 
         loop {
@@ -362,11 +384,12 @@ impl SessionRuntimeCache {
                     continue;
                 }
                 InflightOutcome::OwnGuard(guard) => {
-                    let result = SessionRuntime::bootstrap_with_permissions(
+                    let result = SessionRuntime::bootstrap_with_permissions_and_sandbox(
                         profile,
                         session_key.clone(),
                         workspace_hint,
                         permissions,
+                        sandbox_override,
                     )
                     .await;
                     match result {

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -204,6 +204,26 @@ impl SessionRuntime {
         workspace_hint: Option<PathBuf>,
         permissions: EffectivePermissions,
     ) -> Result<Arc<Self>> {
+        Self::bootstrap_with_permissions_and_sandbox(
+            profile,
+            session_key,
+            workspace_hint,
+            permissions,
+            None,
+        )
+        .await
+    }
+
+    /// Construct a [`SessionRuntime`] with explicit effective permissions and
+    /// an optional, already-validated sandbox override. The override must be
+    /// derived from and no wider than the profile-level sandbox policy.
+    pub async fn bootstrap_with_permissions_and_sandbox(
+        profile: &Arc<ProfileRuntime>,
+        session_key: SessionKey,
+        workspace_hint: Option<PathBuf>,
+        permissions: EffectivePermissions,
+        sandbox_override: Option<SandboxConfig>,
+    ) -> Result<Arc<Self>> {
         // Step 1: resolve workspace_root.
         let workspace_root = resolve_workspace_root(profile, &session_key, workspace_hint)?;
         std::fs::create_dir_all(&workspace_root).wrap_err_with(|| {
@@ -246,7 +266,8 @@ impl SessionRuntime {
         // `fm_tts` and friends emit into this session's
         // `<workspace>/skill-output/` rather than the profile-template
         // path.
-        let sandbox = permissions.apply_to_sandbox(&profile.default_sandbox);
+        let sandbox = sandbox_override
+            .unwrap_or_else(|| permissions.apply_to_sandbox(&profile.default_sandbox));
         let mut tools = profile.tool_specs.rebind_cwd_with_permissions(
             &workspace_root,
             create_sandbox(&sandbox),
@@ -756,11 +777,19 @@ mod tests {
         data_dir: PathBuf,
         system_prompt: String,
     ) -> Arc<ProfileRuntime> {
+        make_profile_with_prompt_and_sandbox(data_dir, system_prompt, SandboxConfig::default())
+            .await
+    }
+
+    async fn make_profile_with_prompt_and_sandbox(
+        data_dir: PathBuf,
+        system_prompt: String,
+        sandbox: SandboxConfig,
+    ) -> Arc<ProfileRuntime> {
         std::fs::create_dir_all(&data_dir).unwrap();
         let memory = Arc::new(EpisodeStore::open(&data_dir).await.unwrap());
         let memory_store = Arc::new(MemoryStore::open(&data_dir).await.unwrap());
         let tool_config = Arc::new(octos_agent::ToolConfigStore::open(&data_dir).await.unwrap());
-        let sandbox = SandboxConfig::default();
         let base_tools =
             ToolRegistry::with_builtins_and_sandbox(&data_dir, create_sandbox(&sandbox));
         Arc::new(ProfileRuntime {
@@ -794,6 +823,14 @@ mod tests {
             lane_routing: None,
             voice: crate::config::VoiceConfig::default(),
         })
+    }
+
+    async fn make_profile_with_sandbox(
+        data_dir: PathBuf,
+        sandbox: SandboxConfig,
+    ) -> Arc<ProfileRuntime> {
+        make_profile_with_prompt_and_sandbox(data_dir, "test-system-prompt".to_string(), sandbox)
+            .await
     }
 
     #[tokio::test]
@@ -867,6 +904,50 @@ mod tests {
         assert!(scope.shared_zones().is_empty());
         // Critical for propagation: scope.workspace() == workspace_root.
         assert_eq!(scope.workspace(), rt.workspace_root.as_path());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_with_explicit_sandbox_overrides_are_per_session() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("profile-data");
+        let profile = make_profile_with_sandbox(
+            data_dir,
+            SandboxConfig {
+                allow_network: true,
+                ..SandboxConfig::default()
+            },
+        )
+        .await;
+
+        let gamma_sandbox = SandboxConfig {
+            allow_network: false,
+            ..profile.default_sandbox.clone()
+        };
+
+        let gamma = SessionRuntime::bootstrap_with_permissions_and_sandbox(
+            &profile,
+            SessionKey::new("api", "gamma"),
+            Some(tmp.path().join("gamma")),
+            EffectivePermissions::workspace_write(),
+            Some(gamma_sandbox),
+        )
+        .await
+        .expect("gamma bootstrap");
+        let delta = SessionRuntime::bootstrap_with_permissions_and_sandbox(
+            &profile,
+            SessionKey::new("api", "delta"),
+            Some(tmp.path().join("delta")),
+            EffectivePermissions::workspace_write(),
+            None,
+        )
+        .await
+        .expect("delta bootstrap");
+
+        assert!(profile.default_sandbox.allow_network);
+        assert!(!gamma.sandbox.allow_network);
+        assert!(delta.sandbox.allow_network);
+        assert_ne!(gamma.workspace_root, delta.workspace_root);
+        assert!(!Arc::ptr_eq(&gamma.tools, &delta.tools));
     }
 
     #[tokio::test]

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -106,6 +106,9 @@ pub const UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1: &str = "pane.snapshots.v1";
 /// Feature flag for UPCR-2026-003 per-session workspace cwd requests.
 pub const UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1: &str = "session.workspace_cwd.v1";
 
+/// Feature flag for UPCR-2026-022 per-session sandbox narrowing requests.
+pub const UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1: &str = "session.sandbox.v1";
+
 /// Feature flag for harness task registry/control commands.
 pub const UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1: &str = "harness.task_control.v1";
 
@@ -246,6 +249,7 @@ pub const UI_PROTOCOL_KNOWN_FEATURES: &[&str] = &[
     UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
     UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
     UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+    UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1,
     UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
     UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
     UI_PROTOCOL_FEATURE_THREAD_GRAPH_V1,
@@ -1345,6 +1349,7 @@ impl UiProtocolCapabilities {
             UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
             UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1,
             UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1,
+            UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1,
             UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1,
             UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1,
             UI_PROTOCOL_FEATURE_SESSION_HYDRATE_V1,
@@ -1693,8 +1698,25 @@ pub struct SessionOpenParams {
     pub profile_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<SessionSandboxParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after: Option<UiCursor>,
+}
+
+/// Optional session-scoped sandbox narrowing requested by `session/open`.
+///
+/// The server validates this object against the profile-derived sandbox before
+/// constructing the session runtime. Requests may keep or narrow the inherited
+/// policy; they must not widen network, filesystem, or sandbox isolation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionSandboxParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_access: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub read_allow_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -6113,6 +6135,7 @@ mod tests {
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
+        assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
         assert!(capabilities.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1));
         assert!(capabilities.supports_method(methods::TASK_LIST));
@@ -6150,6 +6173,7 @@ mod tests {
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1));
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_PANE_SNAPSHOTS_V1));
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_SESSION_WORKSPACE_CWD_V1));
+        assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_SESSION_SANDBOX_V1));
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_CONTROL_V1));
         assert!(!decoded.supports_feature(UI_PROTOCOL_FEATURE_HARNESS_TASK_ARTIFACTS_V1));
     }
@@ -6170,18 +6194,26 @@ mod tests {
     }
 
     #[test]
-    fn session_open_params_topic_and_cwd_are_additive_and_round_trip() {
+    fn session_open_params_topic_cwd_and_sandbox_are_additive_and_round_trip() {
         let params = SessionOpenParams {
             session_id: SessionKey("local:demo".into()),
             topic: Some("research".into()),
             profile_id: Some("coding".into()),
             cwd: Some("/repo".into()),
+            sandbox: Some(SessionSandboxParams {
+                enabled: Some(true),
+                network_access: Some(false),
+                read_allow_paths: vec!["/repo/docs".into()],
+            }),
             after: None,
         };
 
         let wire = serde_json::to_value(&params).expect("serialize session/open params");
         assert_eq!(wire["topic"], json!("research"));
         assert_eq!(wire["cwd"], json!("/repo"));
+        assert_eq!(wire["sandbox"]["enabled"], json!(true));
+        assert_eq!(wire["sandbox"]["network_access"], json!(false));
+        assert_eq!(wire["sandbox"]["read_allow_paths"], json!(["/repo/docs"]));
 
         let decoded: SessionOpenParams =
             serde_json::from_value(wire).expect("deserialize session/open params");
@@ -6195,6 +6227,7 @@ mod tests {
             serde_json::from_value(legacy).expect("legacy session/open params");
         assert!(decoded_legacy.topic.is_none());
         assert!(decoded_legacy.cwd.is_none());
+        assert!(decoded_legacy.sandbox.is_none());
     }
 
     #[test]
@@ -6778,6 +6811,7 @@ mod tests {
                     "approval.typed.v1",
                     "pane.snapshots.v1",
                     "session.workspace_cwd.v1",
+                    "session.sandbox.v1",
                     "harness.task_control.v1",
                     "state.session_hydrate.v1",
                     "state.thread_graph.v1",

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -339,9 +339,22 @@ mod tests {
         store.append_today("note 1").await.unwrap();
         store.append_today("note 2").await.unwrap();
 
-        let content = store.read_today().await.unwrap();
+        let content = read_all_daily_notes(dir.path()).await;
         assert!(content.contains("note 1"));
         assert!(content.contains("note 2"));
+    }
+
+    async fn read_all_daily_notes(data_dir: &Path) -> String {
+        let mut entries = tokio::fs::read_dir(data_dir.join("memory")).await.unwrap();
+        let mut content = String::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let path = entry.path();
+            if path.file_name().and_then(|name| name.to_str()) == Some("MEMORY.md") {
+                continue;
+            }
+            content.push_str(&tokio::fs::read_to_string(path).await.unwrap());
+        }
+        content
     }
 
     #[tokio::test]

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_022_SESSION_POLICY.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_022_SESSION_POLICY.md
@@ -1,0 +1,77 @@
+# UPCR-2026-022: Session Sandbox Narrowing
+
+Status: proposed
+Date: 2026-05-25
+
+## Summary
+
+Add an optional, capability-gated sandbox policy object to `session/open` so a
+client can narrow the sandbox for one session without changing the profile's
+default runtime policy.
+
+This closes the protocol gap found by the M11 SOAK-5 validation: two sessions
+under one profile need to prove distinct sandbox policies such as one
+network-denied room and one default room. The client request is not trusted as a
+source of authority. The server validates it against the profile-derived
+sandbox and rejects any request that would widen access.
+
+## Capability
+
+Clients must negotiate:
+
+- `session.sandbox.v1`
+
+Servers that advertise this feature accept `session/open.params.sandbox`.
+Servers that do not advertise it reject the field with a typed
+`feature_required` error.
+
+## Request Shape
+
+`session/open.params.sandbox` is optional:
+
+```json
+{
+  "session_id": "coding:local:gamma",
+  "profile_id": "coding",
+  "sandbox": {
+    "enabled": true,
+    "network_access": false,
+    "read_allow_paths": ["/repo/docs"]
+  }
+}
+```
+
+Fields:
+
+- `enabled`: optional boolean. `false` is rejected when the inherited profile
+  sandbox is enabled.
+- `network_access`: optional boolean. `true` is rejected when the inherited
+  profile sandbox denies network.
+- `read_allow_paths`: optional list of existing paths. When the inherited
+  profile has a read allowlist, every requested path must be equal to or under
+  one inherited allowlist root. When the inherited list is empty, a non-empty
+  requested list narrows the backward-compatible "allow reads" default.
+
+## Validation
+
+The effective policy is derived in this order:
+
+1. Profile `SandboxConfig`.
+2. Effective permission profile for the session.
+3. Validated `session/open.params.sandbox` narrowing.
+
+Any request that cannot be proven to narrow the derived profile policy fails
+closed with `permission_denied` and `kind:
+session_sandbox_would_widen_profile`.
+
+## Non-Production Proof
+
+The local validation path is:
+
+```bash
+bash scripts/validate-session-policy-local.sh
+```
+
+It runs focused protocol and runtime tests, including a two-session same-profile
+runtime case where `gamma` narrows network access while `delta` inherits the
+profile default.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -27,6 +27,7 @@
     "ux:tmux:run": "node scripts/ux-tmux-run.mjs",
     "ux:tmux:validate": "node scripts/ux-tmux-validate.mjs",
     "soak:m14:codex-tool-parity": "node scripts/m14-codex-tool-parity-soak.mjs",
+    "soak:m11:session-sandbox": "cd .. && bash scripts/validate-session-policy-local.sh",
     "soak:m18:appui-transport-parity": "node scripts/m18-appui-transport-parity-soak.mjs",
     "soak:m11:post-eviction-replay": "bash scripts/m11-post-eviction-replay-local.sh",
     "matrix": "node matrix/run.mjs",

--- a/scripts/validate-session-policy-local.sh
+++ b/scripts/validate-session-policy-local.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-/private/tmp/octos-session-sandbox-target}"
+
+echo "==> protocol: session sandbox capability and validation"
+cargo test -p octos-core session_open_params_topic_cwd_and_sandbox_are_additive_and_round_trip -- --nocapture
+cargo test -p octos-cli --features api session_sandbox_ -- --nocapture
+
+echo "==> runtime: same profile, distinct per-session sandbox policies"
+cargo test -p octos-cli --features api bootstrap_with_explicit_sandbox_overrides_are_per_session -- --nocapture
+
+echo "session sandbox local validation passed"


### PR DESCRIPTION
## Summary

- Add `session.sandbox.v1` and optional `session/open.params.sandbox` protocol support.
- Validate requested session sandbox policies as profile-derived narrowing only; requests can narrow network/filesystem policy but cannot widen beyond the profile maximum.
- Plumb validated sandbox overrides through session open, runtime cache, memory persistence, and session bootstrap so two sessions under one profile can have distinct sandbox policies.
- Add UPCR coverage plus a local non-production validation script for the per-session sandbox path.

Closes #1279

## Current-main refresh

- Refreshed onto current GitHub `main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Refreshed head: `59b8dcfd952dcadf1a7ddbdf44c9ad0eb3bf9dbc`.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1281-refresh-current.SavVtC/octos`.
- Root checkout left untouched.
- Conflict resolution in `crates/octos-cli/src/runtime/session.rs` preserved both the existing #1377 workspace-hint session test and the #1279 per-session sandbox test.
- No generated artifacts are included; `git ls-files --others --exclude-standard` is empty in the isolated checkout.

## Environment

- Darwin 25.5.0 arm64
- `rustc 1.95.0 (59807616e 2026-04-14)`
- `cargo 1.95.0 (f2d3ce0bd 2026-03-21)`
- Node `v24.10.0`
- npm `11.6.0`
- Cargo target: `/private/tmp/octos-1281-current-4adbe-target`
- npm cache: `/private/tmp/octos-npm-cache-1281-current`

## Validation

Passed locally:

- `git diff --check origin/main...HEAD`
- `bash -n scripts/validate-session-policy-local.sh`
- `bash scripts/check-ui-protocol-upcr.sh`
- `node -e "JSON.parse(require('fs').readFileSync('e2e/package.json','utf8')); console.log('e2e/package.json ok')"`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/octos-1281-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1281-current npm --prefix e2e run --silent soak:m11:session-sandbox`
  - core session/open sandbox round-trip: 1/1 passed
  - UI protocol `session_sandbox_` tests: 4/4 passed
  - runtime distinct per-session sandbox policy proof: 1/1 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1281-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api bootstrap_roots_scope_at_repo_for_workspace_hint_session -- --nocapture` - passed 1/1
- `CARGO_TARGET_DIR=/private/tmp/octos-1281-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/octos-1281-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --no-default-features --features api,telegram,discord,slack,whatsapp,feishu,email,matrix,audio_mp3` - passed with unrelated existing optional-channel warnings only
- `CARGO_TARGET_DIR=/private/tmp/octos-1281-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --test security_sandbox --no-run`
- `CARGO_TARGET_DIR=/private/tmp/octos-1281-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-memory` - 56/56 passed
- `git ls-files --others --exclude-standard` - empty

Security note: full local `security_sandbox` execution is blocked by the outer macOS sandbox here, so local security evidence is compile/no-run only. Hosted GitHub CI `security` passed on this refreshed head.

## CI / merge status

- GitHub CI is green on head `59b8dcfd952dcadf1a7ddbdf44c9ad0eb3bf9dbc`: https://github.com/octos-org/octos/actions/runs/26787565053
- Passing checks include `check`, `check-matrix`, `test-octos-cli`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `security`, `e2e-tool-regression`, `dashboard`, `swarm-app`, `typos`, SPA reducer replay, and author-email checks.
- Merge remains branch-protection blocked by required review (`BLOCKED`, `REVIEW_REQUIRED`).
