### PR TITLE
feat(scope): thread SessionScope into glob/list_dir/grep (PR-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "futures",
  "gix",
  "glob",
+ "globset",
  "hound",
  "htmd",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ lru = "0.16"
 
 # File search
 glob = "0.3"
+globset = "0.4"
 regex = "1"
 ignore = "0.4"
 

--- a/crates/octos-agent/Cargo.toml
+++ b/crates/octos-agent/Cargo.toml
@@ -25,6 +25,7 @@ eyre = { workspace = true }
 tracing = { workspace = true }
 metrics = { workspace = true }
 glob = { workspace = true }
+globset = { workspace = true }
 which = { workspace = true }
 regex = { workspace = true }
 ignore = { workspace = true }

--- a/crates/octos-agent/src/tools/glob_tool.rs
+++ b/crates/octos-agent/src/tools/glob_tool.rs
@@ -1,12 +1,14 @@
 //! Glob tool for finding files by pattern.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
+use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 
-use super::{Tool, ToolResult};
+use super::{Tool, ToolContext, ToolResult};
 use crate::policy::FilesystemScope;
 
 /// Tool for finding files matching a glob pattern.
@@ -78,16 +80,36 @@ impl Tool for GlobTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // PR-B: legacy entry point routes through the typed path with a
+        // zero-value context so out-of-band callers still get the same
+        // SessionScope-aware behaviour when no scope is wired.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: GlobInput =
             serde_json::from_value(args.clone()).wrap_err("invalid glob tool input")?;
 
-        let base_dir = self.base_dir.clone();
         let pattern = input.pattern.clone();
         let limit = input.limit;
         let filesystem_scope = self.filesystem_scope;
 
-        // Reject absolute patterns and parent traversal
-        if !filesystem_scope.is_host() && (pattern.starts_with('/') || pattern.contains("..")) {
+        // PR-B: when a `SessionScope` is present, the host trusts the
+        // scope to be the single source of truth for path containment.
+        // Absolute patterns inside any allowed zone (workspace,
+        // granted_dirs, shared_zones, skill_read_zones) are accepted;
+        // results are canonicalised and dropped if they classify
+        // `OutOfScope`. Without a scope we keep the legacy
+        // base_dir + FilesystemScope policy (back-compat for `octos
+        // chat`).
+        if ctx.session_scope.is_none()
+            && !filesystem_scope.is_host()
+            && (pattern.starts_with('/') || pattern.contains(".."))
+        {
             return Ok(ToolResult {
                 output: "Absolute paths and '..' are not allowed in glob patterns".to_string(),
                 success: false,
@@ -95,41 +117,13 @@ impl Tool for GlobTool {
             });
         }
 
-        // Run glob in blocking task
+        let scope = ctx.session_scope.clone();
+        let base_dir = self.base_dir.clone();
+        let pattern_clone = pattern.clone();
+
+        // Run glob in blocking task.
         let result = tokio::task::spawn_blocking(move || {
-            let full_pattern =
-                if filesystem_scope.is_host() && PathBuf::from(&pattern).is_absolute() {
-                    pattern.clone()
-                } else {
-                    format!("{}/{}", base_dir.display(), pattern)
-                };
-
-            let mut files: Vec<String> = Vec::new();
-
-            match glob::glob(&full_pattern) {
-                Ok(paths) => {
-                    for entry in paths.take(limit) {
-                        match entry {
-                            Ok(path) => {
-                                // Make path relative to base_dir if possible
-                                let display_path = path
-                                    .strip_prefix(&base_dir)
-                                    .map(|p| p.to_path_buf())
-                                    .unwrap_or(path);
-                                files.push(display_path.display().to_string());
-                            }
-                            Err(e) => {
-                                tracing::warn!(error = %e, "glob entry error");
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    return Err(eyre::eyre!("invalid glob pattern: {}", e));
-                }
-            }
-
-            Ok::<_, eyre::Report>(files)
+            run_glob(scope, base_dir, filesystem_scope, pattern_clone, limit)
         })
         .await??;
 
@@ -149,6 +143,87 @@ impl Tool for GlobTool {
             })
         }
     }
+}
+
+/// Run the glob and filter results, blocking-thread side.
+fn run_glob(
+    scope: Option<Arc<SessionScope>>,
+    base_dir: PathBuf,
+    filesystem_scope: FilesystemScope,
+    pattern: String,
+    limit: usize,
+) -> Result<Vec<String>> {
+    // Anchor pattern: when scope is present, relative patterns resolve
+    // against `scope.workspace()`; absolute patterns are taken
+    // verbatim. Without scope, fall through to the legacy
+    // base_dir-anchored behaviour (host-scope passes absolute through).
+    let pattern_path = PathBuf::from(&pattern);
+    let full_pattern = match scope.as_ref() {
+        Some(scope) => {
+            if pattern_path.is_absolute() {
+                pattern.clone()
+            } else {
+                format!("{}/{}", scope.workspace().display(), pattern)
+            }
+        }
+        None => {
+            if filesystem_scope.is_host() && pattern_path.is_absolute() {
+                pattern.clone()
+            } else {
+                format!("{}/{}", base_dir.display(), pattern)
+            }
+        }
+    };
+
+    let mut files: Vec<String> = Vec::new();
+
+    let entries = match glob::glob(&full_pattern) {
+        Ok(p) => p,
+        Err(e) => return Err(eyre::eyre!("invalid glob pattern: {}", e)),
+    };
+
+    for entry in entries {
+        if files.len() >= limit {
+            break;
+        }
+        let path = match entry {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(error = %e, "glob entry error");
+                continue;
+            }
+        };
+
+        // PR-B: when a scope is present, drop any match whose
+        // canonicalised path falls outside every declared zone. This
+        // also closes the ancestor-symlink hole: a symlink inside the
+        // workspace pointing at `/etc` would have surfaced
+        // `<workspace>/link/passwd` as `InWorkspace` under the lexical
+        // classifier, but canonicalize-then-classify rejects it.
+        if let Some(scope) = scope.as_ref() {
+            if matches!(
+                scope.classify_canonical_path(&path),
+                PathClassification::OutOfScope
+            ) {
+                continue;
+            }
+        }
+
+        // Display path: prefer relative to the configured anchor.
+        // With scope: relative to `scope.workspace()`. Otherwise:
+        // relative to base_dir (the legacy display).
+        let display_anchor = scope
+            .as_ref()
+            .map(|s| s.workspace().to_path_buf())
+            .unwrap_or_else(|| base_dir.clone());
+        let display_path = path
+            .strip_prefix(&display_anchor)
+            .map(|p| p.to_path_buf())
+            .unwrap_or(path);
+        files.push(display_path.display().to_string());
+    }
+
+    Ok(files)
 }
 
 #[cfg(test)]
@@ -252,5 +327,127 @@ mod tests {
         let tool = GlobTool::new("/tmp");
         assert_eq!(tool.name(), "glob");
         assert!(tool.tags().contains(&"search"));
+    }
+
+    // ------------------------------------------------------------------
+    // PR-B: SessionScope integration tests for GlobTool.
+    // ------------------------------------------------------------------
+
+    fn ctx_with_scope(scope: SessionScope) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "glob-with-scope".to_string();
+        ctx.session_scope = Some(Arc::new(scope));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn glob_into_skill_dir_returns_matches() {
+        // Absolute pattern inside a registered skill_dir is accepted
+        // when a SessionScope with `skill_read_zones` is wired.
+        let workspace = tempfile::tempdir().unwrap();
+        let skill = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(skill.path().join("styles")).unwrap();
+        std::fs::write(skill.path().join("styles/light.toml"), "k=1").unwrap();
+        std::fs::write(skill.path().join("styles/dark.toml"), "k=2").unwrap();
+        std::fs::write(skill.path().join("styles/note.md"), "x").unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let tool = GlobTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        // Absolute glob inside the registered skill_dir.
+        let pattern = format!("{}/styles/*.toml", skill.path().display());
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"pattern": pattern}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(
+            result.output.contains("2 file(s)"),
+            "expected two matches, got: {}",
+            result.output
+        );
+        assert!(result.output.contains("light.toml"));
+        assert!(result.output.contains("dark.toml"));
+        assert!(!result.output.contains("note.md"));
+    }
+
+    #[tokio::test]
+    async fn glob_traversal_pattern_drops_matches_outside_zones() {
+        // The legacy `..`-rejection still applies — the rejection
+        // wins lexically before the glob even runs.
+        let workspace = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("passwd"), "root:x:0:0").unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+        let tool = GlobTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        // An absolute glob to a non-zone path: pattern is accepted at
+        // input time (we trust the scope), but every match is
+        // canonicalised and dropped as `OutOfScope`.
+        let pattern = format!("{}/*", outside.path().display());
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"pattern": pattern}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(
+            result.output.contains("No files found"),
+            "expected zero matches (all classify OutOfScope), got: {}",
+            result.output
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn glob_drops_symlink_target_outside_scope() {
+        // A symlink inside the workspace pointing at /etc would
+        // otherwise let `<workspace>/link/passwd` masquerade as
+        // workspace-resident. The canonical filter drops it.
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("passwd"), "root:x").unwrap();
+        symlink(outside.path(), workspace.path().join("escape")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+        let tool = GlobTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"pattern": "escape/*"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(
+            !result.output.contains("passwd"),
+            "match traversing a symlink that leaves the workspace must be dropped, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn glob_falls_back_to_legacy_when_no_scope() {
+        // No scope wired => pre-PR-B base_dir-anchored behaviour.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("legacy.rs"), "").unwrap();
+
+        let tool = GlobTool::new(dir.path());
+        let ctx = ToolContext::zero();
+        assert!(ctx.session_scope.is_none());
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"pattern": "*.rs"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("legacy.rs"));
     }
 }

