### PR TITLE
Prevent init defaults from overwriting existing config

### DIFF
--- a/crates/octos-cli/src/commands/init.rs
+++ b/crates/octos-cli/src/commands/init.rs
@@ -167,16 +167,20 @@ impl Executable for InitCommand {
                 "Config already exists:".yellow(),
                 config_path.display()
             );
-            if !self.defaults {
-                print!("Overwrite? [y/N] ");
-                io::stdout().flush()?;
+            if self.defaults {
+                return Err(eyre::eyre!(
+                    "config already exists at {}. Run `octos init` interactively to confirm overwrite.",
+                    config_path.display()
+                ));
+            }
+            print!("Overwrite? [y/N] ");
+            io::stdout().flush()?;
 
-                let mut input = String::new();
-                io::stdin().read_line(&mut input)?;
-                if !input.trim().eq_ignore_ascii_case("y") {
-                    println!("Aborted.");
-                    return Ok(());
-                }
+            let mut input = String::new();
+            io::stdin().read_line(&mut input)?;
+            if !input.trim().eq_ignore_ascii_case("y") {
+                println!("Aborted.");
+                return Ok(());
             }
         }
 

--- a/crates/octos-cli/tests/cli_tests.rs
+++ b/crates/octos-cli/tests/cli_tests.rs
@@ -174,6 +174,33 @@ fn test_init_defaults_in_temp_dir() {
 }
 
 #[test]
+fn test_init_defaults_refuses_to_overwrite_existing_config() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".octos");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_path = config_dir.join("config.json");
+    let original = r#"{"provider":"custom","model":"keep-me"}"#;
+    std::fs::write(&config_path, original).unwrap();
+
+    let mut cmd = Command::new(octos_binary());
+    clear_provider_env(&mut cmd);
+    let output = cmd
+        .env("OPENAI_API_KEY", "test-openai-key")
+        .args(["init", "--defaults", "--cwd"])
+        .arg(temp_dir.path())
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        !output.status.success(),
+        "init --defaults should fail instead of overwriting config"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("config already exists"));
+    assert_eq!(std::fs::read_to_string(&config_path).unwrap(), original);
+}
+
+#[test]
 fn test_init_defaults_uses_octos_home_when_cwd_not_provided() {
     let temp_dir = tempfile::tempdir().unwrap();
     let octos_home = temp_dir.path().join("custom-home");


### PR DESCRIPTION
## Summary

Closes #290.

`octos init --defaults` now refuses to overwrite an existing `config.json` and exits with an error directing the user to run interactive `octos init` if they want to confirm overwrite. Interactive behavior remains unchanged.

## Validation

Local validation run from `codex/issue-290-init-defaults-no-overwrite` at `ee85aa1f33cb7a257d76010ea2044f3838197faf`:

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/private/tmp/octos-290-target cargo test -p octos-cli --test cli_tests test_init_defaults_refuses_to_overwrite_existing_config -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-290-target cargo test -p octos-cli --test cli_tests test_init_defaults -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/octos-290-target cargo check -p octos-cli --no-default-features`
- `CARGO_TARGET_DIR=/private/tmp/octos-290-target cargo clippy -p octos-cli --no-default-features --bin octos --no-deps`
- `git diff --check`
