### PR TITLE
feat(skills): skill_md_auto_inject opt-out flag (PR-D1)

### DIFF
--- a/crates/octos-agent/src/plugins/extras.rs
+++ b/crates/octos-agent/src/plugins/extras.rs
@@ -75,7 +75,13 @@ pub fn resolve_extras(manifest: &PluginManifest, skill_dir: &Path) -> SkillExtra
     // only agents that actually emit the new envelope teach the LLM
     // about it — automatic and consistent with the gating in
     // `execution.rs::is_tool_visible`.
-    if manifest.tools.iter().any(|t| t.spawn_only) {
+    //
+    // PR-D1 of the SKILL.md rethink: a plugin can opt out of this legacy
+    // auto-inject by setting `skill_md_auto_inject: false` in its manifest.
+    // The flag defaults to `true` so unmigrated plugins keep current
+    // behavior; PR-D2 (mofa-skills) opts each mofa-* skill in, and PR-E
+    // eventually flips the default.
+    if manifest.skill_md_auto_inject && manifest.tools.iter().any(|t| t.spawn_only) {
         let skill_md = skill_dir.join("SKILL.md");
         if skill_md.exists() {
             if let Ok(content) = std::fs::read_to_string(&skill_md) {
@@ -383,6 +389,7 @@ mod tests {
             hooks: vec![],
             prompts: None,
             discovery: None,
+            skill_md_auto_inject: true,
         };
         let extras = resolve_extras(&manifest, Path::new("/skills/test"));
         assert!(extras.mcp_servers.is_empty());
@@ -412,6 +419,7 @@ mod tests {
                 include: vec!["prompts/*.md".into()],
             }),
             discovery: None,
+            skill_md_auto_inject: true,
         };
         let extras = resolve_extras(&manifest, dir.path());
         assert_eq!(extras.prompt_fragments.len(), 2);
@@ -433,6 +441,20 @@ mod tests {
         tools: Vec<&str>,
         discovery: Option<crate::plugins::manifest::SkillDiscovery>,
         any_spawn_only: bool,
+    ) -> PluginManifest {
+        manifest_for_card_test_with_flag(name, tools, discovery, any_spawn_only, true)
+    }
+
+    /// Variant of `manifest_for_card_test` that exposes the PR-D1
+    /// `skill_md_auto_inject` flag. The shorter helper above wraps this
+    /// with `skill_md_auto_inject: true` (the default) to keep older
+    /// tests readable.
+    fn manifest_for_card_test_with_flag(
+        name: &str,
+        tools: Vec<&str>,
+        discovery: Option<crate::plugins::manifest::SkillDiscovery>,
+        any_spawn_only: bool,
+        skill_md_auto_inject: bool,
     ) -> PluginManifest {
         use crate::plugins::manifest::PluginToolDef;
         PluginManifest {
@@ -459,6 +481,7 @@ mod tests {
             hooks: vec![],
             prompts: None,
             discovery,
+            skill_md_auto_inject,
         }
     }
 
@@ -632,6 +655,162 @@ mod tests {
         assert!(
             !card.contains("if you need:"),
             "empty hints should NOT render 'if you need:' header: {card}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // SKILL.md PR-D1: skill_md_auto_inject opt-out gates legacy SKILL.md
+    // ------------------------------------------------------------------
+
+    /// Opting out (`skill_md_auto_inject: false`) skips the legacy
+    /// auto-inject even when the manifest has a `spawn_only` tool and a
+    /// `SKILL.md` is present on disk. This is the migration end-state for
+    /// step 2 of the rethink — the new discovery card replaces the
+    /// always-injected SKILL.md body.
+    #[test]
+    fn extras_skips_legacy_auto_inject_when_opted_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# Legacy SKILL.md\nShould NOT be injected when opted out.\n",
+        )
+        .unwrap();
+
+        let manifest = manifest_for_card_test_with_flag(
+            "opted-out",
+            vec!["bg_tool"],
+            None,  // no discovery — purely a legacy-gate test
+            true,  // any_spawn_only triggers the legacy auto-inject path
+            false, // skill_md_auto_inject opt-out
+        );
+
+        let extras = resolve_extras(&manifest, skill_dir);
+        assert!(
+            extras.prompt_fragments.is_empty(),
+            "opted-out plugin must not inject SKILL.md; got {:?}",
+            extras.prompt_fragments
+        );
+    }
+
+    /// Default behavior (no explicit flag in the manifest, mirrored here
+    /// by passing `skill_md_auto_inject: true`) preserves the legacy
+    /// auto-inject so unmigrated plugins keep working.
+    #[test]
+    fn extras_runs_legacy_auto_inject_when_opted_in_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# Legacy SKILL.md\nUnmigrated default behavior.\n",
+        )
+        .unwrap();
+
+        // `manifest_for_card_test` constructs with skill_md_auto_inject:true
+        // — the default — so this exercises the "field omitted" path.
+        let manifest = manifest_for_card_test(
+            "legacy-default",
+            vec!["bg_tool"],
+            None,
+            true, // spawn_only present
+        );
+
+        let extras = resolve_extras(&manifest, skill_dir);
+        assert_eq!(
+            extras.prompt_fragments.len(),
+            1,
+            "default plugin must inject SKILL.md exactly once; got {:?}",
+            extras.prompt_fragments
+        );
+        assert!(
+            extras.prompt_fragments[0].contains("Unmigrated default behavior."),
+            "fragment must contain SKILL.md body; got {:?}",
+            extras.prompt_fragments[0]
+        );
+    }
+
+    /// Explicit `true` is equivalent to the default — confirms the gate
+    /// does not silently invert when a manifest opts in loudly.
+    #[test]
+    fn extras_runs_legacy_auto_inject_when_explicitly_true() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# Legacy SKILL.md\nExplicit opt-in body.\n",
+        )
+        .unwrap();
+
+        let manifest = manifest_for_card_test_with_flag(
+            "explicit-legacy",
+            vec!["bg_tool"],
+            None,
+            true,
+            true, // explicit opt-in
+        );
+
+        let extras = resolve_extras(&manifest, skill_dir);
+        assert_eq!(extras.prompt_fragments.len(), 1);
+        assert!(extras.prompt_fragments[0].contains("Explicit opt-in body."));
+    }
+
+    /// Migration end-state regression: when both `discovery` is present
+    /// AND `skill_md_auto_inject: false` is set, the skill card renders
+    /// but the legacy SKILL.md body does not. This is the configuration
+    /// PR-D2 will produce per migrated mofa-* skill.
+    #[test]
+    fn extras_skips_legacy_but_renders_card_when_discovery_present_and_opted_out() {
+        use crate::plugins::manifest::{DiscoveryHint, SkillDiscovery};
+
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# Legacy SKILL.md\nShould NOT appear when opted out.\n",
+        )
+        .unwrap();
+
+        let discovery = SkillDiscovery {
+            summary: Some("Migrated skill.".into()),
+            hints: vec![DiscoveryHint {
+                when: "user wants editable PPT".into(),
+                read: Some("SKILL.md#mode-2".into()),
+                list: None,
+            }],
+        };
+
+        let manifest = manifest_for_card_test_with_flag(
+            "mofa-slides",
+            vec!["slides_generate"],
+            Some(discovery),
+            true,  // spawn_only tool present (would normally trigger legacy)
+            false, // but auto-inject is opted out
+        );
+
+        let extras = resolve_extras(&manifest, skill_dir);
+        assert_eq!(
+            extras.prompt_fragments.len(),
+            1,
+            "migrated plugin must yield card-only (no legacy body); got {:?}",
+            extras.prompt_fragments
+        );
+        let card = &extras.prompt_fragments[0];
+        assert!(card.contains("name: mofa-slides"), "card missing: {card}");
+        assert!(
+            card.contains("purpose: Migrated skill."),
+            "card missing purpose: {card}"
+        );
+        assert!(
+            !card.contains("Should NOT appear"),
+            "legacy SKILL.md body leaked into the card: {card}"
+        );
+        assert!(
+            !extras
+                .prompt_fragments
+                .iter()
+                .any(|f| f.contains("Should NOT appear")),
+            "legacy SKILL.md body leaked as a separate fragment: {:?}",
+            extras.prompt_fragments
         );
     }
 }

