### PR TITLE
feat(routing): per-topic model lane routing (RFC-3)

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -16015,6 +16015,19 @@ async fn run_standalone_turn(
         session_id: Some(session_id.0.clone()),
         turn_id: Some(turn_id.0.to_string()),
     };
+    // RFC-3 (#1292): resolve the session's topic to a capability lane
+    // and stamp it onto a task-local so the AdaptiveRouter narrows
+    // candidate-selection to the lane's `(provider, model)` list. The
+    // gateway/SessionActor side does the same — both turn paths need
+    // identical plumbing for slides/code/research topics to land on
+    // the right model regardless of which transport opened the
+    // session. Built-in defaults apply when the profile has no
+    // `lane_routing` block, so fleet profiles see no behavior change
+    // unless they opt in via config.
+    let lane_ctx = octos_llm::LaneContext::for_topic(
+        session_id.topic(),
+        session_runtime.profile.lane_routing.as_ref(),
+    );
     // Wave-4c (#945): feed turn-end latency into the AdaptiveRouter's
     // per-session auto-escalation state machine so the web/serve path
     // benefits from the same Lane → Hedge auto-flip the gateway has had
@@ -16042,11 +16055,20 @@ async fn run_standalone_turn(
     let (final_reply_tx, final_reply_rx) = tokio::sync::oneshot::channel::<Option<String>>();
     let agent_task = tokio::spawn(async move {
         let start = std::time::Instant::now();
+        // RFC-3 (#1292): wrap the agent.process_message future in the
+        // lane scope FIRST (innermost task-local), then router
+        // context, so the AdaptiveRouter sees both when chat()
+        // recurses through the agent loop. Lane and router contexts
+        // are orthogonal — lane filters slot eligibility, router
+        // context attributes failover events.
         let result = octos_llm::with_router_context(
             router_ctx,
-            octos_agent::tools::TOOL_APPROVAL_CTX.scope(
-                approval_requester,
-                request_agent.process_message(&prompt, &history, turn_media_paths),
+            octos_llm::with_lane_context(
+                lane_ctx,
+                octos_agent::tools::TOOL_APPROVAL_CTX.scope(
+                    approval_requester,
+                    request_agent.process_message(&prompt, &history, turn_media_paths),
+                ),
             ),
         )
         .await;
@@ -30454,6 +30476,7 @@ ignore = []
             cron_service: None,
             pipeline_factory: None,
             hook_executor: None,
+            lane_routing: None,
         })
     }
 

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1218,6 +1218,13 @@ impl GatewayRuntime {
             pending_messages: pending_messages.clone(),
             queue_mode: gw_config.queue_mode,
             adaptive_router: adaptive_router_ref,
+            // RFC-3 (#1292): no UserProfile in scope here (CLI-only
+            // `octos gateway` entry point — see the inline-assembly
+            // branch above for the "no profile" path); use built-in
+            // defaults. The per-profile path through
+            // `ProfileFactory::create_actor_factory_for_profile`
+            // threads the profile's `lane_routing` field.
+            lane_routing: None,
             memory_store: Some(memory_store.clone()),
             plugin_dirs: plugin_dirs_for_spawn.clone(),
             plugin_extra_env: plugin_env.clone(),

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -917,6 +917,11 @@ impl ProfileActorFactoryBuilder {
             pending_messages: self.pending_messages.clone(),
             queue_mode: self.queue_mode,
             adaptive_router,
+            // RFC-3 (#1292): thread per-profile topic→lane overrides
+            // through to the ActorFactory so the SessionActor's
+            // agent_task spawn can build the lane context off
+            // `profile.config.lane_routing`. None = built-in defaults.
+            lane_routing: effective_profile.config.lane_routing.clone(),
             memory_store: Some(self.memory_store.clone()),
             plugin_dirs: actor_plugin_dirs,
             plugin_extra_env: actor_plugin_env,

--- a/crates/octos-cli/src/profiles.rs
+++ b/crates/octos-cli/src/profiles.rs
@@ -129,6 +129,21 @@ pub struct ProfileConfig {
     /// unsigned plugins still load with a warning.
     #[serde(default)]
     pub plugins: crate::config::PluginsConfig,
+    /// RFC-3 (#1292) — per-topic model lane routing. When set, the
+    /// session-actor and the WS turn handler resolve the session's
+    /// `topic()` to a [`octos_llm::Lane`] using these overrides on
+    /// top of the built-in defaults, then scope the LLM chat call
+    /// inside [`octos_llm::with_lane_context`] so the
+    /// [`octos_llm::AdaptiveRouter`] narrows its candidate set to
+    /// the lane's `(provider, model)` list before scoring.
+    ///
+    /// Absent / `None` ⇒ pre-RFC-3 behavior: the router uses the
+    /// profile-default provider chain unchanged. The built-in lane
+    /// defaults still apply for topic prefixes (`slides`, `code`,
+    /// `research`, etc.) — the per-profile field only carries
+    /// **overrides**.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lane_routing: Option<octos_llm::LaneRoutingConfig>,
 }
 
 /// Profile-owned review workflow configuration.

--- a/crates/octos-cli/src/runtime/cache.rs
+++ b/crates/octos-cli/src/runtime/cache.rs
@@ -584,6 +584,7 @@ mod tests {
             cron_service: None,
             pipeline_factory: None,
             hook_executor: None,
+            lane_routing: None,
         })
     }
 

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -306,6 +306,19 @@ pub struct ProfileRuntime {
     /// loop. `None` keeps the legacy behaviour when no hooks are
     /// configured (the agent's default `hooks: None` field).
     pub hook_executor: Option<Arc<HookExecutor>>,
+
+    /// RFC-3 (#1292) — per-topic model lane routing config (overrides
+    /// only; built-in defaults always apply on top of this).
+    ///
+    /// When `Some`, the session-actor and the WS turn handler use this
+    /// to resolve `session.topic()` to a [`octos_llm::Lane`] and pass
+    /// it to the chat call via [`octos_llm::with_lane_context`]. When
+    /// `None`, the built-in defaults from `octos_llm::lane` still apply
+    /// for the well-known prefixes (slides / site / podcast / research
+    /// / code); profiles that haven't opted into RFC-3 see no behavior
+    /// change because the [`octos_llm::AdaptiveRouter`] silently falls
+    /// through when zero candidates match.
+    pub lane_routing: Option<octos_llm::LaneRoutingConfig>,
 }
 
 /// Which OS process is calling [`ProfileRuntime::bootstrap`].
@@ -957,6 +970,7 @@ impl ProfileRuntime {
             cron_service: Some(cron_service),
             pipeline_factory,
             hook_executor,
+            lane_routing: profile.config.lane_routing.clone(),
         }))
     }
 }

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -616,6 +616,7 @@ mod tests {
             cron_service: None,
             pipeline_factory: None,
             hook_executor: None,
+            lane_routing: None,
         })
     }
 
@@ -1095,6 +1096,7 @@ mod tests {
             cron_service: None,
             pipeline_factory: None,
             hook_executor: Some(executor),
+            lane_routing: None,
         })
     }
 
@@ -1146,6 +1148,7 @@ mod tests {
             cron_service: None,
             pipeline_factory: None,
             hook_executor: None,
+            lane_routing: None,
         });
         let key = SessionKey::new("api", "activate-tools-probe");
         let rt = SessionRuntime::bootstrap(&profile, key, None)
