### PR TITLE
feat(skills): manifest discovery field + skill card render (PR-C)

### DIFF
--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 use crate::hooks::HookConfig;
 use crate::mcp::McpServerConfig;
 
-use super::manifest::{PluginManifest, SkillHookDef, SkillMcpServer};
+use super::manifest::{PluginManifest, SkillDiscovery, SkillHookDef, SkillMcpServer};
 
 /// Resolved extras from a skill manifest, ready to merge into agent config.
 #[derive(Debug, Default)]
@@ -47,6 +47,18 @@ pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtra
                 );
             }
         }
+    }
+
+    // PR-C of the SKILL.md rethink: when the manifest declares a
+    // `discovery` block, render a short skill card into the system
+    // prompt so the LLM learns where the skill dir is and what to
+    // read or list first. The card coexists with the legacy SKILL.md
+    // auto-inject below — PR-D + PR-E remove the auto-inject after
+    // per-skill migrations land.
+    if let Some(discovery) = &manifest.discovery {
+        extras
+            .prompt_fragments
+            .push(render_skill_card(manifest, discovery, skill_dir));
     }
 
     // Auto-inject SKILL.md when skill has spawn_only tools so the LLM
@@ -102,6 +114,67 @@ pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtra
     }
 
     extras
+}
+
+/// Render a skill card from manifest discovery hints (PR-C of the SKILL.md
+/// rethink). Output is a fixed-shape text block, ~5-10 lines, suitable for
+/// concatenating into the system prompt alongside (or eventually instead
+/// of) the legacy SKILL.md auto-inject.
+///
+/// Shape:
+/// ```text
+/// - name: <plugin_name>
+///   purpose: <discovery.summary OR "(no summary)">
+///   tools: <comma-separated tool names>
+///   skill_dir: <absolute path>
+///   if you need:
+///     - <hint[0].when> → read <path> OR list <pattern>
+///     ...
+/// ```
+///
+/// When `discovery.hints` is empty, the `if you need:` section is omitted
+/// so the card stays compact (4 lines).
+fn render_skill_card(
+    manifest: &PluginManifest,
+    discovery: &SkillDiscovery,
+    skill_dir: &Path,
+) -> String {
+    let purpose = discovery.summary.as_deref().unwrap_or("(no summary)");
+    let tools = manifest
+        .tools
+        .iter()
+        .map(|t| t.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let mut card = String::with_capacity(256);
+    card.push_str(&format!("- name: {}\n", manifest.name));
+    card.push_str(&format!("  purpose: {purpose}\n"));
+    card.push_str(&format!("  tools: {tools}\n"));
+    card.push_str(&format!("  skill_dir: {}\n", skill_dir.display()));
+
+    if !discovery.hints.is_empty() {
+        card.push_str("  if you need:\n");
+        for hint in &discovery.hints {
+            let action = match (&hint.read, &hint.list) {
+                (Some(r), Some(l)) => format!("read {r} OR list {l}"),
+                (Some(r), None) => format!("read {r}"),
+                (None, Some(l)) => format!("list {l}"),
+                // Deser-time validation rejects (None, None), but
+                // render defensively in case a future construction path
+                // bypasses parse-time validation.
+                (None, None) => continue,
+            };
+            card.push_str(&format!("    - {} → {action}\n", hint.when));
+        }
+    }
+
+    // Strip trailing newline so successive fragments don't accumulate
+    // double blank lines when joined.
+    if card.ends_with('\n') {
+        card.pop();
+    }
+    card
 }
 
 /// Convert a skill MCP server declaration into a runtime `McpServerConfig`.
@@ -309,6 +382,7 @@ mod tests {
             mcp_servers: vec![],
             hooks: vec![],
             prompts: None,
+            discovery: None,
         };
         let extras = resolve_extras(&manifest, Path::new("/skills/test"));
         assert!(extras.mcp_servers.is_empty());
@@ -337,6 +411,7 @@ mod tests {
             prompts: Some(SkillPrompts {
                 include: vec!["prompts/*.md".into()],
             }),
+            discovery: None,
         };
         let extras = resolve_extras(&manifest, dir.path());
         assert_eq!(extras.prompt_fragments.len(), 2);
@@ -346,6 +421,217 @@ mod tests {
                 .prompt_fragments
                 .iter()
                 .any(|f| f.contains("Be careful"))
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // SKILL.md PR-C: skill card rendering from discovery field
+    // ------------------------------------------------------------------
+
+    fn manifest_for_card_test(
+        name: &str,
+        tools: Vec<&str>,
+        discovery: Option<crate::plugins::manifest::SkillDiscovery>,
+        any_spawn_only: bool,
+    ) -> PluginManifest {
+        use crate::plugins::manifest::PluginToolDef;
+        PluginManifest {
+            name: name.into(),
+            version: "1.0.0".into(),
+            tools: tools
+                .into_iter()
+                .map(|t| PluginToolDef {
+                    name: t.into(),
+                    description: "desc".into(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    spawn_only: any_spawn_only,
+                    env: vec![],
+                    risk: None,
+                    spawn_only_message: None,
+                    concurrency_class: None,
+                })
+                .collect(),
+            sha256: None,
+            binaries: HashMap::new(),
+            requires_network: false,
+            timeout_secs: None,
+            mcp_servers: vec![],
+            hooks: vec![],
+            prompts: None,
+            discovery,
+        }
+    }
+
+    #[test]
+    fn extras_renders_skill_card_when_discovery_present() {
+        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
+
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path();
+
+        let discovery = SkillDiscovery {
+            summary: Some("Generate AI presentation slides.".into()),
+            hints: vec![
+                DiscoveryHint {
+                    when: "user asks for editable PPT".into(),
+                    read: Some("SKILL.md#mode-2".into()),
+                    list: None,
+                },
+                DiscoveryHint {
+                    when: "picking a style".into(),
+                    read: None,
+                    list: Some("styles/*.toml".into()),
+                },
+            ],
+        };
+
+        let manifest = manifest_for_card_test(
+            "mofa-slides",
+            vec!["slides_generate", "slides_preview"],
+            Some(discovery),
+            false, // no spawn_only — only the card should appear
+        );
+
+        let extras = resolve_extras(&manifest, skill_dir);
+        // Card is the only fragment.
+        assert_eq!(
+            extras.prompt_fragments.len(),
+            1,
+            "expected exactly one fragment (the skill card); got {:?}",
+            extras.prompt_fragments
+        );
+        let card = &extras.prompt_fragments[0];
+
+        assert!(
+            card.contains("name: mofa-slides"),
+            "card missing name line: {card}"
+        );
+        assert!(
+            card.contains("purpose: Generate AI presentation slides."),
+            "card missing purpose line: {card}"
+        );
+        assert!(
+            card.contains("tools: slides_generate, slides_preview"),
+            "card missing tools line: {card}"
+        );
+        assert!(
+            card.contains(&format!("skill_dir: {}", skill_dir.display())),
+            "card missing skill_dir line: {card}"
+        );
+        assert!(
+            card.contains("if you need:"),
+            "card missing 'if you need:' header: {card}"
+        );
+        assert!(
+            card.contains("user asks for editable PPT"),
+            "card missing first hint when: {card}"
+        );
+        assert!(
+            card.contains("read SKILL.md#mode-2"),
+            "card missing first hint read target: {card}"
+        );
+        assert!(
+            card.contains("picking a style"),
+            "card missing second hint when: {card}"
+        );
+        assert!(
+            card.contains("list styles/*.toml"),
+            "card missing second hint list target: {card}"
+        );
+
+        // Cap at ~10 lines total.
+        let line_count = card.lines().count();
+        assert!(
+            line_count <= 10,
+            "card too long ({line_count} lines): {card}"
+        );
+    }
+
+    #[test]
+    fn extras_omits_skill_card_when_discovery_absent() {
+        // No discovery + no spawn_only + nothing else → no fragments.
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = manifest_for_card_test("legacy", vec!["t"], None, false);
+        let extras = resolve_extras(&manifest, dir.path());
+        assert!(
+            extras.prompt_fragments.is_empty(),
+            "expected no fragments without discovery; got {:?}",
+            extras.prompt_fragments
+        );
+    }
+
+    #[test]
+    fn extras_renders_card_alongside_legacy_auto_inject() {
+        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
+
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path();
+        // Legacy auto-inject writes SKILL.md content into the prompt.
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# Legacy SKILL.md\nMode 1: foo. Mode 2: bar.\n",
+        )
+        .unwrap();
+
+        let discovery = SkillDiscovery {
+            summary: Some("Modes 1+2 for slides.".into()),
+            hints: vec![DiscoveryHint {
+                when: "user wants editable PPT".into(),
+                read: Some("SKILL.md#mode-2".into()),
+                list: None,
+            }],
+        };
+        // any_spawn_only=true → triggers legacy auto-inject.
+        let manifest = manifest_for_card_test(
+            "mofa-slides",
+            vec!["slides_generate"],
+            Some(discovery),
+            true,
+        );
+
+        let extras = resolve_extras(&manifest, skill_dir);
+        assert_eq!(
+            extras.prompt_fragments.len(),
+            2,
+            "expected card + legacy auto-inject; got {:?}",
+            extras.prompt_fragments
+        );
+
+        let has_card = extras
+            .prompt_fragments
+            .iter()
+            .any(|f| f.contains("name: mofa-slides") && f.contains("purpose:"));
+        let has_legacy = extras
+            .prompt_fragments
+            .iter()
+            .any(|f| f.contains("Legacy SKILL.md") && f.contains("Mode 1: foo"));
+
+        assert!(has_card, "card fragment missing");
+        assert!(has_legacy, "legacy SKILL.md fragment missing");
+    }
+
+    #[test]
+    fn extras_renders_card_with_empty_hints() {
+        use crate::plugins::manifest::SkillDiscovery;
+
+        let dir = tempfile::tempdir().unwrap();
+        let discovery = SkillDiscovery {
+            summary: Some("Minimal skill.".into()),
+            hints: vec![],
+        };
+        let manifest = manifest_for_card_test("minimal-skill", vec!["t"], Some(discovery), false);
+
+        let extras = resolve_extras(&manifest, dir.path());
+        assert_eq!(extras.prompt_fragments.len(), 1);
+        let card = &extras.prompt_fragments[0];
+
+        assert!(card.contains("name: minimal-skill"));
+        assert!(card.contains("purpose: Minimal skill."));
+        assert!(card.contains("tools: t"));
+        // No "if you need:" section when hints are empty.
+        assert!(
+            !card.contains("if you need:"),
+            "empty hints should NOT render 'if you need:' header: {card}"
         );
     }
 }

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -4,6 +4,13 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Deserializer};
 
