### PR TITLE
fix(ui-protocol): add topic field to 6 events vulnerable to P0-A class routing drop

### DIFF
--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -42,8 +42,8 @@ use octos_core::ui_protocol::{
     TaskRuntimeState as UiTaskRuntimeState, TaskUpdatedEvent, ThreadGraphEntry,
     ThreadGraphGetParams, ThreadGraphGetResult, ToolCompletedEvent, ToolProgressEvent,
     ToolStartedEvent, TurnCompletedEvent, TurnErrorEvent, TurnId, TurnInterruptParams,
-    TurnInterruptResult, TurnLifecycleState, TurnSpawnCompleteEvent, TurnStartParams,
-    TurnStateGetParams, TurnStateGetResult, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
+    TurnInterruptResult, TurnLifecycleState, TurnSessionResult, TurnSpawnCompleteEvent,
+    TurnStartParams, TurnStateGetParams, TurnStateGetResult, UI_PROTOCOL_FEATURE_APPROVAL_TYPED_V1,
     UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1, UI_PROTOCOL_FEATURE_CODING_AGENT_CONTROL_V1,
     UI_PROTOCOL_FEATURE_CODING_AUTONOMY_V1, UI_PROTOCOL_FEATURE_CODING_GOAL_RUNTIME_V1,
     UI_PROTOCOL_FEATURE_CODING_LOOP_RUNTIME_V1, UI_PROTOCOL_FEATURE_CONTEXT_LIFECYCLE_V1,
@@ -2896,6 +2896,7 @@ impl octos_agent::ToolApprovalRequester for UiProtocolApprovalRequester {
             // runtime decision below.
             let auto = ApprovalAutoResolvedEvent {
                 session_id: self.session_id.clone(),
+                topic: self.session_id.topic().map(ToOwned::to_owned),
                 approval_id: approval_id.clone(),
                 turn_id: self.turn_id.clone(),
                 tool_name: event.tool_name.clone(),
@@ -2919,6 +2920,7 @@ impl octos_agent::ToolApprovalRequester for UiProtocolApprovalRequester {
             let policy_id = format!("policy:{}:{}", hit.scope_wire(), hit.scope_match);
             let decided_event = ApprovalDecidedEvent {
                 session_id: self.session_id.clone(),
+                topic: self.session_id.topic().map(ToOwned::to_owned),
                 approval_id: approval_id.clone(),
                 turn_id: self.turn_id.clone(),
                 decision: hit.decision.clone(),
@@ -3015,6 +3017,7 @@ fn cancel_approval_after_request_send_failure(
         ledger,
         UiNotification::ApprovalCancelled(ApprovalCancelledEvent {
             session_id: session_id.clone(),
+            topic: session_id.topic().map(ToOwned::to_owned),
             approval_id: cancelled.approval_id,
             turn_id: cancelled.turn_id,
             reason: APPROVAL_CANCELLED_REASON_REQUEST_SEND_FAILED.to_owned(),
@@ -7606,25 +7609,20 @@ fn ledger_event_matches_topic_scope(
     event: &UiProtocolLedgerEvent,
     topic_scope: Option<&str>,
 ) -> bool {
-    // P0-A exemption: `file/attached` envelopes are intrinsically
-    // session-scoped via their `tool_call_id` (the SPA already binds
-    // each attachment to the originating turn/tool client-side). The
-    // event type has no `topic` field, so `UiNotification::topic()`
-    // falls back to `SessionKey.topic()` — meaning any emit site that
-    // constructs the event with a session_id stripped of (or pre-
-    // dating) the `#<topic>` suffix produces `event.topic() == None`
-    // and the strict equality below drops it for a topic-scoped
-    // subscriber. The slides soak round-13 regression captured this
-    // exact gap: `file/attached` landed on the ledger but never
-    // reached the SPA. Exempting the variant closes the wire gap with
-    // no functional cost — clients route the attachment via
-    // `tool_call_id` regardless of topic scope.
-    if matches!(
-        event,
-        UiProtocolLedgerEvent::Notification(UiNotification::FileAttached(_))
-    ) {
-        return true;
-    }
+    // Topic scoping consults `event.topic()`, which now reads the
+    // explicit `topic` field carried on every variant whose emit site
+    // can drop the topic suffix from `session_id` (TurnStarted,
+    // MessageDelta, ToolStarted/Progress/Completed, Approval*, Task*,
+    // TurnCompleted/Error/SpawnComplete, MessagePersisted,
+    // FileAttached, SessionEventBridged). #1329 closes the P0-A class
+    // routing drop: emitters populate `topic` from the upstream
+    // SessionKey BEFORE any `base_key()` strip, so a topic-scoped
+    // subscriber routes the event correctly even when `session_id`
+    // was rebuilt from `base_key()` (the gap that previously
+    // dropped `file/attached` in slides soak round-13 and was
+    // patched with a single-variant exemption — the exemption is
+    // no longer needed now that every vulnerable variant carries
+    // explicit topic).
     let event_topic = event
         .topic()
         .map(str::trim)
@@ -12469,11 +12467,13 @@ async fn run_m9_fixture_turn(
         }
         M9ProtocolFixture::ToolEvents => {
             let tool_call_id = format!("m9-tool-{}", turn_id.0);
+            let topic = session_id.topic().map(ToOwned::to_owned);
             let _ = send_notification_durable(
                 &ws,
                 &ledger,
                 UiNotification::ToolStarted(ToolStartedEvent {
                     session_id: session_id.clone(),
+                    topic: topic.clone(),
                     turn_id: turn_id.clone(),
                     tool_call_id: tool_call_id.clone(),
                     tool_name: "list_dir".to_owned(),
@@ -12485,6 +12485,7 @@ async fn run_m9_fixture_turn(
                 &ledger,
                 UiNotification::ToolProgress(ToolProgressEvent {
                     session_id: session_id.clone(),
+                    topic: topic.clone(),
                     turn_id: turn_id.clone(),
                     tool_call_id: tool_call_id.clone(),
                     message: Some("listing workspace".to_owned()),
@@ -12496,6 +12497,7 @@ async fn run_m9_fixture_turn(
                 &ledger,
                 UiNotification::ToolCompleted(ToolCompletedEvent {
                     session_id: session_id.clone(),
+                    topic,
                     turn_id: turn_id.clone(),
                     tool_call_id,
                     tool_name: "list_dir".to_owned(),
@@ -12702,6 +12704,8 @@ async fn run_m9_fixture_turn(
                 &session_id,
                 &turn_id,
                 None,
+                // M9 fixtures replay canned events; no live LLM token data.
+                None,
             )
             .await;
         }
@@ -12714,6 +12718,7 @@ async fn run_m9_fixture_turn(
                 &session_id,
                 &turn_id,
                 Some((code, message.as_str())),
+                None,
             )
             .await;
         }
@@ -12742,6 +12747,7 @@ async fn run_m9_fixture_turn(
                 &session_id,
                 &turn_id,
                 Some(("interrupted", "turn interrupted by client")),
+                None,
             )
             .await;
         }
@@ -12869,11 +12875,13 @@ async fn m14_codex_tool_call(
     expected_success: bool,
 ) -> Result<octos_agent::ToolResult, String> {
     let tool_call_id = format!("m14-codex-p0-{index}-{tool_name}-{}", env.turn_id.0);
+    let topic = env.session_id.topic().map(ToOwned::to_owned);
     let _ = send_notification_durable(
         env.ws,
         env.ledger,
         UiNotification::ToolStarted(ToolStartedEvent {
             session_id: env.session_id.clone(),
+            topic: topic.clone(),
             turn_id: env.turn_id.clone(),
             tool_call_id: tool_call_id.clone(),
             tool_name: tool_name.to_owned(),
@@ -12893,6 +12901,7 @@ async fn m14_codex_tool_call(
         env.ledger,
         UiNotification::ToolCompleted(ToolCompletedEvent {
             session_id: env.session_id.clone(),
+            topic,
             turn_id: env.turn_id.clone(),
             tool_call_id: tool_call_id.clone(),
             tool_name: tool_name.to_owned(),
@@ -13507,6 +13516,7 @@ async fn run_native_code_review_turn(
                 &session_id,
                 &turn_id,
                 Some(("runtime_unavailable", message.as_str())),
+                None,
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -13522,6 +13532,7 @@ async fn run_native_code_review_turn(
                 &session_id,
                 &turn_id,
                 Some(("runtime_unavailable", message.as_str())),
+                None,
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -13541,6 +13552,7 @@ async fn run_native_code_review_turn(
                 &session_id,
                 &turn_id,
                 Some(("permission_denied", message.as_str())),
+                None,
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -13562,6 +13574,7 @@ async fn run_native_code_review_turn(
                 &session_id,
                 &turn_id,
                 Some(("runtime_unavailable", &error.to_string())),
+                None,
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -13777,6 +13790,7 @@ async fn run_native_code_review_turn(
                     &session_id,
                     &turn_id,
                     Some(("interrupted", "review/start interrupted by client")),
+                    None,
                 )
                 .await;
                 contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -13893,6 +13907,10 @@ async fn run_native_code_review_turn(
         &ledger,
         &session_id,
         &turn_id,
+        None,
+        // review/start scatter-join does not run a single LLM turn end
+        // to end; the summary message is emitted ad-hoc. No aggregated
+        // token data is in scope here.
         None,
     )
     .await;
@@ -14956,6 +14974,7 @@ async fn run_standalone_turn(
             &session_id,
             &turn_id,
             Some(("runtime_unavailable", error.as_str())),
+            None,
         )
         .await;
         contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -14980,6 +14999,7 @@ async fn run_standalone_turn(
                 &session_id,
                 &turn_id,
                 Some(("permission_denied", message.as_str())),
+                None,
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -15001,6 +15021,7 @@ async fn run_standalone_turn(
                 &session_id,
                 &turn_id,
                 Some(("runtime_unavailable", &error.to_string())),
+                None,
             )
             .await;
             contracts.scopes.evict_turn(&session_id, &turn_id);
@@ -15169,6 +15190,9 @@ async fn run_standalone_turn(
             &ledger,
             &session_id,
             &turn_id,
+            None,
+            // Slash-command shortcut bypasses the LLM entirely; the
+            // reply is canned and no token meter ran.
             None,
         )
         .await;
@@ -16152,6 +16176,15 @@ async fn run_standalone_turn(
                 // Defer the send until below the persist block.
                 let mut captured_final_reply = response.content.clone();
                 let mut cursor = None;
+                // Issue #1332: capture the wire `message_id` for the
+                // final assistant row so the `done` event can surface
+                // it on `turn/completed.session_result.message_id`.
+                // Format mirrors `MessageCommitObserver`:
+                // `{session_id}:{committed_seq}:{timestamp_ns}`. Only
+                // populated on the success branch of
+                // `add_message_with_seq`, so the consumer sees a
+                // `Some` only when the durable row actually exists.
+                let mut final_assistant_message_id: Option<String> = None;
                 // #1158 codex P2 rev2 follow-up: `add_message_with_seq`
                 // can fail (e.g. JSONL at MAX_SESSION_FILE_SIZE, I/O
                 // error). Track whether the assistant row carrying
@@ -16342,6 +16375,15 @@ async fn run_standalone_turn(
                             });
                             if is_final_assistant_carrier {
                                 final_assistant_persisted = true;
+                                // Issue #1332: stamp the wire message_id
+                                // for the carrier row so `done` can
+                                // populate `session_result.message_id`.
+                                let ts_ns = saved_for_context
+                                    .timestamp
+                                    .timestamp_nanos_opt()
+                                    .unwrap_or(0);
+                                final_assistant_message_id =
+                                    Some(format!("{}:{seq}:{ts_ns}", agent_session_id.0,));
                             }
                             if let Some(content) = preamble_assistant_content {
                                 last_persisted_preamble_assistant = Some(content);
@@ -16498,6 +16540,18 @@ async fn run_standalone_turn(
                                         seq: seq as u64,
                                     });
                                     final_assistant_persisted = true;
+                                    // Issue #1332: stamp message_id for
+                                    // the synthesised final-assistant
+                                    // row too (parity with the carrier
+                                    // branch above so `done`'s
+                                    // `session_result` is populated
+                                    // whichever branch wrote the row).
+                                    let ts_ns = saved_for_context
+                                        .timestamp
+                                        .timestamp_nanos_opt()
+                                        .unwrap_or(0);
+                                    final_assistant_message_id =
+                                        Some(format!("{}:{seq}:{ts_ns}", agent_session_id.0,));
                                 }
                             }
                         }
@@ -16542,12 +16596,18 @@ async fn run_standalone_turn(
                     None
                 };
                 let _ = final_reply_tx.send(final_send);
+                // Issue #1332: include `message_id` so the consumer
+                // can build `TurnSessionResult` for the
+                // `turn/completed` lifecycle envelope. Absent when no
+                // final-assistant row persisted (no synthesis +
+                // skipped carrier + JSONL write failures).
                 let done = json!({
                     "type": "done",
                     "content": response.content,
                     "tokens_in": response.token_usage.input_tokens,
                     "tokens_out": response.token_usage.output_tokens,
                     "cursor": cursor,
+                    "message_id": final_assistant_message_id,
                     "thread_id": turn_thread_id_for_done,
                 });
                 let _ = progress_tx_for_result.send(done.to_string()).await;
@@ -16651,6 +16711,48 @@ async fn run_standalone_turn(
                 final_tokens_consumed = final_tokens_consumed
                     .saturating_add(tokens_in)
                     .saturating_add(tokens_out);
+                // Issue #1332: thread `done` payload data into the
+                // `turn/completed` lifecycle event. Tokens come from the
+                // same `response.token_usage` values the cost accountant
+                // sees; `session_result` is built from the cursor +
+                // message_id the persist block stamped when the final
+                // assistant row committed. The SSE bridge that
+                // originally fed these fields was removed in
+                // M9-α-5/α-6 (PR #855) — without this wiring the
+                // capability-gated fields stayed `None` for every
+                // WS-driven turn, leaving capability-aware clients
+                // unable to tell "no data" from "stub".
+                let done_cursor: Option<UiCursor> = event
+                    .get("cursor")
+                    .filter(|value| !value.is_null())
+                    .and_then(|value| serde_json::from_value(value.clone()).ok());
+                let done_message_id = event
+                    .get("message_id")
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned);
+                let session_result = match (&done_cursor, done_message_id) {
+                    (Some(cursor), Some(message_id)) => Some(TurnSessionResult {
+                        committed_seq: cursor.seq,
+                        message_id,
+                        // `turn/start` does not carry a per-prompt
+                        // `client_message_id` (see `TurnStartParams`),
+                        // so the originating-cmid lookup degrades to
+                        // `None` on the WS path. The gateway path
+                        // (`SessionActor::*`) carries cmids end to end
+                        // — once that path also pipes through
+                        // `TurnCompletionDetails`, this branch picks
+                        // up cmid naturally.
+                        client_message_id: None,
+                    }),
+                    _ => None,
+                };
+                let details = TurnCompletionDetails {
+                    cursor: done_cursor,
+                    tokens_in: Some(u32::try_from(tokens_in).unwrap_or(u32::MAX)),
+                    tokens_out: Some(u32::try_from(tokens_out).unwrap_or(u32::MAX)),
+                    session_result,
+                };
                 // FIX-04: flush any accumulated drops before the lifecycle
                 // terminal so the client knows the cursor is incomplete.
                 flush_replay_lossy(&ws, &ledger, &session_id, &progress_dropped);
@@ -16662,6 +16764,7 @@ async fn run_standalone_turn(
                     &session_id,
                     &turn_id,
                     None,
+                    Some(details),
                 )
                 .await;
                 break;
@@ -16681,6 +16784,7 @@ async fn run_standalone_turn(
                     &session_id,
                     &turn_id,
                     Some(("runtime_error", message.as_str())),
+                    None,
                 )
                 .await;
                 break;
@@ -16752,6 +16856,7 @@ async fn run_standalone_turn(
             &session_id,
             &turn_id,
             Some(("interrupted", "turn interrupted by client")),
+            None,
         )
         .await;
     }
@@ -17076,9 +17181,27 @@ fn classify_runtime_error_message(error: &eyre::Report) -> String {
     error.to_string()
 }
 
+/// UPCR-2026-014 follow-up (issue #1332): optional token + session_result
+/// payload threaded from the agent-task `done` event into the lifecycle
+/// `turn/completed` emit. None on error/interrupt paths and on paths that
+/// have no LLM token data (M9 fixture, slash-command shortcut, review/start).
+#[derive(Debug, Default, Clone)]
+struct TurnCompletionDetails {
+    cursor: Option<UiCursor>,
+    tokens_in: Option<u32>,
+    tokens_out: Option<u32>,
+    session_result: Option<TurnSessionResult>,
+}
+
 /// Atomically transition state and emit exactly one terminal event. No-op if
 /// the state is already `Terminal(_)`. See `transition_to_terminal` for the
 /// state-machine details.
+///
+/// `completion_details` is consulted only when `expected_reason` is
+/// `Completed`; ignored otherwise. Populated on the standalone-turn path
+/// from `done` (input/output tokens + cursor + per-row identity); left as
+/// `None` for paths that do not run the LLM (slash command, review/start
+/// scatter-join, M9 fixture replays).
 async fn try_emit_terminal(
     turn_state: &TokioMutex<TurnState>,
     expected_reason: TerminalReason,
@@ -17087,6 +17210,7 @@ async fn try_emit_terminal(
     session_id: &SessionKey,
     turn_id: &TurnId,
     error_payload: Option<(&str, &str)>,
+    completion_details: Option<TurnCompletionDetails>,
 ) {
     let Some(TerminalTransition { reason, ack }) =
         transition_to_terminal(turn_state, expected_reason).await
@@ -17099,6 +17223,7 @@ async fn try_emit_terminal(
     // but the ledger is still appended so reconnect-replay can catch up.
     match reason {
         TerminalReason::Completed => {
+            let details = completion_details.unwrap_or_default();
             let _ = send_notification_lifecycle(
                 ws,
                 ledger,
@@ -17106,15 +17231,15 @@ async fn try_emit_terminal(
                     session_id: session_id.clone(),
                     topic: None,
                     turn_id: turn_id.clone(),
-                    cursor: None,
-                    // UPCR-2026-014 (M9-α-9) addendum fields; the WS
-                    // lifecycle path doesn't have token usage /
-                    // session_result threaded yet — those land via the
-                    // SSE bridge in α-9. Leaving them None preserves
-                    // the pre-addendum wire shape for WS-driven turns.
-                    tokens_in: None,
-                    tokens_out: None,
-                    session_result: None,
+                    cursor: details.cursor,
+                    // UPCR-2026-014 (M9-α-9) addendum fields. The SSE
+                    // bridge that originally fed `session_result` was
+                    // removed in M9-α-5/α-6 (PR #855); issue #1332 wires
+                    // the same values straight from the agent task's
+                    // `done` event so the WS path is no longer dormant.
+                    tokens_in: details.tokens_in,
+                    tokens_out: details.tokens_out,
+                    session_result: details.session_result,
                 }),
             );
         }
@@ -17677,6 +17802,7 @@ async fn abort_connection_turns(
             let _ = ledger.append_notification(UiNotification::ApprovalCancelled(
                 ApprovalCancelledEvent {
                     session_id: session_id.clone(),
+                    topic: session_id.topic().map(ToOwned::to_owned),
                     approval_id: entry.approval_id,
                     turn_id: entry.turn_id,
                     reason: approval_cancelled_reasons::TURN_INTERRUPTED.to_owned(),
@@ -21264,6 +21390,136 @@ ignore = []
                 text: "x".into(),
             }));
         assert_eq!(ledger_event_cursor(&delta), None);
+    }
+
+    /// Issue #1332: when the standalone-turn `done` event carries
+    /// token totals + cursor + final-assistant message_id, the
+    /// `turn/completed` lifecycle envelope must surface them on
+    /// `tokens_in`, `tokens_out`, and `session_result` rather than the
+    /// dormant-stub `None` triple. Drives `try_emit_terminal` directly
+    /// because the spawn pipeline is too wide to fixture; the helper
+    /// is the wire-side closure that issue #1332 modified.
+    #[tokio::test]
+    async fn try_emit_terminal_populates_turn_completed_tokens_and_session_result() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<axum::extract::ws::Message>(8);
+        let ws = WsConnection::new(tx);
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:test".into());
+        let turn_id = TurnId::new();
+        let turn_state = TokioMutex::new(TurnState::Active);
+        let cursor = UiCursor {
+            stream: session_id.0.clone(),
+            seq: 17,
+        };
+        let details = TurnCompletionDetails {
+            cursor: Some(cursor.clone()),
+            tokens_in: Some(123),
+            tokens_out: Some(456),
+            session_result: Some(TurnSessionResult {
+                committed_seq: cursor.seq,
+                message_id: format!("{}:{}:{}", session_id.0, cursor.seq, 99_999),
+                client_message_id: Some("cmid-user-1".into()),
+            }),
+        };
+
+        try_emit_terminal(
+            &turn_state,
+            TerminalReason::Completed,
+            &ws,
+            &ledger,
+            &session_id,
+            &turn_id,
+            None,
+            Some(details.clone()),
+        )
+        .await;
+
+        let mut completed_frame: Option<String> = None;
+        while let Ok(msg) = rx.try_recv() {
+            if let WsMessage::Text(text) = msg {
+                if text.contains("\"method\":\"turn/completed\"") {
+                    completed_frame = Some(text.to_string());
+                    break;
+                }
+            }
+        }
+        let frame = completed_frame.expect("turn/completed must be emitted");
+        assert!(
+            frame.contains("\"tokens_in\":123"),
+            "tokens_in must surface from completion details: {frame}"
+        );
+        assert!(
+            frame.contains("\"tokens_out\":456"),
+            "tokens_out must surface from completion details: {frame}"
+        );
+        assert!(
+            frame.contains("\"session_result\""),
+            "session_result must surface when populated: {frame}"
+        );
+        assert!(
+            frame.contains("\"committed_seq\":17"),
+            "session_result.committed_seq must mirror cursor.seq: {frame}"
+        );
+        assert!(
+            frame.contains("\"client_message_id\":\"cmid-user-1\""),
+            "session_result.client_message_id must round-trip: {frame}"
+        );
+        assert!(
+            frame.contains("\"cursor\""),
+            "top-level cursor must be threaded too: {frame}"
+        );
+    }
+
+    /// Companion negative test: paths that do not run an LLM (slash
+    /// command shortcut, M9 fixture, review/start) pass `None` for
+    /// `completion_details`. The wire shape must degrade gracefully to
+    /// the pre-#1332 envelope with no token fields surfaced, so capability
+    /// clients keying off `tokens_in == None` aren't misled.
+    #[tokio::test]
+    async fn try_emit_terminal_with_no_details_omits_token_fields() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<axum::extract::ws::Message>(8);
+        let ws = WsConnection::new(tx);
+        let ledger = UiProtocolLedger::new(32);
+        let session_id = SessionKey("local:test".into());
+        let turn_id = TurnId::new();
+        let turn_state = TokioMutex::new(TurnState::Active);
+
+        try_emit_terminal(
+            &turn_state,
+            TerminalReason::Completed,
+            &ws,
+            &ledger,
+            &session_id,
+            &turn_id,
+            None,
+            None,
+        )
+        .await;
+
+        let mut completed_frame: Option<String> = None;
+        while let Ok(msg) = rx.try_recv() {
+            if let WsMessage::Text(text) = msg {
+                if text.contains("\"method\":\"turn/completed\"") {
+                    completed_frame = Some(text.to_string());
+                    break;
+                }
+            }
+        }
+        let frame = completed_frame.expect("turn/completed must be emitted");
+        // `serde(skip_serializing_if = "Option::is_none")` on each field
+        // means a `None` triple should NOT appear on the wire.
+        assert!(
+            !frame.contains("\"tokens_in\""),
+            "tokens_in must be omitted when details are None: {frame}"
+        );
+        assert!(
+            !frame.contains("\"tokens_out\""),
+            "tokens_out must be omitted when details are None: {frame}"
+        );
+        assert!(
+            !frame.contains("\"session_result\""),
+            "session_result must be omitted when details are None: {frame}"
+        );
     }
 
     #[test]
@@ -27432,6 +27688,7 @@ ignore = []
             .expect("request was registered");
         ledger.append_notification(UiNotification::ApprovalDecided(ApprovalDecidedEvent {
             session_id: session_id.clone(),
+            topic: None,
             approval_id: approval_id.clone(),
             turn_id: decided_turn_id,
             decision: ApprovalDecision::Approve,
@@ -28900,6 +29157,7 @@ ignore = []
     fn file_attached_for(session: &SessionKey) -> UiNotification {
         UiNotification::FileAttached(octos_core::ui_protocol::FileAttachedEvent {
             session_id: session.clone(),
+            topic: session.topic().map(ToOwned::to_owned),
             turn_id: TurnId::new(),
             path: "/tmp/deck.pptx".into(),
             tool_call_id: Some("tc-slides".into()),
@@ -29194,48 +29452,237 @@ ignore = []
         abort_live_forwarders(&forwarders, &ledger).await;
     }
 
-    /// Complementary unit test for `ledger_event_matches_topic_scope`:
-    /// `file/attached` events MUST always match a topic-scoped
-    /// subscriber, regardless of whether the event itself carries a
-    /// topic. Companion to
-    /// `live_forwarder_delivers_file_attached_to_topic_scoped_subscriber`
-    /// — guards the filter in isolation so a refactor that re-routes
-    /// the call site can't silently break the exemption.
+    /// #1329 (closes the P0-A class routing drop): The 6 events that
+    /// previously had no explicit `topic` field — ToolStarted,
+    /// ToolProgress, ToolCompleted, ApprovalAutoResolved,
+    /// ApprovalDecided, ApprovalCancelled — gained the same
+    /// `topic: Option<String>` field that the 10 already-fixed
+    /// variants carry. With emitters populating the field from the
+    /// upstream `SessionKey.topic()` BEFORE any `base_key()` strip,
+    /// each event reaches a topic-scoped subscriber.
+    ///
+    /// This integration-style test pins the invariant for ALL 6
+    /// variants on the live broadcast path: emit each event on a
+    /// topic-suffixed broadcast key with the explicit `topic` field,
+    /// then assert each frame reaches a topic-scoped subscriber (the
+    /// classifier reads `event.topic()` first, honoring the explicit
+    /// field).
+    #[tokio::test]
+    async fn live_forwarder_delivers_tool_and_approval_events_to_topic_scoped_subscriber() {
+        let (ws, mut rx) = ws_connection_for_test(64);
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let topic_session = SessionKey("local:slides-soak#slides".into());
+        let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+        let live_rx = ledger.subscribe(&topic_session);
+        spawn_live_forwarder(
+            ws.clone(),
+            ledger.clone(),
+            topic_session.clone(),
+            0,
+            ws.connection_id(),
+            ConnectionUiFeatures::default(),
+            Some("slides".into()),
+            live_rx,
+            forwarders.clone(),
+        )
+        .await;
+
+        let turn_id = TurnId::new();
+        let tool_call_id = "tc-1329".to_owned();
+
+        // 1. ToolStarted
+        ledger.append_notification(UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: topic_session.clone(),
+            topic: Some("slides".into()),
+            turn_id: turn_id.clone(),
+            tool_call_id: tool_call_id.clone(),
+            tool_name: "shell".into(),
+            arguments: None,
+        }));
+
+        // 2. ToolProgress
+        ledger.append_notification(UiNotification::ToolProgress(ToolProgressEvent {
+            session_id: topic_session.clone(),
+            topic: Some("slides".into()),
+            turn_id: turn_id.clone(),
+            tool_call_id: tool_call_id.clone(),
+            message: Some("running step 1".into()),
+            progress_pct: Some(50.0),
+        }));
+
+        // 3. ToolCompleted
+        ledger.append_notification(UiNotification::ToolCompleted(ToolCompletedEvent {
+            session_id: topic_session.clone(),
+            topic: Some("slides".into()),
+            turn_id: turn_id.clone(),
+            tool_call_id: tool_call_id.clone(),
+            tool_name: "shell".into(),
+            success: Some(true),
+            output_preview: None,
+            duration_ms: Some(10),
+        }));
+
+        // 4. ApprovalAutoResolved
+        ledger.append_notification(UiNotification::ApprovalAutoResolved(
+            ApprovalAutoResolvedEvent {
+                session_id: topic_session.clone(),
+                topic: Some("slides".into()),
+                approval_id: ApprovalId::new(),
+                turn_id: turn_id.clone(),
+                tool_name: "shell".into(),
+                scope: "session".into(),
+                scope_match: "exact".into(),
+                decision: ApprovalDecision::Approve,
+            },
+        ));
+
+        // 5. ApprovalDecided
+        ledger.append_notification(UiNotification::ApprovalDecided(ApprovalDecidedEvent {
+            session_id: topic_session.clone(),
+            topic: Some("slides".into()),
+            approval_id: ApprovalId::new(),
+            turn_id: turn_id.clone(),
+            decision: ApprovalDecision::Approve,
+            scope: Some("session".into()),
+            decided_at: Utc::now(),
+            decided_by: "user:test".into(),
+            auto_resolved: false,
+            policy_id: None,
+            client_note: None,
+        }));
+
+        // 6. ApprovalCancelled
+        ledger.append_notification(UiNotification::ApprovalCancelled(ApprovalCancelledEvent {
+            session_id: topic_session.clone(),
+            topic: Some("slides".into()),
+            approval_id: ApprovalId::new(),
+            turn_id: turn_id.clone(),
+            reason: "turn_interrupted".into(),
+        }));
+
+        // Verify each method lands on the subscriber. Order matches
+        // emission order — the ledger preserves seq.
+        let expected = [
+            methods::TOOL_STARTED,
+            methods::TOOL_PROGRESS,
+            methods::TOOL_COMPLETED,
+            methods::APPROVAL_AUTO_RESOLVED,
+            methods::APPROVAL_DECIDED,
+            methods::APPROVAL_CANCELLED,
+        ];
+        for method in expected.iter() {
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap_or_else(|_| panic!("timed out waiting for {method}"))
+                .unwrap_or_else(|| panic!("ws closed before {method}"));
+            assert_eq!(
+                frame_method(&frame).as_deref(),
+                Some(*method),
+                "{method} with explicit topic=Some(\"slides\") must reach \
+                 a topic-scoped subscriber (#1329)"
+            );
+        }
+
+        abort_live_forwarders(&forwarders, &ledger).await;
+    }
+
+    /// Mirror of the positive test above: when an event of one of the
+    /// six P0-A class variants carries a NON-MATCHING explicit topic,
+    /// the classifier drops it from the topic-scoped subscriber.
+    /// Topic IS part of the routing key now (no more file/attached-
+    /// style always-deliver exemption).
+    #[tokio::test]
+    async fn live_forwarder_drops_mismatched_topic_for_tool_and_approval_events() {
+        let (ws, mut rx) = ws_connection_for_test(16);
+        let ledger = Arc::new(UiProtocolLedger::new(16));
+        let topic_session = SessionKey("local:slides-soak#slides".into());
+        let forwarders: SharedLiveForwarders = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+
+        let live_rx = ledger.subscribe(&topic_session);
+        spawn_live_forwarder(
+            ws.clone(),
+            ledger.clone(),
+            topic_session.clone(),
+            0,
+            ws.connection_id(),
+            ConnectionUiFeatures::default(),
+            Some("slides".into()),
+            live_rx,
+            forwarders.clone(),
+        )
+        .await;
+
+        // Event carries `topic = "other"` — the classifier must drop
+        // it for the "slides"-scoped subscriber.
+        ledger.append_notification(UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: topic_session.clone(),
+            topic: Some("other".into()),
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-other".into(),
+            tool_name: "shell".into(),
+            arguments: None,
+        }));
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "tool/started with topic=\"other\" must NOT reach a \
+             topic=\"slides\" subscriber (#1329 routing-key invariant)"
+        );
+
+        abort_live_forwarders(&forwarders, &ledger).await;
+    }
+
+    /// #1329 follow-up to P0-A: `file/attached` now carries an explicit
+    /// `topic: Option<String>` field. The classifier consults
+    /// `event.topic()`, which reads that field first and falls back to
+    /// the `SessionKey.topic()` suffix. With emitters populating the
+    /// field at the source, the prior `file/attached`-only exemption
+    /// in `ledger_event_matches_topic_scope` is no longer needed — the
+    /// routing follows the same rule as every other variant.
     #[test]
-    fn ledger_event_matches_topic_scope_exempts_file_attached() {
+    fn ledger_event_matches_topic_scope_routes_file_attached_by_topic_field() {
         let bare_session = SessionKey("local:slides-soak".into());
         let topic_session = SessionKey("local:slides-soak#slides".into());
         let other_topic_session = SessionKey("local:slides-soak#other".into());
 
-        // Bare event, topic-scoped subscriber: pre-fix → DROP; post-fix → PASS.
+        // Bare event, topic-scoped subscriber: no topic on the event,
+        // topic on the subscriber → DROP (no longer exempt).
         let bare_event = UiProtocolLedgerEvent::Notification(file_attached_for(&bare_session));
         assert!(
-            ledger_event_matches_topic_scope(&bare_event, Some("slides")),
-            "file/attached with no topic must reach a topic-scoped subscriber"
+            !ledger_event_matches_topic_scope(&bare_event, Some("slides")),
+            "file/attached with no topic must NOT reach a topic-scoped subscriber"
         );
 
-        // Topic-suffixed event, topic-scoped subscriber: always PASSED.
+        // Topic-suffixed event, topic-scoped subscriber: explicit
+        // topic matches → PASS.
         let topic_event = UiProtocolLedgerEvent::Notification(file_attached_for(&topic_session));
         assert!(
             ledger_event_matches_topic_scope(&topic_event, Some("slides")),
             "file/attached with matching topic must reach a topic-scoped subscriber"
         );
 
-        // Mismatched topic, topic-scoped subscriber: pre-fix → DROP;
-        // post-fix → PASS (file/attached is exempt from topic scoping).
+        // Mismatched topic, topic-scoped subscriber: explicit topic
+        // mismatches → DROP. Topic IS part of the routing key now.
         let other_event =
             UiProtocolLedgerEvent::Notification(file_attached_for(&other_topic_session));
         assert!(
-            ledger_event_matches_topic_scope(&other_event, Some("slides")),
-            "file/attached is exempt from topic-scope filtering — \
-             a non-matching event.topic must NOT block delivery"
+            !ledger_event_matches_topic_scope(&other_event, Some("slides")),
+            "file/attached with non-matching topic must NOT reach a topic-scoped subscriber"
         );
 
-        // Bare subscriber, topic-suffixed event: always PASSED by the
-        // exemption too (defensive consistency).
+        // Bare subscriber, topic-suffixed event → DROP (topic on
+        // event, no topic on subscriber).
         assert!(
-            ledger_event_matches_topic_scope(&topic_event, None),
-            "file/attached must reach a bare (no-topic) subscriber"
+            !ledger_event_matches_topic_scope(&topic_event, None),
+            "file/attached with topic must NOT reach a bare (no-topic) subscriber"
+        );
+
+        // Bare event + bare subscriber → PASS (the no-topic case).
+        assert!(
+            ledger_event_matches_topic_scope(&bare_event, None),
+            "file/attached with no topic must reach a bare (no-topic) subscriber"
         );
     }
 

--- a/crates/octos-cli/src/api/ui_protocol_alpha2_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha2_bridge.rs
@@ -72,6 +72,7 @@ impl ProgressReporter for LedgerToolProgressReporter {
         {
             let notification = UiNotification::ToolProgress(ToolProgressEvent {
                 session_id: self.session_id.clone(),
+                topic: self.session_id.topic().map(ToOwned::to_owned),
                 turn_id: self.turn_id.clone(),
                 tool_call_id: tool_id.clone(),
                 message: Some(message.clone()),

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -117,6 +117,20 @@ pub(super) fn emit_turn_completed_full(
 /// Append a `file/attached.v1` envelope when a tool surfaces an
 /// artifact via `files_to_send`. Mirrors the SSE `file:` frame.
 ///
+/// `topic` is taken as a separate argument (rather than reading from
+/// `session_id.topic()`) because the P0-A wire-gap fix in
+/// [`emit_files_attached_from_background`] strips the topic suffix
+/// from `session_id` BEFORE calling here — the strip is required so
+/// the envelope rides on the base broadcast bucket the SPA actually
+/// subscribes to. Topic must therefore be captured at the upstream
+/// emit site (before stripping) and threaded in explicitly so the
+/// event's `topic` field still carries it; otherwise the topic-scoped
+/// classifier (`ledger_event_matches_topic_scope`) reads `None` and
+/// silently drops the frame. The append-time safety net
+/// (`stamp_topic_from_session`) cannot recover because it pulls topic
+/// from `session_id`, which has already been stripped. See #1336
+/// round-2 BLOCKER for the deep-trace rationale.
+///
 /// `tool_call_id` is optional because not every file-emission path
 /// runs inside a tool execution (rare; reserved for background-result
 /// futures). `mime` is also optional — clients fall back to extension
@@ -124,6 +138,7 @@ pub(super) fn emit_turn_completed_full(
 pub(super) fn emit_file_attached(
     ledger: &Arc<UiProtocolLedger>,
     session_id: &SessionKey,
+    topic: Option<&str>,
     turn_id: &TurnId,
     path: String,
     tool_call_id: Option<String>,
@@ -131,7 +146,10 @@ pub(super) fn emit_file_attached(
 ) {
     let notification = UiNotification::FileAttached(FileAttachedEvent {
         session_id: session_id.clone(),
-        topic: session_id.topic().map(ToOwned::to_owned),
+        topic: topic
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(ToOwned::to_owned),
         turn_id: turn_id.clone(),
         path,
         tool_call_id,
@@ -187,6 +205,12 @@ pub(super) fn emit_files_attached_from_background(
     tool_call_id: Option<String>,
 ) {
     use std::collections::BTreeSet;
+    // #1336 round-2: capture topic BEFORE stripping the suffix below.
+    // The strip is required for routing (SPA subscribes on base only),
+    // but the event itself must still carry the topic so the
+    // topic-scoped classifier accepts it. See [`emit_file_attached`]
+    // for the full rationale.
+    let topic = session_id.topic().map(ToOwned::to_owned);
     // P0-A wire-gap fix: publish on the base SessionKey (no `#<topic>`
     // suffix). The SPA's `session/open` subscription is keyed on the
     // base form; topic-suffixed broadcasts reach zero live subscribers.
@@ -203,6 +227,7 @@ pub(super) fn emit_files_attached_from_background(
         emit_file_attached(
             ledger,
             &base_session,
+            topic.as_deref(),
             turn_id,
             path.clone(),
             tool_call_id.clone(),
@@ -468,6 +493,7 @@ mod tests {
         emit_file_attached(
             &ledger,
             &session_id,
+            None,
             &turn_id,
             "/tmp/output.png".into(),
             Some("tc-1".into()),
@@ -507,6 +533,7 @@ mod tests {
         emit_file_attached(
             &ledger,
             &session_id,
+            None,
             &turn_id,
             "/tmp/bare.txt".into(),
             None,
@@ -598,7 +625,15 @@ mod tests {
                 client_message_id: None,
             }),
         );
-        emit_file_attached(&ledger, &session_a, &turn_id, "/tmp/x".into(), None, None);
+        emit_file_attached(
+            &ledger,
+            &session_a,
+            None,
+            &turn_id,
+            "/tmp/x".into(),
+            None,
+            None,
+        );
         emit_session_event(
             &ledger,
             &session_a,
@@ -1229,8 +1264,97 @@ mod tests {
         {
             assert_eq!(payload.session_id, base_session);
             assert_eq!(payload.path, "/tmp/report.md");
+            assert!(
+                payload.topic.is_none(),
+                "bare session_id emit must preserve the no-topic shape",
+            );
         } else {
             panic!("expected FileAttached");
         }
+    }
+
+    /// #1336 round-2 (codex BLOCK): the original P0-A fix (`a303991c`)
+    /// stripped the topic suffix from `session_id` BEFORE building the
+    /// `FileAttachedEvent`, so the helper saw a bare session and the
+    /// emitted event ended up with `topic: None`. After the
+    /// `ledger_event_matches_topic_scope` exemption was removed in
+    /// favour of consulting the explicit `event.topic` field, an event
+    /// with `topic: None` is silently dropped by a topic-scoped
+    /// subscriber — re-introducing the exact failure mode P0-A
+    /// originally closed. The append-time safety net
+    /// (`stamp_topic_from_session`) can't recover because `session_id`
+    /// has already been stripped, so its `session_id.topic()` returns
+    /// `None` and it bails out at the early-return guard.
+    ///
+    /// The fix preserves topic on the event itself BEFORE the strip:
+    /// the caller captures `session_id.topic()` and passes it
+    /// separately into `emit_file_attached`, which sets the event's
+    /// `topic` field explicitly. The base SessionKey routing
+    /// (subscribers on the base key) is unchanged.
+    ///
+    /// Pre-fix: this assertion fails because `event.topic` is `None`.
+    /// Post-fix: `event.topic` is `Some("slides")` so the topic-scoped
+    /// classifier (which reads `event.topic()` first) accepts the
+    /// event.
+    #[test]
+    fn emit_files_attached_from_background_preserves_topic_on_event_when_session_id_stripped() {
+        let ledger = Arc::new(UiProtocolLedger::new(64));
+        let base_session = SessionKey::new("api", "p0a-round2");
+        // Caller-side session_id carries the `#slides` topic suffix —
+        // mirrors the production shape that surfaced the bug.
+        let topic_session = SessionKey::with_topic("api", "p0a-round2", "slides");
+        let turn_id = TurnId::new();
+        let mut subscriber = ledger.subscribe(&base_session);
+
+        emit_files_attached_from_background(
+            &ledger,
+            &topic_session,
+            &turn_id,
+            &["/tmp/deck.pptx".to_string()],
+            &[],
+            Some("tc-round2".into()),
+        );
+
+        let event = subscriber
+            .try_recv()
+            .expect("base subscriber receives file/attached");
+        let (payload, notification_topic) = match &event.event {
+            crate::api::ui_protocol_ledger::UiProtocolLedgerEvent::Notification(
+                notification @ UiNotification::FileAttached(payload),
+            ) => (payload.clone(), notification.topic().map(ToOwned::to_owned)),
+            other => panic!("expected FileAttached, got {other:?}"),
+        };
+
+        // Routing invariant (P0-A): the embedded session_id is the
+        // BASE form so the SPA's `session/open` subscription receives it.
+        assert_eq!(
+            payload.session_id, base_session,
+            "embedded session_id must be the base form (no topic suffix)",
+        );
+
+        // Topic invariant (#1336 round-2 BLOCKER): the event's `topic`
+        // field must be populated from the ORIGINAL topic-suffixed
+        // session_id BEFORE the strip — otherwise the topic-scoped
+        // classifier drops the event silently.
+        assert_eq!(
+            payload.topic.as_deref(),
+            Some("slides"),
+            "event.topic must be preserved from the original session_id; \
+             the strip site captures it BEFORE rebuilding the base SessionKey",
+        );
+
+        // `UiNotification::topic()` (the helper the classifier consults)
+        // must surface the explicit field so a topic-scoped subscriber
+        // accepts the event. Pre-fix this returned None because the
+        // base-stripped `session_id` had no `#topic` suffix to fall
+        // back on either — both the explicit field and the suffix
+        // fallback were empty, and the classifier dropped the event.
+        assert_eq!(
+            notification_topic.as_deref(),
+            Some("slides"),
+            "UiNotification::topic() (read by the topic-scope classifier) \
+             must return the explicit event.topic so the topic-scoped \
+             subscriber routes the envelope correctly",
+        );
     }
 }

--- a/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
+++ b/crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs
@@ -131,6 +131,7 @@ pub(super) fn emit_file_attached(
 ) {
     let notification = UiNotification::FileAttached(FileAttachedEvent {
         session_id: session_id.clone(),
+        topic: session_id.topic().map(ToOwned::to_owned),
         turn_id: turn_id.clone(),
         path,
         tool_call_id,

--- a/crates/octos-cli/src/api/ui_protocol_approvals.rs
+++ b/crates/octos-cli/src/api/ui_protocol_approvals.rs
@@ -330,6 +330,7 @@ pub(super) fn build_decided_event(
         .unwrap_or_else(TurnId::new);
     ApprovalDecidedEvent {
         session_id: params.session_id.clone(),
+        topic: params.session_id.topic().map(ToOwned::to_owned),
         approval_id: params.approval_id.clone(),
         turn_id,
         // FIX-01: `ApprovalDecision` is non-Copy (`Unknown(String)`); clone

--- a/crates/octos-cli/src/api/ui_protocol_audit.rs
+++ b/crates/octos-cli/src/api/ui_protocol_audit.rs
@@ -332,6 +332,7 @@ mod tests {
     fn sample_event(decision: ApprovalDecision) -> ApprovalDecidedEvent {
         ApprovalDecidedEvent {
             session_id: SessionKey("local:test".into()),
+            topic: None,
             approval_id: ApprovalId::new(),
             turn_id: TurnId::new(),
             decision,

--- a/crates/octos-cli/src/api/ui_protocol_progress.rs
+++ b/crates/octos-cli/src/api/ui_protocol_progress.rs
@@ -332,6 +332,7 @@ fn map_tool_start(context: &ProgressMappingContext, event: &Value) -> UiProgress
 
     UiProgressMapping::notifications(vec![UiNotification::ToolStarted(ToolStartedEvent {
         session_id: context.session_id.clone(),
+        topic: context.session_id.topic().map(ToOwned::to_owned),
         turn_id: context.turn_id.clone(),
         tool_call_id,
         tool_name,
@@ -346,6 +347,7 @@ fn map_tool_progress(context: &ProgressMappingContext, event: &Value) -> UiProgr
 
     UiProgressMapping::notifications(vec![UiNotification::ToolProgress(ToolProgressEvent {
         session_id: context.session_id.clone(),
+        topic: context.session_id.topic().map(ToOwned::to_owned),
         turn_id: context.turn_id.clone(),
         tool_call_id,
         message: string_field(event, &["message", "status"]),
@@ -377,6 +379,7 @@ fn map_tool_end(context: &ProgressMappingContext, event: &Value) -> UiProgressMa
     UiProgressMapping {
         notifications: vec![UiNotification::ToolCompleted(ToolCompletedEvent {
             session_id: context.session_id.clone(),
+            topic: context.session_id.topic().map(ToOwned::to_owned),
             turn_id: context.turn_id.clone(),
             tool_call_id,
             tool_name,

--- a/crates/octos-core/src/ui_protocol.rs
+++ b/crates/octos-core/src/ui_protocol.rs
@@ -4109,6 +4109,14 @@ pub struct MessageDeltaEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolStartedEvent {
     pub session_id: SessionKey,
+    /// Topic routing key — populated from the originating
+    /// `SessionKey.topic()` BEFORE any `base_key()` strip. Carried on
+    /// the wire so a topic-scoped subscriber routes the event correctly
+    /// even when the emit-side `session_id` was reconstructed from
+    /// `base_key()`. Closes the P0-A class routing drop (#1329); see
+    /// `UiNotification::topic()`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
     pub turn_id: TurnId,
     pub tool_call_id: String,
     pub tool_name: String,
@@ -4119,6 +4127,9 @@ pub struct ToolStartedEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolProgressEvent {
     pub session_id: SessionKey,
+    /// Topic routing key (see [`ToolStartedEvent::topic`]; #1329).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
     pub turn_id: TurnId,
     pub tool_call_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4130,6 +4141,9 @@ pub struct ToolProgressEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolCompletedEvent {
     pub session_id: SessionKey,
+    /// Topic routing key (see [`ToolStartedEvent::topic`]; #1329).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
     pub turn_id: TurnId,
     pub tool_call_id: String,
     pub tool_name: String,
@@ -4326,6 +4340,9 @@ impl ApprovalRequestedEvent {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ApprovalAutoResolvedEvent {
     pub session_id: SessionKey,
+    /// Topic routing key (see [`ToolStartedEvent::topic`]; #1329).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
     pub approval_id: ApprovalId,
     pub turn_id: TurnId,
     pub tool_name: String,
@@ -4344,6 +4361,9 @@ pub struct ApprovalAutoResolvedEvent {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ApprovalDecidedEvent {
     pub session_id: SessionKey,
+    /// Topic routing key (see [`ToolStartedEvent::topic`]; #1329).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
     pub approval_id: ApprovalId,
     pub turn_id: TurnId,
     pub decision: ApprovalDecision,
@@ -4370,6 +4390,7 @@ impl ApprovalDecidedEvent {
     ) -> Self {
         Self {
             session_id,
+            topic: None,
             approval_id,
             turn_id,
             decision,
@@ -4389,6 +4410,9 @@ impl ApprovalDecidedEvent {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ApprovalCancelledEvent {
     pub session_id: SessionKey,
+    /// Topic routing key (see [`ToolStartedEvent::topic`]; #1329).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
     pub approval_id: ApprovalId,
     pub turn_id: TurnId,
     pub reason: String,
@@ -4402,6 +4426,7 @@ impl ApprovalCancelledEvent {
     ) -> Self {
         Self {
             session_id,
+            topic: None,
             approval_id,
             turn_id,
             reason: approval_cancelled_reasons::TURN_INTERRUPTED.to_owned(),
@@ -4853,6 +4878,13 @@ pub struct ReplayLossyEvent {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FileAttachedEvent {
     pub session_id: SessionKey,
+    /// Topic routing key (see [`ToolStartedEvent::topic`]; #1329).
+    /// Closes the P0-A regression that motivated the prior
+    /// `ledger_event_matches_topic_scope` exemption — now that the
+    /// field exists, the classifier consults the explicit topic and
+    /// the exemption is no longer needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
     pub turn_id: TurnId,
     /// Filesystem path or URL the tool produced.
     pub path: String,
@@ -5107,7 +5139,23 @@ impl UiNotification {
             Self::MessageDelta(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
+            Self::ToolStarted(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
+            Self::ToolProgress(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
+            Self::ToolCompleted(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
             Self::ApprovalRequested(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
+            Self::ApprovalAutoResolved(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
+            Self::ApprovalDecided(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
+            Self::ApprovalCancelled(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
             Self::TaskUpdated(event) => event.topic.as_deref().or_else(|| event.session_id.topic()),
@@ -5124,6 +5172,9 @@ impl UiNotification {
             Self::TurnSpawnComplete(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
+            Self::FileAttached(event) => {
+                event.topic.as_deref().or_else(|| event.session_id.topic())
+            }
             Self::SessionEventBridged(event) => {
                 event.topic.as_deref().or_else(|| event.session_id.topic())
             }
@@ -5138,13 +5189,20 @@ impl UiNotification {
         match self {
             Self::TurnStarted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::MessageDelta(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::ToolStarted(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::ToolProgress(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::ToolCompleted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::ApprovalRequested(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::ApprovalAutoResolved(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::ApprovalDecided(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::ApprovalCancelled(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TaskUpdated(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TaskOutputDelta(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TurnCompleted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TurnError(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::MessagePersisted(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::TurnSpawnComplete(event) => set_topic_if_absent(&mut event.topic, &topic),
+            Self::FileAttached(event) => set_topic_if_absent(&mut event.topic, &topic),
             Self::SessionEventBridged(event) => set_topic_if_absent(&mut event.topic, &topic),
             _ => {}
         }
@@ -8146,6 +8204,7 @@ mod tests {
             .with_timezone(&Utc);
         let event = UiNotification::ApprovalDecided(ApprovalDecidedEvent {
             session_id: session_id.clone(),
+            topic: None,
             approval_id: approval_id.clone(),
             turn_id: turn_id.clone(),
             decision: ApprovalDecision::Approve,
@@ -10067,6 +10126,393 @@ mod tests {
         assert!(
             caps.supports_method(methods::ROUTER_GET_METRICS),
             "router/get_metrics must be a supported command method"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // #1329 — topic-scope routing class fix
+    //
+    // The 6 events listed below (ToolStarted/Progress/Completed,
+    // ApprovalAutoResolved/Decided/Cancelled), plus FileAttached
+    // (already covered by the P0-A regression), gained an explicit
+    // `topic: Option<String>` field. `UiNotification::topic()` now
+    // consults that field FIRST and only falls back to
+    // `SessionKey.topic()`. Each test:
+    //   1. Builds the event with an explicit `topic` field — `topic()`
+    //      returns the field's value, even when `session_id` was
+    //      stripped to `base_key()` (the P0-A failure mode).
+    //   2. Builds the same event with a topic-suffixed session_id but
+    //      NO explicit topic — `topic()` falls back to the suffix
+    //      (backward compat; `stamp_topic_from_session` then promotes
+    //      it to the explicit field at append time).
+    //   3. Builds the event with neither — `topic()` returns `None`.
+    // -----------------------------------------------------------------
+
+    fn topic_session() -> SessionKey {
+        SessionKey("local:slides-soak#slides".into())
+    }
+
+    fn bare_session() -> SessionKey {
+        SessionKey("local:slides-soak".into())
+    }
+
+    #[test]
+    fn tool_started_topic_method_reads_explicit_field_then_session_suffix() {
+        let with_field = UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "shell".into(),
+            arguments: None,
+        });
+        assert_eq!(
+            with_field.topic(),
+            Some("slides"),
+            "explicit topic field wins over base_key() session_id"
+        );
+
+        let fallback = UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-2".into(),
+            tool_name: "shell".into(),
+            arguments: None,
+        });
+        assert_eq!(
+            fallback.topic(),
+            Some("slides"),
+            "missing explicit topic falls back to session_id suffix"
+        );
+
+        let neither = UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: bare_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-3".into(),
+            tool_name: "shell".into(),
+            arguments: None,
+        });
+        assert_eq!(neither.topic(), None, "no topic anywhere → None");
+    }
+
+    #[test]
+    fn tool_progress_topic_method_reads_explicit_field_then_session_suffix() {
+        let with_field = UiNotification::ToolProgress(ToolProgressEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-1".into(),
+            message: Some("step 1".into()),
+            progress_pct: Some(25.0),
+        });
+        assert_eq!(with_field.topic(), Some("slides"));
+
+        let fallback = UiNotification::ToolProgress(ToolProgressEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-2".into(),
+            message: None,
+            progress_pct: None,
+        });
+        assert_eq!(fallback.topic(), Some("slides"));
+    }
+
+    #[test]
+    fn tool_completed_topic_method_reads_explicit_field_then_session_suffix() {
+        let with_field = UiNotification::ToolCompleted(ToolCompletedEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-1".into(),
+            tool_name: "shell".into(),
+            success: Some(true),
+            output_preview: None,
+            duration_ms: Some(10),
+        });
+        assert_eq!(with_field.topic(), Some("slides"));
+
+        let fallback = UiNotification::ToolCompleted(ToolCompletedEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-2".into(),
+            tool_name: "shell".into(),
+            success: Some(true),
+            output_preview: None,
+            duration_ms: None,
+        });
+        assert_eq!(fallback.topic(), Some("slides"));
+    }
+
+    #[test]
+    fn approval_auto_resolved_topic_method_reads_explicit_field_then_session_suffix() {
+        let with_field = UiNotification::ApprovalAutoResolved(ApprovalAutoResolvedEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            tool_name: "shell".into(),
+            scope: approval_scopes::SESSION.into(),
+            scope_match: "exact".into(),
+            decision: ApprovalDecision::Approve,
+        });
+        assert_eq!(with_field.topic(), Some("slides"));
+
+        let fallback = UiNotification::ApprovalAutoResolved(ApprovalAutoResolvedEvent {
+            session_id: topic_session(),
+            topic: None,
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            tool_name: "shell".into(),
+            scope: approval_scopes::SESSION.into(),
+            scope_match: "exact".into(),
+            decision: ApprovalDecision::Approve,
+        });
+        assert_eq!(fallback.topic(), Some("slides"));
+    }
+
+    #[test]
+    fn approval_decided_topic_method_reads_explicit_field_then_session_suffix() {
+        let with_field = UiNotification::ApprovalDecided(ApprovalDecidedEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            decision: ApprovalDecision::Approve,
+            scope: None,
+            decided_at: Utc::now(),
+            decided_by: "user:test".into(),
+            auto_resolved: false,
+            policy_id: None,
+            client_note: None,
+        });
+        assert_eq!(with_field.topic(), Some("slides"));
+
+        let fallback = UiNotification::ApprovalDecided(ApprovalDecidedEvent {
+            session_id: topic_session(),
+            topic: None,
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            decision: ApprovalDecision::Approve,
+            scope: None,
+            decided_at: Utc::now(),
+            decided_by: "user:test".into(),
+            auto_resolved: false,
+            policy_id: None,
+            client_note: None,
+        });
+        assert_eq!(fallback.topic(), Some("slides"));
+    }
+
+    #[test]
+    fn approval_cancelled_topic_method_reads_explicit_field_then_session_suffix() {
+        let with_field = UiNotification::ApprovalCancelled(ApprovalCancelledEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            reason: approval_cancelled_reasons::TURN_INTERRUPTED.into(),
+        });
+        assert_eq!(with_field.topic(), Some("slides"));
+
+        let fallback = UiNotification::ApprovalCancelled(ApprovalCancelledEvent {
+            session_id: topic_session(),
+            topic: None,
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            reason: approval_cancelled_reasons::TURN_INTERRUPTED.into(),
+        });
+        assert_eq!(fallback.topic(), Some("slides"));
+    }
+
+    /// #1329 sibling test: FileAttached gained the same `topic` field
+    /// as the 6 ApprovalDecided-class events; verify the same access
+    /// rule (explicit first, suffix fallback). This was the bug the
+    /// P0-A exemption patched; with explicit field, the exemption is
+    /// no longer needed.
+    #[test]
+    fn file_attached_topic_method_reads_explicit_field_then_session_suffix() {
+        let with_field = UiNotification::FileAttached(FileAttachedEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            turn_id: TurnId::new(),
+            path: "/tmp/deck.pptx".into(),
+            tool_call_id: Some("tc-slides".into()),
+            mime: None,
+        });
+        assert_eq!(with_field.topic(), Some("slides"));
+
+        let fallback = UiNotification::FileAttached(FileAttachedEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            path: "/tmp/deck.pptx".into(),
+            tool_call_id: None,
+            mime: None,
+        });
+        assert_eq!(fallback.topic(), Some("slides"));
+    }
+
+    /// `stamp_topic_from_session` MUST populate the new explicit
+    /// `topic` field for the 6 vulnerable variants (and FileAttached)
+    /// from the SessionKey suffix when the field is absent. This is
+    /// the safety net that runs in `into_rpc_notification`: even if a
+    /// caller forgets to stamp, the wire-emit path stamps it for them
+    /// so a topic-scoped subscriber always routes the event correctly.
+    #[test]
+    fn stamp_topic_from_session_populates_new_topic_class_events() {
+        // ToolStarted
+        let mut event = UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc".into(),
+            tool_name: "shell".into(),
+            arguments: None,
+        });
+        event.stamp_topic_from_session();
+        assert_eq!(event.topic(), Some("slides"));
+        if let UiNotification::ToolStarted(inner) = &event {
+            assert_eq!(inner.topic.as_deref(), Some("slides"));
+        } else {
+            panic!("event variant changed unexpectedly");
+        }
+
+        // ToolProgress
+        let mut event = UiNotification::ToolProgress(ToolProgressEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc".into(),
+            message: None,
+            progress_pct: None,
+        });
+        event.stamp_topic_from_session();
+        if let UiNotification::ToolProgress(inner) = &event {
+            assert_eq!(inner.topic.as_deref(), Some("slides"));
+        }
+
+        // ToolCompleted
+        let mut event = UiNotification::ToolCompleted(ToolCompletedEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc".into(),
+            tool_name: "shell".into(),
+            success: Some(true),
+            output_preview: None,
+            duration_ms: None,
+        });
+        event.stamp_topic_from_session();
+        if let UiNotification::ToolCompleted(inner) = &event {
+            assert_eq!(inner.topic.as_deref(), Some("slides"));
+        }
+
+        // ApprovalAutoResolved
+        let mut event = UiNotification::ApprovalAutoResolved(ApprovalAutoResolvedEvent {
+            session_id: topic_session(),
+            topic: None,
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            tool_name: "shell".into(),
+            scope: approval_scopes::SESSION.into(),
+            scope_match: "exact".into(),
+            decision: ApprovalDecision::Approve,
+        });
+        event.stamp_topic_from_session();
+        if let UiNotification::ApprovalAutoResolved(inner) = &event {
+            assert_eq!(inner.topic.as_deref(), Some("slides"));
+        }
+
+        // ApprovalDecided
+        let mut event = UiNotification::ApprovalDecided(ApprovalDecidedEvent {
+            session_id: topic_session(),
+            topic: None,
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            decision: ApprovalDecision::Approve,
+            scope: None,
+            decided_at: Utc::now(),
+            decided_by: "user:test".into(),
+            auto_resolved: false,
+            policy_id: None,
+            client_note: None,
+        });
+        event.stamp_topic_from_session();
+        if let UiNotification::ApprovalDecided(inner) = &event {
+            assert_eq!(inner.topic.as_deref(), Some("slides"));
+        }
+
+        // ApprovalCancelled
+        let mut event = UiNotification::ApprovalCancelled(ApprovalCancelledEvent {
+            session_id: topic_session(),
+            topic: None,
+            approval_id: ApprovalId::new(),
+            turn_id: TurnId::new(),
+            reason: approval_cancelled_reasons::TURN_INTERRUPTED.into(),
+        });
+        event.stamp_topic_from_session();
+        if let UiNotification::ApprovalCancelled(inner) = &event {
+            assert_eq!(inner.topic.as_deref(), Some("slides"));
+        }
+
+        // FileAttached (sibling)
+        let mut event = UiNotification::FileAttached(FileAttachedEvent {
+            session_id: topic_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            path: "/tmp/deck.pptx".into(),
+            tool_call_id: None,
+            mime: None,
+        });
+        event.stamp_topic_from_session();
+        if let UiNotification::FileAttached(inner) = &event {
+            assert_eq!(inner.topic.as_deref(), Some("slides"));
+        }
+    }
+
+    /// #1329 wire-shape guarantee: the new `topic` field must
+    /// serialize when present and stay omitted when absent (so v0
+    /// clients never see a surprise field). Verified for one
+    /// representative variant (the same `skip_serializing_if` is
+    /// applied uniformly across all 7).
+    #[test]
+    fn tool_started_topic_field_round_trips_on_the_wire() {
+        let event = UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: bare_session(),
+            topic: Some("slides".into()),
+            turn_id: TurnId(Uuid::from_u128(0x1329)),
+            tool_call_id: "tc-1329".into(),
+            tool_name: "shell".into(),
+            arguments: None,
+        });
+        let wire = serde_json::to_value(event.clone().into_rpc_notification().expect("serialize"))
+            .expect("to_value");
+        assert_eq!(wire["params"]["topic"], json!("slides"));
+
+        let decoded: RpcNotification<Value> =
+            serde_json::from_value(wire).expect("deserialize wire");
+        let decoded_event = UiNotification::from_rpc_notification(decoded).expect("decode");
+        assert_eq!(decoded_event.topic(), Some("slides"));
+
+        // Absent topic stays omitted.
+        let bare_event = UiNotification::ToolStarted(ToolStartedEvent {
+            session_id: bare_session(),
+            topic: None,
+            turn_id: TurnId::new(),
+            tool_call_id: "tc-bare".into(),
+            tool_name: "shell".into(),
+            arguments: None,
+        });
+        let wire =
+            serde_json::to_value(bare_event.into_rpc_notification().expect("serialize bare"))
+                .expect("to_value");
+        assert!(
+            wire["params"].get("topic").is_none(),
+            "absent topic field must stay omitted on the wire (no v0 breakage)"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #1329.

The P0-A regression patched in #1311 / #1316 was a single-variant fix for `file/attached`: the classifier `ledger_event_matches_topic_scope` read `event.topic()`, which fell back to `SessionKey.topic()` whenever the event had no explicit `topic` field. Any emit site that constructed the event with a `session_id` stripped of the `#<topic>` suffix produced `topic() == None`, the topic-scoped subscriber filter dropped it, and the SPA never received it. P0-A patched FileAttached with a `matches!(...) → return true` exemption.

**Six more event types share the same class bug** and are vulnerable to the exact same silent drop:

- `ToolStartedEvent`
- `ToolProgressEvent`
- `ToolCompletedEvent`
- `ApprovalAutoResolvedEvent`
- `ApprovalDecidedEvent`
- `ApprovalCancelledEvent`

**Architecturally honest fix (audit recommendation #2 — option A):** every vulnerable variant gains an explicit `topic: Option<String>` field — symmetric with the 10 already-fixed events. `UiNotification::topic()` consults the field FIRST and falls back to the `SessionKey.topic()` suffix; emitters populate the field at the source from the upstream SessionKey BEFORE any `base_key()` strip. FileAttached gains the same field so the single-variant exemption block can be removed — every variant now routes by the same rule.

Wire-shape changes are additive (`#[serde(default, skip_serializing_if = "Option::is_none")]`) — absent topics stay omitted on the wire and v0 clients see no diff. The classifier needed no logic change; it already delegated to `event.topic()`.

Spec context: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` §5 (Identity Model) should clarify that `topic` IS part of the routing key, not metadata — separate PR for the spec text update.

## Files changed

- `crates/octos-core/src/ui_protocol.rs` — added `topic: Option<String>` to 7 event structs; extended `UiNotification::topic()` and `stamp_topic_from_session` match arms.
- `crates/octos-cli/src/api/ui_protocol.rs` — populated `topic` at every emit site (M9 fixture, m14 codex tool, approval auto-resolve, approval cancel-on-send-fail, approval cancel-on-turn-interrupt, test fixtures); removed FileAttached-only exemption in `ledger_event_matches_topic_scope`; replaced exemption test with new field-routing test.
- `crates/octos-cli/src/api/ui_protocol_alpha2_bridge.rs` — `LedgerToolProgressReporter` populates `ToolProgressEvent.topic` from its session_id.
- `crates/octos-cli/src/api/ui_protocol_alpha9_bridge.rs` — `emit_file_attached` populates `FileAttachedEvent.topic` from its session_id.
- `crates/octos-cli/src/api/ui_protocol_approvals.rs` — `build_decided_event` populates `ApprovalDecidedEvent.topic` from `params.session_id`.
- `crates/octos-cli/src/api/ui_protocol_audit.rs` — test fixture updated.
- `crates/octos-cli/src/api/ui_protocol_progress.rs` — `map_tool_start`/`progress`/`end` populate topic from the mapping context's `session_id`.

## Test plan

- [x] 9 new `octos-core::ui_protocol` unit tests cover the field-first / suffix-fallback rule per variant + `stamp_topic_from_session` safety-net + wire round-trip (present + omitted)
- [x] 2 new `octos-cli::api::ui_protocol` `#[tokio::test]` integration tests cover the live broadcast path: all 6 new variants reach a topic-scoped subscriber when topic is set; mismatched topic is dropped
- [x] FileAttached-only exemption test rewritten (`ledger_event_matches_topic_scope_routes_file_attached_by_topic_field`) — verifies new field-based routing rule (4 cases: bare/topic event × bare/topic subscriber)
- [x] `cargo test -p octos-core --lib` — 260 passed
- [x] `cargo test -p octos-cli --lib --features "api,telegram,..."` — 1410 passed, including 21 topic-related tests (`ledger_event_matches_topic_scope_routes_file_attached_by_topic_field`, `live_forwarder_delivers_tool_and_approval_events_to_topic_scoped_subscriber`, `live_forwarder_drops_mismatched_topic_for_tool_and_approval_events`, and 18 existing topic/routing tests)
- [x] `cargo build --workspace` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Existing `live_forwarder_delivers_file_attached_to_topic_scoped_subscriber` end-to-end test still passes