@@ -1225,6 +1228,7 @@ mod tests {
             cron_service: None,
             pipeline_factory: None,
             hook_executor: None,
+            lane_routing: None,
         });
 
         let rt_a = SessionRuntime::bootstrap(&profile, SessionKey::new("api", "iso-a"), None)

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -2342,6 +2342,10 @@ pub struct ActorFactory {
     /// Side-channel to the AdaptiveRouter for responsiveness feedback.
     /// None when adaptive routing is disabled or using a static provider chain.
     pub adaptive_router: Option<Arc<AdaptiveRouter>>,
+    /// RFC-3 (#1292): per-profile topic→lane override block, mirrored
+    /// onto every actor at spawn time. `None` keeps the built-in
+    /// defaults from [`octos_llm::lane`] active without further wiring.
+    pub lane_routing: Option<octos_llm::LaneRoutingConfig>,
     /// Memory store for saving long-form outputs (research reports) to the
     /// memory bank so only a summary is injected into session context.
     pub memory_store: Option<Arc<MemoryStore>>,
@@ -3178,6 +3182,7 @@ impl ActorFactory {
             queue_mode: self.queue_mode,
             responsiveness: ResponsivenessObserver::new(),
             adaptive_router: self.adaptive_router.clone(),
+            lane_routing: self.lane_routing.clone(),
             memory_store: self.memory_store.clone(),
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -3651,6 +3656,14 @@ struct SessionActor {
     responsiveness: ResponsivenessObserver,
     /// Side-channel to AdaptiveRouter for toggling auto-protection.
     adaptive_router: Option<Arc<AdaptiveRouter>>,
+    /// RFC-3 (#1292) — per-profile topic→lane overrides. `None`
+    /// means "use built-in defaults"; built-ins still apply on
+    /// every turn via `LaneContext::for_topic(topic, None)`.
+    /// Stashed on the actor (not re-resolved off ProfileRuntime
+    /// every turn) so a hot-reload that swaps the profile's
+    /// `lane_routing` field doesn't race the lane-context build
+    /// inside the agent_task spawn.
+    lane_routing: Option<octos_llm::LaneRoutingConfig>,
     /// Memory store for saving long research reports out-of-band.
     memory_store: Option<Arc<MemoryStore>>,
     /// Active overflow task counter for concurrency limiting.
@@ -5924,6 +5937,17 @@ impl SessionActor {
         // this stamp the gateway's failover surfacing would never fire.
         let router_session_id = self.session_key.to_string();
         let router_turn_id = client_message_id.clone();
+        // RFC-3 (#1292): resolve the session's topic to a capability
+        // lane (slides/code/research/etc. → InstructionStrong /
+        // CodeCapable / etc.) and pass it to the AdaptiveRouter via
+        // `with_lane_context`. The WS turn path in `ui_protocol.rs`
+        // does the same — both paths must stay in lockstep so
+        // model selection is identical whether a session is opened
+        // through gateway or web. Pre-RFC-3 behavior persists for
+        // profiles without `lane_routing` config (built-in defaults
+        // resolve unknown prefixes to General, which is a no-op).
+        let lane_ctx =
+            octos_llm::LaneContext::for_topic(self.session_key.topic(), self.lane_routing.as_ref());
 
         // Snapshot for overflow tasks: conversation context BEFORE the
         // primary task, EXCLUDING the primary user message.  Overflow needs
@@ -5935,19 +5959,25 @@ impl SessionActor {
 
         let mut agent_task = tokio::spawn(async move {
             let start = Instant::now();
+            // RFC-3 (#1292): innermost task-local is the lane scope so
+            // each agent-loop iteration's chat() call sees both the
+            // lane filter and the failover-routing context.
             let result = octos_llm::with_router_context(
                 octos_llm::RouterContext {
                     session_id: Some(router_session_id),
                     turn_id: router_turn_id,
                 },
-                tokio::time::timeout(
-                    session_timeout,
-                    agent.process_message_tracked_with_attachments(
-                        &content,
-                        &history_for_agent,
-                        media,
-                        attachments,
-                        &tracker,
+                octos_llm::with_lane_context(
+                    lane_ctx,
+                    tokio::time::timeout(
+                        session_timeout,
+                        agent.process_message_tracked_with_attachments(
+                            &content,
+                            &history_for_agent,
+                            media,
+                            attachments,
+                            &tracker,
+                        ),
                     ),
                 ),
             )
@@ -9632,6 +9662,7 @@ mod tests {
             queue_mode,
             responsiveness,
             adaptive_router,
+            lane_routing: None,
             memory_store: None,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -9701,6 +9732,7 @@ mod tests {
             queue_mode: QueueMode::Followup,
             responsiveness: ResponsivenessObserver::new(),
             adaptive_router: None,
+            lane_routing: None,
             memory_store: None,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -9851,6 +9883,7 @@ mod tests {
             queue_mode: QueueMode::Followup,
             responsiveness: ResponsivenessObserver::new(),
             adaptive_router: None,
+            lane_routing: None,
             memory_store: None,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -9973,6 +10006,7 @@ mod tests {
             queue_mode: QueueMode::Followup,
             responsiveness: ResponsivenessObserver::new(),
             adaptive_router: None,
+            lane_routing: None,
             memory_store: None,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -10091,6 +10125,7 @@ mod tests {
             queue_mode: QueueMode::Followup,
             responsiveness: ResponsivenessObserver::new(),
             adaptive_router: None,
+            lane_routing: None,
             memory_store: None,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -10181,6 +10216,7 @@ mod tests {
             queue_mode: QueueMode::Speculative,
             responsiveness,
             adaptive_router: Some(router),
+            lane_routing: None,
             memory_store: None,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -10270,6 +10306,7 @@ mod tests {
             queue_mode: QueueMode::Speculative,
             responsiveness,
             adaptive_router: Some(router),
+            lane_routing: None,
             memory_store: None,
             active_overflow_tasks: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             overflow_cancelled: Arc::new(AtomicBool::new(false)),
@@ -12660,6 +12697,7 @@ mod tests {
             pending_messages: Arc::new(Mutex::new(HashMap::new())),
             queue_mode: QueueMode::Followup,
             adaptive_router: None,
+            lane_routing: None,
             memory_store: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),

--- a/crates/octos-cli/tests/coding_multi_session.rs
+++ b/crates/octos-cli/tests/coding_multi_session.rs
@@ -218,6 +218,7 @@ async fn make_m11g_profile(profile_id: &str, data_dir: &std::path::Path) -> Arc<
         cron_service: None,
         pipeline_factory: None,
         hook_executor: None,
+        lane_routing: None,
     })
 }
 

--- a/crates/octos-cli/tests/rfc3_lane_routing_wiring.rs
+++ b/crates/octos-cli/tests/rfc3_lane_routing_wiring.rs
@@ -1,0 +1,244 @@
+//! RFC-3 (#1292) — per-topic model lane routing wiring tests.
+//!
+//! Three behaviors are pinned here to prevent silent regressions:
+//!
+//! 1. Sessions opened against a `slides:*` topic resolve to the
+//!    `InstructionStrong` lane and the [`octos_llm::LaneContext`]
+//!    carries that lane through to the chat call.
+//! 2. When a turn is dispatched with a lane scope active, the
+//!    [`octos_llm::AdaptiveRouter`] filters its candidate set to the
+//!    lane's `(provider, model)` list before scoring.
+//! 3. When the first candidate of a lane has its circuit-breaker
+//!    open, the router advances to the next candidate in the lane
+//!    list (rather than falling through to a non-lane backstop).
+//!
+//! Equivalent unit-level coverage lives in
+//! `crates/octos-llm/src/lane.rs::tests` (resolver + config) and
+//! `crates/octos-llm/src/adaptive.rs::tests` (provider selection);
+//! this file is the cross-crate wiring contract.
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use eyre::Result;
+use octos_core::Message;
+use octos_llm::{
+    AdaptiveConfig, AdaptiveRouter, ChatConfig, ChatResponse, ChatStream, Lane, LaneContext,
+    LaneRoutingConfig, LlmProvider, StopReason, TokenUsage, ToolSpec, with_lane_context,
+};
+
+struct StubProvider {
+    name: &'static str,
+    model: &'static str,
+    fail: bool,
+}
+
+#[async_trait]
+impl LlmProvider for StubProvider {
+    async fn chat(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatResponse> {
+        if self.fail {
+            eyre::bail!("{}/{} simulated failure", self.name, self.model);
+        }
+        Ok(ChatResponse {
+            content: Some(format!("from-{}/{}", self.name, self.model)),
+            reasoning_content: None,
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+            usage: TokenUsage::default(),
+            provider_index: None,
+        })
+    }
+
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSpec],
+        _config: &ChatConfig,
+    ) -> Result<ChatStream> {
+        eyre::bail!("chat_stream not used in this test")
+    }
+
+    fn model_id(&self) -> &str {
+        self.model
+    }
+
+    fn provider_name(&self) -> &str {
+        self.name
+    }
+}
+
+#[tokio::test]
+async fn session_with_slides_topic_stamps_instruction_strong_lane() {
+    // RFC-3 contract: a session whose topic prefix is `slides`
+    // resolves to the InstructionStrong lane via the built-in
+    // defaults, with no profile config required.
+    let ctx = LaneContext::for_topic(Some("slides:fastchain-demo"), None);
+    assert_eq!(ctx.lane, Some(Lane::InstructionStrong));
+
+    let candidates = ctx.candidates();
+    assert!(
+        !candidates.is_empty(),
+        "InstructionStrong lane must carry built-in candidates"
+    );
+    assert!(
+        candidates
+            .iter()
+            .any(|(p, m)| p == "anthropic" && m == "claude-sonnet-4-6"),
+        "claude-sonnet-4-6 must be in the InstructionStrong candidate list"
+    );
+}
+
+#[tokio::test]
+async fn turn_dispatch_with_lane_filters_candidates_to_lane_list() {
+    // RFC-3 contract: when the per-turn LaneContext resolves to a
+    // non-General lane with matching candidates in the router's
+    // slot list, the router routes to a lane candidate even when
+    // a non-lane slot would otherwise win on priority.
+    let router = AdaptiveRouter::new(
+        vec![
+            // Slot 0: high-priority backstop not in the lane.
+            Arc::new(StubProvider {
+                name: "openrouter",
+                model: "gpt-4o-mini",
+                fail: false,
+            }),
+            // Slot 1: in the InstructionStrong lane (claude-sonnet-4-6
+            // is the first default candidate).
+            Arc::new(StubProvider {
+                name: "anthropic",
+                model: "claude-sonnet-4-6",
+                fail: false,
+            }),
+        ],
+        &[],
+        AdaptiveConfig {
+            probe_probability: 0.0,
+            ..Default::default()
+        },
+    );
+
+    // Without the lane scope, priority order picks slot 0.
+    let baseline = router
+        .chat(&[], &[], &ChatConfig::default())
+        .await
+        .expect("baseline turn");
+    assert_eq!(
+        baseline.content.as_deref(),
+        Some("from-openrouter/gpt-4o-mini")
+    );
+
+    // With a `slides:` topic in scope the lane filter narrows
+    // selection to the InstructionStrong candidate list, so the
+    // router picks the anthropic slot.
+    let ctx = LaneContext::for_topic(Some("slides:demo"), None);
+    let scoped = with_lane_context(ctx, async {
+        router.chat(&[], &[], &ChatConfig::default()).await
+    })
+    .await
+    .expect("scoped turn");
+    assert_eq!(
+        scoped.content.as_deref(),
+        Some("from-anthropic/claude-sonnet-4-6"),
+    );
+}
+
+#[tokio::test]
+async fn circuit_breaker_open_on_first_candidate_falls_through_to_second() {
+    // Profile override: lane `slides` → FastChat, lane_models
+    // FastChat = [primary-fail, secondary-ok]. Trip the primary's
+    // circuit, then assert the next call routes to the secondary
+    // (within the lane), not to the out-of-lane slot.
+    let router = AdaptiveRouter::new(
+        vec![
+            // Slot 0: lane primary, failing.
+            Arc::new(StubProvider {
+                name: "wisemodel",
+                model: "kimi-k2.6",
+                fail: true,
+            }),
+            // Slot 1: lane secondary, healthy.
+            Arc::new(StubProvider {
+                name: "deepseek",
+                model: "deepseek-chat",
+                fail: false,
+            }),
+            // Slot 2: out-of-lane backstop.
+            Arc::new(StubProvider {
+                name: "openrouter",
+                model: "fallback",
+                fail: false,
+            }),
+        ],
+        &[],
+        AdaptiveConfig {
+            probe_probability: 0.0,
+            failure_threshold: 1,
+            ..Default::default()
+        },
+    );
+
+    // Trip slot 0's circuit with a baseline call. With
+    // `failure_threshold: 1`, a single failing chat() trips the
+    // breaker; subsequent calls bypass slot 0.
+    let _ = router.chat(&[], &[], &ChatConfig::default()).await;
+
+    // Now the lane filter should advance past slot 0 (circuit
+    // open) and pick slot 1, NOT fall through to slot 2.
+    let mut cfg = LaneRoutingConfig::default();
+    cfg.topic_lanes.insert("loop".to_string(), Lane::FastChat);
+    let ctx = LaneContext::for_topic(Some("loop:test"), Some(&cfg));
+    let resp = with_lane_context(ctx, async {
+        router.chat(&[], &[], &ChatConfig::default()).await
+    })
+    .await
+    .expect("scoped turn after circuit trip");
+    assert_eq!(
+        resp.content.as_deref(),
+        Some("from-deepseek/deepseek-chat"),
+        "lane filter should advance to the second candidate, not the out-of-lane slot",
+    );
+}
+
+#[tokio::test]
+async fn profile_lane_routing_field_round_trips_through_serde() {
+    // RFC-3 backward compat anchor: a profile-config JSON without
+    // a `lane_routing` block must continue to deserialize, and a
+    // round-trip serialize+deserialize must preserve any custom
+    // overrides.
+    let bare = serde_json::json!({
+        "id": "p1",
+        "name": "Test",
+        "enabled": false,
+        "config": {},
+        "created_at": "2026-05-25T00:00:00Z",
+        "updated_at": "2026-05-25T00:00:00Z",
+    });
+    let parsed: octos_cli::profiles::UserProfile =
+        serde_json::from_value(bare).expect("bare profile must deserialize");
+    assert!(
+        parsed.config.lane_routing.is_none(),
+        "profile without lane_routing must parse with field = None",
+    );
+
+    let mut profile = parsed;
+    let mut cfg = LaneRoutingConfig::default();
+    cfg.topic_lanes.insert("custom".to_string(), Lane::FastChat);
+    cfg.lane_models.insert(
+        Lane::InstructionStrong,
+        vec![("my-provider".to_string(), "my-model".to_string())],
+    );
+    profile.config.lane_routing = Some(cfg.clone());
+
+    let serialized =
+        serde_json::to_string(&profile).expect("profile with lane_routing must serialize");
+    let round_trip: octos_cli::profiles::UserProfile =
+        serde_json::from_str(&serialized).expect("round-trip must deserialize");
+    assert_eq!(round_trip.config.lane_routing, Some(cfg));
+}

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -1786,8 +1786,24 @@ impl AdaptiveRouter {
         }
         let mut matched: Vec<usize> = Vec::new();
         for (want_provider, want_model) in &candidates {
+            // Codex P2 follow-up #2: when a profile override
+            // specifies a tagged candidate like `moonshot@autodl`,
+            // honor the tag with an exact match so operators can
+            // pin to a specific endpoint. Untagged candidates
+            // (built-in defaults, plain family names) match against
+            // the normalized slot label so endpoint-tagged slots
+            // still light up. The decision is per-candidate, not
+            // per-slot: a tagged candidate only matches a tagged
+            // slot with the exact same label.
+            let want_is_tagged = want_provider.contains('@');
             for (i, slot) in self.slots.iter().enumerate() {
-                if normalized_provider_name(slot.provider.provider_name()) == want_provider.as_str()
+                let slot_name = slot.provider.provider_name();
+                let provider_matches = if want_is_tagged {
+                    slot_name == want_provider.as_str()
+                } else {
+                    normalized_provider_name(slot_name) == want_provider.as_str()
+                };
+                if provider_matches
                     && slot.provider.model_id() == want_model
                     && !matched.contains(&i)
                 {
@@ -4661,6 +4677,54 @@ mod tests {
         // Should pick the tagged wisemodel slot, not the
         // out-of-lane openrouter slot.
         assert_eq!(resp.content.as_deref(), Some("from-wisemodel@autodl"));
+    }
+
+    #[tokio::test]
+    async fn rfc3_tagged_candidate_in_override_matches_only_tagged_slot() {
+        // Codex P2 follow-up #2: a profile override that names an
+        // endpoint-tagged label (e.g. `moonshot@autodl`) MUST pin to
+        // exactly that slot — the untagged `moonshot` slot or a
+        // differently-tagged `moonshot@other` slot should NOT
+        // satisfy the override.
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "moonshot",
+                    model: "k2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "moonshot@autodl",
+                    model: "k2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                ..Default::default()
+            },
+        );
+        let mut cfg = crate::LaneRoutingConfig::default();
+        cfg.topic_lanes
+            .insert("loop".to_string(), crate::Lane::CodeCapable);
+        cfg.lane_models.insert(
+            crate::Lane::CodeCapable,
+            vec![("moonshot@autodl".to_string(), "k2".to_string())],
+        );
+        let ctx = crate::LaneContext::for_topic(Some("loop:test"), Some(&cfg));
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        // Tagged candidate MUST pick the tagged slot, not the
+        // untagged primary.
+        assert_eq!(resp.content.as_deref(), Some("from-moonshot@autodl"));
     }
 
     #[tokio::test]

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -1747,17 +1747,111 @@ impl AdaptiveRouter {
         we * blended_err + wl * ranking_component + wp * norm_priority + wc * norm_cost
     }
 
+    /// RFC-3 (#1292) — when a per-turn [`crate::LaneContext`] is in
+    /// scope and resolves to a non-`General` lane with at least one
+    /// `(provider, model)` candidate that matches a router slot,
+    /// return the matching slot indices in candidate order.
+    ///
+    /// Returns `None` for:
+    /// - no `LANE_CONTEXT` active (outside a `with_lane_context`
+    ///   scope — test paths, gateway pre-RFC-3 sessions)
+    /// - lane is `General` or `None` (semantics: "no filter")
+    /// - candidate list is empty
+    /// - candidate list matches no provider in the chain
+    ///
+    /// All three "None" cases preserve the pre-RFC-3 behavior: every
+    /// slot remains eligible for selection. This is the backward
+    /// compat anchor — profiles that don't carry a topic resolve to
+    /// `General`, get `None` back, and never observe a behavior
+    /// change.
+    fn lane_filtered_slot_indices(&self) -> Option<Vec<usize>> {
+        let ctx = crate::lane::current_lane_context();
+        let lane = ctx.lane?;
+        if lane == crate::Lane::General {
+            return None;
+        }
+        let candidates = ctx.candidates();
+        if candidates.is_empty() {
+            return None;
+        }
+        let mut matched: Vec<usize> = Vec::new();
+        for (want_provider, want_model) in &candidates {
+            for (i, slot) in self.slots.iter().enumerate() {
+                if slot.provider.provider_name() == want_provider
+                    && slot.provider.model_id() == want_model
+                    && !matched.contains(&i)
+                {
+                    matched.push(i);
+                }
+            }
+        }
+        if matched.is_empty() {
+            // Candidates exist but none of them are in this chain.
+            // Fall through to default selection rather than starving
+            // the router. This matches the RFC-3 "lane defaults must
+            // not break existing profiles" requirement.
+            debug!(
+                lane = lane.as_str(),
+                "lane filter resolved zero matching slots; falling through to default selection"
+            );
+            return None;
+        }
+        debug!(
+            lane = lane.as_str(),
+            matched = matched.len(),
+            total = self.slots.len(),
+            "lane filter narrowed candidate slots"
+        );
+        Some(matched)
+    }
+
     /// Select provider index and whether this is a probe request.
     ///
     /// - Off / Hedge: priority order, skip circuit-broken only.
     ///   (Hedge mode uses this to pick the primary for racing.)
     /// - Lane: score-based selection across all providers.
+    ///
+    /// RFC-3 (#1292): when a per-turn lane is in scope, the eligible
+    /// set is narrowed to slots whose `(provider_name, model_id)` is
+    /// in the lane's candidate list. When the lane filter yields
+    /// zero matches we fall through to the full slot list so the
+    /// router never starves (see [`Self::lane_filtered_slot_indices`]).
     fn select_provider(&self) -> (usize, bool) {
         let mode = self.mode();
+        // RFC-3: lane-filtered eligible set, if any. None ⇒ no
+        // filter; behave identically to pre-RFC-3.
+        let lane_eligible = self.lane_filtered_slot_indices();
 
         // Off and Hedge both use priority order for the primary selection.
         // (Hedge picks the alternate separately in hedged_chat.)
         if mode != AdaptiveMode::Lane {
+            // RFC-3: when a lane filter is active, walk the lane's
+            // candidate list in declared order rather than the full
+            // priority order. The first non-circuit-broken match
+            // wins. Falls through to the full slot list if every
+            // lane candidate has a circuit-open breaker.
+            if let Some(ref eligible) = lane_eligible {
+                for &i in eligible {
+                    let slot = &self.slots[i];
+                    if !slot.metrics.is_circuit_open(self.config.failure_threshold) {
+                        let prev = self.last_selected.swap(i as u32, Ordering::Relaxed);
+                        if prev != i as u32 {
+                            info!(
+                                from = self
+                                    .slots
+                                    .get(prev as usize)
+                                    .map(|s| s.provider.provider_name())
+                                    .unwrap_or("?"),
+                                to = slot.provider.provider_name(),
+                                "provider failover (lane filter, lane changing disabled)"
+                            );
+                        }
+                        return (i, false);
+                    }
+                }
+                // All lane candidates circuit-broken → fall through
+                // to the wider priority walk below.
+            }
             for (i, slot) in self.slots.iter().enumerate() {
                 if !slot.metrics.is_circuit_open(self.config.failure_threshold) {
                     let prev = self.last_selected.swap(i as u32, Ordering::Relaxed);
@@ -1778,14 +1872,38 @@ impl AdaptiveRouter {
             // All circuit-broken — fall through to least-failed logic below
         }
 
-        // Score all non-circuit-broken providers
+        // Score all non-circuit-broken providers. RFC-3: if a lane
+        // filter is active and at least one matching slot is up, the
+        // scoring set is restricted to those slots. When the filter
+        // produces zero usable slots we fall back to the full chain.
         let mut scored: Vec<(usize, f64)> = self
             .slots
             .iter()
             .enumerate()
-            .filter(|(_, s)| !s.metrics.is_circuit_open(self.config.failure_threshold))
+            .filter(|(i, s)| {
+                if !s.metrics.is_circuit_open(self.config.failure_threshold) {
+                    match lane_eligible {
+                        Some(ref eligible) => eligible.contains(i),
+                        None => true,
+                    }
+                } else {
+                    false
+                }
+            })
             .map(|(i, s)| (i, self.score(s)))
             .collect();
+        // RFC-3 fall-through: if the lane filter excluded every
+        // remaining slot, redo without the lane filter so the router
+        // doesn't starve under transient lane outages.
+        if scored.is_empty() && lane_eligible.is_some() {
+            scored = self
+                .slots
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| !s.metrics.is_circuit_open(self.config.failure_threshold))
+                .map(|(i, s)| (i, self.score(s)))
+                .collect();
+        }
 
         // If all circuit-broken, pick least-failed
         if scored.is_empty() {
@@ -2125,16 +2243,12 @@ impl LlmProvider for AdaptiveRouter {
                 );
 
                 // Failover: try remaining providers in score order.
-                let mut scored: Vec<(usize, f64)> = self
-                    .slots
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, s)| {
-                        *i != start_idx && !s.metrics.is_circuit_open(self.config.failure_threshold)
-                    })
-                    .map(|(i, s)| (i, self.score(s)))
-                    .collect();
-                scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+                // RFC-3 (#1292): when a lane filter is active, prefer
+                // the lane's remaining candidates. If every lane
+                // candidate is exhausted or excluded, fall back to the
+                // full unfiltered set so the router never starves.
+                let lane_eligible = self.lane_filtered_slot_indices();
+                let scored = build_failover_candidates(self, start_idx, lane_eligible.as_ref());
 
                 let mut last_error = e;
                 for (idx, _) in scored {
@@ -2210,16 +2324,9 @@ impl LlmProvider for AdaptiveRouter {
                     "adaptive router failing over stream"
                 );
 
-                let mut scored: Vec<(usize, f64)> = self
-                    .slots
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, s)| {
-                        *i != start_idx && !s.metrics.is_circuit_open(self.config.failure_threshold)
-                    })
-                    .map(|(i, s)| (i, self.score(s)))
-                    .collect();
-                scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+                // RFC-3 (#1292): same lane-aware failover as chat() above.
+                let lane_eligible = self.lane_filtered_slot_indices();
+                let scored = build_failover_candidates(self, start_idx, lane_eligible.as_ref());
 
                 let mut last_error = e;
                 for (idx, _) in scored {
@@ -2310,6 +2417,54 @@ impl LlmProvider for AdaptiveRouter {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Build the score-ordered failover candidate list for a router after
+/// the primary slot has errored. RFC-3 (#1292) preference: when
+/// `lane_eligible` is `Some(_)`, only slots in that set are
+/// considered. If that lane-filtered set is empty (every candidate
+/// was either the primary or circuit-broken), the function silently
+/// falls back to the full slot list so the router doesn't starve on
+/// transient lane outages.
+///
+/// Shared between `chat()` and `chat_stream()` so both code paths
+/// retain consistent failover behavior under lane filtering.
+fn build_failover_candidates(
+    router: &AdaptiveRouter,
+    start_idx: usize,
+    lane_eligible: Option<&Vec<usize>>,
+) -> Vec<(usize, f64)> {
+    let circuit_threshold = router.config.failure_threshold;
+    let mut scored: Vec<(usize, f64)> = router
+        .slots
+        .iter()
+        .enumerate()
+        .filter(|(i, s)| {
+            if *i == start_idx || s.metrics.is_circuit_open(circuit_threshold) {
+                return false;
+            }
+            match lane_eligible {
+                Some(eligible) => eligible.contains(i),
+                None => true,
+            }
+        })
+        .map(|(i, s)| (i, router.score(s)))
+        .collect();
+    if scored.is_empty() && lane_eligible.is_some() {
+        // RFC-3 fall-through: lane filter excluded every remaining
+        // slot; widen to the full set so failover still has somewhere
+        // to go. The starting slot has already errored, so the
+        // surviving candidates come from outside the lane.
+        scored = router
+            .slots
+            .iter()
+            .enumerate()
+            .filter(|(i, s)| *i != start_idx && !s.metrics.is_circuit_open(circuit_threshold))
+            .map(|(i, s)| (i, router.score(s)))
+            .collect();
+    }
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored
+}
 
 fn now_epoch_us() -> u64 {
     std::time::SystemTime::now()
@@ -4187,5 +4342,229 @@ mod tests {
             AdaptiveMode::Hedge,
             "router should have escalated on the latency_ceiling_ms path"
         );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // RFC-3 (#1292) — lane-aware provider selection
+    // ──────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn rfc3_lane_filter_steers_chat_to_first_matching_candidate() {
+        // Build a 3-slot router so the lane filter has meaningful
+        // narrowing to do (priority order [primary, code, strong]).
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "openrouter",
+                    model: "gpt-4o-mini",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "deepseek",
+                    model: "deepseek-coder",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "anthropic",
+                    model: "claude-sonnet-4-6",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                ..Default::default()
+            },
+        );
+        // Default mode is Off → priority order; pre-lane this would
+        // pick `openrouter` (index 0).
+        let baseline = router.chat(&[], &[], &ChatConfig::default()).await.unwrap();
+        assert_eq!(baseline.content.as_deref(), Some("from-openrouter"));
+
+        // Now scope a CodeCapable lane — the first lane candidate is
+        // `(anthropic, claude-sonnet-4-6)`, so the router should
+        // route to anthropic even though its priority is lowest.
+        let ctx = crate::LaneContext::for_topic(Some("code:refactor"), None);
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        assert_eq!(resp.content.as_deref(), Some("from-anthropic"));
+    }
+
+    #[tokio::test]
+    async fn rfc3_lane_filter_unknown_topic_preserves_default_behavior() {
+        // Built-in default for `chat:*` is `General` → no filter.
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "wisemodel",
+                    model: "kimi-k2.6",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "anthropic",
+                    model: "claude-sonnet-4-6",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                ..Default::default()
+            },
+        );
+        let ctx = crate::LaneContext::for_topic(Some("chat:hello"), None);
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        // General lane = no filter, so priority-0 (wisemodel) wins.
+        assert_eq!(resp.content.as_deref(), Some("from-wisemodel"));
+    }
+
+    #[tokio::test]
+    async fn rfc3_lane_filter_zero_matches_falls_through_to_full_chain() {
+        // None of the registered providers match the InstructionStrong
+        // defaults — the filter must not starve the router.
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "custom-provider",
+                    model: "custom-model",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "other-provider",
+                    model: "other-model",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                ..Default::default()
+            },
+        );
+        let ctx = crate::LaneContext::for_topic(Some("slides:demo"), None);
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        // Zero lane matches → priority-0 wins (no starvation).
+        assert_eq!(resp.content.as_deref(), Some("from-custom-provider"));
+    }
+
+    #[tokio::test]
+    async fn rfc3_circuit_breaker_open_on_first_lane_candidate_falls_through_to_second() {
+        // Lane has 2 candidates; the first is failing and trips its
+        // circuit, the second is healthy.
+        let router = AdaptiveRouter::new(
+            vec![
+                // Slot 0 — fast-chat lane's first candidate, failing.
+                Arc::new(MockProvider {
+                    name: "wisemodel",
+                    model: "kimi-k2.6",
+                    latency_ms: 0,
+                    fail: true,
+                    error_msg: "503 down",
+                }),
+                // Slot 1 — fast-chat lane's second candidate, healthy.
+                Arc::new(MockProvider {
+                    name: "deepseek",
+                    model: "deepseek-chat",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                // Slot 2 — outside any lane, low-priority backstop.
+                Arc::new(MockProvider {
+                    name: "anthropic",
+                    model: "claude-sonnet-4-6",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                failure_threshold: 1,
+                ..Default::default()
+            },
+        );
+        // Trip the circuit on slot 0 first via a non-lane call.
+        let _ = router.chat(&[], &[], &ChatConfig::default()).await;
+        assert!(router.slots[0].metrics.is_circuit_open(1));
+
+        // Now lane scope `FastChat` — the first candidate is
+        // circuit-open, so the router should advance to the second
+        // (`deepseek-chat`) rather than fall through to anthropic.
+        let mut cfg = crate::LaneRoutingConfig::default();
+        cfg.topic_lanes
+            .insert("loop".to_string(), crate::Lane::FastChat);
+        let ctx = crate::LaneContext::for_topic(Some("loop:test"), Some(&cfg));
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        assert_eq!(resp.content.as_deref(), Some("from-deepseek"));
+    }
+
+    #[tokio::test]
+    async fn rfc3_lane_filter_general_is_no_op() {
+        // A `General` lane has no candidates and must not change
+        // anything about how the router behaves vs. an absent scope.
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "primary",
+                    model: "m1",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "fallback",
+                    model: "m2",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                ..Default::default()
+            },
+        );
+        let ctx = crate::LaneContext {
+            lane: Some(crate::Lane::General),
+            config: None,
+        };
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        assert_eq!(resp.content.as_deref(), Some("from-primary"));
     }
 }

--- a/crates/octos-llm/src/adaptive.rs
+++ b/crates/octos-llm/src/adaptive.rs
@@ -1764,6 +1764,16 @@ impl AdaptiveRouter {
     /// compat anchor — profiles that don't carry a topic resolve to
     /// `General`, get `None` back, and never observe a behavior
     /// change.
+    ///
+    /// **Codex P2 follow-up:** `provider_name()` for OpenAI-compatible
+    /// providers (DeepSeek / Moonshot / Wisemodel via
+    /// `OpenAIProvider::with_base_url`) is endpoint-tagged as
+    /// `name@endpoint` (e.g. `moonshot@autodl`). Lane defaults and
+    /// profile config use untagged family identifiers, so the
+    /// comparison normalizes via [`normalized_provider_name`] which
+    /// strips any `@suffix` before matching. Without this
+    /// normalization, `code:*` against a Wisemodel-backed profile
+    /// would produce zero matches and silently fall through.
     fn lane_filtered_slot_indices(&self) -> Option<Vec<usize>> {
         let ctx = crate::lane::current_lane_context();
         let lane = ctx.lane?;
@@ -1777,7 +1787,7 @@ impl AdaptiveRouter {
         let mut matched: Vec<usize> = Vec::new();
         for (want_provider, want_model) in &candidates {
             for (i, slot) in self.slots.iter().enumerate() {
-                if slot.provider.provider_name() == want_provider
+                if normalized_provider_name(slot.provider.provider_name()) == want_provider.as_str()
                     && slot.provider.model_id() == want_model
                     && !matched.contains(&i)
                 {
@@ -1925,13 +1935,21 @@ impl AdaptiveRouter {
         scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
         let best_idx = scored[0].0;
 
-        // Probe: with some probability, redirect to a stale non-primary provider
+        // Probe: with some probability, redirect to a stale non-primary provider.
+        // RFC-3 (#1292) — codex P2: when a lane filter is active,
+        // restrict probe targets to the lane's eligible slots so a
+        // probe under `slides:*`/`code:*` can never route the user
+        // turn to an out-of-lane model.
         if self.slots.len() > 1 && self.should_probe() {
             // Find a stale provider that isn't the best
             for (i, slot) in self.slots.iter().enumerate() {
                 if i != best_idx
                     && slot.metrics.is_stale(self.config.probe_interval_secs)
                     && !slot.metrics.is_circuit_open(self.config.failure_threshold)
+                    && match lane_eligible {
+                        Some(ref eligible) => eligible.contains(&i),
+                        None => true,
+                    }
                 {
                     debug!(
                         probe_provider = slot.provider.provider_name(),
@@ -1987,15 +2005,32 @@ impl AdaptiveRouter {
         // Pick the cheapest alternate provider for hedging. When cost data is
         // available, always hedge with the lowest-cost provider. Falls back to
         // score-based selection when no cost data exists.
+        //
+        // RFC-3 (#1292) — codex P2: when a lane filter is active,
+        // confine hedge alternates to the lane's eligible slots so a
+        // race under `slides:*`/`code:*` can't be won by an
+        // out-of-lane model. When the filter excludes every
+        // alternate, the hedge skips (`None` return) and the caller
+        // falls back to the single-provider path against the
+        // primary — preserving lane integrity at the cost of
+        // hedging on that turn.
         let primary_name = self.slots[primary_idx].provider.provider_name();
+        let lane_eligible = self.lane_filtered_slot_indices();
         let candidates: Vec<(usize, &AdaptiveSlot)> = self
             .slots
             .iter()
             .enumerate()
             .filter(|(i, s)| {
-                *i != primary_idx
-                    && s.provider.provider_name() != primary_name
-                    && !s.metrics.is_circuit_open(self.config.failure_threshold)
+                if *i == primary_idx
+                    || s.provider.provider_name() == primary_name
+                    || s.metrics.is_circuit_open(self.config.failure_threshold)
+                {
+                    return false;
+                }
+                match lane_eligible {
+                    Some(ref eligible) => eligible.contains(i),
+                    None => true,
+                }
             })
             .collect();
         let alternate_idx = {
@@ -2417,6 +2452,20 @@ impl LlmProvider for AdaptiveRouter {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Normalize a `provider_name()` for RFC-3 (#1292) lane matching.
+///
+/// `OpenAIProvider::with_base_url` tags the provider label with the
+/// endpoint suffix when a non-canonical base URL is in play
+/// (`moonshot@autodl`, `deepseek@api`, etc. — see
+/// `openai.rs:with_base_url`). Lane defaults and profile config use
+/// untagged family identifiers (`moonshot`, `deepseek`,
+/// `wisemodel`), so this helper strips the `@suffix` before
+/// comparison. Anthropic / Gemini / native OpenAI return their bare
+/// name and pass through unchanged.
+fn normalized_provider_name(name: &str) -> &str {
+    name.split_once('@').map(|(p, _)| p).unwrap_or(name)
+}
 
 /// Build the score-ordered failover candidate list for a router after
 /// the primary slot has errored. RFC-3 (#1292) preference: when
@@ -4566,5 +4615,105 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(resp.content.as_deref(), Some("from-primary"));
+    }
+
+    #[tokio::test]
+    async fn rfc3_lane_filter_normalizes_endpoint_tagged_provider_names() {
+        // Codex P2 follow-up: profiles using OpenAI-compatible
+        // providers carry endpoint-tagged labels (e.g.
+        // `wisemodel@autodl`). The lane filter normalizes by
+        // stripping the `@suffix` before matching against lane
+        // candidate strings.
+        let router = AdaptiveRouter::new(
+            vec![
+                // Out-of-lane (untagged).
+                Arc::new(MockProvider {
+                    name: "openrouter",
+                    model: "gpt-4o-mini",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+                // In-lane after `@` strip: `wisemodel@autodl` →
+                // `wisemodel` matches the FastChat default.
+                Arc::new(MockProvider {
+                    name: "wisemodel@autodl",
+                    model: "kimi-k2.6",
+                    latency_ms: 0,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                ..Default::default()
+            },
+        );
+        let mut cfg = crate::LaneRoutingConfig::default();
+        cfg.topic_lanes.insert("loop".into(), crate::Lane::FastChat);
+        let ctx = crate::LaneContext::for_topic(Some("loop:t"), Some(&cfg));
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        // Should pick the tagged wisemodel slot, not the
+        // out-of-lane openrouter slot.
+        assert_eq!(resp.content.as_deref(), Some("from-wisemodel@autodl"));
+    }
+
+    #[tokio::test]
+    async fn rfc3_hedge_confines_alternate_to_lane_when_filter_active() {
+        // Codex P2 follow-up: under `AdaptiveMode::Hedge`, the
+        // alternate hedge target must be in-lane. Build a chain
+        // where the lane candidate is a SLOW out-of-priority slot
+        // and a non-lane slot is fast: without the fix, hedge would
+        // race the fast non-lane slot and return its content; with
+        // the fix, hedge skips when no in-lane alternate is healthy
+        // and the single-provider path runs against the primary.
+        //
+        // Topology:
+        //   slot 0 primary = `anthropic / claude-sonnet-4-6` (in lane, fast)
+        //   slot 1 alt     = `openrouter / out-of-lane` (fast, NOT in lane)
+        // Expectation: hedge candidate set is empty (the only
+        // out-of-lane slot is filtered out), so hedge falls through
+        // and the response comes from the primary.
+        let router = AdaptiveRouter::new(
+            vec![
+                Arc::new(MockProvider {
+                    name: "anthropic",
+                    model: "claude-sonnet-4-6",
+                    latency_ms: 5,
+                    fail: false,
+                    error_msg: "",
+                }),
+                Arc::new(MockProvider {
+                    name: "openrouter",
+                    model: "out-of-lane",
+                    latency_ms: 5,
+                    fail: false,
+                    error_msg: "",
+                }),
+            ],
+            &[],
+            AdaptiveConfig {
+                probe_probability: 0.0,
+                ..Default::default()
+            },
+        );
+        router.set_mode(AdaptiveMode::Hedge);
+
+        let ctx = crate::LaneContext::for_topic(Some("slides:demo"), None);
+        let resp = crate::with_lane_context(ctx, async {
+            router.chat(&[], &[], &ChatConfig::default()).await
+        })
+        .await
+        .unwrap();
+        // Lane filter excludes openrouter from the hedge alternate
+        // set, so the only hedge candidate is none → fall through
+        // to single-provider path against the primary (anthropic
+        // is in-lane).
+        assert_eq!(resp.content.as_deref(), Some("from-anthropic"));
     }
 }

--- a/crates/octos-llm/src/lane.rs
+++ b/crates/octos-llm/src/lane.rs
@@ -1,0 +1,493 @@
+//! Per-topic model lane routing (RFC-3, issue #1292).
+//!
+//! Routes session topics (e.g. `slides:*`, `code:*`, `research:*`) to a
+//! capability lane (`instruction_strong`, `code_capable`, `general`,
+//! `fast_chat`), which the [`crate::AdaptiveRouter`] uses to filter
+//! candidate models before lane-scoring.
+//!
+//! Architecture lives in the [`Lane`] enum, the topic→lane resolver
+//! ([`resolve_lane_for_topic`]), and the lane→candidate-list defaults
+//! ([`default_lane_candidates`]). Both can be overridden per-profile
+//! by carrying [`LaneRoutingConfig`] off [`crate::AdaptiveRouter`]'s
+//! task-local scope ([`LANE_CONTEXT`]).
+//!
+//! # Backward compatibility
+//!
+//! Profiles without a `topic_lanes` block (the M9 status quo) see no
+//! behavior change: `resolve_lane_for_topic` returns `None` for any
+//! topic that doesn't carry one of the registered prefixes, and the
+//! [`AdaptiveRouter::select_provider`](crate::AdaptiveRouter)
+//! lane-filter is a no-op when [`LANE_CONTEXT`] is unset. The hot
+//! `chat()` path still selects via priority + circuit-breaker logic
+//! exactly as before for those callers.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Capability lanes used to group models by aptitude on different task
+/// classes. Each lane maps to an ordered list of `(provider, model_id)`
+/// candidates via [`default_lane_candidates`] or
+/// [`LaneRoutingConfig::lane_models`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Lane {
+    /// Models tuned for following long, structured prompts (slides
+    /// builders, site builders, research synthesis pipelines). High
+    /// instruction-following matters more than raw speed.
+    InstructionStrong,
+    /// Models specialized for code generation / refactoring / debugging.
+    /// Code-specific fine-tunes outscore general chat models here.
+    CodeCapable,
+    /// Default lane. Falls through to the profile's configured model
+    /// (existing behavior pre-RFC-3). Treat as "no preference".
+    General,
+    /// Cheap, fast models for short turns / one-shot Q&A. Used by
+    /// default-chat sessions where latency dominates quality.
+    FastChat,
+}
+
+impl Lane {
+    /// Stable lowercase identifier used in profile config JSON
+    /// (`lane_models["instruction_strong"]`) and for telemetry.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Lane::InstructionStrong => "instruction_strong",
+            Lane::CodeCapable => "code_capable",
+            Lane::General => "general",
+            Lane::FastChat => "fast_chat",
+        }
+    }
+
+    /// Parse from the same lowercase identifier emitted by [`Self::as_str`].
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s {
+            "instruction_strong" => Some(Lane::InstructionStrong),
+            "code_capable" => Some(Lane::CodeCapable),
+            "general" => Some(Lane::General),
+            "fast_chat" => Some(Lane::FastChat),
+            _ => None,
+        }
+    }
+}
+
+/// Built-in defaults: lane → ordered list of `(provider_name, model_id)`
+/// candidates. The router filters its slots to this list (matching by
+/// `provider_name() == provider && model_id() == model`) before
+/// scoring. When the filter produces zero matches, the lane is treated
+/// as inactive and the router falls back to its full slot list — i.e.
+/// the existing pre-RFC-3 behavior. This guarantees built-in defaults
+/// never make a profile worse off.
+///
+/// `InstructionStrong`, `CodeCapable`, and `FastChat` carry opinionated
+/// lists. `General` returns an empty vec on purpose — its semantics are
+/// "no filter; use the profile-default chain".
+pub fn default_lane_candidates(lane: Lane) -> Vec<(String, String)> {
+    let pairs: &[(&str, &str)] = match lane {
+        Lane::InstructionStrong => &[
+            ("anthropic", "claude-sonnet-4-6"),
+            ("wisemodel", "kimi-k2.5"),
+            ("openai", "gpt-4.1"),
+        ],
+        Lane::CodeCapable => &[
+            ("anthropic", "claude-sonnet-4-6"),
+            ("openai", "gpt-4.1"),
+            ("deepseek", "deepseek-coder"),
+        ],
+        Lane::General => &[],
+        Lane::FastChat => &[
+            ("wisemodel", "kimi-k2.6"),
+            ("deepseek", "deepseek-chat"),
+            ("openai", "gpt-4o-mini"),
+        ],
+    };
+    pairs
+        .iter()
+        .map(|(p, m)| ((*p).to_string(), (*m).to_string()))
+        .collect()
+}
+
+/// Built-in topic-prefix → lane mapping. The prefix is the substring
+/// before the first whitespace/colon in `session.topic()`:
+/// `slides:fastchain-demo` → `slides`, `code: refactor` → `code`,
+/// `research/2026-q2` → `research` (we accept `/` as a separator too
+/// because the slides bus uses it internally).
+///
+/// Unknown prefixes (or no topic at all) return `None`, which
+/// [`resolve_lane_for_topic`] interprets as "fall through to General"
+/// — i.e. no lane filter. This is the backward-compat path.
+fn default_topic_prefix_lane(prefix: &str) -> Option<Lane> {
+    match prefix {
+        "slides" => Some(Lane::InstructionStrong),
+        "site" => Some(Lane::InstructionStrong),
+        "podcast" => Some(Lane::InstructionStrong),
+        "research" => Some(Lane::InstructionStrong),
+        "code" => Some(Lane::CodeCapable),
+        _ => None,
+    }
+}
+
+/// Extract the topic prefix used for lane resolution. Splits on the
+/// first occurrence of `:`, `/`, ` ` (space), or `\t` (tab). An empty
+/// topic returns `""`.
+///
+/// Examples:
+/// - `"slides:fastchain-demo"` → `"slides"`
+/// - `"slides fastchain"` → `"slides"`
+/// - `"code/refactor"` → `"code"`
+/// - `"plain-chat"` → `"plain-chat"` (no separator)
+pub fn topic_prefix(topic: &str) -> &str {
+    let end = topic
+        .find(|c: char| c == ':' || c == '/' || c.is_whitespace())
+        .unwrap_or(topic.len());
+    &topic[..end]
+}
+
+/// Per-profile override of lane defaults. Both fields are optional;
+/// when absent or empty the built-in defaults in this module apply.
+///
+/// Serialized in the profile config as:
+///
+/// ```json
+/// {
+///     "topic_lanes": { "slides": "instruction_strong", "blog": "code_capable" },
+///     "lane_models": {
+///         "instruction_strong": [["anthropic", "claude-sonnet-4-6"]]
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct LaneRoutingConfig {
+    /// Topic-prefix overrides. Keys are bare prefixes (no `:` or `*`),
+    /// values are lane identifiers (`instruction_strong`, etc.).
+    /// Unknown lane strings are ignored at resolve time.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub topic_lanes: HashMap<String, Lane>,
+    /// Lane → candidate list overrides. When a lane has an explicit
+    /// (possibly empty) entry, that list wins outright over
+    /// [`default_lane_candidates`] for that lane. Use an empty list to
+    /// say "this lane is intentionally unconfigured" — the router will
+    /// then fall through to the profile default.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub lane_models: HashMap<Lane, Vec<(String, String)>>,
+}
+
+impl LaneRoutingConfig {
+    /// Resolve a topic to its lane using this config as the override
+    /// layer over the built-in defaults. Profile config wins, then
+    /// built-in defaults, then fall through to `Lane::General`.
+    pub fn resolve_lane(&self, topic: Option<&str>) -> Lane {
+        let Some(topic) = topic.map(str::trim).filter(|t| !t.is_empty()) else {
+            return Lane::General;
+        };
+        let prefix = topic_prefix(topic);
+        if let Some(lane) = self.topic_lanes.get(prefix).copied() {
+            return lane;
+        }
+        default_topic_prefix_lane(prefix).unwrap_or(Lane::General)
+    }
+
+    /// Resolve a lane to its candidate `(provider, model)` list. When
+    /// the profile config carries a non-empty entry for `lane`, that
+    /// wins; otherwise the built-in defaults apply.
+    pub fn candidates_for_lane(&self, lane: Lane) -> Vec<(String, String)> {
+        if let Some(entries) = self.lane_models.get(&lane) {
+            if !entries.is_empty() {
+                return entries.clone();
+            }
+        }
+        default_lane_candidates(lane)
+    }
+}
+
+/// Standalone resolver for callers that don't have a profile config
+/// in scope. Identical to `LaneRoutingConfig::default().resolve_lane`.
+pub fn resolve_lane_for_topic(topic: Option<&str>) -> Lane {
+    LaneRoutingConfig::default().resolve_lane(topic)
+}
+
+/// Per-turn lane context. Passed by the session-actor / WS handler
+/// into the chat() task-local so [`crate::AdaptiveRouter::select_provider`]
+/// can filter its slots to the lane's candidate list before scoring.
+#[derive(Debug, Clone, Default)]
+pub struct LaneContext {
+    /// The lane selected for this turn. `None` (or `Some(Lane::General)`)
+    /// means "no filter — use the profile-default chain".
+    pub lane: Option<Lane>,
+    /// Profile-level lane overrides (topic→lane and lane→models).
+    /// `None` means "use the built-in defaults". Carried alongside the
+    /// lane itself so the router doesn't need to consult any profile
+    /// state — keeping the lane filter agnostic of the CLI crate.
+    pub config: Option<LaneRoutingConfig>,
+}
+
+impl LaneContext {
+    /// Build a context from a session topic + optional profile config.
+    /// Use this at the session-actor / WS handler call site to bake
+    /// both inputs (topic, profile override) into the one task-local.
+    pub fn for_topic(topic: Option<&str>, config: Option<&LaneRoutingConfig>) -> Self {
+        let resolved = match config {
+            Some(cfg) => cfg.resolve_lane(topic),
+            None => resolve_lane_for_topic(topic),
+        };
+        Self {
+            lane: Some(resolved),
+            config: config.cloned(),
+        }
+    }
+
+    /// Return the ordered list of `(provider, model)` candidates for
+    /// the resolved lane. Returns an empty vec for `General` or when
+    /// `lane` is `None` — both meaning "no filter".
+    pub fn candidates(&self) -> Vec<(String, String)> {
+        let Some(lane) = self.lane else {
+            return Vec::new();
+        };
+        if lane == Lane::General {
+            return Vec::new();
+        }
+        match self.config {
+            Some(ref cfg) => cfg.candidates_for_lane(lane),
+            None => default_lane_candidates(lane),
+        }
+    }
+}
+
+tokio::task_local! {
+    /// Per-turn lane scope read by [`crate::AdaptiveRouter::select_provider`].
+    /// Defaults to [`LaneContext::default()`] (no lane, no filter) when
+    /// the caller hasn't wrapped the chat() future. Mirrors
+    /// [`crate::adaptive::ROUTER_CONTEXT`] in shape.
+    pub static LANE_CONTEXT: LaneContext;
+}
+
+/// Run `fut` inside a [`LANE_CONTEXT`] scope. The session-actor and
+/// the WS turn handler wrap `provider.chat()` / `process_message()`
+/// with this so the router sees the resolved lane.
+pub async fn with_lane_context<F, T>(ctx: LaneContext, fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    LANE_CONTEXT.scope(ctx, fut).await
+}
+
+/// Snapshot of the active [`LANE_CONTEXT`] for callers outside the
+/// task-local scope (test paths, debug logging, etc.). Returns
+/// [`LaneContext::default()`] when no scope is active.
+pub fn current_lane_context() -> LaneContext {
+    LANE_CONTEXT.try_with(|ctx| ctx.clone()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Topic prefix extraction ────────────────────────────────────
+
+    #[test]
+    fn topic_prefix_splits_on_colon() {
+        assert_eq!(topic_prefix("slides:fastchain-demo"), "slides");
+        assert_eq!(topic_prefix("code:refactor"), "code");
+    }
+
+    #[test]
+    fn topic_prefix_splits_on_whitespace() {
+        assert_eq!(topic_prefix("slides fastchain"), "slides");
+        assert_eq!(topic_prefix("research deep crawl"), "research");
+    }
+
+    #[test]
+    fn topic_prefix_splits_on_slash() {
+        assert_eq!(topic_prefix("code/refactor"), "code");
+    }
+
+    #[test]
+    fn topic_prefix_returns_whole_topic_without_separator() {
+        assert_eq!(topic_prefix("plain-chat"), "plain-chat");
+        assert_eq!(topic_prefix(""), "");
+    }
+
+    // ── Topic → lane resolution (the RFC-3 test suite) ──────────────
+
+    #[test]
+    fn topic_to_lane_slides_resolves_to_instruction_strong() {
+        assert_eq!(
+            resolve_lane_for_topic(Some("slides:demo")),
+            Lane::InstructionStrong,
+        );
+        assert_eq!(
+            resolve_lane_for_topic(Some("slides fastchain")),
+            Lane::InstructionStrong,
+        );
+    }
+
+    #[test]
+    fn topic_to_lane_research_resolves_to_instruction_strong() {
+        assert_eq!(
+            resolve_lane_for_topic(Some("research:q2-2026")),
+            Lane::InstructionStrong,
+        );
+    }
+
+    #[test]
+    fn topic_to_lane_site_and_podcast_resolve_to_instruction_strong() {
+        assert_eq!(
+            resolve_lane_for_topic(Some("site:landing")),
+            Lane::InstructionStrong,
+        );
+        assert_eq!(
+            resolve_lane_for_topic(Some("podcast:ep-42")),
+            Lane::InstructionStrong,
+        );
+    }
+
+    #[test]
+    fn topic_to_lane_code_resolves_to_code_capable() {
+        assert_eq!(
+            resolve_lane_for_topic(Some("code:refactor")),
+            Lane::CodeCapable,
+        );
+    }
+
+    #[test]
+    fn topic_to_lane_unknown_resolves_to_general() {
+        assert_eq!(resolve_lane_for_topic(Some("xyzzy:foo")), Lane::General);
+        assert_eq!(resolve_lane_for_topic(Some("chat:hello")), Lane::General);
+    }
+
+    #[test]
+    fn topic_to_lane_empty_or_none_resolves_to_general() {
+        assert_eq!(resolve_lane_for_topic(None), Lane::General);
+        assert_eq!(resolve_lane_for_topic(Some("")), Lane::General);
+        assert_eq!(resolve_lane_for_topic(Some("   ")), Lane::General);
+    }
+
+    // ── Profile override behavior ───────────────────────────────────
+
+    #[test]
+    fn profile_override_takes_precedence() {
+        // Profile says "slides → code_capable" — overrides the default
+        // mapping that sends slides to InstructionStrong.
+        let mut cfg = LaneRoutingConfig::default();
+        cfg.topic_lanes
+            .insert("slides".to_string(), Lane::CodeCapable);
+
+        assert_eq!(cfg.resolve_lane(Some("slides:demo")), Lane::CodeCapable);
+
+        // Unconfigured prefixes still resolve via the built-in defaults.
+        assert_eq!(cfg.resolve_lane(Some("code:foo")), Lane::CodeCapable);
+        assert_eq!(
+            cfg.resolve_lane(Some("research:foo")),
+            Lane::InstructionStrong,
+        );
+    }
+
+    #[test]
+    fn profile_override_can_add_new_prefix() {
+        let mut cfg = LaneRoutingConfig::default();
+        cfg.topic_lanes.insert("blog".to_string(), Lane::FastChat);
+        assert_eq!(cfg.resolve_lane(Some("blog:post-1")), Lane::FastChat);
+        // And the built-in defaults are still in play.
+        assert_eq!(cfg.resolve_lane(Some("slides:x")), Lane::InstructionStrong);
+    }
+
+    #[test]
+    fn lane_models_override_takes_precedence() {
+        let mut cfg = LaneRoutingConfig::default();
+        cfg.lane_models.insert(
+            Lane::InstructionStrong,
+            vec![("custom".to_string(), "my-model".to_string())],
+        );
+
+        let cands = cfg.candidates_for_lane(Lane::InstructionStrong);
+        assert_eq!(cands, vec![("custom".to_string(), "my-model".to_string())]);
+
+        // Unconfigured lanes still use built-in defaults.
+        let code = cfg.candidates_for_lane(Lane::CodeCapable);
+        assert!(!code.is_empty(), "code lane should fall back to defaults");
+        assert!(
+            code.iter()
+                .any(|(p, m)| p == "anthropic" && m == "claude-sonnet-4-6")
+        );
+    }
+
+    #[test]
+    fn lane_models_empty_entry_falls_through_to_defaults() {
+        let mut cfg = LaneRoutingConfig::default();
+        cfg.lane_models.insert(Lane::CodeCapable, vec![]);
+        let cands = cfg.candidates_for_lane(Lane::CodeCapable);
+        // Empty config entry = "intentionally unconfigured" → default.
+        assert!(!cands.is_empty());
+    }
+
+    // ── Default candidate lists smoke test ──────────────────────────
+
+    #[test]
+    fn default_candidates_match_rfc3_spec() {
+        let strong = default_lane_candidates(Lane::InstructionStrong);
+        assert!(
+            strong
+                .iter()
+                .any(|(p, m)| p == "anthropic" && m == "claude-sonnet-4-6")
+        );
+        assert!(
+            strong
+                .iter()
+                .any(|(p, m)| p == "wisemodel" && m == "kimi-k2.5")
+        );
+
+        let code = default_lane_candidates(Lane::CodeCapable);
+        assert!(
+            code.iter()
+                .any(|(p, m)| p == "anthropic" && m == "claude-sonnet-4-6")
+        );
+
+        let fast = default_lane_candidates(Lane::FastChat);
+        assert!(
+            fast.iter()
+                .any(|(p, m)| p == "wisemodel" && m == "kimi-k2.6")
+        );
+
+        // General is intentionally empty (no filter).
+        assert!(default_lane_candidates(Lane::General).is_empty());
+    }
+
+    // ── LaneContext shape ───────────────────────────────────────────
+
+    #[test]
+    fn lane_context_for_topic_resolves_lane_and_carries_config() {
+        let cfg = LaneRoutingConfig::default();
+        let ctx = LaneContext::for_topic(Some("slides:demo"), Some(&cfg));
+        assert_eq!(ctx.lane, Some(Lane::InstructionStrong));
+        // Candidates use the lane's defaults.
+        let cands = ctx.candidates();
+        assert!(!cands.is_empty());
+    }
+
+    #[test]
+    fn lane_context_general_has_empty_candidates() {
+        let ctx = LaneContext::for_topic(Some("chat:hello"), None);
+        assert_eq!(ctx.lane, Some(Lane::General));
+        assert!(ctx.candidates().is_empty());
+    }
+
+    #[test]
+    fn lane_context_default_is_no_filter() {
+        let ctx = LaneContext::default();
+        assert_eq!(ctx.lane, None);
+        assert!(ctx.candidates().is_empty());
+    }
+
+    #[tokio::test]
+    async fn current_lane_context_outside_scope_returns_default() {
+        let ctx = current_lane_context();
+        assert_eq!(ctx.lane, None);
+    }
+
+    #[tokio::test]
+    async fn current_lane_context_inside_scope_returns_set_value() {
+        let scoped = LaneContext::for_topic(Some("slides:x"), None);
+        let observed = with_lane_context(scoped.clone(), async { current_lane_context() }).await;
+        assert_eq!(observed.lane, scoped.lane);
+    }
+}

--- a/crates/octos-llm/src/lib.rs
+++ b/crates/octos-llm/src/lib.rs
@@ -15,6 +15,7 @@ pub mod credential_pool;
 pub mod embedding;
 mod failover;
 mod fallback;
+pub mod lane;
 pub mod pricing;
 mod provider;
 pub mod responsiveness;
@@ -65,6 +66,10 @@ pub use error::{LlmError, LlmErrorKind};
 pub use failover::ProviderChain;
 pub use fallback::FallbackProvider;
 pub use high_level::LlmClient;
+pub use lane::{
+    LANE_CONTEXT, Lane, LaneContext, LaneRoutingConfig, current_lane_context,
+    default_lane_candidates, resolve_lane_for_topic, topic_prefix, with_lane_context,
+};
 pub use middleware::{LlmMiddleware, MiddlewareStack};
 pub use ominix::{OminixClient, PlatformModels};
 pub use provider::{


### PR DESCRIPTION
## Summary

Implements RFC-3 (#1292): per-topic model lane routing. Session topics now route to a capability lane (`InstructionStrong` / `CodeCapable` / `General` / `FastChat`) which the existing `AdaptiveRouter` uses to filter candidate models before lane-scoring.

- New `octos-llm::lane` module: `Lane` enum, `LaneRoutingConfig`, topic→lane resolver, `LANE_CONTEXT` task-local
- `AdaptiveRouter::select_provider` + failover loops respect the lane scope with safe fall-through (zero matches => unchanged behavior)
- `SessionActor` (gateway path) + `run_standalone_turn` (WS path) both wrap chat in `with_lane_context` so model selection is consistent across transports
- `ProfileConfig` gains an optional `lane_routing` field (`serde(default)`); profiles without it see no behavior change

### Built-in defaults

| Lane | Candidates (in order) |
|------|----------------------|
| `InstructionStrong` | `anthropic/claude-sonnet-4-6`, `wisemodel/kimi-k2.5`, `openai/gpt-4.1` |
| `CodeCapable` | `anthropic/claude-sonnet-4-6`, `openai/gpt-4.1`, `deepseek/deepseek-coder` |
| `General` | _empty_ (no filter — profile default) |
| `FastChat` | `wisemodel/kimi-k2.6`, `deepseek/deepseek-chat`, `openai/gpt-4o-mini` |

Topic prefix → lane: `slides|site|podcast|research → InstructionStrong`, `code → CodeCapable`, unknown/default → `General`.

### Profile config (optional)

```json
{
  "lane_routing": {
    "topic_lanes": { "blog": "fast_chat" },
    "lane_models": {
      "instruction_strong": [["anthropic", "claude-sonnet-4-6"]]
    }
  }
}
```

## Test plan

- [x] `cargo test -p octos-llm --lib` — 338 pass (20 lane unit + 5 RFC-3 adaptive-router tests new)
- [x] `cargo test -p octos-cli --features api --test rfc3_lane_routing_wiring` — 4 wiring tests pass
- [x] `cargo test -p octos-pipeline --lib` — 210 pass
- [x] `cargo build --workspace` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p octos-llm --lib --tests -- -D warnings` — clean
- [x] Backward compat: profiles without `lane_routing` field continue to deserialize and behave identically to pre-RFC-3 (see `profile_lane_routing_field_round_trips_through_serde`)
- [x] Safe fall-through: when no slot matches a lane's candidate list, the router uses the full chain (see `rfc3_lane_filter_zero_matches_falls_through_to_full_chain`)