+/// Maximum number of discovery hints a skill manifest may declare.
+///
+/// The hints render into the LLM system prompt as a per-skill "skill card";
+/// growing the list without bound would silently push out other system
+/// prompt content. 8 keeps each card to a ~10-line budget.
+pub const MAX_DISCOVERY_HINTS: usize = 8;
+
 /// A plugin manifest (manifest.json).
 #[derive(Debug, Deserialize)]
 pub struct PluginManifest {
@@ -43,6 +50,16 @@ pub struct PluginManifest {
     /// Prompt fragments to inject into the system prompt.
     #[serde(default)]
     pub prompts: Option<SkillPrompts>,
+    /// Optional LLM-facing discovery hints.
+    ///
+    /// When present, `resolve_extras` renders a short "skill card" into the
+    /// system prompt so the agent learns (1) the skill exists, (2) where
+    /// its directory lives, and (3) which files to read or list first.
+    /// This is the opt-in migration affordance for the SKILL.md rethink:
+    /// plugins that add `discovery` get the card; plugins without it keep
+    /// the legacy SKILL.md auto-inject only (see `extras.rs`).
+    #[serde(default, deserialize_with = "deserialize_discovery")]
+    pub discovery: Option<SkillDiscovery>,
 }
 
 impl PluginManifest {
@@ -70,6 +87,108 @@ where
         )),
         other => Ok(other),
     }
