### PR TITLE
Return JSON bodies for admin email conflicts

### DIFF
--- a/crates/octos-cli/src/api/user_admin.rs
+++ b/crates/octos-cli/src/api/user_admin.rs
@@ -55,6 +55,26 @@ pub struct ActionResponse {
     pub message: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct ErrorBody {
+    pub code: &'static str,
+    pub message: String,
+}
+
+fn error_body(
+    status: StatusCode,
+    code: &'static str,
+    message: impl Into<String>,
+) -> (StatusCode, Json<ErrorBody>) {
+    (
+        status,
+        Json(ErrorBody {
+            code,
+            message: message.into(),
+        }),
+    )
+}
+
 /// GET /api/admin/users
 pub async fn list_users(
     State(state): State<Arc<AppState>>,
@@ -104,28 +124,51 @@ pub async fn list_allowed_emails(
 pub async fn add_allowed_email(
     State(state): State<Arc<AppState>>,
     Json(req): Json<AllowlistRequest>,
-) -> Result<(StatusCode, Json<AllowlistEntryResponse>), StatusCode> {
-    let allowlist = state
-        .allowlist_store
-        .as_ref()
-        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+) -> Result<(StatusCode, Json<AllowlistEntryResponse>), (StatusCode, Json<ErrorBody>)> {
+    let allowlist = state.allowlist_store.as_ref().ok_or_else(|| {
+        error_body(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "admin_not_configured",
+            "admin allowlist is not configured",
+        )
+    })?;
     let email = crate::login_allowlist::normalize_email(&req.email);
-    super::admin::validate_email(&email).map_err(|_| StatusCode::BAD_REQUEST)?;
+    super::admin::validate_email(&email)
+        .map_err(|message| error_body(StatusCode::BAD_REQUEST, "invalid_email", message))?;
 
-    if allowlist
-        .contains(&email)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    {
-        return Err(StatusCode::CONFLICT);
+    if allowlist.contains(&email).map_err(|error| {
+        tracing::error!(error = %error, "failed to check allowlist entry");
+        error_body(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "allowlist_lookup_failed",
+            "failed to check allowlist entry",
+        )
+    })? {
+        return Err(error_body(
+            StatusCode::CONFLICT,
+            "allowed_email_exists",
+            format!("email '{email}' is already on the allowlist"),
+        ));
     }
 
     if let Some(user_store) = state.user_store.as_ref() {
         if user_store
             .get_by_email(&email)
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .map_err(|error| {
+                tracing::error!(error = %error, "failed to check registered users");
+                error_body(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "user_lookup_failed",
+                    "failed to check registered users",
+                )
+            })?
             .is_some()
         {
-            return Err(StatusCode::CONFLICT);
+            return Err(error_body(
+                StatusCode::CONFLICT,
+                "registered_email_exists",
+                format!("email '{email}' is already registered"),
+            ));
         }
     }
 
@@ -143,9 +186,14 @@ pub async fn add_allowed_email(
         claimed_user_id: None,
         claimed_at: None,
     };
-    allowlist
-        .save(&entry)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    allowlist.save(&entry).map_err(|error| {
+        tracing::error!(error = %error, "failed to save allowlist entry");
+        error_body(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "allowlist_save_failed",
+            "failed to save allowlist entry",
+        )
+    })?;
 
     Ok((
         StatusCode::CREATED,
@@ -224,6 +272,21 @@ pub async fn delete_user(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use crate::login_allowlist::LoginAllowlistStore;
+    use crate::user_store::{User, UserRole, UserStore};
+
+    fn state_with_stores(
+        allowlist_store: Arc<LoginAllowlistStore>,
+        user_store: Option<Arc<UserStore>>,
+    ) -> Arc<AppState> {
+        Arc::new(AppState {
+            allowlist_store: Some(allowlist_store),
+            user_store,
+            ..AppState::empty_for_tests()
+        })
+    }
 
     #[test]
     fn users_list_response_serialize() {
@@ -252,5 +315,93 @@ mod tests {
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["ok"], false);
         assert_eq!(json["message"], "not found");
+    }
+
+    #[test]
+    fn error_body_serializes_code_and_message() {
+        let body = ErrorBody {
+            code: "registered_email_exists",
+            message: "email 'alice@example.com' is already registered".into(),
+        };
+
+        let json = serde_json::to_value(&body).unwrap();
+
+        assert_eq!(json["code"], "registered_email_exists");
+        assert_eq!(
+            json["message"],
+            "email 'alice@example.com' is already registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_allowed_email_returns_json_conflict_for_existing_allowlist_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let allowlist = Arc::new(LoginAllowlistStore::open(dir.path()).unwrap());
+        allowlist
+            .save(&AllowedLogin {
+                email: "alice@example.com".into(),
+                note: None,
+                created_at: Utc::now(),
+                claimed_user_id: None,
+                claimed_at: None,
+            })
+            .unwrap();
+        let state = state_with_stores(allowlist, None);
+
+        let result = add_allowed_email(
+            State(state),
+            Json(AllowlistRequest {
+                email: "ALICE@example.com".into(),
+                note: None,
+            }),
+        )
+        .await;
+
+        let Err((status, Json(body))) = result else {
+            panic!("expected duplicate allowlist entry to return a conflict");
+        };
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body.code, "allowed_email_exists");
+        assert_eq!(
+            body.message,
+            "email 'alice@example.com' is already on the allowlist"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_allowed_email_returns_json_conflict_for_existing_user() {
+        let dir = tempfile::tempdir().unwrap();
+        let allowlist = Arc::new(LoginAllowlistStore::open(dir.path()).unwrap());
+        let user_store = Arc::new(UserStore::open(dir.path()).unwrap());
+        user_store
+            .save(&User {
+                id: "alice".into(),
+                email: "alice@example.com".into(),
+                name: "Alice".into(),
+                role: UserRole::User,
+                created_at: Utc::now(),
+                last_login_at: None,
+            })
+            .unwrap();
+        let state = state_with_stores(allowlist, Some(user_store));
+
+        let result = add_allowed_email(
+            State(state),
+            Json(AllowlistRequest {
+                email: "alice@example.com".into(),
+                note: None,
+            }),
+        )
+        .await;
+
+        let Err((status, Json(body))) = result else {
+            panic!("expected registered user email to return a conflict");
+        };
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body.code, "registered_email_exists");
+        assert_eq!(
+            body.message,
+            "email 'alice@example.com' is already registered"
+        );
     }
 }

--- a/dashboard/src/api.test.ts
+++ b/dashboard/src/api.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { api } from './api'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('dashboard api errors', () => {
+  it('throws structured ApiError details for JSON error bodies', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 'registered_email_exists',
+            message: "email 'alice@example.com' is already registered",
+          }),
+          {
+            status: 409,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      ),
+    )
+
+    await expect(api.addAllowedEmail({ email: 'alice@example.com' })).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 409,
+      code: 'registered_email_exists',
+      message: "email 'alice@example.com' is already registered",
+    })
+  })
+
+  it('keeps legacy text errors readable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('HTTP 409', { status: 409 })),
+    )
+
+    await expect(api.addAllowedEmail({ email: 'alice@example.com' })).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 409,
+      message: 'HTTP 409',
+    })
+  })
+})

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -28,16 +28,48 @@ const BASE = '/api/admin'
 /// common "auth failed, hand back to the login flow" branch.
 export class ApiError extends Error {
   public readonly status: number
+  public readonly code?: string
+  public readonly details?: unknown
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code?: string, details?: unknown) {
     super(message || `HTTP ${status}`)
     this.name = 'ApiError'
     this.status = status
+    this.code = code
+    this.details = details
   }
 
   static isAuthError(err: unknown): boolean {
     return err instanceof ApiError && (err.status === 401 || err.status === 403)
   }
