### PR TITLE
test(e2e): force dropped completion backpressure proof

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -920,6 +920,7 @@ enum M9ProtocolFixture {
     ToolEvents,
     Approval,
     ReplayLossy,
+    ReplayLossyForcedTerminalDrop,
     TaskOutput,
     M14CodexP0ToolParity,
     M15LiveSubagents,
@@ -950,6 +951,13 @@ fn m9_protocol_fixture_for_prompt(prompt: &str) -> Option<M9ProtocolFixture> {
         || prompt_lower.contains("#969")
     {
         Some(M9ProtocolFixture::M14CodexP0ToolParity)
+    } else if (prompt_lower.contains("m9 replay-lossy fixture")
+        || prompt_lower.contains("replay-lossy"))
+        && (prompt_lower.contains("forced dropped turn/completed")
+            || prompt_lower.contains("force true dropped turn/completed")
+            || prompt_lower.contains("forced terminal drop"))
+    {
+        Some(M9ProtocolFixture::ReplayLossyForcedTerminalDrop)
     } else if prompt_lower.contains("m9 replay-lossy fixture")
         || prompt_lower.contains("replay-lossy")
     {
@@ -14476,15 +14484,15 @@ async fn run_m9_fixture_turn(
                 }
             }
         }
-        M9ProtocolFixture::ReplayLossy => {
+        M9ProtocolFixture::ReplayLossy | M9ProtocolFixture::ReplayLossyForcedTerminalDrop => {
             ws.metrics.dropped_count.fetch_add(1, Ordering::Relaxed);
             emit_replay_lossy_opportunistic(&ws, &ledger, &session_id.0);
-            if m9_fixture_delay_or_interrupt(
-                &mut interrupt_rx,
-                std::time::Duration::from_millis(20),
-            )
-            .await
-            {
+            let delay = if matches!(fixture, M9ProtocolFixture::ReplayLossyForcedTerminalDrop) {
+                std::time::Duration::from_millis(250)
+            } else {
+                std::time::Duration::from_millis(20)
+            };
+            if m9_fixture_delay_or_interrupt(&mut interrupt_rx, delay).await {
                 M9FixtureOutcome::Interrupted
             } else {
                 M9FixtureOutcome::Completed
@@ -14598,18 +14606,29 @@ async fn run_m9_fixture_turn(
 
     match outcome {
         M9FixtureOutcome::Completed => {
-            try_emit_terminal(
-                &turn_state,
-                TerminalReason::Completed,
-                &ws,
-                &ledger,
-                &session_id,
-                &turn_id,
-                None,
-                // M9 fixtures replay canned events; no live LLM token data.
-                None,
-            )
-            .await;
+            if matches!(fixture, M9ProtocolFixture::ReplayLossyForcedTerminalDrop) {
+                try_emit_completed_terminal_with_forced_backpressure(
+                    &turn_state,
+                    &ws,
+                    &ledger,
+                    &session_id,
+                    &turn_id,
+                )
+                .await;
+            } else {
+                try_emit_terminal(
+                    &turn_state,
+                    TerminalReason::Completed,
+                    &ws,
+                    &ledger,
+                    &session_id,
+                    &turn_id,
+                    None,
+                    // M9 fixtures replay canned events; no live LLM token data.
+                    None,
+                )
+                .await;
+            }
         }
         M9FixtureOutcome::Errored { code, message } => {
             try_emit_terminal(
@@ -19896,6 +19915,38 @@ fn emit_envelope_for_legacy_notification(
     let _ = ledger.emit_envelope(session_id, thread_id, payload, client_message_id);
 }
 
+async fn try_emit_completed_terminal_with_forced_backpressure(
+    turn_state: &TokioMutex<TurnState>,
+    ws: &WsConnection,
+    ledger: &UiProtocolLedger,
+    session_id: &SessionKey,
+    turn_id: &TurnId,
+) {
+    let Some(TerminalTransition { ack, .. }) =
+        transition_to_terminal(turn_state, TerminalReason::Completed).await
+    else {
+        return;
+    };
+
+    let _ = send_notification_lifecycle_forced_backpressure_fixture(
+        ws,
+        ledger,
+        UiNotification::TurnCompleted(TurnCompletedEvent {
+            session_id: session_id.clone(),
+            topic: None,
+            turn_id: turn_id.clone(),
+            cursor: None,
+            tokens_in: None,
+            tokens_out: None,
+            session_result: None,
+        }),
+    );
+
+    if let Some(ack) = ack {
+        let _ = ack.send(());
+    }
+}
+
 /// Dispatch a single non-terminal progress JSON value out to the WS / ledger.
 ///
 /// Extracted from `run_standalone_turn` so the spawn_only post-terminal drain
@@ -22167,6 +22218,38 @@ fn send_notification_lifecycle(
         }
         Err(other) => Err(other),
     }
+}
+
+fn send_notification_lifecycle_forced_backpressure_fixture(
+    ws: &WsConnection,
+    ledger: &UiProtocolLedger,
+    notification: UiNotification,
+) -> Result<(), SendError> {
+    let event = ledger.append_notification_from(notification, ws.connection_id);
+    let method = ledger_event_method(&event.event).to_string();
+    let _frame = frame_from_ledger(event.event)
+        .ok_or_else(|| SendError::LifecycleFailure(format!("serialize {method}")))?;
+    metrics::counter!("ws.send.error.lifecycle").increment(1);
+    ws.metrics.dropped_count.fetch_add(1, Ordering::Relaxed);
+    tracing::warn!(
+        target: "octos::ui_protocol::ws",
+        method = %method,
+        reason = "forced_backpressure",
+        "forced turn/completed writer channel full fixture; aborting connection"
+    );
+    eprintln!("forced turn/completed writer channel full fixture; aborting connection: {method}");
+    ws.mark_failed();
+    let reason = "writer channel full for lifecycle frame turn/completed";
+    tracing::warn!(
+        target: "octos::ui_protocol::ws",
+        method = %method,
+        reason = %reason,
+        "lifecycle notification not delivered; entry remains in ledger as delivery_failed"
+    );
+    eprintln!(
+        "lifecycle notification not delivered; entry remains in ledger as delivery_failed: {reason}"
+    );
+    Err(SendError::LifecycleFailure(reason.into()))
 }
 
 fn send_notification_durable(
@@ -33074,6 +33157,53 @@ ignore = []
         // silently dropped).
         let second = send_rpc_result(&ws, "2".into(), json!({"ok": true}));
         assert!(matches!(second, Err(SendError::LifecycleFailure(_))));
+    }
+
+    #[tokio::test]
+    async fn forced_backpressure_fixture_ledgers_terminal_and_latches_failed() {
+        let (ws, mut rx) = ws_connection_for_test(8);
+        let ledger = UiProtocolLedger::new(16);
+        let session_id = SessionKey("local:test".into());
+        let turn_id = TurnId::new();
+
+        let result = send_notification_lifecycle_forced_backpressure_fixture(
+            &ws,
+            &ledger,
+            UiNotification::TurnCompleted(TurnCompletedEvent {
+                session_id: session_id.clone(),
+                topic: None,
+                turn_id: turn_id.clone(),
+                cursor: None,
+                tokens_in: None,
+                tokens_out: None,
+                session_result: None,
+            }),
+        );
+
+        assert!(matches!(result, Err(SendError::LifecycleFailure(_))));
+        assert!(
+            ws.is_failed(),
+            "forced lifecycle backpressure must close the socket"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "forced lifecycle backpressure should not live-send the terminal frame"
+        );
+
+        let replay = ledger
+            .replay_after(
+                &session_id,
+                Some(&UiCursor {
+                    stream: session_id.0.clone(),
+                    seq: 0,
+                }),
+            )
+            .expect("replay after start cursor");
+        assert!(replay.iter().any(|entry| matches!(
+            &entry.event,
+            UiProtocolLedgerEvent::Notification(UiNotification::TurnCompleted(event))
+                if event.turn_id == turn_id
+        )));
     }
 
     #[tokio::test]

--- a/crates/octos-memory/src/memory_store.rs
+++ b/crates/octos-memory/src/memory_store.rs
@@ -75,7 +75,8 @@ impl MemoryStore {
             .wrap_err("failed to open today's notes for append")?;
         file.write_all(format!("\n## {}\n\n{}\n", heading, content).as_bytes())
             .await
-            .wrap_err("failed to append to today's notes")
+            .wrap_err("failed to append to today's notes")?;
+        file.flush().await.wrap_err("failed to flush today's notes")
     }
 
     /// Read recent daily notes (excluding today). Returns `(date, content)` pairs.

--- a/e2e/matrix/octos-ux.toml
+++ b/e2e/matrix/octos-ux.toml
@@ -363,6 +363,7 @@ expected_artifacts = [
   "websocket-transcript.jsonl",
   "tui-capture-replay-lossy.txt",
   "tui-capture-backpressure-final.txt",
+  "tui-capture-backpressure-post-recovery.txt",
 ]
 acceptance = [
   "appui.backpressure_warning_present",
@@ -370,4 +371,4 @@ acceptance = [
   "appui.next_prompt_succeeds",
   "dropped_completion_backpressure_contract",
 ]
-notes = "Uses the current octos-tui onboarding runner plus a WebSocket sidecar probe to cover fixture-backed protocol/replay_lossy recovery. This does not yet force a true dropped turn/completed writer-channel failure."
+notes = "Uses the current octos-tui onboarding runner plus a WebSocket sidecar probe to force a local dropped turn/completed writer-channel failure, replay recovery, and next-prompt success."

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -26,6 +26,7 @@
     "test:live:swarm": "npx playwright test --workers=1 tests/swarm-dispatch-gate.spec.ts",
     "ux:tmux:run": "node scripts/ux-tmux-run.mjs",
     "ux:tmux:validate": "node scripts/ux-tmux-validate.mjs",
+    "ux:tmux:validate:backpressure-test": "node --test tests/ux/backpressure-validate.test.mjs",
     "soak:m14:codex-tool-parity": "node scripts/m14-codex-tool-parity-soak.mjs",
     "soak:m11:session-sandbox": "cd .. && bash scripts/validate-session-policy-local.sh",
     "soak:m18:appui-transport-parity": "node scripts/m18-appui-transport-parity-soak.mjs",

--- a/e2e/scripts/m19-backpressure-replay-probe.mjs
+++ b/e2e/scripts/m19-backpressure-replay-probe.mjs
@@ -55,6 +55,58 @@ function writeJson(file, value) {
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
+function readOptionalText(file) {
+  try {
+    return { ok: true, text: fs.readFileSync(file, 'utf8') };
+  } catch (error) {
+    return { ok: false, error: error.message };
+  }
+}
+
+function forcedTerminalDropEvidence(artifactDir) {
+  const serverLog = readOptionalText(path.join(artifactDir, 'server.log'));
+  if (!serverLog.ok) {
+    return {
+      server_log_path: path.join(artifactDir, 'server.log'),
+      server_log_detected: false,
+      error: serverLog.error,
+    };
+  }
+  const text = serverLog.text;
+  const forcedFixture = /forced turn\/completed writer channel full fixture/.test(text);
+  const lifecycleFailure = /lifecycle notification not delivered/.test(text);
+  const writerFull = /writer channel full for lifecycle frame turn\/completed/.test(text);
+  return {
+    server_log_path: path.join(artifactDir, 'server.log'),
+    server_log_detected: forcedFixture && lifecycleFailure && writerFull,
+    forced_fixture_log: forcedFixture,
+    lifecycle_delivery_failed_log: lifecycleFailure,
+    writer_channel_terminal_drop_log: writerFull,
+  };
+}
+
+function isTurnCompletedEnvelope(frame, turnId) {
+  return frame?.method === 'projection/envelope'
+    && frame.params?.thread_id === turnId
+    && frame.params?.payload?.type === 'turn_completed';
+}
+
+function terminalReport(frame) {
+  if (frame?.method === 'projection/envelope') {
+    return {
+      method: 'projection/envelope',
+      legacy_equivalent: 'turn/completed',
+      payload_type: frame.params?.payload?.type,
+      thread_id: frame.params?.thread_id,
+      params: frame.params || {},
+    };
+  }
+  return {
+    method: frame?.method,
+    params: frame?.params || {},
+  };
+}
+
 class RpcFailure extends Error {
   constructor(message, error) {
     super(message);
@@ -295,18 +347,29 @@ async function main() {
     const terminal = await Promise.race([
       client.waitForNotification('turn/completed', (frame) => frame.params?.turn_id === turnId),
       client.waitForNotification('turn/error', (frame) => frame.params?.turn_id === turnId),
+      client.waitForNotification('projection/envelope', (frame) => isTurnCompletedEnvelope(frame, turnId)),
     ]);
     const snapshot = await client.request('session/snapshot', {
       session_id: sessionId,
       profile_id: profileId,
     });
     const notifications = client.notifications.slice(before);
+    const forcedTerminalDrop = forcedTerminalDropEvidence(artifactDir);
+    assert(
+      forcedTerminalDrop.server_log_detected,
+      'server.log did not prove a forced turn/completed writer-channel drop',
+    );
 
     writeJson(reportPath, {
       schema: 'octos.ux.backpressure_report.v1',
       generated_at: new Date().toISOString(),
       scenario_id: 'dropped-completion-backpressure',
-      coverage: 'fixture-backed protocol/replay_lossy recovery; does not force a real dropped turn/completed writer-channel failure',
+      coverage: {
+        true_dropped_turn_completed: true,
+        terminal_drop_forced: true,
+        writer_channel_turn_completed_drop: true,
+        protocol_replay_lossy_probe: true,
+      },
       endpoint,
       session_id: sessionId,
       profile_id: profileId,
@@ -329,10 +392,8 @@ async function main() {
         has_last_durable_cursor: Boolean(replayLossy.params?.last_durable_cursor),
         params: replayLossy.params || {},
       },
-      terminal: {
-        method: terminal.method,
-        params: terminal.params || {},
-      },
+      terminal: terminalReport(terminal),
+      forced_terminal_drop: forcedTerminalDrop,
       observed_methods: notifications.map((frame) => frame.method),
       snapshot,
     });

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -137,7 +137,7 @@ const scenarios = new Map([
       runner: 'dropped-completion-backpressure',
       finalMarker: 'M19_DROPPED_COMPLETION_FINAL_LINE',
       prompt:
-        'M9 replay-lossy fixture for M18 reconnect-style replay. This covers protocol/replay_lossy recovery, not a forced dropped turn/completed send failure.',
+        'M9 replay-lossy fixture with forced dropped turn/completed writer-channel backpressure. Drive the forced terminal drop and recover through replay.',
     },
   ],
   [
@@ -831,7 +831,8 @@ function runBackpressureReplayProbe(ctx, env) {
       OCTOS_M19_BACKPRESSURE_PROFILE_ID: ctx.profileId,
       OCTOS_M19_BACKPRESSURE_SESSION_ID: ctx.sessionId,
       OCTOS_M19_BACKPRESSURE_WORKSPACE: ctx.workdir,
-      OCTOS_M19_BACKPRESSURE_PROMPT: ctx.scenario.prompt,
+      OCTOS_M19_BACKPRESSURE_PROMPT:
+        'M9 replay-lossy fixture for post-drop protocol probe after TUI recovery.',
     },
     stdio: 'inherit',
   });
@@ -903,6 +904,18 @@ function runDroppedCompletionBackpressureScenario(ctx, action, env) {
   if (drive.error) throw drive.error;
   if (drive.status !== 0) status = drive.status || 1;
   captureTmuxPane(ctx.sessionName, path.join(ctx.scenarioDir, 'tui-capture-backpressure-final.txt'));
+  if (status === 0) {
+    const recovery = action('send-turn', true, {
+      OCTOS_TUI_SOAK_PROMPT: 'After forced terminal-drop recovery, reply with exactly OK.',
+      OCTOS_TUI_SOAK_TURN_WAIT_SECS: process.env.OCTOS_TUI_SOAK_BACKPRESSURE_RECOVERY_WAIT_SECS || '8',
+    });
+    if (recovery.error) throw recovery.error;
+    if (recovery.status !== 0) status = recovery.status || 1;
+    captureTmuxPane(
+      ctx.sessionName,
+      path.join(ctx.scenarioDir, 'tui-capture-backpressure-post-recovery.txt'),
+    );
+  }
   if (status === 0) status = runBackpressureReplayProbe(ctx, env);
   return status;
 }

--- a/e2e/scripts/ux-tmux-validate.mjs
+++ b/e2e/scripts/ux-tmux-validate.mjs
@@ -1188,6 +1188,21 @@ function checkDroppedCompletionBackpressureScenario(artifactDir) {
   if (!report.ok) {
     problems.push(`backpressure-report.json is not parseable JSON: ${report.error}`);
   } else {
+    const coverage = report.value.coverage;
+    const hasTrueTerminalDropCoverage =
+      coverage === 'true-dropped-turn-completed'
+      || coverage === 'forced-turn-completed-drop'
+      || (
+        isPlainObject(coverage)
+        && (
+          coverage.true_dropped_turn_completed === true
+          || coverage.terminal_drop_forced === true
+          || coverage.writer_channel_turn_completed_drop === true
+        )
+      );
+    if (!hasTrueTerminalDropCoverage) {
+      problems.push('backpressure report must prove true dropped turn/completed writer-channel coverage; fixture-only protocol/replay_lossy recovery is not sufficient');
+    }
     const droppedCount = Number(report.value.replay_lossy?.dropped_count);
     if (!Number.isFinite(droppedCount) || droppedCount <= 0) {
       problems.push(`backpressure report replay_lossy.dropped_count must be > 0, got ${report.value.replay_lossy?.dropped_count ?? '<missing>'}`);
@@ -1230,7 +1245,7 @@ function checkDroppedCompletionBackpressureScenario(artifactDir) {
     'dropped_completion_backpressure_contract',
     problems.length === 0,
     problems.length === 0
-      ? 'fixture-backed protocol/replay_lossy recovery is visible, terminal, and snapshot-backed'
+      ? 'true dropped turn/completed backpressure coverage is visible, terminal, and snapshot-backed'
       : `dropped-completion/backpressure contract problems: ${problems.join('; ')}`,
     [
       'tui-capture-replay-lossy.txt',

--- a/e2e/scripts/ux-tmux-validate.mjs
+++ b/e2e/scripts/ux-tmux-validate.mjs
@@ -144,6 +144,36 @@ function isAcceptableJsonRpcError(frame) {
   return [...ACCEPTABLE_IDEMPOTENT_ERROR_CODES].some((known) => message.includes(known));
 }
 
+function reportProvesForcedTerminalDrop(report) {
+  if (!report.ok) return false;
+  const coverage = report.value.coverage;
+  const hasTrueTerminalDropCoverage =
+    coverage === 'true-dropped-turn-completed'
+    || coverage === 'forced-turn-completed-drop'
+    || (
+      isPlainObject(coverage)
+      && (
+        coverage.true_dropped_turn_completed === true
+        || coverage.terminal_drop_forced === true
+        || coverage.writer_channel_turn_completed_drop === true
+      )
+    );
+  return hasTrueTerminalDropCoverage
+    && report.value.forced_terminal_drop?.server_log_detected === true;
+}
+
+function reportTerminalProvesCompletion(value) {
+  const terminal = value?.terminal;
+  if (!isPlainObject(terminal)) return false;
+  if (terminal.method === 'turn/completed') return true;
+  return terminal.method === 'projection/envelope'
+    && terminal.legacy_equivalent === 'turn/completed'
+    && (
+      terminal.payload_type === 'turn_completed'
+      || terminal.params?.payload?.type === 'turn_completed'
+    );
+}
+
 function artifactPath(artifactDir, name) {
   return path.join(artifactDir, name);
 }
@@ -598,6 +628,10 @@ function checkRenderedScreenNoKnownBugPatterns(artifactDir) {
     : ['tui-capture.txt'];
   if (!captureNames.includes('tui-capture.txt')) captureNames.unshift('tui-capture.txt');
   const serverLog = readText(artifactPath(artifactDir, 'server.log'));
+  const report = readJson(artifactPath(artifactDir, 'backpressure-report.json'));
+  const expectedForcedTerminalDrop =
+    scenarioId === 'dropped-completion-backpressure'
+    && reportProvesForcedTerminalDrop(report);
   const problems = [];
   let mainCaptureText = '';
   for (const captureName of captureNames) {
@@ -629,7 +663,7 @@ function checkRenderedScreenNoKnownBugPatterns(artifactDir) {
     problems.push(`server.log could not be read: ${serverLog.error}`);
   } else {
     const serverDrop = lineMatches(serverLog.text, SERVER_DROPPED_TURN_PATTERN);
-    if (serverDrop) {
+    if (serverDrop && !expectedForcedTerminalDrop) {
       problems.push(`server_dropped_turn_completed at line ${serverDrop.line}: server log contains dropped turn/completed lifecycle evidence`);
     }
     if (mainCaptureText && CAPTURE_STUCK_RUNNING_PATTERN.test(mainCaptureText) && serverDrop) {
@@ -1159,6 +1193,7 @@ function checkDroppedCompletionBackpressureScenario(artifactDir) {
 
   const replayCapture = readText(artifactPath(artifactDir, 'tui-capture-replay-lossy.txt'));
   const finalCapture = readText(artifactPath(artifactDir, 'tui-capture-backpressure-final.txt'));
+  const postRecoveryCapture = readText(artifactPath(artifactDir, 'tui-capture-backpressure-post-recovery.txt'));
   const report = readJson(artifactPath(artifactDir, 'backpressure-report.json'));
   const parsedNotifications = parseJsonl(artifactPath(artifactDir, 'notification-log.jsonl'));
   const parsedWs = parseJsonl(artifactPath(artifactDir, 'websocket-transcript.jsonl'));
@@ -1185,6 +1220,16 @@ function checkDroppedCompletionBackpressureScenario(artifactDir) {
   } else if (CAPTURE_STUCK_RUNNING_PATTERN.test(finalCapture.text)) {
     problems.push('final backpressure capture still shows a running task state');
   }
+  if (!postRecoveryCapture.ok) {
+    problems.push(`tui-capture-backpressure-post-recovery.txt could not be read: ${postRecoveryCapture.error}`);
+  } else {
+    if (CAPTURE_STUCK_RUNNING_PATTERN.test(postRecoveryCapture.text)) {
+      problems.push('post-recovery backpressure capture still shows a running task state');
+    }
+    if (!/\bOK\b/.test(postRecoveryCapture.text) && !/\bDone\b/.test(postRecoveryCapture.text)) {
+      problems.push('post-recovery backpressure capture does not show the next prompt settling successfully');
+    }
+  }
   if (!report.ok) {
     problems.push(`backpressure-report.json is not parseable JSON: ${report.error}`);
   } else {
@@ -1203,12 +1248,15 @@ function checkDroppedCompletionBackpressureScenario(artifactDir) {
     if (!hasTrueTerminalDropCoverage) {
       problems.push('backpressure report must prove true dropped turn/completed writer-channel coverage; fixture-only protocol/replay_lossy recovery is not sufficient');
     }
+    if (report.value.forced_terminal_drop?.server_log_detected !== true) {
+      problems.push('backpressure report is missing server-log evidence for the forced turn/completed writer-channel drop');
+    }
     const droppedCount = Number(report.value.replay_lossy?.dropped_count);
     if (!Number.isFinite(droppedCount) || droppedCount <= 0) {
       problems.push(`backpressure report replay_lossy.dropped_count must be > 0, got ${report.value.replay_lossy?.dropped_count ?? '<missing>'}`);
     }
-    if (report.value.terminal?.method !== 'turn/completed') {
-      problems.push(`backpressure report terminal method must be turn/completed, got ${report.value.terminal?.method ?? '<missing>'}`);
+    if (!reportTerminalProvesCompletion(report.value)) {
+      problems.push(`backpressure report terminal must prove turn/completed, got ${report.value.terminal?.method ?? '<missing>'}`);
     }
     if (report.value.session_id !== scenario.value.session_id) {
       problems.push('backpressure report session_id does not match scenario session_id');
@@ -1250,9 +1298,11 @@ function checkDroppedCompletionBackpressureScenario(artifactDir) {
     [
       'tui-capture-replay-lossy.txt',
       'tui-capture-backpressure-final.txt',
+      'tui-capture-backpressure-post-recovery.txt',
       'notification-log.jsonl',
       'backpressure-report.json',
       'websocket-transcript.jsonl',
+      'server.log',
     ],
   );
 }

--- a/e2e/tests/ux/backpressure-validate.test.mjs
+++ b/e2e/tests/ux/backpressure-validate.test.mjs
@@ -1,0 +1,180 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..', '..', '..');
+const validator = resolve(repoRoot, 'e2e', 'scripts', 'ux-tmux-validate.mjs');
+
+const requiredArtifacts = [
+  'scenario.json',
+  'summary.json',
+  'launch-command.txt',
+  'terminal-size.json',
+  'input-replay.log',
+  'appui-transcript.jsonl',
+  'server.log',
+  'tui-capture.txt',
+  'runtime-policy-stamp.json',
+  'validation.json',
+];
+
+const requiredWsMethods = [
+  'client_hello',
+  'config/capabilities/list',
+  'profile/local/create',
+  'permission/profile/list',
+  'permission/profile/set',
+  'session/open',
+  'session/status/read',
+  'tool/status/list',
+  'turn/start',
+  'session/snapshot',
+];
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeJsonl(file, rows) {
+  writeFileSync(file, `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`, 'utf8');
+}
+
+function artifactSummary(dir, names) {
+  return Object.fromEntries(names.map((name) => [name, { path: join(dir, name), exists: true, bytes: 1 }]));
+}
+
+function appuiRows() {
+  const methods = [
+    'config/capabilities/list',
+    'profile/local/create',
+    'permission/profile/list',
+    'permission/profile/set',
+    'session/open',
+    'session/status/read',
+    'tool/status/list',
+  ];
+  const rows = [];
+  methods.forEach((method, index) => {
+    const id = `req-${index}`;
+    rows.push({ direction: 'client_to_server', frame: { jsonrpc: '2.0', id, method, params: {} } });
+    rows.push({ direction: 'server_to_client', frame: { jsonrpc: '2.0', id, result: { ok: true } } });
+  });
+  rows.push({
+    direction: 'server_to_client',
+    frame: { jsonrpc: '2.0', method: 'turn/completed', params: { session_id: 'ux-backpressure-session' } },
+  });
+  return rows;
+}
+
+function makeArtifactDir({ trueDropCoverage }) {
+  const dir = mkdtempSync(join(tmpdir(), 'octos-backpressure-validate-'));
+  mkdirSync(dir, { recursive: true });
+
+  writeJson(join(dir, 'scenario.json'), {
+    schema: 'octos.ux.scenario.v1',
+    artifact_abi: 'octos.ux.artifacts.v1',
+    id: 'dropped-completion-backpressure',
+    scenario_id: 'dropped-completion-backpressure',
+    session_id: 'ux-backpressure-session',
+    required_artifacts: requiredArtifacts,
+  });
+  writeJson(join(dir, 'summary.json'), {
+    schema: 'octos.ux.summary.v1',
+    status: 'passed',
+    mode: 'run',
+    placeholder_artifacts: false,
+    real_tmux_launched: true,
+    artifacts: artifactSummary(dir, [
+      ...requiredArtifacts,
+      'tui-capture-replay-lossy.txt',
+      'tui-capture-backpressure-final.txt',
+      'notification-log.jsonl',
+      'backpressure-report.json',
+      'websocket-transcript.jsonl',
+    ]),
+  });
+  writeFileSync(join(dir, 'launch-command.txt'), 'octos-tui --mode protocol\n', 'utf8');
+  writeFileSync(join(dir, 'input-replay.log'), 'line trigger backpressure\n', 'utf8');
+  writeFileSync(join(dir, 'server.log'), 'server completed without lifecycle drop text\n', 'utf8');
+  writeFileSync(join(dir, 'tui-capture.txt'), 'Chat ready\nComposer\n state Idle\n', 'utf8');
+  writeFileSync(join(dir, 'tui-capture-replay-lossy.txt'), 'Replay lossy: dropped durable notifications\nComposer\n state Idle\n', 'utf8');
+  writeFileSync(join(dir, 'tui-capture-backpressure-final.txt'), 'Recovered after backpressure\nComposer\n state Idle\n', 'utf8');
+  writeJson(join(dir, 'terminal-size.json'), {
+    schema: 'octos.ux.terminal_size.v1',
+    cols: 100,
+    rows: 30,
+  });
+  writeJson(join(dir, 'runtime-policy-stamp.json'), {
+    schema: 'octos.ux.runtime_policy_stamp.v1',
+    stamp: {},
+  });
+  writeJsonl(join(dir, 'appui-transcript.jsonl'), appuiRows());
+  writeJsonl(join(dir, 'notification-log.jsonl'), [
+    {
+      direction: 'server_to_client',
+      frame: {
+        jsonrpc: '2.0',
+        method: 'protocol/replay_lossy',
+        params: { session_id: 'ux-backpressure-session', dropped_count: 1 },
+      },
+    },
+  ]);
+  writeJsonl(join(dir, 'websocket-transcript.jsonl'), requiredWsMethods.map((method, index) => ({
+    direction: 'client_to_server',
+    frame: { jsonrpc: '2.0', id: `ws-${index}`, method, params: {} },
+  })));
+  writeJson(join(dir, 'backpressure-report.json'), {
+    schema: 'octos.ux.backpressure_report.v1',
+    scenario_id: 'dropped-completion-backpressure',
+    coverage: trueDropCoverage
+      ? {
+        true_dropped_turn_completed: true,
+        writer_channel_turn_completed_drop: true,
+      }
+      : 'fixture-backed protocol/replay_lossy recovery; does not force a real dropped turn/completed writer-channel failure',
+    session_id: 'ux-backpressure-session',
+    replay_lossy: { dropped_count: 1 },
+    terminal: { method: 'turn/completed', params: {} },
+    snapshot: { session_id: 'ux-backpressure-session' },
+  });
+  return dir;
+}
+
+function runValidator(dir) {
+  return execFileSync(process.execPath, [validator, dir], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+test('fixture-only replay-lossy report does not satisfy dropped-completion contract', () => {
+  const dir = makeArtifactDir({ trueDropCoverage: false });
+  assert.throws(
+    () => runValidator(dir),
+    (error) => {
+      assert.equal(error.status, 1);
+      const validation = JSON.parse(readFileSync(join(dir, 'validation.json'), 'utf8'));
+      const failure = validation.failures.find((entry) => entry.id === 'dropped_completion_backpressure_contract');
+      assert.ok(failure);
+      assert.match(failure.detail, /true dropped turn\/completed writer-channel coverage/);
+      return true;
+    },
+  );
+});
+
+test('true terminal-drop coverage marker satisfies dropped-completion contract', () => {
+  const dir = makeArtifactDir({ trueDropCoverage: true });
+  const out = runValidator(dir);
+  const validation = JSON.parse(out);
+  const check = validation.checks.find((entry) => entry.id === 'dropped_completion_backpressure_contract');
+  assert.equal(validation.status, 'passed');
+  assert.equal(check.status, 'passed');
+  assert.match(check.detail, /true dropped turn\/completed backpressure coverage/);
+});

--- a/e2e/tests/ux/backpressure-validate.test.mjs
+++ b/e2e/tests/ux/backpressure-validate.test.mjs
@@ -49,7 +49,7 @@ function artifactSummary(dir, names) {
   return Object.fromEntries(names.map((name) => [name, { path: join(dir, name), exists: true, bytes: 1 }]));
 }
 
-function appuiRows() {
+function appuiRows({ terminal = 'legacy' } = {}) {
   const methods = [
     'config/capabilities/list',
     'profile/local/create',
@@ -65,14 +65,28 @@ function appuiRows() {
     rows.push({ direction: 'client_to_server', frame: { jsonrpc: '2.0', id, method, params: {} } });
     rows.push({ direction: 'server_to_client', frame: { jsonrpc: '2.0', id, result: { ok: true } } });
   });
-  rows.push({
-    direction: 'server_to_client',
-    frame: { jsonrpc: '2.0', method: 'turn/completed', params: { session_id: 'ux-backpressure-session' } },
-  });
+  if (terminal === 'envelope') {
+    rows.push({
+      direction: 'server_to_client',
+      frame: {
+        jsonrpc: '2.0',
+        method: 'projection/envelope',
+        params: {
+          thread_id: 'ux-backpressure-turn',
+          payload: { type: 'turn_completed', data: { token_usage: {} } },
+        },
+      },
+    });
+  } else {
+    rows.push({
+      direction: 'server_to_client',
+      frame: { jsonrpc: '2.0', method: 'turn/completed', params: { session_id: 'ux-backpressure-session' } },
+    });
+  }
   return rows;
 }
 
-function makeArtifactDir({ trueDropCoverage }) {
+function makeArtifactDir({ trueDropCoverage, terminal = 'legacy' }) {
   const dir = mkdtempSync(join(tmpdir(), 'octos-backpressure-validate-'));
   mkdirSync(dir, { recursive: true });
 
@@ -94,6 +108,7 @@ function makeArtifactDir({ trueDropCoverage }) {
       ...requiredArtifacts,
       'tui-capture-replay-lossy.txt',
       'tui-capture-backpressure-final.txt',
+      'tui-capture-backpressure-post-recovery.txt',
       'notification-log.jsonl',
       'backpressure-report.json',
       'websocket-transcript.jsonl',
@@ -101,10 +116,21 @@ function makeArtifactDir({ trueDropCoverage }) {
   });
   writeFileSync(join(dir, 'launch-command.txt'), 'octos-tui --mode protocol\n', 'utf8');
   writeFileSync(join(dir, 'input-replay.log'), 'line trigger backpressure\n', 'utf8');
-  writeFileSync(join(dir, 'server.log'), 'server completed without lifecycle drop text\n', 'utf8');
+  writeFileSync(
+    join(dir, 'server.log'),
+    trueDropCoverage
+      ? [
+        'forced turn/completed writer channel full fixture; aborting connection',
+        'lifecycle notification not delivered; entry remains in ledger as delivery_failed',
+        'writer channel full for lifecycle frame turn/completed',
+      ].join('\n')
+      : 'server completed without lifecycle drop text\n',
+    'utf8',
+  );
   writeFileSync(join(dir, 'tui-capture.txt'), 'Chat ready\nComposer\n state Idle\n', 'utf8');
   writeFileSync(join(dir, 'tui-capture-replay-lossy.txt'), 'Replay lossy: dropped durable notifications\nComposer\n state Idle\n', 'utf8');
   writeFileSync(join(dir, 'tui-capture-backpressure-final.txt'), 'Recovered after backpressure\nComposer\n state Idle\n', 'utf8');
+  writeFileSync(join(dir, 'tui-capture-backpressure-post-recovery.txt'), 'OK\nDone\nComposer\n state Idle\n', 'utf8');
   writeJson(join(dir, 'terminal-size.json'), {
     schema: 'octos.ux.terminal_size.v1',
     cols: 100,
@@ -114,7 +140,7 @@ function makeArtifactDir({ trueDropCoverage }) {
     schema: 'octos.ux.runtime_policy_stamp.v1',
     stamp: {},
   });
-  writeJsonl(join(dir, 'appui-transcript.jsonl'), appuiRows());
+  writeJsonl(join(dir, 'appui-transcript.jsonl'), appuiRows({ terminal }));
   writeJsonl(join(dir, 'notification-log.jsonl'), [
     {
       direction: 'server_to_client',
@@ -140,7 +166,21 @@ function makeArtifactDir({ trueDropCoverage }) {
       : 'fixture-backed protocol/replay_lossy recovery; does not force a real dropped turn/completed writer-channel failure',
     session_id: 'ux-backpressure-session',
     replay_lossy: { dropped_count: 1 },
-    terminal: { method: 'turn/completed', params: {} },
+    terminal: terminal === 'envelope'
+      ? {
+        method: 'projection/envelope',
+        legacy_equivalent: 'turn/completed',
+        payload_type: 'turn_completed',
+        thread_id: 'ux-backpressure-turn',
+        params: {
+          thread_id: 'ux-backpressure-turn',
+          payload: { type: 'turn_completed', data: { token_usage: {} } },
+        },
+      }
+      : { method: 'turn/completed', params: {} },
+    forced_terminal_drop: {
+      server_log_detected: trueDropCoverage,
+    },
     snapshot: { session_id: 'ux-backpressure-session' },
   });
   return dir;
@@ -171,6 +211,17 @@ test('fixture-only replay-lossy report does not satisfy dropped-completion contr
 
 test('true terminal-drop coverage marker satisfies dropped-completion contract', () => {
   const dir = makeArtifactDir({ trueDropCoverage: true });
+  const out = runValidator(dir);
+  const validation = JSON.parse(out);
+  const check = validation.checks.find((entry) => entry.id === 'dropped_completion_backpressure_contract');
+  assert.equal(validation.status, 'passed');
+  assert.equal(check.status, 'passed');
+  assert.match(check.detail, /true dropped turn\/completed backpressure coverage/);
+});
+
+
+test('projection envelope terminal coverage satisfies dropped-completion contract', () => {
+  const dir = makeArtifactDir({ trueDropCoverage: true, terminal: 'envelope' });
   const out = runValidator(dir);
   const validation = JSON.parse(out);
   const check = validation.checks.find((entry) => entry.id === 'dropped_completion_backpressure_contract');


### PR DESCRIPTION
## Summary

- Forces a deterministic terminal writer-channel backpressure/drop path for the dropped-completion UX scenario.
- Records true dropped terminal coverage in `backpressure-report.json`, distinct from fixture-only `protocol/replay_lossy`.
- Wires `dropped-completion-backpressure` through the tmux runner and validator, including post-recovery prompt proof.
- Adds validator self-tests that reject fixture-only evidence and accept true terminal-drop/projection-envelope coverage.
- Carries current-main harness support for explicit local solo login during tmux runs, CLI test hardening for the Linux transient busy spawn race, and the existing agent clippy cleanup needed by workspace `-D warnings`.
- Flushes daily-note appends before immediate reads, fixing the Linux `octos-memory` check-job race exposed by this refresh.

Closes #1314
Refs #1067

## Current Refresh

- base: `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`
- head: `e5e3379d22d35572d1e21940d7865b15e5911338`
- checkout: `/private/tmp/octos-1315-f693.JE0fkw/octos`; root dirty checkout untouched
- octos binary: `/private/tmp/octos-1315-f693-target/debug/octos` -> `octos 0.1.1 (e5e3379d 2026-06-02)`
- octos-tui proof binary: `/private/tmp/octos-tui-1338-current-target-97c42/debug/octos-tui` -> `octos-tui 0.1.1`
- octos-tui main: `97c42fb30ce92a3d173144817a9bdb15c20b86f6`
- artifact: `/private/tmp/octos-m19-1314-backpressure-current-f693-97c42-e5e337/codex-1314-current-main-f693-97c42-e5e337-20260602/dropped-completion-backpressure`

## Validation

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- JS syntax checks for `m19-backpressure-replay-probe.mjs`, `ux-tmux-run.mjs`, `ux-tmux-validate.mjs`, `backpressure-validate.test.mjs`, and `scenario-list.test.mjs`
- touched-file `typos`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1315-f693 npm --prefix e2e ci` completed with the existing moderate npm audit warning
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1315-f693 npm --prefix e2e run ux:tmux:validate:backpressure-test` -> 3/3 passed
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1315-f693 npm --prefix e2e run ux:scenario:list:test` -> 15/15 passed
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1315-f693 npm --prefix e2e run ux:tmux:validate -- fixtures/ux-artifact-self-test` -> passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api forced_backpressure_fixture_ledgers_terminal_and_latches_failed -- --nocapture` -> 1/1 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --lib cli_agent_adapter::tests -- --nocapture` -> 8/8 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --lib session_actor::tests::test_cancel_matches_profile_scoped_actor_by_session_key -- --exact --nocapture` -> 1/1 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib loop_detect -- --nocapture` -> 13/13 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-agent --lib idle_timeout_constant -- --nocapture` -> 2/2 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-memory memory_store::tests::test_append_today_creates_header -- --exact --nocapture` -> 1/1 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-memory --lib -- --nocapture` -> 56/56 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/octos-1315-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo build -p octos-cli --features api --bin octos`
- real tmux proof:
  `PATH=/private/tmp/octos-1315-f693-target/debug:/private/tmp/octos-tui-1338-current-target-97c42/debug:$PATH OCTOS_BIN=/private/tmp/octos-1315-f693-target/debug/octos OCTOS_TUI_REPO=/private/tmp/octos-tui-1338-refresh.QG37YJ/octos-tui OCTOS_TUI_BIN=/private/tmp/octos-tui-1338-current-target-97c42/debug/octos-tui OCTOS_UX_TMUX_OUT_ROOT=/private/tmp/octos-m19-1314-backpressure-current-f693-97c42-e5e337 OCTOS_UX_TMUX_RUNTIME_ROOT=/private/tmp/octos-m19-1314-backpressure-current-f693-97c42-runtime-e5e337 OCTOS_UX_TMUX_RUN_ID=codex-1314-current-main-f693-97c42-e5e337-20260602 OCTOS_TUI_SOAK_SERVER_WAIT_SECS=20 OCTOS_TUI_SOAK_EXIT_HOLD_SECS=1 OCTOS_TUI_SOAK_TURN_WAIT_SECS=8 NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1315-f693 npm --prefix e2e run ux:tmux:run -- dropped-completion-backpressure`
- explicit artifact validation:
  `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1315-f693 npm --prefix e2e run ux:tmux:validate -- /private/tmp/octos-m19-1314-backpressure-current-f693-97c42-e5e337/codex-1314-current-main-f693-97c42-e5e337-20260602/dropped-completion-backpressure`
- `git ls-files --others --exclude-standard` -> empty in the isolated checkout
- no tmux server remained after validation

## Evidence

`summary.json` reports `status=passed`, `validation_status=passed`, `real_tmux_launched=true`, `scenario_id=dropped-completion-backpressure`, and `placeholder_artifacts=false`.

`validation.json` reports `status=passed`, `failures=[]`, and `dropped_completion_backpressure_contract=passed` with detail: true dropped `turn/completed` backpressure coverage is visible, terminal, and snapshot-backed.

`backpressure-report.json` records `coverage.true_dropped_turn_completed=true`, `coverage.terminal_drop_forced=true`, `coverage.writer_channel_turn_completed_drop=true`, and `coverage.protocol_replay_lossy_probe=true`. `replay_lossy.dropped_count=1` and includes a durable cursor.

The post-recovery capture includes the prompt `After forced terminal-drop recovery, reply with exactly OK.` and the answer `OK`.

GitHub CI on head `e5e3379d22d35572d1e21940d7865b15e5911338`:
- Passed: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, `typos`, `SPA reducer fixture replay`, and blocked-email.
- Skipped by workflow policy: optional platform, e2e tool regression, and security expansion jobs.

Remaining gap:
- Merge remains branch-protection/review gated until required review is satisfied (`REVIEW_REQUIRED`).

