### PR TITLE
test(e2e): gate live Playwright discovery

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,8 +7,13 @@ const LIVE_E2E_PATTERNS = [
   '**/*mini*.spec.ts',
   '**/fleet-*.spec.ts',
   '**/*fleet*.spec.ts',
+  '**/background-task-header-switching.spec.ts',
+  '**/coding-hardcases.spec.ts',
+  '**/kimi-loop-replay.spec.ts',
   '**/refactor-capabilities.spec.ts',
   '**/runtime-regression.spec.ts',
+  '**/session-recovery.spec.ts',
+  '**/skill-compat-gate.spec.ts',
 ];
 
 function hasExplicitTestSelection(argv: string[]): boolean {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,32 @@
 import { defineConfig } from '@playwright/test';
 
+const LIVE_E2E_PATTERNS = [
+  '**/live-*.spec.ts',
+  '**/*-live.spec.ts',
+  '**/mini*.spec.ts',
+  '**/*mini*.spec.ts',
+  '**/fleet-*.spec.ts',
+  '**/*fleet*.spec.ts',
+  '**/refactor-capabilities.spec.ts',
+  '**/runtime-regression.spec.ts',
+];
+
+function hasExplicitTestSelection(argv: string[]): boolean {
+  return argv.slice(2).some((arg) => {
+    if (arg.startsWith('-')) return false;
+    return (
+      arg.includes('tests/') ||
+      arg.includes('.spec.') ||
+      arg.includes('.test.') ||
+      arg.includes('.property.')
+    );
+  });
+}
+
+const includeLiveE2e =
+  process.env.OCTOS_PLAYWRIGHT_LIVE === '1' ||
+  hasExplicitTestSelection(process.argv);
+
 /**
  * E2E tests for the octos web client + API.
  *
@@ -9,6 +36,10 @@ import { defineConfig } from '@playwright/test';
  *
  * Run:
  *   npx playwright test
+ *
+ * Default discovery excludes live/fleet/mini suites so a normal e2e run cannot
+ * accidentally hit production hosts. Pass an explicit test path/glob, or set
+ * OCTOS_PLAYWRIGHT_LIVE=1, for intentional live validation.
  */
 export default defineConfig({
   testDir: './tests',
@@ -18,6 +49,7 @@ export default defineConfig({
     '**/*.test.mjs',
     '**/*.property.ts',
   ],
+  testIgnore: includeLiveE2e ? [] : LIVE_E2E_PATTERNS,
   timeout: 60_000,
   retries: 0,
   use: {


### PR DESCRIPTION
## Summary

- Exclude live/fleet/mini/default-remote Playwright specs from default `npx playwright test` discovery.
- Also gate documented live/canary specs that do not carry a live/mini/fleet filename prefix: `background-task-header-switching`, `coding-hardcases`, `kimi-loop-replay`, `session-recovery`, and `skill-compat-gate`.
- Keep intentional live discovery working when a test path/glob is passed explicitly or `OCTOS_PLAYWRIGHT_LIVE=1` is set.
- Carry the test-only CLI adapter temp-script race fix because this PR previously reproduced `Text file busy (os error 26)` in `cli_agent_adapter` CI.
- Current-main refresh: rebuilt from GitHub `main` `f6936c452389c5172496ee0c3e13393956086d92`; refreshed head `3e68076617792bcdd71877d4c29323e43fd72864`.

Refs #837 #890 #413 #1023
Refs #1322

This is refs-only for the live-validation issues. It prevents accidental production/live fleet hits in normal e2e discovery, but it does not satisfy the live validation evidence required to close those issues.

## Current-main validation

Base: current GitHub `main` / `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`.
Head: `3e68076617792bcdd71877d4c29323e43fd72864`.
Environment: isolated clone `/private/tmp/octos-1393-f693.c8Xuzv/octos`; root checkout left untouched; `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1325-f693`; `CARGO_TARGET_DIR=/private/tmp/octos-1325-f693-target`; Darwin arm64; `rustc 1.95.0`; `cargo 1.95.0`; Node `v24.10.0`; npm `11.6.0`.

Commands passed on 2026-06-02:
- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `node --check e2e/playwright.config.ts`
- `typos e2e/playwright.config.ts crates/octos-cli/src/cli_agent_adapter.rs`
- `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1325-f693 npm --prefix e2e ci` -> completed with the existing 1 moderate npm audit warning
- default discovery: `NPM_CONFIG_CACHE=/private/tmp/octos-npm-cache-1325-f693 npx playwright test --list > /private/tmp/octos-playwright-default-list-1325-f693.txt`
- explicit newly gated specs: `npx playwright test --list tests/background-task-header-switching.spec.ts tests/coding-hardcases.spec.ts tests/kimi-loop-replay.spec.ts tests/session-recovery.spec.ts tests/skill-compat-gate.spec.ts > /private/tmp/octos-playwright-explicit-new-live-list-1325-f693.txt`
- explicit existing live specs: `npx playwright test --list tests/live-browser.spec.ts tests/mini5-deep-search-verify.spec.ts tests/refactor-capabilities.spec.ts tests/runtime-regression.spec.ts > /private/tmp/octos-playwright-explicit-existing-live-list-1325-f693.txt`
- live flag discovery: `OCTOS_PLAYWRIGHT_LIVE=1 OCTOS_USER_TOKEN=dummy npx playwright test --list > /private/tmp/octos-playwright-live-list-1325-f693.txt`
- file-specific discovery assertions passed: default discovery excluded gated live specs; explicit selection listed the five newly gated suites and four existing live suites; `OCTOS_PLAYWRIGHT_LIVE=1` listed expected live suites.
- `wc -l` counts: default 78, explicit-new-live 14, explicit-existing-live 29, live-flag 152
- `CARGO_TARGET_DIR=/private/tmp/octos-1325-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p octos-cli --features api cli_agent_adapter::tests:: -- --nocapture` -> 8/8 passed
- `CARGO_TARGET_DIR=/private/tmp/octos-1325-f693-target CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo clippy --workspace --all-targets -- -D warnings`
- `git ls-files --others --exclude-standard` -> empty

Result:
- PR diff against current main is limited to `e2e/playwright.config.ts` and `crates/octos-cli/src/cli_agent_adapter.rs`.
- Default Playwright discovery no longer includes the gated live/default-remote specs.
- Explicit selection and `OCTOS_PLAYWRIGHT_LIVE=1` still discover the live suites intentionally.
- No generated artifacts or untracked repo files are included.

GitHub CI:
- Green on `3e68076617792bcdd71877d4c29323e43fd72864`: `check`, `test-octos-cli`, `test-octos-agent (lib)`, `test-octos-agent (integration)`, `dashboard`, `swarm-app`, `check-matrix`, `typos`, and author-email all passed. Optional expansion jobs were skipped.

Remaining gap:
- PR is non-closing support for #837/#890/#413/#1023.
- Merge remains branch-protection blocked by required review.