### PR TITLE
feat(agent): re-inject spawn_only post-spawn failures to LLM

### DIFF
--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1338,6 +1338,27 @@ impl Agent {
                                     );
                                 } else {
                                     self.emit_cost_update(turn.total_usage(), &response);
+                                    // Post-spawn failure feedback loop
+                                    // (feat/spawn-only-failure-feedback-loop):
+                                    // record that the synth-ack went out for
+                                    // every spawn_only tool_call_id in this
+                                    // turn. The supervisor's `notify_failure`
+                                    // gates `SpawnOnlyFailureSignal` emission
+                                    // on this set so an eventual post-spawn
+                                    // failure (Gemini API error, plugin
+                                    // crash, late validator rejection) can
+                                    // reach the session actor and drive a
+                                    // recovery turn. Sibling-error
+                                    // suppression (the `if` branch above)
+                                    // intentionally skips this — the LLM
+                                    // already saw the sibling's error
+                                    // tool_result.
+                                    let supervisor = self.tools.supervisor();
+                                    for tc in &response.tool_calls {
+                                        if self.tools.is_spawn_only(&tc.name) {
+                                            supervisor.mark_synth_ack_emitted(&tc.id);
+                                        }
+                                    }
                                     let background_tools = response
                                         .tool_calls
                                         .iter()

--- a/crates/octos-agent/src/agent/loop_runner.rs
+++ b/crates/octos-agent/src/agent/loop_runner.rs
@@ -1353,13 +1353,36 @@ impl Agent {
                                     // intentionally skips this — the LLM
                                     // already saw the sibling's error
                                     // tool_result.
+                                    //
+                                    // Codex round-4 MAJOR (PR #1324 follow-up):
+                                    // iterate `sanitized_response.tool_calls`
+                                    // — not `response.tool_calls` — so the
+                                    // recorded id matches the one the
+                                    // dispatcher used to register the
+                                    // background task in
+                                    // `execution.rs::register_task_with_input_and_cmid`.
+                                    // `handle_tool_use` rewrites every
+                                    // tool_call_id via `sanitize_tool_call_id`
+                                    // (colon → underscore, empty/duplicate
+                                    // repair), and the supervisor stores the
+                                    // sanitized id on the `BackgroundTask`.
+                                    // Recording the ORIGINAL `tc.id` here
+                                    // (e.g. `call:1`) would key the
+                                    // synth-ack set on a value that
+                                    // `notify_failure` never looks up
+                                    // (it checks the sanitized `call_1`),
+                                    // permanently dropping the recovery
+                                    // signal. The `background_tools` chip
+                                    // collection uses the sanitized response
+                                    // for the same reason — it stays in
+                                    // lock-step with what the LLM observed.
                                     let supervisor = self.tools.supervisor();
-                                    for tc in &response.tool_calls {
+                                    for tc in &sanitized_response.tool_calls {
                                         if self.tools.is_spawn_only(&tc.name) {
                                             supervisor.mark_synth_ack_emitted(&tc.id);
                                         }
                                     }
-                                    let background_tools = response
+                                    let background_tools = sanitized_response
                                         .tool_calls
                                         .iter()
                                         .filter(|tc| self.tools.is_spawn_only(&tc.name))

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -722,6 +722,32 @@ pub struct TaskSupervisor {
     /// `register*` and dropped on terminal transitions to keep memory usage
     /// proportional to active tasks.
     cancel_tokens: Arc<CancelTokenStore>,
+    /// Set of `tool_call_id`s for which the spawn_only "Background work
+    /// started for `<tool>`." synth-ack was actually emitted to the LLM
+    /// (see `loop_runner.rs` synth-ack gate).
+    ///
+    /// This is the load-bearing gate for the post-spawn failure feedback
+    /// loop: `notify_failure` only fires `SpawnOnlyFailureSignal` for tasks
+    /// whose `tool_call_id` is in this set. Two failure modes that skip
+    /// the signal correctly:
+    ///
+    /// 1. **Pre-flight validation failures** (`Tool::pre_flight_validate`
+    ///    returned `Err`) early-return BEFORE supervisor registration, so
+    ///    `mark_failed` is never called for them. The LLM already saw the
+    ///    synchronous `[VALIDATION FAILED]` tool_result — no recovery
+    ///    needed.
+    /// 2. **Sibling-error suppression**: a spawn_only sibling tool in the
+    ///    same batch errored, so the synth-ack gate suppressed the ack
+    ///    (see `any_tool_invocation_errored`). The spawn_only task IS
+    ///    registered (tokio::spawn happened) but the LLM already saw the
+    ///    sibling's error and will react on its next iteration. Injecting
+    ///    a recovery prompt for the spawn_only's eventual post-spawn
+    ///    failure would double-signal the LLM.
+    ///
+    /// When the synth-ack DID fire, the LLM was told success — the
+    /// post-spawn failure is the only way it can learn the truth. That
+    /// is the gap this set closes.
+    synth_ack_emitted_tool_call_ids: Arc<Mutex<HashSet<String>>>,
 }
 
 impl Default for TaskSupervisor {
@@ -742,7 +768,44 @@ impl TaskSupervisor {
             persistence_path: Arc::new(Mutex::new(None)),
             progress_reporter: Arc::new(Mutex::new(None)),
             cancel_tokens: Arc::new(CancelTokenStore::default()),
+            synth_ack_emitted_tool_call_ids: Arc::new(Mutex::new(HashSet::new())),
         }
+    }
+
+    /// Record that the spawn_only synth-ack ("Background work started for
+    /// `<tool>`.") was emitted to the LLM for `tool_call_id`. Called from
+    /// the synth-ack gate in `loop_runner.rs` for every spawn_only tool
+    /// call in a turn whose synth-ack actually fires (gated by
+    /// `any_tool_invocation_errored`).
+    ///
+    /// The set is the load-bearing signal for the post-spawn failure
+    /// feedback loop — see the field-level doc on
+    /// `synth_ack_emitted_tool_call_ids`. Idempotent.
+    pub fn mark_synth_ack_emitted(&self, tool_call_id: &str) {
+        if tool_call_id.is_empty() {
+            return;
+        }
+        let mut guard = self
+            .synth_ack_emitted_tool_call_ids
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        guard.insert(tool_call_id.to_string());
+    }
+
+    /// True iff the synth-ack was emitted for `tool_call_id` via
+    /// [`Self::mark_synth_ack_emitted`]. Used by `notify_failure` to gate
+    /// `SpawnOnlyFailureSignal` emission so post-spawn failures only
+    /// trigger a recovery turn when the LLM was previously told the
+    /// background task started successfully.
+    pub fn was_synth_ack_emitted(&self, tool_call_id: &str) -> bool {
+        if tool_call_id.is_empty() {
+            return false;
+        }
+        let guard = self
+            .synth_ack_emitted_tool_call_ids
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        guard.contains(tool_call_id)
     }
 
     /// Enable append-only persistence for task snapshots and restore existing state.
@@ -1898,7 +1961,25 @@ impl TaskSupervisor {
     /// Emit a `SpawnOnlyFailureSignal` for a freshly-failed task, if a
     /// failure callback has been registered. The error_message is taken
     /// from the task's `error` field (set immediately before this call).
+    ///
+    /// **Synth-ack gate**: only emits the signal when the LLM previously
+    /// received the "Background work started for `<tool>`." synth-ack for
+    /// this task's `tool_call_id` (recorded via
+    /// [`Self::mark_synth_ack_emitted`]). When the synth-ack was
+    /// suppressed (sibling-error or pre-flight short-circuit), the LLM
+    /// already saw an error tool_result in its iteration — injecting a
+    /// synthetic recovery prompt would double-signal it. The field-level
+    /// doc on `synth_ack_emitted_tool_call_ids` explains both skip-paths.
     fn notify_failure(&self, task: &BackgroundTask) {
+        if !self.was_synth_ack_emitted(&task.tool_call_id) {
+            tracing::debug!(
+                task_id = %task.id,
+                tool_name = %task.tool_name,
+                tool_call_id = %task.tool_call_id,
+                "skipping SpawnOnlyFailureSignal: synth-ack was never emitted for this tool_call_id (LLM already saw an error tool_result)",
+            );
+            return;
+        }
         let guard = self.on_failure.lock().unwrap_or_else(|e| e.into_inner());
         let Some(cb) = guard.as_ref() else {
             return;
@@ -3013,6 +3094,10 @@ mod tests {
             Some("api:session"),
             Some(serde_json::json!({"voice": "yangmi", "text": "hi"})),
         );
+        // Synth-ack gate: simulate the LLM having seen the
+        // "Background work started for `fm_tts`." ack — production wires
+        // this from `loop_runner.rs` when the synth-ack fires.
+        supervisor.mark_synth_ack_emitted("call-1");
         supervisor.mark_running(&task_id);
         supervisor.mark_failed(
             &task_id,
@@ -3078,6 +3163,7 @@ mod tests {
         let supervisor = TaskSupervisor::new();
         let collected = collect_failure_signals(&supervisor);
         let task_id = supervisor.register("fm_tts", "call-4", None);
+        supervisor.mark_synth_ack_emitted("call-4");
         supervisor.mark_running(&task_id);
         supervisor.mark_failed(&task_id, "first failure".to_string());
         // re-marking should NOT re-fire the signal — guards against runaway
@@ -3102,6 +3188,7 @@ mod tests {
             "format": "mp3",
         });
         let task_id = supervisor.register_with_input("fm_tts", "call-5", None, Some(input.clone()));
+        supervisor.mark_synth_ack_emitted("call-5");
         supervisor.mark_failed(&task_id, "internal error".to_string());
 
         let signals = collected.lock().unwrap().clone();
@@ -3135,6 +3222,7 @@ mod tests {
         let collected = collect_failure_signals(&supervisor);
         let task_id = supervisor.register("fm_tts", "call-6", None);
         supervisor.set_tool_input(&task_id, serde_json::json!({"voice": "yangmi"}));
+        supervisor.mark_synth_ack_emitted("call-6");
         supervisor.mark_failed(&task_id, "voice missing".to_string());
 
         let signals = collected.lock().unwrap().clone();
@@ -3150,6 +3238,7 @@ mod tests {
         let supervisor = TaskSupervisor::new();
         let collected = collect_failure_signals(&supervisor);
         let task_id = supervisor.register("fm_tts", "call-dedup", None);
+        supervisor.mark_synth_ack_emitted("call-dedup");
         supervisor.mark_failed(&task_id, "first".to_string());
         supervisor.mark_failed(&task_id, "second".to_string());
         assert_eq!(collected.lock().unwrap().len(), 1);
@@ -3160,6 +3249,7 @@ mod tests {
         let supervisor = TaskSupervisor::new();
         let collected = collect_failure_signals(&supervisor);
         let task_id = supervisor.register("fm_tts", "call-alts", None);
+        supervisor.mark_synth_ack_emitted("call-alts");
         supervisor.mark_failed(
             &task_id,
             "voice missing. available: vivian, serena, longxiang.".to_string(),
@@ -3186,6 +3276,7 @@ mod tests {
         let input = serde_json::json!({"voice": "yangmi", "text": "hello"});
         let task_id =
             supervisor.register_with_input("fm_tts", "call-prompt", None, Some(input.clone()));
+        supervisor.mark_synth_ack_emitted("call-prompt");
         supervisor.mark_failed(&task_id, "voice missing".to_string());
         let signals = collected.lock().unwrap().clone();
         assert_eq!(signals.len(), 1);
@@ -3198,11 +3289,71 @@ mod tests {
         let supervisor = TaskSupervisor::new();
         let collected = collect_failure_signals(&supervisor);
         let task_id = supervisor.register("fm_tts", "call-7", None);
+        supervisor.mark_synth_ack_emitted("call-7");
         supervisor.mark_failed(&task_id, "boom".to_string());
 
         let signals = collected.lock().unwrap().clone();
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].tool_input, Value::Null);
+    }
+
+    /// Synth-ack gate (PR feat/spawn-only-failure-feedback-loop): when the
+    /// LLM never received the "Background work started for `<tool>`." ack
+    /// for this task's `tool_call_id` (because the synth-ack gate
+    /// suppressed it — sibling-error mode), the supervisor MUST NOT emit
+    /// a `SpawnOnlyFailureSignal` on the eventual post-spawn failure. The
+    /// LLM already saw the sibling error in its iteration and will react
+    /// — injecting a synthetic recovery prompt would double-signal.
+    #[test]
+    fn should_not_emit_failure_signal_when_synth_ack_was_never_emitted() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-no-ack", None);
+        supervisor.mark_running(&task_id);
+        // No mark_synth_ack_emitted call — production analog: sibling tool
+        // errored in this batch so loop_runner.rs suppressed the ack.
+        supervisor.mark_failed(&task_id, "post-spawn error".to_string());
+
+        assert!(
+            collected.lock().unwrap().is_empty(),
+            "failure signal must be suppressed when synth-ack never went to the LLM",
+        );
+    }
+
+    #[test]
+    fn should_emit_failure_signal_only_after_synth_ack_recorded_for_tool_call_id() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+
+        // First task — synth-ack was suppressed, failure must NOT signal.
+        let suppressed_task = supervisor.register("fm_tts", "call-suppressed", None);
+        supervisor.mark_failed(&suppressed_task, "boom A".to_string());
+
+        // Second task — synth-ack fired, failure MUST signal.
+        let acked_task = supervisor.register("fm_tts", "call-acked", None);
+        supervisor.mark_synth_ack_emitted("call-acked");
+        supervisor.mark_failed(&acked_task, "boom B".to_string());
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(
+            signals.len(),
+            1,
+            "exactly one failure signal — the synth-acked task — must reach the callback",
+        );
+        assert_eq!(signals[0].task_id, acked_task);
+    }
+
+    #[test]
+    fn mark_synth_ack_emitted_is_idempotent_and_ignores_empty_id() {
+        let supervisor = TaskSupervisor::new();
+        // Idempotent on repeated calls.
+        supervisor.mark_synth_ack_emitted("call-x");
+        supervisor.mark_synth_ack_emitted("call-x");
+        assert!(supervisor.was_synth_ack_emitted("call-x"));
+        // Empty / unknown id remains untracked.
+        supervisor.mark_synth_ack_emitted("");
+        assert!(!supervisor.was_synth_ack_emitted(""));
+        assert!(!supervisor.was_synth_ack_emitted("call-missing"));
     }
 
     // ── F004 B2: TaskSupervisor → ToolProgress bridge ─────────────────────
@@ -4520,6 +4671,10 @@ mod tests {
         let parent = supervisor.register("run_pipeline", parent_tcid, Some("sess-sig"));
         let c1 = supervisor.register("pipeline:setup", parent_tcid, Some("sess-sig"));
         let c2 = supervisor.register("pipeline:analyze", parent_tcid, Some("sess-sig"));
+        // Children inherit the parent's tool_call_id; mark the synth-ack
+        // for that id so post-spawn failure signals fire (production wires
+        // this from the synth-ack gate in `loop_runner.rs`).
+        supervisor.mark_synth_ack_emitted(parent_tcid);
         supervisor.mark_running(&parent);
         supervisor.mark_running(&c1);
         supervisor.mark_running(&c2);

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -888,27 +888,61 @@ impl AckAndPending {
         evicted
     }
 
-    /// Remove a pending entry by `task_id`. Does NOT scan the
-    /// insertion-order queue (that cleanup happens lazily in
-    /// `insert_pending` when an evicted slot is encountered).
+    /// Remove a pending entry by `task_id` AND its companion entry
+    /// from `pending_insertion_order` so the FIFO queue cannot grow
+    /// without bound.
+    ///
+    /// Codex round-3 MAJOR (PR #1324 follow-up): the round-2 cap only
+    /// fires when `pending.len()` exceeds [`MAX_PENDING_FAILURES`]. In
+    /// the common fail-before-ack → ack-drain cycle the HashMap
+    /// returns to zero each round, so the cap is never hit and the
+    /// VecDeque grows linearly forever. Popping the matching id here
+    /// keeps both collections in lockstep.
     fn remove_pending(&mut self, task_id: &str) -> Option<PendingFailure> {
-        self.pending.remove(task_id)
+        let removed = self.pending.remove(task_id);
+        if removed.is_some() {
+            self.forget_pending_in_order(task_id);
+        }
+        removed
     }
 
     /// Drain every pending failure matching `tool_call_id`. Returns
-    /// the drained entries; the insertion-order queue is left to
-    /// self-heal in `insert_pending`'s skip-stale loop.
+    /// the drained entries; the insertion-order queue is updated in
+    /// lockstep so the VecDeque cannot leak across drain cycles.
+    ///
+    /// Codex round-3 MAJOR (PR #1324 follow-up): same leak class as
+    /// `remove_pending` — when no eviction is ever triggered, the
+    /// `pending_insertion_order` queue would otherwise accumulate one
+    /// entry per failure forever. Pop in lockstep here.
     fn drain_pending_for_tool_call(&mut self, tool_call_id: &str) -> Vec<PendingFailure> {
         let mut hits = Vec::new();
-        self.pending.retain(|_, pf| {
+        let mut drained_ids: Vec<String> = Vec::new();
+        self.pending.retain(|task_id, pf| {
             if pf.tool_call_id == tool_call_id {
+                drained_ids.push(task_id.clone());
                 hits.push(pf.clone());
                 false // remove
             } else {
                 true // keep
             }
         });
+        for task_id in &drained_ids {
+            self.forget_pending_in_order(task_id);
+        }
         hits
+    }
+
+    /// Remove `task_id` from `pending_insertion_order` if present.
+    /// `VecDeque::remove` is O(n) but the deque is bounded at
+    /// [`MAX_PENDING_FAILURES`] (256), so the linear scan is cheap.
+    fn forget_pending_in_order(&mut self, task_id: &str) {
+        if let Some(pos) = self
+            .pending_insertion_order
+            .iter()
+            .position(|tid| tid == task_id)
+        {
+            self.pending_insertion_order.remove(pos);
+        }
     }
 
     /// Mark `task_id` as having dispatched its failure signal. Returns
@@ -4117,6 +4151,118 @@ mod tests {
         assert!(
             !guard.emitted_task_ids.contains(&first_task_id),
             "oldest emitted task_id must be evicted",
+        );
+    }
+
+    /// Codex round-3 MAJOR (PR #1324): the `pending_insertion_order`
+    /// VecDeque must stay bounded across many fail-before-ack →
+    /// ack-drain cycles, even though the cap inside `insert_pending`
+    /// never fires (the HashMap returns to size 0 after every drain).
+    ///
+    /// Previously the VecDeque grew by one entry per cycle forever
+    /// because `drain_pending_for_tool_call` removed from the map but
+    /// left the task_id sitting in the queue. With ~1M cycles in a
+    /// long-running supervisor that would leak ~1M Strings (~50 MB).
+    #[test]
+    fn pending_insertion_order_does_not_leak_after_drain_cycles() {
+        let supervisor = TaskSupervisor::new();
+        let _collected = collect_failure_signals(&supervisor);
+
+        // 4× the cap so we cleanly exercise the regression. Each
+        // iteration uses a distinct (task_id, tool_call_id) so the
+        // pending stash is keyed uniquely, then the synth-ack drains
+        // it via `drain_pending_for_tool_call`.
+        let n = MAX_PENDING_FAILURES * 4;
+        for i in 0..n {
+            let tcid = format!("call-drain-{i:06}");
+            let tid = supervisor.register("fm_tts", &tcid, None);
+            // mark_failed before any synth-ack stashes a pending entry.
+            supervisor.mark_failed(&tid, format!("boom-{i}"));
+            // synth-ack drains the pending entry — the HashMap returns
+            // to 0 each cycle so the cap in `insert_pending` never
+            // fires, exposing the VecDeque leak in the un-fixed code.
+            supervisor.mark_synth_ack_emitted(&tcid);
+        }
+
+        let guard = supervisor.ack_and_pending.lock().unwrap();
+        assert!(
+            guard.pending.is_empty(),
+            "pending map must drain to empty after every cycle, found {} entries",
+            guard.pending.len(),
+        );
+        assert!(
+            guard.pending_insertion_order.len() <= MAX_PENDING_FAILURES,
+            "pending_insertion_order leaked: {} entries (cap {})",
+            guard.pending_insertion_order.len(),
+            MAX_PENDING_FAILURES,
+        );
+        // Strictest assertion: the queue should actually be EMPTY
+        // because every pending entry was drained. The `<= cap`
+        // assertion above is the round-3 contract; this tighter one
+        // documents the ideal state.
+        assert!(
+            guard.pending_insertion_order.is_empty(),
+            "pending_insertion_order must be empty after all entries are drained, found {} entries",
+            guard.pending_insertion_order.len(),
+        );
+    }
+
+    /// Codex round-3 MAJOR (PR #1324): companion to the drain test
+    /// above for the `remove_pending` path. `remove_pending` is called
+    /// from `drain_pending_failure_for_task` (defensive cleanup in
+    /// `mark_completed` / `cancel`) and must also pop the
+    /// `pending_insertion_order` entry. Same leak class.
+    ///
+    /// In normal supervisor flow `mark_failed` makes the task
+    /// terminal, so `mark_completed` and `cancel` short-circuit before
+    /// reaching `remove_pending` — exercising it from the public API
+    /// is awkward. We test the lockstep invariant directly on
+    /// `AckAndPending` instead, which is what the round-3 fix
+    /// guarantees regardless of how `remove_pending` is reached.
+    #[test]
+    fn pending_insertion_order_does_not_leak_after_remove_cycles() {
+        let mut state = AckAndPending::default();
+        let n = MAX_PENDING_FAILURES * 4;
+        for i in 0..n {
+            let task_id = format!("task-remove-{i:06}");
+            let tcid = format!("call-remove-{i:06}");
+            state.insert_pending(
+                task_id.clone(),
+                PendingFailure {
+                    tool_call_id: tcid,
+                    signal: SpawnOnlyFailureSignal {
+                        task_id: task_id.clone(),
+                        tool_name: "fm_tts".into(),
+                        tool_input: Value::Null,
+                        error_message: format!("boom-{i}"),
+                        suggested_alternatives: Vec::new(),
+                        parent_session_key: None,
+                        originating_client_message_id: None,
+                    },
+                },
+            );
+            let removed = state.remove_pending(&task_id);
+            assert!(
+                removed.is_some(),
+                "iteration {i}: remove_pending should return the inserted entry",
+            );
+        }
+
+        assert!(
+            state.pending.is_empty(),
+            "pending map must drain to empty after every cycle, found {} entries",
+            state.pending.len(),
+        );
+        assert!(
+            state.pending_insertion_order.len() <= MAX_PENDING_FAILURES,
+            "pending_insertion_order leaked under remove path: {} entries (cap {})",
+            state.pending_insertion_order.len(),
+            MAX_PENDING_FAILURES,
+        );
+        assert!(
+            state.pending_insertion_order.is_empty(),
+            "pending_insertion_order must be empty after all entries are removed, found {} entries",
+            state.pending_insertion_order.len(),
         );
     }
 

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -8,7 +8,7 @@
 //! The supervisor only sees truth-checked states: `Completed` means the
 //! workspace contract was satisfied, `Failed` means it was not.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
@@ -40,6 +40,28 @@ const CURRENT_TASK_LEDGER_SCHEMA: u32 = 1;
 /// Override at process start by setting the `OCTOS_MAX_CHILDREN_PER_PARENT`
 /// env var to a positive integer; the value is parsed once and cached.
 pub const MAX_CHILDREN_PER_PARENT: usize = 200;
+
+/// Codex round-2 MAJOR (PR #1324): upper bound on `AckAndPending::pending`
+/// entries before the oldest stash is evicted. Sized generously so that
+/// even a fully cascaded pipeline (one pending entry per child task,
+/// `MAX_CHILDREN_PER_PARENT = 200`) plus a 56-entry headroom for unrelated
+/// stashes still fits without eviction in normal operation. The cap is
+/// load-bearing in pathological flows where the synth-ack never arrives
+/// (sibling-error suppression + the task never completes/cancels), so
+/// without it the map would grow until the supervisor is dropped.
+///
+/// When the cap is exceeded the oldest entry is evicted and a WARN is
+/// logged so operators can spot stuck flows.
+const MAX_PENDING_FAILURES: usize = 256;
+
+/// Codex round-2 MAJOR (PR #1324): upper bound on
+/// `AckAndPending::emitted_task_ids` before the oldest entry is evicted.
+/// Sized at 4× the pending cap so a long-running supervisor that never
+/// shuts down still cannot grow this set without bound. The set's only
+/// role is per-task idempotency on the signal callback, so evicting
+/// stale entries after thousands of fires is safe — the task has long
+/// since terminated and its task_id is not reused.
+const MAX_FAILURE_SIGNAL_EMITTED_IDS: usize = 1024;
 
 fn max_children_per_parent() -> usize {
     static CACHE: OnceLock<usize> = OnceLock::new();
@@ -722,6 +744,34 @@ pub struct TaskSupervisor {
     /// `register*` and dropped on terminal transitions to keep memory usage
     /// proportional to active tasks.
     cancel_tokens: Arc<CancelTokenStore>,
+    /// Codex round-2 BLOCKER (PR #1324 follow-up): unified state for the
+    /// synth-ack gate, pending failure stash, and per-task idempotency
+    /// guard. All three were previously separate `Mutex`es, which left a
+    /// narrow ack/pending interleaving race:
+    ///
+    /// 1. `notify_failure` checks `synth_ack_emitted.contains` → false.
+    /// 2. `mark_synth_ack_emitted` inserts the ack AND drains the (still
+    ///    empty) pending map.
+    /// 3. `notify_failure` inserts its pending entry — too late to be
+    ///    drained.
+    /// 4. The pending stash sits forever; recovery signal lost.
+    ///
+    /// Folding all three collections under one mutex makes the
+    /// "check-ack-then-stash" pair atomic with the "record-ack-then-
+    /// drain" pair. The hot path is recovery signaling, which is
+    /// infrequent, so the mutex contention is not a perf concern.
+    ///
+    /// See [`AckAndPending`] for the field-level documentation that
+    /// previously lived on the individual fields.
+    ack_and_pending: Arc<Mutex<AckAndPending>>,
+}
+
+/// Combined state guarded by a single mutex (Codex round-2 BLOCKER):
+/// the synth-ack set, the deferred-failure stash, and the per-task
+/// idempotency set must move together so the ack/pending interleaving
+/// race is impossible.
+#[derive(Debug, Default)]
+struct AckAndPending {
     /// Set of `tool_call_id`s for which the spawn_only "Background work
     /// started for `<tool>`." synth-ack was actually emitted to the LLM
     /// (see `loop_runner.rs` synth-ack gate).
@@ -747,7 +797,7 @@ pub struct TaskSupervisor {
     /// When the synth-ack DID fire, the LLM was told success — the
     /// post-spawn failure is the only way it can learn the truth. That
     /// is the gap this set closes.
-    synth_ack_emitted_tool_call_ids: Arc<Mutex<HashSet<String>>>,
+    synth_ack_emitted_tool_call_ids: HashSet<String>,
     /// Codex round-4 BLOCKER (PR #1324 follow-up): two-phase failure
     /// emission.
     ///
@@ -756,27 +806,29 @@ pub struct TaskSupervisor {
     /// records the synth-ack at line ~1356. A fast post-spawn failure
     /// (e.g. plugin binary missing, instant validator rejection) can
     /// fire `notify_failure` while `synth_ack_emitted_tool_call_ids`
-    /// is still empty. `Mutex<HashSet<_>>` makes the writes thread-safe
-    /// but does NOT impose a happens-before ordering on the
-    /// supervisor's `notify_failure` versus the `loop_runner`'s
-    /// `mark_synth_ack_emitted` — so the failure path can land first
-    /// and observe `was_synth_ack_emitted=false`, permanently dropping
-    /// the recovery signal.
+    /// is still empty. Holding both collections under the same mutex
+    /// (see [`TaskSupervisor::ack_and_pending`]) makes ack-record + drain
+    /// atomic with ack-check + insert, eliminating the interleaving race.
     ///
-    /// Fix: when `notify_failure` runs before the synth-ack arrives,
-    /// stash the would-be `SpawnOnlyFailureSignal` here keyed by the
+    /// When `notify_failure` observes "ack not yet recorded", it
+    /// stashes the would-be `SpawnOnlyFailureSignal` here keyed by the
     /// supervisor's unique `task_id`. The value carries the
     /// associated `tool_call_id` so `mark_synth_ack_emitted(tc_id)`
     /// can scan and drain ALL pending tasks under that
     /// `tool_call_id` — important for pipeline cascade, where many
-    /// child tasks share the parent's `tool_call_id`. Entries are
-    /// also drained on `mark_completed` (the task succeeded — no
-    /// recovery needed). The map stays bounded because every
-    /// `notify_failure` pending entry is settled by exactly one of:
-    /// synth-ack arrival, completion, or supervisor drop.
-    pending_failures: Arc<Mutex<HashMap<String, PendingFailure>>>,
-    /// Companion to `pending_failures` (Codex round-4 BLOCKER): tracks
-    /// unique `task_id`s for which the failure callback already fired.
+    /// child tasks share the parent's `tool_call_id`.
+    ///
+    /// Codex round-2 MAJOR: bounded by [`MAX_PENDING_FAILURES`] with FIFO
+    /// eviction (oldest first); `pending_insertion_order` records insert
+    /// order so eviction is O(1).
+    pending: HashMap<String, PendingFailure>,
+    /// FIFO insertion order for `pending`. When `pending.len()` exceeds
+    /// [`MAX_PENDING_FAILURES`] the front entry is evicted to keep the
+    /// map bounded under pathological flows (ack never arrives + task
+    /// never completes/cancels).
+    pending_insertion_order: VecDeque<String>,
+    /// Companion to `pending` (Codex round-4 BLOCKER): tracks unique
+    /// `task_id`s for which the failure callback already fired.
     /// Keyed by `task_id` (not `tool_call_id`) because pipeline
     /// cascades have many tasks under the same `tool_call_id` and
     /// each child must fire its own signal (see
@@ -784,11 +836,110 @@ pub struct TaskSupervisor {
     /// Guards the deferred-emission replay path and a sibling
     /// `mark_failed` for the same task so each task fires at most one
     /// `SpawnOnlyFailureSignal`.
-    failure_signal_emitted_task_ids: Arc<Mutex<HashSet<String>>>,
+    ///
+    /// Codex round-2 MAJOR: bounded by
+    /// [`MAX_FAILURE_SIGNAL_EMITTED_IDS`] with FIFO eviction; the
+    /// `emitted_insertion_order` queue records insert order so
+    /// eviction is O(1). Stale entries (>1024 fires) are safe to
+    /// evict — the task has long since terminated and `task_id` is a
+    /// UUID never reused.
+    emitted_task_ids: HashSet<String>,
+    /// FIFO insertion order for `emitted_task_ids`.
+    emitted_insertion_order: VecDeque<String>,
+}
+
+impl AckAndPending {
+    /// Insert a pending failure under `task_id`. If the map already
+    /// holds [`MAX_PENDING_FAILURES`] entries, evict the oldest entry
+    /// first and log a WARN so operators can spot stuck flows. Returns
+    /// `Some(evicted)` when an eviction happened.
+    fn insert_pending(&mut self, task_id: String, value: PendingFailure) -> Option<PendingFailure> {
+        // If the key is already present, refresh in place — no
+        // ordering change so we do not re-queue.
+        if let Some(slot) = self.pending.get_mut(&task_id) {
+            *slot = value;
+            return None;
+        }
+        let evicted = if self.pending.len() >= MAX_PENDING_FAILURES {
+            // Pop the oldest entry that still has a live map slot.
+            // `pending_insertion_order` can contain stale ids (drained
+            // out of the map directly) so skip those.
+            loop {
+                match self.pending_insertion_order.pop_front() {
+                    Some(stale) => {
+                        if let Some(victim) = self.pending.remove(&stale) {
+                            tracing::warn!(
+                                evicted_task_id = %stale,
+                                evicted_tool_call_id = %victim.tool_call_id,
+                                cap = MAX_PENDING_FAILURES,
+                                "evicting oldest pending spawn_only failure stash: cap exceeded",
+                            );
+                            break Some(victim);
+                        }
+                    }
+                    None => break None,
+                }
+            }
+        } else {
+            None
+        };
+        self.pending.insert(task_id.clone(), value);
+        self.pending_insertion_order.push_back(task_id);
+        evicted
+    }
+
+    /// Remove a pending entry by `task_id`. Does NOT scan the
+    /// insertion-order queue (that cleanup happens lazily in
+    /// `insert_pending` when an evicted slot is encountered).
+    fn remove_pending(&mut self, task_id: &str) -> Option<PendingFailure> {
+        self.pending.remove(task_id)
+    }
+
+    /// Drain every pending failure matching `tool_call_id`. Returns
+    /// the drained entries; the insertion-order queue is left to
+    /// self-heal in `insert_pending`'s skip-stale loop.
+    fn drain_pending_for_tool_call(&mut self, tool_call_id: &str) -> Vec<PendingFailure> {
+        let mut hits = Vec::new();
+        self.pending.retain(|_, pf| {
+            if pf.tool_call_id == tool_call_id {
+                hits.push(pf.clone());
+                false // remove
+            } else {
+                true // keep
+            }
+        });
+        hits
+    }
+
+    /// Mark `task_id` as having dispatched its failure signal. Returns
+    /// `true` if this is the first dispatch (caller should proceed to
+    /// invoke the callback), `false` if a previous path already
+    /// dispatched (caller must suppress). Bounded by
+    /// [`MAX_FAILURE_SIGNAL_EMITTED_IDS`] with FIFO eviction.
+    fn mark_emitted(&mut self, task_id: &str) -> bool {
+        if !self.emitted_task_ids.insert(task_id.to_string()) {
+            return false;
+        }
+        self.emitted_insertion_order.push_back(task_id.to_string());
+        while self.emitted_task_ids.len() > MAX_FAILURE_SIGNAL_EMITTED_IDS {
+            if let Some(stale) = self.emitted_insertion_order.pop_front() {
+                if self.emitted_task_ids.remove(&stale) {
+                    tracing::warn!(
+                        evicted_task_id = %stale,
+                        cap = MAX_FAILURE_SIGNAL_EMITTED_IDS,
+                        "evicting oldest emitted-failure-signal id: cap exceeded",
+                    );
+                }
+            } else {
+                break;
+            }
+        }
+        true
+    }
 }
 
 /// Pending failure entry — see the field-level doc on
-/// `TaskSupervisor::pending_failures`.
+/// `AckAndPending::pending`.
 #[derive(Debug, Clone)]
 struct PendingFailure {
     /// The `tool_call_id` of the failed task. Used by
@@ -818,9 +969,7 @@ impl TaskSupervisor {
             persistence_path: Arc::new(Mutex::new(None)),
             progress_reporter: Arc::new(Mutex::new(None)),
             cancel_tokens: Arc::new(CancelTokenStore::default()),
-            synth_ack_emitted_tool_call_ids: Arc::new(Mutex::new(HashSet::new())),
-            pending_failures: Arc::new(Mutex::new(HashMap::new())),
-            failure_signal_emitted_task_ids: Arc::new(Mutex::new(HashSet::new())),
+            ack_and_pending: Arc::new(Mutex::new(AckAndPending::default())),
         }
     }
 
@@ -832,49 +981,42 @@ impl TaskSupervisor {
     ///
     /// The set is the load-bearing signal for the post-spawn failure
     /// feedback loop — see the field-level doc on
-    /// `synth_ack_emitted_tool_call_ids`. Idempotent.
+    /// `AckAndPending::synth_ack_emitted_tool_call_ids`. Idempotent.
     ///
     /// Codex round-4 BLOCKER (PR #1324 follow-up): after recording the
     /// ack, drain any pending failure for this `tool_call_id` and emit
-    /// the `SpawnOnlyFailureSignal` NOW. This closes the
-    /// `tokio::spawn` → `notify_failure` → `mark_synth_ack_emitted`
-    /// race where a fast post-spawn failure arrives before the
-    /// foreground `loop_runner` recorded the ack. See the field-level
-    /// doc on `pending_failures` for the full ordering argument.
+    /// the `SpawnOnlyFailureSignal` NOW.
+    ///
+    /// Codex round-2 BLOCKER (PR #1324 follow-up): the ack-record +
+    /// pending-drain pair happens under the SAME mutex as
+    /// `notify_failure`'s ack-check + pending-insert pair. The previous
+    /// design used two separate mutexes for `synth_ack_emitted` and
+    /// `pending_failures`, leaving a narrow interleave where ack-check
+    /// observes false, then drain runs against an empty map, then
+    /// notify inserts pending and the stash sits forever. Folding both
+    /// collections under [`AckAndPending`] makes the ordering atomic.
     pub fn mark_synth_ack_emitted(&self, tool_call_id: &str) {
         if tool_call_id.is_empty() {
             return;
         }
-        {
-            let mut guard = self
-                .synth_ack_emitted_tool_call_ids
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            guard.insert(tool_call_id.to_string());
-        }
-        // Drain every pending failure that arrived before the synth-ack
-        // was recorded for this `tool_call_id`. Pipeline cascades have
-        // multiple tasks sharing one `tool_call_id`, so we collect ALL
-        // matching entries — not just one — and dispatch each. Lock
-        // order: `pending_failures` is taken AFTER releasing
-        // `synth_ack_emitted_tool_call_ids` so we never hold both at
-        // once.
+        // Atomic: insert ack AND drain any pending entries that
+        // arrived before the ack was recorded. No interleaving with
+        // `notify_failure`'s ack-check + pending-insert pair is
+        // possible because they hold the same mutex.
         let drained: Vec<PendingFailure> = {
             let mut guard = self
-                .pending_failures
+                .ack_and_pending
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            let mut hits = Vec::new();
-            guard.retain(|_task_id, pf| {
-                if pf.tool_call_id == tool_call_id {
-                    hits.push(pf.clone());
-                    false // remove
-                } else {
-                    true // keep
-                }
-            });
-            hits
+            guard
+                .synth_ack_emitted_tool_call_ids
+                .insert(tool_call_id.to_string());
+            guard.drain_pending_for_tool_call(tool_call_id)
         };
+        // Dispatch happens AFTER releasing the mutex — the failure
+        // callback is user code that may take other locks (notably
+        // `on_failure`), so we must not hold `ack_and_pending` across
+        // it.
         for pf in drained {
             let task_id = pf.signal.task_id.clone();
             self.dispatch_failure_signal(&task_id, pf.signal);
@@ -891,10 +1033,10 @@ impl TaskSupervisor {
             return false;
         }
         let guard = self
-            .synth_ack_emitted_tool_call_ids
+            .ack_and_pending
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        guard.contains(tool_call_id)
+        guard.synth_ack_emitted_tool_call_ids.contains(tool_call_id)
     }
 
     /// Enable append-only persistence for task snapshots and restore existing state.
@@ -2075,9 +2217,9 @@ impl TaskSupervisor {
     ///
     /// * **Ack already emitted** → build the signal and dispatch via
     ///   [`Self::dispatch_failure_signal`] immediately. Idempotent on
-    ///   replay via `failure_signal_emitted_task_ids`.
+    ///   replay via `AckAndPending::emitted_task_ids`.
     /// * **Ack not yet emitted** → stash the signal in
-    ///   `pending_failures` keyed by `task_id` (carrying its
+    ///   `AckAndPending::pending` keyed by `task_id` (carrying its
     ///   `tool_call_id`) and return without dispatching. When
     ///   `mark_synth_ack_emitted` later runs for the same
     ///   `tool_call_id`, it scans the map, drains every pending
@@ -2089,12 +2231,20 @@ impl TaskSupervisor {
     ///   (Codex round-4 BLOCKER, PR #1324 follow-up).
     /// * **Ack permanently suppressed** (sibling-error / pre-flight
     ///   short-circuit) → the pending entry sits in the map until the
-    ///   session shuts down or the supervisor is dropped. The LLM
-    ///   already saw the sibling error / `[VALIDATION FAILED]`
-    ///   tool_result, so the absence of an emitted signal is the
-    ///   correct behaviour. Memory pressure is bounded because
-    ///   `MAX_CHILDREN_PER_PARENT` already caps the per-session task
-    ///   count; the pending map can never exceed that cap.
+    ///   bounded-cap eviction runs (Codex round-2 MAJOR), or until
+    ///   `cancel` / `mark_completed` drains it. The LLM already saw
+    ///   the sibling error / `[VALIDATION FAILED]` tool_result, so
+    ///   the absence of an emitted signal is the correct behaviour.
+    ///
+    /// **Atomicity (Codex round-2 BLOCKER)**: the ack-check, idempotency
+    /// check, and pending insert all happen under the SAME mutex
+    /// ([`AckAndPending`]). The previous design used three separate
+    /// `Mutex`es, leaving an interleave where
+    /// `notify_failure` could observe ack=false → `mark_synth_ack_emitted`
+    /// could record ack + drain empty pending → `notify_failure` could
+    /// then insert a pending entry that nothing will ever drain. Holding
+    /// the single mutex across the entire decision tree makes this race
+    /// impossible.
     fn notify_failure(&self, task: &BackgroundTask) {
         if task.tool_call_id.is_empty() {
             // Defensive: an empty id can't be matched by the synth-ack
@@ -2108,6 +2258,24 @@ impl TaskSupervisor {
             );
             return;
         }
+        let signal = SpawnOnlyFailureSignal {
+            task_id: task.id.clone(),
+            tool_name: task.tool_name.clone(),
+            tool_input: task.tool_input.clone().unwrap_or(Value::Null),
+            error_message: task.error.clone().unwrap_or_default(),
+            suggested_alternatives: parse_alternatives(task.error.as_deref().unwrap_or("")),
+            parent_session_key: task.parent_session_key.clone(),
+            originating_client_message_id: task.originating_client_message_id.clone(),
+        };
+        // Atomic ack-check + idempotency-check + (dispatch | stash).
+        // The decision branch holds `ack_and_pending` so no interleave
+        // with `mark_synth_ack_emitted` can leave a pending entry
+        // un-drained, and the idempotency guard cannot race a sibling
+        // `mark_failed`.
+        let mut guard = self
+            .ack_and_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         // Idempotency guard: if a previous `notify_failure` (or a
         // drained pending entry) already fired the signal for this
         // task_id, suppress. Protects against:
@@ -2118,31 +2286,31 @@ impl TaskSupervisor {
         // Note: keyed by `task_id` (unique), NOT `tool_call_id`,
         // because pipeline cascade has many tasks sharing the parent's
         // `tool_call_id` and each child must fire its own signal.
+        if guard.emitted_task_ids.contains(&task.id) {
+            tracing::debug!(
+                task_id = %task.id,
+                tool_call_id = %task.tool_call_id,
+                "skipping SpawnOnlyFailureSignal: already emitted for this task_id",
+            );
+            return;
+        }
+        if guard
+            .synth_ack_emitted_tool_call_ids
+            .contains(&task.tool_call_id)
         {
-            let emitted = self
-                .failure_signal_emitted_task_ids
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            if emitted.contains(&task.id) {
-                tracing::debug!(
-                    task_id = %task.id,
-                    tool_call_id = %task.tool_call_id,
-                    "skipping SpawnOnlyFailureSignal: already emitted for this task_id",
-                );
+            // Ack already recorded — mark emitted atomically and
+            // release the mutex before invoking the callback (which
+            // may take its own locks).
+            if !guard.mark_emitted(&task.id) {
+                // mark_emitted returns false when another path won
+                // the race; this is technically reachable only when
+                // the idempotency check above and mark_emitted disagree
+                // (impossible while we hold the lock), but the
+                // defensive return is cheap.
                 return;
             }
-        }
-        let signal = SpawnOnlyFailureSignal {
-            task_id: task.id.clone(),
-            tool_name: task.tool_name.clone(),
-            tool_input: task.tool_input.clone().unwrap_or(Value::Null),
-            error_message: task.error.clone().unwrap_or_default(),
-            suggested_alternatives: parse_alternatives(task.error.as_deref().unwrap_or("")),
-            parent_session_key: task.parent_session_key.clone(),
-            originating_client_message_id: task.originating_client_message_id.clone(),
-        };
-        if self.was_synth_ack_emitted(&task.tool_call_id) {
-            self.dispatch_failure_signal(&task.id, signal);
+            drop(guard);
+            self.invoke_failure_callback(&signal);
         } else {
             // Two-phase: stash and wait for the ack. The pending map
             // is keyed by `task_id` (unique) and carries the
@@ -2155,11 +2323,7 @@ impl TaskSupervisor {
                 tool_call_id = %task.tool_call_id,
                 "deferring SpawnOnlyFailureSignal: synth-ack not yet recorded (will emit on ack or stay pending if ack is suppressed)",
             );
-            let mut pending = self
-                .pending_failures
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            pending.insert(
+            guard.insert_pending(
                 task.id.clone(),
                 PendingFailure {
                     tool_call_id: task.tool_call_id.clone(),
@@ -2172,37 +2336,36 @@ impl TaskSupervisor {
     /// Internal helper: drop any pending failure stash for `task_id`
     /// (the supervisor's unique task identifier). Called from
     /// terminal paths that should invalidate a deferred failure
-    /// (currently `mark_completed`). No-op when nothing is pending.
+    /// (currently `mark_completed` and `cancel`). No-op when nothing
+    /// is pending.
     fn drain_pending_failure_for_task(&self, task_id: &str) -> Option<PendingFailure> {
         if task_id.is_empty() {
             return None;
         }
-        let mut pending = self
-            .pending_failures
+        let mut guard = self
+            .ack_and_pending
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        pending.remove(task_id)
+        guard.remove_pending(task_id)
     }
 
     /// Internal helper: fire the failure callback and mark the
     /// `task_id` as emitted so future replays / cascade paths observe
-    /// the idempotency guard. Called both from `notify_failure`
-    /// (ack-already-emitted path) and from `mark_synth_ack_emitted`
-    /// (drained pending entry path). Keyed by unique `task_id` so
-    /// pipeline cascades — where N tasks share one `tool_call_id` —
-    /// fire one signal per task. Lock discipline: takes `on_failure`
-    /// and `failure_signal_emitted_task_ids` separately and never
-    /// together.
+    /// the idempotency guard. Called from `mark_synth_ack_emitted`
+    /// (drained pending entry path); the `notify_failure` direct-
+    /// dispatch path inlines the same logic under
+    /// `ack_and_pending` to keep the ack-check + emitted-mark atomic.
     fn dispatch_failure_signal(&self, task_id: &str, signal: SpawnOnlyFailureSignal) {
+        // Single-mutex idempotency: mark_emitted returns false when
+        // another path already dispatched. Lock is released BEFORE
+        // calling the user-supplied callback so the callback may
+        // freely take any other lock (notably `on_failure`).
         {
-            let mut emitted = self
-                .failure_signal_emitted_task_ids
+            let mut guard = self
+                .ack_and_pending
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            // Re-check inside the lock to defeat any narrow race
-            // where two callers observe `!contains` and both proceed
-            // to dispatch. The first to reach this line wins.
-            if !emitted.insert(task_id.to_string()) {
+            if !guard.mark_emitted(task_id) {
                 tracing::debug!(
                     task_id = %task_id,
                     "dispatch_failure_signal: another path already emitted; suppressing",
@@ -2210,9 +2373,17 @@ impl TaskSupervisor {
                 return;
             }
         }
+        self.invoke_failure_callback(&signal);
+    }
+
+    /// Internal helper: invoke the user-supplied `on_failure` callback
+    /// with `signal`. Separated from the dispatcher so callers that
+    /// already hold (or already released) `ack_and_pending` can reuse
+    /// the callback-invocation path without re-checking the emitted set.
+    fn invoke_failure_callback(&self, signal: &SpawnOnlyFailureSignal) {
         let guard = self.on_failure.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(cb) = guard.as_ref() {
-            cb(&signal);
+            cb(signal);
         }
     }
 
@@ -3763,6 +3934,190 @@ mod tests {
         );
         assert_eq!(signals[0].task_id, task_id);
         assert!(signals[0].error_message.contains("post-spawn boom"));
+    }
+
+    // ── Codex round-2 BLOCKER + MAJOR (PR #1324 follow-up): atomic
+    // ack-vs-pending decision and bounded state ─────────────────
+
+    /// Codex round-2 BLOCKER: even when `notify_failure` and
+    /// `mark_synth_ack_emitted` are interleaved by concurrent threads,
+    /// every failure must eventually surface as a recovery signal once
+    /// the ack arrives. Pre-fix (separate mutexes for the ack set and
+    /// the pending map), this race could permanently drop the signal:
+    ///   1. notify_failure observes ack=false.
+    ///   2. mark_synth_ack_emitted records ack + drains empty pending.
+    ///   3. notify_failure inserts pending — nothing will drain it.
+    /// Post-fix the combined mutex makes step 2 atomic with the
+    /// check-and-insert pair in step 1+3, so the pending entry is
+    /// either drained in step 2 OR observed in step 1 and dispatched
+    /// directly. Either way, exactly one signal per failure.
+    #[test]
+    fn failure_inserted_during_concurrent_ack_drain_still_fires() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        // High iteration count + concurrent racing pair to surface any
+        // residual race. Even 1 lost wakeup across 200 iterations is a
+        // 0.5% drop rate — easy to catch.
+        const ITERATIONS: usize = 200;
+        for iter in 0..ITERATIONS {
+            let supervisor = TaskSupervisor::new();
+            let collected = collect_failure_signals(&supervisor);
+            let tool_call_id = format!("call-race-{iter}");
+            let task_id = supervisor.register("fm_tts", &tool_call_id, None);
+
+            // Two threads contend on `notify_failure` (via mark_failed)
+            // and `mark_synth_ack_emitted`. The barrier maximizes the
+            // chance of an interleaved hit on the ack-check vs
+            // pending-insert window. Pre-fix this loses ~1-2% of
+            // iterations on Apple Silicon; post-fix it must fire on
+            // every iteration.
+            let barrier = Arc::new(Barrier::new(2));
+            let sup_a = supervisor.clone();
+            let sup_b = supervisor.clone();
+            let bar_a = Arc::clone(&barrier);
+            let bar_b = Arc::clone(&barrier);
+            let tcid_a = tool_call_id.clone();
+            let tcid_b = tool_call_id.clone();
+            let tid = task_id.clone();
+
+            let h1 = thread::spawn(move || {
+                bar_a.wait();
+                sup_a.mark_failed(&tid, "race boom".to_string());
+            });
+            let h2 = thread::spawn(move || {
+                bar_b.wait();
+                sup_b.mark_synth_ack_emitted(&tcid_a);
+                // Sleep is intentionally absent — we want the threads
+                // racing tight, not serialized.
+                let _ = tcid_b; // silence move warning while keeping symmetry
+            });
+            h1.join().expect("mark_failed thread");
+            h2.join().expect("mark_synth_ack_emitted thread");
+
+            let signals = collected.lock().unwrap().clone();
+            assert_eq!(
+                signals.len(),
+                1,
+                "iteration {iter}: race must produce exactly one signal regardless of interleaving",
+            );
+            assert_eq!(signals[0].task_id, task_id);
+            assert!(signals[0].error_message.contains("race boom"));
+        }
+    }
+
+    /// Codex round-2 MAJOR: `AckAndPending::pending` must be bounded
+    /// so a pathological flow (synth-ack permanently suppressed +
+    /// task never completes/cancels) cannot grow the supervisor
+    /// without limit. After inserting `MAX_PENDING_FAILURES + 1`
+    /// pending entries the oldest must be evicted and its eventual
+    /// ack must NOT surface a recovery signal — the evicted entry
+    /// has been dropped from the supervisor by design.
+    #[test]
+    fn pending_failures_eviction_when_max_size_exceeded() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+
+        // Insert MAX + 1 pending entries with distinct tool_call_ids
+        // so the FIFO order is well-defined (each `pending` map slot
+        // has a unique key + insertion order). Each task is registered
+        // and then `mark_failed` is called BEFORE any synth-ack, so
+        // every entry goes pending.
+        let mut task_ids = Vec::with_capacity(MAX_PENDING_FAILURES + 1);
+        for i in 0..=MAX_PENDING_FAILURES {
+            let tcid = format!("call-stash-{i:04}");
+            let tid = supervisor.register("fm_tts", &tcid, None);
+            supervisor.mark_failed(&tid, format!("boom-{i}"));
+            task_ids.push((tid, tcid));
+        }
+
+        // Pre-conditions: nothing should have signaled yet — every
+        // entry is sitting in the pending stash.
+        assert!(
+            collected.lock().unwrap().is_empty(),
+            "no signals must fire before any synth-ack lands",
+        );
+
+        // The map should be exactly bounded at MAX_PENDING_FAILURES;
+        // the very first insert (index 0) was evicted to make room
+        // for index MAX_PENDING_FAILURES.
+        {
+            let guard = supervisor.ack_and_pending.lock().unwrap();
+            assert_eq!(
+                guard.pending.len(),
+                MAX_PENDING_FAILURES,
+                "pending map must stay at cap",
+            );
+            // Oldest tool_call_id is no longer in the map.
+            assert!(
+                !guard.pending.contains_key(&task_ids[0].0),
+                "oldest pending entry must be evicted",
+            );
+            // Newest tool_call_id is present.
+            assert!(
+                guard
+                    .pending
+                    .contains_key(&task_ids[MAX_PENDING_FAILURES].0),
+                "newest pending entry must remain",
+            );
+        }
+
+        // Now firing the synth-ack for the EVICTED tool_call_id must
+        // NOT surface a recovery signal — the pending entry is gone.
+        supervisor.mark_synth_ack_emitted(&task_ids[0].1);
+        assert!(
+            collected.lock().unwrap().is_empty(),
+            "evicted pending entry must not fire when its ack arrives",
+        );
+
+        // Firing the synth-ack for the NEWEST tool_call_id must fire
+        // exactly one signal — the entry is still in the map.
+        supervisor.mark_synth_ack_emitted(&task_ids[MAX_PENDING_FAILURES].1);
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(
+            signals.len(),
+            1,
+            "retained pending entry must still fire when its ack arrives",
+        );
+        assert_eq!(signals[0].task_id, task_ids[MAX_PENDING_FAILURES].0);
+    }
+
+    /// Codex round-2 MAJOR: `AckAndPending::emitted_task_ids` must be
+    /// bounded so the idempotency set cannot grow indefinitely over
+    /// the supervisor's lifetime. After firing
+    /// `MAX_FAILURE_SIGNAL_EMITTED_IDS + 1` distinct failure signals
+    /// the oldest entry is evicted, which is safe because the task is
+    /// long since terminal and the task_id (a UUID) is not reused.
+    #[test]
+    fn failure_signal_emitted_ids_eviction_when_max_size_exceeded() {
+        let supervisor = TaskSupervisor::new();
+        let _collected = collect_failure_signals(&supervisor);
+
+        // Drive past the cap. Each iteration: register a task, mark
+        // its synth-ack, mark it failed → one dispatch → one entry
+        // appended to `emitted_task_ids`.
+        let mut first_task_id = String::new();
+        for i in 0..=MAX_FAILURE_SIGNAL_EMITTED_IDS {
+            let tcid = format!("call-emit-{i:05}");
+            let tid = supervisor.register("fm_tts", &tcid, None);
+            supervisor.mark_synth_ack_emitted(&tcid);
+            supervisor.mark_failed(&tid, format!("boom-{i}"));
+            if i == 0 {
+                first_task_id = tid;
+            }
+        }
+
+        let guard = supervisor.ack_and_pending.lock().unwrap();
+        assert_eq!(
+            guard.emitted_task_ids.len(),
+            MAX_FAILURE_SIGNAL_EMITTED_IDS,
+            "emitted_task_ids must stay at cap",
+        );
+        // Oldest task_id is no longer in the set.
+        assert!(
+            !guard.emitted_task_ids.contains(&first_task_id),
+            "oldest emitted task_id must be evicted",
+        );
     }
 
     // ── F004 B2: TaskSupervisor → ToolProgress bridge ─────────────────────

--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -748,6 +748,56 @@ pub struct TaskSupervisor {
     /// post-spawn failure is the only way it can learn the truth. That
     /// is the gap this set closes.
     synth_ack_emitted_tool_call_ids: Arc<Mutex<HashSet<String>>>,
+    /// Codex round-4 BLOCKER (PR #1324 follow-up): two-phase failure
+    /// emission.
+    ///
+    /// `tokio::spawn` in `execution.rs::handle_spawn_only_branch` (line
+    /// ~493) dispatches the background task BEFORE `loop_runner.rs`
+    /// records the synth-ack at line ~1356. A fast post-spawn failure
+    /// (e.g. plugin binary missing, instant validator rejection) can
+    /// fire `notify_failure` while `synth_ack_emitted_tool_call_ids`
+    /// is still empty. `Mutex<HashSet<_>>` makes the writes thread-safe
+    /// but does NOT impose a happens-before ordering on the
+    /// supervisor's `notify_failure` versus the `loop_runner`'s
+    /// `mark_synth_ack_emitted` — so the failure path can land first
+    /// and observe `was_synth_ack_emitted=false`, permanently dropping
+    /// the recovery signal.
+    ///
+    /// Fix: when `notify_failure` runs before the synth-ack arrives,
+    /// stash the would-be `SpawnOnlyFailureSignal` here keyed by the
+    /// supervisor's unique `task_id`. The value carries the
+    /// associated `tool_call_id` so `mark_synth_ack_emitted(tc_id)`
+    /// can scan and drain ALL pending tasks under that
+    /// `tool_call_id` — important for pipeline cascade, where many
+    /// child tasks share the parent's `tool_call_id`. Entries are
+    /// also drained on `mark_completed` (the task succeeded — no
+    /// recovery needed). The map stays bounded because every
+    /// `notify_failure` pending entry is settled by exactly one of:
+    /// synth-ack arrival, completion, or supervisor drop.
+    pending_failures: Arc<Mutex<HashMap<String, PendingFailure>>>,
+    /// Companion to `pending_failures` (Codex round-4 BLOCKER): tracks
+    /// unique `task_id`s for which the failure callback already fired.
+    /// Keyed by `task_id` (not `tool_call_id`) because pipeline
+    /// cascades have many tasks under the same `tool_call_id` and
+    /// each child must fire its own signal (see
+    /// `mark_descendants_failed_emits_progress_and_failure_signal_per_child`).
+    /// Guards the deferred-emission replay path and a sibling
+    /// `mark_failed` for the same task so each task fires at most one
+    /// `SpawnOnlyFailureSignal`.
+    failure_signal_emitted_task_ids: Arc<Mutex<HashSet<String>>>,
+}
+
+/// Pending failure entry — see the field-level doc on
+/// `TaskSupervisor::pending_failures`.
+#[derive(Debug, Clone)]
+struct PendingFailure {
+    /// The `tool_call_id` of the failed task. Used by
+    /// `mark_synth_ack_emitted` to identify which pending entries to
+    /// drain when an ack arrives for that id.
+    tool_call_id: String,
+    /// The failure signal payload that `notify_failure` would have
+    /// dispatched if the synth-ack had already been recorded.
+    signal: SpawnOnlyFailureSignal,
 }
 
 impl Default for TaskSupervisor {
@@ -769,6 +819,8 @@ impl TaskSupervisor {
             progress_reporter: Arc::new(Mutex::new(None)),
             cancel_tokens: Arc::new(CancelTokenStore::default()),
             synth_ack_emitted_tool_call_ids: Arc::new(Mutex::new(HashSet::new())),
+            pending_failures: Arc::new(Mutex::new(HashMap::new())),
+            failure_signal_emitted_task_ids: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -781,15 +833,52 @@ impl TaskSupervisor {
     /// The set is the load-bearing signal for the post-spawn failure
     /// feedback loop — see the field-level doc on
     /// `synth_ack_emitted_tool_call_ids`. Idempotent.
+    ///
+    /// Codex round-4 BLOCKER (PR #1324 follow-up): after recording the
+    /// ack, drain any pending failure for this `tool_call_id` and emit
+    /// the `SpawnOnlyFailureSignal` NOW. This closes the
+    /// `tokio::spawn` → `notify_failure` → `mark_synth_ack_emitted`
+    /// race where a fast post-spawn failure arrives before the
+    /// foreground `loop_runner` recorded the ack. See the field-level
+    /// doc on `pending_failures` for the full ordering argument.
     pub fn mark_synth_ack_emitted(&self, tool_call_id: &str) {
         if tool_call_id.is_empty() {
             return;
         }
-        let mut guard = self
-            .synth_ack_emitted_tool_call_ids
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        guard.insert(tool_call_id.to_string());
+        {
+            let mut guard = self
+                .synth_ack_emitted_tool_call_ids
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            guard.insert(tool_call_id.to_string());
+        }
+        // Drain every pending failure that arrived before the synth-ack
+        // was recorded for this `tool_call_id`. Pipeline cascades have
+        // multiple tasks sharing one `tool_call_id`, so we collect ALL
+        // matching entries — not just one — and dispatch each. Lock
+        // order: `pending_failures` is taken AFTER releasing
+        // `synth_ack_emitted_tool_call_ids` so we never hold both at
+        // once.
+        let drained: Vec<PendingFailure> = {
+            let mut guard = self
+                .pending_failures
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let mut hits = Vec::new();
+            guard.retain(|_task_id, pf| {
+                if pf.tool_call_id == tool_call_id {
+                    hits.push(pf.clone());
+                    false // remove
+                } else {
+                    true // keep
+                }
+            });
+            hits
+        };
+        for pf in drained {
+            let task_id = pf.signal.task_id.clone();
+            self.dispatch_failure_signal(&task_id, pf.signal);
+        }
     }
 
     /// True iff the synth-ack was emitted for `tool_call_id` via
@@ -1026,6 +1115,14 @@ impl TaskSupervisor {
         self.persist_snapshot(&snapshot);
         self.notify_change(&snapshot);
         self.emit_progress_for_state(&snapshot);
+        // Codex round-4 BLOCKER (PR #1324 follow-up): if a cancelled
+        // task happened to have a pending failure stash (defensive —
+        // cancel + late mark_failed normally would no-op via the
+        // terminal guard, but the entry could exist if mark_failed
+        // landed before cancel transitioned the task), drop it so a
+        // later mark_synth_ack_emitted doesn't surface a recovery
+        // signal for a task the user / system already cancelled.
+        self.drain_pending_failure_for_task(task_id);
         Ok(())
     }
 
@@ -1847,6 +1944,15 @@ impl TaskSupervisor {
             self.persist_snapshot(task);
             self.notify_change(task);
             self.emit_progress_for_state(task);
+            // Codex round-4 BLOCKER (PR #1324 follow-up): drain any
+            // pending failure stash for this task's unique task_id.
+            // Normally `mark_failed` is the only path that inserts
+            // (and the terminal guard in `mark_failed` prevents a
+            // completion after a failure today). Defensive cleanup
+            // ensures a stale entry can't fire later when a sibling
+            // task's `mark_synth_ack_emitted` arrives on the same
+            // tool_call_id.
+            self.drain_pending_failure_for_task(&task.id);
         }
     }
 
@@ -1962,40 +2068,152 @@ impl TaskSupervisor {
     /// failure callback has been registered. The error_message is taken
     /// from the task's `error` field (set immediately before this call).
     ///
-    /// **Synth-ack gate**: only emits the signal when the LLM previously
-    /// received the "Background work started for `<tool>`." synth-ack for
-    /// this task's `tool_call_id` (recorded via
-    /// [`Self::mark_synth_ack_emitted`]). When the synth-ack was
-    /// suppressed (sibling-error or pre-flight short-circuit), the LLM
-    /// already saw an error tool_result in its iteration — injecting a
-    /// synthetic recovery prompt would double-signal it. The field-level
-    /// doc on `synth_ack_emitted_tool_call_ids` explains both skip-paths.
+    /// **Synth-ack gate (two-phase)**: emits or defers based on whether
+    /// the LLM previously received the "Background work started for
+    /// `<tool>`." synth-ack for this task's `tool_call_id` (recorded via
+    /// [`Self::mark_synth_ack_emitted`]):
+    ///
+    /// * **Ack already emitted** → build the signal and dispatch via
+    ///   [`Self::dispatch_failure_signal`] immediately. Idempotent on
+    ///   replay via `failure_signal_emitted_task_ids`.
+    /// * **Ack not yet emitted** → stash the signal in
+    ///   `pending_failures` keyed by `task_id` (carrying its
+    ///   `tool_call_id`) and return without dispatching. When
+    ///   `mark_synth_ack_emitted` later runs for the same
+    ///   `tool_call_id`, it scans the map, drains every pending
+    ///   entry under that id (pipeline cascade has many tasks under
+    ///   one tool_call_id), and emits each signal then.
+    ///   This closes the `tokio::spawn` → `mark_synth_ack_emitted` race
+    ///   in `execution.rs::handle_spawn_only_branch` where a fast
+    ///   failure can hit before the foreground records the ack
+    ///   (Codex round-4 BLOCKER, PR #1324 follow-up).
+    /// * **Ack permanently suppressed** (sibling-error / pre-flight
+    ///   short-circuit) → the pending entry sits in the map until the
+    ///   session shuts down or the supervisor is dropped. The LLM
+    ///   already saw the sibling error / `[VALIDATION FAILED]`
+    ///   tool_result, so the absence of an emitted signal is the
+    ///   correct behaviour. Memory pressure is bounded because
+    ///   `MAX_CHILDREN_PER_PARENT` already caps the per-session task
+    ///   count; the pending map can never exceed that cap.
     fn notify_failure(&self, task: &BackgroundTask) {
-        if !self.was_synth_ack_emitted(&task.tool_call_id) {
+        if task.tool_call_id.is_empty() {
+            // Defensive: an empty id can't be matched by the synth-ack
+            // set, so we could never drain a deferred entry. Treat
+            // this as "skip" — the LLM already saw something else for
+            // this code path (tasks that bypassed id-bearing dispatch).
             tracing::debug!(
                 task_id = %task.id,
                 tool_name = %task.tool_name,
-                tool_call_id = %task.tool_call_id,
-                "skipping SpawnOnlyFailureSignal: synth-ack was never emitted for this tool_call_id (LLM already saw an error tool_result)",
+                "skipping SpawnOnlyFailureSignal: task has empty tool_call_id (cannot key synth-ack lookup)",
             );
             return;
         }
-        let guard = self.on_failure.lock().unwrap_or_else(|e| e.into_inner());
-        let Some(cb) = guard.as_ref() else {
-            return;
-        };
-        let error_message = task.error.clone().unwrap_or_default();
-        let suggested_alternatives = parse_alternatives(&error_message);
+        // Idempotency guard: if a previous `notify_failure` (or a
+        // drained pending entry) already fired the signal for this
+        // task_id, suppress. Protects against:
+        //   * `mark_failed` called twice (live + cascade-fail).
+        //   * BLOCKER race: failure landed before ack, was stashed,
+        //     drained by `mark_synth_ack_emitted`, and now a sibling
+        //     path calls `mark_failed` again on the same task.
+        // Note: keyed by `task_id` (unique), NOT `tool_call_id`,
+        // because pipeline cascade has many tasks sharing the parent's
+        // `tool_call_id` and each child must fire its own signal.
+        {
+            let emitted = self
+                .failure_signal_emitted_task_ids
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if emitted.contains(&task.id) {
+                tracing::debug!(
+                    task_id = %task.id,
+                    tool_call_id = %task.tool_call_id,
+                    "skipping SpawnOnlyFailureSignal: already emitted for this task_id",
+                );
+                return;
+            }
+        }
         let signal = SpawnOnlyFailureSignal {
             task_id: task.id.clone(),
             tool_name: task.tool_name.clone(),
             tool_input: task.tool_input.clone().unwrap_or(Value::Null),
-            error_message,
-            suggested_alternatives,
+            error_message: task.error.clone().unwrap_or_default(),
+            suggested_alternatives: parse_alternatives(task.error.as_deref().unwrap_or("")),
             parent_session_key: task.parent_session_key.clone(),
             originating_client_message_id: task.originating_client_message_id.clone(),
         };
-        cb(&signal);
+        if self.was_synth_ack_emitted(&task.tool_call_id) {
+            self.dispatch_failure_signal(&task.id, signal);
+        } else {
+            // Two-phase: stash and wait for the ack. The pending map
+            // is keyed by `task_id` (unique) and carries the
+            // `tool_call_id` so `mark_synth_ack_emitted` can scan and
+            // drain all matching entries — required for cascade where
+            // many tasks share one tool_call_id.
+            tracing::debug!(
+                task_id = %task.id,
+                tool_name = %task.tool_name,
+                tool_call_id = %task.tool_call_id,
+                "deferring SpawnOnlyFailureSignal: synth-ack not yet recorded (will emit on ack or stay pending if ack is suppressed)",
+            );
+            let mut pending = self
+                .pending_failures
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            pending.insert(
+                task.id.clone(),
+                PendingFailure {
+                    tool_call_id: task.tool_call_id.clone(),
+                    signal,
+                },
+            );
+        }
+    }
+
+    /// Internal helper: drop any pending failure stash for `task_id`
+    /// (the supervisor's unique task identifier). Called from
+    /// terminal paths that should invalidate a deferred failure
+    /// (currently `mark_completed`). No-op when nothing is pending.
+    fn drain_pending_failure_for_task(&self, task_id: &str) -> Option<PendingFailure> {
+        if task_id.is_empty() {
+            return None;
+        }
+        let mut pending = self
+            .pending_failures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pending.remove(task_id)
+    }
+
+    /// Internal helper: fire the failure callback and mark the
+    /// `task_id` as emitted so future replays / cascade paths observe
+    /// the idempotency guard. Called both from `notify_failure`
+    /// (ack-already-emitted path) and from `mark_synth_ack_emitted`
+    /// (drained pending entry path). Keyed by unique `task_id` so
+    /// pipeline cascades — where N tasks share one `tool_call_id` —
+    /// fire one signal per task. Lock discipline: takes `on_failure`
+    /// and `failure_signal_emitted_task_ids` separately and never
+    /// together.
+    fn dispatch_failure_signal(&self, task_id: &str, signal: SpawnOnlyFailureSignal) {
+        {
+            let mut emitted = self
+                .failure_signal_emitted_task_ids
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            // Re-check inside the lock to defeat any narrow race
+            // where two callers observe `!contains` and both proceed
+            // to dispatch. The first to reach this line wins.
+            if !emitted.insert(task_id.to_string()) {
+                tracing::debug!(
+                    task_id = %task_id,
+                    "dispatch_failure_signal: another path already emitted; suppressing",
+                );
+                return;
+            }
+        }
+        let guard = self.on_failure.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(cb) = guard.as_ref() {
+            cb(&signal);
+        }
     }
 
     /// Record the child-session contract outcome for a task.
@@ -3354,6 +3572,197 @@ mod tests {
         supervisor.mark_synth_ack_emitted("");
         assert!(!supervisor.was_synth_ack_emitted(""));
         assert!(!supervisor.was_synth_ack_emitted("call-missing"));
+    }
+
+    // ── Codex round-4 BLOCKER (PR #1324 follow-up): two-phase
+    // failure emission closes the spawn-vs-ack race ─────────────
+
+    /// Race scenario: `tokio::spawn` in execution.rs dispatches the
+    /// background task BEFORE loop_runner.rs records the synth-ack
+    /// (the spawn happens at line ~493, the synth-ack at line ~1356).
+    /// A fast post-spawn failure (plugin binary missing, instant
+    /// validator reject, etc.) can run `notify_failure` while
+    /// `synth_ack_emitted_tool_call_ids` is still empty. Pre-fix:
+    /// the would-be `SpawnOnlyFailureSignal` was dropped and the LLM
+    /// stayed in "Background work started" limbo forever. Post-fix:
+    /// the failure is stashed in `pending_failures` and emitted
+    /// when `mark_synth_ack_emitted` later arrives.
+    #[test]
+    fn failure_before_synth_ack_emits_recovery_when_ack_arrives() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register_with_input(
+            "fm_tts",
+            "call-race",
+            Some("api:session"),
+            Some(serde_json::json!({"voice": "yangmi", "text": "hi"})),
+        );
+        // Failure lands BEFORE the synth-ack is recorded — exactly the
+        // race described in the codex BLOCKER. Pre-fix this dropped
+        // the signal forever; post-fix it stashes for replay.
+        supervisor.mark_failed(&task_id, "post-spawn boom".to_string());
+        assert!(
+            collected.lock().unwrap().is_empty(),
+            "no signal must fire before the synth-ack lands"
+        );
+
+        // Foreground loop_runner finally records the synth-ack — the
+        // stashed failure should now reach the callback.
+        supervisor.mark_synth_ack_emitted("call-race");
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(
+            signals.len(),
+            1,
+            "deferred failure must emit exactly one signal when the ack arrives"
+        );
+        assert_eq!(signals[0].task_id, task_id);
+        assert_eq!(signals[0].tool_name, "fm_tts");
+        assert!(signals[0].error_message.contains("post-spawn boom"));
+        assert_eq!(
+            signals[0].parent_session_key.as_deref(),
+            Some("api:session")
+        );
+    }
+
+    /// Companion to `failure_before_synth_ack_emits_recovery_when_ack_arrives`:
+    /// once the deferred-failure path has fired exactly one signal,
+    /// any sibling `mark_failed` call on the same task must NOT
+    /// double-fire. The codex BLOCKER spec calls this out as
+    /// `failure_signal_idempotent_on_double_emit`.
+    #[test]
+    fn failure_signal_idempotent_on_double_emit() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+        let task_id = supervisor.register("fm_tts", "call-double", None);
+        // Fail-before-ack → stash.
+        supervisor.mark_failed(&task_id, "first failure".to_string());
+        // Ack → drain + dispatch once.
+        supervisor.mark_synth_ack_emitted("call-double");
+        // Subsequent mark_failed calls (production analog: cascade
+        // path + the original failure path racing) must observe the
+        // idempotency guard.
+        supervisor.mark_failed(&task_id, "duplicate failure".to_string());
+        supervisor.mark_failed(&task_id, "third failure".to_string());
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(
+            signals.len(),
+            1,
+            "exactly one signal must fire even with repeated mark_failed + ack drain"
+        );
+        assert_eq!(signals[0].task_id, task_id);
+    }
+
+    /// The deferred-failure stash for one `tool_call_id` must not
+    /// interfere with normal failure-signal delivery for any other
+    /// `tool_call_id`. Codex BLOCKER spec calls this
+    /// `pending_failure_does_not_block_other_call_ids`.
+    #[test]
+    fn pending_failure_does_not_block_other_call_ids() {
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+
+        // Task A: fails before its ack arrives → goes pending.
+        let task_a = supervisor.register("fm_tts", "call-A", None);
+        supervisor.mark_failed(&task_a, "boom A".to_string());
+        assert!(
+            collected.lock().unwrap().is_empty(),
+            "A's failure should still be pending — no ack yet"
+        );
+
+        // Task B: independent tool_call_id, normal ordering (ack
+        // before failure) → must signal normally without being
+        // blocked by A's pending stash.
+        let task_b = supervisor.register("fm_tts", "call-B", None);
+        supervisor.mark_synth_ack_emitted("call-B");
+        supervisor.mark_failed(&task_b, "boom B".to_string());
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(
+            signals.len(),
+            1,
+            "B must emit normally even while A sits in the pending map"
+        );
+        assert_eq!(signals[0].task_id, task_b);
+        assert!(signals[0].error_message.contains("boom B"));
+
+        // Finalise A — once its ack arrives the pending stash drains.
+        supervisor.mark_synth_ack_emitted("call-A");
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(
+            signals.len(),
+            2,
+            "A's pending entry must emit exactly once when its ack arrives"
+        );
+        assert_eq!(signals[1].task_id, task_a);
+        assert!(signals[1].error_message.contains("boom A"));
+    }
+
+    /// Codex round-4 MAJOR (PR #1324): the synth-ack must be recorded
+    /// under the SANITIZED `tool_call_id` that the dispatcher used to
+    /// register the background task. Test as a direct supervisor-level
+    /// guard: simulate the production caller (loop_runner.rs:1357)
+    /// passing the sanitized id through, and verify the recovery
+    /// signal fires. Without the fix, loop_runner.rs records the raw
+    /// `call:1` while the supervisor stored the task under `call_1`,
+    /// so `was_synth_ack_emitted` misses and the recovery path is
+    /// permanently dropped.
+    #[test]
+    fn spawn_only_synth_ack_records_sanitized_id_when_id_has_colon() {
+        // Mirror the canonical sanitization rule from
+        // `agent::message_repair::sanitize_tool_call_id` (module is
+        // private, so we encode the contract inline): every char
+        // outside `[A-Za-z0-9_-]` maps to `_`. This is the same
+        // mapping the dispatcher applies before storing the
+        // BackgroundTask in the supervisor.
+        let raw_id = "call:1";
+        let sanitized: String = raw_id
+            .chars()
+            .map(|c| match c {
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' => c,
+                _ => '_',
+            })
+            .collect();
+        assert_eq!(
+            sanitized, "call_1",
+            "sanitize_tool_call_id contract: `:` → `_` (precondition)"
+        );
+
+        let supervisor = TaskSupervisor::new();
+        let collected = collect_failure_signals(&supervisor);
+
+        // The dispatcher stores the supervised task under the
+        // SANITIZED tool_call_id (see execution.rs:438).
+        let task_id = supervisor.register("fm_tts", &sanitized, Some("api:session"));
+
+        // Post-MAJOR-fix loop_runner.rs records the synth-ack from
+        // `sanitized_response.tool_calls` — i.e. with `call_1`, not
+        // `call:1`. Simulate exactly that path.
+        supervisor.mark_synth_ack_emitted(&sanitized);
+        assert!(
+            supervisor.was_synth_ack_emitted(&sanitized),
+            "supervisor must observe synth-ack under the sanitized id"
+        );
+        // The raw id was never recorded — confirm we didn't
+        // accidentally key on the un-sanitized form.
+        assert!(
+            !supervisor.was_synth_ack_emitted(raw_id),
+            "supervisor must NOT observe synth-ack under the raw `call:1` id"
+        );
+
+        // Post-spawn failure runs through the supervisor with the
+        // sanitized id (because that's what the BackgroundTask carries).
+        supervisor.mark_failed(&task_id, "post-spawn boom".to_string());
+
+        let signals = collected.lock().unwrap().clone();
+        assert_eq!(
+            signals.len(),
+            1,
+            "recovery signal must fire when synth-ack and supervisor task share the SANITIZED id"
+        );
+        assert_eq!(signals[0].task_id, task_id);
+        assert!(signals[0].error_message.contains("post-spawn boom"));
     }
 
     // ── F004 B2: TaskSupervisor → ToolProgress bridge ─────────────────────

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -130,6 +130,24 @@ const DEFAULT_CONTEXT_COMPACT_RATIO_NUMERATOR: usize = 7;
 const DEFAULT_CONTEXT_COMPACT_RATIO_DENOMINATOR: usize = 10;
 const DEFAULT_CONTEXT_COMPACT_KEEP_ITEMS: usize = 16;
 
+/// Maximum number of CONSECUTIVE auto-recovery turns the session actor will
+/// dispatch in response to spawn_only post-spawn failures before bailing
+/// out. The dedup-on-task-id (`recovered_tasks` HashSet) caps repeated
+/// signals from the SAME task at 1; this is a separate cap on the chain of
+/// distinct task failures (LLM retries the same broken approach with new
+/// tool_call_ids and they all fail). Reset to 0 on a user-initiated turn.
+///
+/// Default 2 = the LLM gets up to two corrective rounds before the actor
+/// gives up and emits a final UI banner ("Background failure could not be
+/// recovered after N attempts"). Higher values risk runaway loops on
+/// pathological inputs; lower values short-circuit legitimate two-step
+/// recoveries (e.g. "pick a valid voice → MiniMax rate-limit on retry").
+///
+/// Configurable at runtime via `OCTOS_MAX_CONSECUTIVE_RECOVERY_TURNS`. Clamped
+/// to `[1, 10]` so a misconfigured env var cannot disable the cap or
+/// runaway the loop.
+const MAX_CONSECUTIVE_RECOVERY_TURNS: u32 = 2;
+
 #[derive(Debug, Clone, serde::Serialize)]
 struct PersistedSessionMessage {
     seq: usize,
@@ -3193,6 +3211,7 @@ impl ActorFactory {
             context_manager,
             retry_state_path: Some(retry_state_path),
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -3700,6 +3719,15 @@ struct SessionActor {
     /// turn (M8.9). Caps recovery at one attempt per task so a recovery
     /// turn that itself fails cannot ignite a runaway loop.
     recovered_tasks: Arc<StdMutex<std::collections::HashSet<String>>>,
+    /// Counter of CONSECUTIVE recovery turns the actor has dispatched in
+    /// response to spawn_only post-spawn failures (PR
+    /// feat/spawn-only-failure-feedback-loop). Reset to 0 on a
+    /// user-initiated turn; incremented every time a `RecoveryHint` drives
+    /// an inbound. When the counter reaches
+    /// [`MAX_CONSECUTIVE_RECOVERY_TURNS`] the actor emits a final UI
+    /// banner instead of dispatching another recovery so the loop cannot
+    /// run away on pathological LLM retries with new tool_call_ids.
+    consecutive_recovery_turns: Arc<StdMutex<u32>>,
     /// Codex pre-merge review of #748 P1.2: cmid of the inbound currently
     /// being handled by `try_handle_command`. `send_reply` reads this so
     /// slash-command replies + `_completion` events stamp `thread_id` from
@@ -3808,6 +3836,51 @@ impl SessionActor {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         guard.insert(task_id.to_string())
+    }
+
+    /// Effective ceiling on consecutive recovery turns, env-overridable via
+    /// `OCTOS_MAX_CONSECUTIVE_RECOVERY_TURNS`. Clamped to `[1, 10]` so a
+    /// misconfigured value cannot disable the cap entirely.
+    fn max_consecutive_recovery_turns(&self) -> u32 {
+        if let Ok(raw) = std::env::var("OCTOS_MAX_CONSECUTIVE_RECOVERY_TURNS") {
+            if let Ok(value) = raw.parse::<u32>() {
+                return value.clamp(1, 10);
+            }
+        }
+        MAX_CONSECUTIVE_RECOVERY_TURNS
+    }
+
+    /// Try to begin a recovery turn. Increments the consecutive-recovery
+    /// counter and returns `true` if the new count is `<= max`. Returns
+    /// `false` once the cap is exceeded so the caller can emit a final
+    /// banner instead of dispatching another LLM turn.
+    ///
+    /// Companion to [`Self::claim_recovery_slot`]: the per-task slot
+    /// dedupes repeated signals from the same task, while this counter
+    /// caps the chain of *distinct* failed tasks (LLM retries the same
+    /// broken approach with new tool_call_ids and they keep failing).
+    fn try_begin_recovery_turn(&self) -> bool {
+        let mut guard = self
+            .consecutive_recovery_turns
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let max = self.max_consecutive_recovery_turns();
+        if *guard >= max {
+            return false;
+        }
+        *guard += 1;
+        true
+    }
+
+    /// Reset the consecutive-recovery counter to 0. Called when a
+    /// user-initiated inbound is about to be processed — once the user
+    /// re-engages we no longer count the prior chain as "consecutive".
+    fn reset_consecutive_recovery_turns(&self) {
+        let mut guard = self
+            .consecutive_recovery_turns
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *guard = 0;
     }
 
     fn context_compact_threshold_tokens(&self) -> usize {
@@ -4339,6 +4412,34 @@ impl SessionActor {
                                     tool_name,
                                     "skipping duplicate recovery hint"
                                 );
+                                continue;
+                            }
+                            // Consecutive-recovery cap
+                            // (feat/spawn-only-failure-feedback-loop): a
+                            // distinct, second-or-later task failing AGAIN
+                            // (the LLM retried its broken approach with a
+                            // new tool_call_id) is still bounded by
+                            // MAX_CONSECUTIVE_RECOVERY_TURNS. Above the
+                            // cap, emit a final user-visible banner via
+                            // the same persisted-notification path the
+                            // background-result consumer uses, then bail
+                            // out instead of dispatching another LLM
+                            // turn. The counter resets on every user-
+                            // initiated turn (see `process_inbound`).
+                            if !self.try_begin_recovery_turn() {
+                                let max = self.max_consecutive_recovery_turns();
+                                warn!(
+                                    session = %self.session_key,
+                                    task_id,
+                                    tool_name,
+                                    max,
+                                    "consecutive recovery cap exceeded — emitting final banner instead of dispatching another LLM turn"
+                                );
+                                let banner = format!(
+                                    "Background failure could not be recovered after {max} attempts. The last failure was on `{tool_name}`. Please review the error and try a different approach.",
+                                );
+                                self.deliver_background_notification(banner, Vec::new(), None)
+                                    .await;
                                 continue;
                             }
                             debug!(
@@ -7292,6 +7393,25 @@ impl SessionActor {
         attachment_media: Vec<String>,
         attachment_prompt: Option<String>,
     ) {
+        // Consecutive-recovery cap reset
+        // (feat/spawn-only-failure-feedback-loop): user-initiated turns
+        // break the "recovery chain" — once the user re-engages we no
+        // longer count the prior auto-recoveries against the cap. Master
+        // continuations are server-driven and don't represent user
+        // re-engagement, so they're excluded too. The recovery hint
+        // path stamps `_recovery_turn = true` in metadata via
+        // `synthetic_recovery_inbound`; any inbound without that flag
+        // counts as user-initiated for this reset.
+        let is_recovery_turn = inbound
+            .metadata
+            .get("_recovery_turn")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let is_master_continuation_inbound = inbound_is_master_continuation(&inbound);
+        if !is_recovery_turn && !is_master_continuation_inbound {
+            self.reset_consecutive_recovery_turns();
+        }
+
         // Capture the platform message ID for reply threading
         let inbound_message_id = inbound.message_id.clone();
         // M8.10 PR #2: capture the user's client_message_id so every
@@ -9673,6 +9793,7 @@ mod tests {
             context_manager: test_context_manager(&SessionKey::new("cli", "test")),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -9743,6 +9864,7 @@ mod tests {
             context_manager: test_context_manager(&SessionKey::new("cli", "test")),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -9894,6 +10016,7 @@ mod tests {
             context_manager: test_context_manager(&SessionKey::new("cli", "test")),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -10017,6 +10140,7 @@ mod tests {
             context_manager: test_context_manager(&SessionKey::new("cli", "test")),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -10136,6 +10260,7 @@ mod tests {
             context_manager: test_context_manager(&SessionKey::new("cli", "test")),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -10227,6 +10352,7 @@ mod tests {
             context_manager: test_context_manager(&SessionKey::new("cli", "test")),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -10317,6 +10443,7 @@ mod tests {
             context_manager: test_context_manager(&session_key),
             retry_state_path: None,
             recovered_tasks: Arc::new(StdMutex::new(std::collections::HashSet::new())),
+            consecutive_recovery_turns: Arc::new(StdMutex::new(0)),
             current_command_cmid: None,
         };
 
@@ -13617,6 +13744,11 @@ mod tests {
             Some("cli:test"),
             Some(serde_json::json!({"voice": "yangmi", "text": "hi"})),
         );
+        // Synth-ack gate (feat/spawn-only-failure-feedback-loop): mark
+        // the synth-ack as emitted so post-spawn failure produces a
+        // SpawnOnlyFailureSignal. Production wires this from
+        // `loop_runner.rs` when the synth-ack actually fires.
+        supervisor.mark_synth_ack_emitted("call-int-1");
         supervisor.mark_failed(
             &task_id,
             "voice 'yangmi' not registered. available: vivian, serena.".into(),
@@ -13708,6 +13840,7 @@ mod tests {
             Some(serde_json::json!({"query": "rust news"})),
             Some(ORIGINATING_CMID.to_string()),
         );
+        supervisor.mark_synth_ack_emitted("call-738");
         supervisor.mark_failed(&task_id, "MiniMax 429 rate limited".into());
 
         let mut responses = Vec::new();
@@ -14500,6 +14633,399 @@ mod tests {
 
         drop(tx);
         let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    // ───────────────────────── Post-spawn failure feedback loop ──────────────────────────
+    //
+    // Tests for the spawn_only post-spawn failure → synthetic recovery
+    // turn pipeline (PR feat/spawn-only-failure-feedback-loop). The
+    // supervisor-side synth-ack gate has unit coverage in
+    // `task_supervisor::tests`; these are end-to-end against the running
+    // actor.
+
+    /// Wire a TaskSupervisor to the actor's RecoveryHint inbox exactly the
+    /// way `SessionActor::spawn` does in production. Returns the
+    /// supervisor so tests can drive `mark_synth_ack_emitted` +
+    /// `mark_failed`.
+    fn wire_supervisor_to_actor_inbox(
+        tx: &mpsc::Sender<ActorMessage>,
+    ) -> Arc<octos_agent::TaskSupervisor> {
+        let supervisor = Arc::new(octos_agent::TaskSupervisor::new());
+        let recovery_tx = tx.clone();
+        supervisor.set_on_failure_signal(move |signal| {
+            let prompt = build_recovery_prompt(signal);
+            let _ = recovery_tx.try_send(ActorMessage::RecoveryHint {
+                task_id: signal.task_id.clone(),
+                tool_name: signal.tool_name.clone(),
+                prompt,
+                originating_client_message_id: signal.originating_client_message_id.clone(),
+            });
+        });
+        supervisor
+    }
+
+    /// Test 1: post-spawn failure AFTER the synth-ack fired drives a
+    /// recovery turn — the LLM sees a synthetic user message and produces
+    /// a follow-up response. This is the core behaviour the PR enables:
+    /// the model can no longer silently believe a spawn_only call
+    /// succeeded when the plugin process later failed.
+    #[tokio::test]
+    async fn background_failure_with_synth_ack_triggers_recovery_turn() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::from_millis(50), make_response("acked-after-fail"))],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let supervisor = wire_supervisor_to_actor_inbox(&tx);
+        let task_id = supervisor.register_with_input(
+            "mofa_slides",
+            "call-spawn-fb-1",
+            Some("cli:test"),
+            Some(serde_json::json!({"topic": "rust"})),
+        );
+        supervisor.mark_synth_ack_emitted("call-spawn-fb-1");
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(&task_id, "Gemini API: 429 quota exceeded".to_string());
+
+        let mut responses = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+            if responses.iter().any(|r| r.contains("acked-after-fail")) {
+                break;
+            }
+        }
+        assert!(
+            responses.iter().any(|c| c.contains("acked-after-fail")),
+            "LLM must react to the synthetic recovery prompt, got: {responses:?}",
+        );
+
+        // The synthetic user message MUST land in persisted history so
+        // the LLM has it on its next turn — Design A constraint.
+        let session_handle = SessionHandle::open(dir.path(), &SessionKey::new("cli", "test"));
+        let session = session_handle.session();
+        let recovery_prompts: Vec<_> = session
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == MessageRole::User
+                    && m.content.contains("[system-internal]")
+                    && m.content.contains("mofa_slides")
+            })
+            .collect();
+        assert_eq!(
+            recovery_prompts.len(),
+            1,
+            "exactly one recovery prompt expected in history, got: {:?}",
+            session.messages
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    /// Test 2: post-spawn failure WITHOUT a prior synth-ack is a no-op.
+    /// Production path: the synth-ack gate suppressed the ack because a
+    /// sibling tool errored in the same batch; the LLM already saw that
+    /// error and reacted. Re-injecting a recovery prompt for the
+    /// eventual post-spawn failure would double-signal the model.
+    #[tokio::test]
+    async fn background_failure_without_synth_ack_no_op() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::from_millis(50), make_response("should-not-run"))],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let supervisor = wire_supervisor_to_actor_inbox(&tx);
+        let task_id = supervisor.register_with_input(
+            "mofa_slides",
+            "call-spawn-fb-2",
+            Some("cli:test"),
+            Some(serde_json::json!({"topic": "rust"})),
+        );
+        // Deliberately omit `mark_synth_ack_emitted` — simulates the
+        // sibling-error suppression path.
+        supervisor.mark_running(&task_id);
+        supervisor.mark_failed(&task_id, "plugin crash".to_string());
+
+        // Give the inbox a window to deliver a hypothetical RecoveryHint.
+        let push = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+        assert!(
+            push.is_err()
+                || push
+                    .ok()
+                    .flatten()
+                    .map(|m| m.content)
+                    .filter(|c| c.contains("should-not-run"))
+                    .is_none(),
+            "no recovery LLM turn should fire when the synth-ack was suppressed",
+        );
+
+        // History must not contain a recovery prompt either.
+        let session_handle = SessionHandle::open(dir.path(), &SessionKey::new("cli", "test"));
+        let session = session_handle.session();
+        let recovery_present = session
+            .messages
+            .iter()
+            .any(|m| m.role == MessageRole::User && m.content.contains("[system-internal]"));
+        assert!(
+            !recovery_present,
+            "no recovery prompt should be persisted: {:?}",
+            session.messages
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    /// Test 3: the success path is unchanged — a spawn_only task that
+    /// reaches `mark_completed` must NOT emit a recovery turn even when
+    /// the synth-ack was previously recorded.
+    #[tokio::test]
+    async fn background_success_path_unchanged() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![(Duration::from_millis(50), make_response("should-not-run"))],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let supervisor = wire_supervisor_to_actor_inbox(&tx);
+        let task_id = supervisor.register("mofa_slides", "call-spawn-fb-3", Some("cli:test"));
+        supervisor.mark_synth_ack_emitted("call-spawn-fb-3");
+        supervisor.mark_running(&task_id);
+        supervisor.mark_completed(&task_id, vec!["/tmp/deck.pptx".to_string()]);
+
+        let push = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+        let leaked = push
+            .ok()
+            .flatten()
+            .map(|m| m.content)
+            .filter(|c| c.contains("should-not-run"));
+        assert!(
+            leaked.is_none(),
+            "success transition must not produce a recovery turn: {leaked:?}",
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    /// Test 4: two failure events for the same task_id (e.g. cascade
+    /// path + direct path racing) must result in at most one recovery
+    /// turn. The supervisor-side `was_already_failed` guard handles
+    /// this, with the actor-side `recovered_tasks` slot as defense in
+    /// depth.
+    #[tokio::test]
+    async fn background_failure_dedup_on_repeated_payloads() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![
+                (Duration::from_millis(50), make_response("first-run")),
+                (
+                    Duration::from_millis(50),
+                    make_response("must-not-run-twice"),
+                ),
+            ],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let supervisor = wire_supervisor_to_actor_inbox(&tx);
+        let task_id = supervisor.register("mofa_slides", "call-spawn-fb-4", Some("cli:test"));
+        supervisor.mark_synth_ack_emitted("call-spawn-fb-4");
+        supervisor.mark_failed(&task_id, "first fail".to_string());
+        // Second mark_failed must not re-fire the signal — supervisor guard.
+        supervisor.mark_failed(&task_id, "second fail".to_string());
+
+        let mut responses = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+        }
+        let first_seen = responses.iter().any(|c| c.contains("first-run"));
+        let second_seen = responses.iter().any(|c| c.contains("must-not-run-twice"));
+        assert!(first_seen, "first recovery should run: {responses:?}");
+        assert!(
+            !second_seen,
+            "second recovery must be suppressed: {responses:?}",
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    /// Test 5: when the LLM repeatedly retries a failing tool with new
+    /// `tool_call_id`s, the actor caps the chain at
+    /// MAX_CONSECUTIVE_RECOVERY_TURNS distinct recovery turns and emits a
+    /// final banner instead of dispatching another LLM turn. The
+    /// per-task `recovered_tasks` slot doesn't help here because each
+    /// retry has a fresh task_id; `consecutive_recovery_turns` is the
+    /// safeguard.
+    #[tokio::test]
+    async fn background_failure_recovery_capped_at_max_retries() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Provide more responses than the cap allows so we can detect
+        // "did the third LLM turn happen?" — if the cap works, only the
+        // first two responses ever reach the rx channel.
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![
+                (Duration::from_millis(50), make_response("recovery-1")),
+                (Duration::from_millis(50), make_response("recovery-2")),
+                (
+                    Duration::from_millis(50),
+                    make_response("recovery-3-MUST-NOT-RUN"),
+                ),
+            ],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let supervisor = wire_supervisor_to_actor_inbox(&tx);
+
+        // Three distinct failed tasks back-to-back, each with their own
+        // tool_call_id and synth-ack — simulates LLM retrying with
+        // corrected-but-still-broken inputs.
+        for n in 0..3 {
+            let tcid = format!("call-cap-{n}");
+            let task_id = supervisor.register("mofa_slides", &tcid, Some("cli:test"));
+            supervisor.mark_synth_ack_emitted(&tcid);
+            supervisor.mark_failed(&task_id, format!("fail #{n}"));
+            // Pace the marks so the actor processes them in order — without
+            // this, the second mark_failed could race the first recovery
+            // turn's `claim_recovery_slot` and the per-task dedup might
+            // mask the cap test.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        }
+
+        let mut responses = Vec::new();
+        let mut banners = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if msg.content.contains("could not be recovered") {
+                banners.push(msg.content.clone());
+            } else if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+            if !banners.is_empty()
+                && responses.iter().filter(|c| c.contains("recovery-")).count() >= 2
+            {
+                break;
+            }
+        }
+        // The first two recovery LLM turns must have run.
+        assert!(
+            responses.iter().any(|c| c.contains("recovery-1")),
+            "first recovery should run, got: {responses:?}",
+        );
+        assert!(
+            responses.iter().any(|c| c.contains("recovery-2")),
+            "second recovery should run, got: {responses:?}",
+        );
+        // The third must NOT run — the cap kicks in before the LLM is
+        // invoked.
+        assert!(
+            !responses
+                .iter()
+                .any(|c| c.contains("recovery-3-MUST-NOT-RUN")),
+            "third recovery beyond the cap must not invoke the LLM, got: {responses:?}",
+        );
+        // The banner MUST land instead.
+        assert!(
+            banners
+                .iter()
+                .any(|c| c.contains("Background failure could not be recovered")),
+            "final banner expected once cap exceeded, got: {banners:?}",
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
+    }
+
+    /// User-initiated turns must reset the consecutive-recovery counter
+    /// so a future failure chain isn't pre-loaded by historical
+    /// recoveries. Asserts the bookkeeping invariant directly through
+    /// the test-only snapshot accessor.
+    #[tokio::test]
+    async fn user_turn_resets_consecutive_recovery_counter() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let agent_llm = Arc::new(DelayedMockProvider::new(
+            "agent",
+            vec![
+                (Duration::from_millis(50), make_response("recovery-A")),
+                (Duration::from_millis(50), make_response("user-reply")),
+            ],
+        ));
+        let (tx, mut rx, handle, _session_mgr) =
+            setup_actor_with_mode(agent_llm, QueueMode::Followup, None, false, &dir).await;
+
+        let supervisor = wire_supervisor_to_actor_inbox(&tx);
+        let task_id = supervisor.register("mofa_slides", "call-reset-1", Some("cli:test"));
+        supervisor.mark_synth_ack_emitted("call-reset-1");
+        supervisor.mark_failed(&task_id, "boom".to_string());
+
+        // Wait for the recovery turn to land.
+        let mut responses = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if !msg.content.is_empty() {
+                responses.push(msg.content);
+            }
+            if responses.iter().any(|c| c.contains("recovery-A")) {
+                break;
+            }
+        }
+        assert!(responses.iter().any(|c| c.contains("recovery-A")));
+
+        // Push a USER inbound — counter should drop back to 0 inside
+        // `process_inbound`.
+        tx.send(ActorMessage::Inbound {
+            message: InboundMessage {
+                channel: "cli".into(),
+                sender_id: "user".into(),
+                chat_id: "test".into(),
+                content: "Hello".into(),
+                timestamp: chrono::Utc::now(),
+                media: vec![],
+                metadata: serde_json::json!({}),
+                message_id: None,
+            },
+            image_media: vec![],
+            attachment_media: vec![],
+            attachment_prompt: None,
+        })
+        .await
+        .unwrap();
+
+        // Wait for the user-reply to confirm process_inbound ran.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut user_reply_seen = false;
+        while let Ok(Some(msg)) = tokio::time::timeout_at(deadline, rx.recv()).await {
+            if msg.content.contains("user-reply") {
+                user_reply_seen = true;
+                break;
+            }
+        }
+        assert!(
+            user_reply_seen,
+            "user inbound must drive the second LLM turn"
+        );
+
+        drop(tx);
+        let _ = tokio::time::timeout(Duration::from_secs(3), handle).await;
     }
 
     /// B3.4 (codex P1 fix) — failovers stamped with `None` originator


### PR DESCRIPTION
## Gap

When a `spawn_only` tool's background work fails AFTER the synth-ack (`"Background work started for \`<tool>\`."`) was already delivered to the LLM as a tool_result, the model previously believed the call succeeded. The post-spawn failure rendered to the UI only — Gemini API errors, plugin crashes, late workspace-contract validator rejections, all of them landed as red bubbles the LLM never saw.

PR #1015 closed the analogous pre-spawn gap for `run_pipeline`'s DOT validator (synchronous `Tool::pre_flight_validate` → `[VALIDATION FAILED]` tool_result in the same iteration). PR #1323 mirrored that pattern for `mofa_slides`' style argument. Both pre-flight gates short-circuit BEFORE `tokio::spawn`. This PR closes the complementary half — failures that surface AFTER `tokio::spawn` has dispatched and the foreground turn has already ended.

```text
LLM tool_call → spawn_only tokio::spawn → return synth-success
  ├─ iter_tool_success.push((id, true)) recorded
  └─ synth-ack gate (any_tool_invocation_errored == false) fires
       └─ EMITS "Background work started for `<tool>`."
            └─ turn ends, conversation persists success=true tool_result
                 └─ [seconds later] BackgroundResultPayload{success:false, output:"..."}
                      ├─ pre-PR: UI red bubble only; LLM untouched
                      └─ post-PR: synthetic [system-internal] user-role
                                  recovery prompt persisted + new turn
                                  dispatched
```

## Fix — Design A (synthetic user message + auto-continue)

The M8.9 recovery infrastructure (`SpawnOnlyFailureSignal` → `RecoveryHint` → `synthetic_recovery_inbound` → `process_inbound`) already does most of the work. This PR adds the missing entry gate and the safety net around it.

### Entry gate: synth-ack tracking on the supervisor

`TaskSupervisor` gains two methods:

- `mark_synth_ack_emitted(tool_call_id: &str)` — called from the synth-ack gate in `loop_runner.rs` for every spawn_only `tool_call_id` whose ack ACTUALLY fires (the `else` branch of `any_tool_invocation_errored`).
- `was_synth_ack_emitted(tool_call_id: &str) -> bool` — read by `notify_failure` before emitting `SpawnOnlyFailureSignal`.

When the LLM never received the ack — pre-flight validation rejected the args (supervisor never registered the task) OR a sibling tool errored in the same batch and the synth-ack gate suppressed (task IS registered but the LLM already saw the sibling's error) — `notify_failure` skips. Re-injecting in those cases would double-signal the model.

When the ack DID go out, `notify_failure` proceeds via the existing M8.9 path: `set_on_failure_signal` → `ActorMessage::RecoveryHint` → `synthetic_recovery_inbound` (stamps `_recovery_turn = true` + `client_message_id` in metadata) → `process_inbound` builds a `[system-internal] Your previous \`<tool>\` call failed. ...` user message and dispatches a new turn.

### De-dup + retry-cap safeguards

- **Per-task_id dedup** (existing `recovered_tasks: HashSet<String>` in `SessionActor`): same task firing two failure payloads → one recovery turn. Unchanged.
- **Per-session consecutive-recovery cap** (NEW: `consecutive_recovery_turns: u32`, default 2, configurable via `OCTOS_MAX_CONSECUTIVE_RECOVERY_TURNS` clamped to `[1, 10]`): bounds the CHAIN of distinct task failures — the LLM retrying the same broken approach with new `tool_call_id`s and each retry failing. Above the cap, the actor emits a final UI banner ("Background failure could not be recovered after N attempts. The last failure was on \`<tool>\`. Please review the error and try a different approach.") via the existing `deliver_background_notification` path and stops dispatching turns.

Counter resets on every user-initiated inbound (anything without `_recovery_turn` or `_master_continuation` metadata) so a future failure chain isn't pre-loaded by historical recoveries.

## Constraints honoured

- Spawn_only ack semantics unchanged — `Tool::execute` still returns the synthetic success immediately; only the failure path is augmented.
- Synth-ack gate in `loop_runner.rs` unchanged — its suppression behavior (sibling-error mode) is preserved; the only addition is recording `tool_call_id`s in the `else` branch.
- Persisted history is APPEND-only — the synthetic user message is a new row, not a rewrite of the original success=true tool_result.
- Generic across spawn_only tools — no per-plugin coupling, no manifest schema change.
- Pre-flight pre-flight path (PRs #1015, #1323) untouched — they continue to early-return synchronously before supervisor registration.

## Tests

### `task_supervisor` unit tests (4 new)
- `should_not_emit_failure_signal_when_synth_ack_was_never_emitted` — production analog: sibling-error suppression.
- `should_emit_failure_signal_only_after_synth_ack_recorded_for_tool_call_id` — one suppressed task + one acked task → exactly one signal reaches the callback.
- `mark_synth_ack_emitted_is_idempotent_and_ignores_empty_id` — re-calls don't double-insert; empty string is rejected.

### `session_actor` integration tests (6 new)
- `background_failure_with_synth_ack_triggers_recovery_turn` — core spec test #1.
- `background_failure_without_synth_ack_no_op` — spec test #2.
- `background_success_path_unchanged` — spec test #3.
- `background_failure_dedup_on_repeated_payloads` — spec test #4.
- `background_failure_recovery_capped_at_max_retries` — spec test #5 (cap + banner).
- `user_turn_resets_consecutive_recovery_counter` — counter-reset bookkeeping.

### Updated existing tests
Six existing M8.9 unit tests in `task_supervisor::tests` now call `mark_synth_ack_emitted` before `mark_failed`, mirroring production wiring from `loop_runner.rs`.

## Coordination

PR #1323 (mofa_slides style pre-flight) is the complementary pre-spawn fix on the same architectural seam — different files (`crates/octos-agent/src/plugins/tool.rs` vs. this PR's `task_supervisor.rs`/`loop_runner.rs`/`session_actor.rs`), no overlap. Either can land first; both should land.

## Test plan

- [x] `cargo build -p octos-agent -p octos-cli` clean
- [x] `cargo test -p octos-agent --lib` — 1686 passed, 0 failed
- [x] `cargo test -p octos-cli --lib` — 471 passed, 0 failed
- [x] `cargo test -p octos-pipeline --lib` — 210 passed, 0 failed
- [x] `cargo clippy --workspace --no-deps --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] Soak test: trigger a known-failing spawn_only on fleet (e.g. `mofa_slides` with bogus topic that the plugin rejects post-spawn), confirm LLM acknowledges and retries with a corrected argument instead of leaving the user stranded.