### PR TITLE
test(e2e): fail required onboarding release skips

### DIFF
--- a/e2e/matrix/README.md
+++ b/e2e/matrix/README.md
@@ -45,7 +45,7 @@ Other invocations:
 
 ```bash
 npm run matrix -- --pack onboarding --tier local     # placeholder scenarios (skipped)
-npm run matrix -- --pack onboarding --tier release   # placeholder scenarios (skipped)
+npm run matrix -- --pack onboarding --tier release   # fails while required release placeholders remain
 ```
 
 Environment knobs:
@@ -62,7 +62,7 @@ Environment knobs:
 | --------- | --------------------- | --------- | ----------------------- | -------------- |
 | `fast`    | No                    | No        | < 30 s per scenario     | Active         |
 | `local`   | Yes (local provider)  | Optional  | < 5 min per scenario    | Placeholder    |
-| `release` | Yes (release lane)    | Yes       | Bounded by gating CI    | Placeholder    |
+| `release` | Yes (release lane)    | Yes       | Bounded by gating CI    | Required placeholder; fails until wired |
 
 `tier=fast` scenarios MUST be mock-or-deterministic. The runner does not
 expose any provider configuration knobs in this PR — the only entry points
@@ -76,7 +76,7 @@ for the full schema. The runner today understands:
 
 - `[pack]` metadata: `name`, `contract`, `issue`.
 - `[[scenarios]]` with: `name`, `tier`, `transport`, `description`,
-  optional `skip_reason`, `validators`, `artifacts`.
+  optional `required`, `skip_reason`, `validators`, `artifacts`.
 - `[[scenarios.steps]]` with: `id`, `rpc`, `params`, optional `expect`.
 
 `expect` supports three light, shape-only checks that the runner enforces
@@ -107,6 +107,13 @@ Inside `params`, the runner substitutes:
 - The TOML parser in `run.mjs` is intentionally minimal: it covers the
   manifest's needs and rejects everything else with a parse error so a
   scenario authoring mistake surfaces immediately.
+
+## Required Scenario Skips
+
+Required scenarios are allowed to carry `skip_reason` while the manifest is
+being built out, but they fail the run instead of reporting `skipped`. This
+keeps release-facing commands from returning green when every required lane is
+still a placeholder.
 
 ## Follow-ups (not in this PR)
 

--- a/e2e/matrix/onboarding.toml
+++ b/e2e/matrix/onboarding.toml
@@ -20,8 +20,10 @@
 #                           when validators + tier-local arrive.
 #   description (string)    Single-line human-readable summary.
 #   skip_reason (string)    Optional. When set, scenario is reported as
-#                           "skipped" with this reason. Required when a
-#                           release-tier scenario is intentionally inert.
+#                           "skipped" with this reason unless `required=true`.
+#   required    (bool)      Optional. Required scenarios fail the run when
+#                           skipped, so release gates cannot pass with only
+#                           placeholders.
 #
 # Per-step keys (each entry in `steps`):
 #
@@ -272,9 +274,8 @@ expect = { result_has = ["requested_path", "exists"] }
 # tier-local / tier-release placeholders.
 #
 # These declare the *intent* so the next PR can grep for them, but they are
-# currently skipped with explicit reasons. The runner respects `skip_reason`
-# on every tier (no enforcement yet on release tier — release-gate
-# enforcement lands with the validators PR).
+# currently skipped with explicit reasons. Required placeholders fail the run
+# rather than producing a green release gate.
 # ---------------------------------------------------------------------------
 
 [[scenarios]]
@@ -292,6 +293,7 @@ name = "release-gate-no-otp"
 tier = "release"
 transport = "stdio"
 description = "Release gate: full onboarding flow must avoid auth/send_code and auth/verify (placeholder)."
+required = true
 validators = ["no_otp_emitted", "no_secret_leak_in_transcripts"]
 artifacts = ["rpc-transcript.jsonl", "redaction-report.json"]
 skip_reason = "tier-release gate enforced once validators ship (PR #2)."

