### PR TITLE
docs(protocol): restore UPCR coverage inventory

### DIFF
--- a/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
+++ b/api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md
@@ -350,25 +350,49 @@ Commands:
 - `session/open`
 - `session/status/read` (accepted `UPCR-2026-017`)
 - `turn/start`
-- `review/start` (capability-gated, accepted `UPCR-2026-019`)
 - `turn/interrupt`
 - `approval/respond`
+- `approval/scopes/list` (accepted `UPCR-2026-007`)
 - `permission/profile/list`, `permission/profile/set`
   (accepted `UPCR-2026-018`)
 - `diff/preview/get`
-- `task/output/read`
 - `task/list` (capability-gated, accepted `UPCR-2026-005`)
 - `task/cancel` (capability-gated, accepted `UPCR-2026-005`)
 - `task/restart_from_node` (capability-gated, accepted `UPCR-2026-005`)
+- `task/output/read`
+- `session/hydrate` (capability-gated, accepted `UPCR-2026-009`)
+- `thread/graph/get` (capability-gated, accepted `UPCR-2026-010`)
+- `turn/state/get` (capability-gated, accepted `UPCR-2026-011`)
+- `agent/list`, `agent/status/read`, `agent/output/read`,
+  `agent/artifact/list`, `agent/artifact/read`, `agent/interrupt`,
+  `agent/close` (capability-gated, accepted `UPCR-2026-021`)
+- `task/artifact/list`, `task/artifact/read`
+  (capability-gated, accepted `UPCR-2026-019`)
+- `session/goal/get`, `session/goal/set`, `session/goal/clear`
+  (capability-gated, accepted `UPCR-2026-021`)
+- `loop/create`, `loop/list`, `loop/delete`, `loop/pause`, `loop/resume`,
+  `loop/fire_now` (capability-gated, accepted `UPCR-2026-021`)
+- `review/start` (capability-gated, accepted `UPCR-2026-019`)
+- `session/list`, `session/snapshot`, `session/messages_page`,
+  `session/status.get`, `session/files.list`, `session/tasks.list`,
+  `session/workspace.get`, `session/title.set`, `session/delete`,
+  `system/status.get`, `content/list`, `content/delete`,
+  `content/bulk_delete` (capability-gated M12 auxiliary REST-to-WS surface)
+- `router/set_mode`, `router/get_metrics` (Wave4-A routing control surface)
 - `auth/status`, `auth/send_code`, `auth/verify`, `auth/me`, `auth/logout`
   (accepted `UPCR-2026-017`)
 - `profile/llm/catalog`, `profile/llm/list`, `profile/llm/upsert`,
   `profile/llm/select`, `profile/llm/delete`, `profile/llm/test`,
   `profile/llm/fetch_models` (accepted `UPCR-2026-017`)
+- `profile/skills/list`, `profile/skills/registry/search`,
+  `profile/skills/install`, `profile/skills/remove`
+  (AppUI runtime skill management surface)
 - `mcp/status/list`, `tool/status/list` (accepted `UPCR-2026-017`)
+- `onboarding/workspace_probe` (accepted `UPCR-2026-018`)
 
 Notifications:
 
+- `session/open`
 - `turn/started`
 - `turn/completed`
 - `turn/error`
@@ -377,9 +401,29 @@ Notifications:
 - `tool/progress`
 - `tool/completed`
 - `approval/requested`
+- `approval/auto_resolved`
+- `approval/decided`
+- `approval/cancelled`
 - `task/updated`
 - `task/output/delta`
+- `progress/updated`
 - `warning`