+}
+
+/// LLM-facing discovery hints declared by a skill manifest.
+///
+/// The renderer in `extras.rs` turns this into a short skill card pushed
+/// into `SkillExtras.prompt_fragments`. The card tells the agent the skill
+/// exists, where its directory lives, and which paths to read or list to
+/// learn more. See PR-C of the SKILL.md rethink.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, Default)]
+pub struct SkillDiscovery {
+    /// One-line description of what the skill does. Falls back to
+    /// `"(no summary)"` in the rendered card.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Up to `MAX_DISCOVERY_HINTS` pointers the LLM can follow on its
+    /// own (via the already-allowlisted `read_file`/`glob`/`list_dir`
+    /// tools from PR-A + PR-B).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<DiscoveryHint>,
+}
+
+/// A single discovery hint: when this trigger applies, the LLM should
+/// either read a file or list a glob pattern under the skill directory.
+///
+/// At least one of `read` or `list` must be set; both is allowed (the
+/// renderer joins them with " OR "). Paths are validated at parse time
+/// to reject `..` traversal — discovery hints feed the system prompt,
+/// so a hostile manifest could otherwise nudge the LLM to read arbitrary
+/// files via the now-permissive skill-dir scope from PR-A.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct DiscoveryHint {
+    /// Human-readable trigger condition, e.g.
+    /// `"user asks for editable PPT"`.
+    pub when: String,
+    /// Path (or fragment-anchored path) to read. Relative to the skill
+    /// directory. Must not contain `..`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read: Option<String>,
+    /// Glob pattern to list. Relative to the skill directory. Must not
+    /// contain `..`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub list: Option<String>,
+}
+
+/// Validating deserializer for `PluginManifest::discovery`.
+///
+/// Enforces:
+/// * At most `MAX_DISCOVERY_HINTS` hints.
+/// * Neither `read` nor `list` may contain `..` (path traversal).
+/// * Each hint must declare at least one of `read` or `list`.
+///
+/// A rejected manifest is a hard error at parse time so a malicious or
+/// typo'd discovery block never reaches the LLM-facing renderer.
+fn deserialize_discovery<'de, D>(d: D) -> Result<Option<SkillDiscovery>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    let maybe = Option::<SkillDiscovery>::deserialize(d)?;
+    let Some(disc) = maybe else {
+        return Ok(None);
+    };
+
+    if disc.hints.len() > MAX_DISCOVERY_HINTS {
+        return Err(D::Error::custom(format!(
+            "manifest.discovery.hints declares {} entries; the maximum allowed is {} (MAX_DISCOVERY_HINTS)",
+            disc.hints.len(),
+            MAX_DISCOVERY_HINTS
+        )));
+    }
+
+    for (idx, hint) in disc.hints.iter().enumerate() {
+        if hint.read.is_none() && hint.list.is_none() {
+            return Err(D::Error::custom(format!(
+                "manifest.discovery.hints[{idx}] declares neither `read` nor `list`; at least one is required"
+            )));
+        }
+        if let Some(path) = &hint.read
+            && hint_path_has_traversal(path)
+        {
+            return Err(D::Error::custom(format!(
+                "manifest.discovery.hints[{idx}].read contains path traversal (..): {path:?}"
+            )));
+        }
+        if let Some(pattern) = &hint.list
+            && hint_path_has_traversal(pattern)
+        {
+            return Err(D::Error::custom(format!(
+                "manifest.discovery.hints[{idx}].list contains path traversal (..): {pattern:?}"
+            )));
+        }
+    }
+
+    Ok(Some(disc))
+}
+
+/// Return `true` if a discovery-hint path (or glob pattern) contains a
+/// `..` traversal segment. Splits on both `/` and `\` to cover Windows
+/// authors editing manifests on Unix and vice versa, then matches the
+/// trimmed segment exactly so `..foo` (legitimate filename) survives.
+fn hint_path_has_traversal(path: &str) -> bool {
+    path.split(['/', '\\']).any(|seg| seg.trim() == "..")
 }
 
 /// An MCP server declared by a skill manifest.
