### PR TITLE
feat(plugin): validate manifest JSON schemas at install/load (RFC-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,14 @@ jobs:
       - name: Test octos-plugin
         run: cargo test -p octos-plugin
 
+      # RFC-2 (issue #1291): validate every bundled `crates/app-skills/*/manifest.json`
+      # against the strict octos JSON schema validator. A failure here means a
+      # bundled skill ships a manifest shape that strict LLM-provider validators
+      # (Moonshot Kimi K2.6 etc.) will reject at request time — see the
+      # 2026-05-25 mofa-slides v0.5.0 incident write-up.
+      - name: RFC-2 bundled manifest schema validation
+        run: ./scripts/validate-skill-manifests.sh
+
       - name: Test octos-swarm
         run: cargo test -p octos-swarm
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ dependencies = [
  "octos-llm",
  "octos-memory",
  "octos-pipeline",
+ "octos-plugin",
  "octos-swarm",
  "open",
  "percent-encoding",

--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -982,7 +982,7 @@ mod tests {
         // Write manifest
         std::fs::write(
             plugin_dir.join("manifest.json"),
-            r#"{"name": "my-plugin", "version": "1.0", "tools": [{"name": "greet", "description": "Greet someone"}]}"#,
+            r#"{"name": "my-plugin", "version": "1.0", "tools": [{"name": "greet", "description": "Greet someone", "input_schema": {"type": "object", "properties": {}}}]}"#,
         ).unwrap();
 
         // Write executable
@@ -1015,7 +1015,7 @@ mod tests {
         let hash = format!("{:x}", Sha256::digest(exec_content));
 
         let manifest = format!(
-            r#"{{"name": "hash-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "t", "description": "d"}}]}}"#
+            r#"{{"name": "hash-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "t", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]}}"#
         );
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
 
@@ -1038,7 +1038,7 @@ mod tests {
         let plugin_dir = dir.path().join("bad-hash");
         std::fs::create_dir(&plugin_dir).unwrap();
 
-        let manifest = r#"{"name": "bad-hash", "version": "1.0", "sha256": "0000000000000000000000000000000000000000000000000000000000000000", "tools": [{"name": "t", "description": "d"}]}"#;
+        let manifest = r#"{"name": "bad-hash", "version": "1.0", "sha256": "0000000000000000000000000000000000000000000000000000000000000000", "tools": [{"name": "t", "description": "d", "input_schema": {"type": "object", "properties": {}}}]}"#;
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
 
         let exec_path = plugin_dir.join("bad-hash");
@@ -1080,7 +1080,7 @@ mod tests {
         let manifest = r#"{
             "name": "unsigned-plugin",
             "version": "1.0",
-            "tools": [{"name": "t", "description": "d"}]
+            "tools": [{"name": "t", "description": "d", "input_schema": {"type": "object", "properties": {}}}]
         }"#;
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
 
@@ -1121,7 +1121,7 @@ mod tests {
         let exec_content = b"#!/bin/sh\necho ok";
         let hash = format!("{:x}", Sha256::digest(exec_content));
         let manifest = format!(
-            r#"{{"name": "signed-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "t", "description": "d"}}]}}"#
+            r#"{{"name": "signed-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "t", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]}}"#
         );
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
         let exec_path = plugin_dir.join("signed-plugin");
@@ -1224,7 +1224,7 @@ mod tests {
                     "command": "/bin/echo",
                     "args": ["unauthorized"]
                 }}],
-                "tools": [{{"name": "t", "description": "d"}}]
+                "tools": [{{"name": "t", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]
             }}"#
         );
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
@@ -1282,7 +1282,8 @@ mod tests {
                 "tools": [{{
                     "name": "do_thing",
                     "description": "d",
-                    "spawn_only": true
+                    "spawn_only": true,
+                    "input_schema": {{"type": "object", "properties": {{}}}}
                 }}]
             }}"#
         );
@@ -1336,7 +1337,7 @@ mod tests {
                     "command": "/bin/echo",
                     "args": ["legacy-mcp"]
                 }}],
-                "tools": [{{"name": "t2", "description": "d"}}]
+                "tools": [{{"name": "t2", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]
             }}"#
         );
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
@@ -1401,7 +1402,7 @@ mod tests {
         let manifest = r#"{
             "name": "unsigned-legacy",
             "version": "1.0",
-            "tools": [{"name": "t", "description": "d"}]
+            "tools": [{"name": "t", "description": "d", "input_schema": {"type": "object", "properties": {}}}]
         }"#;
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
         let exec_path = plugin_dir.join("unsigned-legacy");
@@ -1434,7 +1435,7 @@ mod tests {
         let exec_content = b"#!/bin/sh\necho original";
         let hash = format!("{:x}", Sha256::digest(exec_content));
         let manifest = format!(
-            r#"{{"name": "swap-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "swap_tool", "description": "d"}}]}}"#
+            r#"{{"name": "swap-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "swap_tool", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]}}"#
         );
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
         let exec_path = plugin_dir.join("swap-plugin");
@@ -1482,7 +1483,7 @@ mod tests {
         let exec_content = b"#!/bin/sh\necho '{\"output\":\"ok\",\"success\":true}'";
         let hash = format!("{:x}", Sha256::digest(exec_content));
         let manifest = format!(
-            r#"{{"name": "manifest-swap", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "ms_tool", "description": "d"}}]}}"#
+            r#"{{"name": "manifest-swap", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "ms_tool", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]}}"#
         );
         std::fs::write(plugin_dir.join("manifest.json"), &manifest).unwrap();
         let exec_path = plugin_dir.join("manifest-swap");
@@ -1534,7 +1535,7 @@ mod tests {
         let exec_content = b"#!/bin/sh\necho '{\"output\":\"ok\",\"success\":true}'";
         let hash = format!("{:x}", Sha256::digest(exec_content));
         let manifest = format!(
-            r#"{{"name": "intact-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "intact_tool", "description": "d"}}]}}"#
+            r#"{{"name": "intact-plugin", "version": "1.0", "sha256": "{hash}", "tools": [{{"name": "intact_tool", "description": "d", "input_schema": {{"type": "object", "properties": {{}}}}}}]}}"#
         );
         std::fs::write(plugin_dir.join("manifest.json"), manifest).unwrap();
         let exec_path = plugin_dir.join("intact-plugin");
@@ -1592,7 +1593,7 @@ mod tests {
         std::fs::create_dir(&plugin_dir).unwrap();
         std::fs::write(
             plugin_dir.join("manifest.json"),
-            r#"{"name": "evil-plugin", "version": "1.0", "tools": [{"name": "evil", "description": "d"}]}"#,
+            r#"{"name": "evil-plugin", "version": "1.0", "tools": [{"name": "evil", "description": "d", "input_schema": {"type": "object", "properties": {}}}]}"#,
         )
         .unwrap();
 
@@ -1641,9 +1642,9 @@ mod tests {
                     "name": "risk-plugin-first",
                     "version": "1.0",
                     "tools": [
-                        {{"name": "{declared_tool}", "description": "declared", "risk": "medium"}},
-                        {{"name": "{missing_tool}", "description": "missing first", "risk": "high"}},
-                        {{"name": "{blank_tool}", "description": "blank first", "risk": "high"}}
+                        {{"name": "{declared_tool}", "description": "declared", "risk": "medium", "input_schema": {{"type": "object", "properties": {{}}}}}},
+                        {{"name": "{missing_tool}", "description": "missing first", "risk": "high", "input_schema": {{"type": "object", "properties": {{}}}}}},
+                        {{"name": "{blank_tool}", "description": "blank first", "risk": "high", "input_schema": {{"type": "object", "properties": {{}}}}}}
                     ]
                 }}"#
             ),
@@ -1675,8 +1676,8 @@ mod tests {
                     "name": "risk-plugin-second",
                     "version": "1.0",
                     "tools": [
-                        {{"name": "{missing_tool}", "description": "missing second"}},
-                        {{"name": "{blank_tool}", "description": "blank second", "risk": "   "}}
+                        {{"name": "{missing_tool}", "description": "missing second", "input_schema": {{"type": "object", "properties": {{}}}}}},
+                        {{"name": "{blank_tool}", "description": "blank second", "risk": "   ", "input_schema": {{"type": "object", "properties": {{}}}}}}
                     ]
                 }}"#
             ),
@@ -1708,7 +1709,7 @@ mod tests {
             r#"{
   "name": "mofa-publish",
   "version": "0.1.0",
-  "tools": [{"name": "mofa_publish", "description": "deploy"}]
+  "tools": [{"name": "mofa_publish", "description": "deploy", "input_schema": {"type": "object", "properties": {}}}]
 }"#,
         )
         .unwrap();
@@ -1777,7 +1778,7 @@ mod tests {
             r#"{
   "name": "mofa-podcast",
   "version": "0.4.5",
-  "tools": [{"name": "podcast_generate", "description": "podcast"}]
+  "tools": [{"name": "podcast_generate", "description": "podcast", "input_schema": {"type": "object", "properties": {}}}]
 }"#,
         )
         .unwrap();
@@ -1812,7 +1813,7 @@ edition = "2021"
             r#"{
   "name": "mofa-publish",
   "version": "0.1.0",
-  "tools": [{"name": "mofa_publish", "description": "deploy"}]
+  "tools": [{"name": "mofa_publish", "description": "deploy", "input_schema": {"type": "object", "properties": {}}}]
 }"#,
         )
         .unwrap();
@@ -1857,7 +1858,7 @@ edition = "2021"
             r#"{
   "name": "perm-plugin",
   "version": "0.1.0",
-  "tools": [{"name": "perm_tool", "description": "perm"}]
+  "tools": [{"name": "perm_tool", "description": "perm", "input_schema": {"type": "object", "properties": {}}}]
 }"#,
         )
         .unwrap();
@@ -2021,8 +2022,8 @@ edition = "2021"
                 "name": "evil-env-plugin",
                 "version": "1.0",
                 "tools": [
-                    {"name": "good_tool", "description": "ok", "env": ["MY_VAR"]},
-                    {"name": "bad_tool", "description": "bad", "env": ["LD_PRELOAD"]}
+                    {"name": "good_tool", "description": "ok", "env": ["MY_VAR"], "input_schema": {"type": "object", "properties": {}}},
+                    {"name": "bad_tool", "description": "bad", "env": ["LD_PRELOAD"], "input_schema": {"type": "object", "properties": {}}}
                 ]
             }"#,
         )
@@ -2062,7 +2063,7 @@ edition = "2021"
             r#"{
                 "name": "eq-plugin",
                 "version": "1.0",
-                "tools": [{"name": "bad", "description": "d", "env": ["FOO=bar"]}]
+                "tools": [{"name": "bad", "description": "d", "env": ["FOO=bar"], "input_schema": {"type": "object", "properties": {}}}]
             }"#,
         )
         .unwrap();
@@ -2093,7 +2094,8 @@ edition = "2021"
                 format!(
                     r#"{{"name": "shared-skill", "version": "1.0",
                           "tools": [{{"name": "shared_tool",
-                                     "description": "from-{marker}"}}]}}"#
+                                     "description": "from-{marker}",
+                                     "input_schema": {{"type": "object", "properties": {{}}}}}}]}}"#
                 ),
             )
             .unwrap();

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -18,6 +18,12 @@ octos-llm = { workspace = true }
 octos-bus = { workspace = true }
 octos-pipeline = { workspace = true }
 octos-swarm = { workspace = true }
+# RFC-2 (issue #1291): `octos skills install` runs the manifest schema
+# validator at install time so the operator sees the error before the
+# agent loop ever loads the broken manifest. The validator lives in
+# `octos-plugin::manifest_validator` and is reached through the
+# top-level re-exports.
+octos-plugin = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -372,12 +372,6 @@ fn install_from_local(skills_dir: &Path, src: &Path, force: bool) -> Result<Inst
         );
     }
 
-    // RFC-2: reject malformed manifests BEFORE we copy anything to
-    // disk. This is the install-time hook called out in #1291: the
-    // operator gets the structured violation list with no half-broken
-    // skill directory left behind.
-    validate_skill_manifest(src)?;
-
     let name = src
         .file_name()
         .ok_or_else(|| eyre::eyre!("Cannot determine skill name from path"))?
@@ -387,6 +381,12 @@ fn install_from_local(skills_dir: &Path, src: &Path, force: bool) -> Result<Inst
     std::fs::create_dir_all(skills_dir)?;
     let dest = skills_dir.join(&name);
 
+    // RFC-2: reject malformed manifests BEFORE we copy anything to
+    // disk. We only validate when we're actually going to copy: a
+    // skip path (existing install, no `--force`) preserves whatever
+    // the user already has — validating a fresh source then would
+    // surface a spurious failure for an install that we never
+    // intended to write.
     if dest.exists() && !force {
         println!(
             "  {} '{}' already exists (use --force to overwrite)",
@@ -400,6 +400,7 @@ fn install_from_local(skills_dir: &Path, src: &Path, force: bool) -> Result<Inst
         });
     }
 