+- `protocol/replay_lossy`
+- `message/persisted` (capability-gated, accepted `UPCR-2026-012`)
+- `turn/spawn_complete` (capability-gated spawn completion event)
+- `file/attached` (capability-gated, accepted `UPCR-2026-014`)
+- `session/event` (capability-gated legacy session-event bridge,
+  accepted `UPCR-2026-014`)
+- `router/status`, `router/failover` (Wave4-A routing notifications)
+- `queue/state` (Wave4-A pending-queue snapshot)
+- `agent/updated`, `agent/output/delta`, `agent/artifact/updated`
+  (capability-gated, accepted `UPCR-2026-021`)
+- `session/goal/updated`, `session/goal/cleared`
+  (capability-gated, accepted `UPCR-2026-021`)
+- `loop/updated`, `loop/fired`, `loop/completed`
+  (capability-gated, accepted `UPCR-2026-021`)
+- `context/compaction_completed`, `context/normalization_reported`
+  (capability-gated M16 context lifecycle notifications)
 
 ## 7. Command Semantics
 

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_001_TYPED_APPROVAL.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_001_TYPED_APPROVAL.md
@@ -1,0 +1,84 @@
+# Octos UI Protocol Change Request: Typed Approval Payloads
+
+## Header
+
+- Request id: `UPCR-2026-001`
+- Title: Add typed approval metadata and scoped approval responses
+- Author: M9 protocol review
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related M issue: `M9` review
+
+## Summary
+
+This change request records the accepted typed-approval extension that the
+protocol spec already references. It keeps the fallback approval text contract
+intact while adding structured fields that let clients render command, diff,
+filesystem, network, and sandbox-escalation approvals without parsing prose.
+
+## Motivation
+
+The first AppUI approval surface only guaranteed generic text fields. That was
+enough for a minimal modal, but it made clients infer risk, command previews,
+filesystem paths, and scope semantics from human-readable strings. The shipped
+server and golden protocol tests expose these fields directly, so the protocol
+documentation needs a durable UPCR for the wire-visible contract.
+
+## Change Type
+
+Additive optional fields on an existing notification and command.
+
+## Wire Contract
+
+Affected existing surface:
+
+- Notification method: `approval/requested`
+- Command method: `approval/respond`
+
+Optional fields added to `approval/requested`:
+
+- `approval_kind`: string registry. Initial values are `command`, `diff`,
+  `filesystem`, `network`, and `sandbox_escalation`.
+- `risk`: display/audit risk label.
+- `typed_details`: tagged object. Its `kind` should match `approval_kind` when
+  both fields are present.
+- `render_hints`: optional UI hints such as default decision, danger state,
+  labels, and monospace display groups.
+
+Optional fields added to `approval/respond` params:
+
+- `approval_scope`: string registry. Initial values are `request`, `turn`, and
+  `session`.
+- `client_note`: human-readable client audit note.
+
+The required fallback `title` and `body` fields on `approval/requested` remain
+mandatory so old clients can still render a correct prompt.
+
+## Compatibility
+
+This is additive. Old clients may ignore the typed fields and continue to use
+`title` and `body`. Old servers that omit typed fields remain valid producers.
+Servers must not require `approval_scope` or `client_note` from clients.
+
+## Capability Negotiation
+
+Feature token: `approval.typed.v1`.
+
+Servers advertise the token in `UiProtocolCapabilities.supported_features`.
+Clients request it through `X-Octos-Ui-Features` or the equivalent
+`ui_feature` / `ui_features` query params.
+
+## Tests
+
+Coverage lives in the protocol golden tests and approval handler tests:
+
+- `crates/octos-core/src/ui_protocol.rs` verifies typed approval payload
+  serialization and the advertised method/notification sets.
+- `crates/octos-cli/src/api/ui_protocol.rs` verifies typed approval requests,
+  responses, and durable approval lifecycle notifications.
+
+## Decision
+
+Accepted. The typed fields are optional, backward-compatible, and required for
+clients that need deterministic approval rendering without text scraping.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_002_PANE_SNAPSHOTS.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_002_PANE_SNAPSHOTS.md
@@ -1,0 +1,80 @@
+# Octos UI Protocol Change Request: Pane Snapshots On Session Open
+
+## Header
+
+- Request id: `UPCR-2026-002`
+- Title: Add optional workspace, artifact, and git pane snapshots
+- Author: M9 protocol review
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related M issue: `M9` review
+
+## Summary
+
+This change request records the accepted `session/open` pane snapshot payloads
+referenced by the protocol spec. The extension lets a server return initial
+workspace, artifact, and git panel state during session open so clients can
+hydrate panes without immediate follow-up REST calls.
+
+## Motivation
+
+The AppUI shell needs enough initial state to render the session workspace
+panels immediately after reconnect or reload. Without an in-band snapshot,
+clients either show empty panes until secondary fetches complete or rebuild
+state from unrelated stream events. The accepted pane snapshot contract gives
+clients an explicit, bounded bootstrap payload.
+
+## Change Type
+
+Additive optional field on an existing command result.
+
+## Wire Contract
+
+Affected existing surface:
+
+- Command method: `session/open`
+- Result shape: `SessionOpenResult.opened`
+- Notification shape: `session/open` payload, which shares `SessionOpened`
+
+Optional field:
+
+- `panes`: object containing optional `workspace`, `artifacts`, and `git`
+  snapshots plus non-fatal `limitations`.
+
+Initial workspace entry kinds are string values:
+
+- `directory`
+- `file`
+- `symlink`
+- `other`
+
+Servers must keep each snapshot bounded. If a pane cannot be collected, the
+server should omit that pane or include a limitation rather than failing
+`session/open`.
+
+## Compatibility
+
+This is additive. Old clients ignore `panes`; old servers omit it. Clients must
+keep fallback pane rendering for absent snapshots.
+
+## Capability Negotiation
+
+Feature token: `pane.snapshots.v1`.
+
+Servers may include `panes` only when the feature is negotiated. Clients
+request it through `X-Octos-Ui-Features` or equivalent query params.
+
+## Tests
+
+Coverage lives in:
+
+- `crates/octos-core/src/ui_protocol.rs` golden payload tests for
+  `SessionOpened` and capability advertisement.
+- `crates/octos-cli/src/api/ui_protocol.rs` session-open tests that verify pane
+  snapshot gating and fallback behavior.
+
+## Decision
+
+Accepted. Pane snapshots are a bounded bootstrap aid and do not change the
+canonical session lifecycle or message stream.