+}
+
+type ErrorBody = {
+  code?: unknown
+  message?: unknown
+  error?: unknown
+  details?: unknown
+}
+
+async function apiErrorFromResponse(res: Response): Promise<ApiError> {
+  const text = await res.text()
+  if (text.trim()) {
+    try {
+      const body = JSON.parse(text) as ErrorBody
+      if (body && typeof body === 'object') {
+        const message = typeof body.message === 'string'
+          ? body.message
+          : typeof body.error === 'string'
+            ? body.error
+            : text
+        const code = typeof body.code === 'string' ? body.code : undefined
+        return new ApiError(res.status, message, code, body.details)
+      }
+    } catch {
+      // Fall through to the raw response body for legacy text errors.
+    }
+  }
+  return new ApiError(res.status, text)
 }
 
 export interface SkillRegistryPackage {
@@ -69,8 +101,7 @@ async function request<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
   return res.json()
 }
@@ -81,8 +112,7 @@ async function requestNoContent(path: string, opts?: RequestInit): Promise<void>
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
 }
 
@@ -92,8 +122,7 @@ async function publicRequest<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
   return res.json()
 }
@@ -104,8 +133,7 @@ async function authedRequest<T>(path: string, opts?: RequestInit): Promise<T> {
     ...opts,
   })
   if (!res.ok) {
-    const text = await res.text()
-    throw new ApiError(res.status, text)
+    throw await apiErrorFromResponse(res)
   }
   return res.json()
 }


