### PR TITLE
fix(plugins): move verified-hash cache out of skill source dir + fix install.sh SUDO_USER

### DIFF
--- a/crates/octos-agent/src/plugins/loader.rs
+++ b/crates/octos-agent/src/plugins/loader.rs
@@ -68,6 +68,13 @@ pub struct PluginLoadOptions<'a> {
     /// spawning. When `false` (the default), the legacy permissive flow is
     /// preserved for backward compatibility.
     pub require_signed: bool,
+    /// Override the directory used to store the verified-exe copy. When
+    /// `None`, the loader resolves to `~/.octos/cache/verified/` so the
+    /// copy lives outside the skill source tree (writing inside the source
+    /// dir taints ownership when the daemon runs as a different uid — see
+    /// 2026-05 fleet skill-dir-root-ownership bug). Tests pass a tempdir
+    /// here for isolation; production callers leave this `None`.
+    pub verified_cache_dir: Option<PathBuf>,
 }
 
 impl PluginLoadResult {
@@ -117,6 +124,7 @@ impl PluginLoader {
                 work_dir,
                 synthesis_config: None,
                 require_signed: false,
+                verified_cache_dir: None,
             },
         )
     }
@@ -254,6 +262,7 @@ impl PluginLoader {
                 work_dir,
                 synthesis_config: None,
                 require_signed: false,
+                verified_cache_dir: None,
             },
         )
     }
@@ -281,6 +290,7 @@ impl PluginLoader {
         let work_dir = options.work_dir;
         let synthesis_config = options.synthesis_config;
         let require_signed = options.require_signed;
+        let verified_cache_dir = options.verified_cache_dir.clone();
         let manifest_path = plugin_dir.join("manifest.json");
         let content = std::fs::read_to_string(&manifest_path)
             .map_err(|e| eyre::eyre!("no manifest.json: {e}"))?;
@@ -447,12 +457,21 @@ impl PluginLoader {
             }
         }
 
-        // Write verified bytes to a sibling file so PluginTool executes
-        // exactly what we hashed (prevents TOCTOU file swap attacks).
-        let verified_exe = plugin_dir.join(format!(
-            ".{}_verified",
-            executable.file_name().unwrap_or_default().to_string_lossy()
-        ));
+        // Write verified bytes to a path OUTSIDE the skill source dir so
+        // PluginTool executes exactly what we hashed (TOCTOU defence) without
+        // tainting the skill tree's ownership. Writing into the skill dir is
+        // the original 2026-05 fleet bug: when the daemon runs as root (e.g.
+        // from a `sudo`-installed launchd plist), the verified copy lands as
+        // root:wheel and any subsequent chmod/chown by the operator user
+        // fails. The cache lives at `<verified_cache_dir>/<plugin>/main` —
+        // resolved from `PluginLoadOptions::verified_cache_dir` (tests) or
+        // `~/.octos/cache/verified/` (production).
+        let verified_exe = resolve_verified_path(verified_cache_dir.as_deref(), &manifest.name)?;
+        if let Some(parent) = verified_exe.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                eyre::eyre!("cannot create verified cache dir {}: {e}", parent.display())
+            })?;
+        }
         // Remove existing verified file first so we can refresh the copy on restart.
         let _ = std::fs::remove_file(&verified_exe);
         std::fs::write(&verified_exe, &exe_bytes)
@@ -929,6 +948,77 @@ fn compute_sha256(path: &Path) -> Result<String> {
     Ok(format!("{hash:x}"))
 }
 