--- a/e2e/matrix/run.mjs
+++ b/e2e/matrix/run.mjs
@@ -754,12 +754,17 @@ async function runScenario(scenario, ctx, repoRoot, octosBin, runTimeoutMs) {
   for (const log of [stderrLog, transcriptLog]) fs.closeSync(fs.openSync(log, 'a'));
 
   if (scenario.skip_reason) {
+    const requiredSkip = scenario.required === true;
     const summary = {
       name: scenario.name,
       tier: scenario.tier,
       transport: scenario.transport,
-      status: 'skipped',
+      required: requiredSkip,
+      status: requiredSkip ? 'failed' : 'skipped',
       skip_reason: scenario.skip_reason,
+      failure_reason: requiredSkip
+        ? 'required scenario cannot be skipped'
+        : null,
       validators: scenario.validators || [],
       steps: [],
     };

--- a/e2e/tests/matrix/run-required-skip.test.mjs
+++ b/e2e/tests/matrix/run-required-skip.test.mjs
@@ -1,0 +1,94 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+const cli = path.join(repoRoot, 'e2e', 'matrix', 'run.mjs');
+
+function freshDir(label) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `m22-required-skip-${label}-`));
+}
+
+function writeManifest(dir, { required }) {
+  const manifest = path.join(dir, 'onboarding.toml');
+  fs.writeFileSync(
+    manifest,
+    [
+      '[pack]',
+      'name = "onboarding"',
+      'contract = "UPCR-2026-018"',
+      'issue = "1056"',
+      '',
+      '[[scenarios]]',
+      'name = "release-placeholder"',
+      'tier = "release"',
+      'transport = "stdio"',
+      'description = "placeholder release lane"',
+      `required = ${required ? 'true' : 'false'}`,
+      'validators = ["no_otp_emitted"]',
+      'artifacts = ["rpc-transcript.jsonl"]',
+      'skip_reason = "not wired yet"',
+      '',
+    ].join('\n'),
+  );
+  return manifest;
+}
+
+function runMatrix({ manifest, outDir }) {
+  return execFileSync(
+    process.execPath,
+    [cli, '--pack', 'onboarding', '--tier', 'release', '--manifest', manifest],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        OCTOS_BIN: process.execPath,
+        OCTOS_MATRIX_DIR: outDir,
+      },
+      encoding: 'utf8',
+    },
+  );
+}
+
+test('required skipped release scenario fails the matrix run', () => {
+  const dir = freshDir('required');
+  const manifest = writeManifest(dir, { required: true });
+  const outDir = path.join(dir, 'out');
+
+  assert.throws(
+    () => runMatrix({ manifest, outDir }),
+    (error) => {
+      assert.equal(error.status, 1);
+      return true;
+    },
+  );
+
+  const summary = JSON.parse(fs.readFileSync(path.join(outDir, 'summary.json'), 'utf8'));
+  assert.equal(summary.ok, false);
+  assert.equal(summary.counts.failed, 1);
+  assert.equal(summary.counts.skipped, 0);
+  assert.equal(summary.scenarios[0].status, 'failed');
+  assert.equal(summary.scenarios[0].required, true);
+  assert.equal(summary.scenarios[0].failure_reason, 'required scenario cannot be skipped');
+});
+
+test('optional skipped release scenario remains a skipped audit row', () => {
+  const dir = freshDir('optional');
+  const manifest = writeManifest(dir, { required: false });
+  const outDir = path.join(dir, 'out');
+
+  const stdout = runMatrix({ manifest, outDir });
+  const parsed = JSON.parse(stdout.slice(stdout.indexOf('{')));
+
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.counts.failed, 0);
+  assert.equal(parsed.counts.skipped, 1);
+  assert.equal(parsed.scenarios[0].status, 'skipped');
+  assert.equal(parsed.scenarios[0].required, false);
+});