### PR DESCRIPTION
## Summary
- Return structured JSON error bodies for admin allowed-email 409 conflicts instead of empty responses.
- Preserve plain success responses while surfacing conflict `code` and `message` fields to dashboard callers.
- Add dashboard coverage for conflict-body parsing.

Closes #429

## Current-main refresh
- Refreshed onto `origin/main` `4adbe05fff212cb85d1f0a6d6225da0713446016`.
- Previous PR head: `ffb6a4003c0cb0ab2c12619f54f725ff4bb5e61b`.
- Refreshed head: `32289b1957740846deeda1b2949525a9e3488e27`.
- Force-pushed with exact `--force-with-lease` after rechecking the remote branch.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1294-refresh-current.VWRg6Y/octos`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.
- Diff is limited to `crates/octos-cli/src/api/user_admin.rs`, `dashboard/src/api.ts`, and `dashboard/src/api.test.ts`.

## Validation
- `git diff --check origin/main...HEAD` passed.
- `rustfmt --check crates/octos-cli/src/api/user_admin.rs` passed.
- `cargo fmt --all -- --check` passed.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1294-current-4adbe npm --prefix dashboard ci` passed; npm reported existing audit findings: 3 vulnerabilities, 1 moderate and 2 high.
- `CARGO_TARGET_DIR=/private/tmp/octos-1294-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api api::user_admin::tests -- --nocapture` passed: 6/6 focused user-admin tests.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1294-current-4adbe npm --prefix dashboard test -- api.test.ts` passed: 1 file, 2 tests.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1294-current-4adbe npm --prefix dashboard test` passed: 7 files, 34 tests.
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1294-current-4adbe npm --prefix dashboard run typecheck` passed.
- `VITE_OUT_DIR=/private/tmp/octos-1294-dashboard-dist-current-4adbe NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1294-current-4adbe npm --prefix dashboard run build` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1294-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --features api` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1294-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --features api --lib --no-deps` completed; it emitted pre-existing clippy warnings outside the touched files.
- `CARGO_TARGET_DIR=/private/tmp/octos-1294-current-4adbe-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.
- Final `git status --short --branch` showed only the refreshed branch ahead of `origin/main`.
- Final `git ls-files --others --exclude-standard` was empty in the isolated checkout.

## CI / merge status
- GitHub CI is green on refreshed head `32289b1957740846deeda1b2949525a9e3488e27`: `https://github.com/octos-org/octos/actions/runs/26791199487`.
- Required jobs passed: `dashboard`, `swarm-app`, `typos`, `check`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `test-octos-cli`, `check-matrix`, and `reject blocked author/committer emails`.
- Optional expansion jobs were skipped by workflow rules.
- Merge remains branch-protection blocked by required review: `mergeable=MERGEABLE`, `mergeStateStatus=BLOCKED`, `reviewDecision=REVIEW_REQUIRED`.