--- a/crates/octos-agent/src/plugins/manifest.rs
+++ b/crates/octos-agent/src/plugins/manifest.rs
@@ -60,6 +60,32 @@ pub struct PluginManifest {
     /// the legacy SKILL.md auto-inject only (see `extras.rs`).
     #[serde(default, deserialize_with = "deserialize_discovery")]
     pub discovery: Option<SkillDiscovery>,
+    /// When false, this plugin opts out of having its SKILL.md auto-injected
+    /// into the system prompt. Used in combination with `discovery` (PR-C) to
+    /// migrate plugins from legacy auto-inject to on-demand discovery.
+    ///
+    /// Migration is intentionally three steps so each stage stays revertable:
+    ///   1. Add `discovery` so both legacy auto-inject AND the new skill
+    ///      card render (validate the card works in production).
+    ///   2. Set `skill_md_auto_inject: false` so only the card renders.
+    ///   3. Trim SKILL.md body to <=80 lines now that the LLM reads it on
+    ///      demand instead of having it shoved into every system prompt.
+    ///
+    /// Decoupling step 2 from step 1 via an explicit flag (rather than an
+    /// implicit "presence of discovery disables legacy") is what lets each
+    /// step be independently revertable — see PR-D1.
+    ///
+    /// Default: true (legacy behavior preserved for unmigrated plugins).
+    #[serde(default = "default_true")]
+    pub skill_md_auto_inject: bool,
+}
+
+/// Serde default helper for `bool` fields whose absence should deserialize
+/// to `true`. Locally scoped: `PluginManifest::skill_md_auto_inject` is the
+/// only field in this module that needs it today, but adding more later
+/// (e.g. a `legacy_card_inject` flag) should reuse this helper.
+fn default_true() -> bool {
+    true
 }
 
 impl PluginManifest {
@@ -74,6 +100,13 @@ impl PluginManifest {
     /// check meant a discovery-only manifest became a silent no-op under
     /// strict mode, and a signed tool plugin with discovery had its skill
     /// card dropped without any warning.
+    ///
+    /// PR-D1 note: `skill_md_auto_inject` is intentionally NOT counted as an
+    /// extra. The semantics are inverted relative to the other fields —
+    /// setting it to `false` *removes* an injected fragment rather than
+    /// adding one — so it does not affect whether the manifest carries
+    /// surfaces beyond its tool list. The loader's strict-mode reasoning
+    /// about extras-only manifests therefore continues to apply unchanged.
     pub fn has_extras(&self) -> bool {
         !self.mcp_servers.is_empty()
             || !self.hooks.is_empty()
@@ -1177,5 +1210,59 @@ mod tests {
             msg.to_lowercase().contains("read") || msg.to_lowercase().contains("list"),
             "error must explain hint needs read or list; got: {msg}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // SKILL.md PR-D1: skill_md_auto_inject opt-out flag
+    // ------------------------------------------------------------------
+
+    /// A manifest that omits the field must deserialize to `true` so
+    /// unmigrated plugins keep current behavior (legacy SKILL.md
+    /// auto-inject still runs for `spawn_only` tools).
+    #[test]
+    fn manifest_defaults_skill_md_auto_inject_to_true() {
+        let json = r#"{
+            "name": "legacy",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}]
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(
+            manifest.skill_md_auto_inject,
+            "missing field must default to true (preserves legacy auto-inject)"
+        );
+    }
+
+    /// Explicit `false` opts the plugin out of the legacy SKILL.md
+    /// auto-inject. This is the migration knob PR-D2 will set per skill
+    /// after the new discovery card lands and soaks.
+    #[test]
+    fn manifest_parses_explicit_skill_md_auto_inject_false() {
+        let json = r#"{
+            "name": "migrated",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "skill_md_auto_inject": false
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(
+            !manifest.skill_md_auto_inject,
+            "explicit false must turn off the legacy auto-inject gate"
+        );
+    }
+
+    /// Explicit `true` is equivalent to omitting the field but must still
+    /// be parseable so operators can be loud about opting in during the
+    /// migration window.
+    #[test]
+    fn manifest_parses_explicit_skill_md_auto_inject_true() {
+        let json = r#"{
+            "name": "explicit-legacy",
+            "version": "1.0.0",
+            "tools": [{"name": "t", "description": "d"}],
+            "skill_md_auto_inject": true
+        }"#;
+        let manifest: PluginManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.skill_md_auto_inject);
     }
 }


