### PR TITLE
feat(scope): allow file tools read access to plugin skill_dirs (PR-A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,7 +3848,9 @@ dependencies = [
  "eyre",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio-test",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -574,9 +574,16 @@ impl PluginTool {
             ) {
                 if let Some(path) = value.as_str() {
                     let absolute = absolutise_against_base(path, join_base);
-                    let classification = scope.classify_lexical_path(&absolute);
+                    // Codex round-2 BLOCKER 1: canonical-classify to
+                    // close the ancestor-symlink escape — a `skill_dir`
+                    // (or any zone root) containing
+                    // `link -> /outside` previously let the lexical
+                    // check accept `<skill_dir>/link/secret` as
+                    // `InSkillDir`.
+                    let (classification, normalised) =
+                        classify_canonical_for_plugin_arg(scope, &absolute);
                     let resolved =
-                        accept_for_intent(&classification, &absolute, path, PathIntent::Read)?;
+                        accept_for_intent(&classification, &normalised, path, PathIntent::Read)?;
                     // Codex round-1 P2 + round-2 P2 (scope review):
                     // basename rescue ONLY fires for `InWorkspace`.
                     // Shared zones and granted dirs (when missing)
@@ -596,9 +603,10 @@ impl PluginTool {
             if matches!(key.as_str(), "out" | "slide_dir") {
                 if let Some(path) = value.as_str() {
                     let absolute = absolutise_against_base(path, join_base);
-                    let classification = scope.classify_lexical_path(&absolute);
+                    let (classification, normalised) =
+                        classify_canonical_for_plugin_arg(scope, &absolute);
                     let resolved =
-                        accept_for_intent(&classification, &absolute, path, PathIntent::Write)?;
+                        accept_for_intent(&classification, &normalised, path, PathIntent::Write)?;
                     rewritten.insert(key.clone(), serde_json::Value::String(resolved));
                     continue;
                 }
@@ -629,10 +637,15 @@ impl PluginTool {
                         candidate.is_absolute() || trimmed.contains('/') || trimmed.contains('\\');
                     if looks_like_path {
                         let absolute = absolutise_against_base(trimmed, join_base);
-                        let classification = scope.classify_lexical_path(&absolute);
+                        // Codex round-2 BLOCKER 1: canonical-classify
+                        // the style path so a symlink anywhere on the
+                        // chain (including inside a skill_dir) is
+                        // resolved before the prefix comparison.
+                        let (classification, normalised) =
+                            classify_canonical_for_plugin_arg(scope, &absolute);
                         let resolved = accept_for_intent(
                             &classification,
-                            &absolute,
+                            &normalised,
                             trimmed,
                             PathIntent::Read,
                         )?;
@@ -689,10 +702,15 @@ impl PluginTool {
                             .and_then(|value| value.as_str())
                         {
                             let absolute = absolutise_against_base(source_image, join_base);
-                            let classification = scope.classify_lexical_path(&absolute);
+                            // Codex round-2 BLOCKER 1: canonical-classify
+                            // per-slide source images for the same
+                            // symlink-escape closure as the top-level
+                            // input-path keys.
+                            let (classification, normalised) =
+                                classify_canonical_for_plugin_arg(scope, &absolute);
                             let resolved = accept_for_intent(
                                 &classification,
-                                &absolute,
+                                &normalised,
                                 source_image,
                                 PathIntent::Read,
                             )?;
@@ -1203,8 +1221,8 @@ enum PathIntent {
 /// Lexically join `raw_path` against `base` when relative; return it
 /// unchanged when already absolute. Mirrors
 /// [`absolutize_path_in_work_dir`] but without the `..` guard — the
-/// downstream [`SessionScope::classify_lexical_path`] already refuses
-/// `ParentDir` components via its lexical normalisation step.
+/// downstream [`classify_for_canonical`] applies a strict lexical
+/// `..` refusal before canonicalising.
 ///
 /// `base` is the registry-rebound `self.work_dir` when set, else
 /// `scope.workspace()` — see `rewrite_args_with_scope` doc and codex
@@ -1216,6 +1234,66 @@ fn absolutise_against_base(raw_path: &str, base: &std::path::Path) -> std::path:
     } else {
         base.join(candidate)
     }
+}
+
+/// Codex round-2 BLOCKER 1 fix (PR #1327 review): classify a plugin-arg
+/// absolute path using the canonical containment guard
+/// [`SessionScope::classify_canonical_path`] so a `skill_dir`
+/// containing `link -> /outside` cannot smuggle
+/// `<skill_dir>/link/secret` through as `InSkillDir`. Mirrors the
+/// containment path that file tools use in `tools/mod.rs::resolve_for_scope`.
+///
+/// Pipeline:
+/// 1. Lexically normalise (collapse `.`, refuse `..`). A traversal
+///    surface returns `PathClassification::OutOfScope` immediately so
+///    the canonicalize walk can't accidentally resurface inside a zone
+///    after climbing out.
+/// 2. Canonicalise the normalised candidate AND each zone root, then
+///    apply the same workspace > granted_dirs > skill_read_zones >
+///    shared_zones order as `classify_lexical_path`.
+///
+/// Returns the (lexically-normalised, NOT canonicalised) absolute path
+/// alongside the classification so callers feed `accept_for_intent` and
+/// the basename-rescue helper the same lexical form they used before
+/// (the canonicalisation is for the classification check only). When
+/// the path fails the `..` guard the classification is
+/// `PathClassification::OutOfScope` and the returned path is the
+/// best-effort lexical join (unused by `accept_for_intent` on the
+/// refuse arm).
+fn classify_canonical_for_plugin_arg(
+    scope: &SessionScope,
+    absolute: &std::path::Path,
+) -> (PathClassification, std::path::PathBuf) {
+    match lexical_normalise_strict_local(absolute) {
+        Some(normalised) => {
+            let classification = scope.classify_canonical_path(&normalised);
+            (classification, normalised)
+        }
+        // Round-2 BLOCKER 1: refuse `..` here too. The bespoke
+        // `classify_lexical_path` path used to swallow this via its
+        // own lexical normalise; we replicate that contract so the
+        // accept/refuse error message stays identical.
+        None => (PathClassification::OutOfScope, absolute.to_path_buf()),
+    }
+}
+
+/// Local copy of `tools::lexical_normalise_strict` (codex round-2
+/// BLOCKER 1). The `tools` module's helper is `pub(crate)` but plugin
+/// tooling can't import it directly without dragging in the entire
+/// `tools/mod.rs` symbol set; this keeps the plugin-tool dependency
+/// surface narrow.
+fn lexical_normalise_strict_local(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    use std::path::Component;
+    let mut out = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => return None,
+            Component::Normal(part) => out.push(part),
+        }
+    }
+    Some(out)
 }
 
 /// Accept or refuse the absolute path based on the pre-computed
@@ -1360,8 +1438,16 @@ fn rescue_workspace_input_existence(
     // probe `<workspace>/skill-output/..`, which is still inside the
     // scope but a future widening could regress; reject silently
     // when it escapes.
+    //
+    // Codex round-2 BLOCKER 1: use canonical classification so a
+    // symlinked rescue chain can't sneak the path back out of the
+    // workspace. The rescue always reports `InWorkspace` today (the
+    // resolver only emits workspace-relative paths) but the canonical
+    // check is defence in depth for any future widening that lets the
+    // resolver return scope-external paths.
     let rescued_abs = std::path::PathBuf::from(&rescued);
-    match scope.classify_lexical_path(&rescued_abs) {
+    let (classification, _normalised) = classify_canonical_for_plugin_arg(scope, &rescued_abs);
+    match classification {
         PathClassification::InWorkspace => rescued,
         PathClassification::InGrantedDir { .. }
         | PathClassification::InSharedZone { .. }
@@ -5887,6 +5973,177 @@ mod tests {
         assert!(
             msg.contains("SKILL.md"),
             "error must reference SKILL.md custom-style authoring: {msg}"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Codex round-2 BLOCKER 1 (PR #1327 review): canonical-classify
+    // symlink-escape tests. A skill_dir containing
+    // `link -> /outside` previously let
+    // `<skill_dir>/link/secret` slip through as `InSkillDir`.
+    // These pin the fix.
+    // -----------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn plugin_refuses_input_path_using_symlink_escape_inside_skill_dir() {
+        // Build:
+        //   workspace/              (scope workspace)
+        //   skill_dir/link -> outside/
+        //   outside/secret.txt      (the file the symlink targets)
+        //
+        // Attempting to read `<skill_dir>/link/secret.txt` must be
+        // refused — the canonical classify path resolves the symlink
+        // before the prefix comparison so the candidate lands at
+        // `outside/secret.txt`, which is outside the skill_dir.
+        let workspace = tempfile::tempdir().expect("workspace dir");
+        let skill_dir = tempfile::tempdir().expect("skill dir");
+        let outside = tempfile::tempdir().expect("outside dir");
+        let secret = outside.path().join("secret.txt");
+        std::fs::write(&secret, b"AGENT_MUST_NEVER_READ_THIS").unwrap();
+        let link = skill_dir.path().join("link");
+        std::os::unix::fs::symlink(outside.path(), &link).expect("create symlink");
+
+        // The skill_read_zone is the canonical (resolved) skill_dir,
+        // mirroring what `runtime/session.rs` /  `chat.rs` /
+        // `ActorFactory::spawn` configure after the round-2 BLOCKER 2
+        // fix-closed canonicalisation.
+        let canonical_skill_dir = std::fs::canonicalize(skill_dir.path()).expect("canonicalize");
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .expect("build solo scope")
+            .with_skill_read_zones(vec![canonical_skill_dir])
+            .expect("attach skill_read_zone");
+
+        let tool = PluginTool::new(
+            "plug".into(),
+            input_path_def("audio_path"),
+            PathBuf::from("/bin/true"),
+        );
+
+        // Plugin would pass `<skill_dir>/link/secret.txt` lexically.
+        let candidate = link.join("secret.txt").to_string_lossy().into_owned();
+        let err = tool
+            .rewrite_args_with_scope(
+                &json!({"audio_path": candidate.clone()}),
+                &scope,
+                scope.workspace(),
+            )
+            .expect_err(
+                "scope must refuse a skill_dir/symlink/<file> candidate after canonical classify",
+            );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&candidate),
+            "error must echo the rejected raw path: {msg}",
+        );
+        // Wording follows the OutOfScope arm of `accept_for_intent` — the
+        // canonical classify drops the candidate out of every zone, so
+        // the scope-aware refusal text applies.
+        assert!(
+            msg.contains("escapes plugin work dir"),
+            "error must surface OutOfScope refusal wording: {msg}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plugin_refuses_output_path_using_symlink_escape_inside_workspace() {
+        // Same symlink-escape closure for output keys. Build:
+        //   workspace/link -> outside/
+        //   outside/                 (writable bait location)
+        //
+        // The bespoke #1186 / #1189 chain refused this case because of
+        // its `..` guard; the SessionScope contract has to reach the
+        // same answer without `..` — the canonical classify finds the
+        // candidate is outside the workspace once the symlink is
+        // resolved and refuses the write.
+        let workspace = tempfile::tempdir().expect("workspace dir");
+        let outside = tempfile::tempdir().expect("outside dir");
+        let link = workspace.path().join("link");
+        std::os::unix::fs::symlink(outside.path(), &link).expect("create symlink");
+
+        let scope = solo_scope_at(workspace.path());
+        let def = PluginToolDef {
+            name: "phase2b_output_tool".to_string(),
+            description: "fixture".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"out": {"type": "string"}}
+            }),
+            spawn_only: false,
+            env: vec![],
+            risk: None,
+            spawn_only_message: None,
+            concurrency_class: None,
+        };
+        let tool = PluginTool::new("plug".into(), def, PathBuf::from("/bin/true"));
+
+        let candidate = link.join("artifact.bin").to_string_lossy().into_owned();
+        let err = tool
+            .rewrite_args_with_scope(
+                &json!({"out": candidate.clone()}),
+                &scope,
+                scope.workspace(),
+            )
+            .expect_err(
+                "scope must refuse a workspace/symlink/<artifact> output candidate \
+                 after canonical classify",
+            );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&candidate),
+            "error must echo the rejected raw path: {msg}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plugin_accepts_input_path_inside_real_skill_dir_under_canonical_classify() {
+        // Positive baseline: when the skill_dir really contains the
+        // requested file (no symlinks involved), canonical classify
+        // must still accept it. Without this we'd have no proof the
+        // BLOCKER 1 fix didn't tighten reads off-cliff.
+        let workspace = tempfile::tempdir().expect("workspace dir");
+        let skill_dir = tempfile::tempdir().expect("skill dir");
+        let manifest = skill_dir.path().join("SKILL.md");
+        std::fs::write(&manifest, b"# example").unwrap();
+        let canonical_skill_dir = std::fs::canonicalize(skill_dir.path()).expect("canonicalize");
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .expect("build solo scope")
+            .with_skill_read_zones(vec![canonical_skill_dir.clone()])
+            .expect("attach skill_read_zone");
+
+        let tool = PluginTool::new(
+            "plug".into(),
+            input_path_def("audio_path"),
+            PathBuf::from("/bin/true"),
+        );
+
+        // Pass the canonical form on the way in so the lexical-side
+        // prefix check inside `classify_canonical_path` lines up on
+        // platforms (macOS) where `/var/folders/...` is itself a
+        // symlink to `/private/var/folders/...`. Production callers
+        // already pass canonical paths because `with_skill_read_zones`
+        // is fed the canonicalised list per the round-2 BLOCKER 2 fix.
+        let candidate = canonical_skill_dir
+            .join("SKILL.md")
+            .to_string_lossy()
+            .into_owned();
+        let rewritten = tool
+            .rewrite_args_with_scope(
+                &json!({"audio_path": candidate.clone()}),
+                &scope,
+                scope.workspace(),
+            )
+            .expect("real skill_dir path must be accepted");
+        let path_in = rewritten
+            .get("audio_path")
+            .and_then(|v| v.as_str())
+            .expect("audio_path key must round-trip");
+        assert!(
+            path_in.starts_with(&*canonical_skill_dir.to_string_lossy()),
+            "accepted path must remain inside the canonical skill_dir: {path_in}"
         );
     }
 }

--- a/crates/octos-agent/src/plugins/tool.rs
+++ b/crates/octos-agent/src/plugins/tool.rs
@@ -1251,6 +1251,19 @@ fn accept_for_intent(
             "path '{raw_path}' rejected: shared zone '{}' is read-only — writes refused per SessionScope policy",
             zone.display()
         )),
+        // PR-A: read-only plugin skill dirs follow the same policy as
+        // shared zones — reads allowed, writes refused. Plugin tools
+        // rarely touch their own skill_dir at runtime (skills usually
+        // operate inside the host-provided work_dir), but the match
+        // arm has to be exhaustive and the read/write split here is
+        // consistent with `tools/mod.rs::resolve_for_scope`.
+        (PathClassification::InSkillDir { .. }, PathIntent::Read) => {
+            Ok(absolute.to_string_lossy().into_owned())
+        }
+        (PathClassification::InSkillDir { skill_dir }, PathIntent::Write) => Err(eyre::eyre!(
+            "path '{raw_path}' rejected: plugin skill dir '{}' is read-only — writes refused per SessionScope policy",
+            skill_dir.display()
+        )),
         // Out of scope: refuse for both intents. Echo the raw path so
         // the LLM sees what was refused (matches the round-3/4
         // bespoke-validator error contract).
@@ -1352,6 +1365,7 @@ fn rescue_workspace_input_existence(
         PathClassification::InWorkspace => rescued,
         PathClassification::InGrantedDir { .. }
         | PathClassification::InSharedZone { .. }
+        | PathClassification::InSkillDir { .. }
         | PathClassification::OutOfScope => lexical_absolute.to_string(),
     }
 }

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -38,7 +38,7 @@ use eyre::Result;
 use octos_core::TokenUsage;
 
 use crate::progress::ProgressReporter;
-use octos_core::{PathClassification, ScopeMode, SessionScope};
+use octos_core::{PathClassification, SessionScope};
 
 /// Registry of [`AgentDefinition`]-style manifests available to tools.
 ///
@@ -877,7 +877,13 @@ fn resolve_for_scope(
         Some(p) => p,
         None => return Err("Path outside session scope"),
     };
-    match classify_canonical(scope, &lex_normalised) {
+    // PR-A round-2 (codex BLOCKER 1 follow-up): delegate the canonical
+    // containment guard to `SessionScope::classify_canonical_path` so
+    // every consumer (file tools here, plugin tools in
+    // `plugins/tool.rs`) shares one implementation. The helper lives in
+    // `octos-core` next to `classify_lexical_path` because it has no
+    // dependency on tool-side state.
+    match scope.classify_canonical_path(&lex_normalised) {
         PathClassification::InWorkspace => Ok(lex_normalised),
         PathClassification::InGrantedDir { .. } => Ok(lex_normalised),
         PathClassification::InSharedZone { .. } => {
@@ -902,59 +908,10 @@ fn resolve_for_scope(
     }
 }
 
-/// Classify a path against a scope after canonicalizing both sides.
-/// Closes the ancestor-symlink hole in
-/// [`SessionScope::classify_lexical_path`]. Returns the same
-/// [`PathClassification`] shape so callers can read it the same way.
-fn classify_canonical(scope: &SessionScope, lex_normalised_abs: &Path) -> PathClassification {
-    let canon = canonicalize_lossy(lex_normalised_abs);
-    let canon_ws = canonical_root_lossy(scope.workspace());
-    if canon.starts_with(&canon_ws) {
-        return PathClassification::InWorkspace;
-    }
-    // Per-mode high-trust zone next: granted_dirs are user-approved
-    // and predate skill_read_zones; multi-tenant defers shared_zones
-    // until AFTER skill_read_zones to match
-    // `SessionScope::classify_lexical_path`'s order.
-    if let ScopeMode::Solo { granted_dirs } = scope.mode() {
-        for granted in granted_dirs {
-            let canon_grant = canonical_root_lossy(granted);
-            if canon.starts_with(&canon_grant) {
-                return PathClassification::InGrantedDir {
-                    granted_dir: granted.clone(),
-                };
-            }
-        }
-    }
-    // PR-A: read-only plugin skill directories. Same
-    // canonicalize-both-sides treatment as `InSharedZone` above so a
-    // symlinked ancestor inside a skill_dir cannot smuggle the path
-    // out of the allowlist. Reported `skill_dir` is the un-
-    // canonicalized form (matches what callers configured) so log
-    // messages and tests stay readable.
-    for skill_dir in scope.skill_read_zones() {
-        let canon_skill = canonical_root_lossy(skill_dir);
-        if canon.starts_with(&canon_skill) {
-            return PathClassification::InSkillDir {
-                skill_dir: skill_dir.clone(),
-            };
-        }
-    }
-    if let ScopeMode::MultiTenant { .. } = scope.mode() {
-        for zone in scope.shared_zones() {
-            let canon_zone = canonical_root_lossy(zone);
-            if canon.starts_with(&canon_zone) {
-                return PathClassification::InSharedZone { zone: zone.clone() };
-            }
-        }
-    }
-    PathClassification::OutOfScope
-}
-
 /// Lexical normalise (collapse `.`, refuse `..`). Mirrors the helper
 /// inside `octos_core::session_scope` so the canonicalize walk above
 /// can't absorb a traversal escape.
-fn lexical_normalise_strict(path: &Path) -> Option<PathBuf> {
+pub(crate) fn lexical_normalise_strict(path: &Path) -> Option<PathBuf> {
     let mut out = PathBuf::new();
     for component in path.components() {
         match component {
@@ -965,43 +922,6 @@ fn lexical_normalise_strict(path: &Path) -> Option<PathBuf> {
         }
     }
     Some(out)
-}
-
-/// Canonicalize a path, recovering when the leaf doesn't exist yet
-/// (writes target new files). Mirrors
-/// [`octos_bus::file_handle::canonicalize_lossy`]: walks ancestors to
-/// find the longest existing prefix, canonicalizes that (resolving
-/// symlinked ancestors), and re-attaches the suffix. The input must
-/// already be lexically normalised (no `..`) so the re-attached
-/// suffix is a real would-be on-disk location.
-fn canonicalize_lossy(path: &Path) -> PathBuf {
-    if let Ok(canon) = std::fs::canonicalize(path) {
-        return canon;
-    }
-    let mut existing: &Path = path;
-    let mut suffix = PathBuf::new();
-    while let Some(parent) = existing.parent() {
-        if let Some(name) = existing.file_name() {
-            let mut next_suffix = PathBuf::from(name);
-            next_suffix.push(&suffix);
-            suffix = next_suffix;
-        }
-        existing = parent;
-        if let Ok(canon) = std::fs::canonicalize(existing) {
-            return canon.join(suffix);
-        }
-        if existing.as_os_str().is_empty() {
-            break;
-        }
-    }
-    path.to_path_buf()
-}
-
-/// Canonicalize a root, falling back to the input when the root
-/// doesn't exist (rare for `scope.workspace()` but possible in tests
-/// that pass a not-yet-created directory).
-fn canonical_root_lossy(root: &Path) -> PathBuf {
-    std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
 }
 
 /// Syntactic path normalization (no filesystem access). Collapses `.`

--- a/crates/octos-agent/src/tools/mod.rs
+++ b/crates/octos-agent/src/tools/mod.rs
@@ -887,6 +887,17 @@ fn resolve_for_scope(
                 Ok(lex_normalised)
             }
         }
+        // PR-A: read-only plugin skill dirs. Mirror the
+        // `InSharedZone` policy — reads pass through, writes refuse.
+        // The SKILL.md auto-inject teaches the agent to read files
+        // under the plugin's install directory but never write back.
+        PathClassification::InSkillDir { .. } => {
+            if for_write {
+                Err("Writes to plugin skill directories are not permitted")
+            } else {
+                Ok(lex_normalised)
+            }
+        }
         PathClassification::OutOfScope => Err("Path outside session scope"),
     }
 }
@@ -901,23 +912,39 @@ fn classify_canonical(scope: &SessionScope, lex_normalised_abs: &Path) -> PathCl
     if canon.starts_with(&canon_ws) {
         return PathClassification::InWorkspace;
     }
-    match scope.mode() {
-        ScopeMode::Solo { granted_dirs } => {
-            for granted in granted_dirs {
-                let canon_grant = canonical_root_lossy(granted);
-                if canon.starts_with(&canon_grant) {
-                    return PathClassification::InGrantedDir {
-                        granted_dir: granted.clone(),
-                    };
-                }
+    // Per-mode high-trust zone next: granted_dirs are user-approved
+    // and predate skill_read_zones; multi-tenant defers shared_zones
+    // until AFTER skill_read_zones to match
+    // `SessionScope::classify_lexical_path`'s order.
+    if let ScopeMode::Solo { granted_dirs } = scope.mode() {
+        for granted in granted_dirs {
+            let canon_grant = canonical_root_lossy(granted);
+            if canon.starts_with(&canon_grant) {
+                return PathClassification::InGrantedDir {
+                    granted_dir: granted.clone(),
+                };
             }
         }
-        ScopeMode::MultiTenant { .. } => {
-            for zone in scope.shared_zones() {
-                let canon_zone = canonical_root_lossy(zone);
-                if canon.starts_with(&canon_zone) {
-                    return PathClassification::InSharedZone { zone: zone.clone() };
-                }
+    }
+    // PR-A: read-only plugin skill directories. Same
+    // canonicalize-both-sides treatment as `InSharedZone` above so a
+    // symlinked ancestor inside a skill_dir cannot smuggle the path
+    // out of the allowlist. Reported `skill_dir` is the un-
+    // canonicalized form (matches what callers configured) so log
+    // messages and tests stay readable.
+    for skill_dir in scope.skill_read_zones() {
+        let canon_skill = canonical_root_lossy(skill_dir);
+        if canon.starts_with(&canon_skill) {
+            return PathClassification::InSkillDir {
+                skill_dir: skill_dir.clone(),
+            };
+        }
+    }
+    if let ScopeMode::MultiTenant { .. } = scope.mode() {
+        for zone in scope.shared_zones() {
+            let canon_zone = canonical_root_lossy(zone);
+            if canon.starts_with(&canon_zone) {
+                return PathClassification::InSharedZone { zone: zone.clone() };
             }
         }
     }
@@ -1458,6 +1485,100 @@ mod path_tests {
         // canonical target outside the workspace.
         assert_eq!(resolved, workspace.path().join("secret"));
         assert_ne!(resolved, target);
+    }
+
+    // -------- PR-A: skill_read_zones resolve-for-scope behaviour --------
+
+    /// Reads from a registered skill_dir succeed via the read-side
+    /// resolver. The classifier (canonicalize-both-sides path)
+    /// reports `InSkillDir` and `for_write=false` accepts it.
+    #[test]
+    fn read_file_from_skill_dir_resolves_under_skill_read_zone() {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let skill = tempfile::tempdir().expect("skill tmpdir");
+        let skill_file = skill.path().join("SKILL.md");
+        std::fs::write(&skill_file, b"# skill").unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .expect("skill_dir is absolute");
+
+        let resolved = resolve_path_for_session_scope_read(&scope, &skill_file.to_string_lossy())
+            .expect("read inside skill_dir must succeed");
+        // The lexical absolute form passes through unchanged
+        // (canonicalisation is only used for classification).
+        assert_eq!(resolved, skill_file);
+    }
+
+    /// PR-A core invariant: write attempts inside a registered
+    /// skill_dir are refused even though reads succeed.
+    /// `for_write=true` (the write-side resolver) must take the
+    /// `InSkillDir` branch and bail with the read-only message.
+    #[test]
+    fn write_file_to_skill_dir_classifies_in_skill_dir_but_resolve_for_write_refuses() {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let skill = tempfile::tempdir().expect("skill tmpdir");
+        let skill_file = skill.path().join("SKILL.md");
+        std::fs::write(&skill_file, b"# skill").unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .expect("skill_dir is absolute");
+
+        // Read side: accept.
+        let read_ok = resolve_path_for_session_scope_read(&scope, &skill_file.to_string_lossy());
+        assert!(read_ok.is_ok(), "read must succeed inside skill_dir");
+
+        // Write side: refuse. The error text comes from the
+        // `InSkillDir` arm of `resolve_for_scope`.
+        let write_err = resolve_path_for_session_scope_write(&scope, &skill_file.to_string_lossy())
+            .expect_err("write must refuse inside skill_dir");
+        assert!(
+            write_err.contains("Writes to plugin skill directories are not permitted"),
+            "expected skill-dir read-only message, got: {write_err}"
+        );
+    }
+
+    /// Writes inside the workspace still succeed when skill_read_zones
+    /// are configured (additive — no regression to existing tools).
+    #[test]
+    fn write_to_workspace_still_works_when_skill_read_zones_configured() {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let skill = tempfile::tempdir().expect("skill tmpdir");
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+        let target = workspace.path().join("out.txt");
+        let resolved = resolve_path_for_session_scope_write(&scope, &target.to_string_lossy())
+            .expect("writes inside workspace must succeed");
+        assert_eq!(resolved, target);
+    }
+
+    /// Reads outside any registered zone still refuse after
+    /// skill_read_zones land. Pre-PR-A out-of-scope paths must keep
+    /// failing.
+    #[test]
+    fn read_outside_skill_dir_and_workspace_still_refused() {
+        let workspace = tempfile::tempdir().expect("workspace tmpdir");
+        let skill = tempfile::tempdir().expect("skill tmpdir");
+        let outside = tempfile::tempdir().expect("outside tmpdir");
+        std::fs::write(outside.path().join("secret"), b"x").unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let target = outside.path().join("secret");
+        let err = resolve_path_for_session_scope_read(&scope, &target.to_string_lossy())
+            .expect_err("path outside scope must be refused");
+        assert!(
+            err.contains("Path outside session scope"),
+            "expected out-of-scope refusal, got: {err}"
+        );
     }
 }
 

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -311,7 +311,7 @@ impl ChatCommand {
             cwd.clone(),
             data_dir.clone(),
             tools.provider_policy().cloned(),
-            plugin_dirs,
+            plugin_dirs.clone(),
             config.plugins.require_signed,
             create_embedder(&config),
         );
@@ -452,9 +452,33 @@ impl ChatCommand {
                 .wrap_err("failed to absolutize --cwd: current_dir() unavailable")?
                 .join(&cwd)
         };
-        let session_scope = Arc::new(SessionScope::solo(absolute_cwd, Vec::new()).expect(
-            "solo CWD absolutized just above; SessionScope::solo's only invariant is absolute",
-        ));
+        // PR-A: thread the per-profile plugin install directories
+        // through to the scope so `read_file` can reach the SKILL.md
+        // content the agent's system prompt auto-injects. Each entry
+        // is canonicalized so symlinked plugin install roots line up
+        // with the canonicalized candidate paths the tools-side
+        // resolver compares against; raw path is used when
+        // canonicalize fails (e.g. dir not yet created).
+        let canonical_skill_dirs: Vec<PathBuf> = plugin_dirs
+            .iter()
+            .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+            .collect();
+        let session_scope = {
+            let base = SessionScope::solo(absolute_cwd.clone(), Vec::new()).expect(
+                "solo CWD absolutized just above; SessionScope::solo's only invariant is absolute",
+            );
+            let scope = base
+                .with_skill_read_zones(canonical_skill_dirs)
+                .unwrap_or_else(|err| {
+                    eprintln!(
+                        "Warning: with_skill_read_zones rejected one or more plugin_dirs: {err}; \
+                         continuing without skill_read_zones (read_file may not reach SKILL.md references)"
+                    );
+                    SessionScope::solo(absolute_cwd.clone(), Vec::new())
+                        .expect("absolutized cwd still valid")
+                });
+            Arc::new(scope)
+        };
 
         let mut agent = Agent::new(AgentId::new("chat"), llm, tools, memory)
             .with_config(agent_config)

--- a/crates/octos-cli/src/commands/chat.rs
+++ b/crates/octos-cli/src/commands/chat.rs
@@ -454,15 +454,16 @@ impl ChatCommand {
         };
         // PR-A: thread the per-profile plugin install directories
         // through to the scope so `read_file` can reach the SKILL.md
-        // content the agent's system prompt auto-injects. Each entry
-        // is canonicalized so symlinked plugin install roots line up
-        // with the canonicalized candidate paths the tools-side
-        // resolver compares against; raw path is used when
-        // canonicalize fails (e.g. dir not yet created).
-        let canonical_skill_dirs: Vec<PathBuf> = plugin_dirs
-            .iter()
-            .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
-            .collect();
+        // content the agent's system prompt auto-injects.
+        //
+        // Codex round-2 BLOCKER 2 (PR #1327 review): SKIP dirs that
+        // fail canonicalize (fail-closed). Keeping the raw path was a
+        // fail-open vulnerability — a later symlink replacement
+        // (`/tmp/missing -> /etc`) would canonicalise both sides to
+        // `/etc` and allow reads as `InSkillDir`. The shared helper in
+        // `octos-core` drops the entry and logs a warning per skip.
+        let canonical_skill_dirs: Vec<PathBuf> =
+            octos_core::canonicalize_skill_read_zones(&plugin_dirs);
         let session_scope = {
             let base = SessionScope::solo(absolute_cwd.clone(), Vec::new()).expect(
                 "solo CWD absolutized just above; SessionScope::solo's only invariant is absolute",

--- a/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
+++ b/crates/octos-cli/src/commands/gateway/gateway_runtime.rs
@@ -1227,6 +1227,16 @@ impl GatewayRuntime {
             // threads the profile's `lane_routing` field.
             lane_routing: None,
             memory_store: Some(memory_store.clone()),
+            // Codex round-2 MAJOR 3 (PR #1327 review): the top-level
+            // gateway actor factory is the "admin" path that dispatches
+            // by detected profile through `profile_factory.rs`. It
+            // doesn't own a single profile_id of its own; per-profile
+            // sessions go through `ProfileFactory::build` which sets
+            // this field. Leaving it `None` here means the admin
+            // fallback path (no recognised profile, or main profile)
+            // continues without scope wiring — the legacy resolver
+            // still applies inside `tools/mod.rs`.
+            profile_id: None,
             plugin_dirs: plugin_dirs_for_spawn.clone(),
             plugin_extra_env: plugin_env.clone(),
             // Section B (codex review P1.1): propagate the host

--- a/crates/octos-cli/src/commands/gateway/profile_factory.rs
+++ b/crates/octos-cli/src/commands/gateway/profile_factory.rs
@@ -924,6 +924,11 @@ impl ProfileActorFactoryBuilder {
             // `profile.config.lane_routing`. None = built-in defaults.
             lane_routing: effective_profile.config.lane_routing.clone(),
             memory_store: Some(self.memory_store.clone()),
+            // Codex round-2 MAJOR 3 (PR #1327 review): expose the
+            // profile_id so `ActorFactory::spawn` can build a per-
+            // session SessionScope (multi-tenant) and attach the
+            // canonicalised skill_read_zones to gateway-spawned actors.
+            profile_id: Some(profile_id.to_string()),
             plugin_dirs: actor_plugin_dirs,
             plugin_extra_env: actor_plugin_env,
             // Section B (codex review P1.1): propagate the profile's

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -324,17 +324,20 @@ impl SessionRuntime {
                     // directories through to the scope so file tools
                     // (`read_file` today, glob/grep/list_dir in
                     // PR-B) can reach the SKILL.md content the
-                    // agent's system prompt references. Canonicalize
-                    // each entry so symlinked plugin install roots
-                    // line up with the canonicalized candidate paths
-                    // the tools-side resolver compares against. Fall
-                    // back to the raw path when canonicalize fails
-                    // (the dir may not exist on bootstrap retry).
-                    let skill_dirs: Vec<std::path::PathBuf> = profile
-                        .plugin_dirs
-                        .iter()
-                        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
-                        .collect();
+                    // agent's system prompt references.
+                    //
+                    // Codex round-2 BLOCKER 2 (PR #1327 review): SKIP
+                    // dirs that fail canonicalize (fail-closed). A
+                    // missing dir has no readable SKILL content yet,
+                    // so dropping it is the safe fallback. Keeping the
+                    // raw path was a fail-open vulnerability: if the
+                    // raw path is later created/replaced as a symlink
+                    // to `/etc`, `classify_canonical_path` would
+                    // canonicalize both candidate and zone root to
+                    // `/etc` and allow reads as `InSkillDir`. The
+                    // shared helper logs a warning per skip.
+                    let skill_dirs =
+                        octos_core::canonicalize_skill_read_zones(&profile.plugin_dirs);
                     let scope = scope
                         .with_skill_read_zones(skill_dirs)
                         .unwrap_or_else(|err| {

--- a/crates/octos-cli/src/runtime/session.rs
+++ b/crates/octos-cli/src/runtime/session.rs
@@ -319,7 +319,43 @@ impl SessionRuntime {
                 profile.profile_id.clone(),
                 session_id_raw.clone(),
             ) {
-                Ok(scope) => Some(Arc::new(scope)),
+                Ok(scope) => {
+                    // PR-A: thread the per-profile plugin install
+                    // directories through to the scope so file tools
+                    // (`read_file` today, glob/grep/list_dir in
+                    // PR-B) can reach the SKILL.md content the
+                    // agent's system prompt references. Canonicalize
+                    // each entry so symlinked plugin install roots
+                    // line up with the canonicalized candidate paths
+                    // the tools-side resolver compares against. Fall
+                    // back to the raw path when canonicalize fails
+                    // (the dir may not exist on bootstrap retry).
+                    let skill_dirs: Vec<std::path::PathBuf> = profile
+                        .plugin_dirs
+                        .iter()
+                        .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
+                        .collect();
+                    let scope = scope
+                        .with_skill_read_zones(skill_dirs)
+                        .unwrap_or_else(|err| {
+                            tracing::warn!(
+                                profile_id = %profile.profile_id,
+                                session = %session_key,
+                                error = %err,
+                                "with_skill_read_zones rejected one or more plugin_dirs; \
+                                 continuing without skill_read_zones (read_file may not reach SKILL.md references)",
+                            );
+                            // Reconstruct the scope without skill
+                            // zones — non-fatal additive feature.
+                            SessionScope::multi_tenant_with_default_zones(
+                                profile.data_dir.clone(),
+                                profile.profile_id.clone(),
+                                session_id_raw.clone(),
+                            )
+                            .expect("scope was buildable above; rebuilding with the same inputs must succeed")
+                        });
+                    Some(Arc::new(scope))
+                }
                 Err(err) => {
                     tracing::warn!(
                         profile_id = %profile.profile_id,

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -15314,4 +15314,73 @@ mod tests {
             "every plugin_dir missing => no skill_read_zones (fail-closed)",
         );
     }
+
+    /// Codex round-2 MAJOR (PR #1327 review): cross-profile isolation
+    /// is structurally correct by construction — each profile's
+    /// `SessionScope` only carries that profile's `plugin_dirs` as
+    /// `skill_read_zones`, so a session bound to profile A can never
+    /// resolve profile B's skill_dir to `InSkillDir`. This test pins
+    /// the invariant explicitly so a future refactor that widens
+    /// `plugin_dirs` (e.g. union across profiles, global skill cache)
+    /// can't silently regress the boundary.
+    #[test]
+    fn build_gateway_session_scope_classifies_cross_profile_skill_dir_as_out_of_scope() {
+        use octos_core::PathClassification;
+
+        let root = tempfile::TempDir::new().unwrap();
+
+        // Profile A: data_dir + one skill_dir with a file inside.
+        let profile_a_data = root.path().join("profile_a");
+        let profile_a_skill = profile_a_data.join("skills").join("mofa-slides");
+        std::fs::create_dir_all(profile_a_skill.join("styles")).unwrap();
+        let profile_a_skill_file = profile_a_skill.join("styles").join("nb-pro.toml");
+        std::fs::write(&profile_a_skill_file, "[meta]\nname = 'nb-pro'\n").unwrap();
+
+        // Profile B: separate data_dir + a different skill_dir with a
+        // file inside. Lives outside profile A's data_dir entirely.
+        let profile_b_data = root.path().join("profile_b");
+        let profile_b_skill = profile_b_data.join("skills").join("mofa-cards");
+        std::fs::create_dir_all(profile_b_skill.join("styles")).unwrap();
+        let profile_b_skill_file = profile_b_skill.join("styles").join("custom.toml");
+        std::fs::write(&profile_b_skill_file, "[meta]\nname = 'custom'\n").unwrap();
+
+        // Build a `SessionScope` for profile A using ONLY profile A's
+        // plugin_dirs. This is exactly the production wiring: each
+        // `ProfileFactory` constructs scopes from its own
+        // `plugin_dirs`, never from another profile's.
+        let session_key = SessionKey("web-cross-profile".to_string());
+        let plugin_dirs = vec![profile_a_skill.clone()];
+        let scope = build_gateway_session_scope(
+            Some("profile_a"),
+            &profile_a_data,
+            &session_key,
+            &plugin_dirs,
+        )
+        .expect("scope build for profile A must succeed");
+
+        // Positive control: profile A's OWN skill file classifies as
+        // `InSkillDir`. If this regresses, the test fixture is broken
+        // (not the cross-profile assertion below).
+        let a_classification = scope.classify_canonical_path(&profile_a_skill_file);
+        assert!(
+            matches!(a_classification, PathClassification::InSkillDir { .. }),
+            "profile A's own skill file must be InSkillDir under profile A's scope; \
+             got {a_classification:?}",
+        );
+
+        // The invariant under test: profile B's skill file MUST
+        // classify as `OutOfScope` because profile B's skill_dir is
+        // not in profile A's `skill_read_zones`, not in profile A's
+        // workspace, and not in profile A's shared zones
+        // (`<profile_a>/skills`, `<profile_a>/research`). A future
+        // change that, e.g., merged all profiles' plugin_dirs into a
+        // global pool would flip this to `InSkillDir` and the test
+        // would catch it.
+        let b_classification = scope.classify_canonical_path(&profile_b_skill_file);
+        assert!(
+            matches!(b_classification, PathClassification::OutOfScope),
+            "profile B's skill file MUST be OutOfScope under profile A's scope; \
+             got {b_classification:?}",
+        );
+    }
 }

--- a/crates/octos-cli/src/session_actor.rs
+++ b/crates/octos-cli/src/session_actor.rs
@@ -37,7 +37,7 @@ use octos_bus::{
 use octos_core::AgentId;
 use octos_core::{
     InboundMessage, MAIN_PROFILE_ID, METADATA_SENDER_USER_ID, Message, MessageRole,
-    OutboundMessage, SessionKey,
+    OutboundMessage, SessionKey, SessionScope, is_safe_session_id,
 };
 use octos_llm::{
     AdaptiveMode, AdaptiveRouter, EmbeddingProvider, FailoverEvent, LlmProvider, ProviderRouter,
@@ -2367,6 +2367,18 @@ pub struct ActorFactory {
     /// Memory store for saving long-form outputs (research reports) to the
     /// memory bank so only a summary is injected into session context.
     pub memory_store: Option<Arc<MemoryStore>>,
+    /// Profile id (= tenant id in [`SessionScope::multi_tenant`]). Used
+    /// to construct a per-session [`SessionScope`] when spawning gateway
+    /// session actors. `None` for the top-level admin factory (the
+    /// admin path constructs its own scope) and for test fixtures that
+    /// don't exercise the scope wiring.
+    ///
+    /// Codex round-2 MAJOR 3 (PR #1327 review): without this the
+    /// gateway-spawned session actors had `ctx.session_scope = None`,
+    /// so `read_file` fell back to the workspace-only legacy resolver
+    /// and couldn't reach the per-profile skill_dirs the SKILL.md
+    /// auto-inject teaches the agent about.
+    pub profile_id: Option<String>,
     /// Plugin directories for SpawnTool subagents to load plugin tools.
     pub plugin_dirs: Vec<std::path::PathBuf>,
     /// Extra environment variables for plugin processes in subagents.
@@ -2433,6 +2445,92 @@ impl ToolRegistryFactory for SnapshotToolRegistryFactory {
         // Re-bind cwd-bound tools to the per-user workspace while
         // preserving non-cwd tools (web_search, browser, MCP, plugins, etc.)
         self.base.rebind_cwd(workspace, sandbox)
+    }
+}
+
+/// Codex round-2 MAJOR 3 (PR #1327 review): construct the per-session
+/// [`SessionScope`] for gateway-routed actors. Factored out of
+/// `ActorFactory::spawn` so the wiring can be unit-tested without
+/// having to drive an entire actor through a tokio mpsc channel.
+///
+/// Returns `Some(scope)` when:
+/// - `profile_id` is `Some` (per-profile actors created by
+///   `ProfileFactory::build` always supply it; the admin / test
+///   ActorFactory leaves it `None`), AND
+/// - `session_key.base_key()` satisfies [`is_safe_session_id`] (SPA
+///   `web-/slides-/site-` shapes pass; channel-prefixed `api:...`
+///   shapes do not — those route through the legacy resolver).
+///
+/// Returns `None` (= legacy resolver) for the admin path, the
+/// channel-prefixed shapes, or when the scope builder rejects the
+/// inputs entirely.
+///
+/// Fail-closed canonicalisation per round-2 BLOCKER 2: any
+/// `plugin_dir` that fails canonicalize is dropped (logged at `warn`).
+/// Mirrors `runtime/session.rs` and `commands/chat.rs`.
+pub(crate) fn build_gateway_session_scope(
+    profile_id: Option<&str>,
+    data_dir: &std::path::Path,
+    session_key: &SessionKey,
+    plugin_dirs: &[std::path::PathBuf],
+) -> Option<Arc<SessionScope>> {
+    let session_id_raw = session_key.base_key().to_string();
+    let Some(profile_id) = profile_id else {
+        tracing::debug!(
+            session = %session_key,
+            "ActorFactory::spawn skipping SessionScope: factory has no profile_id (admin / test path)",
+        );
+        return None;
+    };
+    if !is_safe_session_id(&session_id_raw) {
+        tracing::debug!(
+            profile_id = %profile_id,
+            session = %session_key,
+            "ActorFactory::spawn skipping SessionScope: session id outside is_safe_session_id alphabet \
+             (legacy channel-prefixed shape)",
+        );
+        return None;
+    }
+    match SessionScope::multi_tenant_with_default_zones(
+        data_dir.to_path_buf(),
+        profile_id.to_string(),
+        session_id_raw.clone(),
+    ) {
+        Ok(scope) => {
+            // Round-2 BLOCKER 2: fail-closed canonicalisation. Drop
+            // any plugin dir that can't be canonicalised so a later
+            // symlink replacement can't be legitimised as `InSkillDir`.
+            let skill_dirs = octos_core::canonicalize_skill_read_zones(plugin_dirs);
+            match scope.with_skill_read_zones(skill_dirs) {
+                Ok(scope) => Some(Arc::new(scope)),
+                Err(err) => {
+                    tracing::warn!(
+                        profile_id = %profile_id,
+                        session = %session_key,
+                        error = %err,
+                        "ActorFactory::spawn with_skill_read_zones rejected one or more plugin_dirs; \
+                         attaching scope without skill_read_zones",
+                    );
+                    SessionScope::multi_tenant_with_default_zones(
+                        data_dir.to_path_buf(),
+                        profile_id.to_string(),
+                        session_id_raw,
+                    )
+                    .map(Arc::new)
+                    .ok()
+                }
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                profile_id = %profile_id,
+                session = %session_key,
+                error = %err,
+                "ActorFactory::spawn SessionScope construction failed; \
+                 continuing without scope",
+            );
+            None
+        }
     }
 }
 
@@ -3115,6 +3213,22 @@ impl ActorFactory {
                 self.data_dir.clone(),
                 context_manager.clone(),
             ));
+
+        // Codex round-2 MAJOR 3 (PR #1327 review): construct a
+        // per-session SessionScope so gateway-spawned actors get the
+        // same skill_read_zones wiring that `runtime/session.rs` gives
+        // SPA web sessions. Without this the agent's `ctx.session_scope`
+        // stayed `None` for every gateway-routed session, so
+        // `read_file` fell back to the workspace-only legacy resolver
+        // and could not reach the per-profile skill_dirs the
+        // SKILL.md auto-inject teaches the agent to use.
+        let session_scope_arc = build_gateway_session_scope(
+            self.profile_id.as_deref(),
+            &self.data_dir,
+            &session_key,
+            &self.plugin_dirs,
+        );
+
         let mut agent = Agent::new(agent_id, session_llm, tools, self.memory.clone())
             .with_config(self.agent_config.clone())
             .with_reporter(Arc::new(octos_agent::SilentReporter))
@@ -3129,6 +3243,9 @@ impl ActorFactory {
             // surface output and status to dashboards.
             .with_subagent_output_router(self.subagent_output_router.clone())
             .with_subagent_summary_generator(subagent_summary_generator);
+        if let Some(scope) = session_scope_arc.clone() {
+            agent = agent.with_session_scope(scope);
+        }
 
         if let Some(ref embedder) = self.embedder {
             agent = agent.with_embedder(embedder.clone());
@@ -12826,6 +12943,7 @@ mod tests {
             adaptive_router: None,
             lane_routing: None,
             memory_store: None,
+            profile_id: None,
             plugin_dirs: Vec::new(),
             plugin_extra_env: Vec::new(),
             plugin_require_signed: false,
@@ -15066,5 +15184,134 @@ mod tests {
 
         drop(tx);
         let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    }
+
+    // -----------------------------------------------------------------
+    // Codex round-2 MAJOR 3 (PR #1327 review): gateway session scope
+    // wiring. Pins that `ActorFactory::spawn` (via
+    // `build_gateway_session_scope`) attaches a non-None SessionScope
+    // with the expected skill_read_zones for per-profile gateway
+    // actors. Pre-fix the agent's `ctx.session_scope` stayed `None`
+    // for every gateway-routed session, so `read_file` fell back to
+    // the workspace-only legacy resolver.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn build_gateway_session_scope_attaches_scope_for_per_profile_session() {
+        // Per-profile gateway path: `ProfileFactory::build` sets
+        // `profile_id: Some(..)` and supplies plugin_dirs. The session
+        // id is a safe SPA shape (`web-...`). SPA WS sessions construct
+        // `SessionKey` with the bare session id (no channel prefix)
+        // so `base_key()` passes `is_safe_session_id`.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        // Two plugin dirs: one exists (gets canonicalised in), one
+        // missing (gets dropped fail-closed).
+        let plugin_a = tmp.path().join("skills").join("mofa-slides");
+        std::fs::create_dir_all(&plugin_a).unwrap();
+        let plugin_missing = tmp.path().join("skills").join("ghost-skill");
+        let plugin_dirs = vec![plugin_a.clone(), plugin_missing.clone()];
+
+        let session_key = SessionKey("web-1779574360679-o8x9kv".to_string());
+        // Sanity: pin that the test fixture matches the production
+        // SPA path that routes through `runtime/session.rs`.
+        assert!(
+            octos_core::is_safe_session_id(session_key.base_key()),
+            "test fixture must use a safe SPA session id",
+        );
+        let scope =
+            build_gateway_session_scope(Some("dspfac"), &data_dir, &session_key, &plugin_dirs)
+                .expect("per-profile + safe session id must build a scope");
+
+        // The factory's data_dir maps to scope.root (the profile data
+        // dir in the multi-tenant constructor).
+        assert_eq!(
+            scope.root(),
+            data_dir.as_path(),
+            "scope root mirrors data_dir"
+        );
+        // skill_read_zones contains the canonicalised existing
+        // plugin_dir AND drops the missing one (round-2 BLOCKER 2
+        // fail-closed).
+        let zones = scope.skill_read_zones();
+        assert_eq!(
+            zones.len(),
+            1,
+            "fail-closed canonicalise must drop missing plugin_dir: zones = {zones:?}"
+        );
+        let canon_plugin_a = std::fs::canonicalize(&plugin_a).unwrap();
+        assert_eq!(zones[0], canon_plugin_a);
+    }
+
+    #[test]
+    fn build_gateway_session_scope_returns_none_for_admin_factory() {
+        // Top-level / admin factory path: `profile_id: None`. We MUST
+        // NOT construct a scope because the admin factory's data_dir
+        // isn't laid out as the per-profile multi-tenant shape.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let session_key = SessionKey("web-1779574360679-o8x9kv".to_string());
+        let scope = build_gateway_session_scope(None, tmp.path(), &session_key, &[]);
+        assert!(
+            scope.is_none(),
+            "admin factory (profile_id = None) must skip scope construction",
+        );
+    }
+
+    #[test]
+    fn build_gateway_session_scope_returns_none_for_unsafe_session_id() {
+        // Channel-prefixed legacy shapes (`api:web-1234`,
+        // `telegram:12345`, etc.) produce a `base_key()` containing
+        // `:`, which fails `is_safe_session_id`. We MUST route those
+        // through the legacy resolver (= None) rather than building a
+        // scope against the unsafe id.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let session_key = SessionKey::new("telegram", "12345");
+        // Sanity: pin the regression — channel-prefixed shape really
+        // fails the safe-id check.
+        assert!(
+            !octos_core::is_safe_session_id(session_key.base_key()),
+            "this test relies on channel-prefixed keys failing is_safe_session_id; \
+             update the test if SessionKey's representation changes",
+        );
+
+        let scope = build_gateway_session_scope(Some("dspfac"), tmp.path(), &session_key, &[]);
+        assert!(
+            scope.is_none(),
+            "unsafe session id must skip scope (legacy resolver path)",
+        );
+    }
+
+    #[test]
+    fn build_gateway_session_scope_handles_empty_plugin_dirs() {
+        // Edge: profile_id set, session id safe, but plugin_dirs empty
+        // (profile has no installed skills). Scope must still build —
+        // just with empty skill_read_zones.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let session_key = SessionKey("web-empty".to_string());
+        let scope = build_gateway_session_scope(Some("dspfac"), tmp.path(), &session_key, &[])
+            .expect("empty plugin_dirs is a legitimate configuration");
+        assert!(
+            scope.skill_read_zones().is_empty(),
+            "no plugin_dirs => no skill_read_zones",
+        );
+    }
+
+    #[test]
+    fn build_gateway_session_scope_drops_all_missing_plugin_dirs() {
+        // Edge: all plugin_dirs are missing — fail-closed drops them
+        // all, scope still builds (empty skill_read_zones is safe).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let session_key = SessionKey("web-allmissing".to_string());
+        let plugin_dirs = vec![
+            tmp.path().join("skills").join("ghost-a"),
+            tmp.path().join("skills").join("ghost-b"),
+        ];
+        let scope =
+            build_gateway_session_scope(Some("dspfac"), tmp.path(), &session_key, &plugin_dirs)
+                .expect("scope must still build when every plugin_dir is missing");
+        assert!(
+            scope.skill_read_zones().is_empty(),
+            "every plugin_dir missing => no skill_read_zones (fail-closed)",
+        );
     }
 }

--- a/crates/octos-core/Cargo.toml
+++ b/crates/octos-core/Cargo.toml
@@ -12,9 +12,11 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 eyre = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
 tokio-test = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/octos-core/src/lib.rs
+++ b/crates/octos-core/src/lib.rs
@@ -25,7 +25,8 @@ pub use message::AgentMessage;
 pub use session_scope::{
     DEFAULT_MULTI_TENANT_SHARED_ZONE_NAMES, MULTI_TENANT_USERS_DIR_NAME,
     MULTI_TENANT_WORKSPACE_DIR_NAME, PathClassification, SESSION_SCOPE_SCHEMA_VERSION, ScopeMode,
-    SessionScope, SessionScopeError, is_safe_session_id,
+    SessionScope, SessionScopeError, canonical_root_lossy, canonicalize_lossy,
+    canonicalize_skill_read_zones, is_safe_session_id,
 };
 pub use task::{
     DecisionRecord, FileRecord, SESSION_SUMMARY_SCHEMA_VERSION, STALE_DECISION_PREFIX,

--- a/crates/octos-core/src/session_scope.rs
+++ b/crates/octos-core/src/session_scope.rs
@@ -127,7 +127,15 @@ use serde::Serialize;
 
 /// Schema version of the [`SessionScope`] shape. Bump on incompatible
 /// changes.
-pub const SESSION_SCOPE_SCHEMA_VERSION: u32 = 1;
+///
+/// Version history:
+/// - v1: workspace + shared_zones (MultiTenant) / workspace +
+///   granted_dirs (Solo).
+/// - v2 (PR-A SKILL.md injection rethink): adds `skill_read_zones`,
+///   a read-only allowlist that lets file tools reach plugin
+///   `skill_dir` trees. Writes remain workspace-only. Additive — old
+///   callers that pass an empty list keep v1 behaviour.
+pub const SESSION_SCOPE_SCHEMA_VERSION: u32 = 2;
 
 /// Default name of the per-session workspace subdirectory inside
 /// `<root>/users/<session_id>/`. Held as a constant so the resolver
@@ -188,6 +196,11 @@ pub enum SessionScopeError {
         users_subtree: PathBuf,
         zone: PathBuf,
     },
+
+    /// A `skill_read_zone` is not absolute. Skill directories must be
+    /// absolute so they can be compared unambiguously against caller
+    /// paths (same invariant as `granted_dirs`).
+    SkillReadZoneNotAbsolute(usize, PathBuf),
 }
 
 impl std::fmt::Display for SessionScopeError {
@@ -236,6 +249,11 @@ impl std::fmt::Display for SessionScopeError {
                 zone.display(),
                 users_subtree.display()
             ),
+            Self::SkillReadZoneNotAbsolute(idx, p) => write!(
+                f,
+                "skill_read_zones[{idx}] must be absolute, got: {}",
+                p.display()
+            ),
         }
     }
 }
@@ -266,13 +284,22 @@ pub enum PathClassification {
     /// Reads and writes allowed; the user explicitly granted access
     /// via a Claude-Code-style permission prompt.
     InGrantedDir { granted_dir: PathBuf },
+    /// Path is inside one of `scope.skill_read_zones` (any mode).
+    /// **Reads allowed; writes refused.** Used by the auto-injected
+    /// plugin SKILL.md guidance so the agent can `read_file` against
+    /// references the SKILL.md mentions (helper scripts, example
+    /// data, etc.) without needing per-skill workspace copies.
+    /// Workspace and granted_dirs still take precedence — if a path
+    /// happens to be inside both, the higher-trust zone wins.
+    InSkillDir { skill_dir: PathBuf },
     /// Path is outside every declared zone (workspace, shared_zones,
-    /// granted_dirs). Refuse — this is either a tenant-boundary
-    /// escape (multi-tenant) or a path the user has not granted
-    /// (solo). The previous `InRootButOutsideZones` variant was
-    /// dropped per codex round-1 review: with `shared_data == root`
-    /// it was unreachable; with named shared zones, there are no
-    /// "almost legitimate" paths to distinguish from full escapes.
+    /// granted_dirs, skill_read_zones). Refuse — this is either a
+    /// tenant-boundary escape (multi-tenant) or a path the user has
+    /// not granted (solo). The previous `InRootButOutsideZones`
+    /// variant was dropped per codex round-1 review: with
+    /// `shared_data == root` it was unreachable; with named shared
+    /// zones, there are no "almost legitimate" paths to distinguish
+    /// from full escapes.
     OutOfScope,
 }
 
@@ -355,6 +382,27 @@ pub struct SessionScope {
     /// system. Per codex round-1: typed mode-specific fields prevent
     /// illegal-state construction.
     mode: ScopeMode,
+    /// Read-only allowlist of plugin `skill_dir` trees the agent may
+    /// reach with read-side file tools (`read_file` today; `glob` /
+    /// `grep` / `list_dir` in PR-B). **Reads allowed; writes
+    /// refused.** Cross-mode (both solo and multi-tenant carry it)
+    /// because the SKILL.md auto-inject in
+    /// `octos-agent/src/plugins/extras.rs` happens regardless of
+    /// scope mode — the agent needs the same read access in both.
+    ///
+    /// Empty by default. Callers opt in by passing a non-empty vec
+    /// to [`Self::multi_tenant`] / [`Self::solo`] or layering on
+    /// with [`Self::with_skill_read_zones`]. Each entry must be
+    /// absolute (canonicalisation is the caller's responsibility —
+    /// the tools-side `resolve_for_scope` canonicalizes both sides
+    /// before comparing, matching how `InSharedZone` is handled).
+    ///
+    /// Classification order: workspace, then granted_dirs, then
+    /// `skill_read_zones`, then shared_zones, then OutOfScope. Per
+    /// the PR-A spec, workspace and granted_dirs always win as the
+    /// higher-priority classifications even when a skill_dir happens
+    /// to live inside them.
+    skill_read_zones: Vec<PathBuf>,
 }
 
 /// Canonical names of shared zones under `<root>` for the dspfac /
@@ -431,6 +479,7 @@ impl SessionScope {
                 session_id,
                 shared_zones,
             },
+            skill_read_zones: Vec::new(),
         })
     }
 
@@ -470,6 +519,7 @@ impl SessionScope {
             workspace: cwd.clone(),
             root: cwd,
             mode: ScopeMode::Solo { granted_dirs },
+            skill_read_zones: Vec::new(),
         })
     }
 
@@ -494,6 +544,39 @@ impl SessionScope {
 
     pub fn mode(&self) -> &ScopeMode {
         &self.mode
+    }
+
+    /// Return the read-only plugin skill directories the agent may
+    /// reach. See the `skill_read_zones` field doc on [`SessionScope`].
+    pub fn skill_read_zones(&self) -> &[PathBuf] {
+        &self.skill_read_zones
+    }
+
+    /// Return a new `SessionScope` with `skill_read_zones` replacing
+    /// any previously-set list.
+    ///
+    /// Each entry MUST be absolute. The caller is responsible for
+    /// canonicalising paths (the tools-side `resolve_for_scope`
+    /// canonicalizes both sides before comparing, matching the
+    /// existing `InSharedZone` containment guard).
+    ///
+    /// Cross-mode: both solo and multi-tenant accept skill read zones
+    /// because the auto-injected SKILL.md guidance fires regardless
+    /// of scope mode. The classifier consults this list AFTER
+    /// workspace and granted_dirs so the higher-trust zones still win
+    /// when paths overlap (e.g. a skill_dir nested inside the
+    /// workspace would classify as `InWorkspace`, not `InSkillDir`).
+    pub fn with_skill_read_zones(mut self, dirs: Vec<PathBuf>) -> Result<Self, SessionScopeError> {
+        for (idx, dir) in dirs.iter().enumerate() {
+            if !dir.is_absolute() {
+                return Err(SessionScopeError::SkillReadZoneNotAbsolute(
+                    idx,
+                    dir.clone(),
+                ));
+            }
+        }
+        self.skill_read_zones = dirs;
+        Ok(self)
     }
 
     /// Return a new `SessionScope` with `dir` added to `granted_dirs`.
@@ -545,21 +628,40 @@ impl SessionScope {
         if normalised.starts_with(&self.workspace) {
             return PathClassification::InWorkspace;
         }
-        match &self.mode {
-            ScopeMode::Solo { granted_dirs } => {
-                for granted in granted_dirs {
-                    if normalised.starts_with(granted) {
-                        return PathClassification::InGrantedDir {
-                            granted_dir: granted.clone(),
-                        };
-                    }
+        // Per-mode high-trust zones come next. For solo this is
+        // `granted_dirs` (user-approved); for multi-tenant we
+        // intentionally defer `shared_zones` until AFTER
+        // `skill_read_zones` per the PR-A classification order
+        // (workspace > granted_dirs > skill_read_zones > shared_zones).
+        if let ScopeMode::Solo { granted_dirs } = &self.mode {
+            for granted in granted_dirs {
+                if normalised.starts_with(granted) {
+                    return PathClassification::InGrantedDir {
+                        granted_dir: granted.clone(),
+                    };
                 }
             }
-            ScopeMode::MultiTenant { shared_zones, .. } => {
-                for zone in shared_zones {
-                    if normalised.starts_with(zone) {
-                        return PathClassification::InSharedZone { zone: zone.clone() };
-                    }
+        }
+        // Read-only plugin skill directories. Consulted AFTER
+        // workspace and granted_dirs so the higher-priority zones
+        // still classify a path inside both (degenerate case where a
+        // skill_dir is nested inside the workspace) as `InWorkspace`,
+        // not `InSkillDir`. Consulted BEFORE shared_zones because
+        // skill dirs are plugin-installed read material, not the
+        // declared cross-session "research/skills" zones; treating
+        // them the same would let plugin paths inherit
+        // `InSharedZone` semantics by accident.
+        for skill_dir in &self.skill_read_zones {
+            if normalised.starts_with(skill_dir) {
+                return PathClassification::InSkillDir {
+                    skill_dir: skill_dir.clone(),
+                };
+            }
+        }
+        if let ScopeMode::MultiTenant { shared_zones, .. } = &self.mode {
+            for zone in shared_zones {
+                if normalised.starts_with(zone) {
+                    return PathClassification::InSharedZone { zone: zone.clone() };
                 }
             }
         }
@@ -879,5 +981,199 @@ mod tests {
             err,
             SessionScopeError::GrantNotAllowedInMultiTenant
         ));
+    }
+
+    // -------- PR-A: skill_read_zones --------
+
+    /// Read paths inside a registered skill_dir classify as
+    /// [`PathClassification::InSkillDir`]. This is the lexical
+    /// classification check — `tools/mod.rs::resolve_for_scope`
+    /// layers the canonicalize-both-sides treatment and the
+    /// read/write split on top.
+    #[test]
+    fn read_file_from_allowlisted_skill_dir_classifies_in_skill_dir() {
+        let workspace = abs("/octos/profiles/dspfac/data");
+        let skill_dir = abs("/octos/plugins/mofa-podcast");
+        let scope = mt_default(&workspace, "web-1")
+            .with_skill_read_zones(vec![skill_dir.clone()])
+            .expect("absolute skill_dir is valid");
+        assert_eq!(
+            scope.classify_lexical_path(&skill_dir.join("SKILL.md")),
+            PathClassification::InSkillDir {
+                skill_dir: skill_dir.clone()
+            }
+        );
+        assert_eq!(
+            scope.classify_lexical_path(&skill_dir.join("data/example.json")),
+            PathClassification::InSkillDir { skill_dir }
+        );
+    }
+
+    /// A path that resolves outside the skill_dir via `..` traversal
+    /// must classify as `OutOfScope`, never `InSkillDir`. The
+    /// lexical normaliser rejects `..` outright per the existing
+    /// contract — this pins that behaviour for skill_read_zones too.
+    #[test]
+    fn traversal_attempt_in_skill_dir_classifies_out_of_scope() {
+        let workspace = abs("/octos/profiles/dspfac/data");
+        let skill_dir = abs("/octos/plugins/mofa-podcast");
+        let scope = mt_default(&workspace, "web-1")
+            .with_skill_read_zones(vec![skill_dir.clone()])
+            .unwrap();
+        // Lexical `..` is refused at the normaliser layer, regardless
+        // of whether the canonical destination would land inside the
+        // skill_dir.
+        let traversal = skill_dir.join("../../../etc/passwd");
+        assert_eq!(
+            scope.classify_lexical_path(&traversal),
+            PathClassification::OutOfScope
+        );
+    }
+
+    /// Multiple skill_dirs all participate — the classifier returns
+    /// the matching dir, not the first/last entry by chance.
+    #[test]
+    fn multiple_skill_dirs_all_classify_in_skill_dir() {
+        let workspace = abs("/octos/profiles/dspfac/data");
+        let dirs = [
+            abs("/octos/plugins/mofa-podcast"),
+            abs("/octos/plugins/mofa-research"),
+            abs("/octos/plugins/mofa-slides"),
+        ];
+        let scope = mt_default(&workspace, "web-1")
+            .with_skill_read_zones(dirs.to_vec())
+            .unwrap();
+        for dir in &dirs {
+            assert_eq!(
+                scope.classify_lexical_path(&dir.join("SKILL.md")),
+                PathClassification::InSkillDir {
+                    skill_dir: dir.clone()
+                },
+                "expected InSkillDir match for {}",
+                dir.display()
+            );
+        }
+    }
+
+    /// Degenerate case: a skill_dir that happens to live inside the
+    /// workspace must still classify as `InWorkspace`. Workspace
+    /// takes precedence so writes to the dir keep working (writes to
+    /// `InSkillDir` are refused, writes to `InWorkspace` succeed).
+    #[test]
+    fn workspace_path_still_wins_over_skill_dir() {
+        let workspace = abs("/octos/profiles/dspfac/data");
+        // Pretend a skill dir was registered inside the workspace
+        // tree (e.g. someone moved a skill_dir into
+        // `<data>/users/web-1/workspace/skill-copy/`).
+        let session_workspace = workspace.join("users/web-1/workspace");
+        let nested_skill = session_workspace.join("skill-copy");
+        let scope = mt_default(&workspace, "web-1")
+            .with_skill_read_zones(vec![nested_skill.clone()])
+            .unwrap();
+        let inner = nested_skill.join("manifest.json");
+        assert_eq!(
+            scope.classify_lexical_path(&inner),
+            PathClassification::InWorkspace,
+            "workspace must outrank skill_read_zones even when a skill_dir is nested inside it",
+        );
+    }
+
+    /// Solo mode also accepts skill_read_zones (the SKILL.md
+    /// auto-inject fires regardless of scope mode, so solo callers
+    /// need the same allowlist).
+    #[test]
+    fn solo_with_skill_read_zones_classifies_in_skill_dir() {
+        let cwd = abs("/home/yc/my-project");
+        let skill_dir = abs("/opt/octos/plugins/mofa-podcast");
+        let scope = SessionScope::solo(cwd, vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill_dir.clone()])
+            .unwrap();
+        assert_eq!(
+            scope.classify_lexical_path(&skill_dir.join("SKILL.md")),
+            PathClassification::InSkillDir { skill_dir }
+        );
+    }
+
+    /// Solo `granted_dirs` must outrank `skill_read_zones`. Grants
+    /// are explicit user approvals and carry full read+write rights;
+    /// skill dirs are read-only. If a skill_dir overlapped with a
+    /// granted dir, a path inside both would classify as
+    /// `InGrantedDir` (read+write) rather than `InSkillDir` (read
+    /// only).
+    #[test]
+    fn solo_granted_dir_outranks_skill_read_zone() {
+        let cwd = abs("/home/yc/my-project");
+        let shared_parent = abs("/opt/octos/plugins");
+        let nested = shared_parent.join("mofa-podcast");
+        let scope = SessionScope::solo(cwd, vec![shared_parent.clone()])
+            .unwrap()
+            .with_skill_read_zones(vec![nested.clone()])
+            .unwrap();
+        assert_eq!(
+            scope.classify_lexical_path(&nested.join("SKILL.md")),
+            PathClassification::InGrantedDir {
+                granted_dir: shared_parent
+            }
+        );
+    }
+
+    /// Multi-tenant: skill_read_zones consult AFTER workspace but
+    /// BEFORE shared_zones. If a skill_dir overlapped with a shared
+    /// zone, the skill_dir wins. The classification order matters
+    /// because writes are refused for both, but `InSharedZone` carries
+    /// the cross-session-zone semantics from the host while
+    /// `InSkillDir` is plugin-install material.
+    #[test]
+    fn skill_read_zone_outranks_shared_zone() {
+        let data = abs("/octos/profiles/dspfac/data");
+        let shared_research = data.join("research");
+        let nested_skill = shared_research.join("mofa-podcast");
+        let scope = mt_default(&data, "web-1")
+            .with_skill_read_zones(vec![nested_skill.clone()])
+            .unwrap();
+        assert_eq!(
+            scope.classify_lexical_path(&nested_skill.join("SKILL.md")),
+            PathClassification::InSkillDir {
+                skill_dir: nested_skill
+            }
+        );
+    }
+
+    /// Empty `skill_read_zones` (the default) leaves classification
+    /// behaviour identical to v1 — `InSkillDir` is never returned
+    /// and pre-PR-A callers see no observable change.
+    #[test]
+    fn empty_skill_read_zones_preserves_v1_classification() {
+        let data = abs("/octos/profiles/dspfac/data");
+        let scope = mt_default(&data, "web-1");
+        assert!(scope.skill_read_zones().is_empty());
+        // Pick a path that would have been `InSkillDir` if the zone
+        // had been registered.
+        let outside = abs("/octos/plugins/mofa-podcast/SKILL.md");
+        assert_eq!(
+            scope.classify_lexical_path(&outside),
+            PathClassification::OutOfScope
+        );
+    }
+
+    #[test]
+    fn with_skill_read_zones_refuses_relative_paths() {
+        let scope = mt_default(&abs("/octos/profiles/dspfac/data"), "web-1");
+        let err = scope
+            .with_skill_read_zones(vec![PathBuf::from("relative/skill")])
+            .unwrap_err();
+        assert!(
+            matches!(err, SessionScopeError::SkillReadZoneNotAbsolute(0, _)),
+            "expected SkillReadZoneNotAbsolute, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn schema_version_bumped_to_v2_for_skill_read_zones() {
+        // Pin the PR-A bump so a future PR cannot silently revert
+        // the schema version without updating this test (and the
+        // module-level history comment on the constant).
+        assert_eq!(SESSION_SCOPE_SCHEMA_VERSION, 2);
     }
 }

--- a/crates/octos-core/src/session_scope.rs
+++ b/crates/octos-core/src/session_scope.rs
@@ -667,6 +667,133 @@ impl SessionScope {
         }
         PathClassification::OutOfScope
     }
+
+    /// Classify `path` against this scope after canonicalising both
+    /// sides. Closes the ancestor-symlink hole in
+    /// [`Self::classify_lexical_path`]: a symlink anywhere on the
+    /// `path` chain (or inside one of the scope roots) is resolved
+    /// before the prefix comparison, so a skill_dir containing
+    /// `link -> /outside` cannot smuggle `<skill_dir>/link/secret` as
+    /// `InSkillDir`.
+    ///
+    /// Input MUST be lexically normalised (no `..` components). Callers
+    /// that don't have a pre-normalised path should call
+    /// [`Self::classify_lexical_path`] first (which rejects `..`) and
+    /// only fall through to this method when they need the canonical
+    /// containment guarantee.
+    ///
+    /// Same return shape as [`Self::classify_lexical_path`]. The reported
+    /// `skill_dir` / `zone` / `granted_dir` is the un-canonicalised form
+    /// (matches what callers configured) so log messages and tests stay
+    /// readable; the comparison itself uses canonicalised roots.
+    ///
+    /// Filesystem access: canonicalises `path` and every zone root via
+    /// [`canonicalize_lossy`] (walks ancestors when the leaf is missing,
+    /// e.g. for writes that target new files). When a path or root
+    /// can't be canonicalised at all, the lossy fallback is the input
+    /// itself, which keeps `OutOfScope` as the default-deny answer for
+    /// fully-virtual paths.
+    pub fn classify_canonical_path(&self, path: &Path) -> PathClassification {
+        let canon = canonicalize_lossy(path);
+        let canon_ws = canonical_root_lossy(&self.workspace);
+        if canon.starts_with(&canon_ws) {
+            return PathClassification::InWorkspace;
+        }
+        if let ScopeMode::Solo { granted_dirs } = &self.mode {
+            for granted in granted_dirs {
+                let canon_grant = canonical_root_lossy(granted);
+                if canon.starts_with(&canon_grant) {
+                    return PathClassification::InGrantedDir {
+                        granted_dir: granted.clone(),
+                    };
+                }
+            }
+        }
+        for skill_dir in &self.skill_read_zones {
+            let canon_skill = canonical_root_lossy(skill_dir);
+            if canon.starts_with(&canon_skill) {
+                return PathClassification::InSkillDir {
+                    skill_dir: skill_dir.clone(),
+                };
+            }
+        }
+        if let ScopeMode::MultiTenant { shared_zones, .. } = &self.mode {
+            for zone in shared_zones {
+                let canon_zone = canonical_root_lossy(zone);
+                if canon.starts_with(&canon_zone) {
+                    return PathClassification::InSharedZone { zone: zone.clone() };
+                }
+            }
+        }
+        PathClassification::OutOfScope
+    }
+}
+
+/// Canonicalise a path, walking ancestors when the leaf doesn't exist
+/// yet (writes targeting new files inside an existing directory).
+/// Mirrors `octos_agent::tools::canonicalize_lossy` (and
+/// `octos_bus::file_handle::canonicalize_lossy`). Re-exported here so
+/// `SessionScope::classify_canonical_path` and the canonicalize-then-skip
+/// helper in the CLI can share one implementation.
+///
+/// The input must already be lexically normalised (no `..`) so the
+/// re-attached suffix names a real would-be on-disk location.
+pub fn canonicalize_lossy(path: &Path) -> PathBuf {
+    if let Ok(canon) = std::fs::canonicalize(path) {
+        return canon;
+    }
+    let mut existing: &Path = path;
+    let mut suffix = PathBuf::new();
+    while let Some(parent) = existing.parent() {
+        if let Some(name) = existing.file_name() {
+            let mut next_suffix = PathBuf::from(name);
+            next_suffix.push(&suffix);
+            suffix = next_suffix;
+        }
+        existing = parent;
+        if let Ok(canon) = std::fs::canonicalize(existing) {
+            return canon.join(suffix);
+        }
+        if existing.as_os_str().is_empty() {
+            break;
+        }
+    }
+    path.to_path_buf()
+}
+
+/// Canonicalise a zone root, falling back to the input when the root
+/// doesn't exist (rare for `scope.workspace()` but possible in tests
+/// that pass a not-yet-created directory).
+pub fn canonical_root_lossy(root: &Path) -> PathBuf {
+    std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf())
+}
+
+/// Canonicalise a list of skill plugin directories, dropping (with a
+/// warning log) any entry whose canonicalisation fails. Fail-closed:
+/// when the path can't be canonicalised — typically because it does
+/// not exist on disk yet — we drop it rather than keeping the raw form,
+/// because a raw path is later vulnerable to symlink replacement
+/// (`/tmp/missing -> /etc`) that the canonicalize-on-classify guard
+/// would then legitimise.
+///
+/// Returns the canonicalised list in input order, minus skipped
+/// entries. A missing dir has no readable SKILL content yet, so
+/// dropping it is the safe fallback; the agent loses a read zone it
+/// can't reach anyway.
+pub fn canonicalize_skill_read_zones(dirs: &[PathBuf]) -> Vec<PathBuf> {
+    dirs.iter()
+        .filter_map(|p| match std::fs::canonicalize(p) {
+            Ok(canon) => Some(canon),
+            Err(e) => {
+                tracing::warn!(
+                    path = %p.display(),
+                    err = %e,
+                    "skipping skill_read_zone (canonicalize failed; fail-closed)",
+                );
+                None
+            }
+        })
+        .collect()
 }
 
 /// Allowed alphabet for session ids that participate in the on-disk
@@ -1175,5 +1302,144 @@ mod tests {
         // the schema version without updating this test (and the
         // module-level history comment on the constant).
         assert_eq!(SESSION_SCOPE_SCHEMA_VERSION, 2);
+    }
+
+    // -----------------------------------------------------------------
+    // Codex round-2 BLOCKER 2 (PR #1327 review): canonicalize-then-skip
+    // helper. The pre-fix loop kept the raw path when canonicalize
+    // failed; that was fail-open — a later symlink replacement
+    // (`/tmp/missing -> /etc`) would canonicalise both candidate and
+    // zone root to `/etc` at classify time and accept reads.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn canonicalize_skill_read_zones_skips_missing_paths() {
+        // Two inputs: one real on-disk dir, one missing path. The fail-
+        // closed helper must KEEP the real dir and SKIP the missing
+        // one. The pre-fix code kept the missing path in raw form,
+        // which was fail-open.
+        let real = tempfile::tempdir().expect("create real skill dir");
+        let missing = real.path().join("does-not-exist");
+        let input = vec![real.path().to_path_buf(), missing.clone()];
+        let out = canonicalize_skill_read_zones(&input);
+        assert_eq!(out.len(), 1, "missing entry must be dropped: out = {out:?}");
+        let canonical_real = std::fs::canonicalize(real.path()).expect("canonicalize real");
+        assert_eq!(out[0], canonical_real);
+    }
+
+    #[test]
+    fn canonicalize_skill_read_zones_handles_all_missing_paths() {
+        // Edge case: every entry fails canonicalize. Helper must
+        // return an empty vec (no fail-open fallbacks). Caller then
+        // constructs the scope with empty `skill_read_zones`, which
+        // is the safe state.
+        let parent = tempfile::tempdir().expect("create parent dir");
+        let input = vec![parent.path().join("ghost-a"), parent.path().join("ghost-b")];
+        let out = canonicalize_skill_read_zones(&input);
+        assert!(
+            out.is_empty(),
+            "every entry missing must drop them all: out = {out:?}"
+        );
+    }
+
+    #[test]
+    fn canonicalize_skill_read_zones_preserves_order_when_all_present() {
+        // Order-stability test: helper drops failures but preserves
+        // input order for surviving entries. Callers (the scope
+        // builders) rely on the classifier consulting zones in
+        // declaration order.
+        let a = tempfile::tempdir().expect("a");
+        let b = tempfile::tempdir().expect("b");
+        let c = tempfile::tempdir().expect("c");
+        let input = vec![
+            a.path().to_path_buf(),
+            b.path().to_path_buf(),
+            c.path().to_path_buf(),
+        ];
+        let out = canonicalize_skill_read_zones(&input);
+        assert_eq!(out.len(), 3, "no entries should drop: out = {out:?}");
+        let canon_a = std::fs::canonicalize(a.path()).expect("canon a");
+        let canon_b = std::fs::canonicalize(b.path()).expect("canon b");
+        let canon_c = std::fs::canonicalize(c.path()).expect("canon c");
+        assert_eq!(out, vec![canon_a, canon_b, canon_c]);
+    }
+
+    // -----------------------------------------------------------------
+    // Codex round-2 BLOCKER 1 (PR #1327 review): canonical classify
+    // exposed as a SessionScope method so plugin tools and file tools
+    // share one symlink-safe gate.
+    // -----------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_canonical_path_refuses_symlink_escape_from_skill_dir() {
+        // Build:
+        //   skill_dir/link -> outside/
+        //   outside/                  (target of the symlink)
+        //   classify <skill_dir>/link/secret must NOT be InSkillDir;
+        //   canonical classify resolves through `link` and lands at
+        //   `outside/secret`, which is outside the zone => OutOfScope.
+        let workspace = tempfile::tempdir().expect("workspace");
+        let skill_dir = tempfile::tempdir().expect("skill_dir");
+        let outside = tempfile::tempdir().expect("outside");
+        let link = skill_dir.path().join("link");
+        std::os::unix::fs::symlink(outside.path(), &link).expect("create symlink");
+
+        // Use the *canonical* skill_dir on both sides so the lexical
+        // prefix actually matches before canonicalisation. On macOS the
+        // tmpdir lives under `/var/folders/...` which canonicalises to
+        // `/private/var/folders/...`; if the skill_dir we configure
+        // doesn't share the candidate's lexical prefix, the lexical
+        // classify already returns OutOfScope and we can't pin the
+        // regression scenario.
+        let canonical_skill = std::fs::canonicalize(skill_dir.path()).expect("canon skill");
+        let workspace_canon = std::fs::canonicalize(workspace.path()).expect("canon workspace");
+        let canonical_link = canonical_skill.join("link");
+        let candidate = canonical_link.join("secret");
+
+        let scope = SessionScope::solo(workspace_canon, vec![])
+            .expect("build solo scope")
+            .with_skill_read_zones(vec![canonical_skill.clone()])
+            .expect("attach skill_read_zone");
+
+        // Lexical classify accepts because the lexical path is
+        // `<skill_dir>/link/secret` and `link` is a Normal component
+        // before the canonical walk happens. Pin that this is the
+        // exact regression scenario.
+        assert!(
+            matches!(
+                scope.classify_lexical_path(&candidate),
+                PathClassification::InSkillDir { .. }
+            ),
+            "lexical classify wrongly accepts symlink escape — the bug we're fixing",
+        );
+        // Canonical classify must refuse.
+        assert_eq!(
+            scope.classify_canonical_path(&candidate),
+            PathClassification::OutOfScope,
+            "canonical classify must refuse <skill_dir>/symlink/<file> when the symlink escapes",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_canonical_path_accepts_real_skill_dir_files() {
+        // Positive baseline: when no symlinks are involved, canonical
+        // classify must still accept files under a skill_dir.
+        let workspace = tempfile::tempdir().expect("workspace");
+        let skill_dir = tempfile::tempdir().expect("skill_dir");
+        let manifest = skill_dir.path().join("SKILL.md");
+        std::fs::write(&manifest, b"# fixture").unwrap();
+        let canonical_skill = std::fs::canonicalize(skill_dir.path()).expect("canon skill");
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .expect("build solo scope")
+            .with_skill_read_zones(vec![canonical_skill.clone()])
+            .expect("attach skill_read_zone");
+        match scope.classify_canonical_path(&manifest) {
+            PathClassification::InSkillDir { skill_dir: dir } => {
+                assert_eq!(dir, canonical_skill, "report the configured skill_dir form");
+            }
+            other => panic!("expected InSkillDir for real skill_dir file, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Problem

`SKILL.md` is auto-injected into the system prompt for every `spawn_only` plugin in `octos-agent/src/plugins/extras.rs:66-73`, but the `SessionScope` contract added in #270-#276 limits `read_file` to the per-session workspace.

The agent therefore cannot follow SKILL.md references (e.g. "read the example config under `<skill_dir>/data/...`") even though those files ship as part of the plugin install — every reference fails with `Path outside session scope`.

## Design (additive, no existing behaviour changes)

- `SessionScope` grows a `skill_read_zones: Vec<PathBuf>` field with a read-only `with_skill_read_zones()` builder. Each entry must be absolute; canonicalisation is the caller's responsibility (mirrors how `InSharedZone` containment is handled today).
- New `PathClassification::InSkillDir { skill_dir }` variant. The classifier consults `skill_read_zones` **after** workspace and granted_dirs (so higher-trust zones still win when paths overlap) and **before** shared_zones (so plugin material doesn't inherit cross-session-zone semantics by accident).
- `tools/mod.rs::resolve_for_scope` handles `InSkillDir`: reads pass through, writes refuse with *"Writes to plugin skill directories are not permitted"*. Same canonicalize-both-sides treatment as `InSharedZone` to guard against symlinked plugin install roots.
- `plugins/tool.rs::accept_for_intent` mirrors the read/write split for the validator runner so plugin-tool path checks stay consistent with the file-tool path checks.
- `cli/src/runtime/session.rs` and `cli/src/commands/chat.rs` thread the canonicalized `plugin_dirs` from `ProfileRuntime` into the `SessionScope` constructor at bootstrap. Canonicalize-failures fall back to the raw path (the dir may not exist on first boot); a `with_skill_read_zones` rejection (e.g. relative path) logs and rebuilds the scope without skill zones — never crashes.
- `SESSION_SCOPE_SCHEMA_VERSION` bumped to 2 with version history comment on the constant.

## Not in this PR (each its own follow-up)

- **PR-B**: wire `glob` / `list_dir` / `grep` to read `skill_read_zones` too.
- **PR-C**: manifest `discovery` field so plugins declare exactly which sub-paths inside their `skill_dir` are exposed.
- **PR-D**: per-skill SKILL.md cleanup (today's content references paths the agent could not reach).
- **PR-E**: remove the unconditional SKILL.md auto-inject in `extras.rs:66-73`.

## Tests added

`session_scope.rs` (11 new):
- `read_file_from_allowlisted_skill_dir_classifies_in_skill_dir`
- `write_file_to_skill_dir_classifies_in_skill_dir_but_resolve_for_write_refuses` *(see `tools/mod.rs`)*
- `traversal_attempt_in_skill_dir_classifies_out_of_scope`
- `multiple_skill_dirs_all_classify_in_skill_dir`
- `workspace_path_still_wins_over_skill_dir`
- `solo_with_skill_read_zones_classifies_in_skill_dir`
- `solo_granted_dir_outranks_skill_read_zone`
- `skill_read_zone_outranks_shared_zone`
- `empty_skill_read_zones_preserves_v1_classification`
- `with_skill_read_zones_refuses_relative_paths`
- `schema_version_bumped_to_v2_for_skill_read_zones`

`tools/mod.rs::path_tests` (4 new):
- `read_file_from_skill_dir_resolves_under_skill_read_zone`
- `write_file_to_skill_dir_classifies_in_skill_dir_but_resolve_for_write_refuses`
- `write_to_workspace_still_works_when_skill_read_zones_configured`
- `read_outside_skill_dir_and_workspace_still_refused`

## Verification

- `cargo build --workspace` — clean
- `cargo test -p octos-core session_scope` — 29 passed (including 11 new PR-A tests)
- `cargo test -p octos-agent` — all passed
- `cargo test --workspace` — all passed (1708 in core lib alone), 0 failed
- `cargo clippy --workspace --no-deps -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Test plan

- [ ] CI green
- [ ] Manual: bootstrap a profile with at least one `spawn_only` plugin (e.g. `mofa-podcast`), confirm `read_file` against `<plugin_dir>/SKILL.md` succeeds in chat
- [ ] Manual: confirm `write_file` against `<plugin_dir>/anything` is refused with the read-only message
- [ ] Manual: confirm pre-existing reads/writes inside the workspace continue to work