@@ -840,6 +959,150 @@ mod tests {
         assert_eq!(
             def_with_concurrency(Some("   ")).classify_concurrency_class(),
             ConcurrencyClassClassification::Unset
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // SKILL.md PR-C: discovery field
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn manifest_parses_with_discovery_field() {
+        let json = r#"{
+            "name": "mofa-slides",
+            "version": "0.6.1",
+            "tools": [{"name": "t", "description": "d"}],
+            "discovery": {
+                "summary": "Generate AI presentation slides with full-bleed Gemini images.",
+                "hints": [
+                    { "when": "user asks for editable PPT", "read": "SKILL.md#mode-2" },
+                    { "when": "picking a style", "list": "styles/*.toml" },
+                    { "when": "authoring custom styles", "read": "docs/custom-styles.md" }
+                ]
+            }
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        let discovery = manifest.discovery.expect("discovery present");
+        assert_eq!(
+            discovery.summary.as_deref(),
+            Some("Generate AI presentation slides with full-bleed Gemini images.")
+        );
+        assert_eq!(discovery.hints.len(), 3);
+        assert_eq!(discovery.hints[0].when, "user asks for editable PPT");
+        assert_eq!(discovery.hints[0].read.as_deref(), Some("SKILL.md#mode-2"));
+        assert!(discovery.hints[0].list.is_none());
+        assert_eq!(discovery.hints[1].when, "picking a style");
+        assert!(discovery.hints[1].read.is_none());
+        assert_eq!(discovery.hints[1].list.as_deref(), Some("styles/*.toml"));
+        assert_eq!(discovery.hints[2].when, "authoring custom styles");
+        assert_eq!(
+            discovery.hints[2].read.as_deref(),
+            Some("docs/custom-styles.md")
+        );
+    }
+
+    #[test]
+    fn manifest_parses_without_discovery_field() {
+        let json = r#"{
+            "name": "legacy-plugin",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.discovery.is_none());
+    }
+
+    #[test]
+    fn manifest_rejects_too_many_hints() {
+        // 9 hints — exceeds MAX_DISCOVERY_HINTS (8).
+        let json = r#"{
+            "name": "noisy",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "discovery": {
+                "summary": "Too many hints.",
+                "hints": [
+                    { "when": "a", "read": "a.md" },
+                    { "when": "b", "read": "b.md" },
+                    { "when": "c", "read": "c.md" },
+                    { "when": "d", "read": "d.md" },
+                    { "when": "e", "read": "e.md" },
+                    { "when": "f", "read": "f.md" },
+                    { "when": "g", "read": "g.md" },
+                    { "when": "h", "read": "h.md" },
+                    { "when": "i", "read": "i.md" }
+                ]
+            }
+        }"#;
+        let err =
+            serde_json::from_str::<PluginManifest>(json).expect_err("9 hints must fail to parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("hints") && msg.contains("8"),
+            "error must mention hint cap; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn manifest_rejects_traversal_in_hint_read() {
+        let json = r#"{
+            "name": "evil",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "discovery": {
+                "hints": [
+                    { "when": "exfil", "read": "../etc/passwd" }
+                ]
+            }
+        }"#;
+        let err = serde_json::from_str::<PluginManifest>(json)
+            .expect_err("traversal in `read` must fail to parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("..") || msg.to_lowercase().contains("traversal"),
+            "error must mention traversal; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn manifest_rejects_traversal_in_hint_list() {
+        let json = r#"{
+            "name": "evil",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "discovery": {
+                "hints": [
+                    { "when": "exfil", "list": "../../*" }
+                ]
+            }
+        }"#;
+        let err = serde_json::from_str::<PluginManifest>(json)
+            .expect_err("traversal in `list` must fail to parse");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("..") || msg.to_lowercase().contains("traversal"),
+            "error must mention traversal; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn manifest_rejects_hint_with_no_read_or_list() {
+        let json = r#"{
+            "name": "blank",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "discovery": {
+                "hints": [
+                    { "when": "user wants thing" }
+                ]
+            }
+        }"#;
+        let err = serde_json::from_str::<PluginManifest>(json)
+            .expect_err("hint with neither read nor list must fail to parse");
+        let msg = err.to_string();
+        assert!(
+            msg.to_lowercase().contains("read") || msg.to_lowercase().contains("list"),
+            "error must explain hint needs read or list; got: {msg}"
         );
     }
 }

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -63,11 +63,22 @@ pub struct PluginManifest {
 }
 
 impl PluginManifest {
-    /// Whether this manifest declares any extras (MCP servers, hooks, or prompts).
+    /// Whether this manifest declares any extras (MCP servers, hooks, prompts,
+    /// or discovery).
+    ///
+    /// Round-2 codex review BLOCKER 2: `discovery` MUST be counted here. The
+    /// loader's strict-mode paths use `has_extras()` both to reject
+    /// extras-only manifests (so the operator splits executable + extras into
+    /// two skills they can hash independently) and to warn when dropping
+    /// extras under `plugins.require_signed`. Omitting `discovery` from this
+    /// check meant a discovery-only manifest became a silent no-op under
+    /// strict mode, and a signed tool plugin with discovery had its skill
+    /// card dropped without any warning.
     pub fn has_extras(&self) -> bool {
         !self.mcp_servers.is_empty()
             || !self.hooks.is_empty()
             || self.prompts.as_ref().is_some_and(|p| !p.include.is_empty())
+            || self.discovery.is_some()
     }
 }
 
