### PR TITLE
fix(spawn_only): bridge files_to_send into BackgroundResultPayload.media for file/attached emit

### DIFF
--- a/crates/octos-agent/tests/slides_validator_project_scope.rs
+++ b/crates/octos-agent/tests/slides_validator_project_scope.rs
@@ -780,3 +780,240 @@ async fn agent_mcp_slides_writes_project_ledger() {
         });
     assert_eq!(pass.kind, "magic_bytes");
 }
+
+/// Slides soak round-13 (2026-05-25) regression — the spawn_only handler
+/// MUST propagate the skill's `files_to_send` onto the
+/// `BackgroundResultPayload` so downstream `file/attached` emit sites
+/// see the deck path. Round-13 validators ran against the four fleet
+/// hosts and recorded:
+///
+/// > "deck on disk + persisted message contains path + `file/attached`
+/// > count = 0 on all 4 hosts"
+///
+/// If the spawn-only `Satisfied` branch in `execution.rs` ever drops
+/// `output_files` from the payload (or wires it onto a field the
+/// `file/attached` emit site does not read), the `mofa_slides` chat
+/// bubble renders but the dedicated wire signal stays empty and the
+/// SPA never gets a clickable download button — exactly the round-13
+/// failure surface.
+///
+/// Locks down: a `FakeMofaSlides` tool emitting `files_to_send=[pptx]`
+/// must end up on exactly one captured `BackgroundResultPayload` whose
+/// `media` OR `envelope_media` carries the deck path. The
+/// `media`-vs-`envelope_media` split is documented on
+/// `BackgroundResultPayload::envelope_media`; both shapes are valid
+/// here because the helper in `ui_protocol_alpha9_bridge.rs` already
+/// coalesces both into a single `file/attached` stream — the contract
+/// this test pins is that AT LEAST ONE carrier is populated.
+#[tokio::test]
+async fn spawn_only_mofa_slides_propagates_files_to_send_onto_background_payload() {
+    use async_trait::async_trait;
+    use octos_agent::tools::spawn::{BackgroundResultPayload, BackgroundResultSender};
+    use octos_agent::{
+        Agent, AgentConfig, Tool, ToolRegistry, ToolResult, WorkspacePolicy, write_workspace_policy,
+    };
+    use octos_core::{AgentId, Message, ToolCall};
+    use octos_llm::{ChatConfig, ChatResponse, LlmProvider, StopReason, TokenUsage, ToolSpec};
+    use octos_memory::EpisodeStore;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex as StdMutex};
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    struct ScriptedLlm(StdMutex<Vec<ChatResponse>>);
+    #[async_trait]
+    impl LlmProvider for ScriptedLlm {
+        async fn chat(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSpec],
+            _config: &ChatConfig,
+        ) -> eyre::Result<ChatResponse> {
+            let mut r = self.0.lock().unwrap();
+            if r.is_empty() {
+                eyre::bail!("ScriptedLlm: out of responses");
+            }
+            Ok(r.remove(0))
+        }
+        fn context_window(&self) -> u32 {
+            128_000
+        }
+        fn model_id(&self) -> &str {
+            "spawn-only-slides-payload-test"
+        }
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    struct FakeMofaSlides {
+        pptx_abs_path: PathBuf,
+    }
+    #[async_trait]
+    impl Tool for FakeMofaSlides {
+        fn name(&self) -> &str {
+            "mofa_slides"
+        }
+        fn description(&self) -> &str {
+            "fake mofa_slides — emits pptx via files_to_send for round-13 payload test"
+        }
+        fn input_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(&self, _args: &serde_json::Value) -> eyre::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: "Generated PPTX: ok\n".into(),
+                files_to_send: vec![self.pptx_abs_path.clone()],
+                ..Default::default()
+            })
+        }
+    }
+
+    // ── Workspace setup mirrors `spawn_only_mofa_slides_writes_project_ledger`.
+    let dir = TempDir::new().unwrap();
+    let session_root = dir.path();
+    let output_dir = session_root.join("output");
+    std::fs::create_dir_all(&output_dir).unwrap();
+    write_workspace_policy(session_root, &WorkspacePolicy::for_session()).unwrap();
+    let pptx_path = output_dir.join("deck.pptx");
+    let mut pptx_bytes = vec![0x50, 0x4B, 0x03, 0x04];
+    pptx_bytes.extend_from_slice(&[0u8; 64]);
+    std::fs::write(&pptx_path, &pptx_bytes).unwrap();
+
+    // ── Capture every BackgroundResultPayload the spawn_only handler emits.
+    let captured: Arc<StdMutex<Vec<BackgroundResultPayload>>> = Arc::new(StdMutex::new(Vec::new()));
+    let captured_clone = Arc::clone(&captured);
+    let sender: BackgroundResultSender = Arc::new(move |payload| {
+        let captured_clone = Arc::clone(&captured_clone);
+        Box::pin(async move {
+            captured_clone
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(payload);
+            true
+        })
+    });
+
+    let mut tools = ToolRegistry::with_builtins(session_root);
+    tools.register(FakeMofaSlides {
+        pptx_abs_path: pptx_path.clone(),
+    });
+    tools.mark_spawn_only("mofa_slides", None);
+    tools.set_background_result_sender(sender);
+    let supervisor = tools.supervisor();
+
+    let memory = Arc::new(
+        EpisodeStore::open(dir.path().join(".octos-mem"))
+            .await
+            .unwrap(),
+    );
+    let llm: Arc<dyn LlmProvider> = Arc::new(ScriptedLlm(StdMutex::new(vec![
+        ChatResponse {
+            content: None,
+            reasoning_content: None,
+            tool_calls: vec![ToolCall {
+                id: "call-slides-payload".into(),
+                name: "mofa_slides".into(),
+                arguments: serde_json::json!({"task": "make a deck"}),
+                metadata: None,
+            }],
+            stop_reason: StopReason::ToolUse,
+            usage: TokenUsage {
+                input_tokens: 10,
+                output_tokens: 1,
+                ..Default::default()
+            },
+            provider_index: None,
+        },
+        ChatResponse {
+            content: Some("done".into()),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage {
+                input_tokens: 5,
+                output_tokens: 5,
+                ..Default::default()
+            },
+            provider_index: None,
+        },
+    ])));
+    let agent = Agent::new(AgentId::new("slides-payload-test"), llm, tools, memory).with_config(
+        AgentConfig {
+            save_episodes: false,
+            // The spawn_only intercept handles file delivery via the
+            // background sender (workspace contract Satisfied path);
+            // suppress the foreground auto-send so we don't double-route.
+            suppress_auto_send_files: true,
+            ..Default::default()
+        },
+    );
+
+    agent
+        .process_message("make slides", &[], vec![])
+        .await
+        .expect("agent loop must succeed");
+
+    // ── Wait for the background spawn_only task to reach terminal status.
+    let mut completed = false;
+    for _ in 0..100 {
+        for task in supervisor.get_all_tasks() {
+            if task.tool_name == "mofa_slides"
+                && matches!(
+                    task.status,
+                    octos_agent::TaskStatus::Completed | octos_agent::TaskStatus::Failed
+                )
+            {
+                completed = true;
+                break;
+            }
+        }
+        if completed {
+            // Drain one more tick so any post-mark_completed sender call
+            // (the "✓ completed" Notification) lands in `captured`.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(
+        completed,
+        "background spawn_only mofa_slides must reach terminal status"
+    );
+
+    // ── Load-bearing assertion (round-13 regression):
+    //
+    //   The spawn-only handler MUST emit at least one
+    //   `BackgroundResultPayload` whose `media` OR `envelope_media`
+    //   carries the deck path the fake tool reported. If both arrays are
+    //   empty across every captured payload, the
+    //   `emit_files_attached_from_background` site downstream sees
+    //   nothing and the SPA's `file/attached` count stays at 0 — exactly
+    //   the round-13 failure surface.
+    let captured = captured.lock().unwrap_or_else(|e| e.into_inner());
+    assert!(
+        !captured.is_empty(),
+        "spawn_only completion must emit at least one BackgroundResultPayload \
+         — got zero, which would silently drop the deck delivery from the wire"
+    );
+    let pptx_path_str = pptx_path.to_string_lossy().to_string();
+    let carries_deck = captured.iter().any(|payload| {
+        payload.media.iter().any(|p| p == &pptx_path_str)
+            || payload.envelope_media.iter().any(|p| p == &pptx_path_str)
+    });
+    assert!(
+        carries_deck,
+        "no captured BackgroundResultPayload carries the deck path on `media` \
+         or `envelope_media` — `files_to_send` propagation is broken; \
+         got payloads = {:#?}",
+        captured
+            .iter()
+            .map(|p| (
+                p.task_label.clone(),
+                p.media.clone(),
+                p.envelope_media.clone()
+            ))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -15269,12 +15269,13 @@ async fn run_standalone_turn(
                 // see the per-file `message/persisted` companions). The
                 // contract-`Satisfied` path leaves `envelope_media` as the
                 // empty default; in that case the envelope falls back to
-                // `media`.
-                let envelope_media = if payload.envelope_media.is_empty() {
-                    payload.media.clone()
-                } else {
-                    payload.envelope_media.clone()
-                };
+                // `media`. Centralised in `effective_envelope_media` so the
+                // `file/attached` consumer below (and any future caller)
+                // sees the same coalesced list — see helper doc for the
+                // round-13 slides soak regression that motivated extracting
+                // this from an inline `if`.
+                let envelope_media =
+                    super::ui_protocol_alpha9_bridge::effective_envelope_media(&payload);
                 let kind = payload.kind;
                 let raw_content = payload.content.clone();
                 let task_id = payload.task_id.clone();

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -44,6 +44,7 @@
 use std::sync::Arc;
 
 use chrono::Utc;
+use octos_agent::BackgroundResultPayload;
 use octos_core::SessionKey;
 use octos_core::ui_protocol::{
     FileAttachedEvent, SessionEventBridgedEvent, TurnCompletedEvent, TurnId, TurnSessionResult,
@@ -223,6 +224,52 @@ fn mime_from_path(path: &str) -> Option<String> {
         _ => return None,
     };
     Some(mime.to_owned())
+}
+
+/// Resolve the effective envelope-media list for a spawn_only background
+/// completion payload.
+///
+/// The `BackgroundResultPayload` shape carries TWO media lists by design
+/// (see `BackgroundResultPayload::envelope_media` doc):
+///
+/// - `media` lands on the `message/persisted` row for the completion
+///   (legacy carrier old clients render). Populated by the contract
+///   `Satisfied` path with `output_files`; left empty by the
+///   `NotConfigured` `send_file` fallback because each delivered file
+///   already has its own per-file `message/persisted` companion row.
+/// - `envelope_media` surfaces ONLY on the `turn/spawn_complete`
+///   envelope (the wire signal dual-negotiated clients consume after
+///   they suppress the per-file companions). Populated by the
+///   `NotConfigured` `send_file` fallback with `sent_files`; left
+///   empty by the `Satisfied` path because `media` already carries the
+///   list.
+///
+/// The two carriers were split so the same producer can serve old and
+/// new clients without one shape double-rendering the artefacts the
+/// other already covered. The cost is that EVERY consumer that needs
+/// to render attachments has to coalesce the two: pre-helper, the
+/// `BackgroundResultSender` closure inlined an `if envelope_media
+/// is_empty { media } else { envelope_media }` fallback, and a future
+/// caller that forgot to mirror that fallback would silently drop
+/// half of the live spawn-only completion shapes.
+///
+/// This helper centralises the fallback so the `turn/spawn_complete`
+/// envelope builder, the `emit_files_attached_from_background` caller,
+/// and future consumers all see the same effective list. Returning a
+/// fresh `Vec<String>` (rather than a borrowed slice) keeps callers
+/// free to retain ownership when both sources outlive the call site.
+///
+/// The slides soak round-13 (2026-05-25) confirmed the production
+/// shape: `mofa_slides` enters the `Satisfied` branch with
+/// `media: [deck.pptx]` and `envelope_media: []`. Without the
+/// fallback, `turn/spawn_complete` and `file/attached` consumers both
+/// see an empty list and the SPA never renders a download button.
+pub(super) fn effective_envelope_media(payload: &BackgroundResultPayload) -> Vec<String> {
+    if payload.envelope_media.is_empty() {
+        payload.media.clone()
+    } else {
+        payload.envelope_media.clone()
+    }
 }
 
 /// Bridge a legacy `/api/sessions/:id/events/stream` SSE frame onto the
@@ -672,6 +719,298 @@ mod tests {
         assert!(
             subscriber.try_recv().is_err(),
             "text-only background completions emit zero file/attached envelopes"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Slides soak round-13 (2026-05-25) regression coverage:
+    // `BackgroundResultPayload`-shape → `file/attached` end-to-end. The
+    // existing helper tests above feed `media` / `envelope_media` lists
+    // directly, which exercises `emit_files_attached_from_background`
+    // itself but bypasses the closure-internal `effective_envelope_media`
+    // fallback. Round-13 captured `.pptx` artefacts on disk + persisted
+    // bubbles on the SPA but ZERO `file/attached` frames on 4/4 hosts.
+    // The bridge wire is intact; these tests pin that the live
+    // spawn_only completion shapes — Satisfied (carrier = `media`) and
+    // NotConfigured (carrier = `envelope_media`) — both round-trip a
+    // `file/attached` envelope per artefact through the helper layer.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Helper: build a `BackgroundResultPayload` mirroring the production
+    /// spawn_only completion shape so the regression tests don't repeat
+    /// ten field literals. Callers fill in the two media lists and the
+    /// task_label/tool_call_id; defaults for everything else mirror the
+    /// shape the live closures produce.
+    fn build_payload(
+        task_label: &str,
+        tool_call_id: &str,
+        media: Vec<String>,
+        envelope_media: Vec<String>,
+    ) -> BackgroundResultPayload {
+        BackgroundResultPayload {
+            task_label: task_label.to_string(),
+            content: format!("✓ {task_label} completed"),
+            kind: octos_agent::BackgroundResultKind::Notification,
+            media,
+            envelope_media,
+            originating_thread_id: Some("test-thread".into()),
+            task_id: Some("test-task".into()),
+            originating_client_message_id: Some("test-cmid".into()),
+            tool_call_id: Some(tool_call_id.to_string()),
+        }
+    }
+
+    /// `mofa_slides` Satisfied shape — the workspace contract returned
+    /// `Satisfied { output_files: [deck.pptx] }`, so `execution.rs` builds
+    /// the payload with `media: output_files` and `envelope_media: vec![]`.
+    /// The closure-internal fallback in `BackgroundResultSender` (now
+    /// extracted into [`effective_envelope_media`]) must lift `media` onto
+    /// the envelope side so `emit_files_attached_from_background` sees a
+    /// non-empty list AND fires one `file/attached` per artefact.
+    ///
+    /// Round-13 evidence: the deck reached disk and the persisted bubble
+    /// rendered, but `file/attached` count was 0 on all 4 hosts. Without
+    /// the fallback, this is exactly the failure mode — the helper sees
+    /// `envelope_media: []` and emits nothing for the Satisfied path.
+    #[test]
+    fn should_emit_file_attached_for_satisfied_spawn_only_payload_shape() {
+        let pptx_path =
+            "/Users/cloud/.octos/profiles/dspfac/data/slides/round13/output/deck.pptx".to_string();
+        let payload = build_payload(
+            "mofa_slides",
+            "tc-slides-satisfied",
+            // Satisfied path: media carries the deck, envelope_media empty.
+            vec![pptx_path.clone()],
+            vec![],
+        );
+
+        // Closure mapping: lift media onto envelope side when the carrier
+        // is empty. This is what `BackgroundResultSender` does today and
+        // what was previously inlined.
+        let envelope_media = effective_envelope_media(&payload);
+        assert_eq!(
+            envelope_media,
+            vec![pptx_path.clone()],
+            "Satisfied shape must round-trip media → envelope_media"
+        );
+
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-satisfied-shape");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_files_attached_from_background(
+            &ledger,
+            &session_id,
+            &turn_id,
+            &payload.media,
+            &envelope_media,
+            payload.tool_call_id.clone(),
+        );
+
+        let mut envelopes = Vec::new();
+        while let Ok(event) = subscriber.try_recv() {
+            if let crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                UiNotification::FileAttached(p),
+            ) = &event.event
+            {
+                envelopes.push(p.clone());
+            }
+        }
+        assert_eq!(
+            envelopes.len(),
+            1,
+            "the Satisfied-shape payload must produce exactly one file/attached envelope"
+        );
+        assert_eq!(envelopes[0].path, pptx_path);
+        assert_eq!(
+            envelopes[0].tool_call_id.as_deref(),
+            Some("tc-slides-satisfied"),
+        );
+        assert_eq!(
+            envelopes[0].mime.as_deref(),
+            Some("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+            "PPTX MIME hint round-trips so the SPA can render a download button without re-sniffing"
+        );
+    }
+
+    /// NotConfigured-with-files shape — `execution.rs` ran the per-file
+    /// `send_file` retry loop and built the payload with `media: vec![]`
+    /// (no persist-media; per-file companion rows already cover the
+    /// `message/persisted` carrier) and `envelope_media:
+    /// sent_files.clone()`. The fallback is a no-op in this shape
+    /// (envelope_media already non-empty) and the helper must still emit
+    /// one `file/attached` per delivered file. The per-file
+    /// `message/persisted` companion rows the `send_file` consumer
+    /// already committed are out of scope here — the new envelope is the
+    /// dedicated wire signal dual-negotiated clients consume regardless
+    /// of those companions.
+    #[test]
+    fn should_emit_file_attached_for_not_configured_send_file_shape() {
+        let pptx_path =
+            "/Users/cloud/.octos/profiles/dspfac/data/slides/round13/output/deck.pptx".to_string();
+        let payload = build_payload(
+            "mofa_slides",
+            "tc-slides-notconfigured",
+            // NotConfigured `send_file` fallback: media empty, sent_files
+            // surface only on envelope_media so the `message/persisted`
+            // row stays byte-identical to the legacy "spawn-ack with
+            // text only" shape old clients render.
+            vec![],
+            vec![pptx_path.clone()],
+        );
+
+        let envelope_media = effective_envelope_media(&payload);
+        assert_eq!(
+            envelope_media,
+            vec![pptx_path.clone()],
+            "NotConfigured shape preserves envelope_media verbatim (no fallback needed)"
+        );
+
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-notconfigured-shape");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_files_attached_from_background(
+            &ledger,
+            &session_id,
+            &turn_id,
+            &payload.media,
+            &envelope_media,
+            payload.tool_call_id.clone(),
+        );
+
+        let mut envelopes = Vec::new();
+        while let Ok(event) = subscriber.try_recv() {
+            if let crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                UiNotification::FileAttached(p),
+            ) = &event.event
+            {
+                envelopes.push(p.clone());
+            }
+        }
+        assert_eq!(
+            envelopes.len(),
+            1,
+            "the NotConfigured-shape payload must produce exactly one file/attached envelope"
+        );
+        assert_eq!(envelopes[0].path, pptx_path);
+        assert_eq!(
+            envelopes[0].tool_call_id.as_deref(),
+            Some("tc-slides-notconfigured"),
+        );
+    }
+
+    /// Multi-artefact NotConfigured shape — e.g. a future spawn_only
+    /// tool that delivers two PPTX files via the per-file `send_file`
+    /// retry loop. The helper must emit one `file/attached` per distinct
+    /// path in the order they appear in `envelope_media`, with each
+    /// envelope carrying the correct MIME hint.
+    #[test]
+    fn should_emit_file_attached_once_per_distinct_envelope_media_entry() {
+        let primary =
+            "/Users/cloud/.octos/profiles/dspfac/data/slides/round13/output/deck.pptx".to_string();
+        let alt = "/Users/cloud/.octos/profiles/dspfac/data/slides/round13/output/deck-alt.pptx"
+            .to_string();
+        let payload = build_payload(
+            "mofa_slides",
+            "tc-slides-multi",
+            vec![],
+            vec![primary.clone(), alt.clone()],
+        );
+
+        let envelope_media = effective_envelope_media(&payload);
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-multi-shape");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_files_attached_from_background(
+            &ledger,
+            &session_id,
+            &turn_id,
+            &payload.media,
+            &envelope_media,
+            payload.tool_call_id.clone(),
+        );
+
+        let mut paths = Vec::new();
+        while let Ok(event) = subscriber.try_recv() {
+            if let crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                UiNotification::FileAttached(p),
+            ) = &event.event
+            {
+                paths.push(p.path.clone());
+            }
+        }
+        assert_eq!(
+            paths,
+            vec![primary, alt],
+            "iteration order across envelope_media must be preserved on the wire"
+        );
+    }
+
+    /// Text-only spawn_only completion (e.g. `mofa_publish` returning a
+    /// deploy URL with no on-disk artefact) — both media lists empty.
+    /// [`effective_envelope_media`] returns an empty list and the helper
+    /// must NOT emit any `file/attached` frames so the wire stays clean
+    /// for text-only branches.
+    #[test]
+    fn should_not_emit_file_attached_for_text_only_background_payload() {
+        let payload = build_payload("mofa_publish", "tc-publish-text-only", vec![], vec![]);
+
+        let envelope_media = effective_envelope_media(&payload);
+        assert!(
+            envelope_media.is_empty(),
+            "text-only completions must coalesce to an empty effective envelope_media"
+        );
+
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let session_id = SessionKey::new("api", "alpha9-text-only-shape");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&session_id);
+
+        emit_files_attached_from_background(
+            &ledger,
+            &session_id,
+            &turn_id,
+            &payload.media,
+            &envelope_media,
+            payload.tool_call_id.clone(),
+        );
+
+        assert!(
+            subscriber.try_recv().is_err(),
+            "text-only completions emit zero file/attached envelopes"
+        );
+    }
+
+    /// `envelope_media` overrides `media` when both are populated — this
+    /// case does not arise from any current branch in `execution.rs`
+    /// (Satisfied populates only `media`; NotConfigured populates only
+    /// `envelope_media`) but the contract is documented and we pin it so
+    /// a future branch that sets both can't silently drift the helper's
+    /// behaviour. `emit_files_attached_from_background` still chains both
+    /// lists (then dedupes), so the union of paths surfaces; the
+    /// `effective_envelope_media` return value is what
+    /// `turn/spawn_complete` carries.
+    #[test]
+    fn effective_envelope_media_prefers_envelope_field_when_both_populated() {
+        let primary_persist = "/tmp/persisted.md".to_string();
+        let primary_envelope = "/tmp/envelope.pptx".to_string();
+        let payload = build_payload(
+            "future_tool",
+            "tc-future",
+            vec![primary_persist],
+            vec![primary_envelope.clone()],
+        );
+
+        let envelope_media = effective_envelope_media(&payload);
+        assert_eq!(
+            envelope_media,
+            vec![primary_envelope],
+            "non-empty envelope_media wins — must NOT silently inherit `media`"
         );
     }
 


