### PR TITLE
fix(routing): lane defaults reference production providers (RFC-3 follow-up)

### DIFF
--- a/crates/octos-llm/src/lane.rs
+++ b/crates/octos-llm/src/lane.rs
@@ -99,14 +99,20 @@ pub fn default_lane_candidates(lane: Lane) -> Vec<(String, String)> {
     let pairs: &[(&str, &str)] = match lane {
         Lane::InstructionStrong => &[
             ("anthropic", "claude-sonnet-4-6"),
-            // Production fleet fallback observed on 2026-05-25 mini1
-            // round-14 retest: primary `deepseek-v4-pro`, fallback
-            // `moonshot/kimi-k2.6`. Pin k2.6 FIRST so the documented
-            // shape actually matches — pinning only k2.5 would leave
-            // the lane inert because mini1's fallback is k2.6.
-            ("moonshot", "kimi-k2.6"),
-            // Production fleet alternative (mini3/5 declared primary).
+            // Production fleet declared primary (mini3/5). k2.5 is the
+            // stronger instruction-following model in the kimi family;
+            // pin it AHEAD of k2.6 so `select_provider` in Off/Hedge
+            // mode (which walks the lane-eligible list in candidate
+            // order) picks k2.5 first when both are configured. Codex
+            // round-2 P2 flagged that reversing this would route mini3/5
+            // turns to the faster fallback instead of the operator's
+            // declared primary.
             ("moonshot", "kimi-k2.5"),
+            // Production fleet fallback observed on 2026-05-25 mini1
+            // round-14 retest (primary `deepseek-v4-pro`, fallback
+            // `moonshot/kimi-k2.6`). MUST be present so the mini1 chain
+            // matches; ordered AFTER k2.5 per the precedence above.
+            ("moonshot", "kimi-k2.6"),
             // Legacy compat: non-fleet profiles routing via wisemodel.
             ("wisemodel", "kimi-k2.5"),
             ("openai", "gpt-4.1"),
@@ -550,6 +556,36 @@ mod tests {
             "InstructionStrong must match the mini1 fallback (moonshot/kimi-k2.6); \
              matched slots: {:?}",
             matched,
+        );
+    }
+
+    #[test]
+    fn instruction_strong_orders_k25_before_k26() {
+        // Codex round-2 P2: `select_provider` in Off/Hedge mode walks the
+        // lane-eligible list in candidate-declaration order. If a profile
+        // has BOTH moonshot/kimi-k2.5 (mini3/5 declared primary, stronger
+        // instruction-following) and moonshot/kimi-k2.6 (mini1 fallback,
+        // faster) in its chain, the lane filter must pick k2.5 first so
+        // the operator's declared primary wins. Pin the relative order
+        // of these two entries here so a future re-shuffle can't silently
+        // demote the primary.
+        let strong = default_lane_candidates(Lane::InstructionStrong);
+        let k25_idx = strong
+            .iter()
+            .position(|(p, m)| p == "moonshot" && m == "kimi-k2.5")
+            .expect("k2.5 must be present");
+        let k26_idx = strong
+            .iter()
+            .position(|(p, m)| p == "moonshot" && m == "kimi-k2.6")
+            .expect("k2.6 must be present");
+        assert!(
+            k25_idx < k26_idx,
+            "moonshot/kimi-k2.5 (primary) must precede moonshot/kimi-k2.6 \
+             (fallback) so Off/Hedge mode picks k2.5 when both are in the \
+             chain; got k2.5_idx={} k2.6_idx={}, list={:?}",
+            k25_idx,
+            k26_idx,
+            strong,
         );
     }
 

--- a/crates/octos-llm/src/lane.rs
+++ b/crates/octos-llm/src/lane.rs
@@ -82,10 +82,26 @@ impl Lane {
 /// `InstructionStrong`, `CodeCapable`, and `FastChat` carry opinionated
 /// lists. `General` returns an empty vec on purpose — its semantics are
 /// "no filter; use the profile-default chain".
+///
+/// # Production fleet coverage (RFC-3 follow-up)
+///
+/// The dspfac fleet (mini1/3/5) runs `moonshot` + `deepseek` providers
+/// — NOT `wisemodel`. The 2026-05-25 round-14 retest confirmed the
+/// `provider_name == candidate_provider` filter found zero matches and
+/// fell through to the per-profile primary (`deepseek-v4-pro`), which
+/// doesn't follow long structured prompts strongly enough to invoke
+/// `mofa_slides`. Production providers are now pinned into each
+/// opinionated lane so RFC-3 is no longer inert on the live fleet.
+/// `wisemodel` entries are kept for backward compatibility with
+/// non-fleet profiles. Order: `anthropic` first (premium user pick),
+/// then production providers (fleet match), then legacy compat.
 pub fn default_lane_candidates(lane: Lane) -> Vec<(String, String)> {
     let pairs: &[(&str, &str)] = match lane {
         Lane::InstructionStrong => &[
             ("anthropic", "claude-sonnet-4-6"),
+            // Production fleet primary lane for instruction-following.
+            ("moonshot", "kimi-k2.5"),
+            // Legacy compat: non-fleet profiles routing via wisemodel.
             ("wisemodel", "kimi-k2.5"),
             ("openai", "gpt-4.1"),
         ],
@@ -93,9 +109,14 @@ pub fn default_lane_candidates(lane: Lane) -> Vec<(String, String)> {
             ("anthropic", "claude-sonnet-4-6"),
             ("openai", "gpt-4.1"),
             ("deepseek", "deepseek-coder"),
+            // Production fleet fallback: k2.5 is decent at code too.
+            ("moonshot", "kimi-k2.5"),
         ],
         Lane::General => &[],
         Lane::FastChat => &[
+            // Production fleet primary for short-turn chat.
+            ("moonshot", "kimi-k2.6"),
+            // Legacy compat: non-fleet profiles routing via wisemodel.
             ("wisemodel", "kimi-k2.6"),
             ("deepseek", "deepseek-chat"),
             ("openai", "gpt-4o-mini"),
@@ -450,6 +471,110 @@ mod tests {
 
         // General is intentionally empty (no filter).
         assert!(default_lane_candidates(Lane::General).is_empty());
+    }
+
+    // ── Production fleet coverage (RFC-3 follow-up) ─────────────────
+    //
+    // The dspfac fleet (mini1/3/5) runs `moonshot` + `deepseek` providers
+    // — not `wisemodel`. The 2026-05-25 round-14 retest confirmed the
+    // lane filter found zero matches and fell through to the per-profile
+    // primary (deepseek-v4-pro), which doesn't follow long structured
+    // prompts strongly enough to invoke `mofa_slides`. These tests pin
+    // the production providers into the built-in defaults so RFC-3 is
+    // no longer inert on the live fleet.
+
+    #[test]
+    fn instruction_strong_default_includes_moonshot_kimi_k25() {
+        let strong = default_lane_candidates(Lane::InstructionStrong);
+        assert!(
+            strong
+                .iter()
+                .any(|(p, m)| p == "moonshot" && m == "kimi-k2.5"),
+            "moonshot/kimi-k2.5 must appear in InstructionStrong defaults \
+             so dspfac fleet sessions match the lane filter; current list: {:?}",
+            strong,
+        );
+    }
+
+    #[test]
+    fn instruction_strong_filter_matches_dspfac_fleet_shape() {
+        // Simulate the dspfac fleet's slot list (primary + fallback).
+        // The 2026-05-25 round-14 retest observed exactly this shape on
+        // mini1 — primary `deepseek-v4-pro`, fallback `moonshot/kimi-k2.6`
+        // — and the lane filter returned zero matches against the old
+        // `[anthropic, wisemodel, openai]` defaults.
+        let fleet_slots: Vec<(&str, &str)> = vec![
+            ("deepseek", "deepseek-v4-pro"),
+            ("moonshot", "kimi-k2.6"),
+            ("moonshot", "kimi-k2.5"),
+        ];
+        let defaults = default_lane_candidates(Lane::InstructionStrong);
+        let matched: Vec<_> = fleet_slots
+            .iter()
+            .filter(|(p, m)| defaults.iter().any(|(dp, dm)| dp == p && dm == m))
+            .collect();
+        assert!(
+            !matched.is_empty(),
+            "InstructionStrong filter found zero matches against fleet \
+             slots — RFC-3 still inert. defaults={:?} slots={:?}",
+            defaults,
+            fleet_slots,
+        );
+    }
+
+    #[test]
+    fn fast_chat_default_includes_moonshot_kimi_k26() {
+        let fast = default_lane_candidates(Lane::FastChat);
+        assert!(
+            fast.iter()
+                .any(|(p, m)| p == "moonshot" && m == "kimi-k2.6"),
+            "moonshot/kimi-k2.6 must appear in FastChat defaults so dspfac \
+             fleet primary matches the lane filter; current list: {:?}",
+            fast,
+        );
+    }
+
+    #[test]
+    fn code_capable_default_includes_moonshot_for_fleet_fallback() {
+        // The fleet's secondary slot is k2.5 on moonshot. Including it
+        // in CodeCapable keeps `code:*` sessions on a known-good model
+        // when the LLM picks deepseek-coder isn't available.
+        let code = default_lane_candidates(Lane::CodeCapable);
+        assert!(
+            code.iter()
+                .any(|(p, m)| p == "moonshot" && m == "kimi-k2.5"),
+            "moonshot/kimi-k2.5 must appear in CodeCapable defaults; \
+             current list: {:?}",
+            code,
+        );
+    }
+
+    #[test]
+    fn fast_chat_keeps_wisemodel_for_backward_compat() {
+        // Compat sanity: wisemodel/kimi-k2.6 must remain so non-fleet
+        // profiles already routing through wisemodel still match.
+        let fast = default_lane_candidates(Lane::FastChat);
+        assert!(
+            fast.iter()
+                .any(|(p, m)| p == "wisemodel" && m == "kimi-k2.6"),
+            "wisemodel/kimi-k2.6 must remain in FastChat defaults for \
+             backward compatibility; current list: {:?}",
+            fast,
+        );
+    }
+
+    #[test]
+    fn instruction_strong_keeps_anthropic_at_front() {
+        // Per task spec: anthropic stays at index 0 because users
+        // routinely route claude-sonnet for `slides:*` and friends.
+        let strong = default_lane_candidates(Lane::InstructionStrong);
+        assert_eq!(
+            strong.first().map(|(p, m)| (p.as_str(), m.as_str())),
+            Some(("anthropic", "claude-sonnet-4-6")),
+            "anthropic/claude-sonnet-4-6 must remain at the front of \
+             InstructionStrong defaults; current list: {:?}",
+            strong,
+        );
     }
 
     // ── LaneContext shape ───────────────────────────────────────────

--- a/crates/octos-llm/src/lane.rs
+++ b/crates/octos-llm/src/lane.rs
@@ -99,7 +99,13 @@ pub fn default_lane_candidates(lane: Lane) -> Vec<(String, String)> {
     let pairs: &[(&str, &str)] = match lane {
         Lane::InstructionStrong => &[
             ("anthropic", "claude-sonnet-4-6"),
-            // Production fleet primary lane for instruction-following.
+            // Production fleet fallback observed on 2026-05-25 mini1
+            // round-14 retest: primary `deepseek-v4-pro`, fallback
+            // `moonshot/kimi-k2.6`. Pin k2.6 FIRST so the documented
+            // shape actually matches — pinning only k2.5 would leave
+            // the lane inert because mini1's fallback is k2.6.
+            ("moonshot", "kimi-k2.6"),
+            // Production fleet alternative (mini3/5 declared primary).
             ("moonshot", "kimi-k2.5"),
             // Legacy compat: non-fleet profiles routing via wisemodel.
             ("wisemodel", "kimi-k2.5"),
@@ -491,34 +497,80 @@ mod tests {
                 .iter()
                 .any(|(p, m)| p == "moonshot" && m == "kimi-k2.5"),
             "moonshot/kimi-k2.5 must appear in InstructionStrong defaults \
-             so dspfac fleet sessions match the lane filter; current list: {:?}",
+             (mini3/5 declared primary); current list: {:?}",
             strong,
         );
     }
 
     #[test]
-    fn instruction_strong_filter_matches_dspfac_fleet_shape() {
-        // Simulate the dspfac fleet's slot list (primary + fallback).
-        // The 2026-05-25 round-14 retest observed exactly this shape on
-        // mini1 — primary `deepseek-v4-pro`, fallback `moonshot/kimi-k2.6`
-        // — and the lane filter returned zero matches against the old
-        // `[anthropic, wisemodel, openai]` defaults.
-        let fleet_slots: Vec<(&str, &str)> = vec![
-            ("deepseek", "deepseek-v4-pro"),
-            ("moonshot", "kimi-k2.6"),
-            ("moonshot", "kimi-k2.5"),
-        ];
+    fn instruction_strong_default_includes_moonshot_kimi_k26() {
+        // The mini1 round-14 fallback slot is k2.6 (NOT k2.5). The lane
+        // filter must match this exact `(provider, model)` pair, otherwise
+        // slides/research sessions still fall through to deepseek-v4-pro.
+        // Codex review (PR #1305 round 1) flagged this gap. The fix MUST
+        // pin k2.6 into InstructionStrong, not only k2.5.
+        let strong = default_lane_candidates(Lane::InstructionStrong);
+        assert!(
+            strong
+                .iter()
+                .any(|(p, m)| p == "moonshot" && m == "kimi-k2.6"),
+            "moonshot/kimi-k2.6 must appear in InstructionStrong defaults \
+             — this is the observed mini1 fallback slot. current list: {:?}",
+            strong,
+        );
+    }
+
+    #[test]
+    fn instruction_strong_filter_matches_documented_mini1_shape() {
+        // EXACT documented mini1 shape from the 2026-05-25 round-14
+        // retest — primary `deepseek-v4-pro`, fallback `moonshot/kimi-k2.6`.
+        // No padding slots; this is the literal chain the AdaptiveRouter
+        // saw on the live fleet. The lane filter MUST return at least
+        // one match here, otherwise RFC-3 is still inert on production.
+        let mini1_slots: Vec<(&str, &str)> =
+            vec![("deepseek", "deepseek-v4-pro"), ("moonshot", "kimi-k2.6")];
         let defaults = default_lane_candidates(Lane::InstructionStrong);
-        let matched: Vec<_> = fleet_slots
+        let matched: Vec<_> = mini1_slots
             .iter()
             .filter(|(p, m)| defaults.iter().any(|(dp, dm)| dp == p && dm == m))
             .collect();
         assert!(
             !matched.is_empty(),
-            "InstructionStrong filter found zero matches against fleet \
-             slots — RFC-3 still inert. defaults={:?} slots={:?}",
+            "InstructionStrong filter found zero matches against the \
+             documented mini1 chain — RFC-3 still inert on production. \
+             defaults={:?} slots={:?}",
             defaults,
-            fleet_slots,
+            mini1_slots,
+        );
+        // And confirm the match is on the fallback slot specifically.
+        assert!(
+            matched
+                .iter()
+                .any(|(p, m)| *p == "moonshot" && *m == "kimi-k2.6"),
+            "InstructionStrong must match the mini1 fallback (moonshot/kimi-k2.6); \
+             matched slots: {:?}",
+            matched,
+        );
+    }
+
+    #[test]
+    fn instruction_strong_filter_matches_mini3_mini5_shape() {
+        // mini3 and mini5 declare `moonshot/kimi-k2.5` as primary.
+        // Keep this shape covered too — both production sub-fleets
+        // must hit the lane filter.
+        let slots: Vec<(&str, &str)> =
+            vec![("moonshot", "kimi-k2.5"), ("deepseek", "deepseek-v4-pro")];
+        let defaults = default_lane_candidates(Lane::InstructionStrong);
+        let matched: Vec<_> = slots
+            .iter()
+            .filter(|(p, m)| defaults.iter().any(|(dp, dm)| dp == p && dm == m))
+            .collect();
+        assert!(
+            !matched.is_empty(),
+            "InstructionStrong filter found zero matches against the \
+             mini3/5 declared chain. defaults={:?} slots={:?}",
+            defaults,
+            slots,
         );
     }
 


### PR DESCRIPTION
## Summary

- RFC-3 (#1301) shipped per-topic lane routing but the built-in candidate lists pointed only at `anthropic` / `wisemodel` / `openai`. The dspfac production fleet runs `moonshot` + `deepseek`, so the lane filter's literal `provider_name == candidate_provider` matching returned zero matches on every fleet session → AdaptiveRouter fell through to the per-profile primary → RFC-3 inert on production.
- Pin `moonshot/kimi-k2.5` AND `moonshot/kimi-k2.6` into `InstructionStrong`; pin `moonshot/kimi-k2.5` into `CodeCapable`; pin `moonshot/kimi-k2.6` into `FastChat`. `wisemodel` entries remain for non-fleet compat. `anthropic` stays at index 0. `General` unchanged.
- k2.5 is ordered AHEAD of k2.6 in `InstructionStrong` so `select_provider` in Off/Hedge mode picks the operator's declared primary when both are configured (mini3/5 declared primary is k2.5; mini1 fallback is k2.6).
- Scope: built-in defaults only — no new providers in `octos-llm/src/providers/`, no fleet `profile.json` edits, no gateway/WS wiring touched.

## Evidence

2026-05-25 round-14 retest, mini1 (dspfac):
- Slots: `[(deepseek, deepseek-v4-pro), (moonshot, kimi-k2.6)]`
- Lane defaults (pre-fix): `[(anthropic, claude-sonnet-4-6), (wisemodel, kimi-k2.5), (openai, gpt-4.1)]`
- Filter intersection: 0 → fall-through to `deepseek-v4-pro` → slides session DID NOT invoke `mofa_slides`.

## Backward compat

- Profiles with explicit `lane_models` overrides still win — `LaneRoutingConfig::candidates_for_lane` short-circuits to the override when non-empty.
- Built-in defaults only apply when no profile override exists.

## Test plan

- [x] `cargo test -p octos-llm` — 350 lib tests pass (incl. 9 new lane tests)
- [x] `cargo test -p octos-cli --test rfc3_lane_routing_wiring --features api` — 4/4 pass
- [x] `cargo build --workspace`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --lib --tests -- -D warnings`
- [x] `codex review --commit 6c8d1084` → P1 (missing k2.6 in InstructionStrong) → fixed in 257f9d9a
- [x] `codex review --commit 257f9d9a` → P2 (k2.6 ahead of k2.5) → fixed in 2d653273
- [x] `codex review --commit 2d653273` → "no clear functional regression" (clean)
- [ ] Post-merge: fleet retest on mini1/3/5 — `slides:*` session should now route through `moonshot/kimi-k2.5` (or k2.6 on mini1) and invoke `mofa_slides`.

## New tests (9)

- `instruction_strong_default_includes_moonshot_kimi_k25`
- `instruction_strong_default_includes_moonshot_kimi_k26`
- `instruction_strong_orders_k25_before_k26` (precedence pin)
- `instruction_strong_filter_matches_documented_mini1_shape` (exact mini1 chain)
- `instruction_strong_filter_matches_mini3_mini5_shape`
- `fast_chat_default_includes_moonshot_kimi_k26`
- `code_capable_default_includes_moonshot_for_fleet_fallback`
- `fast_chat_keeps_wisemodel_for_backward_compat`
- `instruction_strong_keeps_anthropic_at_front`