### PR DESCRIPTION
## Context

PR-A (#1327), PR-B (#1333), and PR-C (#1339) of the SKILL.md rethink merged the SessionScope skill-zone reads, threaded the scope through `glob`/`list_dir`/`grep`, and added the manifest `discovery` field that renders a short skill card alongside the legacy SKILL.md auto-inject.

PR-D1 adds the per-plugin opt-out flag so individual skills can disable the legacy SKILL.md auto-inject after migrating to the new card.

## Summary

- New `PluginManifest` field `skill_md_auto_inject: bool` (default `true` — legacy behavior preserved for unmigrated plugins).
- Gate added at `crates/octos-agent/src/plugins/extras.rs`: the SKILL.md auto-inject for `spawn_only` tools now requires `manifest.skill_md_auto_inject == true`.
- `has_extras()` intentionally does NOT count the flag — its semantics are inverted (false removes a fragment instead of adding one), so the loader's "manifest carries surfaces beyond tools" reasoning is unaffected. A comment in manifest.rs documents this.

## Why a separate field instead of "presence of discovery disables legacy"

The migration is intentionally three steps so each stays revertable:
1. Add `discovery` so both legacy auto-inject AND the new skill card render — validate the card in production.
2. Set `skill_md_auto_inject: false` so only the card renders.
3. Trim `SKILL.md` body to <=80 lines now that the LLM reads it on demand.

An implicit "presence of discovery disables legacy" couples steps 1+2, forcing plugins to drop legacy the moment they add discovery. The explicit flag keeps each step independent.

## Follow-up

- **PR-D2** (separate, in `mofa-skills` repo): opts each `mofa-*` skill into `skill_md_auto_inject: false` and trims their SKILL.md bodies. Driven per skill after card soaks in production.
- **PR-E**: flips the workspace default to `false` after broader soak.

This PR is the gate; it neither removes the legacy auto-inject nor flips the default.

## Tests (7 new)

`crates/octos-agent/src/plugins/manifest.rs`:
- `manifest_defaults_skill_md_auto_inject_to_true` — omitted field deserializes to `true`.
- `manifest_parses_explicit_skill_md_auto_inject_false` — `false` parses correctly.
- `manifest_parses_explicit_skill_md_auto_inject_true` — explicit `true` parses correctly.

`crates/octos-agent/src/plugins/extras.rs`:
- `extras_skips_legacy_auto_inject_when_opted_out` — `false` + spawn_only + SKILL.md present -> no fragments.
- `extras_runs_legacy_auto_inject_when_opted_in_default` — default (via constructor) + spawn_only + SKILL.md -> fragment includes SKILL.md body.
- `extras_runs_legacy_auto_inject_when_explicitly_true` — explicit `true` + spawn_only + SKILL.md -> fragment includes SKILL.md body.
- `extras_skips_legacy_but_renders_card_when_discovery_present_and_opted_out` — migration end-state: discovery + `false` -> card renders, legacy body does not.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p octos-agent --lib -- plugins::` (191 passed)
- [x] `cargo test -p octos-agent --lib -- --test-threads=4` (1749 passed)
- [x] `cargo clippy --workspace --no-deps -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] PR-D2 follow-up: opt each mofa-* skill in after this lands and soaks.