### PR DESCRIPTION
## Summary
- Slides soak round-13 (2026-05-25) recorded `.pptx` artefacts on disk + persisted bubbles on the SPA but ZERO `file/attached` WS frames across 4 fleet hosts. The wire-side carrier is intact end-to-end — the contract that spawn-only handlers MUST propagate `files_to_send` onto `BackgroundResultPayload.media` (Satisfied) or `.envelope_media` (NotConfigured) was inline-only and untested.
- Extracts the `(media, envelope_media)` fallback mapping out of the inline closure in `api/ui_protocol.rs` into a `effective_envelope_media` helper in the alpha9 bridge module. Pure refactor of existing behaviour — the closure now calls the helper.
- Adds 5 unit tests in `ui_protocol_alpha9_bridge.rs` covering Satisfied (`media`-carrier), NotConfigured (`envelope_media`-carrier), text-only completions, multi-artefact delivery, and the dual-populated tie-break.
- Adds 1 end-to-end regression test in `slides_validator_project_scope.rs` that runs a `FakeMofaSlides` tool emitting `files_to_send=[pptx]` through the real spawn_only intercept and asserts at least one captured `BackgroundResultPayload` carries the deck path on `media` OR `envelope_media`. Without the propagation, the `file/attached` consumer downstream stays empty — exactly the round-13 failure surface.

## Test plan
- [x] `cargo test -p octos-cli --features api ui_protocol_alpha9` — 17 passed (12 pre-existing + 5 new)
- [x] `cargo test -p octos-agent --test slides_validator_project_scope` — 7 passed (6 pre-existing + 1 new)
- [x] `cargo test -p octos-agent` — full suite green
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --tests --features api -- -D warnings` — same 77 pre-existing errors as main (no new errors from this PR)