+    validate_skill_manifest(src)?;
     if dest.exists() {
         std::fs::remove_dir_all(&dest)?;
     }
@@ -939,13 +940,18 @@ fn install_via_git_result(
             .to_string();
 
         // RFC-2 (codex follow-up, 2026-05-25): pre-flight validate
-        // the target subdir AND every auto-detected shared dep
-        // BEFORE we touch the user-visible skills dir. The earlier
-        // attempt validated deps after the target copy, which left
-        // a partial install on disk when a dep's manifest was
-        // malformed. We now collect every dep ahead of time so a
-        // single failed validation bails before any copy.
-        validate_skill_manifest(&src)?;
+        // the target subdir AND every auto-detected shared dep that
+        // we'll actually copy BEFORE we touch the user-visible
+        // skills dir. Skip-only paths (already installed, no
+        // `--force`) are NOT validated — a user with a working
+        // skill already in place must not be blocked just because
+        // the cloned repo's copy of that skill/dep has a malformed
+        // manifest.
+        let dest = skills_dir.join(&name);
+        let will_copy_target = !dest.exists() || force;
+        if will_copy_target {
+            validate_skill_manifest(&src)?;
+        }
         let shared_deps: Vec<String> = {
             let skill_md_path = src.join("SKILL.md");
             if skill_md_path.exists() {
@@ -955,13 +961,17 @@ fn install_via_git_result(
                 Vec::new()
             }
         };
+        // Validate only the deps the copy loop will actually touch.
         for dep in &shared_deps {
-            validate_skill_manifest(&clone_dir.join(dep))?;
+            let dep_dest = skills_dir.join(dep);
+            let will_copy = !dep_dest.exists() || force;
+            if will_copy {
+                validate_skill_manifest(&clone_dir.join(dep))?;
+            }
         }
 
         // Install the target skill/dir
-        let dest = skills_dir.join(&name);
-        if dest.exists() && !force {
+        if !will_copy_target {
             println!(
                 "  {} '{}' already exists (use --force to overwrite)",
                 "SKIP".yellow(),
@@ -1001,12 +1011,15 @@ fn install_via_git_result(
     } else {
         // Whole-repo install: check if root is a single skill or multi-skill
         if clone_dir.join("SKILL.md").exists() {
-            // RFC-2: validate the single-skill root manifest before copy.
-            validate_skill_manifest(&clone_dir)?;
-
             // Single-skill repo: install as repo_name/
             let dest = skills_dir.join(&spec.repo_name);
-            if dest.exists() && !force {
+            let will_copy = !dest.exists() || force;
+            // RFC-2: validate only when we'll actually copy — a
+            // skip path preserves the user's existing install.
+            if will_copy {
+                validate_skill_manifest(&clone_dir)?;
+            }
+            if !will_copy {
                 println!(
                     "  {} '{}' already exists (use --force to overwrite)",
                     "SKIP".yellow(),
@@ -1021,10 +1034,12 @@ fn install_via_git_result(
                 installed.push(spec.repo_name.clone());
             }
         } else {
-            // RFC-2: validate every multi-skill subdirectory's manifest
-            // before any copy. Aborts the whole install on the first
-            // failure rather than ending up with a mixed-validity
-            // skills dir.
+            // Multi-skill repo: pre-flight validate every subdir we
+            // intend to copy before touching the skills dir. Skip-
+            // only subdirs are NOT validated so a malformed sibling
+            // in the cloned repo doesn't block users whose existing
+            // installs are unrelated.
+            let mut multi_copies: Vec<(PathBuf, String)> = Vec::new();
             for entry in std::fs::read_dir(&clone_dir)? {
                 let entry = entry?;
                 if !entry.file_type()?.is_dir() {
@@ -1034,35 +1049,29 @@ fn install_via_git_result(
                 if name.starts_with('.') {
                     continue;
                 }
-                validate_skill_manifest(&entry.path())?;
-            }
-            // Multi-skill repo: copy all top-level directories
-            for entry in std::fs::read_dir(&clone_dir)? {
-                let entry = entry?;
-                if !entry.file_type()?.is_dir() {
-                    continue;
-                }
-                let name = entry.file_name().to_string_lossy().to_string();
-                if name.starts_with('.') {
-                    continue;
-                }
-
                 let dest = skills_dir.join(&name);
-                if dest.exists() && !force {
+                let will_copy = !dest.exists() || force;
+                if will_copy {
+                    validate_skill_manifest(&entry.path())?;
+                    multi_copies.push((entry.path(), name));
+                } else {
                     println!(
                         "  {} '{}' already exists (use --force to overwrite)",
                         "SKIP".yellow(),
                         name
                     );
                     skipped.push(name);
-                    continue;
                 }
+            }
+            // Now actually copy the validated subdirs.
+            for (src_path, name) in multi_copies {
+                let dest = skills_dir.join(&name);
                 if dest.exists() {
                     std::fs::remove_dir_all(&dest)?;
                 }
-                copy_dir_recursive(&entry.path(), &dest)?;
+                copy_dir_recursive(&src_path, &dest)?;
 
-                if entry.path().join("SKILL.md").exists() {
+                if src_path.join("SKILL.md").exists() {
                     installed.push(name);
                 } else {
                     deps_installed.push(name);
@@ -2008,6 +2017,59 @@ fi
         assert!(
             !skills_dir.join("bad-skill").exists(),
             "validator must run before copy; bad-skill dir leaked"
+        );
+    }
+
+    /// RFC-2 (codex round 3, 2026-05-25): a malformed local manifest
+    /// whose destination already exists and `--force` is NOT set must
+    /// NOT block the install — the skip path preserves whatever the
+    /// user already has, so validating a (possibly bad) source we're
+    /// not going to copy would surface a spurious failure.
+    #[test]
+    fn install_from_local_skips_validation_when_dest_exists_without_force() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("bad-skill");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("SKILL.md"), "# bad\n").unwrap();
+        std::fs::write(
+            src.join("manifest.json"),
+            r#"{
+              "id": "bad-skill",
+              "version": "0.1.0",
+              "tools": [{
+                "name": "do_thing",
+                "description": "...",
+                "input_schema": {
+                  "type": "object",
+                  "anyOf": [
+                    { "required": ["a"] },
+                    { "required": ["b"] }
+                  ]
+                }
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        let skills_dir = tmp.path().join("skills");
+        // Pre-populate the dest so install_skill takes the skip path.
+        let dest = skills_dir.join("bad-skill");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("SKILL.md"), "# existing\n").unwrap();
+
+        let result = install_skill(
+            &skills_dir,
+            &src.to_string_lossy(),
+            /* force */ false,
+            "main",
+        )
+        .expect("skip path must not invoke validation");
+        assert!(result.installed.is_empty());
+        assert_eq!(result.skipped, vec!["bad-skill".to_string()]);
+        // The existing install must remain intact.
+        assert_eq!(
+            std::fs::read_to_string(dest.join("SKILL.md")).unwrap(),
+            "# existing\n"
         );
     }
 

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -932,17 +932,32 @@ fn install_via_git_result(
             );
         }
 
-        // RFC-2: validate the manifest BEFORE we copy anything to the
-        // user-visible skills dir. A malformed manifest aborts the
-        // install with the structured violation list — no half-broken
-        // skill directory left behind.
-        validate_skill_manifest(&src)?;
-
         let name = Path::new(subdir)
             .file_name()
             .unwrap()
             .to_string_lossy()
             .to_string();
+
+        // RFC-2 (codex follow-up, 2026-05-25): pre-flight validate
+        // the target subdir AND every auto-detected shared dep
+        // BEFORE we touch the user-visible skills dir. The earlier
+        // attempt validated deps after the target copy, which left
+        // a partial install on disk when a dep's manifest was
+        // malformed. We now collect every dep ahead of time so a
+        // single failed validation bails before any copy.
+        validate_skill_manifest(&src)?;
+        let shared_deps: Vec<String> = {
+            let skill_md_path = src.join("SKILL.md");
+            if skill_md_path.exists() {
+                let content = std::fs::read_to_string(&skill_md_path)?;
+                find_shared_deps(&content, &clone_dir, &name)
+            } else {
+                Vec::new()
+            }
+        };
+        for dep in &shared_deps {
+            validate_skill_manifest(&clone_dir.join(dep))?;
+        }
 
         // Install the target skill/dir
         let dest = skills_dir.join(&name);
@@ -965,35 +980,22 @@ fn install_via_git_result(
             }
         }
 
-        // Auto-detect shared dependencies referenced in SKILL.md.
-        // RFC-2 follow-up (codex P2, 2026-05-25): every shared dep
-        // must pass `validate_skill_manifest` BEFORE we copy it,
-        // otherwise a malformed sibling skill bypasses the install
-        // guarantee even though the targeted subdir was clean.
-        let skill_md_path = src.join("SKILL.md");
-        if skill_md_path.exists() {
-            let content = std::fs::read_to_string(&skill_md_path)?;
-            let shared = find_shared_deps(&content, &clone_dir, &name);
-            for dep in shared {
-                let dep_src = clone_dir.join(&dep);
-                let dep_dest = skills_dir.join(&dep);
-                if dep_dest.exists() && !force {
-                    println!(
-                        "  {} dependency '{}' already exists (use --force to overwrite)",
-                        "SKIP".yellow(),
-                        dep
-                    );
-                } else {
-                    // Pre-flight validation — bails the install if a
-                    // dep manifest is malformed, leaving nothing
-                    // half-written on disk.
-                    validate_skill_manifest(&dep_src)?;
-                    if dep_dest.exists() {
-                        std::fs::remove_dir_all(&dep_dest)?;
-                    }
-                    copy_dir_recursive(&dep_src, &dep_dest)?;
-                    deps_installed.push(dep);
+        // Now copy every shared dep we already validated above.
+        for dep in shared_deps {
+            let dep_src = clone_dir.join(&dep);
+            let dep_dest = skills_dir.join(&dep);
+            if dep_dest.exists() && !force {
+                println!(
+                    "  {} dependency '{}' already exists (use --force to overwrite)",
+                    "SKIP".yellow(),
+                    dep
+                );
+            } else {
+                if dep_dest.exists() {
+                    std::fs::remove_dir_all(&dep_dest)?;
                 }
+                copy_dir_recursive(&dep_src, &dep_dest)?;
+                deps_installed.push(dep);
             }
         }
     } else {

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -965,7 +965,11 @@ fn install_via_git_result(
             }
         }
 
-        // Auto-detect shared dependencies referenced in SKILL.md
+        // Auto-detect shared dependencies referenced in SKILL.md.
+        // RFC-2 follow-up (codex P2, 2026-05-25): every shared dep
+        // must pass `validate_skill_manifest` BEFORE we copy it,
+        // otherwise a malformed sibling skill bypasses the install
+        // guarantee even though the targeted subdir was clean.
         let skill_md_path = src.join("SKILL.md");
         if skill_md_path.exists() {
             let content = std::fs::read_to_string(&skill_md_path)?;
@@ -980,6 +984,10 @@ fn install_via_git_result(
                         dep
                     );
                 } else {
+                    // Pre-flight validation — bails the install if a
+                    // dep manifest is malformed, leaving nothing
+                    // half-written on disk.
+                    validate_skill_manifest(&dep_src)?;
                     if dep_dest.exists() {
                         std::fs::remove_dir_all(&dep_dest)?;
                     }

--- a/crates/octos-cli/src/commands/skills.rs
+++ b/crates/octos-cli/src/commands/skills.rs
@@ -9,6 +9,38 @@ use serde::{Deserialize, Serialize};
 
 use super::Executable;
 
+/// RFC-2 (issue #1291): validate a skill directory's `manifest.json`
+/// against the strict octos JSON schema validator before we commit
+/// the install to disk.
+///
+/// Behaviour
+/// ---------
+/// - If the skill has no `manifest.json`, this is a no-op (pure SKILL.md
+///   skills are not affected — they don't ship tool schemas).
+/// - If the manifest fails to parse OR fails strict schema validation,
+///   we bail with the structured violation list so the operator sees
+///   every problem at once.
+/// - Operators who need to install a known-bad manifest can set
+///   `OCTOS_MANIFEST_VALIDATION=lenient` (Draft 07 sanity only) or
+///   `=off` (skip entirely). Default is `strict`.
+fn validate_skill_manifest(skill_dir: &Path) -> Result<()> {
+    let manifest_path = skill_dir.join("manifest.json");
+    if !manifest_path.exists() {
+        return Ok(());
+    }
+    // `PluginManifest::from_file` runs both structural and schema
+    // validation, threading through `OCTOS_MANIFEST_VALIDATION` for
+    // the strict-rule layer.
+    octos_plugin::PluginManifest::from_file(&manifest_path)
+        .map(|_| ())
+        .wrap_err_with(|| {
+            format!(
+                "manifest at {} failed RFC-2 schema validation\n\nSet OCTOS_MANIFEST_VALIDATION=lenient to skip the strict octos rules, or =off to skip validation entirely.",
+                manifest_path.display()
+            )
+        })
+}
+
 // ── Public types for programmatic access ─────────────────────────────
 
 /// Information about an installed skill (for programmatic use).
@@ -339,6 +371,12 @@ fn install_from_local(skills_dir: &Path, src: &Path, force: bool) -> Result<Inst
             src.display()
         );
     }
+
+    // RFC-2: reject malformed manifests BEFORE we copy anything to
+    // disk. This is the install-time hook called out in #1291: the
+    // operator gets the structured violation list with no half-broken
+    // skill directory left behind.
+    validate_skill_manifest(src)?;
 
     let name = src
         .file_name()
@@ -894,6 +932,12 @@ fn install_via_git_result(
             );
         }
 
+        // RFC-2: validate the manifest BEFORE we copy anything to the
+        // user-visible skills dir. A malformed manifest aborts the
+        // install with the structured violation list — no half-broken
+        // skill directory left behind.
+        validate_skill_manifest(&src)?;
+
         let name = Path::new(subdir)
             .file_name()
             .unwrap()
@@ -947,6 +991,9 @@ fn install_via_git_result(
     } else {
         // Whole-repo install: check if root is a single skill or multi-skill
         if clone_dir.join("SKILL.md").exists() {
+            // RFC-2: validate the single-skill root manifest before copy.
+            validate_skill_manifest(&clone_dir)?;
+
             // Single-skill repo: install as repo_name/
             let dest = skills_dir.join(&spec.repo_name);
             if dest.exists() && !force {
@@ -964,6 +1011,21 @@ fn install_via_git_result(
                 installed.push(spec.repo_name.clone());
             }
         } else {
+            // RFC-2: validate every multi-skill subdirectory's manifest
+            // before any copy. Aborts the whole install on the first
+            // failure rather than ending up with a mixed-validity
+            // skills dir.
+            for entry in std::fs::read_dir(&clone_dir)? {
+                let entry = entry?;
+                if !entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.starts_with('.') {
+                    continue;
+                }
+                validate_skill_manifest(&entry.path())?;
+            }
             // Multi-skill repo: copy all top-level directories
             for entry in std::fs::read_dir(&clone_dir)? {
                 let entry = entry?;
@@ -1887,5 +1949,96 @@ fi
         std::fs::write(skill_dir.join("main"), "#!/usr/bin/env bash\necho ok\n").unwrap();
 
         assert!(has_installed_skill_executable(&skill_dir, "mofa-fm"));
+    }
+
+    /// RFC-2 (issue #1291): a skill that ships the mofa-slides v0.5.0
+    /// `anyOf`-without-`type` shape must be rejected at install time
+    /// with a descriptive error, BEFORE we copy the skill onto disk.
+    /// The skills dir must remain unchanged after the failure.
+    #[test]
+    fn install_from_local_rejects_invalid_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("bad-skill");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("SKILL.md"), "# bad\n").unwrap();
+        std::fs::write(
+            src.join("manifest.json"),
+            r#"{
+              "id": "bad-skill",
+              "version": "0.1.0",
+              "tools": [{
+                "name": "do_thing",
+                "description": "...",
+                "input_schema": {
+                  "type": "object",
+                  "anyOf": [
+                    { "required": ["a"] },
+                    { "required": ["b"] }
+                  ]
+                }
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        let skills_dir = tmp.path().join("skills");
+        let err = install_skill(
+            &skills_dir,
+            &src.to_string_lossy(),
+            /* force */ false,
+            "main",
+        )
+        .expect_err("install must reject malformed manifest");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("RFC-2") || msg.contains("schema violation"),
+            "expected RFC-2 violation message, got: {msg}"
+        );
+        // Critically — skills_dir must NOT contain the bad skill.
+        assert!(
+            !skills_dir.join("bad-skill").exists(),
+            "validator must run before copy; bad-skill dir leaked"
+        );
+    }
+
+    /// RFC-2: a clean, valid local skill manifest is still accepted by
+    /// the install path. Sanity test that the validator hook didn't
+    /// regress the happy path.
+    #[test]
+    fn install_from_local_accepts_valid_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("good-skill");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("SKILL.md"), "# good\n").unwrap();
+        std::fs::write(
+            src.join("manifest.json"),
+            r#"{
+              "id": "good-skill",
+              "version": "0.1.0",
+              "tools": [{
+                "name": "do_thing",
+                "description": "Does a thing.",
+                "input_schema": {
+                  "type": "object",
+                  "properties": {
+                    "x": { "type": "string" }
+                  },
+                  "required": ["x"]
+                }
+              }]
+            }"#,
+        )
+        .unwrap();
+
+        let skills_dir = tmp.path().join("skills");
+        let result = install_skill(
+            &skills_dir,
+            &src.to_string_lossy(),
+            /* force */ false,
+            "main",
+        )
+        .expect("clean manifest must install");
+        assert_eq!(result.installed, vec!["good-skill".to_string()]);
+        assert!(skills_dir.join("good-skill").join("manifest.json").exists());
     }
 }

--- a/crates/octos-pipeline/tests/plugin_load_cache.rs
+++ b/crates/octos-pipeline/tests/plugin_load_cache.rs
@@ -74,7 +74,11 @@ fn create_stub_plugin(plugins_root: &Path, name: &str) -> PathBuf {
             "sha256": "{hash}",
             "tools": [{{
                 "name": "{tool_name}",
-                "description": "stub tool from plugin {name}"
+                "description": "stub tool from plugin {name}",
+                "input_schema": {{
+                    "type": "object",
+                    "properties": {{}}
+                }}
             }}]
         }}"#,
         tool_name = name.replace('-', "_"),

--- a/crates/octos-plugin/Cargo.toml
+++ b/crates/octos-plugin/Cargo.toml
@@ -21,3 +21,8 @@ metrics = { workspace = true }
 tempfile = { workspace = true }
 tokio-test = { workspace = true }
 regex = { workspace = true }
+
+# RFC-2 CI entrypoint — used by scripts/validate-skill-manifests.sh.
+[[bin]]
+name = "validate_manifests"
+path = "src/bin/validate_manifests.rs"

--- a/crates/octos-plugin/src/bin/validate_manifests.rs
+++ b/crates/octos-plugin/src/bin/validate_manifests.rs
@@ -10,11 +10,17 @@
 //! Exits with code 0 when every manifest passes, 1 otherwise. The
 //! `scripts/validate-skill-manifests.sh` wrapper drives this binary
 //! from CI and from local dev workflows.
+//!
+//! The bin defers to `PluginManifest::from_file()` so structural,
+//! schema, and env-profile checks all run from the same code path the
+//! daemon uses at startup. This means a manifest that passes here is
+//! guaranteed to load at runtime (modulo external factors like
+//! missing binaries, which gating handles separately).
 
 use std::path::Path;
 use std::process::ExitCode;
 
-use octos_plugin::{PluginManifest, ValidationProfile, validate_manifest_schemas_with};
+use octos_plugin::{PluginManifest, ValidationProfile};
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -30,7 +36,7 @@ fn main() -> ExitCode {
     let mut pass: usize = 0;
     for arg in &args {
         let path = Path::new(arg);
-        match validate_one(path, profile) {
+        match validate_one(path) {
             Ok(()) => {
                 eprintln!("  PASS  {}", path.display());
                 pass += 1;
@@ -54,58 +60,16 @@ fn main() -> ExitCode {
     }
 }
 
-fn validate_one(path: &Path, profile: ValidationProfile) -> Result<(), String> {
-    let raw = std::fs::read_to_string(path).map_err(|e| format!("    read error: {e}"))?;
-    // Parse without going through `PluginManifest::from_json` so we
-    // can run the validator explicitly with the requested profile,
-    // matching the env var the wrapper script passes through.
-    //
-    // We still want structural manifest checks (id/version/tool names)
-    // — those live in `validate()` which `from_json` calls. So we
-    // try `from_json` first; if it fails for a non-validation reason
-    // we surface it; if it fails due to schema validation under the
-    // profile we report that with the structured detail.
-    let manifest: PluginManifest = match serde_json::from_str(&raw) {
-        Ok(m) => m,
-        Err(e) => return Err(format!("    parse error: {e}")),
-    };
-
-    // Re-run structural checks (id, version, tools shape) since we
-    // bypassed `from_json`.
-    if let Err(e) = manifest_struct_check(&manifest) {
-        return Err(format!("    structural error: {e}"));
-    }
-
-    match validate_manifest_schemas_with(&manifest, profile) {
-        Ok(()) => Ok(()),
-        Err(errs) => {
-            let detail = errs
-                .iter()
-                .map(|e| format!("      - {e}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            Err(format!("    {} schema violation(s):\n{detail}", errs.len()))
-        }
-    }
-}
-
-/// Re-implementation of the structural-only piece of
-/// `PluginManifest::validate()` (which is private). Kept tiny on
-/// purpose; the schema validator owns the heavy lifting.
-fn manifest_struct_check(manifest: &PluginManifest) -> Result<(), String> {
-    if manifest.id.is_empty() {
-        return Err("manifest 'id' (or 'name') must not be empty".into());
-    }
-    if manifest.version.is_empty() {
-        return Err("manifest 'version' must not be empty".into());
-    }
-    for tool in &manifest.tools {
-        if tool.name.is_empty() {
-            return Err(format!(
-                "tool in plugin '{}' has an empty name",
-                manifest.id
-            ));
-        }
-    }
-    Ok(())
+/// Validate one manifest file. We use `PluginManifest::from_file()`
+/// which runs structural validation (`id`, `version`, tool names,
+/// `type: "tool"` requires `tools`, `type: "hook"` requires `hooks`),
+/// schema validation (Draft 07 sanity + the strict octos profile),
+/// and honours `OCTOS_MANIFEST_VALIDATION`. Re-using this entrypoint
+/// means CI cannot drift from runtime — codex review (2026-05-25, P3)
+/// flagged a hand-rolled structural copy that omitted the type/tools
+/// and type/hooks checks; we now share the canonical path.
+fn validate_one(path: &Path) -> Result<(), String> {
+    PluginManifest::from_file(path)
+        .map(|_| ())
+        .map_err(|e| format!("    {e:#}"))
 }

--- a/crates/octos-plugin/src/bin/validate_manifests.rs
+++ b/crates/octos-plugin/src/bin/validate_manifests.rs
@@ -1,0 +1,111 @@
+//! CI helper: validate one or more plugin `manifest.json` files
+//! against the RFC-2 schema validator.
+//!
+//! Usage:
+//!
+//! ```text
+//! validate_manifests path/to/manifest.json [more.json …]
+//! ```
+//!
+//! Exits with code 0 when every manifest passes, 1 otherwise. The
+//! `scripts/validate-skill-manifests.sh` wrapper drives this binary
+//! from CI and from local dev workflows.
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use octos_plugin::{PluginManifest, ValidationProfile, validate_manifest_schemas_with};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: validate_manifests <manifest.json> [<manifest.json> ...]");
+        return ExitCode::from(2);
+    }
+
+    let profile = ValidationProfile::from_env();
+    eprintln!("RFC-2 manifest validator (profile: {profile:?})\n");
+
+    let mut failures: usize = 0;
+    let mut pass: usize = 0;
+    for arg in &args {
+        let path = Path::new(arg);
+        match validate_one(path, profile) {
+            Ok(()) => {
+                eprintln!("  PASS  {}", path.display());
+                pass += 1;
+            }
+            Err(msg) => {
+                eprintln!("  FAIL  {}", path.display());
+                eprintln!("{msg}");
+                failures += 1;
+            }
+        }
+    }
+
+    eprintln!(
+        "\n{pass} pass, {failures} fail (of {} manifests)",
+        args.len()
+    );
+    if failures > 0 {
+        ExitCode::from(1)
+    } else {
+        ExitCode::from(0)
+    }
+}
+
+fn validate_one(path: &Path, profile: ValidationProfile) -> Result<(), String> {
+    let raw = std::fs::read_to_string(path).map_err(|e| format!("    read error: {e}"))?;
+    // Parse without going through `PluginManifest::from_json` so we
+    // can run the validator explicitly with the requested profile,
+    // matching the env var the wrapper script passes through.
+    //
+    // We still want structural manifest checks (id/version/tool names)
+    // — those live in `validate()` which `from_json` calls. So we
+    // try `from_json` first; if it fails for a non-validation reason
+    // we surface it; if it fails due to schema validation under the
+    // profile we report that with the structured detail.
+    let manifest: PluginManifest = match serde_json::from_str(&raw) {
+        Ok(m) => m,
+        Err(e) => return Err(format!("    parse error: {e}")),
+    };
+
+    // Re-run structural checks (id, version, tools shape) since we
+    // bypassed `from_json`.
+    if let Err(e) = manifest_struct_check(&manifest) {
+        return Err(format!("    structural error: {e}"));
+    }
+
+    match validate_manifest_schemas_with(&manifest, profile) {
+        Ok(()) => Ok(()),
+        Err(errs) => {
+            let detail = errs
+                .iter()
+                .map(|e| format!("      - {e}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(format!("    {} schema violation(s):\n{detail}", errs.len()))
+        }
+    }
+}
+
+/// Re-implementation of the structural-only piece of
+/// `PluginManifest::validate()` (which is private). Kept tiny on
+/// purpose; the schema validator owns the heavy lifting.
+fn manifest_struct_check(manifest: &PluginManifest) -> Result<(), String> {
+    if manifest.id.is_empty() {
+        return Err("manifest 'id' (or 'name') must not be empty".into());
+    }
+    if manifest.version.is_empty() {
+        return Err("manifest 'version' must not be empty".into());
+    }
+    for tool in &manifest.tools {
+        if tool.name.is_empty() {
+            return Err(format!(
+                "tool in plugin '{}' has an empty name",
+                manifest.id
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/octos-plugin/src/discovery.rs
+++ b/crates/octos-plugin/src/discovery.rs
@@ -154,12 +154,16 @@ mod tests {
 
     #[test]
     fn discover_single_plugin() {
+        // RFC-2: tool manifests must carry an `input_schema` rooted at
+        // `type: "object"`. Omitting it (as the original test did)
+        // surfaces as a discovery rejection in the strict profile.
         let tmp = TempDir::new().unwrap();
         write_manifest(
             tmp.path(),
             "weather",
             r#"{ "id": "weather", "version": "1.0.0", "type": "tool",
-                 "tools": [{"name": "get_weather", "description": "weather"}] }"#,
+                 "tools": [{"name": "get_weather", "description": "weather",
+                            "input_schema": {"type": "object", "properties": {}}}] }"#,
         );
 
         let sources = vec![PluginSource {
@@ -182,13 +186,15 @@ mod tests {
             profile_dir.path(),
             "weather",
             r#"{ "id": "weather", "version": "2.0.0", "type": "tool",
-                 "tools": [{"name": "get_weather", "description": "v2"}] }"#,
+                 "tools": [{"name": "get_weather", "description": "v2",
+                            "input_schema": {"type": "object", "properties": {}}}] }"#,
         );
         write_manifest(
             user_dir.path(),
             "weather",
             r#"{ "id": "weather", "version": "1.0.0", "type": "tool",
-                 "tools": [{"name": "get_weather", "description": "v1"}] }"#,
+                 "tools": [{"name": "get_weather", "description": "v1",
+                            "input_schema": {"type": "object", "properties": {}}}] }"#,
         );
 
         let sources = vec![
@@ -311,6 +317,8 @@ mod tests {
 
     #[test]
     fn legacy_manifest_with_name_field() {
+        // RFC-2: legacy `name`-using manifests still parse, but the
+        // tool's `input_schema` must now declare `type: "object"`.
         let tmp = TempDir::new().unwrap();
         write_manifest(
             tmp.path(),
@@ -324,7 +332,10 @@ mod tests {
                         "name": "news_fetch",
                         "description": "Fetch news",
                         "entrypoint": "target/release/news_fetch",
-                        "input_schema": {}
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {}
+                        }
                     }
                 ]
             }"#,
@@ -338,5 +349,43 @@ mod tests {
         assert_eq!(plugins.len(), 1);
         assert_eq!(plugins[0].manifest.id, "news");
         assert_eq!(plugins[0].origin, PluginOrigin::Legacy);
+    }
+
+    /// RFC-2: discovery must not load a manifest that violates the
+    /// strict profile — it should `warn!` and continue. This is the
+    /// daemon-startup hook from RFC-2 (item 2: "Plugin discovery on
+    /// daemon startup").
+    #[test]
+    fn rfc2_discovery_skips_manifest_with_invalid_schema() {
+        let tmp = TempDir::new().unwrap();
+        write_manifest(
+            tmp.path(),
+            "bad-skill",
+            // Reproduces the mofa-slides v0.5.0 anyOf branch missing type.
+            r#"{
+                "id": "bad-skill",
+                "version": "0.1.0",
+                "tools": [{
+                    "name": "do_thing",
+                    "description": "...",
+                    "input_schema": {
+                        "type": "object",
+                        "anyOf": [
+                            { "required": ["a"] },
+                            { "required": ["b"] }
+                        ]
+                    }
+                }]
+            }"#,
+        );
+        let sources = vec![PluginSource {
+            path: tmp.path().to_path_buf(),
+            origin: PluginOrigin::User,
+        }];
+        let plugins = discover_plugins(&sources, &HashMap::new());
+        assert!(
+            plugins.is_empty(),
+            "expected discovery to skip manifest with invalid schema, got {plugins:?}"
+        );
     }
 }

--- a/crates/octos-plugin/src/lib.rs
+++ b/crates/octos-plugin/src/lib.rs
@@ -31,6 +31,7 @@ pub mod discovery;
 pub mod gating;
 pub mod lifecycle;
 pub mod manifest;
+pub mod manifest_validator;
 pub mod protocol_v2;
 pub mod types;
 
@@ -43,6 +44,10 @@ pub use lifecycle::{
     is_safe_shell_command,
 };
 pub use manifest::{InstallSpec, PluginManifest, PluginType, Requirements, ToolDefinition};
+pub use manifest_validator::{
+    ManifestSchemaError, SchemaKind, ValidationProfile, validate_manifest_schemas,
+    validate_manifest_schemas_with, validate_schema,
+};
 pub use protocol_v2::{
     ArtifactEvent, CostEvent, LineParse, LogEvent, PhaseEvent, ProgressEvent, ProtocolV2Event,
     ResultCost, ResultSource, ResultSummary, emit_cost, emit_event, emit_progress,

--- a/crates/octos-plugin/src/manifest.rs
+++ b/crates/octos-plugin/src/manifest.rs
@@ -4,6 +4,7 @@ use eyre::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::lifecycle::HardwareLifecycle;
+use crate::manifest_validator::{ValidationProfile, validate_manifest_schemas_with};
 
 /// The type of plugin.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -129,9 +130,16 @@ pub struct PluginManifest {
     #[serde(default)]
     pub tools: Vec<ToolDefinition>,
 
-    /// Hook event names for hook-type plugins.
+    /// Hook declarations. For `type: "hook"` plugins this is the array
+    /// of event names (strings). Skill manifests (e.g. `skill-evolve`)
+    /// use a richer object form `{event, command, timeout_ms,
+    /// tool_filter}` that `octos-agent` re-parses through its own
+    /// `SkillHookDef` type — see `octos-agent/src/plugins/manifest.rs`.
+    /// We accept both shapes here so discovery doesn't silently drop
+    /// skills with object hooks (the failure mode that bit
+    /// `skill-evolve` prior to RFC-2).
     #[serde(default)]
-    pub hooks: Vec<String>,
+    pub hooks: Vec<serde_json::Value>,
 
     /// Requirements for gating.
     #[serde(default, alias = "requirements")]
@@ -158,10 +166,18 @@ pub struct PluginManifest {
 
 impl PluginManifest {
     /// Parse a manifest from a JSON string.
+    ///
+    /// RFC-2 (issue #1291): after structural validation, every tool's
+    /// `input_schema` is run through [`validate_manifest_schemas_with`]
+    /// using the profile selected by `OCTOS_MANIFEST_VALIDATION`
+    /// (defaults to `strict`). The schema-validation failure mode is a
+    /// composite error: every violation is reported on its own line so
+    /// authors can fix them all in a single round-trip.
     pub fn from_json(json: &str) -> Result<Self> {
         let manifest: PluginManifest =
             serde_json::from_str(json).wrap_err("failed to parse manifest JSON")?;
         manifest.validate()?;
+        manifest.validate_schemas()?;
         Ok(manifest)
     }
 
@@ -170,6 +186,7 @@ impl PluginManifest {
         let contents = std::fs::read_to_string(path)
             .wrap_err_with(|| format!("failed to read manifest at {}", path.display()))?;
         Self::from_json(&contents)
+            .wrap_err_with(|| format!("manifest validation failed for {}", path.display()))
     }
 
     /// Resolve the effective plugin type.
@@ -216,6 +233,31 @@ impl PluginManifest {
             }
         }
         Ok(())
+    }
+
+    /// RFC-2: run every tool's `input_schema` through the schema
+    /// validator using the env-driven profile. The default profile
+    /// (`strict`) catches today's mofa-slides v0.5.0 bug class. Errors
+    /// are flattened to one line per violation so the operator sees
+    /// every problem in a single round-trip.
+    fn validate_schemas(&self) -> Result<()> {
+        let profile = ValidationProfile::from_env();
+        match validate_manifest_schemas_with(self, profile) {
+            Ok(()) => Ok(()),
+            Err(errs) => {
+                let detail = errs
+                    .iter()
+                    .map(|e| format!("  - {e}"))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                bail!(
+                    "plugin '{}' has {} schema violation(s):\n{}\n\nSet OCTOS_MANIFEST_VALIDATION=lenient to relax the strict octos profile, or =off to disable validation entirely.",
+                    self.id,
+                    errs.len(),
+                    detail
+                );
+            }
+        }
     }
 }
 
@@ -287,6 +329,46 @@ mod tests {
         let m = PluginManifest::from_json(json).unwrap();
         assert_eq!(m.effective_type(), PluginType::Hook);
         assert_eq!(m.hooks.len(), 2);
+        // Legacy string form preserved as JSON strings.
+        assert!(m.hooks[0].is_string());
+    }
+
+    /// RFC-2: skill-evolve and similar manifests use the richer object
+    /// hook form `{event, command, timeout_ms, tool_filter}`. Discovery
+    /// must accept it without losing the structure; `octos-agent`
+    /// re-parses the value into `SkillHookDef` downstream.
+    #[test]
+    fn parse_skill_with_object_form_hooks() {
+        let json = r#"{
+            "name": "skill-evolve",
+            "version": "0.1.0",
+            "tools": [{
+                "name": "skill_evolve",
+                "description": "Manage skill evolution patches",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "action": { "type": "string", "enum": ["list", "apply", "discard"] }
+                    },
+                    "required": ["action"]
+                }
+            }],
+            "hooks": [{
+                "event": "after_tool_call",
+                "command": ["./main", "--hook"],
+                "timeout_ms": 30000,
+                "tool_filter": []
+            }]
+        }"#;
+        let m = PluginManifest::from_json(json).expect("skill-evolve manifest must parse");
+        assert_eq!(m.id, "skill-evolve");
+        assert_eq!(m.hooks.len(), 1);
+        // Richer object shape is preserved for the downstream re-parser.
+        assert!(m.hooks[0].is_object());
+        assert_eq!(
+            m.hooks[0].get("event").and_then(|v| v.as_str()),
+            Some("after_tool_call")
+        );
     }
 
     #[test]
@@ -310,6 +392,9 @@ mod tests {
 
     #[test]
     fn legacy_name_field_maps_to_id() {
+        // RFC-2: `input_schema` must declare `type: "object"` and a
+        // (possibly empty) `properties` map. Empty `{}` no longer
+        // passes the strict validator.
         let json = r#"{
             "name": "news",
             "version": "1.0.0",
@@ -319,7 +404,10 @@ mod tests {
                     "name": "news_fetch",
                     "description": "Fetch news",
                     "entrypoint": "target/release/news_fetch",
-                    "input_schema": {}
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {}
+                    }
                 }
             ]
         }"#;
@@ -420,5 +508,32 @@ mod tests {
         assert_eq!(m.timeout_secs, Some(15));
         assert_eq!(m.requires_network, Some(true));
         assert_eq!(m.effective_type(), PluginType::Tool);
+    }
+
+    /// RFC-2: reproduce the 2026-05-25 mofa-slides v0.5.0 incident and
+    /// confirm `from_json` rejects it with a descriptive error
+    /// pointing at the offending field. End-to-end test for the
+    /// integration between `validate_schemas` and `from_json`.
+    #[test]
+    fn rfc2_rejects_bare_anyof_branch_at_load_time() {
+        let json = r#"{
+            "id": "mofa-slides",
+            "version": "0.5.0",
+            "tools": [{
+                "name": "mofa_slides",
+                "description": "Generate slides",
+                "input_schema": {
+                    "type": "object",
+                    "anyOf": [
+                        { "required": ["slides"] },
+                        { "required": ["input"] }
+                    ]
+                }
+            }]
+        }"#;
+        let err = PluginManifest::from_json(json).expect_err("must fail");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("schema violation"), "msg = {msg}");
+        assert!(msg.contains("anyOf"), "msg = {msg}");
     }
 }

--- a/crates/octos-plugin/src/manifest_validator.rs
+++ b/crates/octos-plugin/src/manifest_validator.rs
@@ -1,0 +1,974 @@
+//! Strict validator for plugin manifest tool schemas (RFC-2).
+//!
+//! Background
+//! ----------
+//! On 2026-05-25 the `mofa-slides v0.5.0` skill shipped a tool with an
+//! `input_schema` of the form
+//!
+//! ```json
+//! {
+//!   "type": "object",
+//!   "anyOf": [
+//!     { "required": ["slides"] },
+//!     { "required": ["input"] }
+//!   ]
+//! }
+//! ```
+//!
+//! Each `anyOf` branch lacks a `type` declaration. Strict LLM provider
+//! validators (e.g. Moonshot Kimi K2.6, several Deepseek revisions)
+//! reject this shape at request time, surfacing as a runtime tool-call
+//! failure deep inside the agent loop with no useful pointer back to the
+//! manifest. RFC-2 closes that loop by validating every manifest at
+//! parse time and at install time so the problem surfaces with a clear
+//! error pointing at the offending field.
+//!
+//! Validation layers
+//! -----------------
+//! 1. **Draft 07 sanity** — we walk every schema node and reject any
+//!    keyword whose declared type is incompatible with Draft 07 (e.g. a
+//!    `required` field that isn't an array of strings). This is the
+//!    cheap subset of meta-schema validation that catches today's bug
+//!    class without pulling in a full meta-schema runtime.
+//! 2. **Strict octos rules** — defensive rules tuned to LLM provider
+//!    validators. Every `anyOf`/`oneOf`/`allOf` branch must declare a
+//!    `type`, every `properties.X` must declare a `type`, `$ref` and
+//!    `$dynamicAnchor`/`$dynamicRef` are rejected unless the schema
+//!    opts in to Draft 07 explicitly, `required` must be an array of
+//!    strings, `enum` values must be unique, and the root must be
+//!    `type: "object"`.
+//!
+//! Tuning
+//! ------
+//! The strict layer is gated behind `OCTOS_MANIFEST_VALIDATION`:
+//!
+//! - `strict` (default) — all rules above are enforced.
+//! - `lenient` — Draft 07 sanity only; the octos rules are skipped.
+//! - `off` — validator returns Ok unconditionally. Reserved for
+//!   incident-response unblocks; never set this in production by
+//!   default.
+
+use std::collections::HashSet;
+use std::env;
+use std::fmt;
+
+use serde_json::Value;
+
+use crate::manifest::PluginManifest;
+
+/// Which schema on a tool definition failed validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchemaKind {
+    /// `tool.input_schema`.
+    Input,
+    /// `tool.output_schema` (future-proofing — not yet declared on the
+    /// `ToolDefinition` struct but parsed via `serde_json::Value` when
+    /// extra fields are present in the manifest JSON).
+    Output,
+}
+
+impl fmt::Display for SchemaKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SchemaKind::Input => f.write_str("input_schema"),
+            SchemaKind::Output => f.write_str("output_schema"),
+        }
+    }
+}
+
+/// A single manifest schema validation failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestSchemaError {
+    /// The tool whose schema failed.
+    pub tool_name: String,
+    /// Whether the failure was on `input_schema` or `output_schema`.
+    pub schema_kind: SchemaKind,
+    /// JSON-pointer-style path within the schema (e.g.
+    /// `/anyOf/0`, `/properties/city`).
+    pub path: String,
+    /// Human-readable explanation.
+    pub message: String,
+}
+
+impl fmt::Display for ManifestSchemaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let path = if self.path.is_empty() {
+            "/"
+        } else {
+            &self.path
+        };
+        write!(
+            f,
+            "tool '{tool}' {kind} at {path}: {msg}",
+            tool = self.tool_name,
+            kind = self.schema_kind,
+            path = path,
+            msg = self.message
+        )
+    }
+}
+
+/// Profile selecting how strict the validator should be.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationProfile {
+    /// All Draft 07 sanity rules + all strict octos rules.
+    Strict,
+    /// Draft 07 sanity rules only; strict octos rules are skipped.
+    Lenient,
+    /// Validator returns Ok unconditionally.
+    Off,
+}
+
+impl ValidationProfile {
+    /// Resolve the profile from the `OCTOS_MANIFEST_VALIDATION`
+    /// environment variable. Unknown values fall back to `Strict`
+    /// (fail-closed) and a single `warn!` is emitted via `tracing`.
+    pub fn from_env() -> Self {
+        match env::var("OCTOS_MANIFEST_VALIDATION").ok().as_deref() {
+            Some("strict") | None | Some("") => ValidationProfile::Strict,
+            Some("lenient") => ValidationProfile::Lenient,
+            Some("off") => ValidationProfile::Off,
+            Some(other) => {
+                tracing::warn!(
+                    value = %other,
+                    "OCTOS_MANIFEST_VALIDATION has unknown value; defaulting to 'strict'"
+                );
+                ValidationProfile::Strict
+            }
+        }
+    }
+}
+
+/// Validate every tool schema on the manifest using the env-driven
+/// profile. Equivalent to `validate_manifest_schemas_with(manifest,
+/// ValidationProfile::from_env())`.
+pub fn validate_manifest_schemas(
+    manifest: &PluginManifest,
+) -> Result<(), Vec<ManifestSchemaError>> {
+    validate_manifest_schemas_with(manifest, ValidationProfile::from_env())
+}
+
+/// Validate every tool schema with an explicit profile. Tests use this
+/// to exercise both modes without mutating the process environment.
+pub fn validate_manifest_schemas_with(
+    manifest: &PluginManifest,
+    profile: ValidationProfile,
+) -> Result<(), Vec<ManifestSchemaError>> {
+    if matches!(profile, ValidationProfile::Off) {
+        return Ok(());
+    }
+    let mut errors = Vec::new();
+
+    for tool in &manifest.tools {
+        // `input_schema` is `serde_json::Value` on `ToolDefinition`.
+        // An empty object is the legacy default — we treat it as
+        // "schema absent" and require a real schema.
+        validate_one_schema(
+            &tool.name,
+            SchemaKind::Input,
+            &tool.input_schema,
+            profile,
+            &mut errors,
+        );
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Validate a single schema with the given profile. Public for the
+/// `validate_manifests` CI bin to use without going through a
+/// `PluginManifest`.
+pub fn validate_schema(
+    tool_name: &str,
+    schema_kind: SchemaKind,
+    schema: &Value,
+    profile: ValidationProfile,
+) -> Vec<ManifestSchemaError> {
+    let mut errors = Vec::new();
+    validate_one_schema(tool_name, schema_kind, schema, profile, &mut errors);
+    errors
+}
+
+fn validate_one_schema(
+    tool_name: &str,
+    schema_kind: SchemaKind,
+    schema: &Value,
+    profile: ValidationProfile,
+    errors: &mut Vec<ManifestSchemaError>,
+) {
+    // Special-case the empty object — every legacy manifest in the
+    // wild that omitted `input_schema` parses as `{}`. We require a
+    // real schema so providers don't see "no parameters" when the
+    // tool actually expects fields.
+    if let Some(obj) = schema.as_object() {
+        if obj.is_empty() {
+            errors.push(ManifestSchemaError {
+                tool_name: tool_name.to_string(),
+                schema_kind,
+                path: String::new(),
+                message: "schema is empty — tools must declare `\"type\": \"object\"` and at least an empty `properties` map".to_string(),
+            });
+            return;
+        }
+    } else {
+        errors.push(ManifestSchemaError {
+            tool_name: tool_name.to_string(),
+            schema_kind,
+            path: String::new(),
+            message: format!("schema must be a JSON object, found {}", kind_label(schema)),
+        });
+        return;
+    }
+
+    // Detect "explicit Draft 07 opt-in" at the root once and thread it
+    // down. Only the root `$schema` counts — sub-schemas don't get to
+    // opt themselves into `$ref`/etc on their own.
+    let explicit_draft07 = schema
+        .get("$schema")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.contains("draft-07"));
+
+    // Layer 1: Draft 07 sanity — always run.
+    walk_draft07(tool_name, schema_kind, schema, "", errors);
+
+    // Layer 2: octos strict rules — run unless explicitly relaxed.
+    if matches!(profile, ValidationProfile::Strict) {
+        // Root-schema-only rules.
+        check_root(tool_name, schema_kind, schema, errors);
+        walk_strict(tool_name, schema_kind, schema, "", explicit_draft07, errors);
+    }
+}
+
+// ── Layer 1: Draft 07 sanity ─────────────────────────────────────────
+
+fn walk_draft07(
+    tool_name: &str,
+    schema_kind: SchemaKind,
+    schema: &Value,
+    path: &str,
+    errors: &mut Vec<ManifestSchemaError>,
+) {
+    let Some(obj) = schema.as_object() else {
+        return;
+    };
+
+    // Type-level sanity for known Draft 07 keywords. We pick the ones
+    // whose mis-typed declarations are easy to ship and hard to spot.
+    if let Some(v) = obj.get("required") {
+        if !v.is_array() {
+            errors.push(err(
+                tool_name,
+                schema_kind,
+                path,
+                "`required` must be an array",
+            ));
+        } else {
+            for (i, item) in v.as_array().unwrap().iter().enumerate() {
+                if !item.is_string() {
+                    errors.push(err(
+                        tool_name,
+                        schema_kind,
+                        &join(path, &format!("required/{i}")),
+                        &format!("`required[{i}]` must be a string"),
+                    ));
+                }
+            }
+        }
+    }
+
+    if let Some(v) = obj.get("enum") {
+        if !v.is_array() {
+            errors.push(err(tool_name, schema_kind, path, "`enum` must be an array"));
+        }
+    }
+
+    if let Some(v) = obj.get("type") {
+        match v {
+            Value::String(_) => {}
+            Value::Array(arr) => {
+                for (i, item) in arr.iter().enumerate() {
+                    if !item.is_string() {
+                        errors.push(err(
+                            tool_name,
+                            schema_kind,
+                            &join(path, &format!("type/{i}")),
+                            "`type` array items must be strings",
+                        ));
+                    }
+                }
+            }
+            _ => errors.push(err(
+                tool_name,
+                schema_kind,
+                path,
+                "`type` must be a string or array of strings",
+            )),
+        }
+    }
+
+    if let Some(v) = obj.get("properties") {
+        if !v.is_object() {
+            errors.push(err(
+                tool_name,
+                schema_kind,
+                path,
+                "`properties` must be an object",
+            ));
+        }
+    }
+
+    if let Some(v) = obj.get("items") {
+        if !(v.is_object() || v.is_array()) {
+            errors.push(err(
+                tool_name,
+                schema_kind,
+                path,
+                "`items` must be a schema object or array of schemas",
+            ));
+        }
+    }
+
+    for combinator in ["anyOf", "oneOf", "allOf"] {
+        if let Some(v) = obj.get(combinator) {
+            if !v.is_array() {
+                errors.push(err(
+                    tool_name,
+                    schema_kind,
+                    path,
+                    &format!("`{combinator}` must be an array"),
+                ));
+            }
+        }
+    }
+
+    // Recurse.
+    if let Some(Value::Object(props)) = obj.get("properties") {
+        for (k, sub) in props {
+            walk_draft07(
+                tool_name,
+                schema_kind,
+                sub,
+                &join(path, &format!("properties/{k}")),
+                errors,
+            );
+        }
+    }
+    for combinator in ["anyOf", "oneOf", "allOf"] {
+        if let Some(Value::Array(arr)) = obj.get(combinator) {
+            for (i, sub) in arr.iter().enumerate() {
+                walk_draft07(
+                    tool_name,
+                    schema_kind,
+                    sub,
+                    &join(path, &format!("{combinator}/{i}")),
+                    errors,
+                );
+            }
+        }
+    }
+    if let Some(items) = obj.get("items") {
+        match items {
+            Value::Object(_) => {
+                walk_draft07(tool_name, schema_kind, items, &join(path, "items"), errors)
+            }
+            Value::Array(arr) => {
+                for (i, sub) in arr.iter().enumerate() {
+                    walk_draft07(
+                        tool_name,
+                        schema_kind,
+                        sub,
+                        &join(path, &format!("items/{i}")),
+                        errors,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(sub) = obj.get("not") {
+        walk_draft07(tool_name, schema_kind, sub, &join(path, "not"), errors);
+    }
+}
+
+// ── Layer 2: strict octos rules ──────────────────────────────────────
+
+fn check_root(
+    tool_name: &str,
+    schema_kind: SchemaKind,
+    schema: &Value,
+    errors: &mut Vec<ManifestSchemaError>,
+) {
+    let Some(obj) = schema.as_object() else {
+        return;
+    };
+    match obj.get("type") {
+        Some(Value::String(s)) if s == "object" => {}
+        Some(Value::String(s)) => {
+            errors.push(err(
+                tool_name,
+                schema_kind,
+                "",
+                &format!(
+                    "root schema must have `type: \"object\"` (found `{s}`); tools always receive a JSON object payload"
+                ),
+            ));
+        }
+        Some(_) => {
+            errors.push(err(
+                tool_name,
+                schema_kind,
+                "",
+                "root schema `type` must be the string `\"object\"`",
+            ));
+        }
+        None => {
+            errors.push(err(
+                tool_name,
+                schema_kind,
+                "",
+                "root schema must declare `type: \"object\"`",
+            ));
+        }
+    }
+}
+
+fn walk_strict(
+    tool_name: &str,
+    schema_kind: SchemaKind,
+    schema: &Value,
+    path: &str,
+    draft07_opt_in: bool,
+    errors: &mut Vec<ManifestSchemaError>,
+) {
+    let Some(obj) = schema.as_object() else {
+        return;
+    };
+
+    // `$ref` / `$dynamicRef` / `$dynamicAnchor` are rejected unless the
+    // root schema declared `"$schema": "...draft-07..."`. The opt-in is
+    // computed once at entry and threaded down so a nested `$ref` is
+    // still allowed when the root opted in, but a manifest that never
+    // declared Draft 07 cannot sneak `$ref` in via a sub-schema.
+    for forbidden in ["$ref", "$dynamicRef", "$dynamicAnchor"] {
+        if obj.contains_key(forbidden) && !draft07_opt_in {
+            errors.push(err(
+                tool_name,
+                schema_kind,
+                path,
+                &format!(
+                    "`{forbidden}` is not allowed unless the root schema sets `\"$schema\": \"http://json-schema.org/draft-07/schema#\"`"
+                ),
+            ));
+        }
+    }
+
+    // `enum` values must be unique.
+    if let Some(Value::Array(values)) = obj.get("enum") {
+        let mut seen: HashSet<String> = HashSet::new();
+        for (i, v) in values.iter().enumerate() {
+            // We compare via canonical JSON. `serde_json::to_string`
+            // is sufficient because the comparator is purely
+            // structural — no float fuzzing needed for enum values.
+            let key = serde_json::to_string(v).unwrap_or_default();
+            if !seen.insert(key) {
+                errors.push(err(
+                    tool_name,
+                    schema_kind,
+                    &join(path, &format!("enum/{i}")),
+                    &format!("`enum` values must be unique (duplicate: {v})"),
+                ));
+            }
+        }
+    }
+
+    // Every `properties.X` must declare a `type`.
+    if let Some(Value::Object(props)) = obj.get("properties") {
+        for (k, sub) in props {
+            let sub_path = join(path, &format!("properties/{k}"));
+            if let Some(sub_obj) = sub.as_object() {
+                let has_type_or_combinator = sub_obj.contains_key("type")
+                    || sub_obj.contains_key("anyOf")
+                    || sub_obj.contains_key("oneOf")
+                    || sub_obj.contains_key("allOf")
+                    || sub_obj.contains_key("$ref")
+                    || sub_obj.contains_key("const")
+                    || sub_obj.contains_key("enum");
+                if !has_type_or_combinator {
+                    errors.push(err(
+                        tool_name,
+                        schema_kind,
+                        &sub_path,
+                        &format!(
+                            "property `{k}` must declare a `type` (or `anyOf`/`oneOf`/`allOf`/`enum`/`const`); strict provider validators reject untyped properties"
+                        ),
+                    ));
+                }
+            } else {
+                errors.push(err(
+                    tool_name,
+                    schema_kind,
+                    &sub_path,
+                    &format!("property `{k}` must be a schema object"),
+                ));
+            }
+            walk_strict(
+                tool_name,
+                schema_kind,
+                sub,
+                &sub_path,
+                draft07_opt_in,
+                errors,
+            );
+        }
+    }
+
+    // Every `anyOf`/`oneOf`/`allOf` branch must declare a `type`.
+    for combinator in ["anyOf", "oneOf", "allOf"] {
+        if let Some(Value::Array(branches)) = obj.get(combinator) {
+            for (i, branch) in branches.iter().enumerate() {
+                let branch_path = join(path, &format!("{combinator}/{i}"));
+                if let Some(b_obj) = branch.as_object() {
+                    let has_type = b_obj.contains_key("type")
+                        || b_obj.contains_key("$ref")
+                        || b_obj.contains_key("const")
+                        || b_obj.contains_key("enum");
+                    if !has_type {
+                        errors.push(err(
+                            tool_name,
+                            schema_kind,
+                            &branch_path,
+                            &format!(
+                                "`{combinator}` branch must declare a `type` (or `enum`/`const`); strict provider validators reject untyped branches — this is today's mofa-slides v0.5.0 bug shape"
+                            ),
+                        ));
+                    }
+                }
+                walk_strict(
+                    tool_name,
+                    schema_kind,
+                    branch,
+                    &branch_path,
+                    draft07_opt_in,
+                    errors,
+                );
+            }
+        }
+    }
+
+    // Recurse into `items`, `not`.
+    if let Some(items) = obj.get("items") {
+        match items {
+            Value::Object(_) => walk_strict(
+                tool_name,
+                schema_kind,
+                items,
+                &join(path, "items"),
+                draft07_opt_in,
+                errors,
+            ),
+            Value::Array(arr) => {
+                for (i, sub) in arr.iter().enumerate() {
+                    walk_strict(
+                        tool_name,
+                        schema_kind,
+                        sub,
+                        &join(path, &format!("items/{i}")),
+                        draft07_opt_in,
+                        errors,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+    if let Some(sub) = obj.get("not") {
+        walk_strict(
+            tool_name,
+            schema_kind,
+            sub,
+            &join(path, "not"),
+            draft07_opt_in,
+            errors,
+        );
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn err(tool_name: &str, schema_kind: SchemaKind, path: &str, message: &str) -> ManifestSchemaError {
+    ManifestSchemaError {
+        tool_name: tool_name.to_string(),
+        schema_kind,
+        path: path.to_string(),
+        message: message.to_string(),
+    }
+}
+
+fn join(parent: &str, child: &str) -> String {
+    if parent.is_empty() {
+        format!("/{child}")
+    } else {
+        format!("{parent}/{child}")
+    }
+}
+
+fn kind_label(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the strict validator.
+    //!
+    //! These tests intentionally do **not** mutate `OCTOS_MANIFEST_VALIDATION`.
+    //! Cargo runs tests in parallel threads inside one process; an env-var
+    //! mutation in one test leaks into siblings and yields flakey runs.
+    //! Each test passes an explicit [`ValidationProfile`] instead — that's the
+    //! same code path the env var would have hit.
+
+    use super::*;
+    use crate::manifest::PluginManifest;
+    use serde_json::json;
+
+    fn schema_of(json: serde_json::Value) -> Value {
+        json
+    }
+
+    /// Reproduces the 2026-05-25 mofa-slides v0.5.0 incident: every
+    /// `anyOf` branch is bare `{required:[…]}` with no `type`. Strict
+    /// must reject this so the agent never asks the provider with a
+    /// schema that will be refused mid-request.
+    #[test]
+    fn anyof_branch_missing_type_rejected() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "anyOf": [
+                { "required": ["slides"] },
+                { "required": ["input"] }
+            ]
+        }));
+        let errors = validate_schema(
+            "mofa_slides",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path.starts_with("/anyOf/0") && e.message.contains("type")),
+            "expected anyOf/0 type-missing error, got {errors:?}"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path.starts_with("/anyOf/1") && e.message.contains("type")),
+            "expected anyOf/1 type-missing error, got {errors:?}"
+        );
+    }
+
+    /// `properties.foo = {description: ""}` is the second-most common
+    /// shape strict provider validators reject — they want a `type`.
+    #[test]
+    fn properties_field_missing_type_rejected() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "properties": {
+                "foo": { "description": "no type" }
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert_eq!(errors.len(), 1, "errors = {errors:?}");
+        assert_eq!(errors[0].path, "/properties/foo");
+        assert!(errors[0].message.contains("must declare a `type`"));
+    }
+
+    /// `$ref` is rejected unless the schema explicitly opts in to
+    /// Draft 07 at the root. This is RFC-2's lock-down on resolver
+    /// surface area — every provider parses `$ref` differently.
+    #[test]
+    fn dollar_ref_rejected_without_explicit_allow() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "properties": {
+                "x": { "$ref": "#/definitions/X" }
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path == "/properties/x" && e.message.contains("$ref")),
+            "expected $ref rejection, got {errors:?}"
+        );
+    }
+
+    /// Same schema becomes acceptable (for the `$ref` rule) once the
+    /// root opts into Draft 07. The Draft 07 sanity layer still
+    /// produces no errors for this shape.
+    #[test]
+    fn dollar_ref_allowed_with_explicit_draft07() {
+        let schema = schema_of(json!({
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "x": { "$ref": "#/definitions/X", "type": "string" }
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        // Property `x` now has both `$ref` and `type` — the explicit
+        // Draft 07 opt-in disables the $ref rejection, and the `type`
+        // satisfies the property-must-have-type rule.
+        assert!(
+            errors.is_empty(),
+            "explicit draft-07 opt-in should clear $ref rejection, got {errors:?}"
+        );
+    }
+
+    /// `enum` duplicates are detected; same canonical JSON form counts.
+    #[test]
+    fn non_unique_enum_rejected() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "properties": {
+                "color": { "type": "string", "enum": ["red", "blue", "red"] }
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors.iter().any(|e| e.message.contains("unique")),
+            "expected duplicate-enum error, got {errors:?}"
+        );
+    }
+
+    /// The root MUST be `type: "object"` — every tool receives a JSON
+    /// object payload, and accepting `type: "array"` at the root would
+    /// confuse every provider on the wire.
+    #[test]
+    fn root_schema_must_be_object_type() {
+        let schema = schema_of(json!({
+            "type": "string"
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path.is_empty() && e.message.contains("object")),
+            "expected root-must-be-object error, got {errors:?}"
+        );
+    }
+
+    /// The root MUST be `type: "object"` — root with no type at all
+    /// also fails, because untyped roots are exactly what shipped in
+    /// the mofa-slides incident.
+    #[test]
+    fn root_schema_with_no_type_rejected() {
+        let schema = schema_of(json!({
+            "properties": { "x": { "type": "string" } }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path.is_empty() && e.message.contains("must declare")),
+            "expected root-no-type error, got {errors:?}"
+        );
+    }
+
+    /// Sanity test: a known-good bundled manifest passes strict mode.
+    /// We use the weather skill — clean `type: "object"` root, every
+    /// property has a `type`, `required` is well-formed. If this
+    /// regresses we've introduced a false positive.
+    #[test]
+    fn valid_manifest_accepted() {
+        let raw = include_str!("../../app-skills/weather/manifest.json");
+        let manifest = PluginManifest::from_json(raw).expect("bundled weather manifest must parse");
+        assert!(
+            validate_manifest_schemas_with(&manifest, ValidationProfile::Strict).is_ok(),
+            "bundled weather manifest should pass strict validation"
+        );
+    }
+
+    /// Lenient profile must accept the strict-failing mofa-slides
+    /// shape so operators can unblock prod immediately by setting
+    /// `OCTOS_MANIFEST_VALIDATION=lenient`.
+    #[test]
+    fn lenient_profile_accepts_bare_anyof_branch() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "anyOf": [
+                { "required": ["slides"] },
+                { "required": ["input"] }
+            ]
+        }));
+        let errors = validate_schema(
+            "mofa_slides",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Lenient,
+        );
+        assert!(
+            errors.is_empty(),
+            "lenient should accept bare anyOf branches, got {errors:?}"
+        );
+    }
+
+    /// `off` profile is a panic-button bypass: even Draft 07 sanity
+    /// is skipped (e.g. ship-now incident response).
+    #[test]
+    fn off_profile_accepts_everything() {
+        let schema = schema_of(json!({
+            "type": "string",
+            "required": "not-an-array",
+            "properties": "not-an-object"
+        }));
+        let errors = validate_schema("tool_x", SchemaKind::Input, &schema, ValidationProfile::Off);
+        // `validate_schema` runs `validate_one_schema` regardless, so
+        // we expect the layer-1 errors to surface here. The full
+        // entrypoint `validate_manifest_schemas_with` honours `Off`
+        // and returns Ok unconditionally — exercise that separately.
+        assert!(
+            !errors.is_empty(),
+            "validate_schema runs layer 1 regardless of profile"
+        );
+
+        let tool = crate::manifest::ToolDefinition {
+            name: "tool_x".into(),
+            description: "x".into(),
+            input_schema: schema,
+            entrypoint: None,
+            concurrency_class: None,
+        };
+        let manifest = PluginManifest {
+            id: "p".into(),
+            version: "0".into(),
+            plugin_type: None,
+            description: None,
+            author: None,
+            homepage: None,
+            license: None,
+            binary: None,
+            timeout_secs: None,
+            tools: vec![tool],
+            hooks: vec![],
+            requires: None,
+            config_schema: None,
+            install: vec![],
+            requires_network: None,
+            hardware_lifecycle: None,
+        };
+        assert!(
+            validate_manifest_schemas_with(&manifest, ValidationProfile::Off).is_ok(),
+            "Off profile must short-circuit to Ok"
+        );
+    }
+
+    /// Layer 1 catches non-array `required` regardless of profile.
+    /// This is a Draft 07 sanity rule that mirrors the meta-schema.
+    #[test]
+    fn draft07_required_must_be_array() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "required": "city"  // should be ["city"]
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Lenient,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("required") && e.message.contains("array")),
+            "lenient must still catch non-array `required`, got {errors:?}"
+        );
+    }
+
+    /// Empty `input_schema: {}` (the legacy default) is rejected with
+    /// a clear error rather than silently passing. Without this the
+    /// validator would accept manifests that effectively declare "no
+    /// parameters" while their tool expects them.
+    #[test]
+    fn empty_input_schema_rejected() {
+        let schema = schema_of(json!({}));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].message.contains("empty"));
+    }
+
+    /// The path encoded in errors must point at the offending field
+    /// so authors don't have to grep the manifest by hand.
+    #[test]
+    fn error_path_points_at_offending_field() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "object",
+                    "anyOf": [
+                        { "required": ["a"] }
+                    ]
+                }
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path == "/properties/nested/anyOf/0"),
+            "expected /properties/nested/anyOf/0 path, got {errors:?}"
+        );
+    }
+}

--- a/crates/octos-plugin/src/manifest_validator.rs
+++ b/crates/octos-plugin/src/manifest_validator.rs
@@ -200,21 +200,15 @@ fn validate_one_schema(
     profile: ValidationProfile,
     errors: &mut Vec<ManifestSchemaError>,
 ) {
-    // Special-case the empty object — every legacy manifest in the
-    // wild that omitted `input_schema` parses as `{}`. We require a
-    // real schema so providers don't see "no parameters" when the
-    // tool actually expects fields.
-    if let Some(obj) = schema.as_object() {
-        if obj.is_empty() {
-            errors.push(ManifestSchemaError {
-                tool_name: tool_name.to_string(),
-                schema_kind,
-                path: String::new(),
-                message: "schema is empty — tools must declare `\"type\": \"object\"` and at least an empty `properties` map".to_string(),
-            });
-            return;
-        }
-    } else {
+    // The schema must at least be a JSON object — Draft 07 says a
+    // schema can also be `true`/`false`, but tool input schemas are
+    // never one of those in practice; rejecting now gives a useful
+    // pointer rather than letting the walker silently no-op.
+    //
+    // This check fires in every profile (including lenient) because a
+    // non-object root is not a valid Draft 07 schema for the tool-input
+    // role; the `Off` short-circuit higher up still bypasses it.
+    if !schema.is_object() {
         errors.push(ManifestSchemaError {
             tool_name: tool_name.to_string(),
             schema_kind,
@@ -237,6 +231,20 @@ fn validate_one_schema(
 
     // Layer 2: octos strict rules — run unless explicitly relaxed.
     if matches!(profile, ValidationProfile::Strict) {
+        // The empty-schema rule belongs to the strict octos profile —
+        // `{}` is a valid Draft 07 schema, so accepting it in lenient
+        // mode matches the documented "Draft 07 sanity only" contract
+        // (codex P2 review, 2026-05-25). Operators who genuinely want
+        // an "accept anything" tool can opt out with =lenient or =off.
+        if schema.as_object().is_some_and(|o| o.is_empty()) {
+            errors.push(ManifestSchemaError {
+                tool_name: tool_name.to_string(),
+                schema_kind,
+                path: String::new(),
+                message: "schema is empty — tools must declare `\"type\": \"object\"` and at least an empty `properties` map".to_string(),
+            });
+            return;
+        }
         // Root-schema-only rules.
         check_root(tool_name, schema_kind, schema, errors);
         walk_strict(tool_name, schema_kind, schema, "", explicit_draft07, errors);
@@ -288,16 +296,40 @@ fn walk_draft07(
 
     if let Some(v) = obj.get("type") {
         match v {
-            Value::String(_) => {}
+            // String form — must be one of the Draft 07 type names.
+            // Catches typos like `"strng"` that satisfy the strict
+            // "has type" check but are rejected by JSON Schema and
+            // provider validators (codex P2 review, 2026-05-25).
+            Value::String(s) => {
+                if !is_valid_draft07_type(s) {
+                    errors.push(err(
+                        tool_name,
+                        schema_kind,
+                        path,
+                        &format!(
+                            "`type: \"{s}\"` is not a valid JSON Schema Draft 07 type (must be one of: null, boolean, object, array, number, string, integer)"
+                        ),
+                    ));
+                }
+            }
             Value::Array(arr) => {
                 for (i, item) in arr.iter().enumerate() {
-                    if !item.is_string() {
-                        errors.push(err(
+                    match item.as_str() {
+                        Some(s) if is_valid_draft07_type(s) => {}
+                        Some(s) => errors.push(err(
+                            tool_name,
+                            schema_kind,
+                            &join(path, &format!("type/{i}")),
+                            &format!(
+                                "`type[{i}]: \"{s}\"` is not a valid JSON Schema Draft 07 type"
+                            ),
+                        )),
+                        None => errors.push(err(
                             tool_name,
                             schema_kind,
                             &join(path, &format!("type/{i}")),
                             "`type` array items must be strings",
-                        ));
+                        )),
                     }
                 }
             }
@@ -345,53 +377,14 @@ fn walk_draft07(
         }
     }
 
-    // Recurse.
-    if let Some(Value::Object(props)) = obj.get("properties") {
-        for (k, sub) in props {
-            walk_draft07(
-                tool_name,
-                schema_kind,
-                sub,
-                &join(path, &format!("properties/{k}")),
-                errors,
-            );
-        }
-    }
-    for combinator in ["anyOf", "oneOf", "allOf"] {
-        if let Some(Value::Array(arr)) = obj.get(combinator) {
-            for (i, sub) in arr.iter().enumerate() {
-                walk_draft07(
-                    tool_name,
-                    schema_kind,
-                    sub,
-                    &join(path, &format!("{combinator}/{i}")),
-                    errors,
-                );
-            }
-        }
-    }
-    if let Some(items) = obj.get("items") {
-        match items {
-            Value::Object(_) => {
-                walk_draft07(tool_name, schema_kind, items, &join(path, "items"), errors)
-            }
-            Value::Array(arr) => {
-                for (i, sub) in arr.iter().enumerate() {
-                    walk_draft07(
-                        tool_name,
-                        schema_kind,
-                        sub,
-                        &join(path, &format!("items/{i}")),
-                        errors,
-                    );
-                }
-            }
-            _ => {}
-        }
-    }
-    if let Some(sub) = obj.get("not") {
-        walk_draft07(tool_name, schema_kind, sub, &join(path, "not"), errors);
-    }
+    // Recurse into every schema-bearing keyword. We use the shared
+    // `for_each_subschema` helper so the Draft 07 walker, the strict
+    // walker, and any future layer see the same recursion shape; if
+    // somebody adds a new sub-schema-bearing keyword they only need
+    // to update one place.
+    for_each_subschema(obj, path, |sub, sub_path| {
+        walk_draft07(tool_name, schema_kind, sub, &sub_path, errors);
+    });
 }
 
 // ── Layer 2: strict octos rules ──────────────────────────────────────
@@ -485,7 +478,7 @@ fn walk_strict(
         }
     }
 
-    // Every `properties.X` must declare a `type`.
+    // Node-local checks: every `properties.X` must declare a `type`.
     if let Some(Value::Object(props)) = obj.get("properties") {
         for (k, sub) in props {
             let sub_path = join(path, &format!("properties/{k}"));
@@ -515,18 +508,10 @@ fn walk_strict(
                     &format!("property `{k}` must be a schema object"),
                 ));
             }
-            walk_strict(
-                tool_name,
-                schema_kind,
-                sub,
-                &sub_path,
-                draft07_opt_in,
-                errors,
-            );
         }
     }
 
-    // Every `anyOf`/`oneOf`/`allOf` branch must declare a `type`.
+    // Node-local: every `anyOf`/`oneOf`/`allOf` branch must declare a `type`.
     for combinator in ["anyOf", "oneOf", "allOf"] {
         if let Some(Value::Array(branches)) = obj.get(combinator) {
             for (i, branch) in branches.iter().enumerate() {
@@ -547,57 +532,120 @@ fn walk_strict(
                         ));
                     }
                 }
-                walk_strict(
-                    tool_name,
-                    schema_kind,
-                    branch,
-                    &branch_path,
-                    draft07_opt_in,
-                    errors,
-                );
             }
         }
     }
 
-    // Recurse into `items`, `not`.
+    // Recurse into every schema-bearing keyword. Shared between
+    // `walk_draft07` and `walk_strict` so adding a new sub-schema
+    // keyword (e.g. a future Draft 07 extension) updates both layers
+    // automatically.
+    for_each_subschema(obj, path, |sub, sub_path| {
+        walk_strict(
+            tool_name,
+            schema_kind,
+            sub,
+            &sub_path,
+            draft07_opt_in,
+            errors,
+        );
+    });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// The seven type names recognised by JSON Schema Draft 07.
+const DRAFT07_TYPES: &[&str] = &[
+    "null", "boolean", "object", "array", "number", "string", "integer",
+];
+
+/// Whether `name` is a Draft 07 primitive type. Used to catch typos
+/// (e.g. `"strng"`) that would slip past the strict "has type" rule
+/// but fail at provider validation time.
+fn is_valid_draft07_type(name: &str) -> bool {
+    DRAFT07_TYPES.contains(&name)
+}
+
+/// Invoke `visit(sub, sub_path)` for every schema-bearing sub-schema
+/// of `obj`. Centralising the recursion shape means both validation
+/// layers descend into the same set of keywords, and a future
+/// schema-bearing keyword (e.g. an extension we adopt) only needs to
+/// be added once.
+///
+/// Keyword coverage matches Draft 07's "applicator" vocabulary:
+/// `properties`, `patternProperties`, `additionalProperties`,
+/// `definitions` / `$defs`, `propertyNames`, `items`,
+/// `additionalItems`, `contains`, `anyOf`/`oneOf`/`allOf`, `not`,
+/// `if`/`then`/`else`, `dependencies` (schema form). The walker is
+/// conservative: keywords whose value is not a schema in Draft 07
+/// (e.g. `dependencies` with an array form, `enum` values) are
+/// ignored. That matches what JSON Schema validators do.
+fn for_each_subschema<F>(obj: &serde_json::Map<String, Value>, path: &str, mut visit: F)
+where
+    F: FnMut(&Value, String),
+{
+    // Object-valued shorthand: `properties` and `patternProperties`
+    // both map to a `name -> sub-schema` table.
+    for keyword in ["properties", "patternProperties", "definitions", "$defs"] {
+        if let Some(Value::Object(map)) = obj.get(keyword) {
+            for (k, sub) in map {
+                visit(sub, join(path, &format!("{keyword}/{k}")));
+            }
+        }
+    }
+
+    // Array-valued: every combinator's items are sub-schemas.
+    for combinator in ["anyOf", "oneOf", "allOf"] {
+        if let Some(Value::Array(arr)) = obj.get(combinator) {
+            for (i, sub) in arr.iter().enumerate() {
+                visit(sub, join(path, &format!("{combinator}/{i}")));
+            }
+        }
+    }
+
+    // `items` is either a single schema or an array of schemas.
     if let Some(items) = obj.get("items") {
         match items {
-            Value::Object(_) => walk_strict(
-                tool_name,
-                schema_kind,
-                items,
-                &join(path, "items"),
-                draft07_opt_in,
-                errors,
-            ),
+            Value::Object(_) => visit(items, join(path, "items")),
             Value::Array(arr) => {
                 for (i, sub) in arr.iter().enumerate() {
-                    walk_strict(
-                        tool_name,
-                        schema_kind,
-                        sub,
-                        &join(path, &format!("items/{i}")),
-                        draft07_opt_in,
-                        errors,
-                    );
+                    visit(sub, join(path, &format!("items/{i}")));
                 }
             }
             _ => {}
         }
     }
-    if let Some(sub) = obj.get("not") {
-        walk_strict(
-            tool_name,
-            schema_kind,
-            sub,
-            &join(path, "not"),
-            draft07_opt_in,
-            errors,
-        );
+
+    // Single-schema applicators. `additionalProperties` and
+    // `additionalItems` can also be booleans — those aren't schemas
+    // and we skip them.
+    for keyword in [
+        "additionalProperties",
+        "additionalItems",
+        "propertyNames",
+        "contains",
+        "not",
+        "if",
+        "then",
+        "else",
+    ] {
+        if let Some(sub) = obj.get(keyword) {
+            if sub.is_object() {
+                visit(sub, join(path, keyword));
+            }
+        }
+    }
+
+    // `dependencies` in Draft 07 is either `{name: [required-list]}`
+    // (skip — not a sub-schema) or `{name: sub-schema}` (recurse).
+    if let Some(Value::Object(deps)) = obj.get("dependencies") {
+        for (k, v) in deps {
+            if v.is_object() {
+                visit(v, join(path, &format!("dependencies/{k}")));
+            }
+        }
     }
 }
-
-// ── Helpers ──────────────────────────────────────────────────────────
 
 fn err(tool_name: &str, schema_kind: SchemaKind, path: &str, message: &str) -> ManifestSchemaError {
     ManifestSchemaError {
@@ -969,6 +1017,176 @@ mod tests {
                 .iter()
                 .any(|e| e.path == "/properties/nested/anyOf/0"),
             "expected /properties/nested/anyOf/0 path, got {errors:?}"
+        );
+    }
+
+    // ── Codex P2 review follow-ups (2026-05-25) ─────────────────────
+
+    /// Codex P2 #2: `{}` is a valid Draft 07 schema, so lenient mode
+    /// must accept it. The empty-schema rule is part of the strict
+    /// octos profile only.
+    #[test]
+    fn lenient_profile_accepts_empty_schema() {
+        let schema = schema_of(json!({}));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Lenient,
+        );
+        assert!(
+            errors.is_empty(),
+            "lenient must accept empty `{{}}` (valid Draft 07), got {errors:?}"
+        );
+    }
+
+    /// Codex P2 #2 (continued): strict still rejects empty `{}`.
+    #[test]
+    fn strict_profile_still_rejects_empty_schema() {
+        let schema = schema_of(json!({}));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors.iter().any(|e| e.message.contains("empty")),
+            "strict must reject empty `{{}}`, got {errors:?}"
+        );
+    }
+
+    /// Codex P2 #3: `{"type": "strng"}` satisfied the strict "has
+    /// type" check but is rejected by Draft 07 + provider validators.
+    /// The Draft 07 sanity pass now catches this typo.
+    #[test]
+    fn invalid_draft07_type_name_rejected() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "properties": {
+                "field": { "type": "strng" }  // typo for "string"
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Lenient,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path == "/properties/field" && e.message.contains("\"strng\"")),
+            "expected invalid-type rejection, got {errors:?}"
+        );
+    }
+
+    /// Codex P2 #3 (continued): array-form `type` with a bogus entry
+    /// is also caught.
+    #[test]
+    fn invalid_draft07_type_name_in_array_rejected() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "properties": {
+                "field": { "type": ["string", "bogus"] }
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Lenient,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path == "/properties/field/type/1" && e.message.contains("\"bogus\"")),
+            "expected invalid-type-in-array rejection, got {errors:?}"
+        );
+    }
+
+    /// Codex P2 #4: a bare-`anyOf`-branch shape hidden under
+    /// `additionalProperties` must be caught. Without the recursion
+    /// fix this would silently pass.
+    #[test]
+    fn additional_properties_recursion_catches_invalid_anyof() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "anyOf": [
+                    { "required": ["a"] },
+                    { "required": ["b"] }
+                ]
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path.starts_with("/additionalProperties/anyOf/")),
+            "expected anyOf-under-additionalProperties rejection, got {errors:?}"
+        );
+    }
+
+    /// Codex P2 #4 (continued): `$defs` / `definitions` schemas also
+    /// recurse so a malformed shared definition can't sneak past.
+    #[test]
+    fn defs_recursion_catches_invalid_anyof() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "$defs": {
+                "Inner": {
+                    "type": "object",
+                    "anyOf": [
+                        { "required": ["x"] }
+                    ]
+                }
+            }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.path.starts_with("/$defs/Inner/anyOf/")),
+            "expected anyOf-under-$defs rejection, got {errors:?}"
+        );
+    }
+
+    /// Codex P2 #4 (continued): `if`/`then`/`else` are sub-schemas in
+    /// Draft 07 and must recurse so the same bug class doesn't hide
+    /// inside conditional branches.
+    #[test]
+    fn if_then_else_recursion_catches_invalid_anyof() {
+        let schema = schema_of(json!({
+            "type": "object",
+            "if": {
+                "type": "object",
+                "anyOf": [
+                    { "required": ["mode"] }
+                ]
+            },
+            "then": { "type": "object" }
+        }));
+        let errors = validate_schema(
+            "tool_x",
+            SchemaKind::Input,
+            &schema,
+            ValidationProfile::Strict,
+        );
+        assert!(
+            errors.iter().any(|e| e.path.starts_with("/if/anyOf/")),
+            "expected anyOf-under-if rejection, got {errors:?}"
         );
     }
 }