@@ -164,18 +175,16 @@ where
                 "manifest.discovery.hints[{idx}] declares neither `read` nor `list`; at least one is required"
             )));
         }
-        if let Some(path) = &hint.read
-            && hint_path_has_traversal(path)
-        {
+        if hint.read.as_deref().is_some_and(hint_path_has_traversal) {
             return Err(D::Error::custom(format!(
-                "manifest.discovery.hints[{idx}].read contains path traversal (..): {path:?}"
+                "manifest.discovery.hints[{idx}].read contains path traversal (..): {:?}",
+                hint.read
             )));
         }
-        if let Some(pattern) = &hint.list
-            && hint_path_has_traversal(pattern)
-        {
+        if hint.list.as_deref().is_some_and(hint_path_has_traversal) {
             return Err(D::Error::custom(format!(
-                "manifest.discovery.hints[{idx}].list contains path traversal (..): {pattern:?}"
+                "manifest.discovery.hints[{idx}].list contains path traversal (..): {:?}",
+                hint.list
             )));
         }
     }
@@ -1083,6 +1092,70 @@ mod tests {
             msg.contains("..") || msg.to_lowercase().contains("traversal"),
             "error must mention traversal; got: {msg}"
         );
+    }
+
+    /// Round-2 codex BLOCKER 2 regression: `has_extras()` must report true
+    /// for a manifest whose only extras-bearing field is `discovery`. The
+    /// loader's strict-mode rejection path (`require_signed && tools.is_empty()
+    /// && has_extras()`) and the warn-then-drop path both rely on this; a
+    /// false return here means a discovery-only signed manifest becomes a
+    /// silent no-op instead of either failing closed or being announced in
+    /// logs.
+    #[test]
+    fn has_extras_returns_true_for_discovery_only_manifest() {
+        let json = r#"{
+            "name": "discovery-only",
+            "version": "1.0.0",
+            "tools": [],
+            "discovery": {
+                "summary": "Card-only skill.",
+                "hints": [
+                    { "when": "user asks anything", "read": "SKILL.md" }
+                ]
+            }
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.mcp_servers.is_empty());
+        assert!(manifest.hooks.is_empty());
+        assert!(manifest.prompts.is_none());
+        assert!(
+            manifest.has_extras(),
+            "discovery-only manifest must count as extras-bearing"
+        );
+    }
+
+    /// Companion check: a manifest with discovery alongside a tool also
+    /// reports `has_extras() == true`, so the loader's "drop extras under
+    /// require_signed" warn path fires (otherwise the skill card silently
+    /// disappears for signed tool plugins).
+    #[test]
+    fn has_extras_returns_true_when_discovery_paired_with_tool() {
+        let json = r#"{
+            "name": "tool-with-discovery",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "discovery": {
+                "hints": [
+                    { "when": "user asks anything", "read": "SKILL.md" }
+                ]
+            }
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.has_extras());
+    }
+
+    /// Negative control: a manifest with no MCP, no hooks, no prompts, and
+    /// no discovery still reports `has_extras() == false` so the loader's
+    /// `tools.is_empty() && has_extras()` reject does not over-fire.
+    #[test]
+    fn has_extras_returns_false_for_bare_manifest() {
+        let json = r#"{
+            "name": "bare",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(!manifest.has_extras());
     }
 
     #[test]


