### PR TITLE
feat(bridge): add work secret session ingress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3897,6 +3897,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
+ "tokio-tungstenite 0.26.2",
  "toml",
  "tower",
  "tower-http",

--- a/crates/octos-agent/src/bridge/mod.rs
+++ b/crates/octos-agent/src/bridge/mod.rs
@@ -1,0 +1,7 @@
+//! External agent bridge contracts.
+//!
+//! The bridge module owns small, transport-agnostic primitives that let
+//! `octos serve` issue short-lived session ingress credentials without
+//! coupling guest agents to dashboard or OAuth auth flows.
+
+pub mod work_secret;

--- a/crates/octos-agent/src/bridge/work_secret.rs
+++ b/crates/octos-agent/src/bridge/work_secret.rs
@@ -1,0 +1,321 @@
+//! Short-lived external session ingress credentials.
+
+use std::path::{Path, PathBuf};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Duration, Utc};
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const WORK_SECRET_VERSION: u8 = 1;
+const FILE_NAME: &str = "work_secrets.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkSecret {
+    pub version: u8,
+    pub session_ingress_token: String,
+    pub api_base_url: String,
+}
+
+impl WorkSecret {
+    pub fn new(api_base_url: impl Into<String>, session_ingress_token: impl Into<String>) -> Self {
+        Self {
+            version: WORK_SECRET_VERSION,
+            session_ingress_token: session_ingress_token.into(),
+            api_base_url: api_base_url.into(),
+        }
+    }
+
+    pub fn encode(&self) -> Result<String> {
+        let body = serde_json::to_vec(self)?;
+        Ok(URL_SAFE_NO_PAD.encode(body))
+    }
+
+    pub fn decode(encoded: &str) -> Result<Self> {
+        let body = URL_SAFE_NO_PAD
+            .decode(encoded.trim())
+            .wrap_err("work secret is not valid base64url")?;
+        let secret: Self =
+            serde_json::from_slice(&body).wrap_err("work secret is not valid JSON")?;
+        if secret.version != WORK_SECRET_VERSION {
+            eyre::bail!(
+                "unsupported work secret version {} (expected {})",
+                secret.version,
+                WORK_SECRET_VERSION
+            );
+        }
+        if secret.session_ingress_token.trim().is_empty() {
+            eyre::bail!("work secret missing session_ingress_token");
+        }
+        if secret.api_base_url.trim().is_empty() {
+            eyre::bail!("work secret missing api_base_url");
+        }
+        Ok(secret)
+    }
+
+    pub fn session_ingress_ws_url(&self, session_id: &str) -> Result<String> {
+        let mut base = self.api_base_url.trim().trim_end_matches('/').to_owned();
+        if let Some(rest) = base.strip_prefix("https://") {
+            base = format!("wss://{rest}");
+        } else if let Some(rest) = base.strip_prefix("http://") {
+            base = format!("ws://{rest}");
+        } else if !(base.starts_with("ws://") || base.starts_with("wss://")) {
+            eyre::bail!("api_base_url must start with http://, https://, ws://, or wss://");
+        }
+        Ok(format!(
+            "{base}/v1/session_ingress/ws/{}",
+            percent_encode_path_segment(session_id)
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkSecretGrantRecord {
+    pub token_hash: String,
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_id: Option<String>,
+    pub api_base_url: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl WorkSecretGrantRecord {
+    pub fn active(&self, now: DateTime<Utc>) -> bool {
+        self.revoked_at.is_none() && self.expires_at > now
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct WorkSecretGrantFile {
+    #[serde(default)]
+    grants: Vec<WorkSecretGrantRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkSecretValidationError {
+    Missing,
+    SessionMismatch,
+    Expired,
+    Revoked,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkSecretGrantStore {
+    path: PathBuf,
+}
+
+impl WorkSecretGrantStore {
+    pub fn new(data_dir: &Path) -> Self {
+        Self {
+            path: data_dir.join(FILE_NAME),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn issue(
+        &self,
+        session_id: impl Into<String>,
+        token: &str,
+        api_base_url: impl Into<String>,
+        ttl: Duration,
+        profile_id: Option<String>,
+    ) -> Result<WorkSecretGrantRecord> {
+        if token.trim().is_empty() {
+            eyre::bail!("session ingress token cannot be empty");
+        }
+        if ttl <= Duration::zero() {
+            eyre::bail!("ttl must be positive");
+        }
+        let now = Utc::now();
+        let record = WorkSecretGrantRecord {
+            token_hash: hash_token(token),
+            session_id: session_id.into(),
+            profile_id,
+            api_base_url: api_base_url.into(),
+            created_at: now,
+            expires_at: now + ttl,
+            revoked_at: None,
+        };
+        let mut file = self.load_file()?;
+        file.grants.retain(|grant| {
+            !(grant.token_hash == record.token_hash || grant.session_id == record.session_id)
+        });
+        file.grants.push(record.clone());
+        self.save_file(&file)?;
+        Ok(record)
+    }
+
+    pub fn validate(
+        &self,
+        session_id: &str,
+        token: &str,
+    ) -> std::result::Result<WorkSecretGrantRecord, WorkSecretValidationError> {
+        let hash = hash_token(token);
+        let file = self
+            .load_file()
+            .map_err(|_| WorkSecretValidationError::Missing)?;
+        let Some(record) = file
+            .grants
+            .into_iter()
+            .find(|grant| constant_time_eq(grant.token_hash.as_bytes(), hash.as_bytes()))
+        else {
+            return Err(WorkSecretValidationError::Missing);
+        };
+        if record.session_id != session_id {
+            return Err(WorkSecretValidationError::SessionMismatch);
+        }
+        if record.revoked_at.is_some() {
+            return Err(WorkSecretValidationError::Revoked);
+        }
+        if record.expires_at <= Utc::now() {
+            return Err(WorkSecretValidationError::Expired);
+        }
+        Ok(record)
+    }
+
+    pub fn revoke_token(&self, token: &str) -> Result<bool> {
+        let hash = hash_token(token);
+        let mut file = self.load_file()?;
+        let now = Utc::now();
+        let mut changed = false;
+        for grant in &mut file.grants {
+            if constant_time_eq(grant.token_hash.as_bytes(), hash.as_bytes())
+                && grant.revoked_at.is_none()
+            {
+                grant.revoked_at = Some(now);
+                changed = true;
+            }
+        }
+        if changed {
+            self.save_file(&file)?;
+        }
+        Ok(changed)
+    }
+
+    fn load_file(&self) -> Result<WorkSecretGrantFile> {
+        if !self.path.exists() {
+            return Ok(WorkSecretGrantFile::default());
+        }
+        let body = std::fs::read_to_string(&self.path)
+            .wrap_err_with(|| format!("failed to read {}", self.path.display()))?;
+        serde_json::from_str(&body)
+            .wrap_err_with(|| format!("failed to parse {}", self.path.display()))
+    }
+
+    fn save_file(&self, file: &WorkSecretGrantFile) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("failed to create dir: {}", parent.display()))?;
+        }
+        let body = serde_json::to_string_pretty(file)?;
+        let tmp = self.path.with_extension("json.tmp");
+        std::fs::write(&tmp, body)
+            .wrap_err_with(|| format!("failed to write {}", tmp.display()))?;
+        std::fs::rename(&tmp, &self.path)
+            .wrap_err_with(|| format!("failed to rename into {}", self.path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            if let Err(error) = std::fs::set_permissions(&self.path, perms) {
+                tracing::warn!(path = %self.path.display(), %error, "failed to chmod work_secrets.json");
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn hash_token(token: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(token.as_bytes()))
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let len_eq = a.len() ^ b.len();
+    let mut result = 0u8;
+    for i in 0..a.len().max(b.len()) {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        result |= x ^ y;
+    }
+    result == 0 && len_eq == 0
+}
+
+fn percent_encode_path_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b':' | b'@' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn work_secret_round_trips_as_base64url_json() {
+        let secret = WorkSecret::new("http://127.0.0.1:50080", "token-123");
+        let encoded = secret.encode().unwrap();
+        assert!(!encoded.contains('='));
+        assert_eq!(WorkSecret::decode(&encoded).unwrap(), secret);
+    }
+
+    #[test]
+    fn work_secret_rejects_version_mismatch() {
+        let encoded = URL_SAFE_NO_PAD
+            .encode(br#"{"version":2,"session_ingress_token":"t","api_base_url":"http://x"}"#);
+        let error = WorkSecret::decode(&encoded).unwrap_err().to_string();
+        assert!(error.contains("unsupported work secret version"));
+    }
+
+    #[test]
+    fn work_secret_builds_ws_url() {
+        let secret = WorkSecret::new("https://api.example.test/", "token-123");
+        assert_eq!(
+            secret
+                .session_ingress_ws_url("dspfac:local:tui#coding")
+                .unwrap(),
+            "wss://api.example.test/v1/session_ingress/ws/dspfac:local:tui%23coding"
+        );
+    }
+
+    #[test]
+    fn grant_store_validates_and_revokes_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = WorkSecretGrantStore::new(dir.path());
+        store
+            .issue(
+                "profile:local:demo",
+                "plain-token",
+                "http://127.0.0.1:50080",
+                Duration::minutes(5),
+                Some("profile".into()),
+            )
+            .unwrap();
+
+        let grant = store.validate("profile:local:demo", "plain-token").unwrap();
+        assert_eq!(grant.profile_id.as_deref(), Some("profile"));
+        assert!(matches!(
+            store.validate("profile:local:other", "plain-token"),
+            Err(WorkSecretValidationError::SessionMismatch)
+        ));
+
+        assert!(store.revoke_token("plain-token").unwrap());
+        assert!(matches!(
+            store.validate("profile:local:demo", "plain-token"),
+            Err(WorkSecretValidationError::Revoked)
+        ));
+    }
+}

--- a/crates/octos-agent/src/lib.rs
+++ b/crates/octos-agent/src/lib.rs
@@ -13,6 +13,7 @@ pub mod agents;
 pub mod approval;
 pub mod behaviour;
 pub mod bootstrap;
+pub mod bridge;
 pub mod builtin_skills;
 pub mod bundled_app_skills;
 pub mod bundled_pipelines;

--- a/crates/octos-cli/Cargo.toml
+++ b/crates/octos-cli/Cargo.toml
@@ -148,6 +148,7 @@ axum = { workspace = true }
 # failover-surfacing tests can call `publish_failover_for_subscribers`.
 # Production builds don't see this; only `cargo test -p octos-cli`.
 octos-llm = { workspace = true, features = ["test-utils"] }
+tokio-tungstenite.workspace = true
 
 [[test]]
 name = "build_output_dir_validation"

--- a/crates/octos-cli/src/api/mod.rs
+++ b/crates/octos-cli/src/api/mod.rs
@@ -24,6 +24,7 @@ pub mod preview;
 pub mod preview_tokens;
 pub mod purge;
 mod router;
+pub(crate) mod session_ingress;
 pub(crate) mod solo_auth;
 pub(crate) mod specialist_runner;
 mod static_files;
@@ -314,6 +315,13 @@ pub struct AppState {
     /// invalidates every outstanding grant. See
     /// [`crate::api::preview_tokens`] for full design rationale.
     pub preview_tokens: SharedPreviewTokens,
+    /// Persistent session-ingress grant store for external CLI agents.
+    ///
+    /// `octos auth issue-work-secret` writes short-lived grants here and
+    /// `/v1/session_ingress/ws/{session_id}` revalidates the token on
+    /// every frame, so revocation applies to already-open sockets without
+    /// requiring a daemon restart.
+    pub work_secret_store: Arc<octos_agent::bridge::work_secret::WorkSecretGrantStore>,
     /// Owning handle to the background sweeper task spawned for
     /// `preview_tokens` (issue #1009). Storing it here ties the
     /// task's lifetime to `AppState`: when the last `Arc<AppState>` is
@@ -380,6 +388,9 @@ impl AppState {
             task_query_store: None,
             appui_default_session_cwd: None,
             preview_tokens: Arc::new(PreviewTokens::new()),
+            work_secret_store: Arc::new(
+                octos_agent::bridge::work_secret::WorkSecretGrantStore::new(&tmp),
+            ),
             // Tests don't spawn the sweeper. Tests that exercise the
             // sweeper either drive `sweep_expired_all` directly or
             // build their own `PreviewSweeperHandle::spawn(...)`.

--- a/crates/octos-cli/src/api/router.rs
+++ b/crates/octos-cli/src/api/router.rs
@@ -20,6 +20,7 @@ use super::frps_plugin;
 use super::handlers;
 use super::metrics;
 use super::purge;
+use super::session_ingress;
 use super::solo_auth;
 use super::static_files;
 use super::swarm as swarm_api;
@@ -675,6 +676,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/preview-signed/{token}/{*path}",
             get(handlers::serve_signed_preview),
+        )
+        .route(
+            "/v1/session_ingress/ws/{session_id}",
+            get(session_ingress::ws_handler),
         )
         .merge(webhook_routes)
         .merge(version_routes)

--- a/crates/octos-cli/src/api/session_ingress.rs
+++ b/crates/octos-cli/src/api/session_ingress.rs
@@ -1,0 +1,115 @@
+//! External CLI-agent session ingress over WebSocket.
+
+use std::sync::Arc;
+
+use axum::extract::ws::{WebSocketUpgrade, rejection::WebSocketUpgradeRejection};
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, Uri};
+use axum::response::{IntoResponse, Response};
+use octos_agent::bridge::work_secret::WorkSecretValidationError;
+use octos_core::SessionKey;
+
+use super::AppState;
+
+pub(crate) async fn ws_handler(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    headers: HeaderMap,
+    uri: Uri,
+    ws: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
+) -> Response {
+    let token = extract_session_ingress_token(&headers, &uri);
+    if token.is_empty() {
+        return (
+            axum::http::StatusCode::UNAUTHORIZED,
+            "missing session ingress token",
+        )
+            .into_response();
+    }
+
+    let session_id = SessionKey(session_id);
+    let grant = match state.work_secret_store.validate(&session_id.0, &token) {
+        Ok(grant) => grant,
+        Err(error) => {
+            let (status, message) = match error {
+                WorkSecretValidationError::Missing => {
+                    (axum::http::StatusCode::UNAUTHORIZED, "invalid token")
+                }
+                WorkSecretValidationError::SessionMismatch => {
+                    (axum::http::StatusCode::FORBIDDEN, "session mismatch")
+                }
+                WorkSecretValidationError::Expired => {
+                    (axum::http::StatusCode::UNAUTHORIZED, "token expired")
+                }
+                WorkSecretValidationError::Revoked => {
+                    (axum::http::StatusCode::UNAUTHORIZED, "token revoked")
+                }
+            };
+            return (status, message).into_response();
+        }
+    };
+
+    super::ui_protocol::ws_handler_for_session_ingress(
+        state,
+        session_id,
+        grant.profile_id,
+        token,
+        headers,
+        uri,
+        ws,
+    )
+    .await
+}
+
+fn extract_session_ingress_token(headers: &HeaderMap, uri: &Uri) -> String {
+    let header_token = headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .unwrap_or("");
+    if !header_token.is_empty() {
+        return header_token.to_owned();
+    }
+    let query_token = uri
+        .query()
+        .and_then(|query| {
+            query.split('&').find_map(|pair| {
+                pair.strip_prefix("token=")
+                    .or_else(|| pair.strip_prefix("_token="))
+                    .or_else(|| pair.strip_prefix("session_ingress_token="))
+            })
+        })
+        .unwrap_or("");
+    percent_encoding::percent_decode_str(query_token)
+        .decode_utf8_lossy()
+        .into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, Uri};
+
+    use super::extract_session_ingress_token;
+
+    #[test]
+    fn extracts_bearer_token_before_query_token() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer header-token".parse().unwrap());
+        let uri: Uri = "/v1/session_ingress/ws/s?token=query-token"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            extract_session_ingress_token(&headers, &uri),
+            "header-token"
+        );
+    }
+
+    #[test]
+    fn extracts_percent_decoded_query_token() {
+        let headers = HeaderMap::new();
+        let uri: Uri = "/v1/session_ingress/ws/s?session_ingress_token=A%2FB%3DC"
+            .parse()
+            .unwrap();
+        assert_eq!(extract_session_ingress_token(&headers, &uri), "A/B=C");
+    }
+}

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -117,6 +117,7 @@ use crate::context_manager::{
     CompactContextPolicy, ContextCompactionRecord, ContextManager, ForkPolicy, PromptBuildPolicy,
     PromptFrame, load_or_rebuild_context_manager, persist_context_manager_snapshot,
 };
+use crate::user_store::UserRole;
 
 const MAX_DIFF_PREVIEW_BYTES: usize = 256 * 1024;
 const PROGRESS_CHANNEL_CAPACITY: usize = 1024;
@@ -3813,24 +3814,102 @@ pub async fn ws_handler(
         ui_protocol_connection(
             socket,
             state,
-            connection_profile_id,
-            routed_profile_id,
-            features,
-            headers,
-            auth_identity,
+            UiProtocolConnectionOptions {
+                connection_profile_id,
+                routed_profile_id,
+                features,
+                headers,
+                identity: auth_identity,
+                session_ingress_scope: None,
+            },
         )
     })
+}
+
+#[derive(Clone)]
+pub(crate) struct SessionIngressScope {
+    session_id: SessionKey,
+    token: String,
+}
+
+/// Upgrade a work-secret authenticated socket into the UI Protocol dispatcher.
+///
+/// The route that calls this function has already validated the token for
+/// `session_id`. The dispatcher revalidates on every client frame and applies
+/// a session-scope gate before executing any RPC.
+pub(crate) async fn ws_handler_for_session_ingress(
+    state: Arc<AppState>,
+    session_id: SessionKey,
+    profile_id: Option<String>,
+    token: String,
+    headers: HeaderMap,
+    uri: Uri,
+    ws: Result<WebSocketUpgrade, axum::extract::ws::rejection::WebSocketUpgradeRejection>,
+) -> Response {
+    match decide_ws_origin_gate(&headers, state.base_domain.as_deref(), true) {
+        WsOriginDecision::Allow => {}
+        WsOriginDecision::RejectDisallowed { origin } => {
+            tracing::warn!(
+                target: "octos::ui_protocol::session_ingress",
+                origin = %origin,
+                "rejected session ingress WS upgrade from disallowed Origin"
+            );
+            return (axum::http::StatusCode::FORBIDDEN, "disallowed origin").into_response();
+        }
+        WsOriginDecision::RejectMalformed => {
+            return (axum::http::StatusCode::FORBIDDEN, "invalid origin").into_response();
+        }
+    }
+    let ws = match ws {
+        Ok(ws) => ws,
+        Err(rejection) => return rejection.into_response(),
+    };
+    let connection_profile_id =
+        profile_id.or_else(|| session_id.profile_id().map(ToOwned::to_owned));
+    let auth_identity = connection_profile_id.clone().map(|id| AuthIdentity::User {
+        id,
+        role: UserRole::User,
+    });
+    let features = ConnectionUiFeatures::from_headers_and_query(&headers, uri.query());
+    let scope = SessionIngressScope { session_id, token };
+    ws.on_upgrade(move |socket| {
+        ui_protocol_connection(
+            socket,
+            state,
+            UiProtocolConnectionOptions {
+                connection_profile_id,
+                routed_profile_id: None,
+                features,
+                headers,
+                identity: auth_identity,
+                session_ingress_scope: Some(scope),
+            },
+        )
+    })
+}
+
+struct UiProtocolConnectionOptions {
+    connection_profile_id: Option<String>,
+    routed_profile_id: Option<String>,
+    features: ConnectionUiFeatures,
+    headers: HeaderMap,
+    identity: Option<AuthIdentity>,
+    session_ingress_scope: Option<SessionIngressScope>,
 }
 
 async fn ui_protocol_connection(
     socket: WebSocket,
     state: Arc<AppState>,
-    connection_profile_id: Option<String>,
-    routed_profile_id: Option<String>,
-    mut features: ConnectionUiFeatures,
-    connection_headers: HeaderMap,
-    connection_identity: Option<AuthIdentity>,
+    options: UiProtocolConnectionOptions,
 ) {
+    let UiProtocolConnectionOptions {
+        connection_profile_id,
+        routed_profile_id,
+        mut features,
+        headers: connection_headers,
+        identity: connection_identity,
+        session_ingress_scope,
+    } = options;
     let (ws_sink, mut ws_rx) = socket.split();
     // Decouple the network sink from request handlers via a bounded channel
     // and a dedicated drainer task. No handler ever holds a lock across an
@@ -3951,6 +4030,16 @@ async fn ui_protocol_connection(
             WsMessage::Ping(_) => continue,
             _ => continue,
         };
+        if let Some(scope) = session_ingress_scope.as_ref() {
+            if state
+                .work_secret_store
+                .validate(&scope.session_id.0, &scope.token)
+                .is_err()
+            {
+                let _ = close_ws_with_code(&ws, 1008, "session_ingress_revoked");
+                break;
+            }
+        }
 
         let request = match parse_ws_text_frame(text.as_str()) {
             Ok(ParsedFrame::Request(request)) => request,
@@ -4010,6 +4099,13 @@ async fn ui_protocol_connection(
                 continue;
             }
         };
+        if let Some(scope) = session_ingress_scope.as_ref() {
+            if let Err(error) = validate_session_ingress_command_scope(&command, &scope.session_id)
+            {
+                let _ = send_rpc_error(&ws, Some(id), error);
+                continue;
+            }
+        }
 
         match command {
             UiCommand::ProfileLocalCreate(params) => {
@@ -8045,6 +8141,84 @@ fn route_rpc_command(
         }
     }
     UiCommand::from_rpc_request(request)
+}
+
+fn string_session_with_optional_topic(session_id: &str, topic: Option<&str>) -> SessionKey {
+    session_key_with_optional_topic(&SessionKey(session_id.to_owned()), topic)
+}
+
+fn validate_session_ingress_command_scope(
+    command: &UiCommand,
+    allowed_session_id: &SessionKey,
+) -> Result<(), RpcError> {
+    let actual = match command {
+        UiCommand::ProfileLocalCreate(_)
+        | UiCommand::SessionList(_)
+        | UiCommand::SystemStatusGet(_)
+        | UiCommand::ContentList(_)
+        | UiCommand::ContentDelete(_)
+        | UiCommand::ContentBulkDelete(_) => {
+            return Err(RpcError::invalid_request(
+                "session ingress credentials may only call session-scoped methods",
+            ));
+        }
+        UiCommand::SessionOpen(params) => {
+            session_key_with_optional_topic(&params.session_id, params.topic.as_deref())
+        }
+        UiCommand::TurnStart(params) => {
+            session_key_with_optional_topic(&params.session_id, params.topic.as_deref())
+        }
+        UiCommand::TurnInterrupt(params) => params.session_id.clone(),
+        UiCommand::ApprovalRespond(params) => params.session_id.clone(),
+        UiCommand::UserQuestionRespond(params) => params.session_id.clone(),
+        UiCommand::ApprovalScopesList(params) => params.session_id.clone(),
+        UiCommand::PermissionProfileList(params) => params.session_id.clone(),
+        UiCommand::PermissionProfileSet(params) => params.session_id.clone(),
+        UiCommand::DiffPreviewGet(params) => params.session_id.clone(),
+        UiCommand::TaskList(params) => {
+            session_key_with_optional_topic(&params.session_id, params.topic.as_deref())
+        }
+        UiCommand::TaskCancel(params) => params.session_id.clone().ok_or_else(|| {
+            RpcError::invalid_params(
+                "session ingress task/cancel requires params.session_id to enforce scope",
+            )
+        })?,
+        UiCommand::TaskRestartFromNode(params) => params.session_id.clone().ok_or_else(|| {
+            RpcError::invalid_params(
+                "session ingress task/restart_from_node requires params.session_id to enforce scope",
+            )
+        })?,
+        UiCommand::TaskOutputRead(params) => params.session_id.clone(),
+        UiCommand::TaskArtifactList(params) => params.session_id.clone(),
+        UiCommand::TaskArtifactRead(params) => params.session_id.clone(),
+        UiCommand::SessionHydrate(params) => params.session_id.clone(),
+        UiCommand::ThreadGraphGet(params) => params.session_id.clone(),
+        UiCommand::TurnStateGet(params) => params.session_id.clone(),
+        UiCommand::SessionSnapshot(params) => {
+            string_session_with_optional_topic(&params.session_id, params.topic.as_deref())
+        }
+        UiCommand::SessionMessagesPage(params) => SessionKey(params.session_id.clone()),
+        UiCommand::SessionStatusGet(params) => {
+            string_session_with_optional_topic(&params.session_id, params.topic.as_deref())
+        }
+        UiCommand::SessionFilesList(params) => SessionKey(params.session_id.clone()),
+        UiCommand::SessionTasksList(params) => {
+            string_session_with_optional_topic(&params.session_id, params.topic.as_deref())
+        }
+        UiCommand::SessionWorkspaceGet(params) => SessionKey(params.session_id.clone()),
+        UiCommand::SessionTitleSet(params) => SessionKey(params.session_id.clone()),
+        UiCommand::SessionDelete(params) => SessionKey(params.session_id.clone()),
+        UiCommand::RouterSetMode(params) => params.session_id.clone(),
+        UiCommand::RouterGetMetrics(params) => params.session_id.clone(),
+    };
+
+    if actual == *allowed_session_id {
+        Ok(())
+    } else {
+        Err(RpcError::invalid_request(
+            "session ingress credential is scoped to a different session",
+        ))
+    }
 }
 
 fn ui_protocol_server_supported_methods() -> Vec<&'static str> {
@@ -30780,6 +30954,38 @@ ignore = []
                 "{method} must reject with METHOD_NOT_SUPPORTED even with no header",
             );
         }
+    }
+
+    #[test]
+    fn session_ingress_scope_accepts_matching_topic_folded_turn() {
+        let allowed = SessionKey("dspfac:local:tui#coding".into());
+        let command = UiCommand::TurnStart(TurnStartParams {
+            session_id: SessionKey("dspfac:local:tui".into()),
+            turn_id: TurnId::new(),
+            input: vec![InputItem::Text {
+                text: "hello".into(),
+            }],
+            media: Vec::new(),
+            topic: Some("coding".into()),
+            rewrite_for: None,
+        });
+        validate_session_ingress_command_scope(&command, &allowed).expect("scope matches");
+    }
+
+    #[test]
+    fn session_ingress_scope_rejects_global_methods_and_mismatched_sessions() {
+        let allowed = SessionKey("dspfac:local:tui".into());
+        let global = UiCommand::SystemStatusGet(SystemStatusGetParams {});
+        assert!(validate_session_ingress_command_scope(&global, &allowed).is_err());
+
+        let mismatched = UiCommand::SessionOpen(SessionOpenParams {
+            session_id: SessionKey("other:local:tui".into()),
+            topic: None,
+            profile_id: None,
+            cwd: None,
+            after: None,
+        });
+        assert!(validate_session_ingress_command_scope(&mismatched, &allowed).is_err());
     }
 
     /// Codex review 2026-05-12 (BLOCK 1, companion): the legacy

--- a/crates/octos-cli/src/commands/auth.rs
+++ b/crates/octos-cli/src/commands/auth.rs
@@ -1,10 +1,12 @@
 //! Auth command: login, logout, status, and keychain management.
 
 use std::io::Write as _;
+use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 use colored::Colorize;
 use eyre::Result;
+use octos_agent::bridge::work_secret::{WorkSecret, WorkSecretGrantStore};
 
 use super::Executable;
 use crate::auth::{AuthStore, keychain, oauth, token};
@@ -89,6 +91,36 @@ pub enum AuthAction {
         #[arg(long)]
         password: Option<String>,
     },
+
+    /// Issue a short-lived session ingress secret for an external CLI agent.
+    #[command(name = "issue-work-secret")]
+    IssueWorkSecret {
+        /// Session id the external agent may access.
+        #[arg(long)]
+        session: String,
+        /// Grant lifetime, e.g. 15m, 1h, or 3600s.
+        #[arg(long, default_value = "1h")]
+        ttl: String,
+        /// Public API base URL the guest should connect to.
+        #[arg(long, default_value = "http://127.0.0.1:50080")]
+        api_base_url: String,
+        /// Profile id to bind on authenticated AppUI dispatch.
+        #[arg(long)]
+        profile: Option<String>,
+        /// Data directory that `octos serve` uses.
+        #[arg(long)]
+        data_dir: Option<PathBuf>,
+    },
+
+    /// Revoke a previously issued work secret.
+    #[command(name = "revoke-work-secret")]
+    RevokeWorkSecret {
+        /// Encoded work secret or raw session_ingress_token.
+        token_or_secret: String,
+        /// Data directory that `octos serve` uses.
+        #[arg(long)]
+        data_dir: Option<PathBuf>,
+    },
 }
 
 impl Executable for AuthCommand {
@@ -117,6 +149,17 @@ impl AuthCommand {
             AuthAction::Keys { profile } => list_keys(profile.as_deref()),
             AuthAction::RemoveKey { name, profile } => remove_key(&name, profile.as_deref()),
             AuthAction::Unlock { password } => unlock_keychain(password),
+            AuthAction::IssueWorkSecret {
+                session,
+                ttl,
+                api_base_url,
+                profile,
+                data_dir,
+            } => issue_work_secret(&session, &ttl, &api_base_url, profile, data_dir),
+            AuthAction::RevokeWorkSecret {
+                token_or_secret,
+                data_dir,
+            } => revoke_work_secret(&token_or_secret, data_dir),
         }
     }
 }
@@ -494,6 +537,75 @@ fn unlock_keychain(password: Option<String>) -> Result<()> {
     Ok(())
 }
 
+fn issue_work_secret(
+    session: &str,
+    ttl: &str,
+    api_base_url: &str,
+    profile: Option<String>,
+    data_dir: Option<PathBuf>,
+) -> Result<()> {
+    let secret = create_work_secret(session, ttl, api_base_url, profile, data_dir)?;
+    println!("{}", secret.encode()?);
+    Ok(())
+}
+
+fn create_work_secret(
+    session: &str,
+    ttl: &str,
+    api_base_url: &str,
+    profile: Option<String>,
+    data_dir: Option<PathBuf>,
+) -> Result<WorkSecret> {
+    let data_dir = super::resolve_data_dir(data_dir)?;
+    let ttl = parse_ttl(ttl)?;
+    let token = generate_ingress_token()?;
+    let store = WorkSecretGrantStore::new(&data_dir);
+    store.issue(session, &token, api_base_url, ttl, profile)?;
+    Ok(WorkSecret::new(api_base_url, token))
+}
+
+fn revoke_work_secret(token_or_secret: &str, data_dir: Option<PathBuf>) -> Result<()> {
+    let data_dir = super::resolve_data_dir(data_dir)?;
+    let token = WorkSecret::decode(token_or_secret)
+        .map(|secret| secret.session_ingress_token)
+        .unwrap_or_else(|_| token_or_secret.to_string());
+    let store = WorkSecretGrantStore::new(&data_dir);
+    if store.revoke_token(&token)? {
+        println!("{} Revoked work secret", "OK".green().bold());
+    } else {
+        println!("No active work secret matched the provided token");
+    }
+    Ok(())
+}
+
+fn generate_ingress_token() -> Result<String> {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes).map_err(|error| eyre::eyre!(error))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn parse_ttl(input: &str) -> Result<chrono::Duration> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        eyre::bail!("ttl cannot be empty");
+    }
+    let (number, multiplier) = match trimmed.chars().last().unwrap() {
+        's' | 'S' => (&trimmed[..trimmed.len() - 1], 1),
+        'm' | 'M' => (&trimmed[..trimmed.len() - 1], 60),
+        'h' | 'H' => (&trimmed[..trimmed.len() - 1], 60 * 60),
+        'd' | 'D' => (&trimmed[..trimmed.len() - 1], 24 * 60 * 60),
+        _ => (trimmed, 1),
+    };
+    let value: i64 = number
+        .parse()
+        .map_err(|_| eyre::eyre!("ttl must be a positive integer with optional s/m/h/d suffix"))?;
+    if value <= 0 {
+        eyre::bail!("ttl must be positive");
+    }
+    Ok(chrono::Duration::seconds(value.saturating_mul(multiplier)))
+}
+
 /// Get profiles matching the optional filter, or all profiles.
 fn get_profiles(
     store: &ProfileStore,
@@ -512,6 +624,7 @@ fn get_profiles(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use octos_agent::bridge::work_secret::{WorkSecret, WorkSecretGrantStore};
 
     #[test]
     fn keychain_target_scopes_by_name_and_by_content() {
@@ -606,5 +719,43 @@ mod tests {
         let plan = plan_removal(&entries, NAME, |_| true);
         assert!(plan.profiles_to_update.is_empty());
         assert!(plan.accounts_to_delete.is_empty());
+    }
+
+    #[test]
+    fn parses_work_secret_ttl_suffixes() {
+        assert_eq!(parse_ttl("30s").unwrap().num_seconds(), 30);
+        assert_eq!(parse_ttl("15m").unwrap().num_seconds(), 900);
+        assert_eq!(parse_ttl("2h").unwrap().num_seconds(), 7200);
+        assert_eq!(parse_ttl("1d").unwrap().num_seconds(), 86_400);
+        assert_eq!(parse_ttl("45").unwrap().num_seconds(), 45);
+    }
+
+    #[test]
+    fn rejects_invalid_work_secret_ttl() {
+        assert!(parse_ttl("").is_err());
+        assert!(parse_ttl("0s").is_err());
+        assert!(parse_ttl("abc").is_err());
+    }
+
+    #[test]
+    fn issue_work_secret_persists_decodable_grant() {
+        let dir = tempfile::tempdir().unwrap();
+        let secret = create_work_secret(
+            "local:auth-test",
+            "5m",
+            "http://127.0.0.1:50080",
+            Some("profile-a".into()),
+            Some(dir.path().to_path_buf()),
+        )
+        .unwrap();
+        let encoded = secret.encode().unwrap();
+        let decoded = WorkSecret::decode(&encoded).unwrap();
+        assert_eq!(decoded.api_base_url, "http://127.0.0.1:50080");
+
+        let store = WorkSecretGrantStore::new(dir.path());
+        let grant = store
+            .validate("local:auth-test", &decoded.session_ingress_token)
+            .unwrap();
+        assert_eq!(grant.profile_id.as_deref(), Some("profile-a"));
     }
 }

--- a/crates/octos-cli/src/commands/serve.rs
+++ b/crates/octos-cli/src/commands/serve.rs
@@ -713,6 +713,9 @@ impl ServeCommand {
             // invalidates every grant (see
             // `crate::api::preview_tokens` for the design rationale).
             preview_tokens,
+            work_secret_store: Arc::new(
+                octos_agent::bridge::work_secret::WorkSecretGrantStore::new(&data_dir),
+            ),
             // Issue #1009: owning sweeper handle. `Drop` aborts the
             // tokio task when the last `Arc<AppState>` is released,
             // replacing the previous `_preview_sweeper` local that

--- a/crates/octos-cli/tests/session_ingress_work_secret.rs
+++ b/crates/octos-cli/tests/session_ingress_work_secret.rs
@@ -1,0 +1,116 @@
+//! Issue #296: work-secret session ingress must authenticate a guest
+//! WebSocket, bridge normal UI Protocol JSON-RPC frames, and close an
+//! already-open socket after revocation.
+
+#![cfg(feature = "api")]
+
+use std::sync::Arc;
+
+use chrono::Duration;
+use futures::{SinkExt, StreamExt};
+use octos_agent::bridge::work_secret::WorkSecretGrantStore;
+use octos_cli::api::{AppState, build_router};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+
+fn state_with_work_secret_store(dir: &TempDir) -> (Arc<AppState>, Arc<WorkSecretGrantStore>) {
+    let store = Arc::new(WorkSecretGrantStore::new(dir.path()));
+    let state = Arc::new(AppState {
+        work_secret_store: store.clone(),
+        ..AppState::empty_for_tests()
+    });
+    (state, store)
+}
+
+async fn spawn_api(state: Arc<AppState>) -> (String, tokio::task::JoinHandle<()>) {
+    let app = build_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app.into_make_service())
+            .await
+            .unwrap();
+    });
+    tokio::task::yield_now().await;
+    (format!("127.0.0.1:{}", addr.port()), server)
+}
+
+#[tokio::test]
+async fn work_secret_ws_round_trip_and_revocation_close() {
+    let dir = TempDir::new().unwrap();
+    let session_id = "local:work-secret";
+    let token = "guest-token";
+    let (state, store) = state_with_work_secret_store(&dir);
+    store
+        .issue(
+            session_id,
+            token,
+            "http://127.0.0.1:50080",
+            Duration::minutes(5),
+            None,
+        )
+        .unwrap();
+    let (addr, server) = spawn_api(state).await;
+
+    let url = format!(
+        "ws://{addr}/v1/session_ingress/ws/{session_id}?session_ingress_token={token}&ui_feature=auxiliary.rest_to_ws.v1"
+    );
+    let (mut ws, _response) = connect_async(url).await.unwrap();
+
+    ws.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-before-revoke",
+            "method": "session/status.get",
+            "params": { "session_id": session_id }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let response = tokio::time::timeout(std::time::Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for session ingress response")
+        .expect("websocket ended before first response")
+        .expect("failed to read first response");
+    let Message::Text(body) = response else {
+        panic!("expected JSON-RPC text response, got {response:?}");
+    };
+    let body: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(body["id"], "status-before-revoke");
+    assert_eq!(body["result"]["status"]["active"], false);
+
+    assert!(store.revoke_token(token).unwrap());
+
+    ws.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "status-after-revoke",
+            "method": "session/status.get",
+            "params": { "session_id": session_id }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+    let close = tokio::time::timeout(std::time::Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for revocation close")
+        .expect("websocket ended without close frame")
+        .expect("failed to read revocation close");
+    let Message::Close(Some(frame)) = close else {
+        panic!("expected policy-violation close frame, got {close:?}");
+    };
+    assert_eq!(frame.code, CloseCode::Policy);
+    assert_eq!(frame.reason, "session_ingress_revoked");
+
+    server.abort();
+    let _ = server.await;
+}

--- a/docs/OCTOS_WORK_SECRET_SESSION_INGRESS.md
+++ b/docs/OCTOS_WORK_SECRET_SESSION_INGRESS.md
@@ -1,0 +1,101 @@
+# Work Secret Session Ingress
+
+Status: implemented
+
+Issue: #296
+
+## Purpose
+
+Work secrets are short-lived, session-scoped credentials for external CLI
+agents. They avoid giving guest tools a dashboard bearer token while still
+allowing them to attach to one existing AppUI session.
+
+The encoded secret is base64url JSON:
+
+```json
+{
+  "version": 1,
+  "session_ingress_token": "<opaque bearer>",
+  "api_base_url": "http://127.0.0.1:50080"
+}
+```
+
+## Issue A Secret
+
+```bash
+octos auth issue-work-secret \
+  --session dspfac:local:tui#coding \
+  --profile dspfac \
+  --ttl 1h \
+  --api-base-url http://127.0.0.1:50080
+```
+
+The command writes a hashed grant to `$OCTOS_HOME/work_secrets.json` (or
+`~/.octos/work_secrets.json`) and prints the encoded secret to stdout.
+
+## Connect
+
+Decode the secret, then connect to:
+
+```text
+ws://127.0.0.1:50080/v1/session_ingress/ws/dspfac:local:tui%23coding
+```
+
+Pass `session_ingress_token` as `Authorization: Bearer <token>`. WebSocket
+clients that cannot set headers may use `?session_ingress_token=<token>`.
+
+The socket speaks the normal UI Protocol v1 JSON-RPC frames. The server
+revalidates the grant before every client frame and rejects any method whose
+`session_id` is not the granted session. Non-session global methods such as
+`system/status.get` and `content/list` are not available through a work secret.
+
+Tiny Python client:
+
+```python
+import asyncio
+import base64
+import json
+from urllib.parse import quote
+
+import websockets
+
+SESSION_ID = "dspfac:local:tui#coding"
+ENCODED_SECRET = "<paste octos auth issue-work-secret output>"
+
+
+def decode_secret(encoded):
+    padded = encoded + "=" * (-len(encoded) % 4)
+    return json.loads(base64.urlsafe_b64decode(padded))
+
+
+async def main():
+    secret = decode_secret(ENCODED_SECRET)
+    api = secret["api_base_url"].rstrip("/")
+    ws_base = api.replace("https://", "wss://", 1).replace("http://", "ws://", 1)
+    url = (
+        f"{ws_base}/v1/session_ingress/ws/{quote(SESSION_ID, safe=':@')}"
+        f"?session_ingress_token={quote(secret['session_ingress_token'], safe='')}"
+        "&ui_feature=auxiliary.rest_to_ws.v1"
+    )
+    async with websockets.connect(url) as ws:
+        await ws.send(json.dumps({
+            "jsonrpc": "2.0",
+            "id": "status-1",
+            "method": "session/status.get",
+            "params": {"session_id": SESSION_ID},
+        }))
+        print(await ws.recv())
+
+
+asyncio.run(main())
+```
+
+## Revoke
+
+```bash
+octos auth revoke-work-secret '<encoded-secret>'
+```
+
+Revocation is read from disk by `octos serve` on each frame, so an already-open
+session ingress socket is closed with policy-violation code `1008` after the
+grant is revoked or expires.


### PR DESCRIPTION
## Summary
- add `octos_agent::bridge::work_secret` for base64url work-secret encode/decode, version validation, hashed short-TTL grant storage, validation, and revocation
- add `octos auth issue-work-secret` / `revoke-work-secret` plus `GET /v1/session_ingress/ws/{session_id}` for work-secret-authenticated UI Protocol ingress
- scope session-ingress RPCs to the granted session, revalidate on every frame, close open sockets with WS policy code 1008 after revoke/expiry, and document a worked Python client
- preserve current-main solo auth wiring while adding the session-ingress API module and route

Closes #296

## Current-main refresh
- Base: `f6936c452389c5172496ee0c3e13393956086d92`.
- Head: `0b79fde896fb3f309f9735fd8677f6c7d0a8eded`.
- Isolated checkout: `/Users/yuechen/home/octos/target/octos-1303-fresh.77hjSf/octos`.
- Environment: Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`.
- Refresh conflicts resolved only in `crates/octos-cli/src/api/mod.rs` and `crates/octos-cli/src/api/router.rs`, keeping both current-main `solo_auth` and new `session_ingress` wiring.
- Final refreshed diff is limited to work-secret/session-ingress source, CLI auth wiring, API route wiring, one integration test, and docs.

## Validation
- `git status --short --branch` showed a clean isolated checkout at push time.
- `git ls-files --others --exclude-standard` was empty at push time.
- `git diff --check origin/main...HEAD` passed.
- `cargo fmt --all -- --check` passed after applying rustfmt ordering to the conflict-resolved module/import lists.
- `typos` on touched files passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent bridge::work_secret --lib -- --nocapture` passed: 4 tests.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli auth::tests:: --lib -- --nocapture` passed: 10 tests.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api session_ingress --lib -- --nocapture` passed: 4 tests; emitted existing current-main API-feature warnings outside this slice.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api --test session_ingress_work_secret -- --nocapture` passed: 1 test.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo check -p octos-cli --features api --bin octos` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-agent --lib --tests -- -D warnings` passed.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy -p octos-cli --features api --lib --tests` exited 0; it still reports existing API-feature warnings in current-main files outside this slice.
- `CARGO_TARGET_DIR=/private/tmp/octos-1303-f693-workspace-clippy-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings` passed.

## CI / merge status
- GitHub CI is green on refreshed head `0b79fde896fb3f309f9735fd8677f6c7d0a8eded`.
- Merge is branch-protection blocked by required review: `reviewDecision=REVIEW_REQUIRED`.

