### PR TITLE
Use ConfirmDialog for user deletion flows

### DIFF
--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+
 interface Props {
   open: boolean
   title: string
@@ -17,12 +19,31 @@ export default function ConfirmDialog({
   onConfirm,
   onCancel,
 }: Props) {
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onCancel()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onCancel, open])
+
   if (!open) return null
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="bg-surface rounded-xl border border-gray-700/50 shadow-2xl p-6 max-w-sm w-full mx-4">
-        <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        className="bg-surface rounded-xl border border-gray-700/50 shadow-2xl p-6 max-w-sm w-full mx-4"
+      >
+        <h3 id="confirm-dialog-title" className="text-lg font-semibold text-white mb-2">{title}</h3>
         <p className="text-sm text-gray-400 mb-6">{message}</p>
         <div className="flex justify-end gap-3">
           <button

--- a/dashboard/src/pages/UsersPage.test.tsx
+++ b/dashboard/src/pages/UsersPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import UsersPage from './UsersPage'
@@ -74,6 +74,21 @@ describe('UsersPage destructive confirmations', () => {
     })
   })
 
+  it('cancels allowlist removal without calling the API', async () => {
+    const user = userEvent.setup()
+
+    render(<UsersPage />)
+
+    await screen.findAllByText('alice@example.com')
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    const dialog = screen.getByRole('dialog', { name: 'Remove Allowlisted Email' })
+    await user.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByRole('dialog', { name: 'Remove Allowlisted Email' })).not.toBeInTheDocument()
+    expect(mockApi.deleteAllowedEmail).not.toHaveBeenCalled()
+  })
+
   it('uses ConfirmDialog instead of native confirm for account deletion', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm')
     const user = userEvent.setup()
@@ -93,5 +108,21 @@ describe('UsersPage destructive confirmations', () => {
     await waitFor(() => {
       expect(mockApi.deleteUser).toHaveBeenCalledWith('alice')
     })
+  })
+
+  it('closes the account deletion dialog with Escape without calling the API', async () => {
+    const user = userEvent.setup()
+
+    render(<UsersPage />)
+
+    await screen.findAllByText('alice@example.com')
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(screen.getByRole('dialog', { name: 'Delete Account' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(screen.queryByRole('dialog', { name: 'Delete Account' })).not.toBeInTheDocument()
+    expect(mockApi.deleteUser).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/pages/UsersPage.test.tsx
+++ b/dashboard/src/pages/UsersPage.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import UsersPage from './UsersPage'
+
+const mockApi = vi.hoisted(() => ({
+  listAllowedEmails: vi.fn(),
+  listUsers: vi.fn(),
+  addAllowedEmail: vi.fn(),
+  deleteAllowedEmail: vi.fn(),
+  deleteUser: vi.fn(),
+}))
+
+const mockToast = vi.hoisted(() => vi.fn())
+
+vi.mock('../api', () => ({ api: mockApi }))
+vi.mock('../components/Toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+const allowedEntry = {
+  email: 'alice@example.com',
+  note: null,
+  created_at: '2026-05-01T00:00:00Z',
+  claimed_user_id: null,
+  claimed_at: null,
+  registered: true,
+  registered_user_id: 'alice',
+  registered_name: 'Alice',
+  last_login_at: null,
+}
+
+const account = {
+  id: 'alice',
+  email: 'alice@example.com',
+  name: 'Alice',
+  role: 'user',
+  created_at: '2026-05-01T00:00:00Z',
+  last_login_at: null,
+}
+
+beforeEach(() => {
+  Object.values(mockApi).forEach((fn) => fn.mockReset())
+  mockToast.mockReset()
+  mockApi.listAllowedEmails.mockResolvedValue({ entries: [allowedEntry] })
+  mockApi.listUsers.mockResolvedValue({ users: [account] })
+  mockApi.deleteAllowedEmail.mockResolvedValue({ ok: true })
+  mockApi.deleteUser.mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('UsersPage destructive confirmations', () => {
+  it('uses ConfirmDialog instead of native confirm for allowlist removal', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    const user = userEvent.setup()
+
+    render(<UsersPage />)
+
+    await screen.findAllByText('alice@example.com')
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.getByText('Remove Allowlisted Email')).toBeInTheDocument()
+    expect(screen.getByText(/already-registered account will remain/i)).toBeInTheDocument()
+
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' })
+    await user.click(removeButtons[removeButtons.length - 1])
+
+    await waitFor(() => {
+      expect(mockApi.deleteAllowedEmail).toHaveBeenCalledWith('alice@example.com')
+    })
+  })
+
+  it('uses ConfirmDialog instead of native confirm for account deletion', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm')
+    const user = userEvent.setup()
+
+    render(<UsersPage />)
+
+    await screen.findAllByText('alice@example.com')
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(confirmSpy).not.toHaveBeenCalled()
+    expect(screen.getByText('Delete Account')).toBeInTheDocument()
+    expect(screen.getByText(/delete the profile and stop its gateway/i)).toBeInTheDocument()
+
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' })
+    await user.click(deleteButtons[deleteButtons.length - 1])
+
+    await waitFor(() => {
+      expect(mockApi.deleteUser).toHaveBeenCalledWith('alice')
+    })
+  })
+})

--- a/dashboard/src/pages/UsersPage.tsx
+++ b/dashboard/src/pages/UsersPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { api } from '../api'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { useToast } from '../components/Toast'
 import type { AllowlistEntry, User } from '../types'
 
@@ -31,6 +32,10 @@ function registrationStatus(entry: AllowlistEntry): {
   }
 }
 
+type PendingConfirm =
+  | { kind: 'allowlist'; entry: AllowlistEntry }
+  | { kind: 'user'; user: User }
+
 export default function UsersPage() {
   const { toast } = useToast()
   const [allowedEmails, setAllowedEmails] = useState<AllowlistEntry[]>([])
@@ -42,6 +47,7 @@ export default function UsersPage() {
   const [newNote, setNewNote] = useState('')
   const [removingEmail, setRemovingEmail] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null)
 
   const loadData = useCallback(async () => {
     try {
@@ -99,14 +105,7 @@ export default function UsersPage() {
     }
   }
 
-  const handleRemoveAllowlist = async (entry: AllowlistEntry) => {
-    const confirmed = confirm(
-      entry.registered
-        ? `Remove "${entry.email}" from the allowlist? The already-registered account will remain, but future OTP signup will no longer be pre-authorized.`
-        : `Remove "${entry.email}" from the allowlist?`,
-    )
-    if (!confirmed) return
-
+  const removeAllowlistEntry = async (entry: AllowlistEntry) => {
     try {
       setRemovingEmail(entry.email)
       await api.deleteAllowedEmail(entry.email)
@@ -119,10 +118,7 @@ export default function UsersPage() {
     }
   }
 
-  const handleDeleteUser = async (user: User) => {
-    if (!confirm(`Delete account "${user.email}"? This will also delete the profile and stop its gateway.`)) {
-      return
-    }
+  const deleteUser = async (user: User) => {
     try {
       setDeletingId(user.id)
       await api.deleteUser(user.id)
@@ -134,6 +130,29 @@ export default function UsersPage() {
       setDeletingId(null)
     }
   }
+
+  const handleConfirm = async () => {
+    const pending = pendingConfirm
+    if (!pending) return
+    setPendingConfirm(null)
+    if (pending.kind === 'allowlist') {
+      await removeAllowlistEntry(pending.entry)
+    } else {
+      await deleteUser(pending.user)
+    }
+  }
+
+  const confirmTitle = pendingConfirm?.kind === 'user'
+    ? 'Delete Account'
+    : 'Remove Allowlisted Email'
+  const confirmMessage = pendingConfirm?.kind === 'user'
+    ? `Delete account "${pendingConfirm.user.email}"? This will also delete the profile and stop its gateway.`
+    : pendingConfirm?.entry.registered
+      ? `Remove "${pendingConfirm.entry.email}" from the allowlist? The already-registered account will remain, but future OTP signup will no longer be pre-authorized.`
+      : pendingConfirm
+        ? `Remove "${pendingConfirm.entry.email}" from the allowlist?`
+        : ''
+  const confirmLabel = pendingConfirm?.kind === 'user' ? 'Delete' : 'Remove'
 
   if (loading) {
     return (
@@ -255,7 +274,7 @@ export default function UsersPage() {
                     </td>
                     <td className="px-4 py-3 text-right">
                       <button
-                        onClick={() => handleRemoveAllowlist(entry)}
+                        onClick={() => setPendingConfirm({ kind: 'allowlist', entry })}
                         disabled={removingEmail === entry.email}
                         className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
                       >
@@ -320,7 +339,7 @@ export default function UsersPage() {
                   </td>
                   <td className="px-4 py-3 text-right">
                     <button
-                      onClick={() => handleDeleteUser(user)}
+                      onClick={() => setPendingConfirm({ kind: 'user', user })}
                       disabled={deletingId === user.id}
                       className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50"
                     >
@@ -340,6 +359,15 @@ export default function UsersPage() {
           </div>
         )}
       </div>
+      <ConfirmDialog
+        open={pendingConfirm !== null}
+        title={confirmTitle}
+        message={confirmMessage}
+        confirmLabel={confirmLabel}
+        danger
+        onConfirm={handleConfirm}
+        onCancel={() => setPendingConfirm(null)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Closes #420.

- replaces native `confirm()` calls in `UsersPage` with the shared `ConfirmDialog` component
- keeps separate destructive copy for allowlist removal and registered account deletion
- adds dialog semantics (`role="dialog"`, `aria-modal`, labelled title) to `ConfirmDialog`
- supports keyboard cancellation with Escape and preserves the explicit Cancel button path
- adds focused React tests that assert native confirm is not used, confirmed actions call the expected API, Cancel does not call the API, and Escape closes the dialog without deleting
- refreshed from current GitHub `main` as a dashboard-only diff; no Rust carry commits or generated artifacts are included

## Current refresh

- base: `origin/main` `29216352956582e8d1f2a4ad198c510aeec88ef1`
- head: `7917656d28d0a387b9fa1fd44fe0324647bdd98f`
- isolated checkout: `/private/tmp/octos-1296-current.Yj9XY2/octos`
- npm cache: `/private/tmp/octos-npm-cache-1296-main-292`
- dashboard build output: `/private/tmp/octos-420-dashboard-build-current-292`
- environment: Darwin arm64; Node `v24.10.0`; npm `11.6.0`; `rustc 1.95.0`; `cargo 1.95.0`

## Validation

Passed locally:

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `typos dashboard/src/components/ConfirmDialog.tsx dashboard/src/pages/UsersPage.test.tsx dashboard/src/pages/UsersPage.tsx`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1296-main-292 npm --prefix dashboard ci` completed with existing npm audit findings only: 3 vulnerabilities, 1 moderate and 2 high
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1296-main-292 npm --prefix dashboard test -- UsersPage.test.tsx` -> 1 file / 4 tests passed
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1296-main-292 npm --prefix dashboard test` -> 7 files / 36 tests passed
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1296-main-292 npm --prefix dashboard run typecheck`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1296-main-292 VITE_OUT_DIR=/private/tmp/octos-420-dashboard-build-current-292 npm --prefix dashboard run build`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1296-main-292 ./scripts/milestone-ci.sh dashboard`
- `git ls-files --others --exclude-standard` -> empty

Diff shape:

- `dashboard/src/components/ConfirmDialog.tsx`
- `dashboard/src/pages/UsersPage.test.tsx`
- `dashboard/src/pages/UsersPage.tsx`

## Coordination

PR #1239 was an older overlapping #420 branch and is closed because it lacked the 2026-05-23 contract-required keyboard/cancel coverage. This PR remains the accurate #420 closure path.

## CI / merge status

GitHub CI is green on refreshed head `7917656d28d0a387b9fa1fd44fe0324647bdd98f`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, `typos`, and author-email passed. Optional expansion jobs were skipped as expected.

Current merge gate: `BLOCKED` / `REVIEW_REQUIRED`.