### PR DESCRIPTION
## Context

PR-C of the SKILL.md rethink series. Builds on:

- **PR-A** (#1327): file tools may read inside any plugin's `skill_dir`.
- **PR-B** (d5429b63): `glob`/`list_dir`/`grep` honour the same scope expansion.

With read access in place, the LLM still doesn't *know* what's inside a `skill_dir` or which file to consult first. This PR adds the LLM-facing affordance: a manifest-declared `discovery` block that renders to a short "skill card" in the system prompt.

## Schema

`PluginManifest.discovery: Option<SkillDiscovery>`:

```rust
SkillDiscovery { summary: Option<String>, hints: Vec<DiscoveryHint> }
DiscoveryHint  { when: String, read: Option<String>, list: Option<String> }
```

`MAX_DISCOVERY_HINTS = 8` caps each card to a ~10-line budget so the discovery surface cannot silently push out other system-prompt content.

## Render shape

For a manifest with `discovery` declared, `resolve_extras` emits one fragment into `SkillExtras.prompt_fragments`:

```text
- name: mofa-slides
  purpose: Generate AI presentation slides with full-bleed Gemini images.
  tools: slides_generate, slides_preview
  skill_dir: /Users/cloud/.octos/profile-default/data/skills/mofa-slides
  if you need:
    - user asks for editable PPT → read SKILL.md#mode-2
    - picking a style → list styles/*.toml
    - authoring custom styles → read docs/custom-styles.md
```

Empty `hints` collapses to a 4-line compact card (no `if you need:` section). Missing `summary` falls back to `"(no summary)"`. Hints with both `read` and `list` render as `read X OR list Y`.

## Migration gradient

The card is rendered **alongside** the existing SKILL.md auto-inject (`extras.rs:78-85`, kept verbatim). Plugins without a `discovery` block keep the legacy auto-inject only — no behavior change. Plugins that opt in get both, until PR-D removes the auto-inject after per-skill manifest migrations land.

## Validation

Parse-time deserializer rejects:

- More than 8 hints (cap by `MAX_DISCOVERY_HINTS`).
- `..` segments in `read` or `list` (path traversal — discovery feeds the LLM, so a hostile manifest could otherwise nudge the LLM to exfiltrate via PR-A's permissive read scope).
- Hints with neither `read` nor `list` (renders to no action).

Path-segment matching splits on both `/` and `\` so the check survives Windows-authored manifests, and trims each segment exactly so legitimate names like `..foo` are not rejected.

## Tests

`manifest.rs` (6 new):
- `manifest_parses_with_discovery_field`
- `manifest_parses_without_discovery_field`
- `manifest_rejects_too_many_hints`
- `manifest_rejects_traversal_in_hint_read`
- `manifest_rejects_traversal_in_hint_list`
- `manifest_rejects_hint_with_no_read_or_list`

`extras.rs` (4 new):
- `extras_renders_skill_card_when_discovery_present`
- `extras_omits_skill_card_when_discovery_absent`
- `extras_renders_card_alongside_legacy_auto_inject`
- `extras_renders_card_with_empty_hints`

## Out of scope

This PR does NOT:

- add a `skill_md_auto_inject` opt-out flag (deferred to PR-D);
- edit any per-skill `manifest.json` (deferred to PR-D);
- remove SKILL.md auto-inject (deferred to PR-D + PR-E).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p octos-agent plugins::manifest` — 35 passed (6 new)
- [x] `cargo test -p octos-agent plugins::extras` — 12 passed (4 new)
- [x] `cargo test -p octos-agent --lib -- --test-threads=4` — 1721 passed, 0 failed
- [x] `cargo clippy --workspace --no-deps -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green