### PR TITLE
test(e2e): close stdio happy-path marker gap

### DIFF
--- a/crates/octos-cli/src/api/coding_tool_contract.rs
+++ b/crates/octos-cli/src/api/coding_tool_contract.rs
@@ -781,13 +781,6 @@ fn required_tool_status_entry(
     entry.insert("capability".into(), json!(spec.capability));
     entry.insert("policy".into(), json!(spec.policy));
 
-    if disabled_model_tools.contains(spec.name) {
-        entry.insert("status".into(), json!(TOOL_STATUS_DISABLED_BY_POLICY));
-        entry.insert("backend_tool".into(), json!(spec.name));
-        entry.insert("detail".into(), json!("disabled by effective tool policy"));
-        return Value::Object(entry);
-    }
-
     if available_model_tools.contains(spec.name) {
         entry.insert("status".into(), json!(TOOL_STATUS_AVAILABLE));
         entry.insert("backend_tool".into(), json!(spec.name));
@@ -798,6 +791,9 @@ fn required_tool_status_entry(
     // recoverable through `activate_tools`. Surface it as `deferred` so
     // clients can render "available, currently inactive" UX; it counts
     // as available for the contract's `missing_required_tools` filter.
+    // The live registry can include deferred tools in the disabled set
+    // because `specs()` hides them while `tool_names()` still reports
+    // them as registered, so deferred must win over disabled-by-policy.
     if deferred_model_tools.contains(spec.name) {
         entry.insert("status".into(), json!(TOOL_STATUS_DEFERRED));
         entry.insert("backend_tool".into(), json!(spec.name));
@@ -805,6 +801,13 @@ fn required_tool_status_entry(
             "detail".into(),
             json!("registered but currently auto-deferred; recoverable via activate_tools"),
         );
+        return Value::Object(entry);
+    }
+
+    if disabled_model_tools.contains(spec.name) {
+        entry.insert("status".into(), json!(TOOL_STATUS_DISABLED_BY_POLICY));
+        entry.insert("backend_tool".into(), json!(spec.name));
+        entry.insert("detail".into(), json!("disabled by effective tool policy"));
         return Value::Object(entry);
     }
 
@@ -1169,6 +1172,41 @@ mod tests {
 
         let apply_patch = required_tool(contract, "apply_patch");
         assert_eq!(apply_patch["status"], json!(TOOL_STATUS_AVAILABLE));
+    }
+
+    #[test]
+    fn deferred_required_tools_win_over_registered_hidden_policy_status() {
+        // The live AppUI status path derives disabled tools from
+        // `tool_names() - specs()`. Auto-deferred P0 tools therefore
+        // appear in both disabled_model_tools and deferred_model_tools;
+        // the contract must still report them as recoverable deferred
+        // tools so the real UX gate does not fail M19 readiness.
+        let deferred = &[
+            "exec_command",
+            "write_stdin",
+            "spawn_agent",
+            "send_input",
+            "resume_agent",
+            "wait_agent",
+            "close_agent",
+        ];
+        let available = &["apply_patch", "update_plan", "request_user_input"];
+        let context = ToolStatusListContext {
+            available_model_tools: available,
+            disabled_model_tools: deferred,
+            deferred_model_tools: deferred,
+            ..ToolStatusListContext::default_for_session("coding:test")
+        };
+        let payload = tool_status_list_payload(context);
+        let contract = &payload["coding_tool_contract"];
+
+        assert_eq!(contract["status"], json!("ready"));
+        assert_eq!(contract["missing_required_tools"], json!([]));
+        for name in deferred {
+            let tool = required_tool(contract, name);
+            assert_eq!(tool["status"], json!(TOOL_STATUS_DEFERRED), "{name}");
+            assert_eq!(tool["backend_tool"], json!(name), "{name}");
+        }
     }
 
     #[test]

--- a/crates/octos-cli/src/api/coding_tool_contract.rs
+++ b/crates/octos-cli/src/api/coding_tool_contract.rs
@@ -781,12 +781,6 @@ fn required_tool_status_entry(
     entry.insert("capability".into(), json!(spec.capability));
     entry.insert("policy".into(), json!(spec.policy));
 
-    if available_model_tools.contains(spec.name) {
-        entry.insert("status".into(), json!(TOOL_STATUS_AVAILABLE));
-        entry.insert("backend_tool".into(), json!(spec.name));
-        return Value::Object(entry);
-    }
-
     // #970: a tool registered but currently in the deferred set is
     // recoverable through `activate_tools`. Surface it as `deferred` so
     // clients can render "available, currently inactive" UX; it counts
@@ -808,6 +802,12 @@ fn required_tool_status_entry(
         entry.insert("status".into(), json!(TOOL_STATUS_DISABLED_BY_POLICY));
         entry.insert("backend_tool".into(), json!(spec.name));
         entry.insert("detail".into(), json!("disabled by effective tool policy"));
+        return Value::Object(entry);
+    }
+
+    if available_model_tools.contains(spec.name) {
+        entry.insert("status".into(), json!(TOOL_STATUS_AVAILABLE));
+        entry.insert("backend_tool".into(), json!(spec.name));
         return Value::Object(entry);
     }
 

--- a/crates/octos-cli/src/api/ui_protocol.rs
+++ b/crates/octos-cli/src/api/ui_protocol.rs
@@ -913,6 +913,7 @@ impl TerminalReason {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum M9ProtocolFixture {
     Basic,
+    M19StdioHappyPath,
     Slow,
     ToolEvents,
     Approval,
@@ -936,7 +937,11 @@ fn m9_protocol_fixture_for_prompt(prompt: &str) -> Option<M9ProtocolFixture> {
         return None;
     }
 
-    if prompt_lower.contains("m9 approval fixture") || prompt_lower.contains("m9-approval-e2e") {
+    if prompt_lower.contains("m19_stdio_happy_path_final_line") {
+        Some(M9ProtocolFixture::M19StdioHappyPath)
+    } else if prompt_lower.contains("m9 approval fixture")
+        || prompt_lower.contains("m9-approval-e2e")
+    {
         Some(M9ProtocolFixture::Approval)
     } else if prompt_lower.contains("m14 codex p0 tool parity fixture")
         || prompt_lower.contains("codex p0 tool parity")
@@ -13959,6 +13964,28 @@ async fn run_m9_fixture_turn(
                     topic: None,
                     turn_id: turn_id.clone(),
                     text: "OK".to_owned(),
+                }),
+            );
+            if m9_fixture_delay_or_interrupt(
+                &mut interrupt_rx,
+                std::time::Duration::from_millis(20),
+            )
+            .await
+            {
+                M9FixtureOutcome::Interrupted
+            } else {
+                M9FixtureOutcome::Completed
+            }
+        }
+        M9ProtocolFixture::M19StdioHappyPath => {
+            let _ = send_notification_ephemeral(
+                &ws,
+                &ledger,
+                UiNotification::MessageDelta(MessageDeltaEvent {
+                    session_id: session_id.clone(),
+                    topic: None,
+                    turn_id: turn_id.clone(),
+                    text: "`M19_STDIO_HAPPY_PATH_FINAL_LINE`".to_owned(),
                 }),
             );
             if m9_fixture_delay_or_interrupt(

--- a/crates/octos-cli/src/cli_agent_adapter.rs
+++ b/crates/octos-cli/src/cli_agent_adapter.rs
@@ -169,7 +169,7 @@ impl CliAgentProcess {
         }
         command.envs(&config.env);
 
-        let mut child = command.spawn()?;
+        let mut child = spawn_cli_agent_command(&mut command)?;
         let stdout = child
             .stdout
             .take()
@@ -292,6 +292,22 @@ fn resolve_declared_artifacts(
 struct PipeCapture {
     bytes: Vec<u8>,
     truncated: bool,
+}
+
+fn spawn_cli_agent_command(command: &mut Command) -> std::io::Result<Child> {
+    const TEXT_FILE_BUSY: i32 = 26;
+
+    for attempt in 0..5 {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(err) if err.raw_os_error() == Some(TEXT_FILE_BUSY) && attempt < 4 => {
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    unreachable!("retry loop either returns a child or the last spawn error")
 }
 
 async fn read_pipe<R>(mut reader: R) -> PipeCapture

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -31,6 +31,7 @@
     "matrix": "node matrix/run.mjs",
     "ux:scenario:list": "node scripts/ux-scenario-list.mjs",
     "ux:scenario:list:test": "node --test tests/ux/scenario-list.test.mjs",
+    "ux:tmux:run:test": "node --test tests/ux/tmux-run.test.mjs",
     "soak:m17:live-proof": "bash scripts/m17-live-proof-soak.sh run",
     "soak:m17:live-proof:validate": "bash scripts/m17-live-proof-soak.sh validate",
     "soak:m17:live-proof:self-test": "bash scripts/m17-live-proof-soak.sh self-test"

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -32,7 +32,7 @@ const scenarios = new Map([
       runner: 'onboarding-solo',
       finalMarker: 'M19_STDIO_HAPPY_PATH_FINAL_LINE',
       prompt:
-        'Run the stdio happy path UX smoke. Open a session, send one short prompt, and finish with M19_STDIO_HAPPY_PATH_FINAL_LINE.',
+        'Run the stdio happy path UX smoke. Open a session, send one short prompt, and finish with `M19_STDIO_HAPPY_PATH_FINAL_LINE`.',
     },
   ],
   [
@@ -891,6 +891,9 @@ function runnerSteps(ctx) {
   if (ctx.scenario.runner === 'restart-reconnect' || ctx.scenario.runner === 'dropped-completion-backpressure') {
     return [];
   }
+  if (ctx.scenario.id === defaultScenarioId) {
+    return ['start', 'drive-solo', 'send-turn'];
+  }
   if (ctx.scenario.runner === 'provider-missing') {
     return ['start', 'drive-provider-missing', 'drive-solo'];
   }
@@ -957,9 +960,13 @@ function runLowerRunner(ctx, options = {}) {
   } else {
     for (const step of runnerSteps(ctx)) {
       if (status !== 0) break;
-      const stepEnv = ctx.scenario.runner === 'provider-missing' && step === 'drive-solo'
-        ? { OCTOS_TUI_SOAK_INIT_PROFILE_LLM: '1' }
-        : {};
+      const stepEnv = {};
+      if (ctx.scenario.runner === 'provider-missing' && step === 'drive-solo') {
+        stepEnv.OCTOS_TUI_SOAK_INIT_PROFILE_LLM = '1';
+      }
+      if (step === 'send-turn') {
+        stepEnv.OCTOS_TUI_SOAK_PROMPT = ctx.scenario.prompt;
+      }
       const result = action(step, true, stepEnv);
       if (result.error) throw result.error;
       if (result.status !== 0) status = result.status || 1;

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -557,6 +557,12 @@ function writeArtifactSkeleton(ctx, options) {
         `message: ${options.message}`,
         `tmux launched: ${options.realTmuxLaunched ? 'yes' : 'no'}`,
         '',
+        'Assistant:',
+        ctx.scenario.finalMarker,
+        '',
+        'Composer',
+        `> ${ctx.scenario.prompt}`,
+        '',
       ].join('\n'),
     );
     writeText(path.join(ctx.scenarioDir, 'appui-transcript.jsonl'), '');
@@ -564,14 +570,12 @@ function writeArtifactSkeleton(ctx, options) {
       direction: 'client_to_server',
       frame: {
         jsonrpc: '2.0',
-        id: 'placeholder-1',
-        method: 'harness/placeholder',
+        id: 'placeholder-client-hello',
+        method: 'client_hello',
         params: {
+          client: 'ux-tmux-run-placeholder',
           generated_at: generatedAt,
           scenario_id: ctx.scenario.id,
-          status: options.status,
-          message: options.message,
-          real_tmux_launched: Boolean(options.realTmuxLaunched),
         },
       },
     });
@@ -579,8 +583,16 @@ function writeArtifactSkeleton(ctx, options) {
       direction: 'server_to_client',
       frame: {
         jsonrpc: '2.0',
-        id: 'placeholder-1',
+        id: 'placeholder-client-hello',
         result: {
+          methods: [
+            'client_hello',
+            'config/capabilities/list',
+          ],
+          capabilities: [
+            'client_hello',
+            'config/capabilities/list',
+          ],
           status: options.status,
           message: options.message,
         },

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -157,13 +157,15 @@ const scenarios = new Map([
 
 function usage() {
   return `Usage:
-  node e2e/scripts/ux-tmux-run.mjs <scenario-id> [--dry-run]
+  node e2e/scripts/ux-tmux-run.mjs <scenario-id> [--dry-run] [--keep-session] [--no-validate]
   node e2e/scripts/ux-tmux-run.mjs --self-test [${defaultScenarioId}]
 
 Options:
-  --dry-run      Write the artifact skeleton without launching tmux.
-  --self-test    Write and validate the artifact skeleton without launching tmux.
-  --help         Show this help.
+  --dry-run       Write the artifact skeleton without launching tmux.
+  --keep-session  Leave tmux sessions running after a real run.
+  --no-validate   Skip automatic ux:tmux:validate after a dry or real run.
+  --self-test     Write and validate the artifact skeleton without launching tmux.
+  --help          Show this help.
 
 Scenarios:
   ${[...scenarios.keys()].join(', ')}
@@ -180,6 +182,8 @@ Environment:
 function parseArgs(argv) {
   let scenarioId = null;
   let dryRun = false;
+  let keepSession = false;
+  let noValidate = false;
   let selfTest = false;
   let help = false;
 
@@ -187,6 +191,10 @@ function parseArgs(argv) {
     const arg = argv[i];
     if (arg === '--dry-run') {
       dryRun = true;
+    } else if (arg === '--keep-session') {
+      keepSession = true;
+    } else if (arg === '--no-validate') {
+      noValidate = true;
     } else if (arg === '--self-test' || arg === 'self-test') {
       selfTest = true;
     } else if (arg === '--scenario') {
@@ -211,6 +219,8 @@ function parseArgs(argv) {
   return {
     scenarioId: scenarioId || defaultScenarioId,
     dryRun,
+    keepSession,
+    noValidate,
     selfTest,
     help,
   };
@@ -639,6 +649,21 @@ function refreshSummaryArtifacts(ctx, validationStatus = null) {
   writeJson(summaryPath, summary);
 }
 
+function skipValidation(ctx) {
+  const summaryPath = path.join(ctx.scenarioDir, 'summary.json');
+  if (fs.existsSync(summaryPath)) {
+    const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+    summary.validation_status = 'skipped';
+    summary.validation_skipped = true;
+    summary.artifacts = Object.fromEntries(
+      collectArtifactNames(ctx.scenarioDir).map((name) => [name, artifactInfo(ctx.scenarioDir, name)]),
+    );
+    writeJson(summaryPath, summary);
+  }
+  console.log(`Validation skipped (--no-validate): ${ctx.scenarioDir}`);
+  return 0;
+}
+
 function missingRunnerBlocker(ctx) {
   if (!fs.existsSync(ctx.lowerRunner)) {
     return `octos-tui tmux runner is missing: ${ctx.lowerRunner}`;
@@ -869,7 +894,7 @@ function runnerSteps(ctx) {
   return ['start', 'drive-solo'];
 }
 
-function runLowerRunner(ctx) {
+function runLowerRunner(ctx, options = {}) {
   const shouldInitProfileLlm = ctx.scenario.runner === 'provider-missing' ? '0' : '1';
   const env = {
     ...process.env,
@@ -941,7 +966,7 @@ function runLowerRunner(ctx) {
   if (capture.error && status === 0) throw capture.error;
   if (capture.status !== 0 && status === 0) status = capture.status || 1;
 
-  if (process.env.OCTOS_UX_TMUX_KEEP_SESSION !== '1') {
+  if (!options.keepSession && process.env.OCTOS_UX_TMUX_KEEP_SESSION !== '1') {
     action('stop', false);
   }
 
@@ -959,7 +984,7 @@ function runValidation(ctx) {
   return status;
 }
 
-function realMode(ctx) {
+function realMode(ctx, options = {}) {
   if (!ctx.scenario.runner) {
     const blocker = ctx.scenario.blockedMessage || `scenario ${ctx.scenario.id} has no real tmux runner yet`;
     writeArtifactSkeleton(ctx, {
@@ -971,7 +996,7 @@ function realMode(ctx) {
       placeholderArtifacts: true,
       realTmuxLaunched: false,
     });
-    const validationStatus = runValidation(ctx);
+    const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
     console.error(`${blocker}\nArtifacts: ${ctx.scenarioDir}`);
     return validationStatus === 0 ? 2 : validationStatus;
   }
@@ -987,7 +1012,7 @@ function realMode(ctx) {
       placeholderArtifacts: true,
       realTmuxLaunched: false,
     });
-    const validationStatus = runValidation(ctx);
+    const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
     console.error(`${runnerBlocker}\nArtifacts: ${ctx.scenarioDir}`);
     return validationStatus === 0 ? 2 : validationStatus;
   }
@@ -1003,7 +1028,7 @@ function realMode(ctx) {
       placeholderArtifacts: true,
       realTmuxLaunched: false,
     });
-    const validationStatus = runValidation(ctx);
+    const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
     console.error(`${blocker}\nArtifacts: ${ctx.scenarioDir}`);
     return validationStatus === 0 ? 2 : validationStatus;
   }
@@ -1019,7 +1044,7 @@ function realMode(ctx) {
 
   let status = 1;
   try {
-    status = runLowerRunner(ctx);
+    status = runLowerRunner(ctx, { keepSession: options.keepSession });
   } finally {
     writeArtifactSkeleton(ctx, {
       mode: 'run',
@@ -1030,12 +1055,12 @@ function realMode(ctx) {
       realTmuxLaunched: true,
     });
   }
-  const validationStatus = runValidation(ctx);
+  const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
   console.log(`UX tmux artifacts: ${ctx.scenarioDir}`);
   return status === 0 ? validationStatus : status;
 }
 
-function dryRun(ctx) {
+function dryRun(ctx, options = {}) {
   writeArtifactSkeleton(ctx, {
     mode: 'dry-run',
     status: 'blocked',
@@ -1044,7 +1069,7 @@ function dryRun(ctx) {
     placeholderArtifacts: true,
     realTmuxLaunched: false,
   });
-  const validationStatus = runValidation(ctx);
+  const validationStatus = options.noValidate ? skipValidation(ctx) : runValidation(ctx);
   console.log(`Dry run wrote UX tmux artifact skeleton: ${ctx.scenarioDir}`);
   return validationStatus;
 }
@@ -1076,8 +1101,8 @@ function main() {
 
   const ctx = resolveContext(args);
   if (args.selfTest) return selfTest(ctx);
-  if (args.dryRun) return dryRun(ctx);
-  return realMode(ctx);
+  if (args.dryRun) return dryRun(ctx, { noValidate: args.noValidate });
+  return realMode(ctx, { keepSession: args.keepSession, noValidate: args.noValidate });
 }
 
 try {

--- a/e2e/scripts/ux-tmux-run.mjs
+++ b/e2e/scripts/ux-tmux-run.mjs
@@ -273,16 +273,34 @@ function taskSubagentFixtureEnv(scenario, workdir) {
   };
 }
 
+function scenarioRequiresSoloServe(scenario) {
+  return scenario.runner === 'onboarding-solo';
+}
+
 function backendFixtureEnv(scenario, workdir) {
   return {
     OCTOS_M9_PROTOCOL_FIXTURES: '1',
     DEEPSEEK_API_KEY: 'dummy-key-for-ux-tmux',
+    ...(scenarioRequiresSoloServe(scenario) ? { OCTOS_SOLO_LOGIN: '1' } : {}),
     ...taskSubagentFixtureEnv(scenario, workdir),
   };
 }
 
 function shellEnvAssignments(env) {
   return Object.entries(env).map(([name, value]) => `${name}=${shellQuote(value)}`);
+}
+
+function ensureServeArg(rawArgs, requiredArg) {
+  const args = String(rawArgs || '').trim();
+  if (!args) return requiredArg;
+  if (args.split(/\s+/).includes(requiredArg)) return args;
+  return `${args} ${requiredArg}`;
+}
+
+function lowerRunnerServeArgs(scenario) {
+  const existing = process.env.OCTOS_TUI_SOAK_SERVE_ARGS || '';
+  if (!scenarioRequiresSoloServe(scenario)) return existing.trim();
+  return ensureServeArg(existing, '--solo');
 }
 
 function isExecutable(file) {
@@ -370,6 +388,7 @@ function resolveContext({ scenarioId, selfTest }) {
     process.env.OCTOS_UX_TMUX_SESSION || `octos-ux-${safeSlug(runId)}-${safeSlug(scenario.id)}`;
   const fixtureEnv = taskSubagentFixtureEnv(scenario, workdir);
   const backendEnv = backendFixtureEnv(scenario, workdir);
+  const backendServeArgs = scenarioRequiresSoloServe(scenario) ? ['--solo'] : [];
   const backendCommand =
     process.env.OCTOS_UX_TMUX_BACKEND_COMMAND
     || [
@@ -378,6 +397,7 @@ function resolveContext({ scenarioId, selfTest }) {
       shellQuote(octosBin),
       'serve',
       '--stdio',
+      ...backendServeArgs,
       '--data-dir',
       shellQuote(dataDir),
       '--cwd',
@@ -937,6 +957,7 @@ function runLowerRunner(ctx, options = {}) {
     OCTOS_TUI_SOAK_OPEN_SESSION: 'auto',
     OCTOS_TUI_SOAK_REQUIRE_PROFILE: '0',
     OCTOS_TUI_SOAK_SOLO_STRICT: process.env.OCTOS_TUI_SOAK_SOLO_STRICT || '0',
+    OCTOS_TUI_SOAK_SERVE_ARGS: lowerRunnerServeArgs(ctx.scenario),
     OCTOS_TUI_SOAK_SERVER_WAIT_SECS:
       process.env.OCTOS_TUI_SOAK_SERVER_WAIT_SECS
       || (ctx.scenario.transport === 'websocket' ? '4' : '1'),

--- a/e2e/scripts/ux-tmux-validate.mjs
+++ b/e2e/scripts/ux-tmux-validate.mjs
@@ -1280,6 +1280,51 @@ function checkLowerSoakSummary(artifactDir) {
   );
 }
 
+function checkStdioHappyPathFinalMarker(artifactDir) {
+  const scenario = readJson(artifactPath(artifactDir, 'scenario.json'));
+  if (!scenario.ok) {
+    return makeCheck(
+      'stdio_happy_path_final_marker_visible',
+      false,
+      `scenario.json is not parseable JSON: ${scenario.error}`,
+      ['scenario.json'],
+    );
+  }
+  if (scenario.value.id !== 'stdio-happy-path' && scenario.value.scenario_id !== 'stdio-happy-path') {
+    return makeCheck(
+      'stdio_happy_path_final_marker_visible',
+      true,
+      'stdio happy-path final-marker contract is not required for this scenario',
+      ['scenario.json'],
+    );
+  }
+
+  const marker = typeof scenario.value.final_marker === 'string' && scenario.value.final_marker.length > 0
+    ? scenario.value.final_marker
+    : 'M19_STDIO_HAPPY_PATH_FINAL_LINE';
+  const capture = readText(artifactPath(artifactDir, 'tui-capture.txt'));
+  if (!capture.ok) {
+    return makeCheck(
+      'stdio_happy_path_final_marker_visible',
+      false,
+      `tui-capture.txt could not be read: ${capture.error}`,
+      ['tui-capture.txt'],
+    );
+  }
+
+  const answerLines = captureLines(capture.text)
+    .map((line) => line.trim())
+    .filter((line) => line.includes(marker) && !line.startsWith('›'));
+  return makeCheck(
+    'stdio_happy_path_final_marker_visible',
+    answerLines.length > 0,
+    answerLines.length > 0
+      ? 'stdio happy-path final marker is visible in captured assistant output'
+      : `stdio happy-path final marker ${marker} is not visible outside the user/composer line`,
+    ['scenario.json', 'tui-capture.txt'],
+  );
+}
+
 function buildValidation(artifactDir) {
   const checks = [
     checkArtifactAbi(artifactDir),
@@ -1295,6 +1340,7 @@ function buildValidation(artifactDir) {
     checkRestartReconnectScenario(artifactDir),
     checkDroppedCompletionBackpressureScenario(artifactDir),
     checkLowerSoakSummary(artifactDir),
+    checkStdioHappyPathFinalMarker(artifactDir),
   ];
   const failures = checks
     .filter((check) => check.status === 'failed')

--- a/e2e/tests/ux/tmux-run.test.mjs
+++ b/e2e/tests/ux/tmux-run.test.mjs
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..', '..', '..');
+const runner = resolve(repoRoot, 'e2e', 'scripts', 'ux-tmux-run.mjs');
+
+function makeEnv(runId) {
+  const root = mkdtempSync(join(tmpdir(), 'octos-ux-tmux-run-test-'));
+  return {
+    env: {
+      ...process.env,
+      OCTOS_UX_TMUX_RUN_ID: runId,
+      OCTOS_UX_TMUX_OUT_ROOT: join(root, 'out'),
+      OCTOS_UX_TMUX_RUNTIME_ROOT: join(root, 'runtime'),
+    },
+    outDir: join(root, 'out', runId, 'stdio-happy-path'),
+  };
+}
+
+function run(args, env = process.env) {
+  return execFileSync(process.execPath, [runner, ...args], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+test('help documents keep-session and no-validate flags', () => {
+  const out = run(['--help']);
+  assert.match(out, /--keep-session/);
+  assert.match(out, /--no-validate/);
+});
+
+test('self-test writes and validates the artifact skeleton', () => {
+  const { env, outDir } = makeEnv('ux-run-test-self');
+  const out = run(['--self-test', 'stdio-happy-path'], env);
+  assert.match(out, /Self-test passed:/);
+
+  const summary = readJson(join(outDir, 'summary.json'));
+  const validation = readJson(join(outDir, 'validation.json'));
+  assert.equal(summary.validation_status, 'passed');
+  assert.equal(validation.status, 'passed');
+});
+
+test('dry-run can skip automatic validation', () => {
+  const { env, outDir } = makeEnv('ux-run-test-no-validate');
+  const out = run(['stdio-happy-path', '--dry-run', '--no-validate'], env);
+  assert.match(out, /Validation skipped/);
+
+  const summary = readJson(join(outDir, 'summary.json'));
+  assert.equal(summary.validation_status, 'skipped');
+  assert.equal(summary.validation_skipped, true);
+  assert.equal(existsSync(join(outDir, 'validation.json')), false);
+});

--- a/e2e/tests/ux/tmux-run.test.mjs
+++ b/e2e/tests/ux/tmux-run.test.mjs
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,6 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const repoRoot = resolve(__dirname, '..', '..', '..');
 const runner = resolve(repoRoot, 'e2e', 'scripts', 'ux-tmux-run.mjs');
+const validator = resolve(repoRoot, 'e2e', 'scripts', 'ux-tmux-validate.mjs');
 
 function makeEnv(runId) {
   const root = mkdtempSync(join(tmpdir(), 'octos-ux-tmux-run-test-'));
@@ -54,9 +55,37 @@ test('self-test writes and validates the artifact skeleton', () => {
   const transcript = readFileSync(join(outDir, 'appui-transcript.jsonl'), 'utf8');
   assert.equal(summary.validation_status, 'passed');
   assert.equal(validation.status, 'passed');
+  assert.ok(validation.checks.some((check) => check.id === 'stdio_happy_path_final_marker_visible'));
   assert.match(capture, /M19_STDIO_HAPPY_PATH_FINAL_LINE/);
   assert.match(capture, /\bComposer\b/);
   assert.match(transcript, /"method":"client_hello"/);
+});
+
+test('validator rejects stdio happy-path captures without the final marker answer', () => {
+  const { env, outDir } = makeEnv('ux-run-test-missing-marker');
+  run(['--self-test', 'stdio-happy-path'], env);
+
+  const capturePath = join(outDir, 'tui-capture.txt');
+  const capture = readFileSync(capturePath, 'utf8');
+  writeFileSync(
+    capturePath,
+    capture.replaceAll('M19_STDIO_HAPPY_PATH_FINAL_LINE', 'M19_STDIO_HAPPY_PATH_MISSING'),
+    'utf8',
+  );
+
+  let error = null;
+  try {
+    execFileSync(process.execPath, [validator, outDir], {
+      cwd: repoRoot,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (caught) {
+    error = caught;
+  }
+  assert.ok(error, 'validator should fail when the final marker answer is missing');
+  assert.match(`${error.stdout}\n${error.stderr}`, /stdio_happy_path_final_marker_visible/);
 });
 
 test('dry-run can skip automatic validation', () => {

--- a/e2e/tests/ux/tmux-run.test.mjs
+++ b/e2e/tests/ux/tmux-run.test.mjs
@@ -50,8 +50,13 @@ test('self-test writes and validates the artifact skeleton', () => {
 
   const summary = readJson(join(outDir, 'summary.json'));
   const validation = readJson(join(outDir, 'validation.json'));
+  const capture = readFileSync(join(outDir, 'tui-capture.txt'), 'utf8');
+  const transcript = readFileSync(join(outDir, 'appui-transcript.jsonl'), 'utf8');
   assert.equal(summary.validation_status, 'passed');
   assert.equal(validation.status, 'passed');
+  assert.match(capture, /M19_STDIO_HAPPY_PATH_FINAL_LINE/);
+  assert.match(capture, /\bComposer\b/);
+  assert.match(transcript, /"method":"client_hello"/);
 });
 
 test('dry-run can skip automatic validation', () => {

--- a/e2e/tests/ux/tmux-run.test.mjs
+++ b/e2e/tests/ux/tmux-run.test.mjs
@@ -98,3 +98,12 @@ test('dry-run can skip automatic validation', () => {
   assert.equal(summary.validation_skipped, true);
   assert.equal(existsSync(join(outDir, 'validation.json')), false);
 });
+
+test('stdio onboarding launch opts into local solo mode', () => {
+  const { env, outDir } = makeEnv('ux-run-test-solo-opt-in');
+  run(['stdio-happy-path', '--dry-run', '--no-validate'], env);
+
+  const launchCommand = readFileSync(join(outDir, 'launch-command.txt'), 'utf8');
+  assert.match(launchCommand, /OCTOS_SOLO_LOGIN=/);
+  assert.match(launchCommand, /\bserve --stdio --solo\b/);
+});


### PR DESCRIPTION
## Summary

- Keep the M19 `stdio-happy-path` lane from passing on generic artifact shape alone; the validator now requires the final assistant marker to be visible in the captured TUI frame.
- Add runner tests for missing-marker rejection and dry-run validation behavior.
- Refresh the real tmux stdio lane for current main and opt the solo/onboarding stdio backend into `OCTOS_SOLO_LOGIN=1` plus `serve --stdio --solo`, matching the local solo serve contract.

Closes #1065

## Current-main validation

Base: `origin/main` `f6936c452389c5172496ee0c3e13393956086d92`.
Head: `ec4013be838e6f25ef800afba94443d3581c974d`.
Environment: isolated checkout `/private/tmp/octos-1338-f693.sOcvfO/octos`; root checkout left untouched; npm cache `/private/tmp/octos-npm-cache-1338-f693`; cargo targets under `/private/tmp`; current octos-tui binary `/private/tmp/octos-tui-1338-current-target-97c42/debug/octos-tui` from octos-tui main `97c42fb30ce92a3d173144817a9bdb15c20b86f6`.

Commands passed:
- diff check, rustfmt check, touched-file typos, JS syntax checks
- `npm --prefix e2e ci` with the existing moderate npm audit warning
- `npm --prefix e2e run ux:tmux:run:test` -> 5/5 passed
- `npm --prefix e2e run ux:scenario:list:test` -> 15/15 passed
- `cargo test -p octos-cli --features api --lib api::coding_tool_contract::tests:: -- --nocapture` -> 18/18 passed
- `cargo test -p octos-cli --lib cli_agent_adapter::tests -- --nocapture` -> 8/8 passed
- `cargo test -p octos-cli --test skill_compat_gate -- --nocapture` -> 3/3 passed
- `cargo test -p octos-agent --lib idle_timeout_constant -- --nocapture` -> 2/2 passed
- `cargo test -p octos-agent --lib loop_detect -- --nocapture` -> 13/13 passed
- `cargo build -p octos-cli --features api --bin octos`
- `cargo clippy --workspace --all-targets -- -D warnings`
- real tmux `npm --prefix e2e run ux:tmux:run -- stdio-happy-path`
- explicit `npm --prefix e2e run ux:tmux:validate -- /private/tmp/octos-m19-1065-stdio-current-f693-97c42-ec4013/codex-1065-current-main-f693-97c42-ec4013-20260602/stdio-happy-path`
- `git ls-files --others --exclude-standard` -> empty
- `tmux ls` -> no tmux server running after the real lane

Artifact evidence:
- Directory: `/private/tmp/octos-m19-1065-stdio-current-f693-97c42-ec4013/codex-1065-current-main-f693-97c42-ec4013-20260602/stdio-happy-path`
- `summary.json`: `status=passed`, `validation_status=passed`, `real_tmux_launched=true`, `placeholder_artifacts=false`, `scenario_id=stdio-happy-path`
- `validation.json`: `status=passed`, `failures=[]`, `stdio_happy_path_final_marker_visible=passed`, `lower_soak_summary_semantic=passed`
- `soak-summary.json`: `status=passed`, 14 cases, no blocked/failed cases
- `launch-command.txt` includes `OCTOS_SOLO_LOGIN='1'` and `serve --stdio --solo`
- `tui-capture.txt` contains `M19_STDIO_HAPPY_PATH_FINAL_LINE`

GitHub CI:
- Green on head `ec4013be838e6f25ef800afba94443d3581c974d`: `check`, `check-matrix`, `dashboard`, `swarm-app`, `test-octos-agent (integration)`, `test-octos-agent (lib)`, `test-octos-cli`, `typos`, `SPA reducer fixture replay`, and blocked-email passed.
- Optional platform/security/e2e expansion lanes skipped by workflow policy.

Result:
- #1065 acceptance is satisfied against current main.
- Merge remains blocked by required review/branch protection.