--- a/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_003_SESSION_WORKSPACE_CWD.md
+++ b/docs/OCTOS_UI_PROTOCOL_CHANGE_REQUEST_UPCR_2026_003_SESSION_WORKSPACE_CWD.md
@@ -1,0 +1,80 @@
+# Octos UI Protocol Change Request: Session Workspace Cwd Binding
+
+## Header
+
+- Request id: `UPCR-2026-003`
+- Title: Bind a session to a server-approved workspace cwd
+- Author: M9 protocol review
+- Date: 2026-04-30
+- Target protocol: `octos-ui/v1alpha1`
+- Status: accepted
+- Related M issue: `M9` review
+
+## Summary
+
+This change request records the accepted per-session workspace cwd extension
+referenced by the protocol spec. It lets a client request a cwd during
+`session/open` and lets the server return the canonical approved
+`workspace_root` used by cwd-scoped tools.
+
+## Motivation
+
+Coding and workspace tools need a deterministic server-approved root. Letting
+clients infer tool scope from their requested path is unsafe because the server
+may canonicalize, reject, or narrow the workspace. The wire contract therefore
+separates the requested `cwd` from the returned `workspace_root`.
+
+## Change Type
+
+Additive optional command param and additive optional result/notification
+field.
+
+## Wire Contract
+
+Affected existing surface:
+
+- Command method: `session/open`
+- Params field: `cwd`
+- Result shape: `SessionOpenResult.opened`
+- Notification shape: `session/open` payload, which shares `SessionOpened`
+
+Optional param:
+
+- `cwd`: client-requested workspace path.
+
+Optional result/notification field:
+
+- `workspace_root`: canonical server-approved root used to bind cwd-scoped
+  tools for the session.
+
+Servers must canonicalize and approve `cwd` against runtime filesystem roots
+before binding it. A client must not treat its requested `cwd` as approved
+until it receives `workspace_root`.
+
+## Compatibility
+
+This is additive. Old clients omit `cwd` and ignore `workspace_root`. Old
+servers omit `workspace_root`. Servers that receive `cwd` without negotiated
+support must reject it with `invalid_params` and `kind: feature_required`.
+
+## Capability Negotiation
+
+Feature token: `session.workspace_cwd.v1`.
+
+Clients request the feature through `X-Octos-Ui-Features` or equivalent query
+params. A server may include `workspace_root` when it has an approved workspace
+for the session, including sessions whose workspace was already known.
+
+## Tests
+
+Coverage lives in:
+
+- `crates/octos-core/src/ui_protocol.rs` capability and golden payload tests.
+- `crates/octos-cli/src/api/ui_protocol.rs` session-open tests covering cwd
+  acceptance, rejection without feature negotiation, and returned
+  `workspace_root`.
+
+## Decision
+
+Accepted. The extension makes workspace binding explicit and preserves server
+authority over filesystem scope.


### PR DESCRIPTION
## Summary
- restore accepted UPCR docs for `UPCR-2026-001`, `UPCR-2026-002`, and `UPCR-2026-003`, which the v1 spec already linked
- update the spec §6 command inventory to include shipped methods such as `approval/scopes/list`, state-control RPCs, agent/goal/loop RPCs, auxiliary REST-to-WS methods, profile skill methods, and routing controls
- update the spec §6 notification inventory to include shipped approval lifecycle, progress, replay, message, spawn/file, router, queue, agent, goal, loop, and context lifecycle notifications

Refs #716 — the full closure path remains PR #1228, which includes the route/method inventory artifacts required by the issue.

## Validation
- `git diff --check`
- `bash scripts/check-ui-protocol-upcr.sh`
- `python3 - <<'PY' ...` inventory check comparing `crates/octos-core/src/ui_protocol.rs` golden command/notification lists against spec text: `core method and notification inventories are documented in spec section text`