+/// Resolve where to store the verified-exe copy for a plugin.
+///
+/// Resolution order:
+/// 1. Explicit `override_dir` from [`PluginLoadOptions::verified_cache_dir`]
+///    (used by tests to isolate from the real cache).
+/// 2. Under `cargo test`, a process-scoped tempdir auto-cleaned at exit —
+///    keeps the test suite from polluting `~/.octos/cache/verified/` and
+///    avoids cross-test races on shared plugin names.
+/// 3. `~/.octos/cache/verified/` derived from `dirs::home_dir()`.
+/// 4. `std::env::temp_dir().join("octos-verified")` as a last resort when
+///    HOME is unavailable (e.g. sandbox).
+///
+/// Returns `<base>/<plugin_name>/main`. The caller is responsible for
+/// `create_dir_all` on the parent before writing.
+fn resolve_verified_path(override_dir: Option<&Path>, plugin_name: &str) -> Result<PathBuf> {
+    // Guard against a plugin name with path separators that would let a
+    // malicious manifest escape the cache root. The manifest loader already
+    // validates this for tool registration, but we belt-and-brace here so
+    // future call sites that bypass tool validation still land in a safe
+    // subdir.
+    if plugin_name.contains('/')
+        || plugin_name.contains('\\')
+        || plugin_name == "."
+        || plugin_name == ".."
+        || plugin_name.is_empty()
+    {
+        eyre::bail!("plugin name {plugin_name:?} not safe for cache path");
+    }
+    let base = if let Some(dir) = override_dir {
+        dir.to_path_buf()
+    } else if cfg!(test) {
+        // Tests that don't care about the verified-exe location still go
+        // through this default path; keep them out of the user's real
+        // cache (and let TempDir auto-cleanup at process exit).
+        test_default_cache_dir()
+    } else if let Some(home) = dirs::home_dir() {
+        home.join(".octos").join("cache").join("verified")
+    } else {
+        std::env::temp_dir().join("octos-verified")
+    };
+    Ok(base.join(plugin_name).join("main"))
+}
+
+/// Process-scoped tempdir for tests that don't explicitly pass a
+/// `verified_cache_dir`. Created once on first access; auto-cleaned when
+/// the test process exits. Without this, every test would write into the
+/// dev machine's real `~/.octos/cache/verified/` and tests reusing the
+/// same plugin name in parallel would race.
+#[cfg(test)]
+fn test_default_cache_dir() -> PathBuf {
+    use std::sync::OnceLock;
+    static TEST_CACHE: OnceLock<tempfile::TempDir> = OnceLock::new();
+    TEST_CACHE
+        .get_or_init(|| {
+            tempfile::Builder::new()
+                .prefix("octos-verified-test-")
+                .tempdir()
+                .expect("create test verified cache tempdir")
+        })
+        .path()
+        .to_path_buf()
+}
+
+/// Non-test stub so the default branch in `resolve_verified_path` compiles
+/// outside `cfg(test)` without a `cfg!(test)` flicker.
+#[cfg(not(test))]
+#[allow(dead_code)]
+fn test_default_cache_dir() -> PathBuf {
+    PathBuf::new()
+}
+
 /// Check if a path is a regular executable file (Unix).
 /// Rejects symlinks as defense-in-depth against link-swap attacks.
 #[cfg(unix)]