### PR DESCRIPTION
## Summary

- Make required release-tier onboarding scenarios fail closed when they are still skipped/placeholders.
- Keep optional skipped release scenarios as audit rows.
- Document that the release onboarding tier fails until the real release lane is wired.
- Current-main refresh: rebuilt from `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`; refreshed head `5032d223868ef8cc3cbf8a4b0e5d5841c0b51e77`.

Refs #1056

This intentionally avoids a closing keyword. This is one onboarding support slice, not full #1056 closure.

## Current-main validation

Base: current `origin/main` / GitHub `main` `f6936c452389c5172496ee0c3e13393956086d92`.
Head: `5032d223868ef8cc3cbf8a4b0e5d5841c0b51e77`.
Environment: isolated clone `/private/tmp/octos-1304-f693.2vskjq/octos`; root checkout left untouched; `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1304-f693`; `CARGO_INCREMENTAL=0`; `CARGO_PROFILE_DEV_DEBUG=0`.
Octos binary: `/private/tmp/octos-1304-f693-target/debug/octos` -> `octos 0.1.1 (5032d223 2026-06-02)`.
Fast artifact root: `/private/tmp/octos-1056-fast-required-current-f693-1304`.
Release expected-fail artifact root: `/private/tmp/octos-1056-release-required-current-f693-1304`.

Commands passed:
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `node --check e2e/matrix/run.mjs`
- `node --check e2e/tests/matrix/run-required-skip.test.mjs`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1304-f693 npm --prefix e2e ci` -> completed with the existing 1 moderate audit warning
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1304-f693 node --test e2e/tests/matrix/*.test.mjs` -> 4/4 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1304-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo build -p octos-cli --features api --bin octos`
- `OCTOS_BIN=/private/tmp/octos-1304-f693-target/debug/octos OCTOS_MATRIX_DIR=/private/tmp/octos-1056-fast-required-current-f693-1304 npm --prefix e2e run matrix -- --pack onboarding --tier fast` -> `ok=true`, `passed=7 failed=0 skipped=0 total=7`
- `OCTOS_BIN=/private/tmp/octos-1304-f693-target/debug/octos OCTOS_MATRIX_DIR=/private/tmp/octos-1056-release-required-current-f693-1304 npm --prefix e2e run matrix -- --pack onboarding --tier release` -> expected exit `1`, `ok=false`, `passed=0 failed=1 skipped=0 total=1`; `release-gate-no-otp.required=true`, `failure_reason=required scenario cannot be skipped`
- `typos e2e/matrix/README.md e2e/matrix/onboarding.toml e2e/matrix/run.mjs e2e/tests/matrix/run-required-skip.test.mjs`
- `CARGO_TARGET_DIR=/private/tmp/octos-1304-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/octos-1304-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-memory -- --nocapture` -> 56/56 plus doc tests passed locally after GitHub's first broad `check` attempt hit a transient `test_append_today_appends` failure
- `git ls-files --others --exclude-standard` -> empty

Result:
- Fast onboarding scenarios still pass.
- Required release skip now fails closed instead of silently passing as a skipped placeholder.
- No generated matrix artifacts or untracked repo files were left in the isolated clone.

## CI / merge status
GitHub CI is green on refreshed head `5032d223868ef8cc3cbf8a4b0e5d5841c0b51e77`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, `typos`, and blocked-email all passed. Optional platform/e2e/security lanes were skipped by workflow policy.

Note: the first broad `check` attempt failed in `octos-memory::memory_store::tests::test_append_today_appends`; the same suite passed locally, and rerunning failed GitHub jobs made `check` pass.

Remaining gap:
- PR is non-closing support for #1056.
- Full closure still needs local/tmux onboarding evidence, runtime policy stamp coverage, provider secret redaction, unsupported-method gating, required release enforcement on the real release lane, and final real release onboarding proof.
- Merge remains branch-protection blocked by required review (`BLOCKED` / `REVIEW_REQUIRED`).
