### PR TITLE
fix(agent): satisfy task supervisor doc clippy

### DIFF
--- a/crates/octos-agent/src/task_supervisor.rs
+++ b/crates/octos-agent/src/task_supervisor.rs
@@ -3981,6 +3981,7 @@ mod tests {
     ///   1. notify_failure observes ack=false.
     ///   2. mark_synth_ack_emitted records ack + drains empty pending.
     ///   3. notify_failure inserts pending — nothing will drain it.
+    ///
     /// Post-fix the combined mutex makes step 2 atomic with the
     /// check-and-insert pair in step 1+3, so the pending entry is
     /// either drained in step 2 OR observed in step 1 and dispatched


### PR DESCRIPTION
## Summary
- separate the task supervisor race-test doc list from the following paragraph so Rust 1.95 clippy no longer reports `doc_lazy_continuation`
- no production behavior changes

Refs #1325

This is a queue-unblocker for current `main`; several TUI/UX PRs hit this same base clippy failure in the broad `check` job and are temporarily carrying the same one-line fix.

## Validation
Base: `main` / `origin/main` at `4e58cd4972c82d9916b1d05cb044782c6c106e7b`
Head: `fcd40a7acd7a958379c742d62004934dea5bf4f0`
Environment: isolated clone `/private/tmp/octos-ws1-audit-527a`; root checkout left untouched; `CARGO_TARGET_DIR=/private/tmp/octos-1326-clippy-target`; `CARGO_INCREMENTAL=0`.

```bash
git fetch origin main codex/task-supervisor-doc-clippy
git switch -C codex/1326-current-main-doc-clippy origin/main
git cherry-pick 1a557a29990eb6d9aae4741d00d574b431a83277
git diff --name-status origin/main...HEAD
git diff --check origin/main...HEAD
cargo fmt --all -- --check
CARGO_TARGET_DIR=/private/tmp/octos-1326-clippy-target CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings
git status --short --branch
git ls-files --others --exclude-standard
```

Result:
- PR diff against current main is only `crates/octos-agent/src/task_supervisor.rs`.
- `git diff --check`, `cargo fmt`, and full workspace clippy with `-D warnings` passed.
- No untracked files were left in the isolated clone.
