### PR TITLE
test(appui): validate post-eviction replay

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol_ledger.rs
+++ b/crates/octos-cli/src/api/ui_protocol_ledger.rs
@@ -1529,6 +1529,12 @@ impl UiProtocolLedger {
         inner.subscribers.len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn has_session_in_memory_for_test(&self, session_id: &SessionKey) -> bool {
+        let inner = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+        inner.sessions.contains_key(session_id)
+    }
+
     /// Snapshot of the observability counters. Useful for tests and the
     /// `/metrics` endpoint integration.
     #[cfg_attr(not(test), allow(dead_code))]
@@ -2179,6 +2185,23 @@ mod tests {
             .collect()
     }
 
+    fn session_log_payload(data_dir: &Path, session_id: &SessionKey) -> String {
+        let session_dir = data_dir
+            .join("ui-protocol")
+            .join(encode_session_dir_name(session_id));
+        let mut log_files = list_log_files(&session_dir).expect("list session log files");
+        log_files.sort();
+        assert!(
+            !log_files.is_empty(),
+            "expected persisted JSONL log files for {}",
+            session_id.0
+        );
+        log_files
+            .iter()
+            .map(|path| std::fs::read_to_string(path).expect("read session log file"))
+            .collect::<String>()
+    }
+
     #[test]
     fn ledger_replays_notifications_after_cursor_in_order() {
         let ledger = UiProtocolLedger::new(8);
@@ -2378,6 +2401,45 @@ mod tests {
             .expect("replay evicted session from disk");
 
         assert_eq!(replay_texts(&replay), vec!["two", "three"]);
+    }
+
+    #[test]
+    fn ledger_post_eviction_validation_path_replays_from_persisted_jsonl() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut config = LedgerConfig::durable(temp.path().into());
+        config.retained_per_session = 4;
+        config.active_session_cap = 1;
+        let ledger = UiProtocolLedger::with_config(config);
+        let target = SessionKey("local:post-eviction-target".into());
+        let filler = SessionKey("local:post-eviction-filler".into());
+
+        ledger.append_notification(delta(&target, "target-one"));
+        ledger.append_notification(delta(&target, "target-two"));
+        assert!(ledger.has_session_in_memory_for_test(&target));
+        assert!(session_log_payload(temp.path(), &target).contains("target-two"));
+
+        ledger.append_notification(delta(&filler, "filler-evicts-target"));
+        let post_eviction_metrics = ledger.metrics();
+        assert_eq!(post_eviction_metrics.sessions_evicted, 1);
+        assert_eq!(post_eviction_metrics.sessions_active, 1);
+        assert!(!ledger.has_session_in_memory_for_test(&target));
+        assert!(ledger.has_session_in_memory_for_test(&filler));
+
+        let (replayed, cursor) = ledger
+            .snapshot_with_cursor(
+                &target,
+                Some(&UiCursor {
+                    stream: target.0.clone(),
+                    seq: 1,
+                }),
+            )
+            .expect("hydrate evicted target session from JSONL");
+
+        assert_eq!(replay_texts(&replayed), vec!["target-two"]);
+        assert_eq!(cursor.seq, 2);
+        assert!(ledger.has_session_in_memory_for_test(&target));
+        assert!(!ledger.has_session_in_memory_for_test(&filler));
+        assert_eq!(ledger.metrics().sessions_evicted, 2);
     }
 
     #[test]

--- a/docs/POST_EVICTION_REPLAY_VALIDATION.md
+++ b/docs/POST_EVICTION_REPLAY_VALIDATION.md
@@ -1,0 +1,24 @@
+# Post-Eviction Replay Validation
+
+Issue #1280 tracks a safe way to prove AppUI replay after the target
+session has been evicted from the in-memory ledger cache. The default
+live soak did not prove that path because the production active-session
+cap is high enough that its filler sessions did not evict the target.
+
+Use the non-production validator:
+
+```sh
+npm --prefix e2e run soak:m11:post-eviction-replay
+```
+
+The validator runs one focused Rust test with a temporary durable ledger
+directory and a one-session active cache cap. It proves:
+
+- the target session writes a JSONL ledger under `ui-protocol/<session>/`;
+- a filler session evicts the target from memory before reconnect;
+- `snapshot_with_cursor`, the production hydrate path, reloads the target
+  from persisted JSONL and returns only events after the supplied cursor.
+
+The script does not start, restart, or reconfigure production daemons, and
+it does not change `idle_ttl`. It writes build output only under
+`CARGO_TARGET_DIR`, defaulting to `/private/tmp/octos-post-eviction-replay-target`.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -26,6 +26,7 @@
     "ux:tmux:validate": "node scripts/ux-tmux-validate.mjs",
     "soak:m14:codex-tool-parity": "node scripts/m14-codex-tool-parity-soak.mjs",
     "soak:m18:appui-transport-parity": "node scripts/m18-appui-transport-parity-soak.mjs",
+    "soak:m11:post-eviction-replay": "bash scripts/m11-post-eviction-replay-local.sh",
     "matrix": "node matrix/run.mjs",
     "ux:scenario:list": "node scripts/ux-scenario-list.mjs",
     "ux:scenario:list:test": "node --test tests/ux/scenario-list.test.mjs",

--- a/e2e/scripts/m11-post-eviction-replay-local.sh
+++ b/e2e/scripts/m11-post-eviction-replay-local.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+target_dir="${CARGO_TARGET_DIR:-/private/tmp/octos-post-eviction-replay-target}"
+
+cd "$repo_root"
+export CARGO_TARGET_DIR="$target_dir"
+
+cargo test \
+  -p octos-cli \
+  --features api \
+  ledger_post_eviction_validation_path_replays_from_persisted_jsonl \
+  -- --nocapture


### PR DESCRIPTION
## Summary
- Add a non-production M11 validator for post-eviction AppUI replay.
- Assert the target session is evicted from memory before hydrate and replayed by `snapshot_with_cursor` from persisted JSONL.
- Document the local operator-safe command and add `npm --prefix e2e run soak:m11:post-eviction-replay`.

Closes #1280

## Current-main refresh
- Refreshed onto `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Head: `afe55ade52da844113c6fce64c7fdb7ca72b4131`.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1284-refresh-current.0M9Xzc/octos`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.

## Validation
- `git diff --check origin/main...HEAD` passed.
- `bash -n e2e/scripts/m11-post-eviction-replay-local.sh` passed.
- `node -e "JSON.parse(require('fs').readFileSync('e2e/package.json','utf8')); console.log('e2e/package.json ok')"` passed.
- `cargo fmt --all -- --check` passed.
- `typos crates/octos-cli/src/api/ui_protocol_ledger.rs docs/POST_EVICTION_REPLAY_VALIDATION.md e2e/package.json e2e/scripts/m11-post-eviction-replay-local.sh` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1284-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api ledger_post_eviction_validation_path_replays_from_persisted_jsonl -- --nocapture` passed: focused test passed 1/1.
- `CARGO_TARGET_DIR=/private/tmp/octos-1284-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 npm --prefix e2e run --silent soak:m11:post-eviction-replay` passed: wrapper reran the focused validation path and passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1284-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.
- `git ls-files --others --exclude-standard` was empty in the isolated checkout.

## CI / merge status
- GitHub CI is green on refreshed head `afe55ade52da844113c6fce64c7fdb7ca72b4131`.
- Merge remains branch-protection blocked by required review.