@@ -1097,6 +1187,7 @@ mod tests {
                 work_dir: None,
                 synthesis_config: None,
                 require_signed: true,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -1137,6 +1228,7 @@ mod tests {
                 work_dir: None,
                 synthesis_config: None,
                 require_signed: true,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -1182,6 +1274,7 @@ mod tests {
                 work_dir: None,
                 synthesis_config: None,
                 require_signed: true,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -1241,6 +1334,7 @@ mod tests {
                 work_dir: None,
                 synthesis_config: None,
                 require_signed: true,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -1302,6 +1396,7 @@ mod tests {
                 work_dir: None,
                 synthesis_config: None,
                 require_signed: true,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -1420,8 +1515,9 @@ mod tests {
 
     /// Section C: when the verified-exe bytes on disk are swapped between
     /// load and invocation, the pre-spawn re-hash gate refuses to spawn the
-    /// process. We simulate the swap by overwriting `.<name>_verified`
-    /// after `load_into` returns.
+    /// process. We simulate the swap by overwriting the verified-cache copy
+    /// (now stored under `verified_cache_dir`, not the skill source tree)
+    /// after `load_into_with_options` returns.
     #[cfg(unix)]
     #[tokio::test]
     async fn pre_spawn_rehash_detects_swap() {
@@ -1442,16 +1538,28 @@ mod tests {
         std::fs::write(&exec_path, exec_content).unwrap();
         std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
+        let cache_dir = dir.path().join("cache");
         let mut registry = ToolRegistry::new();
-        let result =
-            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+        let result = PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: false,
+                verified_cache_dir: Some(cache_dir.clone()),
+            },
+        )
+        .unwrap();
         assert_eq!(result.tool_count, 1);
 
-        // Swap the verified-exe bytes on disk so the re-hash gate fires.
-        let verified_exe = plugin_dir.join(".swap-plugin_verified");
+        // Swap the verified-cache bytes on disk so the re-hash gate fires.
+        let verified_exe = cache_dir.join("swap-plugin").join("main");
         assert!(
             verified_exe.exists(),
-            "loader must write a verified-exe sibling"
+            "loader must write a verified-exe copy at {}",
+            verified_exe.display()
         );
         std::fs::write(&verified_exe, b"#!/bin/sh\necho TAMPERED").unwrap();
 
@@ -1499,6 +1607,7 @@ mod tests {
                 work_dir: None,
                 synthesis_config: None,
                 require_signed: true,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -1873,12 +1982,24 @@ edition = "2021"
         )
         .unwrap();
 
+        let cache_dir = dir.path().join("cache");
         let mut registry = ToolRegistry::new();
-        let result =
-            PluginLoader::load_into(&mut registry, &[dir.path().to_path_buf()], &[]).unwrap();
+        let result = PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: false,
+                verified_cache_dir: Some(cache_dir.clone()),
+            },
+        )
+        .unwrap();
         assert_eq!(result.tool_count, 1);
 
-        let verified = plugin_dir.join(".perm-plugin_verified");
+        // Verified copy lives under cache_dir, not the skill source dir.
+        let verified = cache_dir.join("perm-plugin").join("main");
         let mode = std::fs::metadata(&verified).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755);
     }
@@ -1932,6 +2053,7 @@ edition = "2021"
                 work_dir: None,
                 synthesis_config: Some(cfg),
                 require_signed: false,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -1990,6 +2112,7 @@ edition = "2021"
                 work_dir: None,
                 synthesis_config: Some(cfg),
                 require_signed: false,
+                verified_cache_dir: None,
             },
         )
         .unwrap();
@@ -2135,5 +2258,71 @@ edition = "2021"
             "from-corrected",
             "first dir (dir_a / corrected) must win — got the shadow copy"
         );
+    }
+
+    /// Regression: the verified-exe copy must live OUTSIDE the skill source
+    /// directory so that running `octos serve` as root (or any non-operator
+    /// uid) does not taint the skill tree with foreign ownership and lock
+    /// out the operator's interactive CLI. The cache is keyed by plugin
+    /// name and lives under `verified_cache_dir`.
+    #[cfg(unix)]
+    #[test]
+    fn verified_path_lives_under_cache_dir_not_skill_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join("isolated-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            r#"{"name": "isolated-plugin", "version": "1.0", "tools": [{"name": "iso_tool", "description": "d", "input_schema": {"type": "object", "properties": {}}}]}"#,
+        )
+        .unwrap();
+        let exec_path = plugin_dir.join("isolated-plugin");
+        std::fs::write(&exec_path, b"#!/bin/sh\necho hi").unwrap();
+        std::fs::set_permissions(&exec_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let cache_dir = dir.path().join("cache-root");
+        let mut registry = ToolRegistry::new();
+        PluginLoader::load_into_with_options(
+            &mut registry,
+            &[dir.path().to_path_buf()],
+            &[],
+            PluginLoadOptions {
+                work_dir: None,
+                synthesis_config: None,
+                require_signed: false,
+                verified_cache_dir: Some(cache_dir.clone()),
+            },
+        )
+        .unwrap();
+
+        // The verified copy must live under cache_dir/<plugin>/main.
+        let expected = cache_dir.join("isolated-plugin").join("main");
+        assert!(
+            expected.is_file(),
+            "verified copy must live at {} (got nothing); cache_dir contents: {:?}",
+            expected.display(),
+            std::fs::read_dir(&cache_dir).ok().map(|rd| {
+                rd.filter_map(|e| e.ok().map(|e| e.path()))
+                    .collect::<Vec<_>>()
+            }),
+        );
+
+        // The skill source dir must NOT contain a `.isolated-plugin_verified`
+        // or `.main_verified` sibling — that was the old taint vector.
+        let skill_entries: Vec<_> = std::fs::read_dir(&plugin_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        for name in &skill_entries {
+            assert!(
+                !name.ends_with("_verified") && name != ".main_verified",
+                "skill source dir should not contain verified-copy file '{}' (full list: {:?})",
+                name,
+                skill_entries,
+            );
+        }
     }
 }