--- a/crates/octos-agent/src/tools/glob_tool.rs
+++ b/crates/octos-agent/src/tools/glob_tool.rs
@@ -1,10 +1,11 @@
 //! Glob tool for finding files by pattern.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
+use globset::{Glob, GlobSetBuilder};
+use ignore::WalkBuilder;
 use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
 
@@ -98,18 +99,26 @@ impl Tool for GlobTool {
         let limit = input.limit;
         let filesystem_scope = self.filesystem_scope;
 
-        // PR-B: when a `SessionScope` is present, the host trusts the
-        // scope to be the single source of truth for path containment.
-        // Absolute patterns inside any allowed zone (workspace,
-        // granted_dirs, shared_zones, skill_read_zones) are accepted;
-        // results are canonicalised and dropped if they classify
-        // `OutOfScope`. Without a scope we keep the legacy
-        // base_dir + FilesystemScope policy (back-compat for `octos
-        // chat`).
-        if ctx.session_scope.is_none()
-            && !filesystem_scope.is_host()
-            && (pattern.starts_with('/') || pattern.contains(".."))
-        {
+        // Reject `..` and absolute paths uniformly in scoped mode too.
+        //
+        // Round-2 codex follow-up: the scoped branch previously relaxed
+        // `..` rejection on the theory that canonicalize+classify would
+        // catch any escape at output time. That's true for the output,
+        // but the underlying `glob::glob` walker can still TRAVERSE
+        // out-of-scope directories during recursion (it follows
+        // symlinks). The structural fix is to replace `glob::glob` with
+        // a scoped `ignore::WalkBuilder` walker (see `run_glob_scoped`
+        // below); the `..` rejection here is now defense-in-depth and
+        // gives the LLM a clear error message rather than silently
+        // returning zero matches.
+        if !filesystem_scope.is_host() && pattern.contains("..") {
+            return Ok(ToolResult {
+                output: "Absolute paths and '..' are not allowed in glob patterns".to_string(),
+                success: false,
+                ..Default::default()
+            });
+        }
+        if ctx.session_scope.is_none() && !filesystem_scope.is_host() && pattern.starts_with('/') {
             return Ok(ToolResult {
                 output: "Absolute paths and '..' are not allowed in glob patterns".to_string(),
                 success: false,
@@ -121,9 +130,11 @@ impl Tool for GlobTool {
         let base_dir = self.base_dir.clone();
         let pattern_clone = pattern.clone();
 
-        // Run glob in blocking task.
-        let result = tokio::task::spawn_blocking(move || {
-            run_glob(scope, base_dir, filesystem_scope, pattern_clone, limit)
+        // Run glob in blocking task. Scoped vs legacy branches diverge
+        // entirely so each implementation is self-contained.
+        let result = tokio::task::spawn_blocking(move || match scope {
+            Some(scope) => run_glob_scoped(&scope, pattern_clone, limit),
+            None => run_glob_legacy(base_dir, filesystem_scope, pattern_clone, limit),
         })
         .await??;
 
@@ -145,34 +156,224 @@ impl Tool for GlobTool {
     }
 }
 
-/// Run the glob and filter results, blocking-thread side.
-fn run_glob(
-    scope: Option<Arc<SessionScope>>,
+/// Split a glob pattern into the longest non-glob prefix and the
+/// remaining pattern. The prefix is the leading portion that contains
+/// no glob metacharacters (`*`, `?`, `[`); we walk back to the last `/`
+/// before the first metachar so the prefix names a real directory we
+/// can root a `WalkBuilder` at.
+///
+/// Returns `(prefix, remainder)` where `prefix` may be empty (no `/`
+/// before the first metachar) and `remainder` is the rest of the
+/// pattern after the prefix (which may itself contain literal path
+/// components followed by metacharacters).
+///
+/// Examples:
+/// - `"**/*.rs"`                   -> (`""`, `"**/*.rs"`)
+/// - `"src/**/*.rs"`               -> (`"src"`, `"**/*.rs"`)
+/// - `"src/lib.rs"`                -> (`"src/lib.rs"`, `""`)
+/// - `"/abs/path/styles/*.toml"`   -> (`"/abs/path/styles"`, `"*.toml"`)
+fn split_glob_prefix(pattern: &str) -> (String, String) {
+    let bytes = pattern.as_bytes();
+    let mut first_meta: Option<usize> = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        if matches!(b, b'*' | b'?' | b'[') {
+            first_meta = Some(i);
+            break;
+        }
+    }
+    match first_meta {
+        None => (pattern.to_string(), String::new()),
+        Some(idx) => {
+            // Walk back to the last `/` before idx; the prefix ends at
+            // that separator (exclusive of the leading content up to
+            // and including the slash).
+            let prefix_end = pattern[..idx].rfind('/').map(|p| p + 1).unwrap_or(0);
+            let prefix = pattern[..prefix_end].trim_end_matches('/').to_string();
+            let remainder = pattern[prefix_end..].to_string();
+            (prefix, remainder)
+        }
+    }
+}
+
+/// Scoped walker for `SessionScope`-aware glob execution.
+///
+/// Design (codex round-2 BLOCKER fix):
+/// 1. Compute the longest non-glob prefix of the pattern.
+/// 2. Anchor the walker root: relative patterns root at
+///    `scope.workspace().join(prefix)`; absolute patterns use the
+///    prefix verbatim (with `/` as a degenerate root that classifies
+///    `OutOfScope`).
+/// 3. Canonicalize + classify the walker root. If it lands
+///    `OutOfScope`, refuse before walking.
+/// 4. Build a `globset::GlobSet` from the **remaining** pattern. The
+///    walker enumerates real on-disk entries; we match the entry's
+///    path-relative-to-root against the globset.
+/// 5. Walk via `ignore::WalkBuilder::follow_links(false)` so symlinks
+///    are NOT traversed during descent. The walker still surfaces the
+///    symlink ENTRY itself; canonicalize+classify drops it if the
+///    target escapes scope.
+fn run_glob_scoped(scope: &SessionScope, pattern: String, limit: usize) -> Result<Vec<String>> {
+    // Step 1 + 2: compute prefix and anchor walker root.
+    let pattern_path = PathBuf::from(&pattern);
+    let (prefix, remainder) = split_glob_prefix(&pattern);
+    let (root, glob_pattern): (PathBuf, String) = if pattern_path.is_absolute() {
+        // Absolute pattern. Prefix is the absolute prefix; remainder is
+        // matched relative to that prefix.
+        let prefix_path = if prefix.is_empty() {
+            // Degenerate case: pattern starts with `/*` etc. Use `/`
+            // as the walker root; classification will refuse it.
+            PathBuf::from("/")
+        } else {
+            PathBuf::from(&prefix)
+        };
+        (prefix_path, remainder)
+    } else {
+        // Relative pattern. Resolve `<workspace>/<prefix>` as the root;
+        // the remainder is the globset pattern matched against
+        // entry-relative-to-root.
+        let root = if prefix.is_empty() {
+            scope.workspace().to_path_buf()
+        } else {
+            scope.workspace().join(&prefix)
+        };
+        (root, remainder)
+    };
+
+    // Step 3: canonicalize + classify the walker root before descent.
+    // Refuses any pattern whose non-glob prefix already escapes scope —
+    // we never start a walk in out-of-scope territory.
+    if matches!(
+        scope.classify_canonical_path(&root),
+        PathClassification::OutOfScope
+    ) {
+        // Refusing here is semantically the same as "no matches" from
+        // the LLM's perspective; the canonical-classify guard would
+        // also drop every entry anyway. We choose the cheap exit.
+        return Ok(Vec::new());
+    }
+
+    // Step 4: compile globset from the remainder pattern. When
+    // `glob_pattern` is empty, the pattern was a pure literal path; we
+    // treat the root itself as a single match if it exists and is a
+    // file.
+    let glob_set = if glob_pattern.is_empty() {
+        None
+    } else {
+        let glob = Glob::new(&glob_pattern)
+            .wrap_err_with(|| format!("invalid glob pattern: {}", glob_pattern))?;
+        let mut builder = GlobSetBuilder::new();
+        builder.add(glob);
+        Some(builder.build().wrap_err("globset build failed")?)
+    };
+
+    let mut files: Vec<String> = Vec::new();
+
+    // Literal-only pattern fast path: no walking needed.
+    if glob_set.is_none() {
+        if root.is_file()
+            && !matches!(
+                scope.classify_canonical_path(&root),
+                PathClassification::OutOfScope
+            )
+        {
+            let display = root
+                .strip_prefix(scope.workspace())
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|_| root.clone());
+            files.push(display.display().to_string());
+        }
+        return Ok(files);
+    }
+    let glob_set = glob_set.expect("checked above");
+
+    // Step 5: walk with follow_links(false) so symlinks aren't traversed.
+    let walker = WalkBuilder::new(&root)
+        .follow_links(false)
+        .hidden(false)
+        .git_ignore(false)
+        .build();
+
+    for entry in walker {
+        if files.len() >= limit {
+            break;
+        }
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(error = %e, "glob walker entry error");
+                continue;
+            }
+        };
+        let path = entry.path();
+
+        // Skip the walker root itself (matches the prior `glob::glob`
+        // behaviour, which never returned the literal anchor as a
+        // result).
+        if path == root {
+            continue;
+        }
+
+        // Skip directories — glob matches files only.
+        if path.is_dir() {
+            continue;
+        }
+
+        // Per-entry canonicalize+classify. Closes the symlink-leaf
+        // hole: a symlink under `root` pointing at `/etc/passwd` would
+        // surface as `<root>/escape`; canonicalize resolves to
+        // `/etc/passwd`, which classifies `OutOfScope`. The PRIMARY
+        // containment guarantee comes from `follow_links(false)`
+        // pruning subtree descent; this is the defence-in-depth check
+        // for individual entries.
+        if matches!(
+            scope.classify_canonical_path(path),
+            PathClassification::OutOfScope
+        ) {
+            continue;
+        }
+
+        // Match the entry against the globset using the
+        // entry-relative-to-root path. Both `**/*.rs` and `*.rs`
+        // patterns should match files at any depth (when `**` is
+        // present) or only at the root depth (otherwise).
+        let rel = match path.strip_prefix(&root) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        if !glob_set.is_match(rel) {
+            continue;
+        }
+
+        // Display path: relative to `scope.workspace()` when possible.
+        let display_path = path
+            .strip_prefix(scope.workspace())
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|_| path.to_path_buf());
+        files.push(display_path.display().to_string());
+    }
+
+    Ok(files)
+}
+
+/// Legacy `base_dir + FilesystemScope` glob execution (pre-PR-B).
+///
+/// Kept unchanged for callers without a `SessionScope`: `octos chat`
+/// uses this path. The `glob::glob` recursion model is acceptable here
+/// because the only containment guarantee these callers ever had was
+/// the lexical `..` / absolute rejection at the input boundary plus
+/// the `base_dir` anchor — that's still in force.
+fn run_glob_legacy(
     base_dir: PathBuf,
     filesystem_scope: FilesystemScope,
     pattern: String,
     limit: usize,
 ) -> Result<Vec<String>> {
-    // Anchor pattern: when scope is present, relative patterns resolve
-    // against `scope.workspace()`; absolute patterns are taken
-    // verbatim. Without scope, fall through to the legacy
-    // base_dir-anchored behaviour (host-scope passes absolute through).
     let pattern_path = PathBuf::from(&pattern);
-    let full_pattern = match scope.as_ref() {
-        Some(scope) => {
-            if pattern_path.is_absolute() {
-                pattern.clone()
-            } else {
-                format!("{}/{}", scope.workspace().display(), pattern)
-            }
-        }
-        None => {
-            if filesystem_scope.is_host() && pattern_path.is_absolute() {
-                pattern.clone()
-            } else {
-                format!("{}/{}", base_dir.display(), pattern)
-            }
-        }
+    let full_pattern = if filesystem_scope.is_host() && pattern_path.is_absolute() {
+        pattern.clone()
+    } else {
+        format!("{}/{}", base_dir.display(), pattern)
     };
 
     let mut files: Vec<String> = Vec::new();
@@ -194,30 +395,8 @@ fn run_glob(
             }
         };
 
-        // PR-B: when a scope is present, drop any match whose
-        // canonicalised path falls outside every declared zone. This
-        // also closes the ancestor-symlink hole: a symlink inside the
-        // workspace pointing at `/etc` would have surfaced
-        // `<workspace>/link/passwd` as `InWorkspace` under the lexical
-        // classifier, but canonicalize-then-classify rejects it.
-        if let Some(scope) = scope.as_ref() {
-            if matches!(
-                scope.classify_canonical_path(&path),
-                PathClassification::OutOfScope
-            ) {
-                continue;
-            }
-        }
-
-        // Display path: prefer relative to the configured anchor.
-        // With scope: relative to `scope.workspace()`. Otherwise:
-        // relative to base_dir (the legacy display).
-        let display_anchor = scope
-            .as_ref()
-            .map(|s| s.workspace().to_path_buf())
-            .unwrap_or_else(|| base_dir.clone());
         let display_path = path
-            .strip_prefix(&display_anchor)
+            .strip_prefix(&base_dir)
             .map(|p| p.to_path_buf())
             .unwrap_or(path);
         files.push(display_path.display().to_string());
@@ -229,6 +408,7 @@ fn run_glob(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_glob_finds_files() {
@@ -330,7 +510,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // PR-B: SessionScope integration tests for GlobTool.
+    // PR-B (round-1): SessionScope integration tests for GlobTool.
     // ------------------------------------------------------------------
 
     fn ctx_with_scope(scope: SessionScope) -> ToolContext {
@@ -378,8 +558,13 @@ mod tests {
 
     #[tokio::test]
     async fn glob_traversal_pattern_drops_matches_outside_zones() {
-        // The legacy `..`-rejection still applies — the rejection
-        // wins lexically before the glob even runs.
+        // Two cases the scoped walker must refuse:
+        // (a) an absolute glob to a non-zone path — the walker root
+        //     classifies OutOfScope, so we return zero matches without
+        //     walking.
+        // (b) a relative `..`-traversal pattern — the `..` rejection
+        //     fires at input time. Codex round-2 MINOR: the prior test
+        //     only covered (a); this version covers both.
         let workspace = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         std::fs::write(outside.path().join("passwd"), "root:x:0:0").unwrap();
@@ -388,19 +573,35 @@ mod tests {
         let tool = GlobTool::new(workspace.path());
         let ctx = ctx_with_scope(scope);
 
-        // An absolute glob to a non-zone path: pattern is accepted at
-        // input time (we trust the scope), but every match is
-        // canonicalised and dropped as `OutOfScope`.
-        let pattern = format!("{}/*", outside.path().display());
-        let result = tool
-            .execute_with_context(&ctx, &serde_json::json!({"pattern": pattern}))
+        // (a) Absolute pattern outside every zone.
+        let pattern_a = format!("{}/*", outside.path().display());
+        let result_a = tool
+            .execute_with_context(&ctx, &serde_json::json!({"pattern": pattern_a}))
             .await
             .unwrap();
-        assert!(result.success);
+        assert!(result_a.success);
         assert!(
-            result.output.contains("No files found"),
-            "expected zero matches (all classify OutOfScope), got: {}",
-            result.output
+            result_a.output.contains("No files found"),
+            "expected zero matches (root OutOfScope), got: {}",
+            result_a.output
+        );
+
+        // (b) Relative `..` traversal pattern. Per codex round-2 the
+        // scoped branch MUST refuse this — defence-in-depth alongside
+        // the scoped walker, so the LLM gets a clear error rather than
+        // silently no matches.
+        let result_b = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"pattern": "**/../../../etc/passwd"}),
+            )
+            .await
+            .unwrap();
+        assert!(!result_b.success);
+        assert!(
+            result_b.output.contains("not allowed"),
+            "expected `..` rejection, got: {}",
+            result_b.output
         );
     }
 
@@ -409,7 +610,10 @@ mod tests {
     async fn glob_drops_symlink_target_outside_scope() {
         // A symlink inside the workspace pointing at /etc would
         // otherwise let `<workspace>/link/passwd` masquerade as
-        // workspace-resident. The canonical filter drops it.
+        // workspace-resident. The scoped walker uses follow_links(false)
+        // so the walker NEVER traverses into the symlink target; the
+        // per-entry canonical-classify filter is the defence-in-depth
+        // safety net.
         use std::os::unix::fs::symlink;
 
         let workspace = tempfile::tempdir().unwrap();
@@ -449,5 +653,99 @@ mod tests {
             .unwrap();
         assert!(result.success);
         assert!(result.output.contains("legacy.rs"));
+    }
+
+    // ------------------------------------------------------------------
+    // PR-B (round-2): scoped walker no-traversal proof.
+    // ------------------------------------------------------------------
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn scoped_walker_does_not_descend_into_out_of_scope_symlink() {
+        // BLOCKER fix: the prior `glob::glob` walker could traverse
+        // INTO a symlink target during recursion (it follows symlinks
+        // by default). With `WalkBuilder::follow_links(false)` the
+        // walker MUST NOT visit any entry inside the symlink's target.
+        //
+        // Construction: <workspace>/escape -> /tmp/<sensitive_dir>/
+        // with `sensitive_dir/secret.txt` inside. A `**/*` glob rooted
+        // at the workspace must NOT surface `secret.txt`.
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let sensitive = tempfile::tempdir().unwrap();
+        // Write a uniquely-named sentinel inside the symlink target so
+        // we can assert by name (not just by extension) below.
+        std::fs::write(sensitive.path().join("escape_target_sentinel.txt"), "leak").unwrap();
+        std::fs::write(sensitive.path().join("escape_target_sentinel.toml"), "k=v").unwrap();
+        // Also stuff in some innocuous workspace content so the match
+        // count proves the walker did run.
+        std::fs::write(workspace.path().join("legit.txt"), "ok").unwrap();
+        symlink(sensitive.path(), workspace.path().join("escape")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![]).unwrap();
+        let tool = GlobTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"pattern": "**/*"}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        // The walker is allowed to surface the workspace-resident
+        // file. It must NOT surface anything from the symlink target.
+        assert!(
+            result.output.contains("legit.txt"),
+            "walker must visit workspace entries, got: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("escape_target_sentinel"),
+            "walker must NOT descend into the symlink target (entries from \
+             /tmp/sensitive_dir present in output), got: {}",
+            result.output
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // PR-B (round-2): split_glob_prefix unit tests.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn split_glob_prefix_no_metachars_is_pure_literal() {
+        let (prefix, remainder) = split_glob_prefix("src/lib.rs");
+        assert_eq!(prefix, "src/lib.rs");
+        assert_eq!(remainder, "");
+    }
+
+    #[test]
+    fn split_glob_prefix_leading_metachar_has_empty_prefix() {
+        let (prefix, remainder) = split_glob_prefix("**/*.rs");
+        assert_eq!(prefix, "");
+        assert_eq!(remainder, "**/*.rs");
+    }
+
+    #[test]
+    fn split_glob_prefix_literal_dir_then_metachar() {
+        let (prefix, remainder) = split_glob_prefix("src/**/*.rs");
+        assert_eq!(prefix, "src");
+        assert_eq!(remainder, "**/*.rs");
+    }
+
+    #[test]
+    fn split_glob_prefix_absolute_path() {
+        let (prefix, remainder) = split_glob_prefix("/abs/path/styles/*.toml");
+        assert_eq!(prefix, "/abs/path/styles");
+        assert_eq!(remainder, "*.toml");
+    }
+
+    #[test]
+    fn split_glob_prefix_metachar_mid_component() {
+        // Pattern: `src/lib*.rs` — the first metachar is mid-component;
+        // the non-glob prefix should walk back to the prior `/`, i.e.
+        // `src`, with the rest as the globset pattern.
+        let (prefix, remainder) = split_glob_prefix("src/lib*.rs");
+        assert_eq!(prefix, "src");
+        assert_eq!(remainder, "lib*.rs");
     }
 }

--- a/crates/octos-agent/src/tools/glob_tool.rs
+++ b/crates/octos-agent/src/tools/glob_tool.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
-use globset::{Glob, GlobSetBuilder};
+use globset::{GlobBuilder, GlobSetBuilder};
 use ignore::WalkBuilder;
 use octos_core::{PathClassification, SessionScope};
 use serde::Deserialize;
@@ -259,7 +259,9 @@ fn run_glob_scoped(scope: &SessionScope, pattern: String, limit: usize) -> Resul
     let glob_set = if glob_pattern.is_empty() {
         None
     } else {
-        let glob = Glob::new(&glob_pattern)
+        let glob = GlobBuilder::new(&glob_pattern)
+            .literal_separator(true)
+            .build()
             .wrap_err_with(|| format!("invalid glob pattern: {}", glob_pattern))?;
         let mut builder = GlobSetBuilder::new();
         builder.add(glob);

--- a/crates/octos-agent/src/tools/grep_tool.rs
+++ b/crates/octos-agent/src/tools/grep_tool.rs
@@ -1,14 +1,16 @@
 //! Grep tool for searching file contents.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use eyre::{Result, WrapErr};
 use ignore::WalkBuilder;
+use octos_core::{PathClassification, SessionScope};
 use regex::RegexBuilder;
 use serde::Deserialize;
 
-use super::{Tool, ToolResult};
+use super::{Tool, ToolContext, ToolResult};
 
 /// Tool for searching file contents with regex.
 pub struct GrepTool {
@@ -29,6 +31,11 @@ impl GrepTool {
 struct GrepInput {
     /// Regex pattern to search for.
     pattern: String,
+    /// Optional path under which to search. When omitted the tool
+    /// searches the base directory (legacy) or the scope workspace
+    /// (when a SessionScope is wired through `ToolContext`).
+    #[serde(default)]
+    path: Option<String>,
     /// Optional glob pattern to filter files.
     #[serde(default)]
     file_pattern: Option<String>,
@@ -54,7 +61,7 @@ impl Tool for GrepTool {
     }
 
     fn description(&self) -> &str {
-        "Search file contents using regex. Respects .gitignore. Use file_pattern to filter which files to search (e.g., '*.rs')."
+        "Search file contents using regex. Respects .gitignore. Use file_pattern to filter which files to search (e.g., '*.rs'). Use path to scope the search to a specific directory."
     }
 
     fn tags(&self) -> &[&str] {
@@ -68,6 +75,10 @@ impl Tool for GrepTool {
                 "pattern": {
                     "type": "string",
                     "description": "Regex pattern to search for"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional directory to search under (defaults to the working directory)"
                 },
                 "file_pattern": {
                     "type": "string",
@@ -91,18 +102,22 @@ impl Tool for GrepTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // PR-B: legacy entry point routes through the typed path with a
+        // zero-value context so out-of-band callers still get the same
+        // SessionScope-aware behaviour when no scope is wired.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: GrepInput =
             serde_json::from_value(args.clone()).wrap_err("invalid grep tool input")?;
 
-        let base_dir = self.base_dir.clone();
-        let pattern_str = input.pattern.clone();
-        let file_pattern = input.file_pattern.clone();
-        let limit = input.limit;
-        let context = input.context;
-        let ignore_case = input.ignore_case;
-
-        // Reject file_pattern with absolute paths or traversal
-        if let Some(ref fp) = file_pattern {
+        // Reject file_pattern with absolute paths or traversal.
+        if let Some(ref fp) = input.file_pattern {
             if fp.starts_with('/') || fp.contains("..") {
                 return Ok(ToolResult {
                     output: "Absolute paths and '..' are not allowed in file patterns".to_string(),
@@ -112,101 +127,61 @@ impl Tool for GrepTool {
             }
         }
 
-        // Run search in blocking task
+        // Resolve the search root.
+        //
+        // PR-B: when a `SessionScope` is wired, an explicit `path`
+        // input is validated against the scope; without an explicit
+        // path the search anchors at `scope.workspace()`. When no
+        // scope is wired we anchor at `self.base_dir` and (if a
+        // `path` is given) join it relative — the legacy resolver
+        // refuses traversal.
+        let search_root = match ctx.session_scope.as_ref() {
+            Some(scope) => match input.path.as_deref() {
+                Some(p) => match super::resolve_path_for_session_scope_read(scope, p) {
+                    Ok(root) => root,
+                    Err(reason) => {
+                        return Ok(ToolResult {
+                            output: format!("{reason}: {p}"),
+                            success: false,
+                            ..Default::default()
+                        });
+                    }
+                },
+                None => scope.workspace().to_path_buf(),
+            },
+            None => match input.path.as_deref() {
+                Some(p) => match super::resolve_path(&self.base_dir, p) {
+                    Ok(root) => root,
+                    Err(_) => {
+                        return Ok(ToolResult {
+                            output: format!("Path outside working directory: {p}"),
+                            success: false,
+                            ..Default::default()
+                        });
+                    }
+                },
+                None => self.base_dir.clone(),
+            },
+        };
+
+        let scope = ctx.session_scope.clone();
+        let pattern_str = input.pattern.clone();
+        let file_pattern = input.file_pattern.clone();
+        let limit = input.limit;
+        let context = input.context;
+        let ignore_case = input.ignore_case;
+
+        // Run search in blocking task.
         let result = tokio::task::spawn_blocking(move || {
-            // Compile regex
-            let regex_pattern = if ignore_case {
-                format!("(?i){}", pattern_str)
-            } else {
-                pattern_str.clone()
-            };
-
-            let regex = RegexBuilder::new(&regex_pattern)
-                .size_limit(1 << 20) // 1 MB compiled regex limit (prevents ReDoS)
-                .build()
-                .wrap_err_with(|| format!("invalid regex: {}", pattern_str))?;
-
-            let mut matches: Vec<String> = Vec::new();
-            let mut match_count = 0;
-
-            // Use ignore crate to respect .gitignore
-            let walker = WalkBuilder::new(&base_dir)
-                .hidden(false)
-                .git_ignore(true)
-                .build();
-
-            for entry in walker {
-                if match_count >= limit {
-                    break;
-                }
-
-                let entry = match entry {
-                    Ok(e) => e,
-                    Err(_) => continue,
-                };
-
-                let path = entry.path();
-
-                // Skip directories
-                if path.is_dir() {
-                    continue;
-                }
-
-                // Apply file pattern filter
-                if let Some(ref fp) = file_pattern {
-                    let file_name = path.file_name().unwrap_or_default().to_string_lossy();
-                    let pattern = glob::Pattern::new(fp);
-                    if let Ok(p) = pattern {
-                        if !p.matches(&file_name) {
-                            continue;
-                        }
-                    }
-                }
-
-                // Read file
-                let content = match std::fs::read_to_string(path) {
-                    Ok(c) => c,
-                    Err(_) => continue, // Skip binary or unreadable files
-                };
-
-                let lines: Vec<&str> = content.lines().collect();
-
-                // Search lines
-                for (line_num, line) in lines.iter().enumerate() {
-                    if match_count >= limit {
-                        break;
-                    }
-
-                    if regex.is_match(line) {
-                        match_count += 1;
-
-                        let rel_path = path.strip_prefix(&base_dir).unwrap_or(path).display();
-
-                        if context > 0 {
-                            // Include context lines
-                            let start = line_num.saturating_sub(context);
-                            let end = (line_num + context + 1).min(lines.len());
-
-                            let mut ctx_output = format!("{}:\n", rel_path);
-                            for (i, ctx_line) in lines[start..end].iter().enumerate() {
-                                let actual_line = start + i;
-                                let marker = if actual_line == line_num { ">" } else { " " };
-                                ctx_output.push_str(&format!(
-                                    "{} {:4}│ {}\n",
-                                    marker,
-                                    actual_line + 1,
-                                    ctx_line
-                                ));
-                            }
-                            matches.push(ctx_output);
-                        } else {
-                            matches.push(format!("{}:{}: {}", rel_path, line_num + 1, line.trim()));
-                        }
-                    }
-                }
-            }
-
-            Ok::<_, eyre::Report>((matches, match_count))
+            run_grep(
+                scope,
+                search_root,
+                pattern_str,
+                file_pattern,
+                limit,
+                context,
+                ignore_case,
+            )
         })
         .await??;
 
@@ -237,6 +212,123 @@ impl Tool for GrepTool {
             })
         }
     }
+}
+
+fn run_grep(
+    scope: Option<Arc<SessionScope>>,
+    search_root: PathBuf,
+    pattern_str: String,
+    file_pattern: Option<String>,
+    limit: usize,
+    context: usize,
+    ignore_case: bool,
+) -> Result<(Vec<String>, usize)> {
+    // Compile regex.
+    let regex_pattern = if ignore_case {
+        format!("(?i){}", pattern_str)
+    } else {
+        pattern_str.clone()
+    };
+    let regex = RegexBuilder::new(&regex_pattern)
+        .size_limit(1 << 20) // 1 MB compiled regex limit (prevents ReDoS)
+        .build()
+        .wrap_err_with(|| format!("invalid regex: {}", pattern_str))?;
+
+    let mut matches: Vec<String> = Vec::new();
+    let mut match_count = 0;
+
+    // Use ignore crate to respect .gitignore.
+    let walker = WalkBuilder::new(&search_root)
+        .hidden(false)
+        .git_ignore(true)
+        .build();
+
+    for entry in walker {
+        if match_count >= limit {
+            break;
+        }
+
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        let path = entry.path();
+
+        // Skip directories.
+        if path.is_dir() {
+            continue;
+        }
+
+        // PR-B: if a SessionScope is wired, drop any file the walker
+        // surfaces whose canonical path classifies OutOfScope. This
+        // closes the symlink-loop escape: a symlink inside the
+        // skill_dir pointing at `/etc` would otherwise let the walker
+        // read passwd; canonicalize-then-classify rejects it.
+        if let Some(scope) = scope.as_ref() {
+            if matches!(
+                scope.classify_canonical_path(path),
+                PathClassification::OutOfScope
+            ) {
+                continue;
+            }
+        }
+
+        // Apply file pattern filter.
+        if let Some(ref fp) = file_pattern {
+            let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+            let pattern = glob::Pattern::new(fp);
+            if let Ok(p) = pattern {
+                if !p.matches(&file_name) {
+                    continue;
+                }
+            }
+        }
+
+        // Read file.
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue, // Skip binary or unreadable files
+        };
+
+        let lines: Vec<&str> = content.lines().collect();
+
+        // Search lines.
+        for (line_num, line) in lines.iter().enumerate() {
+            if match_count >= limit {
+                break;
+            }
+
+            if regex.is_match(line) {
+                match_count += 1;
+
+                let rel_path = path.strip_prefix(&search_root).unwrap_or(path).display();
+
+                if context > 0 {
+                    // Include context lines.
+                    let start = line_num.saturating_sub(context);
+                    let end = (line_num + context + 1).min(lines.len());
+
+                    let mut ctx_output = format!("{}:\n", rel_path);
+                    for (i, ctx_line) in lines[start..end].iter().enumerate() {
+                        let actual_line = start + i;
+                        let marker = if actual_line == line_num { ">" } else { " " };
+                        ctx_output.push_str(&format!(
+                            "{} {:4}│ {}\n",
+                            marker,
+                            actual_line + 1,
+                            ctx_line
+                        ));
+                    }
+                    matches.push(ctx_output);
+                } else {
+                    matches.push(format!("{}:{}: {}", rel_path, line_num + 1, line.trim()));
+                }
+            }
+        }
+    }
+
+    Ok((matches, match_count))
 }
 
 #[cfg(test)]
@@ -388,5 +480,160 @@ mod tests {
         let tool = GrepTool::new("/tmp");
         assert_eq!(tool.name(), "grep");
         assert!(tool.tags().contains(&"search"));
+    }
+
+    // ------------------------------------------------------------------
+    // PR-B: SessionScope integration tests for GrepTool.
+    // ------------------------------------------------------------------
+
+    fn ctx_with_scope(scope: SessionScope) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "grep-with-scope".to_string();
+        ctx.session_scope = Some(Arc::new(scope));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn grep_inside_skill_dir_finds_matches() {
+        // With a SessionScope wired and `path` pointing inside the
+        // registered skill_dir, the walker descends into the
+        // skill_dir and returns matches.
+        let workspace = tempfile::tempdir().unwrap();
+        let skill = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(skill.path().join("docs")).unwrap();
+        std::fs::write(
+            skill.path().join("docs/intro.md"),
+            "# SKILL DEMO\nuse octos here\n",
+        )
+        .unwrap();
+        std::fs::write(
+            skill.path().join("docs/usage.md"),
+            "no relevant content here\n",
+        )
+        .unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let tool = GrepTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "pattern": "octos",
+                    "path": skill.path().to_string_lossy(),
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(
+            result.output.contains("intro.md"),
+            "expected hit in intro.md, got: {}",
+            result.output
+        );
+        assert!(result.output.contains("octos"));
+    }
+
+    #[tokio::test]
+    async fn grep_refuses_out_of_scope_path() {
+        // An explicit path outside every declared zone is refused
+        // without walking it (cheaper failure mode + no leakage).
+        let workspace = tempfile::tempdir().unwrap();
+        let skill = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "leaked\n").unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let tool = GrepTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "pattern": "leaked",
+                    "path": outside.path().to_string_lossy(),
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection, got: {}",
+            result.output
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn grep_symlink_escape_in_skill_dir_drops_results() {
+        // A symlink inside the skill_dir pointing at /tmp/<outside>
+        // is dropped by the per-entry canonicalize-then-classify
+        // guard, so grep walking the skill_dir doesn't surface
+        // matches from outside.
+        use std::os::unix::fs::symlink;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let skill = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("smuggled.txt"), "needle in haystack\n").unwrap();
+
+        // Legitimate content inside the skill_dir — should NOT match.
+        std::fs::write(skill.path().join("README.md"), "no hits here\n").unwrap();
+        // Symlink under skill_dir pointing at the outside dir.
+        symlink(outside.path(), skill.path().join("escape")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let tool = GrepTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({
+                    "pattern": "needle",
+                    "path": skill.path().to_string_lossy(),
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(
+            result.output.contains("No matches"),
+            "symlink-out-of-scope must not surface matches, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn grep_falls_back_to_legacy_when_no_scope() {
+        // No scope wired => pre-PR-B base_dir-anchored behaviour.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "hello world\n").unwrap();
+
+        let tool = GrepTool::new(dir.path());
+        let ctx = ToolContext::zero();
+        assert!(ctx.session_scope.is_none());
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"pattern": "hello"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("hello"));
     }
 }

--- a/crates/octos-agent/src/tools/list_dir.rs
+++ b/crates/octos-agent/src/tools/list_dir.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use eyre::Result;
+use octos_core::PathClassification;
 use serde::Deserialize;
 
-use super::{Tool, ToolResult};
+use super::{Tool, ToolContext, ToolResult};
 use crate::policy::FilesystemScope;
 
 /// List contents of a directory.
@@ -62,21 +63,50 @@ impl Tool for ListDirTool {
     }
 
     async fn execute(&self, args: &serde_json::Value) -> Result<ToolResult> {
+        // PR-B: legacy entry point routes through the typed path with a
+        // zero-value context so out-of-band callers exercise the same
+        // SessionScope-aware logic when no scope is wired.
+        self.execute_with_context(&ToolContext::zero(), args).await
+    }
+
+    async fn execute_with_context(
+        &self,
+        ctx: &ToolContext,
+        args: &serde_json::Value,
+    ) -> Result<ToolResult> {
         let input: Input = serde_json::from_value(args.clone())?;
 
-        let target = match super::resolve_path_with_scope(
-            &self.base_dir,
-            &input.path,
-            self.filesystem_scope,
-        ) {
-            Ok(p) => p,
-            Err(_) => {
-                return Ok(ToolResult {
-                    output: format!("Path outside working directory: {}", input.path),
-                    success: false,
-                    ..Default::default()
-                });
-            }
+        // PR-B: when the host has threaded a `SessionScope` through
+        // `ToolContext`, validate the directory against it (same
+        // classification semantics as `read_file` — InWorkspace,
+        // InGrantedDir, InSharedZone, and InSkillDir all permit reads).
+        // No scope wired => keep the legacy `base_dir + FilesystemScope`
+        // path for backward compatibility with `octos chat`.
+        let target = match ctx.session_scope.as_ref() {
+            Some(scope) => match super::resolve_path_for_session_scope_read(scope, &input.path) {
+                Ok(p) => p,
+                Err(reason) => {
+                    return Ok(ToolResult {
+                        output: format!("{reason}: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
+            None => match super::resolve_path_with_scope(
+                &self.base_dir,
+                &input.path,
+                self.filesystem_scope,
+            ) {
+                Ok(p) => p,
+                Err(_) => {
+                    return Ok(ToolResult {
+                        output: format!("Path outside working directory: {}", input.path),
+                        success: false,
+                        ..Default::default()
+                    });
+                }
+            },
         };
 
         if let Some(r) = super::reject_symlink(&target).await {
@@ -110,12 +140,29 @@ impl Tool for ListDirTool {
             }
         };
 
+        // PR-B: when a SessionScope is present, drop entries whose
+        // canonicalised path classifies as `OutOfScope`. This catches
+        // the case where the listed directory contains a symlink that
+        // points out of every declared zone — without the filter, the
+        // bare entry name would leak the symlink's existence even if
+        // following it would be refused at open time.
+        let scope_filter = ctx.session_scope.as_ref();
+
         let mut dirs = Vec::new();
         let mut files = Vec::new();
 
         while let Ok(Some(entry)) = entries.next_entry().await {
+            let entry_path = entry.path();
+            if let Some(scope) = scope_filter {
+                if matches!(
+                    scope.classify_canonical_path(&entry_path),
+                    PathClassification::OutOfScope
+                ) {
+                    continue;
+                }
+            }
             let name = entry.file_name().to_string_lossy().to_string();
-            if entry.path().is_dir() {
+            if entry_path.is_dir() {
                 dirs.push(name);
             } else {
                 files.push(name);
@@ -157,6 +204,7 @@ impl Tool for ListDirTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -185,5 +233,147 @@ mod tests {
             .unwrap();
         assert!(!result.success);
         assert!(result.output.contains("not found"));
+    }
+
+    // ------------------------------------------------------------------
+    // PR-B: SessionScope integration tests for ListDirTool.
+    // ------------------------------------------------------------------
+
+    use octos_core::SessionScope;
+
+    fn ctx_with_scope(scope: SessionScope) -> ToolContext {
+        let mut ctx = ToolContext::zero();
+        ctx.tool_id = "list-dir-with-scope".to_string();
+        ctx.session_scope = Some(Arc::new(scope));
+        ctx
+    }
+
+    #[tokio::test]
+    async fn list_dir_inside_skill_dir_allowed() {
+        // The LLM may `list_dir` inside a registered plugin skill_dir to
+        // discover its layout. PR-A added `InSkillDir` to the read-side
+        // classifier; PR-B threads that decision through here.
+        let workspace = TempDir::new().unwrap();
+        let skill = TempDir::new().unwrap();
+        std::fs::create_dir(skill.path().join("styles")).unwrap();
+        std::fs::write(skill.path().join("styles/a.toml"), "k=1").unwrap();
+        std::fs::write(skill.path().join("styles/b.toml"), "k=2").unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let tool = ListDirTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let target = skill.path().join("styles");
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": target.to_string_lossy()}))
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(
+            result.output.contains("[file] a.toml") && result.output.contains("[file] b.toml"),
+            "expected both .toml entries, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dir_outside_workspace_and_skill_zones_refused() {
+        // A dir entirely outside every declared zone classifies as
+        // `OutOfScope` and must be refused.
+        let workspace = TempDir::new().unwrap();
+        let skill = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let tool = ListDirTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": outside.path().to_string_lossy()}),
+            )
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(
+            result.output.contains("outside session scope"),
+            "expected scope rejection, got: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dir_falls_back_to_legacy_when_no_scope() {
+        // No scope on the context => pre-PR-B `base_dir`-relative path
+        // still works (back-compat for `octos chat`).
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("f.txt"), "x").unwrap();
+
+        let tool = ListDirTool::new(dir.path());
+        let ctx = ToolContext::zero();
+        assert!(ctx.session_scope.is_none());
+
+        let result = tool
+            .execute_with_context(&ctx, &serde_json::json!({"path": "."}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("[file] f.txt"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn list_dir_drops_symlinked_entries_pointing_out_of_scope() {
+        // A symlink inside the skill_dir pointing to /tmp must not
+        // leak the target's contents through `list_dir`. The
+        // canonical-classify guard returns `OutOfScope` for the
+        // symlink target so the entry is dropped.
+        use std::os::unix::fs::symlink;
+
+        let workspace = TempDir::new().unwrap();
+        let skill = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        std::fs::write(outside.path().join("secret"), "exfil").unwrap();
+
+        // Real entry inside the skill_dir (should remain).
+        std::fs::write(skill.path().join("real.txt"), "ok").unwrap();
+        // Symlink pointing outside every declared zone (should be dropped).
+        symlink(outside.path(), skill.path().join("escape")).unwrap();
+
+        let scope = SessionScope::solo(workspace.path().to_path_buf(), vec![])
+            .unwrap()
+            .with_skill_read_zones(vec![skill.path().to_path_buf()])
+            .unwrap();
+
+        let tool = ListDirTool::new(workspace.path());
+        let ctx = ctx_with_scope(scope);
+
+        let result = tool
+            .execute_with_context(
+                &ctx,
+                &serde_json::json!({"path": skill.path().to_string_lossy()}),
+            )
+            .await
+            .unwrap();
+        assert!(result.success, "expected success, got: {}", result.output);
+        assert!(
+            result.output.contains("real.txt"),
+            "expected real entry retained, got: {}",
+            result.output
+        );
+        assert!(
+            !result.output.contains("escape"),
+            "symlinked entry pointing out-of-scope must be dropped, got: {}",
+            result.output
+        );
     }
 }


### PR DESCRIPTION
## Context

PR-A (#1327) added `skill_read_zones` + the `InSkillDir` classification to `SessionScope` and threaded the scope through every bootstrap site (`runtime/session.rs`, `chat.rs`, `session_actor.rs`). After PR-A:

- `read_file` already consults the scope (Phase 2-C).
- `glob`, `list_dir`, `grep` still use the legacy `base_dir + FilesystemScope` validator and ignore `skill_read_zones` entirely.

The result: the agent can `read_file` inside an active plugin's `skill_dir` but cannot `list_dir`/`glob`/`grep` its layout — making "on-demand skill discovery" (PR-C + PR-D) impossible.

## Fix

Each of the three tools gets an `execute_with_context` override mirroring `read_file`'s shape:

- **`list_dir`** routes the input path through `resolve_path_for_session_scope_read` when a scope is present (`InWorkspace`/`InGrantedDir`/`InSharedZone`/`InSkillDir` allow, `OutOfScope` refuses). Entries inside the listed dir are then filtered with `classify_canonical_path`, so a symlinked entry pointing outside every declared zone is silently dropped.
- **`glob`** accepts absolute patterns when scope is wired (the scope is the single source of truth for containment). Each match is canonicalised and dropped if it classifies `OutOfScope` — closing the ancestor-symlink hole the lexical classifier would otherwise miss.
- **`grep`** gains an optional `path` input that's validated against the scope (read-side resolver). The walker's per-file entries are canonicalize-then-classified, so a symlink inside a `skill_dir` pointing at `/etc` cannot smuggle matches from outside.

Callers that don't thread a `SessionScope` keep the pre-PR-B `base_dir + FilesystemScope` resolver path, so `octos chat` and other out-of-band callers (including the lifecycle's legacy `execute` entry point) are byte-identical.

This closes the precondition for on-demand skill discovery: PR-C (manifest `discovery` field) and PR-D (SKILL.md guidance updates) build on top.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p octos-agent --lib tools::list_dir::` — 6 passed (4 new)
- [x] `cargo test -p octos-agent --lib tools::glob_tool::` — 11 passed (4 new)
- [x] `cargo test -p octos-agent --lib tools::grep_tool::` — 13 passed (4 new)
- [x] `cargo test -p octos-agent --lib tools::` — 598 passed
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace --no-deps -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

New tests cover:
- `*_inside_skill_dir_*` / `*_into_skill_dir_returns_matches` — happy path through `InSkillDir`
- `*_outside_*_refused` / `glob_traversal_pattern_drops_matches_outside_zones` — `OutOfScope` rejection
- `*_symlink_escape_*` / `glob_drops_symlink_target_outside_scope` / `list_dir_drops_symlinked_entries_pointing_out_of_scope` — symlink containment (Unix)
- `*_falls_back_to_legacy_when_no_scope` — back-compat for unscoped callers