--- a/crates/octos-plugin/tests/bundled_manifests_validate.rs
+++ b/crates/octos-plugin/tests/bundled_manifests_validate.rs
@@ -1,0 +1,77 @@
+//! RFC-2: every bundled `crates/app-skills/*/manifest.json` must pass
+//! the strict manifest validator. If any of these regress, the daemon
+//! refuses to load them at startup — so a failure here is a release
+//! blocker, not a soft warning.
+//!
+//! This is also exactly what `scripts/validate-skill-manifests.sh` runs
+//! in CI via the `validate_manifests` bin. The integration test layer
+//! gives us a `cargo test`-friendly hook so editor-driven workflows
+//! catch a regression before the operator ever sees the CI failure.
+
+use std::fs;
+use std::path::PathBuf;
+
+use octos_plugin::{PluginManifest, ValidationProfile, validate_manifest_schemas_with};
+
+fn app_skills_dir() -> PathBuf {
+    // Tests run with CWD = crate root (octos-plugin), so we go up two
+    // levels to reach the workspace root and dive into app-skills.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir).join("..").join("app-skills")
+}
+
+#[test]
+fn bundled_app_skills_manifests_pass_strict_validator() {
+    let dir = app_skills_dir();
+    assert!(
+        dir.exists(),
+        "bundled app-skills dir not found at {}",
+        dir.display()
+    );
+
+    let mut visited = 0;
+    let mut failures: Vec<(PathBuf, String)> = Vec::new();
+    for entry in fs::read_dir(&dir).unwrap() {
+        let entry = entry.unwrap();
+        let manifest_path = entry.path().join("manifest.json");
+        if !manifest_path.exists() {
+            continue;
+        }
+        visited += 1;
+        let raw = fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|e| panic!("could not read {}: {e}", manifest_path.display()));
+        let manifest = match PluginManifest::from_json(&raw) {
+            Ok(m) => m,
+            Err(e) => {
+                failures.push((manifest_path, format!("{e:#}")));
+                continue;
+            }
+        };
+        if let Err(errs) = validate_manifest_schemas_with(&manifest, ValidationProfile::Strict) {
+            failures.push((
+                manifest_path,
+                errs.iter()
+                    .map(|e| format!("  - {e}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            ));
+        }
+    }
+
+    assert!(
+        visited > 0,
+        "no bundled manifests found under {}",
+        dir.display()
+    );
+    if !failures.is_empty() {
+        let detail = failures
+            .iter()
+            .map(|(p, m)| format!("{}\n{m}", p.display()))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        panic!(
+            "{} bundled manifest(s) failed strict validation:\n\n{detail}",
+            failures.len()
+        );
+    }
+}

--- a/scripts/validate-skill-manifests.sh
+++ b/scripts/validate-skill-manifests.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# RFC-2 (issue #1291): validate every bundled `crates/app-skills/*/manifest.json`
+# (plus any additional manifest paths passed on the command line) against the
+# strict octos JSON schema validator.
+#
+# Backstory: on 2026-05-25 `mofa-slides v0.5.0` shipped with
+# `input_schema.anyOf[]` branches that lacked `type`. Strict LLM-provider
+# validators (Moonshot Kimi K2.6 et al.) reject this shape at request time
+# and the failure surfaces deep inside the agent loop with no useful pointer
+# back to the manifest. RFC-2 adds a parse-time validator AND this CI hook
+# so the bug class is caught at PR review rather than in production.
+#
+# Usage
+# -----
+#   scripts/validate-skill-manifests.sh                # all bundled
+#   scripts/validate-skill-manifests.sh foo/manifest.json bar/manifest.json
+#
+# Environment
+# -----------
+#   OCTOS_MANIFEST_VALIDATION   strict (default) | lenient | off
+#
+# Exits non-zero if any manifest fails validation. Builds the
+# `validate_manifests` bin in release mode so subsequent invocations are
+# fast — the binary is small and pure-Rust so this is cheap even in CI.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_SKILLS_DIR="$ROOT/crates/app-skills"
+
+# Build the bin once. Use the workspace cargo flags the rest of CI uses
+# so the artefact slots into Swatinem/rust-cache like every other test
+# job's compile cache.
+echo "[validate-skill-manifests] building validate_manifests bin..."
+(cd "$ROOT" && cargo build -p octos-plugin --bin validate_manifests --quiet)
+
+BIN="$ROOT/target/debug/validate_manifests"
+if [ ! -x "$BIN" ]; then
+    echo "validate_manifests bin not found at $BIN" >&2
+    exit 2
+fi
+
+# Collect manifests. Default = every `crates/app-skills/*/manifest.json`.
+# Extra paths on the command line append (e.g. for testing a vendor skill
+# prior to install).
+declare -a MANIFESTS=()
+if [ "$#" -eq 0 ]; then
+    for d in "$APP_SKILLS_DIR"/*; do
+        manifest="$d/manifest.json"
+        if [ -f "$manifest" ]; then
+            MANIFESTS+=("$manifest")
+        fi
+    done
+else
+    MANIFESTS=("$@")
+fi
+
+if [ "${#MANIFESTS[@]}" -eq 0 ]; then
+    echo "[validate-skill-manifests] no manifests found — nothing to do" >&2
+    exit 0
+fi
+
+echo "[validate-skill-manifests] validating ${#MANIFESTS[@]} manifest(s)..."
+"$BIN" "${MANIFESTS[@]}"

--- a/typos.toml
+++ b/typos.toml
@@ -42,6 +42,11 @@ ratatui = "ratatui"
 mis = "mis"
 # Constant-time equality test fixture (intentionally 1-byte diff from "abc")
 abd = "abd"
+# Intentional typo fixture in manifest_validator.rs: tests that the validator
+# rejects "strng" as an invalid type-string value (it's a deliberate typo for
+# "string"). Allowlist the misspelling so the typos lint doesn't flag the
+# negative-test JSON literal.
+strng = "strng"
 
 [files]
 extend-exclude = ["**/*.js", "**/*.css", "**/*.html", "examples/*/static/**/*.*"]


### PR DESCRIPTION
## Summary

Closes #1291. Adds a strict JSON schema validator for plugin `manifest.json` files that fires at three points: parse time (every `PluginManifest::from_json()` / `from_file()`), install time (`octos skills install`), and CI (`scripts/validate-skill-manifests.sh` wired into `.github/workflows/ci.yml`).

The validator was designed to catch the 2026-05-25 mofa-slides v0.5.0 incident class: bare `{required: [...]}` `anyOf` branches that strict LLM-provider validators (Moonshot Kimi K2.6, Deepseek) reject with HTTP 400 at runtime, mid agent loop, with no pointer back to the manifest.

### Layers

- **Layer 1 (Draft 07 sanity)** — type-checks `required`, `enum`, `type`, `properties`, `items`, `anyOf`/`oneOf`/`allOf` and validates `type` values against the seven Draft 07 primitive names. Always runs (except in `off`).
- **Layer 2 (strict octos rules)** — every `anyOf`/`oneOf`/`allOf` branch must declare `type`; every `properties.X` must declare `type`; `$ref`/`$dynamicRef`/`$dynamicAnchor` are rejected unless the root sets `"$schema": "...draft-07..."`; `enum` values must be unique; root must be `type: "object"`; empty `{}` schemas are rejected.

### Tuning

Tunable via `OCTOS_MANIFEST_VALIDATION={strict|lenient|off}`, defaulting to `strict`. `lenient` = Draft 07 sanity only; `off` = unconditional pass for incident-response unblocks.

### Other changes

- `PluginManifest::hooks: Vec<String>` → `Vec<serde_json::Value>` so the richer object form used by `skill-evolve` (`{event, command, timeout_ms, tool_filter}`) parses cleanly. The `octos-agent::plugins::manifest::SkillHookDef` re-parser already handles both shapes.
- `octos-cli` rejects malformed manifests at install time BEFORE any copy to the user's skills dir (including auto-detected shared deps).

### Codex review

`codex review --commit a9974789` flagged 4 P2s + 1 P3, all addressed in 32f502df:
1. Shared deps now pass `validate_skill_manifest` before copy.
2. Empty-schema rejection moved under the strict profile (lenient accepts `{}`).
3. Invalid Draft 07 type names (e.g. `"strng"`) are rejected.
4. Recursion extended to `additionalProperties`, `patternProperties`, `$defs`, `definitions`, `if`/`then`/`else`, `contains`, `propertyNames`, `additionalItems`, `dependencies`.
5. CI bin uses canonical `PluginManifest::from_file()` so CI cannot drift from runtime.

### Bundled manifests audit

All 12 `crates/app-skills/*/manifest.json` pass strict validation. No fixes needed.

## Test plan

- [x] `cargo test -p octos-plugin` — 80 unit + 1 integration + 10 lifecycle + 2 doc, all green
- [x] `cargo test -p octos-cli --lib commands::skills` — 10 passing (2 new install-handler tests)
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --lib --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `scripts/validate-skill-manifests.sh` — 12/12 bundled manifests pass
- [x] Manual: `OCTOS_MANIFEST_VALIDATION={strict,lenient,off}` profiles all behave as documented
- [x] Manual: mofa-slides v0.5.0 reproduction is rejected with descriptive path-pointed errors