--- a/crates/octos-agent/src/tools/spawn.rs
+++ b/crates/octos-agent/src/tools/spawn.rs
@@ -2462,6 +2462,7 @@ impl Tool for SpawnTool {
                         work_dir: Some(&self.working_dir),
                         synthesis_config: None,
                         require_signed: self.plugin_require_signed,
+                        verified_cache_dir: None,
                     },
                 );
             }
@@ -2891,6 +2892,7 @@ impl Tool for SpawnTool {
                             work_dir: Some(&working_dir),
                             synthesis_config: None,
                             require_signed: plugin_require_signed,
+                            verified_cache_dir: None,
                         },
                     );
                 }

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -273,6 +273,7 @@ impl ChatCommand {
                     work_dir: None,
                     synthesis_config: None,
                     require_signed: config.plugins.require_signed,
+                    verified_cache_dir: None,
                 },
             ) {
                 Ok(result) => plugin_result = result,

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -723,6 +723,7 @@ impl GatewayRuntime {
                             // is `false` (backward compatible — unsigned plugins
                             // still load with a warning).
                             require_signed: config.plugins.require_signed,
+                            verified_cache_dir: None,
                         },
                     ) {
                         Ok(result) => plugin_result = result,

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -629,6 +629,7 @@ impl ProfileActorFactoryBuilder {
                         // (backward compatible — unsigned plugins still
                         // load with a warning).
                         require_signed: profile_config.plugins.require_signed,
+                        verified_cache_dir: None,
                     },
                 ) {
                     Ok(result) => {

--- a/crates/octos-cli/src/runtime/profile.rs
+++ b/crates/octos-cli/src/runtime/profile.rs
@@ -606,6 +606,7 @@ impl ProfileRuntime {
                     // `config_from_profile` so operators can opt into
                     // strict signature enforcement per deployment.
                     require_signed: config.plugins.require_signed,
+                    verified_cache_dir: None,
                 },
             ) {
                 Ok(result) => plugin_result = result,

--- a/crates/octos-pipeline/src/handler.rs
+++ b/crates/octos-pipeline/src/handler.rs
@@ -72,6 +72,7 @@ impl CachedPluginRegistration {
 fn build_cached_plugin_registration(
     plugin_dirs: &[PathBuf],
     require_signed: bool,
+    verified_cache_dir: Option<PathBuf>,
 ) -> CachedPluginRegistration {
     if plugin_dirs.is_empty() {
         return CachedPluginRegistration::default();
@@ -92,6 +93,7 @@ fn build_cached_plugin_registration(
             work_dir: None,
             synthesis_config: None,
             require_signed,
+            verified_cache_dir,
         },
     );
     let elapsed = started.elapsed();
@@ -313,6 +315,12 @@ pub struct CodergenHandler {
     /// is the missing wiring that lets cross-domain episodes
     /// contaminate worker prompts.
     embedder: Option<Arc<dyn EmbeddingProvider>>,
+    /// Override the directory used to store verified-exe copies
+    /// (`PluginLoadOptions::verified_cache_dir`). When `None`, the
+    /// loader picks `~/.octos/cache/verified/` (production) or a
+    /// per-process tempdir (`cfg(test)` inside octos-agent). Tests
+    /// pass a tempdir here to isolate from the user's cache.
+    plugin_verified_cache_dir: Option<PathBuf>,
 }
 
 impl CodergenHandler {
@@ -337,7 +345,17 @@ impl CodergenHandler {
             host_context: crate::host_context::PipelineHostContext::default(),
             plugin_cache: Arc::new(OnceLock::new()),
             embedder: None,
+            plugin_verified_cache_dir: None,
         }
+    }
+
+    /// Override where plugin verified-exe copies live. Production
+    /// callers leave this unset; tests pass a tempdir.
+    pub fn with_plugin_verified_cache_dir(mut self, dir: Option<PathBuf>) -> Self {
+        self.plugin_verified_cache_dir = dir;
+        // Reset the cache so a builder-time override is honoured.
+        self.plugin_cache = Arc::new(OnceLock::new());
+        self
     }
 
     /// NEW-06 fix: attach the parent embedder. Each per-node worker
@@ -491,6 +509,7 @@ impl CodergenHandler {
                 Arc::new(build_cached_plugin_registration(
                     &self.plugin_dirs,
                     self.plugin_require_signed,
+                    self.plugin_verified_cache_dir.clone(),
                 ))
             })
             .clone()

--- a/crates/octos-pipeline/tests/plugin_load_cache.rs
+++ b/crates/octos-pipeline/tests/plugin_load_cache.rs
@@ -92,16 +92,22 @@ fn create_stub_plugin(plugins_root: &Path, name: &str) -> PathBuf {
     plugin_dir
 }
 
-/// Acceptance — the cached-plugin path writes the verified-bytes sibling
+/// Acceptance — the cached-plugin path writes the verified-bytes copy
 /// exactly once across many invocations, even when several plugin dirs
 /// are configured. This is the per-node-spawn cost the bug report
 /// flagged: prior to caching every node re-read + re-hashed every
-/// plugin and re-wrote `.<name>_verified` files, so the mtime advanced
-/// on every node execution.
+/// plugin and re-wrote the verified copy, so the mtime advanced on
+/// every node execution.
+///
+/// Post 2026-05 fix (`fix/skill-dir-root-ownership-bug`) the verified
+/// copy lives under `verified_cache_dir`, NOT inside the skill source
+/// tree. The test passes its own tempdir for isolation from the user's
+/// real `~/.octos/cache/verified/`.
 #[tokio::test]
 async fn pipeline_plugin_load_is_cached_across_nodes() {
     let plugins_root = tempfile::tempdir().unwrap();
     let working_dir = tempfile::tempdir().unwrap();
+    let verified_cache = tempfile::tempdir().unwrap();
 
     // Two stub plugins so the test exercises a multi-dir scan.
     create_stub_plugin(plugins_root.path(), "stub-alpha");
@@ -113,13 +119,14 @@ async fn pipeline_plugin_load_is_cached_across_nodes() {
         working_dir.path().to_path_buf(),
         Arc::new(std::sync::atomic::AtomicBool::new(false)),
     )
-    .with_plugin_dirs(vec![plugins_root.path().to_path_buf()]);
+    .with_plugin_dirs(vec![plugins_root.path().to_path_buf()])
+    .with_plugin_verified_cache_dir(Some(verified_cache.path().to_path_buf()));
 
-    // First load — verified files get written.
+    // First load — verified files get written under the cache dir.
     handler.warm_plugin_cache_for_test();
 
-    let alpha_verified = plugins_root.path().join("stub-alpha/.stub-alpha_verified");
-    let beta_verified = plugins_root.path().join("stub-beta/.stub-beta_verified");
+    let alpha_verified = verified_cache.path().join("stub-alpha").join("main");
+    let beta_verified = verified_cache.path().join("stub-beta").join("main");
     assert!(
         alpha_verified.exists(),
         "first load should have written {}",
@@ -129,6 +136,16 @@ async fn pipeline_plugin_load_is_cached_across_nodes() {
         beta_verified.exists(),
         "first load should have written {}",
         beta_verified.display()
+    );
+
+    // Regression: the verified copy must NOT taint the skill source dir.
+    let alpha_skill_sibling = plugins_root.path().join("stub-alpha/.stub-alpha_verified");
+    let alpha_skill_sibling_main = plugins_root.path().join("stub-alpha/.main_verified");
+    assert!(
+        !alpha_skill_sibling.exists() && !alpha_skill_sibling_main.exists(),
+        "skill source dir must not host a verified-copy file (saw {} or {})",
+        alpha_skill_sibling.display(),
+        alpha_skill_sibling_main.display(),
     );
 
     let alpha_mtime_1 = std::fs::metadata(&alpha_verified)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -562,8 +562,16 @@ write_octos_service() {
         <string>--auth-token</string>
         <string>$AUTH_TOKEN</string>
     </array>
+    <!--
+      UserName: prefer SUDO_USER (the operator who invoked sudo) over `whoami`.
+      When this installer is run as `sudo ./install.sh`, `whoami` resolves to
+      `root` and the daemon would start as root — which then writes its caches
+      (e.g. `.main_verified` under skill dirs) with root ownership, locking out
+      the operator's interactive `octos` CLI. Falling back to `whoami` keeps
+      the non-sudo path working unchanged.
+    -->
     <key>UserName</key>
-    <string>$(whoami)</string>
+    <string>${SUDO_USER:-$(whoami)}</string>
     <key>KeepAlive</key>
     <true/>
     <key>RunAtLoad</key>


### PR DESCRIPTION
## Summary

Two coordinated fixes that together stop the 2026-05 fleet
skill-dir-root-ownership bug (mini1, mini3, mini5).

- **Plugin loader** writes verified-exe copies to
  `~/.octos/cache/verified/<plugin>/main` (production) or to
  `PluginLoadOptions::verified_cache_dir` (tests) instead of writing
  `<plugin_dir>/.<name>_verified` into the skill SOURCE tree. When the
  daemon ran as root, the in-source copy landed root-owned and the
  whole skill tree progressively rotted into root:wheel, locking out
  the operator's interactive `octos` CLI. New `resolve_verified_path`
  helper has plugin-name guards and a `cfg(test)` default tempdir so
  the test suite never pollutes the dev user's real cache.
- **`scripts/install.sh`** now writes `<UserName>` as
  `${SUDO_USER:-$(whoami)}`. When the operator runs `sudo
  ./install.sh`, the launchd daemon launches as the invoking user, not
  root, and never re-creates the root-owned cache files in the first
  place. Non-sudo flow is unchanged.

Additional thread-through: `CodergenHandler` learned
`with_plugin_verified_cache_dir(...)` so pipeline integration tests can
isolate their verified-copy artifacts.

## Test plan

- [x] `cargo test -p octos-agent` (1683 + integration tests pass)
- [x] `cargo test -p octos-pipeline --test plugin_load_cache` (4/4)
- [x] `cargo test --workspace --no-fail-fast` (all pass)
- [x] `cargo build --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --lib --tests -- -D warnings` clean
- [x] New regression test `verified_path_lives_under_cache_dir_not_skill_dir`
- [x] Migrated `pre_spawn_rehash_detects_swap`,
      `test_verified_executable_is_world_executable`, and
      `pipeline_plugin_load_is_cached_across_nodes` to the new layout.

## Operational follow-ups (outside this PR)

- Operational chown `~/.octos/profiles/dspfac/data/skills/` completed
  on mini1/2/3/5 BEFORE this rolls. All four hosts now show
  `cloud:staff` only.
- Fleet daemon plist `<UserName>` may still be `root` on hosts whose
  install.sh predates this fix. A separate ops pass updates the plist
  + reloads the daemon (chown ran first so the daemon-restart finds a
  consistent tree).